### PR TITLE
feat(leader): verify PR mergeability before submit_for_review

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -305,9 +305,18 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 
 - **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "defer"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.
   - You may call \`send_to_worker\` multiple times as reviewer results arrive.
-- **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval
-- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).
+- **Only P3 nits or no issues** → verify PR mergeability (Step 5), then \`submit_for_review\` with the PR URL for human approval
+- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, verify PR mergeability (Step 5), then \`submit_for_review\` with the PR URL (let human decide).
 - **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`
+
+### Step 5: Verify PR Mergeability (before submit_for_review)
+
+Before calling \`submit_for_review\`, verify the PR is ready to merge:
+- Check CI: \`gh pr checks <PR_NUMBER>\`
+- Check conflicts: \`gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus\`
+- If CI is **failing** → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
+- If **merge conflicts** exist (mergeStateStatus is DIRTY or CONFLICTING) → send to worker: "PR has merge conflicts. Rebase and force push."
+- Only call \`submit_for_review\` when CI passes and no conflicts exist.
 
 Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first. After the planner runs Phase 2 and you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\`, call \`complete_task\`.`;
 }
@@ -326,10 +335,16 @@ ${helperSection}## Plan Review Guidelines
 3. Review the plan PR yourself and post your honest, critical, and actionable feedback on the PR using \`gh pr review\`.
 4. Route strictly by severity from your posted review:
    - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "defer") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message.
-   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval.
-   - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).
-5. **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`.
-6. Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first.
+   - **Only P3 nits or no issues** → verify PR mergeability (step 5), then \`submit_for_review\` with the PR URL for human approval.
+   - **Review post TIMEOUT/ERROR** → verify PR mergeability (step 5), then \`submit_for_review\` with the PR URL (let human decide).
+5. **Before calling \`submit_for_review\`**, verify the PR is ready to merge:
+   - Check CI: \`gh pr checks <PR_NUMBER>\`
+   - Check conflicts: \`gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus\`
+   - If CI is **failing** → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
+   - If **merge conflicts** exist (mergeStateStatus is DIRTY or CONFLICTING) → send to worker: "PR has merge conflicts. Rebase and force push."
+   - Only call \`submit_for_review\` when CI passes and no conflicts exist.
+6. **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`.
+7. Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first.
 
 **Phase 2 (task creation)**: When you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\` showing "Tasks created: N", call \`complete_task\` with a summary of the tasks created.`;
 }
@@ -385,9 +400,18 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 
 - **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "defer"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.
   - You may call \`send_to_worker\` multiple times as reviewer results arrive.
-- **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL
-- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).
-- **Fundamentally broken** → \`fail_task\` or \`replan_goal\``;
+- **Only P3 nits or no issues** → verify PR mergeability (Step 5), then \`submit_for_review\` with the PR URL
+- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, verify PR mergeability (Step 5), then \`submit_for_review\` with the PR URL (let human decide).
+- **Fundamentally broken** → \`fail_task\` or \`replan_goal\`
+
+### Step 5: Verify PR Mergeability (before submit_for_review)
+
+Before calling \`submit_for_review\`, verify the PR is ready to merge:
+- Check CI: \`gh pr checks <PR_NUMBER>\`
+- Check conflicts: \`gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus\`
+- If CI is **failing** → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
+- If **merge conflicts** exist (mergeStateStatus is DIRTY or CONFLICTING) → send to worker: "PR has merge conflicts. Rebase and force push."
+- Only call \`submit_for_review\` when CI passes and no conflicts exist.`;
 }
 
 function leaderCodeReviewSimpleSection(helperNames: string[]): string {
@@ -404,8 +428,14 @@ ${helperSection}## Code Review Guidelines
 3. Review the PR yourself and post your honest, critical, and actionable feedback on the PR using \`gh pr review\`.
 4. Route strictly by severity from your posted review:
    - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "defer") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message.
-   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL.
-   - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).
+   - **Only P3 nits or no issues** → verify PR mergeability (step 5), then \`submit_for_review\` with the PR URL.
+   - **Review post TIMEOUT/ERROR** → verify PR mergeability (step 5), then \`submit_for_review\` with the PR URL (let human decide).
+5. **Before calling \`submit_for_review\`**, verify the PR is ready to merge:
+   - Check CI: \`gh pr checks <PR_NUMBER>\`
+   - Check conflicts: \`gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus\`
+   - If CI is **failing** → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
+   - If **merge conflicts** exist (mergeStateStatus is DIRTY or CONFLICTING) → send to worker: "PR has merge conflicts. Rebase and force push."
+   - Only call \`submit_for_review\` when CI passes and no conflicts exist.
 
 - Use \`fail_task\` if this specific task is not achievable but the overall plan is still sound
 - Use \`replan_goal\` if the failure reveals the overall approach needs rethinking — this cancels remaining tasks and triggers a fresh plan`;

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -261,6 +261,31 @@ function leaderPlanReviewGuidelinesSection(reviewerNames: string[], helperNames:
 	return leaderPlanReviewSimpleSection(helperNames);
 }
 
+/**
+ * Shared prompt block instructing the leader to verify PR mergeability
+ * before calling `submit_for_review`. Used in all four review sections
+ * (simple/orchestration × code/plan) to ensure consistent behavior.
+ *
+ * Uses a single `gh pr view --json mergeable,mergeStateStatus,statusCheckRollup`
+ * command, matching the runtime gate in checkPrIsMergeable, so the leader's
+ * proactive check and the gate use the same data source.
+ *
+ * @param stepLabel - e.g. "Step 5" (orchestration) or "step 5" (numbered list)
+ * @param asSubList - true to format as an indented sub-list (for numbered-step sections)
+ */
+function prMergeabilityCheckBlock(stepLabel: string, asSubList: boolean): string {
+	const indent = asSubList ? '   ' : '';
+	return `${indent}**Before calling \`submit_for_review\`**, run one command to verify the PR is ready:
+${indent}\`\`\`
+${indent}gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,statusCheckRollup
+${indent}\`\`\`
+${indent}Then check the output:
+${indent}- If \`mergeStateStatus\` is \`DIRTY\` or \`CONFLICTING\` → send to worker: "PR has merge conflicts. Rebase and force push: \`git fetch && git rebase origin/<base-branch>\`."
+${indent}- If \`mergeStateStatus\` is \`BEHIND\` → send to worker: "PR branch is behind base. Rebase and force push: \`git fetch && git rebase origin/<base-branch>\`."
+${indent}- If any \`statusCheckRollup\` entry has \`conclusion: FAILURE\` or \`conclusion: TIMED_OUT\` → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
+${indent}- Only call \`submit_for_review\` when \`mergeStateStatus\` is \`CLEAN\` (or \`UNKNOWN\`) and no checks have failed.`;
+}
+
 function leaderPlanReviewOrchestrationSection(
 	reviewerNames: string[],
 	helperNames: string[]
@@ -311,12 +336,7 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 
 ### Step 5: Verify PR Mergeability (before submit_for_review)
 
-Before calling \`submit_for_review\`, verify the PR is ready to merge:
-- Check CI: \`gh pr checks <PR_NUMBER>\`
-- Check conflicts: \`gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus\`
-- If CI is **failing** → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
-- If **merge conflicts** exist (mergeStateStatus is DIRTY or CONFLICTING) → send to worker: "PR has merge conflicts. Rebase and force push."
-- Only call \`submit_for_review\` when CI passes and no conflicts exist.
+${prMergeabilityCheckBlock('Step 5', false)}
 
 Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first. After the planner runs Phase 2 and you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\`, call \`complete_task\`.`;
 }
@@ -337,12 +357,7 @@ ${helperSection}## Plan Review Guidelines
    - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "defer") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message.
    - **Only P3 nits or no issues** → verify PR mergeability (step 5), then \`submit_for_review\` with the PR URL for human approval.
    - **Review post TIMEOUT/ERROR** → verify PR mergeability (step 5), then \`submit_for_review\` with the PR URL (let human decide).
-5. **Before calling \`submit_for_review\`**, verify the PR is ready to merge:
-   - Check CI: \`gh pr checks <PR_NUMBER>\`
-   - Check conflicts: \`gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus\`
-   - If CI is **failing** → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
-   - If **merge conflicts** exist (mergeStateStatus is DIRTY or CONFLICTING) → send to worker: "PR has merge conflicts. Rebase and force push."
-   - Only call \`submit_for_review\` when CI passes and no conflicts exist.
+5. ${prMergeabilityCheckBlock('step 5', true)}
 6. **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`.
 7. Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first.
 
@@ -406,12 +421,7 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 
 ### Step 5: Verify PR Mergeability (before submit_for_review)
 
-Before calling \`submit_for_review\`, verify the PR is ready to merge:
-- Check CI: \`gh pr checks <PR_NUMBER>\`
-- Check conflicts: \`gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus\`
-- If CI is **failing** → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
-- If **merge conflicts** exist (mergeStateStatus is DIRTY or CONFLICTING) → send to worker: "PR has merge conflicts. Rebase and force push."
-- Only call \`submit_for_review\` when CI passes and no conflicts exist.`;
+${prMergeabilityCheckBlock('Step 5', false)}`;
 }
 
 function leaderCodeReviewSimpleSection(helperNames: string[]): string {
@@ -430,12 +440,7 @@ ${helperSection}## Code Review Guidelines
    - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "defer") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message.
    - **Only P3 nits or no issues** → verify PR mergeability (step 5), then \`submit_for_review\` with the PR URL.
    - **Review post TIMEOUT/ERROR** → verify PR mergeability (step 5), then \`submit_for_review\` with the PR URL (let human decide).
-5. **Before calling \`submit_for_review\`**, verify the PR is ready to merge:
-   - Check CI: \`gh pr checks <PR_NUMBER>\`
-   - Check conflicts: \`gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus\`
-   - If CI is **failing** → send to worker: "CI checks are failing: <check names>. Fix the failures and push."
-   - If **merge conflicts** exist (mergeStateStatus is DIRTY or CONFLICTING) → send to worker: "PR has merge conflicts. Rebase and force push."
-   - Only call \`submit_for_review\` when CI passes and no conflicts exist.
+5. ${prMergeabilityCheckBlock('step 5', true)}
 
 - Use \`fail_task\` if this specific task is not achievable but the overall plan is still sound
 - Use \`replan_goal\` if the failure reveals the overall approach needs rethinking — this cancels remaining tasks and triggers a fresh plan`;
@@ -1158,7 +1163,7 @@ export function createLeaderAgentInit(
 			description:
 				'Coordinator that orchestrates code review. Dispatches reviewer and helper sub-agents, collects their results, and routes decisions using MCP tools.',
 			prompt: buildLeaderSystemPrompt(config),
-			tools: ['Task', 'TaskOutput', 'TaskStop', 'Read', 'Grep', 'Glob'],
+			tools: ['Task', 'TaskOutput', 'TaskStop', 'Read', 'Grep', 'Glob', 'Bash'],
 			model: toAgentModel(config.model ?? DEFAULT_LEADER_MODEL),
 		};
 

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -545,8 +545,8 @@ export async function checkPrIsMergeable(
 	try {
 		const pr = JSON.parse(prJson);
 
-		// Check mergeStateStatus for DIRTY or CONFLICTING (both indicate conflicts)
-		// Note: mergeable field is deprecated and returns a string enum, but mergeStateStatus is more reliable
+		// Check mergeStateStatus — more reliable than the deprecated mergeable field
+		// DIRTY/CONFLICTING = merge conflicts; BEHIND = branch is behind base and needs rebase
 		if (pr.mergeStateStatus === 'DIRTY' || pr.mergeStateStatus === 'CONFLICTING') {
 			return {
 				pass: false,
@@ -554,6 +554,16 @@ export async function checkPrIsMergeable(
 				bounceMessage:
 					'Fix merge conflicts: `git fetch && git rebase origin/main` (or base branch), ' +
 					'resolve conflicts, force push, then try again.',
+			};
+		}
+
+		if (pr.mergeStateStatus === 'BEHIND') {
+			return {
+				pass: false,
+				reason: 'PR branch is behind the base branch. Please rebase before submitting for review.',
+				bounceMessage:
+					'PR branch is behind base: `git fetch && git rebase origin/<base-branch>`, ' +
+					'then force push.',
 			};
 		}
 

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -299,6 +299,59 @@ describe('Leader Agent', () => {
 			expect(prompt).toContain('submit_for_review');
 			expect(prompt).toContain('If no PR exists yet');
 		});
+
+		it('instructs leader to verify PR mergeability before submit_for_review (simple code review)', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig());
+			expect(prompt).toContain('gh pr checks');
+			expect(prompt).toContain('mergeable,mergeStateStatus');
+			expect(prompt).toContain('CI checks are failing');
+			expect(prompt).toContain('merge conflicts');
+		});
+
+		it('instructs leader to verify PR mergeability before submit_for_review (orchestration code review)', () => {
+			const prompt = buildLeaderSystemPrompt(
+				makeConfig({
+					room: makeRoom({
+						config: {
+							agentSubagents: {
+								leader: [{ model: 'claude-opus-4-6' }],
+							},
+						},
+					}),
+				})
+			);
+			expect(prompt).toContain('gh pr checks');
+			expect(prompt).toContain('mergeable,mergeStateStatus');
+			expect(prompt).toContain('CI checks are failing');
+			expect(prompt).toContain('merge conflicts');
+		});
+
+		it('instructs leader to verify PR mergeability before submit_for_review (plan review)', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
+			expect(prompt).toContain('gh pr checks');
+			expect(prompt).toContain('mergeable,mergeStateStatus');
+			expect(prompt).toContain('CI checks are failing');
+			expect(prompt).toContain('merge conflicts');
+		});
+
+		it('instructs leader to verify PR mergeability before submit_for_review (plan review with reviewers)', () => {
+			const prompt = buildLeaderSystemPrompt(
+				makeConfig({
+					reviewContext: 'plan_review',
+					room: makeRoom({
+						config: {
+							agentSubagents: {
+								leader: [{ model: 'claude-opus-4-6' }],
+							},
+						},
+					}),
+				})
+			);
+			expect(prompt).toContain('gh pr checks');
+			expect(prompt).toContain('mergeable,mergeStateStatus');
+			expect(prompt).toContain('CI checks are failing');
+			expect(prompt).toContain('merge conflicts');
+		});
 	});
 
 	describe('buildLeaderTaskContext', () => {

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -302,10 +302,12 @@ describe('Leader Agent', () => {
 
 		it('instructs leader to verify PR mergeability before submit_for_review (simple code review)', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig());
-			expect(prompt).toContain('gh pr checks');
-			expect(prompt).toContain('mergeable,mergeStateStatus');
+			expect(prompt).toContain(
+				'gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,statusCheckRollup'
+			);
 			expect(prompt).toContain('CI checks are failing');
 			expect(prompt).toContain('merge conflicts');
+			expect(prompt).toContain('BEHIND');
 		});
 
 		it('instructs leader to verify PR mergeability before submit_for_review (orchestration code review)', () => {
@@ -320,18 +322,22 @@ describe('Leader Agent', () => {
 					}),
 				})
 			);
-			expect(prompt).toContain('gh pr checks');
-			expect(prompt).toContain('mergeable,mergeStateStatus');
+			expect(prompt).toContain(
+				'gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,statusCheckRollup'
+			);
 			expect(prompt).toContain('CI checks are failing');
 			expect(prompt).toContain('merge conflicts');
+			expect(prompt).toContain('BEHIND');
 		});
 
 		it('instructs leader to verify PR mergeability before submit_for_review (plan review)', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
-			expect(prompt).toContain('gh pr checks');
-			expect(prompt).toContain('mergeable,mergeStateStatus');
+			expect(prompt).toContain(
+				'gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,statusCheckRollup'
+			);
 			expect(prompt).toContain('CI checks are failing');
 			expect(prompt).toContain('merge conflicts');
+			expect(prompt).toContain('BEHIND');
 		});
 
 		it('instructs leader to verify PR mergeability before submit_for_review (plan review with reviewers)', () => {
@@ -347,10 +353,12 @@ describe('Leader Agent', () => {
 					}),
 				})
 			);
-			expect(prompt).toContain('gh pr checks');
-			expect(prompt).toContain('mergeable,mergeStateStatus');
+			expect(prompt).toContain(
+				'gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,statusCheckRollup'
+			);
 			expect(prompt).toContain('CI checks are failing');
 			expect(prompt).toContain('merge conflicts');
+			expect(prompt).toContain('BEHIND');
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -368,6 +368,24 @@ describe('checkPrIsMergeable', () => {
 		expect(result.reason).toContain('merge conflicts');
 	});
 
+	test('fails when PR has BEHIND mergeStateStatus', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json mergeable,mergeStateStatus,statusCheckRollup': {
+				stdout: JSON.stringify({
+					mergeable: null,
+					mergeStateStatus: 'BEHIND',
+					statusCheckRollup: [],
+				}),
+				exitCode: 0,
+			},
+		});
+		const result = await checkPrIsMergeable(makeLeaderCtx(), opts);
+		expect(result.pass).toBe(false);
+		expect(result.reason).toContain('behind the base branch');
+		expect(result.bounceMessage).toContain('rebase');
+	});
+
 	test('fails when CI checks are failing', async () => {
 		const opts = mockRunner({
 			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
@@ -1315,6 +1333,30 @@ describe('runLeaderSubmitGate', () => {
 		);
 		expect(result.pass).toBe(false);
 		expect(result.reason).toContain('CI checks failing');
+	});
+
+	test('fails when PR branch is BEHIND base', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr list --head feat/add-alerts --json number --state open': {
+				stdout: '[{"number":1}]',
+				exitCode: 0,
+			},
+			'gh pr view feat/add-alerts --json mergeable,mergeStateStatus,statusCheckRollup': {
+				stdout: JSON.stringify({
+					mergeable: null,
+					mergeStateStatus: 'BEHIND',
+					statusCheckRollup: [],
+				}),
+				exitCode: 0,
+			},
+		});
+		const result = await runLeaderSubmitGate(
+			makeLeaderCtx({ workerRole: 'coder', hasReviewers: false }),
+			opts
+		);
+		expect(result.pass).toBe(false);
+		expect(result.reason).toContain('behind the base branch');
 	});
 
 	test('checks mergeability before reviews when hasReviewers is true', async () => {


### PR DESCRIPTION
Add instructions to all four leader review prompt sections (simple code
review, orchestration code review, simple plan review, orchestration
plan review) directing the leader to check CI status and merge conflicts
via `gh pr checks` and `gh pr view --json mergeable,mergeStateStatus`
before calling `submit_for_review`.

The runtime gate (runLeaderSubmitGate → checkPrIsMergeable) already
enforces this as a safety net; the prompt change makes the leader
proactively verify PR readiness and report specific failure reasons
to the worker rather than relying on a gate bounce.

Add four unit tests verifying the mergeability check instructions
are present in all four prompt code paths.
