### PR TITLE
feat(storage+rpc): add per-room MCP enablement storage and RPC (Task 4.1)

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -549,9 +549,6 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		workflowId: string;
 	};
 
-	// MCP registry events (global events - use 'global' as sessionId)
-	'mcp.registry.changed': { sessionId: string };
-
 	// Feature Flag events (PHASE 3: Gradual rollout infrastructure)
 	'featureFlag.updated': {
 		sessionId: string;

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -549,6 +549,9 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		workflowId: string;
 	};
 
+	// MCP registry events (global events - use 'global' as sessionId)
+	'mcp.registry.changed': { sessionId: string };
+
 	// Feature Flag events (PHASE 3: Gradual rollout infrastructure)
 	'featureFlag.updated': {
 		sessionId: string;

--- a/packages/daemon/src/lib/rpc-handlers/app-mcp-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/app-mcp-handlers.ts
@@ -1,16 +1,28 @@
 /**
- * App MCP Registry RPC Handlers
+ * App MCP RPC Handlers
  *
- * Exposes the application-level MCP server registry via RPC:
- * - mcp.registry.list       — list all registry entries
- * - mcp.registry.get        — get a single entry by id
- * - mcp.registry.create     — add a new entry, emit mcp.registry.changed
- * - mcp.registry.update     — update an entry, emit mcp.registry.changed
- * - mcp.registry.delete     — remove an entry, emit mcp.registry.changed
- * - mcp.registry.setEnabled — toggle enabled flag, emit mcp.registry.changed
+ * Contains two sets of handlers:
  *
- * Note: mcp.registry.listErrors is registered in mcp-handlers.ts (requires
- * the concrete AppMcpLifecycleManager).
+ * 1. App MCP Registry RPC Handlers (registerAppMcpHandlers)
+ *    Exposes the application-level MCP server registry via RPC:
+ *    - mcp.registry.list       — list all registry entries
+ *    - mcp.registry.get        — get a single entry by id
+ *    - mcp.registry.create     — add a new entry, emit mcp.registry.changed
+ *    - mcp.registry.update     — update an entry, emit mcp.registry.changed
+ *    - mcp.registry.delete     — remove an entry, emit mcp.registry.changed
+ *    - mcp.registry.setEnabled — toggle enabled flag, emit mcp.registry.changed
+ *
+ *    Note: mcp.registry.listErrors is registered in mcp-handlers.ts (requires
+ *    the concrete AppMcpLifecycleManager).
+ *
+ * 2. Per-Room MCP Enablement RPC Handlers (setupAppMcpHandlers)
+ *    Provides RPC methods for managing per-room MCP enablement overrides:
+ *    - mcp.room.getEnabled    — list server IDs enabled for a room
+ *    - mcp.room.setEnabled    — upsert an enablement override for one server
+ *    - mcp.room.resetToGlobal — remove all per-room overrides for a room
+ *
+ *    Each mutating handler emits `mcp.registry.changed` so that daemon-internal
+ *    components (e.g., the lifecycle manager) can hot-reload configuration.
  */
 
 import type { MessageHub } from '@neokai/shared';
@@ -21,12 +33,21 @@ import type {
 } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
+import type { Database } from '../../storage/database';
+import type {
+	McpRoomGetEnabledRequest,
+	McpRoomGetEnabledResponse,
+	McpRoomSetEnabledRequest,
+	McpRoomSetEnabledResponse,
+	McpRoomResetToGlobalRequest,
+	McpRoomResetToGlobalResponse,
+} from '@neokai/shared';
 import { Logger } from '../logger';
 
 const log = new Logger('app-mcp-handlers');
 
 // ---------------------------------------------------------------------------
-// Handler context
+// Registry handler context
 // ---------------------------------------------------------------------------
 
 export interface AppMcpHandlerContext {
@@ -45,7 +66,7 @@ function emitChanged(daemonHub: DaemonHub): void {
 }
 
 // ---------------------------------------------------------------------------
-// Handler registration
+// Registry handler registration
 // ---------------------------------------------------------------------------
 
 export function registerAppMcpHandlers(messageHub: MessageHub, ctx: AppMcpHandlerContext): void {
@@ -150,5 +171,64 @@ export function registerAppMcpHandlers(messageHub: MessageHub, ctx: AppMcpHandle
 		emitChanged(daemonHub);
 		log.info(`mcp.registry.setEnabled: set entry ${id} enabled=${enabled}`);
 		return { server } satisfies { server: AppMcpServer };
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Per-room enablement handler registration
+// ---------------------------------------------------------------------------
+
+export function setupAppMcpHandlers(
+	messageHub: MessageHub,
+	daemonHub: DaemonHub,
+	db: Database
+): void {
+	/**
+	 * Get the IDs of all MCP servers that are explicitly enabled for a room.
+	 * Only returns servers with an explicit override row; servers with no override
+	 * are not included (consumers should treat them as following global defaults).
+	 */
+	messageHub.onRequest('mcp.room.getEnabled', (data) => {
+		const { roomId } = data as McpRoomGetEnabledRequest;
+		const serverIds = db.roomMcpEnablement.getEnabledServerIds(roomId);
+		return { serverIds } satisfies McpRoomGetEnabledResponse;
+	});
+
+	/**
+	 * Upsert an enablement override for a single MCP server in a room.
+	 * Emits `mcp.registry.changed` after writing.
+	 */
+	messageHub.onRequest('mcp.room.setEnabled', (data) => {
+		const { roomId, serverId, enabled } = data as McpRoomSetEnabledRequest;
+
+		// Validate that the server exists
+		const server = db.appMcpServers.get(serverId);
+		if (!server) {
+			throw new Error(`MCP server not found: ${serverId}`);
+		}
+
+		db.roomMcpEnablement.setEnabled(roomId, serverId, enabled);
+
+		daemonHub
+			.emit('mcp.registry.changed', { sessionId: 'global' })
+			.catch((err) => log.warn('Failed to emit mcp.registry.changed:', err));
+
+		return { ok: true } satisfies McpRoomSetEnabledResponse;
+	});
+
+	/**
+	 * Remove all per-room enablement overrides for a room, reverting to global defaults.
+	 * Emits `mcp.registry.changed` after writing.
+	 */
+	messageHub.onRequest('mcp.room.resetToGlobal', (data) => {
+		const { roomId } = data as McpRoomResetToGlobalRequest;
+
+		db.roomMcpEnablement.resetToGlobal(roomId);
+
+		daemonHub
+			.emit('mcp.registry.changed', { sessionId: 'global' })
+			.catch((err) => log.warn('Failed to emit mcp.registry.changed:', err));
+
+		return { ok: true } satisfies McpRoomResetToGlobalResponse;
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -77,7 +77,7 @@ import { setupReferenceHandlers } from './reference-handlers';
 import { FileIndex } from '../file-index';
 import { LiveQueryEngine } from '../../storage/live-query';
 import type { AppMcpLifecycleManager } from '../mcp';
-import { registerAppMcpHandlers } from './app-mcp-handlers';
+import { registerAppMcpHandlers, setupAppMcpHandlers } from './app-mcp-handlers';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -297,6 +297,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		db: deps.db,
 		daemonHub: deps.daemonHub,
 	});
+
+	// Per-room MCP enablement RPC handlers
+	setupAppMcpHandlers(deps.messageHub, deps.daemonHub, deps.db);
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -264,6 +264,7 @@ SELECT
 FROM room_mcp_enablement rme
 JOIN app_mcp_servers ams ON ams.id = rme.server_id
 WHERE rme.room_id = ?
+ORDER BY ams.id ASC
 `.trim();
 
 function mapMcpEnablementRow(row: Record<string, unknown>): Record<string, unknown> {

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -254,6 +254,25 @@ function mapMcpServerRow(row: Record<string, unknown>): Record<string, unknown> 
 	};
 }
 
+const MCP_ENABLEMENT_BY_ROOM_SQL = `
+SELECT
+  rme.server_id   AS serverId,
+  rme.enabled,
+  ams.name,
+  ams.source_type AS sourceType,
+  ams.description
+FROM room_mcp_enablement rme
+JOIN app_mcp_servers ams ON ams.id = rme.server_id
+WHERE rme.room_id = ?
+`.trim();
+
+function mapMcpEnablementRow(row: Record<string, unknown>): Record<string, unknown> {
+	return {
+		...row,
+		enabled: row.enabled === 1,
+	};
+}
+
 /**
  * Canonical task timeline query (no projection table):
  * - SDK messages are read directly from sdk_messages joined through session_group_members.
@@ -361,6 +380,14 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			mapRow: mapMcpServerRow,
 		},
 	],
+	[
+		'mcpEnablement.byRoom',
+		{
+			sql: MCP_ENABLEMENT_BY_ROOM_SQL,
+			paramCount: 1,
+			mapRow: mapMcpEnablementRow,
+		},
+	],
 ]);
 
 // ============================================================================
@@ -421,7 +448,11 @@ export function setupLiveQueryHandlers(
 		}
 
 		// 4. Authorization checks
-		if (queryName === 'tasks.byRoom' || queryName === 'goals.byRoom') {
+		if (
+			queryName === 'tasks.byRoom' ||
+			queryName === 'goals.byRoom' ||
+			queryName === 'mcpEnablement.byRoom'
+		) {
 			const roomId = params[0] as string;
 			if (!stmtRoom.get(roomId)) {
 				throw new Error(`Unauthorized: room "${roomId}" not found`);

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -35,6 +35,7 @@ import {
 import { JobQueueRepository } from './repositories/job-queue-repository';
 import { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 import { TaskRepository } from './repositories/task-repository';
+import { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -57,6 +58,7 @@ export { GoalRepository } from './repositories/goal-repository';
 export { TaskRepository } from './repositories/task-repository';
 export { SpaceAgentRepository } from './repositories/space-agent-repository';
 export { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
+export { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
 
 /**
  * Database facade class that maintains backward compatibility with the original Database class.
@@ -75,6 +77,7 @@ export class Database {
 	private jobQueueRepo!: JobQueueRepository;
 	private appMcpServerRepo!: AppMcpServerRepository;
 	private taskRepo!: TaskRepository;
+	private roomMcpEnablementRepo!: RoomMcpEnablementRepository;
 	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
@@ -97,6 +100,7 @@ export class Database {
 		this.taskRepo = new TaskRepository(db, reactiveDb, shortIdAllocator);
 		this.jobQueueRepo = new JobQueueRepository(db);
 		this.appMcpServerRepo = new AppMcpServerRepository(db, reactiveDb);
+		this.roomMcpEnablementRepo = new RoomMcpEnablementRepository(db, reactiveDb);
 	}
 
 	// ============================================================================
@@ -446,6 +450,13 @@ export class Database {
 	 */
 	get appMcpServers(): AppMcpServerRepository {
 		return this.appMcpServerRepo;
+	}
+
+	/**
+	 * Get the per-room MCP enablement repository
+	 */
+	get roomMcpEnablement(): RoomMcpEnablementRepository {
+		return this.roomMcpEnablementRepo;
 	}
 
 	close(): void {

--- a/packages/daemon/src/storage/repositories/room-mcp-enablement-repository.ts
+++ b/packages/daemon/src/storage/repositories/room-mcp-enablement-repository.ts
@@ -1,0 +1,144 @@
+/**
+ * RoomMcpEnablementRepository
+ *
+ * Stores per-room overrides for which application-level MCP servers are enabled.
+ * Each write calls reactiveDb.notifyChange('room_mcp_enablement') so that
+ * LiveQueryEngine can invalidate frontend subscriptions on every change.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type { AppMcpServer, AppMcpServerSourceType } from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+
+// ---------------------------------------------------------------------------
+// Internal row types
+// ---------------------------------------------------------------------------
+
+interface EnablementRow {
+	room_id: string;
+	server_id: string;
+	enabled: number;
+}
+
+interface EnablementWithServerRow {
+	server_id: string;
+	enabled: number;
+	name: string;
+	source_type: string;
+	description: string | null;
+	command: string | null;
+	args: string | null;
+	env: string | null;
+	url: string | null;
+	headers: string | null;
+	created_at: number | null;
+	updated_at: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+export class RoomMcpEnablementRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb: ReactiveDatabase
+	) {}
+
+	/**
+	 * Upsert an enablement override for a single server in a room.
+	 * Calling with enabled=true or enabled=false sets an explicit override.
+	 * Use resetToGlobal() to remove overrides entirely.
+	 */
+	setEnabled(roomId: string, serverId: string, enabled: boolean): void {
+		this.db
+			.prepare(
+				`INSERT INTO room_mcp_enablement (room_id, server_id, enabled)
+         VALUES (?, ?, ?)
+         ON CONFLICT(room_id, server_id) DO UPDATE SET enabled = excluded.enabled`
+			)
+			.run(roomId, serverId, enabled ? 1 : 0);
+		this.reactiveDb.notifyChange('room_mcp_enablement');
+	}
+
+	/**
+	 * Returns the server IDs that are explicitly marked enabled for a room.
+	 * Servers with no override row are not included.
+	 */
+	getEnabledServerIds(roomId: string): string[] {
+		const rows = this.db
+			.prepare(`SELECT server_id FROM room_mcp_enablement WHERE room_id = ? AND enabled = 1`)
+			.all(roomId) as Array<{ server_id: string }>;
+		return rows.map((r) => r.server_id);
+	}
+
+	/**
+	 * Returns full AppMcpServer entries for servers explicitly enabled for a room,
+	 * by joining room_mcp_enablement with app_mcp_servers.
+	 */
+	getEnabledServers(roomId: string): AppMcpServer[] {
+		const rows = this.db
+			.prepare(
+				`SELECT
+          rme.server_id,
+          rme.enabled,
+          ams.name,
+          ams.source_type,
+          ams.description,
+          ams.command,
+          ams.args,
+          ams.env,
+          ams.url,
+          ams.headers,
+          ams.created_at,
+          ams.updated_at
+        FROM room_mcp_enablement rme
+        JOIN app_mcp_servers ams ON ams.id = rme.server_id
+        WHERE rme.room_id = ? AND rme.enabled = 1`
+			)
+			.all(roomId) as EnablementWithServerRow[];
+
+		return rows.map((row) => rowToServer(row));
+	}
+
+	/**
+	 * Remove all per-room overrides for a room, reverting to global defaults.
+	 */
+	resetToGlobal(roomId: string): void {
+		this.db.prepare(`DELETE FROM room_mcp_enablement WHERE room_id = ?`).run(roomId);
+		this.reactiveDb.notifyChange('room_mcp_enablement');
+	}
+
+	/**
+	 * Get the raw enablement row for a specific (roomId, serverId) pair.
+	 * Returns null if no override exists.
+	 */
+	getOverride(roomId: string, serverId: string): { enabled: boolean } | null {
+		const row = this.db
+			.prepare(`SELECT enabled FROM room_mcp_enablement WHERE room_id = ? AND server_id = ?`)
+			.get(roomId, serverId) as EnablementRow | undefined;
+		if (!row) return null;
+		return { enabled: row.enabled === 1 };
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToServer(row: EnablementWithServerRow): AppMcpServer {
+	return {
+		id: row.server_id,
+		name: row.name,
+		...(row.description !== null ? { description: row.description } : {}),
+		sourceType: row.source_type as AppMcpServerSourceType,
+		...(row.command !== null ? { command: row.command } : {}),
+		...(row.args !== null ? { args: JSON.parse(row.args) as string[] } : {}),
+		...(row.env !== null ? { env: JSON.parse(row.env) as Record<string, string> } : {}),
+		...(row.url !== null ? { url: row.url } : {}),
+		...(row.headers !== null ? { headers: JSON.parse(row.headers) as Record<string, string> } : {}),
+		enabled: true,
+		...(row.created_at !== null ? { createdAt: row.created_at } : {}),
+		...(row.updated_at !== null ? { updatedAt: row.updated_at } : {}),
+	};
+}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -23,6 +23,8 @@ export { runMigration48 } from './migrations';
 export { runMigration49 } from './migrations';
 // knip-ignore-next-line
 export { runMigration50 } from './migrations';
+// knip-ignore-next-line
+export { runMigration51 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -347,6 +349,16 @@ export function createTables(db: BunDatabase): void {
         enabled INTEGER NOT NULL DEFAULT 1,
         created_at INTEGER,
         updated_at INTEGER
+      )
+    `);
+
+	// Per-room MCP enablement overrides
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS room_mcp_enablement (
+        room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+        server_id TEXT NOT NULL REFERENCES app_mcp_servers(id) ON DELETE CASCADE,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        PRIMARY KEY (room_id, server_id)
       )
     `);
 

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -205,6 +205,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// it marks a task completed. This is the canonical location for agent completion state
 	// (alongside the existing status, completed_at, and task_agent_session_id columns).
 	runMigration51(db);
+
+	// Migration 52: Create room_mcp_enablement table for per-room MCP enablement overrides.
+	runMigration52(db);
 }
 
 /**
@@ -3191,6 +3194,24 @@ export function runMigration50(db: BunDatabase): void {
       enabled INTEGER NOT NULL DEFAULT 1,
       created_at INTEGER,
       updated_at INTEGER
+    )
+  `);
+}
+
+/**
+ * Migration 52: Create room_mcp_enablement table for per-room MCP enablement overrides.
+ *
+ * Stores which registry servers are explicitly enabled/disabled per room.
+ * ON DELETE CASCADE ensures orphaned rows are removed when an app_mcp_servers entry is deleted,
+ * or when a room is deleted.
+ */
+export function runMigration52(db: BunDatabase): void {
+	db.exec(`
+    CREATE TABLE IF NOT EXISTS room_mcp_enablement (
+      room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+      server_id TEXT NOT NULL REFERENCES app_mcp_servers(id) ON DELETE CASCADE,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      PRIMARY KEY (room_id, server_id)
     )
   `);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -3202,8 +3202,8 @@ export function runMigration50(db: BunDatabase): void {
  * Migration 52: Create room_mcp_enablement table for per-room MCP enablement overrides.
  *
  * Stores which registry servers are explicitly enabled/disabled per room.
- * ON DELETE CASCADE ensures orphaned rows are removed when an app_mcp_servers entry is deleted,
- * or when a room is deleted.
+ * ON DELETE CASCADE on both FKs ensures orphaned rows are removed when a room or
+ * app_mcp_servers entry is deleted.
  */
 export function runMigration52(db: BunDatabase): void {
 	db.exec(`

--- a/packages/daemon/tests/unit/rpc/app-mcp-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/app-mcp-handlers.test.ts
@@ -1,6 +1,7 @@
 /**
- * Unit tests for App MCP Registry RPC Handlers
+ * Unit tests for App MCP RPC Handlers
  *
+ * Part 1: App MCP Registry RPC Handlers (registerAppMcpHandlers)
  * Covers:
  * - mcp.registry.list
  * - mcp.registry.get
@@ -15,22 +16,34 @@
  * - Correct repo methods are called with correct arguments
  * - mcp.registry.changed event is emitted on write operations
  * - Validation errors are thrown for bad input
+ *
+ * Part 2: Per-Room MCP Enablement RPC Handlers (setupAppMcpHandlers)
+ * Tests for mcp.room.getEnabled, mcp.room.setEnabled, and mcp.room.resetToGlobal
+ * using an in-memory SQLite database and mock MessageHub / DaemonHub.
  */
 
-import { describe, expect, it, beforeEach, mock } from 'bun:test';
+import { describe, expect, it, test, beforeEach, afterEach, mock } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import { AppMcpServerRepository } from '../../../src/storage/repositories/app-mcp-server-repository';
+import { RoomMcpEnablementRepository } from '../../../src/storage/repositories/room-mcp-enablement-repository';
 import type { MessageHub } from '@neokai/shared';
 import {
 	registerAppMcpHandlers,
+	setupAppMcpHandlers,
 	type AppMcpHandlerContext,
 } from '../../../src/lib/rpc-handlers/app-mcp-handlers';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 import type { AppMcpServer } from '@neokai/shared';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+import type { Database } from '../../../src/storage/database';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+type RequestHandler = (data: unknown, context?: unknown) => unknown;
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -50,7 +63,7 @@ const MCP_ENTRY: AppMcpServer = {
 };
 
 // ---------------------------------------------------------------------------
-// Mock factories
+// Mock factories (shared)
 // ---------------------------------------------------------------------------
 
 function createMockMessageHub(): {
@@ -58,13 +71,13 @@ function createMockMessageHub(): {
 	handlers: Map<string, RequestHandler>;
 } {
 	const handlers = new Map<string, RequestHandler>();
-
 	const hub = {
 		onRequest: mock((method: string, handler: RequestHandler) => {
 			handlers.set(method, handler);
 			return () => handlers.delete(method);
 		}),
 		onEvent: mock(() => () => {}),
+		onClientDisconnect: mock(() => () => {}),
 		request: mock(async () => {}),
 		event: mock(() => {}),
 		joinChannel: mock(async () => {}),
@@ -83,7 +96,11 @@ function createMockMessageHub(): {
 	return { hub, handlers };
 }
 
-function createMockDaemonHub(): {
+// ---------------------------------------------------------------------------
+// Part 1: Registry handler mock factories
+// ---------------------------------------------------------------------------
+
+function createMockDaemonHubForRegistry(): {
 	daemonHub: DaemonHub;
 	emit: ReturnType<typeof mock>;
 } {
@@ -111,10 +128,6 @@ function createMockRepo() {
 	};
 }
 
-// ---------------------------------------------------------------------------
-// Helper — build handler context
-// ---------------------------------------------------------------------------
-
 function buildContext(overrides?: {
 	repo?: ReturnType<typeof createMockRepo>;
 	emit?: ReturnType<typeof mock>;
@@ -128,7 +141,7 @@ function buildContext(overrides?: {
 	const repo = overrides?.repo ?? createMockRepo();
 	const { daemonHub, emit } = overrides?.daemonHub
 		? { daemonHub: overrides.daemonHub, emit: overrides.emit! }
-		: createMockDaemonHub();
+		: createMockDaemonHubForRegistry();
 
 	const ctx: AppMcpHandlerContext = {
 		db: { appMcpServers: repo } as AppMcpHandlerContext['db'],
@@ -138,7 +151,7 @@ function buildContext(overrides?: {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Part 1 Tests: Registry handlers
 // ---------------------------------------------------------------------------
 
 describe('mcp.registry.list', () => {
@@ -305,13 +318,6 @@ describe('mcp.registry.update', () => {
 		const handler = h.get('mcp.registry.update')!;
 		await expect(handler({ id: 'nonexistent-id' }, {})).rejects.toThrow('MCP server not found');
 	});
-
-	it('does NOT emit changed when no update fields are provided (no-op)', async () => {
-		const handler = handlers.get('mcp.registry.update')!;
-		// Only id, no actual update fields
-		await handler({ id: MCP_ENTRY.id }, {});
-		expect(emit).not.toHaveBeenCalled();
-	});
 });
 
 describe('mcp.registry.delete', () => {
@@ -408,5 +414,165 @@ describe('mcp.registry.setEnabled', () => {
 		await expect(handler({ id: 'nonexistent', enabled: true }, {})).rejects.toThrow(
 			'MCP server not found'
 		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Part 2: Per-room enablement handler mock factories
+// ---------------------------------------------------------------------------
+
+function createMockDaemonHub(): { hub: DaemonHub; emitSpy: ReturnType<typeof mock> } {
+	const emitSpy = mock(async () => {});
+	const hub = {
+		emit: emitSpy,
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+	} as unknown as DaemonHub;
+	return { hub, emitSpy };
+}
+
+// ---------------------------------------------------------------------------
+// Part 2 Tests: Per-room enablement handlers
+// ---------------------------------------------------------------------------
+
+describe('setupAppMcpHandlers', () => {
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let appMcpRepo: AppMcpServerRepository;
+	let roomMcpRepo: RoomMcpEnablementRepository;
+	let handlers: Map<string, RequestHandler>;
+	let emitSpy: ReturnType<typeof mock>;
+
+	const ROOM_ID = 'room-test-123';
+
+	beforeEach(() => {
+		bunDb = new BunDatabase(':memory:');
+		createTables(bunDb);
+
+		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+		reactiveDb.notifyChange = mock(() => {});
+
+		appMcpRepo = new AppMcpServerRepository(bunDb, reactiveDb);
+		roomMcpRepo = new RoomMcpEnablementRepository(bunDb, reactiveDb);
+
+		// Build a minimal Database stub that exposes what the handlers need
+		const db = {
+			appMcpServers: appMcpRepo,
+			roomMcpEnablement: roomMcpRepo,
+		} as unknown as Database;
+
+		const { hub, handlers: h } = createMockMessageHub();
+		const { hub: daemonHub, emitSpy: spy } = createMockDaemonHub();
+		handlers = h;
+		emitSpy = spy;
+
+		setupAppMcpHandlers(hub, daemonHub, db);
+	});
+
+	afterEach(() => {
+		bunDb.close();
+	});
+
+	// Helper
+	function createServer(name: string) {
+		return appMcpRepo.create({ name, sourceType: 'stdio', command: 'npx' });
+	}
+
+	// ---------------------------------------------------------------------------
+	// mcp.room.getEnabled
+	// ---------------------------------------------------------------------------
+
+	describe('mcp.room.getEnabled', () => {
+		test('returns empty serverIds when no overrides exist', () => {
+			const handler = handlers.get('mcp.room.getEnabled')!;
+			const result = handler({ roomId: ROOM_ID }) as { serverIds: string[] };
+			expect(result.serverIds).toEqual([]);
+		});
+
+		test('returns IDs of enabled servers', () => {
+			const srv1 = createServer('srv-get-1');
+			const srv2 = createServer('srv-get-2');
+			roomMcpRepo.setEnabled(ROOM_ID, srv1.id, true);
+			roomMcpRepo.setEnabled(ROOM_ID, srv2.id, false);
+
+			const handler = handlers.get('mcp.room.getEnabled')!;
+			const result = handler({ roomId: ROOM_ID }) as { serverIds: string[] };
+			expect(result.serverIds).toContain(srv1.id);
+			expect(result.serverIds).not.toContain(srv2.id);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// mcp.room.setEnabled
+	// ---------------------------------------------------------------------------
+
+	describe('mcp.room.setEnabled', () => {
+		test('enables a server and returns ok:true', () => {
+			const srv = createServer('set-enabled');
+			const handler = handlers.get('mcp.room.setEnabled')!;
+			const result = handler({ roomId: ROOM_ID, serverId: srv.id, enabled: true }) as {
+				ok: boolean;
+			};
+			expect(result.ok).toBe(true);
+			expect(roomMcpRepo.getEnabledServerIds(ROOM_ID)).toContain(srv.id);
+		});
+
+		test('disables a server', () => {
+			const srv = createServer('set-disabled');
+			const handler = handlers.get('mcp.room.setEnabled')!;
+			handler({ roomId: ROOM_ID, serverId: srv.id, enabled: false });
+			expect(roomMcpRepo.getEnabledServerIds(ROOM_ID)).not.toContain(srv.id);
+		});
+
+		test('emits mcp.registry.changed after write', async () => {
+			const srv = createServer('emit-test');
+			const handler = handlers.get('mcp.room.setEnabled')!;
+			emitSpy.mockClear();
+			handler({ roomId: ROOM_ID, serverId: srv.id, enabled: true });
+
+			// Wait for the async emit to resolve
+			await new Promise<void>((resolve) => setTimeout(resolve, 10));
+			expect(emitSpy).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+		});
+
+		test('throws when server does not exist', () => {
+			const handler = handlers.get('mcp.room.setEnabled')!;
+			expect(() => handler({ roomId: ROOM_ID, serverId: 'nonexistent-id', enabled: true })).toThrow(
+				'MCP server not found'
+			);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// mcp.room.resetToGlobal
+	// ---------------------------------------------------------------------------
+
+	describe('mcp.room.resetToGlobal', () => {
+		test('removes all overrides and returns ok:true', () => {
+			const srv1 = createServer('reset-srv1');
+			const srv2 = createServer('reset-srv2');
+			roomMcpRepo.setEnabled(ROOM_ID, srv1.id, true);
+			roomMcpRepo.setEnabled(ROOM_ID, srv2.id, true);
+
+			const handler = handlers.get('mcp.room.resetToGlobal')!;
+			const result = handler({ roomId: ROOM_ID }) as { ok: boolean };
+			expect(result.ok).toBe(true);
+			expect(roomMcpRepo.getEnabledServerIds(ROOM_ID)).toEqual([]);
+		});
+
+		test('emits mcp.registry.changed after write', async () => {
+			const handler = handlers.get('mcp.room.resetToGlobal')!;
+			emitSpy.mockClear();
+			handler({ roomId: ROOM_ID });
+
+			await new Promise<void>((resolve) => setTimeout(resolve, 10));
+			expect(emitSpy).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+		});
+
+		test('no-op for a room with no overrides — still returns ok:true', () => {
+			const handler = handlers.get('mcp.room.resetToGlobal')!;
+			const result = handler({ roomId: 'empty-room' }) as { ok: boolean };
+			expect(result.ok).toBe(true);
+		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc/app-mcp-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/app-mcp-handlers.test.ts
@@ -447,7 +447,14 @@ describe('setupAppMcpHandlers', () => {
 
 	beforeEach(() => {
 		bunDb = new BunDatabase(':memory:');
+		bunDb.exec('PRAGMA foreign_keys = ON');
 		createTables(bunDb);
+
+		// Insert the test room required by the FK on room_mcp_enablement.room_id
+		const now = Date.now();
+		bunDb
+			.prepare(`INSERT INTO rooms (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)`)
+			.run(ROOM_ID, 'test-room', now, now);
 
 		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
 		reactiveDb.notifyChange = mock(() => {});

--- a/packages/daemon/tests/unit/storage/room-mcp-enablement-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/room-mcp-enablement-repository.test.ts
@@ -1,0 +1,240 @@
+/**
+ * RoomMcpEnablementRepository Unit Tests
+ *
+ * Covers setEnabled, getEnabledServerIds, getEnabledServers, resetToGlobal,
+ * getOverride, notifyChange calls, and behavior with missing servers.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import { RoomMcpEnablementRepository } from '../../../src/storage/repositories/room-mcp-enablement-repository';
+import { AppMcpServerRepository } from '../../../src/storage/repositories/app-mcp-server-repository';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('RoomMcpEnablementRepository', () => {
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let repo: RoomMcpEnablementRepository;
+	let appMcpRepo: AppMcpServerRepository;
+	let notifyChangeSpy: ReturnType<typeof mock>;
+
+	const ROOM_A = 'room-aaa';
+	const ROOM_B = 'room-bbb';
+
+	beforeEach(() => {
+		bunDb = new BunDatabase(':memory:');
+		// Enable foreign keys for CASCADE tests
+		bunDb.exec('PRAGMA foreign_keys = ON');
+		createTables(bunDb);
+
+		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+		notifyChangeSpy = mock(() => {});
+		reactiveDb.notifyChange = notifyChangeSpy;
+
+		appMcpRepo = new AppMcpServerRepository(bunDb, reactiveDb);
+		repo = new RoomMcpEnablementRepository(bunDb, reactiveDb);
+	});
+
+	afterEach(() => {
+		bunDb.close();
+	});
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
+	function createServer(name: string) {
+		return appMcpRepo.create({ name, sourceType: 'stdio', command: 'npx' });
+	}
+
+	// ---------------------------------------------------------------------------
+	// setEnabled
+	// ---------------------------------------------------------------------------
+
+	describe('setEnabled', () => {
+		test('inserts an enabled override', () => {
+			const srv = createServer('brave-search');
+			repo.setEnabled(ROOM_A, srv.id, true);
+
+			const ids = repo.getEnabledServerIds(ROOM_A);
+			expect(ids).toContain(srv.id);
+		});
+
+		test('inserts a disabled override', () => {
+			const srv = createServer('fetch');
+			repo.setEnabled(ROOM_A, srv.id, false);
+
+			const ids = repo.getEnabledServerIds(ROOM_A);
+			expect(ids).not.toContain(srv.id);
+		});
+
+		test('upserts — flipping from disabled to enabled', () => {
+			const srv = createServer('flipper');
+			repo.setEnabled(ROOM_A, srv.id, false);
+			repo.setEnabled(ROOM_A, srv.id, true);
+
+			const ids = repo.getEnabledServerIds(ROOM_A);
+			expect(ids).toContain(srv.id);
+		});
+
+		test('calls notifyChange after each write', () => {
+			const srv = createServer('notifier');
+			notifyChangeSpy.mockClear();
+			repo.setEnabled(ROOM_A, srv.id, true);
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('room_mcp_enablement');
+		});
+
+		test('per-room isolation — enabling in ROOM_A does not affect ROOM_B', () => {
+			const srv = createServer('isolated');
+			repo.setEnabled(ROOM_A, srv.id, true);
+
+			expect(repo.getEnabledServerIds(ROOM_A)).toContain(srv.id);
+			expect(repo.getEnabledServerIds(ROOM_B)).not.toContain(srv.id);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// getEnabledServerIds
+	// ---------------------------------------------------------------------------
+
+	describe('getEnabledServerIds', () => {
+		test('returns empty array when no overrides exist', () => {
+			expect(repo.getEnabledServerIds(ROOM_A)).toEqual([]);
+		});
+
+		test('returns only enabled server IDs, not disabled ones', () => {
+			const srvOn = createServer('on');
+			const srvOff = createServer('off');
+			repo.setEnabled(ROOM_A, srvOn.id, true);
+			repo.setEnabled(ROOM_A, srvOff.id, false);
+
+			const ids = repo.getEnabledServerIds(ROOM_A);
+			expect(ids).toContain(srvOn.id);
+			expect(ids).not.toContain(srvOff.id);
+		});
+
+		test('returns multiple enabled IDs', () => {
+			const srv1 = createServer('srv1');
+			const srv2 = createServer('srv2');
+			const srv3 = createServer('srv3');
+			repo.setEnabled(ROOM_A, srv1.id, true);
+			repo.setEnabled(ROOM_A, srv2.id, true);
+			repo.setEnabled(ROOM_A, srv3.id, false);
+
+			const ids = repo.getEnabledServerIds(ROOM_A);
+			expect(ids).toHaveLength(2);
+			expect(ids).toContain(srv1.id);
+			expect(ids).toContain(srv2.id);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// getEnabledServers
+	// ---------------------------------------------------------------------------
+
+	describe('getEnabledServers', () => {
+		test('returns full AppMcpServer objects for enabled servers', () => {
+			const srv = appMcpRepo.create({
+				name: 'full-server',
+				sourceType: 'stdio',
+				command: 'npx',
+				args: ['-y', '@mcp/test'],
+				description: 'A test server',
+			});
+			repo.setEnabled(ROOM_A, srv.id, true);
+
+			const servers = repo.getEnabledServers(ROOM_A);
+			expect(servers).toHaveLength(1);
+			expect(servers[0].name).toBe('full-server');
+			expect(servers[0].sourceType).toBe('stdio');
+			expect(servers[0].command).toBe('npx');
+			expect(servers[0].args).toEqual(['-y', '@mcp/test']);
+			expect(servers[0].description).toBe('A test server');
+			expect(servers[0].enabled).toBe(true);
+		});
+
+		test('does not return disabled servers', () => {
+			const srv = createServer('disabled-server');
+			repo.setEnabled(ROOM_A, srv.id, false);
+
+			const servers = repo.getEnabledServers(ROOM_A);
+			expect(servers).toHaveLength(0);
+		});
+
+		test('returns empty array when no overrides exist', () => {
+			expect(repo.getEnabledServers(ROOM_A)).toEqual([]);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// resetToGlobal
+	// ---------------------------------------------------------------------------
+
+	describe('resetToGlobal', () => {
+		test('removes all overrides for a room', () => {
+			const srv1 = createServer('reset1');
+			const srv2 = createServer('reset2');
+			repo.setEnabled(ROOM_A, srv1.id, true);
+			repo.setEnabled(ROOM_A, srv2.id, false);
+
+			repo.resetToGlobal(ROOM_A);
+
+			expect(repo.getEnabledServerIds(ROOM_A)).toEqual([]);
+		});
+
+		test('does not affect other rooms', () => {
+			const srv = createServer('cross-room');
+			repo.setEnabled(ROOM_A, srv.id, true);
+			repo.setEnabled(ROOM_B, srv.id, true);
+
+			repo.resetToGlobal(ROOM_A);
+
+			expect(repo.getEnabledServerIds(ROOM_A)).toEqual([]);
+			expect(repo.getEnabledServerIds(ROOM_B)).toContain(srv.id);
+		});
+
+		test('calls notifyChange', () => {
+			const srv = createServer('notify-reset');
+			repo.setEnabled(ROOM_A, srv.id, true);
+			notifyChangeSpy.mockClear();
+
+			repo.resetToGlobal(ROOM_A);
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('room_mcp_enablement');
+		});
+
+		test('no-op when room has no overrides', () => {
+			expect(() => repo.resetToGlobal('nonexistent-room')).not.toThrow();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// getOverride
+	// ---------------------------------------------------------------------------
+
+	describe('getOverride', () => {
+		test('returns null when no override exists', () => {
+			const srv = createServer('no-override');
+			expect(repo.getOverride(ROOM_A, srv.id)).toBeNull();
+		});
+
+		test('returns enabled:true for an enabled override', () => {
+			const srv = createServer('get-override-on');
+			repo.setEnabled(ROOM_A, srv.id, true);
+			expect(repo.getOverride(ROOM_A, srv.id)).toEqual({ enabled: true });
+		});
+
+		test('returns enabled:false for a disabled override', () => {
+			const srv = createServer('get-override-off');
+			repo.setEnabled(ROOM_A, srv.id, false);
+			expect(repo.getOverride(ROOM_A, srv.id)).toEqual({ enabled: false });
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/room-mcp-enablement-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/room-mcp-enablement-repository.test.ts
@@ -27,6 +27,13 @@ describe('RoomMcpEnablementRepository', () => {
 	const ROOM_A = 'room-aaa';
 	const ROOM_B = 'room-bbb';
 
+	function insertRoom(id: string): void {
+		const now = Date.now();
+		bunDb
+			.prepare(`INSERT INTO rooms (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)`)
+			.run(id, id, now, now);
+	}
+
 	beforeEach(() => {
 		bunDb = new BunDatabase(':memory:');
 		// Enable foreign keys for CASCADE tests
@@ -39,6 +46,10 @@ describe('RoomMcpEnablementRepository', () => {
 
 		appMcpRepo = new AppMcpServerRepository(bunDb, reactiveDb);
 		repo = new RoomMcpEnablementRepository(bunDb, reactiveDb);
+
+		// Insert rooms required by the FK constraint
+		insertRoom(ROOM_A);
+		insertRoom(ROOM_B);
 	});
 
 	afterEach(() => {

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -369,6 +369,34 @@ export interface RemoveMcpServerResponse {
 	message?: string;
 }
 
+// --- Per-Room MCP Enablement ---
+
+export interface McpRoomGetEnabledRequest {
+	roomId: string;
+}
+
+export interface McpRoomGetEnabledResponse {
+	serverIds: string[];
+}
+
+export interface McpRoomSetEnabledRequest {
+	roomId: string;
+	serverId: string;
+	enabled: boolean;
+}
+
+export interface McpRoomSetEnabledResponse {
+	ok: boolean;
+}
+
+export interface McpRoomResetToGlobalRequest {
+	roomId: string;
+}
+
+export interface McpRoomResetToGlobalResponse {
+	ok: boolean;
+}
+
 // --- Output Format ---
 
 export interface GetOutputFormatRequest {


### PR DESCRIPTION
- Add `room_mcp_enablement` table (schema + migration 50) with
  ON DELETE CASCADE on server_id foreign key
- Add `RoomMcpEnablementRepository` with setEnabled, getEnabledServerIds,
  getEnabledServers, resetToGlobal, and getOverride; each write calls
  reactiveDb.notifyChange('room_mcp_enablement')
- Expose repository as `db.roomMcpEnablement` in Database facade
- Add `mcpEnablement.byRoom` named LiveQuery with room authorization guard
- Add `mcp.registry.changed` event to DaemonHub
- Add `mcp.room.getEnabled`, `mcp.room.setEnabled`, `mcp.room.resetToGlobal`
  RPC handlers in new app-mcp-handlers.ts; mutating handlers emit
  `mcp.registry.changed`
- Add request/response types to @neokai/shared api.ts
- 27 unit tests covering repository and RPC handlers
