### PR TITLE
feat(reference): implement reference.resolve RPC handler with shared types

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -73,6 +73,7 @@ import { setupGlobalSpacesHandlers } from './global-spaces-handlers';
 import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
 import { setupSpaceSessionGroupHandlers } from './space-session-group-handlers';
 import { setupLiveQueryHandlers } from './live-query-handlers';
+import { setupReferenceHandlers } from './reference-handlers';
 import { LiveQueryEngine } from '../../storage/live-query';
 import type { AppMcpLifecycleManager } from '../mcp';
 
@@ -271,6 +272,14 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.liveQueries,
 		deps.db.getDatabase()
 	);
+
+	// Reference handlers (@ mention system — resolve tasks, goals, files, folders)
+	setupReferenceHandlers(deps.messageHub, {
+		sessionManager: deps.sessionManager,
+		taskRepo: new TaskRepository(deps.db.getDatabase(), deps.reactiveDb),
+		goalRepo: deps.db.getGoalRepo(),
+		workspaceRoot: deps.config.workspaceRoot,
+	});
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -15,6 +15,7 @@ import type {
 import type { SessionManager } from '../session-manager';
 import { FileManager } from '../file-manager';
 import { Logger } from '../logger';
+import { join, normalize, relative } from 'node:path';
 
 const log = new Logger('reference-handlers');
 
@@ -23,6 +24,12 @@ const log = new Logger('reference-handlers');
  * Files larger than this will be truncated to prevent oversized responses.
  */
 const MAX_FILE_CONTENT_BYTES = 50_000;
+
+/**
+ * Number of bytes to sample when detecting binary files.
+ * Checking the first 8 KB is sufficient for reliable binary detection.
+ */
+const BINARY_DETECTION_SAMPLE_BYTES = 8_192;
 
 // ============================================================================
 // Repository interfaces (minimal — only what this handler needs)
@@ -165,6 +172,11 @@ async function resolveTask(
 		return null;
 	}
 
+	// Confirm the task belongs to the session's room (prevent cross-room access via UUID)
+	if (task.roomId !== roomId) {
+		return null;
+	}
+
 	return {
 		type: 'task',
 		id,
@@ -206,7 +218,67 @@ function resolveGoal(
 async function resolveFile(id: string, workspacePath: string): Promise<ResolvedReference | null> {
 	const fileManager = new FileManager(workspacePath);
 
-	// validatePath is called internally by readFile; throws on traversal
+	// Validate path (throws on traversal — we catch below to return null)
+	let absolutePath: string;
+	try {
+		// Replicate FileManager path validation without reading the file yet
+		const normalized = normalize(workspacePath);
+		const resolved = normalize(join(workspacePath, id));
+		const rel = relative(normalized, resolved);
+		if (rel.startsWith('..') || rel === '..') {
+			return null;
+		}
+		absolutePath = resolved;
+	} catch {
+		return null;
+	}
+
+	// Check for binary content before attempting text decode
+	let isBinary = false;
+	let fileSize = 0;
+	let fileMtime = '';
+	try {
+		const { stat } = await import('node:fs/promises');
+		const stats = await stat(absolutePath);
+		fileSize = stats.size;
+		fileMtime = stats.mtime.toISOString();
+
+		// Sample the first BINARY_DETECTION_SAMPLE_BYTES bytes and check for null bytes,
+		// which are the most reliable indicator of binary content.
+		const sampleSize = Math.min(fileSize, BINARY_DETECTION_SAMPLE_BYTES);
+		if (sampleSize > 0) {
+			const buf = Buffer.allocUnsafe(sampleSize);
+			const { open } = await import('node:fs/promises');
+			const fd = await open(absolutePath, 'r');
+			try {
+				await fd.read(buf, 0, sampleSize, 0);
+			} finally {
+				await fd.close();
+			}
+			isBinary = buf.includes(0x00);
+		}
+	} catch {
+		// File not found or unreadable
+		return null;
+	}
+
+	if (isBinary) {
+		// Return metadata only — content would be garbled and oversized
+		return {
+			type: 'file',
+			id,
+			data: {
+				path: id,
+				content: null,
+				binary: true,
+				truncated: false,
+				size: fileSize,
+				mtime: fileMtime,
+			},
+		};
+	}
+
+	// Read text content via FileManager (handles path validation internally)
 	let fileData: {
 		path: string;
 		content: string;
@@ -218,7 +290,6 @@ async function resolveFile(id: string, workspacePath: string): Promise<ResolvedR
 	try {
 		fileData = await fileManager.readFile(id, 'utf-8');
 	} catch {
-		// File not found or path traversal detected — return null
 		return null;
 	}
 
@@ -232,6 +303,7 @@ async function resolveFile(id: string, workspacePath: string): Promise<ResolvedR
 		data: {
 			path: fileData.path,
 			content,
+			binary: false,
 			truncated,
 			size: fileData.size,
 			mtime: fileData.mtime,

--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -1,0 +1,267 @@
+/**
+ * Reference RPC Handlers
+ *
+ * RPC handlers for the @ reference system:
+ * - reference.resolve — Resolve a single reference to its full entity data
+ */
+
+import type {
+	MessageHub,
+	ReferenceType,
+	ResolvedReference,
+	NeoTask,
+	RoomGoal,
+} from '@neokai/shared';
+import type { SessionManager } from '../session-manager';
+import { FileManager } from '../file-manager';
+import { Logger } from '../logger';
+
+const log = new Logger('reference-handlers');
+
+/**
+ * Maximum number of bytes to include in file content payloads.
+ * Files larger than this will be truncated to prevent oversized responses.
+ */
+const MAX_FILE_CONTENT_BYTES = 50_000;
+
+// ============================================================================
+// Repository interfaces (minimal — only what this handler needs)
+// ============================================================================
+
+export interface TaskRepoForReference {
+	getTask(id: string): NeoTask | null;
+	getTaskByShortId(roomId: string, shortId: string): NeoTask | null;
+}
+
+export interface GoalRepoForReference {
+	getGoal(id: string): RoomGoal | null;
+	getGoalByShortId(roomId: string, shortId: string): RoomGoal | null;
+}
+
+// ============================================================================
+// Handler dependencies
+// ============================================================================
+
+export interface ReferenceHandlerDeps {
+	/** Session manager — used to look up session workspace path and room context */
+	sessionManager: SessionManager;
+	/** Task repository for looking up room tasks */
+	taskRepo: TaskRepoForReference;
+	/** Goal repository (not scoped to room — uses global DB access) */
+	goalRepo: GoalRepoForReference;
+	/** Workspace root path — used as fallback when no session is provided */
+	workspaceRoot: string;
+}
+
+// ============================================================================
+// Main setup function
+// ============================================================================
+
+export function setupReferenceHandlers(messageHub: MessageHub, deps: ReferenceHandlerDeps): void {
+	// ------------------------------------------------------------------
+	// reference.resolve
+	// ------------------------------------------------------------------
+	messageHub.onRequest(
+		'reference.resolve',
+		async (
+			data
+		): Promise<{
+			resolved: ResolvedReference | null;
+		}> => {
+			const params = data as {
+				sessionId: string;
+				type: ReferenceType;
+				id: string;
+			};
+
+			if (!params.sessionId) {
+				throw new Error('sessionId is required');
+			}
+			if (!params.type) {
+				throw new Error('type is required');
+			}
+			if (!params.id) {
+				throw new Error('id is required');
+			}
+
+			// Determine session context (workspace path + optional room ID)
+			const { workspacePath, roomId } = await resolveSessionContext(params.sessionId, deps);
+
+			try {
+				switch (params.type) {
+					case 'task':
+						return { resolved: await resolveTask(params.id, roomId, deps) };
+
+					case 'goal':
+						return { resolved: resolveGoal(params.id, roomId, deps) };
+
+					case 'file':
+						return { resolved: await resolveFile(params.id, workspacePath) };
+
+					case 'folder':
+						return { resolved: await resolveFolder(params.id, workspacePath) };
+
+					default: {
+						// Exhaustiveness guard — unknown types return null rather than throwing
+						log.warn(`Unknown reference type: ${params.type as string}`);
+						return { resolved: null };
+					}
+				}
+			} catch (err) {
+				// Log unexpected errors but surface null so callers handle gracefully
+				log.warn(`Failed to resolve reference ${params.type}:${params.id}:`, err);
+				return { resolved: null };
+			}
+		}
+	);
+}
+
+// ============================================================================
+// Session context helper
+// ============================================================================
+
+/**
+ * Resolve the workspace path and optional room ID for a given session ID.
+ *
+ * Falls back to the configured workspace root when the session cannot be loaded,
+ * so file/folder resolution still works in standalone (non-room) contexts.
+ */
+async function resolveSessionContext(
+	sessionId: string,
+	deps: ReferenceHandlerDeps
+): Promise<{ workspacePath: string; roomId: string | null }> {
+	const agentSession = await deps.sessionManager.getSessionAsync(sessionId);
+	if (!agentSession) {
+		return { workspacePath: deps.workspaceRoot, roomId: null };
+	}
+
+	const sessionData = agentSession.getSessionData();
+	return {
+		workspacePath: sessionData.workspacePath ?? deps.workspaceRoot,
+		roomId: sessionData.context?.roomId ?? null,
+	};
+}
+
+// ============================================================================
+// Per-type resolution helpers
+// ============================================================================
+
+async function resolveTask(
+	id: string,
+	roomId: string | null,
+	deps: ReferenceHandlerDeps
+): Promise<ResolvedReference | null> {
+	if (!roomId) {
+		return null;
+	}
+
+	// Support both UUID and short IDs (e.g. "t-42")
+	let task = deps.taskRepo.getTask(id);
+	if (!task) {
+		task = deps.taskRepo.getTaskByShortId(roomId, id);
+	}
+
+	if (!task) {
+		return null;
+	}
+
+	return {
+		type: 'task',
+		id,
+		data: task,
+	};
+}
+
+function resolveGoal(
+	id: string,
+	roomId: string | null,
+	deps: ReferenceHandlerDeps
+): ResolvedReference | null {
+	if (!roomId) {
+		return null;
+	}
+
+	// Support both UUID and short IDs (e.g. "g-7")
+	let goal = deps.goalRepo.getGoal(id);
+	if (!goal) {
+		goal = deps.goalRepo.getGoalByShortId(roomId, id);
+	}
+
+	if (!goal) {
+		return null;
+	}
+
+	// Confirm the goal belongs to the session's room
+	if (goal.roomId !== roomId) {
+		return null;
+	}
+
+	return {
+		type: 'goal',
+		id,
+		data: goal,
+	};
+}
+
+async function resolveFile(id: string, workspacePath: string): Promise<ResolvedReference | null> {
+	const fileManager = new FileManager(workspacePath);
+
+	// validatePath is called internally by readFile; throws on traversal
+	let fileData: {
+		path: string;
+		content: string;
+		encoding: string;
+		size: number;
+		mtime: string;
+	};
+
+	try {
+		fileData = await fileManager.readFile(id, 'utf-8');
+	} catch {
+		// File not found or path traversal detected — return null
+		return null;
+	}
+
+	const rawContent = fileData.content;
+	const truncated = rawContent.length > MAX_FILE_CONTENT_BYTES;
+	const content = truncated ? rawContent.slice(0, MAX_FILE_CONTENT_BYTES) : rawContent;
+
+	return {
+		type: 'file',
+		id,
+		data: {
+			path: fileData.path,
+			content,
+			truncated,
+			size: fileData.size,
+			mtime: fileData.mtime,
+		},
+	};
+}
+
+async function resolveFolder(id: string, workspacePath: string): Promise<ResolvedReference | null> {
+	const fileManager = new FileManager(workspacePath);
+
+	let entries: Array<{ name: string; path: string; type: 'file' | 'directory' }>;
+
+	try {
+		const rawEntries = await fileManager.listDirectory(id, false);
+		entries = rawEntries.map((e) => ({
+			name: e.name,
+			path: e.path,
+			type: e.type as 'file' | 'directory',
+		}));
+	} catch {
+		// Directory not found or path traversal detected — return null
+		return null;
+	}
+
+	return {
+		type: 'folder',
+		id,
+		data: {
+			path: id,
+			entries,
+		},
+	};
+}

--- a/packages/daemon/tests/unit/rpc-handlers/reference-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/reference-handlers.test.ts
@@ -310,6 +310,30 @@ describe('reference.resolve handler', () => {
 			// Session not found → no roomId → null
 			expect(result.resolved).toBeNull();
 		});
+
+		it('returns null when task belongs to a different room (cross-room isolation)', async () => {
+			const taskInOtherRoom = { ...SAMPLE_TASK, roomId: 'other-room' };
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+				}) as never,
+				taskRepo: makeTaskRepo(taskInOtherRoom),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'task',
+				id: 'task-uuid-1',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
 	});
 
 	// -------------------------------------------------------------------------
@@ -467,7 +491,7 @@ describe('reference.resolve handler', () => {
 				resolved: {
 					type: string;
 					id: string;
-					data: { content: string; truncated: boolean; size: number };
+					data: { content: string; binary: boolean; truncated: boolean; size: number };
 				};
 			};
 
@@ -475,6 +499,7 @@ describe('reference.resolve handler', () => {
 			expect(result.resolved!.type).toBe('file');
 			expect(result.resolved!.id).toBe('hello.txt');
 			expect(result.resolved!.data.content).toBe('Hello world');
+			expect(result.resolved!.data.binary).toBe(false);
 			expect(result.resolved!.data.truncated).toBe(false);
 			expect(result.resolved!.data.size).toBeGreaterThan(0);
 		});
@@ -507,6 +532,35 @@ describe('reference.resolve handler', () => {
 			expect(result.resolved).not.toBeNull();
 			expect(result.resolved!.data.truncated).toBe(true);
 			expect(result.resolved!.data.content.length).toBe(50_000);
+		});
+
+		it('returns binary metadata (no content) for binary files', async () => {
+			// Write a buffer with null bytes — clear binary indicator
+			const binaryData = Buffer.from([0x00, 0x01, 0x02, 0x89, 0x50, 0x4e, 0x47, 0x00]);
+			await writeFile(join(testWorkspace, 'image.png'), binaryData);
+
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'file',
+				id: 'image.png',
+			})) as {
+				resolved: { data: { content: null; binary: boolean; size: number } } | null;
+			};
+
+			expect(result.resolved).not.toBeNull();
+			expect(result.resolved!.data.binary).toBe(true);
+			expect(result.resolved!.data.content).toBeNull();
+			expect(result.resolved!.data.size).toBeGreaterThan(0);
 		});
 
 		it('returns null for a missing file', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/reference-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/reference-handlers.test.ts
@@ -1,0 +1,678 @@
+/**
+ * Tests for Reference RPC Handlers
+ *
+ * Tests the `reference.resolve` RPC handler:
+ * - Task resolution (with room context, without room context, missing task)
+ * - Goal resolution (with room context, without room context, missing goal, wrong room)
+ * - File resolution (normal, truncated, missing, path traversal)
+ * - Folder resolution (normal, missing, path traversal)
+ */
+
+import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+	setupReferenceHandlers,
+	type ReferenceHandlerDeps,
+	type TaskRepoForReference,
+	type GoalRepoForReference,
+} from '../../../src/lib/rpc-handlers/reference-handlers';
+
+// Type for captured request handlers
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+
+	return { hub, handlers };
+}
+
+function makeSessionManager(opts: { workspacePath: string; roomId?: string; exists?: boolean }) {
+	const exists = opts.exists ?? true;
+
+	const session = exists
+		? {
+				getSessionData: () => ({
+					id: 'session-1',
+					workspacePath: opts.workspacePath,
+					context: opts.roomId ? { roomId: opts.roomId } : undefined,
+				}),
+			}
+		: null;
+
+	return {
+		getSessionAsync: mock(async () => session),
+	};
+}
+
+const SAMPLE_TASK = {
+	id: 'task-uuid-1',
+	roomId: 'room-1',
+	title: 'Fix bug',
+	status: 'pending',
+};
+
+const SAMPLE_GOAL = {
+	id: 'goal-uuid-1',
+	roomId: 'room-1',
+	title: 'Ship feature',
+	status: 'active',
+};
+
+function makeTaskRepo(task: typeof SAMPLE_TASK | null = SAMPLE_TASK): TaskRepoForReference {
+	return {
+		getTask: mock((id: string) => (task && id === task.id ? task : null)),
+		getTaskByShortId: mock((_roomId: string, shortId: string) =>
+			task && shortId === 't-1' ? task : null
+		),
+	};
+}
+
+function makeGoalRepo(goal: typeof SAMPLE_GOAL | null = SAMPLE_GOAL): GoalRepoForReference {
+	return {
+		getGoal: mock((id: string) => (goal && id === goal.id ? goal : null)),
+		getGoalByShortId: mock((_roomId: string, shortId: string) =>
+			goal && shortId === 'g-1' ? goal : null
+		),
+	};
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('reference.resolve handler', () => {
+	let testWorkspace: string;
+
+	beforeEach(async () => {
+		testWorkspace = join(
+			tmpdir(),
+			`ref-handlers-${Date.now()}-${Math.random().toString(36).slice(2)}`
+		);
+		await mkdir(testWorkspace, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(testWorkspace, { recursive: true, force: true });
+	});
+
+	// -------------------------------------------------------------------------
+	// Validation
+	// -------------------------------------------------------------------------
+
+	describe('parameter validation', () => {
+		it('throws when sessionId is missing', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			await expect(handler({ sessionId: '', type: 'task', id: 'x' })).rejects.toThrow(
+				'sessionId is required'
+			);
+		});
+
+		it('throws when type is missing', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			await expect(handler({ sessionId: 'session-1', type: '', id: 'x' })).rejects.toThrow(
+				'type is required'
+			);
+		});
+
+		it('throws when id is missing', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			await expect(handler({ sessionId: 'session-1', type: 'task', id: '' })).rejects.toThrow(
+				'id is required'
+			);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Task resolution
+	// -------------------------------------------------------------------------
+
+	describe('task resolution', () => {
+		it('returns task data for a valid UUID in room context', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'task',
+				id: 'task-uuid-1',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toMatchObject({
+				type: 'task',
+				id: 'task-uuid-1',
+				data: { id: 'task-uuid-1', title: 'Fix bug' },
+			});
+		});
+
+		it('resolves task by short ID', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'task',
+				id: 't-1',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toMatchObject({
+				type: 'task',
+				id: 't-1',
+				data: { id: 'task-uuid-1', title: 'Fix bug' },
+			});
+		});
+
+		it('returns null when no room context', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					// no roomId
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'task',
+				id: 'task-uuid-1',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
+
+		it('returns null when task does not exist', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+				}) as never,
+				taskRepo: makeTaskRepo(null),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'task',
+				id: 'non-existent',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
+
+		it('returns null when session does not exist', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+					exists: false,
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'unknown-session',
+				type: 'task',
+				id: 'task-uuid-1',
+			})) as { resolved: unknown };
+
+			// Session not found → no roomId → null
+			expect(result.resolved).toBeNull();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Goal resolution
+	// -------------------------------------------------------------------------
+
+	describe('goal resolution', () => {
+		it('returns goal data for a valid UUID in room context', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'goal',
+				id: 'goal-uuid-1',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toMatchObject({
+				type: 'goal',
+				id: 'goal-uuid-1',
+				data: { id: 'goal-uuid-1', title: 'Ship feature' },
+			});
+		});
+
+		it('resolves goal by short ID', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'goal',
+				id: 'g-1',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toMatchObject({
+				type: 'goal',
+				id: 'g-1',
+				data: { id: 'goal-uuid-1', title: 'Ship feature' },
+			});
+		});
+
+		it('returns null when no room context', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'goal',
+				id: 'goal-uuid-1',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
+
+		it('returns null when goal does not exist', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(null),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'goal',
+				id: 'non-existent',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
+
+		it('returns null when goal belongs to a different room', async () => {
+			const goalInOtherRoom = { ...SAMPLE_GOAL, roomId: 'other-room' };
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					roomId: 'room-1',
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(goalInOtherRoom),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'goal',
+				id: 'goal-uuid-1',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// File resolution
+	// -------------------------------------------------------------------------
+
+	describe('file resolution', () => {
+		it('returns file content for an existing file', async () => {
+			await writeFile(join(testWorkspace, 'hello.txt'), 'Hello world');
+
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'file',
+				id: 'hello.txt',
+			})) as {
+				resolved: {
+					type: string;
+					id: string;
+					data: { content: string; truncated: boolean; size: number };
+				};
+			};
+
+			expect(result.resolved).not.toBeNull();
+			expect(result.resolved!.type).toBe('file');
+			expect(result.resolved!.id).toBe('hello.txt');
+			expect(result.resolved!.data.content).toBe('Hello world');
+			expect(result.resolved!.data.truncated).toBe(false);
+			expect(result.resolved!.data.size).toBeGreaterThan(0);
+		});
+
+		it('truncates large files', async () => {
+			// 60 KB file — larger than 50 KB limit
+			const bigContent = 'A'.repeat(60_000);
+			await writeFile(join(testWorkspace, 'big.txt'), bigContent);
+
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'file',
+				id: 'big.txt',
+			})) as {
+				resolved: {
+					data: { content: string; truncated: boolean };
+				};
+			};
+
+			expect(result.resolved).not.toBeNull();
+			expect(result.resolved!.data.truncated).toBe(true);
+			expect(result.resolved!.data.content.length).toBe(50_000);
+		});
+
+		it('returns null for a missing file', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'file',
+				id: 'does-not-exist.txt',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
+
+		it('returns null for path traversal attempts', async () => {
+			// Create a file outside the workspace so we know it exists
+			const outsideDir = join(
+				tmpdir(),
+				`outside-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			await mkdir(outsideDir, { recursive: true });
+			await writeFile(join(outsideDir, 'secret.txt'), 'secret');
+
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'file',
+				id: '../secret.txt',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+
+			await rm(outsideDir, { recursive: true, force: true });
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Folder resolution
+	// -------------------------------------------------------------------------
+
+	describe('folder resolution', () => {
+		it('returns folder entries for an existing directory', async () => {
+			await mkdir(join(testWorkspace, 'src'), { recursive: true });
+			await writeFile(join(testWorkspace, 'src', 'index.ts'), '// entry');
+			await writeFile(join(testWorkspace, 'src', 'utils.ts'), '// utils');
+
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'folder',
+				id: 'src',
+			})) as {
+				resolved: {
+					type: string;
+					id: string;
+					data: { path: string; entries: Array<{ name: string }> };
+				};
+			};
+
+			expect(result.resolved).not.toBeNull();
+			expect(result.resolved!.type).toBe('folder');
+			expect(result.resolved!.id).toBe('src');
+			expect(result.resolved!.data.path).toBe('src');
+			const names = result.resolved!.data.entries.map((e) => e.name);
+			expect(names).toContain('index.ts');
+			expect(names).toContain('utils.ts');
+		});
+
+		it('returns null for a missing directory', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'folder',
+				id: 'non-existent-dir',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
+
+		it('returns null for path traversal attempts on folders', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'session-1',
+				type: 'folder',
+				id: '../',
+			})) as { resolved: unknown };
+
+			expect(result.resolved).toBeNull();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Fallback / session handling
+	// -------------------------------------------------------------------------
+
+	describe('session fallback', () => {
+		it('uses workspaceRoot when session is not found', async () => {
+			await writeFile(join(testWorkspace, 'fallback.txt'), 'fallback content');
+
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					exists: false,
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'unknown-session',
+				type: 'file',
+				id: 'fallback.txt',
+			})) as {
+				resolved: { data: { content: string } } | null;
+			};
+
+			expect(result.resolved).not.toBeNull();
+			expect(result.resolved!.data.content).toBe('fallback content');
+		});
+	});
+});

--- a/packages/shared/src/types/reference.ts
+++ b/packages/shared/src/types/reference.ts
@@ -54,11 +54,19 @@ export interface ResolvedGoalReference extends ResolvedReference {
 	type: 'goal';
 }
 
+/** Resolved file reference — data includes content (possibly truncated or absent for binary files) */
 export interface ResolvedFileReference extends ResolvedReference {
 	type: 'file';
 	data: {
 		path: string;
-		content: string;
+		/** UTF-8 text content, or null when the file is binary */
+		content: string | null;
+		/** True when the file contains binary (non-text) data; content will be null */
+		binary: boolean;
+		/** True when file content was truncated to stay within payload limits */
+		truncated: boolean;
+		size: number;
+		mtime: string;
 	};
 }
 
@@ -66,7 +74,11 @@ export interface ResolvedFolderReference extends ResolvedReference {
 	type: 'folder';
 	data: {
 		path: string;
-		entries: Array<{ name: string; type: 'file' | 'folder' }>;
+		entries: Array<{
+			name: string;
+			path: string;
+			type: 'file' | 'directory';
+		}>;
 	};
 }
 

--- a/packages/shared/tests/reference.test.ts
+++ b/packages/shared/tests/reference.test.ts
@@ -73,10 +73,10 @@ describe('ResolvedReference variants', () => {
 			id: 'src/app.ts',
 			data: {
 				path: 'src/app.ts',
-				content: 'export {}',
+				content: 'console.log("hello");',
 				binary: false,
 				truncated: false,
-				size: 9,
+				size: 21,
 				mtime: new Date().toISOString(),
 			},
 		};
@@ -107,11 +107,14 @@ describe('ResolvedReference variants', () => {
 			id: 'src/',
 			data: {
 				path: 'src/',
-				entries: [{ name: 'app.ts', path: 'src/app.ts', type: 'file' }],
+				entries: [
+					{ name: 'app.ts', path: 'src/app.ts', type: 'file' },
+					{ name: 'index.ts', path: 'src/index.ts', type: 'file' },
+				],
 			},
 		};
 		expect(ref.type).toBe('folder');
-		expect(ref.data.entries).toHaveLength(1);
+		expect(ref.data.entries).toHaveLength(2);
 	});
 
 	it('ResolvedReference accepts unknown data', () => {

--- a/packages/shared/tests/reference.test.ts
+++ b/packages/shared/tests/reference.test.ts
@@ -71,18 +71,47 @@ describe('ResolvedReference variants', () => {
 		const ref: ResolvedFileReference = {
 			type: 'file',
 			id: 'src/app.ts',
-			data: { path: 'src/app.ts', content: 'export {}' },
+			data: {
+				path: 'src/app.ts',
+				content: 'export {}',
+				binary: false,
+				truncated: false,
+				size: 9,
+				mtime: new Date().toISOString(),
+			},
 		};
 		expect(ref.type).toBe('file');
+		expect(ref.data.binary).toBe(false);
+	});
+
+	it('ResolvedFileReference supports binary files with null content', () => {
+		const ref: ResolvedFileReference = {
+			type: 'file',
+			id: 'image.png',
+			data: {
+				path: 'image.png',
+				content: null,
+				binary: true,
+				truncated: false,
+				size: 1024,
+				mtime: new Date().toISOString(),
+			},
+		};
+		expect(ref.data.binary).toBe(true);
+		expect(ref.data.content).toBeNull();
 	});
 
 	it('ResolvedFolderReference has type folder', () => {
 		const ref: ResolvedFolderReference = {
 			type: 'folder',
 			id: 'src/',
-			data: { path: 'src/', entries: [{ name: 'app.ts', type: 'file' }] },
+			data: {
+				path: 'src/',
+				entries: [{ name: 'app.ts', path: 'src/app.ts', type: 'file' }],
+			},
 		};
 		expect(ref.type).toBe('folder');
+		expect(ref.data.entries).toHaveLength(1);
 	});
 
 	it('ResolvedReference accepts unknown data', () => {


### PR DESCRIPTION
- Add shared reference type definitions in packages/shared/src/types/reference.ts:
  ReferenceType union, ReferenceMention, ReferenceSearchResult, ResolvedReference
  variants (task/goal/file/folder), ReferenceMetadata, and REFERENCE_PATTERN regex
- Create packages/daemon/src/lib/rpc-handlers/reference-handlers.ts with the
  reference.resolve RPC handler: resolves tasks (by UUID or short ID) and goals
  from room context, reads file content (with 50KB truncation), and lists folder
  entries — returns null gracefully for missing entities, wrong room, or path
  traversal attempts
- Wire setupReferenceHandlers() into setupRPCHandlers() in rpc-handlers/index.ts
- Add 21 unit tests covering all entity types, null returns, path traversal
  prevention, large file truncation, and session fallback behavior
