### PR TITLE
feat(space): resolve base + override config at runtime when spawning agent sessions

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -33,6 +33,17 @@ const CUSTOM_AGENT_FEATURES: SessionFeatures = {
 // Config
 // ============================================================================
 
+/**
+ * Per-slot overrides from a `WorkflowNodeAgent` entry.
+ * Applied on top of the base `SpaceAgent` config when spawning a specific slot.
+ */
+export interface SlotOverrides {
+	/** Override the agent's default model for this slot */
+	model?: string;
+	/** Override the agent's default system prompt for this slot */
+	systemPrompt?: string;
+}
+
 export interface CustomAgentConfig {
 	/** The custom Space agent definition */
 	customAgent: SpaceAgent;
@@ -53,6 +64,12 @@ export interface CustomAgentConfig {
 	workspacePath: string;
 	/** Summaries of previously completed tasks for context */
 	previousTaskSummaries?: string[];
+	/**
+	 * Optional per-slot overrides from the `WorkflowNodeAgent` entry.
+	 * When provided, `model` replaces the agent's default model and `systemPrompt`
+	 * replaces the agent's default system prompt for this execution slot.
+	 */
+	slotOverrides?: SlotOverrides;
 }
 
 // ============================================================================
@@ -334,15 +351,23 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
  * room-runtime pattern where the initial user message is sent after session start.
  */
 export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionInit {
-	const { customAgent, space, sessionId, workspacePath } = config;
+	const { customAgent, space, sessionId, workspacePath, slotOverrides } = config;
 
 	const customTools =
 		customAgent.tools && customAgent.tools.length > 0 ? customAgent.tools : undefined;
 
-	const model = customAgent.model ?? space.defaultModel ?? DEFAULT_CUSTOM_AGENT_MODEL;
+	// Apply per-slot overrides: slot model takes precedence over agent default.
+	const model =
+		slotOverrides?.model ?? customAgent.model ?? space.defaultModel ?? DEFAULT_CUSTOM_AGENT_MODEL;
 	const provider = inferProviderForModel(model);
 
-	const behavioralPrompt = buildCustomAgentSystemPrompt(customAgent);
+	// Apply per-slot systemPrompt override: slot override replaces agent's default system prompt.
+	// The override is applied by building the prompt with a modified agent copy.
+	const agentForPrompt: SpaceAgent =
+		slotOverrides?.systemPrompt !== undefined
+			? { ...customAgent, systemPrompt: slotOverrides.systemPrompt }
+			: customAgent;
+	const behavioralPrompt = buildCustomAgentSystemPrompt(agentForPrompt);
 
 	// When custom tools are configured, use the agent/agents pattern so the SDK
 	// enforces the allowlist. Otherwise, fall back to the simple preset path.
@@ -418,6 +443,12 @@ export interface ResolveAgentInitConfig {
 	workflow?: SpaceWorkflow | null;
 	/** Summaries of previously completed tasks */
 	previousTaskSummaries?: string[];
+	/**
+	 * Optional per-slot overrides from the `WorkflowNodeAgent` entry for this execution slot.
+	 * When provided, the slot's `model` and/or `systemPrompt` replace the base agent's defaults.
+	 * Used when the same agent appears multiple times in a node with different per-slot configs.
+	 */
+	slotOverrides?: SlotOverrides;
 }
 
 /**
@@ -442,6 +473,7 @@ export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionIn
 		workflowRun,
 		workflow,
 		previousTaskSummaries,
+		slotOverrides,
 	} = config;
 
 	if (!task.customAgentId) {
@@ -464,6 +496,7 @@ export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionIn
 		sessionId,
 		workspacePath,
 		previousTaskSummaries,
+		slotOverrides,
 	});
 }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -343,6 +343,7 @@ export class SpaceRuntime {
 					workflowNodeId: startStep.id,
 					taskType: resolved.taskType,
 					customAgentId: resolved.customAgentId,
+					slotRole: agentEntry.role,
 					status: 'pending',
 					goalId: run.goalId,
 				});

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -464,6 +464,7 @@ export class WorkflowExecutor {
 				workflowNodeId: nextStep.id,
 				taskType: resolved?.taskType as import('@neokai/shared').SpaceTaskType | undefined,
 				customAgentId: resolved !== undefined ? resolved.customAgentId : agentEntry.agentId,
+				slotRole: agentEntry.role,
 				status: 'pending',
 				goalId: this.run.goalId,
 			});

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -295,7 +295,8 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			// WorkflowExecutor sets customAgentId to undefined for coder/general preset roles,
 			// but those agents are still SpaceAgent records. Use resolveNodeAgents to get the
 			// correct primary agentId regardless of whether the step uses agentId or agents[].
-			const primaryAgentId = resolveNodeAgents(step)[0]?.agentId;
+			const nodeAgents = resolveNodeAgents(step);
+			const primaryAgentId = nodeAgents[0]?.agentId;
 			const effectiveTask = {
 				...stepTask,
 				customAgentId: stepTask.customAgentId ?? primaryAgentId,
@@ -306,13 +307,24 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				effectiveTask.description = instructions;
 			}
 
+			// Find the WorkflowNodeAgent slot that matches this task's agent.
+			// The slot holds the per-slot role (used for channel routing and group membership)
+			// and optional model/systemPrompt overrides that supersede the base agent config.
+			const agentSlot = nodeAgents.find((a) => a.agentId === effectiveTask.customAgentId);
+
+			// Extract slot-level overrides (model and systemPrompt) if present.
+			const slotOverrides =
+				agentSlot?.model !== undefined || agentSlot?.systemPrompt !== undefined
+					? { model: agentSlot?.model, systemPrompt: agentSlot?.systemPrompt }
+					: undefined;
+
 			// Generate a new session ID for the sub-session.
 			// Note: the factory may assign a different ID internally. All subsequent code
 			// uses `actualSessionId` returned by sessionFactory.create(), not subSessionId.
 			// The subSessionId is embedded in the init only so the SDK can pre-wire it.
 			const subSessionId = randomUUID();
 
-			// Resolve the agent session init
+			// Resolve the agent session init, applying per-slot overrides when present.
 			let init: AgentSessionInit;
 			try {
 				init = resolveAgentInit({
@@ -323,6 +335,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					workspacePath,
 					workflowRun: run,
 					workflow,
+					slotOverrides,
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -334,12 +347,18 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			// should always succeed — null here would be a data inconsistency.
 			const agentForMember = agentManager.getById(effectiveTask.customAgentId!);
 
+			// Use the slot's role (WorkflowNodeAgent.role) for channel routing and group membership.
+			// This ensures that when the same agent appears multiple times in a node with different
+			// slot roles (e.g. "strict-reviewer" and "quick-reviewer"), each session is registered
+			// with its unique slot role so ChannelResolver.canSend() checks work correctly.
+			// Falls back to the base agent's role, then 'agent' if neither is available.
+			const memberRole = agentSlot?.role ?? agentForMember?.role ?? 'agent';
+
 			// Attach step agent peer communication MCP server if a factory is provided.
-			// The server is built with the resolved session ID and agent role so it can
-			// validate channels and inject messages into the correct peer sessions.
-			const agentRole = agentForMember?.role ?? 'agent';
+			// The server is built with the slot role so it can validate channels using the
+			// same role that was registered in the session group.
 			if (buildStepAgentMcpServer) {
-				const stepMcpServer = buildStepAgentMcpServer(subSessionId, agentRole);
+				const stepMcpServer = buildStepAgentMcpServer(subSessionId, memberRole);
 				init = {
 					...init,
 					mcpServers: { ...init.mcpServers, 'step-agent': stepMcpServer },
@@ -351,7 +370,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			try {
 				actualSessionId = await sessionFactory.create(init, {
 					agentId: effectiveTask.customAgentId ?? undefined,
-					role: agentForMember?.role ?? 'agent',
+					role: memberRole,
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -319,7 +319,11 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				: nodeAgents.find((a) => a.agentId === effectiveTask.customAgentId);
 
 			// Extract slot-level overrides (model and systemPrompt) if present.
-			// Always construct the object — undefined values are handled downstream.
+			// Always construct the object; undefined values are handled downstream
+			// (createCustomAgentInit guards on !== undefined for each field).
+			// When agentSlot is undefined (stale slotRole: the workflow was edited after
+			// the task was created and the slot no longer exists), both fields are undefined
+			// and no override is applied — the base agent config is used as-is.
 			const slotOverrides = { model: agentSlot?.model, systemPrompt: agentSlot?.systemPrompt };
 
 			// Generate a new session ID for the sub-session.

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -307,16 +307,20 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				effectiveTask.description = instructions;
 			}
 
-			// Find the WorkflowNodeAgent slot that matches this task's agent.
-			// The slot holds the per-slot role (used for channel routing and group membership)
-			// and optional model/systemPrompt overrides that supersede the base agent config.
-			const agentSlot = nodeAgents.find((a) => a.agentId === effectiveTask.customAgentId);
+			// Find the WorkflowNodeAgent slot that spawned this task.
+			// When slotRole is stored on the task (migration 46+), use it for an exact match.
+			// This correctly handles nodes where the same agentId appears multiple times with
+			// different slot roles (e.g. "strict-reviewer" and "quick-reviewer"): each task
+			// was created with its own slotRole, so the lookup is unambiguous.
+			// For tasks created before migration 46 (no slotRole), fall back to find-by-agentId,
+			// which always returns the first matching slot — acceptable for legacy data.
+			const agentSlot = effectiveTask.slotRole
+				? nodeAgents.find((a) => a.role === effectiveTask.slotRole)
+				: nodeAgents.find((a) => a.agentId === effectiveTask.customAgentId);
 
 			// Extract slot-level overrides (model and systemPrompt) if present.
-			const slotOverrides =
-				agentSlot?.model !== undefined || agentSlot?.systemPrompt !== undefined
-					? { model: agentSlot?.model, systemPrompt: agentSlot?.systemPrompt }
-					: undefined;
+			// Always construct the object — undefined values are handled downstream.
+			const slotOverrides = { model: agentSlot?.model, systemPrompt: agentSlot?.systemPrompt };
 
 			// Generate a new session ID for the sub-session.
 			// Note: the factory may assign a different ID internally. All subsequent code

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -25,8 +25,8 @@ export class SpaceTaskRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, slot_role, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -39,6 +39,7 @@ export class SpaceTaskRepository {
 			params.taskType ?? null,
 			params.assignedAgent ?? 'coder',
 			params.customAgentId ?? null,
+			params.slotRole ?? null,
 			params.workflowRunId ?? null,
 			params.workflowNodeId ?? null,
 			params.createdByTaskId ?? null,
@@ -353,6 +354,7 @@ export class SpaceTaskRepository {
 			taskType: (row.task_type as SpaceTask['taskType'] | null) ?? undefined,
 			assignedAgent: (row.assigned_agent as SpaceTask['assignedAgent'] | null) ?? undefined,
 			customAgentId: (row.custom_agent_id as string | null) ?? undefined,
+			slotRole: (row.slot_role as string | null) ?? undefined,
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
 			workflowNodeId: (row.workflow_node_id as string | null) ?? undefined,
 			createdByTaskId: (row.created_by_task_id as string | null) ?? undefined,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -173,6 +173,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// - current_step_id -> current_node_id in space_workflow_runs
 	// - current_step_id -> current_node_id in space_session_groups
 	runMigration45(db);
+
+	// Migration 46: Add slot_role column to space_tasks
+	// Stores the WorkflowNodeAgent.role of the slot that spawned a task, enabling
+	// unambiguous slot lookup when the same agentId appears multiple times in a node.
+	runMigration46(db);
 }
 
 /**
@@ -2892,5 +2897,21 @@ function runMigration45(db: BunDatabase): void {
 		throw e;
 	} finally {
 		db.exec(`PRAGMA foreign_keys = ON`);
+	}
+}
+
+/**
+ * Migration 46: Add slot_role column to space_tasks.
+ *
+ * Stores the `WorkflowNodeAgent.role` of the specific agent slot that spawned a task.
+ * This allows `spawn_step_agent` to unambiguously identify the correct slot even when
+ * the same `agentId` appears multiple times in a node with different slot roles and overrides.
+ *
+ * Existing rows get NULL for slot_role (backward compatible — the old lookup-by-agentId
+ * path handles the null case by falling back to the first matching slot).
+ */
+function runMigration46(db: BunDatabase): void {
+	if (!tableHasColumn(db, 'space_tasks', 'slot_role')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN slot_role TEXT`);
 	}
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -142,6 +142,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			assigned_agent TEXT
 				CHECK(assigned_agent IN ('coder', 'general')),
 			custom_agent_id TEXT,
+			slot_role TEXT,
 			workflow_run_id TEXT,
 			workflow_node_id TEXT,
 			created_by_task_id TEXT,

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -582,6 +582,31 @@ describe('createCustomAgentInit — slotOverrides', () => {
 		// Still uses agent/agents path
 		expect(init.agents).toBeDefined();
 	});
+
+	it('systemPrompt override works with agent/agents path (custom tools) — override lands in agents[key].prompt', () => {
+		// When SpaceAgent.tools is set, createCustomAgentInit uses the agent/agents pattern.
+		// The behavioral prompt (including the systemPrompt override) is placed in
+		// agentDef.prompt, NOT in init.systemPrompt.append — this code path must be tested
+		// separately from the simple (no-tools) path.
+		const config = makeConfig({
+			customAgent: makeAgent({
+				name: 'CodeReviewer',
+				tools: ['Read', 'Bash'],
+				systemPrompt: 'Original agent instructions.',
+			}),
+			slotOverrides: { systemPrompt: 'Slot-level security focus.' },
+		});
+		const init = createCustomAgentInit(config);
+		// Must use agent/agents path
+		expect(init.agents).toBeDefined();
+		// systemPrompt.append is not used on this path
+		expect(init.systemPrompt?.append).toBeUndefined();
+		// The override must appear in agentDef.prompt
+		const agentKey = Object.keys(init.agents!)[0];
+		const agentDef = init.agents![agentKey];
+		expect(agentDef?.prompt).toContain('Slot-level security focus.');
+		expect(agentDef?.prompt).not.toContain('Original agent instructions.');
+	});
 });
 
 // ============================================================================

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -459,6 +459,191 @@ describe('createCustomAgentInit', () => {
 });
 
 // ============================================================================
+// createCustomAgentInit — slot overrides
+// ============================================================================
+
+describe('createCustomAgentInit — slotOverrides', () => {
+	it('model override replaces agent default model', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'claude-sonnet-4-5-20250929' }),
+			slotOverrides: { model: 'claude-haiku-4-5-20251001' },
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-haiku-4-5-20251001');
+	});
+
+	it('model override replaces space default model', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: undefined }),
+			space: makeSpace({ defaultModel: 'claude-sonnet-4-5-20250929' }),
+			slotOverrides: { model: 'claude-opus-4-6' },
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-opus-4-6');
+	});
+
+	it('model override sets correct provider', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'claude-sonnet-4-5-20250929' }),
+			slotOverrides: { model: 'glm-4-flash' },
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('glm-4-flash');
+		expect(init.provider).toBe('glm');
+	});
+
+	it('systemPrompt override replaces agent default system prompt', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ systemPrompt: 'Original agent instructions.' }),
+			slotOverrides: { systemPrompt: 'Override: focus on security.' },
+		});
+		const init = createCustomAgentInit(config);
+		// The override should appear in the append/prompt
+		const promptText = init.systemPrompt?.append ?? '';
+		expect(promptText).toContain('Override: focus on security.');
+		expect(promptText).not.toContain('Original agent instructions.');
+	});
+
+	it('systemPrompt override replaces agent prompt in Agent Instructions section', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ systemPrompt: 'Base instructions.' }),
+			slotOverrides: { systemPrompt: 'Slot-specific instructions.' },
+		});
+		const init = createCustomAgentInit(config);
+		const promptText = init.systemPrompt?.append ?? '';
+		expect(promptText).toContain('Agent Instructions');
+		expect(promptText).toContain('Slot-specific instructions.');
+	});
+
+	it('empty string systemPrompt override removes agent instructions section', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ systemPrompt: 'Some instructions.' }),
+			slotOverrides: { systemPrompt: '' },
+		});
+		const init = createCustomAgentInit(config);
+		const promptText = init.systemPrompt?.append ?? '';
+		// Empty override → the Agent Instructions section is not included
+		// (buildCustomAgentSystemPrompt only adds it when systemPrompt is truthy)
+		expect(promptText).not.toContain('Some instructions.');
+	});
+
+	it('undefined slotOverrides leaves base agent model unchanged', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'claude-opus-4-6' }),
+			slotOverrides: undefined,
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-opus-4-6');
+	});
+
+	it('undefined slotOverrides leaves base agent system prompt unchanged', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ systemPrompt: 'Base prompt.' }),
+			slotOverrides: undefined,
+		});
+		const init = createCustomAgentInit(config);
+		const promptText = init.systemPrompt?.append ?? '';
+		expect(promptText).toContain('Base prompt.');
+	});
+
+	it('partial override: only model provided leaves systemPrompt from agent', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({
+				model: 'claude-sonnet-4-5-20250929',
+				systemPrompt: 'Agent prompt.',
+			}),
+			slotOverrides: { model: 'claude-haiku-4-5-20251001' },
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-haiku-4-5-20251001');
+		const promptText = init.systemPrompt?.append ?? '';
+		expect(promptText).toContain('Agent prompt.');
+	});
+
+	it('partial override: only systemPrompt provided leaves model from agent', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'claude-opus-4-6', systemPrompt: 'Agent prompt.' }),
+			slotOverrides: { systemPrompt: 'Slot prompt.' },
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-opus-4-6');
+		const promptText = init.systemPrompt?.append ?? '';
+		expect(promptText).toContain('Slot prompt.');
+		expect(promptText).not.toContain('Agent prompt.');
+	});
+
+	it('model override works with agent/agents path (custom tools)', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'claude-sonnet-4-5-20250929', tools: ['Read', 'Bash'] }),
+			slotOverrides: { model: 'claude-haiku-4-5-20251001' },
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-haiku-4-5-20251001');
+		// Still uses agent/agents path
+		expect(init.agents).toBeDefined();
+	});
+});
+
+// ============================================================================
+// resolveAgentInit — slot overrides pass-through
+// ============================================================================
+
+describe('resolveAgentInit — slotOverrides pass-through', () => {
+	function makeMockAgentManagerForOverrides(agent: SpaceAgent | null): SpaceAgentManager {
+		return {
+			getById: mock(() => agent),
+		} as unknown as SpaceAgentManager;
+	}
+
+	function makeResolveConfigWithOverrides(
+		overrides?: Partial<ResolveAgentInitConfig>
+	): ResolveAgentInitConfig {
+		return {
+			task: makeTask({ customAgentId: 'agent-1' }),
+			space: makeSpace(),
+			agentManager: makeMockAgentManagerForOverrides(makeAgent({ id: 'agent-1' })),
+			sessionId: 'session-override-test',
+			workspacePath: '/workspace/project',
+			workflowRun: null,
+			...overrides,
+		};
+	}
+
+	it('slotOverrides model is applied to the resolved session init', () => {
+		const agent = makeAgent({ id: 'agent-1', model: 'claude-sonnet-4-5-20250929' });
+		const config = makeResolveConfigWithOverrides({
+			agentManager: makeMockAgentManagerForOverrides(agent),
+			slotOverrides: { model: 'claude-haiku-4-5-20251001' },
+		});
+		const init = resolveAgentInit(config);
+		expect(init.model).toBe('claude-haiku-4-5-20251001');
+	});
+
+	it('slotOverrides systemPrompt is applied to the resolved session init', () => {
+		const agent = makeAgent({ id: 'agent-1', systemPrompt: 'Base prompt.' });
+		const config = makeResolveConfigWithOverrides({
+			agentManager: makeMockAgentManagerForOverrides(agent),
+			slotOverrides: { systemPrompt: 'Slot-specific override.' },
+		});
+		const init = resolveAgentInit(config);
+		const promptText = init.systemPrompt?.append ?? '';
+		expect(promptText).toContain('Slot-specific override.');
+		expect(promptText).not.toContain('Base prompt.');
+	});
+
+	it('no slotOverrides means base agent config is used unchanged', () => {
+		const agent = makeAgent({ id: 'agent-1', model: 'claude-opus-4-6', systemPrompt: 'Base.' });
+		const config = makeResolveConfigWithOverrides({
+			agentManager: makeMockAgentManagerForOverrides(agent),
+		});
+		const init = resolveAgentInit(config);
+		expect(init.model).toBe('claude-opus-4-6');
+		const promptText = init.systemPrompt?.append ?? '';
+		expect(promptText).toContain('Base.');
+	});
+});
+
+// ============================================================================
 // resolveAgentInit
 // ============================================================================
 

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -1970,8 +1970,8 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		expect(parsed.success).toBe(true);
 
 		// For agentId shorthand, slot role === agentId (synthetic). Fall back to base agent role.
-		// The memberRole logic: agentSlot.role (agentId) ?? agentForMember.role ('coder') ?? 'agent'
-		// agentSlot.role is the agentId string (synthetic), so it is set.
+		// memberRole = agentSlot.role (synthetic: equals agentId) || agentForMember.role ('coder') || 'agent'
+		// agentSlot.role is the synthetic agentId string, so it is always set for agentId shorthand nodes.
 		const sessionId = parsed.sessionId;
 		const capturedInfo = (
 			factory as ReturnType<typeof makeMockSessionFactory>
@@ -2073,7 +2073,11 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		expect(promptText).toContain(overridePrompt);
 	});
 
-	test('same agent twice in one node uses distinct slot roles for each session', async () => {
+	test('same agent twice in one node: last task uses its own slot role (not the first slot)', async () => {
+		// Regression test for the slot disambiguation bug:
+		// When the same agentId appears twice in a node with different slot roles,
+		// spawn_step_agent must select the task's own slot role — not always the first match.
+		// The fix stores slotRole on the task at creation time so the lookup is exact.
 		const agentId = ctx.agentId;
 		const stepId = `step-dual-${Math.random().toString(36).slice(2)}`;
 
@@ -2099,26 +2103,29 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		// The executor creates two tasks for this step (one per agent slot)
 		const { run, mainTask } = await startRun(ctx, wf);
 
-		// Verify two tasks were created for this step
+		// Verify two tasks were created with the correct slotRole each
 		const stepTasks = ctx.taskRepo
 			.listByWorkflowRun(run.id)
-			.filter((t) => t.workflowNodeId === stepId);
+			.filter((t) => t.workflowNodeId === stepId)
+			.sort((a, b) => a.createdAt - b.createdAt);
 		expect(stepTasks).toHaveLength(2);
+		expect(stepTasks[0]?.slotRole).toBe('strict-reviewer');
+		expect(stepTasks[1]?.slotRole).toBe('quick-reviewer');
 
-		// Spawn the second task (last created — the quick-reviewer slot)
+		// spawn_step_agent picks stepTasks[last] = the quick-reviewer task
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 		const result = await handlers.spawn_step_agent({ step_id: stepId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
-		// The spawned session should use one of the slot roles, not the base 'coder' role
+		// The spawned session must use 'quick-reviewer' — NOT 'strict-reviewer' (the first slot),
+		// confirming that slotRole-based lookup picks the correct slot.
 		const sessionId = parsed.sessionId;
 		const capturedInfo = (
 			factory as ReturnType<typeof makeMockSessionFactory>
 		)._capturedMemberInfos.get(sessionId);
-		expect(['strict-reviewer', 'quick-reviewer']).toContain(capturedInfo?.role);
-		// Specifically NOT the base agent's SpaceAgent.role
+		expect(capturedInfo?.role).toBe('quick-reviewer');
 		expect(capturedInfo?.role).not.toBe('coder');
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -1969,15 +1969,15 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
-		// For agentId shorthand, slot role === agentId (synthetic). Fall back to base agent role.
-		// memberRole = agentSlot.role (synthetic: equals agentId) || agentForMember.role ('coder') || 'agent'
-		// agentSlot.role is the synthetic agentId string, so it is always set for agentId shorthand nodes.
+		// For agentId shorthand, resolveNodeAgents synthesizes role = agentId (the UUID string).
+		// spawn_step_agent picks memberRole = agentSlot.role (always set to the synthetic UUID),
+		// so no fallback to agentForMember.role ('coder') ever occurs on this path.
 		const sessionId = parsed.sessionId;
 		const capturedInfo = (
 			factory as ReturnType<typeof makeMockSessionFactory>
 		)._capturedMemberInfos.get(sessionId);
-		// The role should be set (either the synthetic agentId role or base agent role)
-		expect(capturedInfo?.role).toBeTruthy();
+		// The member role must be the synthetic agentId string, not the base SpaceAgent.role ('coder').
+		expect(capturedInfo?.role).toBe(ctx.agentId);
 	});
 
 	test('model override from WorkflowNodeAgent slot is applied to the spawned session', async () => {
@@ -2121,11 +2121,66 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 
 		// The spawned session must use 'quick-reviewer' — NOT 'strict-reviewer' (the first slot),
 		// confirming that slotRole-based lookup picks the correct slot.
+		// Note: this test only covers the last-created (quick-reviewer) task because
+		// spawn_step_agent selects stepTasks[last]. In practice the Task Agent calls
+		// spawn_step_agent once per task; the strict-reviewer task is covered by the
+		// slot-role membership test above which uses the single-agent (agents[]) path.
 		const sessionId = parsed.sessionId;
 		const capturedInfo = (
 			factory as ReturnType<typeof makeMockSessionFactory>
 		)._capturedMemberInfos.get(sessionId);
 		expect(capturedInfo?.role).toBe('quick-reviewer');
 		expect(capturedInfo?.role).not.toBe('coder');
+	});
+
+	test('stale slotRole (slot removed after task creation) falls back to base agent config', async () => {
+		// If the workflow is edited after a task was created and the slot no longer exists,
+		// agentSlot will be undefined. slotOverrides becomes { model: undefined, systemPrompt: undefined }
+		// so no override is applied — the base agent config is used as-is.
+		const agentId = ctx.agentId;
+		const stepId = `step-stale-${Math.random().toString(36).slice(2)}`;
+
+		const wf = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Stale SlotRole WF',
+			nodes: [
+				{
+					id: stepId,
+					name: 'Single Agent Step',
+					agents: [{ agentId, role: 'reviewer', model: 'claude-opus-4-6' }],
+				},
+			],
+			transitions: [],
+			startNodeId: stepId,
+			rules: [],
+		});
+
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Inject a stale slotRole directly via raw SQL (no public API for this scenario —
+		// it simulates the workflow definition being edited and removing the 'reviewer' slot
+		// after the task was already created).
+		ctx.db
+			.prepare(`UPDATE space_tasks SET slot_role = ? WHERE workflow_node_id = ?`)
+			.run('deleted-slot-role', stepId);
+
+		// Capture the init to verify no model override is applied
+		let capturedInit: { model?: string } | null = null;
+		const factory = makeMockSessionFactory({
+			create: async (init: unknown) => {
+				capturedInit = init as { model?: string };
+				return `session-${Math.random().toString(36).slice(2)}`;
+			},
+		});
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		// Spawn must succeed — stale slotRole is not a hard error
+		expect(parsed.success).toBe(true);
+		// The slot model override ('claude-opus-4-6') must NOT be applied because the slot
+		// was not found; base agent config is used instead (no model set → DEFAULT_CUSTOM_AGENT_MODEL)
+		expect(capturedInit?.model).not.toBe('claude-opus-4-6');
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -635,7 +635,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		expect(secondParsed.sessionId).toBe(firstSessionId);
 	});
 
-	test('passes agentId and role as memberInfo to sessionFactory.create()', async () => {
+	test('passes agentId and slot role as memberInfo to sessionFactory.create()', async () => {
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
 		const { run, mainTask } = await startRun(ctx, wf);
 		const factory = makeMockSessionFactory();
@@ -651,8 +651,9 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		// memberInfo must carry the agent's ID and role
 		expect(memberInfo).toBeDefined();
 		expect(memberInfo?.agentId).toBe(ctx.agentId);
-		// The seed agent has role 'coder' (see seedAgentRow in test context)
-		expect(memberInfo?.role).toBe('coder');
+		// For agentId shorthand nodes, resolveNodeAgents synthesizes role = agentId.
+		// The slot role is used for group membership (not the base SpaceAgent.role).
+		expect(memberInfo?.role).toBe(ctx.agentId);
 	});
 });
 
@@ -1900,5 +1901,224 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 
 		const reviewerMember = parsed.members.find((m: { role: string }) => m.role === 'reviewer');
 		expect(reviewerMember.permittedTargets).toEqual([]); // reviewer cannot send to coder (one-way)
+	});
+});
+
+// ===========================================================================
+// spawn_step_agent — slot role and overrides
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrides', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('uses slot role for session group membership when WorkflowNodeAgent has a distinct role', async () => {
+		// Create an agent and a workflow where the node uses the agents[] format with a custom slot role
+		const agentId = ctx.agentId;
+		const stepId = `step-slot-role-${Math.random().toString(36).slice(2)}`;
+		const wf = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Slot Role Test WF',
+			nodes: [
+				{
+					id: stepId,
+					name: 'Slot Role Step',
+					agents: [
+						{
+							agentId,
+							role: 'strict-reviewer', // slot role differs from SpaceAgent.role ('coder')
+						},
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: stepId,
+			rules: [],
+		});
+
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+
+		// The session should be registered with the slot role, not the base agent's role
+		const sessionId = parsed.sessionId;
+		const capturedInfo = (
+			factory as ReturnType<typeof makeMockSessionFactory>
+		)._capturedMemberInfos.get(sessionId);
+		expect(capturedInfo?.role).toBe('strict-reviewer'); // slot role, not 'coder' (base agent role)
+	});
+
+	test('uses base agent role when slot has no distinct role (single-agent agentId format)', async () => {
+		// Single-agent step uses agentId shorthand; resolveNodeAgents synthesizes role = agentId
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+
+		// For agentId shorthand, slot role === agentId (synthetic). Fall back to base agent role.
+		// The memberRole logic: agentSlot.role (agentId) ?? agentForMember.role ('coder') ?? 'agent'
+		// agentSlot.role is the agentId string (synthetic), so it is set.
+		const sessionId = parsed.sessionId;
+		const capturedInfo = (
+			factory as ReturnType<typeof makeMockSessionFactory>
+		)._capturedMemberInfos.get(sessionId);
+		// The role should be set (either the synthetic agentId role or base agent role)
+		expect(capturedInfo?.role).toBeTruthy();
+	});
+
+	test('model override from WorkflowNodeAgent slot is applied to the spawned session', async () => {
+		const agentId = ctx.agentId;
+		const stepId = `step-model-override-${Math.random().toString(36).slice(2)}`;
+		const overrideModel = 'claude-haiku-4-5-20251001';
+
+		const wf = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Model Override Test WF',
+			nodes: [
+				{
+					id: stepId,
+					name: 'Model Override Step',
+					agents: [
+						{
+							agentId,
+							role: 'fast-coder',
+							model: overrideModel, // slot-level model override
+						},
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: stepId,
+			rules: [],
+		});
+
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Capture the init passed to sessionFactory.create
+		let capturedInit: { model?: string } | null = null;
+		const factory = makeMockSessionFactory({
+			create: async (init: unknown) => {
+				capturedInit = init as { model?: string };
+				return `session-${Math.random().toString(36).slice(2)}`;
+			},
+		});
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+
+		// The session init should use the slot's model override
+		expect(capturedInit?.model).toBe(overrideModel);
+	});
+
+	test('systemPrompt override from WorkflowNodeAgent slot is applied to spawned session', async () => {
+		const agentId = ctx.agentId;
+		const stepId = `step-prompt-override-${Math.random().toString(36).slice(2)}`;
+		const overridePrompt = 'Focus exclusively on security vulnerabilities.';
+
+		const wf = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Prompt Override Test WF',
+			nodes: [
+				{
+					id: stepId,
+					name: 'Prompt Override Step',
+					agents: [
+						{
+							agentId,
+							role: 'security-reviewer',
+							systemPrompt: overridePrompt, // slot-level systemPrompt override
+						},
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: stepId,
+			rules: [],
+		});
+
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Capture the init passed to sessionFactory.create
+		let capturedInit: { systemPrompt?: { append?: string } } | null = null;
+		const factory = makeMockSessionFactory({
+			create: async (init: unknown) => {
+				capturedInit = init as { systemPrompt?: { append?: string } };
+				return `session-${Math.random().toString(36).slice(2)}`;
+			},
+		});
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+
+		// The session init system prompt should contain the override text
+		const promptText = capturedInit?.systemPrompt?.append ?? '';
+		expect(promptText).toContain(overridePrompt);
+	});
+
+	test('same agent twice in one node uses distinct slot roles for each session', async () => {
+		const agentId = ctx.agentId;
+		const stepId = `step-dual-${Math.random().toString(36).slice(2)}`;
+
+		// Both slots use the same agentId but different roles
+		const wf = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Dual Instance WF',
+			nodes: [
+				{
+					id: stepId,
+					name: 'Dual Instance Step',
+					agents: [
+						{ agentId, role: 'strict-reviewer' },
+						{ agentId, role: 'quick-reviewer' },
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: stepId,
+			rules: [],
+		});
+
+		// The executor creates two tasks for this step (one per agent slot)
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Verify two tasks were created for this step
+		const stepTasks = ctx.taskRepo
+			.listByWorkflowRun(run.id)
+			.filter((t) => t.workflowNodeId === stepId);
+		expect(stepTasks).toHaveLength(2);
+
+		// Spawn the second task (last created — the quick-reviewer slot)
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+
+		// The spawned session should use one of the slot roles, not the base 'coder' role
+		const sessionId = parsed.sessionId;
+		const capturedInfo = (
+			factory as ReturnType<typeof makeMockSessionFactory>
+		)._capturedMemberInfos.get(sessionId);
+		expect(['strict-reviewer', 'quick-reviewer']).toContain(capturedInfo?.role);
+		// Specifically NOT the base agent's SpaceAgent.role
+		expect(capturedInfo?.role).not.toBe('coder');
 	});
 });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -160,6 +160,12 @@ export interface SpaceTask {
 	assignedAgent?: 'coder' | 'general';
 	/** ID of a custom Space agent assigned to execute this task */
 	customAgentId?: string;
+	/**
+	 * The `WorkflowNodeAgent.role` of the specific agent slot that spawned this task.
+	 * Stored at task creation time so `spawn_step_agent` can unambiguously map the task
+	 * back to the correct slot even when the same `agentId` appears multiple times in the node.
+	 */
+	slotRole?: string;
 	/** ID of the workflow run that spawned this task (if any) */
 	workflowRunId?: string;
 	/** ID of the workflow node that spawned this task (if any) */
@@ -221,6 +227,11 @@ export interface CreateSpaceTaskParams {
 	assignedAgent?: 'coder' | 'general';
 	/** Custom Space agent to execute this task */
 	customAgentId?: string;
+	/**
+	 * The `WorkflowNodeAgent.role` of the specific slot that spawned this task.
+	 * See `SpaceTask.slotRole` for details.
+	 */
+	slotRole?: string;
 	/** Workflow run that spawned this task */
 	workflowRunId?: string;
 	/** Workflow node that spawned this task */
@@ -585,15 +596,9 @@ export interface WorkflowNodeAgent {
 	 * a numeric suffix is appended automatically (e.g. `"coder"` → `"coder-2"`).
 	 */
 	role: string;
-	/**
-	 * Override the agent's default model for this slot.
-	 * TODO: Not yet applied at runtime — workflow-executor.ts does not read this field.
-	 */
+	/** Override the agent's default model for this slot. */
 	model?: string;
-	/**
-	 * Override the agent's default system prompt for this slot.
-	 * TODO: Not yet applied at runtime — workflow-executor.ts does not read this field.
-	 */
+	/** Override the agent's default system prompt for this slot. */
 	systemPrompt?: string;
 	/** Per-agent instructions override — appended to the agent's system prompt */
 	instructions?: string;
@@ -887,15 +892,9 @@ export interface ExportedWorkflowNodeAgent {
 	 * Must be unique across all agents in the same exported node.
 	 */
 	role: string;
-	/**
-	 * Override the agent's default model for this slot.
-	 * TODO: Not yet applied at runtime — workflow-executor.ts does not read this field.
-	 */
+	/** Override the agent's default model for this slot. */
 	model?: string;
-	/**
-	 * Override the agent's default system prompt for this slot.
-	 * TODO: Not yet applied at runtime — workflow-executor.ts does not read this field.
-	 */
+	/** Override the agent's default system prompt for this slot. */
 	systemPrompt?: string;
 	/** Per-agent instructions override */
 	instructions?: string;


### PR DESCRIPTION
- Add SlotOverrides interface and slotOverrides field to CustomAgentConfig and
  ResolveAgentInitConfig in custom-agent.ts
- Apply slot model/systemPrompt overrides in createCustomAgentInit: slot model
  takes precedence over agent default; slot systemPrompt replaces agent default
- Update resolveAgentInit to pass slotOverrides through to createCustomAgentInit
- In spawn_step_agent handler: find the WorkflowNodeAgent slot that matches the
  task's customAgentId, extract slot overrides and slot role, pass overrides to
  resolveAgentInit, and use the slot role (WorkflowNodeAgent.role) for session
  group membership and step-agent MCP server — enabling correct channel routing
  when the same agent appears multiple times with different slot roles
- Add 13 unit tests for slot override scenarios in custom-agent.test.ts
- Add 5 integration-style tests for slot role and override behavior in
  task-agent-tools.test.ts; update existing memberInfo role test to reflect
  new slot-role-first behavior
