### PR TITLE
feat(session): implement message preprocessing with @ reference resolution

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -215,7 +215,10 @@ function resolveGoal(
 	};
 }
 
-async function resolveFile(id: string, workspacePath: string): Promise<ResolvedReference | null> {
+export async function resolveFile(
+	id: string,
+	workspacePath: string
+): Promise<ResolvedReference | null> {
 	const fileManager = new FileManager(workspacePath);
 
 	// Validate path (throws on traversal — we catch below to return null)
@@ -311,7 +314,10 @@ async function resolveFile(id: string, workspacePath: string): Promise<ResolvedR
 	};
 }
 
-async function resolveFolder(id: string, workspacePath: string): Promise<ResolvedReference | null> {
+export async function resolveFolder(
+	id: string,
+	workspacePath: string
+): Promise<ResolvedReference | null> {
 	const fileManager = new FileManager(workspacePath);
 
 	let entries: Array<{ name: string; path: string; type: 'file' | 'directory' }>;

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -10,7 +10,14 @@
  * - Emit events for downstream processing
  */
 
-import type { MessageContent, MessageDeliveryMode, MessageHub, MessageImage } from '@neokai/shared';
+import type {
+	MessageContent,
+	MessageDeliveryMode,
+	MessageHub,
+	MessageImage,
+	ReferenceMetadata,
+	Session,
+} from '@neokai/shared';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
 import type { Database } from '../../storage/database';
@@ -18,6 +25,11 @@ import type { DaemonHub } from '../daemon-hub';
 import { expandBuiltInCommand } from '../built-in-commands';
 import { Logger } from '../logger';
 import type { SessionCache } from './session-cache';
+import {
+	ReferenceResolver,
+	type PreprocessedMessage,
+	type ResolutionContext,
+} from './reference-resolver';
 
 export interface MessagePersistenceData {
 	sessionId: string;
@@ -34,9 +46,49 @@ export class MessagePersistence {
 		private sessionCache: SessionCache,
 		private db: Database,
 		private messageHub: MessageHub,
-		private eventBus: DaemonHub
+		private eventBus: DaemonHub,
+		private referenceResolver?: ReferenceResolver
 	) {
 		this.logger = new Logger('MessagePersistence');
+	}
+
+	/**
+	 * Extract and resolve @ references from a message text.
+	 *
+	 * Returns a PreprocessedMessage with the original text unchanged and a
+	 * populated referenceMetadata map. If no references are found, or if
+	 * resolution fails entirely, returns empty metadata so the message
+	 * still persists normally.
+	 */
+	private async preprocessReferences(text: string, session: Session): Promise<PreprocessedMessage> {
+		try {
+			const mentions = ReferenceResolver.extractReferences(text);
+			if (mentions.length === 0) {
+				return { text, referenceMetadata: {} };
+			}
+
+			const context: ResolutionContext = {
+				workspacePath: session.workspacePath,
+				roomId: session.context?.roomId ?? null,
+			};
+
+			const resolved = await this.referenceResolver!.resolveAllReferences(mentions, context);
+
+			// Convert ResolvedReference values to ReferenceMetadata entries
+			const referenceMetadata: ReferenceMetadata = {};
+			for (const [token, ref] of Object.entries(resolved)) {
+				referenceMetadata[token] = {
+					type: ref.type,
+					id: ref.id,
+					displayText: ref.id,
+				};
+			}
+
+			return { text, referenceMetadata };
+		} catch (err) {
+			this.logger.warn('[MessagePersistence] Reference preprocessing failed, skipping:', err);
+			return { text, referenceMetadata: {} };
+		}
 	}
 
 	/**
@@ -87,11 +139,16 @@ export class MessagePersistence {
 			const expandedContent = expandBuiltInCommand(content);
 			const finalContent = expandedContent || content;
 
+			// 2b. Preprocess @ references (extract + resolve) if resolver is available
+			const preprocessed = this.referenceResolver
+				? await this.preprocessReferences(finalContent, session)
+				: { text: finalContent, referenceMetadata: {} as ReferenceMetadata };
+
 			// 3. Build message content (text + images)
 			const messageContent = buildMessageContent(finalContent, images);
 
 			// 4. Create SDK user message
-			const sdkUserMessage: SDKUserMessage = {
+			const sdkUserMessage: SDKUserMessage & { referenceMetadata?: ReferenceMetadata } = {
 				type: 'user' as const,
 				uuid: messageId as UUID,
 				session_id: sessionId,
@@ -103,6 +160,9 @@ export class MessagePersistence {
 							? [{ type: 'text' as const, text: messageContent }]
 							: messageContent,
 				},
+				...(Object.keys(preprocessed.referenceMetadata).length > 0 && {
+					referenceMetadata: preprocessed.referenceMetadata,
+				}),
 			};
 
 			// 5. Save to database with delivery-aware status

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -74,14 +74,30 @@ export class MessagePersistence {
 
 			const resolved = await this.referenceResolver!.resolveAllReferences(mentions, context);
 
-			// Convert ResolvedReference values to ReferenceMetadata entries
 			const referenceMetadata: ReferenceMetadata = {};
+
+			// Include resolved references with entity titles as displayText
 			for (const [token, ref] of Object.entries(resolved)) {
 				referenceMetadata[token] = {
 					type: ref.type,
 					id: ref.id,
-					displayText: ref.id,
+					displayText: extractDisplayText(ref.type, ref.id, ref.data),
 				};
+			}
+
+			// Include unresolved references with status: 'unresolved' so the UI can surface failures
+			const seenTokens = new Set<string>();
+			for (const mention of mentions) {
+				const token = `@ref{${mention.type}:${mention.id}}`;
+				if (!seenTokens.has(token) && !(token in referenceMetadata)) {
+					seenTokens.add(token);
+					referenceMetadata[token] = {
+						type: mention.type,
+						id: mention.id,
+						displayText: mention.id,
+						status: 'unresolved',
+					};
+				}
 			}
 
 			return { text, referenceMetadata };
@@ -226,6 +242,25 @@ export class MessagePersistence {
 			throw error;
 		}
 	}
+}
+
+/**
+ * Extract a human-readable display text from a resolved reference's entity data.
+ *
+ * For tasks and goals, uses the entity title. For files and folders, uses the path.
+ * Falls back to the raw ID if the data shape is unexpected.
+ */
+function extractDisplayText(type: string, id: string, data: unknown): string {
+	if (data !== null && typeof data === 'object') {
+		const d = data as Record<string, unknown>;
+		if ((type === 'task' || type === 'goal') && typeof d['title'] === 'string') {
+			return d['title'];
+		}
+		if ((type === 'file' || type === 'folder') && typeof d['path'] === 'string') {
+			return d['path'];
+		}
+	}
+	return id;
 }
 
 /**

--- a/packages/daemon/src/lib/session/reference-resolver.ts
+++ b/packages/daemon/src/lib/session/reference-resolver.ts
@@ -1,0 +1,181 @@
+/**
+ * Reference Resolver
+ *
+ * Provides static extraction and async resolution of @ references embedded
+ * in user message text. Used by MessagePersistence to attach resolved entity
+ * data to persisted messages as ReferenceMetadata.
+ */
+
+import type { ReferenceMention, ReferenceMetadata, ResolvedReference } from '@neokai/shared';
+import { REFERENCE_PATTERN } from '@neokai/shared';
+import type {
+	TaskRepoForReference,
+	GoalRepoForReference,
+} from '../rpc-handlers/reference-handlers';
+import { resolveFile, resolveFolder } from '../rpc-handlers/reference-handlers';
+import { Logger } from '../logger';
+
+const log = new Logger('ReferenceResolver');
+
+// ============================================================================
+// Public interfaces
+// ============================================================================
+
+export interface ResolutionContext {
+	workspacePath: string;
+	roomId: string | null;
+}
+
+export interface PreprocessedMessage {
+	/** Original text, unchanged */
+	text: string;
+	/** Resolved reference data, keyed by @ref{type:id} token */
+	referenceMetadata: ReferenceMetadata;
+}
+
+export interface ReferenceResolverDeps {
+	taskRepo: TaskRepoForReference;
+	goalRepo: GoalRepoForReference;
+}
+
+// ============================================================================
+// ReferenceResolver class
+// ============================================================================
+
+export class ReferenceResolver {
+	constructor(private deps: ReferenceResolverDeps) {}
+
+	/**
+	 * Extract all @ref{type:id} tokens from a text string.
+	 *
+	 * NOTE: REFERENCE_PATTERN uses the 'g' flag and is stateful. lastIndex is
+	 * always reset to 0 before use to prevent stale state from prior calls.
+	 */
+	static extractReferences(text: string): ReferenceMention[] {
+		REFERENCE_PATTERN.lastIndex = 0;
+		const mentions: ReferenceMention[] = [];
+		let match: RegExpExecArray | null;
+
+		while ((match = REFERENCE_PATTERN.exec(text)) !== null) {
+			const type = match[1] as ReferenceMention['type'];
+			const id = match[2];
+
+			// Only accept known reference types
+			if (type !== 'task' && type !== 'goal' && type !== 'file' && type !== 'folder') {
+				continue;
+			}
+
+			mentions.push({ type, id, displayText: id });
+		}
+
+		return mentions;
+	}
+
+	/**
+	 * Resolve a single reference mention to its entity data.
+	 * Returns null when the reference cannot be found or the type is unknown.
+	 */
+	async resolveReference(
+		mention: ReferenceMention,
+		context: ResolutionContext
+	): Promise<ResolvedReference | null> {
+		try {
+			switch (mention.type) {
+				case 'task':
+					return this.resolveTask(mention.id, context.roomId);
+
+				case 'goal':
+					return this.resolveGoal(mention.id, context.roomId);
+
+				case 'file':
+					return resolveFile(mention.id, context.workspacePath);
+
+				case 'folder':
+					return resolveFolder(mention.id, context.workspacePath);
+
+				default: {
+					log.warn(`Unknown reference type: ${mention.type as string}`);
+					return null;
+				}
+			}
+		} catch (err) {
+			log.warn(`Failed to resolve reference ${mention.type}:${mention.id}:`, err);
+			return null;
+		}
+	}
+
+	/**
+	 * Resolve all mentions in parallel.
+	 *
+	 * Returns a map keyed by the raw @ref{type:id} token string.
+	 * Null (unresolved) results are excluded from the returned map.
+	 */
+	async resolveAllReferences(
+		mentions: ReferenceMention[],
+		context: ResolutionContext
+	): Promise<Record<string, ResolvedReference>> {
+		const tokens = mentions.map((m) => `@ref{${m.type}:${m.id}}`);
+
+		const results = await Promise.all(
+			mentions.map((mention) => this.resolveReference(mention, context))
+		);
+
+		const metadata: Record<string, ResolvedReference> = {};
+		for (let i = 0; i < results.length; i++) {
+			const resolved = results[i];
+			if (resolved !== null) {
+				metadata[tokens[i]] = resolved;
+			}
+		}
+
+		return metadata;
+	}
+
+	// ============================================================================
+	// Private per-type resolution helpers
+	// ============================================================================
+
+	private resolveTask(id: string, roomId: string | null): ResolvedReference | null {
+		if (!roomId) {
+			return null;
+		}
+
+		let task = this.deps.taskRepo.getTask(id);
+		if (!task) {
+			task = this.deps.taskRepo.getTaskByShortId(roomId, id);
+		}
+
+		if (!task) {
+			return null;
+		}
+
+		// Confirm the task belongs to the session's room (prevent cross-room access via UUID)
+		if (task.roomId !== roomId) {
+			return null;
+		}
+
+		return { type: 'task', id, data: task };
+	}
+
+	private resolveGoal(id: string, roomId: string | null): ResolvedReference | null {
+		if (!roomId) {
+			return null;
+		}
+
+		let goal = this.deps.goalRepo.getGoal(id);
+		if (!goal) {
+			goal = this.deps.goalRepo.getGoalByShortId(roomId, id);
+		}
+
+		if (!goal) {
+			return null;
+		}
+
+		// Confirm the goal belongs to the session's room
+		if (goal.roomId !== roomId) {
+			return null;
+		}
+
+		return { type: 'goal', id, data: goal };
+	}
+}

--- a/packages/daemon/src/lib/session/reference-resolver.ts
+++ b/packages/daemon/src/lib/session/reference-resolver.ts
@@ -107,6 +107,7 @@ export class ReferenceResolver {
 	/**
 	 * Resolve all mentions in parallel.
 	 *
+	 * Deduplicates by token before resolving to avoid redundant I/O.
 	 * Returns a map keyed by the raw @ref{type:id} token string.
 	 * Null (unresolved) results are excluded from the returned map.
 	 */
@@ -114,17 +115,27 @@ export class ReferenceResolver {
 		mentions: ReferenceMention[],
 		context: ResolutionContext
 	): Promise<Record<string, ResolvedReference>> {
-		const tokens = mentions.map((m) => `@ref{${m.type}:${m.id}}`);
+		// Deduplicate by token to avoid redundant resolution work
+		const seen = new Map<string, ReferenceMention>();
+		for (const mention of mentions) {
+			const token = `@ref{${mention.type}:${mention.id}}`;
+			if (!seen.has(token)) {
+				seen.set(token, mention);
+			}
+		}
+
+		const uniqueTokens = Array.from(seen.keys());
+		const uniqueMentions = Array.from(seen.values());
 
 		const results = await Promise.all(
-			mentions.map((mention) => this.resolveReference(mention, context))
+			uniqueMentions.map((mention) => this.resolveReference(mention, context))
 		);
 
 		const metadata: Record<string, ResolvedReference> = {};
 		for (let i = 0; i < results.length; i++) {
 			const resolved = results[i];
 			if (resolved !== null) {
-				metadata[tokens[i]] = resolved;
+				metadata[uniqueTokens[i]] = resolved;
 			}
 		}
 

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -34,6 +34,7 @@ import {
 } from './session-lifecycle';
 import { ToolsConfigManager } from './tools-config';
 import { MessagePersistence } from './message-persistence';
+import { ReferenceResolver } from './reference-resolver';
 
 /**
  * Cleanup state machine for SessionManager
@@ -106,8 +107,18 @@ export class SessionManager {
 			createAgentSession
 		);
 
-		// Initialize message persistence
-		this.messagePersistence = new MessagePersistence(this.sessionCache, db, messageHub, eventBus);
+		// Initialize message persistence with @ reference resolver
+		const referenceResolver = new ReferenceResolver({
+			taskRepo: db.getTaskRepo(),
+			goalRepo: db.getGoalRepo(),
+		});
+		this.messagePersistence = new MessagePersistence(
+			this.sessionCache,
+			db,
+			messageHub,
+			eventBus,
+			referenceResolver
+		);
 
 		// Setup EventBus subscribers for async message processing
 		this.setupEventSubscriptions();

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -34,6 +34,7 @@ import {
 } from './repositories/goal-repository';
 import { JobQueueRepository } from './repositories/job-queue-repository';
 import { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
+import { TaskRepository } from './repositories/task-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -53,6 +54,7 @@ export type { JobHandler, JobQueueProcessorOptions } from './job-queue-processor
 // @public - Library export
 // Re-export repository classes for direct use
 export { GoalRepository } from './repositories/goal-repository';
+export { TaskRepository } from './repositories/task-repository';
 export { SpaceAgentRepository } from './repositories/space-agent-repository';
 export { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 
@@ -72,6 +74,7 @@ export class Database {
 	private goalRepo!: GoalRepository;
 	private jobQueueRepo!: JobQueueRepository;
 	private appMcpServerRepo!: AppMcpServerRepository;
+	private taskRepo!: TaskRepository;
 	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
@@ -91,6 +94,7 @@ export class Database {
 		this.githubMappingRepo = new GitHubMappingRepository(db);
 		this.inboxItemRepo = new InboxItemRepository(db);
 		this.goalRepo = new GoalRepository(db, reactiveDb, shortIdAllocator);
+		this.taskRepo = new TaskRepository(db, reactiveDb, shortIdAllocator);
 		this.jobQueueRepo = new JobQueueRepository(db);
 		this.appMcpServerRepo = new AppMcpServerRepository(db, reactiveDb);
 	}
@@ -411,6 +415,14 @@ export class Database {
 	 */
 	getGoalRepo(): GoalRepository {
 		return this.goalRepo;
+	}
+
+	/**
+	 * Get the task repository
+	 * Used by ReferenceResolver for task lookups during message preprocessing
+	 */
+	getTaskRepo(): TaskRepository {
+		return this.taskRepo;
 	}
 
 	/**

--- a/packages/daemon/tests/unit/reference-message-persistence.test.ts
+++ b/packages/daemon/tests/unit/reference-message-persistence.test.ts
@@ -218,6 +218,23 @@ describe('ReferenceResolver.resolveAllReferences', () => {
 		expect(result['@ref{task:t-1}']).toBeDefined();
 		expect(result['@ref{task:t-999}']).toBeUndefined();
 	});
+
+	it('deduplicates duplicate references before resolving', async () => {
+		const text = '@ref{task:t-1} and again @ref{task:t-1}';
+		const mentions = ReferenceResolver.extractReferences(text);
+		expect(mentions).toHaveLength(2); // extraction returns duplicates
+
+		const getTaskSpy = taskRepo.getTask as ReturnType<typeof mock>;
+		const getByShortIdSpy = taskRepo.getTaskByShortId as ReturnType<typeof mock>;
+
+		await resolver.resolveAllReferences(mentions, { workspacePath: '/ws', roomId: 'room-1' });
+
+		// getTask should be called at most once for t-1 (deduplication)
+		const taskCallCount =
+			(getTaskSpy.mock.calls.length as number) + (getByShortIdSpy.mock.calls.length as number);
+		// With deduplication, we resolve each unique token once
+		expect(taskCallCount).toBeLessThanOrEqual(2); // at most 1 getTask + 1 getByShortId for the single unique token
+	});
 });
 
 // ============================================================================
@@ -367,14 +384,15 @@ describe('MessagePersistence with ReferenceResolver', () => {
 			'test-session-id',
 			expect.objectContaining({
 				referenceMetadata: {
-					'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 't-1' },
+					// displayText uses the task title, not the raw ID
+					'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Task one' },
 				},
 			}),
 			'consumed'
 		);
 	});
 
-	it('persists message without metadata when all references fail to resolve', async () => {
+	it('includes unresolved references in metadata with status: unresolved', async () => {
 		const resolver = new ReferenceResolver({
 			taskRepo: {
 				getTask: mock(() => null),
@@ -402,7 +420,16 @@ describe('MessagePersistence with ReferenceResolver', () => {
 
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
-			expect.not.objectContaining({ referenceMetadata: expect.anything() }),
+			expect.objectContaining({
+				referenceMetadata: {
+					'@ref{task:t-999}': {
+						type: 'task',
+						id: 't-999',
+						displayText: 't-999',
+						status: 'unresolved',
+					},
+				},
+			}),
 			'consumed'
 		);
 	});
@@ -490,7 +517,15 @@ describe('MessagePersistence with ReferenceResolver', () => {
 			'test-session-id',
 			expect.objectContaining({
 				referenceMetadata: {
-					'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 't-1' },
+					// Resolved reference uses entity title
+					'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Task one' },
+					// Unresolved reference is included with status: 'unresolved'
+					'@ref{task:t-999}': {
+						type: 'task',
+						id: 't-999',
+						displayText: 't-999',
+						status: 'unresolved',
+					},
 				},
 			}),
 			'consumed'

--- a/packages/daemon/tests/unit/reference-message-persistence.test.ts
+++ b/packages/daemon/tests/unit/reference-message-persistence.test.ts
@@ -1,0 +1,499 @@
+/**
+ * Reference Resolver + MessagePersistence integration tests
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { MessageHub, Session } from '@neokai/shared';
+import type { Database } from '../../src/storage/database';
+import type { DaemonHub } from '../../src/lib/daemon-hub';
+import { MessagePersistence } from '../../src/lib/session/message-persistence';
+import { ReferenceResolver } from '../../src/lib/session/reference-resolver';
+import type { SessionCache } from '../../src/lib/session/session-cache';
+import type {
+	TaskRepoForReference,
+	GoalRepoForReference,
+} from '../../src/lib/rpc-handlers/reference-handlers';
+import type { NeoTask, RoomGoal } from '@neokai/shared';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+	return {
+		id: 'test-session-id',
+		title: 'Test Session',
+		workspacePath: '/test/workspace',
+		createdAt: new Date().toISOString(),
+		lastActiveAt: new Date().toISOString(),
+		status: 'active',
+		config: {
+			model: 'claude-sonnet-4-20250514',
+			maxTokens: 8192,
+			temperature: 1.0,
+			queryMode: 'immediate',
+		},
+		metadata: {
+			messageCount: 0,
+			totalTokens: 0,
+			inputTokens: 0,
+			outputTokens: 0,
+			totalCost: 0,
+			toolCallCount: 0,
+			titleGenerated: true,
+		},
+		...overrides,
+	};
+}
+
+// ============================================================================
+// ReferenceResolver.extractReferences
+// ============================================================================
+
+describe('ReferenceResolver.extractReferences', () => {
+	it('returns empty array when text has no references', () => {
+		const result = ReferenceResolver.extractReferences('hello world');
+		expect(result).toEqual([]);
+	});
+
+	it('returns empty array for empty string', () => {
+		expect(ReferenceResolver.extractReferences('')).toEqual([]);
+	});
+
+	it('extracts a single task reference', () => {
+		const result = ReferenceResolver.extractReferences('Please check @ref{task:t-42} for details');
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ type: 'task', id: 't-42' });
+	});
+
+	it('extracts a single goal reference', () => {
+		const result = ReferenceResolver.extractReferences('Goal @ref{goal:g-7} is relevant');
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ type: 'goal', id: 'g-7' });
+	});
+
+	it('extracts a file reference', () => {
+		const result = ReferenceResolver.extractReferences('See @ref{file:src/index.ts}');
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ type: 'file', id: 'src/index.ts' });
+	});
+
+	it('extracts a folder reference', () => {
+		const result = ReferenceResolver.extractReferences('Folder @ref{folder:src/lib}');
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ type: 'folder', id: 'src/lib' });
+	});
+
+	it('extracts multiple references from a single message', () => {
+		const text = 'See @ref{task:t-1} and @ref{goal:g-2} and @ref{file:README.md}';
+		const result = ReferenceResolver.extractReferences(text);
+		expect(result).toHaveLength(3);
+		expect(result[0]).toMatchObject({ type: 'task', id: 't-1' });
+		expect(result[1]).toMatchObject({ type: 'goal', id: 'g-2' });
+		expect(result[2]).toMatchObject({ type: 'file', id: 'README.md' });
+	});
+
+	it('skips malformed tokens that do not match the pattern', () => {
+		// No colon separator — won't match
+		const result = ReferenceResolver.extractReferences('Bad: @ref{taskonly} and @ref{} and text');
+		expect(result).toEqual([]);
+	});
+
+	it('is not affected by stateful regex between multiple calls', () => {
+		const text = '@ref{task:t-10}';
+		// Call multiple times — lastIndex should be reset each time
+		const r1 = ReferenceResolver.extractReferences(text);
+		const r2 = ReferenceResolver.extractReferences(text);
+		const r3 = ReferenceResolver.extractReferences(text);
+		expect(r1).toHaveLength(1);
+		expect(r2).toHaveLength(1);
+		expect(r3).toHaveLength(1);
+	});
+});
+
+// ============================================================================
+// ReferenceResolver.resolveAllReferences
+// ============================================================================
+
+describe('ReferenceResolver.resolveAllReferences', () => {
+	let taskRepo: TaskRepoForReference;
+	let goalRepo: GoalRepoForReference;
+	let resolver: ReferenceResolver;
+
+	const mockTask: NeoTask = {
+		id: 'task-uuid-1',
+		roomId: 'room-1',
+		shortId: 't-1',
+		title: 'Task one',
+		description: '',
+		status: 'open',
+		priority: 'medium',
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	};
+
+	const mockGoal: RoomGoal = {
+		id: 'goal-uuid-1',
+		roomId: 'room-1',
+		shortId: 'g-1',
+		title: 'Goal one',
+		description: '',
+		status: 'active',
+		missionType: 'one_shot',
+		autonomyLevel: 'supervised',
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	};
+
+	beforeEach(() => {
+		taskRepo = {
+			getTask: mock((id: string) => (id === 'task-uuid-1' ? mockTask : null)),
+			getTaskByShortId: mock((roomId: string, shortId: string) =>
+				roomId === 'room-1' && shortId === 't-1' ? mockTask : null
+			),
+		};
+
+		goalRepo = {
+			getGoal: mock((id: string) => (id === 'goal-uuid-1' ? mockGoal : null)),
+			getGoalByShortId: mock((roomId: string, shortId: string) =>
+				roomId === 'room-1' && shortId === 'g-1' ? mockGoal : null
+			),
+		};
+
+		resolver = new ReferenceResolver({ taskRepo, goalRepo });
+	});
+
+	it('returns empty map when no mentions are provided', async () => {
+		const result = await resolver.resolveAllReferences([], {
+			workspacePath: '/ws',
+			roomId: 'room-1',
+		});
+		expect(result).toEqual({});
+	});
+
+	it('resolves a task mention by short ID', async () => {
+		const mentions = ReferenceResolver.extractReferences('@ref{task:t-1}');
+		const result = await resolver.resolveAllReferences(mentions, {
+			workspacePath: '/ws',
+			roomId: 'room-1',
+		});
+		expect(result['@ref{task:t-1}']).toMatchObject({ type: 'task', id: 't-1', data: mockTask });
+	});
+
+	it('resolves a goal mention by short ID', async () => {
+		const mentions = ReferenceResolver.extractReferences('@ref{goal:g-1}');
+		const result = await resolver.resolveAllReferences(mentions, {
+			workspacePath: '/ws',
+			roomId: 'room-1',
+		});
+		expect(result['@ref{goal:g-1}']).toMatchObject({ type: 'goal', id: 'g-1', data: mockGoal });
+	});
+
+	it('excludes null results (unresolved references)', async () => {
+		const mentions = ReferenceResolver.extractReferences('@ref{task:t-999}');
+		const result = await resolver.resolveAllReferences(mentions, {
+			workspacePath: '/ws',
+			roomId: 'room-1',
+		});
+		expect(Object.keys(result)).toHaveLength(0);
+	});
+
+	it('returns null for task when roomId is null', async () => {
+		const mentions = ReferenceResolver.extractReferences('@ref{task:t-1}');
+		const result = await resolver.resolveAllReferences(mentions, {
+			workspacePath: '/ws',
+			roomId: null,
+		});
+		expect(Object.keys(result)).toHaveLength(0);
+	});
+
+	it('handles partial resolution — includes resolved refs, excludes unresolved', async () => {
+		const text = '@ref{task:t-1} and @ref{task:t-999}';
+		const mentions = ReferenceResolver.extractReferences(text);
+		const result = await resolver.resolveAllReferences(mentions, {
+			workspacePath: '/ws',
+			roomId: 'room-1',
+		});
+		expect(Object.keys(result)).toHaveLength(1);
+		expect(result['@ref{task:t-1}']).toBeDefined();
+		expect(result['@ref{task:t-999}']).toBeUndefined();
+	});
+});
+
+// ============================================================================
+// MessagePersistence.persist with ReferenceResolver
+// ============================================================================
+
+describe('MessagePersistence with ReferenceResolver', () => {
+	let mockSessionCache: SessionCache;
+	let mockDb: Database;
+	let mockMessageHub: MessageHub;
+	let mockEventBus: DaemonHub;
+	let mockSession: Session;
+	let mockAgentSession: {
+		getSessionData: ReturnType<typeof mock>;
+		getProcessingState: ReturnType<typeof mock>;
+	};
+	let saveUserMessageSpy: ReturnType<typeof mock>;
+	let eventBusEmitSpy: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		mockSession = makeSession({
+			context: { roomId: 'room-1' },
+		});
+
+		mockAgentSession = {
+			getSessionData: mock(() => mockSession),
+			getProcessingState: mock(() => ({ status: 'idle' })),
+		};
+
+		mockSessionCache = {
+			getAsync: mock(async () => mockAgentSession),
+		} as unknown as SessionCache;
+
+		saveUserMessageSpy = mock(() => 'db-msg-1');
+		mockDb = {
+			saveUserMessage: saveUserMessageSpy,
+		} as unknown as Database;
+
+		mockMessageHub = {
+			event: mock(async () => {}),
+			onRequest: mock((_method: string, _handler: Function) => () => {}),
+			query: mock(async () => ({})),
+			command: mock(async () => {}),
+		} as unknown as MessageHub;
+
+		eventBusEmitSpy = mock(async () => {});
+		mockEventBus = {
+			emit: eventBusEmitSpy,
+		} as unknown as DaemonHub;
+	});
+
+	it('persists without referenceMetadata when no resolver is provided', async () => {
+		const persistence = new MessagePersistence(
+			mockSessionCache,
+			mockDb,
+			mockMessageHub,
+			mockEventBus
+		);
+
+		await persistence.persist({
+			sessionId: 'test-session-id',
+			messageId: 'msg-1',
+			content: 'hello @ref{task:t-1}',
+		});
+
+		expect(saveUserMessageSpy).toHaveBeenCalledWith(
+			'test-session-id',
+			expect.not.objectContaining({ referenceMetadata: expect.anything() }),
+			'consumed'
+		);
+	});
+
+	it('persists without referenceMetadata when message has no @ references', async () => {
+		const resolver = new ReferenceResolver({
+			taskRepo: {
+				getTask: mock(() => null),
+				getTaskByShortId: mock(() => null),
+			},
+			goalRepo: {
+				getGoal: mock(() => null),
+				getGoalByShortId: mock(() => null),
+			},
+		});
+
+		const persistence = new MessagePersistence(
+			mockSessionCache,
+			mockDb,
+			mockMessageHub,
+			mockEventBus,
+			resolver
+		);
+
+		await persistence.persist({
+			sessionId: 'test-session-id',
+			messageId: 'msg-2',
+			content: 'plain text, no references',
+		});
+
+		expect(saveUserMessageSpy).toHaveBeenCalledWith(
+			'test-session-id',
+			expect.not.objectContaining({ referenceMetadata: expect.anything() }),
+			'consumed'
+		);
+	});
+
+	it('embeds referenceMetadata in saved message when resolver resolves a reference', async () => {
+		const mockTask: NeoTask = {
+			id: 'task-uuid-1',
+			roomId: 'room-1',
+			shortId: 't-1',
+			title: 'Task one',
+			description: '',
+			status: 'open',
+			priority: 'medium',
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+
+		const resolver = new ReferenceResolver({
+			taskRepo: {
+				getTask: mock(() => null),
+				getTaskByShortId: mock((roomId: string, shortId: string) =>
+					roomId === 'room-1' && shortId === 't-1' ? mockTask : null
+				),
+			},
+			goalRepo: {
+				getGoal: mock(() => null),
+				getGoalByShortId: mock(() => null),
+			},
+		});
+
+		const persistence = new MessagePersistence(
+			mockSessionCache,
+			mockDb,
+			mockMessageHub,
+			mockEventBus,
+			resolver
+		);
+
+		await persistence.persist({
+			sessionId: 'test-session-id',
+			messageId: 'msg-3',
+			content: 'Check @ref{task:t-1} please',
+		});
+
+		expect(saveUserMessageSpy).toHaveBeenCalledWith(
+			'test-session-id',
+			expect.objectContaining({
+				referenceMetadata: {
+					'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 't-1' },
+				},
+			}),
+			'consumed'
+		);
+	});
+
+	it('persists message without metadata when all references fail to resolve', async () => {
+		const resolver = new ReferenceResolver({
+			taskRepo: {
+				getTask: mock(() => null),
+				getTaskByShortId: mock(() => null),
+			},
+			goalRepo: {
+				getGoal: mock(() => null),
+				getGoalByShortId: mock(() => null),
+			},
+		});
+
+		const persistence = new MessagePersistence(
+			mockSessionCache,
+			mockDb,
+			mockMessageHub,
+			mockEventBus,
+			resolver
+		);
+
+		await persistence.persist({
+			sessionId: 'test-session-id',
+			messageId: 'msg-4',
+			content: 'See @ref{task:t-999} which does not exist',
+		});
+
+		expect(saveUserMessageSpy).toHaveBeenCalledWith(
+			'test-session-id',
+			expect.not.objectContaining({ referenceMetadata: expect.anything() }),
+			'consumed'
+		);
+	});
+
+	it('still persists message when resolver throws an error', async () => {
+		const badResolver = new ReferenceResolver({
+			taskRepo: {
+				getTask: mock(() => {
+					throw new Error('DB connection failed');
+				}),
+				getTaskByShortId: mock(() => {
+					throw new Error('DB connection failed');
+				}),
+			},
+			goalRepo: {
+				getGoal: mock(() => null),
+				getGoalByShortId: mock(() => null),
+			},
+		});
+
+		const persistence = new MessagePersistence(
+			mockSessionCache,
+			mockDb,
+			mockMessageHub,
+			mockEventBus,
+			badResolver
+		);
+
+		// Should not throw — errors are swallowed in preprocessReferences
+		await persistence.persist({
+			sessionId: 'test-session-id',
+			messageId: 'msg-5',
+			content: 'See @ref{task:t-1}',
+		});
+
+		// Message is still saved — without metadata
+		expect(saveUserMessageSpy).toHaveBeenCalledWith(
+			'test-session-id',
+			expect.objectContaining({ uuid: 'msg-5', type: 'user' }),
+			'consumed'
+		);
+	});
+
+	it('embeds partial metadata when only some references resolve', async () => {
+		const mockTask: NeoTask = {
+			id: 'task-uuid-1',
+			roomId: 'room-1',
+			shortId: 't-1',
+			title: 'Task one',
+			description: '',
+			status: 'open',
+			priority: 'medium',
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+
+		const resolver = new ReferenceResolver({
+			taskRepo: {
+				getTask: mock(() => null),
+				getTaskByShortId: mock((roomId: string, shortId: string) =>
+					roomId === 'room-1' && shortId === 't-1' ? mockTask : null
+				),
+			},
+			goalRepo: {
+				getGoal: mock(() => null),
+				getGoalByShortId: mock(() => null),
+			},
+		});
+
+		const persistence = new MessagePersistence(
+			mockSessionCache,
+			mockDb,
+			mockMessageHub,
+			mockEventBus,
+			resolver
+		);
+
+		await persistence.persist({
+			sessionId: 'test-session-id',
+			messageId: 'msg-6',
+			content: 'See @ref{task:t-1} and @ref{task:t-999}',
+		});
+
+		expect(saveUserMessageSpy).toHaveBeenCalledWith(
+			'test-session-id',
+			expect.objectContaining({
+				referenceMetadata: {
+					'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 't-1' },
+				},
+			}),
+			'consumed'
+		);
+	});
+});

--- a/packages/daemon/tests/unit/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/session/session-manager.test.ts
@@ -64,6 +64,14 @@ describe('SessionManager', () => {
 			countMessagesAfter: mock(() => 0),
 			updateMessage: mock(() => {}),
 			saveUserMessage: mock(() => {}),
+			getTaskRepo: mock(() => ({
+				getTask: mock(() => null),
+				getTaskByShortId: mock(() => null),
+			})),
+			getGoalRepo: mock(() => ({
+				getGoal: mock(() => null),
+				getGoalByShortId: mock(() => null),
+			})),
 		} as unknown as Database;
 
 		// Message hub mocks


### PR DESCRIPTION
Adds ReferenceResolver service and wires it into MessagePersistence so
that @ref{type:id} tokens in user messages are resolved and attached as
referenceMetadata on the persisted SDK message blob.
