### PR TITLE
fix: prevent TaskView error on tab resume due to race condition

### DIFF
--- a/packages/web/src/hooks/__tests__/useTaskViewData.test.ts
+++ b/packages/web/src/hooks/__tests__/useTaskViewData.test.ts
@@ -19,13 +19,21 @@ const mockOnEvent = vi.fn((_eventName: string, _handler: unknown) => () => {});
 const mockJoinRoom = vi.fn();
 const mockLeaveRoom = vi.fn();
 
+// Module-level state for dynamic mocking (used by tab-resume tests)
+const mockMessageHubState = {
+	isConnected: true,
+	requestThrows: false,
+};
+
 vi.mock('../useMessageHub.ts', () => ({
 	useMessageHub: () => ({
 		request: mockRequest,
 		onEvent: mockOnEvent,
 		joinRoom: mockJoinRoom,
 		leaveRoom: mockLeaveRoom,
-		isConnected: true,
+		get isConnected() {
+			return mockMessageHubState.isConnected;
+		},
 	}),
 }));
 
@@ -88,6 +96,128 @@ function makeGroup() {
 // -------------------------------------------------------
 // Tests
 // -------------------------------------------------------
+
+describe('useTaskViewData — tab resume behavior', () => {
+	beforeEach(() => {
+		// Reset state for each test
+		mockMessageHubState.isConnected = true;
+		mockMessageHubState.requestThrows = false;
+		mockRequest.mockReset();
+		mockOnEvent.mockClear();
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+
+		mockRequest.mockImplementation(async (method: string) => {
+			if (mockMessageHubState.requestThrows) throw new Error('Connection lost');
+			if (method === 'task.get') return { task: makeTask('in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup() };
+			if (method === 'session.get') return { session: null };
+			return {};
+		});
+	});
+
+	it('returns early and clears error when isConnected is false', async () => {
+		// First render with connection - loads successfully
+		const { result, rerender } = renderHook(() => useTaskViewData('room-1', 'task-1'));
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.task).not.toBeNull();
+		expect(result.current.error).toBeNull();
+
+		// Simulate connection loss by setting isConnected to false
+		// This simulates what happens when connectionState becomes 'disconnected' or 'reconnecting'
+		mockMessageHubState.isConnected = false;
+
+		// Rerender to trigger effect (isConnected changed from true to false)
+		rerender();
+
+		// Wait for the effect to run
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		// Error should be cleared because load() returned early due to !isConnected
+		expect(result.current.error).toBeNull();
+	});
+
+	it('clears stale error and loads task when isConnected becomes true', async () => {
+		// Start with isConnected = false
+		mockMessageHubState.isConnected = false;
+
+		const { result, rerender } = renderHook(() => useTaskViewData('room-1', 'task-1'));
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		// Error should be null because load() returned early
+		expect(result.current.error).toBeNull();
+		expect(result.current.task).toBeNull();
+
+		// Now simulate reconnection - isConnected becomes true
+		mockMessageHubState.isConnected = true;
+
+		// Rerender to trigger effect (isConnected changed from false to true)
+		rerender();
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		// Task should be loaded successfully, error should be cleared
+		expect(result.current.error).toBeNull();
+		expect(result.current.task).not.toBeNull();
+	});
+
+	it('does not permanently show error when isConnected transitions during reconnection', async () => {
+		// Simulate the bug scenario: same hook, isConnected transitions
+		// isConnected=true -> isConnected=false -> isConnected=true
+		// (what happens when connectionState goes disconnected -> reconnecting -> connected)
+
+		// Start with isConnected = true but request will fail
+		mockMessageHubState.requestThrows = true;
+
+		const { result, rerender } = renderHook(() => useTaskViewData('room-1', 'task-1'));
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		// Error is set because request failed (simulating mid-resume failure)
+		expect(result.current.error).toBe('Connection lost');
+
+		// Simulate reconnection: isConnected goes false (reconnecting)
+		mockMessageHubState.isConnected = false;
+		mockMessageHubState.requestThrows = false; // Will succeed when reconnected
+
+		// Rerender to trigger effect (isConnected changed from true to false)
+		rerender();
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		// Error should be cleared because load() returned early due to !isConnected
+		expect(result.current.error).toBeNull();
+
+		// Simulate reconnection complete: isConnected goes true
+		mockMessageHubState.isConnected = true;
+
+		// Rerender to trigger effect (isConnected changed from false to true)
+		rerender();
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		// Task should be loaded, error should remain cleared
+		expect(result.current.error).toBeNull();
+		expect(result.current.task).not.toBeNull();
+	});
+});
 
 describe('useTaskViewData', () => {
 	beforeEach(() => {

--- a/packages/web/src/hooks/useTaskViewData.ts
+++ b/packages/web/src/hooks/useTaskViewData.ts
@@ -151,6 +151,17 @@ export function useTaskViewData(roomId: string, taskId: string): UseTaskViewData
 		};
 
 		const load = async () => {
+			// Guard: skip load if not connected (the effect will re-trigger when connection is restored)
+			if (!isConnected) {
+				setError(null);
+				setIsLoading(false);
+				return;
+			}
+
+			// Clear any stale error from previous failed attempts
+			setError(null);
+			setIsLoading(true);
+
 			try {
 				const taskRes = await request<{ task: NeoTask }>('task.get', { roomId, taskId });
 				if (!cancelled) {

--- a/packages/web/src/lib/connection-manager.ts
+++ b/packages/web/src/lib/connection-manager.ts
@@ -106,6 +106,9 @@ export class ConnectionManager {
 	// Event-driven connection handlers
 	private connectionHandlers: Set<ConnectionHandler> = new Set();
 
+	// Flag to prevent premature 'connected' state during resume validation
+	private _isResuming = false;
+
 	constructor(baseUrl?: string) {
 		this.baseUrl = baseUrl || getDaemonWsUrl();
 		this.setupVisibilityHandlers();
@@ -300,6 +303,15 @@ export class ConnectionManager {
 
 		// Listen to connection state changes and update global state
 		this.messageHub.onConnection((state) => {
+			// During resume validation, don't report 'connected' until validation completes.
+			// This prevents the UI from seeing a false-positive 'connected' state while
+			// the health check and channel rejoin are still in progress.
+			if (state === 'connected' && this._isResuming) {
+				// Still notify handlers since the WebSocket IS connected, but don't
+				// update connectionState (which drives isConnected in useMessageHub)
+				this.notifyConnectionHandlers();
+				return;
+			}
 			connectionState.value = state;
 
 			// Notify connection handlers when connected
@@ -477,46 +489,61 @@ export class ConnectionManager {
 	 * receive updates after returning from background.
 	 */
 	private async validateConnectionOnResume(): Promise<void> {
-		if (!this.messageHub || !this.transport) {
-			// No connection exists - try to reconnect from scratch
-			await this.reconnect();
-			return;
-		}
+		// Mark that we're in resume validation - this prevents connectionState from
+		// reporting 'connected' until validation completes
+		this._isResuming = true;
 
 		try {
-			// Send a lightweight health check with short timeout
-			// If this fails, the connection is dead and needs reconnect
-			await this.messageHub.request('system.health', {}, { timeout: 3000 });
-
-			// CRITICAL FIX: Re-join channels on resume
-			// Safari may pause WebSocket without closing it, causing server-side
-			// channel memberships to expire while client thinks it's still connected.
-			await this.messageHub.joinChannel('global');
-			const activeRoomId = roomStore.roomId.value;
-			if (activeRoomId) {
-				await this.messageHub.joinChannel(`room:${activeRoomId}`);
-			}
-			const activeSpaceId = spaceStore.spaceId.value;
-			if (activeSpaceId) {
-				await this.messageHub.joinChannel(`space:${activeSpaceId}`);
+			if (!this.messageHub || !this.transport) {
+				// No connection exists - try to reconnect from scratch
+				await this.reconnect();
+				return;
 			}
 
-			// CRITICAL: Refresh ALL state (session store, app state, and global state)
-			// This ensures UI is in sync even if events were missed during background
-			// FIX: Added sessionStore.refresh() to sync agent state for status bar
-			// Without this, status bar would show "Online" instead of actual state
-			await Promise.all([
-				sessionStore.refresh(),
-				appState.refreshAll(),
-				globalStore.refresh(),
-				roomStore.refresh(),
-				spaceStore.refresh(),
-			]);
-		} catch {
-			// FIX: Use forceReconnect() instead of close()
-			// close() sets closed=true which prevents auto-reconnect
-			if (this.transport) {
-				this.transport.forceReconnect();
+			try {
+				// Send a lightweight health check with short timeout
+				// If this fails, the connection is dead and needs reconnect
+				await this.messageHub.request('system.health', {}, { timeout: 3000 });
+
+				// CRITICAL FIX: Re-join channels on resume
+				// Safari may pause WebSocket without closing it, causing server-side
+				// channel memberships to expire while client thinks it's still connected.
+				await this.messageHub.joinChannel('global');
+				const activeRoomId = roomStore.roomId.value;
+				if (activeRoomId) {
+					await this.messageHub.joinChannel(`room:${activeRoomId}`);
+				}
+				const activeSpaceId = spaceStore.spaceId.value;
+				if (activeSpaceId) {
+					await this.messageHub.joinChannel(`space:${activeSpaceId}`);
+				}
+
+				// CRITICAL: Refresh ALL state (session store, app state, and global state)
+				// This ensures UI is in sync even if events were missed during background
+				// FIX: Added sessionStore.refresh() to sync agent state for status bar
+				// Without this, status bar would show "Online" instead of actual state
+				await Promise.all([
+					sessionStore.refresh(),
+					appState.refreshAll(),
+					globalStore.refresh(),
+					roomStore.refresh(),
+					spaceStore.refresh(),
+				]);
+			} catch {
+				// FIX: Use forceReconnect() instead of close()
+				// close() sets closed=true which prevents auto-reconnect
+				if (this.transport) {
+					this.transport.forceReconnect();
+				}
+			}
+		} finally {
+			// Mark that resume validation is complete - now connectionState can update normally
+			this._isResuming = false;
+			// If connection was re-established during resume (e.g. reconnect path), update state now
+			// since the 'connected' event was suppressed while _isResuming was true
+			if (this.transport?.isReady()) {
+				connectionState.value = 'connected';
+				this.notifyConnectionHandlers();
 			}
 		}
 	}


### PR DESCRIPTION
When switching browser tabs, the TaskView could show "not connected to
server" error due to a race condition between visibilitychange handler
and useTaskViewData useEffect:

1. Tab returns to foreground -> validateConnectionOnResume() starts
2. During reconnection, connectionState bounces: connected -> disconnected
3. useEffect runs on isConnected change, calling load()
4. If reconnection hasn't completed, request() throws ConnectionNotReadyError
5. Error is set permanently (no retry)

Fix by combining two approaches:

- connection-manager.ts: Don't report 'connected' state until
  validateConnectionOnResume() fully completes. Added _isResuming flag
  to suppress premature 'connected' state updates during validation.

- useTaskViewData.ts: Clear stale errors at start of load() and add
  connection guard. If not connected, load() returns early without
  setting an error, allowing the effect to re-trigger when connection
  is properly restored.

Also adds unit tests covering tab-resume scenarios.

Test plan:
- All 5359 web tests pass
- TypeScript build passes
