### PR TITLE
fix(e2e): use exact text match for 'Message number 1' selector

### DIFF
--- a/packages/e2e/tests/features/task-message-pagination.e2e.ts
+++ b/packages/e2e/tests/features/task-message-pagination.e2e.ts
@@ -127,7 +127,9 @@ test.describe('TaskView — Message Pagination', () => {
 			await expect(page.getByText('Message number 1', { exact: true })).toBeVisible({
 				timeout: 10000,
 			});
-			await expect(page.locator('text=Message number 3')).toBeVisible({ timeout: 10000 });
+			await expect(page.getByText('Message number 3', { exact: true })).toBeVisible({
+				timeout: 10000,
+			});
 
 			// No "Load earlier" button shown
 			await expect(page.getByTestId('load-earlier-messages')).not.toBeVisible();
@@ -162,7 +164,9 @@ test.describe('TaskView — Message Pagination', () => {
 			);
 
 			// The newest message (55) should be visible
-			await expect(page.locator('text=Message number 55')).toBeVisible({ timeout: 10000 });
+			await expect(page.getByText('Message number 55', { exact: true })).toBeVisible({
+				timeout: 10000,
+			});
 
 			// The oldest messages should NOT be visible initially (they're hidden by pagination)
 			await expect(page.getByText('Message number 1', { exact: true })).not.toBeVisible();
@@ -181,7 +185,9 @@ test.describe('TaskView — Message Pagination', () => {
 			await expect(page.getByTestId('load-earlier-messages')).toBeVisible({ timeout: 10000 });
 
 			// Verify newest message (55) is visible
-			await expect(page.locator('text=Message number 55')).toBeVisible({ timeout: 5000 });
+			await expect(page.getByText('Message number 55', { exact: true })).toBeVisible({
+				timeout: 5000,
+			});
 
 			// Scroll the container all the way to the bottom first. Status messages are thin
 			// divider rows (~24px each) and the task chrome varies by environment, so content
@@ -218,7 +224,7 @@ test.describe('TaskView — Message Pagination', () => {
 			await expect(page.getByTestId('load-earlier-messages')).not.toBeVisible();
 
 			// Verify newest messages are still present (they should not have disappeared)
-			await expect(page.locator('text=Message number 55')).toBeVisible();
+			await expect(page.getByText('Message number 55', { exact: true })).toBeVisible();
 
 			// Verify scroll position was preserved (not jumped to top).
 			// Only assert when scrollBefore > 0 — if the container was too short to

--- a/packages/e2e/tests/features/task-message-pagination.e2e.ts
+++ b/packages/e2e/tests/features/task-message-pagination.e2e.ts
@@ -124,7 +124,9 @@ test.describe('TaskView — Message Pagination', () => {
 			});
 
 			// All 3 messages visible
-			await expect(page.locator('text=Message number 1')).toBeVisible({ timeout: 10000 });
+			await expect(page.getByText('Message number 1', { exact: true })).toBeVisible({
+				timeout: 10000,
+			});
 			await expect(page.locator('text=Message number 3')).toBeVisible({ timeout: 10000 });
 
 			// No "Load earlier" button shown
@@ -163,7 +165,7 @@ test.describe('TaskView — Message Pagination', () => {
 			await expect(page.locator('text=Message number 55')).toBeVisible({ timeout: 10000 });
 
 			// The oldest messages should NOT be visible initially (they're hidden by pagination)
-			await expect(page.locator('text=Message number 1')).not.toBeVisible();
+			await expect(page.getByText('Message number 1', { exact: true })).not.toBeVisible();
 
 			// "Load earlier messages" button should appear at the top
 			await expect(page.getByTestId('load-earlier-messages')).toBeVisible({ timeout: 5000 });
@@ -208,7 +210,9 @@ test.describe('TaskView — Message Pagination', () => {
 
 			// After clicking, older messages should appear
 			// With 55 messages and pageSize=50, clicking once shows all 55
-			await expect(page.locator('text=Message number 1')).toBeVisible({ timeout: 5000 });
+			await expect(page.getByText('Message number 1', { exact: true })).toBeVisible({
+				timeout: 5000,
+			});
 
 			// The Load Earlier button should now be gone (all messages loaded)
 			await expect(page.getByTestId('load-earlier-messages')).not.toBeVisible();


### PR DESCRIPTION
The partial text selector 'text=Message number 1' was matching multiple
messages (e.g., "Message number 10", "Message number 11", etc.) causing
strict mode violations. Changed to getByText('Message number 1', { exact: true })
to ensure exact matching.
