### PR TITLE
feat(reference): implement reference.search RPC handler with FileIndex

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -74,6 +74,7 @@ import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
 import { setupSpaceSessionGroupHandlers } from './space-session-group-handlers';
 import { setupLiveQueryHandlers } from './live-query-handlers';
 import { setupReferenceHandlers } from './reference-handlers';
+import { FileIndex } from '../file-index';
 import { LiveQueryEngine } from '../../storage/live-query';
 import type { AppMcpLifecycleManager } from '../mcp';
 
@@ -266,20 +267,28 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);
 
+	// Reference handlers (@ mention system — search + resolve tasks, goals, files, folders)
+	const fileIndex = new FileIndex(deps.config.workspaceRoot);
+	fileIndex.init().catch((err) => {
+		log.warn('FileIndex init failed:', err);
+	});
+	setupReferenceHandlers(deps.messageHub, {
+		db: deps.db.getDatabase(),
+		reactiveDb: deps.reactiveDb,
+		shortIdAllocator: deps.db.getShortIdAllocator(),
+		sessionManager: deps.sessionManager,
+		taskRepo: new TaskRepository(deps.db.getDatabase(), deps.reactiveDb),
+		goalRepo: deps.db.getGoalRepo(),
+		workspaceRoot: deps.config.workspaceRoot,
+		fileIndex,
+	});
+
 	// LiveQuery subscribe/unsubscribe handlers
 	const unsubLiveQuery = setupLiveQueryHandlers(
 		deps.messageHub,
 		deps.liveQueries,
 		deps.db.getDatabase()
 	);
-
-	// Reference handlers (@ mention system — resolve tasks, goals, files, folders)
-	setupReferenceHandlers(deps.messageHub, {
-		sessionManager: deps.sessionManager,
-		taskRepo: new TaskRepository(deps.db.getDatabase(), deps.reactiveDb),
-		goalRepo: deps.db.getGoalRepo(),
-		workspaceRoot: deps.config.workspaceRoot,
-	});
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());
@@ -460,6 +469,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			unsubLiveQuery();
 			roomRuntimeService.stop();
 			spaceRuntimeService.stop();
+			fileIndex.dispose();
 		},
 		spaceRuntimeService,
 		taskAgentManager,

--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -274,10 +274,7 @@ export function setupReferenceHandlers(messageHub: MessageHub, deps: ReferenceHa
 
 			try {
 				// Fetch extra entries to account for post-search type filtering
-				const fileEntries = fileIndex.search(
-					query,
-					RESULTS_PER_CATEGORY * fileTypes.length * 2
-				);
+				const fileEntries = fileIndex.search(query, RESULTS_PER_CATEGORY * fileTypes.length * 2);
 				// Filter to requested types and enforce per-type limit
 				const byType = new Map<string, number>([
 					['file', 0],

--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -3,16 +3,24 @@
  *
  * RPC handlers for the @ reference system:
  * - reference.resolve — Resolve a single reference to its full entity data
+ * - reference.search — search tasks, goals, files, and folders by query string
  */
 
 import type {
 	MessageHub,
 	ReferenceType,
+	ReferenceSearchResult,
 	ResolvedReference,
 	NeoTask,
 	RoomGoal,
 } from '@neokai/shared';
 import type { SessionManager } from '../session-manager';
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type { ReactiveDatabase } from '../../storage/reactive-database';
+import { TaskRepository } from '../../storage/repositories/task-repository';
+import { GoalRepository } from '../../storage/repositories/goal-repository';
+import type { ShortIdAllocator } from '../short-id-allocator';
+import type { FileIndex } from '../file-index';
 import { FileManager } from '../file-manager';
 import { Logger } from '../logger';
 import { join, normalize, relative } from 'node:path';
@@ -30,6 +38,8 @@ const MAX_FILE_CONTENT_BYTES = 50_000;
  * Checking the first 8 KB is sufficient for reliable binary detection.
  */
 const BINARY_DETECTION_SAMPLE_BYTES = 8_192;
+
+const RESULTS_PER_CATEGORY = 10;
 
 // ============================================================================
 // Repository interfaces (minimal — only what this handler needs)
@@ -50,21 +60,70 @@ export interface GoalRepoForReference {
 // ============================================================================
 
 export interface ReferenceHandlerDeps {
+	/** Raw SQLite database (used to instantiate repositories for reference.search) */
+	db: BunDatabase;
+	/** Reactive database (passed to repositories; only used on writes — safe for read-only search) */
+	reactiveDb: ReactiveDatabase;
+	/**
+	 * Short ID allocator — enables lazy backfill of shortIds for tasks/goals that haven't been
+	 * viewed via task.list/goal.list yet. Without this, some results may lack their shortId.
+	 */
+	shortIdAllocator: ShortIdAllocator;
 	/** Session manager — used to look up session workspace path and room context */
 	sessionManager: SessionManager;
-	/** Task repository for looking up room tasks */
+	/** Task repository for looking up room tasks (reference.resolve) */
 	taskRepo: TaskRepoForReference;
 	/** Goal repository (not scoped to room — uses global DB access) */
 	goalRepo: GoalRepoForReference;
 	/** Workspace root path — used as fallback when no session is provided */
 	workspaceRoot: string;
+	/** File index for fast file/folder search (reference.search) */
+	fileIndex: FileIndex;
+}
+
+// ============================================================================
+// Relevance scoring helpers (reference.search)
+// ============================================================================
+
+/** Relevance score used for sorting across categories. */
+function scoreResult(displayText: string, query: string): number {
+	const t = displayText.toLowerCase();
+	const q = query.toLowerCase();
+	if (t === q) return 4;
+	if (t.startsWith(q)) return 3;
+	if (t.includes(q)) return 2;
+	return 1;
+}
+
+/** Filter a list of ReferenceSearchResult by query and return top N sorted by relevance. */
+function filterAndSort(
+	results: ReferenceSearchResult[],
+	query: string,
+	limit: number
+): ReferenceSearchResult[] {
+	const q = query.toLowerCase();
+	const scored = results
+		.filter((r) => {
+			const t = r.displayText.toLowerCase();
+			const s = (r.subtitle ?? '').toLowerCase();
+			return t.includes(q) || s.includes(q);
+		})
+		.map((r) => ({ r, score: scoreResult(r.displayText, query) }));
+
+	scored.sort((a, b) => b.score - a.score);
+	return scored.slice(0, limit).map((s) => s.r);
 }
 
 // ============================================================================
 // Main setup function
 // ============================================================================
 
+/**
+ * Register reference RPC handlers on the MessageHub.
+ */
 export function setupReferenceHandlers(messageHub: MessageHub, deps: ReferenceHandlerDeps): void {
+	const { db, reactiveDb, shortIdAllocator, sessionManager, fileIndex } = deps;
+
 	// ------------------------------------------------------------------
 	// reference.resolve
 	// ------------------------------------------------------------------
@@ -121,6 +180,128 @@ export function setupReferenceHandlers(messageHub: MessageHub, deps: ReferenceHa
 			}
 		}
 	);
+
+	// ------------------------------------------------------------------
+	// reference.search
+	// ------------------------------------------------------------------
+
+	/**
+	 * reference.search — search across tasks, goals, files, and folders.
+	 *
+	 * Parameters:
+	 *   sessionId: string        — used to resolve room context
+	 *   query:     string        — search query
+	 *   types?:    ReferenceType[] — filter to specific types (default: all)
+	 *
+	 * Returns: { results: ReferenceSearchResult[] }
+	 */
+	messageHub.onRequest('reference.search', async (data) => {
+		const params = data as {
+			sessionId: string;
+			query: string;
+			types?: ReferenceType[];
+		};
+
+		if (!params.sessionId) throw new Error('sessionId is required');
+		if (typeof params.query !== 'string') throw new Error('query must be a string');
+
+		const query = params.query.trim();
+		// Empty/whitespace-only query would match everything — return nothing instead
+		if (!query) return { results: [] };
+
+		const requestedTypes: ReferenceType[] =
+			params.types && params.types.length > 0 ? params.types : ['task', 'goal', 'file', 'folder'];
+
+		// Resolve room context from session
+		const session = sessionManager.getSessionFromDB(params.sessionId);
+		const roomId = session?.context?.roomId;
+
+		const allResults: ReferenceSearchResult[] = [];
+
+		// ── Task search ───────────────────────────────────────────────────────
+		if (requestedTypes.includes('task')) {
+			if (roomId) {
+				try {
+					const taskRepo = new TaskRepository(db, reactiveDb, shortIdAllocator);
+					const tasks = taskRepo.listTasks(roomId);
+					const taskResults: ReferenceSearchResult[] = tasks.map((t) => ({
+						type: 'task' as const,
+						id: t.id,
+						shortId: t.shortId ?? undefined,
+						displayText: t.title,
+						subtitle: t.status,
+					}));
+					allResults.push(...filterAndSort(taskResults, query, RESULTS_PER_CATEGORY));
+				} catch (err) {
+					log.warn('Failed to search tasks:', err);
+				}
+			}
+			// No room context → skip task results silently
+		}
+
+		// ── Goal search ───────────────────────────────────────────────────────
+		if (requestedTypes.includes('goal')) {
+			if (roomId) {
+				try {
+					const goalRepo = new GoalRepository(db, reactiveDb, shortIdAllocator);
+					const goals = goalRepo.listGoals(roomId);
+					const goalResults: ReferenceSearchResult[] = goals.map((g) => ({
+						type: 'goal' as const,
+						id: g.id,
+						shortId: g.shortId ?? undefined,
+						displayText: g.title,
+						subtitle: g.status,
+					}));
+					allResults.push(...filterAndSort(goalResults, query, RESULTS_PER_CATEGORY));
+				} catch (err) {
+					log.warn('Failed to search goals:', err);
+				}
+			}
+			// No room context → skip goal results silently
+		}
+
+		// ── File / Folder search ──────────────────────────────────────────────
+		const fileTypes: Array<'file' | 'folder'> = [];
+		if (requestedTypes.includes('file')) fileTypes.push('file');
+		if (requestedTypes.includes('folder')) fileTypes.push('folder');
+
+		if (fileTypes.length > 0 && query.length > 0) {
+			// Path traversal check — reject queries with .. or absolute paths
+			if (query.includes('..') || query.startsWith('/')) {
+				// Return what we have so far without file results
+				return { results: allResults };
+			}
+
+			try {
+				// Fetch extra entries to account for post-search type filtering
+				const fileEntries = fileIndex.search(
+					query,
+					RESULTS_PER_CATEGORY * fileTypes.length * 2
+				);
+				// Filter to requested types and enforce per-type limit
+				const byType = new Map<string, number>([
+					['file', 0],
+					['folder', 0],
+				]);
+				for (const e of fileEntries) {
+					if (!fileTypes.includes(e.type as 'file' | 'folder')) continue;
+					const count = byType.get(e.type) ?? 0;
+					if (count >= RESULTS_PER_CATEGORY) continue;
+					allResults.push({
+						type: e.type as ReferenceType,
+						id: e.path,
+						displayText: e.name,
+						subtitle: e.path,
+					});
+					byType.set(e.type, count + 1);
+				}
+			} catch (err) {
+				log.warn('Failed to search file index:', err);
+			}
+		}
+
+		return { results: allResults };
+	});
 }
 
 // ============================================================================

--- a/packages/daemon/tests/unit/reference-handlers.test.ts
+++ b/packages/daemon/tests/unit/reference-handlers.test.ts
@@ -11,9 +11,10 @@
  * - Relevance sorting (exact > starts-with > contains)
  */
 
-import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import type { MessageHub } from '@neokai/shared';
+import { REFERENCE_PATTERN } from '@neokai/shared';
 import { setupReferenceHandlers } from '../../src/lib/rpc-handlers/reference-handlers';
 import type { ReferenceHandlerDeps } from '../../src/lib/rpc-handlers/reference-handlers';
 import type { FileIndex, FileIndexEntry } from '../../src/lib/file-index';
@@ -188,6 +189,11 @@ function buildReactiveDb(): ReactiveDatabase {
 	return { notifyChange: () => {} } as unknown as ReactiveDatabase;
 }
 
+/** Build a no-op ShortIdAllocator stub (read-only tests don't need real allocation). */
+function buildShortIdAllocator() {
+	return { allocate: () => null } as never;
+}
+
 /** Build a mock SessionManager that returns sessions by ID. */
 function buildSessionManager(sessionMap: Map<string, { roomId?: string }>) {
 	return {
@@ -247,6 +253,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -270,6 +277,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -290,6 +298,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -310,6 +319,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -335,6 +345,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -356,6 +367,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -383,6 +395,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(files),
 			});
@@ -412,6 +425,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(entries),
 			});
@@ -433,6 +447,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(files),
 			});
@@ -457,6 +472,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -477,6 +493,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -495,6 +512,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -519,6 +537,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(files),
 			});
@@ -540,6 +559,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(files),
 			});
@@ -553,29 +573,38 @@ describe('reference.search handler', () => {
 			expect(result.results).toHaveLength(0);
 		});
 
-		it('still returns task/goal results when file query is traversal but types include task', async () => {
-			insertTask(db, roomId, 'task-1', 'Fix traversal bug', 't-1');
+		it('traversal guard is in the file/folder branch — task search is unaffected', async () => {
+			// Add tasks whose titles match a normal (non-traversal) query
+			insertTask(db, roomId, 'task-1', 'traversal fix', 't-1');
+			insertTask(db, roomId, 'task-2', 'other task', 't-2');
 
 			const sessions = new Map([['sess-1', { roomId }]]);
 			const { hub, call } = buildMessageHub();
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
 
-			// Note: traversal check only skips file results, not task/goal results
-			const result = (await call('reference.search', {
+			// A normal task query still works
+			const resultTask = (await call('reference.search', {
 				sessionId: 'sess-1',
-				query: '../../Fix traversal',
+				query: 'traversal',
 				types: ['task'],
-			})) as { results: Array<{ type: string }> };
+			})) as { results: Array<{ type: string; id: string }> };
+			expect(resultTask.results.filter((r) => r.type === 'task')).toHaveLength(1);
+			expect(resultTask.results[0].id).toBe('task-1');
 
-			// Tasks should be searched normally; query contains '..' but type=task
-			// The traversal guard is inside file/folder branch only
-			expect(result.results.filter((r) => r.type === 'task')).toHaveLength(0);
-			// Empty because query doesn't match title with '..' prefix
+			// The same query with file type included but no FileIndex entries returns no files
+			const resultMixed = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'traversal',
+				types: ['task', 'file'],
+			})) as { results: Array<{ type: string }> };
+			expect(resultMixed.results.filter((r) => r.type === 'task')).toHaveLength(1);
+			expect(resultMixed.results.filter((r) => r.type === 'file')).toHaveLength(0);
 		});
 	});
 
@@ -592,6 +621,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(files),
 			});
@@ -618,6 +648,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(files),
 			});
@@ -644,6 +675,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(files),
 			});
@@ -673,6 +705,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(sessions) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -697,6 +730,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(new Map()) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -711,6 +745,7 @@ describe('reference.search handler', () => {
 			setupReferenceHandlers(hub, {
 				db: db as never,
 				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
 				sessionManager: buildSessionManager(new Map()) as never,
 				fileIndex: buildFileIndex(),
 			});
@@ -719,5 +754,82 @@ describe('reference.search handler', () => {
 				'query must be a string'
 			);
 		});
+
+		it('returns empty results for whitespace-only query', async () => {
+			insertTask(db, roomId, 'task-1', 'Some task', 't-1');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: '   ',
+			})) as { results: unknown[] };
+
+			expect(result.results).toHaveLength(0);
+		});
+	});
+});
+
+// ─── REFERENCE_PATTERN tests ──────────────────────────────────────────────────
+
+describe('REFERENCE_PATTERN', () => {
+	it('matches @ref{task:t-42}', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const match = REFERENCE_PATTERN.exec('@ref{task:t-42}');
+		expect(match).not.toBeNull();
+		expect(match![1]).toBe('task');
+		expect(match![2]).toBe('t-42');
+	});
+
+	it('matches @ref{goal:g-7}', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const match = REFERENCE_PATTERN.exec('@ref{goal:g-7}');
+		expect(match).not.toBeNull();
+		expect(match![1]).toBe('goal');
+		expect(match![2]).toBe('g-7');
+	});
+
+	it('matches @ref{file:src/index.ts}', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const match = REFERENCE_PATTERN.exec('@ref{file:src/index.ts}');
+		expect(match).not.toBeNull();
+		expect(match![1]).toBe('file');
+		expect(match![2]).toBe('src/index.ts');
+	});
+
+	it('matches @ref{folder:packages/daemon}', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const match = REFERENCE_PATTERN.exec('@ref{folder:packages/daemon}');
+		expect(match).not.toBeNull();
+		expect(match![1]).toBe('folder');
+		expect(match![2]).toBe('packages/daemon');
+	});
+
+	it('does not match plain @mentions', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const match = REFERENCE_PATTERN.exec('@username');
+		expect(match).toBeNull();
+	});
+
+	it('does not match markdown links', () => {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const match = REFERENCE_PATTERN.exec('[link](https://example.com)');
+		expect(match).toBeNull();
+	});
+
+	it('matches multiple references in a string via matchAll', () => {
+		const text = 'Fix @ref{task:t-1} related to @ref{goal:g-2}';
+		const matches = [...text.matchAll(/@ref\{([^}:]+):([^}]+)\}/g)];
+		expect(matches).toHaveLength(2);
+		expect(matches[0][1]).toBe('task');
+		expect(matches[1][1]).toBe('goal');
 	});
 });

--- a/packages/daemon/tests/unit/reference-handlers.test.ts
+++ b/packages/daemon/tests/unit/reference-handlers.test.ts
@@ -1,0 +1,723 @@
+/**
+ * Unit Tests for Reference RPC Handlers
+ *
+ * Tests the reference.search RPC handler covering:
+ * - Task search with room context
+ * - Goal search with room context
+ * - File/folder search via FileIndex
+ * - Standalone sessions (no room context) — file/folder only
+ * - Path traversal rejection in file queries
+ * - Type filtering via the `types` parameter
+ * - Relevance sorting (exact > starts-with > contains)
+ */
+
+import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import type { MessageHub } from '@neokai/shared';
+import { setupReferenceHandlers } from '../../src/lib/rpc-handlers/reference-handlers';
+import type { ReferenceHandlerDeps } from '../../src/lib/rpc-handlers/reference-handlers';
+import type { FileIndex, FileIndexEntry } from '../../src/lib/file-index';
+import type { ReactiveDatabase } from '../../src/storage/reactive-database';
+
+// ─── Test DB helpers ──────────────────────────────────────────────────────────
+
+function createTestDb(): Database {
+	const db = new Database(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS rooms (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			background_context TEXT,
+			instructions TEXT,
+			allowed_paths TEXT DEFAULT '[]',
+			default_path TEXT,
+			default_model TEXT,
+			allowed_models TEXT DEFAULT '[]',
+			session_ids TEXT DEFAULT '[]',
+			status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'archived')),
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS tasks (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived', 'rate_limited', 'usage_limited')),
+			priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			progress INTEGER,
+			current_step TEXT,
+			result TEXT,
+			error TEXT,
+			depends_on TEXT DEFAULT '[]',
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			task_type TEXT DEFAULT 'coding' CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'goal_review')),
+			assigned_agent TEXT DEFAULT 'coder',
+			created_by_task_id TEXT,
+			archived_at INTEGER,
+			active_session TEXT,
+			pr_url TEXT,
+			pr_number INTEGER,
+			pr_created_at INTEGER,
+			input_draft TEXT,
+			updated_at INTEGER,
+			short_id TEXT,
+			restrictions TEXT,
+			FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS goals (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'needs_human', 'completed', 'archived')),
+			priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			progress INTEGER DEFAULT 0,
+			linked_task_ids TEXT DEFAULT '[]',
+			metrics TEXT DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			planning_attempts INTEGER DEFAULT 0,
+			goal_review_attempts INTEGER DEFAULT 0,
+			mission_type TEXT NOT NULL DEFAULT 'one_shot' CHECK(mission_type IN ('one_shot', 'measurable', 'recurring')),
+			autonomy_level TEXT NOT NULL DEFAULT 'supervised' CHECK(autonomy_level IN ('supervised', 'semi_autonomous')),
+			schedule TEXT,
+			schedule_paused INTEGER NOT NULL DEFAULT 0,
+			next_run_at INTEGER,
+			structured_metrics TEXT,
+			max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+			max_planning_attempts INTEGER NOT NULL DEFAULT 0,
+			consecutive_failures INTEGER NOT NULL DEFAULT 0,
+			replan_count INTEGER NOT NULL DEFAULT 0,
+			short_id TEXT,
+			FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS short_id_counters (
+			entity_type TEXT NOT NULL,
+			scope_id TEXT NOT NULL,
+			counter INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (entity_type, scope_id)
+		)
+	`);
+
+	return db;
+}
+
+function insertRoom(db: Database, id: string, name = 'Test Room'): void {
+	const now = Date.now();
+	db.prepare(`INSERT INTO rooms (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)`).run(
+		id,
+		name,
+		now,
+		now
+	);
+}
+
+function insertTask(
+	db: Database,
+	roomId: string,
+	id: string,
+	title: string,
+	shortId?: string,
+	status = 'pending'
+): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO tasks (id, room_id, title, description, status, created_at, updated_at, short_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(id, roomId, title, '', status, now, now, shortId ?? null);
+}
+
+function insertGoal(
+	db: Database,
+	roomId: string,
+	id: string,
+	title: string,
+	shortId?: string,
+	status = 'active'
+): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO goals (id, room_id, title, status, created_at, updated_at, short_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`
+	).run(id, roomId, title, status, now, now, shortId ?? null);
+}
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+/** Build a minimal mock MessageHub that captures registered handlers. */
+function buildMessageHub(): {
+	hub: MessageHub;
+	call: (method: string, data: unknown) => Promise<unknown>;
+} {
+	const handlers = new Map<string, (data: unknown) => Promise<unknown>>();
+	const hub = {
+		onRequest: (method: string, handler: (data: unknown) => Promise<unknown>) => {
+			handlers.set(method, handler);
+			return () => {};
+		},
+	} as unknown as MessageHub;
+
+	return {
+		hub,
+		call: async (method: string, data: unknown) => {
+			const handler = handlers.get(method);
+			if (!handler) throw new Error(`No handler for ${method}`);
+			return handler(data);
+		},
+	};
+}
+
+/** Build a minimal no-op ReactiveDatabase stub. */
+function buildReactiveDb(): ReactiveDatabase {
+	return { notifyChange: () => {} } as unknown as ReactiveDatabase;
+}
+
+/** Build a mock SessionManager that returns sessions by ID. */
+function buildSessionManager(sessionMap: Map<string, { roomId?: string }>) {
+	return {
+		getSessionFromDB: (sessionId: string) => {
+			const entry = sessionMap.get(sessionId);
+			if (!entry) return null;
+			return { context: { roomId: entry.roomId } };
+		},
+	};
+}
+
+/** Build a mock FileIndex. */
+function buildFileIndex(entries: FileIndexEntry[] = []): FileIndex {
+	return {
+		isReady: () => true,
+		search: (query: string, limit = 50) => {
+			const q = query.toLowerCase();
+			return entries
+				.filter((e) => e.name.toLowerCase().includes(q) || e.path.toLowerCase().includes(q))
+				.slice(0, limit);
+		},
+		init: async () => {},
+		dispose: () => {},
+		invalidate: () => {},
+		invalidateAll: () => {},
+		setIgnorePatterns: () => {},
+		size: () => entries.length,
+	} as unknown as FileIndex;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('reference.search handler', () => {
+	let db: Database;
+	let roomId: string;
+
+	beforeEach(() => {
+		db = createTestDb();
+		roomId = 'room-test-001';
+		insertRoom(db, roomId);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// ── Task search ────────────────────────────────────────────────────────────
+
+	describe('task search', () => {
+		it('returns tasks matching the query', async () => {
+			insertTask(db, roomId, 'task-1', 'Fix authentication bug', 't-1');
+			insertTask(db, roomId, 'task-2', 'Add login page', 't-2');
+			insertTask(db, roomId, 'task-3', 'Refactor database layer', 't-3');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'auth',
+			})) as { results: Array<{ type: string; id: string; displayText: string }> };
+
+			expect(result.results).toHaveLength(1);
+			expect(result.results[0].type).toBe('task');
+			expect(result.results[0].id).toBe('task-1');
+			expect(result.results[0].displayText).toBe('Fix authentication bug');
+		});
+
+		it('includes shortId when available', async () => {
+			insertTask(db, roomId, 'task-1', 'Implement feature', 't-42');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'Implement',
+			})) as { results: Array<{ shortId?: string }> };
+
+			expect(result.results[0].shortId).toBe('t-42');
+		});
+
+		it('includes task status as subtitle', async () => {
+			insertTask(db, roomId, 'task-1', 'Deploy app', 't-1', 'in_progress');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'Deploy',
+			})) as { results: Array<{ subtitle?: string }> };
+
+			expect(result.results[0].subtitle).toBe('in_progress');
+		});
+
+		it('returns empty task results when query does not match', async () => {
+			insertTask(db, roomId, 'task-1', 'Fix login flow', 't-1');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'xxxxnonexistent',
+			})) as { results: unknown[] };
+
+			expect(result.results).toHaveLength(0);
+		});
+	});
+
+	// ── Goal search ────────────────────────────────────────────────────────────
+
+	describe('goal search', () => {
+		it('returns goals matching the query', async () => {
+			insertGoal(db, roomId, 'goal-1', 'Improve code quality', 'g-1');
+			insertGoal(db, roomId, 'goal-2', 'Launch new feature', 'g-2');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'code',
+			})) as { results: Array<{ type: string; id: string }> };
+
+			expect(result.results.filter((r) => r.type === 'goal')).toHaveLength(1);
+			expect(result.results[0].id).toBe('goal-1');
+		});
+
+		it('includes goal status as subtitle', async () => {
+			insertGoal(db, roomId, 'goal-1', 'Ship MVP', 'g-1', 'completed');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'Ship',
+			})) as { results: Array<{ subtitle?: string }> };
+
+			expect(result.results[0].subtitle).toBe('completed');
+		});
+	});
+
+	// ── File/folder search ─────────────────────────────────────────────────────
+
+	describe('file/folder search', () => {
+		it('returns file results from FileIndex', async () => {
+			const files: FileIndexEntry[] = [
+				{ path: 'src/components/Button.tsx', name: 'Button.tsx', type: 'file' },
+				{ path: 'src/components/Modal.tsx', name: 'Modal.tsx', type: 'file' },
+			];
+
+			const sessions = new Map([['sess-1', { roomId: undefined }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(files),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'Button',
+			})) as {
+				results: Array<{ type: string; id: string; displayText: string; subtitle: string }>;
+			};
+
+			const fileResults = result.results.filter((r) => r.type === 'file');
+			expect(fileResults).toHaveLength(1);
+			expect(fileResults[0].id).toBe('src/components/Button.tsx');
+			expect(fileResults[0].displayText).toBe('Button.tsx');
+			expect(fileResults[0].subtitle).toBe('src/components/Button.tsx');
+		});
+
+		it('returns folder results from FileIndex', async () => {
+			const entries: FileIndexEntry[] = [
+				{ path: 'src/components', name: 'components', type: 'folder' },
+				{ path: 'src/lib', name: 'lib', type: 'folder' },
+			];
+
+			const sessions = new Map([['sess-1', {}]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(entries),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'comp',
+			})) as { results: Array<{ type: string }> };
+
+			const folderResults = result.results.filter((r) => r.type === 'folder');
+			expect(folderResults).toHaveLength(1);
+		});
+
+		it('always returns file/folder results even for sessions without room context', async () => {
+			const files: FileIndexEntry[] = [{ path: 'README.md', name: 'README.md', type: 'file' }];
+
+			const sessions = new Map([['sess-standalone', {}]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(files),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-standalone',
+				query: 'README',
+			})) as { results: Array<{ type: string }> };
+
+			expect(result.results.filter((r) => r.type === 'file')).toHaveLength(1);
+		});
+	});
+
+	// ── Standalone sessions ────────────────────────────────────────────────────
+
+	describe('standalone sessions (no room context)', () => {
+		it('returns no task results for sessions without roomId', async () => {
+			insertTask(db, roomId, 'task-1', 'Some task', 't-1');
+
+			const sessions = new Map([['sess-standalone', {}]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-standalone',
+				query: 'Some',
+			})) as { results: Array<{ type: string }> };
+
+			expect(result.results.filter((r) => r.type === 'task')).toHaveLength(0);
+		});
+
+		it('returns no goal results for sessions without roomId', async () => {
+			insertGoal(db, roomId, 'goal-1', 'Some goal', 'g-1');
+
+			const sessions = new Map([['sess-standalone', {}]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-standalone',
+				query: 'Some',
+			})) as { results: Array<{ type: string }> };
+
+			expect(result.results.filter((r) => r.type === 'goal')).toHaveLength(0);
+		});
+
+		it('does not throw for unknown sessionId', async () => {
+			const sessions = new Map<string, { roomId?: string }>();
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'unknown-session',
+				query: 'anything',
+			})) as { results: unknown[] };
+
+			expect(result.results).toHaveLength(0);
+		});
+	});
+
+	// ── Path traversal prevention ──────────────────────────────────────────────
+
+	describe('path traversal prevention', () => {
+		it('returns empty file results for queries containing ..', async () => {
+			const files: FileIndexEntry[] = [{ path: 'src/secret.ts', name: 'secret.ts', type: 'file' }];
+
+			const sessions = new Map([['sess-1', {}]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(files),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: '../../etc/passwd',
+				types: ['file', 'folder'],
+			})) as { results: unknown[] };
+
+			expect(result.results).toHaveLength(0);
+		});
+
+		it('returns empty file results for absolute path queries', async () => {
+			const files: FileIndexEntry[] = [{ path: 'src/main.ts', name: 'main.ts', type: 'file' }];
+
+			const sessions = new Map([['sess-1', {}]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(files),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: '/etc/passwd',
+				types: ['file', 'folder'],
+			})) as { results: unknown[] };
+
+			expect(result.results).toHaveLength(0);
+		});
+
+		it('still returns task/goal results when file query is traversal but types include task', async () => {
+			insertTask(db, roomId, 'task-1', 'Fix traversal bug', 't-1');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			// Note: traversal check only skips file results, not task/goal results
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: '../../Fix traversal',
+				types: ['task'],
+			})) as { results: Array<{ type: string }> };
+
+			// Tasks should be searched normally; query contains '..' but type=task
+			// The traversal guard is inside file/folder branch only
+			expect(result.results.filter((r) => r.type === 'task')).toHaveLength(0);
+			// Empty because query doesn't match title with '..' prefix
+		});
+	});
+
+	// ── Type filtering ─────────────────────────────────────────────────────────
+
+	describe('type filtering', () => {
+		it('returns only task results when types=["task"]', async () => {
+			insertTask(db, roomId, 'task-1', 'Auth feature', 't-1');
+			insertGoal(db, roomId, 'goal-1', 'Auth goal', 'g-1');
+			const files: FileIndexEntry[] = [{ path: 'auth.ts', name: 'auth.ts', type: 'file' }];
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(files),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'Auth',
+				types: ['task'],
+			})) as { results: Array<{ type: string }> };
+
+			expect(result.results.every((r) => r.type === 'task')).toBe(true);
+			expect(result.results).toHaveLength(1);
+		});
+
+		it('returns only file results when types=["file"]', async () => {
+			insertTask(db, roomId, 'task-1', 'index task', 't-1');
+			const files: FileIndexEntry[] = [
+				{ path: 'src/index.ts', name: 'index.ts', type: 'file' },
+				{ path: 'src', name: 'src', type: 'folder' },
+			];
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(files),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'index',
+				types: ['file'],
+			})) as { results: Array<{ type: string }> };
+
+			expect(result.results.every((r) => r.type === 'file')).toBe(true);
+		});
+
+		it('returns all types when types is omitted', async () => {
+			insertTask(db, roomId, 'task-1', 'main feature', 't-1');
+			insertGoal(db, roomId, 'goal-1', 'main goal', 'g-1');
+			const files: FileIndexEntry[] = [
+				{ path: 'main.ts', name: 'main.ts', type: 'file' },
+				{ path: 'src', name: 'src', type: 'folder' },
+			];
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(files),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'main',
+			})) as { results: Array<{ type: string }> };
+
+			const types = new Set(result.results.map((r) => r.type));
+			expect(types.has('task')).toBe(true);
+			expect(types.has('goal')).toBe(true);
+			expect(types.has('file')).toBe(true);
+		});
+	});
+
+	// ── Relevance sorting ──────────────────────────────────────────────────────
+
+	describe('relevance sorting', () => {
+		it('sorts exact name match above starts-with above contains', async () => {
+			insertTask(db, roomId, 'task-1', 'login', 't-1');
+			insertTask(db, roomId, 'task-2', 'login page', 't-2');
+			insertTask(db, roomId, 'task-3', 'fix login bug', 't-3');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: 'login',
+				types: ['task'],
+			})) as { results: Array<{ id: string }> };
+
+			expect(result.results[0].id).toBe('task-1'); // exact match first
+			expect(result.results[1].id).toBe('task-2'); // starts-with second
+			expect(result.results[2].id).toBe('task-3'); // contains last
+		});
+	});
+
+	// ── Input validation ───────────────────────────────────────────────────────
+
+	describe('input validation', () => {
+		it('throws when sessionId is missing', async () => {
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(new Map()) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			await expect(call('reference.search', { query: 'test' })).rejects.toThrow(
+				'sessionId is required'
+			);
+		});
+
+		it('throws when query is not a string', async () => {
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				sessionManager: buildSessionManager(new Map()) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			await expect(call('reference.search', { sessionId: 'sess-1', query: 42 })).rejects.toThrow(
+				'query must be a string'
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Defines core `@reference` system types in `packages/shared/src/types/reference.ts`: `ReferenceType`, `ReferenceSearchResult`, `ReferenceMention`, `ResolvedReference` variants, `ReferenceMetadata`, and `REFERENCE_PATTERN`
- Implements `FileIndex` class (`packages/daemon/src/lib/file-index.ts`) with polling-based refresh, `.gitignore` parsing, path traversal prevention, and relevance-scored fuzzy search
- Adds `reference.search` RPC handler (`packages/daemon/src/lib/rpc-handlers/reference-handlers.ts`) that searches tasks/goals using session room context and files/folders via FileIndex — standalone sessions silently skip task/goal results
- Registers `setupReferenceHandlers` in `setupRPCHandlers` with FileIndex lifecycle management (init on start, dispose on cleanup)

## Test plan

- [x] 21 unit tests in `packages/daemon/tests/unit/reference-handlers.test.ts` covering:
  - Task search returning matching tasks with shortId and status subtitle
  - Goal search returning matching goals
  - File/folder search via FileIndex
  - Standalone sessions (no roomId) return only file/folder results, no task/goal results
  - Path traversal rejection (`..` and absolute paths in file queries)
  - Type filtering via `types` parameter
  - Relevance sorting (exact > starts-with > contains)
  - Input validation (missing sessionId, non-string query)
- [x] All 7595 unit tests pass, lint clean, typecheck clean