### PR TITLE
refactor: remove request_peer_input tool from step agent tools

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -155,7 +155,7 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 		`You are part of a multi-agent team within this workflow step. ` +
 			`You have MCP tools for communicating with peer agents in the same group.`
 	);
-	sections.push(`\n### Primary: \`send_message\` (channel-validated direct messaging)\n`);
+	sections.push(`\n### \`send_message\` (channel-validated direct messaging)\n`);
 	sections.push(
 		`Use \`send_message\` to send messages directly to permitted peers based on the declared channel topology.`
 	);
@@ -166,18 +166,7 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 	);
 	sections.push(
 		`This tool validates against declared channels. ` +
-			`If the channel is not declared, it returns an error with available channels and suggests \`request_peer_input\`.`
-	);
-	sections.push(`\n### Fallback: \`request_peer_input\` (Task Agent mediated)\n`);
-	sections.push(
-		`Use \`request_peer_input\` when no direct channel is declared or as a fallback when \`send_message\` fails validation.`
-	);
-	sections.push(
-		`This is **async and non-blocking** — the tool returns immediately with an acknowledgment. ` +
-			`The peer's answer will arrive as a separate user turn prefixed with: \`[Peer response from {role}]: ...\``
-	);
-	sections.push(
-		`**Do NOT wait for an immediate reply.** Continue your work and handle peer responses when they arrive.`
+			`If the channel is not declared, it returns an error with available channels.`
 	);
 	sections.push(`\n### Discovering peers: \`list_peers\`\n`);
 	sections.push(
@@ -186,9 +175,8 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 	);
 	sections.push(`\n### Communication model rules\n`);
 	sections.push(
-		`- If this step has declared channels: use \`send_message\` for permitted directions, ` +
-			`\`request_peer_input\` for undeclared directions\n` +
-			`- If this step has no declared channels: all communication goes through \`request_peer_input\`\n` +
+		`- Use \`send_message\` for all peer communication — channel topology determines permitted targets\n` +
+			`- If a direction is not declared in the channel topology, \`send_message\` returns an error\n` +
 			`- All communication is scoped to this group — you cannot message agents in other tasks`
 	);
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -673,7 +673,7 @@ export class TaskAgentManager {
 		if (!taskWorkflowRunId) {
 			log.warn(
 				`TaskAgentManager.createSubSessionFactory: task ${taskId} has no workflowRunId — ` +
-					`step-agent channel topology will be unavailable (request_peer_input still works)`
+					`step-agent channel topology will be unavailable`
 			);
 		}
 
@@ -1345,11 +1345,8 @@ export class TaskAgentManager {
 	 * Build a step agent MCP server for a newly spawned sub-session.
 	 * Called from the `buildStepAgentMcpServer` callback passed to createTaskAgentMcpServer().
 	 *
-	 * The server gives the step agent peer communication tools (list_peers, send_message,
-	 * request_peer_input) that are scoped to its group and channel topology.
-	 *
-	 * The `injectToTaskAgent` callback routes `request_peer_input` requests through the
-	 * Task Agent, which has unrestricted relay access to all group members.
+	 * The server gives the step agent peer communication tools (list_peers, send_message)
+	 * that are scoped to its group and channel topology.
 	 */
 	private buildStepAgentMcpServerForSession(
 		taskId: string,
@@ -1368,7 +1365,6 @@ export class TaskAgentManager {
 			workflowRunRepo: this.config.workflowRunRepo,
 			messageInjector: (targetSessionId, message) =>
 				this.injectSubSessionMessage(targetSessionId, message),
-			injectToTaskAgent: (message) => this.injectTaskAgentMessage(taskId, message),
 		});
 	}
 }

--- a/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
@@ -1,11 +1,10 @@
 /**
- * Step Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 3
+ * Step Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 2
  * peer communication tools available to step agent sub-sessions.
  *
  * Tools:
- *   list_peers          — list other group members with their roles, statuses, and permitted channels
- *   send_message       — primary channel-validated direct messaging tool
- *   request_peer_input  — fallback Task Agent mediated messaging tool
+ *   list_peers   — list other group members with their roles, statuses, and permitted channels
+ *   send_message — channel-validated direct messaging tool
  *
  * This file contains only schema definitions — no runtime logic or side effects.
  *
@@ -42,9 +41,6 @@ export type ListPeersInput = z.infer<typeof ListPeersSchema>;
  *   - Point-to-point: `target: 'coder'`
  *   - Broadcast to all permitted: `target: '*'`
  *   - Multicast: `target: ['coder', 'reviewer']`
- *
- * Returns an error with available channels and suggests `request_peer_input` when
- * the channel topology does not permit the requested direction.
  */
 export const SendMessageSchema = z.object({
 	/**
@@ -68,37 +64,6 @@ export const SendMessageSchema = z.object({
 export type SendMessageInput = z.infer<typeof SendMessageSchema>;
 
 // ---------------------------------------------------------------------------
-// request_peer_input
-// ---------------------------------------------------------------------------
-
-/**
- * Schema for `request_peer_input` input.
- *
- * Fallback Task Agent mediated communication tool. Available when no direct channel
- * is declared for the target role, or when `send_message` fails validation.
- *
- * This is ASYNC and NON-BLOCKING — the tool returns an acknowledgment immediately.
- * The peer's answer will arrive as a separate user turn prefixed with:
- *   `[Peer response from {role}]: ...`
- *
- * Do NOT wait for an immediate reply. Continue working and handle the peer's
- * response when it arrives in the conversation.
- */
-export const RequestPeerInputSchema = z.object({
-	/** Role of the peer to ask (e.g., 'reviewer', 'coder'). */
-	target_role: z
-		.string()
-		.describe("Role of the peer to request input from (e.g., 'reviewer', 'coder')"),
-	/** The question or request to send to the peer via the Task Agent. */
-	question: z
-		.string()
-		.min(1)
-		.describe('The question or request to relay to the peer through the Task Agent'),
-});
-
-export type RequestPeerInputInput = z.infer<typeof RequestPeerInputSchema>;
-
-// ---------------------------------------------------------------------------
 // Aggregate export
 // ---------------------------------------------------------------------------
 
@@ -108,7 +73,6 @@ export type RequestPeerInputInput = z.infer<typeof RequestPeerInputSchema>;
 export const STEP_AGENT_TOOL_SCHEMAS = {
 	list_peers: ListPeersSchema,
 	send_message: SendMessageSchema,
-	request_peer_input: RequestPeerInputSchema,
 } as const;
 
 export type StepAgentToolName = keyof typeof STEP_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/step-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tools.ts
@@ -4,14 +4,11 @@
  * These handlers implement peer communication tools for step agents within
  * the same workflow step group:
  *
- *   list_peers          — discover other group members with roles and permitted channels
- *   send_message       — primary channel-validated direct messaging tool
- *   request_peer_input  — fallback Task Agent mediated messaging (async)
+ *   list_peers   — discover other group members with roles and permitted channels
+ *   send_message — primary channel-validated direct messaging tool
  *
  * Communication model:
  * - Step agents communicate via declared channel topology (`send_message`).
- * - When no channel is declared, or as a fallback, use `request_peer_input`
- *   which routes through the Task Agent.
  * - `list_peers` reveals who is in the group and what channels are available.
  *
  * Channel topology patterns supported:
@@ -20,15 +17,11 @@
  *   - Fan-out one-way: hub→[spoke1, spoke2, ...]
  *   - Hub-spoke: hub↔spokes (hub sends to all, spokes only reply to hub)
  *
- * When no channels are declared for a step, all `send_message` calls fail with
- * a suggestion to use `request_peer_input` instead.
- *
  * Design:
  * - Handlers are pure functions tested independently of any MCP server layer.
  * - Dependencies are injected via `StepAgentToolsConfig`.
  * - `messageInjector` is backed by `injectSubSessionMessage` → `injectMessageIntoSession`
  *   → `session.messageQueue.enqueueWithId()`, which provides per-session write ordering.
- * - The `injectToTaskAgent` callback is used by `request_peer_input` for routing.
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
@@ -37,16 +30,8 @@ import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/s
 import { ChannelResolver } from '../runtime/channel-resolver';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
-import {
-	ListPeersSchema,
-	SendMessageSchema,
-	RequestPeerInputSchema,
-} from './step-agent-tool-schemas';
-import type {
-	ListPeersInput,
-	SendMessageInput,
-	RequestPeerInputInput,
-} from './step-agent-tool-schemas';
+import { ListPeersSchema, SendMessageSchema } from './step-agent-tool-schemas';
+import type { ListPeersInput, SendMessageInput } from './step-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
@@ -79,11 +64,6 @@ export interface StepAgentToolsConfig {
 	 * Used by `send_message` to deliver messages to target sessions.
 	 */
 	messageInjector: (sessionId: string, message: string) => Promise<void>;
-	/**
-	 * Injects a message into the Task Agent session.
-	 * Used by `request_peer_input` to route questions through the Task Agent.
-	 */
-	injectToTaskAgent: (message: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -104,7 +84,6 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		getGroupId,
 		workflowRunRepo,
 		messageInjector,
-		injectToTaskAgent,
 	} = config;
 
 	type GroupLoaded = {
@@ -191,7 +170,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 					`Found ${peers.length} peer(s). ` +
 					(channelTopologyDeclared
 						? `Permitted direct targets via send_message: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`
-						: 'No channel topology declared — use request_peer_input to communicate with peers.'),
+						: 'No channel topology declared.'),
 			});
 		},
 
@@ -199,8 +178,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		 * Send a message directly to one or more peer agents.
 		 *
 		 * Validates the requested direction(s) against the declared channel topology
-		 * before routing. On validation failure, returns an error with available channels
-		 * and suggests `request_peer_input` as a fallback.
+		 * before routing.
 		 *
 		 * Target forms:
 		 *   - `target: 'coder'` — point-to-point to a single role
@@ -219,17 +197,13 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 			if (!loaded.ok) return loaded.error;
 			const { group, resolver } = loaded;
 
-			// When no channel topology is declared for this step, all send_message calls
-			// fail. Agents in a step with no declared channels must use request_peer_input
-			// so that all inter-agent communication is mediated by the Task Agent.
+			// When no channel topology is declared for this step, all send_message calls fail.
 			if (resolver.isEmpty()) {
 				return jsonResult({
 					success: false,
 					error:
 						`No channel topology declared for this step. ` +
-						`Direct messaging via send_message is not available. ` +
-						`Use request_peer_input to communicate with peers through the Task Agent.`,
-					suggestion: 'request_peer_input',
+						`Direct messaging via send_message is not available.`,
 				});
 			}
 
@@ -246,7 +220,6 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 							`No permitted targets for role '${myRole}' in the declared channel topology. ` +
 							`Broadcast ('*') requires at least one permitted outgoing channel.`,
 						availableTargets: [],
-						suggestion: 'request_peer_input',
 					});
 				}
 				targetRoles = permitted;
@@ -269,8 +242,6 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 						`Permitted targets: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`,
 					unauthorizedRoles,
 					permittedTargets,
-					suggestion:
-						'Use request_peer_input to route through the Task Agent for undeclared channels.',
 				});
 			}
 
@@ -338,51 +309,6 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 					'.',
 			});
 		},
-
-		/**
-		 * Route a question or request through the Task Agent to a peer.
-		 *
-		 * This is the FALLBACK tool for when no direct channel is declared, or when
-		 * `send_message` fails validation. It routes through the Task Agent, which
-		 * has unrestricted relay access to all group members.
-		 *
-		 * ASYNC and NON-BLOCKING — returns immediately with an acknowledgment.
-		 * The peer's answer will arrive as a separate user turn in this session,
-		 * prefixed with: `[Peer response from {role}]: ...`
-		 *
-		 * Do NOT wait for an immediate reply. Continue working and process the peer's
-		 * response when it arrives.
-		 */
-		async request_peer_input(args: RequestPeerInputInput): Promise<ToolResult> {
-			const { target_role, question } = args;
-
-			// Format the routing request for the Task Agent
-			const routingMessage =
-				`[Peer input request from '${myRole}' (session ${mySessionId}) to '${target_role}']: ` +
-				`${question}\n\n` +
-				`Please relay this question to the '${target_role}' peer and forward their response back to '${myRole}' ` +
-				`(session ${mySessionId}) prefixed with: [Peer response from ${target_role}]: ...`;
-
-			try {
-				await injectToTaskAgent(routingMessage);
-			} catch (err) {
-				const msg = err instanceof Error ? err.message : String(err);
-				return jsonResult({
-					success: false,
-					error: `Failed to route request through Task Agent: ${msg}`,
-				});
-			}
-
-			return jsonResult({
-				success: true,
-				targetRole: target_role,
-				message:
-					`Request routed to Task Agent for delivery to '${target_role}'. ` +
-					`This is async — continue your work. ` +
-					`The peer's response will arrive as a user turn prefixed with: [Peer response from ${target_role}]: ...`,
-				async: true,
-			});
-		},
 	};
 }
 
@@ -410,19 +336,9 @@ export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
 			'send_message',
 			'Send a message directly to one or more peer agents via declared channel topology. ' +
 				"Supports point-to-point ('coder'), broadcast ('*'), and multicast (['coder','reviewer']). " +
-				'Validates against declared channels — returns an error with available channels if unauthorized. ' +
-				'Use request_peer_input as a fallback when no channel is declared.',
+				'Validates against declared channels — returns an error with available channels if unauthorized.',
 			SendMessageSchema.shape,
 			(args) => handlers.send_message(args)
-		),
-		tool(
-			'request_peer_input',
-			'Route a question or request to a peer through the Task Agent. ' +
-				'Use this when no direct channel is declared or as a fallback when send_message fails. ' +
-				'Call list_peers first to verify the target_role exists in the group. ' +
-				'ASYNC: returns immediately. The peer response arrives later as a user turn prefixed with [Peer response from {role}]: ...',
-			RequestPeerInputSchema.shape,
-			(args) => handlers.request_peer_input(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -171,8 +171,7 @@ function makeStepConfig(
 	role: string,
 	groupId: string,
 	workflowRunId: string,
-	injector: (sessionId: string, message: string) => Promise<void>,
-	taskAgentInjector?: (message: string) => Promise<void>
+	injector: (sessionId: string, message: string) => Promise<void>
 ): StepAgentToolsConfig {
 	return {
 		mySessionId: sessionId,
@@ -183,7 +182,6 @@ function makeStepConfig(
 		getGroupId: () => groupId,
 		workflowRunRepo: tdb.workflowRunRepo,
 		messageInjector: injector,
-		injectToTaskAgent: taskAgentInjector ?? (async () => {}),
 	};
 }
 
@@ -1337,7 +1335,6 @@ describe('data reload and DB-based validation', () => {
 			getGroupId: () => group.id, // Still returns correct group ID
 			workflowRunRepo: freshRunRepo,
 			messageInjector: injector,
-			injectToTaskAgent: async () => {},
 		};
 
 		const handlers = createStepAgentToolHandlers(config);
@@ -1483,7 +1480,6 @@ describe('error paths — missing group ID', () => {
 			getGroupId: () => undefined,
 			workflowRunRepo: tdb.workflowRunRepo,
 			messageInjector: injector,
-			injectToTaskAgent: async () => {},
 		};
 
 		const handlers = createStepAgentToolHandlers(config);
@@ -1505,7 +1501,6 @@ describe('error paths — missing group ID', () => {
 			getGroupId: () => undefined,
 			workflowRunRepo: tdb.workflowRunRepo,
 			messageInjector: async () => {},
-			injectToTaskAgent: async () => {},
 		};
 
 		const handlers = createStepAgentToolHandlers(config);

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -4,9 +4,8 @@
  * Exercises the full messaging stack with a real SQLite DB and mock injectors
  * (no real agent sessions). Focuses on end-to-end behavioral enforcement:
  *
- *   send_message         — channel validation, target modes, fan-out, hub-spoke
- *   request_peer_input    — Task Agent mediated async flow
- *   list_peers            — peer discovery with channel info
+ *   send_message  — channel validation, target modes, fan-out, hub-spoke
+ *   list_peers    — peer discovery with channel info
  *   list_group_members    — Task Agent group view
  *   relay_message         — Task Agent unrestricted relay, cross-group rejection
  *
@@ -185,10 +184,8 @@ function makeStepConfig(
 	overrides: Partial<StepAgentToolsConfig> = {}
 ): StepAgentToolsConfig & {
 	injectedMessages: Array<{ sessionId: string; message: string }>;
-	taskAgentMessages: string[];
 } {
 	const injectedMessages: Array<{ sessionId: string; message: string }> = [];
-	const taskAgentMessages: string[] = [];
 
 	const config = {
 		mySessionId,
@@ -201,13 +198,10 @@ function makeStepConfig(
 		messageInjector: async (sessionId: string, message: string) => {
 			injectedMessages.push({ sessionId, message });
 		},
-		injectToTaskAgent: async (message: string) => {
-			taskAgentMessages.push(message);
-		},
 		...overrides,
 	};
 
-	return Object.assign(config, { injectedMessages, taskAgentMessages });
+	return Object.assign(config, { injectedMessages });
 }
 
 // ===========================================================================
@@ -547,7 +541,7 @@ describe('send_message — no channels declared', () => {
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('all send_message calls fail with suggestion to use request_peer_input', async () => {
+	test('all send_message calls fail when no channels declared', async () => {
 		ctx = makeStepCtx([
 			{ sessionId: 'sess-coder', role: 'coder' },
 			{ sessionId: 'sess-reviewer', role: 'reviewer' },
@@ -559,7 +553,6 @@ describe('send_message — no channels declared', () => {
 
 		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'Hi' }));
 		expect(result.success).toBe(false);
-		expect(result.suggestion).toBe('request_peer_input');
 		expect(cfg.injectedMessages).toHaveLength(0);
 	});
 });
@@ -688,97 +681,7 @@ describe('send_message — hub-spoke bidirectional: hub broadcasts, spokes reply
 });
 
 // ===========================================================================
-// 5. request_peer_input — Task Agent mediated async flow
-// ===========================================================================
-
-describe('request_peer_input — async routing through Task Agent', () => {
-	let ctx: StepCtx;
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('routes question to Task Agent and returns async acknowledgment', async () => {
-		ctx = makeStepCtx([
-			{ sessionId: 'sess-coder', role: 'coder' },
-			{ sessionId: 'sess-reviewer', role: 'reviewer' },
-		]);
-		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
-		const handlers = createStepAgentToolHandlers(cfg);
-
-		const result = parse(
-			await handlers.request_peer_input({
-				target_role: 'reviewer',
-				question: 'Does the API look correct?',
-			})
-		);
-		expect(result.success).toBe(true);
-		expect(result.async).toBe(true);
-		expect(result.targetRole).toBe('reviewer');
-		expect(cfg.taskAgentMessages).toHaveLength(1);
-	});
-
-	test('routing message includes sender identity, session ID, and target role', async () => {
-		ctx = makeStepCtx([{ sessionId: 'sess-coder', role: 'coder' }]);
-		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
-		const handlers = createStepAgentToolHandlers(cfg);
-
-		await handlers.request_peer_input({ target_role: 'reviewer', question: 'Any concerns?' });
-
-		const msg = cfg.taskAgentMessages[0];
-		expect(msg).toContain('coder');
-		expect(msg).toContain('reviewer');
-		expect(msg).toContain('sess-coder');
-		expect(msg).toContain('Any concerns?');
-	});
-
-	test('routing message asks Task Agent to forward response back with prefix', async () => {
-		ctx = makeStepCtx([{ sessionId: 'sess-coder', role: 'coder' }]);
-		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
-		const handlers = createStepAgentToolHandlers(cfg);
-
-		await handlers.request_peer_input({ target_role: 'reviewer', question: 'Question' });
-
-		const msg = cfg.taskAgentMessages[0];
-		expect(msg).toContain('[Peer response from reviewer]');
-	});
-
-	test('available even when no channels declared (fallback mode)', async () => {
-		ctx = makeStepCtx([{ sessionId: 'sess-coder', role: 'coder' }]);
-		// No channels set — resolver is empty, send_message would fail
-		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
-		const handlers = createStepAgentToolHandlers(cfg);
-
-		// send_message should fail
-		const fbResult = parse(await handlers.send_message({ target: 'reviewer', message: 'Hi' }));
-		expect(fbResult.success).toBe(false);
-
-		// request_peer_input should succeed
-		const rpResult = parse(
-			await handlers.request_peer_input({ target_role: 'reviewer', question: 'Hi' })
-		);
-		expect(rpResult.success).toBe(true);
-	});
-
-	test('returns error when Task Agent injection fails', async () => {
-		ctx = makeStepCtx([{ sessionId: 'sess-coder', role: 'coder' }]);
-		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
-			injectToTaskAgent: async () => {
-				throw new Error('Task Agent session not found');
-			},
-		});
-		const handlers = createStepAgentToolHandlers(cfg);
-
-		const result = parse(
-			await handlers.request_peer_input({ target_role: 'reviewer', question: 'Q' })
-		);
-		expect(result.success).toBe(false);
-		expect(result.error as string).toContain('Task Agent session not found');
-	});
-});
-
-// ===========================================================================
-// 6. list_peers — peer discovery
+// 5. list_peers — peer discovery
 // ===========================================================================
 
 describe('list_peers — peer discovery with channel info', () => {
@@ -1259,17 +1162,17 @@ describe('relay_message — cross-group rejection', () => {
 });
 
 // ===========================================================================
-// 12. Step with no channels declared — open model (all via request_peer_input)
+// 12. Step with no channels declared — no messaging available
 // ===========================================================================
 
-describe('Step with no channels declared — open model', () => {
+describe('Step with no channels declared', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('send_message always fails; request_peer_input always succeeds', async () => {
+	test('send_message fails when no channels declared', async () => {
 		ctx = makeStepCtx([
 			{ sessionId: 'sess-a', role: 'agent-a' },
 			{ sessionId: 'sess-b', role: 'agent-b' },
@@ -1283,13 +1186,6 @@ describe('Step with no channels declared — open model', () => {
 			await handlersA.send_message({ target: 'agent-b', message: 'Direct msg' })
 		);
 		expect(fbResult.success).toBe(false);
-		expect(fbResult.suggestion).toBe('request_peer_input');
-
-		const rpResult = parse(
-			await handlersA.request_peer_input({ target_role: 'agent-b', question: 'Q?' })
-		);
-		expect(rpResult.success).toBe(true);
-		expect(rpResult.async).toBe(true);
 	});
 
 	test('list_peers shows no permitted targets when no channels declared', async () => {

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -158,20 +158,12 @@ describe('buildCustomAgentSystemPrompt', () => {
 		expect(prompt).toContain('pullrequestreview');
 	});
 
-	it('includes peer communication section with all three tools', () => {
+	it('includes peer communication section with list_peers and send_message', () => {
 		const agent = makeAgent();
 		const prompt = buildCustomAgentSystemPrompt(agent);
 		expect(prompt).toContain('Peer Communication');
 		expect(prompt).toContain('list_peers');
 		expect(prompt).toContain('send_message');
-		expect(prompt).toContain('request_peer_input');
-	});
-
-	it('explains async nature of request_peer_input', () => {
-		const agent = makeAgent();
-		const prompt = buildCustomAgentSystemPrompt(agent);
-		expect(prompt).toContain('[Peer response from {role}]:');
-		expect(prompt).toContain('async and non-blocking');
 	});
 
 	it('no role produces role-specific instructions (roles are display labels only)', () => {

--- a/packages/daemon/tests/unit/space/step-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/step-agent-tools.test.ts
@@ -2,9 +2,8 @@
  * Unit tests for createStepAgentToolHandlers()
  *
  * Covers all step agent peer communication tools:
- *   list_peers          — list peers excluding self and task-agent
- *   send_message        — channel-validated direct messaging (renamed from send_feedback)
- *   request_peer_input  — Task Agent mediated async fallback
+ *   list_peers   — list peers excluding self and task-agent
+ *   send_message — channel-validated direct messaging
  *
  * Tests use a real SQLite database (via runMigrations) and mock message
  * injectors so no real agent sessions are created.
@@ -182,7 +181,6 @@ function makeConfig(
 	overrides: Partial<StepAgentToolsConfig> = {}
 ): StepAgentToolsConfig {
 	const injectedMessages: Array<{ sessionId: string; message: string }> = [];
-	const taskAgentMessages: string[] = [];
 
 	return {
 		mySessionId: ctx.coderSessionId,
@@ -194,9 +192,6 @@ function makeConfig(
 		workflowRunRepo: ctx.workflowRunRepo,
 		messageInjector: async (sessionId, message) => {
 			injectedMessages.push({ sessionId, message });
-		},
-		injectToTaskAgent: async (message) => {
-			taskAgentMessages.push(message);
 		},
 		...overrides,
 	};
@@ -341,7 +336,6 @@ describe('step-agent-tools: send_message', () => {
 		expect(data.success).toBe(false);
 		expect(data.error).toContain("does not permit 'coder' to send to: reviewer");
 		expect(data.unauthorizedRoles).toContain('reviewer');
-		expect(data.suggestion).toContain('request_peer_input');
 	});
 
 	test('returns error when no channels declared at all (empty topology blocks send_message)', async () => {
@@ -350,11 +344,9 @@ describe('step-agent-tools: send_message', () => {
 		const result = await handlers.send_message({ target: 'reviewer', message: 'test' });
 		const data = JSON.parse(result.content[0].text);
 
-		// With no declared channels, send_message is unavailable — all communication
-		// must go through request_peer_input (Task Agent mediated).
+		// With no declared channels, send_message is unavailable.
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('No channel topology declared');
-		expect(data.suggestion).toBe('request_peer_input');
 	});
 
 	test('broadcast (*) succeeds and delivers to all permitted targets', async () => {
@@ -388,10 +380,9 @@ describe('step-agent-tools: send_message', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.error).toContain("No permitted targets for role 'coder'");
-		expect(data.suggestion).toBe('request_peer_input');
 	});
 
-	test('broadcast (*) with empty topology returns suggestion to use request_peer_input', async () => {
+	test('broadcast (*) with empty topology returns error', async () => {
 		// No channels declared at all
 		const config = makeConfig(ctx);
 		const handlers = createStepAgentToolHandlers(config);
@@ -400,7 +391,6 @@ describe('step-agent-tools: send_message', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('No channel topology declared');
-		expect(data.suggestion).toBe('request_peer_input');
 	});
 
 	test('multicast delivers to all specified target roles', async () => {
@@ -676,120 +666,6 @@ describe('step-agent-tools: send_message', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: request_peer_input
-// ---------------------------------------------------------------------------
-
-describe('step-agent-tools: request_peer_input', () => {
-	let ctx: TestCtx;
-
-	beforeEach(() => {
-		ctx = makeCtx();
-	});
-
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('routes request to Task Agent and returns acknowledgment', async () => {
-		const taskAgentMessages: string[] = [];
-		const config = makeConfig(ctx, {
-			injectToTaskAgent: async (msg) => {
-				taskAgentMessages.push(msg);
-			},
-		});
-		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.request_peer_input({
-			target_role: 'reviewer',
-			question: 'Can you review my PR?',
-		});
-		const data = JSON.parse(result.content[0].text);
-
-		expect(data.success).toBe(true);
-		expect(data.targetRole).toBe('reviewer');
-		expect(data.async).toBe(true);
-		expect(data.message).toContain('async');
-		expect(data.message).toContain('[Peer response from reviewer]:');
-		expect(taskAgentMessages).toHaveLength(1);
-		expect(taskAgentMessages[0]).toContain("from 'coder'");
-		expect(taskAgentMessages[0]).toContain("to 'reviewer'");
-		expect(taskAgentMessages[0]).toContain('Can you review my PR?');
-	});
-
-	test('formats routing message with session ID prefix', async () => {
-		let capturedMessage = '';
-		const config = makeConfig(ctx, {
-			injectToTaskAgent: async (msg) => {
-				capturedMessage = msg;
-			},
-		});
-		const handlers = createStepAgentToolHandlers(config);
-		await handlers.request_peer_input({
-			target_role: 'reviewer',
-			question: 'Is the code correct?',
-		});
-
-		expect(capturedMessage).toContain(`session ${ctx.coderSessionId}`);
-		expect(capturedMessage).toContain('reviewer');
-		expect(capturedMessage).toContain('[Peer response from reviewer]:');
-	});
-
-	test('returns error when Task Agent injection fails', async () => {
-		const config = makeConfig(ctx, {
-			injectToTaskAgent: async () => {
-				throw new Error('Task Agent unavailable');
-			},
-		});
-		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.request_peer_input({
-			target_role: 'reviewer',
-			question: 'Help?',
-		});
-		const data = JSON.parse(result.content[0].text);
-
-		expect(data.success).toBe(false);
-		expect(data.error).toContain('Task Agent unavailable');
-	});
-
-	test('is available when no channels declared (fallback mode)', async () => {
-		// No workflowRunId means no channels declared — request_peer_input should work
-		const taskAgentMessages: string[] = [];
-		const config = makeConfig(ctx, {
-			injectToTaskAgent: async (msg) => {
-				taskAgentMessages.push(msg);
-			},
-		});
-		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.request_peer_input({
-			target_role: 'coder',
-			question: 'What should I do?',
-		});
-		const data = JSON.parse(result.content[0].text);
-
-		expect(data.success).toBe(true);
-		expect(taskAgentMessages).toHaveLength(1);
-	});
-
-	test('sends acknowledgment regardless of whether target role exists in group', async () => {
-		// request_peer_input does NOT validate group membership — that's the Task Agent's job
-		const config = makeConfig(ctx, {
-			injectToTaskAgent: async () => {
-				/* no-op */
-			},
-		});
-		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.request_peer_input({
-			target_role: 'nonexistent-role',
-			question: 'Are you there?',
-		});
-		const data = JSON.parse(result.content[0].text);
-
-		// request_peer_input does not validate target role existence
-		expect(data.success).toBe(true);
-	});
-});
-
-// ---------------------------------------------------------------------------
 // Tests: createStepAgentMcpServer (factory)
 // ---------------------------------------------------------------------------
 
@@ -841,10 +717,7 @@ describe('step-agent-tools: system prompt includes peer communication section', 
 
 		expect(prompt).toContain('Peer Communication');
 		expect(prompt).toContain('send_message');
-		expect(prompt).toContain('request_peer_input');
 		expect(prompt).toContain('list_peers');
 		expect(prompt).toContain('channel-validated');
-		expect(prompt).toContain('async and non-blocking');
-		expect(prompt).toContain('[Peer response from {role}]:');
 	});
 });


### PR DESCRIPTION
Step agents now communicate exclusively via list_peers and send_message.
Removed request_peer_input handler, schema, injectToTaskAgent callback,
and all system prompt references. Updated all affected tests.
