### PR TITLE
feat(storage): add short ID assignment and backfill in TaskRepository

### DIFF
--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -10,11 +10,13 @@ import { generateUUID } from '@neokai/shared';
 import type { NeoTask, TaskFilter, CreateTaskParams, UpdateTaskParams } from '@neokai/shared';
 import type { SQLiteValue } from '../types';
 import type { ReactiveDatabase } from '../reactive-database';
+import type { ShortIdAllocator } from '../../lib/short-id-allocator';
 
 export class TaskRepository {
 	constructor(
 		private db: BunDatabase,
-		private reactiveDb: ReactiveDatabase
+		private reactiveDb: ReactiveDatabase,
+		private shortIdAllocator?: ShortIdAllocator
 	) {}
 
 	/**
@@ -23,10 +25,11 @@ export class TaskRepository {
 	createTask(params: CreateTaskParams): NeoTask {
 		const id = generateUUID();
 		const now = Date.now();
+		const shortId = this.shortIdAllocator?.allocate('task', params.roomId) ?? null;
 
 		const stmt = this.db.prepare(
-			`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, task_type, assigned_agent, created_by_task_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, task_type, assigned_agent, created_by_task_id, short_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -40,12 +43,13 @@ export class TaskRepository {
 			params.taskType ?? 'coding',
 			params.assignedAgent ?? 'coder',
 			params.createdByTaskId ?? null,
+			shortId,
 			now,
 			now
 		);
 
 		this.reactiveDb.notifyChange('tasks');
-		return this.getTask(id)!;
+		return this.getTaskDirect(id)!;
 	}
 
 	/**
@@ -65,12 +69,35 @@ export class TaskRepository {
 	}
 
 	/**
-	 * Get a task by ID
+	 * Get a task by ID (raw, no backfill — used internally to avoid recursion)
 	 */
-	getTask(id: string): NeoTask | null {
+	private getTaskDirect(id: string): NeoTask | null {
 		const stmt = this.db.prepare(`SELECT * FROM tasks WHERE id = ?`);
 		const row = stmt.get(id) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return this.rowToTask(row);
+	}
 
+	/**
+	 * Get a task by ID, with lazy short ID backfill for legacy rows.
+	 */
+	getTask(id: string): NeoTask | null {
+		const task = this.getTaskDirect(id);
+		if (!task) return null;
+		if (!task.shortId && this.shortIdAllocator) {
+			const shortId = this.shortIdAllocator.allocate('task', task.roomId);
+			this.db.prepare(`UPDATE tasks SET short_id = ? WHERE id = ?`).run(shortId, id);
+			return { ...task, shortId };
+		}
+		return task;
+	}
+
+	/**
+	 * Get a task by its short ID within a room.
+	 */
+	getTaskByShortId(roomId: string, shortId: string): NeoTask | null {
+		const stmt = this.db.prepare(`SELECT * FROM tasks WHERE room_id = ? AND short_id = ?`);
+		const row = stmt.get(roomId, shortId) as Record<string, unknown> | undefined;
 		if (!row) return null;
 		return this.rowToTask(row);
 	}
@@ -79,6 +106,7 @@ export class TaskRepository {
 	 * List tasks for a room, optionally filtered.
 	 * By default, archived tasks (status = 'archived') are excluded.
 	 * Use filter.includeArchived = true to include archived tasks.
+	 * Lazy backfill: any row missing short_id gets one assigned inline.
 	 */
 	listTasks(roomId: string, filter?: TaskFilter): NeoTask[] {
 		let query = `SELECT * FROM tasks WHERE room_id = ?`;
@@ -101,7 +129,15 @@ export class TaskRepository {
 
 		const stmt = this.db.prepare(query);
 		const rows = stmt.all(...params) as Record<string, unknown>[];
-		return rows.map((r) => this.rowToTask(r));
+		return rows.map((row) => {
+			const task = this.rowToTask(row);
+			if (!task.shortId && this.shortIdAllocator) {
+				const shortId = this.shortIdAllocator.allocate('task', roomId);
+				this.db.prepare(`UPDATE tasks SET short_id = ? WHERE id = ?`).run(shortId, task.id);
+				return { ...task, shortId };
+			}
+			return task;
+		});
 	}
 
 	/**
@@ -291,6 +327,7 @@ export class TaskRepository {
 		return {
 			id: row.id as string,
 			roomId: row.room_id as string,
+			shortId: (row.short_id as string | null) ?? undefined,
 			title: row.title as string,
 			description: row.description as string,
 			status: row.status as NeoTask['status'],

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -129,6 +129,13 @@ export class TaskRepository {
 
 		const stmt = this.db.prepare(query);
 		const rows = stmt.all(...params) as Record<string, unknown>[];
+		// Backfill: allocate a short ID for any row that was created before migration 47
+		// or via a code path that lacked an allocator. Each allocation is a separate
+		// atomic counter increment, so under SQLite's single-writer model concurrent
+		// callers cannot observe the same counter value — a second concurrent listTasks
+		// for the same room would block on the write lock and read already-written
+		// short_id values when it proceeds. Counter values are never reused; a skipped
+		// value is cosmetic and does not affect correctness.
 		return rows.map((row) => {
 			const task = this.rowToTask(row);
 			if (!task.shortId && this.shortIdAllocator) {
@@ -312,7 +319,9 @@ export class TaskRepository {
 	 * Convert a database row to a NeoTask object
 	 */
 	/**
-	 * Get draft tasks created by a specific planning task
+	 * Get draft tasks created by a specific planning task.
+	 * Applies the same lazy short ID backfill as listTasks so callers always
+	 * receive tasks with shortId populated.
 	 */
 	getDraftTasksByCreator(createdByTaskId: string): NeoTask[] {
 		const rows = this.db
@@ -320,7 +329,15 @@ export class TaskRepository {
 				`SELECT * FROM tasks WHERE created_by_task_id = ? AND status = 'draft' ORDER BY created_at ASC`
 			)
 			.all(createdByTaskId) as Record<string, unknown>[];
-		return rows.map((r) => this.rowToTask(r));
+		return rows.map((row) => {
+			const task = this.rowToTask(row);
+			if (!task.shortId && this.shortIdAllocator) {
+				const shortId = this.shortIdAllocator.allocate('task', task.roomId);
+				this.db.prepare(`UPDATE tasks SET short_id = ? WHERE id = ?`).run(shortId, task.id);
+				return { ...task, shortId };
+			}
+			return task;
+		});
 	}
 
 	private rowToTask(row: Record<string, unknown>): NeoTask {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -79,6 +79,7 @@ describe('Room Agent Tools', () => {
 				pr_url TEXT,
 				pr_number INTEGER,
 				pr_created_at INTEGER,
+				short_id TEXT,
 				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -425,6 +425,7 @@ describe('RoomRuntimeService restart recovery', () => {
 				pr_url TEXT,
 				pr_number INTEGER,
 				pr_created_at INTEGER,
+				short_id TEXT,
 				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -170,6 +170,7 @@ const DB_SCHEMA = `
 		pr_url TEXT,
 		pr_number INTEGER,
 		pr_created_at INTEGER,
+		short_id TEXT,
 		updated_at INTEGER
 	);
 	CREATE TABLE session_groups (

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -136,6 +136,7 @@ describe('Runtime Recovery', () => {
 				pr_url TEXT,
 				pr_number INTEGER,
 				pr_created_at INTEGER,
+				short_id TEXT,
 				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (

--- a/packages/daemon/tests/unit/room/session-group-repository-reactive.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository-reactive.test.ts
@@ -44,6 +44,7 @@ CREATE TABLE tasks (
     pr_url TEXT,
     pr_number INTEGER,
     pr_created_at INTEGER,
+    short_id TEXT,
     updated_at INTEGER
 );
 CREATE TABLE session_groups (

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -41,6 +41,7 @@ describe('SessionGroupRepository', () => {
 				pr_url TEXT,
 				pr_number INTEGER,
 				pr_created_at INTEGER,
+				short_id TEXT,
 				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -240,6 +240,7 @@ describe('TaskGroupManager', () => {
 				pr_url TEXT,
 				pr_number INTEGER,
 				pr_created_at INTEGER,
+				short_id TEXT,
 				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (

--- a/packages/daemon/tests/unit/storage/task-repository-short-id.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository-short-id.test.ts
@@ -1,0 +1,214 @@
+/**
+ * TaskRepository — Short ID tests
+ *
+ * Covers:
+ *  - createTask assigns shortId when allocator is present
+ *  - getTaskByShortId finds by short ID
+ *  - getTaskByShortId returns null for unknown short ID
+ *  - lazy backfill in getTask
+ *  - lazy backfill in listTasks (mixed rows)
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { TaskRepository } from '../../../src/storage/repositories/task-repository';
+import { ShortIdAllocator } from '../../../src/lib/short-id-allocator';
+import { noOpReactiveDb } from '../../helpers/reactive-database';
+
+function makeDb(): Database {
+	const db = new Database(':memory:');
+	db.exec(`
+		CREATE TABLE tasks (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending',
+			priority TEXT NOT NULL DEFAULT 'normal',
+			task_type TEXT NOT NULL DEFAULT 'coding',
+			assigned_agent TEXT DEFAULT 'coder',
+			created_by_task_id TEXT,
+			progress INTEGER,
+			current_step TEXT,
+			result TEXT,
+			error TEXT,
+			depends_on TEXT NOT NULL DEFAULT '[]',
+			short_id TEXT,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			archived_at INTEGER,
+			active_session TEXT,
+			pr_url TEXT,
+			pr_number INTEGER,
+			pr_created_at INTEGER,
+			updated_at INTEGER
+		);
+
+		CREATE TABLE short_id_counters (
+			entity_type TEXT NOT NULL,
+			scope_id    TEXT NOT NULL,
+			counter     INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (entity_type, scope_id)
+		);
+
+		CREATE INDEX idx_tasks_room ON tasks(room_id);
+	`);
+	return db;
+}
+
+describe('TaskRepository — short ID', () => {
+	let db: Database;
+	let allocator: ShortIdAllocator;
+	let repo: TaskRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		allocator = new ShortIdAllocator(db);
+		repo = new TaskRepository(db, noOpReactiveDb, allocator);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('createTask assigns shortId when allocator is present', () => {
+		const task = repo.createTask({ roomId: 'room-1', title: 'T', description: 'D' });
+		expect(task.shortId).toBe('t-1');
+	});
+
+	it('createTask increments short IDs sequentially within the same room', () => {
+		const t1 = repo.createTask({ roomId: 'room-1', title: 'T1', description: 'D' });
+		const t2 = repo.createTask({ roomId: 'room-1', title: 'T2', description: 'D' });
+		const t3 = repo.createTask({ roomId: 'room-1', title: 'T3', description: 'D' });
+		expect(t1.shortId).toBe('t-1');
+		expect(t2.shortId).toBe('t-2');
+		expect(t3.shortId).toBe('t-3');
+	});
+
+	it('createTask uses separate counters per room', () => {
+		const a = repo.createTask({ roomId: 'room-A', title: 'T', description: 'D' });
+		const b = repo.createTask({ roomId: 'room-B', title: 'T', description: 'D' });
+		expect(a.shortId).toBe('t-1');
+		expect(b.shortId).toBe('t-1');
+	});
+
+	it('createTask without allocator leaves shortId undefined', () => {
+		const repoNoAlloc = new TaskRepository(db, noOpReactiveDb);
+		const task = repoNoAlloc.createTask({ roomId: 'room-1', title: 'T', description: 'D' });
+		expect(task.shortId).toBeUndefined();
+	});
+
+	describe('getTaskByShortId', () => {
+		it('finds the task by its short ID', () => {
+			const created = repo.createTask({ roomId: 'room-1', title: 'Find me', description: 'D' });
+			const found = repo.getTaskByShortId('room-1', 't-1');
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(created.id);
+			expect(found!.shortId).toBe('t-1');
+		});
+
+		it('returns null for an unknown short ID', () => {
+			repo.createTask({ roomId: 'room-1', title: 'T', description: 'D' });
+			expect(repo.getTaskByShortId('room-1', 't-999')).toBeNull();
+		});
+
+		it('returns null when room does not match', () => {
+			repo.createTask({ roomId: 'room-1', title: 'T', description: 'D' });
+			expect(repo.getTaskByShortId('room-2', 't-1')).toBeNull();
+		});
+	});
+
+	describe('lazy backfill in getTask', () => {
+		it('assigns a short ID to a legacy row (created without short_id)', () => {
+			// Insert a row directly without a short_id to simulate a legacy record
+			db.prepare(
+				`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at, updated_at)
+				 VALUES ('legacy-id', 'room-1', 'Legacy', 'Desc', 'pending', 'normal', '[]', 1000, 1000)`
+			).run();
+
+			const task = repo.getTask('legacy-id');
+			expect(task).not.toBeNull();
+			expect(task!.shortId).toBeDefined();
+			expect(task!.shortId).toBe('t-1');
+
+			// Verify the row was actually updated in the DB
+			const row = db.prepare(`SELECT short_id FROM tasks WHERE id = 'legacy-id'`).get() as {
+				short_id: string;
+			};
+			expect(row.short_id).toBe('t-1');
+		});
+
+		it('does not alter shortId for a row that already has one', () => {
+			const task = repo.createTask({ roomId: 'room-1', title: 'T', description: 'D' });
+			expect(task.shortId).toBe('t-1');
+
+			// Counter is at 1; calling getTask should not allocate another
+			const fetched = repo.getTask(task.id);
+			expect(fetched!.shortId).toBe('t-1');
+			expect(allocator.getCounter('task', 'room-1')).toBe(1);
+		});
+
+		it('returns null for non-existent task (no backfill attempted)', () => {
+			expect(repo.getTask('does-not-exist')).toBeNull();
+		});
+	});
+
+	describe('lazy backfill in listTasks', () => {
+		it('backfills tasks that are missing short_id', () => {
+			// Insert two legacy rows without short_id
+			db.prepare(
+				`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at, updated_at)
+				 VALUES ('leg-1', 'room-1', 'L1', 'D', 'pending', 'normal', '[]', 1000, 1000)`
+			).run();
+			db.prepare(
+				`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at, updated_at)
+				 VALUES ('leg-2', 'room-1', 'L2', 'D', 'pending', 'normal', '[]', 1001, 1001)`
+			).run();
+
+			const tasks = repo.listTasks('room-1');
+			expect(tasks.length).toBe(2);
+			expect(tasks.every((t) => t.shortId !== undefined)).toBe(true);
+			const shorts = tasks.map((t) => t.shortId).sort();
+			expect(shorts).toEqual(['t-1', 't-2']);
+		});
+
+		it('returns mix of tasks with and without short_id, all populated after call', () => {
+			// Task created with allocator gets t-1
+			const withShortId = repo.createTask({
+				roomId: 'room-1',
+				title: 'Has short ID',
+				description: 'D',
+			});
+			expect(withShortId.shortId).toBe('t-1');
+
+			// Legacy row without short_id
+			db.prepare(
+				`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at, updated_at)
+				 VALUES ('leg-old', 'room-1', 'Legacy', 'D', 'pending', 'normal', '[]', 999, 999)`
+			).run();
+
+			const tasks = repo.listTasks('room-1');
+			expect(tasks.length).toBe(2);
+			expect(tasks.every((t) => !!t.shortId)).toBe(true);
+
+			// The legacy row should have gotten t-2 (counter was already at 1)
+			const legacyTask = tasks.find((t) => t.id === 'leg-old');
+			expect(legacyTask!.shortId).toBe('t-2');
+		});
+
+		it('does not alter already-assigned short IDs during listTasks', () => {
+			const t1 = repo.createTask({ roomId: 'room-1', title: 'T1', description: 'D' });
+			const t2 = repo.createTask({ roomId: 'room-1', title: 'T2', description: 'D' });
+
+			const beforeCounter = allocator.getCounter('task', 'room-1');
+			const tasks = repo.listTasks('room-1');
+			const afterCounter = allocator.getCounter('task', 'room-1');
+
+			// Counter should not have changed — no new allocations needed
+			expect(afterCounter).toBe(beforeCounter);
+			expect(tasks.find((t) => t.id === t1.id)!.shortId).toBe('t-1');
+			expect(tasks.find((t) => t.id === t2.id)!.shortId).toBe('t-2');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/task-repository-short-id.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository-short-id.test.ts
@@ -211,4 +211,42 @@ describe('TaskRepository — short ID', () => {
 			expect(tasks.find((t) => t.id === t2.id)!.shortId).toBe('t-2');
 		});
 	});
+
+	describe('lazy backfill in getDraftTasksByCreator', () => {
+		it('backfills short_id for legacy draft rows', () => {
+			// Insert a legacy draft row without short_id
+			db.prepare(
+				`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_by_task_id, created_at, updated_at)
+				 VALUES ('draft-leg', 'room-1', 'Draft Legacy', 'D', 'draft', 'normal', '[]', 'planner-1', 1000, 1000)`
+			).run();
+
+			const tasks = repo.getDraftTasksByCreator('planner-1');
+			expect(tasks.length).toBe(1);
+			expect(tasks[0].shortId).toBe('t-1');
+
+			// Verify the DB row was updated
+			const row = db.prepare(`SELECT short_id FROM tasks WHERE id = 'draft-leg'`).get() as {
+				short_id: string;
+			};
+			expect(row.short_id).toBe('t-1');
+		});
+
+		it('does not alter already-assigned short IDs in getDraftTasksByCreator', () => {
+			const task = repo.createTask({
+				roomId: 'room-1',
+				title: 'Draft',
+				description: 'D',
+				status: 'draft',
+				createdByTaskId: 'planner-2',
+			});
+			expect(task.shortId).toBe('t-1');
+
+			const beforeCounter = allocator.getCounter('task', 'room-1');
+			const tasks = repo.getDraftTasksByCreator('planner-2');
+			const afterCounter = allocator.getCounter('task', 'room-1');
+
+			expect(afterCounter).toBe(beforeCounter);
+			expect(tasks[0].shortId).toBe('t-1');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/storage/task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository.test.ts
@@ -39,6 +39,7 @@ describe('TaskRepository', () => {
 				result TEXT,
 				error TEXT,
 				depends_on TEXT NOT NULL DEFAULT '[]',
+				short_id TEXT,
 				created_at INTEGER NOT NULL,
 				started_at INTEGER,
 				completed_at INTEGER,


### PR DESCRIPTION
- Accept optional ShortIdAllocator as third constructor param
- createTask() allocates a short ID (e.g. t-1) via allocator and stores it in short_id column
- rowToTask() maps short_id → shortId field on NeoTask
- Add getTaskByShortId(roomId, shortId) for direct lookup
- getTask() lazy-backfills short_id for legacy rows on first read
- listTasks() lazy-backfills any rows missing short_id inline
- Add short_id column to existing task-repository test schema
- Add task-repository-short-id.test.ts with 15 unit tests covering all new behaviour
