### PR TITLE
plan: simplify ID and folder path system

### DIFF
--- a/docs/plans/simplify-id-and-folder-path-system/00-overview.md
+++ b/docs/plans/simplify-id-and-folder-path-system/00-overview.md
@@ -38,7 +38,7 @@ Worktree path shortening: use the first 8 characters of the room UUID as a proje
 2. **Repository Layer** — Add short ID assignment on create and lookup-by-short-id to Task, Goal, and Room repositories
 3. **API Compatibility Layer** — Update all RPC handlers to return `shortId` and accept both UUID and short ID as input; update URL route regexes in the web router
 4. **Worktree Path Shortening** — Shorten worktree base directory using a project short key derived from the repo path
-5. **UI Display** — Display short IDs in task/goal/session cards and copy-to-clipboard helpers in the web frontend
+5. **UI Display** — Display short IDs in task/goal cards and copy-to-clipboard helpers in the web frontend
 6. **Tests and Validation** — Unit tests for short ID utilities, repository layer, API compatibility, and multi-tenant isolation
 
 ## Cross-Milestone Dependencies

--- a/docs/plans/simplify-id-and-folder-path-system/00-overview.md
+++ b/docs/plans/simplify-id-and-folder-path-system/00-overview.md
@@ -21,7 +21,7 @@ These make logs unreadable, URLs unmemorable, and directory paths excessively lo
 Format:
 - Tasks: `t-42` (sequential integer per room, formatted with prefix)
 - Goals: `g-7` (sequential integer per room)
-- Sessions: use the short task ID for worker sessions where possible
+- Sessions: **out of scope for this goal** — session IDs involve complex worker/leader lifecycle coupling; session short IDs are a separate future effort
 
 Worktree path shortening: use the first 8 characters of the room UUID as a project directory name instead of the full encoded repo path.
 

--- a/docs/plans/simplify-id-and-folder-path-system/00-overview.md
+++ b/docs/plans/simplify-id-and-folder-path-system/00-overview.md
@@ -1,0 +1,53 @@
+# Simplify ID and Folder Path System — Overview
+
+## Goal
+
+Replace opaque full UUIDs in user-facing surfaces (URLs, logs, CLI, UI) with short, human-readable IDs scoped to their parent context, while preserving full backward compatibility and zero-migration policy for existing data.
+
+## Problem Statement
+
+NeoKai currently uses full UUIDs everywhere:
+- Task IDs: `d8a578c6-d3cb-4c84-926b-958cbd433d32`
+- Room session IDs: `room:chat:04062505-780f-4881-a3be-9cb9062790fb`
+- Worktree paths: `~/.neokai/projects/-Users-lsm-focus-dev-neokai/worktrees/planner-04062505-780f-4881-a3be-9cb9062790fb-144eca1d-06fc-49e1-92f3-afa246aecc4d-2bb0b719`
+- Worker session IDs: `coder:04062505-780f-4881-a3be-9cb9062790fb:d8a578c6-d3cb-4c84-926b-958cbd433d32:abc12345`
+
+These make logs unreadable, URLs unmemorable, and directory paths excessively long.
+
+## Approach
+
+**Scoped counter-based short IDs** — each entity type gets a monotonically increasing integer counter scoped to its parent context (room). The full UUID remains the primary key; the short ID is a derived, secondary address.
+
+Format:
+- Tasks: `t-42` (sequential integer per room, formatted with prefix)
+- Goals: `g-7` (sequential integer per room)
+- Sessions: use the short task ID for worker sessions where possible
+
+Worktree path shortening: use the first 8 characters of the room UUID as a project directory name instead of the full encoded repo path.
+
+**Key design constraints:**
+1. Zero DB migration — add nullable `short_id` columns; compute on first access for old records
+2. Backward compatibility — all APIs accept both UUID and short ID as input
+3. Both IDs always returned in API responses (`id` + `shortId`)
+4. Multi-tenant safe — counters are scoped to room, preventing cross-tenant collisions
+5. URL routing updated to accept both formats
+
+## Milestones
+
+1. **Short ID Infrastructure** — Add `short_id` columns, counter tables, and `generateShortId()` utility in shared package
+2. **Repository Layer** — Add short ID assignment on create and lookup-by-short-id to Task, Goal, and Room repositories
+3. **API Compatibility Layer** — Update all RPC handlers to return `shortId` and accept both UUID and short ID as input; update URL route regexes in the web router
+4. **Worktree Path Shortening** — Shorten worktree base directory using a project short key derived from the repo path
+5. **UI Display** — Display short IDs in task/goal/session cards and copy-to-clipboard helpers in the web frontend
+6. **Tests and Validation** — Unit tests for short ID utilities, repository layer, API compatibility, and multi-tenant isolation
+
+## Cross-Milestone Dependencies
+
+- Milestones 2, 3, 4 all depend on Milestone 1 (infrastructure must exist first)
+- Milestone 5 depends on Milestone 3 (API must return `shortId` before UI can display it)
+- Milestone 6 should be written alongside each coding milestone but can be consolidated into a final validation pass
+- Milestone 4 (path shortening) is independent of Milestones 2–3 and can run in parallel with them
+
+## Estimated Task Count
+
+~18 tasks across 6 milestones

--- a/docs/plans/simplify-id-and-folder-path-system/01-short-id-infrastructure.md
+++ b/docs/plans/simplify-id-and-folder-path-system/01-short-id-infrastructure.md
@@ -1,0 +1,116 @@
+# Milestone 1 — Short ID Infrastructure
+
+## Goal
+
+Establish the foundation for the short ID system: a utility function, shared type definitions, a DB migration adding nullable `short_id` columns to `tasks` and `goals`, and a `short_id_counters` table scoped per room.
+
+## Context
+
+All entities (rooms, tasks, goals) currently use full UUIDs from `generateUUID()` in `packages/shared/src/utils.ts`. The new system needs:
+- A `short_id_counters` table in SQLite for per-room, per-entity-type counters
+- Nullable `short_id TEXT UNIQUE` columns on `tasks` and `goals`
+- A `formatShortId(prefix, counter)` utility that produces readable strings like `t-42`, `g-7`
+- A `resolveEntityId(input)` helper that returns the UUID given either a UUID or short ID
+
+No existing data is migrated — short IDs are computed lazily on first access for old records.
+
+## Tasks
+
+---
+
+### Task 1.1 — Add Short ID Types and Utility to Shared Package
+
+**Description**: Add the `formatShortId` utility and `ShortIdPrefix` constants to `packages/shared/src/utils.ts`. Export from `packages/shared/src/mod.ts`. No DB changes in this task.
+
+**Subtasks**:
+1. Add `ShortIdPrefix` constants: `export const SHORT_ID_PREFIX = { TASK: 't', GOAL: 'g', ROOM: 'r' } as const`
+2. Add `formatShortId(prefix: string, counter: number): string` — returns `${prefix}-${counter}` (e.g., `t-42`)
+3. Add `parseShortId(shortId: string): { prefix: string; counter: number } | null` — parses `t-42` back into prefix + counter, returns null on invalid input
+4. Add `isUUID(value: string): boolean` — returns true if value matches UUID v4 format (`/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i`)
+5. Export all new exports from `mod.ts`
+6. Write unit tests in `packages/daemon/tests/unit/` for `formatShortId`, `parseShortId`, `isUUID`
+
+**Acceptance Criteria**:
+- `formatShortId('t', 42)` returns `'t-42'`
+- `parseShortId('t-42')` returns `{ prefix: 't', counter: 42 }`
+- `parseShortId('not-valid')` returns `null`
+- `isUUID('04062505-780f-4881-a3be-9cb9062790fb')` returns `true`
+- `isUUID('t-42')` returns `false`
+- All utilities are exported from `@neokai/shared`
+- Unit tests pass
+
+**Depends on**: Nothing
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 1.2 — DB Migration: Add short_id Columns and Counter Table
+
+**Description**: Add a new DB migration (next sequential number after current highest migration) that:
+1. Adds a `short_id TEXT` nullable column to the `tasks` table with a UNIQUE constraint
+2. Adds a `short_id TEXT` nullable column to the `goals` table with a UNIQUE constraint
+3. Creates a new `short_id_counters` table for per-room, per-entity-type monotonic counters
+
+**Subtasks**:
+1. Determine the next migration number by reading `packages/daemon/src/storage/schema/migrations.ts` (currently ends around migration 46 — check the file for the actual highest number)
+2. Implement `runMigrationNN(db)` in `migrations.ts`:
+   - `ALTER TABLE tasks ADD COLUMN short_id TEXT` (idempotent: wrapped in try/catch or checked with `PRAGMA table_info`)
+   - `ALTER TABLE goals ADD COLUMN short_id TEXT` (idempotent)
+   - Create `short_id_counters` table if not exists:
+     ```sql
+     CREATE TABLE IF NOT EXISTS short_id_counters (
+       entity_type TEXT NOT NULL,
+       scope_id TEXT NOT NULL,
+       counter INTEGER NOT NULL DEFAULT 0,
+       PRIMARY KEY (entity_type, scope_id)
+     )
+     ```
+3. Add `CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_short_id ON tasks(short_id) WHERE short_id IS NOT NULL`
+4. Add `CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_short_id ON goals(short_id) WHERE short_id IS NOT NULL`
+5. Add the migration call in `runMigrations()` with a descriptive comment
+6. Write a unit test that verifies the migration runs idempotently (running it twice does not error)
+
+**Acceptance Criteria**:
+- After migration, `tasks` has a `short_id TEXT` column (nullable, unique where not null)
+- After migration, `goals` has a `short_id TEXT` column (nullable, unique where not null)
+- `short_id_counters` table exists with `(entity_type, scope_id)` as PK
+- Migration is idempotent — running twice does not throw
+- Unit test passes
+
+**Depends on**: Task 1.1 (imports `formatShortId` for use in validation)
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 1.3 — Short ID Allocator Service
+
+**Description**: Create `packages/daemon/src/lib/short-id-allocator.ts` — a service that atomically increments the per-scope counter and returns a new formatted short ID. This uses SQLite's atomic `UPDATE ... RETURNING` or a transaction pattern.
+
+**Subtasks**:
+1. Create `ShortIdAllocator` class in `packages/daemon/src/lib/short-id-allocator.ts`
+2. Constructor takes `db: BunDatabase`
+3. Implement `allocate(entityType: 'task' | 'goal', scopeId: string): string`:
+   - Uses a SQLite transaction to atomically insert-or-increment the counter in `short_id_counters`
+   - Returns `formatShortId(prefix, counter)` using the appropriate prefix from `SHORT_ID_PREFIX`
+   - SQL pattern: `INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES (?, ?, 1) ON CONFLICT(entity_type, scope_id) DO UPDATE SET counter = counter + 1 RETURNING counter`
+4. Implement `getCounter(entityType: string, scopeId: string): number` — reads current counter without incrementing (useful for admin/debugging)
+5. Export `ShortIdAllocator` from `packages/daemon/src/lib/short-id-allocator.ts`
+6. Write unit tests covering: first allocation returns counter=1, second returns counter=2, concurrent allocations produce unique IDs, different scopes are independent
+
+**Acceptance Criteria**:
+- `allocate('task', roomId)` returns `'t-1'` on first call, `'t-2'` on second call for same scope
+- `allocate('task', roomId1)` and `allocate('task', roomId2)` are independent (both can return `'t-1'`)
+- Allocation is atomic (SQLite transaction ensures no duplicate counters)
+- Unit tests pass
+
+**Depends on**: Task 1.1, Task 1.2
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.

--- a/docs/plans/simplify-id-and-folder-path-system/01-short-id-infrastructure.md
+++ b/docs/plans/simplify-id-and-folder-path-system/01-short-id-infrastructure.md
@@ -23,20 +23,23 @@ No existing data is migrated — short IDs are computed lazily on first access f
 **Description**: Add the `formatShortId` utility and `ShortIdPrefix` constants to `packages/shared/src/utils.ts`. Export from `packages/shared/src/mod.ts`. No DB changes in this task.
 
 **Subtasks**:
-1. Add `ShortIdPrefix` constants: `export const SHORT_ID_PREFIX = { TASK: 't', GOAL: 'g', ROOM: 'r' } as const`
+1. Add `ShortIdPrefix` constants: `export const SHORT_ID_PREFIX = { TASK: 't', GOAL: 'g' } as const` — **do NOT include `ROOM: 'r'`**; room short IDs are out of scope for this goal and an unused export will trigger a Knip warning in `bun run check`
 2. Add `formatShortId(prefix: string, counter: number): string` — returns `${prefix}-${counter}` (e.g., `t-42`)
-3. Add `parseShortId(shortId: string): { prefix: string; counter: number } | null` — parses `t-42` back into prefix + counter, returns null on invalid input
+3. Add `parseShortId(shortId: string): { prefix: string; counter: number } | null` — parses `t-42` back into prefix + counter; valid short IDs must match `/^[a-z]-(\d+)$/` where the counter is a positive integer; returns null for anything else
 4. Add `isUUID(value: string): boolean` — returns true if value matches UUID v4 format (`/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i`)
 5. Export all new exports from `mod.ts`
-6. Write unit tests in `packages/daemon/tests/unit/` for `formatShortId`, `parseShortId`, `isUUID`
+6. Write unit tests in `packages/daemon/tests/unit/short-id/utils.test.ts` for `formatShortId`, `parseShortId`, `isUUID`. **Note on test location**: `packages/shared` has no test runner configured; following the project's existing pattern for shared utility tests (which are tested from the daemon package), tests live in `packages/daemon/tests/unit/`. Check how existing `generateUUID` or other shared utils are tested and follow the same convention.
 
 **Acceptance Criteria**:
 - `formatShortId('t', 42)` returns `'t-42'`
 - `parseShortId('t-42')` returns `{ prefix: 't', counter: 42 }`
-- `parseShortId('not-valid')` returns `null`
+- `parseShortId('t-abc')` returns `null` (non-numeric counter)
+- `parseShortId('t-')` returns `null` (empty counter)
+- `parseShortId('t-0')` returns `null` (counter must be positive integer ≥ 1)
 - `isUUID('04062505-780f-4881-a3be-9cb9062790fb')` returns `true`
 - `isUUID('t-42')` returns `false`
 - All utilities are exported from `@neokai/shared`
+- `bun run check` passes (no Knip unused-export warnings)
 - Unit tests pass
 
 **Depends on**: Nothing
@@ -80,7 +83,7 @@ No existing data is migrated — short IDs are computed lazily on first access f
 - Migration is idempotent — running twice does not throw
 - Unit test passes
 
-**Depends on**: Task 1.1 (imports `formatShortId` for use in validation)
+**Depends on**: Task 1.1 (for sequencing — types should exist before schema changes; the migration itself does NOT import `formatShortId` at runtime)
 
 **Agent type**: coder
 
@@ -98,7 +101,9 @@ No existing data is migrated — short IDs are computed lazily on first access f
 3. Implement `allocate(entityType: 'task' | 'goal', scopeId: string): string`:
    - Uses a SQLite transaction to atomically insert-or-increment the counter in `short_id_counters`
    - Returns `formatShortId(prefix, counter)` using the appropriate prefix from `SHORT_ID_PREFIX`
-   - SQL pattern: `INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES (?, ?, 1) ON CONFLICT(entity_type, scope_id) DO UPDATE SET counter = counter + 1 RETURNING counter`
+   - **`RETURNING` clause caveat**: `RETURNING` support in `bun:sqlite` has not been validated in this codebase (no existing uses found). The coder must first check whether `db.prepare('... RETURNING counter').get(...)` works with Bun's SQLite driver. If `RETURNING` is not supported or behaves unexpectedly, use the established project pattern instead: run `db.run(insertOrUpdate)` inside a transaction, then issue a separate `SELECT counter FROM short_id_counters WHERE entity_type = ? AND scope_id = ?` to read back the value. The transaction ensures atomicity regardless of which pattern is used.
+   - Preferred SQL attempt: `INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES (?, ?, 1) ON CONFLICT(entity_type, scope_id) DO UPDATE SET counter = counter + 1 RETURNING counter`
+   - Fallback if `RETURNING` doesn't work: wrap `INSERT ... ON CONFLICT ... DO UPDATE` + `SELECT counter` in a `db.transaction()`
 4. Implement `getCounter(entityType: string, scopeId: string): number` — reads current counter without incrementing (useful for admin/debugging)
 5. Export `ShortIdAllocator` from `packages/daemon/src/lib/short-id-allocator.ts`
 6. Write unit tests covering: first allocation returns counter=1, second returns counter=2, concurrent allocations produce unique IDs, different scopes are independent

--- a/docs/plans/simplify-id-and-folder-path-system/02-repository-layer.md
+++ b/docs/plans/simplify-id-and-folder-path-system/02-repository-layer.md
@@ -50,16 +50,19 @@ Integrate short ID assignment into the `TaskRepository` and `GoalRepository` cre
 3. Update `rowToTask()` to include `shortId: (row.short_id as string | null) ?? undefined`
 4. Add `getTaskByShortId(roomId: string, shortId: string): NeoTask | null` — queries `SELECT * FROM tasks WHERE room_id = ? AND short_id = ?`
 5. Add lazy backfill in `getTask(id)`: if the returned task has no `shortId` and allocator is present, allocate one, update the row, and return the updated object
-6. Write unit tests:
+6. Add lazy backfill in `listTasks(roomId)`: after fetching all rows for the room, for any row where `short_id` is null, call `allocate('task', roomId)`, issue an `UPDATE tasks SET short_id = ? WHERE id = ?`, and return the updated object. This is bounded and safe — rooms have at most hundreds of tasks.
+7. Write unit tests:
    - Creating a task with an allocator produces a non-null `shortId`
    - `getTaskByShortId` finds the task by its short ID
    - `getTaskByShortId` returns null for unknown short ID
    - Lazy backfill on `getTask` assigns a short ID to a record that was created without one
+   - `listTasks` with a mix of tasks (some with `short_id`, some without) returns all tasks with `shortId` populated after the call
 
 **Acceptance Criteria**:
 - New tasks created with `ShortIdAllocator` present have a `shortId` like `t-1`, `t-2`, etc.
 - `getTaskByShortId(roomId, 't-1')` returns the correct task
 - Tasks created before migration (no `short_id`) get a short ID on first `getTask()` call
+- `listTasks` returns all tasks with `shortId` populated (backfilled inline for legacy rows)
 - All unit tests pass
 
 **Depends on**: Task 2.1, Milestone 1 complete
@@ -80,8 +83,9 @@ Integrate short ID assignment into the `TaskRepository` and `GoalRepository` cre
 3. Update the row-to-object mapping method to include `shortId: (row.short_id as string | null) ?? undefined`
 4. Add `getGoalByShortId(roomId: string, shortId: string): RoomGoal | null`
 5. Add lazy backfill in `getGoal(id)` (same pattern as Task 2.2)
-6. Wire `ShortIdAllocator` into `GoalRepository` instantiation in the database layer (`packages/daemon/src/storage/database.ts` or wherever repositories are instantiated)
-7. Write unit tests covering the same cases as Task 2.2 for goals (uses `g-` prefix)
+6. Add lazy backfill in `listGoals(roomId)` — same pattern as `listTasks` in Task 2.2: for any row without `short_id`, allocate one and update the DB inline
+7. Wire `ShortIdAllocator` into `GoalRepository` instantiation in the database layer (`packages/daemon/src/storage/database.ts` or wherever repositories are instantiated)
+8. Write unit tests covering the same cases as Task 2.2 for goals (uses `g-` prefix), including a `listGoals` backfill test
 
 **Acceptance Criteria**:
 - New goals have `shortId` like `g-1`, `g-2`, per room
@@ -98,17 +102,36 @@ Integrate short ID assignment into the `TaskRepository` and `GoalRepository` cre
 
 ### Task 2.4 — Wire ShortIdAllocator into Database and Room Manager
 
-**Description**: Ensure `ShortIdAllocator` is instantiated at the database level and injected into `TaskRepository`, `GoalRepository`, and the `TaskManager` / `GoalManager` so all production code paths use it.
+**Description**: Ensure `ShortIdAllocator` is instantiated at the database level and injected into `TaskRepository`, `GoalRepository`, and **all** instantiation sites of `TaskManager` / `GoalManager` so all production code paths use it.
+
+**Critical context**: `TaskManager` creates its own `TaskRepository` internally (`this.taskRepo = new TaskRepository(db, this.reactiveDb)` in `task-manager.ts`). `TaskManager` is instantiated in **four places**:
+- `packages/daemon/src/lib/rpc-handlers/task-handlers.ts` (line ~57)
+- `packages/daemon/src/lib/rpc-handlers/index.ts` (line ~138)
+- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` (lines ~426 and ~658 — two separate instantiation points)
+
+`GoalManager` is instantiated in:
+- `packages/daemon/src/lib/rpc-handlers/index.ts` (line ~133)
+- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` (line ~427)
+
+A coder who only looks at `app.ts` or `RoomManager` will miss `room-runtime-service.ts`, causing live room operations (started via the room runtime) to silently skip short ID assignment. **All six instantiation sites must be updated.**
 
 **Subtasks**:
-1. In `packages/daemon/src/storage/database.ts` (or whichever file creates repository instances), instantiate `ShortIdAllocator` from the db connection and pass it to `TaskRepository` and `GoalRepository` constructors
-2. Verify that `TaskManager` (which internally creates `TaskRepository`) also receives the allocator — trace the dependency chain from `DaemonApp`/`app.ts` through `RoomManager` and `TaskManager`
-3. Run the full daemon unit test suite (`make test-daemon`) to confirm nothing is broken by the wiring
-4. Confirm no circular dependencies are introduced (the allocator is a pure DB utility)
+1. Instantiate `ShortIdAllocator` once from the db connection (e.g., in a shared factory or passed through the constructor chain), and pass it into `TaskManager` as a new constructor parameter
+2. `TaskManager` should accept `shortIdAllocator?: ShortIdAllocator` and forward it to its internal `TaskRepository` constructor
+3. Update **all four** `TaskManager` instantiation sites to pass the allocator:
+   - `packages/daemon/src/lib/rpc-handlers/task-handlers.ts`
+   - `packages/daemon/src/lib/rpc-handlers/index.ts`
+   - `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` (both instantiation points)
+4. Update **both** `GoalManager` instantiation sites analogously:
+   - `packages/daemon/src/lib/rpc-handlers/index.ts`
+   - `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`
+5. Run the full daemon unit test suite (`make test-daemon`) to confirm nothing is broken
+6. Confirm no circular dependencies are introduced (the allocator is a pure DB utility with no app-layer imports)
 
 **Acceptance Criteria**:
-- In production code paths, `TaskRepository.createTask()` always assigns a short ID
-- In production code paths, `GoalRepository.createGoal()` always assigns a short ID
+- In ALL production code paths (including live room runtime), `TaskRepository.createTask()` assigns a short ID
+- In ALL production code paths, `GoalRepository.createGoal()` assigns a short ID
+- All six instantiation sites are updated (verify by searching for `new TaskManager` and `new GoalManager` in the codebase)
 - `make test-daemon` passes
 
 **Depends on**: Task 2.3

--- a/docs/plans/simplify-id-and-folder-path-system/02-repository-layer.md
+++ b/docs/plans/simplify-id-and-folder-path-system/02-repository-layer.md
@@ -1,0 +1,118 @@
+# Milestone 2 — Repository Layer
+
+## Goal
+
+Integrate short ID assignment into the `TaskRepository` and `GoalRepository` create paths, and add `getByShortId` lookup methods. Old records without short IDs get one on first read (lazy backfill).
+
+## Context
+
+- `packages/daemon/src/storage/repositories/task-repository.ts` — `createTask()` generates UUID via `generateUUID()`, writes to `tasks` table. `getTask(id)` and `listTasks(roomId)` are the main read paths.
+- `packages/daemon/src/storage/repositories/goal-repository.ts` — same pattern for goals.
+- `ShortIdAllocator` from Milestone 1 will be injected into both repositories.
+- The `rowToTask()` and `rowToGoal()` methods map DB rows to typed objects — they must include `shortId` in their output.
+- The `NeoTask` and `RoomGoal` shared types must gain an optional `shortId?: string` field.
+
+## Tasks
+
+---
+
+### Task 2.1 — Add shortId Field to Shared Types
+
+**Description**: Add `shortId?: string` to `NeoTask` and `RoomGoal` in `packages/shared/src/types/neo.ts`. This is a non-breaking optional field.
+
+**Subtasks**:
+1. In `packages/shared/src/types/neo.ts`, add `/** Human-readable short ID (e.g. 't-42'), scoped to parent room */ shortId?: string;` to the `NeoTask` interface (after the `id` field)
+2. Add the same `shortId?: string` field to the `RoomGoal` interface
+3. Run `bun run typecheck` to confirm no type errors from the addition
+4. Run `bun run lint` to confirm no lint violations
+
+**Acceptance Criteria**:
+- `NeoTask.shortId` is an optional string field
+- `RoomGoal.shortId` is an optional string field
+- `bun run typecheck` passes
+- `bun run lint` passes
+
+**Depends on**: Milestone 1 complete
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 2.2 — Short ID Assignment in TaskRepository
+
+**Description**: Modify `TaskRepository` to inject `ShortIdAllocator`, assign a short ID on task creation, include `short_id` in row-to-object mapping, and add `getTaskByShortId(roomId, shortId)` lookup.
+
+**Subtasks**:
+1. Update `TaskRepository` constructor to accept `ShortIdAllocator` as an optional third parameter (`private shortIdAllocator?: ShortIdAllocator`)
+2. In `createTask()`, after generating the UUID, call `this.shortIdAllocator?.allocate('task', params.roomId)` and store the result; include `short_id` in the `INSERT` statement
+3. Update `rowToTask()` to include `shortId: (row.short_id as string | null) ?? undefined`
+4. Add `getTaskByShortId(roomId: string, shortId: string): NeoTask | null` — queries `SELECT * FROM tasks WHERE room_id = ? AND short_id = ?`
+5. Add lazy backfill in `getTask(id)`: if the returned task has no `shortId` and allocator is present, allocate one, update the row, and return the updated object
+6. Write unit tests:
+   - Creating a task with an allocator produces a non-null `shortId`
+   - `getTaskByShortId` finds the task by its short ID
+   - `getTaskByShortId` returns null for unknown short ID
+   - Lazy backfill on `getTask` assigns a short ID to a record that was created without one
+
+**Acceptance Criteria**:
+- New tasks created with `ShortIdAllocator` present have a `shortId` like `t-1`, `t-2`, etc.
+- `getTaskByShortId(roomId, 't-1')` returns the correct task
+- Tasks created before migration (no `short_id`) get a short ID on first `getTask()` call
+- All unit tests pass
+
+**Depends on**: Task 2.1, Milestone 1 complete
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 2.3 — Short ID Assignment in GoalRepository
+
+**Description**: Same pattern as Task 2.2, applied to `GoalRepository` for goals.
+
+**Subtasks**:
+1. Update `GoalRepository` constructor to accept `ShortIdAllocator` as an optional parameter
+2. In `createGoal()`, allocate a short ID with `allocate('goal', params.roomId)` and include `short_id` in the INSERT
+3. Update the row-to-object mapping method to include `shortId: (row.short_id as string | null) ?? undefined`
+4. Add `getGoalByShortId(roomId: string, shortId: string): RoomGoal | null`
+5. Add lazy backfill in `getGoal(id)` (same pattern as Task 2.2)
+6. Wire `ShortIdAllocator` into `GoalRepository` instantiation in the database layer (`packages/daemon/src/storage/database.ts` or wherever repositories are instantiated)
+7. Write unit tests covering the same cases as Task 2.2 for goals (uses `g-` prefix)
+
+**Acceptance Criteria**:
+- New goals have `shortId` like `g-1`, `g-2`, per room
+- `getGoalByShortId(roomId, 'g-1')` returns the correct goal
+- Unit tests pass
+
+**Depends on**: Task 2.2
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 2.4 — Wire ShortIdAllocator into Database and Room Manager
+
+**Description**: Ensure `ShortIdAllocator` is instantiated at the database level and injected into `TaskRepository`, `GoalRepository`, and the `TaskManager` / `GoalManager` so all production code paths use it.
+
+**Subtasks**:
+1. In `packages/daemon/src/storage/database.ts` (or whichever file creates repository instances), instantiate `ShortIdAllocator` from the db connection and pass it to `TaskRepository` and `GoalRepository` constructors
+2. Verify that `TaskManager` (which internally creates `TaskRepository`) also receives the allocator — trace the dependency chain from `DaemonApp`/`app.ts` through `RoomManager` and `TaskManager`
+3. Run the full daemon unit test suite (`make test-daemon`) to confirm nothing is broken by the wiring
+4. Confirm no circular dependencies are introduced (the allocator is a pure DB utility)
+
+**Acceptance Criteria**:
+- In production code paths, `TaskRepository.createTask()` always assigns a short ID
+- In production code paths, `GoalRepository.createGoal()` always assigns a short ID
+- `make test-daemon` passes
+
+**Depends on**: Task 2.3
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.

--- a/docs/plans/simplify-id-and-folder-path-system/03-api-compatibility-layer.md
+++ b/docs/plans/simplify-id-and-folder-path-system/03-api-compatibility-layer.md
@@ -1,0 +1,147 @@
+# Milestone 3 — API Compatibility Layer
+
+## Goal
+
+Update all RPC handlers for tasks and goals to (a) return `shortId` in responses, and (b) accept either a UUID or short ID wherever an ID is received as input. Also update URL route regexes in the web frontend to accept short ID formats.
+
+## Context
+
+RPC handlers in `packages/daemon/src/lib/rpc-handlers/`:
+- `task-handlers.ts` — handles `task.create`, `task.get`, `task.list`, `task.cancel`, `task.setStatus`, `task.reject`, `task.getGroup`, `task.sendHumanMessage`, `task.updateDraft`
+- `goal-handlers.ts` — handles `goal.create`, `goal.list`, `goal.get`, `goal.update`, `goal.delete`, `goal.listExecutions`
+- `room-handlers.ts` — handles `room.overview` (which embeds task and goal summaries)
+
+The input resolution pattern: create a `resolveTaskId(input, roomId, taskRepo)` helper that checks if the input looks like a UUID (`isUUID(input)`); if not, looks it up via `getTaskByShortId(roomId, input)`. Returns the UUID, or throws `404 Not Found` if neither resolves.
+
+URL routing in `packages/web/src/lib/router.ts` uses patterns like `/room/:roomId/task/:taskId` where `:taskId` matches `[a-f0-9-]+` (UUID-only regex). This must be extended to also match short ID format.
+
+## Tasks
+
+---
+
+### Task 3.1 — ID Resolution Helpers
+
+**Description**: Create `packages/daemon/src/lib/id-resolution.ts` with helper functions for resolving either UUID or short ID to a UUID, for use in all RPC handlers.
+
+**Subtasks**:
+1. Create `packages/daemon/src/lib/id-resolution.ts`
+2. Implement `resolveTaskId(input: string, roomId: string, taskRepo: TaskRepository): string`:
+   - If `isUUID(input)`, return `input` directly (UUID pass-through)
+   - Otherwise call `taskRepo.getTaskByShortId(roomId, input)` and return the task's UUID
+   - Throw `new Error('Task not found')` with a 404-equivalent message if neither resolves
+3. Implement `resolveGoalId(input: string, roomId: string, goalRepo: GoalRepository): string` — same pattern for goals
+4. Export both helpers
+5. Write unit tests for both resolvers, testing UUID pass-through, short ID resolution, and not-found error
+
+**Acceptance Criteria**:
+- `resolveTaskId('d8a578c6-...', roomId, repo)` returns the UUID without DB lookup
+- `resolveTaskId('t-42', roomId, repo)` looks up by short ID and returns the UUID
+- `resolveTaskId('t-9999', roomId, repo)` throws when task not found
+- Unit tests pass
+
+**Depends on**: Milestone 2 complete
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 3.2 — Task RPC Handlers: Return shortId and Accept Short IDs
+
+**Description**: Update `task-handlers.ts` to include `shortId` in all task responses and use `resolveTaskId` for all input IDs.
+
+**Subtasks**:
+1. Identify all handler functions in `task-handlers.ts` that receive a task ID as input: `task.get`, `task.cancel`, `task.setStatus`, `task.reject`, `task.getGroup`, `task.sendHumanMessage`, `task.updateDraft`, `task.interruptSession`
+2. For each handler that accepts `taskId`, wrap the raw input: `const resolvedId = resolveTaskId(rawTaskId, roomId, taskRepo)` before using it for DB lookup
+3. Confirm that `task.list` responses already return full `NeoTask` objects — since `rowToTask()` now maps `short_id`, the `shortId` field will be included automatically
+4. For `task.get`, ensure the response includes the `shortId` field
+5. Write unit tests for two handlers: `task.get` (assert response contains `shortId`) and `task.cancel` with a short ID input (assert the correct task is cancelled)
+
+**Acceptance Criteria**:
+- `task.get` with a short ID input (`t-1`) returns the correct task
+- `task.get` response includes `shortId` field
+- `task.list` response items include `shortId` field
+- Unit tests pass
+
+**Depends on**: Task 3.1
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 3.3 — Goal RPC Handlers: Return shortId and Accept Short IDs
+
+**Description**: Update `goal-handlers.ts` analogously to Task 3.2 for goals.
+
+**Subtasks**:
+1. Identify all handler functions in `goal-handlers.ts` that receive a goal ID as input: `goal.get`, `goal.update`, `goal.delete`, `goal.listExecutions`
+2. For each handler, use `resolveGoalId` to accept either UUID or short ID
+3. Confirm `goal.list` and `goal.get` responses include `shortId` (comes from `rowToGoal()` mapping)
+4. Write unit tests for `goal.get` with short ID input and `goal.update` with short ID
+
+**Acceptance Criteria**:
+- `goal.get` with `g-1` input returns the correct goal
+- `goal.list` response items include `shortId`
+- Unit tests pass
+
+**Depends on**: Task 3.1
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 3.4 — Update URL Route Patterns to Accept Short IDs
+
+**Description**: The web router in `packages/web/src/lib/router.ts` uses strict UUID regex patterns for route matching. These must be relaxed to also accept short ID formats (`t-42`, `g-7`, etc.).
+
+**Subtasks**:
+1. Open `packages/web/src/lib/router.ts` and locate all route pattern constants:
+   - `ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/`
+   - `ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/`
+   - `SESSION_ROUTE_PATTERN = /^\/session\/([a-f0-9-]+)$/`
+   - `ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/`
+   - Other patterns with `[a-f0-9-]+`
+2. Update the task/goal ID capture groups to also accept short ID format: change `([a-f0-9-]+)` to `([a-f0-9-]+|[a-z]-\d+)` for segments that can be task or goal IDs. Keep room/session/space ID segments as UUID-only (they are not user-facing short IDs in this milestone).
+3. Run `make test-web` to confirm no routing tests break
+4. Write unit tests for the updated patterns verifying both UUID and short ID URLs are matched
+
+**Acceptance Criteria**:
+- `/room/04062505-.../task/t-42` is matched by `ROOM_TASK_ROUTE_PATTERN`
+- `/room/04062505-.../task/d8a578c6-...` still matches (backward compat)
+- `make test-web` passes
+- Unit tests for updated patterns pass
+
+**Depends on**: Task 3.2, Task 3.3 (conceptually; can be done in parallel but should be shipped together)
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 3.5 — Room Overview Handler: Include shortId in Task and Goal Summaries
+
+**Description**: The `room.overview` RPC handler assembles a `RoomOverview` object containing task and goal summaries. Ensure `shortId` is included in `TaskSummary` and that goal summaries also carry short IDs.
+
+**Subtasks**:
+1. Locate `RoomOverview` and `TaskSummary` types in `packages/shared/src/types/neo.ts`
+2. Add `shortId?: string` to `TaskSummary` if not already present
+3. In `room-handlers.ts` (or `room-manager.ts` where `RoomOverview` is assembled), ensure the `shortId` from each `NeoTask` is propagated into the summary
+4. Run `bun run typecheck` to confirm no regressions
+5. Verify with a unit test that `room.overview` response task items include `shortId`
+
+**Acceptance Criteria**:
+- `room.overview` response contains tasks with `shortId` populated for new tasks
+- `TaskSummary` type includes optional `shortId` field
+- `bun run typecheck` passes
+
+**Depends on**: Task 3.2, Task 3.3
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.

--- a/docs/plans/simplify-id-and-folder-path-system/03-api-compatibility-layer.md
+++ b/docs/plans/simplify-id-and-folder-path-system/03-api-compatibility-layer.md
@@ -52,14 +52,16 @@ URL routing in `packages/web/src/lib/router.ts` uses patterns like `/room/:roomI
 **Description**: Update `task-handlers.ts` to include `shortId` in all task responses and use `resolveTaskId` for all input IDs.
 
 **Subtasks**:
-1. Identify all handler functions in `task-handlers.ts` that receive a task ID as input: `task.get`, `task.cancel`, `task.setStatus`, `task.reject`, `task.getGroup`, `task.sendHumanMessage`, `task.updateDraft`, `task.interruptSession`
+1. Identify all handler functions in `task-handlers.ts` that receive a task ID as input. The complete list includes: `task.get`, `task.cancel`, `task.setStatus`, `task.reject`, `task.getGroup`, `task.sendHumanMessage`, `task.updateDraft`, `task.interruptSession`, **`task.fail`** (line ~206), and **`task.archive`** (line ~317). All of these must use `resolveTaskId`.
 2. For each handler that accepts `taskId`, wrap the raw input: `const resolvedId = resolveTaskId(rawTaskId, roomId, taskRepo)` before using it for DB lookup
-3. Confirm that `task.list` responses already return full `NeoTask` objects — since `rowToTask()` now maps `short_id`, the `shortId` field will be included automatically
-4. For `task.get`, ensure the response includes the `shortId` field
-5. Write unit tests for two handlers: `task.get` (assert response contains `shortId`) and `task.cancel` with a short ID input (assert the correct task is cancelled)
+3. **Explicitly excluded handlers** (note in code comment, no change needed): `task.group.create` and `task.group.addMessage` are non-production/internal handlers that operate on session groups rather than top-level task IDs; they do not need short ID resolution in this milestone.
+4. Confirm that `task.list` responses already return full `NeoTask` objects — since `rowToTask()` now maps `short_id`, the `shortId` field will be included automatically
+5. For `task.get`, ensure the response includes the `shortId` field
+6. Write unit tests for two handlers: `task.get` (assert response contains `shortId`) and `task.cancel` with a short ID input (assert the correct task is cancelled)
 
 **Acceptance Criteria**:
 - `task.get` with a short ID input (`t-1`) returns the correct task
+- `task.fail` and `task.archive` also accept short ID inputs (not just UUIDs)
 - `task.get` response includes `shortId` field
 - `task.list` response items include `shortId` field
 - Unit tests pass
@@ -100,19 +102,22 @@ URL routing in `packages/web/src/lib/router.ts` uses patterns like `/room/:roomI
 **Description**: The web router in `packages/web/src/lib/router.ts` uses strict UUID regex patterns for route matching. These must be relaxed to also accept short ID formats (`t-42`, `g-7`, etc.).
 
 **Subtasks**:
-1. Open `packages/web/src/lib/router.ts` and locate all route pattern constants:
+1. Open `packages/web/src/lib/router.ts` and locate all route pattern constants that include task ID segments:
    - `ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/`
+   - `SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/` (line ~40)
    - `ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/`
    - `SESSION_ROUTE_PATTERN = /^\/session\/([a-f0-9-]+)$/`
    - `ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/`
-   - Other patterns with `[a-f0-9-]+`
-2. Update the task/goal ID capture groups to also accept short ID format: change `([a-f0-9-]+)` to `([a-f0-9-]+|[a-z]-\d+)` for segments that can be task or goal IDs. Keep room/session/space ID segments as UUID-only (they are not user-facing short IDs in this milestone).
-3. Run `make test-web` to confirm no routing tests break
-4. Write unit tests for the updated patterns verifying both UUID and short ID URLs are matched
+2. Update the **task ID** capture groups in `ROOM_TASK_ROUTE_PATTERN` and `SPACE_TASK_ROUTE_PATTERN` to also accept short ID format: change the task-ID segment `([a-f0-9-]+)` to `([a-f0-9-]+|[a-z]-\d+)`. The room, space, and session ID segments remain UUID-only (not user-facing short IDs in this milestone).
+   - **`SPACE_TASK_ROUTE_PATTERN` decision**: Space tasks currently use the same UUID format. Even though space-level short IDs are not in scope for this goal, the task-ID segment in this route is structurally identical to `ROOM_TASK_ROUTE_PATTERN` and should be updated consistently. This avoids a confusing inconsistency where room task short ID URLs work but space task short ID URLs silently fail.
+3. Keep room/session/space ID segments as UUID-only (these do not receive short IDs in this goal's scope)
+4. Run `make test-web` to confirm no routing tests break
+5. Write unit tests for the updated patterns verifying both UUID and short ID URLs are matched for both room-task and space-task routes
 
 **Acceptance Criteria**:
 - `/room/04062505-.../task/t-42` is matched by `ROOM_TASK_ROUTE_PATTERN`
 - `/room/04062505-.../task/d8a578c6-...` still matches (backward compat)
+- `/space/04062505-.../task/t-42` is matched by `SPACE_TASK_ROUTE_PATTERN` (consistent treatment)
 - `make test-web` passes
 - Unit tests for updated patterns pass
 

--- a/docs/plans/simplify-id-and-folder-path-system/04-worktree-path-shortening.md
+++ b/docs/plans/simplify-id-and-folder-path-system/04-worktree-path-shortening.md
@@ -29,28 +29,40 @@ The `WorktreeManager` does not store anything in the DB — it operates purely o
 
 ### Task 4.1 — Implement Project Short Key Generation in WorktreeManager
 
-**Description**: Add a `getProjectShortKey(repoPath: string): string` method to `WorktreeManager` that produces a short, deterministic, human-readable directory name for a given repo path, and update `getWorktreeBaseDir` to use it.
+**Description**: Add a `getProjectShortKey(repoPath: string): string` method to `WorktreeManager` that produces a short, deterministic, human-readable directory name for a given repo path, and update `getWorktreeBaseDir` to use it — with collision detection via a sentinel file to handle the (rare) case where two different repo paths hash to the same short key.
 
 **Subtasks**:
 1. In `packages/daemon/src/lib/worktree-manager.ts`, add a private method `getProjectShortKey(repoPath: string): string`:
    - Extract the last component of the path: `basename(repoPath)` — e.g., `dev-neokai`
-   - Compute a 8-character hex hash of the full normalized path using `Bun.hash()` or a simple djb2/FNV-1a hash (avoid importing crypto for this small utility)
+   - Compute an 8-character hex hash of the full normalized path using `Bun.hash()` or a simple djb2/FNV-1a hash (avoid importing crypto for this small utility)
    - Return `${lastComponent}-${hash8chars}` — e.g., `dev-neokai-a3b2c1d4`
    - Sanitize: replace characters invalid in directory names with `-` (keep alphanumeric, hyphens, underscores)
-2. Update `getWorktreeBaseDir(gitRoot: string)` to call `getProjectShortKey(gitRoot)` instead of `encodeRepoPath(gitRoot)`, so new worktrees go into the short path
-3. Keep `encodeRepoPath` — it is still used by `cleanupOrphanedWorktrees` to detect session worktrees (the `.includes('.neokai/projects')` check still works regardless of key format)
-4. Write unit tests for `getProjectShortKey`:
+2. Update `getWorktreeBaseDir(gitRoot: string)` to resolve the short key with collision detection (see subtask 3), so new worktrees go into the short path
+3. Implement collision detection in `getWorktreeBaseDir` using a sentinel file approach:
+   - After computing `shortKey`, determine the candidate base dir: `~/.neokai/projects/{shortKey}`
+   - **On first use** (directory doesn't exist yet): create the directory and write a `.neokai-repo-root` sentinel file inside it containing the full normalized `gitRoot` path (UTF-8 text, one line). Then return this directory as the base dir.
+   - **On subsequent use** (directory already exists): read the `.neokai-repo-root` sentinel file (if present) and compare its contents to the normalized `gitRoot`.
+     - If they match (same repo): proceed normally, return the short-key base dir.
+     - If they differ (collision — different repo mapped to same short key): log a warning (e.g., `console.warn('[WorktreeManager] Short key collision detected for "${shortKey}": expected "${storedPath}", got "${gitRoot}". Falling back to full encoding.')`) and fall back to `encodeRepoPath(gitRoot)` to produce the full-length base dir. This preserves the existing safe behavior for the colliding repo.
+   - If the directory exists but has no sentinel file (e.g., created by an older version): write the sentinel for the current repo path and proceed normally.
+4. Keep `encodeRepoPath` — it remains used by `cleanupOrphanedWorktrees` and as the collision fallback
+5. Write unit tests for `getProjectShortKey`:
    - Same path always returns the same key (deterministic)
-   - Different paths return different keys (collision resistance via hash)
    - Output contains only safe filesystem characters
    - Output is shorter than the full encoded path
+6. Write unit tests for the collision detection logic in `getWorktreeBaseDir`:
+   - **No collision**: first call for a fresh directory creates the sentinel file and returns the short-key path
+   - **Same repo, second call**: reads sentinel, confirms match, returns same short-key path
+   - **Collision scenario**: simulate two different repo paths producing the same `shortKey` — first repo claims the directory and writes its sentinel; second repo detects a mismatch, logs a warning, and falls back to the full `encodeRepoPath` encoding (the two repos resolve to different base directories)
 
 **Acceptance Criteria**:
 - `getProjectShortKey('/Users/alice/code/my-project')` returns a string like `my-project-a3b2c1d4`
 - The key is deterministic — calling twice with the same input returns the same result
-- New worktrees are created at `~/.neokai/projects/{shortKey}/worktrees/...`
+- New worktrees for a repo are created at `~/.neokai/projects/{shortKey}/worktrees/...` after the sentinel file is written
+- A `.neokai-repo-root` sentinel file is written into each short-key directory on first use, containing the full normalized repo path
+- When two different repo paths produce the same short key, the second repo logs a warning and falls back to the full `encodeRepoPath` directory — both repos operate on distinct directories with no data mixing
 - Old worktrees (with long paths) continue to work — `verifyWorktree` checks the `worktreePath` stored in DB, so existing records still point to the old path which still exists on disk
-- Unit tests pass
+- All unit tests pass (including the collision scenario test)
 
 **Depends on**: Milestone 1 complete (can run in parallel with Milestones 2–3)
 

--- a/docs/plans/simplify-id-and-folder-path-system/04-worktree-path-shortening.md
+++ b/docs/plans/simplify-id-and-folder-path-system/04-worktree-path-shortening.md
@@ -32,28 +32,29 @@ The `WorktreeManager` does not store anything in the DB — it operates purely o
 **Description**: Add a `getProjectShortKey(repoPath: string): string` method to `WorktreeManager` that produces a short, deterministic, human-readable directory name for a given repo path, and update `getWorktreeBaseDir` to use it — with collision detection via a sentinel file to handle the (rare) case where two different repo paths hash to the same short key.
 
 **Subtasks**:
-1. In `packages/daemon/src/lib/worktree-manager.ts`, add a private method `getProjectShortKey(repoPath: string): string`:
+1. In `packages/daemon/src/lib/worktree-manager.ts`, add a **public** method `getProjectShortKey(repoPath: string): string` (not private — must be accessible from unit tests; see subtask 6):
    - Extract the last component of the path: `basename(repoPath)` — e.g., `dev-neokai`
-   - Compute an 8-character hex hash of the full normalized path using `Bun.hash()` or a simple djb2/FNV-1a hash (avoid importing crypto for this small utility)
+   - Compute an 8-character hex hash of the full normalized path using `Bun.hash()`. **Important**: `Bun.hash()` returns `number | bigint`; use `(BigInt(Bun.hash(normalizedPath)) & 0xFFFFFFFFn).toString(16).padStart(8, '0')` to produce a safe 8-character hex string without BigInt truncation issues (plain `Number(bigint).toString(16)` silently truncates above 2^53).
    - Return `${lastComponent}-${hash8chars}` — e.g., `dev-neokai-a3b2c1d4`
-   - Sanitize: replace characters invalid in directory names with `-` (keep alphanumeric, hyphens, underscores)
-2. Update `getWorktreeBaseDir(gitRoot: string)` to resolve the short key with collision detection (see subtask 3), so new worktrees go into the short path
+   - Sanitize `lastComponent`: replace characters invalid in directory names with `-` (keep alphanumeric, hyphens, underscores)
+2. Update `getWorktreeBaseDir(gitRoot: string)` to resolve the short key with collision detection (see subtask 3). **The method signature stays synchronous** (`private getWorktreeBaseDir(gitRoot: string): string`) — all file I/O in this method must use synchronous Node `fs` APIs (`existsSync`, `mkdirSync`, `readFileSync`, `writeFileSync`) consistent with the existing method body, to avoid cascading `async` changes to `createWorktree` and its callers.
 3. Implement collision detection in `getWorktreeBaseDir` using a sentinel file approach:
    - After computing `shortKey`, determine the candidate base dir: `~/.neokai/projects/{shortKey}`
-   - **On first use** (directory doesn't exist yet): create the directory and write a `.neokai-repo-root` sentinel file inside it containing the full normalized `gitRoot` path (UTF-8 text, one line). Then return this directory as the base dir.
-   - **On subsequent use** (directory already exists): read the `.neokai-repo-root` sentinel file (if present) and compare its contents to the normalized `gitRoot`.
+   - **On first use** (directory doesn't exist yet): call `mkdirSync(candidateDir, { recursive: true })` and write a `.neokai-repo-root` sentinel file inside it containing the full normalized `gitRoot` path (use `writeFileSync`). Then return `candidateDir` as the base dir.
+   - **On subsequent use** (directory already exists): read the `.neokai-repo-root` sentinel file with `readFileSync` (if present) and compare its contents (trimmed) to the normalized `gitRoot`.
      - If they match (same repo): proceed normally, return the short-key base dir.
-     - If they differ (collision — different repo mapped to same short key): log a warning (e.g., `console.warn('[WorktreeManager] Short key collision detected for "${shortKey}": expected "${storedPath}", got "${gitRoot}". Falling back to full encoding.')`) and fall back to `encodeRepoPath(gitRoot)` to produce the full-length base dir. This preserves the existing safe behavior for the colliding repo.
-   - If the directory exists but has no sentinel file (e.g., created by an older version): write the sentinel for the current repo path and proceed normally.
+     - If they differ (collision — different repo mapped to same short key): use `this.logger.warn(...)` to log the collision (e.g., `this.logger.warn('Short key collision detected for "${shortKey}": expected "${storedPath}", got "${gitRoot}". Falling back to full encoding.')`) and fall back to `encodeRepoPath(gitRoot)` to produce the full-length base dir. **Do NOT use `console.warn`** — `no-console` is an error in `.oxlintrc.json` and `worktree-manager.ts` is not exempt; the file already uses `this.logger` (initialized at line ~24 as `private logger = new Logger('WorktreeManager')`).
+   - If the directory exists but has no sentinel file (e.g., created by an older version of NeoKai): write the sentinel for the current repo path using `writeFileSync` and proceed normally.
 4. Keep `encodeRepoPath` — it remains used by `cleanupOrphanedWorktrees` and as the collision fallback
 5. Write unit tests for `getProjectShortKey`:
    - Same path always returns the same key (deterministic)
    - Output contains only safe filesystem characters
    - Output is shorter than the full encoded path
-6. Write unit tests for the collision detection logic in `getWorktreeBaseDir`:
-   - **No collision**: first call for a fresh directory creates the sentinel file and returns the short-key path
+   - The 8-char hex hash is derived correctly (no BigInt truncation)
+6. Write unit tests for the collision detection logic in `getWorktreeBaseDir`. **Note on testing the collision scenario**: since `getProjectShortKey` is `public`, the test can call it directly or pass two crafted repo paths that produce the same short key. The simplest approach is to pre-create the sentinel file in a temp directory (using `mkdirSync`/`writeFileSync` in the test setup) so that `getWorktreeBaseDir` sees a directory that already belongs to a different repo — no need to find a real hash collision. Test cases:
+   - **No collision**: first call for a fresh temp directory creates the sentinel file and returns the short-key path
    - **Same repo, second call**: reads sentinel, confirms match, returns same short-key path
-   - **Collision scenario**: simulate two different repo paths producing the same `shortKey` — first repo claims the directory and writes its sentinel; second repo detects a mismatch, logs a warning, and falls back to the full `encodeRepoPath` encoding (the two repos resolve to different base directories)
+   - **Collision scenario**: pre-create the sentinel dir with path A's content, then call `getWorktreeBaseDir` with path B that hashes to the same `shortKey` — assert it logs a warning via `this.logger.warn` and returns the full `encodeRepoPath` result instead of the short-key path
 
 **Acceptance Criteria**:
 - `getProjectShortKey('/Users/alice/code/my-project')` returns a string like `my-project-a3b2c1d4`

--- a/docs/plans/simplify-id-and-folder-path-system/04-worktree-path-shortening.md
+++ b/docs/plans/simplify-id-and-folder-path-system/04-worktree-path-shortening.md
@@ -21,7 +21,7 @@ Proposed short key: last path component of the repo root + first 8 characters of
 
 The `WorktreeManager` does not store anything in the DB — it operates purely on the filesystem. The path shortening is purely a filesystem naming change.
 
-**Backward compatibility**: The old long path must still be recognized when checking if an existing session's worktree path is valid (`verifyWorktree`). The DB `worktree_path` column stores the actual path of the worktree directory, so old sessions already have the long path stored. New sessions get the short path. Both coexist.
+**Backward compatibility**: The old long path must still be recognized when checking if an existing session's worktree path is valid (`verifyWorktree`). Critically, `verifyWorktree` does **not** recompute the path from the repo root — it uses the `worktree_path` value already stored in the DB for that session record. Old session records store the old long path; `verifyWorktree` reads that stored value and checks it against the filesystem. As long as the directory still exists at the old path, old sessions continue to work with zero changes. New session records will store the new short path. Both formats coexist in the DB indefinitely with no conflict.
 
 ## Tasks
 

--- a/docs/plans/simplify-id-and-folder-path-system/04-worktree-path-shortening.md
+++ b/docs/plans/simplify-id-and-folder-path-system/04-worktree-path-shortening.md
@@ -1,0 +1,82 @@
+# Milestone 4 — Worktree Path Shortening
+
+## Goal
+
+Shorten the worktree base directory path by replacing the full encoded repo path (e.g., `-Users-lsm-focus-dev-neokai`) with a short project key derived from the repo path. The git branch name remains unchanged. Existing worktrees continue to work via the old path; new worktrees use the shorter path.
+
+## Context
+
+Current worktree path format:
+```
+~/.neokai/projects/{full-encoded-repo-path}/worktrees/{safeSessionId}
+```
+Example:
+```
+/Users/lsm/.neokai/projects/-Users-lsm-focus-dev-neokai/worktrees/planner-04062505-...
+```
+
+The long encoded path comes from `WorktreeManager.encodeRepoPath()` in `packages/daemon/src/lib/worktree-manager.ts`. The `getWorktreeBaseDir()` method uses this encoding to produce the base directory.
+
+Proposed short key: last path component of the repo root + first 8 characters of a deterministic hash of the full path. Example: `dev-neokai-a3b2c1d4`. This is human-readable, unique, and deterministic (same repo path always produces the same short key).
+
+The `WorktreeManager` does not store anything in the DB — it operates purely on the filesystem. The path shortening is purely a filesystem naming change.
+
+**Backward compatibility**: The old long path must still be recognized when checking if an existing session's worktree path is valid (`verifyWorktree`). The DB `worktree_path` column stores the actual path of the worktree directory, so old sessions already have the long path stored. New sessions get the short path. Both coexist.
+
+## Tasks
+
+---
+
+### Task 4.1 — Implement Project Short Key Generation in WorktreeManager
+
+**Description**: Add a `getProjectShortKey(repoPath: string): string` method to `WorktreeManager` that produces a short, deterministic, human-readable directory name for a given repo path, and update `getWorktreeBaseDir` to use it.
+
+**Subtasks**:
+1. In `packages/daemon/src/lib/worktree-manager.ts`, add a private method `getProjectShortKey(repoPath: string): string`:
+   - Extract the last component of the path: `basename(repoPath)` — e.g., `dev-neokai`
+   - Compute a 8-character hex hash of the full normalized path using `Bun.hash()` or a simple djb2/FNV-1a hash (avoid importing crypto for this small utility)
+   - Return `${lastComponent}-${hash8chars}` — e.g., `dev-neokai-a3b2c1d4`
+   - Sanitize: replace characters invalid in directory names with `-` (keep alphanumeric, hyphens, underscores)
+2. Update `getWorktreeBaseDir(gitRoot: string)` to call `getProjectShortKey(gitRoot)` instead of `encodeRepoPath(gitRoot)`, so new worktrees go into the short path
+3. Keep `encodeRepoPath` — it is still used by `cleanupOrphanedWorktrees` to detect session worktrees (the `.includes('.neokai/projects')` check still works regardless of key format)
+4. Write unit tests for `getProjectShortKey`:
+   - Same path always returns the same key (deterministic)
+   - Different paths return different keys (collision resistance via hash)
+   - Output contains only safe filesystem characters
+   - Output is shorter than the full encoded path
+
+**Acceptance Criteria**:
+- `getProjectShortKey('/Users/alice/code/my-project')` returns a string like `my-project-a3b2c1d4`
+- The key is deterministic — calling twice with the same input returns the same result
+- New worktrees are created at `~/.neokai/projects/{shortKey}/worktrees/...`
+- Old worktrees (with long paths) continue to work — `verifyWorktree` checks the `worktreePath` stored in DB, so existing records still point to the old path which still exists on disk
+- Unit tests pass
+
+**Depends on**: Milestone 1 complete (can run in parallel with Milestones 2–3)
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 4.2 — Update TEST_WORKTREE_BASE_DIR Handling and Integration Tests
+
+**Description**: The `WorktreeManager` has a `TEST_WORKTREE_BASE_DIR` environment variable override for tests. Ensure test infrastructure continues to work with the new short key. Also run the worktree manager unit tests and fix any failures.
+
+**Subtasks**:
+1. Run existing `WorktreeManager` unit tests (`cd packages/daemon && bun test tests/unit/worktree/`) and confirm they still pass after the `getWorktreeBaseDir` change
+2. If tests use hardcoded path expectations that include the old encoded format, update them to use the new short key format
+3. Add a unit test that verifies `getWorktreeBaseDir` with the new format still respects `TEST_WORKTREE_BASE_DIR` when set
+4. Add a unit test that verifies a worktree created with the old long path format is still recognized by `verifyWorktree` (simulate old-format path in the DB record)
+
+**Acceptance Criteria**:
+- All worktree unit tests pass
+- The `TEST_WORKTREE_BASE_DIR` override still works correctly
+- The transition test (old path format still valid in `verifyWorktree`) passes
+
+**Depends on**: Task 4.1
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.

--- a/docs/plans/simplify-id-and-folder-path-system/05-ui-display.md
+++ b/docs/plans/simplify-id-and-folder-path-system/05-ui-display.md
@@ -1,0 +1,98 @@
+# Milestone 5 — UI Display
+
+## Goal
+
+Display short IDs in the web frontend for tasks and goals — in task cards, the room task list, and detail views — and provide a copy-to-clipboard helper that copies the short ID. Short IDs link to the correct URL routes.
+
+## Context
+
+The frontend is a Preact + Signals app. Key files:
+- `packages/web/src/components/room/` — room-related components including task list, task card, goals editor
+- `packages/web/src/lib/room-store.ts` — room data store, receives tasks and goals via RPC/live query
+- Task and goal objects received from the API now include `shortId` (from Milestone 3)
+
+After Milestone 3, the API returns `shortId` on task and goal objects. The UI just needs to display it and use it in URLs where appropriate.
+
+URL pattern for tasks: `/room/{roomId}/task/{taskId}` — for navigation purposes, the short ID can be used in place of the UUID. When navigating with a short ID URL, the router (updated in Milestone 3) correctly matches it, and the RPC handler (also updated in Milestone 3) resolves it.
+
+## Tasks
+
+---
+
+### Task 5.1 — Display Short IDs in Task Cards
+
+**Description**: Update task card and task list components to show the short ID (`t-42`) prominently alongside or instead of the truncated UUID.
+
+**Subtasks**:
+1. Locate the task card component(s) in `packages/web/src/components/room/` (likely `TaskCard.tsx` or similar)
+2. If `task.shortId` is present, display it as a small badge/label (e.g., `#t-42`) near the task title
+3. Make the short ID clickable — clicking it copies `t-42` to the clipboard (use `navigator.clipboard.writeText`)
+4. Add a tooltip on hover: "Click to copy short ID"
+5. If `task.shortId` is absent (old task without short ID), fall back to showing the first 8 chars of the UUID (existing truncation behavior, or no badge)
+6. Update the task detail URL navigation: when constructing `/room/{roomId}/task/{taskId}`, prefer `task.shortId` over `task.id` if available, so URLs are shorter in the address bar
+7. Run `make test-web` to confirm no regressions
+
+**Acceptance Criteria**:
+- Tasks with `shortId` show a `#t-42` badge in the task card
+- Clicking the badge copies the short ID to clipboard
+- Task detail URL uses short ID when available (e.g., `/room/04062505.../task/t-42`)
+- Tasks without `shortId` show no badge (graceful degradation)
+- `make test-web` passes
+
+**Depends on**: Milestone 3 complete (API returns `shortId`)
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 5.2 — Display Short IDs in Goals Editor
+
+**Description**: Update `GoalsEditor.tsx` to show short IDs for goals similarly to Task 5.1 for tasks.
+
+**Subtasks**:
+1. Locate `packages/web/src/components/room/GoalsEditor.tsx`
+2. In the goal list view, add a short ID badge (`#g-7`) near the goal title if `goal.shortId` is present
+3. Make the badge copy the short ID to clipboard on click
+4. Add graceful fallback for goals without `shortId`
+5. Run `make test-web`
+
+**Acceptance Criteria**:
+- Goals with `shortId` display a `#g-7` badge
+- Clicking the badge copies the short ID
+- `make test-web` passes
+
+**Depends on**: Task 5.1
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 5.3 — E2E Test: Short ID Display and Copy
+
+**Description**: Add a Playwright e2e test that verifies short IDs appear in the UI and the copy-to-clipboard action works.
+
+**Subtasks**:
+1. Create `packages/e2e/tests/features/short-id-display.e2e.ts`
+2. Test flow:
+   a. Create a room and create a task via the UI
+   b. Assert that a short ID badge (e.g., `#t-1`) appears in the task card
+   c. Click the badge — verify the clipboard receives the short ID string (use `page.evaluate(() => navigator.clipboard.readText())`)
+   d. Navigate to the task detail page via the short ID URL (e.g., `/room/{roomId}/task/t-1`) and assert the task title is visible
+3. Follow E2E test rules: all actions through UI, no direct RPC in test actions, only cleanup via RPC in `afterEach`
+4. Run the e2e test: `make run-e2e TEST=tests/features/short-id-display.e2e.ts`
+
+**Acceptance Criteria**:
+- Short ID badge appears in the task card after task creation
+- Badge click copies the short ID to clipboard
+- Navigating to `/room/{roomId}/task/t-1` loads the task detail page
+- E2e test passes with `make run-e2e`
+
+**Depends on**: Task 5.1, Task 5.2
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.

--- a/docs/plans/simplify-id-and-folder-path-system/06-tests-and-validation.md
+++ b/docs/plans/simplify-id-and-folder-path-system/06-tests-and-validation.md
@@ -1,0 +1,138 @@
+# Milestone 6 — Tests and Validation
+
+## Goal
+
+Add comprehensive unit tests, integration tests, and validation to confirm the short ID system works end-to-end: multi-tenant isolation, backward compatibility with UUID-only records, short ID stability across daemon restarts, and no regressions in existing functionality.
+
+## Context
+
+By this milestone, all coding work from Milestones 1–5 is complete. This milestone focuses on:
+1. Multi-tenant isolation proof: counters in different rooms are independent
+2. Daemon restart stability: short IDs written to DB survive daemon restart
+3. Backward compat: UUID-only records (old tasks/goals without `short_id`) still work everywhere
+4. No regression: all existing tests still pass, no UUID-based functionality broken
+5. Online test: verify the full flow using a live daemon (using the dev proxy or real API)
+
+## Tasks
+
+---
+
+### Task 6.1 — Multi-Tenant Isolation Unit Tests
+
+**Description**: Write targeted unit tests proving that short ID counters are scoped per room and do not bleed across rooms.
+
+**Subtasks**:
+1. Create `packages/daemon/tests/unit/short-id/multi-tenant.test.ts`
+2. Test cases:
+   - Create tasks in Room A (`t-1`, `t-2`, `t-3`) and Room B (`t-1`, `t-2`) — assert they are completely independent
+   - Attempt to look up Room A's `t-1` using Room B's `getTaskByShortId` — assert it returns `null`
+   - Create goals in Room A and Room B — assert `g-1` exists in both independently
+   - Verify `short_id_counters` table has separate rows for each `(entity_type, scope_id)` pair
+3. Use an in-memory SQLite database for speed (no external dependencies)
+
+**Acceptance Criteria**:
+- Room A and Room B both have `t-1` tasks with different UUIDs
+- Cross-room lookup returns `null`
+- All tests pass
+
+**Depends on**: Milestone 2 complete
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 6.2 — Backward Compatibility Unit Tests
+
+**Description**: Write tests covering the legacy path — tasks and goals that exist in the DB without a `short_id` value (simulating records created before this feature was deployed).
+
+**Subtasks**:
+1. Create `packages/daemon/tests/unit/short-id/backward-compat.test.ts`
+2. Test cases:
+   - Insert a raw task row into the DB without `short_id` (simulating a legacy record)
+   - Call `getTask(id)` on the legacy record — assert it returns a valid `NeoTask` (with `shortId` assigned via lazy backfill)
+   - Call `task.get` RPC handler with the UUID of the legacy record — assert it succeeds and returns `shortId`
+   - Call `task.get` RPC handler with a short ID for the legacy record — assert it resolves (since backfill assigned one on the previous UUID-based call)
+   - Assert that `task.list` for a room with a mix of new tasks (with `short_id`) and old tasks (without) returns all tasks, with `shortId` populated for all (lazy backfill on list)
+3. For the list test: implement lazy backfill in `listTasks` — after fetching rows, for any row with null `short_id`, allocate one and update the DB. This is a controlled, bounded operation since rooms have at most hundreds of tasks.
+
+**Note**: If lazy backfill in `listTasks` is deemed too expensive (unlikely given task counts), the fallback is to return `undefined` `shortId` for legacy tasks in list results, and only backfill on `getTask(id)`. Document the chosen approach.
+
+**Acceptance Criteria**:
+- Legacy tasks (no `short_id` in DB) work with UUID-based API calls
+- Lazy backfill on `getTask` assigns a short ID to legacy tasks on first read
+- `task.list` returns all tasks (legacy and new) without errors
+- Backward compat tests pass
+
+**Depends on**: Milestone 3 complete
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 6.3 — Online Integration Test: Full Short ID Flow
+
+**Description**: Write an online integration test (in `packages/daemon/tests/online/`) that exercises the full short ID lifecycle through the daemon.
+
+**Subtasks**:
+1. Create `packages/daemon/tests/online/room/short-id-flow.test.ts`
+2. Test flow:
+   a. Create a room via `room.create` RPC
+   b. Create two tasks via `task.create` — assert both have `shortId` in the response (`t-1`, `t-2`)
+   c. Fetch each task by short ID via `task.get` with `taskId: 't-1'` — assert correct task returned
+   d. Create a goal via `goal.create` — assert `shortId` is `g-1`
+   e. Fetch `room.overview` — assert task summaries include `shortId`
+   f. Create another room and create a task — assert its `shortId` is also `t-1` (independent counter)
+   g. Clean up rooms via `room.delete`
+3. Add the test module to the CI matrix (in `.github/workflows/` or equivalent CI config)
+4. Run with `NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/room/short-id-flow.test.ts`
+
+**Acceptance Criteria**:
+- Task `shortId` values are `t-1`, `t-2`, etc. in creation order per room
+- Goal `shortId` is `g-1`
+- Cross-room isolation verified: two rooms each have independent `t-1`
+- `room.overview` includes `shortId` in task summaries
+- Test passes with dev proxy
+
+**Depends on**: Task 6.1, Task 6.2
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.
+
+---
+
+### Task 6.4 — Final Regression Pass and PR Merge Readiness Check
+
+**Description**: Run the full test suite, fix any regressions, update CLAUDE.md if needed, and confirm all acceptance criteria from the goal description are met.
+
+**Subtasks**:
+1. Run `make test-daemon` — fix any failures
+2. Run `make test-web` — fix any failures
+3. Run `bun run check` (lint + typecheck + knip) — fix any dead exports or type errors
+4. Run `make run-e2e TEST=tests/features/short-id-display.e2e.ts` — confirm e2e passes
+5. Review the goal's acceptance criteria checklist and confirm each item is satisfied:
+   - Task/goal/session IDs display as short IDs in UI ✓
+   - Both UUID and short ID accepted as input in all APIs ✓
+   - Worktree paths significantly shorter ✓
+   - Existing UUID-based links work ✓
+   - No DB migration required (only additive schema changes) ✓
+   - Multi-tenant isolation verified ✓
+   - Unit tests for short ID computation and parsing ✓
+6. If any item is missing, file a follow-up task or fix it in this PR
+
+**Acceptance Criteria**:
+- All acceptance criteria from the goal description are checked off
+- `make test-daemon` passes
+- `make test-web` passes
+- `bun run check` passes
+- E2e test passes
+
+**Depends on**: All previous tasks complete
+
+**Agent type**: coder
+
+**Branch/PR**: Changes must be on a feature branch with a GitHub PR created via `gh pr create` targeting `dev`.

--- a/docs/plans/simplify-id-and-folder-path-system/06-tests-and-validation.md
+++ b/docs/plans/simplify-id-and-folder-path-system/06-tests-and-validation.md
@@ -47,17 +47,16 @@ By this milestone, all coding work from Milestones 1–5 is complete. This miles
 
 **Description**: Write tests covering the legacy path — tasks and goals that exist in the DB without a `short_id` value (simulating records created before this feature was deployed).
 
+**Note on scope**: This task is **tests-only**. The lazy backfill implementation in `listTasks` was already added to `TaskRepository` in Task 2.2 and the analogous method in `GoalRepository` in Task 2.3. This task verifies correctness of that implementation with targeted backward-compat tests.
+
 **Subtasks**:
 1. Create `packages/daemon/tests/unit/short-id/backward-compat.test.ts`
 2. Test cases:
-   - Insert a raw task row into the DB without `short_id` (simulating a legacy record)
+   - Insert a raw task row into the DB without `short_id` (simulating a legacy record — use direct SQL `INSERT` to bypass `TaskRepository.createTask`)
    - Call `getTask(id)` on the legacy record — assert it returns a valid `NeoTask` (with `shortId` assigned via lazy backfill)
    - Call `task.get` RPC handler with the UUID of the legacy record — assert it succeeds and returns `shortId`
    - Call `task.get` RPC handler with a short ID for the legacy record — assert it resolves (since backfill assigned one on the previous UUID-based call)
-   - Assert that `task.list` for a room with a mix of new tasks (with `short_id`) and old tasks (without) returns all tasks, with `shortId` populated for all (lazy backfill on list)
-3. For the list test: implement lazy backfill in `listTasks` — after fetching rows, for any row with null `short_id`, allocate one and update the DB. This is a controlled, bounded operation since rooms have at most hundreds of tasks.
-
-**Note**: If lazy backfill in `listTasks` is deemed too expensive (unlikely given task counts), the fallback is to return `undefined` `shortId` for legacy tasks in list results, and only backfill on `getTask(id)`. Document the chosen approach.
+   - Assert that `task.list` for a room with a mix of new tasks (with `short_id`) and old tasks (without) returns all tasks with `shortId` populated for all rows (backfill already implemented in Task 2.2)
 
 **Acceptance Criteria**:
 - Legacy tasks (no `short_id` in DB) work with UUID-based API calls
@@ -87,7 +86,10 @@ By this milestone, all coding work from Milestones 1–5 is complete. This miles
    e. Fetch `room.overview` — assert task summaries include `shortId`
    f. Create another room and create a task — assert its `shortId` is also `t-1` (independent counter)
    g. Clean up rooms via `room.delete`
-3. Add the test module to the CI matrix (in `.github/workflows/` or equivalent CI config)
+3. Add the test module to CI in **two places**:
+   - In `.github/workflows/` YAML (the online test matrix), add an entry for the new test file under the `room` module group
+   - In `validate-online-test-matrix.sh` (if it exists), add `short-id-flow.test.ts` to the `ROOM_FILES` array so the validation script doesn't fail
+   - **Note**: Check whether existing room online tests in the YAML matrix are commented out (they may be disabled due to resource usage). If so, add the new test as commented-out too — consistent with the team's decision to gate those tests. Document this in the test file header comment.
 4. Run with `NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/room/short-id-flow.test.ts`
 
 **Acceptance Criteria**:
@@ -115,7 +117,7 @@ By this milestone, all coding work from Milestones 1–5 is complete. This miles
 3. Run `bun run check` (lint + typecheck + knip) — fix any dead exports or type errors
 4. Run `make run-e2e TEST=tests/features/short-id-display.e2e.ts` — confirm e2e passes
 5. Review the goal's acceptance criteria checklist and confirm each item is satisfied:
-   - Task/goal/session IDs display as short IDs in UI ✓
+   - Task and goal IDs display as short IDs in UI ✓ (**session IDs are out of scope** — see overview)
    - Both UUID and short ID accepted as input in all APIs ✓
    - Worktree paths significantly shorter ✓
    - Existing UUID-based links work ✓


### PR DESCRIPTION
## Summary

- Adds a multi-file plan (6 milestones, ~18 tasks) for replacing full UUIDs with short, scoped IDs (`t-42`, `g-7`) in user-facing surfaces
- Covers the full stack: shared utilities, DB migration, repository layer, RPC API compatibility, worktree path shortening, UI display, and e2e tests
- Backward compatible by design: all existing UUID-based APIs continue to work; new short IDs are additive

## Plan Structure

- `00-overview.md` — goal, approach, milestone list, dependencies
- `01-short-id-infrastructure.md` — utilities, DB migration, allocator service
- `02-repository-layer.md` — short ID assignment and lookup in Task/Goal repositories
- `03-api-compatibility-layer.md` — RPC handlers return shortId, accept UUID or short ID; URL route regex updates
- `04-worktree-path-shortening.md` — shorter project key in worktree base directory
- `05-ui-display.md` — short ID badges in task/goal cards, copy-to-clipboard, e2e test
- `06-tests-and-validation.md` — multi-tenant isolation, backward compat, online integration test, regression pass

## Test plan

- [ ] Plan files are readable and self-contained
- [ ] Each task has clear acceptance criteria and dependency chain
- [ ] No implementation code changed in this PR