### PR TITLE
feat: give Task Agent the send_message tool via channel topology

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -20,6 +20,7 @@
  *   - report_result         — Mark the task complete/failed and record the result summary
  *   - request_human_input   — Surface a human gate and block until the user responds
  *   - list_group_members    — List all group members with session IDs and permitted channels
+ *   - send_message          — Send a message to peer step agents via channel topology
  *
  * ## Content interpolation
  * All operator-supplied content (space.backgroundContext, space.instructions,
@@ -209,6 +210,12 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`\`permittedTargets\` (which roles they can message per the declared channel topology). ` +
 			`Use this to discover active sub-sessions and their communication permissions.`
 	);
+	sections.push(
+		`- **send_message** — Send a message directly to one or more peer step agents via declared channel topology. ` +
+			`Supports point-to-point (\`coder\`), broadcast (\`*\`), and multicast (\`[coder, reviewer]\`). ` +
+			`The Task Agent has default bidirectional channels to all node agents, so it can always ` +
+			`message any peer step agent. Use \`list_group_members\` to see permitted targets.`
+	);
 
 	// ---- step_result vs report_result status ---------------------------------
 	sections.push(`\n## Result Fields: \`step_result\` vs \`report_result.status\`\n`);
@@ -291,7 +298,12 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push(
 		`Channel topology is enforced uniformly across all agents. ` +
-			`(Note: peer messaging via \`send_message\` will be added in a follow-up task.)\n`
+			`The Task Agent uses \`send_message\` for all inter-agent communication with step agents.\n`
+	);
+	sections.push(
+		`Default channels: the Task Agent has default bidirectional channels to all node agent roles, ` +
+			`so it can always reach any peer step agent. If a user removes a Task Agent channel, ` +
+			`the Task Agent can no longer message that node until the channel is restored.\n`
 	);
 
 	// ---- Task context -------------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -362,7 +362,7 @@ export class SpaceRuntime {
 		// Resolve channel topology for the start step and store in run config.
 		// TODO: Milestone 6: pass resolvedChannels to session group creation in
 		// TaskAgentManager.spawnTaskAgent() rather than storing in run config.
-		this.storeResolvedChannels(run.id, space.id, startStep);
+		this.resolveAndStoreChannels(run.id, space.id, startStep);
 
 		return { run, tasks };
 	}
@@ -780,7 +780,7 @@ export class SpaceRuntime {
 			} else {
 				// Resolve channel topology for the new step.
 				// TODO: Milestone 6: pass to session group creation instead of run config.
-				this.storeResolvedChannels(runId, meta.spaceId, newStep);
+				this.resolveAndStoreChannels(runId, meta.spaceId, newStep);
 			}
 		} catch (err) {
 			if (!(err instanceof WorkflowTransitionError)) {
@@ -1010,7 +1010,7 @@ export class SpaceRuntime {
 	 * Steps with no `channels` declaration still get default task-agent channels,
 	 * so the Task Agent always has peer communication ability.
 	 */
-	private storeResolvedChannels(runId: string, spaceId: string, step: WorkflowStep): void {
+	resolveAndStoreChannels(runId: string, spaceId: string, step: WorkflowStep): void {
 		const run = this.config.workflowRunRepo.getRun(runId);
 		if (!run) return;
 
@@ -1025,12 +1025,18 @@ export class SpaceRuntime {
 		// These are added regardless of whether user-declared channels exist, ensuring the
 		// Task Agent can always communicate with step agents.
 		const stepAgents = resolveStepAgents(step);
-		const nodeRoles = stepAgents
-			.map((sa) => {
-				const spaceAgent = allAgents.find((a) => a.id === sa.agentId);
-				return spaceAgent?.role ?? null;
-			})
-			.filter((role): role is string => role !== null);
+		// Deduplicate roles — a step may have multiple agents with the same role,
+		// but we only need one bidirectional channel pair per unique role.
+		const nodeRoles = [
+			...new Set(
+				stepAgents
+					.map((sa) => {
+						const spaceAgent = allAgents.find((a) => a.id === sa.agentId);
+						return spaceAgent?.role ?? null;
+					})
+					.filter((role): role is string => role !== null)
+			),
+		];
 
 		// Build a set of existing channel pairs (fromRole→toRole) to avoid duplicates
 		const existingPairs = new Set<string>();
@@ -1038,9 +1044,12 @@ export class SpaceRuntime {
 			existingPairs.add(`${ch.fromRole}→${ch.toRole}`);
 		}
 
-		// Generate default task-agent ↔ node bidirectional channels
+		// Generate default task-agent ↔ node bidirectional channels.
+		// agentId fields use the role string as a placeholder — ChannelResolver.canSend()
+		// only checks fromRole/toRole, so the actual agentId value does not affect routing.
+		// If agentId enforcement is added in the future, this placeholder should be replaced
+		// with the actual agent's ID (and this comment updated).
 		const defaultChannels: typeof userResolved = [];
-		const TASK_AGENT_ID = 'task-agent';
 
 		for (const nodeRole of nodeRoles) {
 			// task-agent → node (if not already declared)
@@ -1048,8 +1057,8 @@ export class SpaceRuntime {
 				defaultChannels.push({
 					fromRole: 'task-agent',
 					toRole: nodeRole,
-					fromAgentId: TASK_AGENT_ID,
-					toAgentId: nodeRole, // Use role as agentId placeholder; canSend only checks roles
+					fromAgentId: 'task-agent',
+					toAgentId: nodeRole,
 					direction: 'one-way',
 					isHubSpoke: false,
 				});
@@ -1059,8 +1068,8 @@ export class SpaceRuntime {
 				defaultChannels.push({
 					fromRole: nodeRole,
 					toRole: 'task-agent',
-					fromAgentId: nodeRole, // Use role as agentId placeholder
-					toAgentId: TASK_AGENT_ID,
+					fromAgentId: nodeRole,
+					toAgentId: 'task-agent',
 					direction: 'one-way',
 					isHubSpoke: false,
 				});

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1000,11 +1000,15 @@ export class SpaceRuntime {
 	 * TODO Milestone 6: pass resolvedChannels to session group metadata in
 	 * TaskAgentManager.spawnTaskAgent() instead of storing in run config.
 	 *
-	 * Steps with no `channels` declaration store an empty array, clearing any
-	 * previously stored topology from prior steps. This prevents stale topology
-	 * from a channel-declaring step from leaking into subsequent steps that have
-	 * no channels — which would cause list_group_members to report incorrect
-	 * permittedTargets and channelTopologyDeclared=true for the wrong step.
+	 * Default task-agent channels:
+	 * When a step has node agents, bidirectional channels are auto-created between
+	 * 'task-agent' and each node agent role. These defaults are added in addition
+	 * to any user-declared channels, ensuring the Task Agent can always reach peers.
+	 * Duplicates are avoided: if the user explicitly declares a task-agent channel,
+	 * it is not re-added.
+	 *
+	 * Steps with no `channels` declaration still get default task-agent channels,
+	 * so the Task Agent always has peer communication ability.
 	 */
 	private storeResolvedChannels(runId: string, spaceId: string, step: WorkflowStep): void {
 		const run = this.config.workflowRunRepo.getRun(runId);
@@ -1012,17 +1016,58 @@ export class SpaceRuntime {
 
 		const config = (run.config ?? {}) as Record<string, unknown>;
 
-		// No channels declared: clear any previously stored topology so list_group_members
-		// does not return stale topology from a prior step.
-		if (!step.channels || step.channels.length === 0) {
-			this.config.workflowRunRepo.updateRun(runId, {
-				config: { ...config, _resolvedChannels: [] },
-			});
-			return;
+		const allAgents = this.config.spaceAgentManager.listBySpaceId(spaceId);
+
+		// Resolve user-declared channels (empty array if none declared)
+		const userResolved = resolveStepChannels(step, allAgents);
+
+		// Auto-generate default bidirectional channels between task-agent and each node agent role.
+		// These are added regardless of whether user-declared channels exist, ensuring the
+		// Task Agent can always communicate with step agents.
+		const stepAgents = resolveStepAgents(step);
+		const nodeRoles = stepAgents
+			.map((sa) => {
+				const spaceAgent = allAgents.find((a) => a.id === sa.agentId);
+				return spaceAgent?.role ?? null;
+			})
+			.filter((role): role is string => role !== null);
+
+		// Build a set of existing channel pairs (fromRole→toRole) to avoid duplicates
+		const existingPairs = new Set<string>();
+		for (const ch of userResolved) {
+			existingPairs.add(`${ch.fromRole}→${ch.toRole}`);
 		}
 
-		const allAgents = this.config.spaceAgentManager.listBySpaceId(spaceId);
-		const resolved = resolveStepChannels(step, allAgents);
+		// Generate default task-agent ↔ node bidirectional channels
+		const defaultChannels: typeof userResolved = [];
+		const TASK_AGENT_ID = 'task-agent';
+
+		for (const nodeRole of nodeRoles) {
+			// task-agent → node (if not already declared)
+			if (!existingPairs.has(`task-agent→${nodeRole}`)) {
+				defaultChannels.push({
+					fromRole: 'task-agent',
+					toRole: nodeRole,
+					fromAgentId: TASK_AGENT_ID,
+					toAgentId: nodeRole, // Use role as agentId placeholder; canSend only checks roles
+					direction: 'one-way',
+					isHubSpoke: false,
+				});
+			}
+			// node → task-agent (if not already declared)
+			if (!existingPairs.has(`${nodeRole}→task-agent`)) {
+				defaultChannels.push({
+					fromRole: nodeRole,
+					toRole: 'task-agent',
+					fromAgentId: nodeRole, // Use role as agentId placeholder
+					toAgentId: TASK_AGENT_ID,
+					direction: 'one-way',
+					isHubSpoke: false,
+				});
+			}
+		}
+
+		const resolved = [...userResolved, ...defaultChannels];
 
 		this.config.workflowRunRepo.updateRun(runId, {
 			config: { ...config, _resolvedChannels: resolved },

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -654,7 +654,13 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					});
 				}
 
-				// Workflow advanced to the next step
+				// Workflow advanced to the next step — resolve and store channel topology for the new step.
+				// This ensures Task Agent can send_message to agents in the new step's topology.
+				const run = workflowRunRepo.getRun(workflowRunId);
+				if (run) {
+					runtime.resolveAndStoreChannels(workflowRunId, run.spaceId, nextStep);
+				}
+
 				return jsonResult({
 					success: true,
 					terminal: false,

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -1,13 +1,14 @@
 /**
  * Task Agent Tools — MCP tool handlers for the Task Agent session.
  *
- * These handlers implement the business logic for the 6 Task Agent tools:
+ * These handlers implement the business logic for the 7 Task Agent tools:
  *   spawn_step_agent      — Spawn a sub-session for a workflow step's assigned agent
  *   check_step_status     — Poll the status of a running step agent sub-session
  *   advance_workflow      — Advance the workflow to the next step after current step completes
  *   report_result         — Mark the task as completed/failed and record the result
  *   request_human_input   — Pause execution and surface a question to the human user
  *   list_group_members    — List all members of the current task's session group
+ *   send_message          — Send a message to peer step agents via channel topology
  *
  * Design:
  * - Handlers are pure functions tested independently of any MCP server layer.
@@ -46,6 +47,7 @@ import {
 	RequestHumanInputSchema,
 	ListGroupMembersSchema,
 } from './task-agent-tool-schemas';
+import { SendMessageSchema } from './step-agent-tool-schemas';
 import { resolveStepAgents } from '@neokai/shared';
 import type {
 	SpawnStepAgentInput,
@@ -55,6 +57,7 @@ import type {
 	RequestHumanInputInput,
 	ListGroupMembersInput,
 } from './task-agent-tool-schemas';
+import type { SendMessageInput } from './step-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
@@ -796,6 +799,161 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		},
 
 		/**
+		 * Send a message directly to one or more peer step agents.
+		 *
+		 * Validates the requested direction(s) against the declared channel topology
+		 * before routing. The Task Agent uses `send_message` for all inter-agent
+		 * communication with step agents.
+		 *
+		 * Target forms:
+		 *   - `target: 'coder'` — point-to-point to a single role
+		 *   - `target: '*'` — broadcast to all permitted targets
+		 *   - `target: ['coder', 'reviewer']` — multicast to multiple roles
+		 *
+		 * The Task Agent's role is `'task-agent'`. Default bidirectional channels
+		 * are auto-created between the Task Agent and all node agent roles at
+		 * step-start, so the Task Agent can reach all peers by default.
+		 */
+		async send_message(args: SendMessageInput): Promise<ToolResult> {
+			const { target, message } = args;
+
+			const groupId = getGroupId();
+			if (!groupId) {
+				return jsonResult({
+					success: false,
+					error:
+						`No session group found for task ${taskId}. ` +
+						`The group may not have been created yet — try after spawn_step_agent.`,
+				});
+			}
+
+			const group = sessionGroupRepo.getGroup(groupId);
+			if (!group) {
+				return jsonResult({
+					success: false,
+					error: `Session group ${groupId} not found in the database.`,
+				});
+			}
+
+			const run = workflowRunRepo.getRun(workflowRunId);
+			const resolver = ChannelResolver.fromRunConfig(
+				run?.config as Record<string, unknown> | undefined
+			);
+
+			// When no channel topology is declared, all send_message calls fail.
+			if (resolver.isEmpty()) {
+				return jsonResult({
+					success: false,
+					error:
+						`No channel topology declared for this step. ` +
+						`Direct messaging via send_message is not available.`,
+				});
+			}
+
+			// Resolve target roles from the target argument
+			let targetRoles: string[];
+
+			if (target === '*') {
+				// Broadcast: expand to all permitted targets
+				const permitted = resolver.getPermittedTargets('task-agent');
+				if (permitted.length === 0) {
+					return jsonResult({
+						success: false,
+						error:
+							`No permitted targets for role 'task-agent' in the declared channel topology. ` +
+							`Broadcast ('*') requires at least one permitted outgoing channel.`,
+						availableTargets: [],
+					});
+				}
+				targetRoles = permitted;
+			} else if (Array.isArray(target)) {
+				// Multicast: validate each requested role
+				targetRoles = target;
+			} else {
+				// Point-to-point: single role
+				targetRoles = [target];
+			}
+
+			// Validate all requested target roles against channel topology
+			const unauthorizedRoles = targetRoles.filter((role) => !resolver.canSend('task-agent', role));
+			if (unauthorizedRoles.length > 0) {
+				const permittedTargets = resolver.getPermittedTargets('task-agent');
+				return jsonResult({
+					success: false,
+					error:
+						`Channel topology does not permit 'task-agent' to send to: ${unauthorizedRoles.join(', ')}. ` +
+						`Permitted targets: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`,
+					unauthorizedRoles,
+					permittedTargets,
+				});
+			}
+
+			// Find the Task Agent's own session ID from the group (to exclude from delivery)
+			const taskAgentMember = group.members.find((m) => m.role === 'task-agent');
+			const mySessionId = taskAgentMember?.sessionId;
+
+			// Find peer sessions for each target role (exclude self and task-agent)
+			const peers = group.members.filter(
+				(m) => m.sessionId !== mySessionId && m.role !== 'task-agent'
+			);
+			const delivered: Array<{ role: string; sessionId: string }> = [];
+			const notFound: string[] = [];
+			const failed: Array<{ role: string; sessionId: string; error: string }> = [];
+
+			// Best-effort delivery: attempt all targets, aggregate errors.
+			for (const targetRole of targetRoles) {
+				const targetSessions = peers.filter((m) => m.role === targetRole);
+				if (targetSessions.length === 0) {
+					notFound.push(targetRole);
+					continue;
+				}
+				for (const targetMember of targetSessions) {
+					const prefixedMessage = `[Message from task-agent]: ${message}`;
+					try {
+						await messageInjector(targetMember.sessionId, prefixedMessage);
+						delivered.push({ role: targetRole, sessionId: targetMember.sessionId });
+					} catch (err) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						failed.push({ role: targetRole, sessionId: targetMember.sessionId, error: errMsg });
+					}
+				}
+			}
+
+			if (notFound.length > 0 && delivered.length === 0 && failed.length === 0) {
+				return jsonResult({
+					success: false,
+					error:
+						`No active sessions found for target role(s): ${notFound.join(', ')}. ` +
+						`Use list_group_members to check which peers are currently active.`,
+					notFoundRoles: notFound,
+				});
+			}
+
+			if (failed.length > 0) {
+				return jsonResult({
+					success: delivered.length > 0 ? 'partial' : false,
+					delivered,
+					failed,
+					notFoundRoles: notFound.length > 0 ? notFound : undefined,
+					message:
+						delivered.length > 0
+							? `Message delivered to ${delivered.length} peer(s) but failed for ${failed.length} peer(s).`
+							: `Message delivery failed for all ${failed.length} target(s).`,
+				});
+			}
+
+			return jsonResult({
+				success: true,
+				delivered,
+				notFoundRoles: notFound.length > 0 ? notFound : undefined,
+				message:
+					`Message delivered to ${delivered.length} peer(s): ` +
+					delivered.map((t) => `${t.role} (${t.sessionId})`).join(', ') +
+					'.',
+			});
+		},
+
+		/**
 		 * Pause workflow execution and surface a question to the human user.
 		 *
 		 * Updates the main task status to `needs_attention` and stores the question
@@ -919,6 +1077,15 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 				'Use this to discover which sub-sessions are active and what messaging channels are declared.',
 			ListGroupMembersSchema.shape,
 			(args) => handlers.list_group_members(args)
+		),
+		tool(
+			'send_message',
+			'Send a message directly to one or more peer step agents via declared channel topology. ' +
+				"Supports point-to-point ('coder'), broadcast ('*'), and multicast (['coder','reviewer']). " +
+				'Validates against declared channels — returns an error with available channels if unauthorized. ' +
+				'The Task Agent has default bidirectional channels to all node agents.',
+			SendMessageSchema.shape,
+			(args) => handlers.send_message(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -1006,3 +1006,516 @@ describe('send_message — sender attribution prefix', () => {
 		expect(cfg.injectedMessages[0].message).toBe('[Message from coder]: Here is my patch');
 	});
 });
+
+// ===========================================================================
+// 11. Task Agent send_message — channel validation and target modes
+// ===========================================================================
+
+describe('Task Agent send_message — point-to-point (target: role)', () => {
+	let ctx: TaskCtx;
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('succeeds when channel is declared', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Set up channel: task-agent → coder (one-way)
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [ch('task-agent', 'coder')],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+
+		const injectedMessages: Array<{ sessionId: string; message: string }> = [];
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+				messageInjector: async (sessionId, message) => {
+					injectedMessages.push({ sessionId, message });
+				},
+			})
+		);
+
+		const result = parse(await handlers.send_message({ target: 'coder', message: 'Hello coder' }));
+		expect(result.success).toBe(true);
+		expect(injectedMessages).toHaveLength(1);
+		expect(injectedMessages[0].sessionId).toBe('coder-session');
+		expect(injectedMessages[0].message).toContain('[Message from task-agent]');
+		expect(injectedMessages[0].message).toContain('Hello coder');
+	});
+
+	test('denied when channel is not declared (task-agent → coder missing)', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Set up channel: coder → task-agent only (reverse direction)
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [ch('coder', 'task-agent')],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+			})
+		);
+
+		const result = parse(await handlers.send_message({ target: 'coder', message: 'Should fail' }));
+		expect(result.success).toBe(false);
+		expect(result.unauthorizedRoles).toEqual(['coder']);
+	});
+
+	test('fails when no channels declared (empty topology)', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// No channels declared
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+			})
+		);
+
+		const result = parse(await handlers.send_message({ target: 'coder', message: 'Should fail' }));
+		expect(result.success).toBe(false);
+		expect((result.error as string).toLowerCase()).toContain('no channel topology');
+	});
+});
+
+describe('Task Agent send_message — broadcast (target: "*")', () => {
+	let ctx: TaskCtx;
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('delivers to all permitted targets', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// task-agent can send to both coder and reviewer
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [ch('task-agent', 'coder'), ch('task-agent', 'reviewer')],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'reviewer-session', {
+			role: 'reviewer',
+			status: 'active',
+		});
+
+		const injectedMessages: Array<{ sessionId: string; message: string }> = [];
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+				messageInjector: async (sessionId, message) => {
+					injectedMessages.push({ sessionId, message });
+				},
+			})
+		);
+
+		const result = parse(await handlers.send_message({ target: '*', message: 'Broadcast!' }));
+		expect(result.success).toBe(true);
+		const delivered = result.delivered as Array<{ sessionId: string }>;
+		expect(delivered.length).toBe(2);
+		const deliveredIds = delivered.map((d) => d.sessionId).sort();
+		expect(deliveredIds).toEqual(['coder-session', 'reviewer-session'].sort());
+	});
+
+	test('fails when task-agent has no permitted targets', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Only coder can send to task-agent, not the other way around
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [ch('coder', 'task-agent')],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+			})
+		);
+
+		const result = parse(await handlers.send_message({ target: '*', message: 'Broadcast!' }));
+		expect(result.success).toBe(false);
+		expect(result.availableTargets).toEqual([]);
+	});
+});
+
+describe('Task Agent send_message — multicast (target: [role1, role2])', () => {
+	let ctx: TaskCtx;
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('delivers to all listed roles when all are permitted', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [ch('task-agent', 'coder'), ch('task-agent', 'reviewer')],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'reviewer-session', {
+			role: 'reviewer',
+			status: 'active',
+		});
+
+		const injectedMessages: Array<{ sessionId: string; message: string }> = [];
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+				messageInjector: async (sessionId, message) => {
+					injectedMessages.push({ sessionId, message });
+				},
+			})
+		);
+
+		const result = parse(
+			await handlers.send_message({ target: ['coder', 'reviewer'], message: 'Multicast' })
+		);
+		expect(result.success).toBe(true);
+		const delivered = result.delivered as Array<{ sessionId: string }>;
+		expect(delivered.length).toBe(2);
+	});
+
+	test('fails when any listed role is not in permitted targets', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Only task-agent → coder declared, not → reviewer
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [ch('task-agent', 'coder')],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'reviewer-session', {
+			role: 'reviewer',
+			status: 'active',
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+			})
+		);
+
+		const result = parse(
+			await handlers.send_message({ target: ['coder', 'reviewer'], message: 'Multicast' })
+		);
+		expect(result.success).toBe(false);
+		expect((result.unauthorizedRoles as string[]).includes('reviewer')).toBe(true);
+	});
+});
+
+describe('Task Agent send_message — default task-agent channels', () => {
+	let ctx: TaskCtx;
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('task-agent has default bidirectional channels to all node agents', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Simulate storeResolvedChannels behavior: default bidirectional channels
+		// between task-agent and all node agents are auto-added
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [
+					// Default task-agent → coder
+					{
+						fromRole: 'task-agent',
+						toRole: 'coder',
+						fromAgentId: 'task-agent',
+						toAgentId: 'coder',
+						direction: 'one-way',
+						isHubSpoke: false,
+					},
+					// Default coder → task-agent
+					{
+						fromRole: 'coder',
+						toRole: 'task-agent',
+						fromAgentId: 'coder',
+						toAgentId: 'task-agent',
+						direction: 'one-way',
+						isHubSpoke: false,
+					},
+				],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+
+		const injectedMessages: Array<{ sessionId: string; message: string }> = [];
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+				messageInjector: async (sessionId, message) => {
+					injectedMessages.push({ sessionId, message });
+				},
+			})
+		);
+
+		// Task Agent can send to coder via default channel
+		const result = parse(
+			await handlers.send_message({ target: 'coder', message: 'Default channel works' })
+		);
+		expect(result.success).toBe(true);
+		expect(injectedMessages).toHaveLength(1);
+		expect(injectedMessages[0].sessionId).toBe('coder-session');
+	});
+
+	test('removing task-agent channel prevents messaging (no bypass)', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// User explicitly removes task-agent → coder channel
+		// Only coder → task-agent is declared (not the default task-agent → coder)
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [
+					// Only coder can message task-agent, not the other way
+					{
+						fromRole: 'coder',
+						toRole: 'task-agent',
+						fromAgentId: 'coder',
+						toAgentId: 'task-agent',
+						direction: 'one-way',
+						isHubSpoke: false,
+					},
+				],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+			})
+		);
+
+		// Task Agent cannot send to coder because the channel was removed
+		const result = parse(
+			await handlers.send_message({ target: 'coder', message: 'Should be blocked' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.unauthorizedRoles).toEqual(['coder']);
+	});
+});
+
+describe('Task Agent send_message — error cases', () => {
+	let ctx: TaskCtx;
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns error when no group exists for task', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// No groupId - getGroupId returns undefined
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory())
+		);
+
+		const result = parse(await handlers.send_message({ target: 'coder', message: 'Hello' }));
+		expect(result.success).toBe(false);
+		expect(result.error as string).toContain('No session group found');
+	});
+
+	test('fails when any multicast target is not in permitted targets', async () => {
+		ctx = makeTaskCtx();
+		const wf = buildSingleStepWf(ctx);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Channel only allows task-agent → coder
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [ch('task-agent', 'coder')],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+
+		const handlers = createTaskAgentToolHandlers(
+			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
+				groupId: group.id,
+			})
+		);
+
+		// Multicast to coder (permitted) and ghost (not permitted)
+		const result = parse(
+			await handlers.send_message({ target: ['coder', 'ghost'], message: 'Test' })
+		);
+		// ghost is not in permitted targets → entire request fails
+		expect(result.success).toBe(false);
+		expect(result.unauthorizedRoles).toEqual(['ghost']);
+	});
+});

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -2095,23 +2095,35 @@ describe('SpaceRuntime', () => {
 			expect((resolvedChannels as unknown[]).length).toBeGreaterThan(0);
 		});
 
-		test('storeResolvedChannels: step without channels stores an empty array (clears stale topology)', async () => {
+		test('storeResolvedChannels: step without channels stores default task-agent channels', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'No Channels', agentId: AGENT_CODER },
 			]);
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Run config should have _resolvedChannels set to [] — this prevents stale
-			// topology from a prior step from leaking into the current step.
+			// Run config should have _resolvedChannels set to default task-agent bidirectional channels
+			// (auto-added even when no user-declared channels exist). This ensures the Task Agent
+			// can always reach node agents.
 			const updatedRun = workflowRunRepo.getRun(run.id)!;
 			const resolvedChannels = (updatedRun.config as Record<string, unknown> | undefined)
-				?._resolvedChannels;
-			expect(resolvedChannels).toEqual([]);
+				?._resolvedChannels as Array<Record<string, unknown>>;
+			expect(Array.isArray(resolvedChannels)).toBe(true);
+			expect(resolvedChannels.length).toBeGreaterThan(0);
+			// Default task-agent ↔ coder channels should be present
+			const taskAgentToCoder = resolvedChannels.find(
+				(ch) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
+			);
+			expect(taskAgentToCoder).toBeDefined();
+			const coderToTaskAgent = resolvedChannels.find(
+				(ch) => ch.fromRole === 'coder' && ch.toRole === 'task-agent'
+			);
+			expect(coderToTaskAgent).toBeDefined();
 		});
 
-		test('storeResolvedChannels: advancing from channel step to no-channel step clears topology', async () => {
-			// Step A has channels; Step B does not. After advancing, topology should be cleared.
+		test('storeResolvedChannels: advancing from channel step to no-channel step replaces topology', async () => {
+			// Step A has channels; Step B does not. After advancing, Step B's default
+			// task-agent channels replace the prior step's channels.
 			const AGENT_REVIEWER = 'agent-reviewer-topo';
 			seedAgentRow(db, AGENT_REVIEWER, SPACE_ID, 'Reviewer', 'reviewer');
 
@@ -2138,10 +2150,10 @@ describe('SpaceRuntime', () => {
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// After start, Step A's channels should be stored
+			// After start, Step A's channels + default task-agent channels should be stored
 			const runAfterStart = workflowRunRepo.getRun(run.id)!;
 			const channelsAfterStart = (runAfterStart.config as Record<string, unknown>)
-				?._resolvedChannels as unknown[];
+				?._resolvedChannels as Array<Record<string, unknown>>;
 			expect(channelsAfterStart.length).toBeGreaterThan(0);
 
 			// Mark step A tasks as completed so we can advance
@@ -2156,11 +2168,16 @@ describe('SpaceRuntime', () => {
 			// path that calls storeResolvedChannels() after a successful advance.
 			await runtime.executeTick();
 
-			// After advancing, topology should be cleared to []
+			// After advancing, Step B's default task-agent channels replace the prior topology
 			const runAfterAdvance = workflowRunRepo.getRun(run.id)!;
 			const channelsAfterAdvance = (runAfterAdvance.config as Record<string, unknown>)
-				?._resolvedChannels;
-			expect(channelsAfterAdvance).toEqual([]);
+				?._resolvedChannels as Array<Record<string, unknown>>;
+			// Step B has a single agent (coder) — it gets default task-agent ↔ coder channels
+			expect(channelsAfterAdvance.length).toBeGreaterThan(0);
+			const taskAgentToCoder = channelsAfterAdvance.find(
+				(ch) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
+			);
+			expect(taskAgentToCoder).toBeDefined();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -2121,6 +2121,49 @@ describe('SpaceRuntime', () => {
 			expect(coderToTaskAgent).toBeDefined();
 		});
 
+		test('storeResolvedChannels: deduplicates channels when step has multiple agents with the same role', async () => {
+			// When a step has two agents that share the same role (e.g., two coder agents),
+			// resolveAndStoreChannels should generate only ONE bidirectional task-agent↔coder
+			// channel pair, not two duplicate pairs.
+			const AGENT_CODER_2 = 'agent-coder-2-duplicate-role';
+			seedAgentRow(db, AGENT_CODER_2, SPACE_ID, 'Coder 2', 'coder');
+
+			const stepId = `step-dedup-${Date.now()}`;
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'Duplicate Role Test',
+				steps: [
+					{
+						id: stepId,
+						name: 'Two Coders Same Role',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_CODER_2 }],
+					},
+				],
+				transitions: [],
+				startStepId: stepId,
+				rules: [],
+			});
+
+			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			const updatedRun = workflowRunRepo.getRun(run.id)!;
+			const resolvedChannels = (updatedRun.config as Record<string, unknown> | undefined)
+				?._resolvedChannels as Array<Record<string, unknown>>;
+			expect(Array.isArray(resolvedChannels)).toBe(true);
+
+			// Should have exactly ONE task-agent→coder channel (not two)
+			const taskAgentToCoderChannels = resolvedChannels.filter(
+				(ch) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
+			);
+			expect(taskAgentToCoderChannels).toHaveLength(1);
+
+			// Should have exactly ONE coder→task-agent channel (not two)
+			const coderToTaskAgentChannels = resolvedChannels.filter(
+				(ch) => ch.fromRole === 'coder' && ch.toRole === 'task-agent'
+			);
+			expect(coderToTaskAgentChannels).toHaveLength(1);
+		});
+
 		test('storeResolvedChannels: advancing from channel step to no-channel step replaces topology', async () => {
 			// Step A has channels; Step B does not. After advancing, Step B's default
 			// task-agent channels replace the prior step's channels.

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -1,13 +1,14 @@
 /**
  * Unit tests for createTaskAgentToolHandlers()
  *
- * Covers all 6 Task Agent tools:
+ * Covers all 7 Task Agent tools:
  *   spawn_step_agent    — creates sub-session, registers callback, injects message
  *   check_step_status   — polling detection of sub-session completion
  *   advance_workflow    — delegates to WorkflowExecutor.advance(), handles gate errors
  *   report_result       — transitions main task to final status
  *   request_human_input — pauses execution, marks task needs_attention
  *   list_group_members  — lists group members with session IDs and channel info
+ *   send_message        — sends message to peer step agents via channel topology
  *
  * Tests use a real SQLite database (via runMigrations) and mock SubSessionFactory
  * so no real agent sessions are created.
@@ -1604,7 +1605,7 @@ describe('createTaskAgentMcpServer', () => {
 		expect(server.name).toBe('task-agent');
 	});
 
-	test('registers all 6 expected tools', async () => {
+	test('registers all 7 expected tools', async () => {
 		const { server } = await makeServerCtx();
 		const registered = Object.keys(server.instance._registeredTools).sort();
 		expect(registered).toEqual([
@@ -1613,6 +1614,7 @@ describe('createTaskAgentMcpServer', () => {
 			'list_group_members',
 			'report_result',
 			'request_human_input',
+			'send_message',
 			'spawn_step_agent',
 		]);
 	});
@@ -1723,9 +1725,9 @@ describe('createTaskAgentMcpServer', () => {
 
 		// Each call returns a distinct server instance
 		expect(server1.instance).not.toBe(server2.instance);
-		// Both register all 6 tools
-		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(6);
-		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(6);
+		// Both register all 7 tools
+		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(7);
+		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(7);
 	});
 });
 
@@ -1813,7 +1815,7 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 		expect(coderMember.agentId).toBe(ctx.agentId);
 	});
 
-	test('channelTopologyDeclared is false when no channels in run config', async () => {
+	test('default task-agent channels are auto-added to run config', async () => {
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
 		const { run, mainTask } = await startRun(ctx, wf);
 
@@ -1821,6 +1823,10 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 			spaceId: ctx.spaceId,
 			name: `task:${mainTask.id}`,
 			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'task-agent-session', {
+			role: 'task-agent',
+			status: 'active',
 		});
 		ctx.sessionGroupRepo.addMember(group.id, 'session-a', {
 			role: 'coder',
@@ -1835,9 +1841,13 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 		const result = await handlers.list_group_members({});
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
-		expect(parsed.channelTopologyDeclared).toBe(false);
-		// permittedTargets should be empty when no channels declared
-		expect(parsed.members[0].permittedTargets).toEqual([]);
+		// Default task-agent channels are auto-added by storeResolvedChannels,
+		// so channelTopologyDeclared is true even with no user-declared channels
+		expect(parsed.channelTopologyDeclared).toBe(true);
+		// The coder member should have task-agent as a permitted target
+		// (default bidirectional channel: coder can reply to task-agent)
+		const coderMember = parsed.members.find((m: { role: string }) => m.role === 'coder');
+		expect(coderMember.permittedTargets).toContain('task-agent');
 	});
 
 	test('returns permitted targets based on resolved channels in run config', async () => {

--- a/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
@@ -1301,18 +1301,31 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 		expect(tasks).toHaveLength(2);
 
 		// storeResolvedChannels called for start step (space-runtime.ts:365)
+		// User-declared channels are stored plus default task-agent bidirectional channels
 		const updatedRun = workflowRunRepo.getRun(run.id)!;
 		const config = (updatedRun.config ?? {}) as Record<string, unknown>;
 		const resolvedChannels = config._resolvedChannels as Array<Record<string, unknown>> | undefined;
 
 		expect(resolvedChannels).toBeDefined();
-		expect(resolvedChannels).toHaveLength(1);
-		expect(resolvedChannels![0]).toMatchObject({
+		// User-declared channel: coder → reviewer
+		const userChannel = resolvedChannels!.find(
+			(ch: Record<string, unknown>) => ch.fromRole === 'coder' && ch.toRole === 'reviewer'
+		);
+		expect(userChannel).toMatchObject({
 			fromRole: 'coder',
 			toRole: 'reviewer',
 			direction: 'one-way',
 			label: 'review-request',
 		});
+		// Default task-agent bidirectional channels are auto-added
+		const taskAgentToCoder = resolvedChannels!.find(
+			(ch: Record<string, unknown>) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
+		);
+		expect(taskAgentToCoder).toBeDefined();
+		const coderToTaskAgent = resolvedChannels!.find(
+			(ch: Record<string, unknown>) => ch.fromRole === 'coder' && ch.toRole === 'task-agent'
+		);
+		expect(coderToTaskAgent).toBeDefined();
 	});
 
 	test('channels for non-start step are stored in run config after executeTick() advances', async () => {
@@ -1336,17 +1349,24 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 
 		const { run, tasks: startTasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-		// Step A has no channels — _resolvedChannels is cleared to [] (not undefined)
-		// because storeResolvedChannels always writes the field to prevent stale topology.
+		// Step A has no user-declared channels but gets default task-agent bidirectional channels
+		// (auto-added by storeResolvedChannels even when no channels are declared).
 		const runAfterStart = workflowRunRepo.getRun(run.id)!;
 		const configAfterStart = (runAfterStart.config ?? {}) as Record<string, unknown>;
-		expect(configAfterStart._resolvedChannels).toEqual([]);
+		const channelsAfterStart = configAfterStart._resolvedChannels as Array<Record<string, unknown>>;
+		// Default task-agent ↔ planner channels are auto-added
+		expect(channelsAfterStart.length).toBeGreaterThan(0);
+		const taskAgentToPlanner = channelsAfterStart.find(
+			(ch: Record<string, unknown>) => ch.fromRole === 'task-agent' && ch.toRole === 'planner'
+		);
+		expect(taskAgentToPlanner).toBeDefined();
 
 		// Advance to Step B (which has channels)
 		taskRepo.updateTask(startTasks[0].id, { status: 'completed' });
 		await runtime.executeTick();
 
 		// storeResolvedChannels called for step B (space-runtime.ts:783)
+		// User-declared channels are stored plus default task-agent bidirectional channels
 		const runAfterAdvance = workflowRunRepo.getRun(run.id)!;
 		const configAfterAdvance = (runAfterAdvance.config ?? {}) as Record<string, unknown>;
 		const resolvedChannels = configAfterAdvance._resolvedChannels as
@@ -1354,12 +1374,20 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 			| undefined;
 
 		expect(resolvedChannels).toBeDefined();
-		expect(resolvedChannels).toHaveLength(1);
-		expect(resolvedChannels![0]).toMatchObject({
+		// User-declared channel: coder → reviewer
+		const userChannel = resolvedChannels!.find(
+			(ch: Record<string, unknown>) => ch.fromRole === 'coder' && ch.toRole === 'reviewer'
+		);
+		expect(userChannel).toMatchObject({
 			fromRole: 'coder',
 			toRole: 'reviewer',
 			direction: 'one-way',
 			label: 'feedback',
 		});
+		// Default task-agent bidirectional channels for step B's agents
+		const taskAgentToCoder = resolvedChannels!.find(
+			(ch: Record<string, unknown>) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
+		);
+		expect(taskAgentToCoder).toBeDefined();
 	});
 });


### PR DESCRIPTION
## Summary

- **send_message MCP tool**: Added to Task Agent MCP server using the same `SendMessageSchema` as step agents. Task Agent uses `'task-agent'` as its role for channel topology validation.
- **Default bidirectional channels**: Auto-generated between `task-agent` and every node agent role at step-start in `storeResolvedChannels`. This ensures the Task Agent can always reach peer step agents without manual channel configuration.
- **System prompt documentation**: Updated to document the new `send_message` tool, default channels behavior, and removal implications.

## Test plan

- [x] All 1335 space unit tests pass
- [x] Typecheck and lint pass
- [x] New tests for Task Agent send_message (point-to-point, broadcast, multicast, default channels, error cases)
- [x] Updated existing tests for new auto-generated channel behavior

## Breaking changes

None — this is an additive feature. Existing channel topology declarations are preserved; default channels are only added when no user-declared channel exists for a given task-agent→node role pair.

Refs: TASK-33