### PR TITLE
feat(web): display short IDs in goals editor with click-to-copy badge

### DIFF
--- a/packages/web/src/components/room/GoalsEditor.test.tsx
+++ b/packages/web/src/components/room/GoalsEditor.test.tsx
@@ -1003,4 +1003,72 @@ describe('GoalsEditor', () => {
 			expect(container.textContent).toContain('Deploy to staging');
 		});
 	});
+
+	describe('Short ID Badge', () => {
+		it('should show short ID badge when goal has shortId', () => {
+			const goals = [createMockGoal('goal-1', { shortId: 'g-7' })];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			const badge = container.querySelector('[data-testid="goal-short-id-badge-g-7"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.textContent).toBe('#g-7');
+		});
+
+		it('should not show short ID badge when goal has no shortId', () => {
+			const goals = [createMockGoal('goal-1')];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			const badge = container.querySelector('[data-testid^="goal-short-id-badge-"]');
+			expect(badge).toBeNull();
+		});
+
+		it('should show tooltip on short ID badge', () => {
+			const goals = [createMockGoal('goal-1', { shortId: 'g-3' })];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			const badge = container.querySelector('[data-testid="goal-short-id-badge-g-3"]');
+			expect(badge?.getAttribute('title')).toBe('Click to copy short ID');
+		});
+
+		it('should stop propagation when clicking badge', () => {
+			const goals = [createMockGoal('goal-1', { shortId: 'g-5' })];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			const badge = container.querySelector(
+				'[data-testid="goal-short-id-badge-g-5"]'
+			) as HTMLElement;
+
+			// Track expand state — clicking header toggles expand; clicking badge should not
+			const header = container.querySelector('[data-testid="goal-item-header"]') as HTMLElement;
+			fireEvent.click(header);
+			const expandedContent = container.innerHTML;
+
+			// Click badge — expansion state should not change again
+			fireEvent.click(badge);
+			expect(container.innerHTML).toBe(expandedContent);
+		});
+
+		it('should copy short ID to clipboard on click', async () => {
+			const writeText = vi.fn().mockResolvedValue(undefined);
+			Object.defineProperty(navigator, 'clipboard', {
+				value: { writeText },
+				writable: true,
+				configurable: true,
+			});
+
+			const goals = [createMockGoal('goal-1', { shortId: 'g-9' })];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			const badge = container.querySelector(
+				'[data-testid="goal-short-id-badge-g-9"]'
+			) as HTMLElement;
+
+			fireEvent.click(badge);
+			expect(writeText).toHaveBeenCalledWith('g-9');
+		});
+
+		it('should show fallback text for goals without shortId', () => {
+			const goals = [createMockGoal('goal-uuid-only')];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			// Goal title still renders
+			expect(container.textContent).toContain('Goal goal-uuid-only');
+			// But no short ID badge
+			expect(container.querySelector('[data-testid^="goal-short-id-badge-"]')).toBeNull();
+		});
+	});
 });

--- a/packages/web/src/components/room/GoalsEditor.test.tsx
+++ b/packages/web/src/components/room/GoalsEditor.test.tsx
@@ -2,7 +2,7 @@
  * Tests for GoalsEditor Component
  */
 
-import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GoalsEditor } from './GoalsEditor';
 import type { RoomGoal, TaskSummary } from '@neokai/shared';
@@ -1060,6 +1060,27 @@ describe('GoalsEditor', () => {
 
 			fireEvent.click(badge);
 			expect(writeText).toHaveBeenCalledWith('g-9');
+		});
+
+		it('should show visual feedback ("✓ copied") after clicking badge', async () => {
+			const writeText = vi.fn().mockResolvedValue(undefined);
+			Object.defineProperty(navigator, 'clipboard', {
+				value: { writeText },
+				writable: true,
+				configurable: true,
+			});
+
+			const goals = [createMockGoal('goal-1', { shortId: 'g-11' })];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+			const badge = container.querySelector(
+				'[data-testid="goal-short-id-badge-g-11"]'
+			) as HTMLElement;
+
+			expect(badge.textContent).toBe('#g-11');
+			fireEvent.click(badge);
+			await waitFor(() => {
+				expect(badge.textContent).toBe('✓ copied');
+			});
 		});
 
 		it('should show fallback text for goals without shortId', () => {

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -266,12 +266,15 @@ function GoalShortIdBadge({ shortId }: { shortId: string }) {
 
 	const handleCopy = (e: MouseEvent) => {
 		e.stopPropagation();
-		navigator.clipboard.writeText(shortId).then(() => {
-			copied.value = true;
-			setTimeout(() => {
-				copied.value = false;
-			}, 1500);
-		});
+		navigator.clipboard
+			.writeText(shortId)
+			.then(() => {
+				copied.value = true;
+				setTimeout(() => {
+					copied.value = false;
+				}, 1500);
+			})
+			.catch(() => {});
 	};
 
 	return (

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useState, useEffect } from 'preact/hooks';
+import { useSignal } from '@preact/signals';
 import type {
 	RoomGoal,
 	GoalPriority,
@@ -255,6 +256,33 @@ function TaskStatusBadge({ status }: { status: TaskStatus }) {
 		>
 			{label}
 		</span>
+	);
+}
+
+// ─── Short ID Badge ───────────────────────────────────────────────────────────
+
+function GoalShortIdBadge({ shortId }: { shortId: string }) {
+	const copied = useSignal(false);
+
+	const handleCopy = (e: MouseEvent) => {
+		e.stopPropagation();
+		navigator.clipboard.writeText(shortId).then(() => {
+			copied.value = true;
+			setTimeout(() => {
+				copied.value = false;
+			}, 1500);
+		});
+	};
+
+	return (
+		<button
+			data-testid={`goal-short-id-badge-${shortId}`}
+			onClick={handleCopy}
+			title="Click to copy short ID"
+			class="inline-flex items-center text-xs font-mono font-medium text-gray-400 bg-dark-700 hover:bg-dark-600 border border-dark-600 px-1.5 py-0.5 rounded flex-shrink-0 transition-colors"
+		>
+			{copied.value ? '\u2713 copied' : `#${shortId}`}
+		</button>
 	);
 }
 
@@ -1258,7 +1286,10 @@ function GoalItem({
 				>
 					{/* Row 1: Title + actions */}
 					<div class="flex items-start justify-between gap-2 mb-1.5">
-						<h4 class="text-sm font-semibold text-gray-100 leading-snug">{goal.title}</h4>
+						<div class="flex items-center gap-2 min-w-0">
+							<h4 class="text-sm font-semibold text-gray-100 leading-snug">{goal.title}</h4>
+							{goal.shortId && <GoalShortIdBadge shortId={goal.shortId} />}
+						</div>
 						<div class="flex items-center gap-1 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
 							<Button variant="ghost" size="sm" onClick={() => setIsEditing(true)}>
 								Edit

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -546,12 +546,15 @@ function ShortIdBadge({ shortId }: { shortId: string }) {
 
 	const handleCopy = (e: MouseEvent) => {
 		e.stopPropagation();
-		navigator.clipboard.writeText(shortId).then(() => {
-			copied.value = true;
-			setTimeout(() => {
-				copied.value = false;
-			}, 1500);
-		});
+		navigator.clipboard
+			.writeText(shortId)
+			.then(() => {
+				copied.value = true;
+				setTimeout(() => {
+					copied.value = false;
+				}, 1500);
+			})
+			.catch(() => {});
 	};
 
 	return (


### PR DESCRIPTION
Add GoalShortIdBadge component to GoalsEditor that renders a #g-N badge
next to goal titles when shortId is present. Badge copies the short ID
to clipboard on click with 1.5s visual feedback, uses stopPropagation
to prevent card expand toggle, and is omitted gracefully for legacy
goals without shortId.

Add 6 unit tests covering badge visibility, tooltip, stopPropagation,
clipboard copy, and fallback for goals without shortId.
