### PR TITLE
feat(web): add ReferenceAutocomplete component for @ reference system

### DIFF
--- a/packages/web/src/components/ReferenceAutocomplete.tsx
+++ b/packages/web/src/components/ReferenceAutocomplete.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useRef } from 'preact/hooks';
+import { cn } from '../lib/utils.ts';
+import { borderColors } from '../lib/design-tokens.ts';
+import type { ReferenceSearchResult, ReferenceType } from '@neokai/shared';
+
+export interface ReferenceAutocompleteProps {
+	results: ReferenceSearchResult[];
+	selectedIndex: number;
+	onSelect: (result: ReferenceSearchResult) => void;
+	onClose: () => void;
+	position?: { top: number; left: number };
+}
+
+const TYPE_ORDER: ReferenceType[] = ['task', 'goal', 'file', 'folder'];
+
+const TYPE_LABELS: Record<ReferenceType, string> = {
+	task: 'Tasks',
+	goal: 'Goals',
+	file: 'Files',
+	folder: 'Folders',
+};
+
+function TypeIcon({ type }: { type: ReferenceType }) {
+	if (type === 'task') {
+		return (
+			<svg
+				class="w-3.5 h-3.5 text-indigo-400 shrink-0"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+				/>
+			</svg>
+		);
+	}
+	if (type === 'goal') {
+		return (
+			<svg
+				class="w-3.5 h-3.5 text-amber-400 shrink-0"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"
+				/>
+			</svg>
+		);
+	}
+	if (type === 'folder') {
+		return (
+			<svg
+				class="w-3.5 h-3.5 text-yellow-400 shrink-0"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+				/>
+			</svg>
+		);
+	}
+	// file
+	return (
+		<svg
+			class="w-3.5 h-3.5 text-blue-400 shrink-0"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+			/>
+		</svg>
+	);
+}
+
+/**
+ * Determine the header label for the autocomplete menu.
+ * Shows "Files & Folders" when results only contain file/folder types,
+ * otherwise shows "References".
+ */
+function resolveHeaderLabel(results: ReferenceSearchResult[]): string {
+	const types = new Set(results.map((r) => r.type));
+	const hasTaskOrGoal = types.has('task') || types.has('goal');
+	if (!hasTaskOrGoal) return 'Files & Folders';
+	return 'References';
+}
+
+export default function ReferenceAutocomplete({
+	results,
+	selectedIndex,
+	onSelect,
+	onClose,
+	position,
+}: ReferenceAutocompleteProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const selectedItemRef = useRef<HTMLButtonElement>(null);
+
+	// Scroll selected item into view
+	useEffect(() => {
+		if (selectedItemRef.current) {
+			selectedItemRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+		}
+	}, [selectedIndex]);
+
+	// Close on click outside
+	useEffect(() => {
+		const handleClickOutside = (e: MouseEvent) => {
+			if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+				onClose();
+			}
+		};
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => document.removeEventListener('mousedown', handleClickOutside);
+	}, [onClose]);
+
+	if (results.length === 0) return null;
+
+	// Group results by type, preserving global index for selection
+	const groups: Array<{
+		type: ReferenceType;
+		items: Array<{ result: ReferenceSearchResult; globalIndex: number }>;
+	}> = [];
+	const indexMap = new Map<ReferenceSearchResult, number>(results.map((r, i) => [r, i]));
+
+	for (const type of TYPE_ORDER) {
+		const items = results
+			.filter((r) => r.type === type)
+			.map((r) => ({ result: r, globalIndex: indexMap.get(r) ?? 0 }));
+		if (items.length > 0) {
+			groups.push({ type, items });
+		}
+	}
+
+	const headerLabel = resolveHeaderLabel(results);
+
+	return (
+		<div
+			ref={containerRef}
+			class={cn(
+				`absolute z-50 bg-dark-800 border ${borderColors.ui.default} rounded-lg shadow-xl`,
+				'overflow-hidden max-h-72 overflow-y-auto',
+				'animate-slideIn'
+			)}
+			style={{
+				bottom: position ? undefined : '100%',
+				left: position?.left ?? 0,
+				top: position?.top,
+				marginBottom: position ? undefined : '8px',
+				minWidth: '280px',
+				maxWidth: '420px',
+			}}
+		>
+			{/* Header */}
+			<div class={`px-3 py-2 border-b ${borderColors.ui.default} bg-dark-850/50`}>
+				<div class="flex items-center gap-2">
+					<svg class="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"
+						/>
+					</svg>
+					<span class="text-xs font-medium text-gray-400">{headerLabel}</span>
+				</div>
+			</div>
+
+			{/* Grouped results */}
+			<div class="py-1">
+				{groups.map(({ type, items }) => (
+					<div key={type}>
+						{/* Section label */}
+						<div class="px-3 pt-2 pb-1">
+							<span class="text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+								{TYPE_LABELS[type]}
+							</span>
+						</div>
+
+						{items.map(({ result, globalIndex }) => (
+							<button
+								key={`${result.type}:${result.id}`}
+								ref={globalIndex === selectedIndex ? selectedItemRef : null}
+								type="button"
+								onClick={() => onSelect(result)}
+								class={cn(
+									'w-full px-3 py-2 text-left transition-colors flex items-start gap-2',
+									'hover:bg-dark-700/50',
+									globalIndex === selectedIndex && 'bg-blue-500/20 border-l-2 border-blue-500'
+								)}
+							>
+								<span class="mt-0.5">
+									<TypeIcon type={result.type} />
+								</span>
+								<span class="flex flex-col min-w-0">
+									<span class="text-sm text-gray-100 truncate">{result.displayText}</span>
+									{result.subtitle && (
+										<span class="text-xs text-gray-500 truncate">{result.subtitle}</span>
+									)}
+								</span>
+							</button>
+						))}
+					</div>
+				))}
+			</div>
+
+			{/* Footer hint */}
+			<div class={`px-3 py-2 border-t ${borderColors.ui.default} bg-dark-850/50`}>
+				<p class="text-xs text-gray-500">
+					<kbd class="px-1.5 py-0.5 bg-dark-700 rounded text-gray-400">↑↓</kbd> navigate{' '}
+					<kbd class="px-1.5 py-0.5 bg-dark-700 rounded text-gray-400">Enter</kbd> select{' '}
+					<kbd class="px-1.5 py-0.5 bg-dark-700 rounded text-gray-400">Esc</kbd> close
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/__tests__/ReferenceAutocomplete.test.tsx
+++ b/packages/web/src/components/__tests__/ReferenceAutocomplete.test.tsx
@@ -1,0 +1,278 @@
+// @ts-nocheck
+/**
+ * Tests for ReferenceAutocomplete Component
+ */
+
+import { render, fireEvent } from '@testing-library/preact';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import ReferenceAutocomplete from '../ReferenceAutocomplete';
+import type { ReferenceSearchResult } from '@neokai/shared';
+
+const taskResult: ReferenceSearchResult = {
+	type: 'task',
+	id: 't-1',
+	displayText: 'Fix login bug',
+	subtitle: 'in-progress',
+};
+
+const goalResult: ReferenceSearchResult = {
+	type: 'goal',
+	id: 'g-1',
+	displayText: 'Launch v2',
+	subtitle: 'active',
+};
+
+const fileResult: ReferenceSearchResult = {
+	type: 'file',
+	id: 'src/app.ts',
+	displayText: 'app.ts',
+	subtitle: 'src/app.ts',
+};
+
+const folderResult: ReferenceSearchResult = {
+	type: 'folder',
+	id: 'src',
+	displayText: 'src',
+	subtitle: 'src/',
+};
+
+const defaultProps = {
+	results: [taskResult, goalResult, fileResult, folderResult],
+	selectedIndex: 0,
+	onSelect: vi.fn(),
+	onClose: vi.fn(),
+};
+
+describe('ReferenceAutocomplete', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('Rendering', () => {
+		it('renders nothing when results is empty', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} results={[]} />);
+			expect(container.firstChild).toBeNull();
+		});
+
+		it('renders the container when results are present', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.querySelector('div')).toBeTruthy();
+		});
+
+		it('shows "References" header when results include tasks or goals', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('References');
+		});
+
+		it('shows "Files & Folders" header when results contain only file/folder types', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[fileResult, folderResult]} />
+			);
+			expect(container.textContent).toContain('Files & Folders');
+		});
+
+		it('shows "Files & Folders" header for file-only results', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[fileResult]} />
+			);
+			expect(container.textContent).toContain('Files & Folders');
+		});
+
+		it('shows "Files & Folders" header for folder-only results', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[folderResult]} />
+			);
+			expect(container.textContent).toContain('Files & Folders');
+		});
+
+		it('shows "References" header when task results are present alongside files', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[taskResult, fileResult]} />
+			);
+			expect(container.textContent).toContain('References');
+		});
+
+		it('renders displayText for each result', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('Fix login bug');
+			expect(container.textContent).toContain('Launch v2');
+			expect(container.textContent).toContain('app.ts');
+			expect(container.textContent).toContain('src');
+		});
+
+		it('renders subtitle for results that have it', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('in-progress');
+			expect(container.textContent).toContain('active');
+			expect(container.textContent).toContain('src/app.ts');
+		});
+
+		it('does not render subtitle element when subtitle is absent', () => {
+			const resultNoSubtitle: ReferenceSearchResult = {
+				type: 'file',
+				id: 'readme.md',
+				displayText: 'README.md',
+			};
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[resultNoSubtitle]} />
+			);
+			// Only one text span inside the button (displayText), no subtitle span
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons.length).toBe(1);
+			const spans = buttons[0].querySelectorAll('span > span');
+			// inner column has one child: displayText only
+			expect(spans.length).toBe(1);
+		});
+
+		it('renders group section labels', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('Tasks');
+			expect(container.textContent).toContain('Goals');
+			expect(container.textContent).toContain('Files');
+			expect(container.textContent).toContain('Folders');
+		});
+
+		it('does not render empty group section labels', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[taskResult]} />
+			);
+			expect(container.textContent).toContain('Tasks');
+			expect(container.textContent).not.toContain('Goals');
+			expect(container.textContent).not.toContain('Files');
+			expect(container.textContent).not.toContain('Folders');
+		});
+
+		it('renders keyboard hint footer', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('↑↓');
+			expect(container.textContent).toContain('Enter');
+			expect(container.textContent).toContain('Esc');
+		});
+	});
+
+	describe('Selection highlighting', () => {
+		it('applies selected styling to the item at selectedIndex', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons[0].className).toContain('bg-blue-500/20');
+			expect(buttons[0].className).toContain('border-blue-500');
+		});
+
+		it('does not apply selected styling to non-selected items', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			for (let i = 1; i < buttons.length; i++) {
+				expect(buttons[i].className).not.toContain('bg-blue-500/20');
+			}
+		});
+
+		it('applies selected styling to the correct item when selectedIndex changes', () => {
+			const { container, rerender } = render(
+				<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />
+			);
+			rerender(<ReferenceAutocomplete {...defaultProps} selectedIndex={2} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons[2].className).toContain('bg-blue-500/20');
+			expect(buttons[0].className).not.toContain('bg-blue-500/20');
+		});
+	});
+
+	describe('Click selection', () => {
+		it('calls onSelect with the correct result when a button is clicked', () => {
+			const onSelect = vi.fn();
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			fireEvent.click(buttons[0]);
+			expect(onSelect).toHaveBeenCalledTimes(1);
+			expect(onSelect).toHaveBeenCalledWith(taskResult);
+		});
+
+		it('calls onSelect with the goal result when goal button is clicked', () => {
+			const onSelect = vi.fn();
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			fireEvent.click(buttons[1]);
+			expect(onSelect).toHaveBeenCalledWith(goalResult);
+		});
+
+		it('calls onSelect with the file result when file button is clicked', () => {
+			const onSelect = vi.fn();
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			fireEvent.click(buttons[2]);
+			expect(onSelect).toHaveBeenCalledWith(fileResult);
+		});
+	});
+
+	describe('Click outside', () => {
+		it('calls onClose when clicking outside the component', () => {
+			const onClose = vi.fn();
+			const { container } = render(
+				<div>
+					<ReferenceAutocomplete {...defaultProps} onClose={onClose} />
+					<div data-testid="outside">Outside</div>
+				</div>
+			);
+			const outside = container.querySelector('[data-testid="outside"]');
+			fireEvent.mouseDown(outside!);
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not call onClose when clicking inside the component', () => {
+			const onClose = vi.fn();
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} onClose={onClose} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			fireEvent.mouseDown(buttons[0]);
+			expect(onClose).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Positioning', () => {
+		it('defaults to bottom positioning (above textarea) when no position is given', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			const dropdown = container.querySelector('div');
+			// style should have marginBottom set and no top
+			expect(dropdown?.style.marginBottom).toBe('8px');
+			expect(dropdown?.style.top).toBe('');
+		});
+
+		it('applies explicit top/left position when position prop is provided', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} position={{ top: 100, left: 50 }} />
+			);
+			const dropdown = container.querySelector('div');
+			expect(dropdown?.style.top).toBe('100px');
+			expect(dropdown?.style.left).toBe('50px');
+		});
+	});
+
+	describe('Group ordering', () => {
+		it('renders groups in order: Tasks, Goals, Files, Folders', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			const sectionLabels = Array.from(container.querySelectorAll('span.text-\\[10px\\]')).map(
+				(el) => el.textContent?.trim()
+			);
+			expect(sectionLabels).toEqual(['Tasks', 'Goals', 'Files', 'Folders']);
+		});
+	});
+
+	describe('Result count', () => {
+		it('renders the correct number of result buttons', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons.length).toBe(4);
+		});
+
+		it('renders only matching buttons for single-type results', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[taskResult]} />
+			);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons.length).toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
Creates the dropdown component that displays reference search results
grouped by type (tasks, goals, files, folders), mirroring the
CommandAutocomplete styling. Features include:
- Grouped sections with section labels (empty groups hidden)
- Type icons with distinct colors per entity type
- Selected item highlighting with blue border
- Auto-scroll selected item into view
- Click-outside dismiss
- Dynamic header: "References" vs "Files & Folders" based on result types
- 26 unit tests covering rendering, selection, grouping, and positioning
