### PR TITLE
feat(file-index): implement workspace file index with polling-based cache refresh

### DIFF
--- a/packages/daemon/.env.example
+++ b/packages/daemon/.env.example
@@ -79,6 +79,15 @@ MAX_SESSIONS=10
 # NEOKAI_SDK_STARTUP_MAX_RETRIES=2
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# File Index Configuration
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# How often (ms) the workspace file index polls for changes.
+# Lower values give faster cache freshness at the cost of more I/O.
+# Default: 10000
+# NEOKAI_FILE_INDEX_POLL_MS=10000
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Job Queue Configuration
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -25,6 +25,7 @@ import { JobQueueProcessor } from './storage/job-queue-processor';
 import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
 import { JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
 import { AppMcpLifecycleManager, seedDefaultMcpEntries } from './lib/mcp';
+import { FileIndex } from './lib/file-index';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -74,6 +75,8 @@ export interface DaemonAppContext {
 	jobProcessor: JobQueueProcessor;
 	/** Application-level MCP lifecycle manager — converts registry entries to SDK configs */
 	appMcpManager: AppMcpLifecycleManager;
+	/** Workspace file index for fast fuzzy file/folder search */
+	fileIndex: FileIndex;
 	/**
 	 * Cleanup function for graceful shutdown.
 	 * Closes all connections, stops sessions, and closes database.
@@ -268,6 +271,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Seed default MCP entries (idempotent — skips entries that already exist)
 	seedDefaultMcpEntries(db);
+
+	// Initialize workspace file index (non-blocking — init runs in the background)
+	const fileIndex = new FileIndex(config.workspaceRoot);
+	void fileIndex.init();
 
 	// Setup RPC handlers (returns cleanup function + exposed services)
 	const {
@@ -512,6 +519,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				providerRegistry.getAll().flatMap((p) => (p.shutdown ? [p.shutdown()] : []))
 			);
 
+			// Stop workspace file index polling
+			fileIndex.dispose();
+
 			// Close database
 			db.close();
 
@@ -542,6 +552,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		jobQueue,
 		jobProcessor,
 		appMcpManager,
+		fileIndex,
 		cleanup,
 	};
 }

--- a/packages/daemon/src/lib/file-index.ts
+++ b/packages/daemon/src/lib/file-index.ts
@@ -1,0 +1,405 @@
+/**
+ * File Index — Workspace file tree cache with polling-based refresh.
+ *
+ * Scans the workspace once on init(), maintains an in-memory cache of all
+ * file and folder entries, and refreshes the cache incrementally via polling.
+ * Designed for fast fuzzy search without recursive directory listing on every query.
+ */
+
+import { join, normalize, relative } from 'node:path';
+import { readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+export interface FileIndexEntry {
+	/** Relative path from workspace root (e.g. "src/utils/helper.ts") */
+	path: string;
+	/** File or directory name (e.g. "helper.ts") */
+	name: string;
+	type: 'file' | 'folder';
+}
+
+interface IgnorePattern {
+	/** Glob pattern string (after stripping `!` prefix and `/` suffix) */
+	pattern: string;
+	negated: boolean;
+	/** True if the pattern only applies to directories */
+	dirOnly: boolean;
+}
+
+// Always-ignored names regardless of .gitignore
+const BUILTIN_IGNORE_NAMES = new Set(['.git', 'node_modules', '.DS_Store']);
+
+function parseGitignoreLines(lines: string[]): IgnorePattern[] {
+	const patterns: IgnorePattern[] = [];
+
+	for (const raw of lines) {
+		const line = raw.trim();
+		if (!line || line.startsWith('#')) continue;
+
+		let pattern = line;
+		const negated = pattern.startsWith('!');
+		if (negated) pattern = pattern.slice(1);
+
+		const dirOnly = pattern.endsWith('/');
+		if (dirOnly) pattern = pattern.slice(0, -1);
+
+		if (!pattern) continue;
+
+		patterns.push({ pattern, negated, dirOnly });
+	}
+
+	return patterns;
+}
+
+/**
+ * Match a single path segment against a simple glob pattern.
+ * Supports: `*` (any chars except `/`), `**` (any sequence), `?` (one char).
+ */
+function matchSegment(pattern: string, segment: string): boolean {
+	// Build a regex from the glob pattern
+	let rx = '^';
+	let i = 0;
+	while (i < pattern.length) {
+		const ch = pattern[i];
+		if (ch === '*' && pattern[i + 1] === '*') {
+			rx += '.*';
+			i += 2;
+			if (pattern[i] === '/') i++;
+		} else if (ch === '*') {
+			rx += '[^/]*';
+			i++;
+		} else if (ch === '?') {
+			rx += '[^/]';
+			i++;
+		} else {
+			// Escape regex metacharacters
+			rx += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+			i++;
+		}
+	}
+	rx += '$';
+	return new RegExp(rx, 'i').test(segment);
+}
+
+/**
+ * Match a full relative path (with `/` separators) against a glob pattern.
+ * Used when the pattern itself contains a `/`.
+ */
+function matchFullPath(pattern: string, relPath: string): boolean {
+	let rx = '^';
+	let i = 0;
+	while (i < pattern.length) {
+		const ch = pattern[i];
+		if (ch === '*' && pattern[i + 1] === '*') {
+			rx += '.*';
+			i += 2;
+			if (pattern[i] === '/') i++;
+		} else if (ch === '*') {
+			rx += '[^/]*';
+			i++;
+		} else if (ch === '?') {
+			rx += '[^/]';
+			i++;
+		} else {
+			rx += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+			i++;
+		}
+	}
+	rx += '$';
+	const regex = new RegExp(rx, 'i');
+	return regex.test(relPath);
+}
+
+function shouldIgnore(relPath: string, isDirectory: boolean, patterns: IgnorePattern[]): boolean {
+	const segments = relPath.split('/');
+
+	// Always ignore built-in names at any depth
+	for (const seg of segments) {
+		if (BUILTIN_IGNORE_NAMES.has(seg)) return true;
+	}
+
+	let ignored = false;
+
+	for (const { pattern, negated, dirOnly } of patterns) {
+		if (dirOnly && !isDirectory) continue;
+
+		let matches = false;
+
+		if (pattern.includes('/')) {
+			// Anchored pattern: match against full relative path
+			matches = matchFullPath(pattern, relPath);
+		} else {
+			// Floating pattern: match against any path segment
+			matches = segments.some((seg) => matchSegment(pattern, seg));
+		}
+
+		if (matches) {
+			ignored = !negated;
+		}
+	}
+
+	return ignored;
+}
+
+/**
+ * Score a search result. Higher is better.
+ *  100 — exact name match (case-insensitive)
+ *   80 — name starts with query
+ *   60 — name contains query
+ *   40 — any path segment contains query
+ *   20 — full path contains query
+ *    0 — no match
+ */
+function scoreEntry(entry: FileIndexEntry, lowerQuery: string): number {
+	const lowerName = entry.name.toLowerCase();
+	const lowerPath = entry.path.toLowerCase();
+
+	if (lowerName === lowerQuery) return 100;
+	if (lowerName.startsWith(lowerQuery)) return 80;
+	if (lowerName.includes(lowerQuery)) return 60;
+
+	// Check individual path segments
+	const segments = lowerPath.split('/');
+	if (segments.some((s) => s.includes(lowerQuery))) return 40;
+
+	if (lowerPath.includes(lowerQuery)) return 20;
+
+	return 0;
+}
+
+/**
+ * Prevent path traversal: return true if the path is safe to use.
+ */
+function isSafePath(workspacePath: string, relPath: string): boolean {
+	// Reject absolute paths
+	if (relPath.startsWith('/')) return false;
+
+	// Reject paths with .. segments
+	const segments = relPath.split('/');
+	if (segments.some((s) => s === '..')) return false;
+
+	// Double-check by resolving and comparing
+	const normalizedWorkspace = normalize(workspacePath);
+	const resolved = normalize(join(workspacePath, relPath));
+	const rel = relative(normalizedWorkspace, resolved);
+
+	return !rel.startsWith('..') && rel !== '..';
+}
+
+export class FileIndex {
+	private cache = new Map<string, FileIndexEntry>();
+	private ready = false;
+	private scanning = false;
+	private pollTimer: ReturnType<typeof setInterval> | null = null;
+	private ignorePatterns: IgnorePattern[] = [];
+	private extraPatterns: IgnorePattern[] = [];
+	private readonly pollInterval: number;
+
+	constructor(
+		private readonly workspacePath: string,
+		pollIntervalMs?: number
+	) {
+		this.pollInterval =
+			pollIntervalMs ?? parseInt(process.env.NEOKAI_FILE_INDEX_POLL_MS ?? '10000', 10);
+	}
+
+	/** Load .gitignore from workspace root if it exists. */
+	private async loadGitignore(): Promise<void> {
+		const gitignorePath = join(this.workspacePath, '.gitignore');
+		try {
+			if (!existsSync(gitignorePath)) return;
+			const content = await readFile(gitignorePath, 'utf-8');
+			this.ignorePatterns = parseGitignoreLines(content.split('\n'));
+		} catch {
+			// Non-fatal: continue without .gitignore patterns
+		}
+	}
+
+	/** Combined ignore patterns (gitignore + extra). */
+	private get allPatterns(): IgnorePattern[] {
+		return [...this.ignorePatterns, ...this.extraPatterns];
+	}
+
+	/** Recursively scan a directory and populate the cache. */
+	private async scanDirectory(absDir: string): Promise<void> {
+		let entries;
+		try {
+			entries = await readdir(absDir, { withFileTypes: true });
+		} catch {
+			// Permission errors or missing dirs — skip silently
+			return;
+		}
+
+		for (const entry of entries) {
+			const absPath = join(absDir, entry.name);
+			const relPath = relative(this.workspacePath, absPath);
+
+			if (!isSafePath(this.workspacePath, relPath)) continue;
+
+			const isDir = entry.isDirectory();
+
+			if (shouldIgnore(relPath, isDir, this.allPatterns)) continue;
+
+			const indexEntry: FileIndexEntry = {
+				path: relPath,
+				name: entry.name,
+				type: isDir ? 'folder' : 'file',
+			};
+
+			this.cache.set(relPath, indexEntry);
+
+			if (isDir) {
+				await this.scanDirectory(absPath);
+			}
+		}
+	}
+
+	/**
+	 * Incremental refresh: walk the workspace and sync the cache.
+	 * Adds new entries and removes stale ones for a single directory pass.
+	 * Uses readdir with withFileTypes (no stat calls) for speed.
+	 */
+	private async refreshDirectory(absDir: string, seen: Set<string>): Promise<void> {
+		let entries;
+		try {
+			entries = await readdir(absDir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+
+		for (const entry of entries) {
+			const absPath = join(absDir, entry.name);
+			const relPath = relative(this.workspacePath, absPath);
+
+			if (!isSafePath(this.workspacePath, relPath)) continue;
+
+			const isDir = entry.isDirectory();
+
+			if (shouldIgnore(relPath, isDir, this.allPatterns)) continue;
+
+			seen.add(relPath);
+
+			if (!this.cache.has(relPath)) {
+				this.cache.set(relPath, {
+					path: relPath,
+					name: entry.name,
+					type: isDir ? 'folder' : 'file',
+				});
+			}
+
+			if (isDir) {
+				await this.refreshDirectory(absPath, seen);
+			}
+		}
+	}
+
+	/** Run a full incremental refresh scan. */
+	private async runRefresh(): Promise<void> {
+		if (this.scanning) return; // Skip if previous scan is still running
+		this.scanning = true;
+
+		try {
+			const seen = new Set<string>();
+			await this.refreshDirectory(this.workspacePath, seen);
+
+			// Remove entries that no longer exist
+			for (const key of this.cache.keys()) {
+				if (!seen.has(key)) {
+					this.cache.delete(key);
+				}
+			}
+		} finally {
+			this.scanning = false;
+		}
+	}
+
+	/**
+	 * Perform the initial workspace scan.
+	 * Must be called before `search()`. Starts the background polling timer.
+	 */
+	async init(): Promise<void> {
+		await this.loadGitignore();
+		await this.scanDirectory(this.workspacePath);
+		this.ready = true;
+
+		// Start background polling
+		this.pollTimer = setInterval(() => {
+			void this.runRefresh();
+		}, this.pollInterval);
+	}
+
+	/**
+	 * Fuzzy-search cached entries by name and path.
+	 * Returns results sorted by relevance score, highest first.
+	 *
+	 * @param query  Search string (case-insensitive)
+	 * @param limit  Maximum number of results (default: 50)
+	 */
+	search(query: string, limit = 50): FileIndexEntry[] {
+		if (!query) {
+			// Return first `limit` entries when query is empty
+			const results: FileIndexEntry[] = [];
+			for (const entry of this.cache.values()) {
+				results.push(entry);
+				if (results.length >= limit) break;
+			}
+			return results;
+		}
+
+		const lowerQuery = query.toLowerCase();
+		const scored: Array<{ entry: FileIndexEntry; score: number }> = [];
+
+		for (const entry of this.cache.values()) {
+			const score = scoreEntry(entry, lowerQuery);
+			if (score > 0) {
+				scored.push({ entry, score });
+			}
+		}
+
+		scored.sort((a, b) => b.score - a.score);
+
+		return scored.slice(0, limit).map((s) => s.entry);
+	}
+
+	/**
+	 * Remove a single path from the cache.
+	 * Useful when a file/folder is known to be deleted or moved.
+	 */
+	invalidate(path: string): void {
+		this.cache.delete(path);
+	}
+
+	/** Clear the entire cache. */
+	invalidateAll(): void {
+		this.cache.clear();
+	}
+
+	/** Whether the initial scan has completed. */
+	isReady(): boolean {
+		return this.ready;
+	}
+
+	/** Number of entries currently in the cache (useful for testing). */
+	size(): number {
+		return this.cache.size;
+	}
+
+	/**
+	 * Set additional ignore patterns at runtime.
+	 * These are layered on top of .gitignore patterns.
+	 */
+	setIgnorePatterns(patterns: string[]): void {
+		this.extraPatterns = parseGitignoreLines(patterns);
+	}
+
+	/**
+	 * Stop the background polling timer and release resources.
+	 * Must be called when the index is no longer needed.
+	 */
+	dispose(): void {
+		if (this.pollTimer !== null) {
+			clearInterval(this.pollTimer);
+			this.pollTimer = null;
+		}
+	}
+}

--- a/packages/daemon/src/lib/file-index.ts
+++ b/packages/daemon/src/lib/file-index.ts
@@ -1,13 +1,19 @@
 /**
- * File Index — Workspace file tree cache with polling-based refresh.
+ * File Index -- Workspace file tree cache with polling-based refresh.
  *
  * Scans the workspace once on init(), maintains an in-memory cache of all
  * file and folder entries, and refreshes the cache incrementally via polling.
  * Designed for fast fuzzy search without recursive directory listing on every query.
+ *
+ * Notes:
+ * - Symbolic links are indexed (as file or folder depending on their target type)
+ *   but symlinked directories are NOT recursed into, to prevent infinite loops.
+ * - Calling setIgnorePatterns() immediately re-filters the cache.
+ * - The polling interval is configurable via NEOKAI_FILE_INDEX_POLL_MS (default 10000 ms).
  */
 
 import { join, normalize, relative } from 'node:path';
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 
 export interface FileIndexEntry {
@@ -19,7 +25,7 @@ export interface FileIndexEntry {
 }
 
 interface IgnorePattern {
-	/** Glob pattern string (after stripping `!` prefix and `/` suffix) */
+	/** Glob pattern string (after stripping negation prefix and dir suffix) */
 	pattern: string;
 	negated: boolean;
 	/** True if the pattern only applies to directories */
@@ -52,19 +58,29 @@ function parseGitignoreLines(lines: string[]): IgnorePattern[] {
 }
 
 /**
- * Match a single path segment against a simple glob pattern.
- * Supports: `*` (any chars except `/`), `**` (any sequence), `?` (one char).
+ * Build a regex string from a glob pattern (without anchors).
+ *
+ * Supported wildcards:
+ *   "**" followed by "/" -- matches any depth including zero (e.g. tests at root or nested)
+ *   "**" elsewhere       -- matches any character sequence
+ *   "*"                  -- matches any characters except "/"
+ *   "?"                  -- matches exactly one character except "/"
+ *   other chars          -- matched literally
  */
-function matchSegment(pattern: string, segment: string): boolean {
-	// Build a regex from the glob pattern
-	let rx = '^';
+function buildGlobRegex(pattern: string): string {
+	let rx = '';
 	let i = 0;
 	while (i < pattern.length) {
 		const ch = pattern[i];
 		if (ch === '*' && pattern[i + 1] === '*') {
-			rx += '.*';
 			i += 2;
-			if (pattern[i] === '/') i++;
+			if (pattern[i] === '/') {
+				i++;
+				// "**/prefix" matches at any depth including root -- use optional group
+				rx += '(?:.*/)?';
+			} else {
+				rx += '.*';
+			}
 		} else if (ch === '*') {
 			rx += '[^/]*';
 			i++;
@@ -72,42 +88,43 @@ function matchSegment(pattern: string, segment: string): boolean {
 			rx += '[^/]';
 			i++;
 		} else {
-			// Escape regex metacharacters
-			rx += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+			// Escape standard regex metacharacters one by one (avoids regex inside regex)
+			let esc = ch;
+			if (ch === '.') esc = '\\.';
+			else if (ch === '+') esc = '\\+';
+			else if (ch === '^') esc = '\\^';
+			else if (ch === '$') esc = '\\$';
+			else if (ch === '{') esc = '\\{';
+			else if (ch === '}') esc = '\\}';
+			else if (ch === '(') esc = '\\(';
+			else if (ch === ')') esc = '\\)';
+			else if (ch === '|') esc = '\\|';
+			else if (ch === '[') esc = '\\[';
+			else if (ch === ']') esc = '\\]';
+			else if (ch === '\\') esc = '\\\\';
+			rx += esc;
 			i++;
 		}
 	}
-	rx += '$';
-	return new RegExp(rx, 'i').test(segment);
+	return rx;
 }
 
 /**
- * Match a full relative path (with `/` separators) against a glob pattern.
- * Used when the pattern itself contains a `/`.
+ * Match a single path segment against a glob pattern (no "/" in segment).
+ * Used for floating patterns that apply to any path component.
+ */
+function matchSegment(pattern: string, segment: string): boolean {
+	const rx = new RegExp('^' + buildGlobRegex(pattern) + '$', 'i');
+	return rx.test(segment);
+}
+
+/**
+ * Match a full relative path against a glob pattern.
+ * Used for anchored patterns that contain "/".
  */
 function matchFullPath(pattern: string, relPath: string): boolean {
-	let rx = '^';
-	let i = 0;
-	while (i < pattern.length) {
-		const ch = pattern[i];
-		if (ch === '*' && pattern[i + 1] === '*') {
-			rx += '.*';
-			i += 2;
-			if (pattern[i] === '/') i++;
-		} else if (ch === '*') {
-			rx += '[^/]*';
-			i++;
-		} else if (ch === '?') {
-			rx += '[^/]';
-			i++;
-		} else {
-			rx += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
-			i++;
-		}
-	}
-	rx += '$';
-	const regex = new RegExp(rx, 'i');
-	return regex.test(relPath);
+	const rx = new RegExp('^' + buildGlobRegex(pattern) + '$', 'i');
+	return rx.test(relPath);
 }
 
 function shouldIgnore(relPath: string, isDirectory: boolean, patterns: IgnorePattern[]): boolean {
@@ -143,12 +160,12 @@ function shouldIgnore(relPath: string, isDirectory: boolean, patterns: IgnorePat
 
 /**
  * Score a search result. Higher is better.
- *  100 — exact name match (case-insensitive)
- *   80 — name starts with query
- *   60 — name contains query
- *   40 — any path segment contains query
- *   20 — full path contains query
- *    0 — no match
+ *  100 -- exact name match (case-insensitive)
+ *   80 -- name starts with query
+ *   60 -- name contains query (name-level matches always beat path-level)
+ *   40 -- any path segment contains query
+ *   20 -- full path contains query
+ *    0 -- no match
  */
 function scoreEntry(entry: FileIndexEntry, lowerQuery: string): number {
 	const lowerName = entry.name.toLowerCase();
@@ -226,7 +243,7 @@ export class FileIndex {
 		try {
 			entries = await readdir(absDir, { withFileTypes: true });
 		} catch {
-			// Permission errors or missing dirs — skip silently
+			// Permission errors or missing dirs -- skip silently
 			return;
 		}
 
@@ -236,17 +253,28 @@ export class FileIndex {
 
 			if (!isSafePath(this.workspacePath, relPath)) continue;
 
-			const isDir = entry.isDirectory();
+			// Resolve symlinks: stat() follows the link to get the target type.
+			// Symlinked directories are NOT recursed into to prevent infinite loops.
+			if (entry.isSymbolicLink()) {
+				try {
+					const targetStat = await stat(absPath);
+					const symType = targetStat.isDirectory() ? 'folder' : 'file';
+					if (shouldIgnore(relPath, symType === 'folder', this.allPatterns)) continue;
+					this.cache.set(relPath, { path: relPath, name: entry.name, type: symType });
+				} catch {
+					// Broken symlink -- skip
+				}
+				continue;
+			}
 
+			const isDir = entry.isDirectory();
 			if (shouldIgnore(relPath, isDir, this.allPatterns)) continue;
 
-			const indexEntry: FileIndexEntry = {
+			this.cache.set(relPath, {
 				path: relPath,
 				name: entry.name,
 				type: isDir ? 'folder' : 'file',
-			};
-
-			this.cache.set(relPath, indexEntry);
+			});
 
 			if (isDir) {
 				await this.scanDirectory(absPath);
@@ -256,8 +284,8 @@ export class FileIndex {
 
 	/**
 	 * Incremental refresh: walk the workspace and sync the cache.
-	 * Adds new entries and removes stale ones for a single directory pass.
-	 * Uses readdir with withFileTypes (no stat calls) for speed.
+	 * Adds new entries, removes stale ones, and re-evaluates existing entries
+	 * against the current ignore patterns (handles setIgnorePatterns calls).
 	 */
 	private async refreshDirectory(absDir: string, seen: Set<string>): Promise<void> {
 		let entries;
@@ -273,8 +301,23 @@ export class FileIndex {
 
 			if (!isSafePath(this.workspacePath, relPath)) continue;
 
-			const isDir = entry.isDirectory();
+			// Resolve symlinks: stat() follows the link; do NOT recurse into symlinked dirs.
+			if (entry.isSymbolicLink()) {
+				try {
+					const targetStat = await stat(absPath);
+					const symType = targetStat.isDirectory() ? 'folder' : 'file';
+					if (shouldIgnore(relPath, symType === 'folder', this.allPatterns)) continue;
+					seen.add(relPath);
+					if (!this.cache.has(relPath)) {
+						this.cache.set(relPath, { path: relPath, name: entry.name, type: symType });
+					}
+				} catch {
+					// Broken symlink -- skip
+				}
+				continue;
+			}
 
+			const isDir = entry.isDirectory();
 			if (shouldIgnore(relPath, isDir, this.allPatterns)) continue;
 
 			seen.add(relPath);
@@ -302,9 +345,17 @@ export class FileIndex {
 			const seen = new Set<string>();
 			await this.refreshDirectory(this.workspacePath, seen);
 
-			// Remove entries that no longer exist
+			// Remove entries that no longer exist on disk
 			for (const key of this.cache.keys()) {
 				if (!seen.has(key)) {
+					this.cache.delete(key);
+				}
+			}
+
+			// Re-evaluate remaining entries against current patterns.
+			// This ensures entries added before a setIgnorePatterns() call are purged.
+			for (const [key, entry] of this.cache) {
+				if (shouldIgnore(entry.path, entry.type === 'folder', this.allPatterns)) {
 					this.cache.delete(key);
 				}
 			}
@@ -315,7 +366,7 @@ export class FileIndex {
 
 	/**
 	 * Perform the initial workspace scan.
-	 * Must be called before `search()`. Starts the background polling timer.
+	 * Must be called before search(). Starts the background polling timer.
 	 */
 	async init(): Promise<void> {
 		await this.loadGitignore();
@@ -337,7 +388,7 @@ export class FileIndex {
 	 */
 	search(query: string, limit = 50): FileIndexEntry[] {
 		if (!query) {
-			// Return first `limit` entries when query is empty
+			// Return first entries when query is empty
 			const results: FileIndexEntry[] = [];
 			for (const entry of this.cache.values()) {
 				results.push(entry);
@@ -387,9 +438,18 @@ export class FileIndex {
 	/**
 	 * Set additional ignore patterns at runtime.
 	 * These are layered on top of .gitignore patterns.
+	 *
+	 * Immediately re-filters the cache: entries that now match the updated patterns
+	 * are removed from the cache right away, without waiting for the next poll.
 	 */
 	setIgnorePatterns(patterns: string[]): void {
 		this.extraPatterns = parseGitignoreLines(patterns);
+		// Re-filter the cache immediately against the updated patterns
+		for (const [key, entry] of this.cache) {
+			if (shouldIgnore(entry.path, entry.type === 'folder', this.allPatterns)) {
+				this.cache.delete(key);
+			}
+		}
 	}
 
 	/**

--- a/packages/daemon/tests/unit/file-index.test.ts
+++ b/packages/daemon/tests/unit/file-index.test.ts
@@ -334,6 +334,70 @@ describe('FileIndex (Unit)', () => {
 			expect(idx.search('file.tmp')).toEqual([]);
 			expect(idx.search('keep.ts').length).toBeGreaterThan(0);
 		});
+
+		it('respects ** double-star pattern: build/**', async () => {
+			await writeFile(join(workspace, '.gitignore'), 'build/**\n');
+			await mkdir(join(workspace, 'build', 'assets'), { recursive: true });
+			await writeFile(join(workspace, 'build', 'assets', 'app.js'), '');
+			await writeFile(join(workspace, 'build', 'index.html'), '');
+			await mkdir(join(workspace, 'src'), { recursive: true });
+			await writeFile(join(workspace, 'src', 'main.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			// Files inside build/ should be excluded
+			expect(idx.search('app.js')).toEqual([]);
+			expect(idx.search('index.html')).toEqual([]);
+		});
+
+		it('respects **/prefix double-star pattern at root depth', async () => {
+			// **/tests should match "tests" at root AND nested paths
+			await writeFile(join(workspace, '.gitignore'), '**/tests\n');
+			await mkdir(join(workspace, 'tests'), { recursive: true });
+			await writeFile(join(workspace, 'tests', 'foo.spec.ts'), '');
+			await mkdir(join(workspace, 'src', 'tests'), { recursive: true });
+			await writeFile(join(workspace, 'src', 'tests', 'bar.spec.ts'), '');
+			await writeFile(join(workspace, 'src', 'app.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			// "tests" directories at both root and nested should be excluded
+			expect(idx.search('foo.spec.ts')).toEqual([]);
+			expect(idx.search('bar.spec.ts')).toEqual([]);
+			// Unrelated files should still be indexed
+			expect(idx.search('app.ts').length).toBeGreaterThan(0);
+		});
+
+		it('respects **/prefix double-star pattern at nested depths', async () => {
+			await writeFile(join(workspace, '.gitignore'), '**/coverage\n');
+			await mkdir(join(workspace, 'packages', 'web', 'coverage'), { recursive: true });
+			await writeFile(join(workspace, 'packages', 'web', 'coverage', 'lcov.info'), '');
+			await writeFile(join(workspace, 'packages', 'web', 'index.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('lcov.info')).toEqual([]);
+			expect(idx.search('index.ts').length).toBeGreaterThan(0);
+		});
+
+		it('respects ? single-character wildcard patterns', async () => {
+			await writeFile(join(workspace, '.gitignore'), 'file?.ts\n');
+			await writeFile(join(workspace, 'file1.ts'), '');
+			await writeFile(join(workspace, 'file2.ts'), '');
+			await writeFile(join(workspace, 'fileAB.ts'), ''); // two chars — should NOT match
+			await writeFile(join(workspace, 'keep.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('file1.ts')).toEqual([]);
+			expect(idx.search('file2.ts')).toEqual([]);
+			expect(idx.search('fileAB.ts').length).toBeGreaterThan(0);
+			expect(idx.search('keep.ts').length).toBeGreaterThan(0);
+		});
 	});
 
 	// ─── setIgnorePatterns ───────────────────────────────────────────────────
@@ -349,6 +413,39 @@ describe('FileIndex (Unit)', () => {
 
 			expect(idx.search('secret.key')).toEqual([]);
 			expect(idx.search('app.ts').length).toBeGreaterThan(0);
+		});
+
+		it('immediately re-filters cache when called after init', async () => {
+			await writeFile(join(workspace, 'secret.key'), '');
+			await writeFile(join(workspace, 'app.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			// Both files are in the cache before pattern update
+			expect(idx.search('secret.key').length).toBeGreaterThan(0);
+			expect(idx.search('app.ts').length).toBeGreaterThan(0);
+
+			// Adding the pattern should purge matching entries immediately
+			idx.setIgnorePatterns(['*.key']);
+
+			expect(idx.search('secret.key')).toEqual([]);
+			expect(idx.search('app.ts').length).toBeGreaterThan(0);
+		});
+
+		it('refresh also removes entries matching patterns set after init', async () => {
+			await writeFile(join(workspace, 'secret.key'), '');
+			await writeFile(join(workspace, 'app.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			idx.setIgnorePatterns(['*.key']);
+
+			// Trigger refresh — should not re-add the secret.key entry
+			await (idx as unknown as { runRefresh(): Promise<void> }).runRefresh();
+
+			expect(idx.search('secret.key')).toEqual([]);
 		});
 	});
 
@@ -495,6 +592,39 @@ describe('FileIndex (Unit)', () => {
 
 			// 100 searches should complete well under 1 second
 			expect(elapsed).toBeLessThan(1000);
+		});
+
+		it('indexes symlinked files', async () => {
+			const { symlink } = await import('node:fs/promises');
+			const target = join(workspace, 'real.ts');
+			const link = join(workspace, 'linked.ts');
+			await writeFile(target, '');
+			await symlink(target, link);
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('linked.ts');
+			expect(results.length).toBeGreaterThan(0);
+			expect(results[0].type).toBe('file');
+		});
+
+		it('indexes symlinked directories as folders without recursing', async () => {
+			const { symlink } = await import('node:fs/promises');
+			const targetDir = join(workspace, 'real-dir');
+			await mkdir(targetDir, { recursive: true });
+			await writeFile(join(targetDir, 'inside.ts'), '');
+
+			const linkDir = join(workspace, 'linked-dir');
+			await symlink(targetDir, linkDir);
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			// The symlinked directory itself should appear as a folder entry
+			const results = idx.search('linked-dir');
+			expect(results.length).toBeGreaterThan(0);
+			expect(results[0].type).toBe('folder');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/file-index.test.ts
+++ b/packages/daemon/tests/unit/file-index.test.ts
@@ -1,0 +1,500 @@
+/**
+ * FileIndex Unit Tests
+ *
+ * Tests the workspace file tree cache: init, search, invalidation,
+ * .gitignore filtering, polling refresh, and path traversal prevention.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { FileIndex } from '../../src/lib/file-index';
+
+// Use a very large poll interval in tests so polling doesn't fire unexpectedly
+const NO_POLL = 9_999_999;
+
+async function makeWorkspace(): Promise<string> {
+	const path = join(
+		tmpdir(),
+		`file-index-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	await mkdir(path, { recursive: true });
+	return path;
+}
+
+describe('FileIndex (Unit)', () => {
+	let workspace: string;
+	let idx: FileIndex;
+
+	beforeEach(async () => {
+		workspace = await makeWorkspace();
+	});
+
+	afterEach(async () => {
+		if (idx) idx.dispose();
+		await rm(workspace, { recursive: true, force: true });
+	});
+
+	// ─── init ────────────────────────────────────────────────────────────────
+
+	describe('init', () => {
+		it('isReady() returns false before init', () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			expect(idx.isReady()).toBe(false);
+		});
+
+		it('isReady() returns true after init', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+			expect(idx.isReady()).toBe(true);
+		});
+
+		it('indexes files created before init', async () => {
+			await writeFile(join(workspace, 'hello.ts'), '');
+			await writeFile(join(workspace, 'world.md'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.size()).toBe(2);
+		});
+
+		it('indexes nested files and folders', async () => {
+			await mkdir(join(workspace, 'src', 'utils'), { recursive: true });
+			await writeFile(join(workspace, 'src', 'utils', 'helper.ts'), '');
+			await writeFile(join(workspace, 'src', 'index.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			// src/, src/utils/, src/index.ts, src/utils/helper.ts
+			expect(idx.size()).toBe(4);
+		});
+
+		it('records folder entries with type "folder"', async () => {
+			await mkdir(join(workspace, 'lib'), { recursive: true });
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('lib');
+			const lib = results.find((e) => e.name === 'lib');
+			expect(lib).toBeDefined();
+			expect(lib!.type).toBe('folder');
+		});
+
+		it('records file entries with type "file"', async () => {
+			await writeFile(join(workspace, 'app.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('app.ts');
+			expect(results[0].type).toBe('file');
+		});
+
+		it('does not crash on empty workspace', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+			expect(idx.size()).toBe(0);
+		});
+	});
+
+	// ─── search ──────────────────────────────────────────────────────────────
+
+	describe('search', () => {
+		beforeEach(async () => {
+			await mkdir(join(workspace, 'src', 'components'), { recursive: true });
+			await mkdir(join(workspace, 'src', 'utils'), { recursive: true });
+			await writeFile(join(workspace, 'src', 'index.ts'), '');
+			await writeFile(join(workspace, 'src', 'components', 'Button.tsx'), '');
+			await writeFile(join(workspace, 'src', 'utils', 'format.ts'), '');
+			await writeFile(join(workspace, 'README.md'), '');
+		});
+
+		it('returns empty array for empty cache', () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			// not initialized — cache is empty
+			expect(idx.search('foo')).toEqual([]);
+		});
+
+		it('finds entries by exact name', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('Button.tsx');
+			expect(results.some((e) => e.name === 'Button.tsx')).toBe(true);
+		});
+
+		it('finds entries case-insensitively', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('button.tsx');
+			expect(results.some((e) => e.name === 'Button.tsx')).toBe(true);
+		});
+
+		it('finds entries by partial name match', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('format');
+			expect(results.some((e) => e.name === 'format.ts')).toBe(true);
+		});
+
+		it('finds entries by path segment', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('components');
+			expect(results.some((e) => e.path.includes('components'))).toBe(true);
+		});
+
+		it('returns results within limit', async () => {
+			// Create many files
+			for (let i = 0; i < 30; i++) {
+				await writeFile(join(workspace, `file${i}.ts`), '');
+			}
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('file', 10);
+			expect(results.length).toBeLessThanOrEqual(10);
+		});
+
+		it('defaults to limit 50', async () => {
+			for (let i = 0; i < 60; i++) {
+				await writeFile(join(workspace, `ts${i}.ts`), '');
+			}
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('ts');
+			expect(results.length).toBeLessThanOrEqual(50);
+		});
+
+		it('returns all entries for empty query (up to limit)', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('');
+			expect(results.length).toBeGreaterThan(0);
+		});
+
+		it('scores exact name matches higher than partial matches', async () => {
+			await writeFile(join(workspace, 'format.ts'), '');
+			await writeFile(join(workspace, 'formatter.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('format.ts');
+			expect(results[0].name).toBe('format.ts');
+		});
+
+		it('scores name-prefix matches higher than contains matches', async () => {
+			await writeFile(join(workspace, 'index.ts'), '');
+			await writeFile(join(workspace, 'main-index.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('index');
+			// index.ts starts with "index"; main-index.ts contains "index"
+			const indexPos = results.findIndex((e) => e.name === 'index.ts');
+			const mainIndexPos = results.findIndex((e) => e.name === 'main-index.ts');
+			expect(indexPos).toBeLessThan(mainIndexPos);
+		});
+
+		it('returns no results when query has no match', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('zzznomatch999');
+			expect(results.length).toBe(0);
+		});
+	});
+
+	// ─── invalidation ────────────────────────────────────────────────────────
+
+	describe('invalidate', () => {
+		it('removes a single entry from the cache', async () => {
+			await writeFile(join(workspace, 'foo.ts'), '');
+			await writeFile(join(workspace, 'bar.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+			expect(idx.size()).toBe(2);
+
+			idx.invalidate('foo.ts');
+			expect(idx.size()).toBe(1);
+			expect(idx.search('foo.ts')).toEqual([]);
+		});
+
+		it('is a no-op for non-existent paths', async () => {
+			await writeFile(join(workspace, 'file.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(() => idx.invalidate('nonexistent.ts')).not.toThrow();
+			expect(idx.size()).toBe(1);
+		});
+	});
+
+	describe('invalidateAll', () => {
+		it('clears the entire cache', async () => {
+			await writeFile(join(workspace, 'a.ts'), '');
+			await writeFile(join(workspace, 'b.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+			expect(idx.size()).toBe(2);
+
+			idx.invalidateAll();
+			expect(idx.size()).toBe(0);
+		});
+	});
+
+	// ─── .gitignore filtering ─────────────────────────────────────────────────
+
+	describe('.gitignore filtering', () => {
+		it('ignores .git directory', async () => {
+			await mkdir(join(workspace, '.git'), { recursive: true });
+			await writeFile(join(workspace, '.git', 'HEAD'), 'ref: refs/heads/main');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('.git')).toEqual([]);
+		});
+
+		it('ignores node_modules directory', async () => {
+			await mkdir(join(workspace, 'node_modules', 'lodash'), { recursive: true });
+			await writeFile(join(workspace, 'node_modules', 'lodash', 'index.js'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('lodash')).toEqual([]);
+			expect(idx.search('node_modules')).toEqual([]);
+		});
+
+		it('ignores .DS_Store files', async () => {
+			await writeFile(join(workspace, '.DS_Store'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('.DS_Store')).toEqual([]);
+			expect(idx.size()).toBe(0);
+		});
+
+		it('respects .gitignore wildcard patterns', async () => {
+			await writeFile(join(workspace, '.gitignore'), '*.log\ndist/\n');
+			await mkdir(join(workspace, 'dist'), { recursive: true });
+			await writeFile(join(workspace, 'dist', 'bundle.js'), '');
+			await writeFile(join(workspace, 'server.log'), '');
+			await writeFile(join(workspace, 'app.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('server.log')).toEqual([]);
+			expect(idx.search('bundle.js')).toEqual([]);
+			expect(idx.search('app.ts').length).toBeGreaterThan(0);
+		});
+
+		it('respects .gitignore negation patterns', async () => {
+			await writeFile(join(workspace, '.gitignore'), '*.log\n!important.log\n');
+			await writeFile(join(workspace, 'debug.log'), '');
+			await writeFile(join(workspace, 'important.log'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('debug.log')).toEqual([]);
+			expect(idx.search('important.log').length).toBeGreaterThan(0);
+		});
+
+		it('ignores gitignore comment lines and blank lines', async () => {
+			await writeFile(
+				join(workspace, '.gitignore'),
+				'# This is a comment\n\n*.tmp\n\n# Another comment\n'
+			);
+			await writeFile(join(workspace, 'file.tmp'), '');
+			await writeFile(join(workspace, 'keep.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('file.tmp')).toEqual([]);
+			expect(idx.search('keep.ts').length).toBeGreaterThan(0);
+		});
+	});
+
+	// ─── setIgnorePatterns ───────────────────────────────────────────────────
+
+	describe('setIgnorePatterns', () => {
+		it('applies extra patterns on subsequent init', async () => {
+			await writeFile(join(workspace, 'secret.key'), '');
+			await writeFile(join(workspace, 'app.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			idx.setIgnorePatterns(['*.key']);
+			await idx.init();
+
+			expect(idx.search('secret.key')).toEqual([]);
+			expect(idx.search('app.ts').length).toBeGreaterThan(0);
+		});
+	});
+
+	// ─── path traversal prevention ───────────────────────────────────────────
+
+	describe('path traversal prevention', () => {
+		it('does not index paths outside the workspace', async () => {
+			await writeFile(join(workspace, 'safe.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			// Cache should only contain entries whose paths stay within workspace
+			for (const entry of idx.search('')) {
+				expect(entry.path.startsWith('..')).toBe(false);
+				expect(entry.path.startsWith('/')).toBe(false);
+			}
+		});
+
+		it('search results never expose absolute paths', async () => {
+			await writeFile(join(workspace, 'file.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('file.ts');
+			expect(results.length).toBeGreaterThan(0);
+			results.forEach((r) => {
+				expect(r.path.startsWith('/')).toBe(false);
+			});
+		});
+	});
+
+	// ─── polling refresh ─────────────────────────────────────────────────────
+
+	describe('polling refresh', () => {
+		it('picks up new files on next refresh', async () => {
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+			expect(idx.size()).toBe(0);
+
+			// Create a file after init
+			await writeFile(join(workspace, 'new.ts'), '');
+
+			// Manually trigger refresh by re-running (simulate poll tick)
+			// Access private method via cast for testing
+			await (idx as unknown as { runRefresh(): Promise<void> }).runRefresh();
+
+			expect(idx.size()).toBe(1);
+			expect(idx.search('new.ts').length).toBeGreaterThan(0);
+		});
+
+		it('removes deleted files on next refresh', async () => {
+			await writeFile(join(workspace, 'delete-me.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+			expect(idx.size()).toBe(1);
+
+			// Delete the file
+			await rm(join(workspace, 'delete-me.ts'));
+
+			// Trigger refresh
+			await (idx as unknown as { runRefresh(): Promise<void> }).runRefresh();
+
+			expect(idx.size()).toBe(0);
+		});
+
+		it('dispose() stops the polling timer', () => {
+			idx = new FileIndex(workspace, 100);
+			idx.dispose();
+			// pollTimer should be cleared — accessing internal state via cast
+			const internal = idx as unknown as { pollTimer: unknown };
+			expect(internal.pollTimer).toBeNull();
+		});
+	});
+
+	// ─── edge cases ──────────────────────────────────────────────────────────
+
+	describe('edge cases', () => {
+		it('handles files with spaces and special characters', async () => {
+			await writeFile(join(workspace, 'my file.ts'), '');
+			await writeFile(join(workspace, 'kebab-case.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('my file.ts').length).toBeGreaterThan(0);
+			expect(idx.search('kebab-case').length).toBeGreaterThan(0);
+		});
+
+		it('returns correct relative paths with forward slashes', async () => {
+			await mkdir(join(workspace, 'a', 'b'), { recursive: true });
+			await writeFile(join(workspace, 'a', 'b', 'deep.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const results = idx.search('deep.ts');
+			expect(results.length).toBeGreaterThan(0);
+			expect(results[0].path).toContain('deep.ts');
+		});
+
+		it('handles deeply nested workspaces', async () => {
+			const deep = join(workspace, 'a', 'b', 'c', 'd', 'e');
+			await mkdir(deep, { recursive: true });
+			await writeFile(join(deep, 'very-deep.ts'), '');
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.search('very-deep').length).toBeGreaterThan(0);
+		});
+
+		it('size() returns accurate count', async () => {
+			for (let i = 0; i < 5; i++) {
+				await writeFile(join(workspace, `file${i}.ts`), '');
+			}
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			expect(idx.size()).toBe(5);
+		});
+
+		it('search is fast for large workspaces', async () => {
+			// Create 200 files across nested directories
+			for (let i = 0; i < 10; i++) {
+				const dir = join(workspace, `pkg${i}`);
+				await mkdir(dir, { recursive: true });
+				for (let j = 0; j < 20; j++) {
+					await writeFile(join(dir, `file${j}.ts`), '');
+				}
+			}
+
+			idx = new FileIndex(workspace, NO_POLL);
+			await idx.init();
+
+			const start = Date.now();
+			for (let i = 0; i < 100; i++) {
+				idx.search(`file${i % 20}`);
+			}
+			const elapsed = Date.now() - start;
+
+			// 100 searches should complete well under 1 second
+			expect(elapsed).toBeLessThan(1000);
+		});
+	});
+});


### PR DESCRIPTION
Adds FileIndex class for fast fuzzy file/folder search without recursive
directory listing on every query. Key features:

- init(): recursive workspace scan, loads .gitignore, starts polling timer
- search(): O(n) fuzzy match scored by exact > starts-with > contains > path-segment
- Polling-based refresh (default 10s, NEOKAI_FILE_INDEX_POLL_MS) with debounce
- .gitignore parsing (*, **, !negation, dir/ suffix) + always-ignore builtins
- Path traversal prevention: rejects .. segments and absolute paths
- setIgnorePatterns() for runtime-configurable extra patterns
- invalidate() / invalidateAll() for manual cache eviction
- 38 unit tests covering all requirements
