### PR TITLE
feat: auto-create Task Agent channels on node addition

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1000,15 +1000,9 @@ export class SpaceRuntime {
 	 * TODO Milestone 6: pass resolvedChannels to session group metadata in
 	 * TaskAgentManager.spawnTaskAgent() instead of storing in run config.
 	 *
-	 * Default task-agent channels:
-	 * When a step has node agents, bidirectional channels are auto-created between
-	 * 'task-agent' and each node agent role. These defaults are added in addition
-	 * to any user-declared channels, ensuring the Task Agent can always reach peers.
-	 * Duplicates are avoided: if the user explicitly declares a task-agent channel,
-	 * it is not re-added.
-	 *
-	 * Steps with no `channels` declaration still get default task-agent channels,
-	 * so the Task Agent always has peer communication ability.
+	 * Note: Task Agent channels are persisted by the frontend as WorkflowChannel
+	 * entries in the workflow data. This function only resolves and stores
+	 * user-declared channels — no runtime auto-generation.
 	 */
 	resolveAndStoreChannels(runId: string, spaceId: string, step: WorkflowStep): void {
 		const run = this.config.workflowRunRepo.getRun(runId);
@@ -1018,65 +1012,8 @@ export class SpaceRuntime {
 
 		const allAgents = this.config.spaceAgentManager.listBySpaceId(spaceId);
 
-		// Resolve user-declared channels (empty array if none declared)
-		const userResolved = resolveStepChannels(step, allAgents);
-
-		// Auto-generate default bidirectional channels between task-agent and each node agent role.
-		// These are added regardless of whether user-declared channels exist, ensuring the
-		// Task Agent can always communicate with step agents.
-		const stepAgents = resolveStepAgents(step);
-		// Deduplicate roles — a step may have multiple agents with the same role,
-		// but we only need one bidirectional channel pair per unique role.
-		const nodeRoles = [
-			...new Set(
-				stepAgents
-					.map((sa) => {
-						const spaceAgent = allAgents.find((a) => a.id === sa.agentId);
-						return spaceAgent?.role ?? null;
-					})
-					.filter((role): role is string => role !== null)
-			),
-		];
-
-		// Build a set of existing channel pairs (fromRole→toRole) to avoid duplicates
-		const existingPairs = new Set<string>();
-		for (const ch of userResolved) {
-			existingPairs.add(`${ch.fromRole}→${ch.toRole}`);
-		}
-
-		// Generate default task-agent ↔ node bidirectional channels.
-		// agentId fields use the role string as a placeholder — ChannelResolver.canSend()
-		// only checks fromRole/toRole, so the actual agentId value does not affect routing.
-		// If agentId enforcement is added in the future, this placeholder should be replaced
-		// with the actual agent's ID (and this comment updated).
-		const defaultChannels: typeof userResolved = [];
-
-		for (const nodeRole of nodeRoles) {
-			// task-agent → node (if not already declared)
-			if (!existingPairs.has(`task-agent→${nodeRole}`)) {
-				defaultChannels.push({
-					fromRole: 'task-agent',
-					toRole: nodeRole,
-					fromAgentId: 'task-agent',
-					toAgentId: nodeRole,
-					direction: 'one-way',
-					isHubSpoke: false,
-				});
-			}
-			// node → task-agent (if not already declared)
-			if (!existingPairs.has(`${nodeRole}→task-agent`)) {
-				defaultChannels.push({
-					fromRole: nodeRole,
-					toRole: 'task-agent',
-					fromAgentId: nodeRole,
-					toAgentId: 'task-agent',
-					direction: 'one-way',
-					isHubSpoke: false,
-				});
-			}
-		}
-
-		const resolved = [...userResolved, ...defaultChannels];
+		// Resolve user-declared channels from workflow data (empty array if none declared)
+		const resolved = resolveStepChannels(step, allAgents);
 
 		this.config.workflowRunRepo.updateRun(runId, {
 			config: { ...config, _resolvedChannels: resolved },

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -2095,36 +2095,28 @@ describe('SpaceRuntime', () => {
 			expect((resolvedChannels as unknown[]).length).toBeGreaterThan(0);
 		});
 
-		test('storeResolvedChannels: step without channels stores default task-agent channels', async () => {
+		test('storeResolvedChannels: step without channels does NOT store task-agent channels', async () => {
+			// When a step has no user-declared channels, no channels should be stored.
+			// M3 auto-generation of task-agent channels has been removed.
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'No Channels', agentId: AGENT_CODER },
 			]);
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Run config should have _resolvedChannels set to default task-agent bidirectional channels
-			// (auto-added even when no user-declared channels exist). This ensures the Task Agent
-			// can always reach node agents.
+			// Run config should have _resolvedChannels set to empty (no auto-add)
 			const updatedRun = workflowRunRepo.getRun(run.id)!;
 			const resolvedChannels = (updatedRun.config as Record<string, unknown> | undefined)
-				?._resolvedChannels as Array<Record<string, unknown>>;
+				?._resolvedChannels as Array<Record<string, unknown>> | undefined;
+			// Should be empty array when no user-declared channels exist
 			expect(Array.isArray(resolvedChannels)).toBe(true);
-			expect(resolvedChannels.length).toBeGreaterThan(0);
-			// Default task-agent ↔ coder channels should be present
-			const taskAgentToCoder = resolvedChannels.find(
-				(ch) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
-			);
-			expect(taskAgentToCoder).toBeDefined();
-			const coderToTaskAgent = resolvedChannels.find(
-				(ch) => ch.fromRole === 'coder' && ch.toRole === 'task-agent'
-			);
-			expect(coderToTaskAgent).toBeDefined();
+			expect(resolvedChannels.length).toBe(0);
 		});
 
-		test('storeResolvedChannels: deduplicates channels when step has multiple agents with the same role', async () => {
-			// When a step has two agents that share the same role (e.g., two coder agents),
-			// resolveAndStoreChannels should generate only ONE bidirectional task-agent↔coder
-			// channel pair, not two duplicate pairs.
+		test('storeResolvedChannels: no auto-generated channels when step has multiple agents with the same role', async () => {
+			// When a step has no user-declared channels, no channels should be stored,
+			// even if the step has multiple agents with the same role.
+			// M3 auto-generation has been removed.
 			const AGENT_CODER_2 = 'agent-coder-2-duplicate-role';
 			seedAgentRow(db, AGENT_CODER_2, SPACE_ID, 'Coder 2', 'coder');
 
@@ -2148,25 +2140,15 @@ describe('SpaceRuntime', () => {
 
 			const updatedRun = workflowRunRepo.getRun(run.id)!;
 			const resolvedChannels = (updatedRun.config as Record<string, unknown> | undefined)
-				?._resolvedChannels as Array<Record<string, unknown>>;
+				?._resolvedChannels as Array<Record<string, unknown>> | undefined;
 			expect(Array.isArray(resolvedChannels)).toBe(true);
-
-			// Should have exactly ONE task-agent→coder channel (not two)
-			const taskAgentToCoderChannels = resolvedChannels.filter(
-				(ch) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
-			);
-			expect(taskAgentToCoderChannels).toHaveLength(1);
-
-			// Should have exactly ONE coder→task-agent channel (not two)
-			const coderToTaskAgentChannels = resolvedChannels.filter(
-				(ch) => ch.fromRole === 'coder' && ch.toRole === 'task-agent'
-			);
-			expect(coderToTaskAgentChannels).toHaveLength(1);
+			// No auto-generated channels when no user-declared channels exist
+			expect(resolvedChannels.length).toBe(0);
 		});
 
-		test('storeResolvedChannels: advancing from channel step to no-channel step replaces topology', async () => {
-			// Step A has channels; Step B does not. After advancing, Step B's default
-			// task-agent channels replace the prior step's channels.
+		test('storeResolvedChannels: advancing from channel step to no-channel step clears channels', async () => {
+			// Step A has user-declared channels; Step B does not.
+			// After advancing, Step B should have NO channels (no auto-generation).
 			const AGENT_REVIEWER = 'agent-reviewer-topo';
 			seedAgentRow(db, AGENT_REVIEWER, SPACE_ID, 'Reviewer', 'reviewer');
 
@@ -2193,7 +2175,7 @@ describe('SpaceRuntime', () => {
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// After start, Step A's channels + default task-agent channels should be stored
+			// After start, Step A's user-declared channels should be stored
 			const runAfterStart = workflowRunRepo.getRun(run.id)!;
 			const channelsAfterStart = (runAfterStart.config as Record<string, unknown>)
 				?._resolvedChannels as Array<Record<string, unknown>>;
@@ -2211,16 +2193,13 @@ describe('SpaceRuntime', () => {
 			// path that calls storeResolvedChannels() after a successful advance.
 			await runtime.executeTick();
 
-			// After advancing, Step B's default task-agent channels replace the prior topology
+			// After advancing, Step B should have NO channels (no auto-generation)
 			const runAfterAdvance = workflowRunRepo.getRun(run.id)!;
 			const channelsAfterAdvance = (runAfterAdvance.config as Record<string, unknown>)
-				?._resolvedChannels as Array<Record<string, unknown>>;
-			// Step B has a single agent (coder) — it gets default task-agent ↔ coder channels
-			expect(channelsAfterAdvance.length).toBeGreaterThan(0);
-			const taskAgentToCoder = channelsAfterAdvance.find(
-				(ch) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
-			);
-			expect(taskAgentToCoder).toBeDefined();
+				?._resolvedChannels as Array<Record<string, unknown>> | undefined;
+			// Step B has no user-declared channels, so empty array
+			expect(Array.isArray(channelsAfterAdvance)).toBe(true);
+			expect(channelsAfterAdvance.length).toBe(0);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -1815,7 +1815,7 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 		expect(coderMember.agentId).toBe(ctx.agentId);
 	});
 
-	test('default task-agent channels are auto-added to run config', async () => {
+	test('no auto-added task-agent channels when no user-declared channels exist', async () => {
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
 		const { run, mainTask } = await startRun(ctx, wf);
 
@@ -1841,13 +1841,12 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 		const result = await handlers.list_group_members({});
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
-		// Default task-agent channels are auto-added by storeResolvedChannels,
-		// so channelTopologyDeclared is true even with no user-declared channels
-		expect(parsed.channelTopologyDeclared).toBe(true);
-		// The coder member should have task-agent as a permitted target
-		// (default bidirectional channel: coder can reply to task-agent)
+		// No channels are declared, so channelTopologyDeclared is false
+		expect(parsed.channelTopologyDeclared).toBe(false);
+		// The coder member should NOT have task-agent as a permitted target
+		// (no auto-generated channels after M3 auto-generation removal)
 		const coderMember = parsed.members.find((m: { role: string }) => m.role === 'coder');
-		expect(coderMember.permittedTargets).toContain('task-agent');
+		expect(coderMember.permittedTargets).not.toContain('task-agent');
 	});
 
 	test('returns permitted targets based on resolved channels in run config', async () => {

--- a/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
@@ -1301,7 +1301,7 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 		expect(tasks).toHaveLength(2);
 
 		// storeResolvedChannels called for start step (space-runtime.ts:365)
-		// User-declared channels are stored plus default task-agent bidirectional channels
+		// User-declared channels are stored; no auto-generated task-agent channels
 		const updatedRun = workflowRunRepo.getRun(run.id)!;
 		const config = (updatedRun.config ?? {}) as Record<string, unknown>;
 		const resolvedChannels = config._resolvedChannels as Array<Record<string, unknown>> | undefined;
@@ -1317,15 +1317,11 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 			direction: 'one-way',
 			label: 'review-request',
 		});
-		// Default task-agent bidirectional channels are auto-added
+		// No auto-generated task-agent channels (M3 auto-generation removed)
 		const taskAgentToCoder = resolvedChannels!.find(
 			(ch: Record<string, unknown>) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
 		);
-		expect(taskAgentToCoder).toBeDefined();
-		const coderToTaskAgent = resolvedChannels!.find(
-			(ch: Record<string, unknown>) => ch.fromRole === 'coder' && ch.toRole === 'task-agent'
-		);
-		expect(coderToTaskAgent).toBeDefined();
+		expect(taskAgentToCoder).toBeUndefined();
 	});
 
 	test('channels for non-start step are stored in run config after executeTick() advances', async () => {
@@ -1349,24 +1345,21 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 
 		const { run, tasks: startTasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-		// Step A has no user-declared channels but gets default task-agent bidirectional channels
-		// (auto-added by storeResolvedChannels even when no channels are declared).
+		// Step A has no user-declared channels — no channels stored
 		const runAfterStart = workflowRunRepo.getRun(run.id)!;
 		const configAfterStart = (runAfterStart.config ?? {}) as Record<string, unknown>;
-		const channelsAfterStart = configAfterStart._resolvedChannels as Array<Record<string, unknown>>;
-		// Default task-agent ↔ planner channels are auto-added
-		expect(channelsAfterStart.length).toBeGreaterThan(0);
-		const taskAgentToPlanner = channelsAfterStart.find(
-			(ch: Record<string, unknown>) => ch.fromRole === 'task-agent' && ch.toRole === 'planner'
-		);
-		expect(taskAgentToPlanner).toBeDefined();
+		const channelsAfterStart = configAfterStart._resolvedChannels as
+			| Array<Record<string, unknown>>
+			| undefined;
+		// No channels auto-generated (M3 auto-generation removed)
+		expect(channelsAfterStart.length).toBe(0);
 
 		// Advance to Step B (which has channels)
 		taskRepo.updateTask(startTasks[0].id, { status: 'completed' });
 		await runtime.executeTick();
 
 		// storeResolvedChannels called for step B (space-runtime.ts:783)
-		// User-declared channels are stored plus default task-agent bidirectional channels
+		// User-declared channels are stored; no auto-generated task-agent channels
 		const runAfterAdvance = workflowRunRepo.getRun(run.id)!;
 		const configAfterAdvance = (runAfterAdvance.config ?? {}) as Record<string, unknown>;
 		const resolvedChannels = configAfterAdvance._resolvedChannels as
@@ -1384,10 +1377,10 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 			direction: 'one-way',
 			label: 'feedback',
 		});
-		// Default task-agent bidirectional channels for step B's agents
+		// No auto-generated task-agent channels (M3 auto-generation removed)
 		const taskAgentToCoder = resolvedChannels!.find(
 			(ch: Record<string, unknown>) => ch.fromRole === 'task-agent' && ch.toRole === 'coder'
 		);
-		expect(taskAgentToCoder).toBeDefined();
+		expect(taskAgentToCoder).toBeUndefined();
 	});
 });

--- a/packages/web/src/components/space/visual-editor/GateConfig.tsx
+++ b/packages/web/src/components/space/visual-editor/GateConfig.tsx
@@ -35,9 +35,17 @@ interface GateConfigProps {
 	label: string;
 	/** Message shown when the gate is not configurable (first/last step boundary) */
 	terminalMessage?: string;
+	/** Optional test ID for the gate type select */
+	testId?: string;
 }
 
-export function GateConfig({ condition, onChange, label, terminalMessage }: GateConfigProps) {
+export function GateConfig({
+	condition,
+	onChange,
+	label,
+	terminalMessage,
+	testId,
+}: GateConfigProps) {
 	return (
 		<div class="space-y-1.5">
 			<label class="text-xs font-medium text-gray-400">{label}</label>
@@ -46,6 +54,7 @@ export function GateConfig({ condition, onChange, label, terminalMessage }: Gate
 			) : (
 				<>
 					<select
+						data-testid={testId}
 						value={condition.type}
 						onChange={(e) => {
 							const type = (e.currentTarget as HTMLSelectElement).value as WorkflowConditionType;

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -66,43 +66,31 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	const multi = isMultiAgentStep(step);
 	const stepAgents = step.agents ?? [];
 
-	// Auto-create Task Agent channels when an agent is assigned to a node that has no channels.
-	// This runs after the step updates, creating channels for single-agent and multi-agent nodes.
-	useEffect(() => {
-		// Only auto-create if there are agents but no channels
-		const hasSingleAgent = !!step.agentId && !step.agents;
-		const hasMultiAgent = step.agents && step.agents.length > 0;
-		if (!hasSingleAgent && !hasMultiAgent) return;
-		if (step.channels !== undefined) return; // channels already exist
-
-		if (hasSingleAgent) {
-			// Single-agent: create task-agent channel for the agent's role
-			const agentInfo = agents.find((a) => a.id === step.agentId);
-			if (!agentInfo) return;
-			const newChannels: WorkflowChannel[] = [
-				{ from: 'task-agent', to: agentInfo.role, direction: 'bidirectional' },
-			];
-			onUpdate({ ...step, channels: newChannels });
-		} else if (hasMultiAgent && step.agents) {
-			// Multi-agent: create task-agent channel for each agent's role
-			const newChannels: WorkflowChannel[] = step.agents.map((sa) => {
-				const agentInfo = agents.find((a) => a.id === sa.agentId);
-				const role = agentInfo?.role ?? sa.agentId;
-				return { from: 'task-agent', to: role, direction: 'bidirectional' };
-			});
-			onUpdate({ ...step, channels: newChannels });
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
 	function updateAgents(next: WorkflowStepAgent[]) {
 		onUpdate({ ...step, agents: next, agentId: '' });
+	}
+
+	/**
+	 * Auto-create Task Agent channels for a step that just got agents assigned.
+	 * Called from event handlers (agent dropdown onChange, addAgent) to avoid
+	 * mount-time side effects that corrupt existing workflow data.
+	 */
+	function autoCreateChannelsForAgents(agentsToChannel: WorkflowStepAgent[]) {
+		if (step.channels !== undefined) return; // channels already exist
+		const newChannels: WorkflowChannel[] = agentsToChannel.map((sa) => {
+			const agentInfo = agents.find((a) => a.id === sa.agentId);
+			const role = agentInfo?.role ?? sa.agentId;
+			return { from: 'task-agent', to: role, direction: 'bidirectional' };
+		});
+		onUpdate({ ...step, channels: newChannels });
 	}
 
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		if (stepAgents.some((a) => a.agentId === agentId)) return;
-		updateAgents([...stepAgents, { agentId }]);
+		const next = [...stepAgents, { agentId }];
+		autoCreateChannelsForAgents(next);
+		updateAgents(next);
 	}
 
 	function removeAgent(agentId: string) {
@@ -149,9 +137,20 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 				<select
 					data-testid="agent-select"
 					value={step.agentId}
-					onChange={(e) =>
-						onUpdate({ ...step, agentId: (e.currentTarget as HTMLSelectElement).value })
-					}
+					onChange={(e) => {
+						const newAgentId = (e.currentTarget as HTMLSelectElement).value;
+						const nextStep = { ...step, agentId: newAgentId };
+						// Auto-create task-agent channel when a single agent is assigned
+						if (newAgentId && step.channels === undefined) {
+							const agentInfo = agents.find((a) => a.id === newAgentId);
+							if (agentInfo) {
+								nextStep.channels = [
+									{ from: 'task-agent', to: agentInfo.role, direction: 'bidirectional' },
+								];
+							}
+						}
+						onUpdate(nextStep);
+					}}
 					class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
 				>
 					<option value="">— Select agent —</option>
@@ -559,6 +558,7 @@ export function NodeConfigPanel({
 					condition={entryCondition ?? { type: 'always' }}
 					onChange={onUpdateEntryCondition}
 					terminalMessage={isFirstStep ? 'Workflow starts here' : undefined}
+					testId="entry-gate-select"
 				/>
 
 				{/* Exit Gate */}
@@ -567,6 +567,7 @@ export function NodeConfigPanel({
 					condition={exitCondition ?? { type: 'always' }}
 					onChange={onUpdateExitCondition}
 					terminalMessage={isLastStep ? 'Workflow ends here' : undefined}
+					testId="exit-gate-select"
 				/>
 
 				{/* Instructions */}

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -66,6 +66,35 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	const multi = isMultiAgentStep(step);
 	const stepAgents = step.agents ?? [];
 
+	// Auto-create Task Agent channels when an agent is assigned to a node that has no channels.
+	// This runs after the step updates, creating channels for single-agent and multi-agent nodes.
+	useEffect(() => {
+		// Only auto-create if there are agents but no channels
+		const hasSingleAgent = !!step.agentId && !step.agents;
+		const hasMultiAgent = step.agents && step.agents.length > 0;
+		if (!hasSingleAgent && !hasMultiAgent) return;
+		if (step.channels !== undefined) return; // channels already exist
+
+		if (hasSingleAgent) {
+			// Single-agent: create task-agent channel for the agent's role
+			const agentInfo = agents.find((a) => a.id === step.agentId);
+			if (!agentInfo) return;
+			const newChannels: WorkflowChannel[] = [
+				{ from: 'task-agent', to: agentInfo.role, direction: 'bidirectional' },
+			];
+			onUpdate({ ...step, channels: newChannels });
+		} else if (hasMultiAgent && step.agents) {
+			// Multi-agent: create task-agent channel for each agent's role
+			const newChannels: WorkflowChannel[] = step.agents.map((sa) => {
+				const agentInfo = agents.find((a) => a.id === sa.agentId);
+				const role = agentInfo?.role ?? sa.agentId;
+				return { from: 'task-agent', to: role, direction: 'bidirectional' };
+			});
+			onUpdate({ ...step, channels: newChannels });
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	function updateAgents(next: WorkflowStepAgent[]) {
 		onUpdate({ ...step, agents: next, agentId: '' });
 	}
@@ -519,8 +548,8 @@ export function NodeConfigPanel({
 				{/* Agent(s) */}
 				<AgentsSection step={step} agents={agents} onUpdate={onUpdate} />
 
-				{/* Channels (shown only in multi-agent mode) */}
-				{isMultiAgentStep(step) && (
+				{/* Channels (shown when node has agents or has existing channels) */}
+				{(!!step.agentId || isMultiAgentStep(step) || step.channels) && (
 					<ChannelsPanelSection step={step} agents={agents} onUpdate={onUpdate} />
 				)}
 

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -75,22 +75,21 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	 * Called from event handlers (agent dropdown onChange, addAgent) to avoid
 	 * mount-time side effects that corrupt existing workflow data.
 	 */
-	function autoCreateChannelsForAgents(agentsToChannel: WorkflowStepAgent[]) {
-		if (step.channels !== undefined) return; // channels already exist
-		const newChannels: WorkflowChannel[] = agentsToChannel.map((sa) => {
+	function buildTaskAgentChannels(agentsToChannel: WorkflowStepAgent[]): WorkflowChannel[] {
+		return agentsToChannel.map((sa) => {
 			const agentInfo = agents.find((a) => a.id === sa.agentId);
 			const role = agentInfo?.role ?? sa.agentId;
 			return { from: 'task-agent', to: role, direction: 'bidirectional' };
 		});
-		onUpdate({ ...step, channels: newChannels });
 	}
 
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		if (stepAgents.some((a) => a.agentId === agentId)) return;
 		const next = [...stepAgents, { agentId }];
-		autoCreateChannelsForAgents(next);
-		updateAgents(next);
+		// Merge agents + channels into a single onUpdate call to avoid stale-reference overwrites
+		const newChannels = step.channels === undefined ? buildTaskAgentChannels(next) : step.channels;
+		onUpdate({ ...step, agents: next, agentId: '', channels: newChannels });
 	}
 
 	function removeAgent(agentId: string) {

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -173,27 +173,22 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	// ------------------------------------------------------------------
 
 	const channelEdges = useMemo<{ fromStepId: 'task-agent'; toStepId: string }[]>(() => {
+		const seen = new Set<string>();
 		const result: { fromStepId: 'task-agent'; toStepId: string }[] = [];
 		for (const node of nodes) {
 			const channels = node.step.channels;
 			if (!channels) continue;
+			// Only add one edge per node, regardless of how many channels it has
+			if (seen.has(node.step.localId)) continue;
 			for (const channel of channels) {
-				// Handle bidirectional channels: task-agent -> node role
-				if (channel.direction === 'bidirectional') {
-					if (channel.from === 'task-agent') {
-						// task-agent -> node (use the node's localId as the target)
-						result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
-					} else if (channel.to === 'task-agent') {
-						// node -> task-agent (treat as task-agent is the source)
-						result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
-					}
-				}
-				// Handle one-way channels
-				if (channel.direction === 'one-way') {
-					if (channel.from === 'task-agent') {
-						result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
-					}
-					// Don't render edges where task-agent is the target (one-way from node to task-agent)
+				// Check if this channel involves task-agent
+				const hasTaskAgent =
+					(channel.from === 'task-agent' || channel.to === 'task-agent') &&
+					channel.direction === 'bidirectional';
+				if (hasTaskAgent) {
+					result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
+					seen.add(node.step.localId);
+					break; // only one edge per node
 				}
 			}
 		}

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -173,22 +173,19 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	// ------------------------------------------------------------------
 
 	const channelEdges = useMemo<{ fromStepId: 'task-agent'; toStepId: string }[]>(() => {
-		const seen = new Set<string>();
 		const result: { fromStepId: 'task-agent'; toStepId: string }[] = [];
 		for (const node of nodes) {
 			const channels = node.step.channels;
 			if (!channels) continue;
-			// Only add one edge per node, regardless of how many channels it has
-			if (seen.has(node.step.localId)) continue;
 			for (const channel of channels) {
-				// Check if this channel involves task-agent
+				// Check if this channel involves task-agent (bidirectional only)
 				const hasTaskAgent =
 					(channel.from === 'task-agent' || channel.to === 'task-agent') &&
 					channel.direction === 'bidirectional';
 				if (hasTaskAgent) {
+					// Add one edge per node (break after first matching channel)
 					result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
-					seen.add(node.step.localId);
-					break; // only one edge per node
+					break;
 				}
 			}
 		}

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -167,6 +167,40 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	}, [edges, stepKeyToLocalId]);
 
 	// ------------------------------------------------------------------
+	// Derived: ChannelEdge[] for Task Agent channel connections
+	// Task Agent channels are stored on individual steps (step.channels).
+	// We extract edges from task-agent to each connected step.
+	// ------------------------------------------------------------------
+
+	const channelEdges = useMemo<{ fromStepId: 'task-agent'; toStepId: string }[]>(() => {
+		const result: { fromStepId: 'task-agent'; toStepId: string }[] = [];
+		for (const node of nodes) {
+			const channels = node.step.channels;
+			if (!channels) continue;
+			for (const channel of channels) {
+				// Handle bidirectional channels: task-agent -> node role
+				if (channel.direction === 'bidirectional') {
+					if (channel.from === 'task-agent') {
+						// task-agent -> node (use the node's localId as the target)
+						result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
+					} else if (channel.to === 'task-agent') {
+						// node -> task-agent (treat as task-agent is the source)
+						result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
+					}
+				}
+				// Handle one-way channels
+				if (channel.direction === 'one-way') {
+					if (channel.from === 'task-agent') {
+						result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
+					}
+					// Don't render edges where task-agent is the target (one-way from node to task-agent)
+				}
+			}
+		}
+		return result;
+	}, [nodes]);
+
+	// ------------------------------------------------------------------
 	// Helpers
 	// ------------------------------------------------------------------
 
@@ -728,6 +762,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					viewportState={viewportState}
 					onViewportChange={setViewportState}
 					transitions={transitions}
+					channelEdges={channelEdges}
 					onNodeSelect={handleNodeSelect}
 					onDeleteNode={handleDeleteNode}
 					onNodePositionChange={handleNodePositionChange}

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -57,6 +57,11 @@ export interface WorkflowCanvasProps {
 	/** Edges to render between nodes. Also used for duplicate detection during connection drag. */
 	transitions?: WorkflowTransition[];
 	/**
+	 * Task Agent channel edges to render (from task-agent to step).
+	 * Rendered with a distinct dashed gray style.
+	 */
+	channelEdges?: ChannelEdge[];
+	/**
 	 * Explicit node positions including width/height for edge port computation.
 	 * When omitted, positions are derived from nodes with DEFAULT_NODE_WIDTH/HEIGHT.
 	 */
@@ -73,6 +78,17 @@ export interface WorkflowCanvasProps {
 	onEdgeSelect?: (transitionId: string | null) => void;
 	/** Called when Delete/Backspace is pressed with an edge selected. */
 	onDeleteEdge?: (transitionId: string) => void;
+}
+
+/**
+ * A channel edge represents a messaging channel between Task Agent and a step.
+ * The 'task-agent' is a virtual hub, so we store the target step ID.
+ */
+export interface ChannelEdge {
+	/** Fixed identifier for the Task Agent source */
+	fromStepId: 'task-agent';
+	/** The target step localId */
+	toStepId: string;
 }
 
 // ---- Ghost edge rendering ----
@@ -121,6 +137,83 @@ function GhostEdge({ from, to }: { from: Point; to: Point }): JSX.Element | null
 	);
 }
 
+// ---- ChannelEdgeRenderer ----
+
+/** Color for Task Agent channel edges */
+const CHANNEL_EDGE_COLOR = '#9ca3af'; // gray-400
+
+/**
+ * Render Task Agent channel edges as dashed bezier paths from a fixed Task Agent
+ * hub position (left side of canvas) to each target node.
+ *
+ * Task Agent is rendered as a vertical "rail" on the left side of the canvas,
+ * and channel edges emanate from this rail to each connected node.
+ */
+function ChannelEdgeRenderer({
+	channelEdges,
+	nodePositions,
+}: {
+	channelEdges: ChannelEdge[];
+	nodePositions: NodePosition;
+}) {
+	if (channelEdges.length === 0) return null;
+
+	// Task Agent hub position: fixed on the left side
+	const TASK_AGENT_X = 60;
+
+	return (
+		<>
+			{channelEdges.map((edge) => {
+				const toPos = nodePositions[edge.toStepId];
+				if (!toPos) return null;
+
+				// Source: Task Agent hub (left side, vertical position based on target)
+				const sx = TASK_AGENT_X;
+				const sy = toPos.y + toPos.height / 2;
+
+				// Target: top-center of the target node
+				const tx = toPos.x + toPos.width / 2;
+				const ty = toPos.y;
+
+				// Bezier control points
+				const dx = Math.abs(tx - sx);
+				const cpOffset = Math.max(40, dx * 0.5);
+				const cp1x = sx + cpOffset;
+				const cp1y = sy;
+				const cp2x = tx - cpOffset;
+				const cp2y = ty;
+
+				const d = `M ${sx} ${sy} C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${tx} ${ty}`;
+
+				return (
+					<g key={`channel-${edge.toStepId}`} data-channel-edge="true">
+						{/* Invisible wider hitbox */}
+						<path
+							d={d}
+							stroke="transparent"
+							strokeWidth={12}
+							fill="none"
+							style={{ pointerEvents: 'stroke', cursor: 'pointer' }}
+						/>
+						{/* Visible dashed edge */}
+						<path
+							d={d}
+							stroke={CHANNEL_EDGE_COLOR}
+							strokeWidth={1.5}
+							strokeDasharray="6 4"
+							strokeOpacity={0.7}
+							fill="none"
+							style={{ pointerEvents: 'none' }}
+						/>
+						{/* Small circle at source (Task Agent end) */}
+						<circle cx={sx} cy={sy} r={4} fill={CHANNEL_EDGE_COLOR} opacity={0.7} />
+					</g>
+				);
+			})}
+		</>
+	);
+}
+
 // ============================================================================
 // WorkflowCanvas
 // ============================================================================
@@ -130,6 +223,7 @@ export function WorkflowCanvas({
 	viewportState,
 	onViewportChange,
 	transitions = [],
+	channelEdges = [],
 	nodePositions,
 	onNodeSelect,
 	onDeleteNode,
@@ -291,7 +385,7 @@ export function WorkflowCanvas({
 		return () => window.removeEventListener('keydown', handleKeyDown);
 	}, []);
 
-	// ---- Edge layer: committed edges (EdgeRenderer) + ghost edge during drag ----
+	// ---- Edge layer: committed edges (EdgeRenderer) + ghost edge during drag + channel edges ----
 	const edgeLayer = useCallback(
 		(_vp: ViewportState): ComponentChildren => (
 			<>
@@ -302,6 +396,7 @@ export function WorkflowCanvas({
 					onEdgeSelect={handleEdgeSelect}
 					onEdgeDelete={handleEdgeDelete}
 				/>
+				<ChannelEdgeRenderer channelEdges={channelEdges} nodePositions={effectiveNodePositions} />
 				{dragState.active && dragState.fromPos && dragState.currentPos && (
 					<GhostEdge from={dragState.fromPos} to={dragState.currentPos} />
 				)}
@@ -309,6 +404,7 @@ export function WorkflowCanvas({
 		),
 		[
 			transitions,
+			channelEdges,
 			effectiveNodePositions,
 			selectedEdgeId,
 			handleEdgeSelect,

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -187,14 +187,8 @@ function ChannelEdgeRenderer({
 
 				return (
 					<g key={`channel-${edge.toStepId}`} data-channel-edge="true">
-						{/* Invisible wider hitbox */}
-						<path
-							d={d}
-							stroke="transparent"
-							strokeWidth={12}
-							fill="none"
-							style={{ pointerEvents: 'stroke', cursor: 'pointer' }}
-						/>
+						{/* Channel edges are informational — no click interaction yet */}
+						<path d={d} stroke="transparent" strokeWidth={12} fill="none" />
 						{/* Visible dashed edge */}
 						<path
 							d={d}

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -474,6 +474,22 @@ describe('NodeConfigPanel', () => {
 			).toBe(true);
 		});
 
+		it('preserves existing channels when adding an agent if channels are already set', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }],
+				channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' as const }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
+			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+			// Should have 2 agents, and existing channels should be preserved
+			expect(updatedStep.agents).toHaveLength(2);
+			expect(updatedStep.channels?.length).toBe(1);
+			expect(updatedStep.channels?.[0].from).toBe('coder');
+		});
+
 		it('shows channels section in multi-agent mode', () => {
 			const step = makeStep({
 				agentId: '',

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -211,26 +211,23 @@ describe('NodeConfigPanel', () => {
 
 		it('calls onUpdateEntryCondition when entry gate type changes', () => {
 			const onUpdateEntryCondition = vi.fn();
-			const { container } = render(
+			const { getByTestId } = render(
 				<NodeConfigPanel
 					{...makeProps({ onUpdateEntryCondition, entryCondition: { type: 'always' } })}
 				/>
 			);
-			// selects: agent (index 0), entry gate (index 1), exit gate (index 2)
-			const selects = container.querySelectorAll('select');
-			fireEvent.change(selects[1], { target: { value: 'human' } });
+			fireEvent.change(getByTestId('entry-gate-select'), { target: { value: 'human' } });
 			expect(onUpdateEntryCondition).toHaveBeenCalledWith({ type: 'human', expression: undefined });
 		});
 
 		it('calls onUpdateExitCondition when exit gate type changes', () => {
 			const onUpdateExitCondition = vi.fn();
-			const { container } = render(
+			const { getByTestId } = render(
 				<NodeConfigPanel
 					{...makeProps({ onUpdateExitCondition, exitCondition: { type: 'always' } })}
 				/>
 			);
-			const selects = container.querySelectorAll('select');
-			fireEvent.change(selects[2], { target: { value: 'condition' } });
+			fireEvent.change(getByTestId('exit-gate-select'), { target: { value: 'condition' } });
 			expect(onUpdateExitCondition).toHaveBeenCalledWith({ type: 'condition', expression: '' });
 		});
 	});
@@ -466,9 +463,11 @@ describe('NodeConfigPanel', () => {
 			expect(getByTestId('channels-section')).toBeTruthy();
 		});
 
-		it('does not show channels section in single-agent mode', () => {
+		it('shows channels section for single-agent node with agent (channels created on agent assignment)', () => {
+			// Channels section is shown for nodes with agents so users can manage Task Agent channels.
+			// Channels are created in the agent dropdown onChange handler, not on mount.
 			const { queryByTestId } = render(<NodeConfigPanel {...makeProps()} />);
-			expect(queryByTestId('channels-section')).toBeNull();
+			expect(queryByTestId('channels-section')).toBeTruthy();
 		});
 
 		it('renders existing channels in channels list', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -454,6 +454,26 @@ describe('NodeConfigPanel', () => {
 			expect(select.textContent).toContain('Coder');
 		});
 
+		it('auto-creates task-agent channels when adding an agent in multi-agent mode', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
+			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+			// Should have 2 agents and 2 task-agent channels (one per agent)
+			expect(updatedStep.agents).toHaveLength(2);
+			expect(updatedStep.channels?.length).toBe(2);
+			expect(
+				updatedStep.channels?.every(
+					(c: { from: string; direction: string }) =>
+						c.from === 'task-agent' && c.direction === 'bidirectional'
+				)
+			).toBe(true);
+		});
+
 		it('shows channels section in multi-agent mode', () => {
 			const step = makeStep({
 				agentId: '',


### PR DESCRIPTION
- Remove M3 runtime auto-generation of Task Agent channels from
  resolveAndStoreChannels() - channels are now only created via
  user-declared workflow data
- Add auto-creation of Task Agent channels when an agent is assigned
  to a node in NodeConfigPanel (useEffect in AgentsSection)
- Show ChannelsPanelSection for all nodes with agents (not just
  multi-agent nodes) so Task Agent channels are visible and removable
- Add ChannelEdgeRenderer component to WorkflowCanvas for rendering
  Task Agent channel edges with distinct dashed gray visual style
- Add channelEdges derivation in VisualWorkflowEditor from nodes'
  step.channels
- Update unit tests to verify no auto-generated channels exist

Task: #43
