### PR TITLE
feat(web): show room-specific bottom tabs on mobile when in room context

### DIFF
--- a/packages/e2e/tests/helpers/room-helpers.ts
+++ b/packages/e2e/tests/helpers/room-helpers.ts
@@ -10,6 +10,18 @@ import type { Page } from '@playwright/test';
 import { waitForWebSocketConnected } from './wait-helpers';
 
 /**
+ * Create a room via RPC. For use in beforeEach setup only.
+ */
+export async function createRoom(page: Page, name: string): Promise<string> {
+	return page.evaluate(async (roomName) => {
+		const hub = window.__messageHub || window.appState?.messageHub;
+		if (!hub?.request) throw new Error('MessageHub not available');
+		const res = await hub.request('room.create', { name: roomName });
+		return (res as { room: { id: string } }).room.id;
+	}, name);
+}
+
+/**
  * Delete a room via RPC. Best-effort — silently ignores errors so it can be
  * used safely in afterEach without masking test failures.
  */

--- a/packages/e2e/tests/responsive/mobile.e2e.ts
+++ b/packages/e2e/tests/responsive/mobile.e2e.ts
@@ -5,10 +5,16 @@
  * - Layout adaptation
  * - Input behavior on mobile
  * - Message display on mobile
+ * - Room agent navigation via bottom tab bar
  */
 
 import { test, expect, devices } from '../../fixtures';
-import { cleanupTestSession, createSessionViaUI } from '../helpers/wait-helpers';
+import {
+	cleanupTestSession,
+	createSessionViaUI,
+	waitForWebSocketConnected,
+} from '../helpers/wait-helpers';
+import { deleteRoom } from '../helpers/room-helpers';
 
 test.describe('Mobile Layout', () => {
 	// Use iPhone 13 viewport for mobile tests
@@ -282,5 +288,118 @@ test.describe('Mobile Messages', () => {
 			// Message should fit within viewport width
 			expect(containerBox.width).toBeLessThanOrEqual(390);
 		}
+	});
+});
+
+test.describe('Mobile Room Agent Navigation', () => {
+	let roomId = '';
+
+	test.use({
+		viewport: { width: 390, height: 844 },
+		userAgent: devices['iPhone 13'].userAgent,
+		hasTouch: true,
+		isMobile: true,
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+
+		// Create a room via RPC (infrastructure setup)
+		roomId = await page.evaluate(async () => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const res = await hub.request('room.create', { name: 'Mobile Agent Nav Test' });
+			return (res as { room: { id: string } }).room.id;
+		});
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (roomId) {
+			await deleteRoom(page, roomId);
+			roomId = '';
+		}
+	});
+
+	test('shows room-specific tabs (Overview + Agent) when in room context', async ({ page }) => {
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for room to load
+		await expect(page.getByRole('button', { name: 'Overview', exact: true })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Bottom tab bar should show room-specific tabs
+		const bottomTabBar = page.getByRole('tablist', { name: 'Main navigation' });
+		await expect(bottomTabBar).toBeVisible();
+
+		// Room context tabs should be present
+		await expect(bottomTabBar.getByRole('tab', { name: 'Overview' })).toBeVisible();
+		await expect(bottomTabBar.getByRole('tab', { name: 'Agent' })).toBeVisible();
+
+		// Global chats/rooms tabs should NOT be visible in room context
+		await expect(bottomTabBar.getByRole('tab', { name: 'Chats' })).not.toBeVisible();
+		await expect(bottomTabBar.getByRole('tab', { name: 'Rooms' })).not.toBeVisible();
+	});
+
+	test('Agent tab navigates to room agent URL', async ({ page }) => {
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.getByRole('button', { name: 'Overview', exact: true })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Click the Agent tab in the bottom bar
+		const bottomTabBar = page.getByRole('tablist', { name: 'Main navigation' });
+		await bottomTabBar.getByRole('tab', { name: 'Agent' }).click();
+
+		// URL should change to room agent path
+		await expect(page).toHaveURL(new RegExp(`/room/${roomId}/agent$`), { timeout: 5000 });
+	});
+
+	test('Overview tab navigates back to room dashboard from agent view', async ({ page }) => {
+		// Start from agent view
+		await page.goto(`/room/${roomId}/agent`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for chat container to appear (room agent view)
+		await expect(page).toHaveURL(new RegExp(`/room/${roomId}/agent$`), { timeout: 10000 });
+
+		// Agent tab should be active
+		const bottomTabBar = page.getByRole('tablist', { name: 'Main navigation' });
+		const agentTab = bottomTabBar.getByRole('tab', { name: 'Agent' });
+		await expect(agentTab).toBeVisible();
+		await expect(agentTab).toHaveAttribute('aria-selected', 'true');
+
+		// Click Overview tab to go back to room dashboard
+		await bottomTabBar.getByRole('tab', { name: 'Overview' }).click();
+
+		// URL should change back to room path
+		await expect(page).toHaveURL(new RegExp(`/room/${roomId}$`), { timeout: 5000 });
+	});
+
+	test('room-specific tabs restore to global tabs when leaving room', async ({ page }) => {
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.getByRole('button', { name: 'Overview', exact: true })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Verify room-specific tabs are shown
+		const bottomTabBar = page.getByRole('tablist', { name: 'Main navigation' });
+		await expect(bottomTabBar.getByRole('tab', { name: 'Agent' })).toBeVisible();
+
+		// Click Inbox tab (present in both room and global contexts)
+		await bottomTabBar.getByRole('tab', { name: 'Inbox' }).click();
+
+		// URL should change to inbox
+		await expect(page).toHaveURL(/\/inbox$/, { timeout: 5000 });
+
+		// Now global tabs should be shown (Rooms tab visible)
+		await expect(bottomTabBar.getByRole('tab', { name: 'Rooms' })).toBeVisible({ timeout: 5000 });
+		await expect(bottomTabBar.getByRole('tab', { name: 'Chats' })).toBeVisible();
 	});
 });

--- a/packages/e2e/tests/responsive/mobile.e2e.ts
+++ b/packages/e2e/tests/responsive/mobile.e2e.ts
@@ -14,7 +14,7 @@ import {
 	createSessionViaUI,
 	waitForWebSocketConnected,
 } from '../helpers/wait-helpers';
-import { deleteRoom } from '../helpers/room-helpers';
+import { createRoom, deleteRoom } from '../helpers/room-helpers';
 
 test.describe('Mobile Layout', () => {
 	// Use iPhone 13 viewport for mobile tests
@@ -304,14 +304,7 @@ test.describe('Mobile Room Agent Navigation', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
-
-		// Create a room via RPC (infrastructure setup)
-		roomId = await page.evaluate(async () => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('MessageHub not available');
-			const res = await hub.request('room.create', { name: 'Mobile Agent Nav Test' });
-			return (res as { room: { id: string } }).room.id;
-		});
+		roomId = await createRoom(page, 'Mobile Agent Nav Test');
 	});
 
 	test.afterEach(async ({ page }) => {
@@ -364,7 +357,7 @@ test.describe('Mobile Room Agent Navigation', () => {
 		await page.goto(`/room/${roomId}/agent`);
 		await waitForWebSocketConnected(page);
 
-		// Wait for chat container to appear (room agent view)
+		// Wait for agent view to load
 		await expect(page).toHaveURL(new RegExp(`/room/${roomId}/agent$`), { timeout: 10000 });
 
 		// Agent tab should be active
@@ -372,6 +365,12 @@ test.describe('Mobile Room Agent Navigation', () => {
 		const agentTab = bottomTabBar.getByRole('tab', { name: 'Agent' });
 		await expect(agentTab).toBeVisible();
 		await expect(agentTab).toHaveAttribute('aria-selected', 'true');
+
+		// Overview tab should not be active
+		await expect(bottomTabBar.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+			'aria-selected',
+			'false'
+		);
 
 		// Click Overview tab to go back to room dashboard
 		await bottomTabBar.getByRole('tab', { name: 'Overview' }).click();
@@ -401,5 +400,60 @@ test.describe('Mobile Room Agent Navigation', () => {
 		// Now global tabs should be shown (Rooms tab visible)
 		await expect(bottomTabBar.getByRole('tab', { name: 'Rooms' })).toBeVisible({ timeout: 5000 });
 		await expect(bottomTabBar.getByRole('tab', { name: 'Chats' })).toBeVisible();
+	});
+
+	test('Overview tab is active on room dashboard but not on task or session sub-views', async ({
+		page,
+	}) => {
+		// Create a task for navigation (infrastructure)
+		const taskId = await page.evaluate(async (rId) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const res = await hub.request('task.create', {
+				roomId: rId,
+				title: 'Mobile Nav Test Task',
+				description: 'Task for mobile nav tab test',
+			});
+			return (res as { task: { id: string } }).task.id;
+		}, roomId);
+
+		const bottomTabBar = page.getByRole('tablist', { name: 'Main navigation' });
+
+		// 1. Room dashboard — Overview should be active
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+		await expect(page.getByRole('button', { name: 'Overview', exact: true })).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(bottomTabBar.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+
+		// 2. Room task view — neither Overview nor Agent should be active
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await waitForWebSocketConnected(page);
+		await expect(page).toHaveURL(new RegExp(`/room/${roomId}/task/${taskId}$`), { timeout: 5000 });
+		await expect(bottomTabBar.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+			'aria-selected',
+			'false'
+		);
+		await expect(bottomTabBar.getByRole('tab', { name: 'Agent' })).toHaveAttribute(
+			'aria-selected',
+			'false'
+		);
+
+		// 3. Room agent — Agent should be active, Overview not
+		await page.goto(`/room/${roomId}/agent`);
+		await waitForWebSocketConnected(page);
+		await expect(page).toHaveURL(new RegExp(`/room/${roomId}/agent$`), { timeout: 5000 });
+		await expect(bottomTabBar.getByRole('tab', { name: 'Agent' })).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		await expect(bottomTabBar.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+			'aria-selected',
+			'false'
+		);
 	});
 });

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -3,6 +3,7 @@ import {
 	navSectionSignal,
 	currentRoomIdSignal,
 	currentRoomSessionIdSignal,
+	currentRoomTaskIdSignal,
 	type NavSection,
 } from '../lib/signals.ts';
 import {
@@ -114,8 +115,11 @@ export function BottomTabBar() {
 	const roomSessionId = currentRoomSessionIdSignal.value;
 	const inboxBadgeCount = inboxStore.reviewCount.value;
 
+	const roomTaskId = currentRoomTaskIdSignal.value;
 	const isInRoomContext = navSection === 'rooms' && roomId !== null;
 	const isViewingRoomAgent = roomSessionId === `room:chat:${roomId}`;
+	// Overview is only active when on the room dashboard (no task and no session open)
+	const isViewingRoomDashboard = roomSessionId === null && roomTaskId === null;
 
 	const tabs = isInRoomContext ? ROOM_BOTTOM_TABS : GLOBAL_BOTTOM_TABS;
 
@@ -145,7 +149,7 @@ export function BottomTabBar() {
 	const isTabActive = (id: TabItem['id']): boolean => {
 		if (isInRoomContext) {
 			if (id === 'room-agent') return isViewingRoomAgent;
-			if (id === 'room-overview') return !isViewingRoomAgent && navSection === 'rooms';
+			if (id === 'room-overview') return isViewingRoomDashboard && navSection === 'rooms';
 		}
 		return navSection === id;
 	};

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -1,105 +1,154 @@
 import type { JSX } from 'preact';
-import { navSectionSignal, type NavSection } from '../lib/signals.ts';
+import {
+	navSectionSignal,
+	currentRoomIdSignal,
+	currentRoomSessionIdSignal,
+	type NavSection,
+} from '../lib/signals.ts';
 import {
 	navigateToSessions,
 	navigateToSettings,
 	navigateToRooms,
 	navigateToInbox,
+	navigateToRoom,
+	navigateToRoomAgent,
 } from '../lib/router.ts';
 import { inboxStore } from '../lib/inbox-store.ts';
 import { InboxBadge } from '../components/ui/InboxBadge.tsx';
 
 interface TabItem {
-	id: NavSection;
+	id: NavSection | 'room-agent' | 'room-overview';
 	label: string;
 	icon: () => JSX.Element;
 }
 
-const BOTTOM_TABS: TabItem[] = [
-	{
-		id: 'inbox',
-		label: 'Inbox',
-		icon: () => (
-			<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
-				/>
-			</svg>
-		),
-	},
-	{
-		id: 'rooms',
-		label: 'Rooms',
-		icon: () => (
-			<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-				/>
-			</svg>
-		),
-	},
-	{
-		id: 'chats',
-		label: 'Chats',
-		icon: () => (
-			<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
-				/>
-			</svg>
-		),
-	},
-	{
-		id: 'settings',
-		label: 'Settings',
-		icon: () => (
-			<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-				/>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-				/>
-			</svg>
-		),
-	},
+const InboxIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+		/>
+	</svg>
+);
+
+const RoomsIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+		/>
+	</svg>
+);
+
+const ChatsIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+		/>
+	</svg>
+);
+
+const SettingsIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+		/>
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+		/>
+	</svg>
+);
+
+const RoomOverviewIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
+		/>
+	</svg>
+);
+
+const RoomAgentIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23-.693L5 14.5m14.8.8l1.402 1.402c1 1 .03 2.7-1.41 2.417l-2.194-.44a9.06 9.06 0 01-5.197 0l-2.193.44c-1.44.283-2.41-1.416-1.41-2.416L5 14.5"
+		/>
+	</svg>
+);
+
+const GLOBAL_BOTTOM_TABS: TabItem[] = [
+	{ id: 'inbox', label: 'Inbox', icon: InboxIcon },
+	{ id: 'rooms', label: 'Rooms', icon: RoomsIcon },
+	{ id: 'chats', label: 'Chats', icon: ChatsIcon },
+	{ id: 'settings', label: 'Settings', icon: SettingsIcon },
 ];
 
-function handleTabClick(id: NavSection): void {
-	switch (id) {
-		case 'inbox':
-			navigateToInbox();
-			break;
-		case 'rooms':
-			navigateToRooms();
-			break;
-		case 'chats':
-			navigateToSessions();
-			break;
-		case 'settings':
-			navigateToSettings();
-			break;
-	}
-}
+const ROOM_BOTTOM_TABS: TabItem[] = [
+	{ id: 'room-overview', label: 'Overview', icon: RoomOverviewIcon },
+	{ id: 'room-agent', label: 'Agent', icon: RoomAgentIcon },
+	{ id: 'inbox', label: 'Inbox', icon: InboxIcon },
+	{ id: 'settings', label: 'Settings', icon: SettingsIcon },
+];
 
 export function BottomTabBar() {
 	const navSection = navSectionSignal.value;
+	const roomId = currentRoomIdSignal.value;
+	const roomSessionId = currentRoomSessionIdSignal.value;
 	const inboxBadgeCount = inboxStore.reviewCount.value;
+
+	const isInRoomContext = navSection === 'rooms' && roomId !== null;
+	const isViewingRoomAgent = roomSessionId === `room:chat:${roomId}`;
+
+	const tabs = isInRoomContext ? ROOM_BOTTOM_TABS : GLOBAL_BOTTOM_TABS;
+
+	const handleTabClick = (id: TabItem['id']) => {
+		switch (id) {
+			case 'inbox':
+				navigateToInbox();
+				break;
+			case 'rooms':
+				navigateToRooms();
+				break;
+			case 'chats':
+				navigateToSessions();
+				break;
+			case 'settings':
+				navigateToSettings();
+				break;
+			case 'room-overview':
+				if (roomId) navigateToRoom(roomId);
+				break;
+			case 'room-agent':
+				if (roomId) navigateToRoomAgent(roomId);
+				break;
+		}
+	};
+
+	const isTabActive = (id: TabItem['id']): boolean => {
+		if (isInRoomContext) {
+			if (id === 'room-agent') return isViewingRoomAgent;
+			if (id === 'room-overview') return !isViewingRoomAgent && navSection === 'rooms';
+		}
+		return navSection === id;
+	};
 
 	return (
 		<div
@@ -107,8 +156,8 @@ export function BottomTabBar() {
 			role="tablist"
 			aria-label="Main navigation"
 		>
-			{BOTTOM_TABS.map((tab) => {
-				const isActive = navSection === tab.id;
+			{tabs.map((tab) => {
+				const isActive = isTabActive(tab.id);
 				const isInbox = tab.id === 'inbox';
 				const badge = isInbox ? inboxBadgeCount : 0;
 

--- a/packages/web/src/islands/__tests__/BottomTabBar.test.tsx
+++ b/packages/web/src/islands/__tests__/BottomTabBar.test.tsx
@@ -17,6 +17,8 @@ vi.mock('../../lib/router.ts', () => ({
 	navigateToRooms: vi.fn(),
 	navigateToInbox: vi.fn(),
 	navigateToSpaces: vi.fn(),
+	navigateToRoom: vi.fn(),
+	navigateToRoomAgent: vi.fn(),
 }));
 
 // Mock inboxStore
@@ -39,17 +41,27 @@ vi.mock('../../lib/inbox-store.ts', () => ({
 }));
 
 import { BottomTabBar } from '../BottomTabBar.tsx';
-import { navSectionSignal } from '../../lib/signals.ts';
+import {
+	navSectionSignal,
+	currentRoomIdSignal,
+	currentRoomSessionIdSignal,
+	currentRoomTaskIdSignal,
+} from '../../lib/signals.ts';
 import {
 	navigateToInbox,
 	navigateToRooms,
 	navigateToSessions,
 	navigateToSettings,
+	navigateToRoom,
+	navigateToRoomAgent,
 } from '../../lib/router.ts';
 
 describe('BottomTabBar', () => {
 	beforeEach(() => {
 		navSectionSignal.value = 'chats';
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
 		mockItemsSignal.value = [];
 		vi.clearAllMocks();
 	});
@@ -301,6 +313,103 @@ describe('BottomTabBar', () => {
 			const roomsTab = screen.getByRole('tab', { name: 'Rooms' });
 			expect(chatsTab.getAttribute('aria-selected')).toBe('false');
 			expect(roomsTab.getAttribute('aria-selected')).toBe('true');
+		});
+	});
+
+	describe('Room Context Tabs', () => {
+		const ROOM_ID = 'test-room-id-123';
+
+		beforeEach(() => {
+			navSectionSignal.value = 'rooms';
+			currentRoomIdSignal.value = ROOM_ID;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+		});
+
+		it('should show room-specific tabs (Overview, Agent, Inbox, Settings) when in room context', () => {
+			render(<BottomTabBar />);
+
+			expect(screen.getByRole('tab', { name: 'Overview' })).toBeTruthy();
+			expect(screen.getByRole('tab', { name: 'Agent' })).toBeTruthy();
+			expect(screen.getByRole('tab', { name: 'Inbox' })).toBeTruthy();
+			expect(screen.getByRole('tab', { name: 'Settings' })).toBeTruthy();
+		});
+
+		it('should hide global Rooms and Chats tabs when in room context', () => {
+			render(<BottomTabBar />);
+
+			expect(screen.queryByRole('tab', { name: 'Rooms' })).toBeNull();
+			expect(screen.queryByRole('tab', { name: 'Chats' })).toBeNull();
+		});
+
+		it('should mark Overview tab as active on room dashboard (no session or task open)', () => {
+			render(<BottomTabBar />);
+
+			const overviewTab = screen.getByRole('tab', { name: 'Overview' });
+			expect(overviewTab.getAttribute('aria-selected')).toBe('true');
+
+			const agentTab = screen.getByRole('tab', { name: 'Agent' });
+			expect(agentTab.getAttribute('aria-selected')).toBe('false');
+		});
+
+		it('should mark Agent tab as active when viewing room agent', () => {
+			currentRoomSessionIdSignal.value = `room:chat:${ROOM_ID}`;
+			render(<BottomTabBar />);
+
+			const agentTab = screen.getByRole('tab', { name: 'Agent' });
+			expect(agentTab.getAttribute('aria-selected')).toBe('true');
+
+			const overviewTab = screen.getByRole('tab', { name: 'Overview' });
+			expect(overviewTab.getAttribute('aria-selected')).toBe('false');
+		});
+
+		it('should not highlight Overview or Agent when viewing a room task', () => {
+			currentRoomTaskIdSignal.value = 'some-task-id';
+			render(<BottomTabBar />);
+
+			const overviewTab = screen.getByRole('tab', { name: 'Overview' });
+			const agentTab = screen.getByRole('tab', { name: 'Agent' });
+			expect(overviewTab.getAttribute('aria-selected')).toBe('false');
+			expect(agentTab.getAttribute('aria-selected')).toBe('false');
+		});
+
+		it('should not highlight Overview or Agent when viewing a room session', () => {
+			currentRoomSessionIdSignal.value = 'some-session-id';
+			render(<BottomTabBar />);
+
+			const overviewTab = screen.getByRole('tab', { name: 'Overview' });
+			const agentTab = screen.getByRole('tab', { name: 'Agent' });
+			expect(overviewTab.getAttribute('aria-selected')).toBe('false');
+			expect(agentTab.getAttribute('aria-selected')).toBe('false');
+		});
+
+		it('should call navigateToRoom when Overview tab is clicked', () => {
+			render(<BottomTabBar />);
+
+			const overviewTab = screen.getByRole('tab', { name: 'Overview' });
+			fireEvent.click(overviewTab);
+
+			expect(navigateToRoom).toHaveBeenCalledWith(ROOM_ID);
+		});
+
+		it('should call navigateToRoomAgent when Agent tab is clicked', () => {
+			render(<BottomTabBar />);
+
+			const agentTab = screen.getByRole('tab', { name: 'Agent' });
+			fireEvent.click(agentTab);
+
+			expect(navigateToRoomAgent).toHaveBeenCalledWith(ROOM_ID);
+		});
+
+		it('should show global tabs when navSection is rooms but roomId is null', () => {
+			currentRoomIdSignal.value = null;
+			render(<BottomTabBar />);
+
+			// Global tabs should be shown when not in a specific room
+			expect(screen.getByRole('tab', { name: 'Rooms' })).toBeTruthy();
+			expect(screen.getByRole('tab', { name: 'Chats' })).toBeTruthy();
+			expect(screen.queryByRole('tab', { name: 'Overview' })).toBeNull();
+			expect(screen.queryByRole('tab', { name: 'Agent' })).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
When the user is viewing a room on mobile (dashboard, agent, task, or
session view), the bottom tab bar now switches from the global tabs
(Inbox / Rooms / Chats / Settings) to room-contextual tabs:

  Overview | Agent | Inbox | Settings

The "Overview" tab navigates back to the room dashboard and the "Agent"
tab jumps directly to the room agent chat (/room/:id/agent), making it
one tap away from any room view instead of requiring the user to open
the left drawer first.

Tabs revert to the global set as soon as the user leaves the room
context (e.g., taps Inbox).

Adds E2E tests covering:
- Room-specific tabs visible in room context
- Agent tab navigates to correct URL
- Overview tab returns to room dashboard from agent view
- Tabs restore to global set when leaving room
