### PR TITLE
feat(visual-editor): add per-slot agent override UI with visual indicators

### DIFF
--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -8,6 +8,7 @@
  * Expanded: name input, agent dropdown, entry/exit gate selectors, instructions
  */
 
+import { useState, useCallback } from 'preact/hooks';
 import type { SpaceAgent, WorkflowNodeAgent, WorkflowChannel } from '@neokai/shared';
 import type { WorkflowConditionType } from '@neokai/shared';
 import { cn } from '../../lib/utils';
@@ -128,6 +129,18 @@ interface MultiAgentSectionProps {
 function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 	const nodeAgents = node.agents ?? [];
 
+	// Track which slots have their override fields expanded (keyed by role)
+	const [expandedSlots, setExpandedSlots] = useState<Set<string>>(new Set());
+
+	const toggleSlotExpanded = useCallback((role: string) => {
+		setExpandedSlots((prev) => {
+			const next = new Set(prev);
+			if (next.has(role)) next.delete(role);
+			else next.add(role);
+			return next;
+		});
+	}, []);
+
 	function updateAgents(next: WorkflowNodeAgent[]) {
 		onUpdate({ ...node, agents: next, agentId: '' });
 	}
@@ -171,6 +184,20 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 		);
 	}
 
+	function updateAgentModel(role: string, model: string) {
+		updateAgents(
+			nodeAgents.map((a) => (a.role === role ? { ...a, model: model || undefined } : a))
+		);
+	}
+
+	function updateAgentSystemPrompt(role: string, systemPrompt: string) {
+		updateAgents(
+			nodeAgents.map((a) =>
+				a.role === role ? { ...a, systemPrompt: systemPrompt || undefined } : a
+			)
+		);
+	}
+
 	// All agents are available; same agent may be added multiple times with different roles.
 	const availableAgents = agents;
 
@@ -202,17 +229,60 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 			<div class="space-y-1.5">
 				{nodeAgents.map((sa) => {
 					const agentInfo = agents.find((a) => a.id === sa.agentId);
+					const hasOverrides = !!(sa.model || sa.systemPrompt);
+					const isExpanded = expandedSlots.has(sa.role);
 					return (
-						<div key={sa.role} class="bg-dark-800 border border-dark-600 rounded p-2 space-y-1">
-							<div class="flex items-center justify-between">
-								<span class="text-xs font-medium text-gray-200">
-									{agentInfo?.name ?? sa.agentId}
-									{agentInfo && <span class="text-gray-500 ml-1">({sa.role})</span>}
-								</span>
+						<div
+							key={sa.role}
+							class={`rounded p-2 space-y-1 border ${hasOverrides ? 'bg-amber-950/20 border-amber-700/40' : 'bg-dark-800 border-dark-600'}`}
+						>
+							{/* Header: role input + override badge + remove */}
+							<div class="flex items-center gap-1">
+								<input
+									type="text"
+									value={sa.role}
+									onInput={(e) => {
+										const newRole = (e.currentTarget as HTMLInputElement).value;
+										updateAgents(
+											nodeAgents.map((a) => (a.role === sa.role ? { ...a, role: newRole } : a))
+										);
+									}}
+									placeholder="slot role"
+									class="flex-1 text-xs font-mono bg-dark-900 border border-dark-700 rounded px-1.5 py-0.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-600 min-w-0"
+								/>
+								{hasOverrides && (
+									<span class="text-xs text-amber-400 bg-amber-900/40 border border-amber-700/50 rounded px-1 py-0.5 flex-shrink-0">
+										overrides
+									</span>
+								)}
+								<button
+									type="button"
+									onClick={() => toggleSlotExpanded(sa.role)}
+									class="text-gray-600 hover:text-gray-300 transition-colors flex-shrink-0"
+									title={isExpanded ? 'Hide overrides' : 'Edit overrides'}
+								>
+									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										{isExpanded ? (
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M5 15l7-7 7 7"
+											/>
+										) : (
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M19 9l-7 7-7-7"
+											/>
+										)}
+									</svg>
+								</button>
 								<button
 									type="button"
 									onClick={() => removeAgent(sa.role)}
-									class="text-gray-600 hover:text-red-400 transition-colors"
+									class="text-gray-600 hover:text-red-400 transition-colors flex-shrink-0"
 									title="Remove agent"
 								>
 									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -225,6 +295,9 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 									</svg>
 								</button>
 							</div>
+							{/* Agent name (readonly) */}
+							<p class="text-xs text-gray-500">{agentInfo?.name ?? sa.agentId}</p>
+							{/* Per-agent instructions */}
 							<input
 								type="text"
 								value={sa.instructions ?? ''}
@@ -234,6 +307,39 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 								placeholder="Per-agent instructions (optional)…"
 								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"
 							/>
+							{/* Expandable overrides section */}
+							{isExpanded && (
+								<div class="space-y-1 pt-1 border-t border-dark-700">
+									<p class="text-xs text-gray-500 font-medium">Slot overrides</p>
+									<div class="space-y-0.5">
+										<label class="text-xs text-gray-600">Model</label>
+										<input
+											type="text"
+											value={sa.model ?? ''}
+											onInput={(e) =>
+												updateAgentModel(sa.role, (e.currentTarget as HTMLInputElement).value)
+											}
+											placeholder="e.g. claude-opus-4-6 (leave blank to use default)"
+											class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"
+										/>
+									</div>
+									<div class="space-y-0.5">
+										<label class="text-xs text-gray-600">System Prompt</label>
+										<textarea
+											value={sa.systemPrompt ?? ''}
+											onInput={(e) =>
+												updateAgentSystemPrompt(
+													sa.role,
+													(e.currentTarget as HTMLTextAreaElement).value
+												)
+											}
+											placeholder="Override system prompt (leave blank to use agent default)…"
+											rows={3}
+											class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
+										/>
+									</div>
+								</div>
+							)}
 						</div>
 					);
 				})}
@@ -521,12 +627,20 @@ export function WorkflowNodeCard({
 							<span class="flex items-center gap-1 flex-wrap">
 								{node.agents!.map((a) => {
 									const name = agents.find((ag) => ag.id === a.agentId)?.name ?? a.agentId;
+									const hasOverrides = !!(a.model || a.systemPrompt);
 									return (
 										<span
-											key={a.agentId}
-											class="text-xs bg-dark-700 border border-dark-600 text-gray-300 rounded px-1 py-0.5"
+											key={a.role}
+											class={`text-xs border rounded px-1 py-0.5 flex items-center gap-0.5 ${hasOverrides ? 'bg-amber-950/30 border-amber-700/50 text-amber-300' : 'bg-dark-700 border-dark-600 text-gray-300'}`}
+											title={`${name} — slot: ${a.role}${hasOverrides ? ' (has overrides)' : ''}`}
 										>
-											{name}
+											<span>{a.role}</span>
+											{hasOverrides && (
+												<span
+													data-testid="override-dot"
+													class="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0"
+												/>
+											)}
 										</span>
 									);
 								})}

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -258,6 +258,7 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 										);
 									}}
 									placeholder="slot role"
+									data-testid="agent-role-input"
 									class="flex-1 text-xs font-mono bg-dark-900 border border-dark-700 rounded px-1.5 py-0.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-600 min-w-0"
 								/>
 								{hasOverrides && (
@@ -271,6 +272,7 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 									class="text-gray-600 hover:text-gray-300 transition-colors flex-shrink-0"
 									title={isExpanded ? 'Hide overrides' : 'Edit overrides'}
 									aria-expanded={isExpanded}
+									data-testid="toggle-overrides-button"
 								>
 									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 										{isExpanded ? (
@@ -320,7 +322,7 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 							/>
 							{/* Expandable overrides section */}
 							{isExpanded && (
-								<div class="space-y-1 pt-1 border-t border-dark-700">
+								<div class="space-y-1 pt-1 border-t border-dark-700" data-testid="slot-overrides">
 									<p class="text-xs text-gray-500 font-medium">Slot overrides</p>
 									<div class="space-y-0.5">
 										<label class="text-xs text-gray-600">Model</label>
@@ -331,6 +333,7 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 												updateAgentModel(sa.role, (e.currentTarget as HTMLInputElement).value)
 											}
 											placeholder="e.g. claude-opus-4-6 (leave blank to use default)"
+											data-testid="agent-model-input"
 											class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"
 										/>
 									</div>
@@ -345,6 +348,7 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 												)
 											}
 											placeholder="Override system prompt (leave blank to use agent default)…"
+											data-testid="agent-system-prompt-input"
 											rows={3}
 											class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
 										/>

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -148,7 +148,8 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		const agentInfo = agents.find((a) => a.id === agentId);
-		const baseRole = agentInfo?.role ?? agentId;
+		// Guard against agents with empty role strings to avoid indistinguishable slot names
+		const baseRole = agentInfo?.role?.trim() || agentId;
 		// Ensure the slot role is unique within this node. When the same agent is added
 		// multiple times, append a numeric suffix to distinguish the slots.
 		const usedRoles = new Set(nodeAgents.map((a) => a.role));
@@ -242,9 +243,18 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 									type="text"
 									value={sa.role}
 									onInput={(e) => {
+										const oldRole = sa.role;
 										const newRole = (e.currentTarget as HTMLInputElement).value;
+										// Keep the override section expanded after a rename by migrating the key
+										setExpandedSlots((prev) => {
+											if (!prev.has(oldRole)) return prev;
+											const next = new Set(prev);
+											next.delete(oldRole);
+											next.add(newRole);
+											return next;
+										});
 										updateAgents(
-											nodeAgents.map((a) => (a.role === sa.role ? { ...a, role: newRole } : a))
+											nodeAgents.map((a) => (a.role === oldRole ? { ...a, role: newRole } : a))
 										);
 									}}
 									placeholder="slot role"
@@ -260,6 +270,7 @@ function MultiAgentSection({ node, agents, onUpdate }: MultiAgentSectionProps) {
 									onClick={() => toggleSlotExpanded(sa.role)}
 									class="text-gray-600 hover:text-gray-300 transition-colors flex-shrink-0"
 									title={isExpanded ? 'Hide overrides' : 'Edit overrides'}
+									aria-expanded={isExpanded}
 								>
 									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 										{isExpanded ? (

--- a/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
@@ -13,7 +13,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, act } from '@testing-library/preact';
+import { useState } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
 import { WorkflowNodeCard } from '../WorkflowNodeCard';
 import type { NodeDraft, ConditionDraft } from '../WorkflowNodeCard';
@@ -419,5 +420,86 @@ describe('WorkflowNodeCard — collapsed header override indicators', () => {
 			<WorkflowNodeCard {...makeProps({ node, expanded: false })} />
 		);
 		expect(getAllByTestId('override-dot')).toHaveLength(2);
+	});
+});
+// ============================================================================
+// Per-slot override section expand/collapse in expanded card view
+// ============================================================================
+
+describe('WorkflowNodeCard — expanded view per-slot override section', () => {
+	afterEach(() => cleanup());
+
+	it('does not show slot-overrides section before toggle is clicked', () => {
+		const node = makeStep({
+			agentId: '',
+			agents: [{ agentId: 'agent-1', role: 'planner' }],
+		});
+		const { queryByTestId } = render(<WorkflowNodeCard {...makeProps({ node, expanded: true })} />);
+		expect(queryByTestId('slot-overrides')).toBeNull();
+	});
+
+	it('shows slot-overrides section after toggle button is clicked', () => {
+		const node = makeStep({
+			agentId: '',
+			agents: [{ agentId: 'agent-1', role: 'planner' }],
+		});
+		const { getByTestId, queryByTestId } = render(
+			<WorkflowNodeCard {...makeProps({ node, expanded: true })} />
+		);
+		expect(queryByTestId('slot-overrides')).toBeNull();
+		fireEvent.click(getByTestId('toggle-overrides-button'));
+		expect(queryByTestId('slot-overrides')).toBeTruthy();
+	});
+
+	it('hides slot-overrides section after second toggle click', () => {
+		const node = makeStep({
+			agentId: '',
+			agents: [{ agentId: 'agent-1', role: 'planner' }],
+		});
+		const { getByTestId, queryByTestId } = render(
+			<WorkflowNodeCard {...makeProps({ node, expanded: true })} />
+		);
+		fireEvent.click(getByTestId('toggle-overrides-button'));
+		expect(queryByTestId('slot-overrides')).toBeTruthy();
+		fireEvent.click(getByTestId('toggle-overrides-button'));
+		expect(queryByTestId('slot-overrides')).toBeNull();
+	});
+
+	it('override section stays expanded after slot role is renamed', async () => {
+		function Wrapper() {
+			const [step, setStep] = useState(
+				makeStep({ agentId: '', agents: [{ agentId: 'agent-1', role: 'planner' }] })
+			);
+			return <WorkflowNodeCard {...makeProps({ node: step, expanded: true, onUpdate: setStep })} />;
+		}
+		const { getByTestId, queryByTestId } = render(<Wrapper />);
+		fireEvent.click(getByTestId('toggle-overrides-button'));
+		expect(queryByTestId('slot-overrides')).toBeTruthy();
+		await act(async () => {
+			fireEvent.input(getByTestId('agent-role-input'), {
+				target: { value: 'lead-planner' },
+			});
+		});
+		expect(queryByTestId('slot-overrides')).toBeTruthy();
+	});
+
+	it('model input inside slot-overrides calls onUpdate with updated model', async () => {
+		const onUpdate = vi.fn();
+		const node = makeStep({
+			agentId: '',
+			agents: [{ agentId: 'agent-1', role: 'coder' }],
+		});
+		const { getByTestId } = render(
+			<WorkflowNodeCard {...makeProps({ node, expanded: true, onUpdate })} />
+		);
+		fireEvent.click(getByTestId('toggle-overrides-button'));
+		await act(async () => {
+			fireEvent.input(getByTestId('agent-model-input'), {
+				target: { value: 'claude-opus-4-6' },
+			});
+		});
+		expect(onUpdate).toHaveBeenCalled();
+		const updated = onUpdate.mock.calls[0][0] as NodeDraft;
+		expect(updated.agents?.[0].model).toBe('claude-opus-4-6');
 	});
 });

--- a/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
@@ -348,3 +348,76 @@ describe('WorkflowNodeCard', () => {
 		});
 	});
 });
+
+// ============================================================================
+// Per-slot override indicators in collapsed header
+// ============================================================================
+
+describe('WorkflowNodeCard — collapsed header override indicators', () => {
+	afterEach(() => cleanup());
+
+	it('shows slot role name in collapsed badge (not agent name)', () => {
+		const node = makeStep({
+			agentId: '',
+			agents: [
+				{ agentId: 'agent-1', role: 'strict-reviewer' },
+				{ agentId: 'agent-2', role: 'quick-reviewer' },
+			],
+		});
+		const { container } = render(<WorkflowNodeCard {...makeProps({ node, expanded: false })} />);
+		expect(container.textContent).toContain('strict-reviewer');
+		expect(container.textContent).toContain('quick-reviewer');
+	});
+
+	it('does not show override-dot when no slot has overrides', () => {
+		const node = makeStep({
+			agentId: '',
+			agents: [
+				{ agentId: 'agent-1', role: 'coder' },
+				{ agentId: 'agent-2', role: 'reviewer' },
+			],
+		});
+		const { queryAllByTestId } = render(
+			<WorkflowNodeCard {...makeProps({ node, expanded: false })} />
+		);
+		expect(queryAllByTestId('override-dot')).toHaveLength(0);
+	});
+
+	it('shows override-dot on slot with model override', () => {
+		const node = makeStep({
+			agentId: '',
+			agents: [
+				{ agentId: 'agent-1', role: 'coder', model: 'claude-opus-4-6' },
+				{ agentId: 'agent-2', role: 'reviewer' },
+			],
+		});
+		const { getAllByTestId } = render(
+			<WorkflowNodeCard {...makeProps({ node, expanded: false })} />
+		);
+		// Only the first slot has overrides
+		expect(getAllByTestId('override-dot')).toHaveLength(1);
+	});
+
+	it('shows override-dot on slot with systemPrompt override', () => {
+		const node = makeStep({
+			agentId: '',
+			agents: [{ agentId: 'agent-1', role: 'coder', systemPrompt: 'Be strict.' }],
+		});
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ node, expanded: false })} />);
+		expect(getByTestId('override-dot')).toBeTruthy();
+	});
+
+	it('shows override-dot on each slot that has overrides (multiple)', () => {
+		const node = makeStep({
+			agentId: '',
+			agents: [
+				{ agentId: 'agent-1', role: 'coder', model: 'claude-opus-4-6' },
+				{ agentId: 'agent-2', role: 'reviewer', systemPrompt: 'Review carefully.' },
+			],
+		});
+		const { getAllByTestId } = render(
+			<WorkflowNodeCard {...makeProps({ node, expanded: false })} />
+		);
+		expect(getAllByTestId('override-dot')).toHaveLength(2);
+	});
+});

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -96,7 +96,8 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		const agentInfo = agents.find((a) => a.id === agentId);
-		const baseRole = agentInfo?.role ?? agentId;
+		// Guard against agents with empty role strings to avoid indistinguishable slot names
+		const baseRole = agentInfo?.role?.trim() || agentId;
 		// Ensure the slot role is unique within this node. When the same agent is added
 		// multiple times, append a numeric suffix to distinguish the slots.
 		const usedRoles = new Set(stepAgents.map((a) => a.role));
@@ -252,10 +253,18 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 									data-testid="agent-role-input"
 									value={sa.role}
 									onInput={(e) => {
-										/* role editing is reflected in display only; updating kept simple */
+										const oldRole = sa.role;
 										const newRole = (e.currentTarget as HTMLInputElement).value;
+										// Keep the override section expanded after a rename by migrating the key
+										setExpandedSlots((prev) => {
+											if (!prev.has(oldRole)) return prev;
+											const next = new Set(prev);
+											next.delete(oldRole);
+											next.add(newRole);
+											return next;
+										});
 										updateAgents(
-											stepAgents.map((a) => (a.role === sa.role ? { ...a, role: newRole } : a))
+											stepAgents.map((a) => (a.role === oldRole ? { ...a, role: newRole } : a))
 										);
 									}}
 									placeholder="slot role"

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -15,7 +15,7 @@
  * - Delete Step button with confirmation (disabled for start node)
  */
 
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useCallback } from 'preact/hooks';
 import type { SpaceAgent, WorkflowNodeAgent, WorkflowChannel } from '@neokai/shared';
 import type { NodeDraft } from '../WorkflowNodeCard';
 import { isMultiAgentNode } from '../WorkflowNodeCard';
@@ -65,6 +65,18 @@ interface AgentsSectionProps {
 function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	const multi = isMultiAgentNode(step);
 	const stepAgents = step.agents ?? [];
+
+	// Track which slots have their override fields expanded (keyed by role)
+	const [expandedSlots, setExpandedSlots] = useState<Set<string>>(new Set());
+
+	const toggleSlotExpanded = useCallback((role: string) => {
+		setExpandedSlots((prev) => {
+			const next = new Set(prev);
+			if (next.has(role)) next.delete(role);
+			else next.add(role);
+			return next;
+		});
+	}, []);
 
 	function updateAgents(next: WorkflowNodeAgent[]) {
 		onUpdate({ ...step, agents: next, agentId: '' });
@@ -119,6 +131,20 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 		updateAgents(
 			stepAgents.map((a) =>
 				a.role === role ? { ...a, instructions: instructions || undefined } : a
+			)
+		);
+	}
+
+	function updateAgentModel(role: string, model: string) {
+		updateAgents(
+			stepAgents.map((a) => (a.role === role ? { ...a, model: model || undefined } : a))
+		);
+	}
+
+	function updateAgentSystemPrompt(role: string, systemPrompt: string) {
+		updateAgents(
+			stepAgents.map((a) =>
+				a.role === role ? { ...a, systemPrompt: systemPrompt || undefined } : a
 			)
 		);
 	}
@@ -210,22 +236,70 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 			<div class="space-y-1.5" data-testid="agents-list">
 				{stepAgents.map((sa) => {
 					const agentInfo = agents.find((a) => a.id === sa.agentId);
+					const hasOverrides = !!(sa.model || sa.systemPrompt);
+					const isExpanded = expandedSlots.has(sa.role);
 					return (
 						<div
 							key={sa.role}
-							class="bg-dark-800 border border-dark-600 rounded p-2 space-y-1"
+							class={`rounded p-2 space-y-1 border ${hasOverrides ? 'bg-amber-950/20 border-amber-700/40' : 'bg-dark-800 border-dark-600'}`}
 							data-testid="agent-entry"
+							data-has-overrides={hasOverrides ? 'true' : undefined}
 						>
-							<div class="flex items-center justify-between">
-								<span class="text-xs font-medium text-gray-200">
-									{agentInfo?.name ?? sa.agentId}
-									{agentInfo && <span class="text-gray-500 ml-1">({sa.role})</span>}
-								</span>
+							{/* Header: role input + override badge + remove button */}
+							<div class="flex items-center gap-1">
+								<input
+									type="text"
+									data-testid="agent-role-input"
+									value={sa.role}
+									onInput={(e) => {
+										/* role editing is reflected in display only; updating kept simple */
+										const newRole = (e.currentTarget as HTMLInputElement).value;
+										updateAgents(
+											stepAgents.map((a) => (a.role === sa.role ? { ...a, role: newRole } : a))
+										);
+									}}
+									placeholder="slot role"
+									class="flex-1 text-xs font-mono bg-dark-900 border border-dark-700 rounded px-1.5 py-0.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-600 min-w-0"
+								/>
+								{hasOverrides && (
+									<span
+										data-testid="override-badge"
+										class="text-xs text-amber-400 bg-amber-900/40 border border-amber-700/50 rounded px-1 py-0.5 flex-shrink-0"
+									>
+										overrides
+									</span>
+								)}
+								<button
+									type="button"
+									data-testid="toggle-overrides-button"
+									onClick={() => toggleSlotExpanded(sa.role)}
+									class="text-gray-600 hover:text-gray-300 transition-colors flex-shrink-0"
+									title={isExpanded ? 'Hide overrides' : 'Edit overrides'}
+									aria-expanded={isExpanded}
+								>
+									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										{isExpanded ? (
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M5 15l7-7 7 7"
+											/>
+										) : (
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M19 9l-7 7-7-7"
+											/>
+										)}
+									</svg>
+								</button>
 								<button
 									type="button"
 									data-testid="remove-agent-button"
 									onClick={() => removeAgent(sa.role)}
-									class="text-gray-600 hover:text-red-400 transition-colors"
+									class="text-gray-600 hover:text-red-400 transition-colors flex-shrink-0"
 									title="Remove agent"
 								>
 									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -238,6 +312,9 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 									</svg>
 								</button>
 							</div>
+							{/* Agent name (readonly) */}
+							<p class="text-xs text-gray-500">{agentInfo?.name ?? sa.agentId}</p>
+							{/* Per-agent instructions */}
 							<input
 								type="text"
 								data-testid="agent-instructions-input"
@@ -248,6 +325,41 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 								placeholder="Per-agent instructions (optional)…"
 								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"
 							/>
+							{/* Expandable overrides section */}
+							{isExpanded && (
+								<div class="space-y-1 pt-1 border-t border-dark-700" data-testid="slot-overrides">
+									<p class="text-xs text-gray-500 font-medium">Slot overrides</p>
+									<div class="space-y-0.5">
+										<label class="text-xs text-gray-600">Model</label>
+										<input
+											type="text"
+											data-testid="agent-model-input"
+											value={sa.model ?? ''}
+											onInput={(e) =>
+												updateAgentModel(sa.role, (e.currentTarget as HTMLInputElement).value)
+											}
+											placeholder="e.g. claude-opus-4-6 (leave blank to use default)"
+											class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"
+										/>
+									</div>
+									<div class="space-y-0.5">
+										<label class="text-xs text-gray-600">System Prompt</label>
+										<textarea
+											data-testid="agent-system-prompt-input"
+											value={sa.systemPrompt ?? ''}
+											onInput={(e) =>
+												updateAgentSystemPrompt(
+													sa.role,
+													(e.currentTarget as HTMLTextAreaElement).value
+												)
+											}
+											placeholder="Override system prompt (leave blank to use agent default)…"
+											rows={3}
+											class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
+										/>
+									</div>
+								</div>
+							)}
 						</div>
 					);
 				})}

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -322,13 +322,20 @@ export function WorkflowNode({
 				{multi ? (
 					<div data-testid="agent-badges" class="flex flex-wrap gap-1 mt-1">
 						{step.agents!.map((sa) => {
-							const name = agents.find((a) => a.id === sa.agentId)?.name ?? sa.agentId;
+							const hasOverrides = !!(sa.model || sa.systemPrompt);
 							return (
 								<span
-									key={sa.agentId}
-									class="text-xs bg-gray-700 text-gray-300 rounded px-1.5 py-0.5"
+									key={sa.role}
+									class={`text-xs rounded px-1.5 py-0.5 flex items-center gap-0.5 ${hasOverrides ? 'bg-amber-900/40 text-amber-300' : 'bg-gray-700 text-gray-300'}`}
+									title={hasOverrides ? `${sa.role} (has overrides)` : sa.role}
 								>
-									{name}
+									{sa.role}
+									{hasOverrides && (
+										<span
+											data-testid="override-indicator"
+											class="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0"
+										/>
+									)}
 								</span>
 							);
 						})}

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -515,9 +515,8 @@ describe('NodeConfigPanel', () => {
 			expect(getByTestId('channels-section')).toBeTruthy();
 		});
 
-		it('shows channels section for single-agent node with agent (channels created on agent assignment)', () => {
-			// Channels section is shown for nodes with agents so users can manage Task Agent channels.
-			// Channels are created in the agent dropdown onChange handler, not on mount.
+		it('shows channels section for single-agent node with agent', () => {
+			// Channels section is always shown so users can manage Task Agent channels.
 			const { queryByTestId } = render(<NodeConfigPanel {...makeProps()} />);
 			expect(queryByTestId('channels-section')).toBeTruthy();
 		});

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -414,8 +414,11 @@ describe('NodeConfigPanel', () => {
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
 			const entry = getByTestId('agents-list');
+			// Agent name appears as text in a <p> element
 			expect(entry.textContent).toContain('Planner');
-			expect(entry.textContent).toContain('planner');
+			// Role appears as the value of the role input field
+			const roleInput = getByTestId('agent-role-input') as HTMLInputElement;
+			expect(roleInput.value).toBe('planner');
 		});
 
 		it('remove agent button calls onUpdate without that agent', () => {
@@ -644,6 +647,180 @@ describe('NodeConfigPanel', () => {
 			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
 			expect(updatedStep.agents).toHaveLength(3);
 			expect(updatedStep.agents[2].role).toBe('coder-3');
+		});
+	});
+
+	// ============================================================================
+	// Per-slot override fields: role, model, systemPrompt
+	// ============================================================================
+
+	describe('per-slot override fields', () => {
+		it('renders a role input for each agent slot in multi-agent mode', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [
+					{ agentId: 'agent-1', role: 'planner' },
+					{ agentId: 'agent-2', role: 'coder' },
+				],
+			});
+			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			const roleInputs = getAllByTestId('agent-role-input');
+			expect(roleInputs).toHaveLength(2);
+			expect((roleInputs[0] as HTMLInputElement).value).toBe('planner');
+			expect((roleInputs[1] as HTMLInputElement).value).toBe('coder');
+		});
+
+		it('editing role input calls onUpdate with updated role', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.input(getByTestId('agent-role-input'), { target: { value: 'lead-planner' } });
+			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+			expect(updatedStep.agents[0].role).toBe('lead-planner');
+		});
+
+		it('shows override-badge when slot has model override', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner', model: 'claude-opus-4-6' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			expect(getByTestId('override-badge')).toBeTruthy();
+		});
+
+		it('shows override-badge when slot has systemPrompt override', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner', systemPrompt: 'You are strict.' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			expect(getByTestId('override-badge')).toBeTruthy();
+		});
+
+		it('does not show override-badge when slot has no overrides', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
+			});
+			const { queryByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			expect(queryByTestId('override-badge')).toBeNull();
+		});
+
+		it('model and systemPrompt fields are hidden by default (before expanding)', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
+			});
+			const { queryByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			expect(queryByTestId('agent-model-input')).toBeNull();
+			expect(queryByTestId('agent-system-prompt-input')).toBeNull();
+		});
+
+		it('clicking toggle-overrides-button reveals model and systemPrompt fields', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			fireEvent.click(getByTestId('toggle-overrides-button'));
+			expect(getByTestId('slot-overrides')).toBeTruthy();
+			expect(getByTestId('agent-model-input')).toBeTruthy();
+			expect(getByTestId('agent-system-prompt-input')).toBeTruthy();
+		});
+
+		it('clicking toggle-overrides-button twice collapses the override section', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
+			});
+			const { getByTestId, queryByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			fireEvent.click(getByTestId('toggle-overrides-button'));
+			expect(getByTestId('slot-overrides')).toBeTruthy();
+			fireEvent.click(getByTestId('toggle-overrides-button'));
+			expect(queryByTestId('slot-overrides')).toBeNull();
+		});
+
+		it('editing model input calls onUpdate with model field set', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			// Expand the overrides section first
+			fireEvent.click(getByTestId('toggle-overrides-button'));
+			fireEvent.input(getByTestId('agent-model-input'), {
+				target: { value: 'claude-opus-4-6' },
+			});
+			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+			expect(updatedStep.agents[0].model).toBe('claude-opus-4-6');
+		});
+
+		it('clearing model input sets model to undefined', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner', model: 'claude-opus-4-6' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.click(getByTestId('toggle-overrides-button'));
+			fireEvent.input(getByTestId('agent-model-input'), { target: { value: '' } });
+			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+			expect(updatedStep.agents[0].model).toBeUndefined();
+		});
+
+		it('editing systemPrompt textarea calls onUpdate with systemPrompt set', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1', role: 'planner' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.click(getByTestId('toggle-overrides-button'));
+			fireEvent.input(getByTestId('agent-system-prompt-input'), {
+				target: { value: 'Be very strict.' },
+			});
+			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+			expect(updatedStep.agents[0].systemPrompt).toBe('Be very strict.');
+		});
+
+		it('adding same agent twice with different roles: both slots shown', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [
+					{ agentId: 'agent-2', role: 'coder' },
+					{ agentId: 'agent-2', role: 'coder-2' },
+				],
+			});
+			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			const roleInputs = getAllByTestId('agent-role-input') as HTMLInputElement[];
+			expect(roleInputs).toHaveLength(2);
+			expect(roleInputs[0].value).toBe('coder');
+			expect(roleInputs[1].value).toBe('coder-2');
+		});
+
+		it('each slot can independently have overrides — override-badge appears only on overridden slot', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [
+					{ agentId: 'agent-2', role: 'coder', model: 'claude-opus-4-6' },
+					{ agentId: 'agent-2', role: 'coder-2' },
+				],
+			});
+			const { getAllByTestId, queryAllByTestId } = render(
+				<NodeConfigPanel {...makeProps({ step })} />
+			);
+			// One badge for the slot with model override
+			expect(getAllByTestId('override-badge')).toHaveLength(1);
+			// Confirm the overridden slot's entry has amber styling via data attribute
+			const entries = getAllByTestId('agent-entry');
+			expect(entries[0].getAttribute('data-has-overrides')).toBe('true');
+			expect(entries[1].getAttribute('data-has-overrides')).toBeNull();
+			// No stray badges in the second slot
+			expect(queryAllByTestId('override-badge')).toHaveLength(1);
 		});
 	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -19,6 +19,7 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, act } from '@testing-library/preact';
+import { useState } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
 import { NodeConfigPanel } from '../NodeConfigPanel';
 import type { NodeConfigPanelProps } from '../NodeConfigPanel';
@@ -821,6 +822,30 @@ describe('NodeConfigPanel', () => {
 			expect(entries[1].getAttribute('data-has-overrides')).toBeNull();
 			// No stray badges in the second slot
 			expect(queryAllByTestId('override-badge')).toHaveLength(1);
+		});
+
+		it('override section stays expanded after the slot role is renamed', async () => {
+			// Use a controlled wrapper so onUpdate actually updates the step prop,
+			// matching how the real parent (VisualWorkflowEditor) behaves.
+			function Wrapper() {
+				const [step, setStep] = useState(
+					makeStep({ agentId: '', agents: [{ agentId: 'agent-1', role: 'planner' }] })
+				);
+				return <NodeConfigPanel {...makeProps({ step, onUpdate: setStep })} />;
+			}
+			const { getByTestId, queryByTestId } = render(<Wrapper />);
+
+			// Expand the overrides section
+			fireEvent.click(getByTestId('toggle-overrides-button'));
+			expect(getByTestId('slot-overrides')).toBeTruthy();
+
+			// Rename the role — expandedSlots must migrate the key from 'planner' to 'lead-planner'
+			await act(async () => {
+				fireEvent.input(getByTestId('agent-role-input'), { target: { value: 'lead-planner' } });
+			});
+
+			// Override section should still be visible after the rename (key migrated in expandedSlots)
+			expect(queryByTestId('slot-overrides')).toBeTruthy();
 		});
 	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -270,9 +270,9 @@ describe('WorkflowNode multi-agent rendering', () => {
 		expect(badges).toBeTruthy();
 		// agent-name element should not be present in multi-agent mode
 		expect(queryByTestId('agent-name')).toBeNull();
-		// Both agent names should appear
-		expect(badges.textContent).toContain('Alpha Agent');
-		expect(badges.textContent).toContain('Beta Agent');
+		// Canvas shows slot role names (not agent names) for compact display
+		expect(badges.textContent).toContain('coder');
+		expect(badges.textContent).toContain('reviewer');
 	});
 
 	it('renders single agent name when agents array is absent', () => {
@@ -289,14 +289,45 @@ describe('WorkflowNode multi-agent rendering', () => {
 		expect(queryByTestId('agent-badges')).toBeNull();
 	});
 
-	it('falls back to agentId as badge label when agent not found', () => {
+	it('shows slot role in badge even when agent lookup fails (agent not found in list)', () => {
 		const step = {
 			...STEP_DRAFT,
 			agentId: '',
 			agents: [{ agentId: 'unknown-agent-id', role: 'coder' }],
 		};
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
-		expect(getByTestId('agent-badges').textContent).toContain('unknown-agent-id');
+		// Badge shows the slot role (always available), not the agent name (which requires lookup)
+		expect(getByTestId('agent-badges').textContent).toContain('coder');
+	});
+
+	it('shows override-indicator dot when slot has model override', () => {
+		const step = {
+			...STEP_DRAFT,
+			agentId: '',
+			agents: [{ agentId: 'agent-1', role: 'coder', model: 'claude-opus-4-6' }],
+		};
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
+		expect(getByTestId('override-indicator')).toBeTruthy();
+	});
+
+	it('shows override-indicator dot when slot has systemPrompt override', () => {
+		const step = {
+			...STEP_DRAFT,
+			agentId: '',
+			agents: [{ agentId: 'agent-1', role: 'coder', systemPrompt: 'Be strict.' }],
+		};
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
+		expect(getByTestId('override-indicator')).toBeTruthy();
+	});
+
+	it('does not show override-indicator when slot has no overrides', () => {
+		const step = {
+			...STEP_DRAFT,
+			agentId: '',
+			agents: [{ agentId: 'agent-1', role: 'coder' }],
+		};
+		const { queryByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
+		expect(queryByTestId('override-indicator')).toBeNull();
 	});
 
 	it('uses wider minWidth for multi-agent steps', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -1228,4 +1228,38 @@ describe('per-slot agent overrides round-trip', () => {
 		expect(agents[1].role).toBe('reviewer-2');
 		expect(agents[1].model).toBe('claude-opus-4-6');
 	});
+
+	it('role rename in visual state is reflected in serialized output', () => {
+		// Simulates the user renaming a slot role via the role input field and then saving.
+		// Channels are NOT automatically updated when a role is renamed — that is intentional.
+		const wf = makeWorkflow({
+			nodes: [
+				{
+					id: 's1',
+					name: 'Code',
+					agents: [{ agentId: 'a1', role: 'coder', model: 'claude-haiku-4-5-20251001' }],
+					channels: [{ from: 'task-agent', to: 'coder', direction: 'bidirectional' as const }],
+				},
+			],
+			transitions: [],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+
+		// Simulate the user renaming 'coder' → 'lead-coder' via the role input
+		const nodeIdx = state.nodes.findIndex((n) => n.step.id === 's1');
+		state.nodes[nodeIdx].step.agents = [
+			{ agentId: 'a1', role: 'lead-coder', model: 'claude-haiku-4-5-20251001' },
+		];
+
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		const node = params.nodes![0];
+
+		// New role is serialized
+		expect(node.agents![0].role).toBe('lead-coder');
+		// Override fields are preserved through the rename
+		expect(node.agents![0].model).toBe('claude-haiku-4-5-20251001');
+		// Channels are NOT auto-updated — still reference the old role (caller responsibility)
+		expect(node.channels![0].to).toBe('coder');
+	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -1073,3 +1073,159 @@ describe('Task Agent virtual node', () => {
 		expect(params.transitions![0]).toMatchObject({ from: 's1', to: 's2' });
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Per-slot agent override serialization round-trips
+// ---------------------------------------------------------------------------
+
+describe('per-slot agent overrides round-trip', () => {
+	it('workflowToVisualState preserves model override on agents', () => {
+		const wf = makeWorkflow({
+			nodes: [
+				{
+					id: 's1',
+					name: 'Review',
+					agents: [
+						{ agentId: 'a1', role: 'strict-reviewer', model: 'claude-opus-4-6' },
+						{ agentId: 'a1', role: 'quick-reviewer' },
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		const node = state.nodes.find((n) => n.step.id === 's1')!;
+		expect(node.step.agents).toHaveLength(2);
+		expect(node.step.agents![0]).toMatchObject({
+			role: 'strict-reviewer',
+			model: 'claude-opus-4-6',
+		});
+		// slot without override has no model field
+		expect(node.step.agents![1].model).toBeUndefined();
+	});
+
+	it('workflowToVisualState preserves systemPrompt override on agents', () => {
+		const wf = makeWorkflow({
+			nodes: [
+				{
+					id: 's1',
+					name: 'Code',
+					agents: [
+						{
+							agentId: 'a1',
+							role: 'coder',
+							systemPrompt: 'You are a strict TypeScript expert.',
+						},
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		const node = state.nodes.find((n) => n.step.id === 's1')!;
+		expect(node.step.agents![0].systemPrompt).toBe('You are a strict TypeScript expert.');
+	});
+
+	it('visualStateToCreateParams passes model and systemPrompt through to output', () => {
+		const wf = makeWorkflow({
+			nodes: [
+				{
+					id: 's1',
+					name: 'Review',
+					agents: [
+						{
+							agentId: 'a1',
+							role: 'strict-reviewer',
+							model: 'claude-opus-4-6',
+							systemPrompt: 'Be strict.',
+						},
+						{ agentId: 'a2', role: 'quick-reviewer' },
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+
+		const node = params.nodes![0];
+		expect(node.agents).toHaveLength(2);
+		expect(node.agents![0]).toMatchObject({
+			role: 'strict-reviewer',
+			model: 'claude-opus-4-6',
+			systemPrompt: 'Be strict.',
+		});
+		expect(node.agents![1].model).toBeUndefined();
+		expect(node.agents![1].systemPrompt).toBeUndefined();
+	});
+
+	it('full round-trip: workflow→visualState→createParams preserves all override fields', () => {
+		const wf = makeWorkflow({
+			nodes: [
+				{
+					id: 's1',
+					name: 'Multi Review',
+					agents: [
+						{
+							agentId: 'a1',
+							role: 'coder',
+							model: 'claude-haiku-4-5-20251001',
+							systemPrompt: 'Fast coder.',
+							instructions: 'Focus on speed.',
+						},
+						{
+							agentId: 'a1',
+							role: 'coder-2',
+							model: 'claude-opus-4-6',
+							instructions: 'Focus on quality.',
+						},
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+
+		const [slot1, slot2] = params.nodes![0].agents!;
+		expect(slot1.role).toBe('coder');
+		expect(slot1.model).toBe('claude-haiku-4-5-20251001');
+		expect(slot1.systemPrompt).toBe('Fast coder.');
+		expect(slot1.instructions).toBe('Focus on speed.');
+		expect(slot2.role).toBe('coder-2');
+		expect(slot2.model).toBe('claude-opus-4-6');
+		expect(slot2.systemPrompt).toBeUndefined();
+		expect(slot2.instructions).toBe('Focus on quality.');
+	});
+
+	it('same agent added twice with different roles: both preserved in create params', () => {
+		const wf = makeWorkflow({
+			nodes: [
+				{
+					id: 's1',
+					name: 'Dual Review',
+					agents: [
+						{ agentId: 'reviewer-agent', role: 'reviewer' },
+						{ agentId: 'reviewer-agent', role: 'reviewer-2', model: 'claude-opus-4-6' },
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		const agents = params.nodes![0].agents!;
+		expect(agents).toHaveLength(2);
+		// Both slots reference the same agentId but with different roles
+		expect(agents[0].agentId).toBe('reviewer-agent');
+		expect(agents[0].role).toBe('reviewer');
+		expect(agents[1].agentId).toBe('reviewer-agent');
+		expect(agents[1].role).toBe('reviewer-2');
+		expect(agents[1].model).toBe('claude-opus-4-6');
+	});
+});


### PR DESCRIPTION
- NodeConfigPanel: add editable role input, expandable model/systemPrompt
  override fields per agent slot; show amber 'overrides' badge when active
- WorkflowNodeCard: show slot role names (not agent names) in collapsed header
  badges with amber styling and dot indicator when overrides are active
- WorkflowNode (canvas): show slot role names in agent badges; render amber
  dot indicator on slots with model or systemPrompt overrides
- serialization.ts already passes all WorkflowNodeAgent fields through correctly
- Tests: add per-slot override tests to NodeConfigPanel and WorkflowNode;
  add serialization round-trip tests for model/systemPrompt/same-agent-twice;
  update existing WorkflowNode badge tests to reflect role-name display
