### PR TITLE
feat(storage): add app_mcp_servers table, types, and repository

### DIFF
--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -33,6 +33,7 @@ import {
 	type UpdateGoalParams,
 } from './repositories/goal-repository';
 import { JobQueueRepository } from './repositories/job-queue-repository';
+import { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -53,6 +54,7 @@ export type { JobHandler, JobQueueProcessorOptions } from './job-queue-processor
 // Re-export repository classes for direct use
 export { GoalRepository } from './repositories/goal-repository';
 export { SpaceAgentRepository } from './repositories/space-agent-repository';
+export { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 
 /**
  * Database facade class that maintains backward compatibility with the original Database class.
@@ -69,6 +71,7 @@ export class Database {
 	private inboxItemRepo!: InboxItemRepository;
 	private goalRepo!: GoalRepository;
 	private jobQueueRepo!: JobQueueRepository;
+	private appMcpServerRepo!: AppMcpServerRepository;
 	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
@@ -89,6 +92,7 @@ export class Database {
 		this.inboxItemRepo = new InboxItemRepository(db);
 		this.goalRepo = new GoalRepository(db, reactiveDb, shortIdAllocator);
 		this.jobQueueRepo = new JobQueueRepository(db);
+		this.appMcpServerRepo = new AppMcpServerRepository(db, reactiveDb);
 	}
 
 	// ============================================================================
@@ -423,6 +427,13 @@ export class Database {
 	 */
 	getJobQueueRepo(): JobQueueRepository {
 		return this.jobQueueRepo;
+	}
+
+	/**
+	 * Get the application-level MCP server repository
+	 */
+	get appMcpServers(): AppMcpServerRepository {
+		return this.appMcpServerRepo;
 	}
 
 	close(): void {

--- a/packages/daemon/src/storage/repositories/app-mcp-server-repository.ts
+++ b/packages/daemon/src/storage/repositories/app-mcp-server-repository.ts
@@ -1,0 +1,214 @@
+/**
+ * AppMcpServerRepository
+ *
+ * CRUD operations for the application-level MCP server registry.
+ * Each write method calls reactiveDb.notifyChange('app_mcp_servers') so that
+ * LiveQueryEngine can invalidate frontend subscriptions on every registry change.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	AppMcpServer,
+	AppMcpServerSourceType,
+	CreateAppMcpServerRequest,
+	UpdateAppMcpServerRequest,
+} from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+import type { SQLiteValue } from '../types';
+
+// ---------------------------------------------------------------------------
+// Internal row type (mirrors SQLite columns)
+// ---------------------------------------------------------------------------
+
+interface AppMcpServerRow {
+	id: string;
+	name: string;
+	description: string | null;
+	source_type: string;
+	command: string | null;
+	args: string | null;
+	env: string | null;
+	url: string | null;
+	headers: string | null;
+	enabled: number;
+	created_at: number | null;
+	updated_at: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToServer(row: AppMcpServerRow): AppMcpServer {
+	return {
+		id: row.id,
+		name: row.name,
+		...(row.description !== null ? { description: row.description } : {}),
+		sourceType: row.source_type as AppMcpServerSourceType,
+		...(row.command !== null ? { command: row.command } : {}),
+		...(row.args !== null ? { args: JSON.parse(row.args) as string[] } : {}),
+		...(row.env !== null ? { env: JSON.parse(row.env) as Record<string, string> } : {}),
+		...(row.url !== null ? { url: row.url } : {}),
+		...(row.headers !== null ? { headers: JSON.parse(row.headers) as Record<string, string> } : {}),
+		enabled: row.enabled === 1,
+		...(row.created_at !== null ? { createdAt: row.created_at } : {}),
+		...(row.updated_at !== null ? { updatedAt: row.updated_at } : {}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+export class AppMcpServerRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb: ReactiveDatabase
+	) {}
+
+	/**
+	 * Create a new MCP server registry entry.
+	 */
+	create(req: CreateAppMcpServerRequest): AppMcpServer {
+		const id = generateUUID();
+		const now = Date.now();
+
+		this.db
+			.prepare(
+				`INSERT INTO app_mcp_servers
+          (id, name, description, source_type, command, args, env, url, headers, enabled, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				req.name,
+				req.description ?? null,
+				req.sourceType,
+				req.command ?? null,
+				req.args !== undefined ? JSON.stringify(req.args) : null,
+				req.env !== undefined ? JSON.stringify(req.env) : null,
+				req.url ?? null,
+				req.headers !== undefined ? JSON.stringify(req.headers) : null,
+				req.enabled ? 1 : 0,
+				now,
+				now
+			);
+
+		this.reactiveDb.notifyChange('app_mcp_servers');
+		return this.get(id)!;
+	}
+
+	/**
+	 * Get a server entry by ID. Returns null if not found.
+	 */
+	get(id: string): AppMcpServer | null {
+		const row = this.db.prepare(`SELECT * FROM app_mcp_servers WHERE id = ?`).get(id) as
+			| AppMcpServerRow
+			| undefined;
+		return row ? rowToServer(row) : null;
+	}
+
+	/**
+	 * Get a server entry by name. Returns null if not found.
+	 */
+	getByName(name: string): AppMcpServer | null {
+		const row = this.db.prepare(`SELECT * FROM app_mcp_servers WHERE name = ?`).get(name) as
+			| AppMcpServerRow
+			| undefined;
+		return row ? rowToServer(row) : null;
+	}
+
+	/**
+	 * List all MCP server entries.
+	 */
+	list(): AppMcpServer[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM app_mcp_servers ORDER BY created_at ASC`)
+			.all() as AppMcpServerRow[];
+		return rows.map(rowToServer);
+	}
+
+	/**
+	 * List only enabled MCP server entries.
+	 */
+	listEnabled(): AppMcpServer[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM app_mcp_servers WHERE enabled = 1 ORDER BY created_at ASC`)
+			.all() as AppMcpServerRow[];
+		return rows.map(rowToServer);
+	}
+
+	/**
+	 * Update an existing MCP server entry. Returns the updated entry or null if not found.
+	 */
+	update(id: string, updates: Omit<UpdateAppMcpServerRequest, 'id'>): AppMcpServer | null {
+		const existing = this.get(id);
+		if (!existing) return null;
+
+		const now = Date.now();
+		const fields: string[] = [];
+		const values: SQLiteValue[] = [];
+
+		if (updates.name !== undefined) {
+			fields.push('name = ?');
+			values.push(updates.name);
+		}
+		if ('description' in updates) {
+			fields.push('description = ?');
+			values.push(updates.description ?? null);
+		}
+		if (updates.sourceType !== undefined) {
+			fields.push('source_type = ?');
+			values.push(updates.sourceType);
+		}
+		if ('command' in updates) {
+			fields.push('command = ?');
+			values.push(updates.command ?? null);
+		}
+		if ('args' in updates) {
+			fields.push('args = ?');
+			values.push(updates.args !== undefined ? JSON.stringify(updates.args) : null);
+		}
+		if ('env' in updates) {
+			fields.push('env = ?');
+			values.push(updates.env !== undefined ? JSON.stringify(updates.env) : null);
+		}
+		if ('url' in updates) {
+			fields.push('url = ?');
+			values.push(updates.url ?? null);
+		}
+		if ('headers' in updates) {
+			fields.push('headers = ?');
+			values.push(updates.headers !== undefined ? JSON.stringify(updates.headers) : null);
+		}
+		if (updates.enabled !== undefined) {
+			fields.push('enabled = ?');
+			values.push(updates.enabled ? 1 : 0);
+		}
+
+		if (fields.length > 0) {
+			fields.push('updated_at = ?');
+			values.push(now);
+			values.push(id);
+			this.db
+				.prepare(`UPDATE app_mcp_servers SET ${fields.join(', ')} WHERE id = ?`)
+				.run(...values);
+			this.reactiveDb.notifyChange('app_mcp_servers');
+		}
+
+		return this.get(id);
+	}
+
+	/**
+	 * Delete an MCP server entry. Returns true if a row was deleted.
+	 */
+	delete(id: string): boolean {
+		const result = this.db.prepare(`DELETE FROM app_mcp_servers WHERE id = ?`).run(id);
+		const deleted = result.changes > 0;
+		if (deleted) {
+			this.reactiveDb.notifyChange('app_mcp_servers');
+		}
+		return deleted;
+	}
+}

--- a/packages/daemon/src/storage/repositories/app-mcp-server-repository.ts
+++ b/packages/daemon/src/storage/repositories/app-mcp-server-repository.ts
@@ -18,6 +18,12 @@ import type { ReactiveDatabase } from '../reactive-database';
 import type { SQLiteValue } from '../types';
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VALID_SOURCE_TYPES = new Set<AppMcpServerSourceType>(['stdio', 'sse', 'http']);
+
+// ---------------------------------------------------------------------------
 // Internal row type (mirrors SQLite columns)
 // ---------------------------------------------------------------------------
 
@@ -57,6 +63,14 @@ function rowToServer(row: AppMcpServerRow): AppMcpServer {
 	};
 }
 
+function validateSourceType(sourceType: string): void {
+	if (!VALID_SOURCE_TYPES.has(sourceType as AppMcpServerSourceType)) {
+		throw new Error(
+			`Invalid sourceType "${sourceType}". Must be one of: ${[...VALID_SOURCE_TYPES].join(', ')}`
+		);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Repository
 // ---------------------------------------------------------------------------
@@ -68,9 +82,31 @@ export class AppMcpServerRepository {
 	) {}
 
 	/**
+	 * Check whether a name is already taken in the registry.
+	 * Pass `excludeId` when renaming an existing entry to avoid a false positive.
+	 */
+	isNameTaken(name: string, excludeId?: string): boolean {
+		if (excludeId) {
+			const row = this.db
+				.prepare(`SELECT 1 FROM app_mcp_servers WHERE name = ? AND id != ?`)
+				.get(name, excludeId);
+			return row !== null;
+		}
+		const row = this.db.prepare(`SELECT 1 FROM app_mcp_servers WHERE name = ?`).get(name);
+		return row !== null;
+	}
+
+	/**
 	 * Create a new MCP server registry entry.
+	 * Throws if the name is already taken or if sourceType is invalid.
 	 */
 	create(req: CreateAppMcpServerRequest): AppMcpServer {
+		validateSourceType(req.sourceType);
+
+		if (this.isNameTaken(req.name)) {
+			throw new Error(`An MCP server named "${req.name}" already exists`);
+		}
+
 		const id = generateUUID();
 		const now = Date.now();
 
@@ -90,7 +126,7 @@ export class AppMcpServerRepository {
 				req.env !== undefined ? JSON.stringify(req.env) : null,
 				req.url ?? null,
 				req.headers !== undefined ? JSON.stringify(req.headers) : null,
-				req.enabled ? 1 : 0,
+				(req.enabled ?? true) ? 1 : 0,
 				now,
 				now
 			);
@@ -120,31 +156,42 @@ export class AppMcpServerRepository {
 	}
 
 	/**
-	 * List all MCP server entries.
+	 * List all MCP server entries, ordered by created_at (NULLs last).
 	 */
 	list(): AppMcpServer[] {
 		const rows = this.db
-			.prepare(`SELECT * FROM app_mcp_servers ORDER BY created_at ASC`)
+			.prepare(`SELECT * FROM app_mcp_servers ORDER BY created_at IS NULL, created_at ASC`)
 			.all() as AppMcpServerRow[];
 		return rows.map(rowToServer);
 	}
 
 	/**
-	 * List only enabled MCP server entries.
+	 * List only enabled MCP server entries, ordered by created_at (NULLs last).
 	 */
 	listEnabled(): AppMcpServer[] {
 		const rows = this.db
-			.prepare(`SELECT * FROM app_mcp_servers WHERE enabled = 1 ORDER BY created_at ASC`)
+			.prepare(
+				`SELECT * FROM app_mcp_servers WHERE enabled = 1 ORDER BY created_at IS NULL, created_at ASC`
+			)
 			.all() as AppMcpServerRow[];
 		return rows.map(rowToServer);
 	}
 
 	/**
 	 * Update an existing MCP server entry. Returns the updated entry or null if not found.
+	 * Throws if the new name is already taken by another entry, or if sourceType is invalid.
 	 */
 	update(id: string, updates: Omit<UpdateAppMcpServerRequest, 'id'>): AppMcpServer | null {
 		const existing = this.get(id);
 		if (!existing) return null;
+
+		if (updates.name !== undefined && this.isNameTaken(updates.name, id)) {
+			throw new Error(`An MCP server named "${updates.name}" already exists`);
+		}
+
+		if (updates.sourceType !== undefined) {
+			validateSourceType(updates.sourceType);
+		}
 
 		const now = Date.now();
 		const fields: string[] = [];

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -328,6 +328,24 @@ export function createTables(db: BunDatabase): void {
       )
     `);
 
+	// Application-level MCP server registry
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS app_mcp_servers (
+        id TEXT PRIMARY KEY,
+        name TEXT UNIQUE NOT NULL,
+        description TEXT,
+        source_type TEXT NOT NULL CHECK(source_type IN ('stdio', 'sse', 'http')),
+        command TEXT,
+        args TEXT,
+        env TEXT,
+        url TEXT,
+        headers TEXT,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `);
+
 	db.exec(`
       CREATE TABLE IF NOT EXISTS job_queue (
         id TEXT PRIMARY KEY,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -189,6 +189,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// causing UNIQUE constraint failures when two different rooms each create their first task.
 	// Short IDs are scoped to their parent room, so uniqueness must be (room_id, short_id).
 	runMigration48(db);
+
+	// Migration 49: Create app_mcp_servers table for application-level MCP server registry.
+	runMigration49(db);
 }
 
 /**
@@ -3008,4 +3011,29 @@ export function runMigration48(db: BunDatabase): void {
 			`CREATE UNIQUE INDEX IF NOT EXISTS idx_goals_room_short_id ON goals(room_id, short_id) WHERE short_id IS NOT NULL`
 		);
 	}
+}
+
+/**
+ * Migration 49: Create app_mcp_servers table for application-level MCP server registry.
+ *
+ * This table stores MCP server configurations registered at the application level,
+ * available to any room or session. Idempotent via CREATE TABLE IF NOT EXISTS.
+ */
+function runMigration49(db: BunDatabase): void {
+	db.exec(`
+    CREATE TABLE IF NOT EXISTS app_mcp_servers (
+      id TEXT PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL,
+      description TEXT,
+      source_type TEXT NOT NULL CHECK(source_type IN ('stdio', 'sse', 'http')),
+      command TEXT,
+      args TEXT,
+      env TEXT,
+      url TEXT,
+      headers TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER,
+      updated_at INTEGER
+    )
+  `);
 }

--- a/packages/daemon/tests/unit/storage/app-mcp-server-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/app-mcp-server-repository.test.ts
@@ -1,0 +1,288 @@
+/**
+ * AppMcpServerRepository Unit Tests
+ *
+ * Covers CRUD operations, listEnabled() filtering, and that
+ * notifyChange('app_mcp_servers') is called after each write.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import { AppMcpServerRepository } from '../../../src/storage/repositories/app-mcp-server-repository';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('AppMcpServerRepository', () => {
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let repo: AppMcpServerRepository;
+	let notifyChangeSpy: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		bunDb = new BunDatabase(':memory:');
+		createTables(bunDb);
+
+		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+
+		// Spy on notifyChange
+		notifyChangeSpy = mock(() => {});
+		reactiveDb.notifyChange = notifyChangeSpy;
+
+		repo = new AppMcpServerRepository(bunDb, reactiveDb);
+	});
+
+	afterEach(() => {
+		bunDb.close();
+	});
+
+	// ---------------------------------------------------------------------------
+	// create
+	// ---------------------------------------------------------------------------
+
+	describe('create', () => {
+		test('creates a stdio server entry and returns it', () => {
+			const server = repo.create({
+				name: 'brave-search',
+				sourceType: 'stdio',
+				command: 'npx',
+				args: ['-y', '@modelcontextprotocol/server-brave-search'],
+				env: { BRAVE_API_KEY: 'BRAVE_API_KEY' },
+				enabled: true,
+			});
+
+			expect(server.id).toBeTruthy();
+			expect(server.name).toBe('brave-search');
+			expect(server.sourceType).toBe('stdio');
+			expect(server.command).toBe('npx');
+			expect(server.args).toEqual(['-y', '@modelcontextprotocol/server-brave-search']);
+			expect(server.env).toEqual({ BRAVE_API_KEY: 'BRAVE_API_KEY' });
+			expect(server.enabled).toBe(true);
+			expect(server.createdAt).toBeTruthy();
+			expect(server.updatedAt).toBeTruthy();
+		});
+
+		test('creates an SSE server entry', () => {
+			const server = repo.create({
+				name: 'sse-server',
+				sourceType: 'sse',
+				url: 'http://localhost:8080/sse',
+				headers: { Authorization: 'Bearer token' },
+				enabled: true,
+			});
+
+			expect(server.sourceType).toBe('sse');
+			expect(server.url).toBe('http://localhost:8080/sse');
+			expect(server.headers).toEqual({ Authorization: 'Bearer token' });
+		});
+
+		test('creates an HTTP server entry', () => {
+			const server = repo.create({
+				name: 'http-server',
+				sourceType: 'http',
+				url: 'http://localhost:9000',
+				enabled: false,
+			});
+
+			expect(server.sourceType).toBe('http');
+			expect(server.enabled).toBe(false);
+		});
+
+		test('omits optional fields when not provided', () => {
+			const server = repo.create({
+				name: 'minimal',
+				sourceType: 'stdio',
+				enabled: true,
+			});
+
+			expect(server.description).toBeUndefined();
+			expect(server.command).toBeUndefined();
+			expect(server.args).toBeUndefined();
+			expect(server.env).toBeUndefined();
+			expect(server.url).toBeUndefined();
+			expect(server.headers).toBeUndefined();
+		});
+
+		test('calls notifyChange("app_mcp_servers") after create', () => {
+			notifyChangeSpy.mockClear();
+			repo.create({ name: 'notify-test', sourceType: 'stdio', enabled: true });
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('app_mcp_servers');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// get
+	// ---------------------------------------------------------------------------
+
+	describe('get', () => {
+		test('returns server by id', () => {
+			const created = repo.create({ name: 'get-test', sourceType: 'stdio', enabled: true });
+			const fetched = repo.get(created.id);
+			expect(fetched).not.toBeNull();
+			expect(fetched!.id).toBe(created.id);
+		});
+
+		test('returns null for unknown id', () => {
+			expect(repo.get('nonexistent-id')).toBeNull();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// getByName
+	// ---------------------------------------------------------------------------
+
+	describe('getByName', () => {
+		test('returns server by name', () => {
+			repo.create({ name: 'named-server', sourceType: 'http', url: 'http://x', enabled: true });
+			const found = repo.getByName('named-server');
+			expect(found).not.toBeNull();
+			expect(found!.name).toBe('named-server');
+		});
+
+		test('returns null for unknown name', () => {
+			expect(repo.getByName('no-such-server')).toBeNull();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// list
+	// ---------------------------------------------------------------------------
+
+	describe('list', () => {
+		test('returns all servers ordered by created_at', () => {
+			repo.create({ name: 'alpha', sourceType: 'stdio', enabled: true });
+			repo.create({ name: 'beta', sourceType: 'stdio', enabled: false });
+			repo.create({ name: 'gamma', sourceType: 'http', url: 'http://g', enabled: true });
+
+			const all = repo.list();
+			expect(all).toHaveLength(3);
+			const names = all.map((s) => s.name);
+			expect(names).toContain('alpha');
+			expect(names).toContain('beta');
+			expect(names).toContain('gamma');
+		});
+
+		test('returns empty array when no servers exist', () => {
+			expect(repo.list()).toHaveLength(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// listEnabled
+	// ---------------------------------------------------------------------------
+
+	describe('listEnabled', () => {
+		test('returns only enabled servers', () => {
+			repo.create({ name: 'enabled-1', sourceType: 'stdio', enabled: true });
+			repo.create({ name: 'disabled-1', sourceType: 'stdio', enabled: false });
+			repo.create({ name: 'enabled-2', sourceType: 'http', url: 'http://e2', enabled: true });
+
+			const enabled = repo.listEnabled();
+			expect(enabled).toHaveLength(2);
+			expect(enabled.every((s) => s.enabled)).toBe(true);
+			const names = enabled.map((s) => s.name);
+			expect(names).toContain('enabled-1');
+			expect(names).toContain('enabled-2');
+			expect(names).not.toContain('disabled-1');
+		});
+
+		test('returns empty array when no enabled servers', () => {
+			repo.create({ name: 'off', sourceType: 'stdio', enabled: false });
+			expect(repo.listEnabled()).toHaveLength(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// update
+	// ---------------------------------------------------------------------------
+
+	describe('update', () => {
+		test('updates name and description', () => {
+			const server = repo.create({ name: 'old-name', sourceType: 'stdio', enabled: true });
+			const updated = repo.update(server.id, { name: 'new-name', description: 'A description' });
+
+			expect(updated).not.toBeNull();
+			expect(updated!.name).toBe('new-name');
+			expect(updated!.description).toBe('A description');
+		});
+
+		test('updates enabled flag', () => {
+			const server = repo.create({ name: 'toggle', sourceType: 'stdio', enabled: true });
+			const updated = repo.update(server.id, { enabled: false });
+
+			expect(updated!.enabled).toBe(false);
+		});
+
+		test('updates args and env as JSON', () => {
+			const server = repo.create({
+				name: 'json-fields',
+				sourceType: 'stdio',
+				command: 'node',
+				enabled: true,
+			});
+			const updated = repo.update(server.id, {
+				args: ['--port', '3000'],
+				env: { PORT: '3000' },
+			});
+
+			expect(updated!.args).toEqual(['--port', '3000']);
+			expect(updated!.env).toEqual({ PORT: '3000' });
+		});
+
+		test('returns null for unknown id', () => {
+			expect(repo.update('nonexistent', { name: 'x' })).toBeNull();
+		});
+
+		test('calls notifyChange("app_mcp_servers") after update', () => {
+			const server = repo.create({ name: 'notify-update', sourceType: 'stdio', enabled: true });
+			notifyChangeSpy.mockClear();
+			repo.update(server.id, { description: 'updated' });
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('app_mcp_servers');
+		});
+
+		test('does not call notifyChange when no fields are changed', () => {
+			const server = repo.create({ name: 'no-change', sourceType: 'stdio', enabled: true });
+			notifyChangeSpy.mockClear();
+			// Call update with an empty updates object (no fields to set)
+			repo.update(server.id, {});
+			expect(notifyChangeSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// delete
+	// ---------------------------------------------------------------------------
+
+	describe('delete', () => {
+		test('deletes an existing entry and returns true', () => {
+			const server = repo.create({ name: 'to-delete', sourceType: 'stdio', enabled: true });
+			const result = repo.delete(server.id);
+
+			expect(result).toBe(true);
+			expect(repo.get(server.id)).toBeNull();
+		});
+
+		test('returns false for unknown id', () => {
+			expect(repo.delete('nonexistent')).toBe(false);
+		});
+
+		test('calls notifyChange("app_mcp_servers") after delete', () => {
+			const server = repo.create({ name: 'notify-delete', sourceType: 'stdio', enabled: true });
+			notifyChangeSpy.mockClear();
+			repo.delete(server.id);
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('app_mcp_servers');
+		});
+
+		test('does not call notifyChange when deleting nonexistent id', () => {
+			notifyChangeSpy.mockClear();
+			repo.delete('nonexistent');
+			expect(notifyChangeSpy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/app-mcp-server-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/app-mcp-server-repository.test.ts
@@ -1,8 +1,8 @@
 /**
  * AppMcpServerRepository Unit Tests
  *
- * Covers CRUD operations, listEnabled() filtering, and that
- * notifyChange('app_mcp_servers') is called after each write.
+ * Covers CRUD operations, listEnabled() filtering, notifyChange calls after
+ * each write, duplicate-name error handling, and invalid sourceType rejection.
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
@@ -51,7 +51,6 @@ describe('AppMcpServerRepository', () => {
 				command: 'npx',
 				args: ['-y', '@modelcontextprotocol/server-brave-search'],
 				env: { BRAVE_API_KEY: 'BRAVE_API_KEY' },
-				enabled: true,
 			});
 
 			expect(server.id).toBeTruthy();
@@ -65,13 +64,22 @@ describe('AppMcpServerRepository', () => {
 			expect(server.updatedAt).toBeTruthy();
 		});
 
+		test('defaults enabled to true when omitted', () => {
+			const server = repo.create({ name: 'default-enabled', sourceType: 'stdio' });
+			expect(server.enabled).toBe(true);
+		});
+
+		test('respects explicit enabled: false', () => {
+			const server = repo.create({ name: 'off', sourceType: 'stdio', enabled: false });
+			expect(server.enabled).toBe(false);
+		});
+
 		test('creates an SSE server entry', () => {
 			const server = repo.create({
 				name: 'sse-server',
 				sourceType: 'sse',
 				url: 'http://localhost:8080/sse',
 				headers: { Authorization: 'Bearer token' },
-				enabled: true,
 			});
 
 			expect(server.sourceType).toBe('sse');
@@ -92,11 +100,7 @@ describe('AppMcpServerRepository', () => {
 		});
 
 		test('omits optional fields when not provided', () => {
-			const server = repo.create({
-				name: 'minimal',
-				sourceType: 'stdio',
-				enabled: true,
-			});
+			const server = repo.create({ name: 'minimal', sourceType: 'stdio' });
 
 			expect(server.description).toBeUndefined();
 			expect(server.command).toBeUndefined();
@@ -106,11 +110,51 @@ describe('AppMcpServerRepository', () => {
 			expect(server.headers).toBeUndefined();
 		});
 
+		test('throws when name is already taken', () => {
+			repo.create({ name: 'duplicate', sourceType: 'stdio' });
+			expect(() => repo.create({ name: 'duplicate', sourceType: 'sse', url: 'http://x' })).toThrow(
+				'already exists'
+			);
+		});
+
+		test('throws when sourceType is invalid', () => {
+			expect(() =>
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				repo.create({ name: 'bad-type', sourceType: 'docker' as any })
+			).toThrow('Invalid sourceType');
+		});
+
 		test('calls notifyChange("app_mcp_servers") after create', () => {
 			notifyChangeSpy.mockClear();
-			repo.create({ name: 'notify-test', sourceType: 'stdio', enabled: true });
+			repo.create({ name: 'notify-test', sourceType: 'stdio' });
 			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
 			expect(notifyChangeSpy).toHaveBeenCalledWith('app_mcp_servers');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// isNameTaken
+	// ---------------------------------------------------------------------------
+
+	describe('isNameTaken', () => {
+		test('returns false when name is not in use', () => {
+			expect(repo.isNameTaken('unused')).toBe(false);
+		});
+
+		test('returns true when name is taken', () => {
+			repo.create({ name: 'taken', sourceType: 'stdio' });
+			expect(repo.isNameTaken('taken')).toBe(true);
+		});
+
+		test('returns false when name is taken by the excluded id (self-rename)', () => {
+			const server = repo.create({ name: 'self', sourceType: 'stdio' });
+			expect(repo.isNameTaken('self', server.id)).toBe(false);
+		});
+
+		test('returns true when name is taken by a different id', () => {
+			repo.create({ name: 'other', sourceType: 'stdio' });
+			const server2 = repo.create({ name: 'server2', sourceType: 'stdio' });
+			expect(repo.isNameTaken('other', server2.id)).toBe(true);
 		});
 	});
 
@@ -120,7 +164,7 @@ describe('AppMcpServerRepository', () => {
 
 	describe('get', () => {
 		test('returns server by id', () => {
-			const created = repo.create({ name: 'get-test', sourceType: 'stdio', enabled: true });
+			const created = repo.create({ name: 'get-test', sourceType: 'stdio' });
 			const fetched = repo.get(created.id);
 			expect(fetched).not.toBeNull();
 			expect(fetched!.id).toBe(created.id);
@@ -137,7 +181,7 @@ describe('AppMcpServerRepository', () => {
 
 	describe('getByName', () => {
 		test('returns server by name', () => {
-			repo.create({ name: 'named-server', sourceType: 'http', url: 'http://x', enabled: true });
+			repo.create({ name: 'named-server', sourceType: 'http', url: 'http://x' });
 			const found = repo.getByName('named-server');
 			expect(found).not.toBeNull();
 			expect(found!.name).toBe('named-server');
@@ -154,9 +198,9 @@ describe('AppMcpServerRepository', () => {
 
 	describe('list', () => {
 		test('returns all servers ordered by created_at', () => {
-			repo.create({ name: 'alpha', sourceType: 'stdio', enabled: true });
+			repo.create({ name: 'alpha', sourceType: 'stdio' });
 			repo.create({ name: 'beta', sourceType: 'stdio', enabled: false });
-			repo.create({ name: 'gamma', sourceType: 'http', url: 'http://g', enabled: true });
+			repo.create({ name: 'gamma', sourceType: 'http', url: 'http://g' });
 
 			const all = repo.list();
 			expect(all).toHaveLength(3);
@@ -169,6 +213,19 @@ describe('AppMcpServerRepository', () => {
 		test('returns empty array when no servers exist', () => {
 			expect(repo.list()).toHaveLength(0);
 		});
+
+		test('rows with null created_at sort after rows with a timestamp', () => {
+			// Insert a row directly with null created_at to simulate migrated data
+			const nullId = 'null-created';
+			bunDb.exec(
+				`INSERT INTO app_mcp_servers (id, name, source_type, enabled) VALUES ('${nullId}', 'null-ts', 'stdio', 1)`
+			);
+			repo.create({ name: 'real-ts', sourceType: 'stdio' });
+
+			const all = repo.list();
+			expect(all[0].name).toBe('real-ts');
+			expect(all[1].name).toBe('null-ts');
+		});
 	});
 
 	// ---------------------------------------------------------------------------
@@ -177,9 +234,9 @@ describe('AppMcpServerRepository', () => {
 
 	describe('listEnabled', () => {
 		test('returns only enabled servers', () => {
-			repo.create({ name: 'enabled-1', sourceType: 'stdio', enabled: true });
+			repo.create({ name: 'enabled-1', sourceType: 'stdio' });
 			repo.create({ name: 'disabled-1', sourceType: 'stdio', enabled: false });
-			repo.create({ name: 'enabled-2', sourceType: 'http', url: 'http://e2', enabled: true });
+			repo.create({ name: 'enabled-2', sourceType: 'http', url: 'http://e2' });
 
 			const enabled = repo.listEnabled();
 			expect(enabled).toHaveLength(2);
@@ -202,7 +259,7 @@ describe('AppMcpServerRepository', () => {
 
 	describe('update', () => {
 		test('updates name and description', () => {
-			const server = repo.create({ name: 'old-name', sourceType: 'stdio', enabled: true });
+			const server = repo.create({ name: 'old-name', sourceType: 'stdio' });
 			const updated = repo.update(server.id, { name: 'new-name', description: 'A description' });
 
 			expect(updated).not.toBeNull();
@@ -211,19 +268,14 @@ describe('AppMcpServerRepository', () => {
 		});
 
 		test('updates enabled flag', () => {
-			const server = repo.create({ name: 'toggle', sourceType: 'stdio', enabled: true });
+			const server = repo.create({ name: 'toggle', sourceType: 'stdio' });
 			const updated = repo.update(server.id, { enabled: false });
 
 			expect(updated!.enabled).toBe(false);
 		});
 
 		test('updates args and env as JSON', () => {
-			const server = repo.create({
-				name: 'json-fields',
-				sourceType: 'stdio',
-				command: 'node',
-				enabled: true,
-			});
+			const server = repo.create({ name: 'json-fields', sourceType: 'stdio', command: 'node' });
 			const updated = repo.update(server.id, {
 				args: ['--port', '3000'],
 				env: { PORT: '3000' },
@@ -237,8 +289,29 @@ describe('AppMcpServerRepository', () => {
 			expect(repo.update('nonexistent', { name: 'x' })).toBeNull();
 		});
 
+		test('throws when new name is already taken by another entry', () => {
+			repo.create({ name: 'existing', sourceType: 'stdio' });
+			const server = repo.create({ name: 'rename-me', sourceType: 'stdio' });
+			expect(() => repo.update(server.id, { name: 'existing' })).toThrow('already exists');
+		});
+
+		test('allows renaming to its own current name (self-rename)', () => {
+			const server = repo.create({ name: 'same-name', sourceType: 'stdio' });
+			const updated = repo.update(server.id, { name: 'same-name', description: 'changed' });
+			expect(updated!.name).toBe('same-name');
+			expect(updated!.description).toBe('changed');
+		});
+
+		test('throws when sourceType update is invalid', () => {
+			const server = repo.create({ name: 'bad-update', sourceType: 'stdio' });
+			expect(() =>
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				repo.update(server.id, { sourceType: 'docker' as any })
+			).toThrow('Invalid sourceType');
+		});
+
 		test('calls notifyChange("app_mcp_servers") after update', () => {
-			const server = repo.create({ name: 'notify-update', sourceType: 'stdio', enabled: true });
+			const server = repo.create({ name: 'notify-update', sourceType: 'stdio' });
 			notifyChangeSpy.mockClear();
 			repo.update(server.id, { description: 'updated' });
 			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
@@ -246,9 +319,8 @@ describe('AppMcpServerRepository', () => {
 		});
 
 		test('does not call notifyChange when no fields are changed', () => {
-			const server = repo.create({ name: 'no-change', sourceType: 'stdio', enabled: true });
+			const server = repo.create({ name: 'no-change', sourceType: 'stdio' });
 			notifyChangeSpy.mockClear();
-			// Call update with an empty updates object (no fields to set)
 			repo.update(server.id, {});
 			expect(notifyChangeSpy).not.toHaveBeenCalled();
 		});
@@ -260,7 +332,7 @@ describe('AppMcpServerRepository', () => {
 
 	describe('delete', () => {
 		test('deletes an existing entry and returns true', () => {
-			const server = repo.create({ name: 'to-delete', sourceType: 'stdio', enabled: true });
+			const server = repo.create({ name: 'to-delete', sourceType: 'stdio' });
 			const result = repo.delete(server.id);
 
 			expect(result).toBe(true);
@@ -272,7 +344,7 @@ describe('AppMcpServerRepository', () => {
 		});
 
 		test('calls notifyChange("app_mcp_servers") after delete', () => {
-			const server = repo.create({ name: 'notify-delete', sourceType: 'stdio', enabled: true });
+			const server = repo.create({ name: 'notify-delete', sourceType: 'stdio' });
 			notifyChangeSpy.mockClear();
 			repo.delete(server.id);
 			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);

--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -19,6 +19,7 @@ export * from './types/github.ts';
 export * from './types/space.ts';
 export * from './types/space-utils.ts';
 export * from './types/tools.ts';
+export * from './types/app-mcp-server.ts';
 export * from './live-query-types.ts';
 export * from './prompts/index.ts';
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2,6 +2,13 @@ import type { SettingSource } from './types/settings.ts';
 import type { ResolvedQuestion } from './state-types.ts';
 import type { SDKConfig, ToolsPresetConfig } from './types/sdk-config.ts';
 
+export type {
+	AppMcpServerSourceType,
+	AppMcpServer,
+	CreateAppMcpServerRequest,
+	UpdateAppMcpServerRequest,
+} from './types/app-mcp-server.ts';
+
 // Re-export SDK config types for convenience
 export type {
 	SDKConfig,

--- a/packages/shared/src/types/app-mcp-server.ts
+++ b/packages/shared/src/types/app-mcp-server.ts
@@ -1,0 +1,59 @@
+/**
+ * Application-level MCP Server Registry Types
+ *
+ * These types define the schema for MCP servers registered at the application level.
+ * Registered servers are available to any room or session that enables them.
+ *
+ * Env var handling note:
+ * The `env` field stores plain JSON key-value pairs intended for non-secret configuration.
+ * For secrets such as BRAVE_API_KEY, the field stores a reference key and the actual value
+ * is read from the system environment at spawn time (process.env[key]). Do NOT store raw
+ * secret values in SQLite.
+ */
+
+export type AppMcpServerSourceType = 'stdio' | 'sse' | 'http';
+
+/**
+ * An MCP server registered at the application level.
+ */
+export interface AppMcpServer {
+	/** Unique identifier (UUID) */
+	id: string;
+	/** Human-readable name, unique across the registry */
+	name: string;
+	/** Optional description of what the server provides */
+	description?: string;
+	/** Transport type: stdio, SSE, or HTTP */
+	sourceType: AppMcpServerSourceType;
+	/** Executable command (stdio servers) */
+	command?: string;
+	/** Command arguments (stdio servers) */
+	args?: string[];
+	/**
+	 * Environment variable overrides for the server process (stdio servers).
+	 * Values are non-secret config or reference keys (e.g. "BRAVE_API_KEY" → read from process.env).
+	 */
+	env?: Record<string, string>;
+	/** Server URL (SSE or HTTP servers) */
+	url?: string;
+	/** Additional HTTP headers (SSE or HTTP servers) */
+	headers?: Record<string, string>;
+	/** Whether this server is enabled globally */
+	enabled: boolean;
+	/** Unix timestamp (ms) when the record was created */
+	createdAt?: number;
+	/** Unix timestamp (ms) when the record was last updated */
+	updatedAt?: number;
+}
+
+/**
+ * Request payload to create a new application-level MCP server entry.
+ * `id` is generated server-side.
+ */
+export type CreateAppMcpServerRequest = Omit<AppMcpServer, 'id'>;
+
+/**
+ * Request payload to update an existing application-level MCP server entry.
+ * All fields except `id` are optional.
+ */
+export type UpdateAppMcpServerRequest = { id: string } & Partial<Omit<AppMcpServer, 'id'>>;

--- a/packages/shared/src/types/app-mcp-server.ts
+++ b/packages/shared/src/types/app-mcp-server.ts
@@ -48,9 +48,11 @@ export interface AppMcpServer {
 
 /**
  * Request payload to create a new application-level MCP server entry.
- * `id` is generated server-side.
+ * `id` is generated server-side. `enabled` defaults to `true` if omitted.
  */
-export type CreateAppMcpServerRequest = Omit<AppMcpServer, 'id'>;
+export type CreateAppMcpServerRequest = Omit<AppMcpServer, 'id' | 'enabled'> & {
+	enabled?: boolean;
+};
 
 /**
  * Request payload to update an existing application-level MCP server entry.


### PR DESCRIPTION
- Add `app_mcp_servers` SQLite table to schema/index.ts with columns for
  stdio/sse/http transport types, JSON-encoded args/env/headers, and enabled flag
- Add migration 49 to create the table incrementally on existing databases
- Add AppMcpServer types to @neokai/shared (AppMcpServer, AppMcpServerSourceType,
  CreateAppMcpServerRequest, UpdateAppMcpServerRequest)
- Implement AppMcpServerRepository with create/get/getByName/list/listEnabled/update/delete;
  each write calls reactiveDb.notifyChange('app_mcp_servers') for LiveQuery invalidation
- Wire repository into Database facade as `appMcpServers` getter
- Add 23 unit tests covering CRUD, listEnabled filtering, and notifyChange calls
