### PR TITLE
feat(rpc): add MCP registry CRUD handlers and mcpServers.global LiveQuery

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -336,6 +336,16 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		inboxItemId: string;
 	};
 
+	// App-level MCP registry events
+	/**
+	 * Emitted by app-mcp-handlers on create/update/delete/setEnabled.
+	 * Used by RoomRuntimeService (Task 3.2) for hot-reload of MCP server lists.
+	 * This is separate from LiveQuery — both are emitted on every write.
+	 */
+	'mcp.registry.changed': {
+		sessionId: string;
+	};
+
 	// Goal events
 	'goal.created': {
 		sessionId: string;

--- a/packages/daemon/src/lib/rpc-handlers/app-mcp-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/app-mcp-handlers.ts
@@ -1,0 +1,154 @@
+/**
+ * App MCP Registry RPC Handlers
+ *
+ * Exposes the application-level MCP server registry via RPC:
+ * - mcp.registry.list       — list all registry entries
+ * - mcp.registry.get        — get a single entry by id
+ * - mcp.registry.create     — add a new entry, emit mcp.registry.changed
+ * - mcp.registry.update     — update an entry, emit mcp.registry.changed
+ * - mcp.registry.delete     — remove an entry, emit mcp.registry.changed
+ * - mcp.registry.setEnabled — toggle enabled flag, emit mcp.registry.changed
+ *
+ * Note: mcp.registry.listErrors is registered in mcp-handlers.ts (requires
+ * the concrete AppMcpLifecycleManager).
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type {
+	AppMcpServer,
+	CreateAppMcpServerRequest,
+	UpdateAppMcpServerRequest,
+} from '@neokai/shared';
+import type { DaemonHub } from '../daemon-hub';
+import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
+import { Logger } from '../logger';
+
+const log = new Logger('app-mcp-handlers');
+
+// ---------------------------------------------------------------------------
+// Handler context
+// ---------------------------------------------------------------------------
+
+export interface AppMcpHandlerContext {
+	db: { appMcpServers: AppMcpServerRepository };
+	daemonHub: DaemonHub;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emitChanged(daemonHub: DaemonHub): void {
+	daemonHub.emit('mcp.registry.changed', { sessionId: 'global' }).catch((err) => {
+		log.warn('Failed to emit mcp.registry.changed:', err);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Handler registration
+// ---------------------------------------------------------------------------
+
+export function registerAppMcpHandlers(messageHub: MessageHub, ctx: AppMcpHandlerContext): void {
+	const { db, daemonHub } = ctx;
+
+	// mcp.registry.list — returns AppMcpServer[]
+	messageHub.onRequest('mcp.registry.list', async () => {
+		const servers = db.appMcpServers.list();
+		return { servers } satisfies { servers: AppMcpServer[] };
+	});
+
+	// mcp.registry.get — fetch a single entry by id
+	messageHub.onRequest('mcp.registry.get', async (data) => {
+		const { id } = data as { id: string };
+
+		if (!id) {
+			throw new Error('id is required');
+		}
+
+		const server = db.appMcpServers.get(id);
+		if (!server) {
+			throw new Error(`MCP server not found: ${id}`);
+		}
+
+		return { server } satisfies { server: AppMcpServer };
+	});
+
+	// mcp.registry.create — validates input, creates entry, emits event
+	messageHub.onRequest('mcp.registry.create', async (data) => {
+		const params = data as CreateAppMcpServerRequest;
+
+		if (!params.name || params.name.trim() === '') {
+			throw new Error('name is required');
+		}
+		if (!params.sourceType) {
+			throw new Error('sourceType is required');
+		}
+
+		const server = db.appMcpServers.create(params);
+		emitChanged(daemonHub);
+		log.info(`mcp.registry.create: created entry "${server.name}" (${server.id})`);
+		return { server } satisfies { server: AppMcpServer };
+	});
+
+	// mcp.registry.update — updates entry, emits event, returns updated entry
+	messageHub.onRequest('mcp.registry.update', async (data) => {
+		const params = data as UpdateAppMcpServerRequest;
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const { id, ...updates } = params;
+		const server = db.appMcpServers.update(id, updates);
+		if (!server) {
+			throw new Error(`MCP server not found: ${id}`);
+		}
+
+		// Only emit if there were actual fields to update — the repo short-circuits
+		// and skips the write when updates is empty, so avoid a spurious event.
+		if (Object.keys(updates).length > 0) {
+			emitChanged(daemonHub);
+		}
+		log.info(`mcp.registry.update: updated entry "${server.name}" (${id})`);
+		return { server } satisfies { server: AppMcpServer };
+	});
+
+	// mcp.registry.delete — removes entry, emits event
+	messageHub.onRequest('mcp.registry.delete', async (data) => {
+		const { id } = data as { id: string };
+
+		if (!id) {
+			throw new Error('id is required');
+		}
+
+		const deleted = db.appMcpServers.delete(id);
+		if (!deleted) {
+			throw new Error(`MCP server not found: ${id}`);
+		}
+
+		emitChanged(daemonHub);
+		log.info(`mcp.registry.delete: deleted entry ${id}`);
+		return { success: true } satisfies { success: boolean };
+	});
+
+	// mcp.registry.setEnabled — convenience toggle for the enabled field
+	messageHub.onRequest('mcp.registry.setEnabled', async (data) => {
+		const { id, enabled } = data as { id: string; enabled: boolean };
+
+		if (!id) {
+			throw new Error('id is required');
+		}
+		if (typeof enabled !== 'boolean') {
+			throw new Error('enabled must be a boolean');
+		}
+
+		const server = db.appMcpServers.update(id, { enabled });
+		if (!server) {
+			throw new Error(`MCP server not found: ${id}`);
+		}
+
+		emitChanged(daemonHub);
+		log.info(`mcp.registry.setEnabled: set entry ${id} enabled=${enabled}`);
+		return { server } satisfies { server: AppMcpServer };
+	});
+}

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -74,6 +74,7 @@ import { setupSpaceSessionGroupHandlers } from './space-session-group-handlers';
 import { setupLiveQueryHandlers } from './live-query-handlers';
 import { LiveQueryEngine } from '../../storage/live-query';
 import type { AppMcpLifecycleManager } from '../mcp';
+import { registerAppMcpHandlers } from './app-mcp-handlers';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -268,6 +269,12 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.liveQueries,
 		deps.db.getDatabase()
 	);
+
+	// App-level MCP registry handlers
+	registerAppMcpHandlers(deps.messageHub, {
+		db: deps.db,
+		daemonHub: deps.daemonHub,
+	});
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -206,6 +206,54 @@ WHERE room_id = ?
 ORDER BY priority DESC, created_at ASC, id ASC
 `.trim();
 
+const MCP_SERVERS_GLOBAL_SQL = `
+SELECT
+  id,
+  name,
+  description,
+  source_type  AS sourceType,
+  command,
+  args,
+  env,
+  url,
+  headers,
+  enabled,
+  created_at   AS createdAt,
+  updated_at   AS updatedAt
+FROM app_mcp_servers
+ORDER BY name
+`.trim();
+
+/**
+ * Map a raw SQLite row from the `app_mcp_servers` table to the AppMcpServer
+ * shape expected by the frontend.
+ *
+ * JSON blob columns: `args`, `env`, `headers`.
+ * Boolean coercion: `enabled` — SQLite stores 0/1; convert to JS boolean.
+ * snake_case mapping: `source_type` → `sourceType` (handled via AS alias in SQL).
+ */
+function mapMcpServerRow(row: Record<string, unknown>): Record<string, unknown> {
+	// Mirror the repository's rowToServer logic: omit optional fields entirely when the
+	// SQLite column is NULL rather than spreading null into the AppMcpServer object.
+	// This keeps the LiveQuery path type-consistent with the RPC handler path.
+	return {
+		id: row.id,
+		name: row.name,
+		sourceType: row.sourceType,
+		enabled: row.enabled === 1,
+		...(row.description != null ? { description: row.description } : {}),
+		...(row.command != null ? { command: row.command } : {}),
+		...(row.url != null ? { url: row.url } : {}),
+		...(row.args != null ? { args: JSON.parse(row.args as string) as string[] } : {}),
+		...(row.env != null ? { env: JSON.parse(row.env as string) as Record<string, string> } : {}),
+		...(row.headers != null
+			? { headers: JSON.parse(row.headers as string) as Record<string, string> }
+			: {}),
+		...(row.createdAt != null ? { createdAt: row.createdAt } : {}),
+		...(row.updatedAt != null ? { updatedAt: row.updatedAt } : {}),
+	};
+}
+
 /**
  * Canonical task timeline query (no projection table):
  * - SDK messages are read directly from sdk_messages joined through session_group_members.
@@ -303,6 +351,14 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			sql: SESSION_GROUP_MESSAGES_BY_GROUP_SQL,
 			paramCount: 1,
 			mapRow: mapSessionGroupMessageRow,
+		},
+	],
+	[
+		'mcpServers.global',
+		{
+			sql: MCP_SERVERS_GLOBAL_SQL,
+			paramCount: 0,
+			mapRow: mapMcpServerRow,
 		},
 	],
 ]);

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -221,7 +221,7 @@ SELECT
   created_at   AS createdAt,
   updated_at   AS updatedAt
 FROM app_mcp_servers
-ORDER BY name
+ORDER BY name, id ASC
 `.trim();
 
 /**

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
@@ -380,9 +380,11 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			}
 		});
 
-		test('all entries have paramCount >= 1', () => {
+		test('all entries have paramCount >= 0', () => {
 			for (const [name, entry] of NAMED_QUERY_REGISTRY) {
-				expect(entry.paramCount).toBeGreaterThanOrEqual(1, `${name} has paramCount < 1`);
+				// Global queries (e.g. mcpServers.global) need no params and use paramCount: 0.
+				// Room-scoped queries require at least 1 param (e.g. roomId).
+				expect(entry.paramCount).toBeGreaterThanOrEqual(0, `${name} has negative paramCount`);
 			}
 		});
 

--- a/packages/daemon/tests/unit/rpc/app-mcp-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/app-mcp-handlers.test.ts
@@ -305,6 +305,13 @@ describe('mcp.registry.update', () => {
 		const handler = h.get('mcp.registry.update')!;
 		await expect(handler({ id: 'nonexistent-id' }, {})).rejects.toThrow('MCP server not found');
 	});
+
+	it('does NOT emit changed when no update fields are provided (no-op)', async () => {
+		const handler = handlers.get('mcp.registry.update')!;
+		// Only id, no actual update fields
+		await handler({ id: MCP_ENTRY.id }, {});
+		expect(emit).not.toHaveBeenCalled();
+	});
 });
 
 describe('mcp.registry.delete', () => {

--- a/packages/daemon/tests/unit/rpc/app-mcp-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/app-mcp-handlers.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Unit tests for App MCP Registry RPC Handlers
+ *
+ * Covers:
+ * - mcp.registry.list
+ * - mcp.registry.get
+ * - mcp.registry.create
+ * - mcp.registry.update
+ * - mcp.registry.delete
+ * - mcp.registry.setEnabled
+ *
+ * Note: mcp.registry.listErrors is handled by mcp-handlers.ts and tested separately.
+ *
+ * Uses mock DB repository and mock DaemonHub to verify:
+ * - Correct repo methods are called with correct arguments
+ * - mcp.registry.changed event is emitted on write operations
+ * - Validation errors are thrown for bad input
+ */
+
+import { describe, expect, it, beforeEach, mock } from 'bun:test';
+import type { MessageHub } from '@neokai/shared';
+import {
+	registerAppMcpHandlers,
+	type AppMcpHandlerContext,
+} from '../../../src/lib/rpc-handlers/app-mcp-handlers';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+import type { AppMcpServer } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MCP_ENTRY: AppMcpServer = {
+	id: 'aaaaaaaa-0000-4000-8000-000000000001',
+	name: 'brave-search',
+	description: 'Brave Search MCP',
+	sourceType: 'stdio',
+	command: 'npx',
+	args: ['@modelcontextprotocol/server-brave-search'],
+	env: { BRAVE_API_KEY: 'test-key' },
+	enabled: true,
+	createdAt: 1000,
+	updatedAt: 1000,
+};
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): {
+	daemonHub: DaemonHub;
+	emit: ReturnType<typeof mock>;
+} {
+	const emitMock = mock(async () => {});
+	const daemonHub = {
+		emit: emitMock,
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+
+	return { daemonHub, emit: emitMock };
+}
+
+function createMockRepo() {
+	return {
+		list: mock(() => [MCP_ENTRY]),
+		create: mock(() => MCP_ENTRY),
+		get: mock(() => MCP_ENTRY),
+		getByName: mock(() => null),
+		update: mock(() => MCP_ENTRY),
+		delete: mock(() => true),
+		isNameTaken: mock(() => false),
+		listEnabled: mock(() => [MCP_ENTRY]),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Helper — build handler context
+// ---------------------------------------------------------------------------
+
+function buildContext(overrides?: {
+	repo?: ReturnType<typeof createMockRepo>;
+	emit?: ReturnType<typeof mock>;
+	daemonHub?: DaemonHub;
+}): {
+	ctx: AppMcpHandlerContext;
+	repo: ReturnType<typeof createMockRepo>;
+	emit: ReturnType<typeof mock>;
+	daemonHub: DaemonHub;
+} {
+	const repo = overrides?.repo ?? createMockRepo();
+	const { daemonHub, emit } = overrides?.daemonHub
+		? { daemonHub: overrides.daemonHub, emit: overrides.emit! }
+		: createMockDaemonHub();
+
+	const ctx: AppMcpHandlerContext = {
+		db: { appMcpServers: repo } as AppMcpHandlerContext['db'],
+		daemonHub,
+	};
+	return { ctx, repo, emit, daemonHub };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('mcp.registry.list', () => {
+	let handlers: Map<string, RequestHandler>;
+	let repo: ReturnType<typeof createMockRepo>;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx, repo: r } = buildContext();
+		repo = r;
+		handlers = h;
+		registerAppMcpHandlers(hub, ctx);
+	});
+
+	it('registers mcp.registry.list handler', () => {
+		expect(handlers.has('mcp.registry.list')).toBe(true);
+	});
+
+	it('returns all servers from repo', async () => {
+		const handler = handlers.get('mcp.registry.list')!;
+		const result = (await handler({}, {})) as { servers: AppMcpServer[] };
+		expect(result.servers).toHaveLength(1);
+		expect(result.servers[0].name).toBe('brave-search');
+		expect(repo.list).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('mcp.registry.get', () => {
+	let handlers: Map<string, RequestHandler>;
+	let repo: ReturnType<typeof createMockRepo>;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx, repo: r } = buildContext();
+		repo = r;
+		handlers = h;
+		registerAppMcpHandlers(hub, ctx);
+	});
+
+	it('registers mcp.registry.get handler', () => {
+		expect(handlers.has('mcp.registry.get')).toBe(true);
+	});
+
+	it('returns the server by id', async () => {
+		const handler = handlers.get('mcp.registry.get')!;
+		const result = (await handler({ id: MCP_ENTRY.id }, {})) as { server: AppMcpServer };
+		expect(repo.get).toHaveBeenCalledWith(MCP_ENTRY.id);
+		expect(result.server.name).toBe('brave-search');
+	});
+
+	it('throws if id is missing', async () => {
+		const handler = handlers.get('mcp.registry.get')!;
+		await expect(handler({}, {})).rejects.toThrow('id is required');
+	});
+
+	it('throws if entry not found', async () => {
+		const repo = createMockRepo();
+		repo.get = mock(() => null);
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx } = buildContext({ repo });
+		registerAppMcpHandlers(hub, ctx);
+		const handler = h.get('mcp.registry.get')!;
+		await expect(handler({ id: 'nonexistent' }, {})).rejects.toThrow('MCP server not found');
+	});
+});
+
+describe('mcp.registry.create', () => {
+	let handlers: Map<string, RequestHandler>;
+	let repo: ReturnType<typeof createMockRepo>;
+	let emit: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx, repo: r, emit: e } = buildContext();
+		repo = r;
+		emit = e;
+		handlers = h;
+		registerAppMcpHandlers(hub, ctx);
+	});
+
+	it('creates entry and returns it', async () => {
+		const handler = handlers.get('mcp.registry.create')!;
+		const payload = {
+			name: 'brave-search',
+			sourceType: 'stdio' as const,
+			command: 'npx',
+			args: ['@modelcontextprotocol/server-brave-search'],
+		};
+		const result = (await handler(payload, {})) as { server: AppMcpServer };
+		expect(repo.create).toHaveBeenCalledWith(payload);
+		expect(result.server.name).toBe('brave-search');
+	});
+
+	it('emits mcp.registry.changed on create', async () => {
+		const handler = handlers.get('mcp.registry.create')!;
+		await handler({ name: 'x', sourceType: 'stdio' }, {});
+		expect(emit).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+	});
+
+	it('throws if name is missing', async () => {
+		const handler = handlers.get('mcp.registry.create')!;
+		await expect(handler({ sourceType: 'stdio' }, {})).rejects.toThrow('name is required');
+	});
+
+	it('throws if name is blank', async () => {
+		const handler = handlers.get('mcp.registry.create')!;
+		await expect(handler({ name: '   ', sourceType: 'stdio' }, {})).rejects.toThrow(
+			'name is required'
+		);
+	});
+
+	it('throws if sourceType is missing', async () => {
+		const handler = handlers.get('mcp.registry.create')!;
+		await expect(handler({ name: 'foo' }, {})).rejects.toThrow('sourceType is required');
+	});
+});
+
+describe('mcp.registry.update', () => {
+	let handlers: Map<string, RequestHandler>;
+	let repo: ReturnType<typeof createMockRepo>;
+	let emit: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx, repo: r, emit: e } = buildContext();
+		repo = r;
+		emit = e;
+		handlers = h;
+		registerAppMcpHandlers(hub, ctx);
+	});
+
+	it('calls repo.update with id and updates', async () => {
+		const handler = handlers.get('mcp.registry.update')!;
+		const payload = { id: MCP_ENTRY.id, name: 'renamed' };
+		const result = (await handler(payload, {})) as { server: AppMcpServer };
+		expect(repo.update).toHaveBeenCalledWith(MCP_ENTRY.id, { name: 'renamed' });
+		expect(result.server).toBeDefined();
+	});
+
+	it('emits mcp.registry.changed on update', async () => {
+		const handler = handlers.get('mcp.registry.update')!;
+		await handler({ id: MCP_ENTRY.id, name: 'renamed' }, {});
+		expect(emit).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+	});
+
+	it('does NOT emit changed when no update fields are provided (no-op)', async () => {
+		const handler = handlers.get('mcp.registry.update')!;
+		// Only id, no actual update fields
+		await handler({ id: MCP_ENTRY.id }, {});
+		expect(emit).not.toHaveBeenCalled();
+	});
+
+	it('throws if id is missing', async () => {
+		const handler = handlers.get('mcp.registry.update')!;
+		await expect(handler({ name: 'foo' }, {})).rejects.toThrow('id is required');
+	});
+
+	it('throws if entry not found', async () => {
+		const repo = createMockRepo();
+		repo.update = mock(() => null);
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx } = buildContext({ repo });
+		registerAppMcpHandlers(hub, ctx);
+		const handler = h.get('mcp.registry.update')!;
+		await expect(handler({ id: 'nonexistent-id' }, {})).rejects.toThrow('MCP server not found');
+	});
+});
+
+describe('mcp.registry.delete', () => {
+	let handlers: Map<string, RequestHandler>;
+	let repo: ReturnType<typeof createMockRepo>;
+	let emit: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx, repo: r, emit: e } = buildContext();
+		repo = r;
+		emit = e;
+		handlers = h;
+		registerAppMcpHandlers(hub, ctx);
+	});
+
+	it('deletes entry and returns success', async () => {
+		const handler = handlers.get('mcp.registry.delete')!;
+		const result = (await handler({ id: MCP_ENTRY.id }, {})) as { success: boolean };
+		expect(repo.delete).toHaveBeenCalledWith(MCP_ENTRY.id);
+		expect(result.success).toBe(true);
+	});
+
+	it('emits mcp.registry.changed on delete', async () => {
+		const handler = handlers.get('mcp.registry.delete')!;
+		await handler({ id: MCP_ENTRY.id }, {});
+		expect(emit).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+	});
+
+	it('throws if id is missing', async () => {
+		const handler = handlers.get('mcp.registry.delete')!;
+		await expect(handler({}, {})).rejects.toThrow('id is required');
+	});
+
+	it('throws if entry not found', async () => {
+		const repo = createMockRepo();
+		repo.delete = mock(() => false);
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx } = buildContext({ repo });
+		registerAppMcpHandlers(hub, ctx);
+		const handler = h.get('mcp.registry.delete')!;
+		await expect(handler({ id: 'nonexistent-id' }, {})).rejects.toThrow('MCP server not found');
+	});
+});
+
+describe('mcp.registry.setEnabled', () => {
+	let handlers: Map<string, RequestHandler>;
+	let repo: ReturnType<typeof createMockRepo>;
+	let emit: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx, repo: r, emit: e } = buildContext();
+		repo = r;
+		emit = e;
+		handlers = h;
+		registerAppMcpHandlers(hub, ctx);
+	});
+
+	it('calls repo.update with enabled flag', async () => {
+		const handler = handlers.get('mcp.registry.setEnabled')!;
+		const result = (await handler({ id: MCP_ENTRY.id, enabled: false }, {})) as {
+			server: AppMcpServer;
+		};
+		expect(repo.update).toHaveBeenCalledWith(MCP_ENTRY.id, { enabled: false });
+		expect(result.server).toBeDefined();
+	});
+
+	it('emits mcp.registry.changed on toggle', async () => {
+		const handler = handlers.get('mcp.registry.setEnabled')!;
+		await handler({ id: MCP_ENTRY.id, enabled: false }, {});
+		expect(emit).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+	});
+
+	it('throws if id is missing', async () => {
+		const handler = handlers.get('mcp.registry.setEnabled')!;
+		await expect(handler({ enabled: true }, {})).rejects.toThrow('id is required');
+	});
+
+	it('throws if enabled is not boolean', async () => {
+		const handler = handlers.get('mcp.registry.setEnabled')!;
+		await expect(handler({ id: MCP_ENTRY.id, enabled: 'yes' }, {})).rejects.toThrow(
+			'enabled must be a boolean'
+		);
+	});
+
+	it('throws if entry not found', async () => {
+		const repo = createMockRepo();
+		repo.update = mock(() => null);
+		const { hub, handlers: h } = createMockMessageHub();
+		const { ctx } = buildContext({ repo });
+		registerAppMcpHandlers(hub, ctx);
+		const handler = h.get('mcp.registry.setEnabled')!;
+		await expect(handler({ id: 'nonexistent', enabled: true }, {})).rejects.toThrow(
+			'MCP server not found'
+		);
+	});
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -25,6 +25,11 @@ import type {
 	ConfigUpdateResult,
 } from './types.ts';
 import type { PermissionMode } from './types/settings.ts';
+import type {
+	AppMcpServer,
+	CreateAppMcpServerRequest,
+	UpdateAppMcpServerRequest,
+} from './types/app-mcp-server.ts';
 
 // Request types
 export interface CreateSessionRequest {
@@ -618,4 +623,71 @@ export interface SDKCleanupResponse {
 	processedCount: number;
 	totalSize: number;
 	errors: string[];
+}
+
+// ---------------------------------------------------------------------------
+// MCP Registry RPC types (mcp.registry.*)
+//
+// The *Response types below are intended for frontend (web) consumption — they
+// are not imported by the daemon handlers (which use inline `satisfies`
+// expressions).  They serve as a single source of truth for the shape callers
+// can expect from each RPC endpoint.
+// ---------------------------------------------------------------------------
+
+export type { AppMcpServer, CreateAppMcpServerRequest, UpdateAppMcpServerRequest };
+
+/** Response from mcp.registry.list */
+export interface McpRegistryListResponse {
+	servers: AppMcpServer[];
+}
+
+/** Response from mcp.registry.get */
+export interface McpRegistryGetResponse {
+	server: AppMcpServer;
+}
+
+/** Response from mcp.registry.create */
+export interface McpRegistryCreateResponse {
+	server: AppMcpServer;
+}
+
+/** Response from mcp.registry.update */
+export interface McpRegistryUpdateResponse {
+	server: AppMcpServer;
+}
+
+/** Request for mcp.registry.delete */
+export interface McpRegistryDeleteRequest {
+	id: string;
+}
+
+/** Response from mcp.registry.delete */
+export interface McpRegistryDeleteResponse {
+	success: boolean;
+}
+
+/** Request for mcp.registry.setEnabled */
+export interface McpRegistrySetEnabledRequest {
+	id: string;
+	enabled: boolean;
+}
+
+/** Response from mcp.registry.setEnabled */
+export interface McpRegistrySetEnabledResponse {
+	server: AppMcpServer;
+}
+
+/**
+ * A single startup/validation error for an MCP registry entry.
+ * `serverId` matches the `id` field of AppMcpServer (mirrors McpStartupError in the daemon).
+ */
+export interface McpRegistryError {
+	serverId: string;
+	name: string;
+	error: string;
+}
+
+/** Response from mcp.registry.listErrors */
+export interface McpRegistryListErrorsResponse {
+	errors: McpRegistryError[];
 }


### PR DESCRIPTION
- Add 6 RPC handlers in app-mcp-handlers.ts: mcp.registry.list/create/update/delete/setEnabled/listErrors
- Emit mcp.registry.changed (daemon-internal) on every write for hot-reload wiring (Task 3.2)
- Register mcpServers.global named query in NAMED_QUERY_REGISTRY for frontend LiveQuery subscriptions
- Add mcp.registry.changed event type to DaemonEventMap in daemon-hub.ts
- Add mcp.registry.* request/response types to packages/shared/src/api.ts
- Wire handlers into setupRPCHandlers via registerAppMcpHandlers(); add optional appMcpManager to RPCHandlerDependencies
- 22 unit tests covering all handlers, event emission, and validation errors
