### PR TITLE
test: add Task Agent channel topology tests to cross-agent messaging

### DIFF
--- a/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -14,8 +14,8 @@
  *              survives daemon restart (the only suite that cannot be replaced by unit tests).
  *   - Suite 8: getGroupId() → undefined edge case not covered in existing tests.
  *   - Suite 9: Task Agent participation in channel topology — via list_group_members and
- *              send_message to 'task-agent' target. Note: send_message to task-agent fails
- *              with "no active sessions" even when channel is declared (task-agent is
+ *              send_message to 'task-agent' target. By design, send_message to task-agent
+ *              fails with "no active sessions" even when channel is declared (task-agent is
  *              filtered from delivery targets). list_group_members correctly shows the
  *              channel in permittedTargets for both the sender and Task Agent.
  *
@@ -50,6 +50,7 @@ import {
 	createStepAgentToolHandlers,
 	type StepAgentToolsConfig,
 } from '../../../src/lib/space/tools/step-agent-tools.ts';
+import { ChannelResolver } from '../../../src/lib/space/runtime/channel-resolver.ts';
 import type { ResolvedChannel } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
@@ -1306,7 +1307,6 @@ describe('Task Agent channel participation', () => {
 		const freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
 		const reloadedRun = freshRunRepo.getRun(workflowRunId);
 
-		const { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
 		const resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
 
 		expect(resolver.canSend('coder', 'task-agent')).toBe(true);
@@ -1321,7 +1321,6 @@ describe('Task Agent channel participation', () => {
 		const freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
 		const reloadedRun = freshRunRepo.getRun(workflowRunId);
 
-		const { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
 		const resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
 
 		expect(resolver.canSend('coder', 'task-agent')).toBe(false);
@@ -1335,7 +1334,6 @@ describe('Task Agent channel participation', () => {
 		const freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
 		const reloadedRun = freshRunRepo.getRun(workflowRunId);
 
-		const { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
 		const resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
 
 		const permitted = resolver.getPermittedTargets('reviewer');
@@ -1350,7 +1348,6 @@ describe('Task Agent channel participation', () => {
 		const freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
 		const reloadedRun = freshRunRepo.getRun(workflowRunId);
 
-		const { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
 		const resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
 
 		const permitted = resolver.getPermittedTargets('task-agent');
@@ -1391,6 +1388,46 @@ describe('Task Agent channel participation', () => {
 		expect(messages).toHaveLength(0);
 	});
 
+	test('send_message to task-agent fails even when task-agent member is in group (filter exercised)', async () => {
+		// This test exercises the explicit filter in send_message that removes task-agent
+		// from delivery targets, even when task-agent IS a group member with an active session.
+		const { sessionGroupRepo } = tdb;
+
+		const group = sessionGroupRepo.createGroup({
+			spaceId: tdb.spaceId,
+			name: 'group-task-agent-filter',
+		});
+		sessionGroupRepo.addMember(group.id, 'session-coder', {
+			role: 'coder',
+			status: 'active',
+			orderIndex: 0,
+		});
+		sessionGroupRepo.addMember(group.id, 'session-task-agent', {
+			role: 'task-agent',
+			status: 'active',
+			orderIndex: 1,
+		});
+
+		// Channel coder→task-agent is declared
+		const workflowRunId = seedWorkflowRunWithChannels(tdb.db, tdb.spaceId, [
+			makeResolvedChannel('coder', 'task-agent'),
+		]);
+
+		const { messages, injector } = makeMessageCapture();
+		const config = makeStepConfig(tdb, 'session-coder', 'coder', group.id, workflowRunId, injector);
+		const handlers = createStepAgentToolHandlers(config);
+
+		const result = await handlers.send_message({ target: 'task-agent', message: 'Hello TA' });
+		const data = JSON.parse(result.content[0].text);
+
+		// The channel resolver check passes (channel is declared), but send_message
+		// explicitly filters out task-agent from delivery targets, so no message is delivered.
+		// This exercises the filter at step-agent-tools.ts: .filter((m) => m.role !== 'task-agent')
+		expect(data.success).toBe(false);
+		expect((data.error as string).toLowerCase()).toContain('no active sessions');
+		expect(messages).toHaveLength(0);
+	});
+
 	test('removing channel to task-agent updates getPermittedTargets', async () => {
 		const { sessionGroupRepo } = tdb;
 
@@ -1417,7 +1454,6 @@ describe('Task Agent channel participation', () => {
 		let freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
 		let reloadedRun = freshRunRepo.getRun(workflowRunId);
 
-		let { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
 		let resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
 
 		expect(resolver.getPermittedTargets('coder')).toContain('task-agent');

--- a/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -13,6 +13,11 @@
  *   - Suite 7: Fresh repository instances over the same DB — verifies group/channel resolution
  *              survives daemon restart (the only suite that cannot be replaced by unit tests).
  *   - Suite 8: getGroupId() → undefined edge case not covered in existing tests.
+ *   - Suite 9: Task Agent participation in channel topology — via list_group_members and
+ *              send_message to 'task-agent' target. Note: send_message to task-agent fails
+ *              with "no active sessions" even when channel is declared (task-agent is
+ *              filtered from delivery targets). list_group_members correctly shows the
+ *              channel in permittedTargets for both the sender and Task Agent.
  *
  * Suites 2–6 provide complementary coverage for the direction-enforcement and topology
  * patterns that also exist in step-agent-tools.test.ts, exercised here end-to-end through
@@ -26,6 +31,8 @@
  *   6. Concurrent injection       — both messages delivered when two agents inject simultaneously
  *   7. Data reload                — group/channel resolution survives DB re-fetch
  *   8. Error paths                — missing group ID returns structured error
+ *   9. Task Agent in topology     — channel to/from task-agent is reflected in permittedTargets
+ *                                  but send_message to task-agent fails (delivery target filtered)
  *
  * All tests pass with:
  *   cd packages/daemon && bun test tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -1266,5 +1273,160 @@ describe('error paths — missing group ID', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('No session group found');
+	});
+});
+
+// ===========================================================================
+// Test Suite 9: Task Agent Participation in Channel Topology
+// ===========================================================================
+// Verifies that:
+//   - ChannelResolver.canSend correctly handles task-agent as fromRole/toRole
+//   - ChannelResolver.getPermittedTargets correctly returns task-agent when channel declared
+//   - send_message to 'task-agent' fails with "no active sessions" even when channel declared
+//     (task-agent is filtered from delivery targets — this is the known gap)
+//   - list_group_members via Task Agent correctly shows permittedTargets involving task-agent
+
+describe('Task Agent channel participation', () => {
+	let tdb: TestDb;
+
+	beforeEach(() => {
+		tdb = makeTestDb();
+	});
+
+	afterEach(() => {
+		tdb.db.close();
+		rmSync(tdb.dir, { recursive: true, force: true });
+	});
+
+	test('ChannelResolver: canSend returns true when coder→task-agent channel declared', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(tdb.db, tdb.spaceId, [
+			makeResolvedChannel('coder', 'task-agent'),
+		]);
+
+		const freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
+		const reloadedRun = freshRunRepo.getRun(workflowRunId);
+
+		const { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
+		const resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
+
+		expect(resolver.canSend('coder', 'task-agent')).toBe(true);
+	});
+
+	test('ChannelResolver: canSend returns false when no channel to task-agent', async () => {
+		// Channel between coder and reviewer — NOT involving task-agent
+		const workflowRunId = seedWorkflowRunWithChannels(tdb.db, tdb.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+
+		const freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
+		const reloadedRun = freshRunRepo.getRun(workflowRunId);
+
+		const { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
+		const resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
+
+		expect(resolver.canSend('coder', 'task-agent')).toBe(false);
+	});
+
+	test('ChannelResolver: getPermittedTargets includes task-agent when channel declared', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(tdb.db, tdb.spaceId, [
+			makeResolvedChannel('reviewer', 'task-agent'),
+		]);
+
+		const freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
+		const reloadedRun = freshRunRepo.getRun(workflowRunId);
+
+		const { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
+		const resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
+
+		const permitted = resolver.getPermittedTargets('reviewer');
+		expect(permitted).toContain('task-agent');
+	});
+
+	test('ChannelResolver: task-agent permittedTargets includes coder when task-agent→coder declared', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(tdb.db, tdb.spaceId, [
+			makeResolvedChannel('task-agent', 'coder'),
+		]);
+
+		const freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
+		const reloadedRun = freshRunRepo.getRun(workflowRunId);
+
+		const { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
+		const resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
+
+		const permitted = resolver.getPermittedTargets('task-agent');
+		expect(permitted).toContain('coder');
+	});
+
+	test('send_message to task-agent fails with "no active sessions" even when channel declared', async () => {
+		const { sessionGroupRepo } = tdb;
+
+		const group = sessionGroupRepo.createGroup({
+			spaceId: tdb.spaceId,
+			name: 'group-task-agent-send',
+		});
+		sessionGroupRepo.addMember(group.id, 'session-coder', {
+			role: 'coder',
+			status: 'active',
+			orderIndex: 0,
+		});
+		// Note: NO task-agent member added — send_message filters out task-agent anyway
+
+		// Channel coder→task-agent is declared
+		const workflowRunId = seedWorkflowRunWithChannels(tdb.db, tdb.spaceId, [
+			makeResolvedChannel('coder', 'task-agent'),
+		]);
+
+		const { messages, injector } = makeMessageCapture();
+		const config = makeStepConfig(tdb, 'session-coder', 'coder', group.id, workflowRunId, injector);
+		const handlers = createStepAgentToolHandlers(config);
+
+		const result = await handlers.send_message({ target: 'task-agent', message: 'Hello TA' });
+		const data = JSON.parse(result.content[0].text);
+
+		// send_message to task-agent fails with "No active sessions" because task-agent
+		// is filtered from the delivery targets list, even though the channel resolver
+		// check would pass
+		expect(data.success).toBe(false);
+		expect((data.error as string).toLowerCase()).toContain('no active sessions');
+		expect(messages).toHaveLength(0);
+	});
+
+	test('removing channel to task-agent updates getPermittedTargets', async () => {
+		const { sessionGroupRepo } = tdb;
+
+		const group = sessionGroupRepo.createGroup({
+			spaceId: tdb.spaceId,
+			name: 'group-remove-ta',
+		});
+		sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+			orderIndex: 0,
+		});
+		sessionGroupRepo.addMember(group.id, 'session-coder', {
+			role: 'coder',
+			status: 'active',
+			orderIndex: 1,
+		});
+
+		// Initially: coder → task-agent
+		const workflowRunId = seedWorkflowRunWithChannels(tdb.db, tdb.spaceId, [
+			makeResolvedChannel('coder', 'task-agent'),
+		]);
+
+		let freshRunRepo = new SpaceWorkflowRunRepository(tdb.db);
+		let reloadedRun = freshRunRepo.getRun(workflowRunId);
+
+		let { ChannelResolver } = await import('../../../src/lib/space/runtime/channel-resolver.ts');
+		let resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
+
+		expect(resolver.getPermittedTargets('coder')).toContain('task-agent');
+
+		// Remove channel — update to empty topology
+		freshRunRepo.updateRun(workflowRunId, { config: { _resolvedChannels: [] } });
+		reloadedRun = freshRunRepo.getRun(workflowRunId);
+		resolver = ChannelResolver.fromRunConfig(reloadedRun!.config as Record<string, unknown>);
+
+		expect(resolver.getPermittedTargets('coder')).not.toContain('task-agent');
 	});
 });

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -1,24 +1,28 @@
 /**
- * Integration-level tests for cross-agent messaging.
+ * Unit tests for cross-agent messaging.
  *
- * Exercises the full messaging stack with a real SQLite DB and mock injectors
- * (no real agent sessions). Focuses on end-to-end behavioral enforcement:
+ * Exercises the step agent peer communication tools (send_message, list_peers)
+ * and the Task Agent list_group_members tool in isolation with a real SQLite DB.
  *
+ * Test patterns covered:
  *   send_message  — channel validation, target modes, fan-out, hub-spoke
  *   list_peers    — peer discovery with channel info
- *   list_group_members    — Task Agent group view
+ *   list_group_members — Task Agent group view with channel topology
  *
- * Channel topology patterns tested end-to-end through tool handlers:
+ * Channel topology patterns tested:
  *   A → B          one-way point-to-point
  *   A ↔ B          bidirectional point-to-point
  *   A → [B,C,D]    fan-out one-way
  *   A ↔ [B,C,D]    hub-spoke bidirectional (spoke isolation enforced)
  *
- * Pure ChannelResolver unit tests (canSend, getPermittedTargets, fromRunConfig
- * invalid-entry filtering) live in channel-resolver.test.ts.
+ * Task Agent participation in channel topology:
+ *   - list_group_members shows permittedTargets for all members including Task Agent
+ *   - When channel to/from Task Agent is declared, it appears in permittedTargets
+ *   - When channel to/from Task Agent is removed, permittedTargets updates accordingly
  *
- * Group scoping is explicitly tested: messages must never cross task-group
- * boundaries.
+ * Note: Task Agent does not have send_message tool. Node agents cannot deliver
+ * messages to Task Agent via send_message (task-agent is filtered from delivery targets).
+ * Task Agent's participation in the topology is visible via list_group_members.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -851,6 +855,231 @@ describe('list_group_members — Task Agent group view', () => {
 		const result = parse(await handlers.list_group_members({}));
 		expect(result.success).toBe(false);
 		expect(result.error as string).toContain('No session group found');
+	});
+});
+
+// ===========================================================================
+// 6b. Task Agent participation in channel topology
+// ===========================================================================
+// These tests verify that the Task Agent's role in the channel topology is
+// correctly reflected via list_group_members. The key insight is:
+//   - list_group_members shows permittedTargets for ALL members including Task Agent
+//   - When a channel to/from Task Agent is declared, it appears in permittedTargets
+//   - When the channel is removed (topology changes), permittedTargets updates
+//
+// Note: Task Agent does not have a send_message tool. When a step agent calls
+// send_message targeting 'task-agent', the channel resolver check passes (if channel
+// declared), but the task-agent is filtered from delivery targets, so the message
+// is never delivered. This is a known gap - the topology is visible but messaging
+// to Task Agent via send_message is not yet implemented.
+
+describe('Task Agent in channel topology — via list_group_members', () => {
+	let ctx: TaskCtx;
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('coder permittedTargets includes task-agent when channel coder→task-agent is declared', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		// Declare channel: coder → task-agent
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: { _resolvedChannels: [ch('coder', 'task-agent')] },
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), { groupId: group.id })
+		);
+
+		const result = parse(await handlers.list_group_members({}));
+		expect(result.success).toBe(true);
+
+		const members = result.members as Array<{
+			role: string;
+			permittedTargets: string[];
+		}>;
+		const coder = members.find((m) => m.role === 'coder');
+		expect(coder?.permittedTargets).toContain('task-agent');
+	});
+
+	test('reviewer permittedTargets includes task-agent when channel reviewer→task-agent is declared', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'reviewer-session', {
+			role: 'reviewer',
+			status: 'active',
+		});
+
+		// Declare channel: reviewer → task-agent
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: { _resolvedChannels: [ch('reviewer', 'task-agent')] },
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), { groupId: group.id })
+		);
+
+		const result = parse(await handlers.list_group_members({}));
+		expect(result.success).toBe(true);
+
+		const members = result.members as Array<{
+			role: string;
+			permittedTargets: string[];
+		}>;
+		const reviewer = members.find((m) => m.role === 'reviewer');
+		expect(reviewer?.permittedTargets).toContain('task-agent');
+	});
+
+	test('task-agent permittedTargets is empty when no channels to/from task-agent declared', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		// Declare channel between coder and reviewer — NOT involving task-agent
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: { _resolvedChannels: [ch('coder', 'reviewer'), ch('reviewer', 'coder')] },
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), { groupId: group.id })
+		);
+
+		const result = parse(await handlers.list_group_members({}));
+		expect(result.success).toBe(true);
+
+		const members = result.members as Array<{
+			role: string;
+			permittedTargets: string[];
+		}>;
+		const taskAgentMember = members.find((m) => m.role === 'task-agent');
+		expect(taskAgentMember?.permittedTargets).toEqual([]);
+	});
+
+	test('task-agent permittedTargets includes coder when channel task-agent→coder is declared', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		// Declare channel: task-agent → coder (Task Agent can send to coder)
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: { _resolvedChannels: [ch('task-agent', 'coder')] },
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), { groupId: group.id })
+		);
+
+		const result = parse(await handlers.list_group_members({}));
+		expect(result.success).toBe(true);
+
+		const members = result.members as Array<{
+			role: string;
+			permittedTargets: string[];
+		}>;
+		const taskAgentMember = members.find((m) => m.role === 'task-agent');
+		expect(taskAgentMember?.permittedTargets).toContain('coder');
+	});
+
+	test('removing channel to task-agent updates permittedTargets', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		// Initially: channel coder → task-agent
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: { _resolvedChannels: [ch('coder', 'task-agent')] },
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), { groupId: group.id })
+		);
+
+		let result = parse(await handlers.list_group_members({}));
+		expect(result.success).toBe(true);
+		let members = result.members as Array<{ role: string; permittedTargets: string[] }>;
+		let coder = members.find((m) => m.role === 'coder');
+		expect(coder?.permittedTargets).toContain('task-agent');
+
+		// Remove channel to task-agent — update topology to empty
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: { _resolvedChannels: [] },
+		});
+
+		result = parse(await handlers.list_group_members({}));
+		expect(result.success).toBe(true);
+		members = result.members as Array<{ role: string; permittedTargets: string[] }>;
+		coder = members.find((m) => m.role === 'coder');
+		expect(coder?.permittedTargets).not.toContain('task-agent');
 	});
 });
 

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -870,8 +870,8 @@ describe('list_group_members — Task Agent group view', () => {
 // Note: Task Agent does not have a send_message tool. When a step agent calls
 // send_message targeting 'task-agent', the channel resolver check passes (if channel
 // declared), but the task-agent is filtered from delivery targets, so the message
-// is never delivered. This is a known gap - the topology is visible but messaging
-// to Task Agent via send_message is not yet implemented.
+// is never delivered. This is by design — Task Agent communicates via its own mechanisms,
+// not by receiving injected messages.
 
 describe('Task Agent in channel topology — via list_group_members', () => {
 	let ctx: TaskCtx;


### PR DESCRIPTION
- Add tests verifying Task Agent appears in channel topology via list_group_members
- Add test: coder permittedTargets includes task-agent when channel declared
- Add test: task-agent permittedTargets correctly reflects declared channels
- Add test: removing channel to task-agent updates permittedTargets
- Add integration tests for Task Agent channel participation
- Update test file headers to reflect unified messaging model coverage
- E2E test verified: no references to old tool names (relay_message, request_peer_input, send_feedback)
