### PR TITLE
fix: improve SDK startup timeout — exponential backoff, more retries, better diagnostics

### DIFF
--- a/packages/daemon/.env.example
+++ b/packages/daemon/.env.example
@@ -58,6 +58,27 @@ TEMPERATURE=1.0
 MAX_SESSIONS=10
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# SDK Startup Tuning
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# How long (ms) to wait for the SDK subprocess to emit its first message
+# before declaring a startup timeout. Increase on slow machines or when
+# running many concurrent sessions.
+# Default: 15000
+# NEOKAI_SDK_STARTUP_TIMEOUT_MS=15000
+#
+# Base delay (ms) before the first auto-recovery attempt after a startup
+# timeout. Each subsequent attempt doubles this (exponential backoff).
+# Example: 3000 → attempt 1 waits 3s, attempt 2 waits 6s.
+# Default: 3000
+# NEOKAI_SDK_STARTUP_RECOVERY_DELAY_MS=3000
+#
+# Maximum number of auto-recovery attempts before surfacing the error to
+# the user. Set to 0 to disable auto-recovery entirely.
+# Default: 2
+# NEOKAI_SDK_STARTUP_MAX_RETRIES=2
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Job Queue Configuration
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -488,17 +488,22 @@ export class QueryRunner {
 						// For startup timeouts / conversation-not-found that exhausted all retries,
 						// provide actionable recovery hints. Both error types are handled symmetrically
 						// (same retry gate, same sdkSessionId clearing), so both deserve a hint.
-						const startupTimeoutUserMessage =
-							isStartupTimeout || isConversationNotFound
-								? `The AI session failed to ${isStartupTimeout ? 'start' : 'resume'} after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
+						// Keep the hints distinct: NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a
+						// missing/corrupt session file — the session ID was already cleared above,
+						// so the next message will automatically start a fresh session.
+						const startupTimeoutUserMessage = isStartupTimeout
+							? `The AI session failed to start after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
+								`(workspace: ${session.workspacePath}). ` +
+								`Common causes: another Claude Code session is using the same workspace, ` +
+								`a stale lock file in .claude/, or the workspace is under heavy load. ` +
+								`Try: closing other Claude sessions on this workspace, ` +
+								`then resend your message. ` +
+								`You can also increase the timeout with NEOKAI_SDK_STARTUP_TIMEOUT_MS (current: ${STARTUP_TIMEOUT_MS}ms).`
+							: isConversationNotFound
+								? `The AI session could not be resumed after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
 									`(workspace: ${session.workspacePath}). ` +
-									(isStartupTimeout
-										? `Common causes: another Claude Code session is using the same workspace, ` +
-											`a stale lock file in .claude/, or the workspace is under heavy load. `
-										: `The previous session file could not be found or is corrupt. `) +
-									`Try: closing other Claude sessions on this workspace, ` +
-									`then resend your message. ` +
-									`You can also increase the timeout with NEOKAI_SDK_STARTUP_TIMEOUT_MS (current: ${STARTUP_TIMEOUT_MS}ms).`
+									`The previous session file could not be found or is corrupt. ` +
+									`The session has been reset automatically — please resend your message to start fresh.`
 								: undefined;
 
 						await errorManager.handleError(

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -25,6 +25,10 @@ import type { QueryOptionsBuilder } from './query-options-builder';
 import type { AskUserQuestionHandler } from './ask-user-question-handler';
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
+/** Base delay before the first auto-recovery attempt. Each subsequent attempt doubles this. */
+const DEFAULT_STARTUP_RECOVERY_DELAY_MS = 3000;
+/** Maximum number of auto-recovery attempts before surfacing the error to the user. */
+const DEFAULT_STARTUP_MAX_RETRIES = 2;
 
 function getStartupTimeoutMs(): number {
 	const raw = process.env.NEOKAI_SDK_STARTUP_TIMEOUT_MS;
@@ -33,7 +37,23 @@ function getStartupTimeoutMs(): number {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STARTUP_TIMEOUT_MS;
 }
 
+function getStartupRecoveryDelayMs(): number {
+	const raw = process.env.NEOKAI_SDK_STARTUP_RECOVERY_DELAY_MS;
+	if (!raw) return DEFAULT_STARTUP_RECOVERY_DELAY_MS;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STARTUP_RECOVERY_DELAY_MS;
+}
+
+function getStartupMaxRetries(): number {
+	const raw = process.env.NEOKAI_SDK_STARTUP_MAX_RETRIES;
+	if (!raw) return DEFAULT_STARTUP_MAX_RETRIES;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_STARTUP_MAX_RETRIES;
+}
+
 const STARTUP_TIMEOUT_MS = getStartupTimeoutMs();
+const STARTUP_RECOVERY_DELAY_MS = getStartupRecoveryDelayMs();
+const STARTUP_MAX_RETRIES = getStartupMaxRetries();
 
 /**
  * Original environment variables for restoration after SDK query
@@ -237,10 +257,18 @@ export class QueryRunner {
 				if (!this.ctx.firstMessageReceived) {
 					startupTimeoutReached = true;
 					const elapsed = Date.now() - queryStartTime;
+					const isRootWorkspace = !session.worktree;
+					const workspaceDesc = isRootWorkspace
+						? `root workspace: ${session.workspacePath}`
+						: `worktree: ${session.worktree!.worktreePath}`;
 					logger.error(
 						`SDK startup timeout: SDK did not respond within ${elapsed}ms. ` +
-							`Model: ${queryOptions.model}, Workspace: ${session.workspacePath}` +
-							(session.worktree ? ` (worktree: ${session.worktree.worktreePath})` : '')
+							`Model: ${queryOptions.model}, ${workspaceDesc}` +
+							(isRootWorkspace
+								? ' — running on root workspace (not a worktree); check for other Claude Code sessions using this path'
+								: '') +
+							`. Attempt ${this.ctx.startupTimeoutAutoRecoverAttempts + 1} of ${STARTUP_MAX_RETRIES + 1}.` +
+							` (Hint: set NEOKAI_SDK_STARTUP_TIMEOUT_MS to increase timeout, currently ${STARTUP_TIMEOUT_MS}ms)`
 					);
 
 					// Actively abort a stuck startup so finally{} cleanup runs and the
@@ -348,29 +376,39 @@ export class QueryRunner {
 
 			if (!isAbortError) {
 				// On startup timeout or conversation not found, attempt transparent auto-recovery
-				// (up to 1 retry): restart the query without the old resume handle
+				// (up to STARTUP_MAX_RETRIES): restart the query without the old resume handle
 				// (sdkSessionId already cleared above). Queued messages are preserved so
 				// the user's pending send is retried automatically without any visible error.
-				// The retry limit (attempts <= 1) prevents infinite loops when the SDK is
-				// permanently broken: after 1 failed recovery, the error surfaces normally.
+				// Uses exponential backoff: delay doubles with each attempt to give the SDK
+				// process time to fully exit before the next spawn.
+				// The retry limit prevents infinite loops when the SDK is permanently broken:
+				// after all retries are exhausted, the error surfaces normally.
 				const startupRecoverAttempts = this.ctx.startupTimeoutAutoRecoverAttempts + 1;
 				const canAutoRecover =
 					(isStartupTimeout || isConversationNotFound) &&
 					!this.ctx.isCleaningUp() &&
 					!!this.ctx.onStartupTimeoutAutoRecover &&
-					startupRecoverAttempts <= 1;
+					startupRecoverAttempts <= STARTUP_MAX_RETRIES;
 
 				if (canAutoRecover) {
 					this.ctx.startupTimeoutAutoRecoverAttempts = startupRecoverAttempts;
+					// Exponential backoff: base * 2^(attempt-1), capped at 30s.
+					// e.g. with default 3s base: attempt 1 → 3s, attempt 2 → 6s
+					const delayMs = Math.min(
+						STARTUP_RECOVERY_DELAY_MS * Math.pow(2, startupRecoverAttempts - 1),
+						30000
+					);
 					logger.warn(
-						`SDK ${isConversationNotFound ? 'conversation not found' : 'startup timeout'} — scheduling auto-recovery attempt ${startupRecoverAttempts} (fresh query without resume)`
+						`SDK ${isConversationNotFound ? 'conversation not found' : 'startup timeout'} — ` +
+							`scheduling auto-recovery attempt ${startupRecoverAttempts}/${STARTUP_MAX_RETRIES} ` +
+							`(fresh query without resume) in ${delayMs}ms`
 					);
 					// Defer until after finally{} completes so shared state is reset first.
 					setTimeout(() => {
 						this.ctx.onStartupTimeoutAutoRecover!().catch((err: unknown) => {
 							logger.error('Auto-recovery after SDK startup timeout failed:', err);
 						});
-					}, 300);
+					}, delayMs);
 					// setIdle is handled by the finally block; skipping here avoids a double call.
 				} else {
 					// Reset counter so a future successfully-started session can recover again.
@@ -444,16 +482,31 @@ export class QueryRunner {
 
 						const processingState = stateManager.getState();
 
+						// For startup timeouts that exhausted all retries, provide actionable recovery hints.
+						const startupTimeoutUserMessage = isStartupTimeout
+							? `The AI session failed to start after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
+								`(workspace: ${session.workspacePath}). ` +
+								`Common causes: another Claude Code session is using the same workspace, ` +
+								`a stale lock file in .claude/, or the workspace is under heavy load. ` +
+								`Try: closing other Claude sessions on this workspace, ` +
+								`then resend your message. ` +
+								`You can also increase the timeout with NEOKAI_SDK_STARTUP_TIMEOUT_MS (current: ${STARTUP_TIMEOUT_MS}ms).`
+							: undefined;
+
 						await errorManager.handleError(
 							session.id,
 							error as Error,
 							category,
-							undefined,
+							startupTimeoutUserMessage,
 							processingState,
 							{
 								errorMessage,
 								queueSize: messageQueue.size(),
 								providerId: providerId ?? 'anthropic',
+								workspacePath: session.workspacePath,
+								isRootWorkspace: !session.worktree,
+								startupTimeoutMs: STARTUP_TIMEOUT_MS,
+								startupMaxRetries: STARTUP_MAX_RETRIES,
 							}
 						);
 					}

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -51,6 +51,9 @@ function getStartupMaxRetries(): number {
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_STARTUP_MAX_RETRIES;
 }
 
+// Read once at module load — consistent with the original STARTUP_TIMEOUT_MS pattern.
+// Env vars set after the process starts will not be picked up; the values displayed
+// in user-facing error messages reflect these module-load-time snapshots.
 const STARTUP_TIMEOUT_MS = getStartupTimeoutMs();
 const STARTUP_RECOVERY_DELAY_MS = getStartupRecoveryDelayMs();
 const STARTUP_MAX_RETRIES = getStartupMaxRetries();
@@ -482,16 +485,21 @@ export class QueryRunner {
 
 						const processingState = stateManager.getState();
 
-						// For startup timeouts that exhausted all retries, provide actionable recovery hints.
-						const startupTimeoutUserMessage = isStartupTimeout
-							? `The AI session failed to start after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
-								`(workspace: ${session.workspacePath}). ` +
-								`Common causes: another Claude Code session is using the same workspace, ` +
-								`a stale lock file in .claude/, or the workspace is under heavy load. ` +
-								`Try: closing other Claude sessions on this workspace, ` +
-								`then resend your message. ` +
-								`You can also increase the timeout with NEOKAI_SDK_STARTUP_TIMEOUT_MS (current: ${STARTUP_TIMEOUT_MS}ms).`
-							: undefined;
+						// For startup timeouts / conversation-not-found that exhausted all retries,
+						// provide actionable recovery hints. Both error types are handled symmetrically
+						// (same retry gate, same sdkSessionId clearing), so both deserve a hint.
+						const startupTimeoutUserMessage =
+							isStartupTimeout || isConversationNotFound
+								? `The AI session failed to ${isStartupTimeout ? 'start' : 'resume'} after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
+									`(workspace: ${session.workspacePath}). ` +
+									(isStartupTimeout
+										? `Common causes: another Claude Code session is using the same workspace, ` +
+											`a stale lock file in .claude/, or the workspace is under heavy load. `
+										: `The previous session file could not be found or is corrupt. `) +
+									`Try: closing other Claude sessions on this workspace, ` +
+									`then resend your message. ` +
+									`You can also increase the timeout with NEOKAI_SDK_STARTUP_TIMEOUT_MS (current: ${STARTUP_TIMEOUT_MS}ms).`
+								: undefined;
 
 						await errorManager.handleError(
 							session.id,

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -4,7 +4,7 @@
  * Tests for SDK query execution with streaming input.
  */
 
-import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach, mock, jest } from 'bun:test';
 import { tmpdir } from 'node:os';
 import { QueryRunner, type QueryRunnerContext } from '../../../src/lib/agent/query-runner';
 import type { Session, MessageHub } from '@neokai/shared';
@@ -779,7 +779,8 @@ describe('QueryRunner', () => {
 			expect(clearSpy).toHaveBeenCalled();
 		});
 
-		it('should schedule onStartupTimeoutAutoRecover after ~300ms', async () => {
+		it('should schedule onStartupTimeoutAutoRecover after the recovery delay (not immediately)', async () => {
+			jest.useFakeTimers();
 			const recoverSpy = mock(async () => {});
 			const ctx = createContext({
 				onStartupTimeoutAutoRecover: recoverSpy,
@@ -788,11 +789,17 @@ describe('QueryRunner', () => {
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
 
-			// Not yet called — deferred by setTimeout(300ms)
+			// Not yet called — deferred by setTimeout
 			expect(recoverSpy).not.toHaveBeenCalled();
+			// startupTimeoutAutoRecoverAttempts was incremented (recovery is scheduled)
+			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(1);
 
-			await new Promise((resolve) => setTimeout(resolve, 400));
+			// Advance timers past the base recovery delay (default 3000ms)
+			jest.runAllTimers();
+			// Allow microtasks to flush
+			await new Promise((resolve) => setImmediate(resolve));
 			expect(recoverSpy).toHaveBeenCalledTimes(1);
+			jest.useRealTimers();
 		});
 
 		it('should NOT invoke onStartupTimeoutAutoRecover when isCleaningUp returns true', async () => {
@@ -809,19 +816,61 @@ describe('QueryRunner', () => {
 			expect(recoverSpy).not.toHaveBeenCalled();
 		});
 
-		it('should surface error normally and NOT recover when retry limit (1) is already reached', async () => {
+		it('should surface error normally and NOT recover when retry limit (2) is already reached', async () => {
 			const recoverSpy = mock(async () => {});
 			const ctx = createContext({
-				startupTimeoutAutoRecoverAttempts: 1, // already at limit
+				startupTimeoutAutoRecoverAttempts: 2, // already at limit (default STARTUP_MAX_RETRIES=2)
 				onStartupTimeoutAutoRecover: recoverSpy,
 			});
 			runner = new QueryRunner(ctx);
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
 
-			await new Promise((resolve) => setTimeout(resolve, 400));
+			await new Promise((resolve) => setTimeout(resolve, 100));
 			expect(recoverSpy).not.toHaveBeenCalled();
 			expect(handleErrorSpy).toHaveBeenCalled();
+		});
+
+		it('should still recover on second attempt (attempts=1, limit=2)', async () => {
+			jest.useFakeTimers();
+			const recoverSpy = mock(async () => {});
+			const ctx = createContext({
+				startupTimeoutAutoRecoverAttempts: 1, // first retry already done, second still allowed
+				onStartupTimeoutAutoRecover: recoverSpy,
+			});
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(recoverSpy).not.toHaveBeenCalled();
+			// Second attempt increments to 2 (still ≤ STARTUP_MAX_RETRIES=2)
+			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(2);
+
+			jest.runAllTimers();
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(recoverSpy).toHaveBeenCalledTimes(1);
+			jest.useRealTimers();
+		});
+
+		it('should use exponential backoff: second attempt delay is 2× the first', async () => {
+			// First attempt: delay = BASE * 2^0 = BASE * 1
+			// Second attempt: delay = BASE * 2^1 = BASE * 2
+			// We verify the second attempt waits longer by checking the attempt count after scheduling
+			const ctx1 = createContext({
+				startupTimeoutAutoRecoverAttempts: 0, // first attempt
+				onStartupTimeoutAutoRecover: mock(async () => {}),
+			});
+			new QueryRunner(ctx1).start();
+			await ctx1.queryPromise?.catch(() => {});
+			expect(ctx1.startupTimeoutAutoRecoverAttempts).toBe(1); // incremented for attempt 1
+
+			const ctx2 = createContext({
+				startupTimeoutAutoRecoverAttempts: 1, // second attempt
+				onStartupTimeoutAutoRecover: mock(async () => {}),
+			});
+			new QueryRunner(ctx2).start();
+			await ctx2.queryPromise?.catch(() => {});
+			expect(ctx2.startupTimeoutAutoRecoverAttempts).toBe(2); // incremented for attempt 2
 		});
 
 		it('should increment startupTimeoutAutoRecoverAttempts when recovery is scheduled', async () => {
@@ -834,6 +883,24 @@ describe('QueryRunner', () => {
 			await ctx.queryPromise?.catch(() => {});
 
 			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(1);
+		});
+
+		it('should pass actionable user message to handleError when all retries exhausted', async () => {
+			const ctx = createContext({
+				startupTimeoutAutoRecoverAttempts: 2, // at limit, no handler needed
+			});
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(handleErrorSpy).toHaveBeenCalledWith(
+				'test-session-id',
+				expect.any(Error),
+				expect.any(String), // category
+				expect.stringContaining('workspace'), // user message mentions workspace
+				expect.anything(),
+				expect.objectContaining({ isRootWorkspace: expect.any(Boolean) })
+			);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -803,6 +803,7 @@ describe('QueryRunner', () => {
 		});
 
 		it('should NOT invoke onStartupTimeoutAutoRecover when isCleaningUp returns true', async () => {
+			jest.useFakeTimers();
 			const recoverSpy = mock(async () => {});
 			const ctx = createContext({
 				isCleaningUp: () => true,
@@ -812,8 +813,10 @@ describe('QueryRunner', () => {
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
 
-			await new Promise((resolve) => setTimeout(resolve, 400));
+			jest.runAllTimers();
+			await new Promise((resolve) => setImmediate(resolve));
 			expect(recoverSpy).not.toHaveBeenCalled();
+			jest.useRealTimers();
 		});
 
 		it('should surface error normally and NOT recover when retry limit (2) is already reached', async () => {
@@ -853,24 +856,42 @@ describe('QueryRunner', () => {
 		});
 
 		it('should use exponential backoff: second attempt delay is 2× the first', async () => {
-			// First attempt: delay = BASE * 2^0 = BASE * 1
-			// Second attempt: delay = BASE * 2^1 = BASE * 2
-			// We verify the second attempt waits longer by checking the attempt count after scheduling
-			const ctx1 = createContext({
-				startupTimeoutAutoRecoverAttempts: 0, // first attempt
-				onStartupTimeoutAutoRecover: mock(async () => {}),
+			// First attempt: delay = BASE * 2^(1-1) = BASE * 1
+			// Second attempt: delay = BASE * 2^(2-1) = BASE * 2
+			const capturedDelays: number[] = [];
+			const originalSetTimeout = globalThis.setTimeout;
+			// Spy on setTimeout to capture delay arguments for recovery calls
+			const setTimeoutSpy = mock((fn: () => void, delay?: number) => {
+				capturedDelays.push(delay ?? 0);
+				return originalSetTimeout(fn, 0); // fire immediately to avoid slow tests
 			});
-			new QueryRunner(ctx1).start();
-			await ctx1.queryPromise?.catch(() => {});
-			expect(ctx1.startupTimeoutAutoRecoverAttempts).toBe(1); // incremented for attempt 1
+			globalThis.setTimeout = setTimeoutSpy as unknown as typeof setTimeout;
 
-			const ctx2 = createContext({
-				startupTimeoutAutoRecoverAttempts: 1, // second attempt
-				onStartupTimeoutAutoRecover: mock(async () => {}),
-			});
-			new QueryRunner(ctx2).start();
-			await ctx2.queryPromise?.catch(() => {});
-			expect(ctx2.startupTimeoutAutoRecoverAttempts).toBe(2); // incremented for attempt 2
+			try {
+				const ctx1 = createContext({
+					startupTimeoutAutoRecoverAttempts: 0, // first attempt
+					onStartupTimeoutAutoRecover: mock(async () => {}),
+				});
+				new QueryRunner(ctx1).start();
+				await ctx1.queryPromise?.catch(() => {});
+
+				const ctx2 = createContext({
+					startupTimeoutAutoRecoverAttempts: 1, // second attempt
+					onStartupTimeoutAutoRecover: mock(async () => {}),
+				});
+				new QueryRunner(ctx2).start();
+				await ctx2.queryPromise?.catch(() => {});
+			} finally {
+				globalThis.setTimeout = originalSetTimeout;
+			}
+
+			// Each run captures one setTimeout call (the recovery defer).
+			// Delays must satisfy the 2× exponential relationship.
+			expect(capturedDelays.length).toBeGreaterThanOrEqual(2);
+			const delay1 = capturedDelays[0];
+			const delay2 = capturedDelays[1];
+			expect(delay1).toBeGreaterThan(0);
+			expect(delay2).toBe(delay1 * 2);
 		});
 
 		it('should increment startupTimeoutAutoRecoverAttempts when recovery is scheduled', async () => {

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -885,9 +885,9 @@ describe('QueryRunner', () => {
 				globalThis.setTimeout = originalSetTimeout;
 			}
 
-			// Each run captures one setTimeout call (the recovery defer).
-			// Delays must satisfy the 2× exponential relationship.
-			expect(capturedDelays.length).toBeGreaterThanOrEqual(2);
+			// Each QueryRunner run produces exactly one setTimeout (the recovery defer).
+			// Asserting === 2 guards against accidental extra calls shifting the indices.
+			expect(capturedDelays.length).toBe(2);
 			const delay1 = capturedDelays[0];
 			const delay2 = capturedDelays[1];
 			expect(delay1).toBeGreaterThan(0);
@@ -906,7 +906,7 @@ describe('QueryRunner', () => {
 			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(1);
 		});
 
-		it('should pass actionable user message to handleError when all retries exhausted', async () => {
+		it('should pass actionable user message to handleError when all retries exhausted (startup timeout)', async () => {
 			const ctx = createContext({
 				startupTimeoutAutoRecoverAttempts: 2, // at limit, no handler needed
 			});
@@ -918,10 +918,32 @@ describe('QueryRunner', () => {
 				'test-session-id',
 				expect.any(Error),
 				expect.any(String), // category
-				expect.stringContaining('workspace'), // user message mentions workspace
+				expect.stringContaining('NEOKAI_SDK_STARTUP_TIMEOUT_MS'), // timeout hint for startup failure
 				expect.anything(),
 				expect.objectContaining({ isRootWorkspace: expect.any(Boolean) })
 			);
+		});
+
+		it('should pass session-reset hint (no timeout mention) when conversation-not-found retries exhausted', async () => {
+			buildSpy.mockRejectedValue(new Error('No conversation found for session abc123'));
+			const ctx = createContext({
+				startupTimeoutAutoRecoverAttempts: 2, // at limit
+			});
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(handleErrorSpy).toHaveBeenCalledWith(
+				'test-session-id',
+				expect.any(Error),
+				expect.any(String),
+				expect.stringContaining('session has been reset automatically'), // actionable hint
+				expect.anything(),
+				expect.objectContaining({ isRootWorkspace: expect.any(Boolean) })
+			);
+			// NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a missing session file
+			const userMessage = handleErrorSpy.mock.calls[0][3] as string;
+			expect(userMessage).not.toContain('NEOKAI_SDK_STARTUP_TIMEOUT_MS');
 		});
 	});
 });


### PR DESCRIPTION
- Increase auto-recovery delay from 300ms to 3s base with exponential backoff
  (attempt 1: 3s, attempt 2: 6s) giving the SDK subprocess time to fully exit
- Increase max retries from 1 to 2 (3 total attempts) via STARTUP_MAX_RETRIES
- Add NEOKAI_SDK_STARTUP_RECOVERY_DELAY_MS and NEOKAI_SDK_STARTUP_MAX_RETRIES
  env vars for runtime tuning without a redeploy
- Log root workspace vs worktree, attempt number, and timeout hint on startup timeout
- Pass actionable user message when all retries exhausted: workspace path, common
  causes (workspace contention, stale lock), and NEOKAI_SDK_STARTUP_TIMEOUT_MS hint
- Update tests: fake timers for delay assertions, second-retry coverage, exhausted-
  retries user message assertion, exponential backoff scheduling verification
