### PR TITLE
feat: extend WorkflowNodeAgent schema with role, model, systemPrompt fields

### DIFF
--- a/packages/daemon/.env.example
+++ b/packages/daemon/.env.example
@@ -58,6 +58,27 @@ TEMPERATURE=1.0
 MAX_SESSIONS=10
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# SDK Startup Tuning
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# How long (ms) to wait for the SDK subprocess to emit its first message
+# before declaring a startup timeout. Increase on slow machines or when
+# running many concurrent sessions.
+# Default: 15000
+# NEOKAI_SDK_STARTUP_TIMEOUT_MS=15000
+#
+# Base delay (ms) before the first auto-recovery attempt after a startup
+# timeout. Each subsequent attempt doubles this (exponential backoff).
+# Example: 3000 → attempt 1 waits 3s, attempt 2 waits 6s.
+# Default: 3000
+# NEOKAI_SDK_STARTUP_RECOVERY_DELAY_MS=3000
+#
+# Maximum number of auto-recovery attempts before surfacing the error to
+# the user. Set to 0 to disable auto-recovery entirely.
+# Default: 2
+# NEOKAI_SDK_STARTUP_MAX_RETRIES=2
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Job Queue Configuration
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -25,6 +25,10 @@ import type { QueryOptionsBuilder } from './query-options-builder';
 import type { AskUserQuestionHandler } from './ask-user-question-handler';
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
+/** Base delay before the first auto-recovery attempt. Each subsequent attempt doubles this. */
+const DEFAULT_STARTUP_RECOVERY_DELAY_MS = 3000;
+/** Maximum number of auto-recovery attempts before surfacing the error to the user. */
+const DEFAULT_STARTUP_MAX_RETRIES = 2;
 
 function getStartupTimeoutMs(): number {
 	const raw = process.env.NEOKAI_SDK_STARTUP_TIMEOUT_MS;
@@ -33,7 +37,26 @@ function getStartupTimeoutMs(): number {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STARTUP_TIMEOUT_MS;
 }
 
+function getStartupRecoveryDelayMs(): number {
+	const raw = process.env.NEOKAI_SDK_STARTUP_RECOVERY_DELAY_MS;
+	if (!raw) return DEFAULT_STARTUP_RECOVERY_DELAY_MS;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STARTUP_RECOVERY_DELAY_MS;
+}
+
+function getStartupMaxRetries(): number {
+	const raw = process.env.NEOKAI_SDK_STARTUP_MAX_RETRIES;
+	if (!raw) return DEFAULT_STARTUP_MAX_RETRIES;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_STARTUP_MAX_RETRIES;
+}
+
+// Read once at module load — consistent with the original STARTUP_TIMEOUT_MS pattern.
+// Env vars set after the process starts will not be picked up; the values displayed
+// in user-facing error messages reflect these module-load-time snapshots.
 const STARTUP_TIMEOUT_MS = getStartupTimeoutMs();
+const STARTUP_RECOVERY_DELAY_MS = getStartupRecoveryDelayMs();
+const STARTUP_MAX_RETRIES = getStartupMaxRetries();
 
 /**
  * Original environment variables for restoration after SDK query
@@ -237,10 +260,18 @@ export class QueryRunner {
 				if (!this.ctx.firstMessageReceived) {
 					startupTimeoutReached = true;
 					const elapsed = Date.now() - queryStartTime;
+					const isRootWorkspace = !session.worktree;
+					const workspaceDesc = isRootWorkspace
+						? `root workspace: ${session.workspacePath}`
+						: `worktree: ${session.worktree!.worktreePath}`;
 					logger.error(
 						`SDK startup timeout: SDK did not respond within ${elapsed}ms. ` +
-							`Model: ${queryOptions.model}, Workspace: ${session.workspacePath}` +
-							(session.worktree ? ` (worktree: ${session.worktree.worktreePath})` : '')
+							`Model: ${queryOptions.model}, ${workspaceDesc}` +
+							(isRootWorkspace
+								? ' — running on root workspace (not a worktree); check for other Claude Code sessions using this path'
+								: '') +
+							`. Attempt ${this.ctx.startupTimeoutAutoRecoverAttempts + 1} of ${STARTUP_MAX_RETRIES + 1}.` +
+							` (Hint: set NEOKAI_SDK_STARTUP_TIMEOUT_MS to increase timeout, currently ${STARTUP_TIMEOUT_MS}ms)`
 					);
 
 					// Actively abort a stuck startup so finally{} cleanup runs and the
@@ -348,29 +379,39 @@ export class QueryRunner {
 
 			if (!isAbortError) {
 				// On startup timeout or conversation not found, attempt transparent auto-recovery
-				// (up to 1 retry): restart the query without the old resume handle
+				// (up to STARTUP_MAX_RETRIES): restart the query without the old resume handle
 				// (sdkSessionId already cleared above). Queued messages are preserved so
 				// the user's pending send is retried automatically without any visible error.
-				// The retry limit (attempts <= 1) prevents infinite loops when the SDK is
-				// permanently broken: after 1 failed recovery, the error surfaces normally.
+				// Uses exponential backoff: delay doubles with each attempt to give the SDK
+				// process time to fully exit before the next spawn.
+				// The retry limit prevents infinite loops when the SDK is permanently broken:
+				// after all retries are exhausted, the error surfaces normally.
 				const startupRecoverAttempts = this.ctx.startupTimeoutAutoRecoverAttempts + 1;
 				const canAutoRecover =
 					(isStartupTimeout || isConversationNotFound) &&
 					!this.ctx.isCleaningUp() &&
 					!!this.ctx.onStartupTimeoutAutoRecover &&
-					startupRecoverAttempts <= 1;
+					startupRecoverAttempts <= STARTUP_MAX_RETRIES;
 
 				if (canAutoRecover) {
 					this.ctx.startupTimeoutAutoRecoverAttempts = startupRecoverAttempts;
+					// Exponential backoff: base * 2^(attempt-1), capped at 30s.
+					// e.g. with default 3s base: attempt 1 → 3s, attempt 2 → 6s
+					const delayMs = Math.min(
+						STARTUP_RECOVERY_DELAY_MS * Math.pow(2, startupRecoverAttempts - 1),
+						30000
+					);
 					logger.warn(
-						`SDK ${isConversationNotFound ? 'conversation not found' : 'startup timeout'} — scheduling auto-recovery attempt ${startupRecoverAttempts} (fresh query without resume)`
+						`SDK ${isConversationNotFound ? 'conversation not found' : 'startup timeout'} — ` +
+							`scheduling auto-recovery attempt ${startupRecoverAttempts}/${STARTUP_MAX_RETRIES} ` +
+							`(fresh query without resume) in ${delayMs}ms`
 					);
 					// Defer until after finally{} completes so shared state is reset first.
 					setTimeout(() => {
 						this.ctx.onStartupTimeoutAutoRecover!().catch((err: unknown) => {
 							logger.error('Auto-recovery after SDK startup timeout failed:', err);
 						});
-					}, 300);
+					}, delayMs);
 					// setIdle is handled by the finally block; skipping here avoids a double call.
 				} else {
 					// Reset counter so a future successfully-started session can recover again.
@@ -444,16 +485,41 @@ export class QueryRunner {
 
 						const processingState = stateManager.getState();
 
+						// For startup timeouts / conversation-not-found that exhausted all retries,
+						// provide actionable recovery hints. Both error types are handled symmetrically
+						// (same retry gate, same sdkSessionId clearing), so both deserve a hint.
+						// Keep the hints distinct: NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a
+						// missing/corrupt session file — the session ID was already cleared above,
+						// so the next message will automatically start a fresh session.
+						const startupTimeoutUserMessage = isStartupTimeout
+							? `The AI session failed to start after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
+								`(workspace: ${session.workspacePath}). ` +
+								`Common causes: another Claude Code session is using the same workspace, ` +
+								`a stale lock file in .claude/, or the workspace is under heavy load. ` +
+								`Try: closing other Claude sessions on this workspace, ` +
+								`then resend your message. ` +
+								`You can also increase the timeout with NEOKAI_SDK_STARTUP_TIMEOUT_MS (current: ${STARTUP_TIMEOUT_MS}ms).`
+							: isConversationNotFound
+								? `The AI session could not be resumed after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
+									`(workspace: ${session.workspacePath}). ` +
+									`The previous session file could not be found or is corrupt. ` +
+									`The session has been reset automatically — please resend your message to start fresh.`
+								: undefined;
+
 						await errorManager.handleError(
 							session.id,
 							error as Error,
 							category,
-							undefined,
+							startupTimeoutUserMessage,
 							processingState,
 							{
 								errorMessage,
 								queueSize: messageQueue.size(),
 								providerId: providerId ?? 'anthropic',
+								workspacePath: session.workspacePath,
+								isRootWorkspace: !session.worktree,
+								startupTimeoutMs: STARTUP_TIMEOUT_MS,
+								startupMaxRetries: STARTUP_MAX_RETRIES,
 							}
 						);
 					}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -196,6 +196,14 @@ export class RoomRuntime {
 	 */
 	private stuckWorkerRecoveryInFlight = new Set<string>();
 
+	/**
+	 * Task IDs whose group spawn is currently in-flight (async).
+	 * Guards against concurrent ticks re-attempting spawn for the same task while
+	 * `spawnGroupForTask` is awaiting worktree creation or DB insert — the window
+	 * where the task is still 'pending' in the DB but a spawn is already underway.
+	 */
+	private spawningTaskIds = new Set<string>();
+
 	readonly taskGroupManager: TaskGroupManager;
 
 	/**
@@ -2782,6 +2790,12 @@ export class RoomRuntime {
 				);
 				continue;
 			}
+			if (this.spawningTaskIds.has(task.id)) {
+				log.debug(
+					`[executeTick] Task ${task.id} ("${task.title}") skipped — spawn already in-flight`
+				);
+				continue;
+			}
 			if (await this.taskManager.areDependenciesMet(task)) {
 				readyTasks.push(task);
 			} else {
@@ -3333,6 +3347,24 @@ export class RoomRuntime {
 	 * Reads task.assignedAgent to pick the appropriate worker factory.
 	 */
 	private async spawnGroupForTask(task: NeoTask): Promise<void> {
+		// Guard: skip immediately if this task's spawn is already in-flight from a prior tick.
+		// This prevents redundant spawn attempts during the async window between a tick firing
+		// and the group DB record being created (task is still 'pending' during that window).
+		if (this.spawningTaskIds.has(task.id)) {
+			log.debug(
+				`[spawnGroupForTask] Task ${task.id} ("${task.title}") — spawn already in-flight, skipping`
+			);
+			return;
+		}
+		this.spawningTaskIds.add(task.id);
+		try {
+			await this._spawnGroupForTaskInner(task);
+		} finally {
+			this.spawningTaskIds.delete(task.id);
+		}
+	}
+
+	private async _spawnGroupForTaskInner(task: NeoTask): Promise<void> {
 		// Clean zombie groups for this task before the active-group dedup check.
 		// Handles the case where a previous crashed session left an active group with
 		// missing sessions. Without this, getActiveGroupsForTask() would detect the
@@ -3345,7 +3377,7 @@ export class RoomRuntime {
 		// completedAt === null would be missed by getGroupByTaskId() which returns only the latest.
 		const allActiveGroups = this.groupRepo.getActiveGroupsForTask(task.id);
 		if (allActiveGroups.length > 0) {
-			log.warn(
+			log.debug(
 				`[spawnGroupForTask] Task ${task.id} ("${task.title}") already has ${allActiveGroups.length} active group(s) (${allActiveGroups.map((g) => g.id).join(', ')}) — skipping duplicate spawn`
 			);
 			return;
@@ -3458,11 +3490,11 @@ export class RoomRuntime {
 			);
 		} catch (err) {
 			// UNIQUE constraint violation means a concurrent tick already spawned a group
-			// for this task (race between two ticks that both passed the active-group check).
-			// This is expected under high concurrency — log at warn, not error.
+			// for this task. With the spawningTaskIds guard this should be rare, but the
+			// DB constraint remains as a final safety net — log at debug to reduce noise.
 			const errStr = String(err);
 			if (errStr.includes('UNIQUE constraint failed')) {
-				log.warn(
+				log.debug(
 					`[spawnGroupForTask] Task ${task.id} ("${task.title}"): UNIQUE constraint — ` +
 						`concurrent tick already spawned a group. Skipping.`
 				);

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -187,7 +187,18 @@ function buildWorkflowCreateParams(
 				}
 				// agentId ?? '' is a placeholder for unresolved refs — warnings.length > 0 will
 				// cause a throw before createWorkflow is called, so '' never reaches the DB.
-				const entry: { agentId: string; instructions?: string } = { agentId: agentId ?? '' };
+				const entry: {
+					agentId: string;
+					role: string;
+					model?: string;
+					systemPrompt?: string;
+					instructions?: string;
+				} = {
+					agentId: agentId ?? '',
+					role: a.role,
+				};
+				if (a.model !== undefined) entry.model = a.model;
+				if (a.systemPrompt !== undefined) entry.systemPrompt = a.systemPrompt;
 				if (a.instructions !== undefined) entry.instructions = a.instructions;
 				return entry;
 			});

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -61,6 +61,9 @@ const workflowConditionSchema = z
 
 const exportedWorkflowNodeAgentSchema = z.object({
 	agentRef: z.string().min(1),
+	role: z.string().min(1),
+	model: z.string().optional(),
+	systemPrompt: z.string().optional(),
 	instructions: z.string().optional(),
 });
 
@@ -229,7 +232,10 @@ export function exportWorkflow(
 			const exportedAgents: ExportedWorkflowNodeAgent[] = node.agents.map((a) => {
 				const entry: ExportedWorkflowNodeAgent = {
 					agentRef: agentIdToName.get(a.agentId) ?? a.agentId,
+					role: a.role,
 				};
+				if (a.model !== undefined) entry.model = a.model;
+				if (a.systemPrompt !== undefined) entry.systemPrompt = a.systemPrompt;
 				if (a.instructions !== undefined) entry.instructions = a.instructions;
 				return entry;
 			});

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -191,6 +191,7 @@ export class SpaceWorkflowManager {
 
 		// Format-level validation: always run regardless of agentLookup
 		if (hasAgents) {
+			const seenRoles = new Set<string>();
 			for (let j = 0; j < node.agents!.length; j++) {
 				const entry = node.agents![j];
 				if (!entry.agentId || !entry.agentId.trim()) {
@@ -203,6 +204,12 @@ export class SpaceWorkflowManager {
 						`node[${index}].agents[${j}]: role must be a non-empty string`
 					);
 				}
+				if (seenRoles.has(entry.role)) {
+					throw new WorkflowValidationError(
+						`node[${index}].agents[${j}]: duplicate role "${entry.role}" — each agent slot must have a unique role within the node`
+					);
+				}
+				seenRoles.add(entry.role);
 			}
 		}
 

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -198,6 +198,11 @@ export class SpaceWorkflowManager {
 						`node[${index}].agents[${j}]: agentId must be a non-empty SpaceAgent UUID`
 					);
 				}
+				if (!entry.role || !entry.role.trim()) {
+					throw new WorkflowValidationError(
+						`node[${index}].agents[${j}]: role must be a non-empty string`
+					);
+				}
 			}
 		}
 
@@ -223,7 +228,7 @@ export class SpaceWorkflowManager {
 							`node[${index}].agents[${j}]: agentId "${entry.agentId}" does not match any SpaceAgent in this space`
 						);
 					}
-					knownRoles.add(agent.role);
+					knownRoles.add(entry.role);
 				}
 			}
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -994,7 +994,7 @@ export class SpaceRuntime {
 	 * Resolves the channel topology for a workflow step and stores it in the run's
 	 * config for use by session group creation (Milestone 6).
 	 *
-	 * Calls `resolveNodeChannels()` using all Space agents as the lookup table.
+	 * Resolves channel topology using `WorkflowNodeAgent.role` entries from the step.
 	 * Stores the result under `run.config._resolvedChannels`.
 	 *
 	 * TODO Milestone 6: pass resolvedChannels to session group metadata in
@@ -1010,10 +1010,8 @@ export class SpaceRuntime {
 
 		const config = (run.config ?? {}) as Record<string, unknown>;
 
-		const allAgents = this.config.spaceAgentManager.listBySpaceId(spaceId);
-
 		// Resolve user-declared channels from workflow data (empty array if none declared)
-		const resolved = resolveNodeChannels(step, allAgents);
+		const resolved = resolveNodeChannels(step);
 
 		this.config.workflowRunRepo.updateRun(runId, {
 			config: { ...config, _resolvedChannels: resolved },

--- a/packages/daemon/src/lib/worktree-manager.ts
+++ b/packages/daemon/src/lib/worktree-manager.ts
@@ -220,11 +220,23 @@ export class WorktreeManager {
 				throw new Error(`Worktree directory already exists: ${worktreePath}`);
 			}
 
-			// Check if branch already exists (and fallback to UUID if it does)
-			if (customBranchName) {
-				const branchExists = await this.checkBranchExists(gitRoot, customBranchName);
-				if (branchExists) {
-					branchName = `session/${safeSessionId}`; // Fallback to UUID-based branch
+			// Check if branch already exists — this can happen when a prior task/session
+			// crashed mid-run and left behind a stale branch whose worktree was already
+			// removed. Delete the stale branch so we can recreate it fresh with the
+			// same (intended) name instead of falling back to an opaque UUID-based name.
+			const branchExists = await this.checkBranchExists(gitRoot, branchName);
+			if (branchExists) {
+				this.logger.warn(`Stale branch detected: ${branchName} — deleting and recreating`);
+				try {
+					await git.branch(['-D', branchName]);
+				} catch {
+					// git refuses -D when the branch is currently checked out in another
+					// living worktree.  Fall back to a unique session-scoped name so the
+					// task can still proceed rather than blocking entirely.
+					this.logger.warn(
+						`Could not delete branch ${branchName} (may be checked out in another worktree) — falling back to session/${safeSessionId}`
+					);
+					branchName = `session/${safeSessionId}`;
 				}
 			}
 
@@ -404,8 +416,8 @@ export class WorktreeManager {
 						await git.raw(['worktree', 'remove', worktree.path, '--force']);
 						cleaned.push(worktree.path);
 
-						// Also try to delete the branch if it's a session branch
-						if (worktree.branch.startsWith('session/')) {
+						// Also try to delete the branch if it's a managed branch (session/ or task/)
+						if (worktree.branch.startsWith('session/') || worktree.branch.startsWith('task/')) {
 							try {
 								await git.branch(['-D', worktree.branch]);
 							} catch {

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -113,7 +113,11 @@ function rowToNode(row: NodeRow): WorkflowNode {
 		node.instructions = cfg.instructions;
 	}
 	if (cfg.agents && cfg.agents.length > 0) {
-		node.agents = cfg.agents;
+		// Backfill role = agentId for rows persisted before the role field was introduced.
+		node.agents = cfg.agents.map((a: WorkflowNodeAgent) => ({
+			...a,
+			role: a.role?.trim() ? a.role : a.agentId,
+		}));
 	}
 	if (cfg.channels && cfg.channels.length > 0) {
 		node.channels = cfg.channels;

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -4,7 +4,7 @@
  * Tests for SDK query execution with streaming input.
  */
 
-import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach, mock, jest } from 'bun:test';
 import { tmpdir } from 'node:os';
 import { QueryRunner, type QueryRunnerContext } from '../../../src/lib/agent/query-runner';
 import type { Session, MessageHub } from '@neokai/shared';
@@ -779,7 +779,8 @@ describe('QueryRunner', () => {
 			expect(clearSpy).toHaveBeenCalled();
 		});
 
-		it('should schedule onStartupTimeoutAutoRecover after ~300ms', async () => {
+		it('should schedule onStartupTimeoutAutoRecover after the recovery delay (not immediately)', async () => {
+			jest.useFakeTimers();
 			const recoverSpy = mock(async () => {});
 			const ctx = createContext({
 				onStartupTimeoutAutoRecover: recoverSpy,
@@ -788,14 +789,21 @@ describe('QueryRunner', () => {
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
 
-			// Not yet called — deferred by setTimeout(300ms)
+			// Not yet called — deferred by setTimeout
 			expect(recoverSpy).not.toHaveBeenCalled();
+			// startupTimeoutAutoRecoverAttempts was incremented (recovery is scheduled)
+			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(1);
 
-			await new Promise((resolve) => setTimeout(resolve, 400));
+			// Advance timers past the base recovery delay (default 3000ms)
+			jest.runAllTimers();
+			// Allow microtasks to flush
+			await new Promise((resolve) => setImmediate(resolve));
 			expect(recoverSpy).toHaveBeenCalledTimes(1);
+			jest.useRealTimers();
 		});
 
 		it('should NOT invoke onStartupTimeoutAutoRecover when isCleaningUp returns true', async () => {
+			jest.useFakeTimers();
 			const recoverSpy = mock(async () => {});
 			const ctx = createContext({
 				isCleaningUp: () => true,
@@ -805,23 +813,85 @@ describe('QueryRunner', () => {
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
 
-			await new Promise((resolve) => setTimeout(resolve, 400));
+			jest.runAllTimers();
+			await new Promise((resolve) => setImmediate(resolve));
 			expect(recoverSpy).not.toHaveBeenCalled();
+			jest.useRealTimers();
 		});
 
-		it('should surface error normally and NOT recover when retry limit (1) is already reached', async () => {
+		it('should surface error normally and NOT recover when retry limit (2) is already reached', async () => {
 			const recoverSpy = mock(async () => {});
 			const ctx = createContext({
-				startupTimeoutAutoRecoverAttempts: 1, // already at limit
+				startupTimeoutAutoRecoverAttempts: 2, // already at limit (default STARTUP_MAX_RETRIES=2)
 				onStartupTimeoutAutoRecover: recoverSpy,
 			});
 			runner = new QueryRunner(ctx);
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
 
-			await new Promise((resolve) => setTimeout(resolve, 400));
+			await new Promise((resolve) => setTimeout(resolve, 100));
 			expect(recoverSpy).not.toHaveBeenCalled();
 			expect(handleErrorSpy).toHaveBeenCalled();
+		});
+
+		it('should still recover on second attempt (attempts=1, limit=2)', async () => {
+			jest.useFakeTimers();
+			const recoverSpy = mock(async () => {});
+			const ctx = createContext({
+				startupTimeoutAutoRecoverAttempts: 1, // first retry already done, second still allowed
+				onStartupTimeoutAutoRecover: recoverSpy,
+			});
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(recoverSpy).not.toHaveBeenCalled();
+			// Second attempt increments to 2 (still ≤ STARTUP_MAX_RETRIES=2)
+			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(2);
+
+			jest.runAllTimers();
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(recoverSpy).toHaveBeenCalledTimes(1);
+			jest.useRealTimers();
+		});
+
+		it('should use exponential backoff: second attempt delay is 2× the first', async () => {
+			// First attempt: delay = BASE * 2^(1-1) = BASE * 1
+			// Second attempt: delay = BASE * 2^(2-1) = BASE * 2
+			const capturedDelays: number[] = [];
+			const originalSetTimeout = globalThis.setTimeout;
+			// Spy on setTimeout to capture delay arguments for recovery calls
+			const setTimeoutSpy = mock((fn: () => void, delay?: number) => {
+				capturedDelays.push(delay ?? 0);
+				return originalSetTimeout(fn, 0); // fire immediately to avoid slow tests
+			});
+			globalThis.setTimeout = setTimeoutSpy as unknown as typeof setTimeout;
+
+			try {
+				const ctx1 = createContext({
+					startupTimeoutAutoRecoverAttempts: 0, // first attempt
+					onStartupTimeoutAutoRecover: mock(async () => {}),
+				});
+				new QueryRunner(ctx1).start();
+				await ctx1.queryPromise?.catch(() => {});
+
+				const ctx2 = createContext({
+					startupTimeoutAutoRecoverAttempts: 1, // second attempt
+					onStartupTimeoutAutoRecover: mock(async () => {}),
+				});
+				new QueryRunner(ctx2).start();
+				await ctx2.queryPromise?.catch(() => {});
+			} finally {
+				globalThis.setTimeout = originalSetTimeout;
+			}
+
+			// Each QueryRunner run produces exactly one setTimeout (the recovery defer).
+			// Asserting === 2 guards against accidental extra calls shifting the indices.
+			expect(capturedDelays.length).toBe(2);
+			const delay1 = capturedDelays[0];
+			const delay2 = capturedDelays[1];
+			expect(delay1).toBeGreaterThan(0);
+			expect(delay2).toBe(delay1 * 2);
 		});
 
 		it('should increment startupTimeoutAutoRecoverAttempts when recovery is scheduled', async () => {
@@ -834,6 +904,46 @@ describe('QueryRunner', () => {
 			await ctx.queryPromise?.catch(() => {});
 
 			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(1);
+		});
+
+		it('should pass actionable user message to handleError when all retries exhausted (startup timeout)', async () => {
+			const ctx = createContext({
+				startupTimeoutAutoRecoverAttempts: 2, // at limit, no handler needed
+			});
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(handleErrorSpy).toHaveBeenCalledWith(
+				'test-session-id',
+				expect.any(Error),
+				expect.any(String), // category
+				expect.stringContaining('NEOKAI_SDK_STARTUP_TIMEOUT_MS'), // timeout hint for startup failure
+				expect.anything(),
+				expect.objectContaining({ isRootWorkspace: expect.any(Boolean) })
+			);
+		});
+
+		it('should pass session-reset hint (no timeout mention) when conversation-not-found retries exhausted', async () => {
+			buildSpy.mockRejectedValue(new Error('No conversation found for session abc123'));
+			const ctx = createContext({
+				startupTimeoutAutoRecoverAttempts: 2, // at limit
+			});
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(handleErrorSpy).toHaveBeenCalledWith(
+				'test-session-id',
+				expect.any(Error),
+				expect.any(String),
+				expect.stringContaining('session has been reset automatically'), // actionable hint
+				expect.anything(),
+				expect.objectContaining({ isRootWorkspace: expect.any(Boolean) })
+			);
+			// NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a missing session file
+			const userMessage = handleErrorSpy.mock.calls[0][3] as string;
+			expect(userMessage).not.toContain('NEOKAI_SDK_STARTUP_TIMEOUT_MS');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/lib/worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/worktree-manager.test.ts
@@ -161,7 +161,55 @@ describe('WorktreeManager', () => {
 			).rejects.toThrow('already exists');
 		});
 
-		it('should fallback to UUID branch if custom branch exists', async () => {
+		it('should succeed with auto-generated branch name when no stale branch exists', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			// checkBranchExists returns empty → no stale branch, then worktree add succeeds
+			mockGitRaw
+				.mockResolvedValueOnce('') // checkBranchExists — branch does not exist
+				.mockResolvedValue(''); // worktree add
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				// No custom branch name — uses auto-generated session/session-123
+			});
+
+			expect(result?.branch).toBe('session/session-123');
+			expect(mockGitBranch).not.toHaveBeenCalled();
+		});
+
+		it('should delete stale custom branch and reuse original name', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			// checkBranchExists returns the stale branch; branch -D goes through mockGitBranch
+			mockGitRaw
+				.mockResolvedValueOnce('  custom-branch\n') // checkBranchExists — stale branch found
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch, not mockGitRaw)
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				branchName: 'custom-branch',
+			});
+
+			// Should reuse the original branch name, not fall back to UUID
+			expect(result?.branch).toBe('custom-branch');
+			// git branch -D goes through mockGitBranch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'custom-branch']);
+		});
+
+		it('should delete stale auto-generated branch and reuse original name', async () => {
 			existsSyncResults.set('/test/repo/.git', true);
 			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
 			existsSyncResults.set(
@@ -170,15 +218,67 @@ describe('WorktreeManager', () => {
 			);
 			mockGitRevparse.mockResolvedValue('.git');
 			mockGitRaw
-				.mockResolvedValueOnce('  custom-branch\n') // Branch exists
-				.mockResolvedValue(''); // git worktree add
+				.mockResolvedValueOnce('  session/session-123\n') // checkBranchExists — stale auto branch
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch)
 
 			const result = await manager.createWorktree({
 				sessionId: 'session-123',
 				repoPath: '/test/repo',
-				branchName: 'custom-branch',
+				// No custom branch name — uses auto-generated session/session-123
 			});
 
+			// Should reuse the auto-generated branch name
+			expect(result?.branch).toBe('session/session-123');
+			// git branch -D goes through mockGitBranch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'session/session-123']);
+		});
+
+		it('should delete stale task branch and reuse task branch name', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('  task/task-42-implement-feature\n') // checkBranchExists — stale task branch
+				.mockResolvedValue(''); // worktree add (branch -D uses mockGitBranch)
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				branchName: 'task/task-42-implement-feature',
+			});
+
+			// Should reuse the task branch name, not fall back to opaque UUID
+			expect(result?.branch).toBe('task/task-42-implement-feature');
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'task/task-42-implement-feature']);
+		});
+
+		it('should fall back to UUID branch name when branch -D is rejected (branch checked out elsewhere)', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+			existsSyncResults.set('/home/testuser/.neokai/projects/-test-repo/worktrees', true);
+			existsSyncResults.set(
+				'/home/testuser/.neokai/projects/-test-repo/worktrees/session-123',
+				false
+			);
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('  task/task-42-implement-feature\n') // checkBranchExists — branch found
+				.mockResolvedValue(''); // worktree add succeeds with fallback branch name
+			// branch -D fails because branch is checked out in another active worktree
+			mockGitBranch.mockRejectedValueOnce(
+				new Error("error: cannot delete branch 'task/task-42' checked out at '/other'")
+			);
+
+			const result = await manager.createWorktree({
+				sessionId: 'session-123',
+				repoPath: '/test/repo',
+				branchName: 'task/task-42-implement-feature',
+			});
+
+			// Should fall back to UUID-based branch so task can still proceed
 			expect(result?.branch).toBe('session/session-123');
 		});
 
@@ -468,6 +568,24 @@ describe('WorktreeManager', () => {
 			const result = await manager.cleanupOrphanedWorktrees('/test/repo');
 
 			expect(result).toContain('/test/repo/.neokai/worktrees/session-1');
+		});
+
+		it('should delete task/ branches for orphaned task worktrees', async () => {
+			existsSyncResults.set('/test/repo/.git', true);
+
+			mockGitRevparse.mockResolvedValue('.git');
+			mockGitRaw
+				.mockResolvedValueOnce('') // prune
+				.mockResolvedValueOnce(
+					'worktree /test/repo\nHEAD abc123\n\nworktree /test/repo/.neokai/worktrees/task-wt\nHEAD def456\nbranch refs/heads/task/task-42-implement-feature\nprunable\n'
+				) // list
+				.mockResolvedValue(''); // remove
+
+			const result = await manager.cleanupOrphanedWorktrees('/test/repo');
+
+			expect(result).toContain('/test/repo/.neokai/worktrees/task-wt');
+			// Should also delete the task/ branch
+			expect(mockGitBranch).toHaveBeenCalledWith(['-D', 'task/task-42-implement-feature']);
 		});
 
 		it('should throw on cleanup failure', async () => {

--- a/packages/daemon/tests/unit/room/room-runtime.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime.test.ts
@@ -113,6 +113,33 @@ describe('RoomRuntime', () => {
 			expect(activeGroups).toHaveLength(1);
 		});
 
+		it('should not double-spawn when concurrent ticks overlap during async spawn', async () => {
+			// Simulate the race: two ticks fire concurrently while the first spawn is
+			// still in-flight (e.g., awaiting worktree creation). The spawningTaskIds
+			// in-memory guard must prevent the second tick from attempting a duplicate spawn.
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+
+			// Fire two ticks concurrently — do NOT await the first before starting the second.
+			const [tick1, tick2] = [ctx.runtime.tick(), ctx.runtime.tick()];
+			await Promise.all([tick1, tick2]);
+
+			// Exactly one group should be active despite concurrent ticks
+			const activeGroups = ctx.groupRepo.getActiveGroups('room-1');
+			expect(activeGroups).toHaveLength(1);
+			expect(activeGroups[0].taskId).toBe(task.id);
+
+			// Only one worker and one leader session should have been created
+			const workerCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] !== 'leader'
+			);
+			const leaderCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+			);
+			expect(workerCalls).toHaveLength(1);
+			expect(leaderCalls).toHaveLength(1);
+		});
+
 		it('should trigger replanning when planning succeeded but all execution tasks failed (maxPlanningRetries=2)', async () => {
 			// Use a room config with maxPlanningRetries=2 to allow retries
 			ctx.runtime.updateRoom({ ...ctx.runtime['room'], config: { maxPlanningRetries: 2 } });

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -2190,11 +2190,13 @@ describe('full export→import round-trip', () => {
 		expect(importedAgentIds).not.toContain('src-coder');
 		expect(importedAgentIds).not.toContain('src-reviewer');
 
-		// Per-agent instructions preserved
+		// Per-agent instructions and roles preserved
 		const coderEntry = importedStep.agents!.find((a) => a.agentId === coderImported.id)!;
 		const reviewerEntry = importedStep.agents!.find((a) => a.agentId === reviewerImported.id)!;
 		expect(coderEntry.instructions).toBe('Implement the feature');
+		expect(coderEntry.role).toBe('coder');
 		expect(reviewerEntry.instructions).toBe('Review thoroughly');
+		expect(reviewerEntry.role).toBe('reviewer');
 
 		// Shared step instructions preserved
 		expect(importedStep.instructions).toBe('Collaborate on the task');
@@ -2205,6 +2207,57 @@ describe('full export→import round-trip', () => {
 		expect(importedStep.channels![0].to).toBe('reviewer');
 		expect(importedStep.channels![0].direction).toBe('bidirectional');
 		expect(importedStep.channels![0].label).toBe('feedback');
+	});
+
+	it('import rejects bundle with empty role in agents[] entry (Zod validation)', async () => {
+		const bundle = {
+			version: 1,
+			name: 'Bad Bundle',
+			agents: [{ version: 1, type: 'agent', name: 'Coder', role: 'coder' }],
+			workflows: [
+				{
+					name: 'Bad Workflow',
+					nodes: [
+						{
+							name: 'Bad Node',
+							agents: [{ agentRef: 'Coder', role: '' }], // empty role — must be rejected
+						},
+					],
+					transitions: [],
+					rules: [],
+					tags: [],
+				},
+			],
+		};
+		await expect(
+			call(handlers, 'spaceImport.execute', { spaceId: SPACE_ID, bundle })
+		).rejects.toThrow();
+	});
+
+	it('import rejects bundle with missing role in agents[] entry (Zod validation)', async () => {
+		const bundle = {
+			version: 1,
+			name: 'Bad Bundle',
+			agents: [{ version: 1, type: 'agent', name: 'Coder', role: 'coder' }],
+			workflows: [
+				{
+					name: 'Bad Workflow',
+					nodes: [
+						{
+							name: 'Bad Node',
+							// @ts-expect-error intentionally omitting required role
+							agents: [{ agentRef: 'Coder' }],
+						},
+					],
+					transitions: [],
+					rules: [],
+					tags: [],
+				},
+			],
+		};
+		await expect(
+			call(handlers, 'spaceImport.execute', { spaceId: SPACE_ID, bundle })
+		).rejects.toThrow();
 	});
 
 	it('channel topology round-trip: one-way channel preserved', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -1438,8 +1438,8 @@ describe('multi-agent step import', () => {
 							multiAgentStep: {
 								name: 'Parallel',
 								agents: [
-									{ agentRef: 'Coder', instructions: 'Write code' },
-									{ agentRef: 'Reviewer' },
+									{ agentRef: 'Coder', role: 'coder', instructions: 'Write code' },
+									{ agentRef: 'Reviewer', role: 'reviewer' },
 								],
 							},
 						},
@@ -1483,8 +1483,8 @@ describe('multi-agent step import', () => {
 							multiAgentStep: {
 								name: 'Parallel',
 								agents: [
-									{ agentRef: 'Coder', instructions: 'Implement the feature' },
-									{ agentRef: 'Reviewer', instructions: 'Review thoroughly' },
+									{ agentRef: 'Coder', role: 'coder', instructions: 'Implement the feature' },
+									{ agentRef: 'Reviewer', role: 'reviewer', instructions: 'Review thoroughly' },
 								],
 							},
 						},
@@ -1521,7 +1521,10 @@ describe('multi-agent step import', () => {
 						{
 							multiAgentStep: {
 								name: 'Parallel',
-								agents: [{ agentRef: 'Coder' }, { agentRef: 'Reviewer' }],
+								agents: [
+									{ agentRef: 'Coder', role: 'coder' },
+									{ agentRef: 'Reviewer', role: 'reviewer' },
+								],
 								channels: [
 									{ from: 'coder', to: 'reviewer', direction: 'bidirectional', label: 'feedback' },
 								],
@@ -1557,8 +1560,8 @@ describe('multi-agent step import', () => {
 							multiAgentStep: {
 								name: 'Parallel',
 								agents: [
-									{ agentRef: 'Coder' },
-									{ agentRef: 'GhostAgent' }, // not in bundle or space
+									{ agentRef: 'Coder', role: 'coder' },
+									{ agentRef: 'GhostAgent', role: 'ghost' }, // not in bundle or space
 								],
 							},
 						},
@@ -1582,7 +1585,10 @@ describe('multi-agent step import', () => {
 						{
 							multiAgentStep: {
 								name: 'Parallel',
-								agents: [{ agentRef: 'Coder' }, { agentRef: 'Missing' }],
+								agents: [
+									{ agentRef: 'Coder', role: 'coder' },
+									{ agentRef: 'Missing', role: 'missing' },
+								],
 							},
 						},
 					],
@@ -1627,7 +1633,10 @@ describe('multi-agent step import', () => {
 						{
 							multiAgentStep: {
 								name: 'Parallel',
-								agents: [{ agentRef: 'Coder' }, { agentRef: 'Reviewer' }],
+								agents: [
+									{ agentRef: 'Coder', role: 'coder' },
+									{ agentRef: 'Reviewer', role: 'reviewer' },
+								],
 								channels: [
 									// 'typo-role' is not matched by coder or reviewer
 									{ from: 'typo-role', to: 'reviewer', direction: 'one-way' as const },
@@ -1657,7 +1666,7 @@ describe('multi-agent step import', () => {
 						{
 							multiAgentStep: {
 								name: 'Solo',
-								agents: [{ agentRef: 'Coder' }],
+								agents: [{ agentRef: 'Coder', role: 'coder' }],
 								channels: [{ from: '*', to: '*', direction: 'bidirectional' as const }],
 							},
 						},
@@ -1688,7 +1697,7 @@ describe('multi-agent step import', () => {
 						{
 							multiAgentStep: {
 								name: 'Step',
-								agents: [{ agentRef: 'LocalCoder' }],
+								agents: [{ agentRef: 'LocalCoder', role: 'coder' }],
 								channels: [
 									// 'bad-role' is not matched by LocalCoder (role='coder')
 									{ from: 'bad-role', to: 'coder', direction: 'one-way' as const },
@@ -1726,7 +1735,10 @@ describe('multi-agent step import', () => {
 						{
 							multiAgentStep: {
 								name: 'Parallel',
-								agents: [{ agentRef: 'LocalCoder' }, { agentRef: 'LocalReviewer' }],
+								agents: [
+									{ agentRef: 'LocalCoder', role: 'coder' },
+									{ agentRef: 'LocalReviewer', role: 'reviewer' },
+								],
 							},
 						},
 					],
@@ -1879,7 +1891,7 @@ type MultiAgentStepEntry =
 	| {
 			multiAgentStep: {
 				name: string;
-				agents: Array<{ agentRef: string; instructions?: string }>;
+				agents: Array<{ agentRef: string; role: string; instructions?: string }>;
 				channels?: Array<{
 					from: string;
 					to: string | string[];
@@ -2132,8 +2144,8 @@ describe('full export→import round-trip', () => {
 					id: 'step-ma',
 					name: 'Code and Review',
 					agents: [
-						{ agentId: 'src-coder', instructions: 'Implement the feature' },
-						{ agentId: 'src-reviewer', instructions: 'Review thoroughly' },
+						{ agentId: 'src-coder', role: 'coder', instructions: 'Implement the feature' },
+						{ agentId: 'src-reviewer', role: 'reviewer', instructions: 'Review thoroughly' },
 					],
 					channels: [
 						{ from: 'coder', to: 'reviewer', direction: 'bidirectional', label: 'feedback' },
@@ -2221,7 +2233,10 @@ describe('full export→import round-trip', () => {
 				{
 					id: 'step-ow',
 					name: 'Directed',
-					agents: [{ agentId: 'src-a' }, { agentId: 'src-b' }],
+					agents: [
+						{ agentId: 'src-a', role: 'alpha' },
+						{ agentId: 'src-b', role: 'beta' },
+					],
 					channels: [{ from: 'alpha', to: 'beta', direction: 'one-way' }],
 				},
 			],
@@ -2280,7 +2295,11 @@ describe('full export→import round-trip', () => {
 				{
 					id: 'step-fo',
 					name: 'Fan Out',
-					agents: [{ agentId: 'src-hub' }, { agentId: 'src-spoke1' }, { agentId: 'src-spoke2' }],
+					agents: [
+						{ agentId: 'src-hub', role: 'hub' },
+						{ agentId: 'src-spoke1', role: 'spoke1' },
+						{ agentId: 'src-spoke2', role: 'spoke2' },
+					],
 					channels: [{ from: 'hub', to: ['spoke1', 'spoke2'], direction: 'one-way' }],
 				},
 			],
@@ -2323,7 +2342,7 @@ describe('full export→import round-trip', () => {
 				{
 					id: 'step-wc',
 					name: 'Broadcast',
-					agents: [{ agentId: 'src-wa' }],
+					agents: [{ agentId: 'src-wa', role: 'wild' }],
 					channels: [{ from: '*', to: '*', direction: 'bidirectional' }],
 				},
 			],
@@ -2389,8 +2408,8 @@ describe('full export→import round-trip', () => {
 					id: 'step-collab',
 					name: 'Implement and Review',
 					agents: [
-						{ agentId: 'src-coder2', instructions: 'Implement' },
-						{ agentId: 'src-review', instructions: 'Review' },
+						{ agentId: 'src-coder2', role: 'coder', instructions: 'Implement' },
+						{ agentId: 'src-review', role: 'reviewer', instructions: 'Review' },
 					],
 					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 				},
@@ -2499,8 +2518,8 @@ describe('full export→import round-trip', () => {
 					id: 'step-bad',
 					name: 'Parallel',
 					agents: [
-						{ agentId: 'src-known' },
-						{ agentId: 'src-ghost' }, // not in bundle
+						{ agentId: 'src-known', role: 'coder' },
+						{ agentId: 'src-ghost', role: 'ghost' }, // not in bundle
 					],
 				},
 			],
@@ -2543,7 +2562,7 @@ describe('full export→import round-trip', () => {
 				{
 					id: 'step-bc',
 					name: 'Work',
-					agents: [{ agentId: 'src-solo' }],
+					agents: [{ agentId: 'src-solo', role: 'coder' }],
 					channels: [
 						// 'nonexistent-role' is not the role of Solo Coder
 						{ from: 'nonexistent-role', to: 'coder', direction: 'one-way' },
@@ -2589,7 +2608,7 @@ describe('full export→import round-trip', () => {
 				{
 					id: 'step-exec-bc',
 					name: 'Work',
-					agents: [{ agentId: 'src-exec-solo' }],
+					agents: [{ agentId: 'src-exec-solo', role: 'coder' }],
 					channels: [
 						// 'bad-exec-role' does not match the agent's role 'coder'
 						{ from: 'bad-exec-role', to: 'coder', direction: 'one-way' },

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -1219,8 +1219,8 @@ describe('exportWorkflow — multi-agent nodes', () => {
 					id: 'node-uuid-1',
 					name: 'Parallel code+review',
 					agents: [
-						{ agentId: 'agent-uuid-1', instructions: 'Write the feature' },
-						{ agentId: 'agent-uuid-3' },
+						{ agentId: 'agent-uuid-1', role: 'coder', instructions: 'Write the feature' },
+						{ agentId: 'agent-uuid-3', role: 'reviewer' },
 					],
 					channels: [
 						{
@@ -1383,7 +1383,10 @@ describe('validateExportedWorkflow — multi-agent and channels', () => {
 			name: 'W',
 			nodes: [
 				{
-					agents: [{ agentRef: 'My Coder', instructions: 'Code it' }, { agentRef: 'Reviewer' }],
+					agents: [
+						{ agentRef: 'My Coder', role: 'coder', instructions: 'Code it' },
+						{ agentRef: 'Reviewer', role: 'reviewer' },
+					],
 					name: 'Parallel Step',
 				},
 			],
@@ -1409,7 +1412,10 @@ describe('validateExportedWorkflow — multi-agent and channels', () => {
 			name: 'W',
 			nodes: [
 				{
-					agents: [{ agentRef: 'Coder' }, { agentRef: 'Reviewer' }],
+					agents: [
+						{ agentRef: 'Coder', role: 'coder' },
+						{ agentRef: 'Reviewer', role: 'reviewer' },
+					],
 					channels: [{ from: 'coder', to: 'reviewer', direction: 'bidirectional' }],
 					name: 'Step',
 				},
@@ -1435,7 +1441,11 @@ describe('validateExportedWorkflow — multi-agent and channels', () => {
 			name: 'W',
 			nodes: [
 				{
-					agents: [{ agentRef: 'Hub' }, { agentRef: 'Spoke1' }, { agentRef: 'Spoke2' }],
+					agents: [
+						{ agentRef: 'Hub', role: 'hub' },
+						{ agentRef: 'Spoke1', role: 'spoke1' },
+						{ agentRef: 'Spoke2', role: 'spoke2' },
+					],
 					channels: [{ from: 'hub', to: ['spoke1', 'spoke2'], direction: 'one-way' }],
 					name: 'Fan-out',
 				},
@@ -1507,8 +1517,8 @@ describe('round-trip: multi-agent + channels', () => {
 					id: 'node-1',
 					name: 'Code and Review',
 					agents: [
-						{ agentId: 'agent-uuid-1', instructions: 'Implement the feature' },
-						{ agentId: 'agent-uuid-3', instructions: 'Review the code' },
+						{ agentId: 'agent-uuid-1', role: 'coder', instructions: 'Implement the feature' },
+						{ agentId: 'agent-uuid-3', role: 'reviewer', instructions: 'Review the code' },
 					],
 					channels: [
 						{ from: 'coder', to: 'reviewer', direction: 'bidirectional', label: 'feedback' },

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -1602,4 +1602,89 @@ describe('round-trip: multi-agent + channels', () => {
 		expect(json).toContain('Reviewer');
 		expect(json).toContain('Simple Agent');
 	});
+
+	test('exported agents[] entries include role field', () => {
+		const workflow = makeMultiAgentWorkflowForRoundTrip();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		const node = exported.nodes[0];
+		expect(node.agents![0].role).toBe('coder');
+		expect(node.agents![1].role).toBe('reviewer');
+	});
+
+	test('role field survives export → JSON → validate round-trip', () => {
+		const workflow = makeMultiAgentWorkflowForRoundTrip();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.nodes[0].agents![0].role).toBe('coder');
+			expect(result.value.nodes[0].agents![1].role).toBe('reviewer');
+		}
+	});
+
+	test('model and systemPrompt slot overrides survive export → JSON → validate round-trip', () => {
+		const workflow: SpaceWorkflow = {
+			id: 'wf-overrides',
+			spaceId: 'space-1',
+			name: 'Override Workflow',
+			nodes: [
+				{
+					id: 'node-1',
+					name: 'Overriding Step',
+					agents: [
+						{
+							agentId: 'agent-uuid-1',
+							role: 'coder',
+							model: 'claude-opus-4-6',
+							systemPrompt: 'You are a strict reviewer.',
+						},
+						{
+							agentId: 'agent-uuid-3',
+							role: 'reviewer',
+							// no model/systemPrompt overrides
+						},
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 'node-1',
+			rules: [],
+			tags: [],
+			createdAt: 1000,
+			updatedAt: 2000,
+		};
+		const agents = [makeAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		// Verify export includes model/systemPrompt
+		const exportedNode = exported.nodes[0];
+		expect(exportedNode.agents![0].model).toBe('claude-opus-4-6');
+		expect(exportedNode.agents![0].systemPrompt).toBe('You are a strict reviewer.');
+		expect(exportedNode.agents![1].model).toBeUndefined();
+		expect(exportedNode.agents![1].systemPrompt).toBeUndefined();
+
+		// Verify round-trip via JSON serialization + validate
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const node = result.value.nodes[0];
+			expect(node.agents![0].agentRef).toBe('My Coder');
+			expect(node.agents![0].role).toBe('coder');
+			expect(node.agents![0].model).toBe('claude-opus-4-6');
+			expect(node.agents![0].systemPrompt).toBe('You are a strict reviewer.');
+			expect(node.agents![1].agentRef).toBe('Reviewer');
+			expect(node.agents![1].role).toBe('reviewer');
+			expect(node.agents![1].model).toBeUndefined();
+			expect(node.agents![1].systemPrompt).toBeUndefined();
+		}
+	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -1328,7 +1328,10 @@ describe('SpaceRuntime — notification events', () => {
 					{
 						id: STEP_A,
 						name: 'Parallel Step',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+						],
 					},
 				],
 				transitions: [],
@@ -1360,7 +1363,10 @@ describe('SpaceRuntime — notification events', () => {
 					{
 						id: STEP_A,
 						name: 'Parallel Partial',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+						],
 					},
 				],
 				transitions: [],
@@ -1413,7 +1419,10 @@ describe('SpaceRuntime — notification events', () => {
 					{
 						id: STEP_A,
 						name: 'Parallel Dedup',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+						],
 					},
 				],
 				transitions: [],

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -233,7 +233,11 @@ describe('SpaceRuntime', () => {
 			const step = {
 				id: STEP_A,
 				name: 'Multi',
-				agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }, { agentId: AGENT_CUSTOM }],
+				agents: [
+					{ agentId: AGENT_PLANNER, role: 'planner' },
+					{ agentId: AGENT_CODER, role: 'coder' },
+					{ agentId: AGENT_CUSTOM, role: 'my-custom-role' },
+				],
 			};
 			const results = runtime.resolveTaskTypesForStep(step);
 			expect(results).toHaveLength(3);
@@ -246,7 +250,10 @@ describe('SpaceRuntime', () => {
 			const step = {
 				id: STEP_A,
 				name: 'Multi',
-				agents: [{ agentId: AGENT_GENERAL }, { agentId: AGENT_CODER }],
+				agents: [
+					{ agentId: AGENT_GENERAL, role: 'general' },
+					{ agentId: AGENT_CODER, role: 'coder' },
+				],
 			};
 			const results = runtime.resolveTaskTypesForStep(step);
 			expect(results).toHaveLength(2);
@@ -258,7 +265,10 @@ describe('SpaceRuntime', () => {
 			const step = {
 				id: STEP_A,
 				name: 'Multi',
-				agents: [{ agentId: AGENT_CODER }, { agentId: 'unknown-agent-id' }],
+				agents: [
+					{ agentId: AGENT_CODER, role: 'coder' },
+					{ agentId: 'unknown-agent-id', role: 'unknown' },
+				],
 			};
 			const results = runtime.resolveTaskTypesForStep(step);
 			expect(results).toHaveLength(2);
@@ -270,7 +280,10 @@ describe('SpaceRuntime', () => {
 			const step = {
 				id: STEP_A,
 				name: 'Multi',
-				agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }],
+				agents: [
+					{ agentId: AGENT_PLANNER, role: 'planner' },
+					{ agentId: AGENT_CODER, role: 'coder' },
+				],
 			};
 			const single = runtime.resolveTaskTypeForStep(step);
 			const multi = runtime.resolveTaskTypesForStep(step);
@@ -544,7 +557,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: STEP_A,
 						name: 'Multi Step',
-						agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }],
+						agents: [
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+							{ agentId: AGENT_CODER, role: 'coder' },
+						],
 					},
 				],
 				transitions: [],
@@ -574,7 +590,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: STEP_A,
 						name: 'Custom Multi Step',
-						agents: [{ agentId: AGENT_CUSTOM }, { agentId: AGENT_CODER }],
+						agents: [
+							{ agentId: AGENT_CUSTOM, role: 'my-custom-role' },
+							{ agentId: AGENT_CODER, role: 'coder' },
+						],
 					},
 				],
 				transitions: [],
@@ -1832,8 +1851,8 @@ describe('SpaceRuntime', () => {
 						id: STEP_A,
 						name: 'Parallel Start',
 						agents: [
-							{ agentId: AGENT_CODER, instructions: 'Coder task' },
-							{ agentId: AGENT_PLANNER, instructions: 'Planner task' },
+							{ agentId: AGENT_CODER, role: 'coder', instructions: 'Coder task' },
+							{ agentId: AGENT_PLANNER, role: 'planner', instructions: 'Planner task' },
 						],
 					},
 				],
@@ -1876,7 +1895,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: STEP_A,
 						name: 'Mixed Start',
-						agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }],
+						agents: [
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+							{ agentId: AGENT_CODER, role: 'coder' },
+						],
 					},
 				],
 				transitions: [],
@@ -1907,7 +1929,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: STEP_A,
 						name: 'Parallel A',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+						],
 					},
 					{ id: STEP_B, name: 'Step B', agentId: AGENT_CODER },
 				],
@@ -1940,7 +1965,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: STEP_A,
 						name: 'Parallel A',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+						],
 					},
 					{ id: STEP_B, name: 'Step B', agentId: AGENT_CODER },
 				],
@@ -1973,7 +2001,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: STEP_A,
 						name: 'Parallel Fail',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+						],
 					},
 				],
 				transitions: [],
@@ -2003,7 +2034,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: STEP_A,
 						name: 'Parallel Waiting',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_PLANNER, role: 'planner' },
+						],
 					},
 				],
 				transitions: [],
@@ -2069,7 +2103,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: STEP_A,
 						name: 'Code and Review',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_REVIEWER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_REVIEWER, role: 'reviewer' },
+						],
 						channels: [
 							{
 								from: 'coder',
@@ -2128,7 +2165,10 @@ describe('SpaceRuntime', () => {
 					{
 						id: stepId,
 						name: 'Two Coders Same Role',
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_CODER_2 }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_CODER_2, role: 'coder-2' },
+						],
 					},
 				],
 				transitions: [],
@@ -2164,7 +2204,10 @@ describe('SpaceRuntime', () => {
 						name: 'With Channels',
 						agentId: AGENT_CODER,
 						channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
-						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_REVIEWER }],
+						agents: [
+							{ agentId: AGENT_CODER, role: 'coder' },
+							{ agentId: AGENT_REVIEWER, role: 'reviewer' },
+						],
 					},
 					{ id: stepB, name: 'Without Channels', agentId: AGENT_CODER },
 				],

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -1105,7 +1105,10 @@ describe('SpaceWorkflowManager', () => {
 			nodes: [
 				{
 					name: 'Step',
-					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					agents: [
+						{ agentId: 'agent-a', role: 'a' },
+						{ agentId: 'agent-b', role: 'b' },
+					],
 				},
 			],
 		});
@@ -1133,7 +1136,10 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						agents: [
+							{ agentId: 'agent-a', role: 'a' },
+							{ agentId: 'agent-b', role: 'b' },
+						],
 						channels: [{ from: 'coder', to: 'reviewer', direction: 'invalid' as never }],
 					},
 				],
@@ -1149,7 +1155,10 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						agents: [
+							{ agentId: 'agent-a', role: 'a' },
+							{ agentId: 'agent-b', role: 'b' },
+						],
 						channels: [{ from: '', to: 'reviewer', direction: 'one-way' }],
 					},
 				],
@@ -1165,7 +1174,10 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						agents: [
+							{ agentId: 'agent-a', role: 'a' },
+							{ agentId: 'agent-b', role: 'b' },
+						],
 						channels: [{ from: 'coder', to: '', direction: 'one-way' }],
 					},
 				],
@@ -1181,7 +1193,10 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						agents: [
+							{ agentId: 'agent-a', role: 'a' },
+							{ agentId: 'agent-b', role: 'b' },
+						],
 						channels: [{ from: 'coder', to: [], direction: 'one-way' }],
 					},
 				],
@@ -1231,7 +1246,10 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						agents: [
+							{ agentId: 'agent-a', role: 'a' },
+							{ agentId: 'agent-b', role: 'b' },
+						],
 						channels: [{ from: '   ', to: 'reviewer', direction: 'one-way' }],
 					},
 				],
@@ -1247,7 +1265,10 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						agents: [
+							{ agentId: 'agent-a', role: 'a' },
+							{ agentId: 'agent-b', role: 'b' },
+						],
 						channels: [{ from: 'coder', to: '   ', direction: 'one-way' }],
 					},
 				],
@@ -1263,7 +1284,10 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						agents: [
+							{ agentId: 'agent-a', role: 'a' },
+							{ agentId: 'agent-b', role: 'b' },
+						],
 						channels: [{ from: 'coder', to: ['reviewer', '   '], direction: 'one-way' }],
 					},
 				],
@@ -1278,7 +1302,10 @@ describe('SpaceWorkflowManager', () => {
 			nodes: [
 				{
 					name: 'Step',
-					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					agents: [
+						{ agentId: 'agent-a', role: 'a' },
+						{ agentId: 'agent-b', role: 'b' },
+					],
 					channels: [
 						{ from: '*', to: 'reviewer', direction: 'one-way' },
 						{ from: 'coder', to: '*', direction: 'bidirectional' },
@@ -1297,7 +1324,10 @@ describe('SpaceWorkflowManager', () => {
 			nodes: [
 				{
 					name: 'Step',
-					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					agents: [
+						{ agentId: 'agent-a', role: 'a' },
+						{ agentId: 'agent-b', role: 'b' },
+					],
 					channels: [{ from: 'hub', to: ['spoke-a', 'spoke-b'], direction: 'bidirectional' }],
 				},
 			],
@@ -1326,7 +1356,10 @@ describe('SpaceWorkflowManager', () => {
 			nodes: [
 				{
 					name: 'Step',
-					agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+					agents: [
+						{ agentId: 'agent-coder-id', role: 'coder' },
+						{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+					],
 					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 				},
 			],
@@ -1349,7 +1382,7 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-coder-id' }],
+						agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 						channels: [{ from: 'unknown-role', to: 'coder', direction: 'one-way' }],
 					},
 				],
@@ -1372,7 +1405,7 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-coder-id' }],
+						agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 						channels: [{ from: 'coder', to: 'unknown-role', direction: 'one-way' }],
 					},
 				],
@@ -1394,7 +1427,7 @@ describe('SpaceWorkflowManager', () => {
 			nodes: [
 				{
 					name: 'Step',
-					agents: [{ agentId: 'agent-coder-id' }],
+					agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 					channels: [{ from: '*', to: 'coder', direction: 'one-way' }],
 				},
 			],
@@ -1417,7 +1450,7 @@ describe('SpaceWorkflowManager', () => {
 					{
 						id: 'step-x',
 						name: 'Step',
-						agents: [{ agentId: 'agent-coder-id' }],
+						agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 						channels: [{ from: 'coder', to: 'bad-role', direction: 'one-way' }],
 					},
 				],
@@ -1438,8 +1471,8 @@ describe('SpaceWorkflowManager', () => {
 					id: 'step-1',
 					name: 'Parallel Review',
 					agents: [
-						{ agentId: 'agent-coder', instructions: 'write code' },
-						{ agentId: 'agent-reviewer' },
+						{ agentId: 'agent-coder', role: 'coder', instructions: 'write code' },
+						{ agentId: 'agent-reviewer', role: 'reviewer' },
 					],
 					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way', label: 'submit' }],
 					instructions: 'shared context',
@@ -1476,7 +1509,10 @@ describe('SpaceWorkflowManager', () => {
 				{
 					id: 'step-new',
 					name: 'New Parallel Step',
-					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					agents: [
+						{ agentId: 'agent-a', role: 'a' },
+						{ agentId: 'agent-b', role: 'b' },
+					],
 					channels: [{ from: 'security', to: ['coder', 'reviewer'], direction: 'bidirectional' }],
 				},
 			],
@@ -1498,7 +1534,10 @@ describe('SpaceWorkflowManager', () => {
 				{
 					id: 'step-1',
 					name: 'Parallel Step',
-					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					agents: [
+						{ agentId: 'agent-a', role: 'a' },
+						{ agentId: 'agent-b', role: 'b' },
+					],
 					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 				},
 			],
@@ -1522,7 +1561,10 @@ describe('SpaceWorkflowManager', () => {
 				{
 					id: 'step-m',
 					name: 'Parallel',
-					agents: [{ agentId: 'agent-x' }, { agentId: 'agent-y' }],
+					agents: [
+						{ agentId: 'agent-x', role: 'x' },
+						{ agentId: 'agent-y', role: 'y' },
+					],
 					channels: [{ from: 'x', to: 'y', direction: 'bidirectional' }],
 				},
 			],

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -333,7 +333,10 @@ describe('SpaceWorkflowRepository', () => {
 				{
 					id: 'step-multi',
 					name: 'Parallel Step',
-					agents: [{ agentId: 'agent-multi-1' }, { agentId: 'agent-multi-2' }],
+					agents: [
+						{ agentId: 'agent-multi-1', role: 'multi-1' },
+						{ agentId: 'agent-multi-2', role: 'multi-2' },
+					],
 				},
 			],
 		});
@@ -365,8 +368,8 @@ describe('SpaceWorkflowRepository', () => {
 					id: 'step-1',
 					name: 'Parallel Step',
 					agents: [
-						{ agentId: 'agent-multi-1', instructions: 'do A' },
-						{ agentId: 'agent-multi-2' },
+						{ agentId: 'agent-multi-1', role: 'multi-1', instructions: 'do A' },
+						{ agentId: 'agent-multi-2', role: 'multi-2' },
 					],
 					instructions: 'shared instructions',
 				},
@@ -401,7 +404,10 @@ describe('SpaceWorkflowRepository', () => {
 				{
 					id: 'step-1',
 					name: 'Channels Step',
-					agents: [{ agentId: 'agent-multi-1' }, { agentId: 'agent-multi-2' }],
+					agents: [
+						{ agentId: 'agent-multi-1', role: 'multi-1' },
+						{ agentId: 'agent-multi-2', role: 'multi-2' },
+					],
 					channels: [
 						{ from: 'coder', to: 'reviewer', direction: 'one-way', label: 'feedback' },
 						{ from: 'reviewer', to: ['coder', 'security'], direction: 'bidirectional' },
@@ -1581,5 +1587,88 @@ describe('SpaceWorkflowManager', () => {
 		const readMulti = manager.getWorkflow(multi.id)!;
 		expect(readMulti.nodes[0].agents).toHaveLength(2);
 		expect(readMulti.nodes[0].channels).toHaveLength(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// Role field validation (no agentLookup needed)
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow rejects agents[] entry with empty role (no lookup)', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Empty Role',
+				nodes: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-a', role: '' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects agents[] with duplicate roles in same node (no lookup)', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Duplicate Roles',
+				nodes: [
+					{
+						name: 'Step',
+						agents: [
+							{ agentId: 'agent-a', role: 'same-role' },
+							{ agentId: 'agent-b', role: 'same-role' },
+						],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow accepts same agentId with different roles (no lookup)', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Same Agent Diff Roles',
+			nodes: [
+				{
+					name: 'Step',
+					agents: [
+						{ agentId: 'agent-a', role: 'strict-reviewer' },
+						{ agentId: 'agent-a', role: 'quick-reviewer' },
+					],
+				},
+			],
+		});
+		expect(wf.nodes[0].agents).toHaveLength(2);
+		expect(wf.nodes[0].agents![0].role).toBe('strict-reviewer');
+		expect(wf.nodes[0].agents![1].role).toBe('quick-reviewer');
+	});
+
+	// -------------------------------------------------------------------------
+	// Read-time backfill for legacy rows without role
+	// -------------------------------------------------------------------------
+
+	test('repo backfills role = agentId for legacy rows persisted without role', () => {
+		// Simulate a legacy row: persist raw JSON without role fields
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Legacy No-Role WF',
+			nodes: [
+				{
+					id: 'step-legacy',
+					name: 'Legacy Step',
+					// @ts-expect-error intentionally omitting role to simulate pre-role DB rows
+					agents: [{ agentId: 'agent-old-1' }, { agentId: 'agent-old-2' }],
+				},
+			],
+		});
+
+		const read = repo.getWorkflow(wf.id)!;
+		const node = read.nodes[0];
+		expect(node.agents).toHaveLength(2);
+		// Backfill: role must equal agentId when absent
+		expect(node.agents![0].role).toBe('agent-old-1');
+		expect(node.agents![1].role).toBe('agent-old-2');
 	});
 });

--- a/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
@@ -151,7 +151,10 @@ describe('WorkflowExecutor — advance() multi-agent', () => {
 				{
 					id: STEP_MULTI,
 					name: 'Parallel Step',
-					agents: [{ agentId: AGENT_A }, { agentId: AGENT_B }],
+					agents: [
+						{ agentId: AGENT_A, role: 'coder' },
+						{ agentId: AGENT_B, role: 'reviewer' },
+					],
 				},
 			],
 			transitions: [{ from: STEP_START, to: STEP_MULTI, condition: { type: 'always' }, order: 0 }],
@@ -187,7 +190,10 @@ describe('WorkflowExecutor — advance() multi-agent', () => {
 				{
 					id: STEP_MULTI,
 					name: 'Parallel',
-					agents: [{ agentId: AGENT_A }, { agentId: AGENT_B }],
+					agents: [
+						{ agentId: AGENT_A, role: 'coder' },
+						{ agentId: AGENT_B, role: 'reviewer' },
+					],
 				},
 			],
 			transitions: [{ from: STEP_START, to: STEP_MULTI, condition: { type: 'always' }, order: 0 }],
@@ -228,8 +234,8 @@ describe('WorkflowExecutor — advance() multi-agent', () => {
 					name: 'Parallel',
 					instructions: 'Shared fallback',
 					agents: [
-						{ agentId: AGENT_A, instructions: 'Agent A specific' },
-						{ agentId: AGENT_B }, // no per-agent instructions → uses step.instructions
+						{ agentId: AGENT_A, role: 'coder', instructions: 'Agent A specific' },
+						{ agentId: AGENT_B, role: 'reviewer' }, // no per-agent instructions → uses step.instructions
 					],
 				},
 			],
@@ -270,7 +276,11 @@ describe('WorkflowExecutor — advance() multi-agent', () => {
 				{
 					id: STEP_MULTI,
 					name: 'Triple Parallel',
-					agents: [{ agentId: AGENT_A }, { agentId: AGENT_B }, { agentId: AGENT_C }],
+					agents: [
+						{ agentId: AGENT_A, role: 'coder' },
+						{ agentId: AGENT_B, role: 'reviewer' },
+						{ agentId: AGENT_C, role: 'planner' },
+					],
 				},
 			],
 			transitions: [{ from: STEP_START, to: STEP_MULTI, condition: { type: 'always' }, order: 0 }],
@@ -347,7 +357,10 @@ describe('WorkflowExecutor — advance() multi-agent', () => {
 					id: STEP_MULTI,
 					name: 'Both Present',
 					agentId: AGENT_A, // should be ignored
-					agents: [{ agentId: AGENT_B }, { agentId: AGENT_C }], // wins
+					agents: [
+						{ agentId: AGENT_B, role: 'reviewer' },
+						{ agentId: AGENT_C, role: 'planner' },
+					], // wins
 				},
 			],
 			transitions: [{ from: STEP_START, to: STEP_MULTI, condition: { type: 'always' }, order: 0 }],
@@ -385,7 +398,10 @@ describe('WorkflowExecutor — advance() multi-agent', () => {
 				{
 					id: STEP_MULTI,
 					name: 'Parallel',
-					agents: [{ agentId: AGENT_A }, { agentId: AGENT_B }],
+					agents: [
+						{ agentId: AGENT_A, role: 'coder' },
+						{ agentId: AGENT_B, role: 'reviewer' },
+					],
 				},
 			],
 			transitions: [{ from: STEP_START, to: STEP_MULTI, condition: { type: 'always' }, order: 0 }],
@@ -894,12 +910,12 @@ describe('resolveNodeChannels()', () => {
 
 	test('returns empty array when no channels defined', () => {
 		const step = makeStep({ agentId: 'agent-coder-id' });
-		expect(resolveNodeChannels(step, allAgents)).toEqual([]);
+		expect(resolveNodeChannels(step)).toEqual([]);
 	});
 
 	test('returns empty array when channels is an empty array', () => {
 		const step = makeStep({ agentId: 'agent-coder-id', channels: [] });
-		expect(resolveNodeChannels(step, allAgents)).toEqual([]);
+		expect(resolveNodeChannels(step)).toEqual([]);
 	});
 
 	// A → B one-way
@@ -911,7 +927,7 @@ describe('resolveNodeChannels()', () => {
 			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(step, allAgents);
+		const result = resolveNodeChannels(step);
 		expect(result).toHaveLength(1);
 		expect(result[0]).toMatchObject({
 			fromRole: 'coder',
@@ -932,7 +948,7 @@ describe('resolveNodeChannels()', () => {
 			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'bidirectional' }],
 		});
-		const result = resolveNodeChannels(step, allAgents);
+		const result = resolveNodeChannels(step);
 		expect(result).toHaveLength(2);
 
 		const forward = result.find((r) => r.fromRole === 'coder' && r.toRole === 'reviewer');
@@ -957,7 +973,7 @@ describe('resolveNodeChannels()', () => {
 			],
 			channels: [{ from: 'coder', to: ['reviewer', 'security'], direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(step, allAgents);
+		const result = resolveNodeChannels(step);
 		expect(result).toHaveLength(2);
 
 		// All originate from coder
@@ -978,7 +994,7 @@ describe('resolveNodeChannels()', () => {
 			],
 			channels: [{ from: 'coder', to: ['reviewer', 'security'], direction: 'bidirectional' }],
 		});
-		const result = resolveNodeChannels(step, allAgents);
+		const result = resolveNodeChannels(step);
 
 		// 2 spokes × 2 directions = 4 channels
 		expect(result).toHaveLength(4);
@@ -1009,7 +1025,7 @@ describe('resolveNodeChannels()', () => {
 			],
 			channels: [{ from: '*', to: 'reviewer', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(step, allAgents);
+		const result = resolveNodeChannels(step);
 
 		// coder→reviewer and security→reviewer (reviewer→reviewer self-loop skipped)
 		expect(result).toHaveLength(2);
@@ -1027,7 +1043,7 @@ describe('resolveNodeChannels()', () => {
 			],
 			channels: [{ from: 'coder', to: '*', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(step, allAgents);
+		const result = resolveNodeChannels(step);
 
 		// coder→reviewer and coder→security (coder→coder self-loop skipped)
 		expect(result).toHaveLength(2);
@@ -1041,7 +1057,7 @@ describe('resolveNodeChannels()', () => {
 			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [{ from: 'coder', to: 'nonexistent-role', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(step, allAgents);
+		const result = resolveNodeChannels(step);
 		expect(result).toHaveLength(0);
 	});
 });

--- a/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
@@ -491,8 +491,8 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 					id: STEP_A,
 					name: 'Parallel Start',
 					agents: [
-						{ agentId: AGENT_CODER, instructions: 'Write code' },
-						{ agentId: AGENT_PLANNER, instructions: 'Plan it' },
+						{ agentId: AGENT_CODER, role: 'coder', instructions: 'Write code' },
+						{ agentId: AGENT_PLANNER, role: 'planner', instructions: 'Plan it' },
 					],
 				},
 			],
@@ -521,8 +521,8 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 					id: STEP_A,
 					name: 'Parallel Start',
 					agents: [
-						{ agentId: AGENT_CODER, instructions: 'Coder task' },
-						{ agentId: AGENT_PLANNER, instructions: 'Planner task' },
+						{ agentId: AGENT_CODER, role: 'coder', instructions: 'Coder task' },
+						{ agentId: AGENT_PLANNER, role: 'planner', instructions: 'Planner task' },
 					],
 				},
 			],
@@ -546,7 +546,10 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 				{
 					id: STEP_A,
 					name: 'Mixed Start',
-					agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }],
+					agents: [
+						{ agentId: AGENT_PLANNER, role: 'planner' },
+						{ agentId: AGENT_CODER, role: 'coder' },
+					],
 				},
 			],
 			transitions: [],
@@ -575,7 +578,10 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 				{
 					id: STEP_A,
 					name: 'Custom Start',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_CUSTOM }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_CUSTOM, role: 'my-custom-role' },
+					],
 				},
 			],
 			transitions: [],
@@ -609,7 +615,10 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 				{
 					id: STEP_A,
 					name: 'Parallel A',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_PLANNER, role: 'planner' },
+					],
 				},
 				{ id: STEP_B, name: 'Next Step', agentId: AGENT_CODER },
 			],
@@ -646,7 +655,10 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 				{
 					id: STEP_A,
 					name: 'Parallel A',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_PLANNER, role: 'planner' },
+					],
 				},
 				{ id: STEP_B, name: 'Next Step', agentId: AGENT_CODER },
 			],
@@ -683,7 +695,10 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 				{
 					id: STEP_A,
 					name: 'Parallel Waiting',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_PLANNER, role: 'planner' },
+					],
 				},
 			],
 			transitions: [],
@@ -717,7 +732,10 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 				{
 					id: STEP_A,
 					name: 'Parallel Fail',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_PLANNER, role: 'planner' },
+					],
 				},
 			],
 			transitions: [],
@@ -750,7 +768,11 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 				{
 					id: STEP_A,
 					name: 'Triple Parallel',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }, { agentId: AGENT_EXTRA }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_PLANNER, role: 'planner' },
+						{ agentId: AGENT_EXTRA, role: 'extra-role' },
+					],
 				},
 			],
 			transitions: [],
@@ -1242,7 +1264,10 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 				{
 					id: STEP_B,
 					name: 'Implement (multi)',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_REVIEWER }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_REVIEWER, role: 'reviewer' },
+					],
 				},
 				{ id: STEP_C, name: 'Finalize (single)', agentId: AGENT_PLANNER },
 			],

--- a/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
@@ -805,7 +805,7 @@ describe('resolveNodeAgents()', () => {
 	test('returns single-element array when only agentId is set', () => {
 		const step = makeStep({ agentId: 'agent-a', instructions: 'do the thing' });
 		const result = resolveNodeAgents(step);
-		expect(result).toEqual([{ agentId: 'agent-a', instructions: 'do the thing' }]);
+		expect(result).toEqual([{ agentId: 'agent-a', role: 'agent-a', instructions: 'do the thing' }]);
 	});
 
 	test('returns agents array when agents is set and non-empty', () => {
@@ -841,8 +841,12 @@ describe('resolveNodeAgents()', () => {
 	});
 
 	test('single-element agents array works correctly', () => {
-		const step = makeStep({ agents: [{ agentId: 'agent-a', instructions: 'custom' }] });
-		expect(resolveNodeAgents(step)).toEqual([{ agentId: 'agent-a', instructions: 'custom' }]);
+		const step = makeStep({
+			agents: [{ agentId: 'agent-a', role: 'agent-a', instructions: 'custom' }],
+		});
+		expect(resolveNodeAgents(step)).toEqual([
+			{ agentId: 'agent-a', role: 'agent-a', instructions: 'custom' },
+		]);
 	});
 
 	test('agentId with no instructions produces entry with undefined instructions', () => {
@@ -879,7 +883,10 @@ describe('resolveNodeChannels()', () => {
 	// A → B one-way
 	test('A→B one-way: resolves to single directed channel', () => {
 		const step = makeStep({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 		});
 		const result = resolveNodeChannels(step, allAgents);
@@ -897,7 +904,10 @@ describe('resolveNodeChannels()', () => {
 	// A ↔ B bidirectional point-to-point
 	test('A↔B bidirectional point-to-point: resolves to two directed channels (A→B and B→A)', () => {
 		const step = makeStep({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'bidirectional' }],
 		});
 		const result = resolveNodeChannels(step, allAgents);
@@ -919,9 +929,9 @@ describe('resolveNodeChannels()', () => {
 	test('A→[B,C,D] fan-out one-way: resolves to three directed channels, no reverse', () => {
 		const step = makeStep({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [{ from: 'coder', to: ['reviewer', 'security'], direction: 'one-way' }],
 		});
@@ -940,9 +950,9 @@ describe('resolveNodeChannels()', () => {
 	test('A↔[B,C,D] hub-spoke: resolves to A→B, A→C, A→D, B→A, C→A, D→A; B cannot send to C', () => {
 		const step = makeStep({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [{ from: 'coder', to: ['reviewer', 'security'], direction: 'bidirectional' }],
 		});
@@ -971,9 +981,9 @@ describe('resolveNodeChannels()', () => {
 	test('*→B wildcard from: resolves to channels from all agents to B', () => {
 		const step = makeStep({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [{ from: '*', to: 'reviewer', direction: 'one-way' }],
 		});
@@ -989,9 +999,9 @@ describe('resolveNodeChannels()', () => {
 	test('A→* wildcard to: resolves to channels from A to all other agents', () => {
 		const step = makeStep({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [{ from: 'coder', to: '*', direction: 'one-way' }],
 		});
@@ -1006,7 +1016,7 @@ describe('resolveNodeChannels()', () => {
 	// Invalid role reference → skipped silently
 	test('invalid role reference is skipped silently (does not throw)', () => {
 		const step = makeStep({
-			agents: [{ agentId: 'agent-coder-id' }],
+			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [{ from: 'coder', to: 'nonexistent-role', direction: 'one-way' }],
 		});
 		const result = resolveNodeChannels(step, allAgents);
@@ -1059,7 +1069,7 @@ describe('Channel validation in SpaceWorkflowManager persistence', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-coder-id' }],
+						agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 						channels: [{ from: 'coder', to: 'nonexistent-role', direction: 'one-way' }],
 					},
 				],
@@ -1083,7 +1093,10 @@ describe('Channel validation in SpaceWorkflowManager persistence', () => {
 			nodes: [
 				{
 					name: 'Step',
-					agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+					agents: [
+						{ agentId: 'agent-coder-id', role: 'coder' },
+						{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+					],
 					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 				},
 			],
@@ -1127,7 +1140,7 @@ describe('Channel validation in SpaceWorkflowManager persistence', () => {
 				nodes: [
 					{
 						name: 'Step',
-						agents: [{ agentId: 'agent-coder-id' }],
+						agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 						channels: [{ from: 'nonexistent', to: 'coder', direction: 'one-way' }],
 					},
 				],
@@ -1150,7 +1163,7 @@ describe('Channel validation in SpaceWorkflowManager persistence', () => {
 			nodes: [
 				{
 					name: 'Step',
-					agents: [{ agentId: 'agent-coder-id' }],
+					agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 					channels: [{ from: '*', to: 'coder', direction: 'one-way' }],
 				},
 			],
@@ -1283,7 +1296,10 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 				{
 					id: STEP_A,
 					name: 'Parallel With Channels',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_REVIEWER }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_REVIEWER, role: 'reviewer' },
+					],
 					channels: [
 						{ from: 'coder', to: 'reviewer', direction: 'one-way', label: 'review-request' },
 					],
@@ -1333,7 +1349,10 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 				{
 					id: STEP_B,
 					name: 'Parallel With Channels',
-					agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_REVIEWER }],
+					agents: [
+						{ agentId: AGENT_CODER, role: 'coder' },
+						{ agentId: AGENT_REVIEWER, role: 'reviewer' },
+					],
 					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way', label: 'feedback' }],
 				},
 			],

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -109,19 +109,13 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
  * - `* → B`        all agents send to B
  * - `A → *`        A sends to all agents
  *
- * @param node   - The workflow node whose channels are to be resolved.
- * @param agents - **Deprecated.** No longer used in resolution. Channel routing now uses
- *   `WorkflowNodeAgent.role` directly. Pass `[]` or any array — the value is ignored.
- *   This parameter will be removed in a future cleanup.
+ * @param node - The workflow node whose channels are to be resolved.
  * @returns Array of concrete `ResolvedChannel` routing rules. Empty when no channels are defined.
  * @throws {Error} When neither `agentId` nor `agents` is provided on the node
  *   (propagated from `resolveNodeAgents`). Callers should validate nodes before calling this.
  */
-export function resolveNodeChannels(node: WorkflowNode, agents: SpaceAgent[]): ResolvedChannel[] {
+export function resolveNodeChannels(node: WorkflowNode): ResolvedChannel[] {
 	if (!node.channels || node.channels.length === 0) return [];
-
-	// agents param is retained for API compatibility; resolution now uses WorkflowNodeAgent.role directly.
-	void agents;
 
 	const nodeAgents = resolveNodeAgents(node);
 

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -21,9 +21,9 @@ import type { SpaceAgent, WorkflowChannel, WorkflowNode, WorkflowNodeAgent } fro
  * Wildcard and array `to` declarations are expanded into one entry per resolved pair.
  */
 export interface ResolvedChannel {
-	/** Role of the sending agent (matches SpaceAgent.role) */
+	/** Role of the sending agent (matches WorkflowNodeAgent.role) */
 	fromRole: string;
-	/** Role of the receiving agent (matches SpaceAgent.role) */
+	/** Role of the receiving agent (matches WorkflowNodeAgent.role) */
 	toRole: string;
 	/** Agent ID of the sender */
 	fromAgentId: string;
@@ -110,8 +110,9 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
  * - `A → *`        A sends to all agents
  *
  * @param node   - The workflow node whose channels are to be resolved.
- * @param agents - All `SpaceAgent` records in the Space (unused in resolution; kept for API
- *   compatibility with `validateNodeChannels`). Pass `[]` when not available.
+ * @param agents - **Deprecated.** No longer used in resolution. Channel routing now uses
+ *   `WorkflowNodeAgent.role` directly. Pass `[]` or any array — the value is ignored.
+ *   This parameter will be removed in a future cleanup.
  * @returns Array of concrete `ResolvedChannel` routing rules. Empty when no channels are defined.
  * @throws {Error} When neither `agentId` nor `agents` is provided on the node
  *   (propagated from `resolveNodeAgents`). Callers should validate nodes before calling this.

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -53,7 +53,9 @@ export interface ResolvedChannel {
  *    (`agentId`, if also set, is silently ignored — callers should validate
  *    and warn users that `agents` overrides `agentId` at edit time.)
  * 2. If only `agentId` is provided, returns a single-element array:
- *    `[{ agentId, instructions: node.instructions }]`.
+ *    `[{ agentId, role: agentId, instructions: node.instructions }]`.
+ *    (The `agentId` is used as a synthetic role since no explicit role is available
+ *    in the legacy shorthand format.)
  * 3. If neither is provided, throws an `Error`.
  *
  * @param node - The workflow node to resolve agents for.
@@ -66,7 +68,7 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
 	}
 
 	if (node.agentId) {
-		return [{ agentId: node.agentId, instructions: node.instructions }];
+		return [{ agentId: node.agentId, role: node.agentId, instructions: node.instructions }];
 	}
 
 	throw new Error(
@@ -85,7 +87,7 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
  *
  * Resolution algorithm:
  * - Each channel's `from`/`to` role strings are resolved against the node's agents via
- *   the provided `SpaceAgent[]` lookup table (role strings matched via SpaceAgent.role).
+ *   the `WorkflowNodeAgent.role` field — the per-slot role set on each agent entry.
  * - `'*'` in `from` or `to` (as the sole element) expands to all agent roles in the node.
  *   Note: `'*'` mixed with other roles in an array `to` is treated as a literal role name;
  *   use `validateNodeChannels` to catch this pattern at edit time.
@@ -94,9 +96,9 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
  *   - **Hub-spoke** (`A ↔ [B, C, D]`): hub→each spoke + each spoke→hub, all with
  *     `isHubSpoke: true`. Spoke-to-spoke routing is intentionally omitted.
  * - Self-loops (fromRole === toRole) are skipped.
- * - Roles not resolvable via the provided `agents` list are skipped silently;
+ * - Roles not present in the node's agent list are skipped silently;
  *   use `validateNodeChannels` to surface these as errors before calling this function.
- * - When two node agents share the same SpaceAgent.role, the last one wins in the
+ * - When two node agents share the same `role`, the last one wins in the
  *   role→agentId map. Duplicate roles are flagged by `validateNodeChannels`.
  *
  * Supported topology patterns:
@@ -108,7 +110,8 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
  * - `A → *`        A sends to all agents
  *
  * @param node   - The workflow node whose channels are to be resolved.
- * @param agents - All `SpaceAgent` records in the Space; used to map agentId → role.
+ * @param agents - All `SpaceAgent` records in the Space (unused in resolution; kept for API
+ *   compatibility with `validateNodeChannels`). Pass `[]` when not available.
  * @returns Array of concrete `ResolvedChannel` routing rules. Empty when no channels are defined.
  * @throws {Error} When neither `agentId` nor `agents` is provided on the node
  *   (propagated from `resolveNodeAgents`). Callers should validate nodes before calling this.
@@ -116,15 +119,15 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
 export function resolveNodeChannels(node: WorkflowNode, agents: SpaceAgent[]): ResolvedChannel[] {
 	if (!node.channels || node.channels.length === 0) return [];
 
+	// agents param is retained for API compatibility; resolution now uses WorkflowNodeAgent.role directly.
+	void agents;
+
 	const nodeAgents = resolveNodeAgents(node);
 
-	// Build role → agentId map for agents present in this node.
+	// Build role → agentId map using the per-slot role on each WorkflowNodeAgent entry.
 	const roleToAgentId = new Map<string, string>();
 	for (const sa of nodeAgents) {
-		const spaceAgent = agents.find((a) => a.id === sa.agentId);
-		if (spaceAgent) {
-			roleToAgentId.set(spaceAgent.role, sa.agentId);
-		}
+		roleToAgentId.set(sa.role, sa.agentId);
 	}
 
 	const allRoles = [...roleToAgentId.keys()];
@@ -206,12 +209,13 @@ function expandChannel(
  * Checks:
  * - At least one of `agentId` or `agents` is provided (delegates to `resolveNodeAgents`).
  * - All node agent IDs are found in the provided `agents` list.
- * - No two node agents share the same `SpaceAgent.role` (ambiguous channel targeting).
- * - `from`/`to` role strings are either the wildcard `'*'` or match a known role.
+ * - No two node agent slots share the same `WorkflowNodeAgent.role` (ambiguous channel targeting).
+ *   Note: the same `agentId` may appear multiple times if each slot has a distinct `role`.
+ * - `from`/`to` role strings are either the wildcard `'*'` or match a known `WorkflowNodeAgent.role`.
  * - `'*'` is not mixed with other roles in an array `to` (use a plain `'*'` string instead).
  *
  * @param node   - The workflow node to validate.
- * @param agents - All `SpaceAgent` records in the Space.
+ * @param agents - All `SpaceAgent` records in the Space (used to verify agentId existence).
  * @returns Array of human-readable error strings. Empty array means no errors.
  * @public
  */
@@ -228,25 +232,27 @@ export function validateNodeChannels(node: WorkflowNode, agents: SpaceAgent[]): 
 		return errors;
 	}
 
-	// Build known roles set from node agents; detect duplicate roles.
+	// Build known roles set from WorkflowNodeAgent.role; detect duplicate slot roles.
 	const knownRoles = new Set<string>();
 	const seenRoles = new Set<string>();
 	for (const sa of nodeAgents) {
-		const spaceAgent = agents.find((a) => a.id === sa.agentId);
-		if (spaceAgent) {
-			if (seenRoles.has(spaceAgent.role)) {
-				errors.push(
-					`Node "${node.name}" has two agents with role "${spaceAgent.role}". ` +
-						'Duplicate roles make channel targeting ambiguous.'
-				);
-			} else {
-				seenRoles.add(spaceAgent.role);
-				knownRoles.add(spaceAgent.role);
-			}
-		} else {
+		// Verify the agentId exists in the space.
+		const spaceAgentExists = agents.some((a) => a.id === sa.agentId);
+		if (!spaceAgentExists) {
 			errors.push(
 				`Node agent with agentId "${sa.agentId}" was not found in the provided space agents list.`
 			);
+		}
+
+		// Validate role uniqueness within the node (duplicate roles make channel targeting ambiguous).
+		if (seenRoles.has(sa.role)) {
+			errors.push(
+				`Node "${node.name}" has two agent slots with role "${sa.role}". ` +
+					'Duplicate roles make channel targeting ambiguous.'
+			);
+		} else {
+			seenRoles.add(sa.role);
+			knownRoles.add(sa.role);
 		}
 	}
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -575,8 +575,14 @@ export interface WorkflowNodeAgent {
 	agentId: string;
 	/**
 	 * Unique identifier for this agent slot within the node.
-	 * Used for channel routing and must be unique across all agents in the same node.
-	 * Example values: "strict-reviewer", "quick-reviewer", "security-scanner".
+	 * Used for channel routing (`WorkflowChannel.from`/`to`) and must be unique across
+	 * all agent slots in the same node.
+	 *
+	 * This is a **slot-specific label** distinct from `SpaceAgent.role`, which identifies
+	 * the agent's job category (e.g. `"coder"`, `"reviewer"`). The same `SpaceAgent` may
+	 * appear in multiple slots with different `WorkflowNodeAgent.role` values (e.g.
+	 * `"strict-reviewer"` and `"quick-reviewer"`). When added via the UI a second time,
+	 * a numeric suffix is appended automatically (e.g. `"coder"` → `"coder-2"`).
 	 */
 	role: string;
 	/**

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -579,9 +579,15 @@ export interface WorkflowNodeAgent {
 	 * Example values: "strict-reviewer", "quick-reviewer", "security-scanner".
 	 */
 	role: string;
-	/** Override the agent's default model for this slot */
+	/**
+	 * Override the agent's default model for this slot.
+	 * TODO: Not yet applied at runtime — workflow-executor.ts does not read this field.
+	 */
 	model?: string;
-	/** Override the agent's default system prompt for this slot */
+	/**
+	 * Override the agent's default system prompt for this slot.
+	 * TODO: Not yet applied at runtime — workflow-executor.ts does not read this field.
+	 */
 	systemPrompt?: string;
 	/** Per-agent instructions override — appended to the agent's system prompt */
 	instructions?: string;
@@ -590,14 +596,14 @@ export interface WorkflowNodeAgent {
 /**
  * A directed messaging channel between agents in a workflow node.
  * Channels define which agents may send messages to which other agents.
- * `from` and `to` reference agent roles (matching `SpaceAgent.role`) or the
+ * `from` and `to` reference agent roles (matching `WorkflowNodeAgent.role`) or the
  * wildcard `'*'` which matches all agents in the node.
  *
  * No channels = no messaging constraints (agents are fully isolated).
  */
 export interface WorkflowChannel {
 	/**
-	 * Source role string (matches SpaceAgent.role) or `'*'` for all agents in the node.
+	 * Source role string (matches `WorkflowNodeAgent.role`) or `'*'` for all agents in the node.
 	 */
 	from: string;
 	/**
@@ -653,7 +659,7 @@ export interface WorkflowNode {
 	/**
 	 * Directed messaging topology between agents in this node.
 	 * No channels = no messaging constraints (agents are fully isolated).
-	 * Roles referenced in `from`/`to` must match `SpaceAgent.role` values for agents
+	 * Roles referenced in `from`/`to` must match `WorkflowNodeAgent.role` values for agents
 	 * in this node, or the wildcard `'*'`.
 	 */
 	channels?: WorkflowChannel[];
@@ -706,7 +712,7 @@ export interface WorkflowNodeInput {
 	instructions?: string;
 	/**
 	 * Directed messaging topology between agents in this node.
-	 * Roles referenced in `from`/`to` must match `SpaceAgent.role` values for agents
+	 * Roles referenced in `from`/`to` must match `WorkflowNodeAgent.role` values for agents
 	 * in this node, or the wildcard `'*'`.
 	 */
 	channels?: WorkflowChannel[];
@@ -859,9 +865,15 @@ export interface ExportedWorkflowNodeAgent {
 	 * Must be unique across all agents in the same exported node.
 	 */
 	role: string;
-	/** Override the agent's default model for this slot */
+	/**
+	 * Override the agent's default model for this slot.
+	 * TODO: Not yet applied at runtime — workflow-executor.ts does not read this field.
+	 */
 	model?: string;
-	/** Override the agent's default system prompt for this slot */
+	/**
+	 * Override the agent's default system prompt for this slot.
+	 * TODO: Not yet applied at runtime — workflow-executor.ts does not read this field.
+	 */
 	systemPrompt?: string;
 	/** Per-agent instructions override */
 	instructions?: string;

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -568,11 +568,21 @@ export type WorkflowTransitionInput = Omit<WorkflowTransition, 'id'>;
 
 /**
  * A single agent entry within a multi-agent workflow node.
- * References a SpaceAgent by ID and optionally overrides instructions for that agent.
+ * References a SpaceAgent by ID with an optional per-slot configuration override.
  */
 export interface WorkflowNodeAgent {
 	/** ID of the SpaceAgent assigned to execute this node slot */
 	agentId: string;
+	/**
+	 * Unique identifier for this agent slot within the node.
+	 * Used for channel routing and must be unique across all agents in the same node.
+	 * Example values: "strict-reviewer", "quick-reviewer", "security-scanner".
+	 */
+	role: string;
+	/** Override the agent's default model for this slot */
+	model?: string;
+	/** Override the agent's default system prompt for this slot */
+	systemPrompt?: string;
 	/** Per-agent instructions override — appended to the agent's system prompt */
 	instructions?: string;
 }
@@ -844,6 +854,15 @@ export interface UpdateSpaceWorkflowParams {
 export interface ExportedWorkflowNodeAgent {
 	/** Name of the SpaceAgent (portable, not a UUID) */
 	agentRef: string;
+	/**
+	 * Unique identifier for this agent slot within the node.
+	 * Must be unique across all agents in the same exported node.
+	 */
+	role: string;
+	/** Override the agent's default model for this slot */
+	model?: string;
+	/** Override the agent's default system prompt for this slot */
+	systemPrompt?: string;
 	/** Per-agent instructions override */
 	instructions?: string;
 }

--- a/packages/shared/tests/space-utils.test.ts
+++ b/packages/shared/tests/space-utils.test.ts
@@ -42,26 +42,32 @@ describe('resolveNodeAgents', () => {
 	test('returns single-element array when only agentId is set', () => {
 		const node = makeNode({ agentId: 'agent-coder-id', instructions: 'do the thing' });
 		const result = resolveNodeAgents(node);
-		expect(result).toEqual([{ agentId: 'agent-coder-id', instructions: 'do the thing' }]);
+		expect(result).toHaveLength(1);
+		expect(result[0].agentId).toBe('agent-coder-id');
+		expect(result[0].instructions).toBe('do the thing');
+		// Synthetic role uses agentId as placeholder
+		expect(result[0].role).toBe('agent-coder-id');
 	});
 
 	test('returns agents array when agents is set (non-empty)', () => {
 		const node = makeNode({
 			agents: [
-				{ agentId: 'agent-coder-id', instructions: 'write code' },
-				{ agentId: 'agent-reviewer-id' },
+				{ agentId: 'agent-coder-id', role: 'coder', instructions: 'write code' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
 			],
 		});
 		const result = resolveNodeAgents(node);
 		expect(result).toHaveLength(2);
 		expect(result[0].agentId).toBe('agent-coder-id');
+		expect(result[0].role).toBe('coder');
 		expect(result[1].agentId).toBe('agent-reviewer-id');
+		expect(result[1].role).toBe('reviewer');
 	});
 
 	test('agents takes precedence over agentId when both are set', () => {
 		const node = makeNode({
 			agentId: 'agent-coder-id',
-			agents: [{ agentId: 'agent-reviewer-id' }],
+			agents: [{ agentId: 'agent-reviewer-id', role: 'reviewer' }],
 		});
 		const result = resolveNodeAgents(node);
 		expect(result).toHaveLength(1);
@@ -82,10 +88,10 @@ describe('resolveNodeAgents', () => {
 
 	test('single-element agents array works correctly', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id', instructions: 'custom' }],
+			agents: [{ agentId: 'agent-coder-id', role: 'coder', instructions: 'custom' }],
 		});
 		expect(resolveNodeAgents(node)).toEqual([
-			{ agentId: 'agent-coder-id', instructions: 'custom' },
+			{ agentId: 'agent-coder-id', role: 'coder', instructions: 'custom' },
 		]);
 	});
 
@@ -93,6 +99,37 @@ describe('resolveNodeAgents', () => {
 		const node = makeNode({ agentId: 'agent-coder-id' });
 		const result = resolveNodeAgents(node);
 		expect(result[0].instructions).toBeUndefined();
+	});
+
+	test('same agentId can appear multiple times with different roles', () => {
+		const node = makeNode({
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'strict-reviewer' },
+				{ agentId: 'agent-coder-id', role: 'quick-reviewer' },
+			],
+		});
+		const result = resolveNodeAgents(node);
+		expect(result).toHaveLength(2);
+		expect(result[0].role).toBe('strict-reviewer');
+		expect(result[1].role).toBe('quick-reviewer');
+		expect(result[0].agentId).toBe('agent-coder-id');
+		expect(result[1].agentId).toBe('agent-coder-id');
+	});
+
+	test('preserves model and systemPrompt override fields', () => {
+		const node = makeNode({
+			agents: [
+				{
+					agentId: 'agent-coder-id',
+					role: 'fast-coder',
+					model: 'claude-haiku-4-5',
+					systemPrompt: 'You are a fast coder.',
+				},
+			],
+		});
+		const result = resolveNodeAgents(node);
+		expect(result[0].model).toBe('claude-haiku-4-5');
+		expect(result[0].systemPrompt).toBe('You are a fast coder.');
 	});
 });
 
@@ -113,7 +150,10 @@ describe('resolveNodeChannels', () => {
 
 	test('A→B one-way: produces one resolved channel', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 		});
 		const result = resolveNodeChannels(node, allAgents);
@@ -130,7 +170,10 @@ describe('resolveNodeChannels', () => {
 
 	test('A↔B bidirectional point-to-point: produces two one-way channels', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'bidirectional' }],
 		});
 		const result = resolveNodeChannels(node, allAgents);
@@ -151,9 +194,9 @@ describe('resolveNodeChannels', () => {
 	test('A→[B,C] fan-out: produces one channel per target', () => {
 		const node = makeNode({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [{ from: 'coder', to: ['reviewer', 'security'], direction: 'one-way' }],
 		});
@@ -175,9 +218,9 @@ describe('resolveNodeChannels', () => {
 	test('A↔[B,C] hub-spoke: produces hub→spoke + spoke→hub, no spoke-to-spoke', () => {
 		const node = makeNode({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [{ from: 'coder', to: ['reviewer', 'security'], direction: 'bidirectional' }],
 		});
@@ -205,9 +248,9 @@ describe('resolveNodeChannels', () => {
 	test('wildcard *→B: all agents send to B', () => {
 		const node = makeNode({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [{ from: '*', to: 'reviewer', direction: 'one-way' }],
 		});
@@ -222,9 +265,9 @@ describe('resolveNodeChannels', () => {
 	test('wildcard A→*: A sends to all other agents', () => {
 		const node = makeNode({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [{ from: 'coder', to: '*', direction: 'one-way' }],
 		});
@@ -239,9 +282,9 @@ describe('resolveNodeChannels', () => {
 	test('channel label is propagated to all resolved channels', () => {
 		const node = makeNode({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [
 				{
@@ -258,7 +301,7 @@ describe('resolveNodeChannels', () => {
 
 	test('skips channels referencing unknown roles (does not throw)', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }],
+			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [{ from: 'coder', to: 'nonexistent-role', direction: 'one-way' }],
 		});
 		const result = resolveNodeChannels(node, allAgents);
@@ -267,7 +310,7 @@ describe('resolveNodeChannels', () => {
 
 	test('self-loop (from === to) is skipped', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }],
+			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [{ from: 'coder', to: 'coder', direction: 'one-way' }],
 		});
 		const result = resolveNodeChannels(node, allAgents);
@@ -277,9 +320,9 @@ describe('resolveNodeChannels', () => {
 	test('multiple channels expand independently', () => {
 		const node = makeNode({
 			agents: [
-				{ agentId: 'agent-coder-id' },
-				{ agentId: 'agent-reviewer-id' },
-				{ agentId: 'agent-security-id' },
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+				{ agentId: 'agent-security-id', role: 'security' },
 			],
 			channels: [
 				{ from: 'coder', to: 'reviewer', direction: 'one-way' },
@@ -295,6 +338,24 @@ describe('resolveNodeChannels', () => {
 	test('backward-compat: node with only agentId and no channels resolves channels to []', () => {
 		const node = makeNode({ agentId: 'agent-coder-id' });
 		expect(resolveNodeChannels(node, allAgents)).toEqual([]);
+	});
+
+	test('same agentId with different roles routes channels correctly', () => {
+		// Two slots using the same agent but different roles
+		const node = makeNode({
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'strict-reviewer' },
+				{ agentId: 'agent-coder-id', role: 'quick-reviewer' },
+			],
+			channels: [{ from: 'strict-reviewer', to: 'quick-reviewer', direction: 'one-way' }],
+		});
+		const result = resolveNodeChannels(node, allAgents);
+		expect(result).toHaveLength(1);
+		expect(result[0].fromRole).toBe('strict-reviewer');
+		expect(result[0].toRole).toBe('quick-reviewer');
+		// Both resolve to the same agentId
+		expect(result[0].fromAgentId).toBe('agent-coder-id');
+		expect(result[0].toAgentId).toBe('agent-coder-id');
 	});
 });
 
@@ -315,7 +376,10 @@ describe('validateNodeChannels', () => {
 
 	test('returns no errors for valid channel references', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 		});
 		expect(validateNodeChannels(node, allAgents)).toEqual([]);
@@ -323,7 +387,10 @@ describe('validateNodeChannels', () => {
 
 	test('accepts wildcard * in from without error', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: '*', to: 'reviewer', direction: 'one-way' }],
 		});
 		expect(validateNodeChannels(node, allAgents)).toEqual([]);
@@ -331,7 +398,10 @@ describe('validateNodeChannels', () => {
 
 	test('accepts wildcard * in to without error', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: '*', direction: 'one-way' }],
 		});
 		expect(validateNodeChannels(node, allAgents)).toEqual([]);
@@ -339,7 +409,7 @@ describe('validateNodeChannels', () => {
 
 	test('reports error for unknown from role', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }],
+			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [{ from: 'nonexistent', to: 'coder', direction: 'one-way' }],
 		});
 		const errors = validateNodeChannels(node, allAgents);
@@ -349,7 +419,7 @@ describe('validateNodeChannels', () => {
 
 	test('reports error for unknown to role', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }],
+			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [{ from: 'coder', to: 'nonexistent', direction: 'one-way' }],
 		});
 		const errors = validateNodeChannels(node, allAgents);
@@ -359,7 +429,10 @@ describe('validateNodeChannels', () => {
 
 	test('reports error for unknown role in array to', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: ['reviewer', 'ghost-role'], direction: 'one-way' }],
 		});
 		const errors = validateNodeChannels(node, allAgents);
@@ -369,7 +442,7 @@ describe('validateNodeChannels', () => {
 
 	test('reports error for agent not found in space agents list', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'unknown-agent-id' }],
+			agents: [{ agentId: 'unknown-agent-id', role: 'coder' }],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 		});
 		const errors = validateNodeChannels(node, allAgents);
@@ -387,7 +460,7 @@ describe('validateNodeChannels', () => {
 
 	test('accumulates multiple errors', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }],
+			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [
 				{ from: 'bad-from', to: 'bad-to', direction: 'one-way' },
 				{ from: 'coder', to: 'another-bad', direction: 'one-way' },
@@ -397,21 +470,38 @@ describe('validateNodeChannels', () => {
 		expect(errors.length).toBeGreaterThanOrEqual(3); // bad-from, bad-to, another-bad
 	});
 
-	test('reports error when two node agents share the same role', () => {
-		// Two coder agents in the same node — duplicate role makes channels ambiguous
-		const dupCoderAgent = makeAgent('agent-coder-2-id', 'coder');
-		const agents = [...allAgents, dupCoderAgent];
+	test('reports error when two agent slots share the same role', () => {
+		// Two slots with the same role — duplicate roles make channels ambiguous
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-coder-2-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'reviewer' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' }, // duplicate role
+			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 		});
-		const errors = validateNodeChannels(node, agents);
+		const errors = validateNodeChannels(node, allAgents);
 		expect(errors.some((e) => e.includes('Duplicate roles'))).toBe(true);
+	});
+
+	test('allows same agentId with different roles (no error)', () => {
+		// Same agent used twice with different roles — this is now permitted
+		const node = makeNode({
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'strict-reviewer' },
+				{ agentId: 'agent-coder-id', role: 'quick-reviewer' },
+			],
+			channels: [{ from: 'strict-reviewer', to: 'quick-reviewer', direction: 'one-way' }],
+		});
+		const errors = validateNodeChannels(node, allAgents);
+		expect(errors).toEqual([]);
 	});
 
 	test('reports error when * is mixed with other roles in array to', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: ['reviewer', '*'], direction: 'one-way' }],
 		});
 		const errors = validateNodeChannels(node, allAgents);
@@ -420,7 +510,10 @@ describe('validateNodeChannels', () => {
 
 	test('plain * in to (not in array) is accepted', () => {
 		const node = makeNode({
-			agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+			agents: [
+				{ agentId: 'agent-coder-id', role: 'coder' },
+				{ agentId: 'agent-reviewer-id', role: 'reviewer' },
+			],
 			channels: [{ from: 'coder', to: '*', direction: 'one-way' }],
 		});
 		expect(validateNodeChannels(node, allAgents)).toEqual([]);
@@ -440,7 +533,11 @@ describe('backward compatibility (nodes with only agentId)', () => {
 			instructions: 'do stuff',
 		};
 		const result = resolveNodeAgents(node);
-		expect(result).toEqual([{ agentId: 'agent-coder-id', instructions: 'do stuff' }]);
+		expect(result).toHaveLength(1);
+		expect(result[0].agentId).toBe('agent-coder-id');
+		expect(result[0].instructions).toBe('do stuff');
+		// Synthetic role = agentId for legacy shorthand
+		expect(result[0].role).toBe('agent-coder-id');
 	});
 
 	test('resolveNodeChannels returns [] for legacy nodes with no channels', () => {

--- a/packages/shared/tests/space-utils.test.ts
+++ b/packages/shared/tests/space-utils.test.ts
@@ -140,12 +140,12 @@ describe('resolveNodeAgents', () => {
 describe('resolveNodeChannels', () => {
 	test('returns empty array when no channels defined', () => {
 		const node = makeNode({ agentId: 'agent-coder-id' });
-		expect(resolveNodeChannels(node, allAgents)).toEqual([]);
+		expect(resolveNodeChannels(node)).toEqual([]);
 	});
 
 	test('returns empty array when channels is an empty array', () => {
 		const node = makeNode({ agentId: 'agent-coder-id', channels: [] });
-		expect(resolveNodeChannels(node, allAgents)).toEqual([]);
+		expect(resolveNodeChannels(node)).toEqual([]);
 	});
 
 	test('A→B one-way: produces one resolved channel', () => {
@@ -156,7 +156,7 @@ describe('resolveNodeChannels', () => {
 			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 		expect(result).toHaveLength(1);
 		expect(result[0]).toMatchObject({
 			fromRole: 'coder',
@@ -176,7 +176,7 @@ describe('resolveNodeChannels', () => {
 			],
 			channels: [{ from: 'coder', to: 'reviewer', direction: 'bidirectional' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 		expect(result).toHaveLength(2);
 
 		const forward = result.find((r) => r.fromRole === 'coder' && r.toRole === 'reviewer');
@@ -200,7 +200,7 @@ describe('resolveNodeChannels', () => {
 			],
 			channels: [{ from: 'coder', to: ['reviewer', 'security'], direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 		expect(result).toHaveLength(2);
 
 		const toReviewer = result.find((r) => r.toRole === 'reviewer');
@@ -224,7 +224,7 @@ describe('resolveNodeChannels', () => {
 			],
 			channels: [{ from: 'coder', to: ['reviewer', 'security'], direction: 'bidirectional' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 
 		// 2 spokes × 2 directions = 4 channels
 		expect(result).toHaveLength(4);
@@ -254,7 +254,7 @@ describe('resolveNodeChannels', () => {
 			],
 			channels: [{ from: '*', to: 'reviewer', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 
 		// coder→reviewer and security→reviewer (reviewer→reviewer self-loop skipped)
 		expect(result).toHaveLength(2);
@@ -271,7 +271,7 @@ describe('resolveNodeChannels', () => {
 			],
 			channels: [{ from: 'coder', to: '*', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 
 		// coder→reviewer and coder→security (coder→coder self-loop skipped)
 		expect(result).toHaveLength(2);
@@ -295,7 +295,7 @@ describe('resolveNodeChannels', () => {
 				},
 			],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 		expect(result.every((r) => r.label === 'feedback')).toBe(true);
 	});
 
@@ -304,7 +304,7 @@ describe('resolveNodeChannels', () => {
 			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [{ from: 'coder', to: 'nonexistent-role', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 		expect(result).toHaveLength(0);
 	});
 
@@ -313,7 +313,7 @@ describe('resolveNodeChannels', () => {
 			agents: [{ agentId: 'agent-coder-id', role: 'coder' }],
 			channels: [{ from: 'coder', to: 'coder', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 		expect(result).toHaveLength(0);
 	});
 
@@ -329,7 +329,7 @@ describe('resolveNodeChannels', () => {
 				{ from: 'reviewer', to: 'security', direction: 'one-way' },
 			],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 		expect(result).toHaveLength(2);
 		expect(result[0]).toMatchObject({ fromRole: 'coder', toRole: 'reviewer' });
 		expect(result[1]).toMatchObject({ fromRole: 'reviewer', toRole: 'security' });
@@ -337,7 +337,7 @@ describe('resolveNodeChannels', () => {
 
 	test('backward-compat: node with only agentId and no channels resolves channels to []', () => {
 		const node = makeNode({ agentId: 'agent-coder-id' });
-		expect(resolveNodeChannels(node, allAgents)).toEqual([]);
+		expect(resolveNodeChannels(node)).toEqual([]);
 	});
 
 	test('same agentId with different roles routes channels correctly', () => {
@@ -349,7 +349,7 @@ describe('resolveNodeChannels', () => {
 			],
 			channels: [{ from: 'strict-reviewer', to: 'quick-reviewer', direction: 'one-way' }],
 		});
-		const result = resolveNodeChannels(node, allAgents);
+		const result = resolveNodeChannels(node);
 		expect(result).toHaveLength(1);
 		expect(result[0].fromRole).toBe('strict-reviewer');
 		expect(result[0].toRole).toBe('quick-reviewer');
@@ -546,7 +546,7 @@ describe('backward compatibility (nodes with only agentId)', () => {
 			name: 'Legacy Node',
 			agentId: 'agent-coder-id',
 		};
-		expect(resolveNodeChannels(node, allAgents)).toEqual([]);
+		expect(resolveNodeChannels(node)).toEqual([]);
 	});
 
 	test('validateNodeChannels returns no errors for legacy nodes with no channels', () => {

--- a/packages/web/src/components/room/AgentTurnBlock.tsx
+++ b/packages/web/src/components/room/AgentTurnBlock.tsx
@@ -649,17 +649,29 @@ function AgentTurnBlockInner({ turn, className, onHeaderClick }: AgentTurnBlockP
 						// Track seen texts for deduplication across nested messages
 						const seenTexts = new Set<string>();
 
-						// Only show last 3 renderable messages
+						// For completed turns, messages are pre-trimmed in useTurnBlocks to
+						// first + last 3. Render all; use turn.hiddenCount for the banner.
+						// For the active (streaming) turn, apply local MESSAGES_TO_SHOW slicing.
 						const MESSAGES_TO_SHOW = 3;
-						const renderableIndices = nestedMessages.reduce<number[]>((acc, msg, idx) => {
-							if (isRenderable(msg)) acc.push(idx);
-							return acc;
-						}, []);
-						const lastRenderableSlice = renderableIndices.slice(-MESSAGES_TO_SHOW);
-						const firstShownIdx =
-							lastRenderableSlice.length > 0 ? lastRenderableSlice[0] : nestedMessages.length;
-						const hasMore = firstShownIdx > 0;
-						const messagesToRender = nestedMessages.slice(firstShownIdx);
+						let messagesToRender: SDKMessage[];
+						let hasMore: boolean;
+						let shownMoreCount: number;
+						if (!turn.isActive) {
+							messagesToRender = nestedMessages;
+							hasMore = turn.hiddenCount > 0;
+							shownMoreCount = turn.hiddenCount;
+						} else {
+							const renderableIndices = nestedMessages.reduce<number[]>((acc, msg, idx) => {
+								if (isRenderable(msg)) acc.push(idx);
+								return acc;
+							}, []);
+							const lastRenderableSlice = renderableIndices.slice(-MESSAGES_TO_SHOW);
+							const firstShownIdx =
+								lastRenderableSlice.length > 0 ? lastRenderableSlice[0] : nestedMessages.length;
+							hasMore = firstShownIdx > 0;
+							shownMoreCount = firstShownIdx;
+							messagesToRender = nestedMessages.slice(firstShownIdx);
+						}
 
 						return (
 							<div class="p-3">
@@ -670,12 +682,12 @@ function AgentTurnBlockInner({ turn, className, onHeaderClick }: AgentTurnBlockP
 									{hasMore && (
 										<div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 py-1">
 											<span class="flex-1 border-t border-gray-300 dark:border-gray-600"></span>
-											<span class="shrink-0">({firstShownIdx}) more messages</span>
+											<span class="shrink-0">({shownMoreCount}) more messages</span>
 											<span class="flex-1 border-t border-gray-300 dark:border-gray-600"></span>
 										</div>
 									)}
 									{messagesToRender.map((msg, idx) => {
-										const actualIdx = firstShownIdx + idx;
+										const actualIdx = idx;
 										const isLastAssistant = actualIdx === lastAssistantIdx;
 										return (
 											<NestedMessageRenderer

--- a/packages/web/src/components/room/TaskViewV2.test.tsx
+++ b/packages/web/src/components/room/TaskViewV2.test.tsx
@@ -298,6 +298,7 @@ function makeTurn(overrides: Partial<TurnBlock> = {}): TurnBlock {
 		isError: false,
 		errorMessage: null,
 		messages: [],
+		hiddenCount: 0,
 		...overrides,
 	};
 }

--- a/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
+++ b/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
@@ -61,6 +61,7 @@ function makeTurn(overrides: Partial<TurnBlock> = {}): TurnBlock {
 		isError: false,
 		errorMessage: null,
 		messages: [],
+		hiddenCount: 0,
 		...overrides,
 	};
 }

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -139,27 +139,33 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 		updateAgents([...nodeAgents, { agentId, role }]);
 	}
 
-	function removeAgent(agentId: string) {
-		const next = nodeAgents.filter((a) => a.agentId !== agentId);
+	function removeAgent(role: string) {
+		const removed = nodeAgents.find((a) => a.role === role);
+		const next = nodeAgents.filter((a) => a.role !== role);
 		if (next.length === 0) {
 			// Switch back to single-agent mode: restore agentId from the removed agent and
 			// clear channels (orphaned channels on a single-agent node are semantically invalid)
-			onUpdate({ ...node, agents: undefined, agentId, channels: undefined });
+			onUpdate({
+				...node,
+				agents: undefined,
+				agentId: removed?.agentId ?? '',
+				channels: undefined,
+			});
 		} else {
 			updateAgents(next);
 		}
 	}
 
-	function updateAgentInstructions(agentId: string, instructions: string) {
+	function updateAgentInstructions(role: string, instructions: string) {
 		updateAgents(
 			nodeAgents.map((a) =>
-				a.agentId === agentId ? { ...a, instructions: instructions || undefined } : a
+				a.role === role ? { ...a, instructions: instructions || undefined } : a
 			)
 		);
 	}
 
-	const usedIds = new Set(nodeAgents.map((a) => a.agentId));
-	const availableAgents = agents.filter((a) => !usedIds.has(a.id));
+	// All agents are available; same agent may be added multiple times with different roles.
+	const availableAgents = agents;
 
 	return (
 		<div class="space-y-2">
@@ -190,15 +196,15 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 				{nodeAgents.map((sa) => {
 					const agentInfo = agents.find((a) => a.id === sa.agentId);
 					return (
-						<div key={sa.agentId} class="bg-dark-800 border border-dark-600 rounded p-2 space-y-1">
+						<div key={sa.role} class="bg-dark-800 border border-dark-600 rounded p-2 space-y-1">
 							<div class="flex items-center justify-between">
 								<span class="text-xs font-medium text-gray-200">
 									{agentInfo?.name ?? sa.agentId}
-									{agentInfo && <span class="text-gray-500 ml-1">({agentInfo.role})</span>}
+									{agentInfo && <span class="text-gray-500 ml-1">({sa.role})</span>}
 								</span>
 								<button
 									type="button"
-									onClick={() => removeAgent(sa.agentId)}
+									onClick={() => removeAgent(sa.role)}
 									class="text-gray-600 hover:text-red-400 transition-colors"
 									title="Remove agent"
 								>
@@ -216,7 +222,7 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 								type="text"
 								value={sa.instructions ?? ''}
 								onInput={(e) =>
-									updateAgentInstructions(sa.agentId, (e.currentTarget as HTMLInputElement).value)
+									updateAgentInstructions(sa.role, (e.currentTarget as HTMLInputElement).value)
 								}
 								placeholder="Per-agent instructions (optional)…"
 								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -135,7 +135,9 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		if (nodeAgents.some((a) => a.agentId === agentId)) return;
-		updateAgents([...nodeAgents, { agentId }]);
+		const agentInfo = agents.find((a) => a.id === agentId);
+		const role = agentInfo?.role ?? agentId;
+		updateAgents([...nodeAgents, { agentId, role }]);
 	}
 
 	function removeAgent(agentId: string) {
@@ -609,7 +611,12 @@ export function WorkflowNodeCard({
 									type="button"
 									onClick={() => {
 										const firstId = node.agentId;
-										const existing: WorkflowNodeAgent[] = firstId ? [{ agentId: firstId }] : [];
+										const firstAgentRole = firstId
+											? (agents.find((a) => a.id === firstId)?.role ?? firstId)
+											: '';
+										const existing: WorkflowNodeAgent[] = firstId
+											? [{ agentId: firstId, role: firstAgentRole }]
+											: [];
 										onUpdate({ ...node, agents: existing, agentId: '' });
 									}}
 									class="text-xs text-blue-400 hover:text-blue-300 transition-colors"

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -284,15 +284,12 @@ function formatTo(to: string | string[]): string {
 	return Array.isArray(to) ? `[${to.join(', ')}]` : to;
 }
 
-function ChannelsSection({ node, agents, onUpdate }: ChannelsSectionProps) {
+function ChannelsSection({ node, onUpdate }: ChannelsSectionProps) {
 	const channels = node.channels ?? [];
 	const nodeAgents = node.agents ?? [];
 
 	// Collect known roles from node agents (+ wildcard)
-	const knownRoles = [
-		'*',
-		...nodeAgents.map((sa) => agents.find((a) => a.id === sa.agentId)?.role ?? sa.agentId),
-	];
+	const knownRoles = ['*', ...nodeAgents.map((sa) => sa.role)];
 
 	function updateChannels(next: WorkflowChannel[]) {
 		onUpdate({ ...node, channels: next.length > 0 ? next : undefined });

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -134,7 +134,6 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 
 	function addAgent(agentId: string) {
 		if (!agentId) return;
-		if (nodeAgents.some((a) => a.agentId === agentId)) return;
 		const agentInfo = agents.find((a) => a.id === agentId);
 		const role = agentInfo?.role ?? agentId;
 		updateAgents([...nodeAgents, { agentId, role }]);

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -135,7 +135,14 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		const agentInfo = agents.find((a) => a.id === agentId);
-		const role = agentInfo?.role ?? agentId;
+		const baseRole = agentInfo?.role ?? agentId;
+		// Ensure the slot role is unique within this node. When the same agent is added
+		// multiple times, append a numeric suffix to distinguish the slots.
+		const usedRoles = new Set(nodeAgents.map((a) => a.role));
+		let role = baseRole;
+		for (let i = 2; usedRoles.has(role); i++) {
+			role = `${baseRole}-${i}`;
+		}
 		updateAgents([...nodeAgents, { agentId, role }]);
 	}
 

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -77,16 +77,16 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	 */
 	function buildTaskAgentChannels(agentsToChannel: WorkflowNodeAgent[]): WorkflowChannel[] {
 		return agentsToChannel.map((sa) => {
-			const agentInfo = agents.find((a) => a.id === sa.agentId);
-			const role = agentInfo?.role ?? sa.agentId;
-			return { from: 'task-agent', to: role, direction: 'bidirectional' };
+			return { from: 'task-agent', to: sa.role, direction: 'bidirectional' };
 		});
 	}
 
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		if (stepAgents.some((a) => a.agentId === agentId)) return;
-		const next = [...stepAgents, { agentId }];
+		const agentInfo = agents.find((a) => a.id === agentId);
+		const role = agentInfo?.role ?? agentId;
+		const next = [...stepAgents, { agentId, role }];
 		// Merge agents + channels into a single onUpdate call to avoid stale-reference overwrites
 		const newChannels = step.channels === undefined ? buildTaskAgentChannels(next) : step.channels;
 		onUpdate({ ...step, agents: next, agentId: '', channels: newChannels });
@@ -125,7 +125,12 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 						data-testid="add-agent-button"
 						onClick={() => {
 							const firstId = step.agentId;
-							const existing: WorkflowNodeAgent[] = firstId ? [{ agentId: firstId }] : [];
+							const firstAgentRole = firstId
+								? (agents.find((a) => a.id === firstId)?.role ?? firstId)
+								: '';
+							const existing: WorkflowNodeAgent[] = firstId
+								? [{ agentId: firstId, role: firstAgentRole }]
+								: [];
 							onUpdate({ ...step, agents: existing, agentId: '' });
 						}}
 						class="text-xs text-blue-400 hover:text-blue-300 transition-colors"

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -83,7 +83,6 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 
 	function addAgent(agentId: string) {
 		if (!agentId) return;
-		if (stepAgents.some((a) => a.agentId === agentId)) return;
 		const agentInfo = agents.find((a) => a.id === agentId);
 		const role = agentInfo?.role ?? agentId;
 		const next = [...stepAgents, { agentId, role }];

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -285,15 +285,12 @@ interface ChannelsPanelSectionProps {
 	onUpdate: (step: NodeDraft) => void;
 }
 
-function ChannelsPanelSection({ step, agents, onUpdate }: ChannelsPanelSectionProps) {
+function ChannelsPanelSection({ step, onUpdate }: ChannelsPanelSectionProps) {
 	const channels = step.channels ?? [];
 	const stepAgents = step.agents ?? [];
 
 	// Collect known roles from step agents (+ wildcard)
-	const knownRoles = [
-		'*',
-		...stepAgents.map((sa) => agents.find((a) => a.id === sa.agentId)?.role ?? sa.agentId),
-	];
+	const knownRoles = ['*', ...stepAgents.map((sa) => sa.role)];
 
 	const [newFrom, setNewFrom] = useState('');
 	const [newTo, setNewTo] = useState('');

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -91,27 +91,33 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 		onUpdate({ ...step, agents: next, agentId: '', channels: newChannels });
 	}
 
-	function removeAgent(agentId: string) {
-		const next = stepAgents.filter((a) => a.agentId !== agentId);
+	function removeAgent(role: string) {
+		const removed = stepAgents.find((a) => a.role === role);
+		const next = stepAgents.filter((a) => a.role !== role);
 		if (next.length === 0) {
 			// Switch back to single-agent mode: restore agentId from the removed agent and
 			// clear channels (orphaned channels on a single-agent step are semantically invalid)
-			onUpdate({ ...step, agents: undefined, agentId, channels: undefined });
+			onUpdate({
+				...step,
+				agents: undefined,
+				agentId: removed?.agentId ?? '',
+				channels: undefined,
+			});
 		} else {
 			updateAgents(next);
 		}
 	}
 
-	function updateAgentInstructions(agentId: string, instructions: string) {
+	function updateAgentInstructions(role: string, instructions: string) {
 		updateAgents(
 			stepAgents.map((a) =>
-				a.agentId === agentId ? { ...a, instructions: instructions || undefined } : a
+				a.role === role ? { ...a, instructions: instructions || undefined } : a
 			)
 		);
 	}
 
-	const usedIds = new Set(stepAgents.map((a) => a.agentId));
-	const availableAgents = agents.filter((a) => !usedIds.has(a.id));
+	// All agents are available; same agent may be added multiple times with different roles.
+	const availableAgents = agents;
 
 	if (!multi) {
 		// Single-agent mode
@@ -199,19 +205,19 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 					const agentInfo = agents.find((a) => a.id === sa.agentId);
 					return (
 						<div
-							key={sa.agentId}
+							key={sa.role}
 							class="bg-dark-800 border border-dark-600 rounded p-2 space-y-1"
 							data-testid="agent-entry"
 						>
 							<div class="flex items-center justify-between">
 								<span class="text-xs font-medium text-gray-200">
 									{agentInfo?.name ?? sa.agentId}
-									{agentInfo && <span class="text-gray-500 ml-1">({agentInfo.role})</span>}
+									{agentInfo && <span class="text-gray-500 ml-1">({sa.role})</span>}
 								</span>
 								<button
 									type="button"
 									data-testid="remove-agent-button"
-									onClick={() => removeAgent(sa.agentId)}
+									onClick={() => removeAgent(sa.role)}
 									class="text-gray-600 hover:text-red-400 transition-colors"
 									title="Remove agent"
 								>
@@ -230,7 +236,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 								data-testid="agent-instructions-input"
 								value={sa.instructions ?? ''}
 								onInput={(e) =>
-									updateAgentInstructions(sa.agentId, (e.currentTarget as HTMLInputElement).value)
+									updateAgentInstructions(sa.role, (e.currentTarget as HTMLInputElement).value)
 								}
 								placeholder="Per-agent instructions (optional)…"
 								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -84,7 +84,14 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		const agentInfo = agents.find((a) => a.id === agentId);
-		const role = agentInfo?.role ?? agentId;
+		const baseRole = agentInfo?.role ?? agentId;
+		// Ensure the slot role is unique within this node. When the same agent is added
+		// multiple times, append a numeric suffix to distinguish the slots.
+		const usedRoles = new Set(stepAgents.map((a) => a.role));
+		let role = baseRole;
+		for (let i = 2; usedRoles.has(role); i++) {
+			role = `${baseRole}-${i}`;
+		}
 		const next = [...stepAgents, { agentId, role }];
 		// Merge agents + channels into a single onUpdate call to avoid stale-reference overwrites
 		const newChannels = step.channels === undefined ? buildTaskAgentChannels(next) : step.channels;

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -452,13 +452,13 @@ describe('NodeConfigPanel', () => {
 			expect(updatedStep.channels).toBeUndefined();
 		});
 
-		it('shows add-agent-select dropdown for agents not yet in step', () => {
+		it('shows add-agent-select dropdown with all agents (same agent may be added multiple times)', () => {
 			const step = makeStep({
 				agentId: '',
 				agents: [{ agentId: 'agent-1', role: 'planner' }],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
-			// agent-2 is not in step yet, should appear in dropdown
+			// All agents appear in the dropdown regardless of whether they are already in the step
 			const select = getByTestId('add-agent-select');
 			expect(select.textContent).toContain('Coder');
 		});

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -596,5 +596,54 @@ describe('NodeConfigPanel', () => {
 			expect(updatedStep.channels[0].to).toBe('reviewer');
 			expect(updatedStep.channels[0].direction).toBe('one-way');
 		});
+
+		it('channel-from-select dropdown options are slot roles (WorkflowNodeAgent.role), not SpaceAgent.role', () => {
+			// When the same agent is added twice with roles "coder" and "coder-2",
+			// both slot roles must appear as distinct options in the channel dropdown.
+			const step = makeStep({
+				agentId: '',
+				agents: [
+					{ agentId: 'agent-2', role: 'coder' },
+					{ agentId: 'agent-2', role: 'coder-2' },
+				],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			const fromSelect = getByTestId('channel-from-select');
+			// Both slot-specific roles must be present as options
+			expect(fromSelect.textContent).toContain('coder');
+			expect(fromSelect.textContent).toContain('coder-2');
+		});
+
+		it('adding the same agent twice generates a unique slot role with numeric suffix', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-2', role: 'coder' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			// Add agent-2 (Coder) a second time
+			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
+			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+			expect(updatedStep.agents).toHaveLength(2);
+			expect(updatedStep.agents[0].role).toBe('coder');
+			// Second slot must get a unique suffix to avoid duplicate-role validation error
+			expect(updatedStep.agents[1].role).toBe('coder-2');
+		});
+
+		it('adding the same agent three times produces coder, coder-2, coder-3', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [
+					{ agentId: 'agent-2', role: 'coder' },
+					{ agentId: 'agent-2', role: 'coder-2' },
+				],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
+			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+			expect(updatedStep.agents).toHaveLength(3);
+			expect(updatedStep.agents[2].role).toBe('coder-3');
+		});
 	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -384,7 +384,10 @@ describe('NodeConfigPanel', () => {
 		it('shows agents list in multi-agent mode', () => {
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
 			});
 			const { getByTestId, queryByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
 			expect(getByTestId('agents-list')).toBeTruthy();
@@ -395,7 +398,10 @@ describe('NodeConfigPanel', () => {
 		it('renders one entry per agent in multi-agent mode', () => {
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
 			});
 			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
 			expect(getAllByTestId('agent-entry')).toHaveLength(2);
@@ -404,7 +410,7 @@ describe('NodeConfigPanel', () => {
 		it('shows agent name and role in each agent entry', () => {
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }],
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
 			const entry = getByTestId('agents-list');
@@ -416,7 +422,10 @@ describe('NodeConfigPanel', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
 			});
 			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
 			fireEvent.click(getAllByTestId('remove-agent-button')[0]);
@@ -429,7 +438,7 @@ describe('NodeConfigPanel', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }],
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
 				channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' as const }],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
@@ -446,7 +455,7 @@ describe('NodeConfigPanel', () => {
 		it('shows add-agent-select dropdown for agents not yet in step', () => {
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }],
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
 			// agent-2 is not in step yet, should appear in dropdown
@@ -458,7 +467,7 @@ describe('NodeConfigPanel', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }],
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
 			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
@@ -478,7 +487,7 @@ describe('NodeConfigPanel', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }],
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
 				channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' as const }],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
@@ -493,7 +502,10 @@ describe('NodeConfigPanel', () => {
 		it('shows channels section in multi-agent mode', () => {
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
 			expect(getByTestId('channels-section')).toBeTruthy();
@@ -509,7 +521,10 @@ describe('NodeConfigPanel', () => {
 		it('renders existing channels in channels list', () => {
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
 				channels: [
 					{ from: 'coder', to: 'reviewer', direction: 'one-way' },
 					{ from: 'reviewer', to: 'coder', direction: 'bidirectional' },
@@ -523,7 +538,10 @@ describe('NodeConfigPanel', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
 				channels: [
 					{ from: 'coder', to: 'reviewer', direction: 'one-way' },
 					{ from: 'reviewer', to: 'coder', direction: 'bidirectional' },
@@ -539,7 +557,10 @@ describe('NodeConfigPanel', () => {
 		it('add channel button is disabled when from or to is empty', () => {
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
 			const addBtn = getByTestId('add-channel-button');
@@ -550,7 +571,10 @@ describe('NodeConfigPanel', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
 			// Set from

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -260,7 +260,10 @@ describe('WorkflowNode multi-agent rendering', () => {
 		const step = {
 			...STEP_DRAFT,
 			agentId: '',
-			agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+			agents: [
+				{ agentId: 'agent-1', role: 'coder' },
+				{ agentId: 'agent-2', role: 'reviewer' },
+			],
 		};
 		const { getByTestId, queryByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
 		const badges = getByTestId('agent-badges');
@@ -279,7 +282,7 @@ describe('WorkflowNode multi-agent rendering', () => {
 	});
 
 	it('renders single agent name when agents array is empty', () => {
-		const step = { ...STEP_DRAFT, agents: [] as { agentId: string }[] };
+		const step = { ...STEP_DRAFT, agents: [] as { agentId: string; role: string }[] };
 		const { getByTestId, queryByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
 		// Empty agents array = single-agent mode
 		expect(getByTestId('agent-name')).toBeTruthy();
@@ -290,7 +293,7 @@ describe('WorkflowNode multi-agent rendering', () => {
 		const step = {
 			...STEP_DRAFT,
 			agentId: '',
-			agents: [{ agentId: 'unknown-agent-id' }],
+			agents: [{ agentId: 'unknown-agent-id', role: 'coder' }],
 		};
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
 		expect(getByTestId('agent-badges').textContent).toContain('unknown-agent-id');
@@ -300,7 +303,10 @@ describe('WorkflowNode multi-agent rendering', () => {
 		const step = {
 			...STEP_DRAFT,
 			agentId: '',
-			agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+			agents: [
+				{ agentId: 'agent-1', role: 'coder' },
+				{ agentId: 'agent-2', role: 'reviewer' },
+			],
 		};
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
 		const node = getByTestId('workflow-node-step-local-1');

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -791,7 +791,10 @@ describe('multi-agent step serialization', () => {
 				{
 					id: 's1',
 					name: 'Parallel Step',
-					agents: [{ agentId: 'a1' }, { agentId: 'a2', instructions: 'focus on security' }],
+					agents: [
+						{ agentId: 'a1', role: 'coder' },
+						{ agentId: 'a2', role: 'reviewer', instructions: 'focus on security' },
+					],
 				},
 			],
 		});
@@ -811,7 +814,10 @@ describe('multi-agent step serialization', () => {
 				{
 					id: 's1',
 					name: 'Parallel Step',
-					agents: [{ agentId: 'a1' }, { agentId: 'a2' }],
+					agents: [
+						{ agentId: 'a1', role: 'coder' },
+						{ agentId: 'a2', role: 'reviewer' },
+					],
 					channels: [
 						{ from: 'coder', to: 'reviewer', direction: 'one-way', label: 'PR' },
 						{ from: 'reviewer', to: ['coder', 'qa'], direction: 'bidirectional' },
@@ -844,7 +850,10 @@ describe('multi-agent step serialization', () => {
 						id: 's1',
 						name: 'Parallel Step',
 						agentId: '',
-						agents: [{ agentId: 'a1' }, { agentId: 'a2', instructions: 'custom' }],
+						agents: [
+							{ agentId: 'a1', role: 'coder' },
+							{ agentId: 'a2', role: 'reviewer', instructions: 'custom' },
+						],
 						channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
 						instructions: '',
 					},
@@ -876,7 +885,7 @@ describe('multi-agent step serialization', () => {
 						id: 's1',
 						name: 'Step',
 						agentId: '',
-						agents: [{ agentId: 'a1' }],
+						agents: [{ agentId: 'a1', role: 'coder' }],
 						channels: [],
 						instructions: '',
 					},
@@ -911,7 +920,10 @@ describe('multi-agent step serialization', () => {
 				{
 					id: 's1',
 					name: 'Parallel',
-					agents: [{ agentId: 'a1', instructions: 'focus on tests' }, { agentId: 'a2' }],
+					agents: [
+						{ agentId: 'a1', role: 'coder', instructions: 'focus on tests' },
+						{ agentId: 'a2', role: 'reviewer' },
+					],
 					channels: [
 						{ from: 'coder', to: 'reviewer', direction: 'one-way' as const },
 						{ from: 'reviewer', to: ['coder', 'qa'], direction: 'bidirectional' as const },

--- a/packages/web/src/hooks/useTurnBlocks.ts
+++ b/packages/web/src/hooks/useTurnBlocks.ts
@@ -71,8 +71,17 @@ export interface TurnBlock {
 	isError: boolean;
 	/** Error text extracted from the first error found in the turn, or null. */
 	errorMessage: string | null;
-	/** All parsed SDKMessages belonging to this turn, in order. */
+	/**
+	 * All parsed SDKMessages belonging to this turn, in order.
+	 * For completed turns, this is trimmed to first message + last TURN_PREVIEW_TAIL messages
+	 * to save memory. Use messageCount for the total.
+	 */
 	messages: SDKMessage[];
+	/**
+	 * Number of messages hidden between the first and the last TURN_PREVIEW_TAIL messages.
+	 * Zero for active turns or turns short enough to need no trimming.
+	 */
+	hiddenCount: number;
 }
 
 /** A runtime/system message that renders inline between turn blocks. */
@@ -348,6 +357,7 @@ export function useTurnBlocks(messages: SessionGroupMessage[], isAtTail = true):
 					isError,
 					errorMessage,
 					messages: msgs,
+					hiddenCount: 0,
 				},
 			});
 
@@ -470,6 +480,7 @@ export function useTurnBlocks(messages: SessionGroupMessage[], isAtTail = true):
 					isError: false,
 					errorMessage: null,
 					messages: [held],
+					hiddenCount: 0,
 				},
 			});
 		}
@@ -491,6 +502,27 @@ export function useTurnBlocks(messages: SessionGroupMessage[], isAtTail = true):
 					}
 					break;
 				}
+			}
+		}
+
+		// Trim messages for completed turns: keep first message (input) + last TURN_PREVIEW_TAIL
+		// messages. Stats (toolCallCount etc.) were already computed from all messages above.
+		// This reduces memory for long sessions while preserving the preview content.
+		const TURN_PREVIEW_TAIL = 3;
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
+			if (item.type !== 'turn' || item.turn.isActive) continue;
+			const msgs = item.turn.messages;
+			if (msgs.length > TURN_PREVIEW_TAIL + 1) {
+				const hiddenCount = msgs.length - TURN_PREVIEW_TAIL - 1;
+				items[i] = {
+					type: 'turn',
+					turn: {
+						...item.turn,
+						messages: [msgs[0], ...msgs.slice(-TURN_PREVIEW_TAIL)],
+						hiddenCount,
+					},
+				};
 			}
 		}
 


### PR DESCRIPTION
Add per-slot override fields to WorkflowNodeAgent and ExportedWorkflowNodeAgent:
- role: string (required, unique within node, used for channel routing)
- model?: string (override agent's default model for this slot)
- systemPrompt?: string (override agent's default system prompt for this slot)

Key changes:
- space.ts: WorkflowNodeAgent and ExportedWorkflowNodeAgent get new fields
- space-utils.ts: resolveNodeChannels now uses WorkflowNodeAgent.role directly
  (no longer looks up SpaceAgent.role); validateNodeChannels validates slot role
  uniqueness; resolveNodeAgents uses agentId as synthetic role for legacy shorthand
- export-format.ts: Zod schema and export function include new fields
- space-export-import-handlers.ts: import side preserves role, model, systemPrompt
- All downstream tests updated with required role field on WorkflowNodeAgent objects

Same agentId can now appear multiple times in a node if each slot has a distinct role.
