### PR TITLE
feat(lib): add ID resolution helpers for task and goal UUID/short-ID lookup

### DIFF
--- a/packages/daemon/src/lib/id-resolution.ts
+++ b/packages/daemon/src/lib/id-resolution.ts
@@ -1,0 +1,37 @@
+import { isUUID } from '@neokai/shared';
+import type { TaskRepository } from '../storage/repositories/task-repository';
+import type { GoalRepository } from '../storage/repositories/goal-repository';
+
+/**
+ * Resolves a task identifier (UUID or short ID) to a UUID.
+ * - If `input` is already a UUID, it is returned as-is (no DB lookup).
+ * - Otherwise, performs a short ID lookup via `taskRepo.getTaskByShortId`.
+ * @throws {Error} with message 'Task not found' when the short ID cannot be resolved.
+ */
+export function resolveTaskId(input: string, roomId: string, taskRepo: TaskRepository): string {
+	if (isUUID(input)) {
+		return input;
+	}
+	const task = taskRepo.getTaskByShortId(roomId, input);
+	if (!task) {
+		throw new Error('Task not found');
+	}
+	return task.id;
+}
+
+/**
+ * Resolves a goal identifier (UUID or short ID) to a UUID.
+ * - If `input` is already a UUID, it is returned as-is (no DB lookup).
+ * - Otherwise, performs a short ID lookup via `goalRepo.getGoalByShortId`.
+ * @throws {Error} with message 'Goal not found' when the short ID cannot be resolved.
+ */
+export function resolveGoalId(input: string, roomId: string, goalRepo: GoalRepository): string {
+	if (isUUID(input)) {
+		return input;
+	}
+	const goal = goalRepo.getGoalByShortId(roomId, input);
+	if (!goal) {
+		throw new Error('Goal not found');
+	}
+	return goal.id;
+}

--- a/packages/daemon/src/lib/id-resolution.ts
+++ b/packages/daemon/src/lib/id-resolution.ts
@@ -14,7 +14,7 @@ export function resolveTaskId(input: string, roomId: string, taskRepo: TaskRepos
 	}
 	const task = taskRepo.getTaskByShortId(roomId, input);
 	if (!task) {
-		throw new Error('Task not found');
+		throw new Error(`Task not found: ${input}`);
 	}
 	return task.id;
 }
@@ -31,7 +31,7 @@ export function resolveGoalId(input: string, roomId: string, goalRepo: GoalRepos
 	}
 	const goal = goalRepo.getGoalByShortId(roomId, input);
 	if (!goal) {
-		throw new Error('Goal not found');
+		throw new Error(`Goal not found: ${input}`);
 	}
 	return goal.id;
 }

--- a/packages/daemon/tests/unit/lib/id-resolution.test.ts
+++ b/packages/daemon/tests/unit/lib/id-resolution.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveTaskId, resolveGoalId } from '../../../src/lib/id-resolution';
+import type { TaskRepository } from '../../../src/storage/repositories/task-repository';
+import type { GoalRepository } from '../../../src/storage/repositories/goal-repository';
+import type { NeoTask, RoomGoal } from '@neokai/shared';
+
+const ROOM_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+const TASK_UUID = 'd8a578c6-d3cb-4c84-926b-958cbd433d32';
+const GOAL_UUID = 'f1e2d3c4-b5a6-4789-a123-456789abcdef';
+
+function makeTaskRepo(task: NeoTask | null): Pick<TaskRepository, 'getTaskByShortId'> {
+	return {
+		getTaskByShortId: (_roomId: string, _shortId: string) => task,
+	};
+}
+
+function makeGoalRepo(goal: RoomGoal | null): Pick<GoalRepository, 'getGoalByShortId'> {
+	return {
+		getGoalByShortId: (_roomId: string, _shortId: string) => goal,
+	};
+}
+
+const stubTask = { id: TASK_UUID } as NeoTask;
+const stubGoal = { id: GOAL_UUID } as RoomGoal;
+
+describe('resolveTaskId', () => {
+	test('returns UUID directly without DB lookup', () => {
+		const repo = makeTaskRepo(null);
+		expect(resolveTaskId(TASK_UUID, ROOM_ID, repo as TaskRepository)).toBe(TASK_UUID);
+	});
+
+	test('resolves short ID to UUID', () => {
+		const repo = makeTaskRepo(stubTask);
+		expect(resolveTaskId('t-42', ROOM_ID, repo as TaskRepository)).toBe(TASK_UUID);
+	});
+
+	test('throws when short ID not found', () => {
+		const repo = makeTaskRepo(null);
+		expect(() => resolveTaskId('t-9999', ROOM_ID, repo as TaskRepository)).toThrow(
+			'Task not found'
+		);
+	});
+
+	test('calls getTaskByShortId with correct roomId and shortId', () => {
+		let calledWith: { roomId: string; shortId: string } | null = null;
+		const repo: Pick<TaskRepository, 'getTaskByShortId'> = {
+			getTaskByShortId: (roomId, shortId) => {
+				calledWith = { roomId, shortId };
+				return stubTask;
+			},
+		};
+		resolveTaskId('t-7', ROOM_ID, repo as TaskRepository);
+		expect(calledWith).toEqual({ roomId: ROOM_ID, shortId: 't-7' });
+	});
+
+	test('does not call getTaskByShortId for UUID input', () => {
+		let called = false;
+		const repo: Pick<TaskRepository, 'getTaskByShortId'> = {
+			getTaskByShortId: () => {
+				called = true;
+				return null;
+			},
+		};
+		resolveTaskId(TASK_UUID, ROOM_ID, repo as TaskRepository);
+		expect(called).toBe(false);
+	});
+});
+
+describe('resolveGoalId', () => {
+	test('returns UUID directly without DB lookup', () => {
+		const repo = makeGoalRepo(null);
+		expect(resolveGoalId(GOAL_UUID, ROOM_ID, repo as GoalRepository)).toBe(GOAL_UUID);
+	});
+
+	test('resolves short ID to UUID', () => {
+		const repo = makeGoalRepo(stubGoal);
+		expect(resolveGoalId('g-5', ROOM_ID, repo as GoalRepository)).toBe(GOAL_UUID);
+	});
+
+	test('throws when short ID not found', () => {
+		const repo = makeGoalRepo(null);
+		expect(() => resolveGoalId('g-9999', ROOM_ID, repo as GoalRepository)).toThrow(
+			'Goal not found'
+		);
+	});
+
+	test('calls getGoalByShortId with correct roomId and shortId', () => {
+		let calledWith: { roomId: string; shortId: string } | null = null;
+		const repo: Pick<GoalRepository, 'getGoalByShortId'> = {
+			getGoalByShortId: (roomId, shortId) => {
+				calledWith = { roomId, shortId };
+				return stubGoal;
+			},
+		};
+		resolveGoalId('g-3', ROOM_ID, repo as GoalRepository);
+		expect(calledWith).toEqual({ roomId: ROOM_ID, shortId: 'g-3' });
+	});
+
+	test('does not call getGoalByShortId for UUID input', () => {
+		let called = false;
+		const repo: Pick<GoalRepository, 'getGoalByShortId'> = {
+			getGoalByShortId: () => {
+				called = true;
+				return null;
+			},
+		};
+		resolveGoalId(GOAL_UUID, ROOM_ID, repo as GoalRepository);
+		expect(called).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/lib/id-resolution.test.ts
+++ b/packages/daemon/tests/unit/lib/id-resolution.test.ts
@@ -37,7 +37,7 @@ describe('resolveTaskId', () => {
 	test('throws when short ID not found', () => {
 		const repo = makeTaskRepo(null);
 		expect(() => resolveTaskId('t-9999', ROOM_ID, repo as TaskRepository)).toThrow(
-			'Task not found'
+			'Task not found: t-9999'
 		);
 	});
 
@@ -80,7 +80,7 @@ describe('resolveGoalId', () => {
 	test('throws when short ID not found', () => {
 		const repo = makeGoalRepo(null);
 		expect(() => resolveGoalId('g-9999', ROOM_ID, repo as GoalRepository)).toThrow(
-			'Goal not found'
+			'Goal not found: g-9999'
 		);
 	});
 


### PR DESCRIPTION
Implements resolveTaskId() and resolveGoalId() in id-resolution.ts:
- UUID inputs pass through without any DB lookup
- Short IDs are resolved via getTaskByShortId/getGoalByShortId
- Throws Task/Goal not found when short ID has no match
10 unit tests cover UUID pass-through, short ID resolution, not-found errors, and correct call arguments.
