### PR TITLE
feat(task): make rate/usage limits first-class task concerns with persistence and auto-retry

### DIFF
--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -28,12 +28,21 @@ import type {
 export const VALID_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
 	draft: ['pending'],
 	pending: ['in_progress', 'cancelled'],
-	in_progress: ['review', 'completed', 'needs_attention', 'cancelled'],
+	in_progress: [
+		'review',
+		'completed',
+		'needs_attention',
+		'cancelled',
+		'rate_limited',
+		'usage_limited',
+	],
 	review: ['completed', 'needs_attention', 'in_progress'],
 	completed: ['in_progress', 'archived'], // Reactivate or archive
 	needs_attention: ['pending', 'in_progress', 'review', 'archived'], // Restart allowed + archive
 	cancelled: ['pending', 'in_progress', 'completed', 'archived'], // Restart, complete, or archive
 	archived: [], // True terminal state — no going back
+	rate_limited: ['in_progress', 'needs_attention', 'cancelled'], // Resume or fail
+	usage_limited: ['in_progress', 'needs_attention', 'cancelled'], // Resume or fail
 };
 
 /**
@@ -242,6 +251,14 @@ export class TaskManager {
 			updates.error = null;
 			updates.result = null;
 			updates.progress = null;
+		}
+
+		// Clear restrictions when resuming from a rate/usage limited state.
+		if (
+			(task.status === 'rate_limited' || task.status === 'usage_limited') &&
+			newStatus === 'in_progress'
+		) {
+			updates.restrictions = null;
 		}
 
 		// When transitioning FROM archived (unarchiving), clear the archived_at timestamp

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -24,6 +24,7 @@ import {
 	type RuntimeState,
 	type GlobalSettings,
 	type FallbackModelEntry,
+	type TaskRestriction,
 	MAX_CONCURRENT_GROUPS_LIMIT,
 	MAX_REVIEW_ROUNDS_LIMIT,
 } from '@neokai/shared';
@@ -718,6 +719,12 @@ export class RoomRuntime {
 						resetsAt: backoff.resetsAt,
 						sessionRole: 'worker',
 					});
+					await this.persistTaskRestriction(
+						group.taskId,
+						backoff,
+						'rate_limit',
+						`API rate limit (HTTP 429)`
+					);
 					this.scheduleTickAfterRateLimitReset(groupId);
 					// Try to switch to a fallback model if configured
 					await this.trySwitchToFallbackModel(groupId, group.workerSessionId, 'worker');
@@ -754,6 +761,12 @@ export class RoomRuntime {
 						resetsAt: backoff.resetsAt,
 						sessionRole: 'worker',
 					});
+					await this.persistTaskRestriction(
+						group.taskId,
+						backoff,
+						'usage_limit',
+						`Daily/weekly usage cap`
+					);
 					this.scheduleTickAfterRateLimitReset(groupId);
 					return;
 				}
@@ -1074,6 +1087,12 @@ export class RoomRuntime {
 						resetsAt: backoff.resetsAt,
 						sessionRole: 'leader',
 					});
+					await this.persistTaskRestriction(
+						group.taskId,
+						backoff,
+						'rate_limit',
+						`API rate limit (HTTP 429) in leader`
+					);
 					this.scheduleTickAfterRateLimitReset(groupId);
 					// Try to switch to a fallback model if configured
 					await this.trySwitchToFallbackModel(groupId, group.leaderSessionId, 'leader');
@@ -1106,6 +1125,12 @@ export class RoomRuntime {
 							resetsAt: backoff.resetsAt,
 							sessionRole: 'leader',
 						});
+						await this.persistTaskRestriction(
+							group.taskId,
+							backoff,
+							'usage_limit',
+							`Daily/weekly usage cap in leader`
+						);
 						this.scheduleTickAfterRateLimitReset(groupId);
 						return;
 					}
@@ -1186,6 +1211,7 @@ export class RoomRuntime {
 
 				// Clear any rate limit backoff since we're starting a new iteration
 				this.groupRepo.clearRateLimit(groupId);
+				await this.clearTaskRestriction(group.taskId);
 
 				// Insert status event into group timeline
 				this.appendGroupEvent(groupId, 'status', {
@@ -2234,6 +2260,12 @@ export class RoomRuntime {
 								resetsAt: rateLimitBackoff.resetsAt,
 								sessionRole,
 							});
+							void this.persistTaskRestriction(
+								group.taskId,
+								rateLimitBackoff,
+								'rate_limit',
+								`API rate limit (HTTP 429) in ${role}`
+							);
 						}
 					}
 
@@ -3078,8 +3110,16 @@ export class RoomRuntime {
 					(typeof linkedTasks)[number]
 				>[];
 				const hasActiveTask = validTasks.some((t) =>
-					(['pending', 'in_progress', 'draft', 'review'] as const).includes(
-						t.status as 'pending' | 'in_progress' | 'draft' | 'review'
+					(
+						['pending', 'in_progress', 'draft', 'review', 'rate_limited', 'usage_limited'] as const
+					).includes(
+						t.status as
+							| 'pending'
+							| 'in_progress'
+							| 'draft'
+							| 'review'
+							| 'rate_limited'
+							| 'usage_limited'
 					)
 				);
 				const executionTasks = validTasks.filter((t) => t.taskType !== 'planning');
@@ -3822,6 +3862,50 @@ export class RoomRuntime {
 		}
 
 		if (this.jobQueue) enqueueRoomTick(this.roomId, this.jobQueue, delayMs);
+	}
+
+	/**
+	 * Persist a rate or usage limit restriction to the task record and update its status.
+	 *
+	 * Called when a rate/usage limit is first detected for a group. Saves the restriction
+	 * data so the UI can display the reset time, and sets the task status to
+	 * 'rate_limited' or 'usage_limited' so it's clearly distinguishable from in_progress.
+	 */
+	private async persistTaskRestriction(
+		taskId: string,
+		backoff: RateLimitBackoff,
+		limitType: 'rate_limit' | 'usage_limit',
+		limitDescription: string
+	): Promise<void> {
+		const task = await this.taskManager.getTask(taskId);
+		if (!task) return;
+		// Only update from in_progress to avoid overwriting a terminal status.
+		if (task.status !== 'in_progress') return;
+
+		const newStatus = limitType === 'rate_limit' ? 'rate_limited' : ('usage_limited' as const);
+		const restriction: TaskRestriction = {
+			type: limitType,
+			limit: limitDescription,
+			resetAt: backoff.resetsAt,
+			sessionRole: backoff.sessionRole,
+		};
+		await this.taskManager.updateTaskStatus(taskId, newStatus, { restrictions: restriction });
+		await this.emitTaskUpdateById(taskId);
+	}
+
+	/**
+	 * Clear a task's restriction data and restore its status to in_progress.
+	 *
+	 * Called when a new worker iteration starts (send_to_worker / clearRateLimit path),
+	 * meaning the restriction has either expired or been superseded by a fallback model.
+	 */
+	private async clearTaskRestriction(taskId: string): Promise<void> {
+		const task = await this.taskManager.getTask(taskId);
+		if (!task) return;
+		if (task.status !== 'rate_limited' && task.status !== 'usage_limited') return;
+
+		await this.taskManager.updateTaskStatus(taskId, 'in_progress', { restrictions: null });
+		await this.emitTaskUpdateById(taskId);
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2260,12 +2260,16 @@ export class RoomRuntime {
 								resetsAt: rateLimitBackoff.resetsAt,
 								sessionRole,
 							});
-							void this.persistTaskRestriction(
+							this.persistTaskRestriction(
 								group.taskId,
 								rateLimitBackoff,
 								'rate_limit',
 								`API rate limit (HTTP 429) in ${role}`
-							);
+							).catch((err: unknown) => {
+								log.error(
+									`Failed to persist rate limit restriction for task ${group.taskId}: ${String(err)}`
+								);
+							});
 						}
 					}
 

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -29,6 +29,8 @@ export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStat
 	needs_attention: ['pending', 'in_progress', 'review', 'archived'], // Restart allowed + archive
 	cancelled: ['pending', 'in_progress', 'completed', 'archived'], // Restart, complete, or archive
 	archived: [], // True terminal state — no going back
+	rate_limited: ['in_progress', 'needs_attention', 'cancelled'],
+	usage_limited: ['in_progress', 'needs_attention', 'cancelled'],
 };
 
 /**

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -7,7 +7,13 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
-import type { NeoTask, TaskFilter, CreateTaskParams, UpdateTaskParams } from '@neokai/shared';
+import type {
+	NeoTask,
+	TaskFilter,
+	CreateTaskParams,
+	UpdateTaskParams,
+	TaskRestriction,
+} from '@neokai/shared';
 import type { SQLiteValue } from '../types';
 import type { ReactiveDatabase } from '../reactive-database';
 import type { ShortIdAllocator } from '../../lib/short-id-allocator';
@@ -241,6 +247,10 @@ export class TaskRepository {
 			fields.push('input_draft = ?');
 			values.push(params.inputDraft ?? null);
 		}
+		if (params.restrictions !== undefined) {
+			fields.push('restrictions = ?');
+			values.push(params.restrictions !== null ? JSON.stringify(params.restrictions) : null);
+		}
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
 			values.push(Date.now());
@@ -341,6 +351,8 @@ export class TaskRepository {
 	}
 
 	private rowToTask(row: Record<string, unknown>): NeoTask {
+		const restrictionsRaw = row.restrictions;
+		const restrictionsJson = typeof restrictionsRaw === 'string' ? restrictionsRaw : null;
 		return {
 			id: row.id as string,
 			roomId: row.room_id as string,
@@ -366,6 +378,7 @@ export class TaskRepository {
 			prUrl: (row.pr_url as string | null) ?? undefined,
 			prNumber: (row.pr_number as number | null) ?? undefined,
 			prCreatedAt: (row.pr_created_at as number | null) ?? undefined,
+			restrictions: restrictionsJson ? (JSON.parse(restrictionsJson) as TaskRestriction) : null,
 			updatedAt: (row.updated_at as number | null) ?? (row.created_at as number),
 		};
 	}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -19,6 +19,8 @@ export { runMigration12 } from './migrations';
 export { runMigration47 } from './migrations';
 // knip-ignore-next-line
 export { runMigration48 } from './migrations';
+// knip-ignore-next-line
+export { runMigration49 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -146,7 +148,7 @@ export function createTables(db: BunDatabase): void {
         room_id TEXT NOT NULL,
         title TEXT NOT NULL,
         description TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived', 'rate_limited', 'usage_limited')),
         priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
         progress INTEGER,
         current_step TEXT,
@@ -167,6 +169,7 @@ export function createTables(db: BunDatabase): void {
         input_draft TEXT,
         updated_at INTEGER,
         short_id TEXT,
+        restrictions TEXT,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
       )
     `);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -189,6 +189,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// causing UNIQUE constraint failures when two different rooms each create their first task.
 	// Short IDs are scoped to their parent room, so uniqueness must be (room_id, short_id).
 	runMigration48(db);
+
+	// Migration 49: Add restrictions column to tasks and expand status CHECK constraint
+	// to include 'rate_limited' and 'usage_limited'. These new statuses let the runtime
+	// surface API limit state in the UI and enable auto-resume on tick.
+	runMigration49(db);
 }
 
 /**
@@ -3008,4 +3013,129 @@ export function runMigration48(db: BunDatabase): void {
 			`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_room_short_id ON goals(room_id, short_id) WHERE short_id IS NOT NULL`
 		);
 	}
+}
+
+/**
+ * Migration 49: Add restrictions column to tasks; expand status CHECK constraint.
+ *
+ * - `tasks.restrictions TEXT` — nullable JSON blob storing TaskRestriction data when a
+ *   task is paused due to an API rate or usage limit. Cleared when the task resumes.
+ *
+ * - Status CHECK constraint gains two new values:
+ *   - `rate_limited`  — task paused because of an HTTP 429 rate limit
+ *   - `usage_limited` — task paused because of a daily/weekly usage cap with no fallback
+ *
+ * SQLite does not support ALTER TABLE to modify a CHECK constraint, so the new values
+ * are added by recreating the tasks table with DROP/INSERT SELECT/RENAME. This is
+ * idempotent: if the column or the new status values already exist the migration is a no-op.
+ */
+export function runMigration49(db: BunDatabase): void {
+	if (!tableExists(db, 'tasks')) return;
+
+	// Add the restrictions column if absent (new databases already have it via createTables).
+	if (!tableHasColumn(db, 'tasks', 'restrictions')) {
+		db.exec(`ALTER TABLE tasks ADD COLUMN restrictions TEXT`);
+	}
+
+	// Expand the status CHECK constraint to include the two new values.
+	// SQLite cannot ALTER a CHECK constraint directly, so we recreate the table.
+	// Guard: if the constraint already includes 'rate_limited' (detectable via sqlite_master),
+	// skip the rebuild to avoid unnecessary work on already-migrated databases.
+	const schemaSql = (
+		db.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'`).get() as
+			| { sql: string }
+			| undefined
+	)?.sql;
+
+	if (schemaSql && schemaSql.includes('rate_limited')) {
+		// Already migrated — constraint already contains new statuses.
+		return;
+	}
+
+	// Recreate with expanded CHECK constraint.
+	db.exec(`DROP TABLE IF EXISTS tasks_migration49_new`);
+	db.exec(`
+		CREATE TABLE tasks_migration49_new (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('draft','pending','in_progress','review','completed','needs_attention','cancelled','archived','rate_limited','usage_limited')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low','normal','high','urgent')),
+			progress INTEGER,
+			current_step TEXT,
+			result TEXT,
+			error TEXT,
+			depends_on TEXT DEFAULT '[]',
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			task_type TEXT DEFAULT 'coding'
+				CHECK(task_type IN ('planning','coding','research','design','goal_review')),
+			assigned_agent TEXT DEFAULT 'coder',
+			created_by_task_id TEXT,
+			archived_at INTEGER,
+			active_session TEXT,
+			pr_url TEXT,
+			pr_number INTEGER,
+			pr_created_at INTEGER,
+			input_draft TEXT,
+			updated_at INTEGER,
+			short_id TEXT,
+			restrictions TEXT,
+			FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+		)
+	`);
+	// Build INSERT SELECT dynamically: only select columns that exist in the old table,
+	// falling back to NULL for optional columns that may be absent in old-schema DBs.
+	// This makes the migration safe against DBs created by migrations 16–48 that lacked
+	// optional columns (e.g. created_by_task_id, archived_at, pr_url, short_id, etc.).
+	const oldColumns = new Set(
+		(db.prepare(`PRAGMA table_info(tasks)`).all() as Array<{ name: string }>).map((r) => r.name)
+	);
+	// All columns present in tasks_migration49_new, in order.
+	const allNewColumns = [
+		'id',
+		'room_id',
+		'title',
+		'description',
+		'status',
+		'priority',
+		'progress',
+		'current_step',
+		'result',
+		'error',
+		'depends_on',
+		'created_at',
+		'started_at',
+		'completed_at',
+		'task_type',
+		'assigned_agent',
+		'created_by_task_id',
+		'archived_at',
+		'active_session',
+		'pr_url',
+		'pr_number',
+		'pr_created_at',
+		'input_draft',
+		'updated_at',
+		'short_id',
+		'restrictions',
+	];
+	const selectExpr = allNewColumns
+		.map((col) => (oldColumns.has(col) ? col : `NULL AS ${col}`))
+		.join(', ');
+	db.exec(`INSERT INTO tasks_migration49_new SELECT ${selectExpr} FROM tasks`);
+	db.exec(`DROP TABLE tasks`);
+	db.exec(`ALTER TABLE tasks_migration49_new RENAME TO tasks`);
+
+	// Restore indexes (IF NOT EXISTS is idempotent).
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)`);
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_room_short_id ON tasks(room_id, short_id) WHERE short_id IS NOT NULL`
+	);
 }

--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for rate/usage limit restriction persistence in RoomRuntime.
+ *
+ * Verifies:
+ * - Task status transitions to rate_limited / usage_limited on first detection
+ * - restrictions field is persisted with correct data (type, resetAt, sessionRole)
+ * - Task status clears back to in_progress when send_to_worker is called
+ * - recoverStuckWorkers skips actively rate-limited tasks (group.rateLimit still active)
+ * - recoverStuckWorkers re-triggers routing after backoff expires
+ */
+
+import { describe, expect, it, afterEach } from 'bun:test';
+import {
+	createRuntimeTestContext,
+	createGoalAndTask,
+	type RuntimeTestContext,
+} from './room-runtime-test-helpers';
+
+describe('RoomRuntime - rate limit restriction persistence', () => {
+	let ctx: RuntimeTestContext;
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	// Rate limit error that includes a parseable reset time
+	const RATE_LIMIT_MSG = "API Error: 429 You've hit your limit · resets 11pm (America/New_York)";
+	// Usage limit message
+	const USAGE_LIMIT_MSG = "You've hit your limit · resets 11pm (America/New_York)";
+
+	function makeWorkerMessages(text: string) {
+		return [{ id: 'msg-1', text, toolCallNames: [] }];
+	}
+
+	async function spawnAndTriggerWorkerTerminal(workerOutput: string) {
+		const { task } = await createGoalAndTask(ctx);
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		const group = groups[0];
+
+		// Put task in_progress so transitions are valid
+		await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+		await ctx.runtime.onWorkerTerminalState(group.id, {
+			sessionId: group.workerSessionId,
+			kind: 'idle',
+		});
+
+		return { group, task };
+	}
+
+	describe('worker rate_limit sets task to rate_limited', () => {
+		it('updates task status to rate_limited on first 429 detection', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			const { task } = await spawnAndTriggerWorkerTerminal('');
+
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.status).toBe('rate_limited');
+		});
+
+		it('persists restrictions with correct type and sessionRole', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			const { task } = await spawnAndTriggerWorkerTerminal('');
+
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.restrictions).toBeDefined();
+			expect(updated!.restrictions!.type).toBe('rate_limit');
+			expect(updated!.restrictions!.sessionRole).toBe('worker');
+			expect(updated!.restrictions!.resetAt).toBeGreaterThan(Date.now());
+		});
+
+		it('group.rateLimit is set and active after first detection', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			const { group } = await spawnAndTriggerWorkerTerminal('');
+
+			// Group has rateLimit set from first detection — it's still active
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(true);
+
+			// The stored backoff resetsAt should be in the future
+			const groupData = ctx.groupRepo.getActiveGroups('room-1').find((g) => g.id === group.id);
+			expect(groupData?.rateLimit).toBeDefined();
+			expect(groupData?.rateLimit?.resetsAt).toBeGreaterThan(Date.now());
+		});
+	});
+
+	describe('worker usage_limit sets task to usage_limited when no fallback', () => {
+		it('updates task status to usage_limited when no fallback model available', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				// No fallback models configured → usage_limit falls through to pause behavior
+				getGlobalSettings: () => ({}) as never,
+			});
+
+			const { task } = await spawnAndTriggerWorkerTerminal('');
+
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.status).toBe('usage_limited');
+			expect(updated!.restrictions).toBeDefined();
+			expect(updated!.restrictions!.type).toBe('usage_limit');
+		});
+	});
+
+	describe('send_to_worker clears task restriction', () => {
+		it('restores task to in_progress when send_to_worker is called', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			const { group, task } = await spawnAndTriggerWorkerTerminal('');
+
+			// Verify task is rate_limited
+			const rateLimited = await ctx.taskManager.getTask(task.id);
+			expect(rateLimited!.status).toBe('rate_limited');
+
+			// Manually expire the rate limit so send_to_worker doesn't get blocked
+			ctx.groupRepo.setRateLimit(group.id, {
+				detectedAt: Date.now() - 120_000,
+				resetsAt: Date.now() - 60_000, // expired
+				sessionRole: 'worker',
+			});
+
+			// Call send_to_worker (the leader tool that clears backoff)
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Please continue from where you left off.',
+			});
+
+			const resumed = await ctx.taskManager.getTask(task.id);
+			expect(resumed!.status).toBe('in_progress');
+			expect(resumed!.restrictions).toBeNull();
+		});
+	});
+
+	describe('recoverStuckWorkers handles rate limit expiry', () => {
+		it('skips groups with active (non-expired) rate limit', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			const { group } = await spawnAndTriggerWorkerTerminal('');
+
+			// Group is actively rate-limited
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(true);
+
+			// Record calls before tick
+			const callsBefore = ctx.sessionFactory.calls.length;
+
+			// Tick — recoverStuckWorkers should skip this group
+			await ctx.runtime.tick();
+
+			// No new routing should have been attempted
+			const callsAfter = ctx.sessionFactory.calls.length;
+			expect(callsAfter).toBe(callsBefore);
+		});
+
+		it('recovers groups after rate limit expires', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			// Set worker session to idle state for stuck worker detection
+			ctx.sessionFactory.processingStates.set('worker-session-1', 'idle');
+
+			const { group } = await spawnAndTriggerWorkerTerminal('');
+
+			// Manually set an expired rate limit
+			ctx.groupRepo.setRateLimit(group.id, {
+				detectedAt: Date.now() - 120_000,
+				resetsAt: Date.now() - 60_000, // expired
+				sessionRole: 'worker',
+			});
+
+			// The group should not be actively rate-limited anymore
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(false);
+
+			// recoverStuckWorkers should re-trigger onWorkerTerminalState for this group
+			// (hasExpiredRateLimit = true, so feedbackIteration check is bypassed)
+			const callsBefore = ctx.sessionFactory.calls.length;
+			await ctx.runtime.tick();
+			const callsAfter = ctx.sessionFactory.calls.length;
+
+			// Some routing call should have been made
+			expect(callsAfter).toBeGreaterThanOrEqual(callsBefore);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it, afterEach } from 'bun:test';
 import {
 	createRuntimeTestContext,
 	createGoalAndTask,
+	spawnAndRouteToLeader,
 	type RuntimeTestContext,
 } from './room-runtime-test-helpers';
 
@@ -192,6 +193,98 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 
 			// Some routing call should have been made
 			expect(callsAfter).toBeGreaterThanOrEqual(callsBefore);
+		});
+	});
+
+	// ─── Leader rate/usage limit paths ───────────────────────────────────────
+	// Worker returns normal output; only the leader session returns the error message.
+	// This ensures no group.rateLimit is set from the worker path, so the leader
+	// detection guard (!group.rateLimit) correctly triggers on first leader detection.
+
+	describe('leader rate_limit sets task to rate_limited', () => {
+		it('updates task status to rate_limited on leader 429 detection', async () => {
+			let leaderSessionId: string | null = null;
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: (sessionId) => {
+					if (leaderSessionId && sessionId === leaderSessionId) {
+						return makeWorkerMessages(RATE_LIMIT_MSG);
+					}
+					// Worker returns normal output — no error
+					return [];
+				},
+			});
+
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+			leaderSessionId = group.leaderSessionId;
+
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.status).toBe('rate_limited');
+		});
+
+		it('persists restrictions with sessionRole=leader on leader rate limit', async () => {
+			let leaderSessionId: string | null = null;
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: (sessionId) => {
+					if (leaderSessionId && sessionId === leaderSessionId) {
+						return makeWorkerMessages(RATE_LIMIT_MSG);
+					}
+					return [];
+				},
+			});
+
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+			leaderSessionId = group.leaderSessionId;
+
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.restrictions).toBeDefined();
+			expect(updated!.restrictions!.type).toBe('rate_limit');
+			expect(updated!.restrictions!.sessionRole).toBe('leader');
+			expect(updated!.restrictions!.resetAt).toBeGreaterThan(Date.now());
+		});
+	});
+
+	describe('leader usage_limit sets task to usage_limited when no fallback', () => {
+		it('updates task status to usage_limited on leader usage limit (no fallback)', async () => {
+			let leaderSessionId: string | null = null;
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: (sessionId) => {
+					if (leaderSessionId && sessionId === leaderSessionId) {
+						return makeWorkerMessages(USAGE_LIMIT_MSG);
+					}
+					return [];
+				},
+				getGlobalSettings: () => ({}) as never,
+			});
+
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+			leaderSessionId = group.leaderSessionId;
+
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.status).toBe('usage_limited');
+			expect(updated!.restrictions).toBeDefined();
+			expect(updated!.restrictions!.type).toBe('usage_limit');
+			expect(updated!.restrictions!.sessionRole).toBe('leader');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -172,7 +172,8 @@ const DB_SCHEMA = `
 		pr_number INTEGER,
 		pr_created_at INTEGER,
 		short_id TEXT,
-		updated_at INTEGER
+		updated_at INTEGER,
+		restrictions TEXT
 	);
 	CREATE TABLE session_groups (
 		id TEXT PRIMARY KEY, group_type TEXT NOT NULL DEFAULT 'task',

--- a/packages/daemon/tests/unit/room/task-restrictions.test.ts
+++ b/packages/daemon/tests/unit/room/task-restrictions.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for task restriction persistence and rate/usage limit status.
+ *
+ * Verifies:
+ * - rate_limited / usage_limited task statuses
+ * - restrictions field persisted on task record
+ * - VALID_STATUS_TRANSITIONS include new statuses
+ * - TaskManager.setTaskStatus clears restrictions when resuming
+ * - Migration 49 adds restrictions column and expands status CHECK constraint
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createTables, runMigration49 } from '../../../src/storage/schema';
+import {
+	TaskManager,
+	VALID_STATUS_TRANSITIONS,
+	isValidStatusTransition,
+} from '../../../src/lib/room/managers/task-manager';
+import { RoomManager } from '../../../src/lib/room/managers/room-manager';
+import { noOpReactiveDb } from '../../helpers/reactive-database';
+import type { TaskRestriction } from '@neokai/shared';
+
+describe('Task restrictions (rate_limited / usage_limited)', () => {
+	let db: Database;
+	let taskManager: TaskManager;
+	let roomId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createTables(db);
+
+		const roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({
+			name: 'Test Room',
+			allowedPaths: [{ path: '/workspace/test' }],
+			defaultPath: '/workspace/test',
+		});
+		roomId = room.id;
+		taskManager = new TaskManager(db, roomId, noOpReactiveDb);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// ─── Status transitions ────────────────────────────────────────────────────
+
+	describe('VALID_STATUS_TRANSITIONS', () => {
+		it('allows in_progress → rate_limited', () => {
+			expect(isValidStatusTransition('in_progress', 'rate_limited')).toBe(true);
+		});
+
+		it('allows in_progress → usage_limited', () => {
+			expect(isValidStatusTransition('in_progress', 'usage_limited')).toBe(true);
+		});
+
+		it('allows rate_limited → in_progress (resume)', () => {
+			expect(isValidStatusTransition('rate_limited', 'in_progress')).toBe(true);
+		});
+
+		it('allows usage_limited → in_progress (resume)', () => {
+			expect(isValidStatusTransition('usage_limited', 'in_progress')).toBe(true);
+		});
+
+		it('allows rate_limited → needs_attention', () => {
+			expect(isValidStatusTransition('rate_limited', 'needs_attention')).toBe(true);
+		});
+
+		it('allows usage_limited → cancelled', () => {
+			expect(isValidStatusTransition('usage_limited', 'cancelled')).toBe(true);
+		});
+
+		it('rejects pending → rate_limited directly', () => {
+			expect(isValidStatusTransition('pending', 'rate_limited')).toBe(false);
+		});
+
+		it('includes rate_limited and usage_limited in transition map', () => {
+			expect(VALID_STATUS_TRANSITIONS).toHaveProperty('rate_limited');
+			expect(VALID_STATUS_TRANSITIONS).toHaveProperty('usage_limited');
+		});
+	});
+
+	// ─── Persistence ──────────────────────────────────────────────────────────
+
+	describe('restrictions field persistence', () => {
+		it('persists restrictions when transitioning to rate_limited', async () => {
+			const task = await taskManager.createTask({
+				title: 'Test task',
+				description: 'desc',
+			});
+			// Manually start the task
+			await taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			const restriction: TaskRestriction = {
+				type: 'rate_limit',
+				limit: 'API rate limit (HTTP 429)',
+				resetAt: Date.now() + 3600_000,
+				sessionRole: 'worker',
+			};
+
+			const updated = await taskManager.updateTaskStatus(task.id, 'rate_limited', {
+				restrictions: restriction,
+			});
+
+			expect(updated.status).toBe('rate_limited');
+			expect(updated.restrictions).toBeDefined();
+			expect(updated.restrictions!.type).toBe('rate_limit');
+			expect(updated.restrictions!.sessionRole).toBe('worker');
+			expect(updated.restrictions!.resetAt).toBeGreaterThan(Date.now());
+		});
+
+		it('persists restrictions when transitioning to usage_limited', async () => {
+			const task = await taskManager.createTask({
+				title: 'Test task',
+				description: 'desc',
+			});
+			await taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			const restriction: TaskRestriction = {
+				type: 'usage_limit',
+				limit: 'Daily/weekly usage cap',
+				resetAt: Date.now() + 7200_000,
+				sessionRole: 'leader',
+			};
+
+			const updated = await taskManager.updateTaskStatus(task.id, 'usage_limited', {
+				restrictions: restriction,
+			});
+
+			expect(updated.status).toBe('usage_limited');
+			expect(updated.restrictions!.type).toBe('usage_limit');
+			expect(updated.restrictions!.sessionRole).toBe('leader');
+		});
+
+		it('restrictions survive a roundtrip through the database', async () => {
+			const task = await taskManager.createTask({
+				title: 'Test task',
+				description: 'desc',
+			});
+			await taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			const resetAt = Date.now() + 3600_000;
+			const restriction: TaskRestriction = {
+				type: 'rate_limit',
+				limit: 'API rate limit (HTTP 429)',
+				resetAt,
+				sessionRole: 'worker',
+				retryAfter: 60,
+			};
+
+			await taskManager.updateTaskStatus(task.id, 'rate_limited', {
+				restrictions: restriction,
+			});
+
+			// Re-fetch from DB
+			const fetched = await taskManager.getTask(task.id);
+			expect(fetched!.restrictions).toBeDefined();
+			expect(fetched!.restrictions!.type).toBe('rate_limit');
+			expect(fetched!.restrictions!.limit).toBe('API rate limit (HTTP 429)');
+			expect(fetched!.restrictions!.resetAt).toBe(resetAt);
+			expect(fetched!.restrictions!.retryAfter).toBe(60);
+		});
+
+		it('tasks without restrictions have null restrictions field', async () => {
+			const task = await taskManager.createTask({
+				title: 'Test task',
+				description: 'desc',
+			});
+			expect(task.restrictions).toBeNull();
+		});
+	});
+
+	// ─── setTaskStatus clears restrictions on resume ──────────────────────────
+
+	describe('setTaskStatus clears restrictions when resuming', () => {
+		it('clears restrictions when rate_limited → in_progress', async () => {
+			const task = await taskManager.createTask({
+				title: 'Test task',
+				description: 'desc',
+			});
+			await taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			const restriction: TaskRestriction = {
+				type: 'rate_limit',
+				limit: 'API rate limit (HTTP 429)',
+				resetAt: Date.now() + 3600_000,
+				sessionRole: 'worker',
+			};
+			await taskManager.updateTaskStatus(task.id, 'rate_limited', {
+				restrictions: restriction,
+			});
+
+			// Now resume via setTaskStatus
+			const resumed = await taskManager.setTaskStatus(task.id, 'in_progress');
+			expect(resumed.status).toBe('in_progress');
+			expect(resumed.restrictions).toBeNull();
+		});
+
+		it('clears restrictions when usage_limited → in_progress', async () => {
+			const task = await taskManager.createTask({
+				title: 'Test task',
+				description: 'desc',
+			});
+			await taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			const restriction: TaskRestriction = {
+				type: 'usage_limit',
+				limit: 'Daily cap',
+				resetAt: Date.now() + 3600_000,
+				sessionRole: 'leader',
+			};
+			await taskManager.updateTaskStatus(task.id, 'usage_limited', {
+				restrictions: restriction,
+			});
+
+			const resumed = await taskManager.setTaskStatus(task.id, 'in_progress');
+			expect(resumed.status).toBe('in_progress');
+			expect(resumed.restrictions).toBeNull();
+		});
+
+		it('does NOT clear restrictions on unrelated transitions', async () => {
+			const task = await taskManager.createTask({
+				title: 'Test task',
+				description: 'desc',
+			});
+			await taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			// Going to review (not resuming from rate limit) — restrictions should not be touched
+			const reviewed = await taskManager.updateTaskStatus(task.id, 'review');
+			expect(reviewed.restrictions).toBeNull();
+		});
+	});
+
+	// ─── Migration 49 ────────────────────────────────────────────────────────
+
+	/** Old-style tasks table (no restrictions column, no rate_limited/usage_limited in CHECK) */
+	const OLD_TASKS_SCHEMA = `
+		CREATE TABLE rooms (
+			id TEXT PRIMARY KEY, name TEXT NOT NULL,
+			created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+		);
+		CREATE TABLE tasks (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('draft','pending','in_progress','review','completed','needs_attention','cancelled','archived')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low','normal','high','urgent')),
+			progress INTEGER,
+			current_step TEXT,
+			result TEXT,
+			error TEXT,
+			depends_on TEXT DEFAULT '[]',
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			task_type TEXT DEFAULT 'coding'
+				CHECK(task_type IN ('planning','coding','research','design','goal_review')),
+			assigned_agent TEXT DEFAULT 'coder',
+			created_by_task_id TEXT,
+			archived_at INTEGER,
+			active_session TEXT,
+			pr_url TEXT,
+			pr_number INTEGER,
+			pr_created_at INTEGER,
+			input_draft TEXT,
+			updated_at INTEGER,
+			short_id TEXT,
+			FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+		);
+	`;
+
+	describe('Migration 49', () => {
+		it('adds restrictions column to existing tasks table', () => {
+			const migDb = new Database(':memory:');
+			migDb.exec(OLD_TASKS_SCHEMA);
+
+			// Column should not exist before migration
+			const colsBefore = migDb.prepare(`PRAGMA table_info(tasks)`).all() as Array<{ name: string }>;
+			expect(colsBefore.some((c) => c.name === 'restrictions')).toBe(false);
+
+			// Run migration
+			runMigration49(migDb);
+
+			// Column should exist after migration
+			const colsAfter = migDb.prepare(`PRAGMA table_info(tasks)`).all() as Array<{ name: string }>;
+			expect(colsAfter.some((c) => c.name === 'restrictions')).toBe(true);
+
+			migDb.close();
+		});
+
+		it('is idempotent — running twice does not throw', () => {
+			const migDb = new Database(':memory:');
+			createTables(migDb);
+			expect(() => {
+				runMigration49(migDb);
+				runMigration49(migDb);
+			}).not.toThrow();
+			migDb.close();
+		});
+
+		it('preserves existing rows when recreating the table', () => {
+			const migDb = new Database(':memory:');
+			migDb.exec(OLD_TASKS_SCHEMA);
+			migDb.exec(`INSERT INTO rooms VALUES ('r1', 'Room', 1000, 1000)`);
+			migDb
+				.prepare(
+					`INSERT INTO tasks (id, room_id, title, description, created_at) VALUES (?, ?, ?, ?, ?)`
+				)
+				.run('t1', 'r1', 'My task', 'desc', 1000);
+
+			runMigration49(migDb);
+
+			const row = migDb.prepare(`SELECT * FROM tasks WHERE id = 't1'`).get() as Record<
+				string,
+				unknown
+			>;
+			expect(row).toBeDefined();
+			expect(row.title).toBe('My task');
+			expect(row.restrictions).toBeNull();
+
+			migDb.close();
+		});
+
+		it('allows inserting tasks with rate_limited status after migration', () => {
+			const migDb = new Database(':memory:');
+			migDb.exec(OLD_TASKS_SCHEMA);
+			migDb.exec(`INSERT INTO rooms VALUES ('r1', 'Room', 1000, 1000)`);
+
+			runMigration49(migDb);
+
+			// Should not throw with the new status value
+			expect(() => {
+				migDb
+					.prepare(
+						`INSERT INTO tasks (id, room_id, title, description, status, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+					)
+					.run('t1', 'r1', 'Test', 'desc', 'rate_limited', 1000);
+			}).not.toThrow();
+
+			expect(() => {
+				migDb
+					.prepare(
+						`INSERT INTO tasks (id, room_id, title, description, status, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+					)
+					.run('t2', 'r1', 'Test2', 'desc2', 'usage_limited', 1000);
+			}).not.toThrow();
+
+			migDb.close();
+		});
+	});
+});

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -252,7 +252,27 @@ export type TaskStatus =
 	| 'completed'
 	| 'needs_attention'
 	| 'cancelled'
-	| 'archived';
+	| 'archived'
+	| 'rate_limited'
+	| 'usage_limited';
+
+/**
+ * Restriction data for a task that has hit an API rate or usage limit.
+ * Persisted on the task record so the UI can show reset time and the runtime
+ * can auto-resume without manual intervention.
+ */
+export interface TaskRestriction {
+	/** Type of limit that was hit */
+	type: 'rate_limit' | 'usage_limit';
+	/** Human-readable description of the limit (e.g. "100 req/min", "daily cap") */
+	limit: string;
+	/** Unix timestamp (ms) when the limit resets */
+	resetAt: number;
+	/** Which session hit the limit */
+	sessionRole: 'worker' | 'leader';
+	/** Seconds until retryable (for rate limits with explicit retry-after) */
+	retryAfter?: number;
+}
 
 /**
  * Task priority
@@ -325,6 +345,11 @@ export interface NeoTask {
 	prNumber?: number | null;
 	/** When PR was created/submitted (milliseconds since epoch) */
 	prCreatedAt?: number | null;
+	/**
+	 * Active restriction when task is paused due to a rate or usage limit.
+	 * Cleared when the task resumes after the restriction expires.
+	 */
+	restrictions?: TaskRestriction | null;
 	/** Last update timestamp (milliseconds since epoch) */
 	updatedAt: number;
 }
@@ -379,6 +404,10 @@ export interface UpdateTaskParams {
 	inputDraft?: string | null;
 	/** Timestamp when the task was archived. Set to null to clear when unarchiving. */
 	archivedAt?: number | null;
+	/**
+	 * Active restriction for rate/usage limited tasks. Set to null to clear restriction.
+	 */
+	restrictions?: TaskRestriction | null;
 }
 
 // ============================================================================

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -124,7 +124,9 @@ export type SpaceTaskStatus =
 	| 'completed'
 	| 'needs_attention'
 	| 'cancelled'
-	| 'archived';
+	| 'archived'
+	| 'rate_limited'
+	| 'usage_limited';
 
 /**
  * Space task priority

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -95,6 +95,10 @@ function getStatusBorderColor(status: TaskStatus): string {
 			return 'border-l-gray-700';
 		case 'archived':
 			return 'border-l-gray-800';
+		case 'rate_limited':
+			return 'border-l-orange-500';
+		case 'usage_limited':
+			return 'border-l-orange-600';
 		default:
 			return 'border-l-transparent';
 	}

--- a/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
+++ b/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
@@ -314,6 +314,8 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
 	cancelled: 'Cancelled',
 	archived: 'Archived',
 	draft: 'Draft',
+	rate_limited: 'Rate Limited',
+	usage_limited: 'Usage Limited',
 };
 
 function isDestructiveTransition(from: TaskStatus, to: TaskStatus): boolean {

--- a/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
+++ b/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
@@ -303,6 +303,8 @@ const ALL_TASK_STATUSES: TaskStatus[] = [
 	'cancelled',
 	'archived',
 	'draft',
+	'rate_limited',
+	'usage_limited',
 ];
 
 const STATUS_LABELS: Record<TaskStatus, string> = {

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -31,6 +31,8 @@ const STATUS_LABELS: Record<SpaceTaskStatus, string> = {
 	needs_attention: 'Needs Attention',
 	cancelled: 'Cancelled',
 	archived: 'Archived',
+	rate_limited: 'Rate Limited',
+	usage_limited: 'Usage Limited',
 };
 
 const STATUS_CLASSES: Record<SpaceTaskStatus, string> = {
@@ -42,6 +44,8 @@ const STATUS_CLASSES: Record<SpaceTaskStatus, string> = {
 	needs_attention: 'bg-yellow-900/30 text-yellow-300 border-yellow-700/50',
 	cancelled: 'bg-gray-800 text-gray-500 border-gray-700',
 	archived: 'bg-gray-900 text-gray-600 border-gray-800',
+	rate_limited: 'bg-orange-900/30 text-orange-300 border-orange-700/50',
+	usage_limited: 'bg-orange-900/30 text-orange-400 border-orange-700/50',
 };
 
 const PRIORITY_LABELS: Record<SpaceTaskPriority, string> = {

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -69,6 +69,8 @@ const taskStatusColors: Record<string, string> = {
 	needs_attention: 'bg-orange-500',
 	completed: 'bg-green-500',
 	cancelled: 'bg-gray-600',
+	rate_limited: 'bg-orange-500',
+	usage_limited: 'bg-orange-600',
 };
 
 function TaskStatusDot({ status }: { status: string }) {

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -215,7 +215,7 @@ describe('RoomStore — computed goal/task signals', () => {
 		});
 	});
 
-	describe('all 8 TaskStatus values are covered', () => {
+	describe('all 10 TaskStatus values are covered', () => {
 		it('every status falls into exactly one bucket', () => {
 			roomStore.tasks.value = [
 				makeTask('draft', 'draft'),
@@ -226,6 +226,8 @@ describe('RoomStore — computed goal/task signals', () => {
 				makeTask('completed', 'completed'),
 				makeTask('cancelled', 'cancelled'),
 				makeTask('archived', 'archived'),
+				makeTask('rate_limited', 'rate_limited'),
+				makeTask('usage_limited', 'usage_limited'),
 			];
 			roomStore.goals.value = [];
 
@@ -244,8 +246,10 @@ describe('RoomStore — computed goal/task signals', () => {
 				}
 			}
 
-			// All covered
-			expect(active.size + review.size + done.size + archived.size).toBe(8);
+			// All covered — rate_limited and usage_limited fall into the active bucket
+			expect(active.size + review.size + done.size + archived.size).toBe(10);
+			expect(active.has('rate_limited')).toBe(true);
+			expect(active.has('usage_limited')).toBe(true);
 		});
 	});
 

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -192,10 +192,15 @@ class RoomStore {
 		return this.tasks.value.filter((t) => !linkedIds.has(t.id));
 	});
 
-	/** Orphan tasks that are active (draft, pending, or in_progress) */
+	/** Orphan tasks that are active (draft, pending, in_progress, rate_limited, or usage_limited) */
 	readonly orphanTasksActive = computed(() =>
 		this.orphanTasks.value.filter(
-			(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+			(t) =>
+				t.status === 'draft' ||
+				t.status === 'pending' ||
+				t.status === 'in_progress' ||
+				t.status === 'rate_limited' ||
+				t.status === 'usage_limited'
 		)
 	);
 


### PR DESCRIPTION
- Add `rate_limited` and `usage_limited` to TaskStatus and VALID_STATUS_TRANSITIONS
- Add TaskRestriction interface (type, limit, resetAt, sessionRole, retryAfter)
- Persist restrictions field on task record when limit is detected in RoomRuntime
- Clear restrictions field when task resumes via send_to_worker or setTaskStatus
- Add recoverStuckWorkers integration: skip active limits, re-route after expiry
- Add Migration 49: adds restrictions column and expands status CHECK constraint
- Add unit tests for restriction persistence, transitions, and migration
