### PR TITLE
feat(visual-editor): render Task Agent as distinct pinned node on canvas

### DIFF
--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -314,6 +314,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	}
 
 	const handleNodePositionChange = useCallback((localId: string, newPosition: Point) => {
+		// Task Agent is pinned — its position must never change.
+		if (localId === TASK_AGENT_NODE_ID) return;
 		setNodes((prev) =>
 			prev.map((n) => (n.step.localId === localId ? { ...n, position: newPosition } : n))
 		);

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -422,6 +422,10 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 
 	const handleCreateTransition = useCallback(
 		(fromLocalId: string, toLocalId: string) => {
+			// Task Agent is not a step in the execution flow — prevent it from being
+			// a source or target of workflow transitions.
+			if (fromLocalId === TASK_AGENT_NODE_ID || toLocalId === TASK_AGENT_NODE_ID) return;
+
 			const fromKey = localIdToStepKey.get(fromLocalId) ?? fromLocalId;
 			const toKey = localIdToStepKey.get(toLocalId) ?? toLocalId;
 			setEdges((prev) => {

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -133,6 +133,8 @@ export function WorkflowNode({
 
 	// ---- Window-level listeners (always registered, guard on dragState) ----
 	// Mirrors the pattern used by VisualCanvas for its spacebar+drag pan.
+	// For the Task Agent node, dragState.current is never set (handleMouseDown
+	// returns early), so both handlers short-circuit immediately — they are no-ops.
 	useEffect(() => {
 		const onMouseMove = (e: MouseEvent) => {
 			if (!dragState.current) return;
@@ -158,7 +160,12 @@ export function WorkflowNode({
 			if (!dragState.current) return;
 			dragState.current = null;
 			if (nodeRef.current) {
-				nodeRef.current.style.cursor = 'grab';
+				// Only reset to 'grab' for draggable nodes — Task Agent uses 'default'
+				// and dragState.current can never be set for it, so this branch is
+				// unreachable for Task Agent. Guard here for defence-in-depth.
+				if (!isTaskAgent) {
+					nodeRef.current.style.cursor = 'grab';
+				}
 				nodeRef.current.style.boxShadow = '';
 			}
 		};

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useCallback, useRef } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 import type { NodeDraft } from '../WorkflowNodeCard';
 import { isMultiAgentNode } from '../WorkflowNodeCard';
 import type { Point } from './types';
@@ -104,6 +105,7 @@ export function WorkflowNode({
 	onClick,
 }: WorkflowNodeProps) {
 	const stepId = step.localId;
+	const isTaskAgent = stepId === TASK_AGENT_NODE_ID;
 
 	const multi = isMultiAgentNode(step);
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
@@ -169,9 +171,14 @@ export function WorkflowNode({
 		};
 	}, [stepId]);
 
-	// ---- Card body mousedown — starts drag ----
+	// ---- Card body mousedown — starts drag (disabled for Task Agent) ----
 	const handleMouseDown = useCallback(
 		(e: MouseEvent) => {
+			// Task Agent is pinned — it cannot be dragged
+			if (isTaskAgent) {
+				e.stopPropagation();
+				return;
+			}
 			// Only primary button
 			if (e.button !== 0) return;
 			e.stopPropagation(); // prevent canvas pan from triggering
@@ -191,7 +198,7 @@ export function WorkflowNode({
 				nodeRef.current.style.boxShadow = '0 8px 24px rgba(0,0,0,0.4)';
 			}
 		},
-		[position.x, position.y]
+		[isTaskAgent, position.x, position.y]
 	);
 
 	// ---- Card click — for selection (suppressed after drag) ----
@@ -235,17 +242,66 @@ export function WorkflowNode({
 	}, [onPortMouseLeave, stepId]);
 
 	// ---- Styles ----
-	const borderClass = isStartNode
-		? 'border-green-500'
-		: isSelected
-			? 'border-blue-500'
-			: 'border-gray-700';
+	const borderClass = isTaskAgent
+		? 'border-amber-400'
+		: isStartNode
+			? 'border-green-500'
+			: isSelected
+				? 'border-blue-500'
+				: 'border-gray-700';
+
+	const bgClass = isTaskAgent ? 'bg-amber-950' : 'bg-gray-800';
 
 	const inputPortBg = isDropTarget ? '#22c55e' : '#6b7280';
 	const inputPortBorder = isDropTarget ? '#16a34a' : '#374151';
 	const inputPortScale = isDropTarget ? 'scale(1.4)' : '';
 
 	const ringClass = isSelected ? 'ring-2 ring-blue-500' : '';
+
+	// Task Agent: render a visually distinct pinned node with no ports
+	if (isTaskAgent) {
+		return (
+			<div
+				ref={nodeRef}
+				data-testid={`workflow-node-${stepId}`}
+				data-step-id={stepId}
+				data-task-agent="true"
+				style={{
+					position: 'absolute',
+					left: position.x,
+					top: position.y,
+					minWidth: 160,
+					cursor: 'default',
+					userSelect: 'none',
+					zIndex: 10,
+				}}
+				class={`rounded-lg border-2 ${bgClass} ${borderClass}`}
+				onMouseDown={handleMouseDown}
+			>
+				<div class="px-3 py-2">
+					{/* Header row: Task Agent badge */}
+					<div class="flex items-center justify-between mb-1">
+						<span
+							data-testid="task-agent-badge"
+							class="text-xs font-bold text-amber-400 uppercase tracking-wider"
+						>
+							Task Agent
+						</span>
+					</div>
+					{/* Name */}
+					<p
+						data-testid="step-name"
+						class="text-sm font-medium text-amber-100 truncate"
+						style={{ maxWidth: 180 }}
+					>
+						{step.name || 'Task Agent'}
+					</p>
+					{/* Channel topology */}
+					<ChannelTopologyBadge step={step} />
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div
@@ -260,7 +316,7 @@ export function WorkflowNode({
 				cursor: 'grab',
 				userSelect: 'none',
 			}}
-			class={`rounded-lg border-2 bg-gray-800 ${borderClass} ${ringClass}`}
+			class={`rounded-lg border-2 ${bgClass} ${borderClass} ${ringClass}`}
 			onMouseDown={handleMouseDown}
 			onClick={handleClick}
 		>

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -1030,6 +1030,80 @@ describe('VisualWorkflowEditor', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Task Agent visible node
+	// -------------------------------------------------------------------------
+
+	describe('Task Agent visible node', () => {
+		it('Task Agent node is always rendered in create mode', () => {
+			const { getByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			expect(getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`)).toBeTruthy();
+		});
+
+		it('Task Agent node is always rendered in edit mode', () => {
+			const { getByTestId } = render(
+				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
+			);
+			expect(getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`)).toBeTruthy();
+		});
+
+		it('Task Agent node renders with amber border (distinct style)', () => {
+			const { getByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			expect(node.className).toContain('border-amber-400');
+		});
+
+		it('Task Agent node renders with amber background (distinct style)', () => {
+			const { getByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			expect(node.className).toContain('bg-amber-950');
+		});
+
+		it('Task Agent node shows "Task Agent" badge', () => {
+			const { getByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			expect(getByTestId('task-agent-badge').textContent).toBe('Task Agent');
+		});
+
+		it('Task Agent node has no input port', () => {
+			const { queryByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			// The Task Agent node does not render input/output ports
+			const node = queryByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			expect(node?.querySelector('[data-testid="port-input"]')).toBeNull();
+		});
+
+		it('Task Agent node has no output port', () => {
+			const { queryByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			const node = queryByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			expect(node?.querySelector('[data-testid="port-output"]')).toBeNull();
+		});
+
+		it('Task Agent node cannot be deleted via keyboard Delete', () => {
+			const { getAllByTestId, getByTestId } = render(
+				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
+			);
+			// Click the Task Agent node — it should not become selected
+			const taskAgentNode = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			fireEvent.click(taskAgentNode);
+			// Press Delete — should not delete the Task Agent
+			fireEvent.keyDown(document.body, { key: 'Delete' });
+			// Task Agent must still be present
+			expect(getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`)).toBeTruthy();
+			// Total node count unchanged
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(3); // Task Agent + 2 steps
+		});
+
+		it('Task Agent node cannot be deleted via Backspace', () => {
+			const { getAllByTestId, getByTestId } = render(
+				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
+			);
+			const taskAgentNode = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+			fireEvent.click(taskAgentNode);
+			fireEvent.keyDown(document.body, { key: 'Backspace' });
+			expect(getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`)).toBeTruthy();
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(3);
+		});
+	});
+
+	// -------------------------------------------------------------------------
 	// Rules section
 	// -------------------------------------------------------------------------
 

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Focused tests for the handleCreateTransition Task Agent guard in VisualWorkflowEditor.
+ *
+ * Port-drag is not simulatable in JSDOM (useConnectionDrag requires real mouse events
+ * across port elements), so we mock WorkflowCanvas to capture the onCreateTransition
+ * callback and invoke it directly. This lets us verify the guard without UI coupling.
+ *
+ * Tests:
+ * - Does not add edge when fromLocalId is TASK_AGENT_NODE_ID
+ * - Does not add edge when toLocalId is TASK_AGENT_NODE_ID
+ * - Does add edge for two regular node IDs (positive case)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/preact';
+import { signal, type Signal } from '@preact/signals';
+import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
+
+// ---- Capture WorkflowCanvas.onCreateTransition without breaking the component ----
+
+let capturedOnCreateTransition: ((from: string, to: string) => void) | null = null;
+
+vi.mock('../WorkflowCanvas', async (importOriginal) => {
+	const mod = await importOriginal<typeof import('../WorkflowCanvas')>();
+	const Original = mod.WorkflowCanvas;
+	return {
+		...mod,
+		WorkflowCanvas: (props: Parameters<typeof Original>[0]) => {
+			capturedOnCreateTransition = props.onCreateTransition ?? null;
+			return <Original {...props} />;
+		},
+	};
+});
+
+// ---- Mocks for VisualWorkflowEditor dependencies ----
+
+const mockAgents: Signal<SpaceAgent[]> = signal([]);
+const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
+const mockCreateWorkflow = vi.fn();
+const mockUpdateWorkflow = vi.fn();
+
+vi.mock('../../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			agents: mockAgents,
+			workflows: mockWorkflows,
+			createWorkflow: mockCreateWorkflow,
+			updateWorkflow: mockUpdateWorkflow,
+		};
+	},
+}));
+
+vi.mock('../../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+import { VisualWorkflowEditor } from '../VisualWorkflowEditor';
+
+// ---- Helpers ----
+
+function makeAgent(id: string, name: string): SpaceAgent {
+	return { id, spaceId: 'space-1', name, role: 'coder', createdAt: 0, updatedAt: 0 };
+}
+
+function makeWorkflow(): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		spaceId: 'space-1',
+		name: 'My Workflow',
+		description: '',
+		nodes: [
+			{ id: 'step-1', name: 'Plan', agentId: 'agent-1', instructions: '' },
+			{ id: 'step-2', name: 'Code', agentId: 'agent-2', instructions: '' },
+		],
+		transitions: [],
+		startNodeId: 'step-1',
+		rules: [],
+		tags: [],
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+// ============================================================================
+// Setup / Teardown
+// ============================================================================
+
+beforeEach(() => {
+	cleanup();
+	capturedOnCreateTransition = null;
+	mockAgents.value = [makeAgent('agent-1', 'Planner'), makeAgent('agent-2', 'Coder')];
+	mockWorkflows.value = [];
+	mockCreateWorkflow.mockResolvedValue({ id: 'new-wf', nodes: [], transitions: [], tags: [] });
+	mockUpdateWorkflow.mockResolvedValue({ id: 'wf-1', nodes: [], transitions: [], tags: [] });
+	mockCreateWorkflow.mockClear();
+	mockUpdateWorkflow.mockClear();
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('VisualWorkflowEditor handleCreateTransition Task Agent guard', () => {
+	it('does not add an edge when fromLocalId is TASK_AGENT_NODE_ID', () => {
+		const { container } = render(
+			<VisualWorkflowEditor workflow={makeWorkflow()} onSave={vi.fn()} onCancel={vi.fn()} />
+		);
+
+		// Verify the callback was captured
+		expect(capturedOnCreateTransition).toBeTruthy();
+
+		const edgesBefore = container.querySelectorAll('[data-edge-id]').length;
+
+		// Simulate what useConnectionDrag would call if a drag from Task Agent completed
+		act(() => {
+			capturedOnCreateTransition!(TASK_AGENT_NODE_ID, 'step-1');
+		});
+
+		// Guard must have blocked the edge
+		expect(container.querySelectorAll('[data-edge-id]').length).toBe(edgesBefore);
+	});
+
+	it('does not add an edge when toLocalId is TASK_AGENT_NODE_ID', () => {
+		const { container } = render(
+			<VisualWorkflowEditor workflow={makeWorkflow()} onSave={vi.fn()} onCancel={vi.fn()} />
+		);
+
+		expect(capturedOnCreateTransition).toBeTruthy();
+
+		const edgesBefore = container.querySelectorAll('[data-edge-id]').length;
+
+		act(() => {
+			capturedOnCreateTransition!('step-1', TASK_AGENT_NODE_ID);
+		});
+
+		expect(container.querySelectorAll('[data-edge-id]').length).toBe(edgesBefore);
+	});
+
+	it('does add an edge for two regular node IDs (positive case)', () => {
+		const { container } = render(
+			<VisualWorkflowEditor workflow={makeWorkflow()} onSave={vi.fn()} onCancel={vi.fn()} />
+		);
+
+		expect(capturedOnCreateTransition).toBeTruthy();
+
+		// makeWorkflow has no transitions, so edges start at 0
+		expect(container.querySelectorAll('[data-edge-id]').length).toBe(0);
+
+		act(() => {
+			capturedOnCreateTransition!('step-1', 'step-2');
+		});
+
+		// A real edge should be created
+		expect(container.querySelectorAll('[data-edge-id]').length).toBe(1);
+	});
+});

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -24,6 +24,7 @@ import { useState } from 'preact/hooks';
 import { WorkflowNode } from '../WorkflowNode';
 import type { WorkflowNodeProps } from '../WorkflowNode';
 import type { SpaceAgent } from '@neokai/shared';
+import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 import type { Point } from '../types';
 
 afterEach(() => cleanup());
@@ -510,5 +511,97 @@ describe('WorkflowNode drag-and-drop', () => {
 		expect(onPositionChange).toHaveBeenLastCalledWith('step-local-1', { x: 80, y: 70 });
 
 		windowMouseUp();
+	});
+});
+
+// ============================================================================
+// Task Agent node tests
+// ============================================================================
+
+const TASK_AGENT_STEP = {
+	localId: TASK_AGENT_NODE_ID,
+	id: TASK_AGENT_NODE_ID,
+	name: 'Task Agent',
+	agentId: '',
+	instructions: '',
+};
+
+describe('WorkflowNode Task Agent rendering', () => {
+	it('renders with data-task-agent attribute', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.getAttribute('data-task-agent')).toBe('true');
+	});
+
+	it('renders Task Agent badge', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		expect(getByTestId('task-agent-badge').textContent).toBe('Task Agent');
+	});
+
+	it('renders step name as amber text', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const stepName = getByTestId('step-name');
+		expect(stepName.className).toContain('text-amber-100');
+	});
+
+	it('applies amber border style', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.className).toContain('border-amber-400');
+	});
+
+	it('applies amber background style', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.className).toContain('bg-amber-950');
+	});
+
+	it('has higher z-index than regular nodes', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.style.zIndex).toBe('10');
+	});
+
+	it('does not render input port', () => {
+		const { queryByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		expect(queryByTestId('port-input')).toBeNull();
+	});
+
+	it('does not render output port', () => {
+		const { queryByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		expect(queryByTestId('port-output')).toBeNull();
+	});
+
+	it('does not show step number badge', () => {
+		const { queryByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		expect(queryByTestId('step-badge')).toBeNull();
+	});
+
+	it('does not trigger drag on mousedown', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP, onPositionChange })} />
+		);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		fireEvent.mouseDown(node, { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(50, 50);
+		expect(onPositionChange).not.toHaveBeenCalled();
+		windowMouseUp();
+	});
+
+	it('does not fire onClick when clicked', () => {
+		const onClick = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP, onClick })} />
+		);
+		// Task Agent node does not register onClick (no handleClick in its JSX)
+		fireEvent.click(getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`));
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it('uses default cursor (not grab)', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.style.cursor).toBe('default');
 	});
 });


### PR DESCRIPTION
- WorkflowNode: detect TASK_AGENT_NODE_ID and render with amber/gold
  style (bg-amber-950, border-amber-400), "Task Agent" badge, no input/
  output ports, no drag, no click selection, zIndex:10 to stay on top
- VisualWorkflowEditor: prevent Task Agent from being a source/target
  in workflow transitions (handleCreateTransition guard)
- Tests: 12 new WorkflowNode tests for Task Agent visual style, ports,
  drag/click behavior; 10 new VisualWorkflowEditor tests for always-
  rendered, amber style, badge, no ports, delete prevention
