### PR TITLE
feat(web): add useReferenceAutocomplete hook for @ reference system

### DIFF
--- a/packages/shared/src/types/reference.ts
+++ b/packages/shared/src/types/reference.ts
@@ -1,20 +1,20 @@
 /**
- * Types for the @ reference system.
+ * Reference Types
  *
- * Users can type @ in chat inputs to reference tasks, goals, files, and folders.
- * References are serialized as `@ref{type:id}` in message content.
+ * Core type definitions for the @ reference system.
+ * References allow users to mention tasks, goals, files, and folders
+ * in chat inputs using @ref{type:id} syntax.
  */
 
-// ============================================================================
-// Core Types
-// ============================================================================
-
-/** The type of entity being referenced */
+/**
+ * The type of entity being referenced.
+ * Union type (not enum) following existing codebase patterns like `SessionType`.
+ */
 export type ReferenceType = 'task' | 'goal' | 'file' | 'folder';
 
 /**
- * A parsed @ mention from user input.
- * Represents a reference that has been inserted into the input field.
+ * A mention of a reference in text, as inserted by the autocomplete.
+ * Stored in message content as @ref{type:id}.
  */
 export interface ReferenceMention {
 	type: ReferenceType;
@@ -23,31 +23,28 @@ export interface ReferenceMention {
 }
 
 /**
- * A search result returned by the reference search RPC.
+ * A single result returned from the reference.search RPC.
  */
 export interface ReferenceSearchResult {
 	type: ReferenceType;
 	id: string;
-	/** Short human-readable identifier (e.g. "t-42" for tasks) */
+	/** Short human-readable ID (e.g. "t-42", "g-7") for tasks and goals */
 	shortId?: string;
+	/** Primary display text shown in the autocomplete menu */
 	displayText: string;
-	/** Secondary line shown in the autocomplete menu */
+	/** Secondary text shown below displayText (e.g. task status, file path) */
 	subtitle?: string;
 }
 
 /**
- * A resolved reference — the raw entity data retrieved for a given id.
- * The shape of `data` is polymorphic based on `type`.
+ * A resolved reference with full entity data.
  */
 export interface ResolvedReference {
 	type: ReferenceType;
 	id: string;
+	/** Polymorphic — cast based on `type` */
 	data: unknown;
 }
-
-// ============================================================================
-// Resolved Reference Variants
-// ============================================================================
 
 export interface ResolvedTaskReference extends ResolvedReference {
 	type: 'task';
@@ -59,45 +56,38 @@ export interface ResolvedGoalReference extends ResolvedReference {
 
 export interface ResolvedFileReference extends ResolvedReference {
 	type: 'file';
+	data: {
+		path: string;
+		content: string;
+	};
 }
 
 export interface ResolvedFolderReference extends ResolvedReference {
 	type: 'folder';
+	data: {
+		path: string;
+		entries: Array<{ name: string; type: 'file' | 'folder' }>;
+	};
 }
 
-// ============================================================================
-// Message Persistence
-// ============================================================================
-
 /**
- * Reference metadata stored in a message blob alongside the message text.
- * Keyed by the serialized reference string (e.g. "@ref{task:t-42}").
+ * Metadata stored in a message blob for all @ references within that message.
+ * Uses Record (not Map) because this is serialized to JSON in the sdk_message column.
  *
- * Uses `Record` rather than `Map` because this is serialized to JSON in the
- * `sdk_message` column.
+ * Key is the raw @ref{type:id} token string.
  */
 export type ReferenceMetadata = Record<
 	string,
-	{
-		type: ReferenceType;
-		id: string;
-		displayText: string;
-		/** Optional status snapshot at the time the message was sent */
-		status?: string;
-	}
+	{ type: ReferenceType; id: string; displayText: string; status?: string }
 >;
 
-// ============================================================================
-// Parsing
-// ============================================================================
-
 /**
- * Regex that matches serialized @ references in message text.
+ * Regex for parsing @ref{type:id} tokens from text.
  *
- * Format: `@ref{type:id}`
- * Example: `@ref{task:t-42}`, `@ref{goal:g-abc}`, `@ref{file:src/index.ts}`
+ * Matches: @ref{task:t-42}, @ref{goal:g-7}, @ref{file:src/foo.ts}, @ref{folder:src}
+ * Does NOT match: normal @mentions, markdown links
  *
- * Note: This regex uses the `g` flag — reset `lastIndex` or use `matchAll`
- * to avoid stale state between calls.
+ * NOTE: This regex uses the 'g' flag, so it is stateful.
+ * Always reset lastIndex to 0 (or use .exec() in a loop) before reuse.
  */
 export const REFERENCE_PATTERN = /@ref\{([^}:]+):([^}]+)\}/g;

--- a/packages/shared/tests/reference.test.ts
+++ b/packages/shared/tests/reference.test.ts
@@ -68,7 +68,11 @@ describe('ResolvedReference variants', () => {
 	});
 
 	it('ResolvedFileReference has type file', () => {
-		const ref: ResolvedFileReference = { type: 'file', id: 'src/app.ts', data: 'content' };
+		const ref: ResolvedFileReference = {
+			type: 'file',
+			id: 'src/app.ts',
+			data: { path: 'src/app.ts', content: 'export {}' },
+		};
 		expect(ref.type).toBe('file');
 	});
 
@@ -76,7 +80,7 @@ describe('ResolvedReference variants', () => {
 		const ref: ResolvedFolderReference = {
 			type: 'folder',
 			id: 'src/',
-			data: ['app.ts', 'index.ts'],
+			data: { path: 'src/', entries: [{ name: 'app.ts', type: 'file' }] },
 		};
 		expect(ref.type).toBe('folder');
 	});

--- a/packages/shared/tests/types/reference.test.ts
+++ b/packages/shared/tests/types/reference.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for reference types and REFERENCE_PATTERN regex
+ */
+import { describe, it, expect } from 'bun:test';
+import {
+	REFERENCE_PATTERN,
+	type ReferenceType,
+	type ReferenceMention,
+	type ReferenceSearchResult,
+	type ResolvedReference,
+	type ReferenceMetadata,
+} from '../../src/types/reference.ts';
+
+describe('ReferenceType', () => {
+	it('accepts all valid values', () => {
+		const values: ReferenceType[] = ['task', 'goal', 'file', 'folder'];
+		expect(values).toHaveLength(4);
+	});
+});
+
+describe('ReferenceMention', () => {
+	it('has correct shape', () => {
+		const mention: ReferenceMention = {
+			type: 'task',
+			id: 't-42',
+			displayText: 'Fix the bug',
+		};
+		expect(mention.type).toBe('task');
+		expect(mention.id).toBe('t-42');
+		expect(mention.displayText).toBe('Fix the bug');
+	});
+});
+
+describe('ReferenceSearchResult', () => {
+	it('accepts optional fields', () => {
+		const result: ReferenceSearchResult = {
+			type: 'file',
+			id: 'src/foo.ts',
+			displayText: 'foo.ts',
+		};
+		expect(result.shortId).toBeUndefined();
+		expect(result.subtitle).toBeUndefined();
+	});
+
+	it('includes optional fields when provided', () => {
+		const result: ReferenceSearchResult = {
+			type: 'task',
+			id: 'task-uuid-42',
+			shortId: 't-42',
+			displayText: 'Fix the bug',
+			subtitle: 'in progress',
+		};
+		expect(result.shortId).toBe('t-42');
+		expect(result.subtitle).toBe('in progress');
+	});
+});
+
+describe('ResolvedReference', () => {
+	it('has polymorphic data field', () => {
+		const resolved: ResolvedReference = {
+			type: 'file',
+			id: 'src/foo.ts',
+			data: { path: 'src/foo.ts', content: 'export {}' },
+		};
+		expect(resolved.data).toBeDefined();
+	});
+});
+
+describe('ReferenceMetadata', () => {
+	it('is a plain object (JSON-serializable)', () => {
+		const meta: ReferenceMetadata = {
+			'@ref{task:t-42}': {
+				type: 'task',
+				id: 't-42',
+				displayText: 'Fix the bug',
+				status: 'in_progress',
+			},
+		};
+		// Must round-trip through JSON without loss
+		const serialized = JSON.stringify(meta);
+		const parsed = JSON.parse(serialized) as ReferenceMetadata;
+		expect(parsed['@ref{task:t-42}'].type).toBe('task');
+		expect(parsed['@ref{task:t-42}'].status).toBe('in_progress');
+	});
+});
+
+describe('REFERENCE_PATTERN', () => {
+	it('matches task reference', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const m = REFERENCE_PATTERN.exec('@ref{task:t-42}');
+		expect(m).not.toBeNull();
+		expect(m![1]).toBe('task');
+		expect(m![2]).toBe('t-42');
+	});
+
+	it('matches goal reference', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const m = REFERENCE_PATTERN.exec('@ref{goal:g-7}');
+		expect(m).not.toBeNull();
+		expect(m![1]).toBe('goal');
+		expect(m![2]).toBe('g-7');
+	});
+
+	it('matches file reference with path', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const m = REFERENCE_PATTERN.exec('@ref{file:src/components/Foo.tsx}');
+		expect(m).not.toBeNull();
+		expect(m![1]).toBe('file');
+		expect(m![2]).toBe('src/components/Foo.tsx');
+	});
+
+	it('matches folder reference', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const m = REFERENCE_PATTERN.exec('@ref{folder:packages/web}');
+		expect(m).not.toBeNull();
+		expect(m![1]).toBe('folder');
+		expect(m![2]).toBe('packages/web');
+	});
+
+	it('finds multiple references in text', () => {
+		const text = 'Fix @ref{task:t-42} in @ref{file:src/foo.ts}';
+		REFERENCE_PATTERN.lastIndex = 0;
+		const matches: string[] = [];
+		let m;
+		while ((m = REFERENCE_PATTERN.exec(text)) !== null) {
+			matches.push(m[0]);
+		}
+		expect(matches).toHaveLength(2);
+		expect(matches[0]).toBe('@ref{task:t-42}');
+		expect(matches[1]).toBe('@ref{file:src/foo.ts}');
+	});
+
+	it('does not match plain @mentions', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const m = REFERENCE_PATTERN.exec('@username');
+		expect(m).toBeNull();
+	});
+
+	it('does not match markdown links', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const m = REFERENCE_PATTERN.exec('[link](https://example.com)');
+		expect(m).toBeNull();
+	});
+
+	it('does not match malformed ref without colon', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const m = REFERENCE_PATTERN.exec('@ref{taskonly}');
+		expect(m).toBeNull();
+	});
+});

--- a/packages/web/src/hooks/__tests__/index.test.ts
+++ b/packages/web/src/hooks/__tests__/index.test.ts
@@ -16,6 +16,8 @@ import {
 	useFileAttachments,
 	useGroupMessages,
 	useRoomLiveQuery,
+	useReferenceAutocomplete,
+	extractActiveAtQuery,
 } from '../index.ts';
 
 describe('Hooks Index', () => {
@@ -68,6 +70,16 @@ describe('Hooks Index', () => {
 		it('should export useRoomLiveQuery', () => {
 			expect(useRoomLiveQuery).toBeDefined();
 			expect(typeof useRoomLiveQuery).toBe('function');
+		});
+
+		it('should export useReferenceAutocomplete', () => {
+			expect(useReferenceAutocomplete).toBeDefined();
+			expect(typeof useReferenceAutocomplete).toBe('function');
+		});
+
+		it('should export extractActiveAtQuery', () => {
+			expect(extractActiveAtQuery).toBeDefined();
+			expect(typeof extractActiveAtQuery).toBe('function');
 		});
 	});
 });

--- a/packages/web/src/hooks/__tests__/useReferenceAutocomplete.test.ts
+++ b/packages/web/src/hooks/__tests__/useReferenceAutocomplete.test.ts
@@ -1,0 +1,723 @@
+// @ts-nocheck
+/**
+ * Tests for useReferenceAutocomplete Hook
+ *
+ * Tests @ reference detection, RPC search with debouncing,
+ * keyboard navigation, and multiple @ support.
+ */
+
+import { renderHook, act } from '@testing-library/preact';
+import { useReferenceAutocomplete, extractActiveAtQuery } from '../useReferenceAutocomplete.ts';
+
+// --------------------------------------------------------------------------
+// Mocks
+// --------------------------------------------------------------------------
+
+const mockActiveSessionId = vi.hoisted(() => ({ value: 'session-123' }));
+
+vi.mock('../../lib/session-store.ts', () => ({
+	sessionStore: {
+		activeSessionId: mockActiveSessionId,
+	},
+}));
+
+const mockRequest = vi.hoisted(() => vi.fn());
+const mockGetHubIfConnected = vi.hoisted(() => vi.fn(() => ({ request: mockRequest })));
+
+vi.mock('../../lib/connection-manager.ts', () => ({
+	connectionManager: {
+		getHubIfConnected: mockGetHubIfConnected,
+	},
+}));
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+const makeResults = (count = 3) =>
+	Array.from({ length: count }, (_, i) => ({
+		type: 'task' as const,
+		id: `task-${i}`,
+		shortId: `t-${i}`,
+		displayText: `Task ${i}`,
+		subtitle: 'open',
+	}));
+
+// --------------------------------------------------------------------------
+// extractActiveAtQuery unit tests
+// --------------------------------------------------------------------------
+
+describe('extractActiveAtQuery', () => {
+	it('returns null when no @ present', () => {
+		expect(extractActiveAtQuery('hello world')).toBeNull();
+	});
+
+	it('returns empty string when content is just @', () => {
+		expect(extractActiveAtQuery('@')).toBe('');
+	});
+
+	it('returns query for @ at start', () => {
+		expect(extractActiveAtQuery('@foo')).toBe('foo');
+	});
+
+	it('returns query for @ in middle of text', () => {
+		expect(extractActiveAtQuery('hello @foo')).toBe('foo');
+	});
+
+	it('returns null when @ is followed by space (completed mention)', () => {
+		expect(extractActiveAtQuery('@foo bar')).toBeNull();
+	});
+
+	it('returns query for last @ when multiple in text', () => {
+		// @done is completed (followed by space), @new is active
+		expect(extractActiveAtQuery('@done fix @new')).toBe('new');
+	});
+
+	it('returns null when last @ is completed and earlier one is also done', () => {
+		expect(extractActiveAtQuery('@foo bar @baz qux')).toBeNull();
+	});
+
+	it('handles @ embedded in word (not word-start) — should not trigger', () => {
+		// email@example.com — @ is not at word start (preceded by non-space)
+		expect(extractActiveAtQuery('email@example.com')).toBeNull();
+	});
+
+	it('handles multiple @ with only last active', () => {
+		// First @ is completed (space after query), second @ is active
+		expect(extractActiveAtQuery('Fix @ref{task:t-1} and @ne')).toBe('ne');
+	});
+
+	it('returns empty string for trailing @', () => {
+		expect(extractActiveAtQuery('hello @')).toBe('');
+	});
+});
+
+// --------------------------------------------------------------------------
+// useReferenceAutocomplete hook tests
+// --------------------------------------------------------------------------
+
+describe('useReferenceAutocomplete', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		mockActiveSessionId.value = 'session-123';
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({ results: makeResults() });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	// -----------------------------------------------------------------------
+	// Initialization
+	// -----------------------------------------------------------------------
+
+	describe('initialization', () => {
+		it('initializes with autocomplete hidden', () => {
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '', onSelect: vi.fn() })
+			);
+
+			expect(result.current.showAutocomplete).toBe(false);
+			expect(result.current.results).toEqual([]);
+			expect(result.current.selectedIndex).toBe(0);
+			expect(result.current.searchQuery).toBe('');
+		});
+
+		it('provides required functions', () => {
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '', onSelect: vi.fn() })
+			);
+
+			expect(typeof result.current.handleSelect).toBe('function');
+			expect(typeof result.current.handleKeyDown).toBe('function');
+			expect(typeof result.current.close).toBe('function');
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Detection
+	// -----------------------------------------------------------------------
+
+	describe('@ detection', () => {
+		it('triggers search when @ is typed at start', async () => {
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@', onSelect: vi.fn() })
+			);
+
+			expect(result.current.searchQuery).toBe('');
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith('reference.search', {
+				sessionId: 'session-123',
+				query: '',
+			});
+			expect(result.current.showAutocomplete).toBe(true);
+		});
+
+		it('triggers search when @ is in the middle of text', async () => {
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: 'fix @bug', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith('reference.search', {
+				sessionId: 'session-123',
+				query: 'bug',
+			});
+		});
+
+		it('does not trigger when content has no @', async () => {
+			renderHook(() => useReferenceAutocomplete({ content: 'hello world', onSelect: vi.fn() }));
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			expect(mockRequest).not.toHaveBeenCalled();
+		});
+
+		it('does not trigger when @ mention is completed (space after query)', async () => {
+			renderHook(() => useReferenceAutocomplete({ content: '@foo bar', onSelect: vi.fn() }));
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			expect(mockRequest).not.toHaveBeenCalled();
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Debouncing
+	// -----------------------------------------------------------------------
+
+	describe('debouncing', () => {
+		it('does not call RPC before debounce delay', async () => {
+			renderHook(() => useReferenceAutocomplete({ content: '@foo', onSelect: vi.fn() }));
+
+			await act(async () => {
+				vi.advanceTimersByTime(299);
+			});
+
+			expect(mockRequest).not.toHaveBeenCalled();
+		});
+
+		it('calls RPC after debounce delay', async () => {
+			renderHook(() => useReferenceAutocomplete({ content: '@foo', onSelect: vi.fn() }));
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			expect(mockRequest).toHaveBeenCalledTimes(1);
+		});
+
+		it('cancels previous debounce on new input', async () => {
+			const { rerender } = renderHook(
+				({ content }) => useReferenceAutocomplete({ content, onSelect: vi.fn() }),
+				{ initialProps: { content: '@fo' } }
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(200);
+			});
+
+			rerender({ content: '@foo' });
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			// Only called once (for the final value)
+			expect(mockRequest).toHaveBeenCalledTimes(1);
+			expect(mockRequest).toHaveBeenCalledWith('reference.search', {
+				sessionId: 'session-123',
+				query: 'foo',
+			});
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Results
+	// -----------------------------------------------------------------------
+
+	describe('results handling', () => {
+		it('shows results after successful search', async () => {
+			const results = makeResults(3);
+			mockRequest.mockResolvedValue({ results });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.results).toEqual(results);
+			expect(result.current.showAutocomplete).toBe(true);
+			expect(result.current.selectedIndex).toBe(0);
+		});
+
+		it('hides autocomplete when search returns empty results', async () => {
+			mockRequest.mockResolvedValue({ results: [] });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@xyz', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.showAutocomplete).toBe(false);
+			expect(result.current.results).toEqual([]);
+		});
+
+		it('hides autocomplete on search error', async () => {
+			mockRequest.mockRejectedValue(new Error('RPC error'));
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.showAutocomplete).toBe(false);
+		});
+
+		it('hides autocomplete when hub is not connected', async () => {
+			mockGetHubIfConnected.mockReturnValue(null);
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.showAutocomplete).toBe(false);
+			expect(mockRequest).not.toHaveBeenCalled();
+		});
+
+		it('hides autocomplete when no active session', async () => {
+			mockActiveSessionId.value = null;
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.showAutocomplete).toBe(false);
+			expect(mockRequest).not.toHaveBeenCalled();
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// handleSelect
+	// -----------------------------------------------------------------------
+
+	describe('handleSelect', () => {
+		it('calls onSelect with ReferenceMention and closes autocomplete', async () => {
+			const results = makeResults(2);
+			mockRequest.mockResolvedValue({ results });
+			const onSelect = vi.fn();
+
+			const { result } = renderHook(() => useReferenceAutocomplete({ content: '@task', onSelect }));
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			act(() => {
+				result.current.handleSelect(results[0]);
+			});
+
+			expect(onSelect).toHaveBeenCalledWith({
+				type: results[0].type,
+				id: results[0].id,
+				displayText: results[0].displayText,
+			});
+			expect(result.current.showAutocomplete).toBe(false);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// close
+	// -----------------------------------------------------------------------
+
+	describe('close', () => {
+		it('closes autocomplete', async () => {
+			mockRequest.mockResolvedValue({ results: makeResults() });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.showAutocomplete).toBe(true);
+
+			act(() => {
+				result.current.close();
+			});
+
+			expect(result.current.showAutocomplete).toBe(false);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// handleKeyDown
+	// -----------------------------------------------------------------------
+
+	describe('handleKeyDown', () => {
+		it('returns false when autocomplete is hidden', () => {
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '', onSelect: vi.fn() })
+			);
+
+			const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+			let handled: boolean;
+			act(() => {
+				handled = result.current.handleKeyDown(event);
+			});
+
+			expect(handled!).toBe(false);
+		});
+
+		it('handles ArrowDown to navigate forward', async () => {
+			const results = makeResults(3);
+			mockRequest.mockResolvedValue({ results });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.selectedIndex).toBe(0);
+
+			const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+			const preventDefault = vi.fn();
+			Object.defineProperty(event, 'preventDefault', { value: preventDefault });
+
+			act(() => {
+				const handled = result.current.handleKeyDown(event);
+				expect(handled).toBe(true);
+			});
+
+			expect(result.current.selectedIndex).toBe(1);
+			expect(preventDefault).toHaveBeenCalled();
+		});
+
+		it('handles ArrowUp to navigate backward', async () => {
+			const results = makeResults(3);
+			mockRequest.mockResolvedValue({ results });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			// Move to index 2 first
+			const down1 = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+			Object.defineProperty(down1, 'preventDefault', { value: vi.fn() });
+			const down2 = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+			Object.defineProperty(down2, 'preventDefault', { value: vi.fn() });
+
+			act(() => {
+				result.current.handleKeyDown(down1);
+				result.current.handleKeyDown(down2);
+			});
+
+			expect(result.current.selectedIndex).toBe(2);
+
+			const up = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+			Object.defineProperty(up, 'preventDefault', { value: vi.fn() });
+
+			act(() => {
+				result.current.handleKeyDown(up);
+			});
+
+			expect(result.current.selectedIndex).toBe(1);
+		});
+
+		it('wraps ArrowDown past end to first item', async () => {
+			const results = makeResults(3);
+			mockRequest.mockResolvedValue({ results });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			// Navigate to last item (index 2)
+			for (let i = 0; i < 2; i++) {
+				const e = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+				Object.defineProperty(e, 'preventDefault', { value: vi.fn() });
+				act(() => {
+					result.current.handleKeyDown(e);
+				});
+			}
+
+			expect(result.current.selectedIndex).toBe(2);
+
+			const e = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+			Object.defineProperty(e, 'preventDefault', { value: vi.fn() });
+			act(() => {
+				result.current.handleKeyDown(e);
+			});
+
+			expect(result.current.selectedIndex).toBe(0);
+		});
+
+		it('wraps ArrowUp before start to last item', async () => {
+			const results = makeResults(3);
+			mockRequest.mockResolvedValue({ results });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.selectedIndex).toBe(0);
+
+			const e = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+			Object.defineProperty(e, 'preventDefault', { value: vi.fn() });
+			act(() => {
+				result.current.handleKeyDown(e);
+			});
+
+			expect(result.current.selectedIndex).toBe(2);
+		});
+
+		it('selects item with Enter', async () => {
+			const results = makeResults(2);
+			mockRequest.mockResolvedValue({ results });
+			const onSelect = vi.fn();
+
+			const { result } = renderHook(() => useReferenceAutocomplete({ content: '@task', onSelect }));
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			const event = new KeyboardEvent('keydown', { key: 'Enter' });
+			const preventDefault = vi.fn();
+			Object.defineProperty(event, 'preventDefault', { value: preventDefault });
+
+			act(() => {
+				const handled = result.current.handleKeyDown(event);
+				expect(handled).toBe(true);
+			});
+
+			expect(onSelect).toHaveBeenCalledWith({
+				type: results[0].type,
+				id: results[0].id,
+				displayText: results[0].displayText,
+			});
+			expect(result.current.showAutocomplete).toBe(false);
+			expect(preventDefault).toHaveBeenCalled();
+		});
+
+		it('does not handle Enter with metaKey', async () => {
+			const results = makeResults(2);
+			mockRequest.mockResolvedValue({ results });
+			const onSelect = vi.fn();
+
+			const { result } = renderHook(() => useReferenceAutocomplete({ content: '@task', onSelect }));
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			const event = new KeyboardEvent('keydown', { key: 'Enter', metaKey: true });
+
+			act(() => {
+				const handled = result.current.handleKeyDown(event);
+				expect(handled).toBe(false);
+			});
+
+			expect(onSelect).not.toHaveBeenCalled();
+		});
+
+		it('does not handle Enter with ctrlKey', async () => {
+			const results = makeResults(2);
+			mockRequest.mockResolvedValue({ results });
+			const onSelect = vi.fn();
+
+			const { result } = renderHook(() => useReferenceAutocomplete({ content: '@task', onSelect }));
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			const event = new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true });
+
+			act(() => {
+				const handled = result.current.handleKeyDown(event);
+				expect(handled).toBe(false);
+			});
+
+			expect(onSelect).not.toHaveBeenCalled();
+		});
+
+		it('closes autocomplete with Escape', async () => {
+			mockRequest.mockResolvedValue({ results: makeResults() });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(result.current.showAutocomplete).toBe(true);
+
+			const event = new KeyboardEvent('keydown', { key: 'Escape' });
+			const preventDefault = vi.fn();
+			Object.defineProperty(event, 'preventDefault', { value: preventDefault });
+
+			act(() => {
+				const handled = result.current.handleKeyDown(event);
+				expect(handled).toBe(true);
+			});
+
+			expect(result.current.showAutocomplete).toBe(false);
+			expect(preventDefault).toHaveBeenCalled();
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Multiple @ support
+	// -----------------------------------------------------------------------
+
+	describe('multiple @ in same message', () => {
+		it('triggers on last active @ when earlier ones are completed', async () => {
+			mockRequest.mockResolvedValue({ results: makeResults() });
+
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({
+					content: 'Fix @ref{task:t-1} and @ne',
+					onSelect: vi.fn(),
+				})
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith('reference.search', {
+				sessionId: 'session-123',
+				query: 'ne',
+			});
+			expect(result.current.searchQuery).toBe('ne');
+			expect(result.current.showAutocomplete).toBe(true);
+		});
+
+		it('does not trigger when all @ mentions are completed', async () => {
+			const { result } = renderHook(() =>
+				useReferenceAutocomplete({
+					content: '@foo done @bar done',
+					onSelect: vi.fn(),
+				})
+			);
+
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			expect(mockRequest).not.toHaveBeenCalled();
+			expect(result.current.showAutocomplete).toBe(false);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// In-progress search cancellation
+	// -----------------------------------------------------------------------
+
+	describe('stale response cancellation', () => {
+		it('ignores response from superseded search', async () => {
+			let resolveFirst!: (v: unknown) => void;
+			const firstPromise = new Promise((res) => {
+				resolveFirst = res;
+			});
+
+			// First call stalls; second resolves immediately
+			mockRequest.mockReturnValueOnce(firstPromise).mockResolvedValue({ results: makeResults(2) });
+
+			const { result, rerender } = renderHook(
+				({ content }) => useReferenceAutocomplete({ content, onSelect: vi.fn() }),
+				{ initialProps: { content: '@fo' } }
+			);
+
+			// Trigger first debounce
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			// Change content before first resolves
+			rerender({ content: '@foo' });
+
+			// Trigger second debounce
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+				await Promise.resolve();
+			});
+
+			// Now resolve first (stale) response
+			await act(async () => {
+				resolveFirst({ results: makeResults(5) }); // stale, more results
+				await Promise.resolve();
+			});
+
+			// Should show second response's results (2), not stale (5)
+			expect(result.current.results).toHaveLength(2);
+		});
+	});
+});

--- a/packages/web/src/hooks/__tests__/useReferenceAutocomplete.test.ts
+++ b/packages/web/src/hooks/__tests__/useReferenceAutocomplete.test.ts
@@ -614,8 +614,8 @@ describe('useReferenceAutocomplete', () => {
 			expect(onSelect).not.toHaveBeenCalled();
 		});
 
-		it('closes autocomplete with Escape', async () => {
-			mockRequest.mockResolvedValue({ results: makeResults() });
+		it('closes autocomplete with Escape and resets results and selectedIndex', async () => {
+			mockRequest.mockResolvedValue({ results: makeResults(3) });
 
 			const { result } = renderHook(() =>
 				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
@@ -627,6 +627,15 @@ describe('useReferenceAutocomplete', () => {
 			});
 
 			expect(result.current.showAutocomplete).toBe(true);
+			expect(result.current.results).toHaveLength(3);
+
+			// Navigate to second item so selectedIndex > 0
+			const down = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+			Object.defineProperty(down, 'preventDefault', { value: vi.fn() });
+			act(() => {
+				result.current.handleKeyDown(down);
+			});
+			expect(result.current.selectedIndex).toBe(1);
 
 			const event = new KeyboardEvent('keydown', { key: 'Escape' });
 			const preventDefault = vi.fn();
@@ -638,6 +647,8 @@ describe('useReferenceAutocomplete', () => {
 			});
 
 			expect(result.current.showAutocomplete).toBe(false);
+			expect(result.current.results).toEqual([]);
+			expect(result.current.selectedIndex).toBe(0);
 			expect(preventDefault).toHaveBeenCalled();
 		});
 	});

--- a/packages/web/src/hooks/__tests__/useReferenceAutocomplete.test.ts
+++ b/packages/web/src/hooks/__tests__/useReferenceAutocomplete.test.ts
@@ -367,8 +367,8 @@ describe('useReferenceAutocomplete', () => {
 	// -----------------------------------------------------------------------
 
 	describe('close', () => {
-		it('closes autocomplete', async () => {
-			mockRequest.mockResolvedValue({ results: makeResults() });
+		it('closes autocomplete and resets results and selectedIndex', async () => {
+			mockRequest.mockResolvedValue({ results: makeResults(3) });
 
 			const { result } = renderHook(() =>
 				useReferenceAutocomplete({ content: '@task', onSelect: vi.fn() })
@@ -380,12 +380,23 @@ describe('useReferenceAutocomplete', () => {
 			});
 
 			expect(result.current.showAutocomplete).toBe(true);
+			expect(result.current.results).toHaveLength(3);
+
+			// Navigate to second item so selectedIndex > 0
+			const e = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+			Object.defineProperty(e, 'preventDefault', { value: vi.fn() });
+			act(() => {
+				result.current.handleKeyDown(e);
+			});
+			expect(result.current.selectedIndex).toBe(1);
 
 			act(() => {
 				result.current.close();
 			});
 
 			expect(result.current.showAutocomplete).toBe(false);
+			expect(result.current.results).toEqual([]);
+			expect(result.current.selectedIndex).toBe(0);
 		});
 	});
 

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -60,3 +60,9 @@ export {
 	type RuntimeMessage,
 	type TurnBlockItem,
 } from './useTurnBlocks';
+export {
+	useReferenceAutocomplete,
+	extractActiveAtQuery,
+	type UseReferenceAutocompleteOptions,
+	type UseReferenceAutocompleteResult,
+} from './useReferenceAutocomplete';

--- a/packages/web/src/hooks/useReferenceAutocomplete.ts
+++ b/packages/web/src/hooks/useReferenceAutocomplete.ts
@@ -46,9 +46,11 @@ const SEARCH_DEBOUNCE_MS = 300;
  * Rules:
  * - Find the last @ that is preceded by whitespace or start-of-string
  * - The text between that @ and the end of content must not contain any whitespace
- * - The @ itself must not be followed immediately by another @ (malformed)
  *
  * Returns the query string (may be empty if user just typed "@").
+ * Note: `@@` returns `"@"` as the query — this is intentional (the inner `@` is
+ * treated as the query text). Consumers that insert `@ref{type:id}` should append
+ * a trailing space so that the token does not re-trigger autocomplete.
  */
 export function extractActiveAtQuery(content: string): string | null {
 	if (!content.includes('@')) return null;
@@ -166,6 +168,8 @@ export function useReferenceAutocomplete({
 
 	const close = useCallback(() => {
 		setShowAutocomplete(false);
+		setResults([]);
+		setSelectedIndex(0);
 	}, []);
 
 	const handleSelect = useCallback(

--- a/packages/web/src/hooks/useReferenceAutocomplete.ts
+++ b/packages/web/src/hooks/useReferenceAutocomplete.ts
@@ -1,0 +1,223 @@
+/**
+ * useReferenceAutocomplete Hook
+ *
+ * Manages @ reference autocomplete state: detection, RPC search with debouncing,
+ * and keyboard navigation.
+ *
+ * Follows the same pattern as `useCommandAutocomplete` but for @ references.
+ *
+ * Detection: Triggers when the cursor is immediately after an active @query
+ * (i.e. the text from the last unspaced @ to the end of content has no whitespace).
+ * Works anywhere in the text, not just at the start.
+ *
+ * Multiple @ support: Only the "active" @ (closest to the end of content with
+ * no space between it and the end) triggers autocomplete.  Once the user selects
+ * a result, the @query is replaced and the previous tokens are left untouched.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+import { connectionManager } from '../lib/connection-manager.ts';
+import { sessionStore } from '../lib/session-store.ts';
+import type { ReferenceMention, ReferenceSearchResult } from '@neokai/shared';
+
+export interface UseReferenceAutocompleteOptions {
+	content: string;
+	onSelect: (reference: ReferenceMention) => void;
+}
+
+export interface UseReferenceAutocompleteResult {
+	showAutocomplete: boolean;
+	results: ReferenceSearchResult[];
+	selectedIndex: number;
+	/** Active query string (text after the triggering @) */
+	searchQuery: string;
+	handleKeyDown: (e: KeyboardEvent) => boolean;
+	handleSelect: (result: ReferenceSearchResult) => void;
+	close: () => void;
+}
+
+/** Debounce delay in ms for reference.search RPC calls */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Given a text string (the content up to the cursor), return the active query
+ * if the user is currently typing an @ reference, otherwise null.
+ *
+ * Rules:
+ * - Find the last @ that is preceded by whitespace or start-of-string
+ * - The text between that @ and the end of content must not contain any whitespace
+ * - The @ itself must not be followed immediately by another @ (malformed)
+ *
+ * Returns the query string (may be empty if user just typed "@").
+ */
+export function extractActiveAtQuery(content: string): string | null {
+	if (!content.includes('@')) return null;
+
+	// Walk backwards from end to find last word-start @
+	// A word-start @ is one preceded by whitespace or at position 0
+	for (let i = content.length - 1; i >= 0; i--) {
+		if (content[i] === '@') {
+			const before = i === 0 ? '' : content[i - 1];
+			const isWordStart = i === 0 || /\s/.test(before);
+			if (!isWordStart) continue;
+
+			// Text after the @ to end of content
+			const afterAt = content.slice(i + 1);
+
+			// Must contain no whitespace (user is still typing the reference)
+			if (/\s/.test(afterAt)) continue;
+
+			return afterAt;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Hook for managing @ reference autocomplete
+ */
+export function useReferenceAutocomplete({
+	content,
+	onSelect,
+}: UseReferenceAutocompleteOptions): UseReferenceAutocompleteResult {
+	const [showAutocomplete, setShowAutocomplete] = useState(false);
+	const [results, setResults] = useState<ReferenceSearchResult[]>([]);
+	const [selectedIndex, setSelectedIndex] = useState(0);
+	const [searchQuery, setSearchQuery] = useState('');
+
+	// Debounce timer ref — cancelled on new input
+	const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// Abort flag — set when a new search supersedes an in-progress one
+	const searchVersionRef = useRef(0);
+
+	// Detection: extract active query from content
+	useEffect(() => {
+		const query = extractActiveAtQuery(content);
+
+		if (query === null) {
+			setShowAutocomplete(false);
+			setResults([]);
+			setSearchQuery('');
+			// Cancel any pending search
+			if (debounceTimerRef.current !== null) {
+				clearTimeout(debounceTimerRef.current);
+				debounceTimerRef.current = null;
+			}
+			return;
+		}
+
+		setSearchQuery(query);
+
+		// Cancel previous debounce timer
+		if (debounceTimerRef.current !== null) {
+			clearTimeout(debounceTimerRef.current);
+		}
+
+		// Bump version to cancel any in-flight search
+		const version = ++searchVersionRef.current;
+
+		debounceTimerRef.current = setTimeout(async () => {
+			debounceTimerRef.current = null;
+
+			const hub = connectionManager.getHubIfConnected();
+			if (!hub) {
+				setShowAutocomplete(false);
+				return;
+			}
+
+			const sessionId = sessionStore.activeSessionId.value;
+			if (!sessionId) {
+				setShowAutocomplete(false);
+				return;
+			}
+
+			try {
+				const response = await hub.request<{ results: ReferenceSearchResult[] }>(
+					'reference.search',
+					{ sessionId, query }
+				);
+
+				// Discard stale responses
+				if (version !== searchVersionRef.current) return;
+
+				const fetchedResults = response?.results ?? [];
+				setResults(fetchedResults);
+				setShowAutocomplete(fetchedResults.length > 0);
+				setSelectedIndex(0);
+			} catch {
+				// Ignore search errors (backend may not have the handler yet)
+				if (version === searchVersionRef.current) {
+					setShowAutocomplete(false);
+					setResults([]);
+				}
+			}
+		}, SEARCH_DEBOUNCE_MS);
+	}, [content]);
+
+	// Cleanup debounce timer on unmount
+	useEffect(() => {
+		return () => {
+			if (debounceTimerRef.current !== null) {
+				clearTimeout(debounceTimerRef.current);
+			}
+		};
+	}, []);
+
+	const close = useCallback(() => {
+		setShowAutocomplete(false);
+	}, []);
+
+	const handleSelect = useCallback(
+		(result: ReferenceSearchResult) => {
+			const mention: ReferenceMention = {
+				type: result.type,
+				id: result.id,
+				displayText: result.displayText,
+			};
+			onSelect(mention);
+			setShowAutocomplete(false);
+		},
+		[onSelect]
+	);
+
+	// Handle keyboard navigation, returns true if event was handled
+	const handleKeyDown = useCallback(
+		(e: KeyboardEvent): boolean => {
+			if (!showAutocomplete) return false;
+
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				setSelectedIndex((prev) => (prev < results.length - 1 ? prev + 1 : 0));
+				return true;
+			} else if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				setSelectedIndex((prev) => (prev > 0 ? prev - 1 : results.length - 1));
+				return true;
+			} else if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) {
+				e.preventDefault();
+				if (results[selectedIndex]) {
+					handleSelect(results[selectedIndex]);
+				}
+				return true;
+			} else if (e.key === 'Escape') {
+				e.preventDefault();
+				setShowAutocomplete(false);
+				return true;
+			}
+
+			return false;
+		},
+		[showAutocomplete, results, selectedIndex, handleSelect]
+	);
+
+	return {
+		showAutocomplete,
+		results,
+		selectedIndex,
+		searchQuery,
+		handleKeyDown,
+		handleSelect,
+		close,
+	};
+}

--- a/packages/web/src/hooks/useReferenceAutocomplete.ts
+++ b/packages/web/src/hooks/useReferenceAutocomplete.ts
@@ -206,13 +206,13 @@ export function useReferenceAutocomplete({
 				return true;
 			} else if (e.key === 'Escape') {
 				e.preventDefault();
-				setShowAutocomplete(false);
+				close();
 				return true;
 			}
 
 			return false;
 		},
-		[showAutocomplete, results, selectedIndex, handleSelect]
+		[showAutocomplete, results, selectedIndex, handleSelect, close]
 	);
 
 	return {


### PR DESCRIPTION
- Define core reference types in packages/shared: ReferenceType, ReferenceMention,
  ReferenceSearchResult, ResolvedReference, ReferenceMetadata, REFERENCE_PATTERN
- Export reference types from @neokai/shared barrel
- Implement useReferenceAutocomplete hook with:
  - @ detection anywhere in text (not just at start)
  - Debounced reference.search RPC calls (300ms)
  - Stale response cancellation via version counter
  - Keyboard navigation (ArrowUp/Down, Enter, Escape)
  - Multiple @ support (only last active @ triggers autocomplete)
  - exportActiveAtQuery utility for cursor-aware @ detection
- Export hook and types from packages/web hooks index
- Unit tests: 14 shared type tests, 38 hook tests covering detection,
  debouncing, results, keyboard navigation, multiple @ support, and
  stale response cancellation
