### PR TITLE
feat(storage): wire ShortIdAllocator into TaskManager and GoalManager at all instantiation sites

### DIFF
--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../storage/repositories/goal-repository';
 import { TaskRepository } from '../../../storage/repositories/task-repository';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
+import type { ShortIdAllocator } from '../../short-id-allocator';
 import type {
 	RoomGoal,
 	GoalStatus,
@@ -45,10 +46,11 @@ export class GoalManager {
 	constructor(
 		private db: BunDatabase,
 		private roomId: string,
-		reactiveDb: ReactiveDatabase
+		reactiveDb: ReactiveDatabase,
+		shortIdAllocator?: ShortIdAllocator
 	) {
-		this.goalRepo = new GoalRepository(db, reactiveDb);
-		this.taskRepo = new TaskRepository(db, reactiveDb);
+		this.goalRepo = new GoalRepository(db, reactiveDb, shortIdAllocator);
+		this.taskRepo = new TaskRepository(db, reactiveDb, shortIdAllocator);
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -11,6 +11,7 @@
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { TaskRepository } from '../../../storage/repositories/task-repository';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
+import type { ShortIdAllocator } from '../../short-id-allocator';
 import type {
 	NeoTask,
 	TaskStatus,
@@ -57,9 +58,10 @@ export class TaskManager {
 	constructor(
 		private db: BunDatabase,
 		private roomId: string,
-		private reactiveDb: ReactiveDatabase
+		private reactiveDb: ReactiveDatabase,
+		shortIdAllocator?: ShortIdAllocator
 	) {
-		this.taskRepo = new TaskRepository(db, this.reactiveDb);
+		this.taskRepo = new TaskRepository(db, this.reactiveDb, shortIdAllocator);
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -422,9 +422,10 @@ export class RoomRuntimeService {
 		if (existing) return existing;
 
 		const rawDb = this.ctx.db.getDatabase();
+		const allocator = this.ctx.db.getShortIdAllocator();
 		const groupRepo = new SessionGroupRepository(rawDb, this.ctx.reactiveDb);
-		const taskManager = new TaskManager(rawDb, room.id, this.ctx.reactiveDb);
-		const goalManager = new GoalManager(rawDb, room.id, this.ctx.reactiveDb);
+		const taskManager = new TaskManager(rawDb, room.id, this.ctx.reactiveDb, allocator);
+		const goalManager = new GoalManager(rawDb, room.id, this.ctx.reactiveDb, allocator);
 		const sdkMessageRepo = new SDKMessageRepository(rawDb);
 		const observer = new SessionObserver(this.ctx.daemonHub);
 		const sessionFactory = this.createSessionFactory();
@@ -655,7 +656,12 @@ export class RoomRuntimeService {
 	): Promise<void> {
 		const rawDb = this.ctx.db.getDatabase();
 		const groupRepo = new SessionGroupRepository(rawDb, this.ctx.reactiveDb);
-		const taskManager = new TaskManager(rawDb, roomId, this.ctx.reactiveDb);
+		const taskManager = new TaskManager(
+			rawDb,
+			roomId,
+			this.ctx.reactiveDb,
+			this.ctx.db.getShortIdAllocator()
+		);
 		const sessionFactory = this.createSessionFactory();
 
 		const checker: SessionStateChecker = {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -130,12 +130,22 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Create factory function for per-room goal managers
 	const goalManagerFactory: GoalManagerFactory = (roomId: string) => {
-		return new GoalManager(deps.db.getDatabase(), roomId, deps.reactiveDb);
+		return new GoalManager(
+			deps.db.getDatabase(),
+			roomId,
+			deps.reactiveDb,
+			deps.db.getShortIdAllocator()
+		);
 	};
 
 	// Create factory function for per-room task managers (used by goal review handlers)
 	const goalTaskManagerFactory: GoalTaskManagerFactory = (roomId: string) => {
-		return new TaskManager(deps.db.getDatabase(), roomId, deps.reactiveDb);
+		return new TaskManager(
+			deps.db.getDatabase(),
+			roomId,
+			deps.reactiveDb,
+			deps.db.getShortIdAllocator()
+		);
 	};
 
 	setupSessionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub, roomManager);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -54,7 +54,7 @@ export function setupTaskHandlers(
 	db: Database,
 	reactiveDb: ReactiveDatabase,
 	taskManagerFactory: TaskManagerFactory = (d, roomId) =>
-		new TaskManager(d.getDatabase(), roomId, reactiveDb),
+		new TaskManager(d.getDatabase(), roomId, reactiveDb, d.getShortIdAllocator()),
 	runtimeService?: RoomRuntimeService
 ): void {
 	const makeGroupRepo = () => new SessionGroupRepository(db.getDatabase(), reactiveDb);

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -17,6 +17,7 @@ import type {
 import type { SDKMessage } from '@neokai/shared/sdk';
 import { DatabaseCore } from './database-core';
 import { ShortIdAllocator } from '../lib/short-id-allocator';
+export { ShortIdAllocator } from '../lib/short-id-allocator';
 import { SessionRepository } from './repositories/session-repository';
 import { SDKMessageRepository, type SendStatus } from './repositories/sdk-message-repository';
 import { SettingsRepository } from './repositories/settings-repository';
@@ -68,6 +69,7 @@ export class Database {
 	private inboxItemRepo!: InboxItemRepository;
 	private goalRepo!: GoalRepository;
 	private jobQueueRepo!: JobQueueRepository;
+	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
 		this.core = new DatabaseCore(dbPath);
@@ -78,7 +80,8 @@ export class Database {
 
 		// Initialize repositories with the raw BunDatabase instance
 		const db = this.core.getDb();
-		const shortIdAllocator = new ShortIdAllocator(db);
+		this.shortIdAllocator = new ShortIdAllocator(db);
+		const shortIdAllocator = this.shortIdAllocator;
 		this.sessionRepo = new SessionRepository(db);
 		this.sdkMessageRepo = new SDKMessageRepository(db);
 		this.settingsRepo = new SettingsRepository(db);
@@ -380,6 +383,14 @@ export class Database {
 	 */
 	getDatabase(): BunDatabase {
 		return this.core.getDb();
+	}
+
+	/**
+	 * Get the shared ShortIdAllocator instance
+	 * Used by TaskManager and GoalManager to assign short IDs on creation
+	 */
+	getShortIdAllocator(): ShortIdAllocator {
+		return this.shortIdAllocator;
 	}
 
 	/**

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -17,6 +17,8 @@ export { runMigrations } from './migrations';
 export { runMigration12 } from './migrations';
 // knip-ignore-next-line
 export { runMigration47 } from './migrations';
+// knip-ignore-next-line
+export { runMigration48 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -215,12 +217,13 @@ export function createTables(db: BunDatabase): void {
       )
     `);
 
-	// Partial unique indexes for short_id on tasks and goals
+	// Partial unique indexes for short_id on tasks and goals — scoped to room so that
+	// different rooms can each have their own t-1, t-2, ... sequence without collision.
 	db.exec(
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_short_id ON tasks(short_id) WHERE short_id IS NOT NULL`
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_room_short_id ON tasks(room_id, short_id) WHERE short_id IS NOT NULL`
 	);
 	db.exec(
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_short_id ON goals(short_id) WHERE short_id IS NOT NULL`
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_room_short_id ON goals(room_id, short_id) WHERE short_id IS NOT NULL`
 	);
 
 	// Mission metric history table

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -183,6 +183,12 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Enables human-readable scoped short IDs for tasks and goals (e.g. t:04062505:42).
 	// New columns are nullable — existing rows get NULL until short IDs are assigned.
 	runMigration47(db);
+
+	// Migration 48: Replace global short_id unique indexes with room-scoped composite indexes.
+	// Migration 47 accidentally created single-column global indexes (unique across ALL rooms),
+	// causing UNIQUE constraint failures when two different rooms each create their first task.
+	// Short IDs are scoped to their parent room, so uniqueness must be (room_id, short_id).
+	runMigration48(db);
 }
 
 /**
@@ -2924,12 +2930,16 @@ function runMigration46(db: BunDatabase): void {
 /**
  * Migration 47: Add short_id columns to tasks and goals; create short_id_counters table.
  *
- * - `tasks.short_id TEXT` — nullable, unique where not null (partial index).
- * - `goals.short_id TEXT` — nullable, unique where not null (partial index).
+ * - `tasks.short_id TEXT` — nullable, unique within room (partial composite index).
+ * - `goals.short_id TEXT` — nullable, unique within room (partial composite index).
  * - `short_id_counters` — per-(entity_type, scope_id) monotonic counter used by the
  *   ShortIdAllocator service when assigning short IDs to new or existing records.
  *
  * Idempotent: ALTER TABLE is guarded by tableHasColumn(); CREATE TABLE/INDEX use IF NOT EXISTS.
+ *
+ * NOTE: The original migration 47 accidentally created single-column global indexes
+ * (idx_tasks_short_id, idx_goals_short_id) instead of room-scoped composite indexes.
+ * Migration 48 corrects this on already-deployed DBs.
  */
 export function runMigration47(db: BunDatabase): void {
 	// On existing DBs, ALTER TABLE adds the column; on fresh DBs the column is already
@@ -2942,16 +2952,17 @@ export function runMigration47(db: BunDatabase): void {
 		db.exec(`ALTER TABLE goals ADD COLUMN short_id TEXT`);
 	}
 
-	// Partial unique indexes — safe on both fresh and existing DBs; also created by createTables()
-	// via IF NOT EXISTS.
+	// Partial unique indexes — scoped to (room_id, short_id) so different rooms can each
+	// have their own t-1, t-2, ... sequence without global uniqueness collisions.
+	// Also created by createTables() via IF NOT EXISTS.
 	if (tableExists(db, 'tasks')) {
 		db.exec(
-			`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_short_id ON tasks(short_id) WHERE short_id IS NOT NULL`
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_room_short_id ON tasks(room_id, short_id) WHERE short_id IS NOT NULL`
 		);
 	}
 	if (tableExists(db, 'goals')) {
 		db.exec(
-			`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_short_id ON goals(short_id) WHERE short_id IS NOT NULL`
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_room_short_id ON goals(room_id, short_id) WHERE short_id IS NOT NULL`
 		);
 	}
 
@@ -2964,4 +2975,37 @@ export function runMigration47(db: BunDatabase): void {
 			PRIMARY KEY (entity_type, scope_id)
 		)
 	`);
+}
+
+/**
+ * Migration 48: Replace global short_id unique indexes with room-scoped composite indexes.
+ *
+ * Migration 47 accidentally created single-column indexes:
+ *   CREATE UNIQUE INDEX idx_tasks_short_id ON tasks(short_id)
+ *   CREATE UNIQUE INDEX idx_goals_short_id ON goals(short_id)
+ *
+ * These are global: two tasks in different rooms both getting short_id='t-1' would violate
+ * the constraint. Short IDs are scoped to their parent room, so the correct constraint is:
+ *   (room_id, short_id) must be unique, not just (short_id).
+ *
+ * This migration drops the old global indexes (if they exist) and creates correct room-scoped
+ * composite indexes. Idempotent via DROP IF EXISTS + CREATE IF NOT EXISTS.
+ */
+export function runMigration48(db: BunDatabase): void {
+	if (tableExists(db, 'tasks')) {
+		// Drop old global index if present (created by old migration 47 code)
+		db.exec(`DROP INDEX IF EXISTS idx_tasks_short_id`);
+		// Create correct room-scoped composite index
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_room_short_id ON tasks(room_id, short_id) WHERE short_id IS NOT NULL`
+		);
+	}
+	if (tableExists(db, 'goals')) {
+		// Drop old global index if present
+		db.exec(`DROP INDEX IF EXISTS idx_goals_short_id`);
+		// Create correct room-scoped composite index
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_room_short_id ON goals(room_id, short_id) WHERE short_id IS NOT NULL`
+		);
+	}
 }

--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -19,6 +19,7 @@ import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { noOpReactiveDb } from '../../helpers/reactive-database';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
+import { ShortIdAllocator } from '../../../src/lib/short-id-allocator';
 import type { NeoTask } from '@neokai/shared';
 
 describe('GoalManager', () => {
@@ -814,5 +815,53 @@ describe('GoalManager', () => {
 
 			expect(updated.metrics).toEqual(metrics);
 		});
+	});
+});
+
+describe('GoalManager ShortIdAllocator wiring', () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createTables(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('assigns a shortId when GoalManager is given a ShortIdAllocator', async () => {
+		const roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({ name: 'R', allowedPaths: [] });
+		const allocator = new ShortIdAllocator(db);
+		const manager = new GoalManager(db, room.id, noOpReactiveDb, allocator);
+
+		const goal = await manager.createGoal({ title: 'G1', description: '' });
+
+		expect(goal.shortId).toBeDefined();
+		expect(goal.shortId).toMatch(/^g-\d+$/);
+	});
+
+	it('shortId is undefined when no ShortIdAllocator is provided', async () => {
+		const roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({ name: 'R', allowedPaths: [] });
+		const manager = new GoalManager(db, room.id, noOpReactiveDb);
+
+		const goal = await manager.createGoal({ title: 'G1', description: '' });
+
+		expect(goal.shortId).toBeUndefined();
+	});
+
+	it('assigns sequential shortIds across multiple goals', async () => {
+		const roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({ name: 'R', allowedPaths: [] });
+		const allocator = new ShortIdAllocator(db);
+		const manager = new GoalManager(db, room.id, noOpReactiveDb, allocator);
+
+		const g1 = await manager.createGoal({ title: 'G1', description: '' });
+		const g2 = await manager.createGoal({ title: 'G2', description: '' });
+
+		expect(g1.shortId).toBe('g-1');
+		expect(g2.shortId).toBe('g-2');
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -224,6 +224,7 @@ describe('RoomRuntimeService', () => {
 			const config: RoomRuntimeServiceConfig = {
 				db: {
 					getDatabase: () => db,
+					getShortIdAllocator: () => undefined,
 					getSession: () => null,
 				} as never,
 				messageHub: { onRequest: () => {} } as never,
@@ -506,6 +507,7 @@ describe('RoomRuntimeService restart recovery', () => {
 		const config: RoomRuntimeServiceConfig = {
 			db: {
 				getDatabase: () => rawDb,
+				getShortIdAllocator: () => undefined,
 				getSession: (sessionId: string) =>
 					sessionId === 'worker:task-1' || sessionId === 'leader:task-1'
 						? ({ id: sessionId } as never)

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -22,6 +22,7 @@ import {
 	VALID_STATUS_TRANSITIONS,
 } from '../../../src/lib/room/managers/task-manager';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
+import { ShortIdAllocator } from '../../../src/lib/short-id-allocator';
 import { noOpReactiveDb } from '../../helpers/reactive-database';
 
 describe('TaskManager', () => {
@@ -1336,5 +1337,53 @@ describe('extractPrNumber', () => {
 
 	it('should return null for empty string', () => {
 		expect(extractPrNumber('')).toBeNull();
+	});
+});
+
+describe('TaskManager ShortIdAllocator wiring', () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createTables(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('assigns a shortId when TaskManager is given a ShortIdAllocator', async () => {
+		const roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({ name: 'R', allowedPaths: [] });
+		const allocator = new ShortIdAllocator(db);
+		const manager = new TaskManager(db, room.id, noOpReactiveDb, allocator);
+
+		const task = await manager.createTask({ title: 'T1', description: '' });
+
+		expect(task.shortId).toBeDefined();
+		expect(task.shortId).toMatch(/^t-\d+$/);
+	});
+
+	it('shortId is undefined when no ShortIdAllocator is provided', async () => {
+		const roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({ name: 'R', allowedPaths: [] });
+		const manager = new TaskManager(db, room.id, noOpReactiveDb);
+
+		const task = await manager.createTask({ title: 'T1', description: '' });
+
+		expect(task.shortId).toBeUndefined();
+	});
+
+	it('assigns sequential shortIds across multiple tasks', async () => {
+		const roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({ name: 'R', allowedPaths: [] });
+		const allocator = new ShortIdAllocator(db);
+		const manager = new TaskManager(db, room.id, noOpReactiveDb, allocator);
+
+		const t1 = await manager.createTask({ title: 'T1', description: '' });
+		const t2 = await manager.createTask({ title: 'T2', description: '' });
+
+		expect(t1.shortId).toBe('t-1');
+		expect(t2.shortId).toBe('t-2');
 	});
 });

--- a/packages/daemon/tests/unit/storage/migrations/migration-47_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-47_test.ts
@@ -15,6 +15,7 @@ import {
 	runMigrations,
 	createTables,
 	runMigration47,
+	runMigration48,
 } from '../../../../src/storage/schema/index.ts';
 
 function columnExists(db: BunDatabase, table: string, column: string): boolean {
@@ -90,12 +91,16 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 		expect(columnExists(db, 'short_id_counters', 'counter')).toBe(true);
 	});
 
-	test('partial unique indexes exist for tasks and goals short_id', () => {
+	test('room-scoped composite unique indexes exist for tasks and goals short_id', () => {
 		runMigrations(db, () => {});
 		createTables(db);
 
-		expect(indexExists(db, 'idx_tasks_short_id')).toBe(true);
-		expect(indexExists(db, 'idx_goals_short_id')).toBe(true);
+		// New room-scoped indexes (created by migration 47 + 48)
+		expect(indexExists(db, 'idx_tasks_room_short_id')).toBe(true);
+		expect(indexExists(db, 'idx_goals_room_short_id')).toBe(true);
+		// Old global indexes must NOT exist (dropped by migration 48)
+		expect(indexExists(db, 'idx_tasks_short_id')).toBe(false);
+		expect(indexExists(db, 'idx_goals_short_id')).toBe(false);
 	});
 
 	// ── Existing DB (ALTER TABLE migration path) ────────────────────────────────
@@ -158,9 +163,9 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 		expect(columnExists(db, 'tasks', 'short_id')).toBe(true);
 		expect(columnExists(db, 'goals', 'short_id')).toBe(true);
 
-		// Indexes should exist
-		expect(indexExists(db, 'idx_tasks_short_id')).toBe(true);
-		expect(indexExists(db, 'idx_goals_short_id')).toBe(true);
+		// Room-scoped composite indexes should exist (created by migration 47 with new names)
+		expect(indexExists(db, 'idx_tasks_room_short_id')).toBe(true);
+		expect(indexExists(db, 'idx_goals_room_short_id')).toBe(true);
 
 		// Counter table should exist
 		expect(tableExists(db, 'short_id_counters')).toBe(true);
@@ -237,7 +242,7 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 		expect(rows.every((r) => r.short_id === null)).toBe(true);
 	});
 
-	test('tasks short_id unique index rejects duplicate non-null values', () => {
+	test('tasks short_id unique index rejects duplicate non-null values within the same room', () => {
 		runMigrations(db, () => {});
 		createTables(db);
 
@@ -247,15 +252,40 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 
 		db.exec(`
 			INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
-			VALUES ('task-uuid-1', 'room-uuid-1', 'Task 1', '', 'pending', 'normal', 1000, 1000, 't:roomabc:1')
+			VALUES ('task-uuid-1', 'room-uuid-1', 'Task 1', '', 'pending', 'normal', 1000, 1000, 't-1')
 		`);
 
 		expect(() => {
 			db.exec(`
 				INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
-				VALUES ('task-uuid-2', 'room-uuid-1', 'Task 2', '', 'pending', 'normal', 1001, 1001, 't:roomabc:1')
+				VALUES ('task-uuid-2', 'room-uuid-1', 'Task 2', '', 'pending', 'normal', 1001, 1001, 't-1')
 			`);
 		}).toThrow();
+	});
+
+	test('tasks short_id unique index allows same short_id value in different rooms', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at) VALUES
+				('room-uuid-1', 'Room 1', 1000, 1000),
+				('room-uuid-2', 'Room 2', 1000, 1000)
+		`);
+
+		// Room 1, task with short_id='t-1'
+		db.exec(`
+			INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
+			VALUES ('task-uuid-1', 'room-uuid-1', 'Task 1', '', 'pending', 'normal', 1000, 1000, 't-1')
+		`);
+
+		// Room 2, task also with short_id='t-1' — must NOT throw (different room)
+		expect(() => {
+			db.exec(`
+				INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
+				VALUES ('task-uuid-2', 'room-uuid-2', 'Task 2', '', 'pending', 'normal', 1001, 1001, 't-1')
+			`);
+		}).not.toThrow();
 	});
 
 	// ── Partial unique index semantics — goals ──────────────────────────────────
@@ -282,7 +312,7 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 		expect(rows.every((r) => r.short_id === null)).toBe(true);
 	});
 
-	test('goals short_id unique index rejects duplicate non-null values', () => {
+	test('goals short_id unique index rejects duplicate non-null values within the same room', () => {
 		runMigrations(db, () => {});
 		createTables(db);
 
@@ -292,15 +322,39 @@ describe('Migration 47: add short_id columns and short_id_counters table', () =>
 
 		db.exec(`
 			INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
-			VALUES ('goal-uuid-1', 'room-uuid-1', 'Goal 1', '', 'active', 1000, 1000, 'g:roomabc:1')
+			VALUES ('goal-uuid-1', 'room-uuid-1', 'Goal 1', '', 'active', 1000, 1000, 'g-1')
 		`);
 
 		expect(() => {
 			db.exec(`
 				INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
-				VALUES ('goal-uuid-2', 'room-uuid-1', 'Goal 2', '', 'active', 1001, 1001, 'g:roomabc:1')
+				VALUES ('goal-uuid-2', 'room-uuid-1', 'Goal 2', '', 'active', 1001, 1001, 'g-1')
 			`);
 		}).toThrow();
+	});
+
+	test('goals short_id unique index allows same short_id value in different rooms', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at) VALUES
+				('room-uuid-1', 'Room 1', 1000, 1000),
+				('room-uuid-2', 'Room 2', 1000, 1000)
+		`);
+
+		db.exec(`
+			INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
+			VALUES ('goal-uuid-1', 'room-uuid-1', 'Goal 1', '', 'active', 1000, 1000, 'g-1')
+		`);
+
+		// Room 2, goal also with short_id='g-1' — must NOT throw (different room)
+		expect(() => {
+			db.exec(`
+				INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
+				VALUES ('goal-uuid-2', 'room-uuid-2', 'Goal 2', '', 'active', 1001, 1001, 'g-1')
+			`);
+		}).not.toThrow();
 	});
 
 	// ── Idempotency ─────────────────────────────────────────────────────────────

--- a/packages/daemon/tests/unit/storage/migrations/migration-48_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-48_test.ts
@@ -1,0 +1,174 @@
+/**
+ * Migration 48 Tests
+ *
+ * Migration 48 fixes the short_id uniqueness constraint introduced by migration 47.
+ *
+ * Migration 47 accidentally created global single-column indexes:
+ *   CREATE UNIQUE INDEX idx_tasks_short_id ON tasks(short_id)
+ *   CREATE UNIQUE INDEX idx_goals_short_id ON goals(short_id)
+ *
+ * These caused UNIQUE constraint failures when two different rooms each created their
+ * first task/goal — both received short_id='t-1'/'g-1'.
+ *
+ * Migration 48 drops the old global indexes and creates room-scoped composite indexes:
+ *   CREATE UNIQUE INDEX idx_tasks_room_short_id ON tasks(room_id, short_id)
+ *   CREATE UNIQUE INDEX idx_goals_room_short_id ON goals(room_id, short_id)
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import {
+	runMigrations,
+	createTables,
+	runMigration48,
+} from '../../../../src/storage/schema/index.ts';
+
+function indexExists(db: BunDatabase, indexName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+		.get(indexName);
+	return !!result;
+}
+
+describe('Migration 48: replace global short_id indexes with room-scoped composite indexes', () => {
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('drops old global idx_tasks_short_id and idx_goals_short_id indexes', () => {
+		// Simulate a DB that ran the old migration 47 (global index names)
+		runMigrations(db, () => {});
+		createTables(db);
+
+		// Manually create the old-style global indexes to simulate pre-fix state
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_short_id ON tasks(short_id) WHERE short_id IS NOT NULL`
+		);
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_short_id ON goals(short_id) WHERE short_id IS NOT NULL`
+		);
+
+		expect(indexExists(db, 'idx_tasks_short_id')).toBe(true);
+		expect(indexExists(db, 'idx_goals_short_id')).toBe(true);
+
+		// Run migration 48
+		runMigration48(db);
+
+		// Old global indexes must be gone
+		expect(indexExists(db, 'idx_tasks_short_id')).toBe(false);
+		expect(indexExists(db, 'idx_goals_short_id')).toBe(false);
+	});
+
+	test('creates new room-scoped composite indexes after migration 48', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		expect(indexExists(db, 'idx_tasks_room_short_id')).toBe(true);
+		expect(indexExists(db, 'idx_goals_room_short_id')).toBe(true);
+	});
+
+	test('after migration 48, same short_id in different rooms is allowed for tasks', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at) VALUES
+				('room-1', 'Room 1', 1000, 1000),
+				('room-2', 'Room 2', 1000, 1000)
+		`);
+
+		db.exec(`
+			INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
+			VALUES ('task-1', 'room-1', 'Task 1', '', 'pending', 'normal', 1000, 1000, 't-1')
+		`);
+
+		// Same short_id 't-1' in a different room — must not throw
+		expect(() => {
+			db.exec(`
+				INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
+				VALUES ('task-2', 'room-2', 'Task 2', '', 'pending', 'normal', 1001, 1001, 't-1')
+			`);
+		}).not.toThrow();
+	});
+
+	test('after migration 48, same short_id in different rooms is allowed for goals', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at) VALUES
+				('room-1', 'Room 1', 1000, 1000),
+				('room-2', 'Room 2', 1000, 1000)
+		`);
+
+		db.exec(`
+			INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
+			VALUES ('goal-1', 'room-1', 'Goal 1', '', 'active', 1000, 1000, 'g-1')
+		`);
+
+		// Same short_id 'g-1' in a different room — must not throw
+		expect(() => {
+			db.exec(`
+				INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
+				VALUES ('goal-2', 'room-2', 'Goal 2', '', 'active', 1001, 1001, 'g-1')
+			`);
+		}).not.toThrow();
+	});
+
+	test('after migration 48, duplicate short_id within the same room still throws for tasks', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'Room 1', 1000, 1000)`
+		);
+
+		db.exec(`
+			INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
+			VALUES ('task-1', 'room-1', 'Task 1', '', 'pending', 'normal', 1000, 1000, 't-1')
+		`);
+
+		expect(() => {
+			db.exec(`
+				INSERT INTO tasks (id, room_id, title, description, status, priority, created_at, updated_at, short_id)
+				VALUES ('task-2', 'room-1', 'Task 2', '', 'pending', 'normal', 1001, 1001, 't-1')
+			`);
+		}).toThrow();
+	});
+
+	test('after migration 48, duplicate short_id within the same room still throws for goals', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'Room 1', 1000, 1000)`
+		);
+
+		db.exec(`
+			INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
+			VALUES ('goal-1', 'room-1', 'Goal 1', '', 'active', 1000, 1000, 'g-1')
+		`);
+
+		expect(() => {
+			db.exec(`
+				INSERT INTO goals (id, room_id, title, description, status, created_at, updated_at, short_id)
+				VALUES ('goal-2', 'room-1', 'Goal 2', '', 'active', 1001, 1001, 'g-1')
+			`);
+		}).toThrow();
+	});
+
+	test('migration 48 is idempotent — running it twice does not throw', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		expect(() => runMigration48(db)).not.toThrow();
+		expect(() => runMigration48(db)).not.toThrow();
+	});
+});


### PR DESCRIPTION
- Add getShortIdAllocator() to Database facade (storage/index.ts) and export ShortIdAllocator
- TaskManager accepts optional ShortIdAllocator and forwards it to TaskRepository constructor
- GoalManager accepts optional ShortIdAllocator and forwards it to GoalRepository and TaskRepository
- Update all 4 TaskManager instantiation sites to pass allocator:
  - rpc-handlers/task-handlers.ts (default factory)
  - rpc-handlers/index.ts (goalTaskManagerFactory)
  - room-runtime-service.ts createOrGetRuntime (lines ~427)
  - room-runtime-service.ts recoverRoomRuntime (line ~659)
- Update both GoalManager instantiation sites to pass allocator:
  - rpc-handlers/index.ts (goalManagerFactory)
  - room-runtime-service.ts createOrGetRuntime (line ~428)
- Fix room-runtime-service tests: add getShortIdAllocator: () => undefined to mock db objects
- Add 6 unit tests in task-manager.test.ts and goal-manager.test.ts verifying shortId assignment
