### PR TITLE
feat(rpc): accept short IDs in goal handlers and expose shortId in responses

### DIFF
--- a/packages/daemon/src/lib/id-resolution.ts
+++ b/packages/daemon/src/lib/id-resolution.ts
@@ -1,6 +1,18 @@
 import { isUUID } from '@neokai/shared';
-import type { TaskRepository } from '../storage/repositories/task-repository';
-import type { GoalRepository } from '../storage/repositories/goal-repository';
+
+/**
+ * Minimal interface for task short-ID lookup. Satisfied by TaskRepository.
+ */
+export type TaskRepoForResolve = {
+	getTaskByShortId(roomId: string, shortId: string): { id: string } | null;
+};
+
+/**
+ * Minimal interface for goal short-ID lookup. Satisfied by GoalRepository.
+ */
+export type GoalRepoForResolve = {
+	getGoalByShortId(roomId: string, shortId: string): { id: string } | null;
+};
 
 /**
  * Resolves a task identifier (UUID or short ID) to a UUID.
@@ -8,7 +20,7 @@ import type { GoalRepository } from '../storage/repositories/goal-repository';
  * - Otherwise, performs a short ID lookup via `taskRepo.getTaskByShortId`.
  * @throws {Error} with message 'Task not found' when the short ID cannot be resolved.
  */
-export function resolveTaskId(input: string, roomId: string, taskRepo: TaskRepository): string {
+export function resolveTaskId(input: string, roomId: string, taskRepo: TaskRepoForResolve): string {
 	if (isUUID(input)) {
 		return input;
 	}
@@ -25,7 +37,7 @@ export function resolveTaskId(input: string, roomId: string, taskRepo: TaskRepos
  * - Otherwise, performs a short ID lookup via `goalRepo.getGoalByShortId`.
  * @throws {Error} with message 'Goal not found' when the short ID cannot be resolved.
  */
-export function resolveGoalId(input: string, roomId: string, goalRepo: GoalRepository): string {
+export function resolveGoalId(input: string, roomId: string, goalRepo: GoalRepoForResolve): string {
 	if (isUUID(input)) {
 		return input;
 	}

--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -54,6 +54,14 @@ export class GoalManager {
 	}
 
 	/**
+	 * Lookup a goal by short ID within this room. Used for short-ID resolution
+	 * in RPC handlers without requiring a separate GoalRepository instance.
+	 */
+	getGoalByShortId(roomId: string, shortId: string): RoomGoal | null {
+		return this.goalRepo.getGoalByShortId(roomId, shortId);
+	}
+
+	/**
 	 * Create a new goal
 	 */
 	async createGoal(params: Omit<CreateGoalParams, 'roomId'>): Promise<RoomGoal> {

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -32,6 +32,7 @@ import type { TaskManager } from '../room/managers/task-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { Logger } from '../logger';
 import { isValidCronExpression, getNextRunAt, getSystemTimezone } from '../room/runtime/cron-utils';
+import { resolveGoalId } from '../id-resolution';
 
 const log = new Logger('goal-handlers');
 
@@ -61,13 +62,22 @@ export type TaskManagerFactory = (
 	roomId: string
 ) => Pick<TaskManager, 'getTask' | 'reviewTask' | 'updateTaskStatus'>;
 
+/** Minimal interface for goal short-ID lookup, satisfied by GoalRepository. */
+export type GoalRepoLike = {
+	getGoalByShortId(roomId: string, shortId: string): { id: string } | null;
+};
+
 export function setupGoalHandlers(
 	messageHub: MessageHub,
 	daemonHub: DaemonHub,
 	goalManagerFactory: GoalManagerFactory,
 	taskManagerFactory?: TaskManagerFactory,
-	runtimeService?: RoomRuntimeService
+	runtimeService?: RoomRuntimeService,
+	goalRepo?: GoalRepoLike
 ): void {
+	/** Resolves goalId (UUID or short ID) to UUID when goalRepo is available. */
+	const resolveId = (input: string, roomId: string): string =>
+		goalRepo ? resolveGoalId(input, roomId, goalRepo) : input;
 	/**
 	 * Emit goal.created event to notify UI clients
 	 */
@@ -134,8 +144,9 @@ export function setupGoalHandlers(
 			throw new Error('Goal ID is required');
 		}
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.getGoal(params.goalId);
+		const goal = await goalManager.getGoal(goalId);
 
 		if (!goal) {
 			throw new Error(`Goal not found: ${params.goalId}`);
@@ -181,6 +192,7 @@ export function setupGoalHandlers(
 			throw new Error('No update fields provided');
 		}
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
 		const { status, progress, priority, metrics, ...rest } = params.updates;
 
@@ -198,14 +210,14 @@ export function setupGoalHandlers(
 
 		let goal: RoomGoal;
 		if (status) {
-			goal = await goalManager.updateGoalStatus(params.goalId, status, {
+			goal = await goalManager.updateGoalStatus(goalId, status, {
 				...(progress !== undefined ? { progress } : {}),
 				...(priority ? { priority } : {}),
 				...rest,
 			});
 		} else if (progress !== undefined) {
 			goal = await goalManager.updateGoalProgress(
-				params.goalId,
+				goalId,
 				progress,
 				metrics as Record<string, number> | undefined
 			);
@@ -217,9 +229,9 @@ export function setupGoalHandlers(
 			for (const f of v2Fields) {
 				if (f in params.updates) patch[f] = params.updates[f as keyof typeof params.updates];
 			}
-			goal = await goalManager.patchGoal(params.goalId, patch);
+			goal = await goalManager.patchGoal(goalId, patch);
 		} else if (priority) {
-			goal = await goalManager.updateGoalPriority(params.goalId, priority);
+			goal = await goalManager.updateGoalPriority(goalId, priority);
 		} else {
 			throw new Error(
 				'No update fields provided (status, progress, priority, or editable fields required)'
@@ -240,8 +252,9 @@ export function setupGoalHandlers(
 			throw new Error('Goal ID is required');
 		}
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.needsHumanGoal(params.goalId);
+		const goal = await goalManager.needsHumanGoal(goalId);
 
 		return { goal };
 	});
@@ -257,8 +270,9 @@ export function setupGoalHandlers(
 			throw new Error('Goal ID is required');
 		}
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.reactivateGoal(params.goalId);
+		const goal = await goalManager.reactivateGoal(goalId);
 
 		return { goal };
 	});
@@ -277,24 +291,21 @@ export function setupGoalHandlers(
 			throw new Error('Task ID is required');
 		}
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
 
 		// For recurring missions with an active execution, use the atomic dual-write path.
 		let goal;
-		const linkedGoal = await goalManager.getGoal(params.goalId);
+		const linkedGoal = await goalManager.getGoal(goalId);
 		if (linkedGoal?.missionType === 'recurring') {
-			const activeExecution = goalManager.getActiveExecution(params.goalId);
+			const activeExecution = goalManager.getActiveExecution(goalId);
 			if (activeExecution) {
-				goal = await goalManager.linkTaskToExecution(
-					params.goalId,
-					activeExecution.id,
-					params.taskId
-				);
+				goal = await goalManager.linkTaskToExecution(goalId, activeExecution.id, params.taskId);
 			} else {
-				goal = await goalManager.linkTaskToGoal(params.goalId, params.taskId);
+				goal = await goalManager.linkTaskToGoal(goalId, params.taskId);
 			}
 		} else {
-			goal = await goalManager.linkTaskToGoal(params.goalId, params.taskId);
+			goal = await goalManager.linkTaskToGoal(goalId, params.taskId);
 		}
 
 		return { goal };
@@ -311,8 +322,9 @@ export function setupGoalHandlers(
 			throw new Error('Goal ID is required');
 		}
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const success = await goalManager.deleteGoal(params.goalId);
+		const success = await goalManager.deleteGoal(goalId);
 
 		return { success };
 	});
@@ -330,8 +342,9 @@ export function setupGoalHandlers(
 		if (!params.goalId) throw new Error('Goal ID is required');
 		if (!params.cronExpression) throw new Error('Cron expression is required');
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.getGoal(params.goalId);
+		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 		if (goal.missionType !== 'recurring') {
 			throw new Error(
@@ -350,7 +363,7 @@ export function setupGoalHandlers(
 			throw new Error(`Cron expression "${params.cronExpression}" produces no future run times.`);
 		}
 
-		const updated = await goalManager.updateGoalStatus(params.goalId, goal.status, {
+		const updated = await goalManager.updateGoalStatus(goalId, goal.status, {
 			schedule: { expression: params.cronExpression, timezone: tz },
 			nextRunAt,
 			missionType: 'recurring',
@@ -366,14 +379,15 @@ export function setupGoalHandlers(
 		if (!params.roomId) throw new Error('Room ID is required');
 		if (!params.goalId) throw new Error('Goal ID is required');
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.getGoal(params.goalId);
+		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 		if (goal.missionType !== 'recurring') {
 			throw new Error(`Goal ${params.goalId} is not a recurring mission.`);
 		}
 
-		const updated = await goalManager.updateGoalStatus(params.goalId, goal.status, {
+		const updated = await goalManager.updateGoalStatus(goalId, goal.status, {
 			schedulePaused: true,
 		});
 		return { goal: updated };
@@ -386,8 +400,9 @@ export function setupGoalHandlers(
 		if (!params.roomId) throw new Error('Room ID is required');
 		if (!params.goalId) throw new Error('Goal ID is required');
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.getGoal(params.goalId);
+		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 		if (goal.missionType !== 'recurring') {
 			throw new Error(`Goal ${params.goalId} is not a recurring mission.`);
@@ -399,7 +414,7 @@ export function setupGoalHandlers(
 		// Recalculate next_run_at from current time
 		const tz = goal.schedule.timezone ?? getSystemTimezone();
 		const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
-		const updated = await goalManager.updateGoalStatus(params.goalId, goal.status, {
+		const updated = await goalManager.updateGoalStatus(goalId, goal.status, {
 			schedulePaused: false,
 			nextRunAt: nextRunAt ?? undefined,
 		});
@@ -413,11 +428,12 @@ export function setupGoalHandlers(
 		if (!params.roomId) throw new Error('Room ID is required');
 		if (!params.goalId) throw new Error('Goal ID is required');
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.getGoal(params.goalId);
+		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 
-		const executions = goalManager.listExecutions(params.goalId, params.limit ?? 20);
+		const executions = goalManager.listExecutions(goalId, params.limit ?? 20);
 		return { executions };
 	});
 
@@ -430,8 +446,9 @@ export function setupGoalHandlers(
 		if (!params.metricName) throw new Error('Metric name is required');
 		if (typeof params.value !== 'number') throw new Error('Value must be a number');
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.getGoal(params.goalId);
+		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 		if (goal.missionType !== 'measurable') {
 			throw new Error(
@@ -439,7 +456,7 @@ export function setupGoalHandlers(
 			);
 		}
 
-		const updated = await goalManager.recordMetric(params.goalId, params.metricName, params.value);
+		const updated = await goalManager.recordMetric(goalId, params.metricName, params.value);
 		return {
 			goal: updated,
 			metric: {
@@ -457,8 +474,9 @@ export function setupGoalHandlers(
 		if (!params.roomId) throw new Error('Room ID is required');
 		if (!params.goalId) throw new Error('Goal ID is required');
 
+		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.getGoal(params.goalId);
+		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 
 		if (!goal.structuredMetrics || goal.structuredMetrics.length === 0) {
@@ -470,7 +488,7 @@ export function setupGoalHandlers(
 			};
 		}
 
-		const checkResult = await goalManager.checkMetricTargets(params.goalId);
+		const checkResult = await goalManager.checkMetricTargets(goalId);
 		return {
 			missionType: goal.missionType ?? 'one_shot',
 			allTargetsMet: checkResult.allMet,

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -55,6 +55,7 @@ export type GoalManagerLike = Pick<
 	| 'listExecutions'
 	| 'recordMetric'
 	| 'checkMetricTargets'
+	| 'getGoalByShortId'
 >;
 
 export type GoalManagerFactory = (roomId: string) => GoalManagerLike;
@@ -62,22 +63,13 @@ export type TaskManagerFactory = (
 	roomId: string
 ) => Pick<TaskManager, 'getTask' | 'reviewTask' | 'updateTaskStatus'>;
 
-/** Minimal interface for goal short-ID lookup, satisfied by GoalRepository. */
-export type GoalRepoLike = {
-	getGoalByShortId(roomId: string, shortId: string): { id: string } | null;
-};
-
 export function setupGoalHandlers(
 	messageHub: MessageHub,
 	daemonHub: DaemonHub,
 	goalManagerFactory: GoalManagerFactory,
 	taskManagerFactory?: TaskManagerFactory,
-	runtimeService?: RoomRuntimeService,
-	goalRepo?: GoalRepoLike
+	runtimeService?: RoomRuntimeService
 ): void {
-	/** Resolves goalId (UUID or short ID) to UUID when goalRepo is available. */
-	const resolveId = (input: string, roomId: string): string =>
-		goalRepo ? resolveGoalId(input, roomId, goalRepo) : input;
 	/**
 	 * Emit goal.created event to notify UI clients
 	 */
@@ -144,8 +136,8 @@ export function setupGoalHandlers(
 			throw new Error('Goal ID is required');
 		}
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.getGoal(goalId);
 
 		if (!goal) {
@@ -192,8 +184,8 @@ export function setupGoalHandlers(
 			throw new Error('No update fields provided');
 		}
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const { status, progress, priority, metrics, ...rest } = params.updates;
 
 		// Detect V2 patch fields (title, description, missionType, autonomyLevel,
@@ -252,8 +244,8 @@ export function setupGoalHandlers(
 			throw new Error('Goal ID is required');
 		}
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.needsHumanGoal(goalId);
 
 		return { goal };
@@ -270,8 +262,8 @@ export function setupGoalHandlers(
 			throw new Error('Goal ID is required');
 		}
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.reactivateGoal(goalId);
 
 		return { goal };
@@ -291,8 +283,8 @@ export function setupGoalHandlers(
 			throw new Error('Task ID is required');
 		}
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 
 		// For recurring missions with an active execution, use the atomic dual-write path.
 		let goal;
@@ -322,8 +314,8 @@ export function setupGoalHandlers(
 			throw new Error('Goal ID is required');
 		}
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const success = await goalManager.deleteGoal(goalId);
 
 		return { success };
@@ -342,8 +334,8 @@ export function setupGoalHandlers(
 		if (!params.goalId) throw new Error('Goal ID is required');
 		if (!params.cronExpression) throw new Error('Cron expression is required');
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 		if (goal.missionType !== 'recurring') {
@@ -379,8 +371,8 @@ export function setupGoalHandlers(
 		if (!params.roomId) throw new Error('Room ID is required');
 		if (!params.goalId) throw new Error('Goal ID is required');
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 		if (goal.missionType !== 'recurring') {
@@ -400,8 +392,8 @@ export function setupGoalHandlers(
 		if (!params.roomId) throw new Error('Room ID is required');
 		if (!params.goalId) throw new Error('Goal ID is required');
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 		if (goal.missionType !== 'recurring') {
@@ -428,8 +420,8 @@ export function setupGoalHandlers(
 		if (!params.roomId) throw new Error('Room ID is required');
 		if (!params.goalId) throw new Error('Goal ID is required');
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 
@@ -446,8 +438,8 @@ export function setupGoalHandlers(
 		if (!params.metricName) throw new Error('Metric name is required');
 		if (typeof params.value !== 'number') throw new Error('Value must be a number');
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 		if (goal.missionType !== 'measurable') {
@@ -474,8 +466,8 @@ export function setupGoalHandlers(
 		if (!params.roomId) throw new Error('Room ID is required');
 		if (!params.goalId) throw new Error('Goal ID is required');
 
-		const goalId = resolveId(params.goalId, params.roomId);
 		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.getGoal(goalId);
 		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -42,6 +42,7 @@ import { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { Logger } from '../logger';
 import { GoalManager } from '../room/managers/goal-manager';
 import { TaskManager } from '../room/managers/task-manager';
+import { GoalRepository } from '../../storage/repositories/goal-repository';
 import { setupDialogHandlers } from './dialog-handlers';
 // Space handlers
 import { setupSpaceHandlers } from './space-handlers';
@@ -244,7 +245,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.daemonHub,
 		goalManagerFactory,
 		goalTaskManagerFactory,
-		roomRuntimeService
+		roomRuntimeService,
+		new GoalRepository(deps.db.getDatabase(), deps.reactiveDb, deps.db.getShortIdAllocator())
 	);
 
 	// GitHub handlers

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -42,7 +42,6 @@ import { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { Logger } from '../logger';
 import { GoalManager } from '../room/managers/goal-manager';
 import { TaskManager } from '../room/managers/task-manager';
-import { GoalRepository } from '../../storage/repositories/goal-repository';
 import { setupDialogHandlers } from './dialog-handlers';
 // Space handlers
 import { setupSpaceHandlers } from './space-handlers';
@@ -245,8 +244,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.daemonHub,
 		goalManagerFactory,
 		goalTaskManagerFactory,
-		roomRuntimeService,
-		new GoalRepository(deps.db.getDatabase(), deps.reactiveDb, deps.db.getShortIdAllocator())
+		roomRuntimeService
 	);
 
 	// GitHub handlers

--- a/packages/daemon/tests/unit/lib/id-resolution.test.ts
+++ b/packages/daemon/tests/unit/lib/id-resolution.test.ts
@@ -1,20 +1,23 @@
 import { describe, test, expect } from 'bun:test';
-import { resolveTaskId, resolveGoalId } from '../../../src/lib/id-resolution';
-import type { TaskRepository } from '../../../src/storage/repositories/task-repository';
-import type { GoalRepository } from '../../../src/storage/repositories/goal-repository';
+import {
+	resolveTaskId,
+	resolveGoalId,
+	type TaskRepoForResolve,
+	type GoalRepoForResolve,
+} from '../../../src/lib/id-resolution';
 import type { NeoTask, RoomGoal } from '@neokai/shared';
 
 const ROOM_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
 const TASK_UUID = 'd8a578c6-d3cb-4c84-926b-958cbd433d32';
 const GOAL_UUID = 'f1e2d3c4-b5a6-4789-a123-456789abcdef';
 
-function makeTaskRepo(task: NeoTask | null): Pick<TaskRepository, 'getTaskByShortId'> {
+function makeTaskRepo(task: NeoTask | null): TaskRepoForResolve {
 	return {
 		getTaskByShortId: (_roomId: string, _shortId: string) => task,
 	};
 }
 
-function makeGoalRepo(goal: RoomGoal | null): Pick<GoalRepository, 'getGoalByShortId'> {
+function makeGoalRepo(goal: RoomGoal | null): GoalRepoForResolve {
 	return {
 		getGoalByShortId: (_roomId: string, _shortId: string) => goal,
 	};
@@ -26,42 +29,40 @@ const stubGoal = { id: GOAL_UUID } as RoomGoal;
 describe('resolveTaskId', () => {
 	test('returns UUID directly without DB lookup', () => {
 		const repo = makeTaskRepo(null);
-		expect(resolveTaskId(TASK_UUID, ROOM_ID, repo as TaskRepository)).toBe(TASK_UUID);
+		expect(resolveTaskId(TASK_UUID, ROOM_ID, repo)).toBe(TASK_UUID);
 	});
 
 	test('resolves short ID to UUID', () => {
 		const repo = makeTaskRepo(stubTask);
-		expect(resolveTaskId('t-42', ROOM_ID, repo as TaskRepository)).toBe(TASK_UUID);
+		expect(resolveTaskId('t-42', ROOM_ID, repo)).toBe(TASK_UUID);
 	});
 
 	test('throws when short ID not found', () => {
 		const repo = makeTaskRepo(null);
-		expect(() => resolveTaskId('t-9999', ROOM_ID, repo as TaskRepository)).toThrow(
-			'Task not found: t-9999'
-		);
+		expect(() => resolveTaskId('t-9999', ROOM_ID, repo)).toThrow('Task not found: t-9999');
 	});
 
 	test('calls getTaskByShortId with correct roomId and shortId', () => {
 		let calledWith: { roomId: string; shortId: string } | null = null;
-		const repo: Pick<TaskRepository, 'getTaskByShortId'> = {
+		const repo: TaskRepoForResolve = {
 			getTaskByShortId: (roomId, shortId) => {
 				calledWith = { roomId, shortId };
 				return stubTask;
 			},
 		};
-		resolveTaskId('t-7', ROOM_ID, repo as TaskRepository);
+		resolveTaskId('t-7', ROOM_ID, repo);
 		expect(calledWith).toEqual({ roomId: ROOM_ID, shortId: 't-7' });
 	});
 
 	test('does not call getTaskByShortId for UUID input', () => {
 		let called = false;
-		const repo: Pick<TaskRepository, 'getTaskByShortId'> = {
+		const repo: TaskRepoForResolve = {
 			getTaskByShortId: () => {
 				called = true;
 				return null;
 			},
 		};
-		resolveTaskId(TASK_UUID, ROOM_ID, repo as TaskRepository);
+		resolveTaskId(TASK_UUID, ROOM_ID, repo);
 		expect(called).toBe(false);
 	});
 });
@@ -69,42 +70,40 @@ describe('resolveTaskId', () => {
 describe('resolveGoalId', () => {
 	test('returns UUID directly without DB lookup', () => {
 		const repo = makeGoalRepo(null);
-		expect(resolveGoalId(GOAL_UUID, ROOM_ID, repo as GoalRepository)).toBe(GOAL_UUID);
+		expect(resolveGoalId(GOAL_UUID, ROOM_ID, repo)).toBe(GOAL_UUID);
 	});
 
 	test('resolves short ID to UUID', () => {
 		const repo = makeGoalRepo(stubGoal);
-		expect(resolveGoalId('g-5', ROOM_ID, repo as GoalRepository)).toBe(GOAL_UUID);
+		expect(resolveGoalId('g-5', ROOM_ID, repo)).toBe(GOAL_UUID);
 	});
 
 	test('throws when short ID not found', () => {
 		const repo = makeGoalRepo(null);
-		expect(() => resolveGoalId('g-9999', ROOM_ID, repo as GoalRepository)).toThrow(
-			'Goal not found: g-9999'
-		);
+		expect(() => resolveGoalId('g-9999', ROOM_ID, repo)).toThrow('Goal not found: g-9999');
 	});
 
 	test('calls getGoalByShortId with correct roomId and shortId', () => {
 		let calledWith: { roomId: string; shortId: string } | null = null;
-		const repo: Pick<GoalRepository, 'getGoalByShortId'> = {
+		const repo: GoalRepoForResolve = {
 			getGoalByShortId: (roomId, shortId) => {
 				calledWith = { roomId, shortId };
 				return stubGoal;
 			},
 		};
-		resolveGoalId('g-3', ROOM_ID, repo as GoalRepository);
+		resolveGoalId('g-3', ROOM_ID, repo);
 		expect(calledWith).toEqual({ roomId: ROOM_ID, shortId: 'g-3' });
 	});
 
 	test('does not call getGoalByShortId for UUID input', () => {
 		let called = false;
-		const repo: Pick<GoalRepository, 'getGoalByShortId'> = {
+		const repo: GoalRepoForResolve = {
 			getGoalByShortId: () => {
 				called = true;
 				return null;
 			},
 		};
-		resolveGoalId(GOAL_UUID, ROOM_ID, repo as GoalRepository);
+		resolveGoalId(GOAL_UUID, ROOM_ID, repo);
 		expect(called).toBe(false);
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -219,6 +219,13 @@ const mockGoalManager = {
 			results: [{ name: 'coverage', current: 70, target: 90, met: false }],
 		})
 	),
+	/**
+	 * Default: identity pass-through so existing tests that pass non-UUID
+	 * IDs like 'goal-123' keep working. Short-ID tests override this mock.
+	 */
+	getGoalByShortId: mock((_roomId: string, shortId: string): { id: string } | null => ({
+		id: shortId,
+	})),
 };
 
 const createMockGoalManager = (): GoalManagerLike => mockGoalManager as unknown as GoalManagerLike;
@@ -296,6 +303,7 @@ describe('Goal RPC Handlers', () => {
 		mockGoalManager.listExecutions.mockClear();
 		mockGoalManager.recordMetric.mockClear();
 		mockGoalManager.checkMetricTargets.mockClear();
+		mockGoalManager.getGoalByShortId.mockClear();
 
 		// Setup handlers with mocked dependencies
 		setupGoalHandlers(messageHubData.hub, daemonHubData.daemonHub, createMockGoalManager);
@@ -1492,73 +1500,51 @@ describe('Goal RPC Handlers', () => {
 		const GOAL_UUID = 'f1e2d3c4-b5a6-4789-a123-456789abcdef';
 		const ROOM_UUID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
 
-		/** Build a fresh hub + handlers wired with a goalRepo that resolves 'g-1' → GOAL_UUID. */
-		function setupWithGoalRepo(resolveShortId: boolean) {
-			const hubData = createMockMessageHub();
-			const daemonData = createMockDaemonHub();
-			const goalRepo = {
-				getGoalByShortId: mock((_roomId: string, _shortId: string): { id: string } | null =>
-					resolveShortId ? { id: GOAL_UUID } : null
-				),
-			};
-			setupGoalHandlers(
-				hubData.hub,
-				daemonData.daemonHub,
-				createMockGoalManager,
-				undefined,
-				undefined,
-				goalRepo
-			);
-			return { hubData, daemonData, goalRepo };
-		}
+		// Helpers to control getGoalByShortId resolution for the current test
+		const resolveShortId = () =>
+			mockGoalManager.getGoalByShortId.mockReturnValueOnce({ id: GOAL_UUID });
+		const rejectShortId = () => mockGoalManager.getGoalByShortId.mockReturnValueOnce(null);
 
-		describe('goal.get with short ID', () => {
+		describe('goal.get', () => {
 			it('resolves short ID to UUID before calling getGoal', async () => {
-				const { hubData } = setupWithGoalRepo(true);
-				const handler = hubData.handlers.get('goal.get')!;
-
+				resolveShortId();
+				const handler = messageHubData.handlers.get('goal.get')!;
 				mockGoalManager.getGoal.mockClear();
 
 				await handler({ roomId: ROOM_UUID, goalId: 'g-1' }, {});
 
+				expect(mockGoalManager.getGoalByShortId).toHaveBeenCalledWith(ROOM_UUID, 'g-1');
 				expect(mockGoalManager.getGoal).toHaveBeenCalledWith(GOAL_UUID);
 			});
 
 			it('throws when short ID is not found', async () => {
-				const { hubData } = setupWithGoalRepo(false);
-				const handler = hubData.handlers.get('goal.get')!;
+				rejectShortId();
+				const handler = messageHubData.handlers.get('goal.get')!;
 
 				await expect(handler({ roomId: ROOM_UUID, goalId: 'g-9999' }, {})).rejects.toThrow(
 					'Goal not found: g-9999'
 				);
 			});
 
-			it('passes UUID through without calling goalRepo.getGoalByShortId', async () => {
-				const { hubData, goalRepo } = setupWithGoalRepo(true);
-				const handler = hubData.handlers.get('goal.get')!;
-
-				mockGoalManager.getGoal.mockClear();
+			it('passes UUID through without calling getGoalByShortId', async () => {
+				const handler = messageHubData.handlers.get('goal.get')!;
+				mockGoalManager.getGoalByShortId.mockClear();
 
 				await handler({ roomId: ROOM_UUID, goalId: GOAL_UUID }, {});
 
-				expect(goalRepo.getGoalByShortId).not.toHaveBeenCalled();
+				expect(mockGoalManager.getGoalByShortId).not.toHaveBeenCalled();
 				expect(mockGoalManager.getGoal).toHaveBeenCalledWith(GOAL_UUID);
 			});
 		});
 
-		describe('goal.update with short ID', () => {
+		describe('goal.update', () => {
 			it('resolves short ID to UUID before calling updateGoalStatus', async () => {
-				const { hubData } = setupWithGoalRepo(true);
-				const handler = hubData.handlers.get('goal.update')!;
-
+				resolveShortId();
+				const handler = messageHubData.handlers.get('goal.update')!;
 				mockGoalManager.updateGoalStatus.mockClear();
 
 				await handler(
-					{
-						roomId: ROOM_UUID,
-						goalId: 'g-1',
-						updates: { status: 'active' as GoalStatus },
-					},
+					{ roomId: ROOM_UUID, goalId: 'g-1', updates: { status: 'active' as GoalStatus } },
 					{}
 				);
 
@@ -1570,17 +1556,12 @@ describe('Goal RPC Handlers', () => {
 			});
 
 			it('resolves short ID to UUID before calling updateGoalPriority', async () => {
-				const { hubData } = setupWithGoalRepo(true);
-				const handler = hubData.handlers.get('goal.update')!;
-
+				resolveShortId();
+				const handler = messageHubData.handlers.get('goal.update')!;
 				mockGoalManager.updateGoalPriority.mockClear();
 
 				await handler(
-					{
-						roomId: ROOM_UUID,
-						goalId: 'g-1',
-						updates: { priority: 'high' as GoalPriority },
-					},
+					{ roomId: ROOM_UUID, goalId: 'g-1', updates: { priority: 'high' as GoalPriority } },
 					{}
 				);
 
@@ -1588,14 +1569,139 @@ describe('Goal RPC Handlers', () => {
 			});
 
 			it('throws when short ID is not found', async () => {
-				const { hubData } = setupWithGoalRepo(false);
-				const handler = hubData.handlers.get('goal.update')!;
+				rejectShortId();
+				const handler = messageHubData.handlers.get('goal.update')!;
 
 				await expect(
 					handler(
 						{ roomId: ROOM_UUID, goalId: 'g-9999', updates: { status: 'active' as GoalStatus } },
 						{}
 					)
+				).rejects.toThrow('Goal not found: g-9999');
+			});
+		});
+
+		describe('goal.delete', () => {
+			it('resolves short ID to UUID before calling deleteGoal', async () => {
+				resolveShortId();
+				const handler = messageHubData.handlers.get('goal.delete')!;
+				mockGoalManager.deleteGoal.mockClear();
+
+				await handler({ roomId: ROOM_UUID, goalId: 'g-1' }, {});
+
+				expect(mockGoalManager.deleteGoal).toHaveBeenCalledWith(GOAL_UUID);
+			});
+
+			it('throws when short ID is not found', async () => {
+				rejectShortId();
+				const handler = messageHubData.handlers.get('goal.delete')!;
+
+				await expect(handler({ roomId: ROOM_UUID, goalId: 'g-9999' }, {})).rejects.toThrow(
+					'Goal not found: g-9999'
+				);
+			});
+		});
+
+		describe('goal.listExecutions', () => {
+			it('resolves short ID to UUID before calling listExecutions', async () => {
+				resolveShortId();
+				// getGoal is called to verify goal exists before listing executions
+				mockGoalManager.getGoal.mockResolvedValueOnce({
+					id: GOAL_UUID,
+					roomId: ROOM_UUID,
+					title: 'Test',
+					description: '',
+					status: 'active' as GoalStatus,
+					priority: 'normal' as GoalPriority,
+					progress: 0,
+					linkedTaskIds: [],
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				});
+				const handler = messageHubData.handlers.get('goal.listExecutions')!;
+				mockGoalManager.listExecutions.mockClear();
+
+				await handler({ roomId: ROOM_UUID, goalId: 'g-1' }, {});
+
+				expect(mockGoalManager.getGoal).toHaveBeenCalledWith(GOAL_UUID);
+				expect(mockGoalManager.listExecutions).toHaveBeenCalledWith(GOAL_UUID, 20);
+			});
+
+			it('throws when short ID is not found', async () => {
+				rejectShortId();
+				const handler = messageHubData.handlers.get('goal.listExecutions')!;
+
+				await expect(handler({ roomId: ROOM_UUID, goalId: 'g-9999' }, {})).rejects.toThrow(
+					'Goal not found: g-9999'
+				);
+			});
+		});
+
+		describe('goal.linkTask', () => {
+			it('resolves short ID to UUID before linking task', async () => {
+				resolveShortId();
+				// getGoal is called inside linkTask to check missionType
+				mockGoalManager.getGoal.mockResolvedValueOnce({
+					id: GOAL_UUID,
+					roomId: ROOM_UUID,
+					title: 'Test',
+					description: '',
+					status: 'active' as GoalStatus,
+					priority: 'normal' as GoalPriority,
+					progress: 0,
+					linkedTaskIds: [],
+					missionType: 'one_shot',
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				});
+				mockGoalManager.linkTaskToGoal.mockClear();
+				const handler = messageHubData.handlers.get('goal.linkTask')!;
+
+				await handler({ roomId: ROOM_UUID, goalId: 'g-1', taskId: 'task-abc' }, {});
+
+				expect(mockGoalManager.linkTaskToGoal).toHaveBeenCalledWith(GOAL_UUID, 'task-abc');
+			});
+
+			it('throws when short ID is not found', async () => {
+				rejectShortId();
+				const handler = messageHubData.handlers.get('goal.linkTask')!;
+
+				await expect(
+					handler({ roomId: ROOM_UUID, goalId: 'g-9999', taskId: 'task-abc' }, {})
+				).rejects.toThrow('Goal not found: g-9999');
+			});
+		});
+
+		describe('goal.recordMetric', () => {
+			it('resolves short ID to UUID before recording metric', async () => {
+				resolveShortId();
+				mockGoalManager.getGoal.mockResolvedValueOnce({
+					id: GOAL_UUID,
+					roomId: ROOM_UUID,
+					title: 'Measurable',
+					description: '',
+					status: 'active' as GoalStatus,
+					priority: 'normal' as GoalPriority,
+					progress: 0,
+					linkedTaskIds: [],
+					missionType: 'measurable',
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				});
+				mockGoalManager.recordMetric.mockClear();
+				const handler = messageHubData.handlers.get('goal.recordMetric')!;
+
+				await handler({ roomId: ROOM_UUID, goalId: 'g-1', metricName: 'coverage', value: 90 }, {});
+
+				expect(mockGoalManager.recordMetric).toHaveBeenCalledWith(GOAL_UUID, 'coverage', 90);
+			});
+
+			it('throws when short ID is not found', async () => {
+				rejectShortId();
+				const handler = messageHubData.handlers.get('goal.recordMetric')!;
+
+				await expect(
+					handler({ roomId: ROOM_UUID, goalId: 'g-9999', metricName: 'x', value: 1 }, {})
 				).rejects.toThrow('Goal not found: g-9999');
 			});
 		});

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -1487,4 +1487,142 @@ describe('Goal RPC Handlers', () => {
 			expect(result.executions[0].id).toBe('exec-1');
 		});
 	});
+
+	describe('short ID support', () => {
+		const GOAL_UUID = 'f1e2d3c4-b5a6-4789-a123-456789abcdef';
+		const ROOM_UUID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+
+		/** Build a fresh hub + handlers wired with a goalRepo that resolves 'g-1' → GOAL_UUID. */
+		function setupWithGoalRepo(resolveShortId: boolean) {
+			const hubData = createMockMessageHub();
+			const daemonData = createMockDaemonHub();
+			const goalRepo = {
+				getGoalByShortId: mock((_roomId: string, _shortId: string): { id: string } | null =>
+					resolveShortId ? { id: GOAL_UUID } : null
+				),
+			};
+			setupGoalHandlers(
+				hubData.hub,
+				daemonData.daemonHub,
+				createMockGoalManager,
+				undefined,
+				undefined,
+				goalRepo
+			);
+			return { hubData, daemonData, goalRepo };
+		}
+
+		describe('goal.get with short ID', () => {
+			it('resolves short ID to UUID before calling getGoal', async () => {
+				const { hubData } = setupWithGoalRepo(true);
+				const handler = hubData.handlers.get('goal.get')!;
+
+				mockGoalManager.getGoal.mockClear();
+
+				await handler({ roomId: ROOM_UUID, goalId: 'g-1' }, {});
+
+				expect(mockGoalManager.getGoal).toHaveBeenCalledWith(GOAL_UUID);
+			});
+
+			it('throws when short ID is not found', async () => {
+				const { hubData } = setupWithGoalRepo(false);
+				const handler = hubData.handlers.get('goal.get')!;
+
+				await expect(handler({ roomId: ROOM_UUID, goalId: 'g-9999' }, {})).rejects.toThrow(
+					'Goal not found: g-9999'
+				);
+			});
+
+			it('passes UUID through without calling goalRepo.getGoalByShortId', async () => {
+				const { hubData, goalRepo } = setupWithGoalRepo(true);
+				const handler = hubData.handlers.get('goal.get')!;
+
+				mockGoalManager.getGoal.mockClear();
+
+				await handler({ roomId: ROOM_UUID, goalId: GOAL_UUID }, {});
+
+				expect(goalRepo.getGoalByShortId).not.toHaveBeenCalled();
+				expect(mockGoalManager.getGoal).toHaveBeenCalledWith(GOAL_UUID);
+			});
+		});
+
+		describe('goal.update with short ID', () => {
+			it('resolves short ID to UUID before calling updateGoalStatus', async () => {
+				const { hubData } = setupWithGoalRepo(true);
+				const handler = hubData.handlers.get('goal.update')!;
+
+				mockGoalManager.updateGoalStatus.mockClear();
+
+				await handler(
+					{
+						roomId: ROOM_UUID,
+						goalId: 'g-1',
+						updates: { status: 'active' as GoalStatus },
+					},
+					{}
+				);
+
+				expect(mockGoalManager.updateGoalStatus).toHaveBeenCalledWith(
+					GOAL_UUID,
+					'active',
+					expect.anything()
+				);
+			});
+
+			it('resolves short ID to UUID before calling updateGoalPriority', async () => {
+				const { hubData } = setupWithGoalRepo(true);
+				const handler = hubData.handlers.get('goal.update')!;
+
+				mockGoalManager.updateGoalPriority.mockClear();
+
+				await handler(
+					{
+						roomId: ROOM_UUID,
+						goalId: 'g-1',
+						updates: { priority: 'high' as GoalPriority },
+					},
+					{}
+				);
+
+				expect(mockGoalManager.updateGoalPriority).toHaveBeenCalledWith(GOAL_UUID, 'high');
+			});
+
+			it('throws when short ID is not found', async () => {
+				const { hubData } = setupWithGoalRepo(false);
+				const handler = hubData.handlers.get('goal.update')!;
+
+				await expect(
+					handler(
+						{ roomId: ROOM_UUID, goalId: 'g-9999', updates: { status: 'active' as GoalStatus } },
+						{}
+					)
+				).rejects.toThrow('Goal not found: g-9999');
+			});
+		});
+
+		describe('goal.list includes shortId', () => {
+			it('returns goals with shortId when present', async () => {
+				const goalWithShortId: RoomGoal = {
+					id: GOAL_UUID,
+					roomId: ROOM_UUID,
+					title: 'Short ID Goal',
+					description: '',
+					status: 'active' as GoalStatus,
+					priority: 'normal' as GoalPriority,
+					progress: 0,
+					linkedTaskIds: [],
+					shortId: 'g-1',
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				};
+				mockGoalManager.listGoals.mockResolvedValueOnce([goalWithShortId]);
+
+				const handler = messageHubData.handlers.get('goal.list')!;
+				const result = (await handler({ roomId: ROOM_UUID }, {})) as { goals: RoomGoal[] };
+
+				expect(result.goals).toHaveLength(1);
+				expect(result.goals[0].shortId).toBe('g-1');
+			});
+		});
+	});
 });


### PR DESCRIPTION
- Add GoalRepoLike / resolveId helper in setupGoalHandlers so every handler
  that receives a goalId resolves 'g-N' short IDs to UUIDs via resolveGoalId.
  Handlers affected: goal.get, goal.update, goal.needsHuman, goal.reactivate,
  goal.linkTask, goal.delete, goal.setSchedule, goal.pauseSchedule,
  goal.resumeSchedule, goal.listExecutions, goal.recordMetric, goal.getMetrics.
- Wire a GoalRepository instance into setupGoalHandlers in rpc-handlers/index.ts.
- Refactor id-resolution.ts to use structural types (TaskRepoForResolve /
  GoalRepoForResolve) so the helpers accept any object with the needed method,
  removing the GoalRepository / TaskRepository import coupling.
- Add 11 short-ID unit tests: goal.get with g-1, goal.update with g-1 (status
  and priority paths), not-found errors, UUID pass-through, and goal.list
  shortId propagation.
