### PR TITLE
test: add E2E tests for Task Agent visible node in visual editor

### DIFF
--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -7,6 +7,7 @@
  * - Load template in visual editor (auto-layout with nodes and edges)
  * - Toggle between List and Visual modes (mode switching with confirmation)
  * - Validation errors when saving incomplete workflows
+ * - Task Agent pinned node visibility and interactions (Change 3 of workflow graph model)
  *
  * Setup: creates a Space via RPC in beforeEach (infrastructure).
  * Cleanup: deletes the Space via RPC in afterEach.
@@ -15,6 +16,13 @@
  * - All test actions go through the UI (clicks, inputs, navigation)
  * - All assertions check visible DOM state
  * - RPC is only used in beforeEach/afterEach for test infrastructure
+ *
+ * Task Agent Node Tests:
+ * - Task Agent node is always visible when opening the visual editor
+ * - Task Agent node cannot be deleted via keyboard
+ * - Adding a new node shows Task Agent channel edges on the canvas
+ * - Task Agent node has distinct visual styling (purple border, pinned-node class)
+ * - Channels to Task Agent can be removed via the config panel
  */
 
 import type { Page } from '@playwright/test';
@@ -424,5 +432,156 @@ test.describe('Visual Workflow Editor', () => {
 
 		// Editor should remain open
 		await expect(editor).toBeVisible();
+	});
+
+	// ─── Task Agent Node Tests ───────────────────────────────────────────────
+
+	// ─── Test 7: Task Agent node is always visible when opening the visual editor ───
+
+	test('Task Agent node is always visible when opening the visual editor', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+
+		// The Task Agent pinned node should be visible even on an empty canvas
+		// It has a distinct data attribute to identify it
+		const taskAgentNode = editor.locator('[data-testid="workflow-node-task-agent"]');
+		await expect(taskAgentNode).toBeVisible({ timeout: 5000 });
+
+		// The Task Agent node should also have the data-task-agent-node attribute
+		await expect(taskAgentNode).toHaveAttribute('data-task-agent-node', 'true');
+
+		// Task Agent node should display "Task Agent" as its name
+		await expect(taskAgentNode.locator('text=Task Agent')).toBeVisible({ timeout: 2000 });
+	});
+
+	// ─── Test 8: Task Agent node cannot be deleted via keyboard ─────────────
+
+	test('Task Agent node cannot be deleted via keyboard', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+
+		// First add a regular node so we have something to select and potentially delete
+		await editor.getByTestId('add-step-button').click();
+		await expect(editor.locator('[data-testid^="workflow-node-"]')).toHaveCount(1, {
+			timeout: 3000,
+		});
+
+		// Select the Task Agent node
+		const taskAgentNode = editor.locator('[data-testid="workflow-node-task-agent"]');
+		await taskAgentNode.click();
+
+		// Try to delete via Delete key
+		await page.keyboard.press('Delete');
+
+		// Task Agent node should still be visible after Delete key
+		await expect(taskAgentNode).toBeVisible({ timeout: 2000 });
+	});
+
+	// ─── Test 9: Adding a new node shows Task Agent channel edges on the canvas ───
+
+	test('Adding a new node shows Task Agent channel edges on the canvas', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+
+		// The Task Agent node should already be visible
+		const taskAgentNode = editor.locator('[data-testid="workflow-node-task-agent"]');
+		await expect(taskAgentNode).toBeVisible({ timeout: 5000 });
+
+		// Add a new node via "Add Step" button
+		await editor.getByTestId('add-step-button').click();
+
+		// Wait for the node to appear
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		// Click the new node to select it and open the config panel
+		await nodes.first().click();
+		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
+
+		// The ChannelTopologyBadge should show a channel to/from Task Agent
+		// Look for "task-agent" text in the channel topology badge
+		const channelBadge = editor.getByTestId('channel-topology-badge');
+		await expect(channelBadge).toBeVisible({ timeout: 2000 });
+		await expect(channelBadge.locator('text=task-agent')).toBeVisible({ timeout: 2000 });
+	});
+
+	// ─── Test 10: Task Agent node has distinct visual styling ───────────────
+
+	test('Task Agent node has distinct visual styling', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+
+		// The Task Agent node should have a distinct border color (purple)
+		const taskAgentNode = editor.locator('[data-testid="workflow-node-task-agent"]');
+		await expect(taskAgentNode).toBeVisible({ timeout: 5000 });
+
+		// Check for the distinct styling class - Task Agent uses purple border
+		// The Task Agent node should have border-purple-500 class
+		await expect(taskAgentNode).toHaveClass(/border-purple-500/);
+
+		// Also verify it has the pinned-node marker class
+		await expect(taskAgentNode).toHaveClass(/pinned-node/);
+	});
+
+	// ─── Test 11: Channels to Task Agent can be removed via config panel ───
+
+	test('Channels to Task Agent can be removed via config panel', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+
+		// Add a node that will have a Task Agent channel
+		await editor.getByTestId('add-step-button').click();
+
+		// Wait for node and select it to open config panel
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		// Configure the node with an agent first
+		await nodes.first().click();
+		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
+		await editor.getByTestId('agent-select').selectOption({ index: 1 });
+		await editor.getByTestId('close-button').click();
+
+		// Now add a second node
+		await editor.getByTestId('add-step-button').click();
+		await expect(nodes).toHaveCount(2, { timeout: 3000 });
+
+		// Select the second node
+		await nodes.nth(1).click();
+		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
+
+		// Verify Task Agent channel exists in the badge
+		const channelBadge = editor.getByTestId('channel-topology-badge');
+		await expect(channelBadge).toBeVisible({ timeout: 2000 });
+
+		// Find and click the remove button for the Task Agent channel
+		// The channel entry should contain "task-agent"
+		const taskAgentChannelEntry = channelBadge.locator('[data-testid="channel-entry"]').filter({
+			has: page.locator('text=task-agent'),
+		});
+		await expect(taskAgentChannelEntry).toBeVisible({ timeout: 2000 });
+
+		// Click the remove button on that channel entry
+		const removeBtn = taskAgentChannelEntry.locator('[data-testid="remove-channel-button"]');
+		await expect(removeBtn).toBeVisible({ timeout: 2000 });
+		await removeBtn.click();
+
+		// Verify the Task Agent channel is no longer in the badge
+		await expect(channelBadge.locator('text=task-agent')).not.toBeVisible({ timeout: 2000 });
 	});
 });

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -7,7 +7,6 @@
  * - Load template in visual editor (auto-layout with nodes and edges)
  * - Toggle between List and Visual modes (mode switching with confirmation)
  * - Validation errors when saving incomplete workflows
- * - Task Agent pinned node visibility and interactions (Change 3 of workflow graph model)
  *
  * Setup: creates a Space via RPC in beforeEach (infrastructure).
  * Cleanup: deletes the Space via RPC in afterEach.
@@ -17,12 +16,16 @@
  * - All assertions check visible DOM state
  * - RPC is only used in beforeEach/afterEach for test infrastructure
  *
- * Task Agent Node Tests:
+ * Task Agent Node Tests (SKIPPED - feature not yet implemented):
  * - Task Agent node is always visible when opening the visual editor
  * - Task Agent node cannot be deleted via keyboard
  * - Adding a new node shows Task Agent channel edges on the canvas
  * - Task Agent node has distinct visual styling (purple border, pinned-node class)
  * - Channels to Task Agent can be removed via the config panel
+ *
+ * These tests are skipped because the Task Agent visible node feature (Change 3 of
+ * the workflow graph model goal) has not been implemented yet. Once the feature is
+ * implemented (Tasks 4.1, 4.2, 4.3), remove the test.skip() annotations.
  */
 
 import type { Page } from '@playwright/test';
@@ -435,10 +438,27 @@ test.describe('Visual Workflow Editor', () => {
 	});
 
 	// ─── Task Agent Node Tests ───────────────────────────────────────────────
+	// These tests are skipped because the Task Agent visible node feature
+	// (Change 3 of the workflow graph model goal) has not been implemented yet.
+	// They require:
+	// - Task Agent rendered as a pinned node in VisualWorkflowEditor
+	// - data-testid="workflow-node-task-agent" attribute on the node
+	// - data-task-agent-node="true" attribute on the node
+	// - border-purple-500 CSS class for distinct styling
+	// - pinned-node CSS class for the pinned marker
+	// - Task Agent node always present at canvas open (not added via add-step-button)
+	// - ChannelTopologyBadge showing task-agent channels on regular nodes
+	// - channels-section in NodeConfigPanel for multi-agent steps showing task-agent channels
+	//
+	// Once the feature is implemented (Tasks 4.1, 4.2, 4.3), remove the test.skip()
+	// and update selectors if the implementation differs from the assumptions below.
+	// See: https://github.com/lsm/neokai/issues (tracking issue for Task Agent visible node)
 
 	// ─── Test 7: Task Agent node is always visible when opening the visual editor ───
 
-	test('Task Agent node is always visible when opening the visual editor', async ({ page }) => {
+	test.skip('Task Agent node is always visible when opening the visual editor', async ({
+		page,
+	}) => {
 		await navigateToSpace(page, spaceId);
 		await openNewWorkflowEditor(page);
 		await switchToVisualMode(page);
@@ -459,7 +479,7 @@ test.describe('Visual Workflow Editor', () => {
 
 	// ─── Test 8: Task Agent node cannot be deleted via keyboard ─────────────
 
-	test('Task Agent node cannot be deleted via keyboard', async ({ page }) => {
+	test.skip('Task Agent node cannot be deleted via keyboard', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 		await openNewWorkflowEditor(page);
 		await switchToVisualMode(page);
@@ -487,7 +507,7 @@ test.describe('Visual Workflow Editor', () => {
 
 	// ─── Test 9: Adding a new node shows Task Agent channel edges on the canvas ───
 
-	test('Adding a new node shows Task Agent channel edges on the canvas', async ({ page }) => {
+	test.skip('Adding a new node shows Task Agent channel edges on the canvas', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 		await openNewWorkflowEditor(page);
 		await switchToVisualMode(page);
@@ -499,7 +519,7 @@ test.describe('Visual Workflow Editor', () => {
 		await expect(taskAgentNode).toBeVisible({ timeout: 5000 });
 
 		// Count nodes before adding (should be 1 - just the Task Agent pinned node)
-		let nodes = editor.locator('[data-testid^="workflow-node-"]');
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
 		await expect(nodes).toHaveCount(1, { timeout: 3000 });
 
 		// Add a new node via "Add Step" button
@@ -512,16 +532,19 @@ test.describe('Visual Workflow Editor', () => {
 		await nodes.nth(1).click();
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 
-		// The ChannelTopologyBadge should show a channel to/from Task Agent
-		// Look for "task-agent" text in the channel topology badge
-		const channelBadge = editor.getByTestId('channel-topology-badge');
-		await expect(channelBadge).toBeVisible({ timeout: 2000 });
-		await expect(channelBadge.locator('text=task-agent')).toBeVisible({ timeout: 2000 });
+		// The ChannelTopologyBadge on the canvas node should show a channel to/from Task Agent
+		// Note: ChannelTopologyBadge truncates "task-agent" to "task-age…" (10 chars → 8 + ellipsis)
+		// So we look for the truncated form. Also verify on the node card itself.
+		const nodeCard = nodes.nth(1);
+		await expect(nodeCard.locator('[data-testid="channel-topology-badge"]')).toBeVisible({
+			timeout: 2000,
+		});
+		await expect(nodeCard.locator('text=task-age')).toBeVisible({ timeout: 2000 });
 	});
 
 	// ─── Test 10: Task Agent node has distinct visual styling ───────────────
 
-	test('Task Agent node has distinct visual styling', async ({ page }) => {
+	test.skip('Task Agent node has distinct visual styling', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 		await openNewWorkflowEditor(page);
 		await switchToVisualMode(page);
@@ -542,7 +565,7 @@ test.describe('Visual Workflow Editor', () => {
 
 	// ─── Test 11: Channels to Task Agent can be removed via config panel ───
 
-	test('Channels to Task Agent can be removed via config panel', async ({ page }) => {
+	test.skip('Channels to Task Agent can be removed via config panel', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 		await openNewWorkflowEditor(page);
 		await switchToVisualMode(page);
@@ -550,7 +573,7 @@ test.describe('Visual Workflow Editor', () => {
 		const editor = page.getByTestId('visual-workflow-editor');
 
 		// Task Agent pinned node should already be visible (1 node)
-		let nodes = editor.locator('[data-testid^="workflow-node-"]');
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
 		await expect(nodes).toHaveCount(1, { timeout: 3000 });
 
 		// Add a node that will have a Task Agent channel
@@ -573,14 +596,16 @@ test.describe('Visual Workflow Editor', () => {
 		await nodes.nth(2).click();
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 
-		// Verify Task Agent channel exists in the badge
-		const channelBadge = editor.getByTestId('channel-topology-badge');
-		await expect(channelBadge).toBeVisible({ timeout: 2000 });
+		// Verify Task Agent channel exists in the NodeConfigPanel's channels-section
+		// (not the ChannelTopologyBadge which is on the canvas node)
+		// channels-section only renders in multi-agent mode, so we need at least 2 agents
+		const channelsSection = editor.getByTestId('node-config-panel').getByTestId('channels-section');
+		await expect(channelsSection).toBeVisible({ timeout: 2000 });
 
-		// Find and click the remove button for the Task Agent channel
-		// The channel entry should contain "task-agent"
-		const taskAgentChannelEntry = channelBadge.locator('[data-testid="channel-entry"]').filter({
-			has: page.locator('text=task-agent'),
+		// Find the channel entry that references task-agent
+		// ChannelTopologyBadge truncates "task-agent" to "task-age…"
+		const taskAgentChannelEntry = channelsSection.locator('[data-testid="channel-entry"]').filter({
+			has: editor.locator('text=task-age'),
 		});
 		await expect(taskAgentChannelEntry).toBeVisible({ timeout: 2000 });
 
@@ -589,7 +614,7 @@ test.describe('Visual Workflow Editor', () => {
 		await expect(removeBtn).toBeVisible({ timeout: 2000 });
 		await removeBtn.click();
 
-		// Verify the Task Agent channel is no longer in the badge
-		await expect(channelBadge.locator('text=task-agent')).not.toBeVisible({ timeout: 2000 });
+		// Verify the Task Agent channel is no longer in the channels section
+		await expect(taskAgentChannelEntry).not.toBeVisible({ timeout: 2000 });
 	});
 });

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -631,7 +631,7 @@ test.describe('Visual Workflow Editor', () => {
 		// NodeConfigPanel does NOT truncate (unlike ChannelTopologyBadge); Playwright's
 		// text= does a case-insensitive substring match, so 'task-age' matches 'task-agent'
 		const taskAgentChannelEntry = channelsSection.locator('[data-testid="channel-entry"]').filter({
-			has: page.locator('text=task-age'),
+			has: page.locator('text=task-agent'),
 		});
 		await expect(taskAgentChannelEntry).toBeVisible({ timeout: 2000 });
 

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -90,6 +90,11 @@ test.describe('Visual Workflow Editor', () => {
 
 	// ─── Test 1: Create workflow with visual editor ──────────────────────────
 
+	// NOTE: When the Task Agent pinned node feature is implemented (Tasks 4.1-4.3), the
+	// toHaveCount assertions in this test will need to add +1 to account for the always-
+	// present Task Agent node. For example, "3" Add-Step clicks will produce 4 nodes
+	// (Task Agent + 3 regular nodes), not 3. Update line ~111 accordingly.
+
 	test('Create workflow with visual editor', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 		await openNewWorkflowEditor(page);
@@ -176,6 +181,9 @@ test.describe('Visual Workflow Editor', () => {
 	});
 
 	// ─── Test 2: Node positions are restored after save and reopen ──────────
+
+	// NOTE: When the Task Agent pinned node feature is implemented, the toHaveCount
+	// assertion on line ~250 will need to change from 2 to 3 (adds Task Agent node).
 
 	test('Node positions are restored after save and reopen', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
@@ -280,6 +288,12 @@ test.describe('Visual Workflow Editor', () => {
 	});
 
 	// ─── Test 3: Load template in visual editor ──────────────────────────────
+
+	// NOTE: When the Task Agent pinned node feature is implemented:
+	// - The toHaveCount on line ~316 will need to change from 2 to 3 (adds Task Agent node)
+	// - The template-picker-button visibility assertion below will be unreachable because
+	//   the Task Agent node is always present, so the canvas is never truly "empty"
+	//   and the picker is hidden immediately on editor open.
 
 	test('Load template in visual editor', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
@@ -386,6 +400,9 @@ test.describe('Visual Workflow Editor', () => {
 
 	// ─── Test 5: Visual editor validation — missing name ────────────────────
 
+	// NOTE: When the Task Agent pinned node feature is implemented, the toHaveCount
+	// assertion on line ~412 will need to change from 1 to 2 (adds Task Agent node).
+
 	test('Visual editor shows error when saving without name', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 		await openNewWorkflowEditor(page);
@@ -410,6 +427,9 @@ test.describe('Visual Workflow Editor', () => {
 	});
 
 	// ─── Test 6: Visual editor validation — missing agent ───────────────────
+
+	// NOTE: When the Task Agent pinned node feature is implemented, the toHaveCount
+	// assertion on line ~442 will need to change from 1 to 2 (adds Task Agent node).
 
 	test('Visual editor shows error when saving without agent assigned', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
@@ -603,9 +623,9 @@ test.describe('Visual Workflow Editor', () => {
 		await expect(channelsSection).toBeVisible({ timeout: 2000 });
 
 		// Find the channel entry that references task-agent
-		// ChannelTopologyBadge truncates "task-agent" to "task-age…"
+		// The channel list truncates role strings (like "task-agent" → "task-age…")
 		const taskAgentChannelEntry = channelsSection.locator('[data-testid="channel-entry"]').filter({
-			has: editor.locator('text=task-age'),
+			has: page.locator('text=task-age'),
 		});
 		await expect(taskAgentChannelEntry).toBeVisible({ timeout: 2000 });
 

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -37,6 +37,8 @@ import {
 	resetEditorModeStorage,
 	openNewWorkflowEditor,
 	switchToVisualMode,
+	setupMultiAgentStep,
+	getDefaultAgentId,
 } from '../helpers/workflow-editor-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
@@ -49,20 +51,6 @@ async function createTestSpace(page: Page): Promise<string> {
 
 async function deleteTestSpace(page: Page, spaceId: string): Promise<void> {
 	return deleteSpace(page, spaceId);
-}
-
-/** Get the default agent ID for the active space (infrastructure only). */
-async function getDefaultAgentId(page: Page, spaceId: string): Promise<string> {
-	return page.evaluate(async (sid) => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('Hub not available');
-		const res = (await hub.request('spaceAgent.list', { spaceId: sid })) as {
-			agents: Array<{ id: string; role: string }>;
-		};
-		const agent = res.agents.find((a) => a.role === 'planner') ?? res.agents[0];
-		if (!agent) throw new Error('No agents found in space');
-		return agent.id;
-	}, spaceId);
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -523,6 +511,11 @@ test.describe('Visual Workflow Editor', () => {
 
 		// Task Agent node should still be visible after Delete key
 		await expect(taskAgentNode).toBeVisible({ timeout: 2000 });
+
+		// Also try Backspace key (graph editors often handle both)
+		await taskAgentNode.click();
+		await page.keyboard.press('Backspace');
+		await expect(taskAgentNode).toBeVisible({ timeout: 2000 });
 	});
 
 	// ─── Test 9: Adding a new node shows Task Agent channel edges on the canvas ───
@@ -553,7 +546,7 @@ test.describe('Visual Workflow Editor', () => {
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 
 		// The ChannelTopologyBadge on the canvas node should show a channel to/from Task Agent
-		// Note: ChannelTopologyBadge truncates "task-agent" to "task-age…" (10 chars → 8 + ellipsis)
+		// "task-agent" is 10 chars; the 8-char truncation limit produces "task-age…"
 		// So we look for the truncated form. Also verify on the node card itself.
 		const nodeCard = nodes.nth(1);
 		await expect(nodeCard.locator('[data-testid="channel-topology-badge"]')).toBeVisible({
@@ -616,14 +609,24 @@ test.describe('Visual Workflow Editor', () => {
 		await nodes.nth(2).click();
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 
+		// Put node in multi-agent mode (channels-section only renders with 2+ agents)
+		// Use index-based selection since agent names are dynamically created in test spaces
+		const panel = editor.getByTestId('node-config-panel');
+		await panel.getByTestId('agent-select').selectOption({ index: 1 });
+		await panel.getByTestId('add-agent-button').click();
+		await expect(panel.getByTestId('agents-list')).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('add-agent-select').selectOption({ index: 2 });
+		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
+			timeout: 3000,
+		});
+
 		// Verify Task Agent channel exists in the NodeConfigPanel's channels-section
 		// (not the ChannelTopologyBadge which is on the canvas node)
-		// channels-section only renders in multi-agent mode, so we need at least 2 agents
-		const channelsSection = editor.getByTestId('node-config-panel').getByTestId('channels-section');
+		const channelsSection = panel.getByTestId('channels-section');
 		await expect(channelsSection).toBeVisible({ timeout: 2000 });
 
 		// Find the channel entry that references task-agent
-		// The channel list truncates role strings (like "task-agent" → "task-age…")
+		// "task-agent" is 10 chars; the 8-char truncation limit produces "task-age…"
 		const taskAgentChannelEntry = channelsSection.locator('[data-testid="channel-entry"]').filter({
 			has: page.locator('text=task-age'),
 		});

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -611,13 +611,13 @@ test.describe('Visual Workflow Editor', () => {
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 
 		// Put node in multi-agent mode (channels-section only renders with 2+ agents)
-		// Use index-based selection: index 1 for first agent, then index 0 for second
-		// (after selecting index 1, the remaining agent is at index 0 in the dropdown)
+		// seedPresetAgents creates 4 agents (Coder, General, Planner, Reviewer).
+		// add-agent-select index 0 is the blank placeholder; real agents start at index 1.
 		const panel = editor.getByTestId('node-config-panel');
 		await panel.getByTestId('agent-select').selectOption({ index: 1 });
 		await panel.getByTestId('add-agent-button').click();
 		await expect(panel.getByTestId('agents-list')).toBeVisible({ timeout: 3000 });
-		await panel.getByTestId('add-agent-select').selectOption({ index: 0 });
+		await panel.getByTestId('add-agent-select').selectOption({ index: 1 });
 		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
 			timeout: 3000,
 		});
@@ -628,7 +628,8 @@ test.describe('Visual Workflow Editor', () => {
 		await expect(channelsSection).toBeVisible({ timeout: 2000 });
 
 		// Find the channel entry that references task-agent
-		// "task-agent" is 10 chars; the 8-char truncation limit produces "task-age…"
+		// NodeConfigPanel does NOT truncate (unlike ChannelTopologyBadge); Playwright's
+		// text= does a case-insensitive substring match, so 'task-age' matches 'task-agent'
 		const taskAgentChannelEntry = channelsSection.locator('[data-testid="channel-entry"]').filter({
 			has: page.locator('text=task-age'),
 		});

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -468,7 +468,9 @@ test.describe('Visual Workflow Editor', () => {
 
 		// First add a regular node so we have something to select and potentially delete
 		await editor.getByTestId('add-step-button').click();
-		await expect(editor.locator('[data-testid^="workflow-node-"]')).toHaveCount(1, {
+
+		// Should have 2 nodes: Task Agent pinned node + 1 regular node
+		await expect(editor.locator('[data-testid^="workflow-node-"]')).toHaveCount(2, {
 			timeout: 3000,
 		});
 
@@ -492,19 +494,22 @@ test.describe('Visual Workflow Editor', () => {
 
 		const editor = page.getByTestId('visual-workflow-editor');
 
-		// The Task Agent node should already be visible
+		// The Task Agent node should already be visible (1 node)
 		const taskAgentNode = editor.locator('[data-testid="workflow-node-task-agent"]');
 		await expect(taskAgentNode).toBeVisible({ timeout: 5000 });
+
+		// Count nodes before adding (should be 1 - just the Task Agent pinned node)
+		let nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
 
 		// Add a new node via "Add Step" button
 		await editor.getByTestId('add-step-button').click();
 
-		// Wait for the node to appear
-		const nodes = editor.locator('[data-testid^="workflow-node-"]');
-		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+		// Wait for the new node to appear - should now be 2 nodes (Task Agent + new node)
+		await expect(nodes).toHaveCount(2, { timeout: 3000 });
 
-		// Click the new node to select it and open the config panel
-		await nodes.first().click();
+		// Click the new node (second one, not the Task Agent) to select it and open the config panel
+		await nodes.nth(1).click();
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 
 		// The ChannelTopologyBadge should show a channel to/from Task Agent
@@ -544,25 +549,28 @@ test.describe('Visual Workflow Editor', () => {
 
 		const editor = page.getByTestId('visual-workflow-editor');
 
+		// Task Agent pinned node should already be visible (1 node)
+		let nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
 		// Add a node that will have a Task Agent channel
 		await editor.getByTestId('add-step-button').click();
 
-		// Wait for node and select it to open config panel
-		const nodes = editor.locator('[data-testid^="workflow-node-"]');
-		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+		// Should now have 2 nodes: Task Agent + 1 regular node
+		await expect(nodes).toHaveCount(2, { timeout: 3000 });
 
-		// Configure the node with an agent first
-		await nodes.first().click();
+		// Configure the first regular node (nth(1), not Task Agent at nth(0)) with an agent
+		await nodes.nth(1).click();
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 		await editor.getByTestId('agent-select').selectOption({ index: 1 });
 		await editor.getByTestId('close-button').click();
 
-		// Now add a second node
+		// Now add a second regular node
 		await editor.getByTestId('add-step-button').click();
-		await expect(nodes).toHaveCount(2, { timeout: 3000 });
+		await expect(nodes).toHaveCount(3, { timeout: 3000 });
 
-		// Select the second node
-		await nodes.nth(1).click();
+		// Select the second regular node (nth(2), Task Agent is nth(0))
+		await nodes.nth(2).click();
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 
 		// Verify Task Agent channel exists in the badge

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -37,7 +37,6 @@ import {
 	resetEditorModeStorage,
 	openNewWorkflowEditor,
 	switchToVisualMode,
-	setupMultiAgentStep,
 	getDefaultAgentId,
 } from '../helpers/workflow-editor-helpers';
 
@@ -547,7 +546,7 @@ test.describe('Visual Workflow Editor', () => {
 
 		// The ChannelTopologyBadge on the canvas node should show a channel to/from Task Agent
 		// "task-agent" is 10 chars; the 8-char truncation limit produces "task-age…"
-		// So we look for the truncated form. Also verify on the node card itself.
+		// so we look for the truncated form.
 		const nodeCard = nodes.nth(1);
 		await expect(nodeCard.locator('[data-testid="channel-topology-badge"]')).toBeVisible({
 			timeout: 2000,
@@ -606,16 +605,19 @@ test.describe('Visual Workflow Editor', () => {
 		await expect(nodes).toHaveCount(3, { timeout: 3000 });
 
 		// Select the second regular node (nth(2), Task Agent is nth(0))
+		// NOTE: DOM ordering assumes Task Agent pinned node is always nth(0). This
+		// assumption should be verified when the feature is implemented.
 		await nodes.nth(2).click();
 		await expect(editor.getByTestId('node-config-panel')).toBeVisible({ timeout: 3000 });
 
 		// Put node in multi-agent mode (channels-section only renders with 2+ agents)
-		// Use index-based selection since agent names are dynamically created in test spaces
+		// Use index-based selection: index 1 for first agent, then index 0 for second
+		// (after selecting index 1, the remaining agent is at index 0 in the dropdown)
 		const panel = editor.getByTestId('node-config-panel');
 		await panel.getByTestId('agent-select').selectOption({ index: 1 });
 		await panel.getByTestId('add-agent-button').click();
 		await expect(panel.getByTestId('agents-list')).toBeVisible({ timeout: 3000 });
-		await panel.getByTestId('add-agent-select').selectOption({ index: 2 });
+		await panel.getByTestId('add-agent-select').selectOption({ index: 0 });
 		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
 			timeout: 3000,
 		});

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -53,6 +53,20 @@ export async function deleteSpace(page: Page, spaceId: string): Promise<void> {
 	}
 }
 
+/** Get the default agent ID for the active space (infrastructure only). */
+export async function getDefaultAgentId(page: Page, spaceId: string): Promise<string> {
+	return page.evaluate(async (sid) => {
+		const hub = window.__messageHub || window.appState?.messageHub;
+		if (!hub?.request) throw new Error('Hub not available');
+		const res = (await hub.request('spaceAgent.list', { spaceId: sid })) as {
+			agents: Array<{ id: string; role: string }>;
+		};
+		const agent = res.agents.find((a) => a.role === 'planner') ?? res.agents[0];
+		if (!agent) throw new Error('No agents found in space');
+		return agent.id;
+	}, spaceId);
+}
+
 // ─── Navigation helpers ────────────────────────────────────────────────────────
 
 export async function navigateToSpace(page: Page, spaceId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Added 5 E2E tests (tests 7-11) to `packages/e2e/tests/features/visual-workflow-editor.e2e.ts` for the Task Agent visible node feature (Change 3 of the workflow graph model goal).

**Current Status: Tests are SKIPPED**

The tests are currently wrapped in `test.skip()` because the Task Agent visible node feature has not been implemented yet. They will pass once Tasks 4.1/4.2/4.3 implement the feature.

## Test Coverage

- **Test 7**: Task Agent node is always visible when opening the visual editor
- **Test 8**: Task Agent node cannot be deleted via keyboard
- **Test 9**: Adding a new node shows Task Agent channel edges on the canvas
- **Test 10**: Task Agent node has distinct visual styling (purple border, pinned-node class)
- **Test 11**: Channels to Task Agent can be removed via config panel

## Implementation Requirements

The tests assume the following implementation details (to be verified against actual implementation):

- `data-testid="workflow-node-task-agent"` on the Task Agent pinned node
- `data-task-agent-node="true"` attribute on the node
- `border-purple-500` CSS class for distinct styling
- `pinned-node` CSS class for pinned marker
- Task Agent node always present at canvas open (0 regular nodes initially)
- `ChannelTopologyBadge` truncates "task-agent" to "task-age…" (8 char limit)
- `channels-section` in `NodeConfigPanel` for multi-agent steps showing task-agent channels

## Verification

All 6 existing tests pass. The 5 new tests are properly skipped.