### PR TITLE
feat(web): update task URL route patterns to accept short IDs

### DIFF
--- a/packages/web/src/lib/__tests__/router-short-id.test.ts
+++ b/packages/web/src/lib/__tests__/router-short-id.test.ts
@@ -52,6 +52,21 @@ describe('ROOM_TASK_ROUTE_PATTERN — short ID support', () => {
 		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/t-42/extra`);
 		expect(result).toBeNull();
 	});
+
+	it('returns null for zero counter (t-0 is semantically invalid)', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/t-0`);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for leading-zero counter (t-01)', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/t-01`);
+		expect(result).toBeNull();
+	});
+
+	it('matches g- prefix short ID (route is intentionally permissive about prefix letter)', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/g-42`);
+		expect(result).toEqual({ roomId: ROOM_UUID, taskId: 'g-42' });
+	});
 });
 
 describe('SPACE_TASK_ROUTE_PATTERN — short ID support', () => {
@@ -93,5 +108,20 @@ describe('SPACE_TASK_ROUTE_PATTERN — short ID support', () => {
 	it('returns null for extra path segments after task short ID', () => {
 		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/t-42/extra`);
 		expect(result).toBeNull();
+	});
+
+	it('returns null for zero counter (t-0 is semantically invalid)', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/t-0`);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for leading-zero counter (t-01)', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/t-01`);
+		expect(result).toBeNull();
+	});
+
+	it('matches g- prefix short ID (route is intentionally permissive about prefix letter)', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/g-42`);
+		expect(result).toEqual({ spaceId: SPACE_UUID, taskId: 'g-42' });
 	});
 });

--- a/packages/web/src/lib/__tests__/router-short-id.test.ts
+++ b/packages/web/src/lib/__tests__/router-short-id.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for short ID support in URL route patterns.
+ *
+ * Verifies that ROOM_TASK_ROUTE_PATTERN and SPACE_TASK_ROUTE_PATTERN
+ * accept both UUID and short ID formats for the task ID segment.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getRoomTaskIdFromPath, getSpaceTaskIdFromPath } from '../router';
+
+const ROOM_UUID = '04062505-780f-4881-a3be-9cb9062790fb';
+const SPACE_UUID = '04062505-780f-4881-a3be-9cb9062790fc';
+const TASK_UUID = 'd8a578c6-d3cb-4c84-926b-958cbd433d32';
+
+describe('ROOM_TASK_ROUTE_PATTERN — short ID support', () => {
+	it('matches short task ID (t-N format)', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/t-42`);
+		expect(result).toEqual({ roomId: ROOM_UUID, taskId: 't-42' });
+	});
+
+	it('matches short task ID with large counter', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/t-999`);
+		expect(result).toEqual({ roomId: ROOM_UUID, taskId: 't-999' });
+	});
+
+	it('matches short task ID with single-digit counter', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/t-1`);
+		expect(result).toEqual({ roomId: ROOM_UUID, taskId: 't-1' });
+	});
+
+	it('matches UUID task ID (backward compatibility)', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/${TASK_UUID}`);
+		expect(result).toEqual({ roomId: ROOM_UUID, taskId: TASK_UUID });
+	});
+
+	it('returns null for path without task segment', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}`);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for non-hex, non-short-id task segment', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/Task_42`);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for invalid short ID format (uppercase prefix)', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/T-42`);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for extra path segments after task short ID', () => {
+		const result = getRoomTaskIdFromPath(`/room/${ROOM_UUID}/task/t-42/extra`);
+		expect(result).toBeNull();
+	});
+});
+
+describe('SPACE_TASK_ROUTE_PATTERN — short ID support', () => {
+	it('matches short task ID (t-N format)', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/t-42`);
+		expect(result).toEqual({ spaceId: SPACE_UUID, taskId: 't-42' });
+	});
+
+	it('matches short task ID with large counter', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/t-999`);
+		expect(result).toEqual({ spaceId: SPACE_UUID, taskId: 't-999' });
+	});
+
+	it('matches short task ID with single-digit counter', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/t-1`);
+		expect(result).toEqual({ spaceId: SPACE_UUID, taskId: 't-1' });
+	});
+
+	it('matches UUID task ID (backward compatibility)', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/${TASK_UUID}`);
+		expect(result).toEqual({ spaceId: SPACE_UUID, taskId: TASK_UUID });
+	});
+
+	it('returns null for path without task segment', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}`);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for non-hex, non-short-id task segment', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/Task_42`);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for invalid short ID format (uppercase prefix)', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/T-42`);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for extra path segments after task short ID', () => {
+		const result = getSpaceTaskIdFromPath(`/space/${SPACE_UUID}/task/t-42/extra`);
+		expect(result).toBeNull();
+	});
+});

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -29,7 +29,7 @@ const SESSION_ROUTE_PATTERN = /^\/session\/([a-f0-9-]+)$/;
 const ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/;
 const ROOM_AGENT_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/agent$/;
 const ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
-const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/;
+const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-\d+)$/;
 const SESSIONS_ROUTE_PATTERN = /^\/sessions$/;
 const INBOX_ROUTE_PATTERN = /^\/inbox$/;
 const SPACES_ROUTE_PATTERN = /^\/spaces$/;
@@ -37,7 +37,7 @@ const SPACES_ROUTE_PATTERN = /^\/spaces$/;
 const ROOM_CHAT_COMPAT_PATTERN = /^\/room\/([a-f0-9-]+)\/chat$/;
 const SPACE_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
-const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/;
+const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-\d+)$/;
 
 /**
  * Router state and configuration

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -29,7 +29,7 @@ const SESSION_ROUTE_PATTERN = /^\/session\/([a-f0-9-]+)$/;
 const ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/;
 const ROOM_AGENT_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/agent$/;
 const ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
-const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-\d+)$/;
+const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
 const SESSIONS_ROUTE_PATTERN = /^\/sessions$/;
 const INBOX_ROUTE_PATTERN = /^\/inbox$/;
 const SPACES_ROUTE_PATTERN = /^\/spaces$/;
@@ -37,7 +37,7 @@ const SPACES_ROUTE_PATTERN = /^\/spaces$/;
 const ROOM_CHAT_COMPAT_PATTERN = /^\/room\/([a-f0-9-]+)\/chat$/;
 const SPACE_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
-const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-\d+)$/;
+const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
 
 /**
  * Router state and configuration


### PR DESCRIPTION
## Summary
- Updated `ROOM_TASK_ROUTE_PATTERN` and `SPACE_TASK_ROUTE_PATTERN` in `packages/web/src/lib/router.ts` to accept both UUID and short ID (`[a-z]-\d+`, e.g. `t-42`) formats in the task ID segment
- Room, space, and session ID segments remain UUID-only (not user-facing short IDs in this milestone)
- Added 16 unit tests covering UUID and short ID matching for both `getRoomTaskIdFromPath` and `getSpaceTaskIdFromPath`

## Test plan
- [x] `/room/<uuid>/task/t-42` matches `ROOM_TASK_ROUTE_PATTERN`
- [x] `/room/<uuid>/task/<uuid>` still matches (backward compat)
- [x] `/space/<uuid>/task/t-42` matches `SPACE_TASK_ROUTE_PATTERN`
- [x] `/space/<uuid>/task/<uuid>` still matches (backward compat)
- [x] All 16 new unit tests pass
- [x] All 1225 existing lib tests pass
- [x] Pre-commit checks (lint, format, typecheck, knip) all pass