### PR TITLE
refactor: rename step → node in storage repositories

### DIFF
--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -437,8 +437,8 @@ export class WorkflowExecutor {
 			}
 		}
 
-		// Persist new currentStepId
-		const updatedRun = this.workflowRunRepo.updateCurrentStep(this.run.id, nextStep.id);
+		// Persist new currentNodeId
+		const updatedRun = this.workflowRunRepo.updateCurrentNode(this.run.id, nextStep.id);
 		if (!updatedRun) throw new Error('Failed to persist step ID update');
 		this.run = updatedRun;
 

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -47,7 +47,7 @@ interface WorkflowRow {
 	updated_at: number;
 }
 
-interface StepRow {
+interface NodeRow {
 	id: string;
 	workflow_id: string;
 	name: string;
@@ -78,7 +78,7 @@ interface WorkflowConfigJson {
 }
 
 // JSON stored inside space_workflow_nodes.config
-interface StepConfigJson {
+interface NodeConfigJson {
 	instructions?: string;
 	/** Multi-agent array — present when the node uses the agents[] format */
 	agents?: WorkflowNodeAgent[];
@@ -99,8 +99,8 @@ function parseJson<T>(raw: string | null | undefined, fallback: T): T {
 	}
 }
 
-function rowToNode(row: StepRow): WorkflowNode {
-	const cfg = parseJson<StepConfigJson>(row.config, {});
+function rowToNode(row: NodeRow): WorkflowNode {
+	const cfg = parseJson<NodeConfigJson>(row.config, {});
 	const node: WorkflowNode = {
 		id: row.id,
 		name: row.name,
@@ -399,7 +399,7 @@ export class SpaceWorkflowRepository {
 			.prepare(
 				`SELECT * FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY order_index ASC, rowid ASC`
 			)
-			.all(workflowId) as StepRow[];
+			.all(workflowId) as NodeRow[];
 		return rows.map(rowToNode);
 	}
 
@@ -419,7 +419,7 @@ export class SpaceWorkflowRepository {
 		index: number,
 		now: number
 	): void {
-		const nodeCfg: StepConfigJson = {
+		const nodeCfg: NodeConfigJson = {
 			instructions: input.instructions,
 		};
 		// Persist agents and channels into the JSON config column so they survive round-trips.

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -166,10 +166,10 @@ export class SpaceWorkflowRunRepository {
 	}
 
 	/**
-	 * Advance the current step ID for a run
+	 * Advance the current node ID for a run
 	 */
-	updateCurrentStep(id: string, stepId: string): SpaceWorkflowRun | null {
-		return this.updateRun(id, { currentNodeId: stepId });
+	updateCurrentNode(id: string, nodeId: string): SpaceWorkflowRun | null {
+		return this.updateRun(id, { currentNodeId: nodeId });
 	}
 
 	/**

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -163,11 +163,11 @@ describe('SpaceWorkflowRunRepository', () => {
 		});
 	});
 
-	describe('updateCurrentStep', () => {
-		it('updates the current step ID', () => {
+	describe('updateCurrentNode', () => {
+		it('updates the current node ID', () => {
 			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
-			const updated = repo.updateCurrentStep(run.id, 'step-abc');
-			expect(updated!.currentNodeId).toBe('step-abc');
+			const updated = repo.updateCurrentNode(run.id, 'node-abc');
+			expect(updated!.currentNodeId).toBe('node-abc');
 		});
 	});
 
@@ -274,12 +274,12 @@ describe('SpaceWorkflowRunRepository', () => {
 			});
 
 			repo.updateStatus(run.id, 'in_progress');
-			repo.updateCurrentStep(run.id, 'step-xyz');
+			repo.updateCurrentNode(run.id, 'node-xyz');
 
 			const updated = repo.getRun(run.id)!;
 			expect(updated.goalId).toBe('goal-456');
 			expect(updated.status).toBe('in_progress');
-			expect(updated.currentNodeId).toBe('step-xyz');
+			expect(updated.currentNodeId).toBe('node-xyz');
 		});
 
 		it('goalId is included when listing runs by space', () => {


### PR DESCRIPTION
- Rename internal StepRow → NodeRow and StepConfigJson → NodeConfigJson
  in space-workflow-repository.ts
- Rename updateCurrentStep → updateCurrentNode in
  space-workflow-run-repository.ts (and update caller in workflow-executor.ts)
- Update tests to match new method name

All 784 storage unit tests pass.
