### PR TITLE
fix(web): fix goal timestamp always showing "now", improve list item layout

### DIFF
--- a/packages/web/src/components/room/GoalsEditor.test.tsx
+++ b/packages/web/src/components/room/GoalsEditor.test.tsx
@@ -26,8 +26,8 @@ describe('GoalsEditor', () => {
 		priority: 'normal',
 		progress: 50,
 		linkedTaskIds: [],
-		createdAt: Math.floor(Date.now() / 1000) - 86400,
-		updatedAt: Math.floor(Date.now() / 1000),
+		createdAt: Date.now() - 86400 * 1000,
+		updatedAt: Date.now(),
 		...overrides,
 	});
 
@@ -127,6 +127,20 @@ describe('GoalsEditor', () => {
 			const goals = [createMockGoal('goal-1', { description: 'Visible description text' })];
 			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
 			expect(container.textContent).toContain('Visible description text');
+		});
+
+		it('should show relative time for createdAt (not "just now" for old goals)', () => {
+			// createdAt is milliseconds since epoch — 1 day ago
+			const goals = [createMockGoal('goal-1', { createdAt: Date.now() - 86400 * 1000 })];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			expect(container.textContent).toContain('1 day ago');
+			expect(container.textContent).not.toContain('just now');
+		});
+
+		it('should show "just now" for very recent goals', () => {
+			const goals = [createMockGoal('goal-1', { createdAt: Date.now() - 5000 })];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			expect(container.textContent).toContain('just now');
 		});
 	});
 

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -109,7 +109,7 @@ const COMMON_TIMEZONES = [
 // ─── Helper Utilities ─────────────────────────────────────────────────────────
 
 function relativeTime(ts: number): string {
-	const diff = Date.now() - ts * 1000;
+	const diff = Date.now() - ts;
 	const mins = Math.floor(diff / 60000);
 	if (mins < 1) return 'just now';
 	if (mins < 60) return `${mins}m ago`;
@@ -1256,16 +1256,9 @@ function GoalItem({
 					class="px-4 py-3 cursor-pointer hover:bg-dark-800/50 transition-colors active:bg-dark-800"
 					onClick={onToggleExpand}
 				>
-					{/* Row 1: Status indicator + priority badge + mission type badge + actions */}
-					<div class="flex items-center justify-between mb-2">
-						<div class="flex items-center gap-2 flex-wrap">
-							<StatusIndicator status={goal.status} />
-							<PriorityBadge priority={goal.priority} />
-							{missionType !== 'one_shot' && <MissionTypeBadge type={missionType} />}
-							{goal.autonomyLevel && goal.autonomyLevel !== 'supervised' && (
-								<AutonomyBadge level={goal.autonomyLevel} />
-							)}
-						</div>
+					{/* Row 1: Title + actions */}
+					<div class="flex items-start justify-between gap-2 mb-1.5">
+						<h4 class="text-sm font-semibold text-gray-100 leading-snug">{goal.title}</h4>
 						<div class="flex items-center gap-1 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
 							<Button variant="ghost" size="sm" onClick={() => setIsEditing(true)}>
 								Edit
@@ -1276,8 +1269,15 @@ function GoalItem({
 						</div>
 					</div>
 
-					{/* Row 2: Title */}
-					<h4 class="text-base font-semibold text-gray-100 leading-snug mb-1">{goal.title}</h4>
+					{/* Row 2: Status + badges */}
+					<div class="flex items-center gap-2 flex-wrap mb-2">
+						<StatusIndicator status={goal.status} />
+						<PriorityBadge priority={goal.priority} />
+						{missionType !== 'one_shot' && <MissionTypeBadge type={missionType} />}
+						{goal.autonomyLevel && goal.autonomyLevel !== 'supervised' && (
+							<AutonomyBadge level={goal.autonomyLevel} />
+						)}
+					</div>
 
 					{/* Row 3: Description (truncated, optional) */}
 					{goal.description && (


### PR DESCRIPTION
- Fix relativeTime() to treat createdAt as milliseconds (not seconds).
  The RoomGoal type documents createdAt as ms since epoch; multiplying
  by 1000 produced a far-future value so diff was always negative,
  returning "just now" for every goal.
- Fix test fixture to use Date.now() - based ms timestamps (was using
  Math.floor(Date.now()/1000) which is seconds, inconsistent with type).
- Add tests verifying "1 day ago" for old goals and "just now" for new.
- Improve GoalItem card layout: put title on row 1 (prominent) with
  actions, and move status/badges to row 2 for better visual hierarchy.
