### PR TITLE
feat: integrate channel edges into WorkflowCanvas

### DIFF
--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -123,6 +123,127 @@ function GhostEdge({ from, to }: { from: Point; to: Point }): JSX.Element | null
 	);
 }
 
+// ---- Channel edge computation ----
+
+/**
+ * Compute channel edges from workflow nodes.
+ *
+ * Collects all WorkflowChannel declarations from all nodes and resolves
+ * channel endpoints to node IDs:
+ * - Intra-node channels (agents within the same node) are skipped - they don't
+ *   need cross-node edges since all agents in a node share the same canvas space.
+ * - Inter-node channels (including Task Agent channels) are resolved to
+ *   actual node IDs and returned as ResolvedWorkflowChannel objects.
+ *
+ * Task Agent channels use 'task-agent' as the special source identifier.
+ * Other channels resolve agent roles to their containing node IDs using the
+ * SpaceAgent.agents array which has role information.
+ */
+export function computeChannelEdges(nodes: WorkflowNodeData[]): ResolvedWorkflowChannel[] {
+	const result: ResolvedWorkflowChannel[] = [];
+
+	// Track seen (fromStepId, toStepId) pairs to avoid duplicates
+	const seenEdges = new Set<string>();
+
+	// Build a map of agent role -> node localId for quick lookup
+	// This is used to resolve channel endpoints that reference agent roles
+	const agentRoleToNodeId = new Map<string, string>();
+	for (const node of nodes) {
+		// node.agents is SpaceAgent[] which has .role
+		if (node.agents) {
+			for (const agent of node.agents) {
+				agentRoleToNodeId.set(agent.role, node.step.localId);
+			}
+		}
+	}
+
+	for (const node of nodes) {
+		const channels = node.step.channels;
+		if (!channels) continue;
+
+		for (const channel of channels) {
+			// Determine if this is an inter-node channel
+			let fromNodeId: string | null = null;
+
+			// Resolve 'from' endpoint
+			if (channel.from === 'task-agent') {
+				fromNodeId = 'task-agent';
+			} else if (channel.from === '*') {
+				// Wildcard: from the node itself
+				fromNodeId = node.step.localId;
+			} else {
+				// Resolve agent role to node ID
+				fromNodeId = agentRoleToNodeId.get(channel.from) ?? null;
+			}
+
+			// Resolve 'to' endpoints (can be a string or array of strings)
+			const toTargets: (string | null)[] =
+				typeof channel.to === 'string'
+					? [resolveToTarget(channel.to, node, agentRoleToNodeId)]
+					: channel.to.map((t) => resolveToTarget(t, node, agentRoleToNodeId));
+
+			// Skip if we couldn't resolve the 'from' endpoint
+			if (!fromNodeId) continue;
+
+			for (const toNodeId of toTargets) {
+				if (!toNodeId) continue;
+
+				// Skip intra-node channels (both endpoints resolve to the same node)
+				if (fromNodeId === toNodeId) continue;
+
+				// Check for duplicate edges
+				const edgeKey = `${fromNodeId}:${toNodeId}`;
+				if (seenEdges.has(edgeKey)) continue;
+				seenEdges.add(edgeKey);
+
+				// For task-agent channels, we always render from task-agent to the other node
+				if (fromNodeId === 'task-agent' && toNodeId !== 'task-agent') {
+					result.push({
+						fromStepId: 'task-agent',
+						toStepId: toNodeId,
+						direction: channel.direction,
+					});
+				} else if (toNodeId === 'task-agent' && fromNodeId !== 'task-agent') {
+					// Also add edge when task-agent is the target (channel is defined on another node)
+					result.push({
+						fromStepId: fromNodeId,
+						toStepId: 'task-agent',
+						direction: channel.direction,
+					});
+				} else if (fromNodeId !== 'task-agent' && toNodeId !== 'task-agent') {
+					// Regular inter-node channel between two non-task-agent nodes
+					result.push({
+						fromStepId: fromNodeId,
+						toStepId: toNodeId,
+						direction: channel.direction,
+					});
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Resolve a 'to' target string to a node ID.
+ */
+function resolveToTarget(
+	toValue: string,
+	node: WorkflowNodeData,
+	agentRoleToNodeId: Map<string, string>
+): string | null {
+	if (toValue === 'task-agent') {
+		return 'task-agent';
+	}
+	if (toValue === '*') {
+		// Wildcard: to the node itself
+		return node.step.localId;
+	}
+	// Resolve agent role to node ID
+	return agentRoleToNodeId.get(toValue) ?? null;
+}
+
 // ============================================================================
 // WorkflowCanvas
 // ============================================================================
@@ -189,6 +310,13 @@ export function WorkflowCanvas({
 		}
 		return result;
 	}, [nodes, nodePositions]);
+
+	// ---- Channel edges ----
+	// Compute channel edges from nodes' channel declarations.
+	// Also merges with any explicitly passed channels prop (for backward compatibility).
+	const computedChannelEdges = useMemo(() => computeChannelEdges(nodes), [nodes]);
+	const effectiveChannels =
+		channels.length > 0 ? [...computedChannelEdges, ...channels] : computedChannelEdges;
 
 	// Clear selection if the selected node is removed externally (e.g. parent deletes it
 	// from the nodes array). Without this, a node re-added with the same stepId would
@@ -304,7 +432,7 @@ export function WorkflowCanvas({
 					selectedEdgeId={selectedEdgeId}
 					onEdgeSelect={handleEdgeSelect}
 					onEdgeDelete={handleEdgeDelete}
-					channels={channels}
+					channels={effectiveChannels}
 				/>
 				{dragState.active && dragState.fromPos && dragState.currentPos && (
 					<GhostEdge from={dragState.fromPos} to={dragState.currentPos} />
@@ -313,7 +441,7 @@ export function WorkflowCanvas({
 		),
 		[
 			transitions,
-			channels,
+			effectiveChannels,
 			effectiveNodePositions,
 			selectedEdgeId,
 			handleEdgeSelect,

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -461,3 +461,171 @@ describe('WorkflowCanvas — edge delete', () => {
 		expect(onDeleteEdge).not.toHaveBeenCalled();
 	});
 });
+
+// ---- Channel edges ----
+
+import { computeChannelEdges } from '../WorkflowCanvas';
+import type { WorkflowChannel } from '@neokai/shared';
+
+describe('computeChannelEdges', () => {
+	function makeAgentWithRole(id: string, role: string): SpaceAgent {
+		return { id, spaceId: 'space-1', name: role, role, createdAt: 0, updatedAt: 0 };
+	}
+
+	function makeNodeWithAgentsAndChannels(
+		localId: string,
+		name: string,
+		agents: SpaceAgent[],
+		channels?: WorkflowChannel[]
+	) {
+		return {
+			step: {
+				localId,
+				name,
+				agentId: agents[0]?.id ?? '',
+				agents: agents.map((a) => ({ agentId: a.id })),
+				channels,
+				instructions: '',
+			},
+			stepIndex: 0,
+			position: { x: 0, y: 0 },
+			agents,
+			isStartNode: false,
+		};
+	}
+
+	it('returns empty array when no nodes have channels', () => {
+		const agents = [makeAgentWithRole('agent-1', 'coder')];
+		const nodes = [
+			makeNodeWithAgentsAndChannels('step-1', 'Step One', agents),
+			makeNodeWithAgentsAndChannels('step-2', 'Step Two', agents),
+		];
+		const result = computeChannelEdges(nodes as any);
+		expect(result).toHaveLength(0);
+	});
+
+	it('extracts task-agent bidirectional channel as edge from task-agent to node', () => {
+		const agents = [makeAgentWithRole('agent-1', 'coder')];
+		const channels: WorkflowChannel[] = [
+			{ from: 'task-agent', to: 'coder', direction: 'bidirectional' },
+		];
+		const nodes = [makeNodeWithAgentsAndChannels('step-1', 'Step One', agents, channels)];
+		const result = computeChannelEdges(nodes as any);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			fromStepId: 'task-agent',
+			toStepId: 'step-1',
+			direction: 'bidirectional',
+		});
+	});
+
+	it('extracts task-agent one-way channel as edge from task-agent to node', () => {
+		const agents = [makeAgentWithRole('agent-1', 'coder')];
+		const channels: WorkflowChannel[] = [{ from: 'task-agent', to: 'coder', direction: 'one-way' }];
+		const nodes = [makeNodeWithAgentsAndChannels('step-1', 'Step One', agents, channels)];
+		const result = computeChannelEdges(nodes as any);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			fromStepId: 'task-agent',
+			toStepId: 'step-1',
+			direction: 'one-way',
+		});
+	});
+
+	it('skips intra-node channels (same from and to node)', () => {
+		const agents = [
+			makeAgentWithRole('agent-1', 'coder'),
+			makeAgentWithRole('agent-2', 'reviewer'),
+		];
+		// Channel within the same node - both coder and reviewer are in step-1
+		const channels: WorkflowChannel[] = [
+			{ from: 'coder', to: 'reviewer', direction: 'bidirectional' },
+		];
+		const nodes = [makeNodeWithAgentsAndChannels('step-1', 'Step One', agents, channels)];
+		const result = computeChannelEdges(nodes as any);
+		expect(result).toHaveLength(0);
+	});
+
+	it('handles wildcard to/from within same node as intra-node (skipped)', () => {
+		const agents = [makeAgentWithRole('agent-1', 'coder')];
+		const channels: WorkflowChannel[] = [{ from: '*', to: 'coder', direction: 'bidirectional' }];
+		const nodes = [makeNodeWithAgentsAndChannels('step-1', 'Step One', agents, channels)];
+		const result = computeChannelEdges(nodes as any);
+		// * to a role in same node = intra-node = skipped
+		expect(result).toHaveLength(0);
+	});
+
+	it('creates edge when channel.to is an array of roles', () => {
+		const agents = [
+			makeAgentWithRole('agent-1', 'coder'),
+			makeAgentWithRole('agent-2', 'reviewer'),
+		];
+		const channels: WorkflowChannel[] = [
+			{ from: 'task-agent', to: ['coder', 'reviewer'], direction: 'bidirectional' },
+		];
+		const nodes = [makeNodeWithAgentsAndChannels('step-1', 'Step One', agents, channels)];
+		const result = computeChannelEdges(nodes as any);
+		// Should create edges to both coder and reviewer roles
+		expect(result).toHaveLength(2);
+		expect(result).toContainEqual({
+			fromStepId: 'task-agent',
+			toStepId: 'step-1',
+			direction: 'bidirectional',
+		});
+	});
+
+	it('returns empty array when node has agents but channel references unknown role', () => {
+		const agents = [makeAgentWithRole('agent-1', 'coder')];
+		const channels: WorkflowChannel[] = [
+			{ from: 'task-agent', to: 'unknown-role', direction: 'bidirectional' },
+		];
+		const nodes = [makeNodeWithAgentsAndChannels('step-1', 'Step One', agents, channels)];
+		const result = computeChannelEdges(nodes as any);
+		// Unknown role can't be resolved, so edge is skipped
+		expect(result).toHaveLength(0);
+	});
+});
+
+describe('WorkflowCanvas — channel edge rendering', () => {
+	it('renders no channel edges when nodes have no channels', () => {
+		const { queryByTestId } = renderCanvas();
+		// No channel edges should be rendered
+		expect(queryByTestId('channel-edge-list')).toBeNull();
+	});
+
+	it('renders channel edges when nodes have task-agent channels', () => {
+		// Create nodes with task-agent channels
+		const agents = [makeAgent('agent-1', 'Coder')];
+		const nodesWithChannels: WorkflowNodeData[] = [
+			{
+				step: {
+					...makeStep('step-1', 'Step One'),
+					agentId: 'agent-1',
+					channels: [{ from: 'task-agent', to: 'coder', direction: 'bidirectional' }],
+				},
+				stepIndex: 1,
+				position: { x: 10, y: 10 },
+				agents,
+				isStartNode: false,
+			},
+		];
+
+		function WrapperWithChannels() {
+			const [vp, setVp] = useState<ViewportState>(VP);
+			return (
+				<WorkflowCanvas
+					nodes={nodesWithChannels}
+					viewportState={vp}
+					onViewportChange={setVp}
+					onNodeSelect={() => {}}
+					onDeleteNode={() => {}}
+				/>
+			);
+		}
+
+		const { container } = render(<WrapperWithChannels />);
+		// Should have channel edge elements
+		const channelEdges = container.querySelectorAll('[data-channel-edge]');
+		expect(channelEdges.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -565,9 +565,10 @@ describe('computeChannelEdges', () => {
 		];
 		const nodes = [makeNodeWithAgentsAndChannels('step-1', 'Step One', agents, channels)];
 		const result = computeChannelEdges(nodes as any);
-		// Should create edges to both coder and reviewer roles
-		expect(result).toHaveLength(2);
-		expect(result).toContainEqual({
+		// Both coder and reviewer roles are in the same node (step-1),
+		// so both resolve to the same target - only one edge is created
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
 			fromStepId: 'task-agent',
 			toStepId: 'step-1',
 			direction: 'bidirectional',
@@ -583,6 +584,46 @@ describe('computeChannelEdges', () => {
 		const result = computeChannelEdges(nodes as any);
 		// Unknown role can't be resolved, so edge is skipped
 		expect(result).toHaveLength(0);
+	});
+
+	it('creates inter-node edge between two regular (non-task-agent) nodes', () => {
+		// Node A has coder, Node B has reviewer
+		// Channel: coder -> reviewer (bidirectional) defined on Node A
+		const nodeAAgents = [makeAgentWithRole('agent-1', 'coder')];
+		const nodeBAgents = [makeAgentWithRole('agent-2', 'reviewer')];
+		const nodeAChannels: WorkflowChannel[] = [
+			{ from: 'coder', to: 'reviewer', direction: 'bidirectional' },
+		];
+		const nodes = [
+			makeNodeWithAgentsAndChannels('node-a', 'Node A', nodeAAgents, nodeAChannels),
+			makeNodeWithAgentsAndChannels('node-b', 'Node B', nodeBAgents, []),
+		];
+		const result = computeChannelEdges(nodes as any);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			fromStepId: 'node-a',
+			toStepId: 'node-b',
+			direction: 'bidirectional',
+		});
+	});
+
+	it('deduplicates edges when same (from, to) pair appears multiple times', () => {
+		// Two nodes both have channels to the same task-agent role
+		const nodeAAgents = [makeAgentWithRole('agent-1', 'coder')];
+		const nodeBAgents = [makeAgentWithRole('agent-2', 'reviewer')];
+		const nodeAChannels: WorkflowChannel[] = [
+			{ from: 'task-agent', to: 'coder', direction: 'bidirectional' },
+		];
+		const nodeBChannels: WorkflowChannel[] = [
+			{ from: 'task-agent', to: 'reviewer', direction: 'bidirectional' },
+		];
+		const nodes = [
+			makeNodeWithAgentsAndChannels('node-a', 'Node A', nodeAAgents, nodeAChannels),
+			makeNodeWithAgentsAndChannels('node-b', 'Node B', nodeBAgents, nodeBChannels),
+		];
+		const result = computeChannelEdges(nodes as any);
+		// Each node should have its own edge to task-agent - no duplicates
+		expect(result).toHaveLength(2);
 	});
 });
 


### PR DESCRIPTION
- Move channel edge computation into WorkflowCanvas from nodes data
- Compute channel edges from step.channels on each node
- Resolve agent roles to node IDs for inter-node channels
- Skip intra-node channels (same node for from/to)
- Support both task-agent and regular node-to-node channels
- Render arrowheads based on direction (bidirectional vs one-way)
- Bidirectional: arrowhead on both ends (↔)
- One-way: arrowhead only on target end (→)
- Maintain backward compatibility with optional channelEdges prop
- Remove redundant channelEdges computation from VisualWorkflowEditor
- Add unit tests for computeChannelEdges function

Test plan:
- 36 tests pass in WorkflowCanvas test file
- Typecheck and lint clean
