### PR TITLE
fix(recurring): auto-compute nextRunAt and implement plan reuse

### DIFF
--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -25,6 +25,7 @@ import type {
 	MissionMetric,
 	MetricHistoryEntry,
 } from '@neokai/shared';
+import { getNextRunAt, getSystemTimezone } from '../runtime/cron-utils';
 
 export interface MetricTargetResult {
 	name: string;
@@ -55,9 +56,19 @@ export class GoalManager {
 	 * Create a new goal
 	 */
 	async createGoal(params: Omit<CreateGoalParams, 'roomId'>): Promise<RoomGoal> {
+		// Auto-compute nextRunAt for recurring goals with a schedule.
+		// Without this, the scheduler (Phase 2 of tickRecurringMissions) would skip the
+		// goal because nextRunAt is null, and the goal would never trigger.
+		let nextRunAt = params.nextRunAt;
+		if (params.missionType === 'recurring' && params.schedule && nextRunAt === undefined) {
+			const tz = params.schedule.timezone ?? getSystemTimezone();
+			nextRunAt = getNextRunAt(params.schedule.expression, tz) ?? undefined;
+		}
+
 		const goal = this.goalRepo.createGoal({
 			...params,
 			roomId: this.roomId,
+			nextRunAt,
 		});
 
 		return goal;

--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -25,7 +25,7 @@ import type {
 	MissionMetric,
 	MetricHistoryEntry,
 } from '@neokai/shared';
-import { getNextRunAt, getSystemTimezone } from '../runtime/cron-utils';
+import { getNextRunAt, getSystemTimezone, isValidCronExpression } from '../runtime/cron-utils';
 
 export interface MetricTargetResult {
 	name: string;
@@ -61,8 +61,19 @@ export class GoalManager {
 		// goal because nextRunAt is null, and the goal would never trigger.
 		let nextRunAt = params.nextRunAt;
 		if (params.missionType === 'recurring' && params.schedule && nextRunAt === undefined) {
+			if (!isValidCronExpression(params.schedule.expression)) {
+				throw new Error(
+					`Invalid cron expression "${params.schedule.expression}" for recurring mission. Use 5-field cron or presets (@daily, @weekly, @hourly, @monthly).`
+				);
+			}
 			const tz = params.schedule.timezone ?? getSystemTimezone();
-			nextRunAt = getNextRunAt(params.schedule.expression, tz) ?? undefined;
+			const computed = getNextRunAt(params.schedule.expression, tz);
+			if (computed === null) {
+				throw new Error(
+					`Cron expression "${params.schedule.expression}" produces no future run times.`
+				);
+			}
+			nextRunAt = computed;
 		}
 
 		const goal = this.goalRepo.createGoal({

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2989,8 +2989,33 @@ export class RoomRuntime {
 			);
 			const previousResultSummary = prevCompleted?.resultSummary;
 
-			// Spawn planning group with executionId
-			await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
+			// Plan reuse: For subsequent executions (executions 2+), skip planning and clone
+			// tasks from the previous successful execution. This avoids redundant planning
+			// for recurring missions where the same plan is executed repeatedly.
+			//
+			// First execution (executionNumber === 1) always goes through the planner to
+			// establish the initial plan.
+			if (execution.executionNumber > 1 && prevCompleted) {
+				const clonedCount = await this.reuseExecutionPlan(
+					goal,
+					execution.id,
+					prevCompleted.taskIds
+				);
+				if (clonedCount > 0) {
+					log.info(
+						`Recurring mission ${goal.id}: execution ${execution.executionNumber} started with ${clonedCount} reused tasks`
+					);
+				} else {
+					// No tasks to clone (e.g., previous execution had no tasks) — fall back to planning
+					log.warn(
+						`Recurring mission ${goal.id}: no tasks to reuse from previous execution — falling back to planning`
+					);
+					await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
+				}
+			} else {
+				// First execution or no previous successful execution — spawn planning group
+				await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
+			}
 		}
 	}
 
@@ -3340,6 +3365,90 @@ export class RoomRuntime {
 			`Spawned planning group for goal ${goal.id} (${goal.title}), attempt ${(goal.planning_attempts ?? 0) + 1}` +
 				(isRecurringExecution ? ` [execution ${executionId}]` : '')
 		);
+	}
+
+	/**
+	 * Reuse the plan from a previous execution by cloning its tasks.
+	 *
+	 * For subsequent executions of a recurring mission, instead of going through
+	 * the planner again, we clone the tasks from the previous successful execution.
+	 * This avoids redundant planning for recurring work.
+	 *
+	 * Clone behavior:
+	 * - New tasks are created with status='pending' (not 'draft' since they're pre-approved)
+	 * - taskType, assignedAgent, priority are preserved from the original
+	 * - Planning tasks are excluded (only execution tasks are cloned)
+	 * - Dependencies are remapped from old task IDs to new task IDs
+	 *
+	 * Returns the number of tasks cloned.
+	 */
+	private async reuseExecutionPlan(
+		goal: RoomGoal,
+		newExecutionId: string,
+		prevExecutionTaskIds: string[]
+	): Promise<number> {
+		if (prevExecutionTaskIds.length === 0) {
+			log.debug(`[reuseExecutionPlan] No tasks to clone for goal ${goal.id}`);
+			return 0;
+		}
+
+		// Get full task details for all previous tasks
+		const prevTasks = await Promise.all(
+			prevExecutionTaskIds.map((id) => this.taskManager.getTask(id))
+		);
+		const validPrevTasks = prevTasks.filter(Boolean) as NeoTask[];
+
+		// Filter out planning tasks — we only reuse execution tasks
+		const executionTasks = validPrevTasks.filter((t) => t.taskType !== 'planning');
+
+		if (executionTasks.length === 0) {
+			log.debug(`[reuseExecutionPlan] No execution tasks to clone for goal ${goal.id}`);
+			return 0;
+		}
+
+		// Create a mapping from old task ID to new task ID for dependency remapping
+		const oldToNewIdMap = new Map<string, string>();
+
+		// First pass: create all new tasks without dependencies (avoids forward-reference issues)
+		for (const prevTask of executionTasks) {
+			const newTask = await this.taskManager.createTask({
+				title: prevTask.title,
+				description: prevTask.description,
+				priority: prevTask.priority,
+				taskType: prevTask.taskType,
+				assignedAgent: prevTask.assignedAgent,
+				status: 'pending',
+				// Note: dependsOn is set in second pass after all tasks exist
+			});
+			oldToNewIdMap.set(prevTask.id, newTask.id);
+
+			// Link the new task to the new execution
+			await this.goalManager.linkTaskToExecution(goal.id, newExecutionId, newTask.id);
+			log.debug(`[reuseExecutionPlan] Cloned task: "${prevTask.title}" → "${newTask.title}"`);
+		}
+
+		// Second pass: update dependsOn to use new task IDs
+		for (const prevTask of executionTasks) {
+			if (prevTask.dependsOn && prevTask.dependsOn.length > 0) {
+				const newDependsOn = prevTask.dependsOn
+					.map((depId) => oldToNewIdMap.get(depId))
+					.filter(Boolean) as string[];
+
+				if (newDependsOn.length > 0) {
+					const newTaskId = oldToNewIdMap.get(prevTask.id);
+					if (newTaskId) {
+						await this.taskManager.updateTaskStatus(newTaskId, 'pending', {
+							dependsOn: newDependsOn,
+						});
+					}
+				}
+			}
+		}
+
+		log.info(
+			`[reuseExecutionPlan] Cloned ${executionTasks.length} tasks for goal ${goal.id} (execution ${newExecutionId})`
+		);
+		return executionTasks.length;
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2996,19 +2996,29 @@ export class RoomRuntime {
 			// First execution (executionNumber === 1) always goes through the planner to
 			// establish the initial plan.
 			if (execution.executionNumber > 1 && prevCompleted) {
-				const clonedCount = await this.reuseExecutionPlan(
-					goal,
-					execution.id,
-					prevCompleted.taskIds
-				);
-				if (clonedCount > 0) {
-					log.info(
-						`Recurring mission ${goal.id}: execution ${execution.executionNumber} started with ${clonedCount} reused tasks`
+				try {
+					const clonedCount = await this.reuseExecutionPlan(
+						goal,
+						execution.id,
+						prevCompleted.taskIds
 					);
-				} else {
-					// No tasks to clone (e.g., previous execution had no tasks) — fall back to planning
+					if (clonedCount > 0) {
+						log.info(
+							`Recurring mission ${goal.id}: execution ${execution.executionNumber} started with ${clonedCount} reused tasks`
+						);
+					} else {
+						// No tasks to clone (e.g., previous execution had no tasks) — fall back to planning
+						log.warn(
+							`Recurring mission ${goal.id}: no tasks to reuse from previous execution — falling back to planning`
+						);
+						await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
+					}
+				} catch (err) {
+					// Plan reuse failed (e.g., DB error mid-clone) — fall back to planning
+					// so the execution isn't orphaned with no tasks and no group.
 					log.warn(
-						`Recurring mission ${goal.id}: no tasks to reuse from previous execution — falling back to planning`
+						`Recurring mission ${goal.id}: plan reuse failed — falling back to planning`,
+						err
 					);
 					await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
 				}
@@ -3430,6 +3440,13 @@ export class RoomRuntime {
 		// Second pass: update dependsOn to use new task IDs
 		for (const prevTask of executionTasks) {
 			if (prevTask.dependsOn && prevTask.dependsOn.length > 0) {
+				const droppedDeps = prevTask.dependsOn.filter((depId) => !oldToNewIdMap.has(depId));
+				if (droppedDeps.length > 0) {
+					log.warn(
+						`[reuseExecutionPlan] Dropped unresolvable dependencies for cloned task "${prevTask.title}": ${droppedDeps.join(', ')}`
+					);
+				}
+
 				const newDependsOn = prevTask.dependsOn
 					.map((depId) => oldToNewIdMap.get(depId))
 					.filter(Boolean) as string[];

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -105,6 +105,15 @@ export function setupGoalHandlers(
 			throw new Error('Goal title is required');
 		}
 
+		// Auto-compute nextRunAt for recurring goals with a schedule.
+		// Without this, the scheduler (Phase 2 of tickRecurringMissions) would skip the
+		// goal because nextRunAt is null, and the goal would never trigger.
+		let nextRunAt: number | undefined;
+		if (params.missionType === 'recurring' && params.schedule) {
+			const tz = params.schedule.timezone ?? getSystemTimezone();
+			nextRunAt = getNextRunAt(params.schedule.expression, tz) ?? undefined;
+		}
+
 		const goalManager = goalManagerFactory(params.roomId);
 		const goal = await goalManager.createGoal({
 			title: params.title,
@@ -115,6 +124,7 @@ export function setupGoalHandlers(
 			structuredMetrics: params.structuredMetrics,
 			schedule: params.schedule,
 			schedulePaused: params.schedulePaused,
+			nextRunAt,
 		});
 
 		// Emit goal.created event

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -105,14 +105,8 @@ export function setupGoalHandlers(
 			throw new Error('Goal title is required');
 		}
 
-		// Auto-compute nextRunAt for recurring goals with a schedule.
-		// Without this, the scheduler (Phase 2 of tickRecurringMissions) would skip the
-		// goal because nextRunAt is null, and the goal would never trigger.
-		let nextRunAt: number | undefined;
-		if (params.missionType === 'recurring' && params.schedule) {
-			const tz = params.schedule.timezone ?? getSystemTimezone();
-			nextRunAt = getNextRunAt(params.schedule.expression, tz) ?? undefined;
-		}
+		// nextRunAt is auto-computed in GoalManager.createGoal for recurring goals
+		// with a schedule. No need to compute it here.
 
 		const goalManager = goalManagerFactory(params.roomId);
 		const goal = await goalManager.createGoal({
@@ -124,7 +118,6 @@ export function setupGoalHandlers(
 			structuredMetrics: params.structuredMetrics,
 			schedule: params.schedule,
 			schedulePaused: params.schedulePaused,
-			nextRunAt,
 		});
 
 		// Emit goal.created event

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -16,8 +16,6 @@
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { createRuntimeTestContext, type RuntimeTestContext } from './room-runtime-test-helpers';
-import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
-import { noOpReactiveDb } from '../../helpers/reactive-database';
 
 // ============================================================
 // Tests
@@ -237,8 +235,7 @@ describe('Recurring Missions: tickRecurringMissions triggers execution', () => {
 			description: 'From previous execution',
 			status: 'completed',
 		});
-		const goalRepo = new GoalRepository(ctx.db as never, noOpReactiveDb);
-		goalRepo.linkTaskToGoal(goal.id, oldTask.id);
+		await ctx.goalManager.linkTaskToGoal(goal.id, oldTask.id);
 
 		ctx.runtime.start();
 		await ctx.runtime.tick();
@@ -553,58 +550,70 @@ describe('replan_goal + recurring mission interaction', () => {
 		expect(updatedGoal!.nextRunAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
 	});
 
-	test('missionType remains recurring after tick triggers and execution starts', async () => {
-		// Regression test: ensure missionType is NOT changed to 'one_shot' after trigger
+	test('missionType remains recurring through full tick lifecycle: trigger → complete → re-trigger', async () => {
+		// Regression test: verify missionType is NOT changed to 'one_shot' through the
+		// full recurring mission lifecycle:
+		// 1. Phase 2 triggers execution (tick #1)
+		// 2. Tasks complete, Phase 1 completes execution and advances next_run_at (tick #2)
+		// 3. Phase 2 re-triggers new execution (tick #3)
 		const pastTime = Math.floor(Date.now() / 1000) - 60;
 		const goal = await ctx.goalManager.createGoal({
-			title: 'Mission type preservation test',
-			description: 'missionType should stay recurring',
+			title: 'Full lifecycle test',
+			description: 'missionType should stay recurring through all phases',
 			missionType: 'recurring',
 			schedule: { expression: '@daily', timezone: 'UTC' },
 			nextRunAt: pastTime,
 		});
 
+		// ── Phase 2 of tick #1: trigger execution ──────────────────────────────
 		ctx.runtime.start();
 		await ctx.runtime.tick();
 
-		// Verify missionType is still 'recurring' after trigger
-		const updatedGoal = await ctx.goalManager.getGoal(goal.id);
-		expect(updatedGoal?.missionType).toBe('recurring');
-
-		// Verify execution was created
-		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
-		expect(activeExecution).not.toBeNull();
-		expect(activeExecution?.status).toBe('running');
-	});
-
-	test('missionType remains recurring after execution completes and next_run_at advances', async () => {
-		// Regression test: ensure missionType is NOT changed to 'one_shot' after execution completes
-		const pastTime = Math.floor(Date.now() / 1000) - 60;
-		const goal = await ctx.goalManager.createGoal({
-			title: 'Mission type after completion',
-			description: 'should stay recurring after completion',
-			missionType: 'recurring',
-			schedule: { expression: '@daily', timezone: 'UTC' },
-			nextRunAt: pastTime,
-		});
-
-		// Start execution manually (simulating what tick does)
-		const execution = ctx.goalManager.startExecution(goal.id);
-		expect(execution).not.toBeNull();
-
-		// Verify missionType is still 'recurring' after execution starts
 		let updatedGoal = await ctx.goalManager.getGoal(goal.id);
 		expect(updatedGoal?.missionType).toBe('recurring');
 
-		// Complete the execution
-		ctx.goalManager.completeExecution(execution.id, 'Test completion');
+		const exec1 = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec1).not.toBeNull();
+		expect(exec1?.status).toBe('running');
+		expect(exec1?.executionNumber).toBe(1);
 
-		// Verify missionType is still 'recurring' after completion
+		// Simulate task completion: mark the execution's tasks as completed
+		// so Phase 1 will complete the execution on the next tick
+		const taskIds = exec1!.taskIds;
+		for (const taskId of taskIds) {
+			await ctx.taskManager.updateTaskStatus(taskId, 'completed');
+		}
+
+		// ── Phase 1 of tick #2: complete execution and advance next_run_at ──────
+		await ctx.runtime.tick();
+
+		// Execution should now be completed (not running)
+		const exec1After = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec1After).toBeNull(); // no active execution
+
+		// missionType should still be 'recurring'
 		updatedGoal = await ctx.goalManager.getGoal(goal.id);
 		expect(updatedGoal?.missionType).toBe('recurring');
 
-		// Note: next_run_at advancement happens in Phase 1 of tickRecurringMissions
-		// when it detects the execution is complete. Calling completeExecution directly
-		// does not advance next_run_at - that requires a tick.
+		// next_run_at should have been advanced to the future
+		expect(updatedGoal!.nextRunAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+
+		// ── Phase 2 of tick #3: re-trigger new execution ───────────────────────
+		// Set next_run_at to the past to trigger again
+		await ctx.goalManager.updateNextRunAt(goal.id, Math.floor(Date.now() / 1000) - 60);
+
+		await ctx.runtime.tick();
+
+		const exec2 = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec2).not.toBeNull();
+		expect(exec2?.status).toBe('running');
+		expect(exec2?.executionNumber).toBe(2); // second execution
+
+		// missionType should STILL be 'recurring' after re-trigger
+		updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(updatedGoal?.missionType).toBe('recurring');
+		// next_run_at should have been re-advanced by startExecution
+		// (may be equal to oldNextRunAt if both computed at same second; verify it's future)
+		expect(updatedGoal!.nextRunAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
 	});
 });

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -645,3 +645,233 @@ describe('replan_goal + recurring mission interaction', () => {
 		expect(updatedGoal!.nextRunAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
 	});
 });
+
+describe('Recurring Missions: plan reuse for subsequent executions', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('subsequent execution clones tasks from previous execution without spawning planning group', async () => {
+		// Test that execution #2+ reuses the plan from execution #1 instead of
+		// spawning a new planning group. This verifies plan reuse behavior.
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Daily report generation',
+			description: 'Generate daily report',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		// ── Execution 1: trigger via tick ─────────────────────────────────────
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const exec1 = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec1).not.toBeNull();
+		expect(exec1?.executionNumber).toBe(1);
+
+		// Manually create execution tasks (simulating what the planner would have created)
+		// and link them to execution 1. In a real run, the planner creates these.
+		const task1 = await ctx.taskManager.createTask({
+			title: 'Fetch data',
+			description: 'Fetch data from API',
+			taskType: 'coding',
+			assignedAgent: 'coder',
+			status: 'pending',
+		});
+		const task2 = await ctx.taskManager.createTask({
+			title: 'Format report',
+			description: 'Format data into report',
+			taskType: 'coding',
+			assignedAgent: 'coder',
+			status: 'pending',
+		});
+		// Link tasks to execution 1
+		await ctx.goalManager.linkTaskToExecution(goal.id, exec1!.id, task1.id);
+		await ctx.goalManager.linkTaskToExecution(goal.id, exec1!.id, task2.id);
+
+		// Complete execution 1's tasks so Phase 1 completes the execution.
+		// The execution's taskIds also includes the planning task created by spawnPlanningGroup,
+		// so we must mark that as completed too.
+		const allTasks = await Promise.all(exec1!.taskIds.map((id) => ctx.taskManager.getTask(id)));
+		const planningTask = allTasks.find((t) => t?.taskType === 'planning');
+		if (planningTask) {
+			await ctx.taskManager.updateTaskStatus(planningTask.id, 'completed');
+		}
+		await ctx.taskManager.updateTaskStatus(task1.id, 'completed');
+		await ctx.taskManager.updateTaskStatus(task2.id, 'completed');
+
+		// Tick to let Phase 1 complete the execution and advance next_run_at
+		await ctx.runtime.tick();
+
+		const exec1After = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec1After).toBeNull(); // execution should be completed
+
+		const completedExecs = ctx.goalManager.listExecutions(goal.id, 10);
+		const completedExec1 = completedExecs.find((e) => e.executionNumber === 1);
+		expect(completedExec1?.status).toBe('completed');
+		expect(completedExec1?.taskIds).toContain(task1.id);
+		expect(completedExec1?.taskIds).toContain(task2.id);
+
+		// ── Execution 2: should reuse plan from execution 1 ─────────────────────
+		// Set next_run_at to past to trigger execution 2
+		await ctx.goalManager.updateNextRunAt(goal.id, Math.floor(Date.now() / 1000) - 60);
+
+		await ctx.runtime.tick();
+
+		const exec2 = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec2).not.toBeNull();
+		expect(exec2?.executionNumber).toBe(2);
+
+		// Verify execution 2 has NEW tasks cloned from execution 1's tasks
+		// (task IDs should be different from task1/task2)
+		expect(exec2!.taskIds).not.toContain(task1.id);
+		expect(exec2!.taskIds).not.toContain(task2.id);
+
+		// Verify the cloned tasks have correct properties and are different IDs from original
+		const clonedTask1Id = exec2!.taskIds.find((id) => id !== task1.id && id !== task2.id);
+		expect(clonedTask1Id).toBeDefined();
+
+		const clonedTask1 = await ctx.taskManager.getTask(clonedTask1Id!);
+		// The cloned task should have the same title as one of the original tasks
+		expect(['Fetch data', 'Format report']).toContain(clonedTask1?.title);
+		// Status may be pending or in_progress (tick's execution flow picks them up)
+		expect(['pending', 'in_progress']).toContain(clonedTask1?.status as string);
+
+		// Verify the log shows plan reuse (not fallback to planning)
+		// This is implicitly verified by checking that exec2 has new tasks
+	});
+
+	test('subsequent execution remaps task dependencies correctly', async () => {
+		// Test that when tasks have dependencies, they are correctly remapped to new task IDs
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Build pipeline',
+			description: 'Multi-step build',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const exec1 = ctx.goalManager.getActiveExecution(goal.id);
+
+		// Create tasks with a dependency: taskB depends on taskA
+		const taskA = await ctx.taskManager.createTask({
+			title: 'Setup',
+			description: 'Initial setup',
+			taskType: 'coding',
+			status: 'pending',
+		});
+		const taskB = await ctx.taskManager.createTask({
+			title: 'Build',
+			description: 'Run build',
+			taskType: 'coding',
+			dependsOn: [taskA.id], // taskB depends on taskA
+			status: 'pending',
+		});
+		await ctx.goalManager.linkTaskToExecution(goal.id, exec1!.id, taskA.id);
+		await ctx.goalManager.linkTaskToExecution(goal.id, exec1!.id, taskB.id);
+
+		// Complete tasks and trigger execution 2.
+		// Also mark the planning task as completed since it's in the execution's taskIds.
+		const exec1AllTasks = await Promise.all(
+			exec1!.taskIds.map((id) => ctx.taskManager.getTask(id))
+		);
+		const exec1PlanningTask = exec1AllTasks.find((t) => t?.taskType === 'planning');
+		if (exec1PlanningTask) {
+			await ctx.taskManager.updateTaskStatus(exec1PlanningTask.id, 'completed');
+		}
+		await ctx.taskManager.updateTaskStatus(taskA.id, 'completed');
+		await ctx.taskManager.updateTaskStatus(taskB.id, 'completed');
+		await ctx.runtime.tick();
+
+		await ctx.goalManager.updateNextRunAt(goal.id, Math.floor(Date.now() / 1000) - 60);
+		await ctx.runtime.tick();
+
+		const exec2 = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec2!.taskIds.length).toBe(2);
+
+		// Get the cloned tasks
+		const clonedTasks = await Promise.all(exec2!.taskIds.map((id) => ctx.taskManager.getTask(id)));
+		const clonedA = clonedTasks.find((t) => t?.title === 'Setup');
+		const clonedB = clonedTasks.find((t) => t?.title === 'Build');
+
+		// Verify clonedB's dependsOn points to clonedA (not original taskA)
+		expect(clonedB?.dependsOn).toContain(clonedA!.id);
+		expect(clonedB?.dependsOn).not.toContain(taskA.id);
+	});
+
+	test('first execution always spawns planning group even if previous execution exists', async () => {
+		// Execution #1 should always go through planning, regardless of any context
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'New recurring mission',
+			description: 'Should always plan on first run',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const exec1 = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec1?.executionNumber).toBe(1);
+
+		// Planning group should have been spawned (verify via session factory calls)
+		const planningCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		expect(planningCalls.length).toBeGreaterThan(0);
+	});
+
+	test('execution with no previous tasks falls back to planning', async () => {
+		// If a previous execution had no tasks (e.g., planning failed), fall back to planning
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Sometimes empty',
+			description: 'May have no tasks some runs',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const exec1 = ctx.goalManager.getActiveExecution(goal.id);
+
+		// Create a task but don't link any tasks to execution (simulating planning failure)
+		// The orphan guard won't trigger since we haven't exceeded 5 minutes
+		// Instead, manually complete the empty execution
+		ctx.goalManager.completeExecution(exec1!.id, 'No tasks created');
+
+		await ctx.runtime.tick();
+		await ctx.goalManager.updateNextRunAt(goal.id, Math.floor(Date.now() / 1000) - 60);
+
+		// Clear session calls to track new planning
+		ctx.sessionFactory.calls.length = 0;
+
+		await ctx.runtime.tick();
+
+		const exec2 = ctx.goalManager.getActiveExecution(goal.id);
+		expect(exec2?.executionNumber).toBe(2);
+
+		// Execution 2 should have spawned a planning group (fallback)
+		const planningCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		expect(planningCalls.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -552,4 +552,59 @@ describe('replan_goal + recurring mission interaction', () => {
 		const updatedGoal = await ctx.goalManager.getGoal(goal.id);
 		expect(updatedGoal!.nextRunAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
 	});
+
+	test('missionType remains recurring after tick triggers and execution starts', async () => {
+		// Regression test: ensure missionType is NOT changed to 'one_shot' after trigger
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Mission type preservation test',
+			description: 'missionType should stay recurring',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Verify missionType is still 'recurring' after trigger
+		const updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(updatedGoal?.missionType).toBe('recurring');
+
+		// Verify execution was created
+		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeExecution).not.toBeNull();
+		expect(activeExecution?.status).toBe('running');
+	});
+
+	test('missionType remains recurring after execution completes and next_run_at advances', async () => {
+		// Regression test: ensure missionType is NOT changed to 'one_shot' after execution completes
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Mission type after completion',
+			description: 'should stay recurring after completion',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		// Start execution manually (simulating what tick does)
+		const execution = ctx.goalManager.startExecution(goal.id);
+		expect(execution).not.toBeNull();
+
+		// Verify missionType is still 'recurring' after execution starts
+		let updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(updatedGoal?.missionType).toBe('recurring');
+
+		// Complete the execution
+		ctx.goalManager.completeExecution(execution.id, 'Test completion');
+
+		// Verify missionType is still 'recurring' after completion
+		updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(updatedGoal?.missionType).toBe('recurring');
+
+		// Note: next_run_at advancement happens in Phase 1 of tickRecurringMissions
+		// when it detects the execution is complete. Calling completeExecution directly
+		// does not advance next_run_at - that requires a tick.
+	});
 });

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -246,6 +246,34 @@ describe('Recurring Missions: tickRecurringMissions triggers execution', () => {
 		const linkedIds = updatedGoal?.linkedTaskIds ?? [];
 		expect(linkedIds).not.toContain(oldTask.id);
 	});
+
+	test('auto-computes nextRunAt when recurring goal created with schedule but no nextRunAt', async () => {
+		// Regression test: creating a recurring goal with a schedule (but no explicit
+		// nextRunAt) should auto-compute nextRunAt so the goal triggers on the next tick.
+		// Without this fix, nextRunAt would be null and Phase 2 would skip the goal.
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Auto-schedule test',
+			description: 'nextRunAt should be auto-computed',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			// NOTE: nextRunAt is NOT set here — that's the bug scenario
+		});
+
+		// nextRunAt should have been auto-computed to a future time
+		expect(goal.nextRunAt).not.toBeNull();
+		expect(goal.nextRunAt!).toBeGreaterThan(Math.floor(Date.now() / 1000));
+
+		// Now set nextRunAt to the past so the tick will trigger
+		await ctx.goalManager.updateNextRunAt(goal.id, Math.floor(Date.now() / 1000) - 60);
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Execution should have been triggered
+		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeExecution).not.toBeNull();
+		expect(activeExecution?.status).toBe('running');
+	});
 });
 
 describe('GoalManager execution methods', () => {

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -852,9 +852,9 @@ describe('Recurring Missions: plan reuse for subsequent executions', () => {
 
 		const exec1 = ctx.goalManager.getActiveExecution(goal.id);
 
-		// Create a task but don't link any tasks to execution (simulating planning failure)
-		// The orphan guard won't trigger since we haven't exceeded 5 minutes
-		// Instead, manually complete the empty execution
+		// Don't create any additional tasks — the execution will have no tasks.
+		// Manually complete the empty execution to simulate a planning failure scenario.
+		// The orphan guard won't trigger since we haven't exceeded 5 minutes.
 		ctx.goalManager.completeExecution(exec1!.id, 'No tasks created');
 
 		await ctx.runtime.tick();


### PR DESCRIPTION
Verify that missionType remains 'recurring' after:
- tick triggers and execution starts
- execution completes and next_run_at advances

These tests catch regressions where missionType could be incorrectly
reset to 'one_shot' during the execution lifecycle.
