### PR TITLE
feat(mcp): add AppMcpLifecycleManager class and wire mcp.registry.listErrors RPC

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -24,6 +24,7 @@ import { JobQueueRepository } from './storage/repositories/job-queue-repository'
 import { JobQueueProcessor } from './storage/job-queue-processor';
 import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
 import { JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
+import { AppMcpLifecycleManager } from './lib/mcp';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -71,6 +72,8 @@ export interface DaemonAppContext {
 	jobQueue: JobQueueRepository;
 	/** Persistent job queue processor */
 	jobProcessor: JobQueueProcessor;
+	/** Application-level MCP lifecycle manager — converts registry entries to SDK configs */
+	appMcpManager: AppMcpLifecycleManager;
 	/**
 	 * Cleanup function for graceful shutdown.
 	 * Closes all connections, stops sessions, and closes database.
@@ -260,6 +263,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		logInfo('[Daemon] GitHub integration disabled - authentication required');
 	}
 
+	// Instantiate application-level MCP lifecycle manager
+	const appMcpManager = new AppMcpLifecycleManager(db);
+
 	// Setup RPC handlers (returns cleanup function + exposed services)
 	const {
 		cleanup: rpcHandlerCleanup,
@@ -280,6 +286,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		jobProcessor,
 		reactiveDb,
 		liveQueries,
+		appMcpManager,
 	});
 
 	// Create WebSocket handlers
@@ -531,6 +538,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		taskAgentManager,
 		jobQueue,
 		jobProcessor,
+		appMcpManager,
 		cleanup,
 	};
 }

--- a/packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts
@@ -16,22 +16,21 @@
  */
 
 import type { Database } from '../../storage/database';
-import type { AppMcpServer } from '@neokai/shared';
 import type {
+	AppMcpServer,
 	McpServerConfig,
 	McpStdioServerConfig,
 	McpSSEServerConfig,
 	McpHttpServerConfig,
+	ValidationResult,
 } from '@neokai/shared';
+
+// Re-export so callers can import from this module without reaching into shared.
+export type { ValidationResult } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-export interface ValidationResult {
-	valid: boolean;
-	error?: string;
-}
 
 export interface McpStartupError {
 	serverId: string;
@@ -61,10 +60,7 @@ export class AppMcpLifecycleManager {
 				continue;
 			}
 
-			const config = this.convertEntry(entry);
-			if (config !== null) {
-				result[entry.name] = config;
-			}
+			result[entry.name] = this.convertEntry(entry);
 		}
 
 		return result;
@@ -152,7 +148,7 @@ export class AppMcpLifecycleManager {
 	// Private helpers
 	// ---------------------------------------------------------------------------
 
-	private convertEntry(entry: AppMcpServer): McpServerConfig | null {
+	private convertEntry(entry: AppMcpServer): McpServerConfig {
 		switch (entry.sourceType) {
 			case 'stdio': {
 				const config: McpStdioServerConfig = {
@@ -186,8 +182,10 @@ export class AppMcpLifecycleManager {
 				return config;
 			}
 
-			default:
-				return null;
+			default: {
+				const exhaustive: never = entry.sourceType;
+				throw new Error(`convertEntry: unhandled sourceType "${exhaustive}"`);
+			}
 		}
 	}
 }

--- a/packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts
@@ -1,0 +1,193 @@
+/**
+ * AppMcpLifecycleManager
+ *
+ * Converts application-level MCP registry entries into SDK McpServerConfig objects
+ * ready for injection into agent sessions.
+ *
+ * Responsibilities:
+ * - Reads the app_mcp_servers registry via the Database facade.
+ * - Filters to enabled entries.
+ * - Converts each entry to the appropriate SDK config type (stdio / sse / http).
+ * - Validates entries and exposes startup errors for the UI warning badge.
+ *
+ * Health-checking and auto-restart are intentionally deferred to a future
+ * iteration and MUST use JobQueueProcessor (following the github.poll pattern)
+ * rather than setInterval or in-memory state.
+ */
+
+import type { Database } from '../../storage/database';
+import type { AppMcpServer } from '@neokai/shared';
+import type {
+	McpServerConfig,
+	McpStdioServerConfig,
+	McpSSEServerConfig,
+	McpHttpServerConfig,
+} from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+	valid: boolean;
+	error?: string;
+}
+
+export interface McpStartupError {
+	serverId: string;
+	name: string;
+	error: string;
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+export class AppMcpLifecycleManager {
+	constructor(private readonly db: Database) {}
+
+	/**
+	 * Returns SDK MCP configs for all globally-enabled registry entries.
+	 * Invalid entries (e.g. missing required fields) are silently skipped —
+	 * call `getStartupErrors()` to surface them to the UI.
+	 */
+	getEnabledMcpConfigs(): Record<string, McpServerConfig> {
+		const entries = this.db.appMcpServers.listEnabled();
+		const result: Record<string, McpServerConfig> = {};
+
+		for (const entry of entries) {
+			const validation = this.validateEntry(entry);
+			if (!validation.valid) {
+				continue;
+			}
+
+			const config = this.convertEntry(entry);
+			if (config !== null) {
+				result[entry.name] = config;
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns SDK MCP configs for a specific room.
+	 *
+	 * Stub: Milestone 4 will add the `room_mcp_enablement` table and per-room
+	 * filtering. Until then this falls back to the global enabled set.
+	 */
+	getEnabledMcpConfigsForRoom(_roomId: string): Record<string, McpServerConfig> {
+		// TODO (Milestone 4): Query room_mcp_enablement for roomId and filter accordingly.
+		return this.getEnabledMcpConfigs();
+	}
+
+	/**
+	 * Validates a single registry entry, checking that required fields are
+	 * present for its source type.
+	 */
+	validateEntry(entry: AppMcpServer): ValidationResult {
+		switch (entry.sourceType) {
+			case 'stdio':
+				if (!entry.command || entry.command.trim() === '') {
+					return {
+						valid: false,
+						error: `stdio server "${entry.name}" is missing required field: command`,
+					};
+				}
+				return { valid: true };
+
+			case 'sse':
+				if (!entry.url || entry.url.trim() === '') {
+					return {
+						valid: false,
+						error: `sse server "${entry.name}" is missing required field: url`,
+					};
+				}
+				return { valid: true };
+
+			case 'http':
+				if (!entry.url || entry.url.trim() === '') {
+					return {
+						valid: false,
+						error: `http server "${entry.name}" is missing required field: url`,
+					};
+				}
+				return { valid: true };
+
+			default: {
+				const exhaustive: never = entry.sourceType;
+				return {
+					valid: false,
+					error: `server "${entry.name}" has unknown sourceType: ${exhaustive}`,
+				};
+			}
+		}
+	}
+
+	/**
+	 * Returns all registry entries (enabled or disabled) that fail validation.
+	 * Exposed via the `mcp.registry.listErrors` RPC so the UI can render a
+	 * warning badge next to misconfigured entries.
+	 */
+	getStartupErrors(): McpStartupError[] {
+		// Check all entries (not just enabled) so users can see invalid drafts too.
+		const allEntries = this.db.appMcpServers.list();
+		const errors: McpStartupError[] = [];
+
+		for (const entry of allEntries) {
+			const validation = this.validateEntry(entry);
+			if (!validation.valid) {
+				errors.push({
+					serverId: entry.id,
+					name: entry.name,
+					error: validation.error ?? 'Unknown validation error',
+				});
+			}
+		}
+
+		return errors;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Private helpers
+	// ---------------------------------------------------------------------------
+
+	private convertEntry(entry: AppMcpServer): McpServerConfig | null {
+		switch (entry.sourceType) {
+			case 'stdio': {
+				const config: McpStdioServerConfig = {
+					type: 'stdio',
+					command: entry.command!,
+					...(entry.args && entry.args.length > 0 ? { args: entry.args } : {}),
+					...(entry.env && Object.keys(entry.env).length > 0 ? { env: entry.env } : {}),
+				};
+				return config;
+			}
+
+			case 'sse': {
+				const config: McpSSEServerConfig = {
+					type: 'sse',
+					url: entry.url!,
+					...(entry.headers && Object.keys(entry.headers).length > 0
+						? { headers: entry.headers }
+						: {}),
+				};
+				return config;
+			}
+
+			case 'http': {
+				const config: McpHttpServerConfig = {
+					type: 'http',
+					url: entry.url!,
+					...(entry.headers && Object.keys(entry.headers).length > 0
+						? { headers: entry.headers }
+						: {}),
+				};
+				return config;
+			}
+
+			default:
+				return null;
+		}
+	}
+}

--- a/packages/daemon/src/lib/mcp/index.ts
+++ b/packages/daemon/src/lib/mcp/index.ts
@@ -1,0 +1,2 @@
+export { AppMcpLifecycleManager } from './app-mcp-lifecycle-manager';
+export type { ValidationResult, McpStartupError } from './app-mcp-lifecycle-manager';

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -73,6 +73,7 @@ import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
 import { setupSpaceSessionGroupHandlers } from './space-session-group-handlers';
 import { setupLiveQueryHandlers } from './live-query-handlers';
 import { LiveQueryEngine } from '../../storage/live-query';
+import type { AppMcpLifecycleManager } from '../mcp';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -101,6 +102,8 @@ export interface RPCHandlerDependencies {
 	reactiveDb: ReactiveDatabase;
 	/** Live query engine for reactive SQL subscriptions */
 	liveQueries: LiveQueryEngine;
+	/** Application-level MCP lifecycle manager */
+	appMcpManager: AppMcpLifecycleManager;
 }
 
 const log = new Logger('rpc-handlers');
@@ -158,7 +161,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// so that it can receive a runtime session lookup function. Room worker/leader
 	// sessions live in RoomRuntimeService.agentSessions (separate from SessionManager),
 	// so the handler needs to check the runtime pool first.
-	registerMcpHandlers(deps.messageHub, deps.sessionManager);
+	registerMcpHandlers(deps.messageHub, deps.sessionManager, deps.appMcpManager);
 	registerSettingsHandlers(deps.messageHub, deps.settingsManager, deps.daemonHub, deps.db);
 	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 	// Use reactiveDb.db so test-injected sdk_messages rows also invalidate LiveQuery.

--- a/packages/daemon/src/lib/rpc-handlers/mcp-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/mcp-handlers.ts
@@ -11,10 +11,15 @@
 
 import type { MessageHub, ToolsConfig, GlobalToolsConfig } from '@neokai/shared';
 import type { SessionManager } from '../session-manager';
+import type { AppMcpLifecycleManager } from '../mcp';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-export function registerMcpHandlers(messageHub: MessageHub, sessionManager: SessionManager): void {
+export function registerMcpHandlers(
+	messageHub: MessageHub,
+	sessionManager: SessionManager,
+	appMcpManager: AppMcpLifecycleManager
+): void {
 	/**
 	 * Save tools configuration for a session
 	 *
@@ -135,5 +140,17 @@ export function registerMcpHandlers(messageHub: MessageHub, sessionManager: Sess
 	 */
 	messageHub.onRequest('globalTools.saveConfig', async (data: { config: GlobalToolsConfig }) => {
 		sessionManager.saveGlobalToolsConfig(data.config);
+	});
+
+	// ============================================================================
+	// Application-level MCP Registry
+	// ============================================================================
+
+	/**
+	 * List registry entries that failed validation (missing required fields, etc.).
+	 * The UI uses this to render a warning badge next to misconfigured entries.
+	 */
+	messageHub.onRequest('mcp.registry.listErrors', async () => {
+		return appMcpManager.getStartupErrors();
 	});
 }

--- a/packages/daemon/tests/unit/mcp/app-mcp-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/mcp/app-mcp-lifecycle-manager.test.ts
@@ -1,0 +1,412 @@
+/**
+ * AppMcpLifecycleManager Unit Tests
+ *
+ * Covers:
+ * - Conversion of stdio / sse / http entries to the correct SDK config shape.
+ * - Disabled entries are excluded from getEnabledMcpConfigs().
+ * - validateEntry() catches missing required fields.
+ * - getStartupErrors() returns invalid entries with descriptive messages.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import { AppMcpServerRepository } from '../../../src/storage/repositories/app-mcp-server-repository';
+import { AppMcpLifecycleManager } from '../../../src/lib/mcp';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+import type { Database } from '../../../src/storage/database';
+
+// ---------------------------------------------------------------------------
+// Minimal Database facade stub
+// ---------------------------------------------------------------------------
+
+function createTestDb(): { bunDb: BunDatabase; reactiveDb: ReactiveDatabase; db: Database } {
+	const bunDb = new BunDatabase(':memory:');
+	createTables(bunDb);
+	const reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+	const repo = new AppMcpServerRepository(bunDb, reactiveDb);
+
+	// Build a minimal Database facade that exposes appMcpServers
+	const db = {
+		appMcpServers: repo,
+	} as unknown as Database;
+
+	return { bunDb, reactiveDb, db };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AppMcpLifecycleManager', () => {
+	let bunDb: BunDatabase;
+	let db: Database;
+	let manager: AppMcpLifecycleManager;
+	let repo: AppMcpServerRepository;
+
+	beforeEach(() => {
+		const setup = createTestDb();
+		bunDb = setup.bunDb;
+		db = setup.db;
+		repo = db.appMcpServers as unknown as AppMcpServerRepository;
+		manager = new AppMcpLifecycleManager(db);
+	});
+
+	afterEach(() => {
+		bunDb.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// getEnabledMcpConfigs — stdio conversion
+	// -------------------------------------------------------------------------
+
+	describe('getEnabledMcpConfigs — stdio', () => {
+		test('converts a stdio entry to McpStdioServerConfig', () => {
+			repo.create({
+				name: 'brave-search',
+				sourceType: 'stdio',
+				command: 'npx',
+				args: ['-y', '@modelcontextprotocol/server-brave-search'],
+				env: { BRAVE_API_KEY: 'BRAVE_API_KEY' },
+			});
+
+			const configs = manager.getEnabledMcpConfigs();
+
+			expect(configs['brave-search']).toBeDefined();
+			expect(configs['brave-search'].type).toBe('stdio');
+
+			const stdioConfig = configs['brave-search'] as {
+				type: string;
+				command: string;
+				args: string[];
+				env: Record<string, string>;
+			};
+			expect(stdioConfig.command).toBe('npx');
+			expect(stdioConfig.args).toEqual(['-y', '@modelcontextprotocol/server-brave-search']);
+			expect(stdioConfig.env).toEqual({ BRAVE_API_KEY: 'BRAVE_API_KEY' });
+		});
+
+		test('stdio entry without optional args/env omits those fields', () => {
+			repo.create({
+				name: 'minimal-stdio',
+				sourceType: 'stdio',
+				command: 'my-server',
+			});
+
+			const configs = manager.getEnabledMcpConfigs();
+			const config = configs['minimal-stdio'] as {
+				command: string;
+				args?: string[];
+				env?: Record<string, string>;
+			};
+
+			expect(config.command).toBe('my-server');
+			expect(config.args).toBeUndefined();
+			expect(config.env).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// getEnabledMcpConfigs — sse conversion
+	// -------------------------------------------------------------------------
+
+	describe('getEnabledMcpConfigs — sse', () => {
+		test('converts an sse entry to McpSSEServerConfig', () => {
+			repo.create({
+				name: 'remote-sse',
+				sourceType: 'sse',
+				url: 'https://example.com/sse',
+				headers: { Authorization: 'Bearer token' },
+			});
+
+			const configs = manager.getEnabledMcpConfigs();
+
+			expect(configs['remote-sse']).toBeDefined();
+			expect(configs['remote-sse'].type).toBe('sse');
+
+			const sseConfig = configs['remote-sse'] as {
+				type: string;
+				url: string;
+				headers: Record<string, string>;
+			};
+			expect(sseConfig.url).toBe('https://example.com/sse');
+			expect(sseConfig.headers).toEqual({ Authorization: 'Bearer token' });
+		});
+
+		test('sse entry without headers omits the headers field', () => {
+			repo.create({
+				name: 'plain-sse',
+				sourceType: 'sse',
+				url: 'https://example.com/sse',
+			});
+
+			const configs = manager.getEnabledMcpConfigs();
+			const config = configs['plain-sse'] as { headers?: Record<string, string> };
+
+			expect(config.headers).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// getEnabledMcpConfigs — http conversion
+	// -------------------------------------------------------------------------
+
+	describe('getEnabledMcpConfigs — http', () => {
+		test('converts an http entry to McpHttpServerConfig', () => {
+			repo.create({
+				name: 'remote-http',
+				sourceType: 'http',
+				url: 'https://example.com/mcp',
+				headers: { 'X-API-Key': 'secret' },
+			});
+
+			const configs = manager.getEnabledMcpConfigs();
+
+			expect(configs['remote-http']).toBeDefined();
+			expect(configs['remote-http'].type).toBe('http');
+
+			const httpConfig = configs['remote-http'] as {
+				type: string;
+				url: string;
+				headers: Record<string, string>;
+			};
+			expect(httpConfig.url).toBe('https://example.com/mcp');
+			expect(httpConfig.headers).toEqual({ 'X-API-Key': 'secret' });
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Disabled entries excluded
+	// -------------------------------------------------------------------------
+
+	describe('disabled entries', () => {
+		test('disabled entries are excluded from getEnabledMcpConfigs()', () => {
+			repo.create({
+				name: 'enabled-server',
+				sourceType: 'stdio',
+				command: 'my-server',
+				enabled: true,
+			});
+			repo.create({
+				name: 'disabled-server',
+				sourceType: 'stdio',
+				command: 'another-server',
+				enabled: false,
+			});
+
+			const configs = manager.getEnabledMcpConfigs();
+
+			expect(configs['enabled-server']).toBeDefined();
+			expect(configs['disabled-server']).toBeUndefined();
+		});
+
+		test('returns empty record when all entries are disabled', () => {
+			repo.create({
+				name: 'disabled-server',
+				sourceType: 'stdio',
+				command: 'my-server',
+				enabled: false,
+			});
+
+			const configs = manager.getEnabledMcpConfigs();
+			expect(Object.keys(configs)).toHaveLength(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// validateEntry
+	// -------------------------------------------------------------------------
+
+	describe('validateEntry', () => {
+		test('valid stdio entry passes validation', () => {
+			const result = manager.validateEntry({
+				id: 'test-id',
+				name: 'test',
+				sourceType: 'stdio',
+				command: 'npx',
+				enabled: true,
+			});
+
+			expect(result.valid).toBe(true);
+			expect(result.error).toBeUndefined();
+		});
+
+		test('stdio entry missing command fails validation', () => {
+			const result = manager.validateEntry({
+				id: 'test-id',
+				name: 'broken-stdio',
+				sourceType: 'stdio',
+				enabled: true,
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain('command');
+			expect(result.error).toContain('broken-stdio');
+		});
+
+		test('stdio entry with empty command fails validation', () => {
+			const result = manager.validateEntry({
+				id: 'test-id',
+				name: 'empty-cmd',
+				sourceType: 'stdio',
+				command: '   ',
+				enabled: true,
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain('command');
+		});
+
+		test('valid sse entry passes validation', () => {
+			const result = manager.validateEntry({
+				id: 'test-id',
+				name: 'test-sse',
+				sourceType: 'sse',
+				url: 'https://example.com/sse',
+				enabled: true,
+			});
+
+			expect(result.valid).toBe(true);
+		});
+
+		test('sse entry missing url fails validation', () => {
+			const result = manager.validateEntry({
+				id: 'test-id',
+				name: 'broken-sse',
+				sourceType: 'sse',
+				enabled: true,
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain('url');
+			expect(result.error).toContain('broken-sse');
+		});
+
+		test('valid http entry passes validation', () => {
+			const result = manager.validateEntry({
+				id: 'test-id',
+				name: 'test-http',
+				sourceType: 'http',
+				url: 'https://example.com/mcp',
+				enabled: true,
+			});
+
+			expect(result.valid).toBe(true);
+		});
+
+		test('http entry missing url fails validation', () => {
+			const result = manager.validateEntry({
+				id: 'test-id',
+				name: 'broken-http',
+				sourceType: 'http',
+				enabled: true,
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain('url');
+			expect(result.error).toContain('broken-http');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// getStartupErrors
+	// -------------------------------------------------------------------------
+
+	describe('getStartupErrors', () => {
+		test('returns empty array when all entries are valid', () => {
+			repo.create({
+				name: 'valid-stdio',
+				sourceType: 'stdio',
+				command: 'my-server',
+			});
+			repo.create({
+				name: 'valid-sse',
+				sourceType: 'sse',
+				url: 'https://example.com/sse',
+			});
+
+			const errors = manager.getStartupErrors();
+			expect(errors).toHaveLength(0);
+		});
+
+		test('returns invalid entries with descriptive error messages', () => {
+			repo.create({
+				name: 'broken-stdio',
+				sourceType: 'stdio',
+				// no command
+			});
+			repo.create({
+				name: 'broken-sse',
+				sourceType: 'sse',
+				// no url
+			});
+			repo.create({
+				name: 'valid-http',
+				sourceType: 'http',
+				url: 'https://example.com/mcp',
+			});
+
+			const errors = manager.getStartupErrors();
+
+			expect(errors).toHaveLength(2);
+
+			const names = errors.map((e) => e.name);
+			expect(names).toContain('broken-stdio');
+			expect(names).toContain('broken-sse');
+
+			const stdioError = errors.find((e) => e.name === 'broken-stdio')!;
+			expect(stdioError.error).toContain('command');
+			expect(stdioError.serverId).toBeTruthy();
+
+			const sseError = errors.find((e) => e.name === 'broken-sse')!;
+			expect(sseError.error).toContain('url');
+			expect(sseError.serverId).toBeTruthy();
+		});
+
+		test('includes disabled invalid entries (not just enabled ones)', () => {
+			repo.create({
+				name: 'disabled-broken',
+				sourceType: 'stdio',
+				enabled: false,
+				// no command
+			});
+
+			const errors = manager.getStartupErrors();
+			expect(errors).toHaveLength(1);
+			expect(errors[0].name).toBe('disabled-broken');
+		});
+
+		test('includes serverId matching the registry entry id', () => {
+			const server = repo.create({
+				name: 'broken-server',
+				sourceType: 'http',
+				// no url
+			});
+
+			const errors = manager.getStartupErrors();
+			expect(errors).toHaveLength(1);
+			expect(errors[0].serverId).toBe(server.id);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// getEnabledMcpConfigsForRoom (stub)
+	// -------------------------------------------------------------------------
+
+	describe('getEnabledMcpConfigsForRoom', () => {
+		test('falls back to global enabled configs (stub behavior)', () => {
+			repo.create({
+				name: 'global-server',
+				sourceType: 'stdio',
+				command: 'my-server',
+				enabled: true,
+			});
+
+			const globalConfigs = manager.getEnabledMcpConfigs();
+			const roomConfigs = manager.getEnabledMcpConfigsForRoom('room-123');
+
+			expect(roomConfigs).toEqual(globalConfigs);
+		});
+	});
+});


### PR DESCRIPTION
- Create packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts with:
  - getEnabledMcpConfigs(): converts enabled registry entries to SDK McpServerConfig
  - getEnabledMcpConfigsForRoom(): stub that falls back to global enabled configs
  - validateEntry(): checks required fields per source type (stdio needs command, sse/http need url)
  - getStartupErrors(): returns all invalid entries for UI warning badge
- Create packages/daemon/src/lib/mcp/index.ts re-exporting the manager
- Instantiate AppMcpLifecycleManager in app.ts and expose as appMcpManager in DaemonAppContext
- Register mcp.registry.listErrors RPC handler in mcp-handlers.ts
- Add 19 unit tests covering stdio/sse/http conversion, disabled filtering, validation, and error reporting
