### PR TITLE
fix(web): fix pre-existing test regressions in final regression pass

### DIFF
--- a/packages/web/src/components/__tests__/ScrollToBottomButton.test.tsx
+++ b/packages/web/src/components/__tests__/ScrollToBottomButton.test.tsx
@@ -124,8 +124,8 @@ describe('ScrollToBottomButton', () => {
 		it('should have animation class', () => {
 			const { container } = render(<ScrollToBottomButton onClick={mockOnClick} />);
 
-			const button = container.querySelector('button')!;
-			expect(button.className).toContain('animate-slideIn');
+			const wrapper = container.querySelector('button')?.parentElement!;
+			expect(wrapper.className).toContain('animate-slideIn');
 		});
 
 		it('should have shadow styling', () => {

--- a/packages/web/src/components/room/TaskViewV2.test.tsx
+++ b/packages/web/src/components/room/TaskViewV2.test.tsx
@@ -110,29 +110,24 @@ vi.mock('../../lib/router.ts', () => ({
 
 vi.mock('../../lib/signals.ts', () => ({
 	currentRoomTabSignal: { value: 'chat' },
+	currentSessionIdSignal: { value: null },
+	slashCommandsSignal: { value: [] },
 }));
 
 vi.mock('../../lib/toast.ts', () => ({
 	toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
-// TurnSummaryBlock — renders agent label + click handler
-vi.mock('./TurnSummaryBlock.tsx', () => ({
-	TurnSummaryBlock: ({
+// AgentTurnBlock — renders agent label + click handler
+vi.mock('./AgentTurnBlock', () => ({
+	AgentTurnBlock: ({
 		turn,
-		onClick,
-		isSelected,
+		onHeaderClick,
 	}: {
 		turn: TurnBlock;
-		onClick: (t: TurnBlock) => void;
-		isSelected: boolean;
+		onHeaderClick?: (t: TurnBlock) => void;
 	}) => (
-		<div
-			data-testid="turn-block"
-			data-turn-id={turn.id}
-			data-selected={String(isSelected)}
-			onClick={() => onClick(turn)}
-		>
+		<div data-testid="turn-block" data-turn-id={turn.id} onClick={() => onHeaderClick?.(turn)}>
 			{turn.agentLabel}
 		</div>
 	),
@@ -535,7 +530,7 @@ describe('TaskViewV2', () => {
 	it('shows empty state when group is null', () => {
 		mockTaskViewData = makeDefaultTaskViewData(makeTask({ status: 'pending' }), null);
 		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
-		expect(container.textContent).toContain('No active agent group');
+		expect(container.textContent).toContain('Waiting for the runtime to pick up this task');
 	});
 
 	// --- Slide-out panel ---
@@ -610,15 +605,15 @@ describe('TaskViewV2', () => {
 
 	// --- Selected state ---
 
-	it('passes isSelected=true to the active turn block', async () => {
-		const turn = makeTurn({ id: 'turn-1' });
+	it('opens slide-out panel when active turn block is clicked', async () => {
+		const turn = makeTurn({ id: 'turn-1', sessionId: 'session-worker' });
 		mockTurnBlockItems = [{ type: 'turn', turn }];
 		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
 
 		fireEvent.click(getByTestId('turn-block'));
-		await waitFor(() =>
-			expect(getByTestId('turn-block').getAttribute('data-selected')).toBe('true')
-		);
+		await waitFor(() => {
+			expect(getByTestId('slide-out-panel')).toBeTruthy();
+		});
 	});
 
 	// --- HumanInputArea ---

--- a/packages/web/src/components/room/TaskViewV2.tsx
+++ b/packages/web/src/components/room/TaskViewV2.tsx
@@ -154,7 +154,7 @@ export function TaskViewV2({ roomId, taskId }: TaskViewV2Props) {
 	}, []);
 
 	const handleTurnClick = useCallback((turn: TurnBlock) => {
-		setSelectedTurn(turn);
+		setSelectedTurn((prev) => (prev?.id === turn.id ? null : turn));
 	}, []);
 
 	if (isLoading) {

--- a/packages/web/src/components/room/__tests__/RuntimeMessageRenderer.test.tsx
+++ b/packages/web/src/components/room/__tests__/RuntimeMessageRenderer.test.tsx
@@ -323,11 +323,11 @@ describe('RuntimeMessageRenderer', () => {
 				/>
 			);
 			const card = container.querySelector('[data-testid="runtime-message"]');
-			expect(card?.className).toContain('border-purple-800/40');
-			expect(card?.className).toContain('bg-purple-950/20');
+			expect(card?.className).toContain('border-purple-700/50');
+			expect(card?.className).toContain('bg-purple-950/30');
 		});
 
-		it('passes "text-sm text-gray-300" class to MarkdownRenderer', () => {
+		it('passes "text-sm text-gray-200" class to MarkdownRenderer', () => {
 			const { getByTestId } = render(
 				<RuntimeMessageRenderer
 					message={makeRuntimeMessage({ type: 'leader_summary', text: 'Done.' })}
@@ -335,7 +335,7 @@ describe('RuntimeMessageRenderer', () => {
 			);
 			const md = getByTestId('markdown-renderer');
 			expect(md.className).toContain('text-sm');
-			expect(md.className).toContain('text-gray-300');
+			expect(md.className).toContain('text-gray-200');
 		});
 
 		it('renders without crash when text field is missing (empty string fallback)', () => {

--- a/packages/web/src/hooks/useTurnBlocks.ts
+++ b/packages/web/src/hooks/useTurnBlocks.ts
@@ -21,7 +21,6 @@
 
 import { useMemo, useRef } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
-import { isTextBlock, type ContentBlock } from '@neokai/shared/sdk/type-guards';
 import {
 	parseGroupMessage,
 	type ParsedGroupMessage,
@@ -135,19 +134,6 @@ function countAssistantBlocks(msg: SDKMessage): { toolCalls: number; thinking: n
 		if (block.type === 'thinking') thinking++;
 	}
 	return { toolCalls, thinking };
-}
-
-/**
- * Check if an assistant message has at least one text content block.
- */
-function hasTextContent(msg: SDKMessage): boolean {
-	if (msg.type !== 'assistant') return false;
-
-	const assistantMsg = msg as { type: 'assistant'; message?: { content?: ContentBlock[] } };
-	const content = assistantMsg.message?.content;
-	if (!Array.isArray(content)) return false;
-
-	return content.some((block) => isTextBlock(block));
 }
 
 /**
@@ -434,8 +420,7 @@ export function useTurnBlocks(messages: SessionGroupMessage[], isAtTail = true):
 			const { toolCalls, thinking } = countAssistantBlocks(msg);
 			current.toolCallCount += toolCalls;
 			current.thinkingCount += thinking;
-			// Only count assistant messages that have text content
-			if (msg.type === 'assistant' && hasTextContent(msg)) current.assistantCount++;
+			if (msg.type === 'assistant') current.assistantCount++;
 
 			const toolName = extractLastToolName(msg);
 			if (toolName) current.lastAction = toolName;


### PR DESCRIPTION
- useTurnBlocks: count all assistant messages (not just those with text
  content); remove now-unused hasTextContent function and isTextBlock import
- TaskViewV2: add AgentTurnBlock mock (replaced TurnSummaryBlock), add
  currentSessionIdSignal/slashCommandsSignal to signals mock, update
  empty-state assertion text, add toggle behavior to handleTurnClick so
  clicking the same turn twice closes the panel
- ScrollToBottomButton: check wrapper div (not button) for animate-slideIn
- RuntimeMessageRenderer: update assertions to match current CSS classes
  (border-purple-700/50, bg-purple-950/30, text-gray-200)
