### PR TITLE
feat(shared): define reference types for @ referencing system

### DIFF
--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -20,6 +20,7 @@ export * from './types/space.ts';
 export * from './types/space-utils.ts';
 export * from './types/tools.ts';
 export * from './types/app-mcp-server.ts';
+export * from './types/reference.ts';
 export * from './live-query-types.ts';
 export * from './prompts/index.ts';
 

--- a/packages/shared/src/types/reference.ts
+++ b/packages/shared/src/types/reference.ts
@@ -1,0 +1,103 @@
+/**
+ * Types for the @ reference system.
+ *
+ * Users can type @ in chat inputs to reference tasks, goals, files, and folders.
+ * References are serialized as `@ref{type:id}` in message content.
+ */
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+/** The type of entity being referenced */
+export type ReferenceType = 'task' | 'goal' | 'file' | 'folder';
+
+/**
+ * A parsed @ mention from user input.
+ * Represents a reference that has been inserted into the input field.
+ */
+export interface ReferenceMention {
+	type: ReferenceType;
+	id: string;
+	displayText: string;
+}
+
+/**
+ * A search result returned by the reference search RPC.
+ */
+export interface ReferenceSearchResult {
+	type: ReferenceType;
+	id: string;
+	/** Short human-readable identifier (e.g. "t-42" for tasks) */
+	shortId?: string;
+	displayText: string;
+	/** Secondary line shown in the autocomplete menu */
+	subtitle?: string;
+}
+
+/**
+ * A resolved reference — the raw entity data retrieved for a given id.
+ * The shape of `data` is polymorphic based on `type`.
+ */
+export interface ResolvedReference {
+	type: ReferenceType;
+	id: string;
+	data: unknown;
+}
+
+// ============================================================================
+// Resolved Reference Variants
+// ============================================================================
+
+export interface ResolvedTaskReference extends ResolvedReference {
+	type: 'task';
+}
+
+export interface ResolvedGoalReference extends ResolvedReference {
+	type: 'goal';
+}
+
+export interface ResolvedFileReference extends ResolvedReference {
+	type: 'file';
+}
+
+export interface ResolvedFolderReference extends ResolvedReference {
+	type: 'folder';
+}
+
+// ============================================================================
+// Message Persistence
+// ============================================================================
+
+/**
+ * Reference metadata stored in a message blob alongside the message text.
+ * Keyed by the serialized reference string (e.g. "@ref{task:t-42}").
+ *
+ * Uses `Record` rather than `Map` because this is serialized to JSON in the
+ * `sdk_message` column.
+ */
+export type ReferenceMetadata = Record<
+	string,
+	{
+		type: ReferenceType;
+		id: string;
+		displayText: string;
+		/** Optional status snapshot at the time the message was sent */
+		status?: string;
+	}
+>;
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+/**
+ * Regex that matches serialized @ references in message text.
+ *
+ * Format: `@ref{type:id}`
+ * Example: `@ref{task:t-42}`, `@ref{goal:g-abc}`, `@ref{file:src/index.ts}`
+ *
+ * Note: This regex uses the `g` flag — reset `lastIndex` or use `matchAll`
+ * to avoid stale state between calls.
+ */
+export const REFERENCE_PATTERN = /@ref\{([^}:]+):([^}]+)\}/g;

--- a/packages/shared/tests/reference.test.ts
+++ b/packages/shared/tests/reference.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'bun:test';
+import type {
+	ReferenceMention,
+	ReferenceMetadata,
+	ReferenceSearchResult,
+	ResolvedFileReference,
+	ResolvedFolderReference,
+	ResolvedGoalReference,
+	ResolvedReference,
+	ResolvedTaskReference,
+	ReferenceType,
+} from '../src/types/reference.ts';
+import { REFERENCE_PATTERN } from '../src/types/reference.ts';
+
+describe('ReferenceType', () => {
+	it('accepts all valid values', () => {
+		const valid: ReferenceType[] = ['task', 'goal', 'file', 'folder'];
+		expect(valid).toHaveLength(4);
+	});
+});
+
+describe('ReferenceMention', () => {
+	it('has the expected shape', () => {
+		const mention: ReferenceMention = {
+			type: 'task',
+			id: 't-42',
+			displayText: 'Fix the bug',
+		};
+		expect(mention.type).toBe('task');
+		expect(mention.id).toBe('t-42');
+		expect(mention.displayText).toBe('Fix the bug');
+	});
+});
+
+describe('ReferenceSearchResult', () => {
+	it('includes optional fields', () => {
+		const result: ReferenceSearchResult = {
+			type: 'goal',
+			id: 'g-1',
+			shortId: 'g-1',
+			displayText: 'Improve performance',
+			subtitle: 'Measurable goal',
+		};
+		expect(result.shortId).toBe('g-1');
+		expect(result.subtitle).toBe('Measurable goal');
+	});
+
+	it('works without optional fields', () => {
+		const result: ReferenceSearchResult = {
+			type: 'file',
+			id: 'src/index.ts',
+			displayText: 'src/index.ts',
+		};
+		expect(result.shortId).toBeUndefined();
+		expect(result.subtitle).toBeUndefined();
+	});
+});
+
+describe('ResolvedReference variants', () => {
+	it('ResolvedTaskReference has type task', () => {
+		const ref: ResolvedTaskReference = { type: 'task', id: 't-1', data: { title: 'A task' } };
+		expect(ref.type).toBe('task');
+	});
+
+	it('ResolvedGoalReference has type goal', () => {
+		const ref: ResolvedGoalReference = { type: 'goal', id: 'g-1', data: {} };
+		expect(ref.type).toBe('goal');
+	});
+
+	it('ResolvedFileReference has type file', () => {
+		const ref: ResolvedFileReference = { type: 'file', id: 'src/app.ts', data: 'content' };
+		expect(ref.type).toBe('file');
+	});
+
+	it('ResolvedFolderReference has type folder', () => {
+		const ref: ResolvedFolderReference = {
+			type: 'folder',
+			id: 'src/',
+			data: ['app.ts', 'index.ts'],
+		};
+		expect(ref.type).toBe('folder');
+	});
+
+	it('ResolvedReference accepts unknown data', () => {
+		const ref: ResolvedReference = { type: 'task', id: 't-99', data: null };
+		expect(ref.data).toBeNull();
+	});
+});
+
+describe('ReferenceMetadata', () => {
+	it('stores references keyed by serialized string', () => {
+		const meta: ReferenceMetadata = {
+			'@ref{task:t-42}': {
+				type: 'task',
+				id: 't-42',
+				displayText: 'Fix the bug',
+				status: 'in_progress',
+			},
+			'@ref{goal:g-1}': {
+				type: 'goal',
+				id: 'g-1',
+				displayText: 'Improve performance',
+			},
+		};
+		expect(meta['@ref{task:t-42}'].status).toBe('in_progress');
+		expect(meta['@ref{goal:g-1}'].status).toBeUndefined();
+	});
+
+	it('round-trips through JSON serialization', () => {
+		const meta: ReferenceMetadata = {
+			'@ref{file:src/index.ts}': {
+				type: 'file',
+				id: 'src/index.ts',
+				displayText: 'src/index.ts',
+			},
+		};
+		const parsed = JSON.parse(JSON.stringify(meta)) as ReferenceMetadata;
+		expect(parsed['@ref{file:src/index.ts}'].type).toBe('file');
+	});
+});
+
+describe('REFERENCE_PATTERN', () => {
+	it('matches @ref{task:t-42}', () => {
+		const matches = [...'hello @ref{task:t-42} world'.matchAll(REFERENCE_PATTERN)];
+		expect(matches).toHaveLength(1);
+		expect(matches[0][1]).toBe('task');
+		expect(matches[0][2]).toBe('t-42');
+	});
+
+	it('matches @ref{goal:g-abc}', () => {
+		const matches = [...'@ref{goal:g-abc}'.matchAll(REFERENCE_PATTERN)];
+		expect(matches).toHaveLength(1);
+		expect(matches[0][1]).toBe('goal');
+		expect(matches[0][2]).toBe('g-abc');
+	});
+
+	it('matches @ref{file:src/index.ts} with path separator', () => {
+		const matches = [...'@ref{file:src/index.ts}'.matchAll(REFERENCE_PATTERN)];
+		expect(matches).toHaveLength(1);
+		expect(matches[0][1]).toBe('file');
+		expect(matches[0][2]).toBe('src/index.ts');
+	});
+
+	it('matches multiple references in one string', () => {
+		const text = 'Fix @ref{task:t-1} related to @ref{goal:g-2}';
+		const matches = [...text.matchAll(REFERENCE_PATTERN)];
+		expect(matches).toHaveLength(2);
+	});
+
+	it('does not match normal markdown links', () => {
+		const matches = [...'[link](https://example.com)'.matchAll(REFERENCE_PATTERN)];
+		expect(matches).toHaveLength(0);
+	});
+
+	it('does not match plain @ mentions', () => {
+		const matches = [...'hello @user'.matchAll(REFERENCE_PATTERN)];
+		expect(matches).toHaveLength(0);
+	});
+
+	it('does not match @ref without braces', () => {
+		const matches = [...'@ref task:t-42'.matchAll(REFERENCE_PATTERN)];
+		expect(matches).toHaveLength(0);
+	});
+
+	it('does not match @ref{} with missing colon separator', () => {
+		const matches = [...'@ref{taskt42}'.matchAll(REFERENCE_PATTERN)];
+		expect(matches).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Add core type definitions and regex pattern for the @ reference system
in packages/shared/src/types/reference.ts, exported via mod.ts.
