### PR TITLE
fix(goal-handlers): resolve short task IDs to full UUIDs in task.approve

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -287,9 +287,14 @@ export function setupGoalHandlers(
 		if (!params.taskId) {
 			throw new Error('Task ID is required');
 		}
+		if (!taskManagerFactory) {
+			throw new Error('Task manager factory is required for goal.linkTask');
+		}
 
 		const goalManager = goalManagerFactory(params.roomId);
 		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
+		const { taskRepo } = taskManagerFactory(params.roomId);
+		const taskId = resolveTaskId(params.taskId, params.roomId, taskRepo);
 
 		// For recurring missions with an active execution, use the atomic dual-write path.
 		let goal;
@@ -297,12 +302,12 @@ export function setupGoalHandlers(
 		if (linkedGoal?.missionType === 'recurring') {
 			const activeExecution = goalManager.getActiveExecution(goalId);
 			if (activeExecution) {
-				goal = await goalManager.linkTaskToExecution(goalId, activeExecution.id, params.taskId);
+				goal = await goalManager.linkTaskToExecution(goalId, activeExecution.id, taskId);
 			} else {
-				goal = await goalManager.linkTaskToGoal(goalId, params.taskId);
+				goal = await goalManager.linkTaskToGoal(goalId, taskId);
 			}
 		} else {
-			goal = await goalManager.linkTaskToGoal(goalId, params.taskId);
+			goal = await goalManager.linkTaskToGoal(goalId, taskId);
 		}
 
 		return { goal };

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -32,7 +32,8 @@ import type { TaskManager } from '../room/managers/task-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { Logger } from '../logger';
 import { isValidCronExpression, getNextRunAt, getSystemTimezone } from '../room/runtime/cron-utils';
-import { resolveGoalId } from '../id-resolution';
+import { resolveGoalId, resolveTaskId } from '../id-resolution';
+import type { TaskRepository } from '../../storage/repositories/task-repository';
 
 const log = new Logger('goal-handlers');
 
@@ -59,9 +60,10 @@ export type GoalManagerLike = Pick<
 >;
 
 export type GoalManagerFactory = (roomId: string) => GoalManagerLike;
-export type TaskManagerFactory = (
-	roomId: string
-) => Pick<TaskManager, 'getTask' | 'reviewTask' | 'updateTaskStatus'>;
+export type TaskManagerFactory = (roomId: string) => {
+	taskManager: Pick<TaskManager, 'getTask' | 'reviewTask' | 'updateTaskStatus'>;
+	taskRepo: TaskRepository;
+};
 
 export function setupGoalHandlers(
 	messageHub: MessageHub,
@@ -518,10 +520,11 @@ export function setupGoalHandlers(
 			);
 		}
 
-		const taskManager = taskManagerFactory(params.roomId);
-		const task = await taskManager.getTask(params.taskId);
+		const { taskManager, taskRepo } = taskManagerFactory(params.roomId);
+		const taskId = resolveTaskId(params.taskId, params.roomId, taskRepo);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
-			throw new Error(`Task not found: ${params.taskId}`);
+			throw new Error(`Task not found: ${taskId}`);
 		}
 		if (task.status !== 'review') {
 			throw new Error(`Task is not in review status (current: ${task.status})`);
@@ -541,16 +544,14 @@ export function setupGoalHandlers(
 				: 'Human has approved the PR. Merge it now by running `gh pr merge`. ' +
 					'After the merge completes, your work is done.';
 
-		const resumed = await runtime.resumeWorkerFromHuman(params.taskId, message, {
+		const resumed = await runtime.resumeWorkerFromHuman(taskId, message, {
 			approved: true,
 		});
 		if (!resumed) {
-			throw new Error(
-				`Failed to resume task ${params.taskId} — no submitted-for-review group found`
-			);
+			throw new Error(`Failed to resume task ${taskId} — no submitted-for-review group found`);
 		}
 
-		log.info(`Task ${params.taskId} approved by human in room ${params.roomId}`);
+		log.info(`Task ${taskId} approved by human in room ${params.roomId}`);
 		return { success: true };
 	};
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -42,6 +42,7 @@ import { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { Logger } from '../logger';
 import { GoalManager } from '../room/managers/goal-manager';
 import { TaskManager } from '../room/managers/task-manager';
+import { TaskRepository } from '../../storage/repositories/task-repository';
 import { setupDialogHandlers } from './dialog-handlers';
 // Space handlers
 import { setupSpaceHandlers } from './space-handlers';
@@ -143,12 +144,14 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Create factory function for per-room task managers (used by goal review handlers)
 	const goalTaskManagerFactory: GoalTaskManagerFactory = (roomId: string) => {
-		return new TaskManager(
+		const taskManager = new TaskManager(
 			deps.db.getDatabase(),
 			roomId,
 			deps.reactiveDb,
 			deps.db.getShortIdAllocator()
 		);
+		const taskRepo = new TaskRepository(deps.db.getDatabase(), deps.reactiveDb);
+		return { taskManager, taskRepo };
 	};
 
 	setupSessionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub, roomManager);

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -1127,13 +1127,18 @@ describe('Goal RPC Handlers', () => {
 	});
 
 	describe('task approval handlers', () => {
-		function setupApprovalHandlers(task: NeoTask | null, resumeResult = true) {
+		function setupApprovalHandlers(
+			task: NeoTask | null,
+			resumeResult = true,
+			taskRepoMock?: { getTaskByShortId: () => { id: string } | null }
+		) {
 			const taskManager = {
 				getTask: mock(async () => task),
 				reviewTask: mock(async () => task),
 				updateTaskStatus: mock(async () => task),
 			};
-			const taskManagerFactory: TaskManagerFactory = mock(() => taskManager);
+			const taskRepo = taskRepoMock ?? { getTaskByShortId: mock(() => null) };
+			const taskManagerFactory: TaskManagerFactory = mock(() => ({ taskManager, taskRepo }));
 
 			const runtime = {
 				resumeWorkerFromHuman: mock(async () => resumeResult),
@@ -1150,7 +1155,7 @@ describe('Goal RPC Handlers', () => {
 				runtimeService
 			);
 
-			return { taskManager, runtime, runtimeService };
+			return { taskManager, runtime, runtimeService, taskRepo };
 		}
 
 		it('registers task.approve handler', async () => {
@@ -1160,7 +1165,7 @@ describe('Goal RPC Handlers', () => {
 
 		it('approves coding task via task.approve and resumes runtime', async () => {
 			const task = {
-				id: 'task-123',
+				id: '08ba6a00-be49-44c5-b1fe-3795f2906b8a',
 				roomId: 'room-123',
 				title: 'Task',
 				description: '',
@@ -1176,12 +1181,15 @@ describe('Goal RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('task.approve');
 			expect(handler).toBeDefined();
 
-			const result = (await handler!({ roomId: 'room-123', taskId: 'task-123' }, {})) as {
+			const result = (await handler!(
+				{ roomId: 'room-123', taskId: '08ba6a00-be49-44c5-b1fe-3795f2906b8a' },
+				{}
+			)) as {
 				success: boolean;
 			};
 
 			expect(runtime.resumeWorkerFromHuman).toHaveBeenCalledWith(
-				'task-123',
+				'08ba6a00-be49-44c5-b1fe-3795f2906b8a',
 				expect.stringContaining('Human has approved the PR'),
 				{ approved: true }
 			);
@@ -1190,7 +1198,7 @@ describe('Goal RPC Handlers', () => {
 
 		it('approves planning task via task.approve and resumes runtime', async () => {
 			const task = {
-				id: 'task-123',
+				id: '08ba6a00-be49-44c5-b1fe-3795f2906b8a',
 				roomId: 'room-123',
 				title: 'Task',
 				description: '',
@@ -1206,12 +1214,15 @@ describe('Goal RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('task.approve');
 			expect(handler).toBeDefined();
 
-			const result = (await handler!({ roomId: 'room-123', taskId: 'task-123' }, {})) as {
+			const result = (await handler!(
+				{ roomId: 'room-123', taskId: '08ba6a00-be49-44c5-b1fe-3795f2906b8a' },
+				{}
+			)) as {
 				success: boolean;
 			};
 
 			expect(runtime.resumeWorkerFromHuman).toHaveBeenCalledWith(
-				'task-123',
+				'08ba6a00-be49-44c5-b1fe-3795f2906b8a',
 				expect.stringContaining('create tasks 1:1 from the approved plan'),
 				{ approved: true }
 			);
@@ -1220,7 +1231,7 @@ describe('Goal RPC Handlers', () => {
 
 		it('throws when task.approve resume fails', async () => {
 			const task = {
-				id: 'task-123',
+				id: '08ba6a00-be49-44c5-b1fe-3795f2906b8a',
 				roomId: 'room-123',
 				title: 'Task',
 				description: '',
@@ -1236,9 +1247,74 @@ describe('Goal RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('task.approve');
 			expect(handler).toBeDefined();
 
-			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
-				'Failed to resume task task-123'
+			await expect(
+				handler!({ roomId: 'room-123', taskId: '08ba6a00-be49-44c5-b1fe-3795f2906b8a' }, {})
+			).rejects.toThrow('Failed to resume task 08ba6a00-be49-44c5-b1fe-3795f2906b8a');
+		});
+
+		it('resolves short ID to full UUID when approving a task', async () => {
+			const task = {
+				id: 'task-08ba6a00-be49-44c5-b1fe-3795f2906b8a',
+				roomId: 'room-123',
+				title: 'Task',
+				description: '',
+				status: 'review',
+				priority: 'normal',
+				taskType: 'coding',
+				progress: 0,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			} as NeoTask;
+			const getTaskByShortId = mock(() => ({ id: task.id }));
+			const { runtime, taskRepo } = setupApprovalHandlers(task, true, { getTaskByShortId });
+			const handler = messageHubData.handlers.get('task.approve');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ roomId: 'room-123', taskId: 't-42' }, {})) as {
+				success: boolean;
+			};
+
+			expect(getTaskByShortId).toHaveBeenCalledWith('room-123', 't-42');
+			expect(runtime.resumeWorkerFromHuman).toHaveBeenCalledWith(
+				'task-08ba6a00-be49-44c5-b1fe-3795f2906b8a',
+				expect.stringContaining('Human has approved the PR'),
+				{ approved: true }
 			);
+			expect(result.success).toBe(true);
+		});
+
+		it('uses full UUID directly when taskId is already a UUID', async () => {
+			const taskId = '08ba6a00-be49-44c5-b1fe-3795f2906b8a';
+			const task = {
+				id: taskId,
+				roomId: 'room-123',
+				title: 'Task',
+				description: '',
+				status: 'review',
+				priority: 'normal',
+				taskType: 'coding',
+				progress: 0,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			} as NeoTask;
+			const getTaskByShortId = mock(() => null);
+			const { runtime } = setupApprovalHandlers(task, true, { getTaskByShortId });
+			const handler = messageHubData.handlers.get('task.approve');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ roomId: 'room-123', taskId }, {})) as {
+				success: boolean;
+			};
+
+			expect(getTaskByShortId).not.toHaveBeenCalled();
+			expect(runtime.resumeWorkerFromHuman).toHaveBeenCalledWith(
+				taskId,
+				expect.stringContaining('Human has approved the PR'),
+				{ approved: true }
+			);
+			expect(result.success).toBe(true);
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -230,6 +230,17 @@ const mockGoalManager = {
 
 const createMockGoalManager = (): GoalManagerLike => mockGoalManager as unknown as GoalManagerLike;
 
+// Mock TaskManagerFactory for goal.linkTask tests
+const mockTaskRepo = {
+	getTaskByShortId: mock((_roomId: string, shortId: string) => ({ id: shortId })),
+};
+const mockTaskManager = {};
+const createMockTaskManagerFactory = (): TaskManagerFactory =>
+	mock(() => ({
+		taskManager: mockTaskManager,
+		taskRepo: mockTaskRepo,
+	})) as unknown as TaskManagerFactory;
+
 // Helper to create a minimal mock MessageHub that captures handlers
 function createMockMessageHub(): {
 	hub: MessageHub;
@@ -304,9 +315,15 @@ describe('Goal RPC Handlers', () => {
 		mockGoalManager.recordMetric.mockClear();
 		mockGoalManager.checkMetricTargets.mockClear();
 		mockGoalManager.getGoalByShortId.mockClear();
+		mockTaskRepo.getTaskByShortId.mockClear();
 
 		// Setup handlers with mocked dependencies
-		setupGoalHandlers(messageHubData.hub, daemonHubData.daemonHub, createMockGoalManager);
+		setupGoalHandlers(
+			messageHubData.hub,
+			daemonHubData.daemonHub,
+			createMockGoalManager,
+			createMockTaskManagerFactory()
+		);
 	});
 
 	afterEach(() => {
@@ -1714,8 +1731,11 @@ describe('Goal RPC Handlers', () => {
 		});
 
 		describe('goal.linkTask', () => {
-			it('resolves short ID to UUID before linking task', async () => {
+			const TASK_UUID = 'task-uuid-1234-5678-abcd';
+
+			it('resolves short IDs to UUIDs before linking task', async () => {
 				resolveShortId();
+				mockTaskRepo.getTaskByShortId.mockReturnValueOnce({ id: TASK_UUID });
 				// getGoal is called inside linkTask to check missionType
 				mockGoalManager.getGoal.mockResolvedValueOnce({
 					id: GOAL_UUID,
@@ -1735,10 +1755,10 @@ describe('Goal RPC Handlers', () => {
 
 				await handler({ roomId: ROOM_UUID, goalId: 'g-1', taskId: 'task-abc' }, {});
 
-				expect(mockGoalManager.linkTaskToGoal).toHaveBeenCalledWith(GOAL_UUID, 'task-abc');
+				expect(mockGoalManager.linkTaskToGoal).toHaveBeenCalledWith(GOAL_UUID, TASK_UUID);
 			});
 
-			it('throws when short ID is not found', async () => {
+			it('throws when goal short ID is not found', async () => {
 				rejectShortId();
 				const handler = messageHubData.handlers.get('goal.linkTask')!;
 


### PR DESCRIPTION
The task.approve and goal.linkTask RPC handlers were receiving short IDs (e.g., 't-42') from the UI but not resolving them to full UUIDs before passing to the task manager and runtime. This caused "Task not found" errors when approving tasks or linking tasks to goals.

Changes:
- Import resolveTaskId from id-resolution and TaskRepository in goal-handlers
- Update TaskManagerFactory type to return both taskManager and taskRepo
- Call resolveTaskId before using taskId in task.approve handler
- Call resolveTaskId before using taskId in goal.linkTask handler
- Error and log messages now use the resolved full UUID
- Update goalTaskManagerFactory in index.ts to return both taskManager and taskRepo
- Update existing tests to use valid UUIDs and add tests for short ID resolution

Test plan:
- [x] Unit tests pass (103 tests in goal-handlers.test.ts)
- [x] Typecheck passes
- [x] Lint passes