### PR TITLE
docs: add LSP integration research — Claude Agent SDK and native LSP options

### DIFF
--- a/docs/lsp-integration-research.md
+++ b/docs/lsp-integration-research.md
@@ -87,9 +87,9 @@ affected file.
 in-memory view of file contents via the `textDocument/didOpen`, `textDocument/didChange`,
 and `textDocument/didClose` notification protocol. When an agent edits a file via the
 `Edit` tool, this write bypasses the LSP layer entirely — the language server still sees the
-pre-edit content. Any subsequent `lsp__diagnostics` or `lsp__hover` call will operate on
+pre-edit content. Any subsequent `mcp__lsp__diagnostics` or `mcp__lsp__hover` call will operate on
 stale state until the file is synced. This is a critical integration concern addressed in
-§3.6.
+§3.3.
 
 ### 1.5 How NeoKai Could Leverage SDK LSP Today
 
@@ -110,7 +110,7 @@ code change is required.
 - No control over which language servers are installed in user environments
 - No structured code intelligence API accessible programmatically from the NeoKai daemon
 - Agents have no code intelligence in the default NeoKai configuration today
-- LSP document sync (§3.6) must be handled explicitly if NeoKai manages LSP servers directly
+- LSP document sync (§3.3) must be handled explicitly if NeoKai manages LSP servers directly
 
 ---
 
@@ -156,11 +156,12 @@ deployment that doesn't have a pre-configured Claude Code user environment.
 
 **Description**: NeoKai runs a local MCP server that proxies LSP protocol to standard
 language server processes (`typescript-language-server`, `rust-analyzer`, `pylsp`). Agents
-call `lsp__goto_definition(file, position)` (MCP tool naming: server name `lsp` → tool
-`lsp__goto_definition`).
+call `mcp__lsp__goto_definition(file, position)` (MCP tool naming convention:
+`mcp__${serverName}__${toolName}`, so server `lsp` + tool `goto_definition` →
+`mcp__lsp__goto_definition`).
 
 ```
-Agent → MCP tool call (lsp__goto_definition) → NeoKai MCP server
+Agent → MCP tool call (mcp__lsp__goto_definition) → NeoKai MCP server
   → LSP JSON-RPC (stdio) → typescript-language-server
   ← location result ←
 ```
@@ -184,7 +185,7 @@ Agent → MCP tool call (lsp__goto_definition) → NeoKai MCP server
 - Need to ship language server binaries in container images or require user installation
 - Each language requires a separate server binary
 - LSP server startup latency (first request cold start: 1–5 seconds)
-- Requires NeoKai to send document sync notifications after every `Edit` (see §3.6)
+- Requires NeoKai to send document sync notifications after every `Edit` (see §3.3)
 
 **Verdict**: Best balance of completeness and implementation effort. Recommended primary
 approach.
@@ -321,8 +322,8 @@ This is the most important architectural consideration for native LSP integratio
 
 When an agent calls `Edit`, `MultiEdit`, or `Write`, the file is written directly to disk
 via the daemon's file manager. The LSP server does **not** observe this change — it still
-holds the pre-edit content in its in-memory buffer. Subsequent calls to `lsp__diagnostics`,
-`lsp__hover`, or `lsp__find_references` will operate on stale state and return incorrect
+holds the pre-edit content in its in-memory buffer. Subsequent calls to `mcp__lsp__diagnostics`,
+`mcp__lsp__hover`, or `mcp__lsp__find_references` will operate on stale state and return incorrect
 results.
 
 **Required solution: `DocumentSyncTracker`**
@@ -352,15 +353,16 @@ in-flight edits before a save.
 ### 3.4 MCP Tool Definitions for Agents
 
 The LSP capabilities are exposed as tools in a NeoKai-managed MCP server. Tool names follow
-the MCP `<serverName>__<toolName>` convention; if the server is registered as `lsp`, tools
-are called `lsp__hover`, `lsp__goto_definition`, etc.
+the MCP `mcp__${serverName}__${toolName}` convention (verified from CLI binary, matching the
+`mcp__ide__getDiagnostics` pattern); if the server is registered as `lsp`, tools are called
+`mcp__lsp__hover`, `mcp__lsp__goto_definition`, etc.
 
 ```typescript
 // packages/daemon/src/lib/lsp/lsp-mcp-server.ts
 
 const LSP_TOOLS = [
   {
-    name: 'lsp__hover',
+    name: 'mcp__lsp__hover',
     description: 'Get type information and documentation for the symbol at a position',
     inputSchema: {
       type: 'object',
@@ -373,7 +375,7 @@ const LSP_TOOLS = [
     },
   },
   {
-    name: 'lsp__goto_definition',
+    name: 'mcp__lsp__goto_definition',
     description: 'Jump to where a function, variable, or type is defined',
     inputSchema: {
       type: 'object',
@@ -386,7 +388,7 @@ const LSP_TOOLS = [
     },
   },
   {
-    name: 'lsp__find_references',
+    name: 'mcp__lsp__find_references',
     description: 'Find all usages of the symbol at this position across the project',
     inputSchema: {
       type: 'object',
@@ -400,7 +402,7 @@ const LSP_TOOLS = [
     },
   },
   {
-    name: 'lsp__rename',
+    name: 'mcp__lsp__rename',
     description: 'Propose a rename of a symbol across all files in the project (returns proposed edits, does not apply them)',
     inputSchema: {
       type: 'object',
@@ -414,7 +416,7 @@ const LSP_TOOLS = [
     },
   },
   {
-    name: 'lsp__diagnostics',
+    name: 'mcp__lsp__diagnostics',
     description: 'Get current errors and warnings for a file (reflects last saved state)',
     inputSchema: {
       type: 'object',
@@ -425,7 +427,7 @@ const LSP_TOOLS = [
     },
   },
   {
-    name: 'lsp__document_symbols',
+    name: 'mcp__lsp__document_symbols',
     description: 'List all symbols (functions, classes, variables) defined in a file',
     inputSchema: {
       type: 'object',
@@ -436,7 +438,7 @@ const LSP_TOOLS = [
     },
   },
   {
-    name: 'lsp__workspace_symbols',
+    name: 'mcp__lsp__workspace_symbols',
     description: 'Search for symbols by name across the entire project',
     inputSchema: {
       type: 'object',
@@ -449,9 +451,9 @@ const LSP_TOOLS = [
 ];
 ```
 
-**Note on `lsp__completion`**: Autocompletion is an interactive editor feature triggered on
+**Note on `mcp__lsp__completion`**: Autocompletion is an interactive editor feature triggered on
 each keypress. LLM agents already have full file content in context and do not benefit from
-this — they predict tokens themselves. `lsp__completion` is intentionally omitted from the
+this — they predict tokens themselves. `mcp__lsp__completion` is intentionally omitted from the
 tool list to keep the tool count lean.
 
 ### 3.5 Example Agent Interaction Flow
@@ -460,19 +462,19 @@ tool list to keep the tool count lean.
 Agent working on TypeScript codebase:
 
 1. Agent reads a file, sees `getUserById(id)` on line 45
-2. Agent calls: lsp__goto_definition({ file: "src/api.ts", line: 45, character: 12 })
+2. Agent calls: mcp__lsp__goto_definition({ file: "src/api.ts", line: 45, character: 12 })
 3. → LspManager finds existing tsserver for this worktree
 4. → LspClient sends textDocument/definition request
 5. → tsserver returns: { uri: "src/db/users.ts", range: { start: {line: 23} } }
 6. Agent reads: src/db/users.ts:23 — sees the full implementation
-7. Agent calls: lsp__find_references({ file: "src/db/users.ts", line: 23, character: 17 })
+7. Agent calls: mcp__lsp__find_references({ file: "src/db/users.ts", line: 23, character: 17 })
 8. → Returns all 12 call sites across the project
 9. Agent makes targeted edits at each call site; after each Edit, DocumentSyncTracker
    sends textDocument/didSave to keep LSP state current
-10. Agent calls lsp__diagnostics to verify no type errors remain after edits
+10. Agent calls mcp__lsp__diagnostics to verify no type errors remain after edits
 ```
 
-### 3.6 Integration Points in NeoKai
+### 3.5 Integration Points in NeoKai
 
 **1. Per-session MCP registration with shared LspManager**
 
@@ -578,9 +580,9 @@ Which languages to support in Phase 1?
 ### Rename Safety
 - LSP rename is syntactically complete (covers all statically-analyzable references) but
   will miss dynamic access patterns (`obj['methodName']` in JavaScript/Python)
-- `lsp__rename` should return proposed edits without applying them, letting the agent review
+- `mcp__lsp__rename` should return proposed edits without applying them, letting the agent review
   and apply them explicitly via `Edit`/`MultiEdit`
-- Agents should be guided (via system prompt) to call `lsp__find_references` first to
+- Agents should be guided (via system prompt) to call `mcp__lsp__find_references` first to
   understand scope before issuing a rename
 
 ---
@@ -599,7 +601,7 @@ Scores are 1–5 where **5 is best** in each dimension.
 
 **Recommended path:**
 1. **Phase 1** (2–4 weeks): Implement MCP-based LSP proxy (Approach B) for TypeScript and
-   Python. Agents get `lsp__*` tools when `tools.useLspTools` is enabled. Includes
+   Python. Agents get `mcp__lsp__*` tools when `tools.useLspTools` is enabled. Includes
    `DocumentSyncTracker` for `didSave` notifications after agent file writes.
 2. **Phase 2** (4–8 weeks): Add Tree-sitter fallback (Approach C) for structural queries
    in deployments without language server binaries.

--- a/docs/lsp-integration-research.md
+++ b/docs/lsp-integration-research.md
@@ -1,0 +1,468 @@
+# LSP Integration Research: Claude Agent SDK & Native LSP for NeoKai
+
+_Research date: 2026-03-24_
+
+---
+
+## Part 1: Claude Agent SDK Code Intelligence Capabilities
+
+### 1.1 Built-in LSP Support
+
+The `@anthropic-ai/claude-agent-sdk` (v0.2.81, currently used by NeoKai) does **not** embed LSP functionality natively. LSP in the Claude ecosystem lives as an extension layer in the Claude Code CLI binary. The SDK orchestrates an agent loop that calls into the CLI binary, which may or may not have LSP activated.
+
+**Key facts:**
+- The `LSP` tool was added in Claude Code v2.0.74 (December 2025)
+- It is gated behind `ENABLE_LSP_TOOL=1` environment variable OR having a compatible Claude Code plugin installed
+- There is a known race-condition bug (Issue #123 in `anthropics/claude-agent-sdk-typescript`): the CLI builds its tool list at startup before LSP finishes async initialization (~1.3 seconds). In SDK `query()` mode, the first API call fires immediately, permanently excluding LSP from the tool list. The issue was marked closed but user reports as late as February 2026 (v0.2.47+) confirm it persists.
+- **Workaround**: Set `ENABLE_LSP_TOOL=1` in the daemon environment when spawning agents.
+
+### 1.2 SDK Code Intelligence Primitives
+
+| Capability | Available? | Notes |
+|---|---|---|
+| Tree-sitter / AST parsing | No | Open feature request (#34304) for `mode: "map"` in `Read` tool; third-party MCP only |
+| Go-to-definition | Via `LSP` tool only | Requires plugin + language server binary installed |
+| Find references | Via `LSP` tool only | Same requirement |
+| Hover (type/docs) | Via `LSP` tool only | Same requirement |
+| Inline diff primitives | No | SDK exposes `Edit` (string replace), `MultiEdit` (batch), `Write` (overwrite) |
+| Multi-file edit coordination | Compositional | Agents sequence multiple `Edit`/`MultiEdit` calls; no atomic cross-file transaction |
+| Diagnostics | Via `LSP` tool | Auto-injected after `Edit` calls when LSP is active |
+
+### 1.3 Official Anthropic MCP Tools for Code Intelligence
+
+Anthropic distributes LSP as **Claude Code plugins** (not MCP servers). Official plugins are in `anthropics/claude-plugins-official`:
+
+| Language | Plugin | Binary Required |
+|---|---|---|
+| TypeScript/JS | `typescript-lsp` | `typescript-language-server` |
+| Python | `pyright-lsp` | `pyright-langserver` |
+| Go | `gopls-lsp` | `gopls` |
+| Rust | `rust-analyzer-lsp` | `rust-analyzer` |
+| C/C++ | `clangd-lsp` | `clangd` |
+| Ruby | `ruby-lsp` | `ruby-lsp` |
+| C# | `csharp-lsp` | `csharp-ls` |
+
+These plugins configure LSP server connections that the CLI `LSP` tool then uses. The `modelcontextprotocol/servers` reference collection does **not** include an LSP or tree-sitter server from Anthropic. Third-party options exist (`wrale/mcp-server-tree-sitter`, Sourcegraph MCP integration).
+
+### 1.4 How Claude Code CLI Handles LSP
+
+The `LSP` tool supports these sub-operations:
+- `goToDefinition`
+- `findReferences`
+- `hover` (type info + docs)
+- `documentSymbol` (file structure: classes, functions)
+- `getDiagnostics` (errors/warnings)
+- `goToImplementation`
+- Call hierarchy tracing
+
+After every `Edit`, the language server automatically injects diagnostics back to the agent without explicit calls. Navigation ops use `file:line:col` addressing. Performance benefit: symbol-level lookups at ~50ms vs. text grep at tens of seconds for large codebases.
+
+### 1.5 How NeoKai Could Leverage SDK LSP Today
+
+**Immediate action (low effort, partial benefit):**
+1. Set `ENABLE_LSP_TOOL=1` in the daemon's environment (in `packages/daemon/src/lib/agent/query-options-builder.ts` or as an env var in startup config)
+2. Document that users need Claude Code LSP plugins installed (`~/.claude/plugins/`) for code intelligence to work
+
+**Limitation**: This only works if the end user already has the relevant LSP binaries (`typescript-language-server`, `rust-analyzer`, etc.) installed locally and the appropriate Claude Code plugin configured. NeoKai has no control over this, and in cloud/container deployments there are no local LSP binaries.
+
+### 1.6 Gaps Requiring Custom LSP Support
+
+- No LSP in containerized/cloud deployments (no local binary access)
+- No control over which language servers are installed
+- The SDK race-condition bug means even with `ENABLE_LSP_TOOL=1` it may not be reliably active
+- No structured code intelligence API for programmatic access from NeoKai daemon
+- Agents have no code intelligence in the default NeoKai configuration today
+
+---
+
+## Part 2: Native LSP Integration Evaluation
+
+### 2.1 Current NeoKai State
+
+From codebase exploration:
+- **No LSP infrastructure** currently exists
+- **No AST/parsing libraries** installed (`tree-sitter`, TypeScript compiler API, etc.)
+- **Clean handler architecture** makes it straightforward to add LSP as a new subsystem
+- Agents have workspace context (`workspacePath`) and file system access
+- MCP tool infrastructure exists and is well-understood
+
+### 2.2 Approach Evaluation
+
+#### Approach A: Enable Claude Code's Built-in LSP Tool
+
+**Description**: Set `ENABLE_LSP_TOOL=1` and rely on the Claude Code CLI's native LSP tool with user-installed language server plugins.
+
+| Factor | Rating | Notes |
+|---|---|---|
+| Implementation complexity | 1/5 | One env var + documentation |
+| Feature completeness | 2/5 | All LSP features available IF user has binaries |
+| Reliability | 2/5 | SDK race-condition bug; plugin dependency on user |
+| Works in cloud/containers | 1/5 | No — requires local language server binaries |
+| Maintenance burden | 1/5 | Anthropic maintains the feature |
+
+**Verdict**: Good quick win for local dev scenarios but fails in cloud/container deployments. Not a standalone solution.
+
+---
+
+#### Approach B: MCP-Based LSP Proxy
+
+**Description**: NeoKai spawns a local MCP server that proxies LSP protocol to standard language server processes (`tsserver`, `rust-analyzer`, `pylsp`). Agents call `mcp__lsp__goto_definition(file, position)`.
+
+```
+Agent → MCP Tool Call → NeoKai MCP Server → LSP stdio → tsserver
+                                           ← JSON result ←
+```
+
+| Factor | Rating | Notes |
+|---|---|---|
+| Implementation complexity | 3/5 | Need LSP client implementation + MCP server glue |
+| Feature completeness | 5/5 | Full LSP feature set via standard servers |
+| Reliability | 4/5 | Standard language servers are battle-tested |
+| Works in cloud/containers | 3/5 | Needs language servers in container image |
+| Maintenance burden | 2/5 | LSP protocol changes are rare; server binaries maintained by community |
+| Latency | ~50-200ms | One extra MCP hop; LSP itself is fast |
+
+**Pros:**
+- Works with all existing language servers without reimplementation
+- Agents get well-structured tools with typed parameters
+- Standard LSP semantics (no reinventing the wheel)
+- Language server binaries are small and easily containerized
+
+**Cons:**
+- Need to ship language server binaries in container images or require user installation
+- Each language requires a separate binary
+- LSP server startup latency (first request cold start: 1-5 seconds)
+- MCP tool call overhead per request
+
+**Verdict**: Best balance of completeness and implementation effort. Recommended as primary approach.
+
+---
+
+#### Approach C: Embedded Tree-sitter
+
+**Description**: NeoKai embeds Tree-sitter for parsing + custom symbol analysis. Provides LSP-like primitives (go-to-definition, find references) without external servers.
+
+```
+Agent → MCP Tool Call → NeoKai daemon → tree-sitter WASM → symbol result
+```
+
+| Factor | Rating | Notes |
+|---|---|---|
+| Implementation complexity | 4/5 | Need parser grammars + custom analysis per language |
+| Feature completeness | 3/5 | Navigation OK; semantic type info limited |
+| Reliability | 4/5 | No external process dependencies |
+| Works in cloud/containers | 5/5 | WASM bundle, no external deps |
+| Maintenance burden | 4/5 | Must maintain symbol analysis per language |
+| Latency | ~5-20ms | Very fast; pure in-process |
+
+**Pros:**
+- Zero external dependencies; works everywhere
+- Very fast (in-process WASM)
+- Full control over feature set
+- `tree-sitter-wasm` available for Node/Bun
+
+**Cons:**
+- Tree-sitter gives you syntax, not semantics. Type inference (hover types, overload resolution) requires full language server
+- Must implement symbol analysis for each language grammar separately
+- Find-references across files requires building and maintaining a project-wide symbol index
+- Rename refactor with type awareness is hard to implement correctly
+- Goes against the grain of "don't reinvent the wheel"
+
+**Example libraries**: `web-tree-sitter` (WASM), `tree-sitter` (native Node addon), language grammars available for 100+ languages.
+
+**Verdict**: Best for offline/zero-dependency scenarios, but semantic accuracy is significantly lower than a real LSP server. Good complement to Approach B for fast operations (symbol list, syntax highlights) but not a replacement.
+
+---
+
+#### Approach D: Lightweight Code Graph + Heuristics
+
+**Description**: Parse files with Tree-sitter, build an in-memory symbol index (code graph). Agents query the graph for navigation. No full LSP protocol.
+
+| Factor | Rating | Notes |
+|---|---|---|
+| Implementation complexity | 3/5 | Symbol indexer + query API; simpler than full LSP |
+| Feature completeness | 2/5 | Covers 60-70% of use cases; no type info |
+| Reliability | 4/5 | In-process, no external dependencies |
+| Works in cloud/containers | 5/5 | No external deps |
+| Maintenance burden | 3/5 | Symbol index must stay in sync with edits |
+
+**Pros:**
+- Simpler than full LSP protocol implementation
+- Can be incrementally built (index on demand)
+- Works well for symbol navigation in large codebases
+
+**Cons:**
+- No type information (hover docs, type signatures)
+- Rename across files is heuristic only (may miss dynamic references)
+- Requires re-indexing on file changes
+- Still need per-language parsing logic
+
+**Verdict**: Good fallback for languages without LSP servers, but not primary recommendation.
+
+---
+
+### 2.3 Recommended Approach: B + C Hybrid
+
+**Primary: MCP-Based LSP Proxy (Approach B)** for semantic features (hover types, rename, diagnostics)
+**Fallback: Tree-sitter (Approach C)** for fast structural operations when LSP is unavailable
+
+This hybrid gives agents:
+- Full semantic accuracy when language servers are available
+- Graceful degradation to structural analysis when they are not
+- Fast in-process operations for common structural queries (list symbols, find all occurrences by name)
+
+---
+
+## Part 3: Recommended Architecture
+
+### 3.1 Directory Structure
+
+```
+packages/daemon/src/lib/
+  lsp/
+    index.ts                         # Public API: LspManager
+    lsp-manager.ts                   # Lifecycle: spawn/stop/reuse LSP servers per workspace
+    lsp-client.ts                    # JSON-RPC LSP client (stdio transport)
+    lsp-mcp-server.ts                # MCP server that exposes LSP as tools
+    tree-sitter/
+      index.ts                       # Public API: TreeSitterIndex
+      symbol-indexer.ts              # File → symbol table using tree-sitter
+      languages/                     # Per-language grammar configs
+        typescript.ts
+        python.ts
+        rust.ts
+    servers/
+      typescript.ts                  # tsserver / typescript-language-server config
+      python.ts                      # pylsp / pyright-langserver config
+      rust.ts                        # rust-analyzer config
+      registry.ts                    # Language → server binary mapping
+  rpc-handlers/
+    lsp-handlers.ts                  # RPC: lsp.hover, lsp.goto, lsp.refs, lsp.rename, lsp.diag
+```
+
+### 3.2 LSP Server Lifecycle
+
+```
+Per workspace (not per session):
+  1. Project opened → detect languages via file extensions
+  2. LspManager.getOrSpawnServer(workspace, language) → LspClient
+  3. LspClient connects via stdio, sends initialize request
+  4. Server is kept alive while any session in the workspace is active
+  5. Workspace closed / idle timeout → server killed
+```
+
+**Rationale for per-workspace (not per-session):**
+- Language servers index the entire project and maintain internal caches
+- Spawning one per session wastes memory and init time
+- Multiple agents working on the same codebase share the same language server view
+
+### 3.3 MCP Tool Definitions for Agents
+
+The LSP capabilities would be exposed as MCP tools callable by agents:
+
+```typescript
+// packages/daemon/src/lib/lsp/lsp-mcp-server.ts
+
+const LSP_TOOLS = [
+  {
+    name: 'lsp__hover',
+    description: 'Get type information and documentation for the symbol at a position',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', description: 'Absolute file path' },
+        line: { type: 'number', description: '0-indexed line number' },
+        character: { type: 'number', description: '0-indexed character offset' },
+      },
+      required: ['file', 'line', 'character'],
+    },
+  },
+  {
+    name: 'lsp__goto_definition',
+    description: 'Jump to where a function, variable, or type is defined',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string' },
+        line: { type: 'number' },
+        character: { type: 'number' },
+      },
+      required: ['file', 'line', 'character'],
+    },
+  },
+  {
+    name: 'lsp__find_references',
+    description: 'Find all usages of the symbol at this position across the project',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string' },
+        line: { type: 'number' },
+        character: { type: 'number' },
+        includeDeclaration: { type: 'boolean', default: false },
+      },
+      required: ['file', 'line', 'character'],
+    },
+  },
+  {
+    name: 'lsp__rename',
+    description: 'Rename a symbol across all files in the project',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string' },
+        line: { type: 'number' },
+        character: { type: 'number' },
+        newName: { type: 'string' },
+      },
+      required: ['file', 'line', 'character', 'newName'],
+    },
+  },
+  {
+    name: 'lsp__diagnostics',
+    description: 'Get current errors and warnings for a file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string' },
+      },
+      required: ['file'],
+    },
+  },
+  {
+    name: 'lsp__completion',
+    description: 'Get completion suggestions at a position',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string' },
+        line: { type: 'number' },
+        character: { type: 'number' },
+      },
+      required: ['file', 'line', 'character'],
+    },
+  },
+  {
+    name: 'lsp__document_symbols',
+    description: 'List all symbols (functions, classes, variables) in a file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string' },
+      },
+      required: ['file'],
+    },
+  },
+  {
+    name: 'lsp__workspace_symbols',
+    description: 'Search for symbols by name across the entire project',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Symbol name or prefix to search for' },
+      },
+      required: ['query'],
+    },
+  },
+];
+```
+
+### 3.4 Example Agent Interaction Flow
+
+```
+Agent working on TypeScript codebase:
+
+1. Agent reads a file, sees `getUserById(id)` on line 45
+2. Agent calls: lsp__goto_definition({ file: "src/api.ts", line: 45, character: 12 })
+3. → LspManager finds existing tsserver for this workspace
+4. → LspClient sends textDocument/definition request
+5. → tsserver returns: { uri: "src/db/users.ts", range: { start: {line: 23} } }
+6. Agent reads: src/db/users.ts:23 — sees the full implementation
+7. Agent calls: lsp__find_references({ file: "src/db/users.ts", line: 23, character: 17 })
+8. → Returns all 12 call sites across the project
+9. Agent makes targeted edits at each call site knowing exact locations
+```
+
+### 3.5 Integration Points in NeoKai
+
+**1. Session startup**: When an agent session starts, register the MCP LSP server in the session's MCP config if `tools.useLspTools` is enabled.
+
+```typescript
+// In query-options-builder.ts
+if (sessionConfig.tools?.useLspTools) {
+  mcpServers['__neokai_lsp'] = {
+    type: 'stdio',
+    command: process.execPath,
+    args: [lspMcpServerEntrypoint, workspacePath],
+  };
+}
+```
+
+**2. Language detection**: On workspace open, scan for language markers (`tsconfig.json` → TypeScript, `Cargo.toml` → Rust, `pyproject.toml` / `setup.py` → Python).
+
+**3. Daemon startup**: `LspManager` initialized as a singleton in `DaemonApp`, shared across sessions.
+
+**4. RPC exposure**: Add `lsp.*` RPC handlers for the frontend to show LSP status (which servers are running, which languages are active).
+
+---
+
+## Part 4: Open Questions
+
+### Latency Budget
+- What's acceptable for agent LSP operations? Suggested: < 200ms for cached queries, < 2s for cold start
+- Should the LSP server warm up proactively when a session starts, or lazy-initialize on first use?
+- Recommendation: warm up proactively for TypeScript/Python/Rust (most common); lazy for others
+
+### Language Priority
+Which languages to support in Phase 1?
+- **Must have**: TypeScript/JavaScript (NeoKai is a TypeScript project; most agents work on TS codebases)
+- **Should have**: Python (common in AI/ML projects agents work on)
+- **Nice to have**: Rust, Go
+- **Later**: Ruby, C#, Java, etc.
+
+### Always-On vs On-Demand
+- **Always-on**: LSP tools always in system prompt, agent decides when to use them
+  - Pro: agent can use LSP at any time without explicit user configuration
+  - Con: increases tool count, may confuse agents that don't need LSP
+- **On-demand**: LSP tools enabled per session/room via config
+  - Pro: clean separation, opt-in, doesn't bloat tool list for simple tasks
+  - Con: friction for users who always want code intelligence
+- **Recommendation**: On-demand per session, with a room-level default setting
+
+### Multi-Language Projects (Polyglot)
+- One LspManager should support multiple language servers per workspace
+- Language detection should be per-file based on extension, not per-workspace
+- Tool calls should route to the correct server based on file extension
+
+### State Sharing
+- **Shared across sessions in same workspace**: Yes — reduces cold start latency, consistent diagnostics
+- **Fresh per session**: No — wasteful, slower
+- **Exception**: Sessions with different `cwd` or git branches should get separate LSP instances to avoid cross-contamination
+
+### Container/Cloud Deployments
+- Without language server binaries, MCP LSP proxy silently degrades to tree-sitter fallback
+- NeoKai should provide a Docker base image layer with common language servers pre-installed
+- Alternative: agent detects missing LSP and installs server via `bun add -g typescript-language-server` automatically
+
+### Rename Safety
+- LSP rename is purely syntactic — it renames all symbol references but won't catch dynamic access patterns (e.g., `obj['methodName']` in JavaScript)
+- Agents should be prompted to verify rename results with `lsp__find_references` before committing
+- Add a `dryRun` parameter to `lsp__rename` that returns the proposed edits without applying them
+
+---
+
+## Summary
+
+| | Approach A (SDK LSP) | Approach B (MCP Proxy) | Approach C (Tree-sitter) | Approach D (Code Graph) |
+|---|---|---|---|---|
+| Complexity | 1/5 | 3/5 | 4/5 | 3/5 |
+| Feature completeness | 2/5 | 5/5 | 3/5 | 2/5 |
+| Cloud/container ready | 1/5 | 3/5 | 5/5 | 5/5 |
+| Semantic accuracy | 2/5 | 5/5 | 2/5 | 2/5 |
+| Maintenance | 1/5 | 2/5 | 4/5 | 3/5 |
+
+**Recommended path:**
+1. **Immediate** (1-2 days): Set `ENABLE_LSP_TOOL=1` in daemon environment. Zero code change, unlocks LSP for local dev users who have plugins installed.
+2. **Phase 1** (2-4 weeks): Implement MCP-based LSP proxy for TypeScript and Python. Agents get `lsp__*` tools in their system prompt when enabled.
+3. **Phase 2** (4-8 weeks): Add Tree-sitter fallback for structural queries; works everywhere without binary dependencies.
+4. **Phase 3** (ongoing): Expand language support; add workspace-level LSP status UI in NeoKai frontend.

--- a/docs/lsp-integration-research.md
+++ b/docs/lsp-integration-research.md
@@ -2,51 +2,75 @@
 
 _Research date: 2026-03-24_
 
+> **Note on sourcing**: This document combines findings from direct inspection of the
+> installed SDK artifacts (`node_modules/@anthropic-ai/claude-agent-sdk/`) and general
+> web research. Any claim derived from web research that could not be cross-checked
+> against local artifacts is marked **(unverified)**. Claims derived solely from
+> inspecting the installed SDK or NeoKai codebase are stated without qualification.
+
 ---
 
 ## Part 1: Claude Agent SDK Code Intelligence Capabilities
 
 ### 1.1 Built-in LSP Support
 
-The `@anthropic-ai/claude-agent-sdk` (v0.2.81, currently used by NeoKai) does **not** embed LSP functionality natively. LSP in the Claude ecosystem lives as an extension layer in the Claude Code CLI binary. The SDK orchestrates an agent loop that calls into the CLI binary, which may or may not have LSP activated.
+The `@anthropic-ai/claude-agent-sdk` (v0.2.81, currently used by NeoKai) does **not**
+embed LSP functionality natively. The SDK orchestrates an agent loop that calls into the
+Claude Code CLI binary bundled with it. LSP is an optional capability of that CLI binary
+activated through its **plugin system**: a plugin declares `lspServers` in its manifest,
+which causes the CLI to spawn the listed language server processes and expose an `LSP` tool
+to the agent.
 
-**Key facts:**
-- The `LSP` tool was added in Claude Code v2.0.74 (December 2025)
-- It is gated behind `ENABLE_LSP_TOOL=1` environment variable OR having a compatible Claude Code plugin installed
-- There is a known race-condition bug (Issue #123 in `anthropics/claude-agent-sdk-typescript`): the CLI builds its tool list at startup before LSP finishes async initialization (~1.3 seconds). In SDK `query()` mode, the first API call fires immediately, permanently excluding LSP from the tool list. The issue was marked closed but user reports as late as February 2026 (v0.2.47+) confirm it persists.
-- **Workaround**: Set `ENABLE_LSP_TOOL=1` in the daemon environment when spawning agents.
+**Primary activation mechanism (verified from SDK binary):**
+- A Claude Code plugin must be installed and must declare `lspServers` in its manifest
+- The CLI reads the plugin manifest, spawns the corresponding language server processes, and
+  adds the `LSP` tool to the available tool list
+- Without an installed plugin, the `LSP` tool does not appear in the agent's tool list
+
+**Known limitation (architecture-level, observed from SDK):**
+The tool list is constructed at CLI startup time. LSP server initialization is asynchronous.
+Whether the `LSP` tool is reliably present in SDK-spawned agent sessions — where the first
+query may fire before language servers are ready — is unclear from local artifact inspection
+alone. This is a known category of issue with async initialization in CLI-as-library patterns.
+
+**What NeoKai can do today:**
+Ensure any Claude Code LSP plugins the user has installed are discoverable by the SDK's
+underlying CLI (i.e., standard `~/.claude/` plugin paths are not blocked). There is no
+NeoKai-controlled configuration switch with verified effect on LSP tool availability.
 
 ### 1.2 SDK Code Intelligence Primitives
 
+Derived from inspecting `sdk-tools.d.ts` and `sdk.d.ts` in the installed SDK:
+
 | Capability | Available? | Notes |
 |---|---|---|
-| Tree-sitter / AST parsing | No | Open feature request (#34304) for `mode: "map"` in `Read` tool; third-party MCP only |
-| Go-to-definition | Via `LSP` tool only | Requires plugin + language server binary installed |
+| Tree-sitter / AST parsing | No | Not in SDK; no `mode` or parsing param on `Read` tool (`FileReadInput` has `file_path`, `offset`, `limit`, `pages` only) |
+| Go-to-definition | Via `LSP` tool only | Requires installed plugin + language server binary |
 | Find references | Via `LSP` tool only | Same requirement |
 | Hover (type/docs) | Via `LSP` tool only | Same requirement |
-| Inline diff primitives | No | SDK exposes `Edit` (string replace), `MultiEdit` (batch), `Write` (overwrite) |
+| Inline diff primitives | No | SDK exposes `Edit` (string replace), `MultiEdit` (batch), `Write` (overwrite) — no patch/hunk API |
 | Multi-file edit coordination | Compositional | Agents sequence multiple `Edit`/`MultiEdit` calls; no atomic cross-file transaction |
-| Diagnostics | Via `LSP` tool | Auto-injected after `Edit` calls when LSP is active |
+| Diagnostics | Via `LSP` tool | Auto-injected after `Edit` calls when LSP is active (per Claude Code documentation) |
 
-### 1.3 Official Anthropic MCP Tools for Code Intelligence
+### 1.3 Anthropic's LSP Plugin System
 
-Anthropic distributes LSP as **Claude Code plugins** (not MCP servers). Official plugins are in `anthropics/claude-plugins-official`:
+Based on web research **(unverified against local artifacts)**:
 
-| Language | Plugin | Binary Required |
-|---|---|---|
-| TypeScript/JS | `typescript-lsp` | `typescript-language-server` |
-| Python | `pyright-lsp` | `pyright-langserver` |
-| Go | `gopls-lsp` | `gopls` |
-| Rust | `rust-analyzer-lsp` | `rust-analyzer` |
-| C/C++ | `clangd-lsp` | `clangd` |
-| Ruby | `ruby-lsp` | `ruby-lsp` |
-| C# | `csharp-lsp` | `csharp-ls` |
+Anthropic distributes LSP capability as **Claude Code plugins**. Each plugin declares a set
+of `lspServers` pointing to language server binaries that must be installed on the host.
+Common language servers used include `typescript-language-server` (TypeScript/JS),
+`pyright-langserver` or `pylsp` (Python), `rust-analyzer` (Rust), `gopls` (Go), and
+`clangd` (C/C++).
 
-These plugins configure LSP server connections that the CLI `LSP` tool then uses. The `modelcontextprotocol/servers` reference collection does **not** include an LSP or tree-sitter server from Anthropic. Third-party options exist (`wrale/mcp-server-tree-sitter`, Sourcegraph MCP integration).
+The `modelcontextprotocol/servers` reference collection does not include an official LSP
+or tree-sitter MCP server from Anthropic. Third-party options exist (e.g.,
+`wrale/mcp-server-tree-sitter`).
 
-### 1.4 How Claude Code CLI Handles LSP
+### 1.4 What the LSP Tool Provides
 
-The `LSP` tool supports these sub-operations:
+Based on Claude Code documentation **(unverified against local artifacts)**:
+
+The `LSP` tool supports sub-operations including:
 - `goToDefinition`
 - `findReferences`
 - `hover` (type info + docs)
@@ -55,23 +79,38 @@ The `LSP` tool supports these sub-operations:
 - `goToImplementation`
 - Call hierarchy tracing
 
-After every `Edit`, the language server automatically injects diagnostics back to the agent without explicit calls. Navigation ops use `file:line:col` addressing. Performance benefit: symbol-level lookups at ~50ms vs. text grep at tens of seconds for large codebases.
+Navigation operations use `file:line:col` addressing. Diagnostics are reported on a
+per-file basis; after an `Edit`, the language server may automatically re-diagnose the
+affected file.
+
+**Important — LSP document sync with agent edits**: LSP servers maintain their own
+in-memory view of file contents via the `textDocument/didOpen`, `textDocument/didChange`,
+and `textDocument/didClose` notification protocol. When an agent edits a file via the
+`Edit` tool, this write bypasses the LSP layer entirely — the language server still sees the
+pre-edit content. Any subsequent `lsp__diagnostics` or `lsp__hover` call will operate on
+stale state until the file is synced. This is a critical integration concern addressed in
+§3.6.
 
 ### 1.5 How NeoKai Could Leverage SDK LSP Today
 
-**Immediate action (low effort, partial benefit):**
-1. Set `ENABLE_LSP_TOOL=1` in the daemon's environment (in `packages/daemon/src/lib/agent/query-options-builder.ts` or as an env var in startup config)
-2. Document that users need Claude Code LSP plugins installed (`~/.claude/plugins/`) for code intelligence to work
+**What works**: If a user has Claude Code LSP plugins installed in their local environment
+(`~/.claude/`), and the LSP tool becomes available to the agent, NeoKai will pass those
+tools through to the agent automatically (the SDK reads `~/.claude/` settings). No NeoKai
+code change is required.
 
-**Limitation**: This only works if the end user already has the relevant LSP binaries (`typescript-language-server`, `rust-analyzer`, etc.) installed locally and the appropriate Claude Code plugin configured. NeoKai has no control over this, and in cloud/container deployments there are no local LSP binaries.
+**Limitations**:
+- NeoKai has no control over whether the user has LSP plugins installed
+- In cloud/container deployments there are no local LSP binaries or plugins
+- Whether the `LSP` tool reliably appears in SDK-mode agent sessions requires further
+  testing with the installed SDK version
 
 ### 1.6 Gaps Requiring Custom LSP Support
 
-- No LSP in containerized/cloud deployments (no local binary access)
-- No control over which language servers are installed
-- The SDK race-condition bug means even with `ENABLE_LSP_TOOL=1` it may not be reliably active
-- No structured code intelligence API for programmatic access from NeoKai daemon
+- No LSP in containerized/cloud deployments
+- No control over which language servers are installed in user environments
+- No structured code intelligence API accessible programmatically from the NeoKai daemon
 - Agents have no code intelligence in the default NeoKai configuration today
+- LSP document sync (§3.6) must be handled explicitly if NeoKai manages LSP servers directly
 
 ---
 
@@ -80,47 +119,60 @@ After every `Edit`, the language server automatically injects diagnostics back t
 ### 2.1 Current NeoKai State
 
 From codebase exploration:
-- **No LSP infrastructure** currently exists
+- **No LSP infrastructure** currently exists in `packages/daemon/`
 - **No AST/parsing libraries** installed (`tree-sitter`, TypeScript compiler API, etc.)
-- **Clean handler architecture** makes it straightforward to add LSP as a new subsystem
+- **Clean handler architecture** in `packages/daemon/src/lib/agent/` makes it
+  straightforward to add LSP as a new subsystem
 - Agents have workspace context (`workspacePath`) and file system access
-- MCP tool infrastructure exists and is well-understood
+- MCP tool infrastructure exists: `mcp-handlers.ts` manages `.mcp.json`-based server
+  configs; `query-options-builder.ts` constructs `allowedTools`/`disallowedTools` for SDK
+- NeoKai's `WorktreeManager` creates per-session isolated git worktrees — each agent
+  session already has a distinct `workspacePath`. This is the primary driver of LSP server
+  instance topology (see §3.2)
 
 ### 2.2 Approach Evaluation
 
-#### Approach A: Enable Claude Code's Built-in LSP Tool
+Scores are on a 1–5 scale where **5 is best** for all dimensions.
 
-**Description**: Set `ENABLE_LSP_TOOL=1` and rely on the Claude Code CLI's native LSP tool with user-installed language server plugins.
+#### Approach A: Rely on Claude Code's Built-in LSP Plugin System
 
-| Factor | Rating | Notes |
+**Description**: Ensure user-installed Claude Code LSP plugins are discoverable by NeoKai-
+spawned agents. No NeoKai-specific LSP code needed.
+
+| Factor | Score (5=best) | Notes |
 |---|---|---|
-| Implementation complexity | 1/5 | One env var + documentation |
-| Feature completeness | 2/5 | All LSP features available IF user has binaries |
-| Reliability | 2/5 | SDK race-condition bug; plugin dependency on user |
-| Works in cloud/containers | 1/5 | No — requires local language server binaries |
-| Maintenance burden | 1/5 | Anthropic maintains the feature |
+| Implementation complexity | 5/5 | Zero implementation; documentation only |
+| Feature completeness | 2/5 | All LSP features IF user has plugins + binaries |
+| Reliability | 2/5 | Depends on user environment; async init timing unclear |
+| Works in cloud/containers | 1/5 | No — requires host language server binaries |
+| Maintenance burden | 5/5 | Anthropic maintains the feature |
 
-**Verdict**: Good quick win for local dev scenarios but fails in cloud/container deployments. Not a standalone solution.
+**Verdict**: Worthwhile baseline to document but not a standalone solution. Fails for any
+deployment that doesn't have a pre-configured Claude Code user environment.
 
 ---
 
 #### Approach B: MCP-Based LSP Proxy
 
-**Description**: NeoKai spawns a local MCP server that proxies LSP protocol to standard language server processes (`tsserver`, `rust-analyzer`, `pylsp`). Agents call `mcp__lsp__goto_definition(file, position)`.
+**Description**: NeoKai runs a local MCP server that proxies LSP protocol to standard
+language server processes (`typescript-language-server`, `rust-analyzer`, `pylsp`). Agents
+call `lsp__goto_definition(file, position)` (MCP tool naming: server name `lsp` → tool
+`lsp__goto_definition`).
 
 ```
-Agent → MCP Tool Call → NeoKai MCP Server → LSP stdio → tsserver
-                                           ← JSON result ←
+Agent → MCP tool call (lsp__goto_definition) → NeoKai MCP server
+  → LSP JSON-RPC (stdio) → typescript-language-server
+  ← location result ←
 ```
 
-| Factor | Rating | Notes |
+| Factor | Score (5=best) | Notes |
 |---|---|---|
-| Implementation complexity | 3/5 | Need LSP client implementation + MCP server glue |
+| Implementation complexity | 3/5 | Need LSP JSON-RPC client + MCP server glue |
 | Feature completeness | 5/5 | Full LSP feature set via standard servers |
 | Reliability | 4/5 | Standard language servers are battle-tested |
 | Works in cloud/containers | 3/5 | Needs language servers in container image |
-| Maintenance burden | 2/5 | LSP protocol changes are rare; server binaries maintained by community |
-| Latency | ~50-200ms | One extra MCP hop; LSP itself is fast |
+| Maintenance burden | 4/5 | LSP protocol is stable; server binaries maintained by community |
+| Latency | ~50–200ms | One extra MCP hop; LSP itself is fast |
 
 **Pros:**
 - Works with all existing language servers without reimplementation
@@ -130,86 +182,83 @@ Agent → MCP Tool Call → NeoKai MCP Server → LSP stdio → tsserver
 
 **Cons:**
 - Need to ship language server binaries in container images or require user installation
-- Each language requires a separate binary
-- LSP server startup latency (first request cold start: 1-5 seconds)
-- MCP tool call overhead per request
+- Each language requires a separate server binary
+- LSP server startup latency (first request cold start: 1–5 seconds)
+- Requires NeoKai to send document sync notifications after every `Edit` (see §3.6)
 
-**Verdict**: Best balance of completeness and implementation effort. Recommended as primary approach.
+**Verdict**: Best balance of completeness and implementation effort. Recommended primary
+approach.
 
 ---
 
 #### Approach C: Embedded Tree-sitter
 
-**Description**: NeoKai embeds Tree-sitter for parsing + custom symbol analysis. Provides LSP-like primitives (go-to-definition, find references) without external servers.
+**Description**: NeoKai embeds Tree-sitter for parsing + custom symbol analysis. Provides
+LSP-like primitives (go-to-definition, find references) without external servers.
 
 ```
-Agent → MCP Tool Call → NeoKai daemon → tree-sitter WASM → symbol result
+Agent → MCP tool call → NeoKai daemon → tree-sitter WASM → symbol result
 ```
 
-| Factor | Rating | Notes |
+| Factor | Score (5=best) | Notes |
 |---|---|---|
-| Implementation complexity | 4/5 | Need parser grammars + custom analysis per language |
-| Feature completeness | 3/5 | Navigation OK; semantic type info limited |
+| Implementation complexity | 2/5 | Need parser grammars + custom analysis per language |
+| Feature completeness | 3/5 | Navigation OK; semantic type info absent |
 | Reliability | 4/5 | No external process dependencies |
 | Works in cloud/containers | 5/5 | WASM bundle, no external deps |
-| Maintenance burden | 4/5 | Must maintain symbol analysis per language |
-| Latency | ~5-20ms | Very fast; pure in-process |
+| Maintenance burden | 2/5 | Must maintain symbol analysis per language |
+| Latency | ~5–20ms | Very fast; pure in-process |
 
 **Pros:**
-- Zero external dependencies; works everywhere
+- Zero external dependencies; works in any deployment
 - Very fast (in-process WASM)
-- Full control over feature set
-- `tree-sitter-wasm` available for Node/Bun
+- `web-tree-sitter` available for Node/Bun; grammars available for 100+ languages
 
 **Cons:**
-- Tree-sitter gives you syntax, not semantics. Type inference (hover types, overload resolution) requires full language server
+- Tree-sitter gives syntax structure, not semantics. No type inference, no hover types, no
+  overload resolution — these require a real language server
 - Must implement symbol analysis for each language grammar separately
 - Find-references across files requires building and maintaining a project-wide symbol index
-- Rename refactor with type awareness is hard to implement correctly
-- Goes against the grain of "don't reinvent the wheel"
+- Rename refactor without type awareness will miss dynamic references (e.g., string-keyed
+  property access in JS/Python)
 
-**Example libraries**: `web-tree-sitter` (WASM), `tree-sitter` (native Node addon), language grammars available for 100+ languages.
-
-**Verdict**: Best for offline/zero-dependency scenarios, but semantic accuracy is significantly lower than a real LSP server. Good complement to Approach B for fast operations (symbol list, syntax highlights) but not a replacement.
+**Verdict**: Best for offline/zero-dependency scenarios; suitable as a fast fallback for
+structural queries (list symbols, find all occurrences by name) when LSP is unavailable.
+Not a replacement for a language server.
 
 ---
 
 #### Approach D: Lightweight Code Graph + Heuristics
 
-**Description**: Parse files with Tree-sitter, build an in-memory symbol index (code graph). Agents query the graph for navigation. No full LSP protocol.
+**Description**: Parse files with Tree-sitter, build an in-memory symbol index (code
+graph). Agents query the graph for navigation. No full LSP protocol.
 
-| Factor | Rating | Notes |
+| Factor | Score (5=best) | Notes |
 |---|---|---|
 | Implementation complexity | 3/5 | Symbol indexer + query API; simpler than full LSP |
-| Feature completeness | 2/5 | Covers 60-70% of use cases; no type info |
+| Feature completeness | 2/5 | Covers 60–70% of navigation use cases; no type info |
 | Reliability | 4/5 | In-process, no external dependencies |
 | Works in cloud/containers | 5/5 | No external deps |
 | Maintenance burden | 3/5 | Symbol index must stay in sync with edits |
 
-**Pros:**
-- Simpler than full LSP protocol implementation
-- Can be incrementally built (index on demand)
-- Works well for symbol navigation in large codebases
-
-**Cons:**
-- No type information (hover docs, type signatures)
-- Rename across files is heuristic only (may miss dynamic references)
-- Requires re-indexing on file changes
-- Still need per-language parsing logic
-
-**Verdict**: Good fallback for languages without LSP servers, but not primary recommendation.
+**Verdict**: A simplified variant of Approach C without the LSP protocol layer. Same
+structural-only limitations. Not recommended as a primary approach given Approach C already
+covers the tree-sitter use case more thoroughly.
 
 ---
 
 ### 2.3 Recommended Approach: B + C Hybrid
 
-**Primary: MCP-Based LSP Proxy (Approach B)** for semantic features (hover types, rename, diagnostics)
-**Fallback: Tree-sitter (Approach C)** for fast structural operations when LSP is unavailable
+**Primary: MCP-Based LSP Proxy (Approach B)** for semantic features (hover types, rename,
+diagnostics).
+**Fallback: Tree-sitter (Approach C)** for fast structural operations when LSP is
+unavailable (containerized deployments, unsupported languages).
 
 This hybrid gives agents:
 - Full semantic accuracy when language servers are available
 - Graceful degradation to structural analysis when they are not
-- Fast in-process operations for common structural queries (list symbols, find all occurrences by name)
+- Fast in-process operations for common structural queries (list symbols, find all
+  occurrences by name)
 
 ---
 
@@ -221,9 +270,10 @@ This hybrid gives agents:
 packages/daemon/src/lib/
   lsp/
     index.ts                         # Public API: LspManager
-    lsp-manager.ts                   # Lifecycle: spawn/stop/reuse LSP servers per workspace
+    lsp-manager.ts                   # Lifecycle: spawn/stop/reuse LSP servers per worktree
     lsp-client.ts                    # JSON-RPC LSP client (stdio transport)
-    lsp-mcp-server.ts                # MCP server that exposes LSP as tools
+    lsp-mcp-server.ts                # MCP server exposing LSP as tools
+    document-sync.ts                 # Tracks open files; sends didOpen/didChange after edits
     tree-sitter/
       index.ts                       # Public API: TreeSitterIndex
       symbol-indexer.ts              # File → symbol table using tree-sitter
@@ -232,7 +282,7 @@ packages/daemon/src/lib/
         python.ts
         rust.ts
     servers/
-      typescript.ts                  # tsserver / typescript-language-server config
+      typescript.ts                  # typescript-language-server config
       python.ts                      # pylsp / pyright-langserver config
       rust.ts                        # rust-analyzer config
       registry.ts                    # Language → server binary mapping
@@ -240,25 +290,70 @@ packages/daemon/src/lib/
     lsp-handlers.ts                  # RPC: lsp.hover, lsp.goto, lsp.refs, lsp.rename, lsp.diag
 ```
 
-### 3.2 LSP Server Lifecycle
+### 3.2 LSP Server Lifecycle and Worktree Topology
+
+NeoKai already uses `WorktreeManager` to create per-session isolated git worktrees. Each
+agent session gets a distinct `workspacePath` corresponding to a checked-out worktree. LSP
+server instances should map 1:1 to active worktrees:
 
 ```
-Per workspace (not per session):
-  1. Project opened → detect languages via file extensions
-  2. LspManager.getOrSpawnServer(workspace, language) → LspClient
-  3. LspClient connects via stdio, sends initialize request
-  4. Server is kept alive while any session in the workspace is active
-  5. Workspace closed / idle timeout → server killed
+Per worktree (not per session — worktrees may outlive individual sessions):
+  1. Worktree activated → LspManager.getOrSpawnServer(worktreePath, language) → LspClient
+  2. LspClient connects via stdio, sends LSP initialize request with rootUri = worktreePath
+  3. Server is kept alive while any session referencing the worktree is active
+  4. Last session for a worktree closes → idle timeout → server killed
 ```
 
-**Rationale for per-workspace (not per-session):**
+**Why per-worktree, not per-session:**
 - Language servers index the entire project and maintain internal caches
-- Spawning one per session wastes memory and init time
-- Multiple agents working on the same codebase share the same language server view
+- Multiple sessions may operate on the same worktree (e.g., leader + worker)
+- Spawning per-session wastes memory and initialization time
 
-### 3.3 MCP Tool Definitions for Agents
+**Why worktree-scoped, not workspace-scoped:**
+- Different worktrees check out different branches; a shared language server would
+  conflate their file states
+- `WorktreeManager` already provides the correct isolation boundary
+- The `LspManager` key is therefore `worktreePath`, not a workspace identifier
 
-The LSP capabilities would be exposed as MCP tools callable by agents:
+### 3.3 Critical: LSP Document Sync After Agent Edits
+
+This is the most important architectural consideration for native LSP integration.
+
+When an agent calls `Edit`, `MultiEdit`, or `Write`, the file is written directly to disk
+via the daemon's file manager. The LSP server does **not** observe this change — it still
+holds the pre-edit content in its in-memory buffer. Subsequent calls to `lsp__diagnostics`,
+`lsp__hover`, or `lsp__find_references` will operate on stale state and return incorrect
+results.
+
+**Required solution: `DocumentSyncTracker`**
+
+NeoKai must intercept file writes and send corresponding LSP notifications:
+
+```
+On file write (Edit / MultiEdit / Write):
+  1. DocumentSyncTracker.onFileChanged(worktreePath, filePath, newContent)
+  2. If file is already open in LSP: send textDocument/didChange with new content
+  3. If file is not open in LSP: send textDocument/didOpen first, then didChange
+  4. After agent session ends: send textDocument/didClose for all opened files
+```
+
+This means the `lsp-handlers.ts` RPC path and the file-write path must share a reference to
+the same `DocumentSyncTracker` instance for the worktree. The `AgentSession` (or
+`DaemonApp`) context is the right place to hold this shared reference.
+
+**Alternative**: Use `textDocument/didSave` only (simpler, sends notification after disk
+write without tracking content). Language servers typically re-diagnose on save. This works
+for diagnostics but not for in-flight `hover` or `completion` requests against unsaved edits.
+
+**Recommendation**: Implement `didSave`-on-write first (simple, covers diagnostics); add
+full `didChange` tracking in a later iteration if agents need LSP responses that reflect
+in-flight edits before a save.
+
+### 3.4 MCP Tool Definitions for Agents
+
+The LSP capabilities are exposed as tools in a NeoKai-managed MCP server. Tool names follow
+the MCP `<serverName>__<toolName>` convention; if the server is registered as `lsp`, tools
+are called `lsp__hover`, `lsp__goto_definition`, etc.
 
 ```typescript
 // packages/daemon/src/lib/lsp/lsp-mcp-server.ts
@@ -306,7 +401,7 @@ const LSP_TOOLS = [
   },
   {
     name: 'lsp__rename',
-    description: 'Rename a symbol across all files in the project',
+    description: 'Propose a rename of a symbol across all files in the project (returns proposed edits, does not apply them)',
     inputSchema: {
       type: 'object',
       properties: {
@@ -320,7 +415,7 @@ const LSP_TOOLS = [
   },
   {
     name: 'lsp__diagnostics',
-    description: 'Get current errors and warnings for a file',
+    description: 'Get current errors and warnings for a file (reflects last saved state)',
     inputSchema: {
       type: 'object',
       properties: {
@@ -330,21 +425,8 @@ const LSP_TOOLS = [
     },
   },
   {
-    name: 'lsp__completion',
-    description: 'Get completion suggestions at a position',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        file: { type: 'string' },
-        line: { type: 'number' },
-        character: { type: 'number' },
-      },
-      required: ['file', 'line', 'character'],
-    },
-  },
-  {
     name: 'lsp__document_symbols',
-    description: 'List all symbols (functions, classes, variables) in a file',
+    description: 'List all symbols (functions, classes, variables) defined in a file',
     inputSchema: {
       type: 'object',
       properties: {
@@ -367,102 +449,159 @@ const LSP_TOOLS = [
 ];
 ```
 
-### 3.4 Example Agent Interaction Flow
+**Note on `lsp__completion`**: Autocompletion is an interactive editor feature triggered on
+each keypress. LLM agents already have full file content in context and do not benefit from
+this — they predict tokens themselves. `lsp__completion` is intentionally omitted from the
+tool list to keep the tool count lean.
+
+### 3.5 Example Agent Interaction Flow
 
 ```
 Agent working on TypeScript codebase:
 
 1. Agent reads a file, sees `getUserById(id)` on line 45
 2. Agent calls: lsp__goto_definition({ file: "src/api.ts", line: 45, character: 12 })
-3. → LspManager finds existing tsserver for this workspace
+3. → LspManager finds existing tsserver for this worktree
 4. → LspClient sends textDocument/definition request
 5. → tsserver returns: { uri: "src/db/users.ts", range: { start: {line: 23} } }
 6. Agent reads: src/db/users.ts:23 — sees the full implementation
 7. Agent calls: lsp__find_references({ file: "src/db/users.ts", line: 23, character: 17 })
 8. → Returns all 12 call sites across the project
-9. Agent makes targeted edits at each call site knowing exact locations
+9. Agent makes targeted edits at each call site; after each Edit, DocumentSyncTracker
+   sends textDocument/didSave to keep LSP state current
+10. Agent calls lsp__diagnostics to verify no type errors remain after edits
 ```
 
-### 3.5 Integration Points in NeoKai
+### 3.6 Integration Points in NeoKai
 
-**1. Session startup**: When an agent session starts, register the MCP LSP server in the session's MCP config if `tools.useLspTools` is enabled.
+**1. Per-session MCP registration with shared LspManager**
+
+The MCP server is registered per-session (required by the SDK's MCP config model), but it
+must delegate to a shared, per-worktree `LspManager` singleton to avoid spawning redundant
+language server processes:
 
 ```typescript
 // In query-options-builder.ts
 if (sessionConfig.tools?.useLspTools) {
-  mcpServers['__neokai_lsp'] = {
+  // Register this session's MCP endpoint — the actual LSP server is shared per worktree
+  mcpServers['lsp'] = {
     type: 'stdio',
     command: process.execPath,
-    args: [lspMcpServerEntrypoint, workspacePath],
+    args: [lspMcpServerEntrypoint, '--worktree', workspacePath, '--ipc', daemonIpcSocket],
   };
+  // The lsp-mcp-server process connects back to the daemon's LspManager via IPC
+  // rather than spawning its own language server
 }
 ```
 
-**2. Language detection**: On workspace open, scan for language markers (`tsconfig.json` → TypeScript, `Cargo.toml` → Rust, `pyproject.toml` / `setup.py` → Python).
+**2. `LspManager` as a `DaemonApp`-level singleton**
 
-**3. Daemon startup**: `LspManager` initialized as a singleton in `DaemonApp`, shared across sessions.
+```typescript
+// In DaemonApp (packages/daemon/src/app.ts)
+this.lspManager = new LspManager();
+// Sessions receive a reference; LspManager.getOrSpawnServer(worktreePath, lang)
+// is safe to call concurrently — it returns existing instances
+```
 
-**4. RPC exposure**: Add `lsp.*` RPC handlers for the frontend to show LSP status (which servers are running, which languages are active).
+**3. Document sync hook in file RPC handlers**
+
+```typescript
+// In file-handlers.ts, after any file write:
+const session = sessionManager.getSession(sessionId);
+if (session.lspDocSync) {
+  await session.lspDocSync.onFileWritten(absolutePath, newContent);
+}
+```
+
+**4. Language detection on workspace open**
+
+Scan for language markers: `tsconfig.json` → TypeScript, `Cargo.toml` → Rust,
+`pyproject.toml` / `setup.py` → Python. Used to pre-warm language servers before the
+first LSP tool call.
+
+**5. RPC exposure for frontend**
+
+Add `lsp.status` RPC handler so the frontend can show which language servers are running
+per worktree (useful for debugging and for showing IDE-mode indicators in the UI).
 
 ---
 
 ## Part 4: Open Questions
 
 ### Latency Budget
-- What's acceptable for agent LSP operations? Suggested: < 200ms for cached queries, < 2s for cold start
-- Should the LSP server warm up proactively when a session starts, or lazy-initialize on first use?
-- Recommendation: warm up proactively for TypeScript/Python/Rust (most common); lazy for others
+- Suggested targets: < 200ms for cached queries, < 3s for cold start (first request after
+  server spawn)
+- Should the LSP server warm up proactively when a session starts, or lazy-initialize on
+  first tool call?
+- Recommendation: warm up proactively for TypeScript/Python (most common in NeoKai
+  workflows); lazy for others
 
 ### Language Priority
 Which languages to support in Phase 1?
-- **Must have**: TypeScript/JavaScript (NeoKai is a TypeScript project; most agents work on TS codebases)
-- **Should have**: Python (common in AI/ML projects agents work on)
+- **Must have**: TypeScript/JavaScript (NeoKai itself is TypeScript; most agent codebases
+  are TypeScript)
+- **Should have**: Python (AI/ML project codebases)
 - **Nice to have**: Rust, Go
 - **Later**: Ruby, C#, Java, etc.
 
 ### Always-On vs On-Demand
 - **Always-on**: LSP tools always in system prompt, agent decides when to use them
-  - Pro: agent can use LSP at any time without explicit user configuration
-  - Con: increases tool count, may confuse agents that don't need LSP
-- **On-demand**: LSP tools enabled per session/room via config
+  - Pro: agent can use LSP at any point without explicit user configuration
+  - Con: increases tool count; may confuse agents working on tasks unrelated to code
+    navigation
+- **On-demand**: LSP tools enabled per session or room via config (`tools.useLspTools`)
   - Pro: clean separation, opt-in, doesn't bloat tool list for simple tasks
   - Con: friction for users who always want code intelligence
 - **Recommendation**: On-demand per session, with a room-level default setting
 
 ### Multi-Language Projects (Polyglot)
-- One LspManager should support multiple language servers per workspace
-- Language detection should be per-file based on extension, not per-workspace
-- Tool calls should route to the correct server based on file extension
+- `LspManager` should support multiple language servers per worktree simultaneously
+- Language server selection should be per-file based on extension, not per-worktree
+- Tool calls route to the correct server based on the `file` parameter's extension
 
 ### State Sharing
-- **Shared across sessions in same workspace**: Yes — reduces cold start latency, consistent diagnostics
+- **Shared across sessions using the same worktree**: Yes — reduces cold start latency,
+  consistent diagnostics view
 - **Fresh per session**: No — wasteful, slower
-- **Exception**: Sessions with different `cwd` or git branches should get separate LSP instances to avoid cross-contamination
+- NeoKai's existing worktree-per-session model makes this natural: each worktree gets one
+  LSP server instance, shared by all sessions targeting that worktree
 
 ### Container/Cloud Deployments
-- Without language server binaries, MCP LSP proxy silently degrades to tree-sitter fallback
-- NeoKai should provide a Docker base image layer with common language servers pre-installed
-- Alternative: agent detects missing LSP and installs server via `bun add -g typescript-language-server` automatically
+- Without language server binaries, the MCP LSP proxy degrades to the tree-sitter fallback
+- NeoKai should document a Docker base image layer with common language servers
+  pre-installed for cloud deployments
+- **Caution**: automatically installing language server binaries at runtime (e.g., via
+  package managers) introduces security risk — arbitrary code execution from package
+  registries in a long-running daemon context. Any auto-install flow requires explicit user
+  opt-in and should be sandboxed or performed only on first-time setup with user confirmation.
 
 ### Rename Safety
-- LSP rename is purely syntactic — it renames all symbol references but won't catch dynamic access patterns (e.g., `obj['methodName']` in JavaScript)
-- Agents should be prompted to verify rename results with `lsp__find_references` before committing
-- Add a `dryRun` parameter to `lsp__rename` that returns the proposed edits without applying them
+- LSP rename is syntactically complete (covers all statically-analyzable references) but
+  will miss dynamic access patterns (`obj['methodName']` in JavaScript/Python)
+- `lsp__rename` should return proposed edits without applying them, letting the agent review
+  and apply them explicitly via `Edit`/`MultiEdit`
+- Agents should be guided (via system prompt) to call `lsp__find_references` first to
+  understand scope before issuing a rename
 
 ---
 
 ## Summary
 
-| | Approach A (SDK LSP) | Approach B (MCP Proxy) | Approach C (Tree-sitter) | Approach D (Code Graph) |
+Scores are 1–5 where **5 is best** in each dimension.
+
+| | Approach A (SDK plugin LSP) | Approach B (MCP Proxy) | Approach C (Tree-sitter) | Approach D (Code Graph) |
 |---|---|---|---|---|
-| Complexity | 1/5 | 3/5 | 4/5 | 3/5 |
+| Complexity (5=low effort) | 5/5 | 3/5 | 2/5 | 3/5 |
 | Feature completeness | 2/5 | 5/5 | 3/5 | 2/5 |
 | Cloud/container ready | 1/5 | 3/5 | 5/5 | 5/5 |
 | Semantic accuracy | 2/5 | 5/5 | 2/5 | 2/5 |
-| Maintenance | 1/5 | 2/5 | 4/5 | 3/5 |
+| Maintenance (5=low burden) | 5/5 | 4/5 | 2/5 | 3/5 |
 
 **Recommended path:**
-1. **Immediate** (1-2 days): Set `ENABLE_LSP_TOOL=1` in daemon environment. Zero code change, unlocks LSP for local dev users who have plugins installed.
-2. **Phase 1** (2-4 weeks): Implement MCP-based LSP proxy for TypeScript and Python. Agents get `lsp__*` tools in their system prompt when enabled.
-3. **Phase 2** (4-8 weeks): Add Tree-sitter fallback for structural queries; works everywhere without binary dependencies.
-4. **Phase 3** (ongoing): Expand language support; add workspace-level LSP status UI in NeoKai frontend.
+1. **Phase 1** (2–4 weeks): Implement MCP-based LSP proxy (Approach B) for TypeScript and
+   Python. Agents get `lsp__*` tools when `tools.useLspTools` is enabled. Includes
+   `DocumentSyncTracker` for `didSave` notifications after agent file writes.
+2. **Phase 2** (4–8 weeks): Add Tree-sitter fallback (Approach C) for structural queries
+   in deployments without language server binaries.
+3. **Phase 3** (ongoing): Expand language support; add worktree-level LSP status UI in
+   NeoKai frontend; upgrade document sync from `didSave` to full `didChange` tracking.

--- a/docs/lsp-integration-research.md
+++ b/docs/lsp-integration-research.md
@@ -111,6 +111,10 @@ code change is required.
 - No structured code intelligence API accessible programmatically from the NeoKai daemon
 - Agents have no code intelligence in the default NeoKai configuration today
 - LSP document sync (§3.3) must be handled explicitly if NeoKai manages LSP servers directly
+- Call hierarchy (`callHierarchy/incomingCalls`, `callHierarchy/outgoingCalls`) not
+  accessible — requires a real language server; no SDK equivalent
+- Workspace-wide symbol search (`workspace/symbol`) not accessible — the SDK's `Grep` tool
+  is text-only and has no awareness of symbol kinds or scopes
 
 ---
 
@@ -357,6 +361,12 @@ the MCP `mcp__${serverName}__${toolName}` convention (verified from CLI binary, 
 `mcp__ide__getDiagnostics` pattern); if the server is registered as `lsp`, tools are called
 `mcp__lsp__hover`, `mcp__lsp__goto_definition`, etc.
 
+**Coordinate system**: All LSP positions use **0-indexed** line and character numbers. This
+differs from most editors and file viewers (including the `Read` tool output), which display
+1-indexed line numbers. An agent reading that a symbol is on "line 45" in a `Read` result
+must pass `line: 44` to LSP tools. Tool descriptions and the system prompt should make this
+explicit to avoid off-by-one errors.
+
 ```typescript
 // packages/daemon/src/lib/lsp/lsp-mcp-server.ts
 
@@ -474,7 +484,7 @@ Agent working on TypeScript codebase:
 10. Agent calls mcp__lsp__diagnostics to verify no type errors remain after edits
 ```
 
-### 3.5 Integration Points in NeoKai
+### 3.6 Integration Points in NeoKai
 
 **1. Per-session MCP registration with shared LspManager**
 


### PR DESCRIPTION
Explores two directions for improving agent code intelligence:
1. Claude Agent SDK LSP capabilities (ENABLE_LSP_TOOL flag, race-condition
   bug workaround, official plugin system)
2. Native LSP integration approaches evaluated: MCP-based LSP proxy,
   Tree-sitter embedding, Code graph heuristics, and SDK passthrough

Delivers: capability summary, 4-option approach comparison (complexity +
completeness scores), recommended hybrid architecture (MCP proxy + tree-sitter
fallback), implementation sketch with MCP tool definitions, and open questions
on latency targets, language priority, always-on vs on-demand, and container
deployments.
