### PR TITLE
feat(web): replace flat progress bar with circular indicator in task list items

### DIFF
--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -464,21 +464,28 @@ describe('RoomTasks', () => {
 			selectedTabSignal.value = 'active';
 		});
 
-		it('should show progress percentage when defined', () => {
+		it('should show circular progress indicator when progress is defined', () => {
 			const tasks = [createTask('t1', 'in_progress', { progress: 75 })];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			expect(container.textContent).toContain('75%');
+			// Circular indicator renders an SVG, not a percentage text
+			const svg = container.querySelector('svg[width="24"]');
+			expect(svg).toBeTruthy();
 		});
 
-		it('should show progress bar when progress is defined', () => {
+		it('should show circular progress indicator instead of flat bar when progress is defined', () => {
 			const tasks = [createTask('t1', 'in_progress', { progress: 50 })];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			const progressBar = container.querySelector('.bg-blue-500');
-			expect(progressBar).toBeTruthy();
+			// No flat blue progress bar
+			const flatBar = container.querySelector('.bg-blue-500');
+			expect(flatBar).toBeFalsy();
+
+			// Circular indicator renders an SVG
+			const svg = container.querySelector('svg[width="24"]');
+			expect(svg).toBeTruthy();
 		});
 	});
 

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -12,6 +12,7 @@ import { useState } from 'preact/hooks';
 import { signal, effect } from '@preact/signals';
 import type { TaskSummary, TaskStatus, RoomGoal } from '@neokai/shared';
 import { toast } from '../../lib/toast.ts';
+import { CircularProgressIndicator } from '../ui/CircularProgressIndicator';
 
 /** Tab filter types */
 export type TaskFilterTab = 'active' | 'review' | 'done' | 'archived';
@@ -672,8 +673,12 @@ function TaskItem({
 					</div>
 				</div>
 				<div class="ml-4 flex items-center gap-2 flex-shrink-0">
-					{task.progress !== undefined && (
-						<span class="text-xs text-gray-400">{task.progress}%</span>
+					{task.progress != null && task.progress > 0 && (
+						<CircularProgressIndicator
+							progress={task.progress}
+							size={24}
+							title={`Task progress: ${task.progress}%`}
+						/>
 					)}
 					{task.prUrl && (
 						<a
@@ -788,14 +793,6 @@ function TaskItem({
 							</span>
 						);
 					})}
-				</div>
-			)}
-			{task.progress !== undefined && (
-				<div class="mt-2 h-1 bg-dark-700 rounded-full overflow-hidden">
-					<div
-						class="h-full bg-blue-500 transition-all duration-300"
-						style={{ width: `${task.progress}%` }}
-					/>
 				</div>
 			)}
 			{/* Reject form — always rendered; max-height controls collapse with transition-all duration-200 */}


### PR DESCRIPTION
Remove the blue horizontal progress bar from TaskItem and replace the
percentage text with a CircularProgressIndicator (size=24), consistent
with the style used in TaskView and TaskViewV2 headers.
