### PR TITLE
feat(room): include shortId in TaskSummary for room.overview

### DIFF
--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -131,6 +131,7 @@ export class RoomManager {
 
 		const toSummary = (task: NeoTask): TaskSummary => ({
 			id: task.id,
+			shortId: task.shortId,
 			title: task.title,
 			status: task.status,
 			priority: task.priority,

--- a/packages/daemon/tests/unit/room/room-manager.test.ts
+++ b/packages/daemon/tests/unit/room/room-manager.test.ts
@@ -279,8 +279,10 @@ describe('RoomManager', () => {
 			expect(withShort?.shortId).toBe('t-1');
 
 			const withoutShort = overview?.activeTasks.find((t) => t.id === 'task-no-short');
-			// Legacy tasks without short_id may have undefined shortId or have it backfilled
 			expect(withoutShort).toBeDefined();
+			// RoomManager creates TaskRepository without a ShortIdAllocator, so lazy backfill
+			// never fires — legacy tasks without short_id in DB always return undefined shortId
+			expect(withoutShort?.shortId).toBeUndefined();
 		});
 
 		it('should include shortId in allTasks summaries', () => {

--- a/packages/daemon/tests/unit/room/room-manager.test.ts
+++ b/packages/daemon/tests/unit/room/room-manager.test.ts
@@ -231,6 +231,86 @@ describe('RoomManager', () => {
 			expect(overview?.activeTasks[0].status).toBe('in_progress');
 			expect(overview?.activeTasks[0].priority).toBe('high');
 		});
+
+		it('should include shortId in task summaries when present', () => {
+			const room = roomManager.createRoom({ name: 'Room With ShortId Tasks' });
+			const dbRaw = db.getDatabase();
+
+			// Insert a task with a short_id
+			dbRaw
+				.prepare(
+					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at, short_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				)
+				.run(
+					'task-short-1',
+					room.id,
+					'Task With Short ID',
+					'Desc',
+					'pending',
+					'normal',
+					'[]',
+					Date.now(),
+					't-1'
+				);
+
+			// Insert a task without a short_id (legacy task)
+			dbRaw
+				.prepare(
+					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+				)
+				.run(
+					'task-no-short',
+					room.id,
+					'Task Without Short ID',
+					'Desc',
+					'in_progress',
+					'normal',
+					'[]',
+					Date.now()
+				);
+
+			const overview = roomManager.getRoomOverview(room.id);
+
+			expect(overview?.activeTasks).toHaveLength(2);
+
+			const withShort = overview?.activeTasks.find((t) => t.id === 'task-short-1');
+			expect(withShort?.shortId).toBe('t-1');
+
+			const withoutShort = overview?.activeTasks.find((t) => t.id === 'task-no-short');
+			// Legacy tasks without short_id may have undefined shortId or have it backfilled
+			expect(withoutShort).toBeDefined();
+		});
+
+		it('should include shortId in allTasks summaries', () => {
+			const room = roomManager.createRoom({ name: 'Room allTasks ShortId' });
+			const dbRaw = db.getDatabase();
+
+			dbRaw
+				.prepare(
+					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at, short_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				)
+				.run(
+					'task-done',
+					room.id,
+					'Completed Task',
+					'Desc',
+					'completed',
+					'normal',
+					'[]',
+					Date.now(),
+					't-2'
+				);
+
+			const overview = roomManager.getRoomOverview(room.id);
+
+			// Completed tasks are excluded from activeTasks but included in allTasks
+			expect(overview?.activeTasks).toHaveLength(0);
+			const inAll = overview?.allTasks?.find((t) => t.id === 'task-done');
+			expect(inAll?.shortId).toBe('t-2');
+		});
 	});
 
 	describe('updateRoom', () => {

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -437,6 +437,8 @@ export interface SessionSummary {
  */
 export interface TaskSummary {
 	id: string;
+	/** Human-readable short ID (e.g. 't-42'), scoped to parent room */
+	shortId?: string;
 	title: string;
 	status: TaskStatus;
 	priority: TaskPriority;


### PR DESCRIPTION
## Summary

- Add optional `shortId` field to `TaskSummary` interface in shared types
- Propagate `task.shortId` in `toSummary()` in `RoomManager.getRoomOverview()` so it appears in both `activeTasks` and `allTasks`
- Add 2 unit tests verifying `shortId` appears correctly in task summaries (including explicit `undefined` assertion for legacy tasks without `short_id` in DB)

Note: `RoomOverview` has no goal summary field, so goal short IDs are not in scope here — goals already carry `shortId` via `RoomGoal` when fetched through `goal.list`/`goal.get`.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun test packages/daemon/tests/unit/room/room-manager.test.ts` — all 44 tests pass
- [ ] `room.overview` response task items include `shortId` for tasks that have `short_id` set in DB
- [ ] Legacy tasks (no `short_id` in DB) return `shortId: undefined` (no allocator in RoomManager, no backfill)