### PR TITLE
feat(rpc): accept short IDs in task handlers and return shortId in responses (#task-32)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -26,6 +26,7 @@ import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { TaskManager, VALID_STATUS_TRANSITIONS } from '../room/managers/task-manager';
 import { TaskRepository } from '../../storage/repositories/task-repository';
+import { resolveTaskId } from '../id-resolution';
 import { SessionGroupRepository } from '../room/state/session-group-repository';
 import { routeHumanMessageToGroup } from '../room/runtime/human-message-routing';
 import { SDKMessageRepository } from '../../storage/repositories/sdk-message-repository';
@@ -58,6 +59,7 @@ export function setupTaskHandlers(
 	runtimeService?: RoomRuntimeService
 ): void {
 	const makeGroupRepo = () => new SessionGroupRepository(db.getDatabase(), reactiveDb);
+	const makeTaskRepo = () => new TaskRepository(db.getDatabase(), reactiveDb);
 
 	/**
 	 * Emit room.task.update event to notify UI clients
@@ -159,8 +161,9 @@ export function setupTaskHandlers(
 			throw new Error('Task ID is required');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const task = await taskManager.getTask(taskId);
 
 		if (!task) {
 			throw new Error(`Task not found: ${params.taskId}`);
@@ -184,9 +187,11 @@ export function setupTaskHandlers(
 			throw new Error('Draft is too long (max 200,000 characters)');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
+
 		// Verify the task belongs to this room
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
@@ -196,8 +201,8 @@ export function setupTaskHandlers(
 		const draft = typeof params.draft === 'string' ? params.draft.trim() || null : null;
 
 		// Update input_draft directly via repository (lightweight, no status side effects)
-		const taskRepo = new TaskRepository(db.getDatabase(), reactiveDb);
-		taskRepo.updateTask(params.taskId, { inputDraft: draft });
+		const taskRepo = makeTaskRepo();
+		taskRepo.updateTask(taskId, { inputDraft: draft });
 
 		return { success: true };
 	});
@@ -213,8 +218,9 @@ export function setupTaskHandlers(
 			throw new Error('Task ID is required');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.failTask(params.taskId, params.error ?? '');
+		const task = await taskManager.failTask(taskId, params.error ?? '');
 
 		emitRoomOverview(params.roomId);
 
@@ -232,8 +238,9 @@ export function setupTaskHandlers(
 			throw new Error('Task ID is required');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
@@ -247,13 +254,13 @@ export function setupTaskHandlers(
 		if (runtimeService) {
 			const runtime = runtimeService.getRuntime(params.roomId);
 			if (runtime) {
-				const result = await runtime.cancelTask(params.taskId);
+				const result = await runtime.cancelTask(taskId);
 				if (!result.success) {
 					throw new Error(
-						`Failed to cancel task ${params.taskId} — runtime cancellation was unsuccessful`
+						`Failed to cancel task ${taskId} — runtime cancellation was unsuccessful`
 					);
 				}
-				const updatedTask = await taskManager.getTask(params.taskId);
+				const updatedTask = await taskManager.getTask(taskId);
 				if (updatedTask) {
 					emitTaskUpdate(params.roomId, updatedTask);
 					emitRoomOverview(params.roomId);
@@ -263,7 +270,7 @@ export function setupTaskHandlers(
 		}
 
 		// No active group - just mark the task as cancelled
-		const cancelledTask = await taskManager.cancelTask(params.taskId);
+		const cancelledTask = await taskManager.cancelTask(taskId);
 		emitTaskUpdate(params.roomId, cancelledTask);
 		emitRoomOverview(params.roomId);
 
@@ -283,8 +290,9 @@ export function setupTaskHandlers(
 			throw new Error('Task ID is required');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
@@ -305,9 +313,9 @@ export function setupTaskHandlers(
 			throw new Error(`No runtime found for room: ${params.roomId}`);
 		}
 
-		const result = await runtime.interruptTaskSession(params.taskId);
+		const result = await runtime.interruptTaskSession(taskId);
 		if (!result.success) {
-			throw new Error(`Failed to interrupt task session for ${params.taskId}`);
+			throw new Error(`Failed to interrupt task session for ${taskId}`);
 		}
 
 		return { success: true };
@@ -324,8 +332,9 @@ export function setupTaskHandlers(
 			throw new Error('Task ID is required');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
@@ -342,20 +351,20 @@ export function setupTaskHandlers(
 		// Without a runtime, we still must set archivedAt so the task is hidden from the UI.
 		const runtime = runtimeService?.getRuntime(params.roomId);
 		if (runtime) {
-			await runtime.archiveTaskGroup(params.taskId);
+			await runtime.archiveTaskGroup(taskId);
 		} else {
 			// No runtime — set archivedAt directly. Worktree cleanup (if any) is skipped;
 			// orphaned worktrees must be reclaimed manually via the worktree.cleanup RPC.
-			await taskManager.archiveTask(params.taskId);
+			await taskManager.archiveTask(taskId);
 		}
 
-		const archivedTask = await taskManager.getTask(params.taskId);
+		const archivedTask = await taskManager.getTask(taskId);
 		if (archivedTask) {
 			emitTaskUpdate(params.roomId, archivedTask);
 			emitRoomOverview(params.roomId);
 		}
 
-		log.info(`Task ${params.taskId} archived in room ${params.roomId}`);
+		log.info(`Task ${taskId} archived in room ${params.roomId}`);
 		return { task: archivedTask };
 	});
 
@@ -380,8 +389,9 @@ export function setupTaskHandlers(
 			throw new Error('Status is required');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
@@ -406,12 +416,12 @@ export function setupTaskHandlers(
 			const runtime = runtimeService?.getRuntime(params.roomId);
 			const modeOpts = params.mode ? { mode: params.mode } : undefined;
 			if (runtime) {
-				await runtime.archiveTaskGroup(params.taskId, modeOpts);
+				await runtime.archiveTaskGroup(taskId, modeOpts);
 			} else {
-				await taskManager.archiveTask(params.taskId, modeOpts);
+				await taskManager.archiveTask(taskId, modeOpts);
 			}
 
-			const archivedTask = await taskManager.getTask(params.taskId);
+			const archivedTask = await taskManager.getTask(taskId);
 			if (archivedTask) {
 				emitTaskUpdate(params.roomId, archivedTask);
 				emitRoomOverview(params.roomId);
@@ -429,13 +439,13 @@ export function setupTaskHandlers(
 					params.status === 'cancelled';
 				if (isTerminalStatus) {
 					if (params.status === 'cancelled') {
-						const cancelResult = await runtime.cancelTask(params.taskId);
+						const cancelResult = await runtime.cancelTask(taskId);
 						if (!cancelResult.success) {
 							throw new Error(
-								`Failed to cancel task ${params.taskId} — runtime cancellation was unsuccessful`
+								`Failed to cancel task ${taskId} — runtime cancellation was unsuccessful`
 							);
 						}
-						const cancelledTask = await taskManager.getTask(params.taskId);
+						const cancelledTask = await taskManager.getTask(taskId);
 						if (!cancelledTask) {
 							throw new Error(`Task not found: ${params.taskId}`);
 						}
@@ -444,10 +454,10 @@ export function setupTaskHandlers(
 						return { task: cancelledTask };
 					}
 
-					const terminated = await runtime.terminateTaskGroup(params.taskId);
+					const terminated = await runtime.terminateTaskGroup(taskId);
 					if (!terminated) {
 						throw new Error(
-							`Failed to terminate task group for task ${params.taskId} — group may have been modified concurrently`
+							`Failed to terminate task group for task ${taskId} — group may have been modified concurrently`
 						);
 					}
 				}
@@ -463,12 +473,12 @@ export function setupTaskHandlers(
 		) {
 			if (params.status === 'pending' || params.status === 'in_progress') {
 				const groupRepo = makeGroupRepo();
-				const group = groupRepo.getGroupByTaskId(params.taskId);
+				const group = groupRepo.getGroupByTaskId(taskId);
 				if (group) {
 					const reset = groupRepo.resetGroupForRestart(group.id);
 					if (!reset) {
 						throw new Error(
-							`Failed to reset group for task ${params.taskId} — group may have been modified concurrently`
+							`Failed to reset group for task ${taskId} — group may have been modified concurrently`
 						);
 					}
 				}
@@ -476,7 +486,7 @@ export function setupTaskHandlers(
 		}
 
 		// Apply status change
-		const updatedTask = await taskManager.setTaskStatus(params.taskId, params.status, {
+		const updatedTask = await taskManager.setTaskStatus(taskId, params.status, {
 			result: params.result,
 			error: params.error,
 			mode: params.mode,
@@ -508,8 +518,9 @@ export function setupTaskHandlers(
 			throw new Error('Runtime service is required for task.reject');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
@@ -523,21 +534,21 @@ export function setupTaskHandlers(
 		}
 
 		const groupRepo = makeGroupRepo();
-		const group = groupRepo.getGroupByTaskId(params.taskId);
+		const group = groupRepo.getGroupByTaskId(taskId);
 		if (!group) {
 			throw new Error('No active session group for this task');
 		}
 
 		// Resume via runtime so review parking flags and task status are updated consistently.
 		const message = `[Human Rejection]\n\n${params.feedback.trim()}`;
-		const resumed = await runtime.resumeWorkerFromHuman(params.taskId, message, {
+		const resumed = await runtime.resumeWorkerFromHuman(taskId, message, {
 			approved: false,
 		});
 		if (!resumed) {
 			throw new Error('Failed to reject task — task may not be awaiting review');
 		}
 
-		log.info(`Task ${params.taskId} rejected by human in room ${params.roomId}`);
+		log.info(`Task ${taskId} rejected by human in room ${params.roomId}`);
 		return { success: true };
 	});
 
@@ -552,8 +563,9 @@ export function setupTaskHandlers(
 			throw new Error('Task ID is required');
 		}
 
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const groupRepo = makeGroupRepo();
-		const group = groupRepo.getGroupByTaskId(params.taskId);
+		const group = groupRepo.getGroupByTaskId(taskId);
 
 		if (!group) {
 			return { group: null };
@@ -977,8 +989,9 @@ export function setupTaskHandlers(
 		}
 		// Cross-room ownership check: verify the task belongs to this room.
 		// TaskManager is room-scoped, so getTask() returns null for tasks in other rooms.
+		const taskId = resolveTaskId(params.taskId, params.roomId, makeTaskRepo());
 		const taskManager = taskManagerFactory(db, params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task ${params.taskId} not found in room ${params.roomId}`);
 		}
@@ -987,7 +1000,7 @@ export function setupTaskHandlers(
 		// lookup so the error is consistent regardless of whether a runtime is active.
 		if (task.status === 'archived') {
 			throw new Error(
-				`Task ${params.taskId} is archived and cannot receive messages. Archive is a terminal state.`
+				`Task ${taskId} is archived and cannot receive messages. Archive is a terminal state.`
 			);
 		}
 
@@ -1019,25 +1032,21 @@ export function setupTaskHandlers(
 			// intermediate status before reviveTaskForMessage restores sessions.
 			const intermediateStatus = task.status === 'needs_attention' ? 'review' : 'in_progress';
 			try {
-				await taskManager.setTaskStatus(params.taskId, intermediateStatus);
+				await taskManager.setTaskStatus(taskId, intermediateStatus);
 			} catch (err) {
-				throw new Error(`Failed to revive task ${params.taskId}: ${String(err)}`);
+				throw new Error(`Failed to revive task ${taskId}: ${String(err)}`);
 			}
 
-			const revived = await runtime.reviveTaskForMessage(
-				params.taskId,
-				params.message.trim(),
-				target
-			);
+			const revived = await runtime.reviveTaskForMessage(taskId, params.message.trim(), target);
 			if (!revived) {
 				// Rollback: restore task to original status
 				try {
-					await taskManager.setTaskStatus(params.taskId, task.status);
+					await taskManager.setTaskStatus(taskId, task.status);
 				} catch {
 					// Best-effort rollback; swallow to avoid masking the revive error
 				}
 				throw new Error(
-					`Failed to revive task ${params.taskId}: agent sessions could not be restored. ` +
+					`Failed to revive task ${taskId}: agent sessions could not be restored. ` +
 						`Task status has been reset to ${task.status}.`
 				);
 			}
@@ -1064,7 +1073,7 @@ export function setupTaskHandlers(
 			runtime,
 			groupRepo,
 			taskManager,
-			params.taskId,
+			taskId,
 			params.message.trim(),
 			target
 		);
@@ -1074,7 +1083,7 @@ export function setupTaskHandlers(
 		}
 
 		// Emit task update after successful message routing (may have changed status)
-		const updatedTask = await taskManager.getTask(params.taskId);
+		const updatedTask = await taskManager.getTask(taskId);
 		if (updatedTask) {
 			emitTaskUpdate(params.roomId, updatedTask);
 		}

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -1060,10 +1060,10 @@ export function setupTaskHandlers(
 		// update the status so the task reflects that work is ongoing again.
 		if (task.status === 'review') {
 			try {
-				await taskManager.setTaskStatus(params.taskId, 'in_progress');
+				await taskManager.setTaskStatus(taskId, 'in_progress');
 			} catch (err) {
 				throw new Error(
-					`Failed to transition task ${params.taskId} from review to in_progress: ${String(err)}`
+					`Failed to transition task ${taskId} from review to in_progress: ${String(err)}`
 				);
 			}
 		}

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -166,7 +166,7 @@ export function setupTaskHandlers(
 		const task = await taskManager.getTask(taskId);
 
 		if (!task) {
-			throw new Error(`Task not found: ${params.taskId}`);
+			throw new Error(`Task not found: ${taskId}`);
 		}
 
 		return { task };
@@ -193,7 +193,7 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.getTask(taskId);
 		if (!task) {
-			throw new Error(`Task not found: ${params.taskId}`);
+			throw new Error(`Task not found: ${taskId}`);
 		}
 
 		// Normalize: treat empty/whitespace strings as null to keep storage consistent
@@ -242,7 +242,7 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.getTask(taskId);
 		if (!task) {
-			throw new Error(`Task not found: ${params.taskId}`);
+			throw new Error(`Task not found: ${taskId}`);
 		}
 
 		// Only allow cancelling pending, in_progress, or review tasks
@@ -294,7 +294,7 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.getTask(taskId);
 		if (!task) {
-			throw new Error(`Task not found: ${params.taskId}`);
+			throw new Error(`Task not found: ${taskId}`);
 		}
 
 		// Only allow interrupting tasks with active agent sessions
@@ -336,7 +336,7 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.getTask(taskId);
 		if (!task) {
-			throw new Error(`Task not found: ${params.taskId}`);
+			throw new Error(`Task not found: ${taskId}`);
 		}
 
 		// Validate task is in a terminal state before archiving
@@ -393,7 +393,7 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.getTask(taskId);
 		if (!task) {
-			throw new Error(`Task not found: ${params.taskId}`);
+			throw new Error(`Task not found: ${taskId}`);
 		}
 
 		// Validate status transition for runtime mode. This must happen here (not just in the
@@ -447,7 +447,7 @@ export function setupTaskHandlers(
 						}
 						const cancelledTask = await taskManager.getTask(taskId);
 						if (!cancelledTask) {
-							throw new Error(`Task not found: ${params.taskId}`);
+							throw new Error(`Task not found: ${taskId}`);
 						}
 						emitTaskUpdate(params.roomId, cancelledTask);
 						emitRoomOverview(params.roomId);
@@ -522,7 +522,7 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.getTask(taskId);
 		if (!task) {
-			throw new Error(`Task not found: ${params.taskId}`);
+			throw new Error(`Task not found: ${taskId}`);
 		}
 		if (task.status !== 'review') {
 			throw new Error(`Task is not in review status (current: ${task.status})`);
@@ -993,7 +993,7 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.getTask(taskId);
 		if (!task) {
-			throw new Error(`Task ${params.taskId} not found in room ${params.roomId}`);
+			throw new Error(`Task ${taskId} not found in room ${params.roomId}`);
 		}
 
 		// Archived tasks are truly terminal — no messaging allowed. Check this before the runtime

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers-short-id.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers-short-id.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Task RPC Handlers — Short ID tests
+ *
+ * Covers:
+ *  - task.get with short ID input returns correct task (shortId field included)
+ *  - task.get response includes shortId field
+ *  - task.cancel with short ID input cancels the correct task
+ *  - task.get with unknown short ID throws 'Task not found'
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { MessageHub } from '@neokai/shared';
+import type { NeoTask } from '@neokai/shared';
+import { setupTaskHandlers } from '../../../src/lib/rpc-handlers/task-handlers';
+import type { TaskManagerFactory } from '../../../src/lib/rpc-handlers/task-handlers';
+import { TaskRepository } from '../../../src/storage/repositories/task-repository';
+import { ShortIdAllocator } from '../../../src/lib/short-id-allocator';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+import type { RoomManager } from '../../../src/lib/room/managers/room-manager';
+import type { Database } from '../../../src/storage/database';
+import { noOpReactiveDb } from '../../helpers/reactive-database';
+
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+// ─── DB Setup ───
+
+function makeRealDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec(`
+		CREATE TABLE tasks (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending',
+			priority TEXT NOT NULL DEFAULT 'normal',
+			task_type TEXT NOT NULL DEFAULT 'coding',
+			assigned_agent TEXT DEFAULT 'coder',
+			created_by_task_id TEXT,
+			progress INTEGER,
+			current_step TEXT,
+			result TEXT,
+			error TEXT,
+			depends_on TEXT NOT NULL DEFAULT '[]',
+			short_id TEXT,
+			input_draft TEXT,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			archived_at INTEGER,
+			active_session TEXT,
+			pr_url TEXT,
+			pr_number INTEGER,
+			pr_created_at INTEGER,
+			updated_at INTEGER
+		);
+
+		CREATE TABLE short_id_counters (
+			entity_type TEXT NOT NULL,
+			scope_id    TEXT NOT NULL,
+			counter     INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (entity_type, scope_id)
+		);
+
+		CREATE INDEX idx_tasks_room ON tasks(room_id);
+	`);
+	return db;
+}
+
+/** Build a Database facade wrapping a real BunDatabase. */
+function makeDbFacade(rawDb: BunDatabase): Database {
+	return {
+		getDatabase: mock(() => rawDb),
+		getShortIdAllocator: mock(() => undefined),
+	} as unknown as Database;
+}
+
+// ─── Mock helpers ───
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {
+		emit: mock(async () => {}),
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+}
+
+const mockRoomManager = {
+	getRoomOverview: mock(() => null),
+} as unknown as RoomManager;
+
+/** Build a TaskManagerFactory that returns a mock manager which resolves getTask by UUID. */
+function makeTaskManagerFactory(tasksByUUID: Map<string, NeoTask>): TaskManagerFactory {
+	const manager = {
+		createTask: mock(async () => {
+			throw new Error('not implemented');
+		}),
+		getTask: mock(async (id: string) => tasksByUUID.get(id) ?? null),
+		listTasks: mock(async () => [...tasksByUUID.values()]),
+		failTask: mock(async (id: string) => {
+			const t = tasksByUUID.get(id);
+			if (!t) throw new Error(`Task not found: ${id}`);
+			return { ...t, status: 'needs_attention' as const };
+		}),
+		cancelTask: mock(async (id: string) => {
+			const t = tasksByUUID.get(id);
+			if (!t) throw new Error(`Task not found: ${id}`);
+			return { ...t, status: 'cancelled' as const };
+		}),
+		setTaskStatus: mock(async (id: string, status: string) => {
+			const t = tasksByUUID.get(id);
+			if (!t) throw new Error(`Task not found: ${id}`);
+			return { ...t, status } as NeoTask;
+		}),
+		archiveTask: mock(async (id: string) => {
+			const t = tasksByUUID.get(id);
+			if (!t) throw new Error(`Task not found: ${id}`);
+			return { ...t, archivedAt: Date.now() };
+		}),
+		updateTaskStatus: mock(async () => {}),
+	};
+	return mock(() => manager);
+}
+
+// ─── Test fixtures ───
+
+const ROOM_ID = 'room-abc';
+const TASK_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const TASK_SHORT_ID = 't-1';
+
+function makeNeoTask(id: string, shortId?: string): NeoTask {
+	return {
+		id,
+		roomId: ROOM_ID,
+		title: 'Test Task',
+		description: 'Test description',
+		status: 'pending',
+		priority: 'normal',
+		taskType: 'coding',
+		progress: 0,
+		dependsOn: [],
+		shortId,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+// ─── Test suite ───
+
+describe('task handlers — short ID support', () => {
+	let rawDb: BunDatabase;
+	let dbFacade: Database;
+	let taskRepo: TaskRepository;
+	let allocator: ShortIdAllocator;
+	let tasksByUUID: Map<string, NeoTask>;
+
+	beforeEach(() => {
+		rawDb = makeRealDb();
+		dbFacade = makeDbFacade(rawDb);
+		allocator = new ShortIdAllocator(rawDb);
+		taskRepo = new TaskRepository(rawDb, noOpReactiveDb, allocator);
+
+		// Insert a task row with short_id = 't-1'
+		const created = taskRepo.createTask({
+			roomId: ROOM_ID,
+			title: 'Test Task',
+			description: 'Test description',
+			priority: 'normal',
+			taskType: 'coding',
+		});
+
+		// Map the real UUID to a NeoTask for the mock manager
+		tasksByUUID = new Map([[created.id, { ...created, id: created.id }]]);
+	});
+
+	function getShortId(): string {
+		// The allocator should have assigned t-1 as the first short ID
+		const row = rawDb
+			.prepare('SELECT short_id FROM tasks WHERE room_id = ?')
+			.get(ROOM_ID) as Record<string, unknown>;
+		return row.short_id as string;
+	}
+
+	function getUUID(): string {
+		const row = rawDb.prepare('SELECT id FROM tasks WHERE room_id = ?').get(ROOM_ID) as Record<
+			string,
+			unknown
+		>;
+		return row.id as string;
+	}
+
+	function setupHandlers(): { handlers: Map<string, RequestHandler> } {
+		const { hub, handlers } = createMockMessageHub();
+		setupTaskHandlers(
+			hub,
+			mockRoomManager,
+			createMockDaemonHub(),
+			dbFacade,
+			noOpReactiveDb,
+			makeTaskManagerFactory(tasksByUUID)
+		);
+		return { handlers };
+	}
+
+	describe('task.get', () => {
+		it('accepts short ID input and returns the correct task', async () => {
+			const { handlers } = setupHandlers();
+			const shortId = getShortId();
+			const uuid = getUUID();
+
+			const handler = handlers.get('task.get')!;
+			const result = (await handler({ roomId: ROOM_ID, taskId: shortId }, {})) as { task: NeoTask };
+
+			expect(result.task).toBeDefined();
+			expect(result.task.id).toBe(uuid);
+		});
+
+		it('response includes shortId field when task has one', async () => {
+			const { handlers } = setupHandlers();
+			const shortId = getShortId();
+			const uuid = getUUID();
+
+			// Update the mock manager's task to include shortId
+			const taskWithShortId = makeNeoTask(uuid, shortId);
+			tasksByUUID.set(uuid, taskWithShortId);
+
+			const handler = handlers.get('task.get')!;
+			const result = (await handler({ roomId: ROOM_ID, taskId: shortId }, {})) as { task: NeoTask };
+
+			expect(result.task.shortId).toBe(shortId);
+		});
+
+		it('still accepts UUID input', async () => {
+			const { handlers } = setupHandlers();
+			const uuid = getUUID();
+
+			const handler = handlers.get('task.get')!;
+			const result = (await handler({ roomId: ROOM_ID, taskId: uuid }, {})) as { task: NeoTask };
+
+			expect(result.task.id).toBe(uuid);
+		});
+
+		it('throws Task not found for unknown short ID', async () => {
+			const { handlers } = setupHandlers();
+			const handler = handlers.get('task.get')!;
+
+			await expect(handler({ roomId: ROOM_ID, taskId: 't-9999' }, {})).rejects.toThrow(
+				'Task not found: t-9999'
+			);
+		});
+	});
+
+	describe('task.cancel', () => {
+		beforeEach(() => {
+			// Set tasks to pending so they can be cancelled
+			const uuid = getUUID();
+			const task = tasksByUUID.get(uuid)!;
+			tasksByUUID.set(uuid, { ...task, status: 'pending' });
+		});
+
+		it('accepts short ID input and cancels the correct task', async () => {
+			const { handlers } = setupHandlers();
+			const shortId = getShortId();
+			const uuid = getUUID();
+
+			const handler = handlers.get('task.cancel')!;
+			const result = (await handler({ roomId: ROOM_ID, taskId: shortId }, {})) as { task: NeoTask };
+
+			expect(result.task).toBeDefined();
+			expect(result.task.id).toBe(uuid);
+			expect(result.task.status).toBe('cancelled');
+		});
+
+		it('still accepts UUID input', async () => {
+			const { handlers } = setupHandlers();
+			const uuid = getUUID();
+
+			const handler = handlers.get('task.cancel')!;
+			const result = (await handler({ roomId: ROOM_ID, taskId: uuid }, {})) as { task: NeoTask };
+
+			expect(result.task.status).toBe('cancelled');
+		});
+
+		it('throws Task not found for unknown short ID', async () => {
+			const { handlers } = setupHandlers();
+			const handler = handlers.get('task.cancel')!;
+
+			await expect(handler({ roomId: ROOM_ID, taskId: 't-9999' }, {})).rejects.toThrow(
+				'Task not found: t-9999'
+			);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -542,26 +542,26 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			const { setTaskStatus, runtime } = setupWithReviewTask();
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'add error handling' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'add error handling' },
 				{}
 			);
 
 			expect(result).toEqual({ success: true });
-			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress');
-			expect(runtime.injectMessageToWorker).toHaveBeenCalledWith('task-1', 'add error handling');
+			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'in_progress');
+			expect(runtime.injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, 'add error handling');
 		});
 
 		it('transitions to in_progress and routes message to leader', async () => {
 			const { setTaskStatus, runtime } = setupWithReviewTask();
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'approve and merge', target: 'leader' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'approve and merge', target: 'leader' },
 				{}
 			);
 
 			expect(result).toEqual({ success: true });
-			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress');
-			expect(runtime.injectMessageToLeader).toHaveBeenCalledWith('task-1', 'approve and merge');
+			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'in_progress');
+			expect(runtime.injectMessageToLeader).toHaveBeenCalledWith(TASK_UUID, 'approve and merge');
 		});
 
 		it('throws when status transition from review to in_progress fails', async () => {
@@ -593,14 +593,14 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			);
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'go ahead' }, {})
-			).rejects.toThrow('Failed to transition task task-1 from review to in_progress');
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'go ahead' }, {})
+			).rejects.toThrow(`Failed to transition task ${TASK_UUID} from review to in_progress`);
 		});
 
 		it('does not call reviveTaskForMessage for review tasks (sessions are still active)', async () => {
 			const { runtime } = setupWithReviewTask();
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'keep going' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'keep going' }, {});
 
 			expect(runtime.reviveTaskForMessage).not.toHaveBeenCalled();
 		});

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -23,6 +23,10 @@ import type { Database } from '../../../src/storage/database';
 
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
 
+// UUID used as task ID in tests — resolveTaskId passes UUIDs through without DB lookup
+// Must match UUID v4 format: third group starts with 4, fourth group starts with 8/9/a/b
+const TASK_UUID = '00000000-0000-4000-8000-000000000001';
+
 // ─── Mock helpers ───
 
 function createMockMessageHub(): {
@@ -63,7 +67,7 @@ function createMockDaemonHub(): DaemonHub {
 }
 
 const mockTask: NeoTask = {
-	id: 'task-1',
+	id: TASK_UUID,
 	roomId: 'room-1',
 	title: 'Test Task',
 	description: 'Test description',
@@ -101,7 +105,7 @@ function makeGroupRow(submittedForReview = false): Record<string, unknown> {
 	return {
 		id: 'group-1',
 		group_type: 'task',
-		ref_id: 'task-1',
+		ref_id: TASK_UUID,
 		state: submittedForReview ? 'awaiting_human' : 'awaiting_worker', // DB column kept for compat
 		version: 1,
 		metadata: JSON.stringify({
@@ -147,7 +151,7 @@ function makeRuntimeService(resumeResult = true, injectResult = true, reviveResu
 	const reviveTaskForMessage = mock(async () => reviveResult);
 	const cancelTask = mock(async () => ({
 		success: injectResult,
-		cancelledTaskIds: injectResult ? ['task-1'] : [],
+		cancelledTaskIds: injectResult ? [TASK_UUID] : [],
 	}));
 	const terminateTaskGroup = mock(async () => injectResult);
 	const interruptTaskSession = mock(async () => ({ success: injectResult }));
@@ -223,7 +227,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 
 	describe('parameter validation', () => {
 		it('throws when roomId is missing', async () => {
-			await expect(getHandler()({ taskId: 'task-1', message: 'hi' }, {})).rejects.toThrow(
+			await expect(getHandler()({ taskId: TASK_UUID, message: 'hi' }, {})).rejects.toThrow(
 				'Room ID is required'
 			);
 		});
@@ -235,20 +239,20 @@ describe('task.sendHumanMessage RPC Handler', () => {
 		});
 
 		it('throws when message is missing', async () => {
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Message is required'
 			);
 		});
 
 		it('throws when message is an empty string', async () => {
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: '' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: '' }, {})
 			).rejects.toThrow('Message is required');
 		});
 
 		it('throws when message is whitespace only', async () => {
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: '   ' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: '   ' }, {})
 			).rejects.toThrow('Message cannot be empty');
 		});
 	});
@@ -259,14 +263,14 @@ describe('task.sendHumanMessage RPC Handler', () => {
 		it('throws when runtimeService is not provided', async () => {
 			setup({ runtimeService: undefined });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'hello' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'hello' }, {})
 			).rejects.toThrow('Runtime service is required');
 		});
 
 		it('throws when runtime is not found for the room', async () => {
 			setup({ runtimeService: makeNullRuntimeService() });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'hello' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'hello' }, {})
 			).rejects.toThrow('No runtime found for room');
 		});
 	});
@@ -278,7 +282,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			const { service } = makeRuntimeService();
 			setup({ task: null, runtimeService: service });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'hello' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'hello' }, {})
 			).rejects.toThrow('not found in room');
 		});
 	});
@@ -291,7 +295,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ submittedForReview: true, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'please continue' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'please continue' },
 				{}
 			);
 			expect(result).toEqual({ success: true });
@@ -302,7 +306,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ submittedForReview: false, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'hello' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'hello' },
 				{}
 			);
 			expect(result).toEqual({ success: true });
@@ -326,7 +330,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			);
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'hello' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'hello' }, {})
 			).rejects.toThrow('No active session group');
 		});
 	});
@@ -338,13 +342,17 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ task: failedTask, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'please retry' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'please retry' },
 				{}
 			);
 
 			expect(result).toEqual({ success: true });
 			// Sets status to review before reviving
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'please retry', 'worker');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
+				TASK_UUID,
+				'please retry',
+				'worker'
+			);
 		});
 
 		it('throws and rolls back status when reviveTaskForMessage returns false', async () => {
@@ -376,13 +384,13 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			);
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'retry' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'retry' }, {})
 			).rejects.toThrow('agent sessions could not be restored');
 
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'retry', 'worker');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(TASK_UUID, 'retry', 'worker');
 			// Verify rollback: first transitioned to 'review', then rolled back to 'needs_attention'
-			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'review');
-			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'needs_attention');
+			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'review');
+			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'needs_attention');
 		});
 	});
 
@@ -393,13 +401,13 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ task: completedTask, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'please continue' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'please continue' },
 				{}
 			);
 
 			expect(result).toEqual({ success: true });
 			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
-				'task-1',
+				TASK_UUID,
 				'please continue',
 				'worker'
 			);
@@ -433,13 +441,13 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			);
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'continue' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'continue' }, {})
 			).rejects.toThrow('agent sessions could not be restored');
 
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'continue', 'worker');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(TASK_UUID, 'continue', 'worker');
 			// Verify intermediate transition to in_progress, then rollback to completed
-			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress');
-			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'completed');
+			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'in_progress');
+			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'completed');
 		});
 	});
 
@@ -450,13 +458,13 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ task: cancelledTask, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'restart please' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'restart please' },
 				{}
 			);
 
 			expect(result).toEqual({ success: true });
 			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
-				'task-1',
+				TASK_UUID,
 				'restart please',
 				'worker'
 			);
@@ -490,13 +498,13 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			);
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'retry' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'retry' }, {})
 			).rejects.toThrow('agent sessions could not be restored');
 
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'retry', 'worker');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(TASK_UUID, 'retry', 'worker');
 			// Verify intermediate transition to in_progress, then rollback to cancelled
-			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress');
-			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'cancelled');
+			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'in_progress');
+			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'cancelled');
 		});
 	});
 
@@ -605,12 +613,16 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ task: needsAttentionTask, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'hello worker', target: 'worker' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'hello worker', target: 'worker' },
 				{}
 			);
 
 			expect(result).toEqual({ success: true });
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'hello worker', 'worker');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
+				TASK_UUID,
+				'hello worker',
+				'worker'
+			);
 		});
 
 		it('passes target=leader to reviveTaskForMessage when human selects leader', async () => {
@@ -619,12 +631,16 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ task: needsAttentionTask, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'hello leader', target: 'leader' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'hello leader', target: 'leader' },
 				{}
 			);
 
 			expect(result).toEqual({ success: true });
-			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'hello leader', 'leader');
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
+				TASK_UUID,
+				'hello leader',
+				'leader'
+			);
 		});
 
 		it('defaults to target=worker when no target specified', async () => {
@@ -633,13 +649,13 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ task: needsAttentionTask, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', message: 'hello default' },
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'hello default' },
 				{}
 			);
 
 			expect(result).toEqual({ success: true });
 			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
-				'task-1',
+				TASK_UUID,
 				'hello default',
 				'worker'
 			);
@@ -653,7 +669,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ task: archivedTask, runtimeService: service });
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'can you still work?' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'can you still work?' }, {})
 			).rejects.toThrow('is archived and cannot receive messages');
 		});
 
@@ -662,7 +678,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			setup({ task: archivedTask, runtimeService: makeNullRuntimeService() });
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'can you still work?' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'can you still work?' }, {})
 			).rejects.toThrow('is archived and cannot receive messages');
 		});
 	});
@@ -708,7 +724,7 @@ describe('task.cancel RPC Handler', () => {
 		});
 
 		it('throws when roomId is missing', async () => {
-			await expect(getHandler()({ taskId: 'task-1' }, {})).rejects.toThrow('Room ID is required');
+			await expect(getHandler()({ taskId: TASK_UUID }, {})).rejects.toThrow('Room ID is required');
 		});
 
 		it('throws when taskId is missing', async () => {
@@ -719,7 +735,7 @@ describe('task.cancel RPC Handler', () => {
 	describe('task status validation', () => {
 		it('throws when task is not found', async () => {
 			setup({ task: null, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Task not found'
 			);
 		});
@@ -727,7 +743,7 @@ describe('task.cancel RPC Handler', () => {
 		it('throws when task status is completed', async () => {
 			const completedTask = { ...mockTask, status: 'completed' as const };
 			setup({ task: completedTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Task cannot be cancelled'
 			);
 		});
@@ -735,7 +751,7 @@ describe('task.cancel RPC Handler', () => {
 		it('throws when task needs attention', async () => {
 			const failedTask = { ...mockTask, status: 'needs_attention' as const };
 			setup({ task: failedTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Task cannot be cancelled'
 			);
 		});
@@ -743,7 +759,7 @@ describe('task.cancel RPC Handler', () => {
 		it('throws when task status is cancelled', async () => {
 			const cancelledTask = { ...mockTask, status: 'cancelled' as const };
 			setup({ task: cancelledTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Task cannot be cancelled'
 			);
 		});
@@ -755,29 +771,29 @@ describe('task.cancel RPC Handler', () => {
 			const { service, runtime } = makeRuntimeService(true);
 			setup({ task: inProgressTask, submittedForReview: false, runtimeService: service });
 
-			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
-			expect(runtime.cancelTask).toHaveBeenCalledWith('task-1');
+			const result = await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
+			expect(runtime.cancelTask).toHaveBeenCalledWith(TASK_UUID);
 			expect(result).toEqual({ task: inProgressTask });
 		});
 
 		it('cancels a pending task without active group', async () => {
 			const pendingTask = { ...mockTask, status: 'pending' as const };
 			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
-			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			const result = await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 			expect(result).toEqual({ task: { ...pendingTask, status: 'cancelled' } });
 		});
 
 		it('cancels an in_progress task without active group', async () => {
 			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
 			setup({ task: inProgressTask, runtimeService: makeNullRuntimeService() });
-			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			const result = await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 			expect(result).toEqual({ task: { ...inProgressTask, status: 'cancelled' } });
 		});
 
 		it('cancels a review task without active group', async () => {
 			const reviewTask = { ...mockTask, status: 'review' as const };
 			setup({ task: reviewTask, runtimeService: makeNullRuntimeService() });
-			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			const result = await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 			expect(result).toEqual({ task: { ...reviewTask, status: 'cancelled' } });
 		});
 	});
@@ -824,7 +840,7 @@ describe('task.reject RPC Handler', () => {
 		});
 
 		it('throws when roomId is missing', async () => {
-			await expect(getHandler()({ taskId: 'task-1', feedback: 'not good' }, {})).rejects.toThrow(
+			await expect(getHandler()({ taskId: TASK_UUID, feedback: 'not good' }, {})).rejects.toThrow(
 				'Room ID is required'
 			);
 		});
@@ -836,20 +852,20 @@ describe('task.reject RPC Handler', () => {
 		});
 
 		it('throws when feedback is missing', async () => {
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Feedback is required for rejection'
 			);
 		});
 
 		it('throws when feedback is empty string', async () => {
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: '' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, feedback: '' }, {})
 			).rejects.toThrow('Feedback is required for rejection');
 		});
 
 		it('throws when feedback is whitespace only', async () => {
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: '   ' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, feedback: '   ' }, {})
 			).rejects.toThrow('Feedback is required for rejection');
 		});
 	});
@@ -858,7 +874,7 @@ describe('task.reject RPC Handler', () => {
 		it('throws when runtimeService is not provided', async () => {
 			setup({ runtimeService: undefined });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'not good' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, feedback: 'not good' }, {})
 			).rejects.toThrow('Runtime service is required');
 		});
 
@@ -866,7 +882,7 @@ describe('task.reject RPC Handler', () => {
 			const reviewTask = { ...mockTask, status: 'review' as const };
 			setup({ task: reviewTask, runtimeService: makeNullRuntimeService() });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'not good' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, feedback: 'not good' }, {})
 			).rejects.toThrow('No runtime found for room');
 		});
 	});
@@ -876,7 +892,7 @@ describe('task.reject RPC Handler', () => {
 			const { service } = makeRuntimeService();
 			setup({ task: null, runtimeService: service });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'not good' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, feedback: 'not good' }, {})
 			).rejects.toThrow('Task not found');
 		});
 
@@ -885,7 +901,7 @@ describe('task.reject RPC Handler', () => {
 			const { service } = makeRuntimeService();
 			setup({ task: inProgressTask, runtimeService: service });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'not good' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, feedback: 'not good' }, {})
 			).rejects.toThrow('Task is not in review status');
 		});
 	});
@@ -911,7 +927,7 @@ describe('task.reject RPC Handler', () => {
 			);
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'not good' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, feedback: 'not good' }, {})
 			).rejects.toThrow('No active session group for this task');
 		});
 	});
@@ -923,11 +939,11 @@ describe('task.reject RPC Handler', () => {
 			setup({ task: reviewTask, submittedForReview: true, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', feedback: 'please fix the bug' },
+				{ roomId: 'room-1', taskId: TASK_UUID, feedback: 'please fix the bug' },
 				{}
 			);
 			expect(runtime.resumeWorkerFromHuman).toHaveBeenCalledWith(
-				'task-1',
+				TASK_UUID,
 				'[Human Rejection]\n\nplease fix the bug',
 				{ approved: false }
 			);
@@ -940,7 +956,7 @@ describe('task.reject RPC Handler', () => {
 			setup({ task: reviewTask, submittedForReview: true, runtimeService: service });
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'please fix' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, feedback: 'please fix' }, {})
 			).rejects.toThrow('Failed to reject task');
 		});
 	});
@@ -993,7 +1009,7 @@ describe('task.setStatus RPC Handler', () => {
 	}) {
 		const cancelTask = mock(async () => ({
 			success: options?.cancelSuccess ?? true,
-			cancelledTaskIds: options?.cancelSuccess === false ? [] : ['task-1'],
+			cancelledTaskIds: options?.cancelSuccess === false ? [] : [TASK_UUID],
 		}));
 		const terminateTaskGroup = mock(async () => options?.terminateSuccess ?? true);
 		const runtime = { cancelTask, terminateTaskGroup };
@@ -1043,7 +1059,7 @@ describe('task.setStatus RPC Handler', () => {
 		});
 
 		it('throws when roomId is missing', async () => {
-			await expect(getHandler()({ taskId: 'task-1', status: 'completed' }, {})).rejects.toThrow(
+			await expect(getHandler()({ taskId: TASK_UUID, status: 'completed' }, {})).rejects.toThrow(
 				'Room ID is required'
 			);
 		});
@@ -1055,7 +1071,7 @@ describe('task.setStatus RPC Handler', () => {
 		});
 
 		it('throws when status is missing', async () => {
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Status is required'
 			);
 		});
@@ -1065,7 +1081,7 @@ describe('task.setStatus RPC Handler', () => {
 		it('throws when task is not found', async () => {
 			setup({ task: null, runtimeService: makeNullRuntimeService() });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'completed' }, {})
 			).rejects.toThrow('Task not found');
 		});
 	});
@@ -1075,7 +1091,7 @@ describe('task.setStatus RPC Handler', () => {
 			const pendingTask = { ...mockTask, status: 'pending' as const };
 			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'completed' }, {})
 			).rejects.toThrow('Invalid status transition');
 		});
 
@@ -1083,7 +1099,7 @@ describe('task.setStatus RPC Handler', () => {
 			const completedTask = { ...mockTask, status: 'completed' as const };
 			setup({ task: completedTask, runtimeService: makeNullRuntimeService() });
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'pending' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'pending' }, {})
 			).rejects.toThrow('Invalid status transition');
 		});
 
@@ -1100,7 +1116,7 @@ describe('task.setStatus RPC Handler', () => {
 				'needs_attention',
 			] as const) {
 				await expect(
-					getHandler()({ roomId: 'room-1', taskId: 'task-1', status: targetStatus }, {})
+					getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: targetStatus }, {})
 				).rejects.toThrow('Invalid status transition');
 			}
 		});
@@ -1117,7 +1133,7 @@ describe('task.setStatus RPC Handler', () => {
 			});
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'completed' }, {})
 			).rejects.toThrow('Failed to terminate task group');
 		});
 
@@ -1131,10 +1147,10 @@ describe('task.setStatus RPC Handler', () => {
 			});
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'completed' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'completed' },
 				{}
 			);
-			expect(terminateTaskGroup).toHaveBeenCalledWith('task-1');
+			expect(terminateTaskGroup).toHaveBeenCalledWith(TASK_UUID);
 			expect(result).toEqual({ task: { ...mockTask, status: 'completed' } });
 		});
 
@@ -1150,10 +1166,10 @@ describe('task.setStatus RPC Handler', () => {
 			});
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'cancelled' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'cancelled' },
 				{}
 			);
-			expect(cancelTask).toHaveBeenCalledWith('task-1');
+			expect(cancelTask).toHaveBeenCalledWith(TASK_UUID);
 			expect(terminateTaskGroup).not.toHaveBeenCalled();
 			expect(result).toEqual({ task: mockTask });
 		});
@@ -1168,7 +1184,7 @@ describe('task.setStatus RPC Handler', () => {
 			});
 
 			// Moving to 'review' is not a terminal state, so group shouldn't be terminated
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'review' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'review' }, {});
 			expect(cancelTask).not.toHaveBeenCalled();
 			expect(terminateTaskGroup).not.toHaveBeenCalled();
 		});
@@ -1183,7 +1199,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			// This should succeed without attempting to cancel any group
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'completed' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'completed' },
 				{}
 			);
 			expect(result).toEqual({ task: { ...mockTask, status: 'completed' } });
@@ -1194,7 +1210,7 @@ describe('task.setStatus RPC Handler', () => {
 		it('allows valid transition from in_progress to completed', async () => {
 			setup({ task: mockTask, runtimeService: makeNullRuntimeService() });
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'completed', result: 'Done' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'completed', result: 'Done' },
 				{}
 			);
 			expect(result).toEqual({ task: { ...mockTask, status: 'completed' } });
@@ -1204,7 +1220,7 @@ describe('task.setStatus RPC Handler', () => {
 			const failedTask = { ...mockTask, status: 'needs_attention' as const };
 			setup({ task: failedTask, runtimeService: makeNullRuntimeService() });
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'pending' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'pending' },
 				{}
 			);
 			expect(result).toEqual({ task: { ...failedTask, status: 'pending' } });
@@ -1214,7 +1230,7 @@ describe('task.setStatus RPC Handler', () => {
 			const cancelledTask = { ...mockTask, status: 'cancelled' as const };
 			setup({ task: cancelledTask, runtimeService: makeNullRuntimeService() });
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'in_progress' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'in_progress' },
 				{}
 			);
 			expect(result).toEqual({ task: { ...cancelledTask, status: 'in_progress' } });
@@ -1226,7 +1242,7 @@ describe('task.setStatus RPC Handler', () => {
 			setup({ task: completedTask, runtimeService: service });
 
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'in_progress' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'in_progress' },
 				{}
 			);
 			// completed → in_progress: group is NOT reset/terminated — lightweight revival
@@ -1263,9 +1279,9 @@ describe('task.setStatus RPC Handler', () => {
 			const { service, runtime } = makeRuntimeService();
 			setup({ task: completedTask, runtimeService: service });
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'archived' }, {});
 
-			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith('task-1', undefined);
+			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith(TASK_UUID, undefined);
 		});
 
 		it('emits task update and room overview after archiving via runtime', async () => {
@@ -1285,7 +1301,7 @@ describe('task.setStatus RPC Handler', () => {
 			);
 
 			const handler = mh.handlers.get('task.setStatus')!;
-			await handler({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
+			await handler({ roomId: 'room-1', taskId: TASK_UUID, status: 'archived' }, {});
 
 			expect(daemonHub.emit).toHaveBeenCalledWith(
 				'room.task.update',
@@ -1298,11 +1314,11 @@ describe('task.setStatus RPC Handler', () => {
 			const factory = makeSetStatusWithArchiveFactory(completedTask);
 			setup({ task: completedTask, runtimeService: undefined, taskManagerFactory: factory });
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'archived' }, {});
 
 			expect(
 				(factory as unknown as { _archiveTask: ReturnType<typeof mock> })._archiveTask
-			).toHaveBeenCalledWith('task-1', undefined);
+			).toHaveBeenCalledWith(TASK_UUID, undefined);
 		});
 
 		it('calls taskManager.archiveTask when runtime has no runtime for room', async () => {
@@ -1314,11 +1330,11 @@ describe('task.setStatus RPC Handler', () => {
 				taskManagerFactory: factory,
 			});
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'archived' }, {});
 
 			expect(
 				(factory as unknown as { _archiveTask: ReturnType<typeof mock> })._archiveTask
-			).toHaveBeenCalledWith('task-1', undefined);
+			).toHaveBeenCalledWith(TASK_UUID, undefined);
 		});
 
 		it('throws for invalid transition from in_progress to archived', async () => {
@@ -1326,7 +1342,7 @@ describe('task.setStatus RPC Handler', () => {
 			setup({ task: inProgressTask, runtimeService: makeNullRuntimeService() });
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'archived' }, {})
 			).rejects.toThrow('Invalid status transition');
 		});
 	});
@@ -1338,7 +1354,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			// pending → completed is invalid in runtime mode but allowed in manual mode
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'completed', mode: 'manual' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'completed', mode: 'manual' },
 				{}
 			);
 			expect(result).toEqual({ task: { ...pendingTask, status: 'completed' } });
@@ -1350,7 +1366,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			// archived → pending is normally terminal (no transitions), but manual mode allows it
 			const result = await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'pending', mode: 'manual' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'pending', mode: 'manual' },
 				{}
 			);
 			expect(result).toEqual({ task: { ...archivedTask, status: 'pending' } });
@@ -1362,7 +1378,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			await expect(
 				getHandler()(
-					{ roomId: 'room-1', taskId: 'task-1', status: 'completed', mode: 'runtime' },
+					{ roomId: 'room-1', taskId: TASK_UUID, status: 'completed', mode: 'runtime' },
 					{}
 				)
 			).rejects.toThrow('Invalid status transition');
@@ -1373,7 +1389,7 @@ describe('task.setStatus RPC Handler', () => {
 			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
 
 			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
+				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, status: 'completed' }, {})
 			).rejects.toThrow('Invalid status transition');
 		});
 
@@ -1387,14 +1403,14 @@ describe('task.setStatus RPC Handler', () => {
 			});
 
 			await getHandler()(
-				{ roomId: 'room-1', taskId: 'task-1', status: 'completed', mode: 'manual' },
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'completed', mode: 'manual' },
 				{}
 			);
 
 			// Verify that setTaskStatus was called with mode: 'manual'
 			const taskManagerInstance = (factory as ReturnType<typeof mock>).mock.results[0].value;
 			expect(taskManagerInstance.setTaskStatus).toHaveBeenCalledWith(
-				'task-1',
+				TASK_UUID,
 				'completed',
 				expect.objectContaining({ mode: 'manual' })
 			);
@@ -1436,7 +1452,7 @@ describe('task.interruptSession RPC Handler', () => {
 		});
 
 		it('throws when roomId is missing', async () => {
-			await expect(getHandler()({ taskId: 'task-1' }, {})).rejects.toThrow('Room ID is required');
+			await expect(getHandler()({ taskId: TASK_UUID }, {})).rejects.toThrow('Room ID is required');
 		});
 
 		it('throws when taskId is missing', async () => {
@@ -1447,7 +1463,7 @@ describe('task.interruptSession RPC Handler', () => {
 	describe('task status validation', () => {
 		it('throws when task is not found', async () => {
 			setup({ task: null, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Task not found'
 			);
 		});
@@ -1455,7 +1471,7 @@ describe('task.interruptSession RPC Handler', () => {
 		it('throws when task status is pending', async () => {
 			const pendingTask = { ...mockTask, status: 'pending' as const };
 			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Task cannot be interrupted'
 			);
 		});
@@ -1463,7 +1479,7 @@ describe('task.interruptSession RPC Handler', () => {
 		it('throws when task status is completed', async () => {
 			const completedTask = { ...mockTask, status: 'completed' as const };
 			setup({ task: completedTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Task cannot be interrupted'
 			);
 		});
@@ -1472,7 +1488,7 @@ describe('task.interruptSession RPC Handler', () => {
 			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
 			// makeNullRuntimeService returns a service with getRuntime() = null (no room runtime)
 			setup({ task: inProgressTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'No runtime found for room'
 			);
 		});
@@ -1484,8 +1500,8 @@ describe('task.interruptSession RPC Handler', () => {
 			const { service, runtime } = makeRuntimeService(true);
 			setup({ task: inProgressTask, runtimeService: service });
 
-			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
-			expect(runtime.interruptTaskSession).toHaveBeenCalledWith('task-1');
+			const result = await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
+			expect(runtime.interruptTaskSession).toHaveBeenCalledWith(TASK_UUID);
 			// Returns just { success: true }, NOT the task (task status is unchanged)
 			expect(result).toEqual({ success: true });
 		});
@@ -1495,8 +1511,8 @@ describe('task.interruptSession RPC Handler', () => {
 			const { service, runtime } = makeRuntimeService(true);
 			setup({ task: reviewTask, runtimeService: service });
 
-			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
-			expect(runtime.interruptTaskSession).toHaveBeenCalledWith('task-1');
+			const result = await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
+			expect(runtime.interruptTaskSession).toHaveBeenCalledWith(TASK_UUID);
 			expect(result).toEqual({ success: true });
 		});
 
@@ -1506,7 +1522,7 @@ describe('task.interruptSession RPC Handler', () => {
 			const { service } = makeRuntimeService(true, false);
 			setup({ task: inProgressTask, runtimeService: service });
 
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Failed to interrupt task session'
 			);
 		});
@@ -1569,7 +1585,7 @@ describe('task.archive RPC Handler', () => {
 		});
 
 		it('throws when roomId is missing', async () => {
-			await expect(getHandler()({ taskId: 'task-1' }, {})).rejects.toThrow('Room ID is required');
+			await expect(getHandler()({ taskId: TASK_UUID }, {})).rejects.toThrow('Room ID is required');
 		});
 
 		it('throws when taskId is missing', async () => {
@@ -1580,7 +1596,7 @@ describe('task.archive RPC Handler', () => {
 	describe('task state validation', () => {
 		it('throws when task is not found', async () => {
 			setup({ task: null, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				'Task not found'
 			);
 		});
@@ -1588,7 +1604,7 @@ describe('task.archive RPC Handler', () => {
 		it('throws when task is in_progress (non-terminal)', async () => {
 			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
 			setup({ task: inProgressTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				"Cannot archive task in 'in_progress' state"
 			);
 		});
@@ -1596,7 +1612,7 @@ describe('task.archive RPC Handler', () => {
 		it('throws when task is pending (non-terminal)', async () => {
 			const pendingTask = { ...mockTask, status: 'pending' as const };
 			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				"Cannot archive task in 'pending' state"
 			);
 		});
@@ -1604,7 +1620,7 @@ describe('task.archive RPC Handler', () => {
 		it('throws when task is review (non-terminal)', async () => {
 			const reviewTask = { ...mockTask, status: 'review' as const };
 			setup({ task: reviewTask, runtimeService: makeNullRuntimeService() });
-			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+			await expect(getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {})).rejects.toThrow(
 				"Cannot archive task in 'review' state"
 			);
 		});
@@ -1616,9 +1632,9 @@ describe('task.archive RPC Handler', () => {
 			const { service, runtime } = makeRuntimeService();
 			setup({ task: completedTask, runtimeService: service });
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 
-			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith('task-1');
+			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith(TASK_UUID);
 		});
 
 		it('allows archiving cancelled tasks via runtime', async () => {
@@ -1626,9 +1642,9 @@ describe('task.archive RPC Handler', () => {
 			const { service, runtime } = makeRuntimeService();
 			setup({ task: cancelledTask, runtimeService: service });
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 
-			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith('task-1');
+			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith(TASK_UUID);
 		});
 
 		it('allows archiving needs_attention tasks via runtime', async () => {
@@ -1636,9 +1652,9 @@ describe('task.archive RPC Handler', () => {
 			const { service, runtime } = makeRuntimeService();
 			setup({ task: failedTask, runtimeService: service });
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 
-			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith('task-1');
+			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith(TASK_UUID);
 		});
 	});
 
@@ -1648,12 +1664,12 @@ describe('task.archive RPC Handler', () => {
 			const factory = makeArchiveTaskManagerFactory(completedTask);
 			setup({ task: completedTask, runtimeService: undefined, taskManagerFactory: factory });
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 
 			// archiveTask must be called even without a runtime
 			expect(
 				(factory as unknown as { _archiveTask: ReturnType<typeof mock> })._archiveTask
-			).toHaveBeenCalledWith('task-1');
+			).toHaveBeenCalledWith(TASK_UUID);
 		});
 
 		it('calls taskManager.archiveTask when runtime is not found for room', async () => {
@@ -1665,20 +1681,20 @@ describe('task.archive RPC Handler', () => {
 				taskManagerFactory: factory,
 			});
 
-			await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 
 			expect(
 				(factory as unknown as { _archiveTask: ReturnType<typeof mock> })._archiveTask
-			).toHaveBeenCalledWith('task-1');
+			).toHaveBeenCalledWith(TASK_UUID);
 		});
 
 		it('returns the task after archiving without runtime', async () => {
 			const completedTask = { ...mockTask, status: 'completed' as const };
 			setup({ task: completedTask, runtimeService: makeNullRuntimeService() });
 
-			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			const result = await getHandler()({ roomId: 'room-1', taskId: TASK_UUID }, {});
 
-			expect(result).toMatchObject({ task: expect.objectContaining({ id: 'task-1' }) });
+			expect(result).toMatchObject({ task: expect.objectContaining({ id: TASK_UUID }) });
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -25,12 +25,16 @@ import type { RoomRuntimeService } from '../../../src/lib/room/runtime/room-runt
 // Type for captured request handlers
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
 
+// UUID used as task ID in tests — resolveTaskId passes UUIDs through without DB lookup
+// Must match UUID v4 format: third group starts with 4, fourth group starts with 8/9/a/b
+const TASK_UUID = '00000000-0000-4000-8000-000000000001';
+
 // Mock TaskManager module
 const mockTaskManager = {
 	createTask: mock(
 		async () =>
 			({
-				id: 'task-123',
+				id: TASK_UUID,
 				roomId: 'room-123',
 				title: 'Test Task',
 				description: 'Test description',
@@ -43,7 +47,7 @@ const mockTaskManager = {
 	getTask: mock(
 		async () =>
 			({
-				id: 'task-123',
+				id: TASK_UUID,
 				roomId: 'room-123',
 				title: 'Test Task',
 				description: 'Test description',
@@ -57,7 +61,7 @@ const mockTaskManager = {
 	failTask: mock(
 		async () =>
 			({
-				id: 'task-123',
+				id: TASK_UUID,
 				roomId: 'room-123',
 				title: 'Test Task',
 				status: 'needs_attention' as TaskStatus,
@@ -194,7 +198,7 @@ function createMockRuntimeService(methodResult = true): {
 function createMockDatabaseWithGroup(groupState: string = 'awaiting_leader'): Database {
 	const groupRow = {
 		id: 'group-123',
-		ref_id: 'task-123',
+		ref_id: TASK_UUID,
 		group_type: 'task_pair',
 		state: groupState,
 		version: 1,
@@ -348,20 +352,20 @@ describe('Task RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('task.get');
 			expect(handler).toBeDefined();
 
-			const result = (await handler!({ roomId: 'room-123', taskId: 'task-123' }, {})) as {
+			const result = (await handler!({ roomId: 'room-123', taskId: TASK_UUID }, {})) as {
 				task: NeoTask;
 			};
 
-			expect(mockTaskManager.getTask).toHaveBeenCalledWith('task-123');
+			expect(mockTaskManager.getTask).toHaveBeenCalledWith(TASK_UUID);
 			expect(result.task).toBeDefined();
-			expect(result.task.id).toBe('task-123');
+			expect(result.task.id).toBe(TASK_UUID);
 		});
 
 		it('throws error when roomId is missing', async () => {
 			const handler = messageHubData.handlers.get('task.get');
 			expect(handler).toBeDefined();
 
-			await expect(handler!({ taskId: 'task-123' }, {})).rejects.toThrow('Room ID is required');
+			await expect(handler!({ taskId: TASK_UUID }, {})).rejects.toThrow('Room ID is required');
 		});
 
 		it('throws error when taskId is missing', async () => {
@@ -375,10 +379,13 @@ describe('Task RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('task.get');
 			expect(handler).toBeDefined();
 
+			// Use a valid UUID so resolveTaskId passes through without a DB lookup,
+			// allowing mockResolvedValueOnce(null) to be consumed by getTask().
+			const nonExistentUUID = '00000000-0000-4000-8000-000000000099';
 			mockTaskManager.getTask.mockResolvedValueOnce(null);
 
-			await expect(handler!({ roomId: 'room-123', taskId: 'non-existent' }, {})).rejects.toThrow(
-				'Task not found: non-existent'
+			await expect(handler!({ roomId: 'room-123', taskId: nonExistentUUID }, {})).rejects.toThrow(
+				`Task not found: ${nonExistentUUID}`
 			);
 		});
 	});
@@ -389,11 +396,11 @@ describe('Task RPC Handlers', () => {
 			expect(handler).toBeDefined();
 
 			const result = (await handler!(
-				{ roomId: 'room-123', taskId: 'task-123', error: 'Something went wrong' },
+				{ roomId: 'room-123', taskId: TASK_UUID, error: 'Something went wrong' },
 				{}
 			)) as { task: NeoTask };
 
-			expect(mockTaskManager.failTask).toHaveBeenCalledWith('task-123', 'Something went wrong');
+			expect(mockTaskManager.failTask).toHaveBeenCalledWith(TASK_UUID, 'Something went wrong');
 			expect(result.task).toBeDefined();
 		});
 
@@ -401,11 +408,11 @@ describe('Task RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('task.fail');
 			expect(handler).toBeDefined();
 
-			const result = (await handler!({ roomId: 'room-123', taskId: 'task-123' }, {})) as {
+			const result = (await handler!({ roomId: 'room-123', taskId: TASK_UUID }, {})) as {
 				task: NeoTask;
 			};
 
-			expect(mockTaskManager.failTask).toHaveBeenCalledWith('task-123', '');
+			expect(mockTaskManager.failTask).toHaveBeenCalledWith(TASK_UUID, '');
 			expect(result.task).toBeDefined();
 		});
 
@@ -413,7 +420,7 @@ describe('Task RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('task.fail');
 			expect(handler).toBeDefined();
 
-			await expect(handler!({ taskId: 'task-123', error: 'Failed' }, {})).rejects.toThrow(
+			await expect(handler!({ taskId: TASK_UUID, error: 'Failed' }, {})).rejects.toThrow(
 				'Room ID is required'
 			);
 		});
@@ -431,7 +438,7 @@ describe('Task RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('task.fail');
 			expect(handler).toBeDefined();
 
-			await handler!({ roomId: 'room-123', taskId: 'task-123', error: 'Failed' }, {});
+			await handler!({ roomId: 'room-123', taskId: TASK_UUID, error: 'Failed' }, {});
 
 			// room.overview must still fire so clients get updated session/task metadata
 			expect(roomManagerData.getRoomOverview).toHaveBeenCalledWith('room-123');
@@ -478,11 +485,11 @@ describe('task.sendHumanMessage handler', () => {
 		expect(handler).toBeDefined();
 
 		const result = (await handler!(
-			{ roomId: 'room-123', taskId: 'task-123', message: 'Looks good!' },
+			{ roomId: 'room-123', taskId: TASK_UUID, message: 'Looks good!' },
 			{}
 		)) as { success: boolean };
 
-		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', 'Looks good!');
+		expect(injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, 'Looks good!');
 		expect(result.success).toBe(true);
 	});
 
@@ -501,9 +508,9 @@ describe('task.sendHumanMessage handler', () => {
 		);
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
-		await handler!({ roomId: 'room-123', taskId: 'task-123', message: '  please fix it  ' }, {});
+		await handler!({ roomId: 'room-123', taskId: TASK_UUID, message: '  please fix it  ' }, {});
 
-		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', 'please fix it');
+		expect(injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, 'please fix it');
 	});
 
 	it('throws error when roomId is missing', async () => {
@@ -521,7 +528,7 @@ describe('task.sendHumanMessage handler', () => {
 		);
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
-		await expect(handler!({ taskId: 'task-123', message: 'hello' }, {})).rejects.toThrow(
+		await expect(handler!({ taskId: TASK_UUID, message: 'hello' }, {})).rejects.toThrow(
 			'Room ID is required'
 		);
 	});
@@ -561,7 +568,7 @@ describe('task.sendHumanMessage handler', () => {
 		);
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
-		await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
+		await expect(handler!({ roomId: 'room-123', taskId: TASK_UUID }, {})).rejects.toThrow(
 			'Message is required'
 		);
 	});
@@ -582,7 +589,7 @@ describe('task.sendHumanMessage handler', () => {
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
 		await expect(
-			handler!({ roomId: 'room-123', taskId: 'task-123', message: '   ' }, {})
+			handler!({ roomId: 'room-123', taskId: TASK_UUID, message: '   ' }, {})
 		).rejects.toThrow('Message cannot be empty');
 	});
 
@@ -601,7 +608,7 @@ describe('task.sendHumanMessage handler', () => {
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
 		await expect(
-			handler!({ roomId: 'room-123', taskId: 'task-123', message: 'hello' }, {})
+			handler!({ roomId: 'room-123', taskId: TASK_UUID, message: 'hello' }, {})
 		).rejects.toThrow('Runtime service is required');
 	});
 
@@ -622,7 +629,7 @@ describe('task.sendHumanMessage handler', () => {
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
 		await expect(
-			handler!({ roomId: 'room-999', taskId: 'task-123', message: 'hello' }, {})
+			handler!({ roomId: 'room-999', taskId: TASK_UUID, message: 'hello' }, {})
 		).rejects.toThrow('No runtime found for room: room-999');
 	});
 
@@ -642,11 +649,11 @@ describe('task.sendHumanMessage handler', () => {
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
 		const result = (await handler!(
-			{ roomId: 'room-123', taskId: 'task-123', message: 'hello' },
+			{ roomId: 'room-123', taskId: TASK_UUID, message: 'hello' },
 			{}
 		)) as { success: boolean };
 
-		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', 'hello');
+		expect(injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, 'hello');
 		expect(result.success).toBe(true);
 	});
 
@@ -666,11 +673,11 @@ describe('task.sendHumanMessage handler', () => {
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
 		const result = (await handler!(
-			{ roomId: 'room-123', taskId: 'task-123', message: 'hello', target: 'worker' },
+			{ roomId: 'room-123', taskId: TASK_UUID, message: 'hello', target: 'worker' },
 			{}
 		)) as { success: boolean };
 
-		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', 'hello');
+		expect(injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, 'hello');
 		expect(result.success).toBe(true);
 	});
 
@@ -691,7 +698,7 @@ describe('task.sendHumanMessage handler', () => {
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
 		const oversizedMessage = 'a'.repeat(10_001);
 		await expect(
-			handler!({ roomId: 'room-123', taskId: 'task-123', message: oversizedMessage }, {})
+			handler!({ roomId: 'room-123', taskId: TASK_UUID, message: oversizedMessage }, {})
 		).rejects.toThrow('Message is too long');
 	});
 
@@ -712,11 +719,11 @@ describe('task.sendHumanMessage handler', () => {
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
 		const maxMessage = 'a'.repeat(10_000);
 		const result = (await handler!(
-			{ roomId: 'room-123', taskId: 'task-123', message: maxMessage },
+			{ roomId: 'room-123', taskId: TASK_UUID, message: maxMessage },
 			{}
 		)) as { success: boolean };
 
-		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', maxMessage);
+		expect(injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, maxMessage);
 		expect(result.success).toBe(true);
 	});
 });


### PR DESCRIPTION
- Import resolveTaskId and add makeTaskRepo() helper in setupTaskHandlers
- Wrap all taskId inputs in resolveTaskId() before DB/manager calls for:
  task.get, task.updateDraft, task.fail, task.cancel, task.interruptSession,
  task.archive, task.setStatus, task.reject, task.getGroup, task.sendHumanMessage
- task.list and task.get responses include shortId automatically via rowToTask()
- Excluded: task.group.create and task.group.addMessage (non-production handlers)
- Add 7 unit tests in task-handlers-short-id.test.ts covering short ID input
  for task.get and task.cancel, UUID pass-through, shortId in response, and
  not-found errors
- Update existing tests to use valid UUID v4 task IDs so resolveTaskId passes
  through without DB lookup; fix unconsumed mockResolvedValueOnce contamination
