### PR TITLE
feat(web): display short IDs in task cards with click-to-copy badge

### DIFF
--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -1054,4 +1054,97 @@ describe('RoomTasks', () => {
 			expect(badge?.getAttribute('title')).toBe('Mission: Specific Goal Name');
 		});
 	});
+
+	describe('Short ID Badge', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'active';
+		});
+
+		it('should show short ID badge when task has shortId', () => {
+			const tasks = [createTask('uuid-123', 'pending', { shortId: 't-42' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const badge = container.querySelector('[data-testid="short-id-badge-t-42"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.textContent).toContain('#t-42');
+		});
+
+		it('should NOT show short ID badge when task has no shortId', () => {
+			const tasks = [createTask('uuid-123', 'pending')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// No badge elements with the short-id-badge prefix
+			const badges = container.querySelectorAll('[data-testid^="short-id-badge-"]');
+			expect(badges).toHaveLength(0);
+		});
+
+		it('should have tooltip "Click to copy short ID" on the badge', () => {
+			const tasks = [createTask('uuid-123', 'pending', { shortId: 't-7' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const badge = container.querySelector('[data-testid="short-id-badge-t-7"]');
+			expect(badge?.getAttribute('title')).toBe('Click to copy short ID');
+		});
+
+		it('should NOT call onTaskClick when short ID badge is clicked (stopPropagation)', () => {
+			const onTaskClick = vi.fn();
+			// Mock clipboard since jsdom doesn't implement it
+			Object.defineProperty(navigator, 'clipboard', {
+				value: { writeText: vi.fn().mockResolvedValue(undefined) },
+				configurable: true,
+			});
+			const tasks = [createTask('uuid-123', 'pending', { shortId: 't-5', title: 'My task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} onTaskClick={onTaskClick} />);
+
+			const badge = container.querySelector(
+				'[data-testid="short-id-badge-t-5"]'
+			) as HTMLButtonElement;
+			fireEvent.click(badge);
+
+			expect(onTaskClick).not.toHaveBeenCalled();
+		});
+
+		it('should use shortId when calling onTaskClick (prefers short ID for navigation)', () => {
+			const onTaskClick = vi.fn();
+			const tasks = [createTask('uuid-123', 'pending', { shortId: 't-42', title: 'My task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} onTaskClick={onTaskClick} />);
+
+			const taskItem = container.querySelector('.cursor-pointer');
+			fireEvent.click(taskItem!);
+
+			expect(onTaskClick).toHaveBeenCalledWith('t-42');
+		});
+
+		it('should fall back to UUID when calling onTaskClick if no shortId', () => {
+			const onTaskClick = vi.fn();
+			const tasks = [createTask('uuid-123', 'pending', { title: 'My task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} onTaskClick={onTaskClick} />);
+
+			const taskItem = container.querySelector('.cursor-pointer');
+			fireEvent.click(taskItem!);
+
+			expect(onTaskClick).toHaveBeenCalledWith('uuid-123');
+		});
+
+		it('should use shortId when calling onView (prefers short ID for navigation)', () => {
+			selectedTabSignal.value = 'review';
+			const onView = vi.fn();
+			const tasks = [createTask('uuid-r', 'review', { shortId: 't-9', title: 'Review task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
+
+			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('View details')
+			) as HTMLButtonElement;
+			fireEvent.click(viewBtn);
+
+			expect(onView).toHaveBeenCalledWith('t-9');
+		});
+	});
 });

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -8,7 +8,7 @@
  * - Archived: hidden by default, expandable
  */
 
-import { signal, effect } from '@preact/signals';
+import { signal, effect, useSignal } from '@preact/signals';
 import type { TaskSummary, TaskStatus, RoomGoal } from '@neokai/shared';
 import { CircularProgressIndicator } from '../ui/CircularProgressIndicator';
 
@@ -540,6 +540,32 @@ function isBlocked(task: TaskSummary, allTasks: TaskSummary[]): boolean {
 	});
 }
 
+/** Short ID badge with click-to-copy behaviour */
+function ShortIdBadge({ shortId }: { shortId: string }) {
+	const copied = useSignal(false);
+
+	const handleCopy = (e: MouseEvent) => {
+		e.stopPropagation();
+		navigator.clipboard.writeText(shortId).then(() => {
+			copied.value = true;
+			setTimeout(() => {
+				copied.value = false;
+			}, 1500);
+		});
+	};
+
+	return (
+		<button
+			data-testid={`short-id-badge-${shortId}`}
+			onClick={handleCopy}
+			title="Click to copy short ID"
+			class="inline-flex items-center text-xs font-mono font-medium text-gray-400 bg-dark-700 hover:bg-dark-600 border border-dark-600 px-1.5 py-0.5 rounded flex-shrink-0 transition-colors"
+		>
+			{copied.value ? '\u2713 copied' : `#${shortId}`}
+		</button>
+	);
+}
+
 function TaskItem({
 	task,
 	allTasks,
@@ -567,16 +593,19 @@ function TaskItem({
 		(task.status === 'completed' || task.status === 'cancelled') && !!onReactivate;
 
 	const borderColor = getStatusBorderColor(task.status);
+	/** Prefer short ID for navigation so URLs are human-readable */
+	const navId = task.shortId ?? task.id;
 
 	return (
 		<div
 			class={`px-4 py-3 border-l-2 ${borderColor} ${isClickable ? 'cursor-pointer hover:bg-dark-800/50 transition-colors' : ''}`}
-			onClick={isClickable ? () => onClick(task.id) : undefined}
+			onClick={isClickable ? () => onClick(navId) : undefined}
 		>
 			<div class="flex items-start justify-between">
 				<div class="flex-1 min-w-0">
 					<div class="flex items-center gap-2 flex-wrap">
 						<h4 class="text-sm font-medium text-gray-100 truncate">{task.title}</h4>
+						{task.shortId && <ShortIdBadge shortId={task.shortId} />}
 						{isWorking && (
 							<span class="inline-flex items-center gap-1 text-xs font-medium text-blue-400 bg-blue-900/20 border border-blue-700/40 px-1.5 py-0.5 rounded-full flex-shrink-0">
 								<span class="w-1.5 h-1.5 bg-blue-400 rounded-full animate-pulse" />
@@ -647,7 +676,7 @@ function TaskItem({
 						<button
 							onClick={(e) => {
 								e.stopPropagation();
-								onView(task.id);
+								onView(navId);
 							}}
 							class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
 						>
@@ -662,7 +691,7 @@ function TaskItem({
 					<button
 						onClick={(e) => {
 							e.stopPropagation();
-							onReactivate(task.id);
+							onReactivate(navId);
 						}}
 						class="px-3 py-1.5 text-xs font-medium text-blue-400 border border-blue-700/50 hover:bg-blue-900/20 rounded-lg transition-colors"
 						data-testid={`task-reactivate-${task.id}`}


### PR DESCRIPTION
- Add ShortIdBadge component showing '#t-42' next to task title when
  shortId is present; absent when task has no shortId (graceful fallback)
- Clicking the badge copies the short ID to clipboard and shows '✓ copied'
  for 1.5s; stopPropagation prevents card navigation
- Badge has tooltip 'Click to copy short ID'
- Task navigation (onClick, onView, onReactivate) now prefers shortId over
  UUID so task detail URLs use the short form (e.g. /room/.../task/t-42)
- 7 new unit tests covering badge rendering, stopPropagation, tooltip,
  shortId-first navigation, and UUID fallback
