### PR TITLE
fix: delete stale branch instead of falling back to UUID in worktree-manager

### DIFF
--- a/packages/daemon/src/lib/worktree-manager.ts
+++ b/packages/daemon/src/lib/worktree-manager.ts
@@ -227,7 +227,17 @@ export class WorktreeManager {
 			const branchExists = await this.checkBranchExists(gitRoot, branchName);
 			if (branchExists) {
 				this.logger.warn(`Stale branch detected: ${branchName} — deleting and recreating`);
-				await git.branch(['-D', branchName]);
+				try {
+					await git.branch(['-D', branchName]);
+				} catch {
+					// git refuses -D when the branch is currently checked out in another
+					// living worktree.  Fall back to a unique session-scoped name so the
+					// task can still proceed rather than blocking entirely.
+					this.logger.warn(
+						`Could not delete branch ${branchName} (may be checked out in another worktree) — falling back to session/${safeSessionId}`
+					);
+					branchName = `session/${safeSessionId}`;
+				}
 			}
 
 			// Create worktree with new branch
@@ -406,8 +416,8 @@ export class WorktreeManager {
 						await git.raw(['worktree', 'remove', worktree.path, '--force']);
 						cleaned.push(worktree.path);
 
-						// Also try to delete the branch if it's a session branch
-						if (worktree.branch.startsWith('session/')) {
+						// Also try to delete the branch if it's a managed branch (session/ or task/)
+						if (worktree.branch.startsWith('session/') || worktree.branch.startsWith('task/')) {
 							try {
 								await git.branch(['-D', worktree.branch]);
 							} catch {

--- a/packages/daemon/src/lib/worktree-manager.ts
+++ b/packages/daemon/src/lib/worktree-manager.ts
@@ -220,12 +220,14 @@ export class WorktreeManager {
 				throw new Error(`Worktree directory already exists: ${worktreePath}`);
 			}
 
-			// Check if branch already exists (and fallback to UUID if it does)
-			if (customBranchName) {
-				const branchExists = await this.checkBranchExists(gitRoot, customBranchName);
-				if (branchExists) {
-					branchName = `session/${safeSessionId}`; // Fallback to UUID-based branch
-				}
+			// Check if branch already exists — this can happen when a prior task/session
+			// crashed mid-run and left behind a stale branch whose worktree was already
+			// removed. Delete the stale branch so we can recreate it fresh with the
+			// same (intended) name instead of falling back to an opaque UUID-based name.
+			const branchExists = await this.checkBranchExists(gitRoot, branchName);
+			if (branchExists) {
+				this.logger.warn(`Stale branch detected: ${branchName} — deleting and recreating`);
+				await git.branch(['-D', branchName]);
 			}
 
 			// Create worktree with new branch

--- a/packages/daemon/tests/unit/lib/worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/worktree-manager.test.ts
@@ -161,7 +161,7 @@ describe('WorktreeManager', () => {
 			).rejects.toThrow('already exists');
 		});
 
-		it('should fallback to UUID branch if custom branch exists', async () => {
+		it('should delete stale custom branch and reuse original name', async () => {
 			existsSyncResults.set('/test/repo/.git', true);
 			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
 			existsSyncResults.set(
@@ -170,8 +170,8 @@ describe('WorktreeManager', () => {
 			);
 			mockGitRevparse.mockResolvedValue('.git');
 			mockGitRaw
-				.mockResolvedValueOnce('  custom-branch\n') // Branch exists
-				.mockResolvedValue(''); // git worktree add
+				.mockResolvedValueOnce('  custom-branch\n') // checkBranchExists — stale branch found
+				.mockResolvedValue(''); // branch -D + git worktree add
 
 			const result = await manager.createWorktree({
 				sessionId: 'session-123',
@@ -179,7 +179,57 @@ describe('WorktreeManager', () => {
 				branchName: 'custom-branch',
 			});
 
+			// Should reuse the original branch name, not fall back to UUID
+			expect(result?.branch).toBe('custom-branch');
+			// Should have called branch -D to remove the stale branch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'custom-branch']);
+		});
+
+		it('should delete stale auto-generated branch and reuse original name', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('  session/session-123\n') // checkBranchExists — stale auto branch
+				.mockResolvedValue(''); // branch -D + git worktree add
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				// No custom branch name — uses auto-generated session/session-123
+			});
+
+			// Should reuse the auto-generated branch name
 			expect(result?.branch).toBe('session/session-123');
+			// Should have called branch -D to remove the stale branch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'session/session-123']);
+		});
+
+		it('should delete stale task branch and reuse task branch name', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('  task/task-42-implement-feature\n') // checkBranchExists — stale task branch
+				.mockResolvedValue(''); // branch -D + git worktree add
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				branchName: 'task/task-42-implement-feature',
+			});
+
+			// Should reuse the task branch name, not fall back to opaque UUID
+			expect(result?.branch).toBe('task/task-42-implement-feature');
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'task/task-42-implement-feature']);
 		});
 
 		it('should return WorktreeMetadata on success', async () => {

--- a/packages/daemon/tests/unit/lib/worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/worktree-manager.test.ts
@@ -161,6 +161,29 @@ describe('WorktreeManager', () => {
 			).rejects.toThrow('already exists');
 		});
 
+		it('should succeed with auto-generated branch name when no stale branch exists', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			// checkBranchExists returns empty → no stale branch, then worktree add succeeds
+			mockGitRaw
+				.mockResolvedValueOnce('') // checkBranchExists — branch does not exist
+				.mockResolvedValue(''); // worktree add
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				// No custom branch name — uses auto-generated session/session-123
+			});
+
+			expect(result?.branch).toBe('session/session-123');
+			expect(mockGitBranch).not.toHaveBeenCalled();
+		});
+
 		it('should delete stale custom branch and reuse original name', async () => {
 			existsSyncResults.set('/test/repo/.git', true);
 			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
@@ -169,9 +192,10 @@ describe('WorktreeManager', () => {
 				false
 			);
 			mockGitRevparse.mockResolvedValue('.git');
+			// checkBranchExists returns the stale branch; branch -D goes through mockGitBranch
 			mockGitRaw
 				.mockResolvedValueOnce('  custom-branch\n') // checkBranchExists — stale branch found
-				.mockResolvedValue(''); // branch -D + git worktree add
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch, not mockGitRaw)
 
 			const result = await manager.createWorktree({
 				sessionId: 'session-123',
@@ -181,7 +205,7 @@ describe('WorktreeManager', () => {
 
 			// Should reuse the original branch name, not fall back to UUID
 			expect(result?.branch).toBe('custom-branch');
-			// Should have called branch -D to remove the stale branch
+			// git branch -D goes through mockGitBranch
 			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'custom-branch']);
 		});
 
@@ -195,7 +219,7 @@ describe('WorktreeManager', () => {
 			mockGitRevparse.mockResolvedValue('.git');
 			mockGitRaw
 				.mockResolvedValueOnce('  session/session-123\n') // checkBranchExists — stale auto branch
-				.mockResolvedValue(''); // branch -D + git worktree add
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch)
 
 			const result = await manager.createWorktree({
 				sessionId: 'session-123',
@@ -205,7 +229,7 @@ describe('WorktreeManager', () => {
 
 			// Should reuse the auto-generated branch name
 			expect(result?.branch).toBe('session/session-123');
-			// Should have called branch -D to remove the stale branch
+			// git branch -D goes through mockGitBranch
 			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'session/session-123']);
 		});
 
@@ -219,7 +243,7 @@ describe('WorktreeManager', () => {
 			mockGitRevparse.mockResolvedValue('.git');
 			mockGitRaw
 				.mockResolvedValueOnce('  task/task-42-implement-feature\n') // checkBranchExists — stale task branch
-				.mockResolvedValue(''); // branch -D + git worktree add
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch)
 
 			const result = await manager.createWorktree({
 				sessionId: 'session-123',
@@ -230,6 +254,32 @@ describe('WorktreeManager', () => {
 			// Should reuse the task branch name, not fall back to opaque UUID
 			expect(result?.branch).toBe('task/task-42-implement-feature');
 			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'task/task-42-implement-feature']);
+		});
+
+		it('should fall back to UUID branch name when branch -D is rejected (branch checked out elsewhere)', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('  task/task-42-implement-feature\n') // checkBranchExists — branch found
+				.mockResolvedValue(''); // worktree add succeeds with fallback branch name
+			// branch -D fails because branch is checked out in another active worktree
+			mockGitBranch.mockRejectedValueOnce(
+				new Error("error: cannot delete branch 'task/task-42' checked out at '/other'")
+			);
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				branchName: 'task/task-42-implement-feature',
+			});
+
+			// Should fall back to UUID-based branch so task can still proceed
+			expect(result?.branch).toBe('session/session-123');
 		});
 
 		it('should return WorktreeMetadata on success', async () => {
@@ -518,6 +568,24 @@ describe('WorktreeManager', () => {
 			const result = await manager.cleanupOrphanedWorktrees('/test/repo');
 
 			expect(result).toContain('/test/repo/.neokai/worktrees/session-1');
+		});
+
+		it('should delete task/ branches for orphaned task worktrees', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('') // prune
+				.mockResolvedValueOnce(
+					'worktree /test/repo\nHEAD abc123\n\nworktree /test/repo/.neokai/worktrees/task-wt\nHEAD def456\nbranch refs/heads/task/task-42-implement-feature\nprunable\n'
+				) // list
+				.mockResolvedValue(''); // remove
+
+			const result = await manager.cleanupOrphanedWorktrees('/test/repo');
+
+			expect(result).toContain('/test/repo/.neokai/worktrees/task-wt');
+			// Should also delete the task/ branch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'task/task-42-implement-feature']);
 		});
 
 		it('should throw on cleanup failure', async () => {


### PR DESCRIPTION
When a task branch (e.g. task/task-42-...) already exists from a prior
run that crashed mid-task, git worktree add -b would fail with "branch
already exists", blocking group spawning entirely.

Previously the code only handled this for customBranchName and fell back
to an opaque session/UUID name. Now the pre-check runs for all branch
names and deletes the stale branch so the original intended name is
preserved and worktree creation succeeds.
