### PR TITLE
feat: rename WorkflowStepCard to WorkflowNodeCard and update all references

### DIFF
--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -5,7 +5,7 @@
  *
  * Features:
  * - Name and description fields
- * - Vertical step list with expandable WorkflowStepCards
+ * - Vertical step list with expandable WorkflowNodeCards
  * - Add Step button
  * - "Start from template" options
  * - Save / Cancel
@@ -15,8 +15,8 @@ import { useState } from 'preact/hooks';
 import type { SpaceWorkflow, SpaceAgent } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
-import { WorkflowStepCard } from './WorkflowStepCard';
-import type { StepDraft, ConditionDraft } from './WorkflowStepCard';
+import { WorkflowNodeCard } from './WorkflowNodeCard';
+import type { StepDraft, ConditionDraft } from './WorkflowNodeCard';
 import { WorkflowRulesEditor } from './WorkflowRulesEditor';
 import type { RuleDraft } from './WorkflowRulesEditor';
 import { rulesToDrafts } from './WorkflowRulesEditor';
@@ -520,7 +520,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 
 					<div class="space-y-2">
 						{steps.map((step, i) => (
-							<WorkflowStepCard
+							<WorkflowNodeCard
 								key={step.localId}
 								step={step}
 								stepIndex={i}

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -16,7 +16,7 @@ import type { SpaceWorkflow, SpaceAgent } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 import { WorkflowNodeCard } from './WorkflowNodeCard';
-import type { StepDraft, ConditionDraft } from './WorkflowNodeCard';
+import type { NodeDraft, ConditionDraft } from './WorkflowNodeCard';
 import { WorkflowRulesEditor } from './WorkflowRulesEditor';
 import type { RuleDraft } from './WorkflowRulesEditor';
 import { rulesToDrafts } from './WorkflowRulesEditor';
@@ -63,7 +63,7 @@ function makeLocalId(): string {
 	return generateUUID();
 }
 
-function makeEmptyStep(): StepDraft {
+function makeEmptyStep(): NodeDraft {
 	return { localId: makeLocalId(), name: '', agentId: '', instructions: '' };
 }
 
@@ -90,20 +90,20 @@ export function filterAgents(agents: SpaceAgent[]): SpaceAgent[] {
  * Defined outside the component so it is not recreated on each render and
  * is clearly a pure initialization helper, not a reactive dependency.
  *
- * NOTE (Milestone 5): `StepDraft` only carries `agentId` (single-agent format).
+ * NOTE (Milestone 5): `NodeDraft` only carries `agentId` (single-agent format).
  * Multi-agent steps (`agents[]`) and `channels[]` are silently dropped when a workflow
  * is loaded into the editor. Saving such a workflow through the UI would overwrite those
  * fields with the single-agent representation. There is no UI to create multi-agent steps
  * yet, so the practical risk is limited to API-created workflows opened in this editor.
  */
 export function initFromWorkflow(wf: SpaceWorkflow): {
-	steps: StepDraft[];
+	steps: NodeDraft[];
 	transitions: ConditionDraft[];
 	rules: RuleDraft[];
 	tags: string[];
 } {
 	const stepMap = new Map(wf.nodes.map((s) => [s.id, s]));
-	const ordered: StepDraft[] = [];
+	const ordered: NodeDraft[] = [];
 	const visited = new Set<string>();
 	let currentId: string | undefined = wf.startNodeId;
 
@@ -175,7 +175,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 
 	const [name, setName] = useState(workflow?.name ?? '');
 	const [description, setDescription] = useState(workflow?.description ?? '');
-	const [steps, setSteps] = useState<StepDraft[]>(initial?.steps ?? [makeEmptyStep()]);
+	const [steps, setSteps] = useState<NodeDraft[]>(initial?.steps ?? [makeEmptyStep()]);
 	const [transitions, setTransitions] = useState<ConditionDraft[]>(initial?.transitions ?? []);
 	const [rules, setRules] = useState<RuleDraft[]>(initial?.rules ?? []);
 	const [tags, setTags] = useState<string[]>(initial?.tags ?? []);
@@ -231,7 +231,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 		setExpandedIndex(other);
 	}
 
-	function updateStep(index: number, step: StepDraft) {
+	function updateStep(index: number, step: NodeDraft) {
 		setSteps((prev) => prev.map((s, i) => (i === index ? step : s)));
 	}
 
@@ -273,7 +273,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 	// ---- Template ----
 
 	function applyTemplate(template: WorkflowTemplate) {
-		const newSteps: StepDraft[] = template.stepRoles.map((role) => {
+		const newSteps: NodeDraft[] = template.stepRoles.map((role) => {
 			const found = agents.find(
 				(a) => a.name.toLowerCase() === role || a.role.toLowerCase() === role
 			);
@@ -522,8 +522,8 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 						{steps.map((step, i) => (
 							<WorkflowNodeCard
 								key={step.localId}
-								step={step}
-								stepIndex={i}
+								node={step}
+								nodeIndex={i}
 								isFirst={i === 0}
 								isLast={i === steps.length - 1}
 								expanded={expandedIndex === i}

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -1,7 +1,7 @@
 /**
- * WorkflowStepCard Component
+ * WorkflowNodeCard Component
  *
- * A single step card in the workflow editor.
+ * A single node card in the workflow editor.
  * Supports collapsed (summary) and expanded (edit) modes.
  *
  * Collapsed: step number, agent name, gate type icons
@@ -15,7 +15,7 @@ import { GateConfig, CONDITION_LABELS } from './visual-editor/GateConfig';
 import type { ConditionDraft } from './visual-editor/GateConfig';
 
 // ============================================================================
-// Draft Types (used by WorkflowEditor + WorkflowStepCard)
+// Draft Types (used by WorkflowEditor + WorkflowNodeCard)
 // ============================================================================
 
 export interface StepDraft {
@@ -37,7 +37,7 @@ export interface StepDraft {
 // Multi-agent helpers
 // ============================================================================
 
-/** Returns true when this step has multiple agents configured. */
+/** Returns true when this node has multiple agents configured. */
 export function isMultiAgentStep(step: StepDraft): boolean {
 	return Array.isArray(step.agents) && step.agents.length > 0;
 }
@@ -142,7 +142,7 @@ function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
 		const next = stepAgents.filter((a) => a.agentId !== agentId);
 		if (next.length === 0) {
 			// Switch back to single-agent mode: restore agentId from the removed agent and
-			// clear channels (orphaned channels on a single-agent step are semantically invalid)
+			// clear channels (orphaned channels on a single-agent node are semantically invalid)
 			onUpdate({ ...step, agents: undefined, agentId, channels: undefined });
 		} else {
 			updateAgents(next);
@@ -438,15 +438,15 @@ function ChannelFormBody({ knownRoles, onAdd }: ChannelFormBodyProps) {
 // Main Component
 // ============================================================================
 
-interface WorkflowStepCardProps {
+interface WorkflowNodeCardProps {
 	step: StepDraft;
 	stepIndex: number;
 	isFirst: boolean;
 	isLast: boolean;
 	expanded: boolean;
-	/** Condition on the transition coming INTO this step. Null for the first step. */
+	/** Condition on the transition coming INTO this node. Null for the first node. */
 	entryCondition: ConditionDraft | null;
-	/** Condition on the transition going OUT from this step. Null for the last step. */
+	/** Condition on the transition going OUT from this node. Null for the last node. */
 	exitCondition: ConditionDraft | null;
 	/** All space agents, excluding 'leader' */
 	agents: SpaceAgent[];
@@ -459,11 +459,11 @@ interface WorkflowStepCardProps {
 	onMoveUp: () => void;
 	onMoveDown: () => void;
 	onRemove: () => void;
-	/** When true, the Remove button is disabled (e.g. only one step remains) */
+	/** When true, the Remove button is disabled (e.g. only one node remains) */
 	disableRemove?: boolean;
 }
 
-export function WorkflowStepCard({
+export function WorkflowNodeCard({
 	step,
 	stepIndex,
 	isFirst,
@@ -480,7 +480,7 @@ export function WorkflowStepCard({
 	onMoveDown,
 	onRemove,
 	disableRemove = false,
-}: WorkflowStepCardProps) {
+}: WorkflowNodeCardProps) {
 	const multi = isMultiAgentStep(step);
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
 
@@ -503,7 +503,7 @@ export function WorkflowStepCard({
 				<div class="flex-1 min-w-0">
 					<div class="flex items-center gap-1.5 min-w-0 flex-wrap">
 						<span class="text-xs font-medium text-gray-200 truncate">
-							{step.name || 'Unnamed Step'}
+							{step.name || 'Unnamed Node'}
 						</span>
 						<span class="text-xs text-gray-600 flex-shrink-0">·</span>
 						{multi ? (
@@ -562,7 +562,7 @@ export function WorkflowStepCard({
 						onClick={onRemove}
 						disabled={disableRemove}
 						class="p-1 rounded text-gray-600 hover:text-red-400 hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-						title="Remove step"
+						title="Remove node"
 					>
 						<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 							<path
@@ -586,7 +586,7 @@ export function WorkflowStepCard({
 				<div class="px-4 py-4 bg-dark-900 space-y-4">
 					{/* Name */}
 					<div class="space-y-1">
-						<label class="text-xs font-medium text-gray-400">Step Name</label>
+						<label class="text-xs font-medium text-gray-400">Node Name</label>
 						<input
 							type="text"
 							value={step.name}
@@ -664,7 +664,7 @@ export function WorkflowStepCard({
 									instructions: (e.currentTarget as HTMLTextAreaElement).value,
 								})
 							}
-							placeholder="Step-specific instructions appended to the agent's system prompt…"
+							placeholder="Node-specific instructions appended to the agent's system prompt…"
 							rows={4}
 							class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
 						/>

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -18,7 +18,7 @@ import type { ConditionDraft } from './visual-editor/GateConfig';
 // Draft Types (used by WorkflowEditor + WorkflowNodeCard)
 // ============================================================================
 
-export interface StepDraft {
+export interface NodeDraft {
 	/** Stable local key for React rendering — not sent to the server */
 	localId: string;
 	/** Existing step ID when editing an existing workflow */
@@ -38,8 +38,8 @@ export interface StepDraft {
 // ============================================================================
 
 /** Returns true when this node has multiple agents configured. */
-export function isMultiAgentStep(step: StepDraft): boolean {
-	return Array.isArray(step.agents) && step.agents.length > 0;
+export function isMultiAgentNode(node: NodeDraft): boolean {
+	return Array.isArray(node.agents) && node.agents.length > 0;
 }
 
 // Re-export ConditionDraft so existing importers don't break
@@ -120,30 +120,30 @@ function ChevronUp() {
 // ============================================================================
 
 interface MultiAgentSectionProps {
-	step: StepDraft;
+	node: NodeDraft;
 	agents: SpaceAgent[];
-	onUpdate: (step: StepDraft) => void;
+	onUpdate: (node: NodeDraft) => void;
 }
 
-function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
-	const stepAgents = step.agents ?? [];
+function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
+	const nodeAgents = node.agents ?? [];
 
 	function updateAgents(next: WorkflowNodeAgent[]) {
-		onUpdate({ ...step, agents: next, agentId: '' });
+		onUpdate({ ...node, agents: next, agentId: '' });
 	}
 
 	function addAgent(agentId: string) {
 		if (!agentId) return;
-		if (stepAgents.some((a) => a.agentId === agentId)) return;
-		updateAgents([...stepAgents, { agentId }]);
+		if (nodeAgents.some((a) => a.agentId === agentId)) return;
+		updateAgents([...nodeAgents, { agentId }]);
 	}
 
 	function removeAgent(agentId: string) {
-		const next = stepAgents.filter((a) => a.agentId !== agentId);
+		const next = nodeAgents.filter((a) => a.agentId !== agentId);
 		if (next.length === 0) {
 			// Switch back to single-agent mode: restore agentId from the removed agent and
 			// clear channels (orphaned channels on a single-agent node are semantically invalid)
-			onUpdate({ ...step, agents: undefined, agentId, channels: undefined });
+			onUpdate({ ...node, agents: undefined, agentId, channels: undefined });
 		} else {
 			updateAgents(next);
 		}
@@ -151,29 +151,29 @@ function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
 
 	function updateAgentInstructions(agentId: string, instructions: string) {
 		updateAgents(
-			stepAgents.map((a) =>
+			nodeAgents.map((a) =>
 				a.agentId === agentId ? { ...a, instructions: instructions || undefined } : a
 			)
 		);
 	}
 
-	const usedIds = new Set(stepAgents.map((a) => a.agentId));
+	const usedIds = new Set(nodeAgents.map((a) => a.agentId));
 	const availableAgents = agents.filter((a) => !usedIds.has(a.id));
 
 	return (
 		<div class="space-y-2">
 			<div class="flex items-center justify-between">
 				<label class="text-xs font-medium text-gray-400">
-					Agents <span class="text-gray-600">({stepAgents.length})</span>
+					Agents <span class="text-gray-600">({nodeAgents.length})</span>
 				</label>
-				{stepAgents.length === 1 && (
+				{nodeAgents.length === 1 && (
 					<button
 						type="button"
 						onClick={() =>
 							onUpdate({
-								...step,
+								...node,
 								agents: undefined,
-								agentId: stepAgents[0]?.agentId ?? '',
+								agentId: nodeAgents[0]?.agentId ?? '',
 								channels: undefined,
 							})
 						}
@@ -186,7 +186,7 @@ function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
 
 			{/* Agent list */}
 			<div class="space-y-1.5">
-				{stepAgents.map((sa) => {
+				{nodeAgents.map((sa) => {
 					const agentInfo = agents.find((a) => a.id === sa.agentId);
 					return (
 						<div key={sa.agentId} class="bg-dark-800 border border-dark-600 rounded p-2 space-y-1">
@@ -245,7 +245,7 @@ function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
 			)}
 
 			{/* Channels section */}
-			<ChannelsSection step={step} agents={agents} onUpdate={onUpdate} />
+			<ChannelsSection node={node} agents={agents} onUpdate={onUpdate} />
 		</div>
 	);
 }
@@ -255,9 +255,9 @@ function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
 // ============================================================================
 
 interface ChannelsSectionProps {
-	step: StepDraft;
+	node: NodeDraft;
 	agents: SpaceAgent[];
-	onUpdate: (step: StepDraft) => void;
+	onUpdate: (node: NodeDraft) => void;
 }
 
 /** Human-readable label for a channel direction. */
@@ -270,18 +270,18 @@ function formatTo(to: string | string[]): string {
 	return Array.isArray(to) ? `[${to.join(', ')}]` : to;
 }
 
-function ChannelsSection({ step, agents, onUpdate }: ChannelsSectionProps) {
-	const channels = step.channels ?? [];
-	const stepAgents = step.agents ?? [];
+function ChannelsSection({ node, agents, onUpdate }: ChannelsSectionProps) {
+	const channels = node.channels ?? [];
+	const nodeAgents = node.agents ?? [];
 
-	// Collect known roles from step agents (+ wildcard)
+	// Collect known roles from node agents (+ wildcard)
 	const knownRoles = [
 		'*',
-		...stepAgents.map((sa) => agents.find((a) => a.id === sa.agentId)?.role ?? sa.agentId),
+		...nodeAgents.map((sa) => agents.find((a) => a.id === sa.agentId)?.role ?? sa.agentId),
 	];
 
 	function updateChannels(next: WorkflowChannel[]) {
-		onUpdate({ ...step, channels: next.length > 0 ? next : undefined });
+		onUpdate({ ...node, channels: next.length > 0 ? next : undefined });
 	}
 
 	function removeChannel(index: number) {
@@ -439,8 +439,8 @@ function ChannelFormBody({ knownRoles, onAdd }: ChannelFormBodyProps) {
 // ============================================================================
 
 interface WorkflowNodeCardProps {
-	step: StepDraft;
-	stepIndex: number;
+	node: NodeDraft;
+	nodeIndex: number;
 	isFirst: boolean;
 	isLast: boolean;
 	expanded: boolean;
@@ -451,10 +451,10 @@ interface WorkflowNodeCardProps {
 	/** All space agents, excluding 'leader' */
 	agents: SpaceAgent[];
 	onToggleExpand: () => void;
-	onUpdate: (step: StepDraft) => void;
-	/** Called when entry condition changes — updates transition[stepIndex-1] */
+	onUpdate: (node: NodeDraft) => void;
+	/** Called when entry condition changes — updates transition[nodeIndex-1] */
 	onUpdateEntryCondition: (cond: ConditionDraft) => void;
-	/** Called when exit condition changes — updates transition[stepIndex] */
+	/** Called when exit condition changes — updates transition[nodeIndex] */
 	onUpdateExitCondition: (cond: ConditionDraft) => void;
 	onMoveUp: () => void;
 	onMoveDown: () => void;
@@ -464,8 +464,8 @@ interface WorkflowNodeCardProps {
 }
 
 export function WorkflowNodeCard({
-	step,
-	stepIndex,
+	node,
+	nodeIndex,
 	isFirst,
 	isLast,
 	expanded,
@@ -481,8 +481,8 @@ export function WorkflowNodeCard({
 	onRemove,
 	disableRemove = false,
 }: WorkflowNodeCardProps) {
-	const multi = isMultiAgentStep(step);
-	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
+	const multi = isMultiAgentNode(node);
+	const agentName = agents.find((a) => a.id === node.agentId)?.name ?? node.agentId;
 
 	return (
 		<div class="border border-dark-700 rounded-lg overflow-hidden">
@@ -496,19 +496,19 @@ export function WorkflowNodeCard({
 			>
 				{/* Step number */}
 				<span class="w-5 h-5 flex items-center justify-center rounded-full bg-dark-700 text-xs font-semibold text-gray-400 flex-shrink-0">
-					{stepIndex + 1}
+					{nodeIndex + 1}
 				</span>
 
 				{/* Step info */}
 				<div class="flex-1 min-w-0">
 					<div class="flex items-center gap-1.5 min-w-0 flex-wrap">
 						<span class="text-xs font-medium text-gray-200 truncate">
-							{step.name || 'Unnamed Node'}
+							{node.name || 'Unnamed Node'}
 						</span>
 						<span class="text-xs text-gray-600 flex-shrink-0">·</span>
 						{multi ? (
 							<span class="flex items-center gap-1 flex-wrap">
-								{step.agents!.map((a) => {
+								{node.agents!.map((a) => {
 									const name = agents.find((ag) => ag.id === a.agentId)?.name ?? a.agentId;
 									return (
 										<span
@@ -589,9 +589,9 @@ export function WorkflowNodeCard({
 						<label class="text-xs font-medium text-gray-400">Node Name</label>
 						<input
 							type="text"
-							value={step.name}
+							value={node.name}
 							onInput={(e) =>
-								onUpdate({ ...step, name: (e.currentTarget as HTMLInputElement).value })
+								onUpdate({ ...node, name: (e.currentTarget as HTMLInputElement).value })
 							}
 							placeholder="e.g. Plan the approach"
 							class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700"
@@ -600,7 +600,7 @@ export function WorkflowNodeCard({
 
 					{/* Agent(s) */}
 					{multi ? (
-						<MultiAgentSection step={step} agents={agents} onUpdate={onUpdate} />
+						<MultiAgentSection node={node} agents={agents} onUpdate={onUpdate} />
 					) : (
 						<div class="space-y-1">
 							<div class="flex items-center justify-between">
@@ -608,9 +608,9 @@ export function WorkflowNodeCard({
 								<button
 									type="button"
 									onClick={() => {
-										const firstId = step.agentId;
+										const firstId = node.agentId;
 										const existing: WorkflowNodeAgent[] = firstId ? [{ agentId: firstId }] : [];
-										onUpdate({ ...step, agents: existing, agentId: '' });
+										onUpdate({ ...node, agents: existing, agentId: '' });
 									}}
 									class="text-xs text-blue-400 hover:text-blue-300 transition-colors"
 								>
@@ -618,9 +618,9 @@ export function WorkflowNodeCard({
 								</button>
 							</div>
 							<select
-								value={step.agentId}
+								value={node.agentId}
 								onChange={(e) =>
-									onUpdate({ ...step, agentId: (e.currentTarget as HTMLSelectElement).value })
+									onUpdate({ ...node, agentId: (e.currentTarget as HTMLSelectElement).value })
 								}
 								class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
 							>
@@ -657,10 +657,10 @@ export function WorkflowNodeCard({
 							Instructions <span class="font-normal text-gray-600">(optional)</span>
 						</label>
 						<textarea
-							value={step.instructions}
+							value={node.instructions}
 							onInput={(e) =>
 								onUpdate({
-									...step,
+									...node,
 									instructions: (e.currentTarget as HTMLTextAreaElement).value,
 								})
 							}

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -6,7 +6,7 @@
  * - Add step button adds a new step card
  * - Remove step removes the card
  * - Reorder: move up / move down
- * - Agent dropdown (via WorkflowStepCard) excludes 'leader' agent
+ * - Agent dropdown (via WorkflowNodeCard) excludes 'leader' agent
  * - Template selection pre-fills steps
  * - Save calls spaceStore.createWorkflow with correct params
  * - Save calls spaceStore.updateWorkflow when editing

--- a/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
@@ -16,7 +16,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import type { SpaceAgent } from '@neokai/shared';
 import { WorkflowNodeCard } from '../WorkflowNodeCard';
-import type { StepDraft, ConditionDraft } from '../WorkflowNodeCard';
+import type { NodeDraft, ConditionDraft } from '../WorkflowNodeCard';
 
 vi.mock('../../../lib/utils', () => ({
 	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
@@ -33,7 +33,7 @@ function makeAgent(id: string, name: string, role = 'coder'): SpaceAgent {
 	};
 }
 
-function makeStep(overrides: Partial<StepDraft> = {}): StepDraft {
+function makeStep(overrides: Partial<NodeDraft> = {}): NodeDraft {
 	return {
 		localId: 'local-1',
 		name: 'My Step',
@@ -51,8 +51,8 @@ const defaultAgents: SpaceAgent[] = [
 
 function makeProps(overrides: Partial<Parameters<typeof WorkflowNodeCard>[0]> = {}) {
 	return {
-		step: makeStep(),
-		stepIndex: 1,
+		node: makeStep(),
+		nodeIndex: 1,
 		isFirst: false,
 		isLast: false,
 		expanded: false,
@@ -77,7 +77,7 @@ describe('WorkflowNodeCard', () => {
 
 	describe('collapsed view', () => {
 		it('renders step number (1-based)', () => {
-			const { getByText } = render(<WorkflowNodeCard {...makeProps({ stepIndex: 2 })} />);
+			const { getByText } = render(<WorkflowNodeCard {...makeProps({ nodeIndex: 2 })} />);
 			expect(getByText('3')).toBeTruthy();
 		});
 
@@ -88,16 +88,16 @@ describe('WorkflowNodeCard', () => {
 
 		it('renders step name in collapsed view', () => {
 			const { getByText } = render(
-				<WorkflowNodeCard {...makeProps({ step: makeStep({ name: 'My Awesome Step' }) })} />
+				<WorkflowNodeCard {...makeProps({ node: makeStep({ name: 'My Awesome Step' }) })} />
 			);
 			expect(getByText('My Awesome Step')).toBeTruthy();
 		});
 
-		it('shows "Unnamed Step" when name is empty', () => {
+		it('shows "Unnamed Node" when name is empty', () => {
 			const { getByText } = render(
-				<WorkflowNodeCard {...makeProps({ step: makeStep({ name: '' }) })} />
+				<WorkflowNodeCard {...makeProps({ node: makeStep({ name: '' }) })} />
 			);
-			expect(getByText('Unnamed Step')).toBeTruthy();
+			expect(getByText('Unnamed Node')).toBeTruthy();
 		});
 
 		it('calls onToggleExpand when header clicked', () => {
@@ -135,18 +135,18 @@ describe('WorkflowNodeCard', () => {
 		it('calls onRemove when remove button clicked', () => {
 			const onRemove = vi.fn();
 			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ onRemove })} />);
-			fireEvent.click(getByTitle('Remove step'));
+			fireEvent.click(getByTitle('Remove node'));
 			expect(onRemove).toHaveBeenCalledOnce();
 		});
 
 		it('disables Remove button when disableRemove is true', () => {
 			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ disableRemove: true })} />);
-			expect((getByTitle('Remove step') as HTMLButtonElement).disabled).toBe(true);
+			expect((getByTitle('Remove node') as HTMLButtonElement).disabled).toBe(true);
 		});
 
 		it('enables Remove button when disableRemove is false', () => {
 			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ disableRemove: false })} />);
-			expect((getByTitle('Remove step') as HTMLButtonElement).disabled).toBe(false);
+			expect((getByTitle('Remove node') as HTMLButtonElement).disabled).toBe(false);
 		});
 
 		it('shows human gate icon when entry condition is human', () => {
@@ -205,7 +205,9 @@ describe('WorkflowNodeCard', () => {
 
 		it('shows currently selected agent in dropdown', () => {
 			const step = makeStep({ agentId: 'agent-2' });
-			const { container } = render(<WorkflowNodeCard {...makeProps({ step, expanded: true })} />);
+			const { container } = render(
+				<WorkflowNodeCard {...makeProps({ node: step, expanded: true })} />
+			);
 			const agentSelect = container.querySelectorAll('select')[0];
 			expect(agentSelect.value).toBe('agent-2');
 		});

--- a/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Unit tests for WorkflowStepCard
+ * Unit tests for WorkflowNodeCard
  *
  * Tests:
  * - Collapsed view: step number, agent name, gate icons
@@ -15,8 +15,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import type { SpaceAgent } from '@neokai/shared';
-import { WorkflowStepCard } from '../WorkflowStepCard';
-import type { StepDraft, ConditionDraft } from '../WorkflowStepCard';
+import { WorkflowNodeCard } from '../WorkflowNodeCard';
+import type { StepDraft, ConditionDraft } from '../WorkflowNodeCard';
 
 vi.mock('../../../lib/utils', () => ({
 	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
@@ -49,7 +49,7 @@ const defaultAgents: SpaceAgent[] = [
 	makeAgent('agent-3', 'general', 'general'),
 ];
 
-function makeProps(overrides: Partial<Parameters<typeof WorkflowStepCard>[0]> = {}) {
+function makeProps(overrides: Partial<Parameters<typeof WorkflowNodeCard>[0]> = {}) {
 	return {
 		step: makeStep(),
 		stepIndex: 1,
@@ -70,39 +70,39 @@ function makeProps(overrides: Partial<Parameters<typeof WorkflowStepCard>[0]> = 
 	};
 }
 
-describe('WorkflowStepCard', () => {
+describe('WorkflowNodeCard', () => {
 	afterEach(() => {
 		cleanup();
 	});
 
 	describe('collapsed view', () => {
 		it('renders step number (1-based)', () => {
-			const { getByText } = render(<WorkflowStepCard {...makeProps({ stepIndex: 2 })} />);
+			const { getByText } = render(<WorkflowNodeCard {...makeProps({ stepIndex: 2 })} />);
 			expect(getByText('3')).toBeTruthy();
 		});
 
 		it('renders agent name in collapsed view', () => {
-			const { getByText } = render(<WorkflowStepCard {...makeProps()} />);
+			const { getByText } = render(<WorkflowNodeCard {...makeProps()} />);
 			expect(getByText('planner')).toBeTruthy();
 		});
 
 		it('renders step name in collapsed view', () => {
 			const { getByText } = render(
-				<WorkflowStepCard {...makeProps({ step: makeStep({ name: 'My Awesome Step' }) })} />
+				<WorkflowNodeCard {...makeProps({ step: makeStep({ name: 'My Awesome Step' }) })} />
 			);
 			expect(getByText('My Awesome Step')).toBeTruthy();
 		});
 
 		it('shows "Unnamed Step" when name is empty', () => {
 			const { getByText } = render(
-				<WorkflowStepCard {...makeProps({ step: makeStep({ name: '' }) })} />
+				<WorkflowNodeCard {...makeProps({ step: makeStep({ name: '' }) })} />
 			);
 			expect(getByText('Unnamed Step')).toBeTruthy();
 		});
 
 		it('calls onToggleExpand when header clicked', () => {
 			const onToggleExpand = vi.fn();
-			const { container } = render(<WorkflowStepCard {...makeProps({ onToggleExpand })} />);
+			const { container } = render(<WorkflowNodeCard {...makeProps({ onToggleExpand })} />);
 			const header = container.querySelector('.cursor-pointer') as HTMLElement;
 			fireEvent.click(header);
 			expect(onToggleExpand).toHaveBeenCalledOnce();
@@ -110,62 +110,62 @@ describe('WorkflowStepCard', () => {
 
 		it('calls onMoveUp when up button clicked', () => {
 			const onMoveUp = vi.fn();
-			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ onMoveUp })} />);
+			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ onMoveUp })} />);
 			fireEvent.click(getByTitle('Move up'));
 			expect(onMoveUp).toHaveBeenCalledOnce();
 		});
 
 		it('calls onMoveDown when down button clicked', () => {
 			const onMoveDown = vi.fn();
-			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ onMoveDown })} />);
+			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ onMoveDown })} />);
 			fireEvent.click(getByTitle('Move down'));
 			expect(onMoveDown).toHaveBeenCalledOnce();
 		});
 
 		it('disables move up button for first step', () => {
-			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ isFirst: true })} />);
+			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ isFirst: true })} />);
 			expect((getByTitle('Move up') as HTMLButtonElement).disabled).toBe(true);
 		});
 
 		it('disables move down button for last step', () => {
-			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ isLast: true })} />);
+			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ isLast: true })} />);
 			expect((getByTitle('Move down') as HTMLButtonElement).disabled).toBe(true);
 		});
 
 		it('calls onRemove when remove button clicked', () => {
 			const onRemove = vi.fn();
-			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ onRemove })} />);
+			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ onRemove })} />);
 			fireEvent.click(getByTitle('Remove step'));
 			expect(onRemove).toHaveBeenCalledOnce();
 		});
 
 		it('disables Remove button when disableRemove is true', () => {
-			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ disableRemove: true })} />);
+			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ disableRemove: true })} />);
 			expect((getByTitle('Remove step') as HTMLButtonElement).disabled).toBe(true);
 		});
 
 		it('enables Remove button when disableRemove is false', () => {
-			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ disableRemove: false })} />);
+			const { getByTitle } = render(<WorkflowNodeCard {...makeProps({ disableRemove: false })} />);
 			expect((getByTitle('Remove step') as HTMLButtonElement).disabled).toBe(false);
 		});
 
 		it('shows human gate icon when entry condition is human', () => {
 			const { getByTitle } = render(
-				<WorkflowStepCard {...makeProps({ entryCondition: { type: 'human' } })} />
+				<WorkflowNodeCard {...makeProps({ entryCondition: { type: 'human' } })} />
 			);
 			expect(getByTitle('Entry: Human Approval')).toBeTruthy();
 		});
 
 		it('shows condition gate icon when exit condition is shell condition', () => {
 			const { getByTitle } = render(
-				<WorkflowStepCard {...makeProps({ exitCondition: { type: 'condition' } })} />
+				<WorkflowNodeCard {...makeProps({ exitCondition: { type: 'condition' } })} />
 			);
 			expect(getByTitle('Exit: Shell Condition')).toBeTruthy();
 		});
 
 		it('does not show gate icons for always conditions', () => {
 			const { container } = render(
-				<WorkflowStepCard
+				<WorkflowNodeCard
 					{...makeProps({
 						entryCondition: { type: 'always' },
 						exitCondition: { type: 'always' },
@@ -181,19 +181,19 @@ describe('WorkflowStepCard', () => {
 	describe('expanded view', () => {
 		it('shows expanded body when expanded=true', () => {
 			const { getByPlaceholderText } = render(
-				<WorkflowStepCard {...makeProps({ expanded: true })} />
+				<WorkflowNodeCard {...makeProps({ expanded: true })} />
 			);
 			expect(getByPlaceholderText('e.g. Plan the approach')).toBeTruthy();
 		});
 
 		it('does not show expanded body when expanded=false', () => {
-			const { container } = render(<WorkflowStepCard {...makeProps({ expanded: false })} />);
+			const { container } = render(<WorkflowNodeCard {...makeProps({ expanded: false })} />);
 			const textarea = container.querySelector('textarea');
 			expect(textarea).toBeNull();
 		});
 
 		it('renders agent dropdown with all passed agents', () => {
-			const { container } = render(<WorkflowStepCard {...makeProps({ expanded: true })} />);
+			const { container } = render(<WorkflowNodeCard {...makeProps({ expanded: true })} />);
 			const selects = container.querySelectorAll('select');
 			// Agent select + entry gate select + exit gate select = 3 selects
 			const agentSelect = selects[0] as HTMLSelectElement;
@@ -205,7 +205,7 @@ describe('WorkflowStepCard', () => {
 
 		it('shows currently selected agent in dropdown', () => {
 			const step = makeStep({ agentId: 'agent-2' });
-			const { container } = render(<WorkflowStepCard {...makeProps({ step, expanded: true })} />);
+			const { container } = render(<WorkflowNodeCard {...makeProps({ step, expanded: true })} />);
 			const agentSelect = container.querySelectorAll('select')[0];
 			expect(agentSelect.value).toBe('agent-2');
 		});
@@ -213,7 +213,7 @@ describe('WorkflowStepCard', () => {
 		it('calls onUpdate when agent changed', () => {
 			const onUpdate = vi.fn();
 			const { container } = render(
-				<WorkflowStepCard {...makeProps({ expanded: true, onUpdate })} />
+				<WorkflowNodeCard {...makeProps({ expanded: true, onUpdate })} />
 			);
 			const agentSelect = container.querySelectorAll('select')[0];
 			fireEvent.change(agentSelect, { target: { value: 'agent-2' } });
@@ -223,7 +223,7 @@ describe('WorkflowStepCard', () => {
 		it('calls onUpdate when name changed', () => {
 			const onUpdate = vi.fn();
 			const { getByPlaceholderText } = render(
-				<WorkflowStepCard {...makeProps({ expanded: true, onUpdate })} />
+				<WorkflowNodeCard {...makeProps({ expanded: true, onUpdate })} />
 			);
 			const nameInput = getByPlaceholderText('e.g. Plan the approach');
 			fireEvent.input(nameInput, { target: { value: 'New Name' } });
@@ -233,7 +233,7 @@ describe('WorkflowStepCard', () => {
 		it('calls onUpdate when instructions changed', () => {
 			const onUpdate = vi.fn();
 			const { container } = render(
-				<WorkflowStepCard {...makeProps({ expanded: true, onUpdate })} />
+				<WorkflowNodeCard {...makeProps({ expanded: true, onUpdate })} />
 			);
 			const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 			fireEvent.input(textarea, { target: { value: 'Do the thing.' } });
@@ -244,14 +244,14 @@ describe('WorkflowStepCard', () => {
 
 		it('renders "Workflow starts here" for first step entry gate', () => {
 			const { getByText } = render(
-				<WorkflowStepCard {...makeProps({ expanded: true, isFirst: true, entryCondition: null })} />
+				<WorkflowNodeCard {...makeProps({ expanded: true, isFirst: true, entryCondition: null })} />
 			);
 			expect(getByText('Workflow starts here')).toBeTruthy();
 		});
 
 		it('renders "Workflow ends here" for last step exit gate', () => {
 			const { getByText } = render(
-				<WorkflowStepCard {...makeProps({ expanded: true, isLast: true, exitCondition: null })} />
+				<WorkflowNodeCard {...makeProps({ expanded: true, isLast: true, exitCondition: null })} />
 			);
 			expect(getByText('Workflow ends here')).toBeTruthy();
 		});
@@ -259,7 +259,7 @@ describe('WorkflowStepCard', () => {
 		describe('gate config — condition type', () => {
 			it('shows shell expression input when condition type is "condition"', () => {
 				const { getByPlaceholderText } = render(
-					<WorkflowStepCard
+					<WorkflowNodeCard
 						{...makeProps({
 							expanded: true,
 							entryCondition: { type: 'condition', expression: '' },
@@ -271,7 +271,7 @@ describe('WorkflowStepCard', () => {
 
 			it('does not show shell expression input for "always" type', () => {
 				const { container } = render(
-					<WorkflowStepCard
+					<WorkflowNodeCard
 						{...makeProps({
 							expanded: true,
 							entryCondition: { type: 'always' },
@@ -286,7 +286,7 @@ describe('WorkflowStepCard', () => {
 			it('calls onUpdateEntryCondition when entry gate type changed', () => {
 				const onUpdateEntryCondition = vi.fn();
 				const { container } = render(
-					<WorkflowStepCard
+					<WorkflowNodeCard
 						{...makeProps({
 							expanded: true,
 							entryCondition: { type: 'always' },
@@ -306,7 +306,7 @@ describe('WorkflowStepCard', () => {
 			it('calls onUpdateExitCondition when exit gate type changed', () => {
 				const onUpdateExitCondition = vi.fn();
 				const { container } = render(
-					<WorkflowStepCard
+					<WorkflowNodeCard
 						{...makeProps({
 							expanded: true,
 							exitCondition: { type: 'always' },
@@ -322,7 +322,7 @@ describe('WorkflowStepCard', () => {
 
 			it('shows "Requires human approval" hint for human type', () => {
 				const { getByText } = render(
-					<WorkflowStepCard
+					<WorkflowNodeCard
 						{...makeProps({
 							expanded: true,
 							entryCondition: { type: 'human' },
@@ -334,7 +334,7 @@ describe('WorkflowStepCard', () => {
 
 			it('shows "fires automatically" hint for always type', () => {
 				const { getAllByText } = render(
-					<WorkflowStepCard
+					<WorkflowNodeCard
 						{...makeProps({
 							expanded: true,
 							entryCondition: { type: 'always' },

--- a/packages/web/src/components/space/index.ts
+++ b/packages/web/src/components/space/index.ts
@@ -13,9 +13,9 @@ export { SpaceTaskPane } from './SpaceTaskPane';
 export { WorkflowEditor, filterAgents, initFromWorkflow } from './WorkflowEditor';
 export { WorkflowList } from './WorkflowList';
 export { WorkflowRulesEditor, makeEmptyRule, rulesToDrafts } from './WorkflowRulesEditor';
-export { WorkflowStepCard } from './WorkflowStepCard';
+export { WorkflowNodeCard } from './WorkflowNodeCard';
 export { ImportPreviewDialog } from './ImportPreviewDialog';
 export { downloadBundle, pickImportFile } from './export-import-utils';
 
 export type { RuleDraft } from './WorkflowRulesEditor';
-export type { StepDraft, ConditionDraft } from './WorkflowStepCard';
+export type { StepDraft, ConditionDraft } from './WorkflowNodeCard';

--- a/packages/web/src/components/space/index.ts
+++ b/packages/web/src/components/space/index.ts
@@ -18,4 +18,4 @@ export { ImportPreviewDialog } from './ImportPreviewDialog';
 export { downloadBundle, pickImportFile } from './export-import-utils';
 
 export type { RuleDraft } from './WorkflowRulesEditor';
-export type { StepDraft, ConditionDraft } from './WorkflowNodeCard';
+export type { NodeDraft, ConditionDraft } from './WorkflowNodeCard';

--- a/packages/web/src/components/space/visual-editor/GateConfig.tsx
+++ b/packages/web/src/components/space/visual-editor/GateConfig.tsx
@@ -2,7 +2,7 @@
  * GateConfig
  *
  * Shared sub-form for configuring workflow transition conditions (entry/exit gates).
- * Extracted so both WorkflowStepCard (list editor) and NodeConfigPanel (visual editor)
+ * Extracted so both WorkflowNodeCard (list editor) and NodeConfigPanel (visual editor)
  * can reuse the same UI without duplication.
  */
 

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -3,7 +3,7 @@
  *
  * A right-anchored slide-in panel that appears when a workflow node is selected
  * in the visual editor. Provides inline editing of all step properties using
- * the same field layout as the WorkflowStepCard expanded view.
+ * the same field layout as the WorkflowNodeCard expanded view.
  *
  * Features:
  * - Step Name input
@@ -17,8 +17,8 @@
 
 import { useState, useEffect } from 'preact/hooks';
 import type { SpaceAgent, WorkflowNodeAgent, WorkflowChannel } from '@neokai/shared';
-import type { StepDraft } from '../WorkflowStepCard';
-import { isMultiAgentStep } from '../WorkflowStepCard';
+import type { StepDraft } from '../WorkflowNodeCard';
+import { isMultiAgentStep } from '../WorkflowNodeCard';
 import { GateConfig } from './GateConfig';
 import type { ConditionDraft } from './GateConfig';
 
@@ -34,12 +34,12 @@ export interface NodeConfigPanelProps {
 	isStartNode: boolean;
 	/**
 	 * When true, the entry gate shows "Workflow starts here" (no selector).
-	 * Mirrors the WorkflowStepCard terminal message for the first step.
+	 * Mirrors the WorkflowNodeCard terminal message for the first step.
 	 */
 	isFirstStep?: boolean;
 	/**
 	 * When true, the exit gate shows "Workflow ends here" (no selector).
-	 * Mirrors the WorkflowStepCard terminal message for the last step.
+	 * Mirrors the WorkflowNodeCard terminal message for the last step.
 	 */
 	isLastStep?: boolean;
 	onUpdate: (step: StepDraft) => void;

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -17,8 +17,8 @@
 
 import { useState, useEffect } from 'preact/hooks';
 import type { SpaceAgent, WorkflowNodeAgent, WorkflowChannel } from '@neokai/shared';
-import type { StepDraft } from '../WorkflowNodeCard';
-import { isMultiAgentStep } from '../WorkflowNodeCard';
+import type { NodeDraft } from '../WorkflowNodeCard';
+import { isMultiAgentNode } from '../WorkflowNodeCard';
 import { GateConfig } from './GateConfig';
 import type { ConditionDraft } from './GateConfig';
 
@@ -27,7 +27,7 @@ import type { ConditionDraft } from './GateConfig';
 // ============================================================================
 
 export interface NodeConfigPanelProps {
-	step: StepDraft;
+	step: NodeDraft;
 	agents: SpaceAgent[];
 	entryCondition: ConditionDraft | null;
 	exitCondition: ConditionDraft | null;
@@ -42,7 +42,7 @@ export interface NodeConfigPanelProps {
 	 * Mirrors the WorkflowNodeCard terminal message for the last step.
 	 */
 	isLastStep?: boolean;
-	onUpdate: (step: StepDraft) => void;
+	onUpdate: (step: NodeDraft) => void;
 	onUpdateEntryCondition: (cond: ConditionDraft) => void;
 	onUpdateExitCondition: (cond: ConditionDraft) => void;
 	/** Designates this step as the workflow start node */
@@ -57,13 +57,13 @@ export interface NodeConfigPanelProps {
 // ============================================================================
 
 interface AgentsSectionProps {
-	step: StepDraft;
+	step: NodeDraft;
 	agents: SpaceAgent[];
-	onUpdate: (step: StepDraft) => void;
+	onUpdate: (step: NodeDraft) => void;
 }
 
 function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
-	const multi = isMultiAgentStep(step);
+	const multi = isMultiAgentNode(step);
 	const stepAgents = step.agents ?? [];
 
 	function updateAgents(next: WorkflowNodeAgent[]) {
@@ -263,9 +263,9 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 // ============================================================================
 
 interface ChannelsPanelSectionProps {
-	step: StepDraft;
+	step: NodeDraft;
 	agents: SpaceAgent[];
-	onUpdate: (step: StepDraft) => void;
+	onUpdate: (step: NodeDraft) => void;
 }
 
 function ChannelsPanelSection({ step, agents, onUpdate }: ChannelsPanelSectionProps) {
@@ -547,7 +547,7 @@ export function NodeConfigPanel({
 				<AgentsSection step={step} agents={agents} onUpdate={onUpdate} />
 
 				{/* Channels (shown when node has agents or has existing channels) */}
-				{(!!step.agentId || isMultiAgentStep(step) || step.channels) && (
+				{(!!step.agentId || isMultiAgentNode(step) || step.channels) && (
 					<ChannelsPanelSection step={step} agents={agents} onUpdate={onUpdate} />
 				)}
 

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -33,7 +33,7 @@ import { filterAgents, TEMPLATES } from '../WorkflowEditor';
 import type { WorkflowTemplate } from '../WorkflowEditor';
 import { WorkflowRulesEditor } from '../WorkflowRulesEditor';
 import type { RuleDraft } from '../WorkflowRulesEditor';
-import type { StepDraft } from '../WorkflowNodeCard';
+import type { NodeDraft } from '../WorkflowNodeCard';
 import type { ConditionDraft } from './GateConfig';
 import type { ViewportState, Point } from './types';
 import type { VisualNode, VisualEdge, VisualEditorState } from './serialization';
@@ -274,7 +274,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 
 	function addStep() {
 		const newLocalId = generateUUID();
-		const newStep: StepDraft = { localId: newLocalId, name: '', agentId: '', instructions: '' };
+		const newStep: NodeDraft = { localId: newLocalId, name: '', agentId: '', instructions: '' };
 
 		// Capture emptiness before the setNodes call so we can call setStartStepId
 		// outside the updater. State setter calls inside updater functions are side
@@ -327,7 +327,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		[nodes, startNodeId]
 	);
 
-	const handleUpdateNode = useCallback((step: StepDraft) => {
+	const handleUpdateNode = useCallback((step: NodeDraft) => {
 		setNodes((prev) => prev.map((n) => (n.step.localId === step.localId ? { ...n, step } : n)));
 	}, []);
 

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -33,7 +33,7 @@ import { filterAgents, TEMPLATES } from '../WorkflowEditor';
 import type { WorkflowTemplate } from '../WorkflowEditor';
 import { WorkflowRulesEditor } from '../WorkflowRulesEditor';
 import type { RuleDraft } from '../WorkflowRulesEditor';
-import type { StepDraft } from '../WorkflowStepCard';
+import type { StepDraft } from '../WorkflowNodeCard';
 import type { ConditionDraft } from './GateConfig';
 import type { ViewportState, Point } from './types';
 import type { VisualNode, VisualEdge, VisualEditorState } from './serialization';

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -16,8 +16,8 @@
 
 import { useEffect, useCallback, useRef } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
-import type { StepDraft } from '../WorkflowNodeCard';
-import { isMultiAgentStep } from '../WorkflowNodeCard';
+import type { NodeDraft } from '../WorkflowNodeCard';
+import { isMultiAgentNode } from '../WorkflowNodeCard';
 import type { Point } from './types';
 
 // ============================================================================
@@ -25,7 +25,7 @@ import type { Point } from './types';
 // ============================================================================
 
 /** Renders a compact text representation of channel topology. */
-function ChannelTopologyBadge({ step }: { step: StepDraft }) {
+function ChannelTopologyBadge({ step }: { step: NodeDraft }) {
 	const channels = step.channels;
 	if (!channels || channels.length === 0) return null;
 
@@ -60,7 +60,7 @@ export type PortType = 'input' | 'output';
 export interface WorkflowNodeProps {
 	/** Zero-based index within the steps array; used for step number badge */
 	stepIndex: number;
-	step: StepDraft;
+	step: NodeDraft;
 	/** Absolute position in canvas coordinates */
 	position: Point;
 	/** Full agents list — used to resolve the agent name from step.agentId */
@@ -105,7 +105,7 @@ export function WorkflowNode({
 }: WorkflowNodeProps) {
 	const stepId = step.localId;
 
-	const multi = isMultiAgentStep(step);
+	const multi = isMultiAgentNode(step);
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
 
 	// ---- Drag state ----

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -16,8 +16,8 @@
 
 import { useEffect, useCallback, useRef } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
-import type { StepDraft } from '../WorkflowStepCard';
-import { isMultiAgentStep } from '../WorkflowStepCard';
+import type { StepDraft } from '../WorkflowNodeCard';
+import { isMultiAgentStep } from '../WorkflowNodeCard';
 import type { Point } from './types';
 
 // ============================================================================

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -22,7 +22,7 @@ import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import type { SpaceAgent } from '@neokai/shared';
 import { NodeConfigPanel } from '../NodeConfigPanel';
 import type { NodeConfigPanelProps } from '../NodeConfigPanel';
-import type { StepDraft } from '../../WorkflowNodeCard';
+import type { NodeDraft } from '../../WorkflowNodeCard';
 import type { ConditionDraft } from '../GateConfig';
 
 afterEach(() => cleanup());
@@ -35,7 +35,7 @@ function makeAgent(id: string, name: string, role = 'coder'): SpaceAgent {
 	return { id, spaceId: 'space-1', name, role, createdAt: Date.now(), updatedAt: Date.now() };
 }
 
-function makeStep(overrides: Partial<StepDraft> = {}): StepDraft {
+function makeStep(overrides: Partial<NodeDraft> = {}): NodeDraft {
 	return {
 		localId: 'step-local-1',
 		name: 'My Step',

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -22,7 +22,7 @@ import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import type { SpaceAgent } from '@neokai/shared';
 import { NodeConfigPanel } from '../NodeConfigPanel';
 import type { NodeConfigPanelProps } from '../NodeConfigPanel';
-import type { StepDraft } from '../../WorkflowStepCard';
+import type { StepDraft } from '../../WorkflowNodeCard';
 import type { ConditionDraft } from '../GateConfig';
 
 afterEach(() => cleanup());

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -22,7 +22,7 @@ import { useState } from 'preact/hooks';
 import type { SpaceAgent, WorkflowTransition } from '@neokai/shared';
 import { WorkflowCanvas } from '../WorkflowCanvas';
 import type { WorkflowNodeData, WorkflowCanvasProps } from '../WorkflowCanvas';
-import type { StepDraft } from '../../WorkflowStepCard';
+import type { StepDraft } from '../../WorkflowNodeCard';
 import type { ViewportState } from '../types';
 
 vi.mock('../../../../lib/utils', () => ({

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -22,7 +22,7 @@ import { useState } from 'preact/hooks';
 import type { SpaceAgent, WorkflowTransition } from '@neokai/shared';
 import { WorkflowCanvas } from '../WorkflowCanvas';
 import type { WorkflowNodeData, WorkflowCanvasProps } from '../WorkflowCanvas';
-import type { StepDraft } from '../../WorkflowNodeCard';
+import type { NodeDraft } from '../../WorkflowNodeCard';
 import type { ViewportState } from '../types';
 
 vi.mock('../../../../lib/utils', () => ({
@@ -39,7 +39,7 @@ function makeAgent(id: string, name: string): SpaceAgent {
 	return { id, spaceId: 'space-1', name, role: 'coder', createdAt: 0, updatedAt: 0 };
 }
 
-function makeStep(localId: string, name: string): StepDraft {
+function makeStep(localId: string, name: string): NodeDraft {
 	return { localId, name, agentId: 'agent-1', instructions: '' };
 }
 

--- a/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
@@ -30,7 +30,7 @@ import type { ViewportState } from '../types';
 import { WorkflowCanvas } from '../WorkflowCanvas';
 import type { WorkflowNodeData, WorkflowCanvasProps } from '../WorkflowCanvas';
 import type { SpaceAgent } from '@neokai/shared';
-import type { StepDraft } from '../../WorkflowStepCard';
+import type { StepDraft } from '../../WorkflowNodeCard';
 
 vi.mock('../../../../lib/utils', () => ({
 	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),

--- a/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
@@ -30,7 +30,7 @@ import type { ViewportState } from '../types';
 import { WorkflowCanvas } from '../WorkflowCanvas';
 import type { WorkflowNodeData, WorkflowCanvasProps } from '../WorkflowCanvas';
 import type { SpaceAgent } from '@neokai/shared';
-import type { StepDraft } from '../../WorkflowNodeCard';
+import type { NodeDraft } from '../../WorkflowNodeCard';
 
 vi.mock('../../../../lib/utils', () => ({
 	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
@@ -48,7 +48,7 @@ function makeAgent(id: string, name = 'Agent'): SpaceAgent {
 	return { id, spaceId: 'space-1', name, role: 'coder', createdAt: 0, updatedAt: 0 };
 }
 
-function makeStep(localId: string, name = 'Step'): StepDraft {
+function makeStep(localId: string, name = 'Step'): NodeDraft {
 	return { localId, name, agentId: 'agent-1', instructions: '' };
 }
 

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -35,7 +35,7 @@ import type {
 	WorkflowChannel,
 } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
-import type { StepDraft } from '../WorkflowNodeCard';
+import type { NodeDraft } from '../WorkflowNodeCard';
 import type { RuleDraft } from '../WorkflowRulesEditor';
 import { rulesToDrafts } from '../WorkflowRulesEditor';
 import type { Point } from './types';
@@ -51,7 +51,7 @@ import { autoLayout } from './layout';
  * `step.localId` is used for React keying.
  */
 export interface VisualNode {
-	step: StepDraft;
+	step: NodeDraft;
 	position: Point;
 }
 
@@ -118,7 +118,7 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 		} else {
 			position = layoutFallback.get(s.id) ?? { x: 0, y: 0 };
 		}
-		const step: StepDraft = {
+		const step: NodeDraft = {
 			localId: generateUUID(),
 			id: s.id,
 			name: s.name,

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -35,7 +35,7 @@ import type {
 	WorkflowChannel,
 } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
-import type { StepDraft } from '../WorkflowStepCard';
+import type { StepDraft } from '../WorkflowNodeCard';
 import type { RuleDraft } from '../WorkflowRulesEditor';
 import { rulesToDrafts } from '../WorkflowRulesEditor';
 import type { Point } from './types';


### PR DESCRIPTION
- Rename WorkflowStepCard.tsx → WorkflowNodeCard.tsx (git mv)
- Rename WorkflowStepCard.test.tsx → WorkflowNodeCard.test.tsx (git mv)
- Update component name: WorkflowStepCard → WorkflowNodeCard
- Update interface: WorkflowStepCardProps → WorkflowNodeCardProps
- Update user-visible text: "Step Name" → "Node Name", "Unnamed Step" → "Unnamed Node", "Remove step" → "Remove node", "Step-specific instructions" → "Node-specific instructions"
- Update all imports across WorkflowEditor.tsx, index.ts, serialization.ts, NodeConfigPanel.tsx, WorkflowNode.tsx, VisualWorkflowEditor.tsx, and test files
- Update comments in GateConfig.tsx and NodeConfigPanel.tsx

Zero WorkflowStep references remain in packages/web/src/. Typecheck and lint pass.
