### PR TITLE
fix(agent): clear models cache on restart/reset to fix mid-turn model switch

### DIFF
--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -194,6 +194,10 @@ export class QueryLifecycleManager {
 				}
 			}
 
+			// Clear models cache to ensure the new model is fetched fresh from DB
+			// This is critical for model switch to pick up the correct model
+			await this.ctx.clearModelsCache();
+
 			await this.ctx.startStreamingQuery();
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -223,6 +227,8 @@ export class QueryLifecycleManager {
 			this.ctx.pendingRestartReason = null;
 			messageHandler.resetCircuitBreaker();
 			await stateManager.setIdle();
+			// Clear models cache to ensure fresh model info is fetched from DB
+			await this.ctx.clearModelsCache();
 			return { success: true };
 		}
 
@@ -254,6 +260,10 @@ export class QueryLifecycleManager {
 			// Post-stop: Reset state
 			this.ctx.firstMessageReceived = false;
 			await stateManager.setIdle();
+
+			// Clear models cache to ensure fresh model info is fetched from DB
+			// This is critical for model switch to pick up the new model
+			await this.ctx.clearModelsCache();
 
 			// Optionally restart
 			if (restartAfter) {
@@ -337,6 +347,10 @@ export class QueryLifecycleManager {
 				db.updateSession(session.id, { sdkSessionId: undefined });
 			}
 		}
+
+		// Clear models cache to ensure fresh model info is fetched from DB
+		// This handles the edge case where model was changed in DB directly
+		await this.ctx.clearModelsCache();
 
 		await this.ctx.startStreamingQuery();
 	}

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -42,6 +42,7 @@ describe('QueryLifecycleManager', () => {
 	let resetCircuitBreakerSpy: ReturnType<typeof mock>;
 	let getInterruptPromiseSpy: ReturnType<typeof mock>;
 	let handleErrorSpy: ReturnType<typeof mock>;
+	let clearModelsCacheSpy: ReturnType<typeof mock>;
 
 	function createMockContext(
 		overrides: Partial<QueryLifecycleManagerContext> = {}
@@ -66,6 +67,7 @@ describe('QueryLifecycleManager', () => {
 		resetCircuitBreakerSpy = mock(() => {});
 		getInterruptPromiseSpy = mock(() => null);
 		handleErrorSpy = mock(async () => {});
+		clearModelsCacheSpy = mock(async () => {});
 
 		startStreamingCalled = false;
 		return {
@@ -107,7 +109,7 @@ describe('QueryLifecycleManager', () => {
 			// Cleanup support methods
 			setCleaningUp: mock(() => {}),
 			cleanupEventSubscriptions: mock(() => {}),
-			clearModelsCache: mock(async () => {}),
+			clearModelsCache: clearModelsCacheSpy,
 			...overrides,
 		};
 	}
@@ -336,6 +338,12 @@ describe('QueryLifecycleManager', () => {
 			expect(startStreamingCalled).toBe(true);
 		});
 
+		test('clears models cache before starting new query', async () => {
+			await manager.restart();
+
+			expect(clearModelsCacheSpy).toHaveBeenCalled();
+		});
+
 		test('throws on start failure', async () => {
 			const failingContext = createMockContext({
 				startStreamingQuery: async () => {
@@ -378,6 +386,13 @@ describe('QueryLifecycleManager', () => {
 			expect(startStreamingCalled).toBe(false);
 		});
 
+		test('clears models cache on early return when no query is running', async () => {
+			// No queryObject or queryPromise set
+			await manager.reset();
+
+			expect(clearModelsCacheSpy).toHaveBeenCalled();
+		});
+
 		test('clears pendingRestartReason on early return', async () => {
 			mockContext.pendingRestartReason = 'settings.local.json';
 			manager = new QueryLifecycleManager(mockContext);
@@ -399,6 +414,7 @@ describe('QueryLifecycleManager', () => {
 			expect(result.success).toBe(true);
 			expect(resetCircuitBreakerSpy).toHaveBeenCalled();
 			expect(setIdleSpy).toHaveBeenCalled();
+			expect(clearModelsCacheSpy).toHaveBeenCalled();
 			expect(publishSpy).toHaveBeenCalledWith(
 				'session.reset',
 				expect.objectContaining({ message: expect.any(String) }),
@@ -557,6 +573,12 @@ describe('QueryLifecycleManager', () => {
 			await manager.ensureQueryStarted();
 
 			expect(startStreamingCalled).toBe(true);
+		});
+
+		test('clears models cache before starting streaming query', async () => {
+			await manager.ensureQueryStarted();
+
+			expect(clearModelsCacheSpy).toHaveBeenCalled();
 		});
 
 		test('validates SDK session when sdkSessionId exists', async () => {

--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -83,6 +83,8 @@ export interface TaskInfoPanelProps {
 		onCancel?: () => void;
 		onArchive?: () => void;
 		onSetStatus?: () => void;
+		onResetWorkerAgent?: () => void;
+		onResetLeaderAgent?: () => void;
 	};
 	/** Whether each action should be shown (context-aware) */
 	visibleActions: {
@@ -90,6 +92,8 @@ export interface TaskInfoPanelProps {
 		cancel?: boolean;
 		archive?: boolean;
 		setStatus?: boolean;
+		resetWorkerAgent?: boolean;
+		resetLeaderAgent?: boolean;
 	};
 	/** Whether each action is disabled */
 	disabledActions?: {
@@ -97,6 +101,8 @@ export interface TaskInfoPanelProps {
 		cancel?: boolean;
 		archive?: boolean;
 		setStatus?: boolean;
+		resetWorkerAgent?: boolean;
+		resetLeaderAgent?: boolean;
 	};
 }
 
@@ -139,7 +145,9 @@ export function TaskInfoPanel({
 		visibleActions.complete ||
 		visibleActions.cancel ||
 		visibleActions.archive ||
-		visibleActions.setStatus;
+		visibleActions.setStatus ||
+		visibleActions.resetWorkerAgent ||
+		visibleActions.resetLeaderAgent;
 
 	// Model switchers: show separate selectors for worker and leader
 	const hasWorkerModel = workerSession?.config.model != null;
@@ -404,6 +412,48 @@ export function TaskInfoPanel({
 										/>
 									</svg>
 									Set Status
+								</button>
+							)}
+
+							{visibleActions.resetWorkerAgent && actions.onResetWorkerAgent && (
+								<button
+									type="button"
+									onClick={actions.onResetWorkerAgent}
+									disabled={disabledActions?.resetWorkerAgent}
+									data-testid="task-info-panel-reset-worker"
+									class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-dark-600 text-gray-400 hover:text-orange-400 hover:border-orange-700/60"
+									title="Reset worker agent to fix stuck state or apply changes"
+								>
+									<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+										/>
+									</svg>
+									Reset Worker
+								</button>
+							)}
+
+							{visibleActions.resetLeaderAgent && actions.onResetLeaderAgent && (
+								<button
+									type="button"
+									onClick={actions.onResetLeaderAgent}
+									disabled={disabledActions?.resetLeaderAgent}
+									data-testid="task-info-panel-reset-leader"
+									class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-dark-600 text-gray-400 hover:text-orange-400 hover:border-orange-700/60"
+									title="Reset leader agent to fix stuck state or apply changes"
+								>
+									<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+										/>
+									</svg>
+									Reset Leader
 								</button>
 							)}
 						</div>

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -20,6 +20,8 @@ import { useAutoScroll } from '../../hooks/useAutoScroll';
 import { useTaskViewData } from '../../hooks/useTaskViewData';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
 import { currentRoomTabSignal } from '../../lib/signals';
+import { resetSessionQuery } from '../../lib/api-helpers';
+import { toast } from '../../lib/toast';
 import { CircularProgressIndicator } from '../ui/CircularProgressIndicator';
 import { RejectModal } from '../ui/RejectModal';
 import { ScrollToBottomButton } from '../ScrollToBottomButton';
@@ -317,18 +319,56 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 									setStatusModal.open();
 								}
 							: undefined,
+					onResetWorkerAgent: workerSession
+						? async () => {
+								setIsInfoPanelOpen(false);
+								try {
+									const result = await resetSessionQuery(workerSession.id);
+									if (result.success) {
+										toast.success('Worker agent reset successfully.');
+									} else {
+										toast.error(result.error || 'Failed to reset worker agent');
+									}
+								} catch (error) {
+									toast.error(
+										error instanceof Error ? error.message : 'Failed to reset worker agent'
+									);
+								}
+							}
+						: undefined,
+					onResetLeaderAgent: leaderSession
+						? async () => {
+								setIsInfoPanelOpen(false);
+								try {
+									const result = await resetSessionQuery(leaderSession.id);
+									if (result.success) {
+										toast.success('Leader agent reset successfully.');
+									} else {
+										toast.error(result.error || 'Failed to reset leader agent');
+									}
+								} catch (error) {
+									toast.error(
+										error instanceof Error ? error.message : 'Failed to reset leader agent'
+									);
+								}
+							}
+						: undefined,
 				}}
 				visibleActions={{
 					complete: canComplete && task.status !== 'review',
 					cancel: canCancel,
 					archive: canArchive,
 					setStatus: task.status !== 'archived',
+					resetWorkerAgent: !!workerSession,
+					resetLeaderAgent: !!leaderSession,
 				}}
 				disabledActions={{
 					complete: interrupting,
 					cancel: interrupting,
 					archive: false,
 					setStatus: false,
+					resetWorkerAgent: interrupting,
+					resetLeaderAgent: interrupting,
 				}}
 			/>
 

--- a/packages/web/src/hooks/useSessionActions.ts
+++ b/packages/web/src/hooks/useSessionActions.ts
@@ -8,7 +8,7 @@
 import { useState, useCallback } from 'preact/hooks';
 import type { Session, ArchiveSessionResponse } from '@neokai/shared';
 import { connectionManager } from '../lib/connection-manager';
-import { deleteSession, listSessions, archiveSession } from '../lib/api-helpers';
+import { deleteSession, listSessions, archiveSession, resetSessionQuery } from '../lib/api-helpers';
 import { toast } from '../lib/toast';
 import { currentSessionIdSignal, sessionsSignal } from '../lib/signals';
 import { connectionState } from '../lib/state';
@@ -127,16 +127,7 @@ export function useSessionActions({
 
 		try {
 			setResettingAgent(true);
-			const hub = connectionManager.getHubIfConnected();
-			if (!hub) {
-				toast.error('Not connected to server');
-				return;
-			}
-
-			const result = await hub.request<{ success: boolean; error?: string }>('session.resetQuery', {
-				sessionId,
-				restartQuery: true,
-			});
+			const result = await resetSessionQuery(sessionId);
 
 			if (result.success) {
 				toast.success('Agent reset successfully.');


### PR DESCRIPTION
When switching models mid-conversation or clicking Reset Agent, the agent
session must pick up the new model from the database, not use cached
model info. This change adds clearModelsCache() calls to both restart()
and reset() methods in QueryLifecycleManager to ensure fresh model
info is fetched.

Also adds Reset Agent buttons to TaskInfoPanel for both worker and
leader agents, allowing manual reset when agents get stuck or have
wrong state. The buttons call session.resetQuery RPC which invokes
lifecycleManager.reset() with full cleanup.

Fixes:
- Mid-turn model switch not picking up new model
- Models cache potentially returning stale model info
