### PR TITLE
feat(storage): add short ID assignment and backfill in GoalRepository (#task-23)

### DIFF
--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -16,6 +16,7 @@ import type {
 } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import { DatabaseCore } from './database-core';
+import { ShortIdAllocator } from '../lib/short-id-allocator';
 import { SessionRepository } from './repositories/session-repository';
 import { SDKMessageRepository, type SendStatus } from './repositories/sdk-message-repository';
 import { SettingsRepository } from './repositories/settings-repository';
@@ -77,12 +78,13 @@ export class Database {
 
 		// Initialize repositories with the raw BunDatabase instance
 		const db = this.core.getDb();
+		const shortIdAllocator = new ShortIdAllocator(db);
 		this.sessionRepo = new SessionRepository(db);
 		this.sdkMessageRepo = new SDKMessageRepository(db);
 		this.settingsRepo = new SettingsRepository(db);
 		this.githubMappingRepo = new GitHubMappingRepository(db);
 		this.inboxItemRepo = new InboxItemRepository(db);
-		this.goalRepo = new GoalRepository(db, reactiveDb);
+		this.goalRepo = new GoalRepository(db, reactiveDb, shortIdAllocator);
 		this.jobQueueRepo = new JobQueueRepository(db);
 	}
 
@@ -334,6 +336,10 @@ export class Database {
 
 	getGoal(id: string): RoomGoal | null {
 		return this.goalRepo.getGoal(id);
+	}
+
+	getGoalByShortId(roomId: string, shortId: string): RoomGoal | null {
+		return this.goalRepo.getGoalByShortId(roomId, shortId);
 	}
 
 	listGoals(roomId: string, status?: import('@neokai/shared').GoalStatus): RoomGoal[] {

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -168,6 +168,11 @@ export class GoalRepository {
 	/**
 	 * List goals for a room.
 	 * Lazy backfill: any row missing short_id gets one assigned inline.
+	 * Each allocation is a separate atomic counter increment; under SQLite's
+	 * single-writer model concurrent callers cannot observe the same counter
+	 * value — a second concurrent listGoals for the same room would block on
+	 * the write lock and read already-written short_id values when it proceeds.
+	 * Counter values are never reused; a skipped value is cosmetic only.
 	 */
 	listGoals(roomId: string, status?: GoalStatus): RoomGoal[] {
 		let query = `SELECT * FROM goals WHERE room_id = ?`;
@@ -368,14 +373,24 @@ export class GoalRepository {
 	}
 
 	/**
-	 * Get goals that have a specific task linked
+	 * Get goals that have a specific task linked.
+	 * Applies the same lazy short ID backfill as listGoals so callers always
+	 * receive goals with shortId populated.
 	 */
 	getGoalsForTask(taskId: string): RoomGoal[] {
 		const stmt = this.db.prepare(
 			`SELECT * FROM goals WHERE linked_task_ids LIKE ? ORDER BY created_at ASC`
 		);
 		const rows = stmt.all(`%"${taskId}"%`) as Record<string, unknown>[];
-		return rows.map((r) => this.rowToGoal(r));
+		return rows.map((row) => {
+			const goal = this.rowToGoal(row);
+			if (!goal.shortId && this.shortIdAllocator) {
+				const shortId = this.shortIdAllocator.allocate('goal', goal.roomId);
+				this.db.prepare(`UPDATE goals SET short_id = ? WHERE id = ?`).run(shortId, goal.id);
+				return { ...goal, shortId };
+			}
+			return goal;
+		});
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -21,6 +21,7 @@ import type {
 } from '@neokai/shared';
 import type { SQLiteValue } from '../types';
 import type { ReactiveDatabase } from '../reactive-database';
+import type { ShortIdAllocator } from '../../lib/short-id-allocator';
 
 export interface CreateGoalParams {
 	roomId: string;
@@ -78,7 +79,8 @@ export interface UpdateExecutionParams {
 export class GoalRepository {
 	constructor(
 		private db: BunDatabase,
-		private reactiveDb: ReactiveDatabase
+		private reactiveDb: ReactiveDatabase,
+		private shortIdAllocator?: ShortIdAllocator
 	) {}
 
 	/**
@@ -87,6 +89,7 @@ export class GoalRepository {
 	createGoal(params: CreateGoalParams): RoomGoal {
 		const id = generateUUID();
 		const now = Date.now();
+		const shortId = this.shortIdAllocator?.allocate('goal', params.roomId) ?? null;
 
 		const stmt = this.db.prepare(
 			`INSERT INTO goals (
@@ -94,9 +97,9 @@ export class GoalRepository {
 				metrics, created_at, updated_at,
 				mission_type, autonomy_level, schedule, schedule_paused, next_run_at,
 				structured_metrics, max_consecutive_failures, max_planning_attempts, consecutive_failures,
-				replan_count
+				replan_count, short_id
 			)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -120,26 +123,51 @@ export class GoalRepository {
 			params.maxConsecutiveFailures ?? 3,
 			params.maxPlanningAttempts ?? 0,
 			params.consecutiveFailures ?? 0,
-			params.replanCount ?? 0
+			params.replanCount ?? 0,
+			shortId
 		);
 
 		this.reactiveDb.notifyChange('goals');
-		return this.getGoal(id)!;
+		return this.getGoalDirect(id)!;
 	}
 
 	/**
-	 * Get a goal by ID
+	 * Get a goal by ID (raw, no backfill — used internally to avoid recursion)
 	 */
-	getGoal(id: string): RoomGoal | null {
+	private getGoalDirect(id: string): RoomGoal | null {
 		const stmt = this.db.prepare(`SELECT * FROM goals WHERE id = ?`);
 		const row = stmt.get(id) as Record<string, unknown> | undefined;
-
 		if (!row) return null;
 		return this.rowToGoal(row);
 	}
 
 	/**
-	 * List goals for a room
+	 * Get a goal by ID, with lazy short ID backfill for legacy rows.
+	 */
+	getGoal(id: string): RoomGoal | null {
+		const goal = this.getGoalDirect(id);
+		if (!goal) return null;
+		if (!goal.shortId && this.shortIdAllocator) {
+			const shortId = this.shortIdAllocator.allocate('goal', goal.roomId);
+			this.db.prepare(`UPDATE goals SET short_id = ? WHERE id = ?`).run(shortId, id);
+			return { ...goal, shortId };
+		}
+		return goal;
+	}
+
+	/**
+	 * Get a goal by its short ID within a room.
+	 */
+	getGoalByShortId(roomId: string, shortId: string): RoomGoal | null {
+		const stmt = this.db.prepare(`SELECT * FROM goals WHERE room_id = ? AND short_id = ?`);
+		const row = stmt.get(roomId, shortId) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return this.rowToGoal(row);
+	}
+
+	/**
+	 * List goals for a room.
+	 * Lazy backfill: any row missing short_id gets one assigned inline.
 	 */
 	listGoals(roomId: string, status?: GoalStatus): RoomGoal[] {
 		let query = `SELECT * FROM goals WHERE room_id = ?`;
@@ -154,7 +182,15 @@ export class GoalRepository {
 
 		const stmt = this.db.prepare(query);
 		const rows = stmt.all(...params) as Record<string, unknown>[];
-		return rows.map((r) => this.rowToGoal(r));
+		return rows.map((row) => {
+			const goal = this.rowToGoal(row);
+			if (!goal.shortId && this.shortIdAllocator) {
+				const shortId = this.shortIdAllocator.allocate('goal', roomId);
+				this.db.prepare(`UPDATE goals SET short_id = ? WHERE id = ?`).run(shortId, goal.id);
+				return { ...goal, shortId };
+			}
+			return goal;
+		});
 	}
 
 	/**
@@ -597,6 +633,7 @@ export class GoalRepository {
 		return {
 			id: row.id as string,
 			roomId: row.room_id as string,
+			shortId: (row.short_id as string | null) ?? undefined,
 			title: row.title as string,
 			description: row.description as string,
 			status: row.status as GoalStatus,

--- a/packages/daemon/tests/unit/room/mission-system-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/room/mission-system-edge-cases.test.ts
@@ -197,7 +197,8 @@ describe('Metrics: dual-write derivation', () => {
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 0,
 				consecutive_failures INTEGER NOT NULL DEFAULT 0,
-				replan_count INTEGER NOT NULL DEFAULT 0
+				replan_count INTEGER NOT NULL DEFAULT 0,
+				short_id TEXT
 			);
 			CREATE TABLE mission_metric_history (
 				id TEXT PRIMARY KEY, goal_id TEXT NOT NULL, metric_name TEXT NOT NULL,
@@ -488,7 +489,8 @@ describe('Migration: legacy goals default to one_shot / supervised', () => {
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 0,
 				consecutive_failures INTEGER NOT NULL DEFAULT 0,
-				replan_count INTEGER NOT NULL DEFAULT 0
+				replan_count INTEGER NOT NULL DEFAULT 0,
+				short_id TEXT
 			);
 			CREATE TABLE mission_metric_history (
 				id TEXT PRIMARY KEY, goal_id TEXT NOT NULL, metric_name TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -54,7 +54,8 @@ describe('Room Agent Tools', () => {
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
 				consecutive_failures INTEGER NOT NULL DEFAULT 0,
-		replan_count INTEGER NOT NULL DEFAULT 0
+		replan_count INTEGER NOT NULL DEFAULT 0,
+				short_id TEXT
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -400,7 +400,8 @@ describe('RoomRuntimeService restart recovery', () => {
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
 				consecutive_failures INTEGER NOT NULL DEFAULT 0,
-				replan_count INTEGER NOT NULL DEFAULT 0
+				replan_count INTEGER NOT NULL DEFAULT 0,
+				short_id TEXT
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -153,7 +153,8 @@ const DB_SCHEMA = `
 		max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 		max_planning_attempts INTEGER NOT NULL DEFAULT 0,
 		consecutive_failures INTEGER NOT NULL DEFAULT 0,
-		replan_count INTEGER NOT NULL DEFAULT 0
+		replan_count INTEGER NOT NULL DEFAULT 0,
+		short_id TEXT
 	);
 	CREATE TABLE tasks (
 		id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -119,7 +119,8 @@ describe('Runtime Recovery', () => {
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
 				consecutive_failures INTEGER NOT NULL DEFAULT 0,
-		replan_count INTEGER NOT NULL DEFAULT 0
+		replan_count INTEGER NOT NULL DEFAULT 0,
+				short_id TEXT
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -223,7 +223,8 @@ describe('TaskGroupManager', () => {
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
 				consecutive_failures INTEGER NOT NULL DEFAULT 0,
-		replan_count INTEGER NOT NULL DEFAULT 0
+		replan_count INTEGER NOT NULL DEFAULT 0,
+				short_id TEXT
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/storage/goal-repository-short-id.test.ts
+++ b/packages/daemon/tests/unit/storage/goal-repository-short-id.test.ts
@@ -1,0 +1,216 @@
+/**
+ * GoalRepository — Short ID tests
+ *
+ * Covers:
+ *  - createGoal assigns shortId when allocator is present
+ *  - createGoal without allocator leaves shortId undefined
+ *  - sequential allocation within the same room
+ *  - separate counters per room
+ *  - getGoalByShortId finds by short ID
+ *  - getGoalByShortId returns null for unknown short ID
+ *  - getGoalByShortId returns null when room does not match
+ *  - lazy backfill in getGoal (legacy rows)
+ *  - getGoal does not alter existing short IDs
+ *  - getGoal returns null for non-existent ID
+ *  - lazy backfill in listGoals (all missing)
+ *  - listGoals mixed rows (some with, some without)
+ *  - listGoals does not alter already-assigned short IDs
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
+import { ShortIdAllocator } from '../../../src/lib/short-id-allocator';
+import { noOpReactiveDb } from '../../helpers/reactive-database';
+
+function makeDb(): Database {
+	const db = new Database(':memory:');
+	db.exec(`
+		CREATE TABLE goals (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active',
+			priority TEXT NOT NULL DEFAULT 'normal',
+			progress INTEGER NOT NULL DEFAULT 0,
+			linked_task_ids TEXT NOT NULL DEFAULT '[]',
+			metrics TEXT NOT NULL DEFAULT '{}',
+			planning_attempts INTEGER DEFAULT 0,
+			goal_review_attempts INTEGER DEFAULT 0,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			mission_type TEXT NOT NULL DEFAULT 'one_shot',
+			autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+			schedule TEXT,
+			schedule_paused INTEGER NOT NULL DEFAULT 0,
+			next_run_at INTEGER,
+			structured_metrics TEXT,
+			max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+			max_planning_attempts INTEGER NOT NULL DEFAULT 0,
+			consecutive_failures INTEGER NOT NULL DEFAULT 0,
+			replan_count INTEGER DEFAULT 0,
+			short_id TEXT
+		);
+
+		CREATE TABLE short_id_counters (
+			entity_type TEXT NOT NULL,
+			scope_id    TEXT NOT NULL,
+			counter     INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (entity_type, scope_id)
+		);
+
+		CREATE INDEX idx_goals_room ON goals(room_id);
+	`);
+	return db;
+}
+
+describe('GoalRepository — short ID', () => {
+	let db: Database;
+	let allocator: ShortIdAllocator;
+	let repo: GoalRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		allocator = new ShortIdAllocator(db);
+		repo = new GoalRepository(db, noOpReactiveDb, allocator);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('createGoal assigns shortId when allocator is present', () => {
+		const goal = repo.createGoal({ roomId: 'room-1', title: 'G' });
+		expect(goal.shortId).toBe('g-1');
+	});
+
+	it('createGoal increments short IDs sequentially within the same room', () => {
+		const g1 = repo.createGoal({ roomId: 'room-1', title: 'G1' });
+		const g2 = repo.createGoal({ roomId: 'room-1', title: 'G2' });
+		const g3 = repo.createGoal({ roomId: 'room-1', title: 'G3' });
+		expect(g1.shortId).toBe('g-1');
+		expect(g2.shortId).toBe('g-2');
+		expect(g3.shortId).toBe('g-3');
+	});
+
+	it('createGoal uses separate counters per room', () => {
+		const a = repo.createGoal({ roomId: 'room-A', title: 'G' });
+		const b = repo.createGoal({ roomId: 'room-B', title: 'G' });
+		expect(a.shortId).toBe('g-1');
+		expect(b.shortId).toBe('g-1');
+	});
+
+	it('createGoal without allocator leaves shortId undefined', () => {
+		const repoNoAlloc = new GoalRepository(db, noOpReactiveDb);
+		const goal = repoNoAlloc.createGoal({ roomId: 'room-1', title: 'G' });
+		expect(goal.shortId).toBeUndefined();
+	});
+
+	describe('getGoalByShortId', () => {
+		it('finds the goal by its short ID', () => {
+			const created = repo.createGoal({ roomId: 'room-1', title: 'Find me' });
+			const found = repo.getGoalByShortId('room-1', 'g-1');
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(created.id);
+			expect(found!.shortId).toBe('g-1');
+		});
+
+		it('returns null for an unknown short ID', () => {
+			repo.createGoal({ roomId: 'room-1', title: 'G' });
+			expect(repo.getGoalByShortId('room-1', 'g-999')).toBeNull();
+		});
+
+		it('returns null when room does not match', () => {
+			repo.createGoal({ roomId: 'room-1', title: 'G' });
+			expect(repo.getGoalByShortId('room-2', 'g-1')).toBeNull();
+		});
+	});
+
+	describe('lazy backfill in getGoal', () => {
+		it('assigns a short ID to a legacy row (created without short_id)', () => {
+			db.prepare(
+				`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids, metrics, created_at, updated_at)
+				 VALUES ('legacy-id', 'room-1', 'Legacy', '', 'active', 'normal', 0, '[]', '{}', 1000, 1000)`
+			).run();
+
+			const goal = repo.getGoal('legacy-id');
+			expect(goal).not.toBeNull();
+			expect(goal!.shortId).toBe('g-1');
+
+			// Verify the row was actually updated in the DB
+			const row = db.prepare(`SELECT short_id FROM goals WHERE id = 'legacy-id'`).get() as {
+				short_id: string;
+			};
+			expect(row.short_id).toBe('g-1');
+		});
+
+		it('does not alter shortId for a row that already has one', () => {
+			const goal = repo.createGoal({ roomId: 'room-1', title: 'G' });
+			expect(goal.shortId).toBe('g-1');
+
+			// Counter is at 1; calling getGoal should not allocate another
+			const fetched = repo.getGoal(goal.id);
+			expect(fetched!.shortId).toBe('g-1');
+			expect(allocator.getCounter('goal', 'room-1')).toBe(1);
+		});
+
+		it('returns null for non-existent goal (no backfill attempted)', () => {
+			expect(repo.getGoal('does-not-exist')).toBeNull();
+		});
+	});
+
+	describe('lazy backfill in listGoals', () => {
+		it('backfills goals that are missing short_id', () => {
+			db.prepare(
+				`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids, metrics, created_at, updated_at)
+				 VALUES ('leg-1', 'room-1', 'L1', '', 'active', 'normal', 0, '[]', '{}', 1000, 1000)`
+			).run();
+			db.prepare(
+				`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids, metrics, created_at, updated_at)
+				 VALUES ('leg-2', 'room-1', 'L2', '', 'active', 'normal', 0, '[]', '{}', 1001, 1001)`
+			).run();
+
+			const goals = repo.listGoals('room-1');
+			expect(goals.length).toBe(2);
+			expect(goals.every((g) => g.shortId !== undefined)).toBe(true);
+			const shorts = goals.map((g) => g.shortId).sort();
+			expect(shorts).toEqual(['g-1', 'g-2']);
+		});
+
+		it('returns mix of goals with and without short_id, all populated after call', () => {
+			// Goal created with allocator gets g-1
+			const withShortId = repo.createGoal({ roomId: 'room-1', title: 'Has short ID' });
+			expect(withShortId.shortId).toBe('g-1');
+
+			// Legacy row without short_id
+			db.prepare(
+				`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids, metrics, created_at, updated_at)
+				 VALUES ('leg-old', 'room-1', 'Legacy', '', 'active', 'normal', 0, '[]', '{}', 999, 999)`
+			).run();
+
+			const goals = repo.listGoals('room-1');
+			expect(goals.length).toBe(2);
+			expect(goals.every((g) => !!g.shortId)).toBe(true);
+
+			// The legacy row should have gotten g-2 (counter was already at 1)
+			const legacyGoal = goals.find((g) => g.id === 'leg-old');
+			expect(legacyGoal!.shortId).toBe('g-2');
+		});
+
+		it('does not alter already-assigned short IDs during listGoals', () => {
+			const g1 = repo.createGoal({ roomId: 'room-1', title: 'G1' });
+			const g2 = repo.createGoal({ roomId: 'room-1', title: 'G2' });
+
+			const beforeCounter = allocator.getCounter('goal', 'room-1');
+			const goals = repo.listGoals('room-1');
+			const afterCounter = allocator.getCounter('goal', 'room-1');
+
+			// Counter should not have changed — no new allocations needed
+			expect(afterCounter).toBe(beforeCounter);
+			expect(goals.find((g) => g.id === g1.id)!.shortId).toBe('g-1');
+			expect(goals.find((g) => g.id === g2.id)!.shortId).toBe('g-2');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/goal-repository-short-id.test.ts
+++ b/packages/daemon/tests/unit/storage/goal-repository-short-id.test.ts
@@ -213,4 +213,39 @@ describe('GoalRepository — short ID', () => {
 			expect(goals.find((g) => g.id === g2.id)!.shortId).toBe('g-2');
 		});
 	});
+
+	describe('lazy backfill in getGoalsForTask', () => {
+		it('backfills short_id for legacy rows returned by getGoalsForTask', () => {
+			// Insert a legacy row without short_id, with task-1 linked
+			db.prepare(
+				`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids, metrics, created_at, updated_at)
+				 VALUES ('goal-leg', 'room-1', 'Legacy Goal', '', 'active', 'normal', 0, '["task-1"]', '{}', 1000, 1000)`
+			).run();
+
+			const goals = repo.getGoalsForTask('task-1');
+			expect(goals.length).toBe(1);
+			expect(goals[0].shortId).toBe('g-1');
+
+			// Verify the DB row was updated
+			const row = db.prepare(`SELECT short_id FROM goals WHERE id = 'goal-leg'`).get() as {
+				short_id: string;
+			};
+			expect(row.short_id).toBe('g-1');
+		});
+
+		it('does not alter already-assigned short IDs in getGoalsForTask', () => {
+			const goal = repo.createGoal({ roomId: 'room-1', title: 'G' });
+			expect(goal.shortId).toBe('g-1');
+
+			// Link task-1 to the goal
+			repo.updateGoal(goal.id, { linkedTaskIds: ['task-1'] });
+
+			const beforeCounter = allocator.getCounter('goal', 'room-1');
+			const goals = repo.getGoalsForTask('task-1');
+			const afterCounter = allocator.getCounter('goal', 'room-1');
+
+			expect(afterCounter).toBe(beforeCounter);
+			expect(goals[0].shortId).toBe('g-1');
+		});
+	});
 });


### PR DESCRIPTION
- Accept optional ShortIdAllocator as third constructor parameter
- createGoal() allocates 'g-N' short ID via allocator and stores in short_id column
- rowToGoal() maps short_id → shortId?: string
- Add getGoalDirect() private method (no backfill, avoids recursion)
- Add getGoalByShortId(roomId, shortId) for lookup by short ID
- Lazy backfill in getGoal(): legacy rows missing short_id get one on first access
- Lazy backfill in listGoals(): all rows without short_id get one assigned inline
- Wire ShortIdAllocator into GoalRepository in Database facade (storage/index.ts)
- Add getGoalByShortId to Database facade
- Add short_id TEXT column to 6 room test helper schemas that were missing it
- 13 unit tests covering all acceptance criteria (sequential IDs, per-room counters,
  lookup by short ID, lazy backfill in getGoal and listGoals)
