### PR TITLE
fix: model switch not taking effect on coder session

### DIFF
--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -175,7 +175,11 @@ export class ModelSwitchHandler {
 			}
 
 			if (!queryObject) {
-				// Query hasn't been created yet - just update config, it will be used when query starts
+				// Query hasn't been created yet OR query was already completed/interrupted.
+				// In both cases, we must call restart() to ensure the new model takes effect:
+				// - restart() validates the SDK session file before starting a new query
+				// - Without this, a stale session file could cause the new query to use old state
+				// - Even if no query is running, restart() ensures clean state for the next query
 				session.config.model = resolvedModel;
 				// newProviderInstance is guaranteed non-null here (we returned early above).
 				session.config.provider = newProviderInstance.id as Provider;
@@ -198,6 +202,10 @@ export class ModelSwitchHandler {
 					source: 'model-switch',
 					session: { config: session.config },
 				});
+
+				// Always restart to ensure new model takes effect, even when queryObject is null.
+				// This validates the session file and starts a fresh query with the new model.
+				await lifecycleManager.restart();
 			} else {
 				// Query exists - always restart to apply the new model/provider.
 				// We must restart even if firstMessageReceived is false because the SDK

--- a/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
@@ -300,7 +300,11 @@ describe('ModelSwitchHandler', () => {
 		const VALID_MODEL = 'opus';
 
 		describe('when query not started', () => {
-			it('should update config only when query not started', async () => {
+			it('should update config and restart when query not started', async () => {
+				// FIX: Always call restart() to ensure new model takes effect.
+				// This validates the session file and starts a fresh query with the new model,
+				// even when queryObject is null. This fixes the bug where model switch
+				// wasn't taking effect for tasks in non-active states (review, needs_attention).
 				handler = createHandler({ queryObject: null });
 				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
@@ -312,7 +316,8 @@ describe('ModelSwitchHandler', () => {
 					})
 				);
 				expect(setModelTrackerSpy).toHaveBeenCalled();
-				expect(restartSpy).not.toHaveBeenCalled();
+				// Restart IS called to ensure the new model takes effect
+				expect(restartSpy).toHaveBeenCalled();
 			});
 
 			it('should pass only serializable config fields (no closures or cyclic refs)', async () => {
@@ -397,16 +402,18 @@ describe('ModelSwitchHandler', () => {
 				expect(restartSpy).toHaveBeenCalled();
 			});
 
-			it('should not restart when queryObject does not exist (query not started)', async () => {
-				// Only when query hasn't been created at all should we skip restart.
-				// The new model will be used when the query finally starts.
+			it('should restart even when queryObject does not exist (query not started)', async () => {
+				// FIX: Always call restart() to ensure new model takes effect.
+				// This is important for tasks in non-active states (review, needs_attention)
+				// where the query might have been completed/interrupted. Without restart,
+				// the new model would not take effect until the task resumes.
 				handler = createHandler({ queryObject: null, firstMessageReceived: false });
 				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(updateSessionSpy).toHaveBeenCalled();
-				// No restart because queryObject doesn't exist
-				expect(restartSpy).not.toHaveBeenCalled();
+				// Restart IS called to ensure the new model takes effect
+				expect(restartSpy).toHaveBeenCalled();
 			});
 		});
 


### PR DESCRIPTION
## Summary
- Model switching on task sessions in non-active states (review, needs_attention) now properly restarts the query
- Previously, only the session config was updated without calling `restart()`, leaving the coder session using the old model
- The fix ensures `restart()` is called regardless of `queryObject` state, validating the session file and emitting a fresh `system:init` with the correct model

## Root Cause
When a task is in a non-active state, `queryObject` is null. The original code only updated the in-memory and DB config but skipped the restart call, so the SDK subprocess kept running with the old model.

## Test plan
- [x] Unit tests updated in `model-switch-handler.test.ts` (27 tests passing)
- [x] All daemon unit tests pass (7574 total)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Typecheck passes