### PR TITLE
refactor: update step→node terminology in runtime comments and export-format

### DIFF
--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -263,9 +263,8 @@ export function exportWorkflow(
 		return exported;
 	});
 
-	// Export startNodeId UUID → node name (support both new startNodeId and legacy startStepId)
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const startId = workflow.startNodeId ?? (workflow as any).startStepId;
+	// Export startNodeId UUID → node name
+	const startId = workflow.startNodeId;
 	const startNode = nodeIdToName.get(startId) ?? startId;
 
 	// Export rules — strip `id`, remap appliesTo node UUIDs → node names

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -484,7 +484,7 @@ export class SpaceRuntime {
 	 * then rehydrates Task Agent sessions if a TaskAgentManager is configured.
 	 *
 	 * Called once at the start of the first executeTick(). Reconstructs
-	 * executors with the run's persisted currentStepId so the tick loop can
+	 * executors with the run's persisted currentNodeId so the tick loop can
 	 * resume advancement from where it left off.
 	 *
 	 * Executor rehydration runs first so that SpaceRuntimeService executors are
@@ -596,7 +596,7 @@ export class SpaceRuntime {
 
 		const currentStep = freshExecutor.getCurrentStep();
 		if (!currentStep) {
-			// Run is in_progress but currentStepId references a step that doesn't exist in
+			// Run is in_progress but currentNodeId references a node that doesn't exist in
 			// the workflow. This is a data inconsistency — cancel the run and clean up maps
 			// so it is not rehydrated on every subsequent restart into the same throw loop.
 			this.executors.delete(runId);

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -9,7 +9,7 @@
  * - Condition evaluation for transitions (always, human, condition)
  * - Timeout enforcement on condition-type transitions
  * - Retry logic: re-evaluate condition only (NOT re-run agent)
- * - Persisting currentStepId on SpaceWorkflowRun after advance
+ * - Persisting currentNodeId on SpaceWorkflowRun after advance
  * - Creating SpaceTask DB records (pending only) — does NOT spawn sessions
  *
  * advance() evaluates outgoing transitions from the current step in ascending
@@ -295,7 +295,7 @@ export class WorkflowExecutor {
 	 *   2. Get outgoing transitions from current step (sorted by order)
 	 *   3. If no transitions → mark run completed, return { step: current, tasks: [] }
 	 *   4. Evaluate each transition's condition (with retry) until one passes
-	 *   5. Persist currentStepId pointing to the transition's target step
+	 *   5. Persist currentNodeId pointing to the transition's target node
 	 *   6. Create a pending SpaceTask for the target step
 	 *
 	 * If no transition's condition passes, the run is set to 'needs_attention'
@@ -403,9 +403,9 @@ export class WorkflowExecutor {
 	}
 
 	/**
-	 * Follows a transition: updates currentStepId and creates one SpaceTask per agent
-	 * in the target step. Multi-agent steps produce multiple parallel tasks, all sharing
-	 * the same `workflowRunId` and `workflowStepId`. Single-agent steps produce one task.
+	 * Follows a transition: updates currentNodeId and creates one SpaceTask per agent
+	 * in the target node. Multi-agent nodes produce multiple parallel tasks, all sharing
+	 * the same `workflowRunId` and `workflowNodeId`. Single-agent nodes produce one task.
 	 */
 	private async followTransition(
 		transition: WorkflowTransition
@@ -437,7 +437,7 @@ export class WorkflowExecutor {
 			}
 		}
 
-		// Persist new currentStepId
+		// Persist new currentNodeId
 		const updatedRun = this.workflowRunRepo.updateCurrentStep(this.run.id, nextStep.id);
 		if (!updatedRun) throw new Error('Failed to persist step ID update');
 		this.run = updatedRun;
@@ -447,7 +447,7 @@ export class WorkflowExecutor {
 		const stepAgents = resolveNodeAgents(nextStep);
 
 		// Create one pending SpaceTask per agent. All tasks share the same workflowRunId
-		// and workflowStepId so SpaceRuntime can track them as a group.
+		// and workflowNodeId so SpaceRuntime can track them as a group.
 		// Per-agent instructions override step-level instructions when present.
 		const tasks: SpaceTask[] = [];
 		for (const agentEntry of stepAgents) {


### PR DESCRIPTION
- Update comments in workflow-executor.ts: currentStepId→currentNodeId,
  workflowStepId→workflowNodeId in JSDoc and inline comments
- Update comments in space-runtime.ts: currentStepId→currentNodeId
- Remove legacy startStepId fallback from export-format.ts (dead code
  since migration 45 renamed all DB columns to node terminology)

Completes acceptance criteria: zero references to WorkflowStep,
currentStepId, workflowStepId, or startStepId in packages/daemon/src/
