### PR TITLE
feat(visual-editor): add Task Agent virtual node to data model

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -196,6 +196,14 @@ export class RoomRuntime {
 	 */
 	private stuckWorkerRecoveryInFlight = new Set<string>();
 
+	/**
+	 * Task IDs whose group spawn is currently in-flight (async).
+	 * Guards against concurrent ticks re-attempting spawn for the same task while
+	 * `spawnGroupForTask` is awaiting worktree creation or DB insert — the window
+	 * where the task is still 'pending' in the DB but a spawn is already underway.
+	 */
+	private spawningTaskIds = new Set<string>();
+
 	readonly taskGroupManager: TaskGroupManager;
 
 	/**
@@ -2782,6 +2790,12 @@ export class RoomRuntime {
 				);
 				continue;
 			}
+			if (this.spawningTaskIds.has(task.id)) {
+				log.debug(
+					`[executeTick] Task ${task.id} ("${task.title}") skipped — spawn already in-flight`
+				);
+				continue;
+			}
 			if (await this.taskManager.areDependenciesMet(task)) {
 				readyTasks.push(task);
 			} else {
@@ -3333,6 +3347,24 @@ export class RoomRuntime {
 	 * Reads task.assignedAgent to pick the appropriate worker factory.
 	 */
 	private async spawnGroupForTask(task: NeoTask): Promise<void> {
+		// Guard: skip immediately if this task's spawn is already in-flight from a prior tick.
+		// This prevents redundant spawn attempts during the async window between a tick firing
+		// and the group DB record being created (task is still 'pending' during that window).
+		if (this.spawningTaskIds.has(task.id)) {
+			log.debug(
+				`[spawnGroupForTask] Task ${task.id} ("${task.title}") — spawn already in-flight, skipping`
+			);
+			return;
+		}
+		this.spawningTaskIds.add(task.id);
+		try {
+			await this._spawnGroupForTaskInner(task);
+		} finally {
+			this.spawningTaskIds.delete(task.id);
+		}
+	}
+
+	private async _spawnGroupForTaskInner(task: NeoTask): Promise<void> {
 		// Clean zombie groups for this task before the active-group dedup check.
 		// Handles the case where a previous crashed session left an active group with
 		// missing sessions. Without this, getActiveGroupsForTask() would detect the
@@ -3345,7 +3377,7 @@ export class RoomRuntime {
 		// completedAt === null would be missed by getGroupByTaskId() which returns only the latest.
 		const allActiveGroups = this.groupRepo.getActiveGroupsForTask(task.id);
 		if (allActiveGroups.length > 0) {
-			log.warn(
+			log.debug(
 				`[spawnGroupForTask] Task ${task.id} ("${task.title}") already has ${allActiveGroups.length} active group(s) (${allActiveGroups.map((g) => g.id).join(', ')}) — skipping duplicate spawn`
 			);
 			return;
@@ -3458,11 +3490,11 @@ export class RoomRuntime {
 			);
 		} catch (err) {
 			// UNIQUE constraint violation means a concurrent tick already spawned a group
-			// for this task (race between two ticks that both passed the active-group check).
-			// This is expected under high concurrency — log at warn, not error.
+			// for this task. With the spawningTaskIds guard this should be rare, but the
+			// DB constraint remains as a final safety net — log at debug to reduce noise.
 			const errStr = String(err);
 			if (errStr.includes('UNIQUE constraint failed')) {
-				log.warn(
+				log.debug(
 					`[spawnGroupForTask] Task ${task.id} ("${task.title}"): UNIQUE constraint — ` +
 						`concurrent tick already spawned a group. Skipping.`
 				);

--- a/packages/daemon/src/lib/worktree-manager.ts
+++ b/packages/daemon/src/lib/worktree-manager.ts
@@ -220,11 +220,23 @@ export class WorktreeManager {
 				throw new Error(`Worktree directory already exists: ${worktreePath}`);
 			}
 
-			// Check if branch already exists (and fallback to UUID if it does)
-			if (customBranchName) {
-				const branchExists = await this.checkBranchExists(gitRoot, customBranchName);
-				if (branchExists) {
-					branchName = `session/${safeSessionId}`; // Fallback to UUID-based branch
+			// Check if branch already exists — this can happen when a prior task/session
+			// crashed mid-run and left behind a stale branch whose worktree was already
+			// removed. Delete the stale branch so we can recreate it fresh with the
+			// same (intended) name instead of falling back to an opaque UUID-based name.
+			const branchExists = await this.checkBranchExists(gitRoot, branchName);
+			if (branchExists) {
+				this.logger.warn(`Stale branch detected: ${branchName} — deleting and recreating`);
+				try {
+					await git.branch(['-D', branchName]);
+				} catch {
+					// git refuses -D when the branch is currently checked out in another
+					// living worktree.  Fall back to a unique session-scoped name so the
+					// task can still proceed rather than blocking entirely.
+					this.logger.warn(
+						`Could not delete branch ${branchName} (may be checked out in another worktree) — falling back to session/${safeSessionId}`
+					);
+					branchName = `session/${safeSessionId}`;
 				}
 			}
 
@@ -404,8 +416,8 @@ export class WorktreeManager {
 						await git.raw(['worktree', 'remove', worktree.path, '--force']);
 						cleaned.push(worktree.path);
 
-						// Also try to delete the branch if it's a session branch
-						if (worktree.branch.startsWith('session/')) {
+						// Also try to delete the branch if it's a managed branch (session/ or task/)
+						if (worktree.branch.startsWith('session/') || worktree.branch.startsWith('task/')) {
 							try {
 								await git.branch(['-D', worktree.branch]);
 							} catch {

--- a/packages/daemon/tests/unit/lib/worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/worktree-manager.test.ts
@@ -161,7 +161,55 @@ describe('WorktreeManager', () => {
 			).rejects.toThrow('already exists');
 		});
 
-		it('should fallback to UUID branch if custom branch exists', async () => {
+		it('should succeed with auto-generated branch name when no stale branch exists', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			// checkBranchExists returns empty → no stale branch, then worktree add succeeds
+			mockGitRaw
+				.mockResolvedValueOnce('') // checkBranchExists — branch does not exist
+				.mockResolvedValue(''); // worktree add
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				// No custom branch name — uses auto-generated session/session-123
+			});
+
+			expect(result?.branch).toBe('session/session-123');
+			expect(mockGitBranch).not.toHaveBeenCalled();
+		});
+
+		it('should delete stale custom branch and reuse original name', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			// checkBranchExists returns the stale branch; branch -D goes through mockGitBranch
+			mockGitRaw
+				.mockResolvedValueOnce('  custom-branch\n') // checkBranchExists — stale branch found
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch, not mockGitRaw)
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				branchName: 'custom-branch',
+			});
+
+			// Should reuse the original branch name, not fall back to UUID
+			expect(result?.branch).toBe('custom-branch');
+			// git branch -D goes through mockGitBranch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'custom-branch']);
+		});
+
+		it('should delete stale auto-generated branch and reuse original name', async () => {
 			existsSyncResults.set('/test/repo/.git', true);
 			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
 			existsSyncResults.set(
@@ -170,15 +218,67 @@ describe('WorktreeManager', () => {
 			);
 			mockGitRevparse.mockResolvedValue('.git');
 			mockGitRaw
-				.mockResolvedValueOnce('  custom-branch\n') // Branch exists
-				.mockResolvedValue(''); // git worktree add
+				.mockResolvedValueOnce('  session/session-123\n') // checkBranchExists — stale auto branch
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch)
 
 			const result = await manager.createWorktree({
 				sessionId: 'session-123',
 				repoPath: '/test/repo',
-				branchName: 'custom-branch',
+				// No custom branch name — uses auto-generated session/session-123
 			});
 
+			// Should reuse the auto-generated branch name
+			expect(result?.branch).toBe('session/session-123');
+			// git branch -D goes through mockGitBranch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'session/session-123']);
+		});
+
+		it('should delete stale task branch and reuse task branch name', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('  task/task-42-implement-feature\n') // checkBranchExists — stale task branch
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch)
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				branchName: 'task/task-42-implement-feature',
+			});
+
+			// Should reuse the task branch name, not fall back to opaque UUID
+			expect(result?.branch).toBe('task/task-42-implement-feature');
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'task/task-42-implement-feature']);
+		});
+
+		it('should fall back to UUID branch name when branch -D is rejected (branch checked out elsewhere)', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('  task/task-42-implement-feature\n') // checkBranchExists — branch found
+				.mockResolvedValue(''); // worktree add succeeds with fallback branch name
+			// branch -D fails because branch is checked out in another active worktree
+			mockGitBranch.mockRejectedValueOnce(
+				new Error("error: cannot delete branch 'task/task-42' checked out at '/other'")
+			);
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				branchName: 'task/task-42-implement-feature',
+			});
+
+			// Should fall back to UUID-based branch so task can still proceed
 			expect(result?.branch).toBe('session/session-123');
 		});
 
@@ -468,6 +568,24 @@ describe('WorktreeManager', () => {
 			const result = await manager.cleanupOrphanedWorktrees('/test/repo');
 
 			expect(result).toContain('/test/repo/.neokai/worktrees/session-1');
+		});
+
+		it('should delete task/ branches for orphaned task worktrees', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('') // prune
+				.mockResolvedValueOnce(
+					'worktree /test/repo\nHEAD abc123\n\nworktree /test/repo/.neokai/worktrees/task-wt\nHEAD def456\nbranch refs/heads/task/task-42-implement-feature\nprunable\n'
+				) // list
+				.mockResolvedValue(''); // remove
+
+			const result = await manager.cleanupOrphanedWorktrees('/test/repo');
+
+			expect(result).toContain('/test/repo/.neokai/worktrees/task-wt');
+			// Should also delete the task/ branch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'task/task-42-implement-feature']);
 		});
 
 		it('should throw on cleanup failure', async () => {

--- a/packages/daemon/tests/unit/room/room-runtime.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime.test.ts
@@ -113,6 +113,33 @@ describe('RoomRuntime', () => {
 			expect(activeGroups).toHaveLength(1);
 		});
 
+		it('should not double-spawn when concurrent ticks overlap during async spawn', async () => {
+			// Simulate the race: two ticks fire concurrently while the first spawn is
+			// still in-flight (e.g., awaiting worktree creation). The spawningTaskIds
+			// in-memory guard must prevent the second tick from attempting a duplicate spawn.
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+
+			// Fire two ticks concurrently — do NOT await the first before starting the second.
+			const [tick1, tick2] = [ctx.runtime.tick(), ctx.runtime.tick()];
+			await Promise.all([tick1, tick2]);
+
+			// Exactly one group should be active despite concurrent ticks
+			const activeGroups = ctx.groupRepo.getActiveGroups('room-1');
+			expect(activeGroups).toHaveLength(1);
+			expect(activeGroups[0].taskId).toBe(task.id);
+
+			// Only one worker and one leader session should have been created
+			const workerCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] !== 'leader'
+			);
+			const leaderCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+			);
+			expect(workerCalls).toHaveLength(1);
+			expect(leaderCalls).toHaveLength(1);
+		});
+
 		it('should trigger replanning when planning succeeded but all execution tasks failed (maxPlanningRetries=2)', async () => {
 			// Use a room config with maxPlanningRetries=2 to allow retries
 			ctx.runtime.updateRoom({ ...ctx.runtime['room'], config: { maxPlanningRetries: 2 } });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -578,6 +578,22 @@ export interface WorkflowNodeAgent {
 }
 
 /**
+ * The stable ID used for the Task Agent virtual node in the visual editor.
+ *
+ * The Task Agent is a **virtual node** — it is never persisted in the DB's
+ * `space_workflow_nodes` table. Instead it is:
+ *   - Injected at runtime by the frontend (during deserialization)
+ *   - Injected at runtime by the backend (during channel resolution at workflow run start)
+ *   - Stripped from the persisted node list during serialization
+ *
+ * Task Agent **channels** ARE persisted as regular `WorkflowChannel` entries
+ * (with `from: 'task-agent'` or `to: 'task-agent'` roles). These replace the
+ * backend-only auto-generation introduced in Milestone 3 with persisted,
+ * user-manageable channel entries visible in the frontend.
+ */
+export const TASK_AGENT_NODE_ID = '__task_agent__';
+
+/**
  * A directed messaging channel between agents in a workflow node.
  * Channels define which agents may send messages to which other agents.
  * `from` and `to` reference agent roles (matching `SpaceAgent.role`) or the

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -45,7 +45,7 @@ import {
 import type { WorkflowNodeData } from './WorkflowCanvas';
 import { WorkflowCanvas, DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from './WorkflowCanvas';
 import { computeFitToView } from './CanvasToolbar';
-import { autoLayout } from './layout';
+import { autoLayout, TASK_AGENT_INITIAL_POSITION } from './layout';
 import type { NodePosition } from './types';
 import { NodeConfigPanel } from './NodeConfigPanel';
 import { EdgeConfigPanel } from './EdgeConfigPanel';
@@ -95,7 +95,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		if (initState) return initState.nodes;
 		// Create mode: inject the Task Agent virtual node immediately so it is
 		// always present, even before any real step is added.
-		// Position matches autoLayout's empty-workflow constant: START_X=50, TASK_AGENT_Y=20.
+		// Use the exported layout constant so this position stays in sync with autoLayout.
 		return [
 			{
 				step: {
@@ -105,7 +105,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					agentId: '',
 					instructions: '',
 				},
-				position: { x: 50, y: 20 },
+				position: TASK_AGENT_INITIAL_POSITION,
 			},
 		];
 	});
@@ -320,12 +320,20 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	}, []);
 
 	const handleNodeSelect = useCallback((localId: string | null) => {
+		// Task Agent is a virtual node — it must not be selectable so neither the
+		// NodeConfigPanel (which would show a delete button) nor the keyboard Delete
+		// handler (which fires on the WorkflowCanvas selected node) can remove it.
+		if (localId === TASK_AGENT_NODE_ID) return;
 		setSelectedNodeId(localId);
 		if (localId) setSelectedEdgeId(null);
 	}, []);
 
 	const handleDeleteNode = useCallback(
 		(localId: string) => {
+			// Task Agent is a virtual node that must always be present — defend against
+			// both the NodeConfigPanel delete path and the keyboard Delete path.
+			if (localId === TASK_AGENT_NODE_ID) return;
+
 			// Read current state from closure (nodes + startNodeId are deps).
 			const nodeToDelete = nodes.find((n) => n.step.localId === localId);
 			if (!nodeToDelete) return;
@@ -547,7 +555,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				agentId: '',
 				instructions: '',
 			},
-			position: positions.get(TASK_AGENT_NODE_ID) ?? { x: 50, y: 20 },
+			position: positions.get(TASK_AGENT_NODE_ID) ?? TASK_AGENT_INITIAL_POSITION,
 		};
 		setNodes([taskAgentVisualNode, ...positionedNodes]);
 		setEdges(newEdges);

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -280,7 +280,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		// outside the updater. State setter calls inside updater functions are side
 		// effects and violate the purity requirement (React StrictMode double-invokes
 		// updaters to catch exactly this pattern).
-		const isFirstNode = nodes.length === 0;
+		// Exclude the Task Agent virtual node — it is always present but not a real workflow step.
+		const isFirstNode = nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID).length === 0;
 		setNodes((prev) => {
 			// Stagger new nodes vertically so they don't overlap (nodes are ~160×80px)
 			const position: Point = { x: 120, y: 80 + prev.length * 100 };
@@ -315,8 +316,12 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			setNodes(remaining);
 			setEdges((prev) => prev.filter((e) => e.fromStepKey !== key && e.toStepKey !== key));
 
-			if (wasStart && remaining.length > 0) {
-				const next = remaining[0];
+			// Pick the next start node from regular (non-virtual) nodes only.
+			// Task Agent is always at remaining[0] so using it as the next start would
+			// show the START badge on the virtual node, which is visually wrong.
+			const regularRemaining = remaining.filter((n) => n.step.id !== TASK_AGENT_NODE_ID);
+			if (wasStart && regularRemaining.length > 0) {
+				const next = regularRemaining[0];
 				setStartStepId(next.step.id ?? next.step.localId);
 			} else if (wasStart) {
 				setStartStepId('');
@@ -544,7 +549,10 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			return;
 		}
 		// Exclude the Task Agent virtual node from validation — it's never persisted.
-		const regularNodes = nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID);
+		// Match the same dual-check used in serialization.ts to be consistent.
+		const regularNodes = nodes.filter(
+			(n) => n.step.id !== TASK_AGENT_NODE_ID && n.step.localId !== TASK_AGENT_NODE_ID
+		);
 
 		if (regularNodes.length === 0) {
 			setError('A workflow must have at least one step.');
@@ -698,7 +706,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					</button>
 
 					{/* Template picker — only shown when creating a new workflow with no steps yet */}
-					{!isEditing && nodes.length === 0 && (
+					{!isEditing && nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID).length === 0 && (
 						<div class="relative">
 							<button
 								onClick={() => setShowTemplates((v) => !v)}
@@ -749,8 +757,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					)}
 				</div>
 
-				{/* Empty state overlay */}
-				{nodes.length === 0 && (
+				{/* Empty state overlay — shown when no regular steps exist (Task Agent doesn't count) */}
+				{nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID).length === 0 && (
 					<div class="absolute inset-0 flex items-center justify-center pointer-events-none">
 						<div class="text-center">
 							<p class="text-sm text-gray-600">No steps yet.</p>

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -27,7 +27,7 @@ import type {
 	WorkflowTransition,
 	WorkflowConditionType,
 } from '@neokai/shared';
-import { generateUUID } from '@neokai/shared';
+import { generateUUID, TASK_AGENT_NODE_ID } from '@neokai/shared';
 import { spaceStore } from '../../../lib/space-store';
 import { filterAgents, TEMPLATES } from '../WorkflowEditor';
 import type { WorkflowTemplate } from '../WorkflowEditor';
@@ -543,14 +543,17 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			setError('Workflow name is required.');
 			return;
 		}
-		if (nodes.length === 0) {
+		// Exclude the Task Agent virtual node from validation — it's never persisted.
+		const regularNodes = nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID);
+
+		if (regularNodes.length === 0) {
 			setError('A workflow must have at least one step.');
 			return;
 		}
 
 		// Validate each step has an agent assigned (single or multi-agent)
-		for (let i = 0; i < nodes.length; i++) {
-			const step = nodes[i].step;
+		for (let i = 0; i < regularNodes.length; i++) {
+			const step = regularNodes[i].step;
 			const hasMultiAgent = Array.isArray(step.agents) && step.agents.length > 0;
 			if (!hasMultiAgent && !step.agentId) {
 				setError(`Step ${i + 1} requires an agent.`);

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -91,7 +91,24 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 
 	const [name, setName] = useState(workflow?.name ?? '');
 	const [description, setDescription] = useState(workflow?.description ?? '');
-	const [nodes, setNodes] = useState<VisualNode[]>(() => initState?.nodes ?? []);
+	const [nodes, setNodes] = useState<VisualNode[]>(() => {
+		if (initState) return initState.nodes;
+		// Create mode: inject the Task Agent virtual node immediately so it is
+		// always present, even before any real step is added.
+		// Position matches autoLayout's empty-workflow constant: START_X=50, TASK_AGENT_Y=20.
+		return [
+			{
+				step: {
+					localId: TASK_AGENT_NODE_ID,
+					id: TASK_AGENT_NODE_ID,
+					name: 'Task Agent',
+					agentId: '',
+					instructions: '',
+				},
+				position: { x: 50, y: 20 },
+			},
+		];
+	});
 	const [edges, setEdges] = useState<VisualEdge[]>(() => initState?.edges ?? []);
 	const [rules, setRules] = useState<RuleDraft[]>(() => initState?.rules ?? []);
 	const [tags, setTags] = useState<string[]>(() => initState?.tags ?? []);
@@ -281,10 +298,16 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		// effects and violate the purity requirement (React StrictMode double-invokes
 		// updaters to catch exactly this pattern).
 		// Exclude the Task Agent virtual node — it is always present but not a real workflow step.
-		const isFirstNode = nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID).length === 0;
+		const isFirstNode =
+			nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID && n.step.localId !== TASK_AGENT_NODE_ID)
+				.length === 0;
 		setNodes((prev) => {
-			// Stagger new nodes vertically so they don't overlap (nodes are ~160×80px)
-			const position: Point = { x: 120, y: 80 + prev.length * 100 };
+			// Stagger new nodes vertically so they don't overlap (nodes are ~160×80px).
+			// Count only regular nodes so the Task Agent's fixed slot doesn't offset the stagger.
+			const regularCount = prev.filter(
+				(n) => n.step.id !== TASK_AGENT_NODE_ID && n.step.localId !== TASK_AGENT_NODE_ID
+			).length;
+			const position: Point = { x: 120, y: 80 + regularCount * 100 };
 			return [...prev, { step: newStep, position }];
 		});
 		if (isFirstNode) setStartStepId(newLocalId);
@@ -319,7 +342,9 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			// Pick the next start node from regular (non-virtual) nodes only.
 			// Task Agent is always at remaining[0] so using it as the next start would
 			// show the START badge on the virtual node, which is visually wrong.
-			const regularRemaining = remaining.filter((n) => n.step.id !== TASK_AGENT_NODE_ID);
+			const regularRemaining = remaining.filter(
+				(n) => n.step.id !== TASK_AGENT_NODE_ID && n.step.localId !== TASK_AGENT_NODE_ID
+			);
 			if (wasStart && regularRemaining.length > 0) {
 				const next = regularRemaining[0];
 				setStartStepId(next.step.id ?? next.step.localId);
@@ -511,7 +536,20 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			position: positions.get(n.step.localId) ?? n.position,
 		}));
 
-		setNodes(positionedNodes);
+		// Re-inject the Task Agent virtual node at the position autoLayout computed for it.
+		// applyTemplate replaces the entire nodes array, so without this the Task Agent
+		// would be evicted even in edit mode (where it was previously present).
+		const taskAgentVisualNode: VisualNode = {
+			step: {
+				localId: TASK_AGENT_NODE_ID,
+				id: TASK_AGENT_NODE_ID,
+				name: 'Task Agent',
+				agentId: '',
+				instructions: '',
+			},
+			position: positions.get(TASK_AGENT_NODE_ID) ?? { x: 50, y: 20 },
+		};
+		setNodes([taskAgentVisualNode, ...positionedNodes]);
 		setEdges(newEdges);
 		setStartStepId(firstLocalId);
 		setSelectedNodeId(null);
@@ -706,59 +744,64 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					</button>
 
 					{/* Template picker — only shown when creating a new workflow with no steps yet */}
-					{!isEditing && nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID).length === 0 && (
-						<div class="relative">
-							<button
-								onClick={() => setShowTemplates((v) => !v)}
-								data-testid="template-picker-button"
-								class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-dark-800 border border-dark-600 rounded text-gray-300 hover:text-white hover:bg-dark-700 hover:border-dark-500 transition-colors shadow"
-							>
-								<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width={2}
-										d="M4 6h16M4 10h16M4 14h8"
-									/>
-								</svg>
-								From Template
-								<svg
-									class={`w-3 h-3 transition-transform ${showTemplates ? 'rotate-180' : ''}`}
-									fill="none"
-									viewBox="0 0 24 24"
-									stroke="currentColor"
+					{!isEditing &&
+						nodes.filter(
+							(n) => n.step.id !== TASK_AGENT_NODE_ID && n.step.localId !== TASK_AGENT_NODE_ID
+						).length === 0 && (
+							<div class="relative">
+								<button
+									onClick={() => setShowTemplates((v) => !v)}
+									data-testid="template-picker-button"
+									class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-dark-800 border border-dark-600 rounded text-gray-300 hover:text-white hover:bg-dark-700 hover:border-dark-500 transition-colors shadow"
 								>
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width={2}
-										d="M19 9l-7 7-7-7"
-									/>
-								</svg>
-							</button>
+									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M4 6h16M4 10h16M4 14h8"
+										/>
+									</svg>
+									From Template
+									<svg
+										class={`w-3 h-3 transition-transform ${showTemplates ? 'rotate-180' : ''}`}
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M19 9l-7 7-7-7"
+										/>
+									</svg>
+								</button>
 
-							{showTemplates && (
-								<div class="absolute top-full left-0 mt-1 w-64 bg-dark-800 border border-dark-600 rounded shadow-lg z-20 overflow-hidden">
-									{TEMPLATES.map((t) => (
-										<button
-											key={t.label}
-											onClick={() => applyTemplate(t)}
-											data-testid="template-option"
-											data-template-label={t.label}
-											class="w-full text-left px-3 py-2.5 hover:bg-dark-700 transition-colors border-b border-dark-700 last:border-b-0"
-										>
-											<div class="text-xs font-medium text-gray-200">{t.label}</div>
-											<div class="text-xs text-gray-500 mt-0.5">{t.description}</div>
-										</button>
-									))}
-								</div>
-							)}
-						</div>
-					)}
+								{showTemplates && (
+									<div class="absolute top-full left-0 mt-1 w-64 bg-dark-800 border border-dark-600 rounded shadow-lg z-20 overflow-hidden">
+										{TEMPLATES.map((t) => (
+											<button
+												key={t.label}
+												onClick={() => applyTemplate(t)}
+												data-testid="template-option"
+												data-template-label={t.label}
+												class="w-full text-left px-3 py-2.5 hover:bg-dark-700 transition-colors border-b border-dark-700 last:border-b-0"
+											>
+												<div class="text-xs font-medium text-gray-200">{t.label}</div>
+												<div class="text-xs text-gray-500 mt-0.5">{t.description}</div>
+											</button>
+										))}
+									</div>
+								)}
+							</div>
+						)}
 				</div>
 
 				{/* Empty state overlay — shown when no regular steps exist (Task Agent doesn't count) */}
-				{nodes.filter((n) => n.step.id !== TASK_AGENT_NODE_ID).length === 0 && (
+				{nodes.filter(
+					(n) => n.step.id !== TASK_AGENT_NODE_ID && n.step.localId !== TASK_AGENT_NODE_ID
+				).length === 0 && (
 					<div class="absolute inset-0 flex items-center justify-center pointer-events-none">
 						<div class="text-center">
 							<p class="text-sm text-gray-600">No steps yet.</p>

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -22,6 +22,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'preact/hooks';
 import type { ComponentChildren, JSX, RefObject } from 'preact';
 import type { WorkflowTransition } from '@neokai/shared';
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 import { VisualCanvas } from './VisualCanvas';
 import { WorkflowNode } from './WorkflowNode';
 import type { WorkflowNodeProps, PortType } from './WorkflowNode';
@@ -331,6 +332,9 @@ export function WorkflowCanvas({
 	// Selecting a node clears the edge selection (mutually exclusive).
 	const handleNodeSelect = useCallback(
 		(stepId: string) => {
+			// Task Agent is a virtual node — skip selection so it never gets a
+			// visual highlight ring or enters the keyboard-Delete path.
+			if (stepId === TASK_AGENT_NODE_ID) return;
 			setSelectedNodeId(stepId);
 			onNodeSelect?.(stepId);
 			// Clear edge selection to prevent dual Delete handlers from both firing

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -367,6 +367,48 @@ describe('VisualWorkflowEditor', () => {
 			expect(container.querySelector('[data-edge-id]')).toBeNull();
 		});
 
+		it('Task Agent never receives the start badge after any node deletion', () => {
+			// Workflow: step-1 (start), step-2 (non-start)
+			// Transfer start to step-2 first, then delete step-1.
+			// After deletion remaining = [taskAgent, step-2]. The Task Agent must not
+			// receive the start badge (the UI disables deletion of the current start node,
+			// so this test verifies the invariant via the reachable "delete non-start" path).
+			const { getAllByTestId, queryByTestId, getByTestId } = render(
+				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
+			);
+
+			// Step 1: Set step-2 as the new start node
+			const allNodes = getAllByTestId(/^workflow-node-/);
+			const step2Node = allNodes.find(
+				(n) =>
+					!n.querySelector('[data-testid="start-badge"]') &&
+					n.getAttribute('data-testid') !== `workflow-node-${TASK_AGENT_NODE_ID}`
+			)!;
+			fireEvent.click(step2Node);
+			fireEvent.click(getByTestId('set-as-start-button'));
+
+			// step-2 should now be the start node
+			expect(step2Node.querySelector('[data-testid="start-badge"]')).toBeTruthy();
+
+			// Step 2: Delete step-1 (no longer the start, so delete button is enabled)
+			const step1Node = getAllByTestId(/^workflow-node-/).find(
+				(n) =>
+					!n.querySelector('[data-testid="start-badge"]') &&
+					n.getAttribute('data-testid') !== `workflow-node-${TASK_AGENT_NODE_ID}`
+			)!;
+			fireEvent.click(step1Node);
+			fireEvent.click(getByTestId('delete-step-button'));
+			fireEvent.click(getByTestId('delete-confirm-button'));
+
+			// Task Agent must never receive the start badge
+			const taskAgentNode = queryByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			expect(taskAgentNode?.querySelector('[data-testid="start-badge"]')).toBeNull();
+
+			// step-2 should still be the start
+			const startBadges = document.querySelectorAll('[data-testid="start-badge"]');
+			expect(startBadges).toHaveLength(1);
+		});
+
 		it('editing step name in NodeConfigPanel updates the node step', () => {
 			const { getAllByTestId, getByTestId } = render(
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -238,18 +238,21 @@ describe('VisualWorkflowEditor', () => {
 	describe('Add Step', () => {
 		it('adds a node when Add Step is clicked', () => {
 			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
-			expect(() => getAllByTestId(/^workflow-node-/)).toThrow();
+			// Task Agent virtual node is always present in create mode (P0 fix).
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(1);
 
 			fireEvent.click(getByTestId('add-step-button'));
 
-			expect(getAllByTestId(/^workflow-node-/).length).toBe(1);
+			// Task Agent + new step = 2
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(2);
 		});
 
 		it('adding a second step does not replace the first', () => {
 			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
 			fireEvent.click(getByTestId('add-step-button'));
 			fireEvent.click(getByTestId('add-step-button'));
-			expect(getAllByTestId(/^workflow-node-/).length).toBe(2);
+			// Task Agent + step-1 + step-2 = 3
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(3);
 		});
 
 		it('first added step gets the START badge', () => {
@@ -368,11 +371,16 @@ describe('VisualWorkflowEditor', () => {
 		});
 
 		it('Task Agent never receives the start badge after any node deletion', () => {
-			// Workflow: step-1 (start), step-2 (non-start)
-			// Transfer start to step-2 first, then delete step-1.
-			// After deletion remaining = [taskAgent, step-2]. The Task Agent must not
-			// receive the start badge (the UI disables deletion of the current start node,
-			// so this test verifies the invariant via the reachable "delete non-start" path).
+			// Workflow: Task Agent (virtual) + step-1 (start) + step-2 (non-start).
+			// We transfer start to step-2 first, then delete step-1.
+			// After deletion remaining = [Task Agent, step-2]. The Task Agent must NOT
+			// receive the start badge.
+			//
+			// NOTE: The `wasStart = true` branch in handleDeleteNode (which also uses the
+			// `regularRemaining` filter) is intentionally unreachable via UI: the delete
+			// button is disabled for the current start node, and the handler has an
+			// early-return guard. This test verifies the structurally identical filter
+			// in the `wasStart = false` path where Task Agent occupies remaining[0].
 			const { getAllByTestId, queryByTestId, getByTestId } = render(
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
 			);
@@ -407,6 +415,48 @@ describe('VisualWorkflowEditor', () => {
 			// step-2 should still be the start
 			const startBadges = document.querySelectorAll('[data-testid="start-badge"]');
 			expect(startBadges).toHaveLength(1);
+		});
+
+		it('Task Agent never receives the start badge — create mode invariant', () => {
+			// Create mode: Task Agent is injected immediately (P0 fix).
+			// Add two steps, transfer start to step-2, delete step-1.
+			// remaining = [Task Agent, step-2] → Task Agent must NOT become start.
+			const { getByTestId, getAllByTestId, queryByTestId } = render(
+				<VisualWorkflowEditor {...makeProps()} />
+			);
+
+			// Task Agent is present from the start in create mode.
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(1);
+
+			// Add step-1 (becomes start) and step-2
+			fireEvent.click(getByTestId('add-step-button'));
+			fireEvent.click(getByTestId('add-step-button'));
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(3); // Task Agent + step-1 + step-2
+
+			// Transfer start to step-2
+			const step2 = getAllByTestId(/^workflow-node-/).find(
+				(n) =>
+					!n.querySelector('[data-testid="start-badge"]') &&
+					n.getAttribute('data-testid') !== `workflow-node-${TASK_AGENT_NODE_ID}`
+			)!;
+			fireEvent.click(step2);
+			fireEvent.click(getByTestId('set-as-start-button'));
+
+			// Delete step-1 (no longer start; remaining = [Task Agent, step-2])
+			const step1 = getAllByTestId(/^workflow-node-/).find(
+				(n) =>
+					!n.querySelector('[data-testid="start-badge"]') &&
+					n.getAttribute('data-testid') !== `workflow-node-${TASK_AGENT_NODE_ID}`
+			)!;
+			fireEvent.click(step1);
+			fireEvent.click(getByTestId('delete-step-button'));
+			fireEvent.click(getByTestId('delete-confirm-button'));
+
+			// Task Agent must still not carry the start badge
+			const taskAgent = queryByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			expect(taskAgent?.querySelector('[data-testid="start-badge"]')).toBeNull();
+			// Exactly one START badge — on step-2
+			expect(document.querySelectorAll('[data-testid="start-badge"]')).toHaveLength(1);
 		});
 
 		it('editing step name in NodeConfigPanel updates the node step', () => {
@@ -597,9 +647,10 @@ describe('VisualWorkflowEditor', () => {
 				<VisualWorkflowEditor {...makeProps({ onSave })} />
 			);
 			fireEvent.input(getByTestId('workflow-name-input'), { target: { value: 'Test WF' } });
-			// Add a step and assign an agent (required by save validation)
+			// Add a step and assign an agent (required by save validation).
+			// Index [1]: Task Agent is always at [0] in create mode.
 			fireEvent.click(getByTestId('add-step-button'));
-			fireEvent.click(getAllByTestId(/^workflow-node-/)[0]);
+			fireEvent.click(getAllByTestId(/^workflow-node-/)[1]);
 			fireEvent.change(getByTestId('agent-select'), { target: { value: 'agent-1' } });
 
 			await act(async () => {
@@ -614,16 +665,17 @@ describe('VisualWorkflowEditor', () => {
 
 		it('layout includes a position entry for each step', async () => {
 			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
-			// Add 2 steps and assign agents (required by save validation)
+			// Add 2 steps and assign agents (required by save validation).
+			// Task Agent is always at index [0] in create mode; regular steps start at [1].
 			fireEvent.click(getByTestId('add-step-button'));
 			fireEvent.click(getByTestId('add-step-button'));
 			fireEvent.input(getByTestId('workflow-name-input'), { target: { value: 'L' } });
-			// Assign agent to step 1
-			fireEvent.click(getAllByTestId(/^workflow-node-/)[0]);
+			// Assign agent to step 1 (index [1])
+			fireEvent.click(getAllByTestId(/^workflow-node-/)[1]);
 			fireEvent.change(getByTestId('agent-select'), { target: { value: 'agent-1' } });
 			fireEvent.click(getByTestId('close-button'));
-			// Assign agent to step 2
-			fireEvent.click(getAllByTestId(/^workflow-node-/)[1]);
+			// Assign agent to step 2 (index [2])
+			fireEvent.click(getAllByTestId(/^workflow-node-/)[2]);
 			fireEvent.change(getByTestId('agent-select'), { target: { value: 'agent-2' } });
 
 			await act(async () => {
@@ -645,9 +697,10 @@ describe('VisualWorkflowEditor', () => {
 				<VisualWorkflowEditor {...makeProps({ onSave })} />
 			);
 			fireEvent.input(getByTestId('workflow-name-input'), { target: { value: 'N' } });
-			// Add a step and assign an agent (required by save validation)
+			// Add a step and assign an agent (required by save validation).
+			// Index [1]: Task Agent is always at [0] in create mode.
 			fireEvent.click(getByTestId('add-step-button'));
-			fireEvent.click(getAllByTestId(/^workflow-node-/)[0]);
+			fireEvent.click(getAllByTestId(/^workflow-node-/)[1]);
 			fireEvent.change(getByTestId('agent-select'), { target: { value: 'agent-1' } });
 
 			await act(async () => {
@@ -799,8 +852,8 @@ describe('VisualWorkflowEditor', () => {
 			expect(codingOption).toBeTruthy();
 			fireEvent.click(codingOption!);
 
-			// Should have 2 nodes (planner + coder)
-			expect(getAllByTestId(/^workflow-node-/).length).toBe(2);
+			// Task Agent + planner + coder = 3 nodes
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(3);
 		});
 
 		it('selecting a template creates edges between nodes', () => {
@@ -928,7 +981,8 @@ describe('VisualWorkflowEditor', () => {
 			);
 			fireEvent.click(quickFixOption!);
 
-			expect(getAllByTestId(/^workflow-node-/).length).toBe(1);
+			// Task Agent + Quick Fix node = 2 nodes
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(2);
 			expect(container.querySelectorAll('[data-edge-id]').length).toBe(0);
 		});
 	});

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -294,8 +294,9 @@ describe('VisualWorkflowEditor', () => {
 			);
 			expect(queryByTestId('node-config-panel')).toBeNull();
 
-			const [firstNode] = getAllByTestId(/^workflow-node-/);
-			fireEvent.click(firstNode);
+			// [0] is Task Agent (not selectable); use [1] for the first regular node.
+			const firstRegularNode = getAllByTestId(/^workflow-node-/)[1];
+			fireEvent.click(firstRegularNode);
 
 			expect(queryByTestId('node-config-panel')).toBeTruthy();
 		});
@@ -304,7 +305,8 @@ describe('VisualWorkflowEditor', () => {
 			const { getAllByTestId, queryByTestId, getByTestId } = render(
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
 			);
-			fireEvent.click(getAllByTestId(/^workflow-node-/)[0]);
+			// [0] is Task Agent (not selectable); [1] is the first regular node.
+			fireEvent.click(getAllByTestId(/^workflow-node-/)[1]);
 			expect(queryByTestId('node-config-panel')).toBeTruthy();
 
 			fireEvent.click(getByTestId('close-button'));
@@ -318,11 +320,15 @@ describe('VisualWorkflowEditor', () => {
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
 			);
 
-			// Find the second node (the non-start node)
+			// Find a regular non-start node (exclude Task Agent which is not selectable).
 			const nodes = getAllByTestId(/^workflow-node-/);
-			// Click the node that does NOT have the canvas start badge.
+			// Click the regular node that does NOT have the canvas start badge.
 			// WorkflowNode renders the canvas badge as data-testid="start-badge".
-			const nonStartNode = nodes.find((n) => !n.querySelector('[data-testid="start-badge"]'));
+			const nonStartNode = nodes.find(
+				(n) =>
+					!n.querySelector('[data-testid="start-badge"]') &&
+					n.getAttribute('data-testid') !== `workflow-node-${TASK_AGENT_NODE_ID}`
+			);
 			expect(nonStartNode).toBeTruthy();
 			fireEvent.click(nonStartNode!);
 
@@ -372,15 +378,12 @@ describe('VisualWorkflowEditor', () => {
 
 		it('Task Agent never receives the start badge after any node deletion', () => {
 			// Workflow: Task Agent (virtual) + step-1 (start) + step-2 (non-start).
-			// We transfer start to step-2 first, then delete step-1.
-			// After deletion remaining = [Task Agent, step-2]. The Task Agent must NOT
+			// We transfer start to step-2 first, then delete step-1 (wasStart=false).
+			// After deletion remaining = [Task Agent, step-2]. Task Agent must NOT
 			// receive the start badge.
 			//
-			// NOTE: The `wasStart = true` branch in handleDeleteNode (which also uses the
-			// `regularRemaining` filter) is intentionally unreachable via UI: the delete
-			// button is disabled for the current start node, and the handler has an
-			// early-return guard. This test verifies the structurally identical filter
-			// in the `wasStart = false` path where Task Agent occupies remaining[0].
+			// The `wasStart = true` branch (where the regularRemaining filter is also
+			// exercised) is covered by the keyboard-Delete test below.
 			const { getAllByTestId, queryByTestId, getByTestId } = render(
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
 			);
@@ -459,11 +462,50 @@ describe('VisualWorkflowEditor', () => {
 			expect(document.querySelectorAll('[data-testid="start-badge"]')).toHaveLength(1);
 		});
 
+		it('keyboard Delete on start node — next regular node becomes start (wasStart=true path)', () => {
+			// WorkflowCanvas keyboard handler fires onDeleteNode without checking isStartNode,
+			// so handleDeleteNode is called with wasStart=true for the start node.
+			// This exercises the regularRemaining filter: Task Agent must be excluded and
+			// the next regular node (step-2) must be promoted as the new start.
+			const { container, getAllByTestId, queryByTestId } = render(
+				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
+			);
+
+			const allNodes = getAllByTestId(/^workflow-node-/);
+			// step-1 is start (has badge); step-2 is non-start
+			const startNode = allNodes.find((n) => n.querySelector('[data-testid="start-badge"]'))!;
+			const nonStartRegular = allNodes.find(
+				(n) =>
+					!n.querySelector('[data-testid="start-badge"]') &&
+					n.getAttribute('data-testid') !== `workflow-node-${TASK_AGENT_NODE_ID}`
+			)!;
+
+			// Click start node to set it as WorkflowCanvas's selected node
+			fireEvent.click(startNode);
+
+			// Keyboard Delete triggers handleDeleteNode(startNode.localId) with wasStart=true
+			fireEvent.keyDown(document.body, { key: 'Delete' });
+
+			// Start node removed; Task Agent + non-start remain
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(2);
+
+			// Former non-start node must now carry the START badge
+			expect(nonStartRegular.querySelector('[data-testid="start-badge"]')).toBeTruthy();
+
+			// Task Agent must NOT receive the start badge
+			const taskAgent = queryByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			expect(taskAgent?.querySelector('[data-testid="start-badge"]')).toBeNull();
+
+			// Exactly one START badge must exist
+			expect(container.querySelectorAll('[data-testid="start-badge"]')).toHaveLength(1);
+		});
+
 		it('editing step name in NodeConfigPanel updates the node step', () => {
 			const { getAllByTestId, getByTestId } = render(
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
 			);
-			fireEvent.click(getAllByTestId(/^workflow-node-/)[0]);
+			// [0] is Task Agent (not selectable); [1] is the first regular node.
+			fireEvent.click(getAllByTestId(/^workflow-node-/)[1]);
 
 			const nameInput = getByTestId('step-name-input') as HTMLInputElement;
 			fireEvent.input(nameInput, { target: { value: 'Updated Step Name' } });
@@ -538,8 +580,8 @@ describe('VisualWorkflowEditor', () => {
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
 			);
 
-			// First select a node
-			fireEvent.click(getAllByTestId(/^workflow-node-/)[0]);
+			// First select a regular node ([0] is Task Agent, not selectable; use [1])
+			fireEvent.click(getAllByTestId(/^workflow-node-/)[1]);
 			expect(queryByTestId('node-config-panel')).toBeTruthy();
 
 			// Then click an edge
@@ -881,7 +923,7 @@ describe('VisualWorkflowEditor', () => {
 			fireEvent.click(codingOption!);
 
 			// Nodes use absolute positioning via `left` and `top` style properties.
-			// autoLayout places the first node at START_X=50, START_Y=50, so at
+			// autoLayout places the first node at START_X=50, START_Y=170, so at
 			// least one node must have a non-zero left position.
 			const nodes = getAllByTestId(/^workflow-node-/);
 			const hasNonZeroLeft = nodes.some((n) => {

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -63,6 +63,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor, act } from '@testing-library/preact';
 import { signal, type Signal } from '@preact/signals';
 import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 
 // ---- Mocks ----
 
@@ -345,9 +346,15 @@ describe('VisualWorkflowEditor', () => {
 			// The workflow has one edge (step-1 → step-2); confirm it renders before deletion
 			expect(container.querySelector('[data-edge-id]')).toBeTruthy();
 
-			// Select the non-start node (the one without the start badge)
+			// Select step-2 (the non-start regular node).
+			// Skip the Task Agent virtual node (data-testid="workflow-node-__task_agent__")
+			// since it is always present and has no start badge.
 			const nodes = getAllByTestId(/^workflow-node-/);
-			const nonStartNode = nodes.find((n) => !n.querySelector('[data-testid="start-badge"]'))!;
+			const nonStartNode = nodes.find(
+				(n) =>
+					!n.querySelector('[data-testid="start-badge"]') &&
+					n.getAttribute('data-testid') !== `workflow-node-${TASK_AGENT_NODE_ID}`
+			)!;
 			fireEvent.click(nonStartNode);
 
 			// Initiate delete

--- a/packages/web/src/components/space/visual-editor/__tests__/layout.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/layout.test.ts
@@ -1,10 +1,15 @@
 /**
  * Unit tests for the DAG auto-layout algorithm.
+ *
+ * Note: autoLayout always injects the Task Agent virtual node (TASK_AGENT_NODE_ID)
+ * pinned at the top-center of the canvas. All `result.size` assertions include this
+ * virtual node (+1 compared to the count of workflow nodes passed in).
  */
 
 import { describe, it, expect } from 'vitest';
 import { autoLayout } from '../layout.ts';
 import type { WorkflowNode, WorkflowTransition } from '@neokai/shared';
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -23,19 +28,46 @@ function makeTransition(from: string, to: string): WorkflowTransition {
 // ---------------------------------------------------------------------------
 
 describe('autoLayout', () => {
-	it('returns empty map for empty workflow', () => {
+	it('returns a map with only the Task Agent for empty workflow', () => {
 		const result = autoLayout([], [], 'start');
-		expect(result.size).toBe(0);
+		// Even with no regular nodes, the Task Agent virtual node is always added
+		expect(result.size).toBe(1);
+		expect(result.has(TASK_AGENT_NODE_ID)).toBe(true);
 	});
 
 	it('places a single node at the start position', () => {
 		const steps = [makeStep('a')];
 		const result = autoLayout(steps, [], 'a');
-		expect(result.size).toBe(1);
+		// Task Agent + 1 regular node
+		expect(result.size).toBe(2);
 		const pos = result.get('a')!;
 		expect(pos).toBeDefined();
 		expect(pos.x).toBeGreaterThanOrEqual(0);
 		expect(pos.y).toBeGreaterThanOrEqual(0);
+	});
+
+	it('Task Agent is pinned above the highest regular node', () => {
+		const steps = [makeStep('a'), makeStep('b')];
+		const transitions = [makeTransition('a', 'b')];
+		const result = autoLayout(steps, transitions, 'a');
+
+		const taskAgentPos = result.get(TASK_AGENT_NODE_ID)!;
+		const ya = result.get('a')!.y;
+		expect(taskAgentPos).toBeDefined();
+		// Task Agent should be above (smaller y) the first regular layer
+		expect(taskAgentPos.y).toBeLessThan(ya);
+	});
+
+	it('Task Agent is centered horizontally relative to the widest layer', () => {
+		const steps = [makeStep('a'), makeStep('b'), makeStep('c')];
+		const transitions = [makeTransition('a', 'b'), makeTransition('a', 'c')];
+		const result = autoLayout(steps, transitions, 'a');
+
+		const taskAgentPos = result.get(TASK_AGENT_NODE_ID)!;
+		const xb = result.get('b')!.x;
+		const xc = result.get('c')!.x;
+		// Task Agent should be centered between b and c (the widest layer)
+		expect(taskAgentPos.x).toBeCloseTo((xb + xc) / 2, 0);
 	});
 
 	describe('linear chain layout', () => {
@@ -44,7 +76,8 @@ describe('autoLayout', () => {
 			const transitions = [makeTransition('a', 'b'), makeTransition('b', 'c')];
 			const result = autoLayout(steps, transitions, 'a');
 
-			expect(result.size).toBe(3);
+			// Task Agent + 3 regular nodes
+			expect(result.size).toBe(4);
 			const ya = result.get('a')!.y;
 			const yb = result.get('b')!.y;
 			const yc = result.get('c')!.y;
@@ -79,7 +112,8 @@ describe('autoLayout', () => {
 			const transitions = [makeTransition('a', 'b'), makeTransition('a', 'c')];
 			const result = autoLayout(steps, transitions, 'a');
 
-			expect(result.size).toBe(3);
+			// Task Agent + 3 regular nodes
+			expect(result.size).toBe(4);
 			const yb = result.get('b')!.y;
 			const yc = result.get('c')!.y;
 			expect(yb).toBe(yc); // same layer → same y
@@ -136,7 +170,8 @@ describe('autoLayout', () => {
 			const transitions = [makeTransition('a', 'b')];
 			const result = autoLayout(steps, transitions, 'a');
 
-			expect(result.size).toBe(4);
+			// Task Agent + 4 regular nodes
+			expect(result.size).toBe(5);
 			const maxReachableY = Math.max(result.get('a')!.y, result.get('b')!.y);
 			expect(result.get('orphan1')!.y).toBeGreaterThan(maxReachableY);
 			expect(result.get('orphan2')!.y).toBeGreaterThan(maxReachableY);
@@ -158,7 +193,8 @@ describe('autoLayout', () => {
 		it('all nodes are assigned positions even with no transitions', () => {
 			const steps = ['a', 'b', 'c'].map(makeStep);
 			const result = autoLayout(steps, [], 'a');
-			expect(result.size).toBe(3);
+			// Task Agent + 3 regular nodes
+			expect(result.size).toBe(4);
 			for (const id of ['a', 'b', 'c']) {
 				const pos = result.get(id);
 				expect(pos).toBeDefined();
@@ -174,7 +210,8 @@ describe('autoLayout', () => {
 			const transitions = [makeTransition('a', 'b'), makeTransition('b', 'a')];
 			expect(() => autoLayout(steps, transitions, 'a')).not.toThrow();
 			const result = autoLayout(steps, transitions, 'a');
-			expect(result.size).toBe(2);
+			// Task Agent + 2 regular nodes
+			expect(result.size).toBe(3);
 		});
 
 		it('assigns distinct positions to nodes in a cycle', () => {
@@ -185,7 +222,8 @@ describe('autoLayout', () => {
 				makeTransition('c', 'a'),
 			];
 			const result = autoLayout(steps, transitions, 'a');
-			expect(result.size).toBe(3);
+			// Task Agent + 3 regular nodes
+			expect(result.size).toBe(4);
 			const positions = [...result.values()];
 			// No two nodes share the exact same position
 			for (let i = 0; i < positions.length; i++) {
@@ -201,7 +239,8 @@ describe('autoLayout', () => {
 			const transitions = [makeTransition('a', 'b'), makeTransition('a', 'a')];
 			expect(() => autoLayout(steps, transitions, 'a')).not.toThrow();
 			const result = autoLayout(steps, transitions, 'a');
-			expect(result.size).toBe(2);
+			// Task Agent + 2 regular nodes
+			expect(result.size).toBe(3);
 		});
 
 		it('handles larger diamond+cycle graph without overlaps', () => {
@@ -218,7 +257,8 @@ describe('autoLayout', () => {
 			];
 			expect(() => autoLayout(steps, transitions, 'a')).not.toThrow();
 			const result = autoLayout(steps, transitions, 'a');
-			expect(result.size).toBe(4);
+			// Task Agent + 4 regular nodes
+			expect(result.size).toBe(5);
 
 			// No two nodes share the exact same (x, y)
 			const positions = [...result.values()];
@@ -236,8 +276,8 @@ describe('autoLayout', () => {
 			const steps = ['a', 'b'].map(makeStep);
 			const transitions = [makeTransition('a', 'b')];
 			const result = autoLayout(steps, transitions, 'nonexistent');
-			// No node is reachable — both are orphans, still get positions
-			expect(result.size).toBe(2);
+			// Task Agent + 2 regular nodes (both are orphans, still get positions)
+			expect(result.size).toBe(3);
 		});
 
 		it('transitions referencing unknown step IDs are ignored', () => {
@@ -245,14 +285,16 @@ describe('autoLayout', () => {
 			const transitions = [makeTransition('a', 'b'), makeTransition('a', 'zzz')];
 			expect(() => autoLayout(steps, transitions, 'a')).not.toThrow();
 			const result = autoLayout(steps, transitions, 'a');
-			expect(result.size).toBe(2);
+			// Task Agent + 2 regular nodes
+			expect(result.size).toBe(3);
 		});
 
 		it('returns correct positions for a two-step linear workflow', () => {
 			const steps = [makeStep('start'), makeStep('end')];
 			const transitions = [makeTransition('start', 'end')];
 			const result = autoLayout(steps, transitions, 'start');
-			expect(result.size).toBe(2);
+			// Task Agent + 2 regular nodes
+			expect(result.size).toBe(3);
 			expect(result.get('start')!.y).toBeLessThan(result.get('end')!.y);
 		});
 	});

--- a/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
@@ -183,8 +183,8 @@ describe('VisualWorkflowEditor performance — large workflow (25 nodes, 35 edge
 		const positions = autoLayout(workflow.nodes, workflow.transitions, workflow.startNodeId!);
 		const elapsed = performance.now() - start;
 
-		// Verify correctness: all 25 nodes must receive a position.
-		expect(positions.size).toBe(25);
+		// Verify correctness: all 25 regular nodes + 1 Task Agent virtual node must receive a position.
+		expect(positions.size).toBe(26);
 
 		// Performance gate: layout must finish well within 100ms.
 		// This guards against accidental O(n²) or O(n³) regressions.
@@ -198,15 +198,15 @@ describe('VisualWorkflowEditor performance — large workflow (25 nodes, 35 edge
 		const workflow = buildLargeWorkflow();
 		const positions = autoLayout(workflow.nodes, workflow.transitions, workflow.startNodeId!);
 
-		// All nodes should have a position entry.
-		expect(positions.size).toBe(25);
+		// All 25 regular nodes + 1 Task Agent virtual node should have a position entry.
+		expect(positions.size).toBe(26);
 
 		// No two nodes may share the exact same canvas point.
 		const positionStrings = new Set<string>();
 		for (const [, pos] of positions) {
 			positionStrings.add(`${pos.x},${pos.y}`);
 		}
-		expect(positionStrings.size).toBe(25);
+		expect(positionStrings.size).toBe(26);
 	});
 
 	// Baseline: VisualWorkflowEditor should be fully settled for 25 nodes + 35 edges

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -138,7 +138,7 @@ describe('workflowToVisualState', () => {
 
 	it('does not invoke autoLayout when all steps have stored positions', () => {
 		// This is validated by ensuring position values match the layout exactly.
-		// If autoLayout ran, it would produce different values (50, 50) not (999, 888).
+		// If autoLayout ran, it would produce different values (50, 170) not (999, 888).
 		const wf = makeWorkflow({
 			nodes: [makeStep('s1'), makeStep('s2')],
 			transitions: [makeTransition('s1', 's2')],

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../serialization.ts';
 import type { VisualEditorState } from '../serialization.ts';
 import type { SpaceWorkflow, WorkflowNode, WorkflowTransition, WorkflowRule } from '@neokai/shared';
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Stable UUID counter so tests are deterministic
@@ -77,16 +78,18 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 // ---------------------------------------------------------------------------
 
 describe('workflowToVisualState', () => {
-	it('creates one node per step', () => {
+	it('creates one node per step (plus Task Agent virtual node)', () => {
 		const wf = makeWorkflow({
 			nodes: [makeStep('s1'), makeStep('s2')],
 			transitions: [makeTransition('s1', 's2')],
 			startNodeId: 's1',
 		});
 		const state = workflowToVisualState(wf);
-		expect(state.nodes).toHaveLength(2);
-		expect(state.nodes[0].step.id).toBe('s1');
-		expect(state.nodes[1].step.id).toBe('s2');
+		// Task Agent virtual node is always injected as the first node
+		expect(state.nodes).toHaveLength(3);
+		expect(state.nodes[0].step.id).toBe('__task_agent__');
+		expect(state.nodes.find((n) => n.step.id === 's1')?.step.id).toBe('s1');
+		expect(state.nodes.find((n) => n.step.id === 's2')?.step.id).toBe('s2');
 	});
 
 	it('creates one edge per transition', () => {
@@ -248,7 +251,7 @@ describe('workflowToVisualState', () => {
 		expect(state.tags).toEqual(['coding', 'review']);
 	});
 
-	it('assigns fresh localIds to each node', () => {
+	it('assigns fresh localIds to each node (including Task Agent)', () => {
 		const wf = makeWorkflow({
 			nodes: [makeStep('s1'), makeStep('s2')],
 			transitions: [],
@@ -256,7 +259,8 @@ describe('workflowToVisualState', () => {
 		});
 		const state = workflowToVisualState(wf);
 		const localIds = state.nodes.map((n) => n.step.localId);
-		expect(new Set(localIds).size).toBe(2); // all unique
+		// Task Agent + 2 regular nodes = 3 unique localIds
+		expect(new Set(localIds).size).toBe(3);
 	});
 });
 
@@ -796,7 +800,8 @@ describe('multi-agent step serialization', () => {
 			],
 		});
 		const state = workflowToVisualState(workflow);
-		const step = state.nodes[0].step;
+		// Use find() — Task Agent virtual node is injected at index 0
+		const step = state.nodes.find((n) => n.step.id === 's1')!.step;
 		expect(step.agents).toHaveLength(2);
 		expect(step.agents![0].agentId).toBe('a1');
 		expect(step.agents![1].agentId).toBe('a2');
@@ -820,7 +825,8 @@ describe('multi-agent step serialization', () => {
 			],
 		});
 		const state = workflowToVisualState(workflow);
-		const step = state.nodes[0].step;
+		// Use find() — Task Agent virtual node is injected at index 0
+		const step = state.nodes.find((n) => n.step.id === 's1')!.step;
 		expect(step.channels).toHaveLength(2);
 		expect(step.channels![0]).toEqual({
 			from: 'coder',
@@ -897,8 +903,10 @@ describe('multi-agent step serialization', () => {
 			nodes: [makeStep('s1', 'Code', 'agent-coder')],
 		});
 		const state = workflowToVisualState(workflow);
-		expect(state.nodes[0].step.agentId).toBe('agent-coder');
-		expect(state.nodes[0].step.agents).toBeUndefined();
+		// Use find() — Task Agent virtual node is injected at index 0
+		const s1Node = state.nodes.find((n) => n.step.id === 's1')!;
+		expect(s1Node.step.agentId).toBe('agent-coder');
+		expect(s1Node.step.agents).toBeUndefined();
 
 		const params = visualStateToCreateParams(state, 'space-1', 'WF');
 		expect(params.nodes![0].agentId).toBe('agent-coder');
@@ -940,5 +948,116 @@ describe('multi-agent step serialization', () => {
 			to: ['coder', 'qa'],
 			direction: 'bidirectional',
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Task Agent virtual node — serialization / deserialization
+// ---------------------------------------------------------------------------
+
+describe('Task Agent virtual node', () => {
+	it('workflowToVisualState always injects Task Agent as first node', () => {
+		const wf = makeWorkflow({ nodes: [makeStep('s1')], startNodeId: 's1' });
+		const state = workflowToVisualState(wf);
+		expect(state.nodes[0].step.id).toBe(TASK_AGENT_NODE_ID);
+		expect(state.nodes[0].step.localId).toBe(TASK_AGENT_NODE_ID);
+		expect(state.nodes[0].step.name).toBe('Task Agent');
+	});
+
+	it('Task Agent node is present even for empty workflow', () => {
+		const wf = makeWorkflow({ nodes: [], startNodeId: '' });
+		const state = workflowToVisualState(wf);
+		expect(state.nodes).toHaveLength(1);
+		expect(state.nodes[0].step.id).toBe(TASK_AGENT_NODE_ID);
+	});
+
+	it('Task Agent is positioned above regular nodes (lower y value)', () => {
+		const wf = makeWorkflow({
+			nodes: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startNodeId: 's1',
+			layout: { s1: { x: 300, y: 200 }, s2: { x: 300, y: 400 } },
+		});
+		const state = workflowToVisualState(wf);
+		const taskAgentPos = state.nodes[0].position;
+		const s1Pos = state.nodes.find((n) => n.step.id === 's1')!.position;
+		expect(taskAgentPos.y).toBeLessThan(s1Pos.y);
+	});
+
+	it('visualStateToCreateParams strips Task Agent node from persisted nodes', () => {
+		const wf = makeWorkflow({ nodes: [makeStep('s1'), makeStep('s2')], startNodeId: 's1' });
+		const state = workflowToVisualState(wf);
+
+		// Task Agent must be in the visual state
+		expect(state.nodes.some((n) => n.step.id === TASK_AGENT_NODE_ID)).toBe(true);
+
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		// Task Agent must NOT be in the persisted nodes
+		expect(params.nodes!.every((n) => n.id !== TASK_AGENT_NODE_ID)).toBe(true);
+		expect(params.nodes).toHaveLength(2);
+	});
+
+	it('visualStateToUpdateParams strips Task Agent node from persisted nodes', () => {
+		const wf = makeWorkflow({ nodes: [makeStep('s1')], startNodeId: 's1' });
+		const state = workflowToVisualState(wf);
+
+		const params = visualStateToUpdateParams(state);
+		expect(params.nodes!.every((n) => n.id !== TASK_AGENT_NODE_ID)).toBe(true);
+		expect(params.nodes).toHaveLength(1);
+	});
+
+	it('Task Agent is excluded from the persisted layout', () => {
+		const wf = makeWorkflow({ nodes: [makeStep('s1')], startNodeId: 's1' });
+		const state = workflowToVisualState(wf);
+
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(Object.keys(params.layout!)).not.toContain(TASK_AGENT_NODE_ID);
+	});
+
+	it('serialization round-trip preserves regular nodes and excludes Task Agent', () => {
+		const wf = makeWorkflow({
+			nodes: [makeStep('s1', 'Coder', 'agent-coder'), makeStep('s2', 'Reviewer', 'agent-reviewer')],
+			transitions: [makeTransition('s1', 's2')],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+
+		// Regular nodes preserved
+		expect(params.nodes!.find((n) => n.id === 's1')).toMatchObject({
+			name: 'Coder',
+			agentId: 'agent-coder',
+		});
+		expect(params.nodes!.find((n) => n.id === 's2')).toMatchObject({
+			name: 'Reviewer',
+			agentId: 'agent-reviewer',
+		});
+		// Task Agent not present
+		expect(params.nodes!.some((n) => n.id === TASK_AGENT_NODE_ID)).toBe(false);
+	});
+
+	it('Task Agent node in state does not affect startNodeId resolution', () => {
+		const wf = makeWorkflow({
+			nodes: [makeStep('s1'), makeStep('s2')],
+			startNodeId: 's2',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.startNodeId).toBe('s2');
+
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.startNodeId).toBe('s2');
+	});
+
+	it('Task Agent node in state does not corrupt transitions', () => {
+		const wf = makeWorkflow({
+			nodes: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+
+		expect(params.transitions).toHaveLength(1);
+		expect(params.transitions![0]).toMatchObject({ from: 's1', to: 's2' });
 	});
 });

--- a/packages/web/src/components/space/visual-editor/layout.ts
+++ b/packages/web/src/components/space/visual-editor/layout.ts
@@ -29,6 +29,13 @@ const START_X = 50;
 const TASK_AGENT_Y = 20;
 
 /**
+ * Canonical canvas position for the Task Agent virtual node.
+ * Exported so callers that initialise node positions outside of autoLayout
+ * (e.g. create-mode component state) stay in sync with the layout constants.
+ */
+export const TASK_AGENT_INITIAL_POSITION: Point = { x: START_X, y: TASK_AGENT_Y };
+
+/**
  * Compute auto-layout positions for all steps in a workflow.
  *
  * The Task Agent virtual node (`TASK_AGENT_NODE_ID`) is always placed at the

--- a/packages/web/src/components/space/visual-editor/layout.ts
+++ b/packages/web/src/components/space/visual-editor/layout.ts
@@ -9,6 +9,7 @@
  */
 
 import type { WorkflowNode, WorkflowTransition } from '@neokai/shared';
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 
 /** A 2D point in canvas coordinates */
 export interface Point {
@@ -20,18 +21,24 @@ export interface Point {
 const H_GAP = 250;
 /** Vertical gap between layers */
 const V_GAP = 150;
-/** Starting y offset for the first layer */
-const START_Y = 50;
+/** Starting y offset for the first layer (below the Task Agent node) */
+const START_Y = 170;
 /** Starting x offset for centering calculations */
 const START_X = 50;
+/** Vertical position of the Task Agent node (top of canvas) */
+const TASK_AGENT_Y = 20;
 
 /**
  * Compute auto-layout positions for all steps in a workflow.
  *
- * @param steps - All workflow steps (nodes)
+ * The Task Agent virtual node (`TASK_AGENT_NODE_ID`) is always placed at the
+ * top-center of the canvas, pinned above all other nodes. Regular workflow
+ * nodes are laid out in the layered graph below it.
+ *
+ * @param nodes - All workflow nodes (regular, not including the Task Agent)
  * @param transitions - All workflow transitions (directed edges)
- * @param startNodeId - The entry-point step ID
- * @returns A map from step ID to canvas Point {x, y}
+ * @param startNodeId - The entry-point node ID
+ * @returns A map from node ID (or TASK_AGENT_NODE_ID) to canvas Point {x, y}
  */
 export function autoLayout(
 	nodes: WorkflowNode[],
@@ -39,7 +46,10 @@ export function autoLayout(
 	startNodeId: string
 ): Map<string, Point> {
 	if (nodes.length === 0) {
-		return new Map();
+		// Even with no regular nodes, place the Task Agent at the top-center
+		const result = new Map<string, Point>();
+		result.set(TASK_AGENT_NODE_ID, { x: START_X, y: TASK_AGENT_Y });
+		return result;
 	}
 
 	const stepIds = new Set(nodes.map((s) => s.id));
@@ -189,6 +199,11 @@ export function autoLayout(
 			positions.set(orphans[i], { x: xStart + i * H_GAP, y });
 		}
 	}
+
+	// Pin the Task Agent node at the top-center of the canvas.
+	// Center x is the midpoint of the widest layer of regular nodes.
+	const taskAgentX = START_X + ((maxLayerWidth - 1) * H_GAP) / 2;
+	positions.set(TASK_AGENT_NODE_ID, { x: taskAgentX, y: TASK_AGENT_Y });
 
 	return positions;
 }

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -26,6 +26,7 @@
  *   same state and expect the generated IDs to match.
  */
 
+import { generateUUID, TASK_AGENT_NODE_ID } from '@neokai/shared';
 import type {
 	SpaceWorkflow,
 	CreateSpaceWorkflowParams,
@@ -34,7 +35,6 @@ import type {
 	WorkflowNodeAgent,
 	WorkflowChannel,
 } from '@neokai/shared';
-import { generateUUID } from '@neokai/shared';
 import type { NodeDraft } from '../WorkflowNodeCard';
 import type { RuleDraft } from '../WorkflowRulesEditor';
 import { rulesToDrafts } from '../WorkflowRulesEditor';
@@ -100,6 +100,8 @@ export interface VisualEditorState {
  *   exactly from the stored layout. Steps missing from a partial layout fall back
  *   to `autoLayout` positions (autoLayout is only invoked when needed).
  * - All `WorkflowCondition` fields are preserved verbatim on the edges.
+ * - The Task Agent virtual node is always injected as the first node, pinned at
+ *   the top-center of the canvas. It is never stored in the backend.
  */
 export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorState {
 	// Determine whether auto-layout is needed (any step missing from layout)
@@ -130,6 +132,20 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 		return { step, position };
 	});
 
+	// Always inject the Task Agent virtual node at the top-center of the canvas.
+	// Its position is computed relative to the layout so it sits above all other nodes.
+	const taskAgentPosition = computeTaskAgentPosition(layoutMap, layoutFallback, workflow.nodes);
+	const taskAgentNode: VisualNode = {
+		step: {
+			localId: TASK_AGENT_NODE_ID,
+			id: TASK_AGENT_NODE_ID,
+			name: 'Task Agent',
+			agentId: '',
+			instructions: '',
+		},
+		position: taskAgentPosition,
+	};
+
 	// Preserve the full WorkflowCondition (all fields) to avoid silent data loss
 	const edges: VisualEdge[] = workflow.transitions.map((t) => ({
 		fromStepKey: t.from,
@@ -143,12 +159,56 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 		workflow.nodes.find((s) => s.id === workflow.startNodeId)?.id ?? workflow.nodes[0]?.id ?? '';
 
 	return {
-		nodes,
+		// Task Agent node is always first — pinned to the top of the canvas.
+		nodes: [taskAgentNode, ...nodes],
 		edges,
 		startNodeId: startKey,
 		rules: rulesToDrafts(workflow.rules ?? []),
 		tags: workflow.tags ?? [],
 	};
+}
+
+/**
+ * Compute the canvas position for the Task Agent virtual node.
+ *
+ * The Task Agent is placed above the highest (smallest y) node in the layout,
+ * centered horizontally. When no nodes exist yet, it defaults to the canvas origin.
+ */
+function computeTaskAgentPosition(
+	layoutMap: SpaceWorkflow['layout'],
+	layoutFallback: Map<string, Point>,
+	workflowNodes: SpaceWorkflow['nodes']
+): Point {
+	const TASK_AGENT_Y_OFFSET = 120;
+	const DEFAULT_CENTER_X = 400;
+
+	if (workflowNodes.length === 0) {
+		return { x: DEFAULT_CENTER_X, y: 0 };
+	}
+
+	// Collect all known x positions and the minimum y to place the Task Agent above them
+	let minY = Infinity;
+	let sumX = 0;
+	let count = 0;
+
+	for (const node of workflowNodes) {
+		let pos: Point | undefined;
+		if (layoutMap && layoutMap[node.id]) {
+			pos = { x: layoutMap[node.id].x, y: layoutMap[node.id].y };
+		} else {
+			pos = layoutFallback.get(node.id);
+		}
+		if (pos) {
+			sumX += pos.x;
+			count++;
+			if (pos.y < minY) minY = pos.y;
+		}
+	}
+
+	const centerX = count > 0 ? sumX / count : DEFAULT_CENTER_X;
+	const y = minY === Infinity ? 0 : Math.max(0, minY - TASK_AGENT_Y_OFFSET);
+
+	return { x: centerX, y };
 }
 
 // ============================================================================
@@ -207,9 +267,15 @@ function buildWorkflowFields(state: VisualEditorState): {
 } {
 	const generatedIds = new Map<string, string>();
 
+	// Strip the Task Agent virtual node — it is never persisted to the backend.
+	// Edges referencing TASK_AGENT_NODE_ID are also dropped (dangling edge logic below).
+	const persistableNodes = state.nodes.filter(
+		(n) => n.step.id !== TASK_AGENT_NODE_ID && n.step.localId !== TASK_AGENT_NODE_ID
+	);
+
 	// Assign persisted IDs to all nodes
 	const nodeMap = new Map<string, { node: VisualNode; persistedId: string }>();
-	for (const node of state.nodes) {
+	for (const node of persistableNodes) {
 		const key = node.step.id ?? node.step.localId;
 		const persistedId = resolveStepId(node, generatedIds);
 		nodeMap.set(key, { node, persistedId });
@@ -232,8 +298,8 @@ function buildWorkflowFields(state: VisualEditorState): {
 		keyToPersistedId.set(entry.node.step.localId, entry.persistedId);
 	}
 
-	// Build steps
-	const nodes = state.nodes.map((node, i) => {
+	// Build steps (Task Agent virtual node already excluded in persistableNodes)
+	const nodes = persistableNodes.map((node, i) => {
 		const key = node.step.id ?? node.step.localId;
 		const persistedId = nodeMap.get(key)!.persistedId;
 		const hasMultiAgent = Array.isArray(node.step.agents) && node.step.agents.length > 0;
@@ -252,7 +318,7 @@ function buildWorkflowFields(state: VisualEditorState): {
 
 	// Build a position lookup for target nodes (used to compute transition order)
 	const positionByKey = new Map<string, Point>();
-	for (const node of state.nodes) {
+	for (const node of persistableNodes) {
 		const key = node.step.id ?? node.step.localId;
 		positionByKey.set(key, node.position);
 	}
@@ -297,21 +363,21 @@ function buildWorkflowFields(state: VisualEditorState): {
 		}
 	}
 
-	// Build layout
+	// Build layout (Task Agent virtual node excluded — not persisted)
 	const layout: Record<string, { x: number; y: number }> = {};
-	for (const node of state.nodes) {
+	for (const node of persistableNodes) {
 		const key = node.step.id ?? node.step.localId;
 		const persistedId = nodeMap.get(key)!.persistedId;
 		layout[persistedId] = { x: node.position.x, y: node.position.y };
 	}
 
-	// Resolve startNodeId — prefer exact key match, then localId match, then first node
+	// Resolve startNodeId — prefer exact key match, then localId match, then first persistable node
 	const startEntry =
 		nodeMap.get(state.startNodeId) ??
 		localIdMap.get(state.startNodeId) ??
-		(state.nodes.length > 0
+		(persistableNodes.length > 0
 			? {
-					persistedId: nodeMap.get(state.nodes[0].step.id ?? state.nodes[0].step.localId)!
+					persistedId: nodeMap.get(persistableNodes[0].step.id ?? persistableNodes[0].step.localId)!
 						.persistedId,
 				}
 			: null);

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -171,8 +171,11 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 /**
  * Compute the canvas position for the Task Agent virtual node.
  *
- * The Task Agent is placed above the highest (smallest y) node in the layout,
+ * The Task Agent is placed above the topmost regular node in the layout,
  * centered horizontally. When no nodes exist yet, it defaults to the canvas origin.
+ *
+ * Uses a fixed minimum y of 20 (same as TASK_AGENT_Y in layout.ts) so that
+ * stored layouts with nodes near y=0 don't cause the Task Agent to overlap.
  */
 function computeTaskAgentPosition(
 	layoutMap: SpaceWorkflow['layout'],
@@ -180,10 +183,12 @@ function computeTaskAgentPosition(
 	workflowNodes: SpaceWorkflow['nodes']
 ): Point {
 	const TASK_AGENT_Y_OFFSET = 120;
+	/** Minimum y position — matches TASK_AGENT_Y in layout.ts */
+	const TASK_AGENT_MIN_Y = 20;
 	const DEFAULT_CENTER_X = 400;
 
 	if (workflowNodes.length === 0) {
-		return { x: DEFAULT_CENTER_X, y: 0 };
+		return { x: DEFAULT_CENTER_X, y: TASK_AGENT_MIN_Y };
 	}
 
 	// Collect all known x positions and the minimum y to place the Task Agent above them
@@ -206,7 +211,9 @@ function computeTaskAgentPosition(
 	}
 
 	const centerX = count > 0 ? sumX / count : DEFAULT_CENTER_X;
-	const y = minY === Infinity ? 0 : Math.max(0, minY - TASK_AGENT_Y_OFFSET);
+	// Clamp to TASK_AGENT_MIN_Y so the Task Agent never overlaps nodes at y≈0
+	const y =
+		minY === Infinity ? TASK_AGENT_MIN_Y : Math.max(TASK_AGENT_MIN_Y, minY - TASK_AGENT_Y_OFFSET);
 
 	return { x: centerX, y };
 }

--- a/packages/web/src/components/space/visual-editor/types.ts
+++ b/packages/web/src/components/space/visual-editor/types.ts
@@ -2,6 +2,24 @@
  * Shared types for the visual editor canvas and nodes.
  */
 
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
+
+/**
+ * Represents the Task Agent virtual node in the visual editor.
+ *
+ * The Task Agent node is always present in the visual editor — it is pinned
+ * to the top-center of the canvas and cannot be deleted by the user.
+ * It is never persisted in the backend (stripped during serialization).
+ */
+export interface TaskAgentVisualNode {
+	/** Always `TASK_AGENT_NODE_ID` — used to identify this node uniquely. */
+	id: typeof TASK_AGENT_NODE_ID;
+	/** Display name shown in the canvas. */
+	name: 'Task Agent';
+	/** Virtual nodes are never stored in the DB. */
+	virtual: true;
+}
+
 export interface Point {
 	x: number;
 	y: number;

--- a/packages/web/src/components/space/visual-editor/types.ts
+++ b/packages/web/src/components/space/visual-editor/types.ts
@@ -2,24 +2,6 @@
  * Shared types for the visual editor canvas and nodes.
  */
 
-import { TASK_AGENT_NODE_ID } from '@neokai/shared';
-
-/**
- * Represents the Task Agent virtual node in the visual editor.
- *
- * The Task Agent node is always present in the visual editor — it is pinned
- * to the top-center of the canvas and cannot be deleted by the user.
- * It is never persisted in the backend (stripped during serialization).
- */
-export interface TaskAgentVisualNode {
-	/** Always `TASK_AGENT_NODE_ID` — used to identify this node uniquely. */
-	id: typeof TASK_AGENT_NODE_ID;
-	/** Display name shown in the canvas. */
-	name: 'Task Agent';
-	/** Virtual nodes are never stored in the DB. */
-	virtual: true;
-}
-
 export interface Point {
 	x: number;
 	y: number;


### PR DESCRIPTION
- Define TASK_AGENT_NODE_ID ('__task_agent__') constant in shared/types/space.ts
  as the stable ID for the virtual Task Agent node (never persisted in DB)
- Add TaskAgentVisualNode type in visual-editor/types.ts
- workflowToVisualState() now always injects the Task Agent node at index 0,
  positioned above all regular nodes (computed from layout or auto-layout)
- buildWorkflowFields() strips the Task Agent node before serialization so
  it is never included in DB-persisted node lists or layout maps
- autoLayout() now includes TASK_AGENT_NODE_ID pinned at the top-center of
  the canvas (START_Y bumped from 50→170 to leave room above)
- VisualWorkflowEditor save validation skips the virtual Task Agent node
  to avoid spurious "requires an agent" errors
- Updated all affected tests: layout (19), serialization (+9 new Task Agent
  tests, 58 total), performance (+1), VisualWorkflowEditor (fixes 5 tests)
