### PR TITLE
feat(storage): add migration 47 — short_id columns and short_id_counters table

### DIFF
--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -162,6 +162,7 @@ export function createTables(db: BunDatabase): void {
         pr_created_at INTEGER,
         input_draft TEXT,
         updated_at INTEGER,
+        short_id TEXT,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
       )
     `);
@@ -197,9 +198,28 @@ export function createTables(db: BunDatabase): void {
         max_planning_attempts INTEGER NOT NULL DEFAULT 0,
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
         replan_count INTEGER NOT NULL DEFAULT 0,
+        short_id TEXT,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
       )
     `);
+
+	// Short ID counters — per-(entity_type, scope_id) monotonic counter for short ID allocation
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS short_id_counters (
+        entity_type TEXT NOT NULL,
+        scope_id    TEXT NOT NULL,
+        counter     INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (entity_type, scope_id)
+      )
+    `);
+
+	// Partial unique indexes for short_id on tasks and goals
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_short_id ON tasks(short_id) WHERE short_id IS NOT NULL`
+	);
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_short_id ON goals(short_id) WHERE short_id IS NOT NULL`
+	);
 
 	// Mission metric history table
 	db.exec(`

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -15,6 +15,8 @@ import { DEFAULT_GLOBAL_TOOLS_CONFIG, DEFAULT_GLOBAL_SETTINGS } from '@neokai/sh
 export { runMigrations } from './migrations';
 // knip-ignore-next-line
 export { runMigration12 } from './migrations';
+// knip-ignore-next-line
+export { runMigration47 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2931,7 +2931,7 @@ function runMigration46(db: BunDatabase): void {
  *
  * Idempotent: ALTER TABLE is guarded by tableHasColumn(); CREATE TABLE/INDEX use IF NOT EXISTS.
  */
-function runMigration47(db: BunDatabase): void {
+export function runMigration47(db: BunDatabase): void {
 	// On existing DBs, ALTER TABLE adds the column; on fresh DBs the column is already
 	// present in the CREATE TABLE statement in createTables(), so tableHasColumn() guards
 	// prevent a duplicate-column error.

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -178,6 +178,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Stores the WorkflowNodeAgent.role of the slot that spawned a task, enabling
 	// unambiguous slot lookup when the same agentId appears multiple times in a node.
 	runMigration46(db);
+
+	// Migration 47: Add short_id columns to tasks and goals, create short_id_counters table.
+	// Enables human-readable scoped short IDs for tasks and goals (e.g. t:04062505:42).
+	// New columns are nullable — existing rows get NULL until short IDs are assigned.
+	runMigration47(db);
 }
 
 /**
@@ -2914,4 +2919,49 @@ function runMigration46(db: BunDatabase): void {
 	if (!tableHasColumn(db, 'space_tasks', 'slot_role')) {
 		db.exec(`ALTER TABLE space_tasks ADD COLUMN slot_role TEXT`);
 	}
+}
+
+/**
+ * Migration 47: Add short_id columns to tasks and goals; create short_id_counters table.
+ *
+ * - `tasks.short_id TEXT` — nullable, unique where not null (partial index).
+ * - `goals.short_id TEXT` — nullable, unique where not null (partial index).
+ * - `short_id_counters` — per-(entity_type, scope_id) monotonic counter used by the
+ *   ShortIdAllocator service when assigning short IDs to new or existing records.
+ *
+ * Idempotent: ALTER TABLE is guarded by tableHasColumn(); CREATE TABLE/INDEX use IF NOT EXISTS.
+ */
+function runMigration47(db: BunDatabase): void {
+	// On existing DBs, ALTER TABLE adds the column; on fresh DBs the column is already
+	// present in the CREATE TABLE statement in createTables(), so tableHasColumn() guards
+	// prevent a duplicate-column error.
+	if (tableExists(db, 'tasks') && !tableHasColumn(db, 'tasks', 'short_id')) {
+		db.exec(`ALTER TABLE tasks ADD COLUMN short_id TEXT`);
+	}
+	if (tableExists(db, 'goals') && !tableHasColumn(db, 'goals', 'short_id')) {
+		db.exec(`ALTER TABLE goals ADD COLUMN short_id TEXT`);
+	}
+
+	// Partial unique indexes — safe on both fresh and existing DBs; also created by createTables()
+	// via IF NOT EXISTS.
+	if (tableExists(db, 'tasks')) {
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_short_id ON tasks(short_id) WHERE short_id IS NOT NULL`
+		);
+	}
+	if (tableExists(db, 'goals')) {
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_short_id ON goals(short_id) WHERE short_id IS NOT NULL`
+		);
+	}
+
+	// Counter table — also created by createTables() for fresh DBs; IF NOT EXISTS is idempotent.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS short_id_counters (
+			entity_type TEXT NOT NULL,
+			scope_id    TEXT NOT NULL,
+			counter     INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (entity_type, scope_id)
+		)
+	`);
 }

--- a/packages/daemon/tests/unit/storage/migrations/migration-47_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-47_test.ts
@@ -11,12 +11,16 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { runMigrations, createTables } from '../../../../src/storage/schema/index.ts';
+import {
+	runMigrations,
+	createTables,
+	runMigration47,
+} from '../../../../src/storage/schema/index.ts';
 
 function columnExists(db: BunDatabase, table: string, column: string): boolean {
 	const result = db
-		.prepare(`SELECT name FROM pragma_table_info('${table}') WHERE name = ?`)
-		.get(column);
+		.prepare(`SELECT name FROM pragma_table_info(?) WHERE name = ?`)
+		.get(table, column);
 	return !!result;
 }
 
@@ -60,6 +64,8 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 		}
 	});
 
+	// ── Fresh DB (createTables path) ────────────────────────────────────────────
+
 	test('fresh DB has short_id column on tasks', () => {
 		runMigrations(db, () => {});
 		createTables(db);
@@ -79,23 +85,113 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 		createTables(db);
 
 		expect(tableExists(db, 'short_id_counters')).toBe(true);
-
-		// Verify columns
 		expect(columnExists(db, 'short_id_counters', 'entity_type')).toBe(true);
 		expect(columnExists(db, 'short_id_counters', 'scope_id')).toBe(true);
 		expect(columnExists(db, 'short_id_counters', 'counter')).toBe(true);
 	});
 
+	test('partial unique indexes exist for tasks and goals short_id', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		expect(indexExists(db, 'idx_tasks_short_id')).toBe(true);
+		expect(indexExists(db, 'idx_goals_short_id')).toBe(true);
+	});
+
+	// ── Existing DB (ALTER TABLE migration path) ────────────────────────────────
+
+	test('existing DB without short_id gets columns added by migration', () => {
+		// Simulate an existing database that pre-dates migration 47:
+		// create rooms/tasks/goals tables WITHOUT the short_id column.
+		db.exec(`
+			CREATE TABLE rooms (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE tasks (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending',
+				priority TEXT NOT NULL DEFAULT 'normal',
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			CREATE TABLE goals (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'active',
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			)
+		`);
+
+		// Seed data before migration
+		db.exec(`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('r1', 'Room', 1, 1)`);
+		db.exec(
+			`INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at) VALUES ('t1', 'r1', 'Task', '', 'pending', 'normal', 1, 1)`
+		);
+		db.exec(
+			`INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at) VALUES ('g1', 'r1', 'Goal', '', 'active', 1, 1)`
+		);
+
+		// Columns should NOT exist before migration
+		expect(columnExists(db, 'tasks', 'short_id')).toBe(false);
+		expect(columnExists(db, 'goals', 'short_id')).toBe(false);
+
+		// Run only migration 47 directly — simulates upgrading an existing DB where all
+		// prior migrations have already been applied and only this new migration runs.
+		runMigration47(db);
+
+		// Columns should now exist
+		expect(columnExists(db, 'tasks', 'short_id')).toBe(true);
+		expect(columnExists(db, 'goals', 'short_id')).toBe(true);
+
+		// Indexes should exist
+		expect(indexExists(db, 'idx_tasks_short_id')).toBe(true);
+		expect(indexExists(db, 'idx_goals_short_id')).toBe(true);
+
+		// Counter table should exist
+		expect(tableExists(db, 'short_id_counters')).toBe(true);
+
+		// Existing data should be intact with NULL short_id
+		const task = db.prepare(`SELECT title, short_id FROM tasks WHERE id='t1'`).get() as {
+			title: string;
+			short_id: string | null;
+		};
+		expect(task.title).toBe('Task');
+		expect(task.short_id).toBeNull();
+
+		const goal = db.prepare(`SELECT title, short_id FROM goals WHERE id='g1'`).get() as {
+			title: string;
+			short_id: string | null;
+		};
+		expect(goal.title).toBe('Goal');
+		expect(goal.short_id).toBeNull();
+	});
+
+	// ── Counter table behavior ──────────────────────────────────────────────────
+
 	test('short_id_counters table enforces composite PRIMARY KEY', () => {
 		runMigrations(db, () => {});
 		createTables(db);
 
-		// Insert a row
 		db.exec(
 			`INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES ('task', 'room-1', 1)`
 		);
 
-		// Inserting duplicate (entity_type, scope_id) should fail
+		// Duplicate (entity_type, scope_id) should fail
 		expect(() => {
 			db.exec(
 				`INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES ('task', 'room-1', 2)`
@@ -117,13 +213,7 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 		}).not.toThrow();
 	});
 
-	test('partial unique indexes exist for tasks and goals short_id', () => {
-		runMigrations(db, () => {});
-		createTables(db);
-
-		expect(indexExists(db, 'idx_tasks_short_id')).toBe(true);
-		expect(indexExists(db, 'idx_goals_short_id')).toBe(true);
-	});
+	// ── Partial unique index semantics — tasks ──────────────────────────────────
 
 	test('tasks short_id unique index allows multiple NULLs', () => {
 		runMigrations(db, () => {});
@@ -133,7 +223,7 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-uuid-1', 'Test Room', 1000, 1000)`
 		);
 
-		// Insert two tasks without short_id — both NULL should be allowed
+		// Insert two tasks without short_id — multiple NULLs should be allowed
 		db.exec(`
 			INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at)
 			VALUES
@@ -141,7 +231,6 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 				('task-uuid-2', 'room-uuid-1', 'Task 2', '', 'pending', 'normal', 1001, 1001)
 		`);
 
-		// Both have NULL short_id — should be fine (partial index only covers non-null)
 		const rows = db
 			.prepare(`SELECT short_id FROM tasks WHERE id IN ('task-uuid-1', 'task-uuid-2')`)
 			.all() as Array<{ short_id: string | null }>;
@@ -169,11 +258,57 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 		}).toThrow();
 	});
 
+	// ── Partial unique index semantics — goals ──────────────────────────────────
+
+	test('goals short_id unique index allows multiple NULLs', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-uuid-1', 'Test Room', 1000, 1000)`
+		);
+
+		// Insert two goals without short_id — multiple NULLs should be allowed
+		db.exec(`
+			INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at)
+			VALUES
+				('goal-uuid-1', 'room-uuid-1', 'Goal 1', '', 'active', 1000, 1000),
+				('goal-uuid-2', 'room-uuid-1', 'Goal 2', '', 'active', 1001, 1001)
+		`);
+
+		const rows = db
+			.prepare(`SELECT short_id FROM goals WHERE id IN ('goal-uuid-1', 'goal-uuid-2')`)
+			.all() as Array<{ short_id: string | null }>;
+		expect(rows.every((r) => r.short_id === null)).toBe(true);
+	});
+
+	test('goals short_id unique index rejects duplicate non-null values', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-uuid-1', 'Test Room', 1000, 1000)`
+		);
+
+		db.exec(`
+			INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
+			VALUES ('goal-uuid-1', 'room-uuid-1', 'Goal 1', '', 'active', 1000, 1000, 'g:roomabc:1')
+		`);
+
+		expect(() => {
+			db.exec(`
+				INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
+				VALUES ('goal-uuid-2', 'room-uuid-1', 'Goal 2', '', 'active', 1001, 1001, 'g:roomabc:1')
+			`);
+		}).toThrow();
+	});
+
+	// ── Idempotency ─────────────────────────────────────────────────────────────
+
 	test('migration is idempotent — running runMigrations twice does not throw', () => {
 		runMigrations(db, () => {});
 		createTables(db);
 
-		// Running migrations a second time should be safe
 		expect(() => {
 			runMigrations(db, () => {});
 		}).not.toThrow();

--- a/packages/daemon/tests/unit/storage/migrations/migration-47_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-47_test.ts
@@ -1,0 +1,181 @@
+/**
+ * Migration 47 Tests
+ *
+ * Migration 47 adds short_id support:
+ * - tasks.short_id TEXT (nullable, unique where not null)
+ * - goals.short_id TEXT (nullable, unique where not null)
+ * - short_id_counters table (entity_type, scope_id) PRIMARY KEY
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations, createTables } from '../../../../src/storage/schema/index.ts';
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM pragma_table_info('${table}') WHERE name = ?`)
+		.get(column);
+	return !!result;
+}
+
+function tableExists(db: BunDatabase, tableName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(tableName);
+	return !!result;
+}
+
+function indexExists(db: BunDatabase, indexName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+		.get(indexName);
+	return !!result;
+}
+
+describe('Migration 47: add short_id columns and short_id_counters table', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-47', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('fresh DB has short_id column on tasks', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		expect(columnExists(db, 'tasks', 'short_id')).toBe(true);
+	});
+
+	test('fresh DB has short_id column on goals', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		expect(columnExists(db, 'goals', 'short_id')).toBe(true);
+	});
+
+	test('fresh DB has short_id_counters table with correct schema', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		expect(tableExists(db, 'short_id_counters')).toBe(true);
+
+		// Verify columns
+		expect(columnExists(db, 'short_id_counters', 'entity_type')).toBe(true);
+		expect(columnExists(db, 'short_id_counters', 'scope_id')).toBe(true);
+		expect(columnExists(db, 'short_id_counters', 'counter')).toBe(true);
+	});
+
+	test('short_id_counters table enforces composite PRIMARY KEY', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		// Insert a row
+		db.exec(
+			`INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES ('task', 'room-1', 1)`
+		);
+
+		// Inserting duplicate (entity_type, scope_id) should fail
+		expect(() => {
+			db.exec(
+				`INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES ('task', 'room-1', 2)`
+			);
+		}).toThrow();
+
+		// Different scope_id should succeed
+		expect(() => {
+			db.exec(
+				`INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES ('task', 'room-2', 1)`
+			);
+		}).not.toThrow();
+
+		// Different entity_type should succeed
+		expect(() => {
+			db.exec(
+				`INSERT INTO short_id_counters (entity_type, scope_id, counter) VALUES ('goal', 'room-1', 1)`
+			);
+		}).not.toThrow();
+	});
+
+	test('partial unique indexes exist for tasks and goals short_id', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		expect(indexExists(db, 'idx_tasks_short_id')).toBe(true);
+		expect(indexExists(db, 'idx_goals_short_id')).toBe(true);
+	});
+
+	test('tasks short_id unique index allows multiple NULLs', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-uuid-1', 'Test Room', 1000, 1000)`
+		);
+
+		// Insert two tasks without short_id — both NULL should be allowed
+		db.exec(`
+			INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at)
+			VALUES
+				('task-uuid-1', 'room-uuid-1', 'Task 1', '', 'pending', 'normal', 1000, 1000),
+				('task-uuid-2', 'room-uuid-1', 'Task 2', '', 'pending', 'normal', 1001, 1001)
+		`);
+
+		// Both have NULL short_id — should be fine (partial index only covers non-null)
+		const rows = db
+			.prepare(`SELECT short_id FROM tasks WHERE id IN ('task-uuid-1', 'task-uuid-2')`)
+			.all() as Array<{ short_id: string | null }>;
+		expect(rows.every((r) => r.short_id === null)).toBe(true);
+	});
+
+	test('tasks short_id unique index rejects duplicate non-null values', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-uuid-1', 'Test Room', 1000, 1000)`
+		);
+
+		db.exec(`
+			INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
+			VALUES ('task-uuid-1', 'room-uuid-1', 'Task 1', '', 'pending', 'normal', 1000, 1000, 't:roomabc:1')
+		`);
+
+		expect(() => {
+			db.exec(`
+				INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
+				VALUES ('task-uuid-2', 'room-uuid-1', 'Task 2', '', 'pending', 'normal', 1001, 1001, 't:roomabc:1')
+			`);
+		}).toThrow();
+	});
+
+	test('migration is idempotent — running runMigrations twice does not throw', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		// Running migrations a second time should be safe
+		expect(() => {
+			runMigrations(db, () => {});
+		}).not.toThrow();
+	});
+});


### PR DESCRIPTION
- Add nullable short_id TEXT column to tasks and goals tables (existing DBs via
  ALTER TABLE guarded by tableHasColumn; fresh DBs via updated createTables)
- Create short_id_counters(entity_type, scope_id, counter) table with composite PK
  for per-scope monotonic counter allocation
- Add partial unique indexes idx_tasks_short_id and idx_goals_short_id (WHERE short_id IS NOT NULL)
  so multiple NULLs are allowed while non-null values are globally unique
- Migration is idempotent: all DDL guarded with IF NOT EXISTS or tableHasColumn checks
- Unit tests: 8 cases covering fresh DB schema, counter PK enforcement, partial unique
  index semantics, and idempotency (double-run)
