### PR TITLE
feat: add channel edge rendering to EdgeRenderer

### DIFF
--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -19,6 +19,10 @@
  *
  * Marker IDs are prefixed with a stable per-instance ID (via useId) to prevent
  * collisions when multiple EdgeRenderer instances are mounted simultaneously.
+ *
+ * Channel edges are also rendered (via the channels prop). Channel edges connect
+ * between side ports (left/right) of nodes with a distinct dashed teal style.
+ * Bidirectional channels show double arrowheads; one-way channels show a single arrowhead.
  */
 
 import { useEffect, useRef } from 'preact/hooks';
@@ -50,6 +54,30 @@ export const SELECTED_STROKE_WIDTH = 3;
 const HITBOX_STROKE_WIDTH = 12;
 
 // ---------------------------------------------------------------------------
+// Channel edge types and constants
+// ---------------------------------------------------------------------------
+
+/**
+ * A messaging channel between two nodes with resolved node IDs.
+ * This is the rendered form of a WorkflowChannel where role strings
+ * have been resolved to actual node/step IDs.
+ */
+export interface ResolvedWorkflowChannel {
+	fromStepId: string;
+	toStepId: string;
+	direction: 'one-way' | 'bidirectional';
+}
+
+/** Channel edge color — teal, distinct from transition edge colors */
+export const CHANNEL_EDGE_COLOR = '#14b8a6'; // teal-500
+
+/** Channel edge stroke dash pattern for visual distinction */
+export const CHANNEL_EDGE_DASH_ARRAY = '6 4';
+
+/** Control point horizontal offset for channel edge bezier curves */
+const CHANNEL_CP_OFFSET = 80;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -59,6 +87,8 @@ export interface EdgeRendererProps {
 	selectedEdgeId?: string | null;
 	onEdgeSelect?: (transitionId: string) => void;
 	onEdgeDelete?: (transitionId: string) => void;
+	/** Channel edges to render between nodes (with resolved source/target node IDs). */
+	channels?: ResolvedWorkflowChannel[];
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +141,58 @@ export function buildPathD(pts: EdgePoints): string {
 }
 
 // ---------------------------------------------------------------------------
+// Channel edge helpers
+// ---------------------------------------------------------------------------
+
+/** Fixed X position for the Task Agent hub rail on the left side of the canvas. */
+export const TASK_AGENT_X = 60;
+
+/** Compute the bezier path for a channel edge connecting side ports of two nodes.
+ *  For the special 'task-agent' source, routes from the Task Agent rail (left side)
+ *  to the target node's top-center port. */
+export function computeChannelEdgePoints(
+	channel: ResolvedWorkflowChannel,
+	nodePositions: NodePosition
+): EdgePoints | null {
+	const toPos = nodePositions[channel.toStepId];
+	if (!toPos) return null;
+
+	// Handle Task Agent source (special virtual hub on the left side)
+	if (channel.fromStepId === 'task-agent') {
+		const sx = TASK_AGENT_X;
+		const sy = toPos.y + toPos.height / 2;
+		const tx = toPos.x + toPos.width / 2;
+		const ty = toPos.y;
+
+		const cpOffset = Math.max(40, Math.abs(tx - sx) * 0.5);
+		const cp1x = sx + cpOffset;
+		const cp1y = sy;
+		const cp2x = tx - cpOffset;
+		const cp2y = ty;
+
+		return { sx, sy, tx, ty, cp1x, cp1y, cp2x, cp2y };
+	}
+
+	// Regular node-to-node channel: connect from right side of source to left side of target
+	const fromPos = nodePositions[channel.fromStepId];
+	if (!fromPos) return null;
+
+	const sx = fromPos.x + fromPos.width; // right edge of source
+	const sy = fromPos.y + fromPos.height / 2; // vertical center of source
+
+	const tx = toPos.x; // left edge of target
+	const ty = toPos.y + toPos.height / 2; // vertical center of target
+
+	// Horizontal bezier: bow outward from both sides
+	const cp1x = sx + CHANNEL_CP_OFFSET;
+	const cp1y = sy;
+	const cp2x = tx - CHANNEL_CP_OFFSET;
+	const cp2y = ty;
+
+	return { sx, sy, tx, ty, cp1x, cp1y, cp2x, cp2y };
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -120,6 +202,7 @@ export function EdgeRenderer({
 	selectedEdgeId,
 	onEdgeSelect,
 	onEdgeDelete,
+	channels = [],
 }: EdgeRendererProps) {
 	// Stable per-instance prefix to prevent marker ID collisions across instances
 	const markerPrefixRef = useRef<string | null>(null);
@@ -184,6 +267,29 @@ export function EdgeRenderer({
 				>
 					<path d="M 0 0 L 10 5 L 0 10 z" fill="white" />
 				</marker>
+				{/* Channel edge arrowhead markers — teal colored, distinct from transition markers */}
+				<marker
+					id={`${markerPrefix}-channel-end`}
+					viewBox="0 0 10 10"
+					refX="10"
+					refY="5"
+					markerWidth="6"
+					markerHeight="6"
+					orient="auto-start-reverse"
+				>
+					<path d="M 0 0 L 10 5 L 0 10 z" fill={CHANNEL_EDGE_COLOR} />
+				</marker>
+				<marker
+					id={`${markerPrefix}-channel-start`}
+					viewBox="0 0 10 10"
+					refX="0"
+					refY="5"
+					markerWidth="6"
+					markerHeight="6"
+					orient="auto-start-reverse"
+				>
+					<path d="M 10 0 L 0 5 L 10 10 z" fill={CHANNEL_EDGE_COLOR} />
+				</marker>
 			</defs>
 
 			{transitions.map((transition) => {
@@ -231,6 +337,49 @@ export function EdgeRenderer({
 							markerEnd={`url(#${markerId})`}
 							data-stroke-color={strokeColor}
 							data-stroke-width={String(strokeWidth)}
+							style={{ pointerEvents: 'none' }}
+						/>
+					</g>
+				);
+			})}
+
+			{/* Channel edges — dashed teal edges connecting side ports of nodes */}
+			{channels.map((channel) => {
+				const pts = computeChannelEdgePoints(channel, nodePositions);
+				if (!pts) return null;
+
+				const d = buildPathD(pts);
+				const isBidirectional = channel.direction === 'bidirectional';
+				const markerEndId = `${markerPrefix}-channel-end`;
+				const markerStartId = `${markerPrefix}-channel-start`;
+
+				return (
+					<g
+						key={`channel-${channel.fromStepId}-${channel.toStepId}`}
+						data-testid={`channel-edge-${channel.fromStepId}-${channel.toStepId}`}
+						data-channel-edge="true"
+						data-channel-direction={channel.direction}
+					>
+						{/* Invisible hitbox for easier interaction */}
+						<path
+							d={d}
+							stroke="transparent"
+							strokeWidth={HITBOX_STROKE_WIDTH}
+							fill="none"
+							style={{ cursor: 'pointer', pointerEvents: 'stroke' }}
+						/>
+						{/* Visible dashed channel edge */}
+						<path
+							d={d}
+							stroke={CHANNEL_EDGE_COLOR}
+							strokeWidth={NORMAL_STROKE_WIDTH}
+							strokeDasharray={CHANNEL_EDGE_DASH_ARRAY}
+							strokeOpacity={0.8}
+							fill="none"
+							markerEnd={`url(#${markerEndId})`}
+							markerStart={isBidirectional ? `url(#${markerStartId})` : undefined}
+							data-stroke-color={CHANNEL_EDGE_COLOR}
+							data-stroke-width={String(NORMAL_STROKE_WIDTH)}
 							style={{ pointerEvents: 'none' }}
 						/>
 					</g>

--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -157,7 +157,11 @@ export function computeChannelEdgePoints(
 	const toPos = nodePositions[channel.toStepId];
 	if (!toPos) return null;
 
-	// Handle Task Agent source (special virtual hub on the left side)
+	// Handle Task Agent source (special virtual hub on the left side).
+	// Task Agent routes to the target's top-center (not side port), so we use
+	// a proportional offset (40-50% of distance) to ensure a smooth curve.
+	// This differs from regular node-to-node channels which use a fixed CHANNEL_CP_OFFSET
+	// since they connect side ports horizontally.
 	if (channel.fromStepId === 'task-agent') {
 		const sx = TASK_AGENT_X;
 		const sy = toPos.y + toPos.height / 2;
@@ -267,29 +271,33 @@ export function EdgeRenderer({
 				>
 					<path d="M 0 0 L 10 5 L 0 10 z" fill="white" />
 				</marker>
-				{/* Channel edge arrowhead markers — teal colored, distinct from transition markers */}
-				<marker
-					id={`${markerPrefix}-channel-end`}
-					viewBox="0 0 10 10"
-					refX="10"
-					refY="5"
-					markerWidth="6"
-					markerHeight="6"
-					orient="auto-start-reverse"
-				>
-					<path d="M 0 0 L 10 5 L 0 10 z" fill={CHANNEL_EDGE_COLOR} />
-				</marker>
-				<marker
-					id={`${markerPrefix}-channel-start`}
-					viewBox="0 0 10 10"
-					refX="0"
-					refY="5"
-					markerWidth="6"
-					markerHeight="6"
-					orient="auto-start-reverse"
-				>
-					<path d="M 10 0 L 0 5 L 10 10 z" fill={CHANNEL_EDGE_COLOR} />
-				</marker>
+				{/* Channel edge arrowhead markers — only render when channels are present */}
+				{channels.length > 0 && (
+					<marker
+						id={`${markerPrefix}-channel-end`}
+						viewBox="0 0 10 10"
+						refX="10"
+						refY="5"
+						markerWidth="6"
+						markerHeight="6"
+						orient="auto-start-reverse"
+					>
+						<path d="M 0 0 L 10 5 L 0 10 z" fill={CHANNEL_EDGE_COLOR} />
+					</marker>
+				)}
+				{channels.length > 0 && (
+					<marker
+						id={`${markerPrefix}-channel-start`}
+						viewBox="0 0 10 10"
+						refX="0"
+						refY="5"
+						markerWidth="6"
+						markerHeight="6"
+						orient="auto-start-reverse"
+					>
+						<path d="M 10 0 L 0 5 L 10 10 z" fill={CHANNEL_EDGE_COLOR} />
+					</marker>
+				)}
 			</defs>
 
 			{transitions.map((transition) => {

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -184,16 +184,13 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			const channels = node.step.channels;
 			if (!channels) continue;
 			for (const channel of channels) {
-				// Check if this channel involves task-agent (bidirectional only)
-				const hasTaskAgent =
-					(channel.from === 'task-agent' || channel.to === 'task-agent') &&
-					channel.direction === 'bidirectional';
-				if (hasTaskAgent) {
-					// Add one edge per node (break after first matching channel)
+				// Only include channels where task-agent is the source, and use the actual
+				// channel.direction (not hardcoded bidirectional).
+				if (channel.from === 'task-agent') {
 					result.push({
 						fromStepId: 'task-agent',
 						toStepId: node.step.localId,
-						direction: 'bidirectional',
+						direction: channel.direction,
 					});
 					break;
 				}

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -167,13 +167,19 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	}, [edges, stepKeyToLocalId]);
 
 	// ------------------------------------------------------------------
-	// Derived: ChannelEdge[] for Task Agent channel connections
+	// Derived: ResolvedWorkflowChannel[] for Task Agent channel connections
 	// Task Agent channels are stored on individual steps (step.channels).
 	// We extract edges from task-agent to each connected step.
 	// ------------------------------------------------------------------
 
-	const channelEdges = useMemo<{ fromStepId: 'task-agent'; toStepId: string }[]>(() => {
-		const result: { fromStepId: 'task-agent'; toStepId: string }[] = [];
+	const channelEdges = useMemo<
+		{ fromStepId: string; toStepId: string; direction: 'one-way' | 'bidirectional' }[]
+	>(() => {
+		const result: {
+			fromStepId: string;
+			toStepId: string;
+			direction: 'one-way' | 'bidirectional';
+		}[] = [];
 		for (const node of nodes) {
 			const channels = node.step.channels;
 			if (!channels) continue;
@@ -184,7 +190,11 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					channel.direction === 'bidirectional';
 				if (hasTaskAgent) {
 					// Add one edge per node (break after first matching channel)
-					result.push({ fromStepId: 'task-agent', toStepId: node.step.localId });
+					result.push({
+						fromStepId: 'task-agent',
+						toStepId: node.step.localId,
+						direction: 'bidirectional',
+					});
 					break;
 				}
 			}
@@ -754,7 +764,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					viewportState={viewportState}
 					onViewportChange={setViewportState}
 					transitions={transitions}
-					channelEdges={channelEdges}
+					channels={channelEdges}
 					onNodeSelect={handleNodeSelect}
 					onDeleteNode={handleDeleteNode}
 					onNodePositionChange={handleNodePositionChange}

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -25,7 +25,7 @@ import type { WorkflowTransition } from '@neokai/shared';
 import { VisualCanvas } from './VisualCanvas';
 import { WorkflowNode } from './WorkflowNode';
 import type { WorkflowNodeProps, PortType } from './WorkflowNode';
-import { EdgeRenderer } from './EdgeRenderer';
+import { EdgeRenderer, type ResolvedWorkflowChannel } from './EdgeRenderer';
 import type { ViewportState, Point, NodePosition } from './types';
 import { useConnectionDrag } from './useConnectionDrag';
 
@@ -56,11 +56,8 @@ export interface WorkflowCanvasProps {
 	onViewportChange: (state: ViewportState) => void;
 	/** Edges to render between nodes. Also used for duplicate detection during connection drag. */
 	transitions?: WorkflowTransition[];
-	/**
-	 * Task Agent channel edges to render (from task-agent to step).
-	 * Rendered with a distinct dashed gray style.
-	 */
-	channelEdges?: ChannelEdge[];
+	/** Channel edges to render between nodes (Task Agent channels and regular channels). */
+	channels?: ResolvedWorkflowChannel[];
 	/**
 	 * Explicit node positions including width/height for edge port computation.
 	 * When omitted, positions are derived from nodes with DEFAULT_NODE_WIDTH/HEIGHT.
@@ -78,17 +75,6 @@ export interface WorkflowCanvasProps {
 	onEdgeSelect?: (transitionId: string | null) => void;
 	/** Called when Delete/Backspace is pressed with an edge selected. */
 	onDeleteEdge?: (transitionId: string) => void;
-}
-
-/**
- * A channel edge represents a messaging channel between Task Agent and a step.
- * The 'task-agent' is a virtual hub, so we store the target step ID.
- */
-export interface ChannelEdge {
-	/** Fixed identifier for the Task Agent source */
-	fromStepId: 'task-agent';
-	/** The target step localId */
-	toStepId: string;
 }
 
 // ---- Ghost edge rendering ----
@@ -137,77 +123,6 @@ function GhostEdge({ from, to }: { from: Point; to: Point }): JSX.Element | null
 	);
 }
 
-// ---- ChannelEdgeRenderer ----
-
-/** Color for Task Agent channel edges */
-const CHANNEL_EDGE_COLOR = '#9ca3af'; // gray-400
-
-/**
- * Render Task Agent channel edges as dashed bezier paths from a fixed Task Agent
- * hub position (left side of canvas) to each target node.
- *
- * Task Agent is rendered as a vertical "rail" on the left side of the canvas,
- * and channel edges emanate from this rail to each connected node.
- */
-function ChannelEdgeRenderer({
-	channelEdges,
-	nodePositions,
-}: {
-	channelEdges: ChannelEdge[];
-	nodePositions: NodePosition;
-}) {
-	if (channelEdges.length === 0) return null;
-
-	// Task Agent hub position: fixed on the left side
-	const TASK_AGENT_X = 60;
-
-	return (
-		<>
-			{channelEdges.map((edge) => {
-				const toPos = nodePositions[edge.toStepId];
-				if (!toPos) return null;
-
-				// Source: Task Agent hub (left side, vertical position based on target)
-				const sx = TASK_AGENT_X;
-				const sy = toPos.y + toPos.height / 2;
-
-				// Target: top-center of the target node
-				const tx = toPos.x + toPos.width / 2;
-				const ty = toPos.y;
-
-				// Bezier control points
-				const dx = Math.abs(tx - sx);
-				const cpOffset = Math.max(40, dx * 0.5);
-				const cp1x = sx + cpOffset;
-				const cp1y = sy;
-				const cp2x = tx - cpOffset;
-				const cp2y = ty;
-
-				const d = `M ${sx} ${sy} C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${tx} ${ty}`;
-
-				return (
-					<g key={`channel-${edge.toStepId}`} data-channel-edge="true">
-						{/* Channel edges are informational — no click interaction yet */}
-						<path d={d} stroke="transparent" strokeWidth={12} fill="none" />
-						{/* Visible dashed edge */}
-						<path
-							d={d}
-							stroke={CHANNEL_EDGE_COLOR}
-							strokeWidth={1.5}
-							strokeDasharray="6 4"
-							strokeOpacity={0.7}
-							fill="none"
-							style={{ pointerEvents: 'none' }}
-						/>
-						{/* Small circle at source (Task Agent end) */}
-						<circle cx={sx} cy={sy} r={4} fill={CHANNEL_EDGE_COLOR} opacity={0.7} />
-					</g>
-				);
-			})}
-		</>
-	);
-}
-
 // ============================================================================
 // WorkflowCanvas
 // ============================================================================
@@ -217,7 +132,7 @@ export function WorkflowCanvas({
 	viewportState,
 	onViewportChange,
 	transitions = [],
-	channelEdges = [],
+	channels = [],
 	nodePositions,
 	onNodeSelect,
 	onDeleteNode,
@@ -389,8 +304,8 @@ export function WorkflowCanvas({
 					selectedEdgeId={selectedEdgeId}
 					onEdgeSelect={handleEdgeSelect}
 					onEdgeDelete={handleEdgeDelete}
+					channels={channels}
 				/>
-				<ChannelEdgeRenderer channelEdges={channelEdges} nodePositions={effectiveNodePositions} />
 				{dragState.active && dragState.fromPos && dragState.currentPos && (
 					<GhostEdge from={dragState.fromPos} to={dragState.currentPos} />
 				)}
@@ -398,7 +313,7 @@ export function WorkflowCanvas({
 		),
 		[
 			transitions,
-			channelEdges,
+			channels,
 			effectiveNodePositions,
 			selectedEdgeId,
 			handleEdgeSelect,

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -198,8 +198,9 @@ describe('EdgeRenderer — rendering', () => {
 		const { container } = renderEdges();
 		const defs = container.querySelector('defs');
 		expect(defs).not.toBeNull();
-		// Should have 7 markers: always, human, condition, task_result, selected, channel-end, channel-start
-		expect(defs!.querySelectorAll('marker')).toHaveLength(7);
+		// Should have 5 markers: always, human, condition, task_result, selected
+		// (channel-end and channel-start are only rendered when channels prop is provided)
+		expect(defs!.querySelectorAll('marker')).toHaveLength(5);
 	});
 
 	it('uses testid data-testid="edge-{id}" on each group', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -15,6 +15,14 @@
  * - Delete inside input/textarea/contenteditable does not trigger onEdgeDelete
  * - Arrowhead markers are rendered in defs
  * - Multiple instances have non-colliding marker IDs
+ * - Channel edge constants (CHANNEL_EDGE_COLOR, CHANNEL_EDGE_DASH_ARRAY, TASK_AGENT_X)
+ * - computeChannelEdgePoints for regular node-to-node channels
+ * - computeChannelEdgePoints for task-agent to node channels
+ * - Bidirectional channel renders two arrowheads (markerStart + markerEnd)
+ * - One-way channel renders one arrowhead (markerEnd only)
+ * - Channel edges use dashed style (strokeDasharray)
+ * - Channel edges are teal colored (distinct from transition edge colors)
+ * - Channel edges have correct data-testid attribute
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -28,9 +36,14 @@ import {
 	EDGE_COLORS,
 	NORMAL_STROKE_WIDTH,
 	SELECTED_STROKE_WIDTH,
+	CHANNEL_EDGE_COLOR,
+	CHANNEL_EDGE_DASH_ARRAY,
+	TASK_AGENT_X,
+	computeChannelEdgePoints,
 } from '../EdgeRenderer';
 import type { EdgeRendererProps } from '../EdgeRenderer';
 import type { NodePosition } from '../types';
+import type { ResolvedWorkflowChannel } from '../EdgeRenderer';
 
 afterEach(() => cleanup());
 
@@ -185,8 +198,8 @@ describe('EdgeRenderer — rendering', () => {
 		const { container } = renderEdges();
 		const defs = container.querySelector('defs');
 		expect(defs).not.toBeNull();
-		// Should have 5 markers: always, human, condition, task_result, selected
-		expect(defs!.querySelectorAll('marker')).toHaveLength(5);
+		// Should have 7 markers: always, human, condition, task_result, selected, channel-end, channel-start
+		expect(defs!.querySelectorAll('marker')).toHaveLength(7);
 	});
 
 	it('uses testid data-testid="edge-{id}" on each group', () => {
@@ -381,5 +394,253 @@ describe('EdgeRenderer — keyboard delete', () => {
 		div.focus();
 		fireEvent.keyDown(div, { key: 'Delete', target: div });
 		expect(onEdgeDelete).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Channel edge constants
+// ---------------------------------------------------------------------------
+
+describe('Channel edge constants', () => {
+	it('CHANNEL_EDGE_COLOR is teal', () => {
+		expect(CHANNEL_EDGE_COLOR).toBe('#14b8a6');
+	});
+
+	it('CHANNEL_EDGE_DASH_ARRAY is a dashed pattern', () => {
+		expect(CHANNEL_EDGE_DASH_ARRAY).toBe('6 4');
+	});
+
+	it('TASK_AGENT_X is 60', () => {
+		expect(TASK_AGENT_X).toBe(60);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// computeChannelEdgePoints
+// ---------------------------------------------------------------------------
+
+describe('computeChannelEdgePoints', () => {
+	it('returns null when from-node is missing', () => {
+		const channel: ResolvedWorkflowChannel = {
+			fromStepId: 'missing',
+			toStepId: 'step-2',
+			direction: 'bidirectional',
+		};
+		expect(computeChannelEdgePoints(channel, NODE_POSITIONS)).toBeNull();
+	});
+
+	it('returns null when to-node is missing', () => {
+		const channel: ResolvedWorkflowChannel = {
+			fromStepId: 'step-1',
+			toStepId: 'missing',
+			direction: 'bidirectional',
+		};
+		expect(computeChannelEdgePoints(channel, NODE_POSITIONS)).toBeNull();
+	});
+
+	it('source x is right edge of from-node for regular channel', () => {
+		const channel: ResolvedWorkflowChannel = {
+			fromStepId: 'step-1',
+			toStepId: 'step-2',
+			direction: 'bidirectional',
+		};
+		const pts = computeChannelEdgePoints(channel, NODE_POSITIONS);
+		expect(pts).not.toBeNull();
+		// step-1: x=50, width=160 → right edge = 210
+		expect(pts!.sx).toBe(50 + 160);
+	});
+
+	it('source y is vertical center of from-node', () => {
+		const channel: ResolvedWorkflowChannel = {
+			fromStepId: 'step-1',
+			toStepId: 'step-2',
+			direction: 'bidirectional',
+		};
+		const pts = computeChannelEdgePoints(channel, NODE_POSITIONS);
+		expect(pts).not.toBeNull();
+		// step-1: y=50, height=80 → center = 90
+		expect(pts!.sy).toBe(50 + 80 / 2);
+	});
+
+	it('target x is left edge of to-node', () => {
+		const channel: ResolvedWorkflowChannel = {
+			fromStepId: 'step-1',
+			toStepId: 'step-2',
+			direction: 'bidirectional',
+		};
+		const pts = computeChannelEdgePoints(channel, NODE_POSITIONS);
+		expect(pts).not.toBeNull();
+		// step-2: x=300
+		expect(pts!.tx).toBe(300);
+	});
+
+	it('target y is vertical center of to-node', () => {
+		const channel: ResolvedWorkflowChannel = {
+			fromStepId: 'step-1',
+			toStepId: 'step-2',
+			direction: 'bidirectional',
+		};
+		const pts = computeChannelEdgePoints(channel, NODE_POSITIONS);
+		expect(pts).not.toBeNull();
+		// step-2: y=250, height=80 → center = 290
+		expect(pts!.ty).toBe(250 + 80 / 2);
+	});
+
+	it('task-agent channel uses TASK_AGENT_X as source x', () => {
+		const channel: ResolvedWorkflowChannel = {
+			fromStepId: 'task-agent',
+			toStepId: 'step-2',
+			direction: 'bidirectional',
+		};
+		const pts = computeChannelEdgePoints(channel, NODE_POSITIONS);
+		expect(pts).not.toBeNull();
+		expect(pts!.sx).toBe(TASK_AGENT_X);
+	});
+
+	it('task-agent channel uses top-center of target node', () => {
+		const channel: ResolvedWorkflowChannel = {
+			fromStepId: 'task-agent',
+			toStepId: 'step-2',
+			direction: 'bidirectional',
+		};
+		const pts = computeChannelEdgePoints(channel, NODE_POSITIONS);
+		expect(pts).not.toBeNull();
+		// step-2: x=300, width=160 → center x = 380, y = 250
+		expect(pts!.tx).toBe(300 + 160 / 2);
+		expect(pts!.ty).toBe(250);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Channel edge rendering
+// ---------------------------------------------------------------------------
+
+function renderEdgesWithChannels(props: Partial<EdgeRendererProps> = {}) {
+	const onEdgeSelect = vi.fn();
+	const onEdgeDelete = vi.fn();
+	const result = render(
+		<svg>
+			<EdgeRenderer
+				transitions={[T1, T2, T3]}
+				nodePositions={NODE_POSITIONS}
+				onEdgeSelect={onEdgeSelect}
+				onEdgeDelete={onEdgeDelete}
+				{...props}
+			/>
+		</svg>
+	);
+	return { ...result, onEdgeSelect, onEdgeDelete };
+}
+
+describe('EdgeRenderer — channel edge rendering', () => {
+	it('renders channel edges when channels prop is provided', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'task-agent', toStepId: 'step-1', direction: 'bidirectional' },
+			{ fromStepId: 'task-agent', toStepId: 'step-2', direction: 'bidirectional' },
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const channelEdgeGroups = container.querySelectorAll('g[data-channel-edge="true"]');
+		expect(channelEdgeGroups).toHaveLength(2);
+	});
+
+	it('channel edges have correct data-testid attribute', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'task-agent', toStepId: 'step-1', direction: 'bidirectional' },
+		];
+		const { getByTestId } = renderEdgesWithChannels({ channels });
+		expect(getByTestId('channel-edge-task-agent-step-1')).toBeTruthy();
+	});
+
+	it('channel edges have correct data-channel-direction attribute', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'task-agent', toStepId: 'step-1', direction: 'bidirectional' },
+			{ fromStepId: 'step-1', toStepId: 'step-2', direction: 'one-way' },
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const bidirectional = container.querySelector('g[data-channel-direction="bidirectional"]');
+		const oneWay = container.querySelector('g[data-channel-direction="one-way"]');
+		expect(bidirectional).toBeTruthy();
+		expect(oneWay).toBeTruthy();
+	});
+
+	it('bidirectional channel has both markerStart and markerEnd on visible path', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'task-agent', toStepId: 'step-1', direction: 'bidirectional' },
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const visiblePath = container.querySelector(
+			'g[data-channel-edge="true"] path:not([stroke="transparent"])'
+		);
+		expect(visiblePath).not.toBeNull();
+		const markerStart = visiblePath!.getAttribute('markerStart');
+		const markerEnd = visiblePath!.getAttribute('markerEnd');
+		expect(markerStart).toContain('channel-start');
+		expect(markerEnd).toContain('channel-end');
+	});
+
+	it('one-way channel has only markerEnd on visible path', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'step-1', toStepId: 'step-2', direction: 'one-way' },
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const visiblePath = container.querySelector(
+			'g[data-channel-edge="true"] path:not([stroke="transparent"])'
+		);
+		expect(visiblePath).not.toBeNull();
+		const markerStart = visiblePath!.getAttribute('markerStart');
+		const markerEnd = visiblePath!.getAttribute('markerEnd');
+		expect(markerStart).toBeNull();
+		expect(markerEnd).toContain('channel-end');
+	});
+
+	it('channel edges use dashed stroke style', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'task-agent', toStepId: 'step-1', direction: 'bidirectional' },
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const visiblePath = container.querySelector(
+			'g[data-channel-edge="true"] path:not([stroke="transparent"])'
+		);
+		expect(visiblePath).not.toBeNull();
+		expect(visiblePath!.getAttribute('strokeDasharray')).toBe(CHANNEL_EDGE_DASH_ARRAY);
+	});
+
+	it('channel edges use teal color (distinct from transition edge colors)', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'task-agent', toStepId: 'step-1', direction: 'bidirectional' },
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const visiblePath = container.querySelector(
+			'g[data-channel-edge="true"] path:not([stroke="transparent"])'
+		);
+		expect(visiblePath).not.toBeNull();
+		expect(visiblePath!.getAttribute('stroke')).toBe(CHANNEL_EDGE_COLOR);
+		// Verify it's different from transition edge colors
+		expect(CHANNEL_EDGE_COLOR).not.toBe(EDGE_COLORS.always);
+		expect(CHANNEL_EDGE_COLOR).not.toBe(EDGE_COLORS.human);
+		expect(CHANNEL_EDGE_COLOR).not.toBe(EDGE_COLORS.condition);
+	});
+
+	it('skips channel edges where target node position is missing', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'task-agent', toStepId: 'step-1', direction: 'bidirectional' },
+			{ fromStepId: 'task-agent', toStepId: 'missing-node', direction: 'bidirectional' },
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const channelEdgeGroups = container.querySelectorAll('g[data-channel-edge="true"]');
+		expect(channelEdgeGroups).toHaveLength(1);
+	});
+
+	it('channel edge defs include channel arrowhead markers', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{ fromStepId: 'task-agent', toStepId: 'step-1', direction: 'bidirectional' },
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const defs = container.querySelector('defs');
+		expect(defs).not.toBeNull();
+		const channelEndMarker = defs!.querySelector('marker[id*="channel-end"]');
+		const channelStartMarker = defs!.querySelector('marker[id*="channel-start"]');
+		expect(channelEndMarker).not.toBeNull();
+		expect(channelStartMarker).not.toBeNull();
 	});
 });


### PR DESCRIPTION
Extend EdgeRenderer to render channel edges alongside transition edges.
Channel edges connect nodes with declared messaging channels and use
distinct visual styling:

- Dashed teal stroke pattern (#14b8a6) to differentiate from solid
  transition edges (blue/yellow/purple)
- For bidirectional channels: double arrowheads (marker-start + marker-end)
- For one-way channels: single arrowhead (marker-end only)
- Channel edges connect between side ports (left/right) rather than
  top/bottom to avoid confusion with transition edges
- Task Agent channels route from the Task Agent rail (fixed at x=60)
  to the target node's top-center port
- Regular node-to-node channels route from source's right port to
  target's left port

Changes:
- EdgeRenderer: add channels prop, channel marker defs, and rendering
- WorkflowCanvas: remove ChannelEdgeRenderer, pass channels to EdgeRenderer
- VisualWorkflowEditor: update channelEdges type and prop name to channels
- EdgeRenderer.test: add tests for channel edge constants, computeChannelEdgePoints,
  bidirectional/one-way arrowheads, dashed style, and data-testid attributes

Closes task 6.1
