### PR TITLE
test: add unit tests for recurring mission schedule tools (set_schedule, pause_schedule, resume_schedule)

### DIFF
--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -2332,6 +2332,155 @@ describe('Room Agent Tools', () => {
 		});
 	});
 
+	describe('set_schedule', () => {
+		it('should set a schedule on a recurring mission', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Daily sync', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(
+				await handlers.set_schedule({ goal_id: goalId, cron_expression: '0 9 * * *' })
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.missionType).toBe('recurring');
+			expect((goal.schedule as Record<string, unknown>).expression).toBe('0 9 * * *');
+			expect(result.nextRunAt).toBeDefined();
+			expect(result.nextRunAtISO).toBeDefined();
+		});
+
+		it('should set a schedule using @daily preset', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Daily check', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(
+				await handlers.set_schedule({ goal_id: goalId, cron_expression: '@daily' })
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect((goal.schedule as Record<string, unknown>).expression).toBe('@daily');
+		});
+
+		it('should return error when setting schedule on non-recurring goal', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'One-shot goal', mission_type: 'one_shot' })
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(
+				await handlers.set_schedule({ goal_id: goalId, cron_expression: '0 9 * * *' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('not a recurring mission');
+		});
+
+		it('should return error for invalid cron expression', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Bad cron', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(
+				await handlers.set_schedule({ goal_id: goalId, cron_expression: 'invalid' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Invalid cron expression');
+		});
+
+		it('should return error for non-existent goal', async () => {
+			const result = parseResult(
+				await handlers.set_schedule({ goal_id: 'no-such-goal', cron_expression: '0 9 * * *' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Goal not found');
+		});
+	});
+
+	describe('pause_schedule', () => {
+		it('should pause a schedule on a recurring mission', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Paused mission', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			// First set a schedule
+			await handlers.set_schedule({ goal_id: goalId, cron_expression: '0 9 * * *' });
+
+			// Then pause it
+			const result = parseResult(await handlers.pause_schedule({ goal_id: goalId }));
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.schedulePaused).toBe(true);
+		});
+
+		it('should return error when pausing non-recurring goal', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'One-shot', mission_type: 'one_shot' })
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(await handlers.pause_schedule({ goal_id: goalId }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('not a recurring mission');
+		});
+
+		it('should return error for non-existent goal', async () => {
+			const result = parseResult(await handlers.pause_schedule({ goal_id: 'no-such' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Goal not found');
+		});
+	});
+
+	describe('resume_schedule', () => {
+		it('should resume a paused schedule on a recurring mission', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Resume mission', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			// Set and pause a schedule
+			await handlers.set_schedule({ goal_id: goalId, cron_expression: '0 9 * * *' });
+			await handlers.pause_schedule({ goal_id: goalId });
+
+			// Resume it
+			const result = parseResult(await handlers.resume_schedule({ goal_id: goalId }));
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.schedulePaused).toBe(false);
+		});
+
+		it('should return error when resuming non-recurring goal', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'One-shot', mission_type: 'one_shot' })
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(await handlers.resume_schedule({ goal_id: goalId }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('not a recurring mission');
+		});
+
+		it('should return error when resuming goal without schedule', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'No schedule', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(await handlers.resume_schedule({ goal_id: goalId }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('no schedule set');
+		});
+
+		it('should return error for non-existent goal', async () => {
+			const result = parseResult(await handlers.resume_schedule({ goal_id: 'no-such' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Goal not found');
+		});
+	});
+
 	describe('set_task_status — archived', () => {
 		it('should archive a completed task', async () => {
 			const task = await taskManager.createTask({ title: 'T', description: 'D' });

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -2377,6 +2377,41 @@ describe('Room Agent Tools', () => {
 			expect(result.error).toContain('not a recurring mission');
 		});
 
+		it('should return error when setting schedule on measurable goal', async () => {
+			const created = parseResult(
+				await handlers.create_goal({
+					title: 'Measurable goal',
+					mission_type: 'measurable',
+					structured_metrics: [{ name: 'kpi', target: 100 }],
+				})
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(
+				await handlers.set_schedule({ goal_id: goalId, cron_expression: '0 9 * * *' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('not a recurring mission');
+		});
+
+		it('should set schedule with timezone parameter', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Timezone test', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			const result = parseResult(
+				await handlers.set_schedule({
+					goal_id: goalId,
+					cron_expression: '0 9 * * *',
+					timezone: 'America/New_York',
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect((goal.schedule as Record<string, unknown>).timezone).toBe('America/New_York');
+		});
+
 		it('should return error for invalid cron expression', async () => {
 			const created = parseResult(
 				await handlers.create_goal({ title: 'Bad cron', mission_type: 'recurring' })
@@ -2427,6 +2462,35 @@ describe('Room Agent Tools', () => {
 			expect(result.error).toContain('not a recurring mission');
 		});
 
+		it('should allow pausing a recurring mission without a schedule set', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'No schedule yet', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			// pause_schedule does not check for schedule existence — this is a no-op but succeeds
+			const result = parseResult(await handlers.pause_schedule({ goal_id: goalId }));
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.schedulePaused).toBe(true);
+		});
+
+		it('should allow double-pause (idempotent)', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Double pause', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			await handlers.set_schedule({ goal_id: goalId, cron_expression: '0 9 * * *' });
+			await handlers.pause_schedule({ goal_id: goalId });
+
+			// Pause again — should be a no-op
+			const result = parseResult(await handlers.pause_schedule({ goal_id: goalId }));
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.schedulePaused).toBe(true);
+		});
+
 		it('should return error for non-existent goal', async () => {
 			const result = parseResult(await handlers.pause_schedule({ goal_id: 'no-such' }));
 			expect(result.success).toBe(false);
@@ -2446,6 +2510,22 @@ describe('Room Agent Tools', () => {
 			await handlers.pause_schedule({ goal_id: goalId });
 
 			// Resume it
+			const result = parseResult(await handlers.resume_schedule({ goal_id: goalId }));
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.schedulePaused).toBe(false);
+		});
+
+		it('should allow resuming a non-paused scheduled mission (idempotent)', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Not paused', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+
+			// Set a schedule but do not pause it
+			await handlers.set_schedule({ goal_id: goalId, cron_expression: '0 9 * * *' });
+
+			// Resume without having paused — should be a no-op
 			const result = parseResult(await handlers.resume_schedule({ goal_id: goalId }));
 			expect(result.success).toBe(true);
 			const goal = result.goal as Record<string, unknown>;


### PR DESCRIPTION
## Summary

The `mission_type` parameter in `create_goal` MCP tool already existed (added in commit `1ba2d4583`). This PR adds comprehensive unit tests for the three schedule-related MCP tool handlers:

- `set_schedule` - set cron schedule on recurring missions
- `pause_schedule` - pause a recurring mission's schedule
- `resume_schedule` - resume a paused schedule

## Test plan

- [x] All 148 room-agent-tools unit tests pass
- [x] All 1455 room unit tests pass
- [x] Typecheck passes

## Changes

Added 18 new tests covering:

**set_schedule:**
- Setting schedule with cron expression and @daily preset
- Setting schedule on non-recurring goal (error case)
- Setting schedule on measurable goal (error case)
- Invalid cron expression handling
- Timezone parameter support
- Non-existent goal error case

**pause_schedule:**
- Pause/resume cycle on recurring mission
- Pause without schedule set (edge case, allowed)
- Double-pause (idempotent behavior)
- Non-recurring goal rejection
- Non-existent goal error case

**resume_schedule:**
- Resume paused schedule
- Resume on non-paused scheduled mission (idempotent)
- Resume without schedule (error case)
- Non-recurring goal rejection
- Non-existent goal error case