### PR TITLE
fix: route human message to correct agent based on target parameter

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1620,7 +1620,7 @@ export class RoomRuntime {
 	 * - Clears the group's completedAt so it becomes active again
 	 * - Restores agent sessions (they were stopped when the task failed)
 	 * - Re-registers terminal-state observers so the runtime hears when agents finish
-	 * - Injects the human message (leader first, worker as fallback)
+	 * - Injects the human message (respects target preference)
 	 *
 	 * On failure, undoes the group revive (re-sets completedAt) so the group is not
 	 * left in an orphaned active state without a running agent. The caller is
@@ -1628,8 +1628,15 @@ export class RoomRuntime {
 	 *
 	 * Returns true on success, false if the group cannot be found or sessions
 	 * cannot be restored / injected.
+	 *
+	 * @param target - Which agent should receive the message ('worker' or 'leader').
+	 *                 Defaults to 'leader' for backward compatibility.
 	 */
-	async reviveTaskForMessage(taskId: string, message: string): Promise<boolean> {
+	async reviveTaskForMessage(
+		taskId: string,
+		message: string,
+		target: 'worker' | 'leader' = 'leader'
+	): Promise<boolean> {
 		const group = this.groupRepo.getGroupByTaskId(taskId);
 		if (!group) return false;
 
@@ -1678,25 +1685,49 @@ export class RoomRuntime {
 			await this.restoreMcpServersForGroup(group);
 		}
 
-		// Inject into leader first (preferred — leader orchestrates the workflow).
-		// Fall back to worker if leader is unavailable.
+		// Inject the message respecting the target preference.
+		// When target is 'worker': try worker first, fall back to leader if unavailable.
+		// When target is 'leader': try leader first (leader orchestrates the workflow),
+		// fall back to worker if leader is unavailable.
 		let injected = false;
-		if (leaderAvailable) {
-			try {
-				// Set leaderHasWork before injecting so the terminal event is not dropped.
-				this.groupRepo.setLeaderHasWork(group.id);
-				await this.sessionFactory.injectMessage(group.leaderSessionId, message);
-				injected = true;
-			} catch (error) {
-				log.warn(`reviveTaskForMessage: leader inject failed for ${taskId}:`, error);
+		if (target === 'worker') {
+			// Prefer worker when human explicitly chose worker
+			if (workerAvailable) {
+				try {
+					await this.sessionFactory.injectMessage(group.workerSessionId, message);
+					injected = true;
+				} catch (error) {
+					log.warn(`reviveTaskForMessage: worker inject failed for ${taskId}:`, error);
+				}
 			}
-		}
-		if (!injected && workerAvailable) {
-			try {
-				await this.sessionFactory.injectMessage(group.workerSessionId, message);
-				injected = true;
-			} catch (error) {
-				log.warn(`reviveTaskForMessage: worker inject failed for ${taskId}:`, error);
+			if (!injected && leaderAvailable) {
+				try {
+					this.groupRepo.setLeaderHasWork(group.id);
+					await this.sessionFactory.injectMessage(group.leaderSessionId, message);
+					injected = true;
+				} catch (error) {
+					log.warn(`reviveTaskForMessage: leader inject failed for ${taskId}:`, error);
+				}
+			}
+		} else {
+			// Prefer leader (default behavior for backward compatibility)
+			if (leaderAvailable) {
+				try {
+					// Set leaderHasWork before injecting so the terminal event is not dropped.
+					this.groupRepo.setLeaderHasWork(group.id);
+					await this.sessionFactory.injectMessage(group.leaderSessionId, message);
+					injected = true;
+				} catch (error) {
+					log.warn(`reviveTaskForMessage: leader inject failed for ${taskId}:`, error);
+				}
+			}
+			if (!injected && workerAvailable) {
+				try {
+					await this.sessionFactory.injectMessage(group.workerSessionId, message);
+					injected = true;
+				} catch (error) {
+					log.warn(`reviveTaskForMessage: worker inject failed for ${taskId}:`, error);
+				}
 			}
 		}
 

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -1024,7 +1024,11 @@ export function setupTaskHandlers(
 				throw new Error(`Failed to revive task ${params.taskId}: ${String(err)}`);
 			}
 
-			const revived = await runtime.reviveTaskForMessage(params.taskId, params.message.trim());
+			const revived = await runtime.reviveTaskForMessage(
+				params.taskId,
+				params.message.trim(),
+				target
+			);
 			if (!revived) {
 				// Rollback: restore task to original status
 				try {

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -344,7 +344,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 
 			expect(result).toEqual({ success: true });
 			// Sets status to review before reviving
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'please retry');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'please retry', 'worker');
 		});
 
 		it('throws and rolls back status when reviveTaskForMessage returns false', async () => {
@@ -379,7 +379,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'retry' }, {})
 			).rejects.toThrow('agent sessions could not be restored');
 
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'retry');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'retry', 'worker');
 			// Verify rollback: first transitioned to 'review', then rolled back to 'needs_attention'
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'review');
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'needs_attention');
@@ -398,7 +398,11 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			);
 
 			expect(result).toEqual({ success: true });
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'please continue');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
+				'task-1',
+				'please continue',
+				'worker'
+			);
 		});
 
 		it('throws and rolls back when reviveTaskForMessage fails for completed task', async () => {
@@ -432,7 +436,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'continue' }, {})
 			).rejects.toThrow('agent sessions could not be restored');
 
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'continue');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'continue', 'worker');
 			// Verify intermediate transition to in_progress, then rollback to completed
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress');
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'completed');
@@ -451,7 +455,11 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			);
 
 			expect(result).toEqual({ success: true });
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'restart please');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
+				'task-1',
+				'restart please',
+				'worker'
+			);
 		});
 
 		it('throws and rolls back when reviveTaskForMessage fails for cancelled task', async () => {
@@ -485,10 +493,58 @@ describe('task.sendHumanMessage RPC Handler', () => {
 				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'retry' }, {})
 			).rejects.toThrow('agent sessions could not be restored');
 
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'retry');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'retry', 'worker');
 			// Verify intermediate transition to in_progress, then rollback to cancelled
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress');
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'cancelled');
+		});
+	});
+
+	describe('target parameter routing for needs_attention tasks', () => {
+		it('passes target=worker to reviveTaskForMessage when human selects worker', async () => {
+			const needsAttentionTask = { ...mockTask, status: 'needs_attention' as const };
+			const { service, runtime } = makeRuntimeService(true, true, true);
+			setup({ task: needsAttentionTask, runtimeService: service });
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', message: 'hello worker', target: 'worker' },
+				{}
+			);
+
+			expect(result).toEqual({ success: true });
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'hello worker', 'worker');
+		});
+
+		it('passes target=leader to reviveTaskForMessage when human selects leader', async () => {
+			const needsAttentionTask = { ...mockTask, status: 'needs_attention' as const };
+			const { service, runtime } = makeRuntimeService(true, true, true);
+			setup({ task: needsAttentionTask, runtimeService: service });
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', message: 'hello leader', target: 'leader' },
+				{}
+			);
+
+			expect(result).toEqual({ success: true });
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'hello leader', 'leader');
+		});
+
+		it('defaults to target=worker when no target specified', async () => {
+			const needsAttentionTask = { ...mockTask, status: 'needs_attention' as const };
+			const { service, runtime } = makeRuntimeService(true, true, true);
+			setup({ task: needsAttentionTask, runtimeService: service });
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', message: 'hello default' },
+				{}
+			);
+
+			expect(result).toEqual({ success: true });
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
+				'task-1',
+				'hello default',
+				'worker'
+			);
 		});
 	});
 


### PR DESCRIPTION
When a task is in needs_attention state and a human sends a message
to the worker, the runtime now respects the target parameter and
delivers to the worker instead of always preferring the leader.

Changes:
- Modified reviveTaskForMessage to accept a target parameter ('worker'
  or 'leader') instead of always preferring leader
- When target='worker': try worker first, fall back to leader
- When target='leader' (default): try leader first, fall back to worker
- Updated task.sendHumanMessage RPC handler to pass target parameter
- Added unit tests for target parameter routing

This fixes Issue 1 where human message to worker was incorrectly
routed to leader.

For Issue 2, the fix ensures that when the human explicitly sends
to worker, the message goes directly to worker without leader
intermediary, preventing unnecessary synthetic feedback generation.
