### PR TITLE
feat(web): integrate reference autocomplete with MessageInput

### DIFF
--- a/packages/web/src/components/InputTextarea.tsx
+++ b/packages/web/src/components/InputTextarea.tsx
@@ -25,6 +25,7 @@
  */
 
 import type { ComponentChildren } from 'preact';
+import type { MutableRef } from 'preact/hooks';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import { cn } from '../lib/utils.ts';
 import { borderColors } from '../lib/design-tokens.ts';
@@ -61,6 +62,8 @@ export interface InputTextareaProps {
 	leadingElement?: ComponentChildren;
 	/** Left padding class used when leadingElement is present */
 	leadingPaddingClass?: string;
+	/** Optional ref forwarded to the underlying textarea element */
+	textareaRef?: MutableRef<HTMLTextAreaElement | null>;
 }
 
 /**
@@ -89,8 +92,10 @@ export function InputTextarea({
 	onPaste,
 	leadingElement,
 	leadingPaddingClass,
+	textareaRef: externalTextareaRef,
 }: InputTextareaProps) {
-	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const internalTextareaRef = useRef<HTMLTextAreaElement>(null);
+	const textareaRef = externalTextareaRef ?? internalTextareaRef;
 	const [isMultiline, setIsMultiline] = useState(false);
 
 	// Detect if device is mobile (touch-based)

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -235,16 +235,22 @@ export default function MessageInput({
 		]
 	);
 
+	// Destructure stable callback refs to avoid recreating handleKeyDown on every render
+	// (hooks return new object instances each render, but the functions inside are stable
+	// via useCallback, so depending on the functions directly is more efficient)
+	const refHandleKeyDown = referenceAutocomplete.handleKeyDown;
+	const cmdHandleKeyDown = commandAutocomplete.handleKeyDown;
+
 	// Keyboard handler
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
 			// Reference autocomplete takes precedence when visible
-			if (referenceAutocomplete.handleKeyDown(e)) {
+			if (refHandleKeyDown(e)) {
 				return;
 			}
 
 			// Then try command autocomplete
-			if (commandAutocomplete.handleKeyDown(e)) {
+			if (cmdHandleKeyDown(e)) {
 				return;
 			}
 
@@ -273,7 +279,7 @@ export default function MessageInput({
 				}
 			}
 		},
-		[referenceAutocomplete, commandAutocomplete, handleSubmit, agentWorking]
+		[refHandleKeyDown, cmdHandleKeyDown, handleSubmit, agentWorking]
 	);
 
 	// Model switch handler
@@ -462,7 +468,9 @@ export default function MessageInput({
 							}}
 							disabled={disabled}
 							placeholder={getPlaceholderForSessionType(sessionType)}
-							showCommandAutocomplete={commandAutocomplete.showAutocomplete}
+							showCommandAutocomplete={
+								commandAutocomplete.showAutocomplete && !referenceAutocomplete.showAutocomplete
+							}
 							filteredCommands={commandAutocomplete.filteredCommands}
 							selectedCommandIndex={commandAutocomplete.selectedIndex}
 							onCommandSelect={commandAutocomplete.handleSelect}

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -7,8 +7,14 @@
  * Refactored to use shared hooks for better separation of concerns.
  */
 
-import { useCallback, useEffect, useState } from 'preact/hooks';
-import type { MessageDeliveryMode, MessageImage, ModelInfo, SessionType } from '@neokai/shared';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import type {
+	MessageDeliveryMode,
+	MessageImage,
+	ModelInfo,
+	ReferenceMention,
+	SessionType,
+} from '@neokai/shared';
 import { isAgentWorking } from '../lib/state.ts';
 import { connectionManager } from '../lib/connection-manager';
 import { AttachmentPreview } from './AttachmentPreview.tsx';
@@ -20,6 +26,8 @@ import {
 	useModelSwitcher,
 	useModal,
 	useCommandAutocomplete,
+	useReferenceAutocomplete,
+	extractActiveAtQuery,
 	useFileAttachments,
 	useInterrupt,
 } from '../hooks';
@@ -74,6 +82,9 @@ export default function MessageInput({
 	// Drag and drop state
 	const [isDragging, setIsDragging] = useState(false);
 
+	// Textarea ref for programmatic focus after reference selection
+	const textareaInputRef = useRef<HTMLTextAreaElement>(null);
+
 	// Use shared hooks
 	const { content, setContent, clear: clearDraft } = useInputDraft(sessionId);
 	const {
@@ -109,6 +120,29 @@ export default function MessageInput({
 	const commandAutocomplete = useCommandAutocomplete({
 		content,
 		onSelect: handleCommandSelect,
+	});
+
+	// Reference autocomplete
+	const handleReferenceSelect = useCallback(
+		(reference: ReferenceMention) => {
+			const query = extractActiveAtQuery(content);
+			if (query === null) return;
+
+			// The @ token starts at (content.length - query.length - 1)
+			const atPos = content.length - query.length - 1;
+			const refToken = `@ref{${reference.type}:${reference.id}} `;
+			const newContent = content.slice(0, atPos) + refToken;
+			setContent(newContent);
+
+			// Restore focus to textarea after selection
+			textareaInputRef.current?.focus();
+		},
+		[content, setContent]
+	);
+
+	const referenceAutocomplete = useReferenceAutocomplete({
+		content,
+		onSelect: handleReferenceSelect,
 	});
 	const agentWorking = isAgentWorking.value;
 	const [queuedForCurrentTurn, setQueuedForCurrentTurn] = useState<QueuedOverlayMessage[]>([]);
@@ -204,7 +238,12 @@ export default function MessageInput({
 	// Keyboard handler
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
-			// Try command autocomplete first
+			// Reference autocomplete takes precedence when visible
+			if (referenceAutocomplete.handleKeyDown(e)) {
+				return;
+			}
+
+			// Then try command autocomplete
 			if (commandAutocomplete.handleKeyDown(e)) {
 				return;
 			}
@@ -234,7 +273,7 @@ export default function MessageInput({
 				}
 			}
 		},
-		[commandAutocomplete, handleSubmit, agentWorking]
+		[referenceAutocomplete, commandAutocomplete, handleSubmit, agentWorking]
 	);
 
 	// Model switch handler
@@ -428,9 +467,15 @@ export default function MessageInput({
 							selectedCommandIndex={commandAutocomplete.selectedIndex}
 							onCommandSelect={commandAutocomplete.handleSelect}
 							onCommandClose={commandAutocomplete.close}
+							showReferenceAutocomplete={referenceAutocomplete.showAutocomplete}
+							referenceResults={referenceAutocomplete.results}
+							selectedReferenceIndex={referenceAutocomplete.selectedIndex}
+							onReferenceSelect={referenceAutocomplete.handleSelect}
+							onReferenceClose={referenceAutocomplete.close}
 							isAgentWorking={agentWorking}
 							onStop={handleInterrupt}
 							onPaste={disabled ? undefined : handlePaste}
+							textareaRef={textareaInputRef}
 						/>
 					</div>
 				</form>

--- a/packages/web/src/components/__tests__/MessageInput.queue-mode.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.queue-mode.test.tsx
@@ -82,6 +82,16 @@ vi.mock('../../hooks', () => ({
 		interrupting: false,
 		handleInterrupt: vi.fn(async () => {}),
 	}),
+	useReferenceAutocomplete: () => ({
+		showAutocomplete: false,
+		results: [],
+		selectedIndex: 0,
+		searchQuery: '',
+		handleSelect: vi.fn(() => {}),
+		close: vi.fn(() => {}),
+		handleKeyDown: vi.fn(() => false),
+	}),
+	extractActiveAtQuery: vi.fn(() => null),
 }));
 
 vi.mock('../../lib/connection-manager', () => ({

--- a/packages/web/src/components/__tests__/MessageInput.reference-autocomplete.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.reference-autocomplete.test.tsx
@@ -6,6 +6,7 @@
  * - useReferenceAutocomplete is wired up and its props are passed to InputTextarea
  * - handleReferenceSelect replaces @query with @ref{type:id} token
  * - Reference autocomplete keyboard events take precedence over command autocomplete
+ * - Command autocomplete is suppressed when reference autocomplete is visible
  */
 
 import { signal } from '@preact/signals';
@@ -23,13 +24,19 @@ const mockRequest = vi.fn(async () => ({ messages: [] }));
 
 // Mutable reference autocomplete state
 let mockReferenceShowAutocomplete = false;
-let mockReferenceResults: unknown[] = [];
+let mockReferenceResults = [];
 let mockReferenceSelectedIndex = 0;
 const mockReferenceHandleKeyDown = vi.fn(() => false);
 const mockReferenceHandleSelect = vi.fn(() => {});
 const mockReferenceClose = vi.fn(() => {});
 
+// Captures the onSelect callback passed to useReferenceAutocomplete so tests can
+// invoke handleReferenceSelect directly and verify its content-replacement logic.
+let capturedOnSelect = null;
+
 // Mutable command autocomplete state
+let mockCommandShowAutocomplete = false;
+let mockCommandFilteredCommands = [];
 const mockCommandHandleKeyDown = vi.fn(() => false);
 
 vi.mock('../../lib/state.ts', () => ({
@@ -62,24 +69,28 @@ vi.mock('../../hooks', () => ({
 		close: vi.fn(() => {}),
 	}),
 	useCommandAutocomplete: () => ({
-		showAutocomplete: false,
-		filteredCommands: [],
+		showAutocomplete: mockCommandShowAutocomplete,
+		filteredCommands: mockCommandFilteredCommands,
 		selectedIndex: 0,
 		handleSelect: vi.fn(() => {}),
 		close: vi.fn(() => {}),
 		handleKeyDown: mockCommandHandleKeyDown,
 	}),
-	useReferenceAutocomplete: () => ({
-		showAutocomplete: mockReferenceShowAutocomplete,
-		results: mockReferenceResults,
-		selectedIndex: mockReferenceSelectedIndex,
-		searchQuery: '',
-		handleSelect: mockReferenceHandleSelect,
-		close: mockReferenceClose,
-		handleKeyDown: mockReferenceHandleKeyDown,
-	}),
-	extractActiveAtQuery: vi.fn((content: string) => {
-		// Real implementation for select tests
+	useReferenceAutocomplete: (opts) => {
+		// Capture the onSelect (= handleReferenceSelect) so tests can call it directly
+		capturedOnSelect = opts.onSelect;
+		return {
+			showAutocomplete: mockReferenceShowAutocomplete,
+			results: mockReferenceResults,
+			selectedIndex: mockReferenceSelectedIndex,
+			searchQuery: '',
+			handleSelect: mockReferenceHandleSelect,
+			close: mockReferenceClose,
+			handleKeyDown: mockReferenceHandleKeyDown,
+		};
+	},
+	extractActiveAtQuery: vi.fn((content) => {
+		// Mirror the real implementation so handleReferenceSelect tests work correctly
 		if (!content.includes('@')) return null;
 		for (let i = content.length - 1; i >= 0; i--) {
 			if (content[i] === '@') {
@@ -136,8 +147,11 @@ describe('MessageInput reference autocomplete', () => {
 		mockReferenceHandleKeyDown.mockClear();
 		mockReferenceHandleSelect.mockClear();
 		mockReferenceClose.mockClear();
+		mockCommandShowAutocomplete = false;
+		mockCommandFilteredCommands = [];
 		mockCommandHandleKeyDown.mockReturnValue(false);
 		mockCommandHandleKeyDown.mockClear();
+		capturedOnSelect = null;
 
 		Object.defineProperty(window, 'matchMedia', {
 			writable: true,
@@ -156,7 +170,7 @@ describe('MessageInput reference autocomplete', () => {
 	describe('keyboard event priority', () => {
 		it('reference autocomplete handleKeyDown is called before command autocomplete', () => {
 			const { container } = renderInput();
-			const textarea = container.querySelector('textarea')!;
+			const textarea = container.querySelector('textarea');
 
 			fireEvent.keyDown(textarea, { key: 'ArrowDown' });
 
@@ -167,7 +181,7 @@ describe('MessageInput reference autocomplete', () => {
 			mockReferenceHandleKeyDown.mockReturnValue(true);
 
 			const { container } = renderInput();
-			const textarea = container.querySelector('textarea')!;
+			const textarea = container.querySelector('textarea');
 
 			fireEvent.keyDown(textarea, { key: 'ArrowDown' });
 
@@ -179,7 +193,7 @@ describe('MessageInput reference autocomplete', () => {
 			mockReferenceHandleKeyDown.mockReturnValue(false);
 
 			const { container } = renderInput();
-			const textarea = container.querySelector('textarea')!;
+			const textarea = container.querySelector('textarea');
 
 			fireEvent.keyDown(textarea, { key: 'ArrowDown' });
 
@@ -194,7 +208,7 @@ describe('MessageInput reference autocomplete', () => {
 
 			const onSend = vi.fn(async () => {});
 			const { container } = render(<MessageInput sessionId="test-session" onSend={onSend} />);
-			const textarea = container.querySelector('textarea')!;
+			const textarea = container.querySelector('textarea');
 
 			fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
@@ -207,7 +221,7 @@ describe('MessageInput reference autocomplete', () => {
 
 			const onSend = vi.fn(async () => {});
 			const { container } = render(<MessageInput sessionId="test-session" onSend={onSend} />);
-			const textarea = container.querySelector('textarea')!;
+			const textarea = container.querySelector('textarea');
 
 			fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
@@ -216,20 +230,84 @@ describe('MessageInput reference autocomplete', () => {
 	});
 
 	describe('reference selection — content replacement', () => {
-		it('replaces @query at end of content with @ref token', async () => {
-			// The hook's handleSelect calls the onSelect callback which is handleReferenceSelect
-			// We test it indirectly by checking setContent was called with the right value
-			// Since the hook is mocked, we simulate what handleReferenceSelect would do
-			// by calling it directly via the component internals.
-			//
-			// However since hooks are mocked, we test the real handleReferenceSelect logic
-			// separately via the extractActiveAtQuery integration below.
+		it('replaces @query at end of content with @ref{type:id} token', () => {
+			mockDraftContent = 'fix @task';
+			renderInput();
 
-			// The hook handleSelect is provided; we verify the onSelect wiring by
-			// checking that the reference autocomplete's handleSelect prop is connected.
-			// This is covered by the keyboard event tests above.
-			// Here we test content replacement via a direct re-render with content set.
-			expect(true).toBe(true); // placeholder - see below for integration
+			expect(capturedOnSelect).not.toBeNull();
+			act(() => {
+				capturedOnSelect({ type: 'task', id: 't-42', displayText: 'Fix login bug' });
+			});
+
+			// content = 'fix @task', query = 'task', atPos = 4
+			// newContent = 'fix ' + '@ref{task:t-42} '
+			expect(mockSetContent).toHaveBeenCalledWith('fix @ref{task:t-42} ');
+		});
+
+		it('replaces @query when combined with a slash command prefix', () => {
+			mockDraftContent = '/agent @task';
+			renderInput();
+
+			expect(capturedOnSelect).not.toBeNull();
+			act(() => {
+				capturedOnSelect({ type: 'task', id: 't-99', displayText: 'Do something' });
+			});
+
+			// content = '/agent @task', query = 'task', atPos = 7
+			// newContent = '/agent ' + '@ref{task:t-99} '
+			expect(mockSetContent).toHaveBeenCalledWith('/agent @ref{task:t-99} ');
+		});
+
+		it('replaces @-only query (just @ with no query text)', () => {
+			mockDraftContent = 'hello @';
+			renderInput();
+
+			expect(capturedOnSelect).not.toBeNull();
+			act(() => {
+				capturedOnSelect({ type: 'goal', id: 'g-5', displayText: 'Launch v2' });
+			});
+
+			// content = 'hello @', query = '', atPos = 6
+			// newContent = 'hello ' + '@ref{goal:g-5} '
+			expect(mockSetContent).toHaveBeenCalledWith('hello @ref{goal:g-5} ');
+		});
+
+		it('returns early without calling setContent when no active @query in content', () => {
+			mockDraftContent = 'no at-sign here';
+			renderInput();
+
+			expect(capturedOnSelect).not.toBeNull();
+			act(() => {
+				capturedOnSelect({ type: 'task', id: 't-1', displayText: 'Something' });
+			});
+
+			expect(mockSetContent).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('menu visibility — no overlap', () => {
+		it('suppresses command autocomplete when reference autocomplete is visible', () => {
+			mockReferenceShowAutocomplete = true;
+			mockCommandShowAutocomplete = true;
+			mockCommandFilteredCommands = ['agent', 'compact'];
+			mockReferenceResults = [{ type: 'task', id: 't-1', displayText: 'Some task' }];
+
+			const { getByText, queryByText } = renderInput();
+
+			// Reference menu should be visible
+			expect(getByText('References')).toBeTruthy();
+			// Command menu should be suppressed
+			expect(queryByText('Slash Commands')).toBeNull();
+		});
+
+		it('shows command autocomplete when reference autocomplete is hidden', () => {
+			mockReferenceShowAutocomplete = false;
+			mockCommandShowAutocomplete = true;
+			mockCommandFilteredCommands = ['agent', 'compact'];
+
+			const { getByText } = renderInput();
+
+			expect(getByText('Slash Commands')).toBeTruthy();
 		});
 	});
 
@@ -240,8 +318,6 @@ describe('MessageInput reference autocomplete', () => {
 
 			const { container } = renderInput();
 
-			// ReferenceAutocomplete renders nothing when results is empty,
-			// so we check that the "References" header is absent
 			expect(container.textContent).not.toContain('References');
 		});
 
@@ -274,11 +350,9 @@ describe('MessageInput reference autocomplete', () => {
 			const { getAllByRole } = renderInput();
 
 			const buttons = getAllByRole('button');
-			// Find the two task buttons (may have more buttons for other UI)
 			const taskButtons = buttons.filter(
 				(b) => b.textContent?.includes('First task') || b.textContent?.includes('Second task')
 			);
-			// The second task button (index 1) should have the selected style
 			expect(taskButtons[1].className).toContain('border-blue-500');
 			expect(taskButtons[0].className).not.toContain('border-blue-500');
 		});

--- a/packages/web/src/components/__tests__/MessageInput.reference-autocomplete.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.reference-autocomplete.test.tsx
@@ -1,0 +1,286 @@
+// @ts-nocheck
+/**
+ * Tests for MessageInput reference autocomplete integration.
+ *
+ * Verifies that:
+ * - useReferenceAutocomplete is wired up and its props are passed to InputTextarea
+ * - handleReferenceSelect replaces @query with @ref{type:id} token
+ * - Reference autocomplete keyboard events take precedence over command autocomplete
+ */
+
+import { signal } from '@preact/signals';
+import { act, cleanup, fireEvent, render } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAgentWorking = signal(false);
+let mockDraftContent = '';
+
+const mockSetContent = vi.fn(() => {});
+const mockClearDraft = vi.fn(() => {});
+const mockClearAttachments = vi.fn(() => {});
+const mockGetImagesForSend = vi.fn(() => undefined);
+const mockRequest = vi.fn(async () => ({ messages: [] }));
+
+// Mutable reference autocomplete state
+let mockReferenceShowAutocomplete = false;
+let mockReferenceResults: unknown[] = [];
+let mockReferenceSelectedIndex = 0;
+const mockReferenceHandleKeyDown = vi.fn(() => false);
+const mockReferenceHandleSelect = vi.fn(() => {});
+const mockReferenceClose = vi.fn(() => {});
+
+// Mutable command autocomplete state
+const mockCommandHandleKeyDown = vi.fn(() => false);
+
+vi.mock('../../lib/state.ts', () => ({
+	get isAgentWorking() {
+		return {
+			get value() {
+				return mockAgentWorking.value;
+			},
+		};
+	},
+}));
+
+vi.mock('../../hooks', () => ({
+	useInputDraft: () => ({
+		content: mockDraftContent,
+		setContent: mockSetContent,
+		clear: mockClearDraft,
+	}),
+	useModelSwitcher: () => ({
+		currentModel: 'mock-model',
+		currentModelInfo: null,
+		availableModels: [],
+		switching: false,
+		loading: false,
+		switchModel: vi.fn(async () => {}),
+	}),
+	useModal: () => ({
+		isOpen: false,
+		toggle: vi.fn(() => {}),
+		close: vi.fn(() => {}),
+	}),
+	useCommandAutocomplete: () => ({
+		showAutocomplete: false,
+		filteredCommands: [],
+		selectedIndex: 0,
+		handleSelect: vi.fn(() => {}),
+		close: vi.fn(() => {}),
+		handleKeyDown: mockCommandHandleKeyDown,
+	}),
+	useReferenceAutocomplete: () => ({
+		showAutocomplete: mockReferenceShowAutocomplete,
+		results: mockReferenceResults,
+		selectedIndex: mockReferenceSelectedIndex,
+		searchQuery: '',
+		handleSelect: mockReferenceHandleSelect,
+		close: mockReferenceClose,
+		handleKeyDown: mockReferenceHandleKeyDown,
+	}),
+	extractActiveAtQuery: vi.fn((content: string) => {
+		// Real implementation for select tests
+		if (!content.includes('@')) return null;
+		for (let i = content.length - 1; i >= 0; i--) {
+			if (content[i] === '@') {
+				const before = i === 0 ? '' : content[i - 1];
+				const isWordStart = i === 0 || /\s/.test(before);
+				if (!isWordStart) continue;
+				const afterAt = content.slice(i + 1);
+				if (/\s/.test(afterAt)) continue;
+				return afterAt;
+			}
+		}
+		return null;
+	}),
+	useFileAttachments: () => ({
+		attachments: [],
+		fileInputRef: { current: null },
+		handleFileSelect: vi.fn(() => {}),
+		handleFileDrop: vi.fn(async () => {}),
+		handleRemove: vi.fn(() => {}),
+		clear: mockClearAttachments,
+		openFilePicker: vi.fn(() => {}),
+		getImagesForSend: mockGetImagesForSend,
+		handlePaste: vi.fn(() => {}),
+	}),
+	useInterrupt: () => ({
+		interrupting: false,
+		handleInterrupt: vi.fn(async () => {}),
+	}),
+}));
+
+vi.mock('../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: () => ({ request: mockRequest }),
+	},
+}));
+
+import MessageInput from '../MessageInput';
+
+describe('MessageInput reference autocomplete', () => {
+	beforeEach(() => {
+		cleanup();
+		mockDraftContent = '';
+		mockAgentWorking.value = false;
+		mockSetContent.mockClear();
+		mockClearDraft.mockClear();
+		mockClearAttachments.mockClear();
+		mockGetImagesForSend.mockClear();
+		mockGetImagesForSend.mockReturnValue(undefined);
+		mockRequest.mockClear();
+		mockReferenceShowAutocomplete = false;
+		mockReferenceResults = [];
+		mockReferenceSelectedIndex = 0;
+		mockReferenceHandleKeyDown.mockReturnValue(false);
+		mockReferenceHandleKeyDown.mockClear();
+		mockReferenceHandleSelect.mockClear();
+		mockReferenceClose.mockClear();
+		mockCommandHandleKeyDown.mockReturnValue(false);
+		mockCommandHandleKeyDown.mockClear();
+
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: vi.fn(() => ({ matches: false })),
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	function renderInput(onSend = vi.fn(async () => {})) {
+		return render(<MessageInput sessionId="test-session" onSend={onSend} />);
+	}
+
+	describe('keyboard event priority', () => {
+		it('reference autocomplete handleKeyDown is called before command autocomplete', () => {
+			const { container } = renderInput();
+			const textarea = container.querySelector('textarea')!;
+
+			fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+
+			expect(mockReferenceHandleKeyDown).toHaveBeenCalledOnce();
+		});
+
+		it('command autocomplete handleKeyDown is NOT called when reference autocomplete handles the event', () => {
+			mockReferenceHandleKeyDown.mockReturnValue(true);
+
+			const { container } = renderInput();
+			const textarea = container.querySelector('textarea')!;
+
+			fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+
+			expect(mockReferenceHandleKeyDown).toHaveBeenCalledOnce();
+			expect(mockCommandHandleKeyDown).not.toHaveBeenCalled();
+		});
+
+		it('command autocomplete handleKeyDown IS called when reference autocomplete does not handle the event', () => {
+			mockReferenceHandleKeyDown.mockReturnValue(false);
+
+			const { container } = renderInput();
+			const textarea = container.querySelector('textarea')!;
+
+			fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+
+			expect(mockReferenceHandleKeyDown).toHaveBeenCalledOnce();
+			expect(mockCommandHandleKeyDown).toHaveBeenCalledOnce();
+		});
+
+		it('Enter key submits form when neither autocomplete handles it', () => {
+			mockReferenceHandleKeyDown.mockReturnValue(false);
+			mockCommandHandleKeyDown.mockReturnValue(false);
+			mockDraftContent = 'hello world';
+
+			const onSend = vi.fn(async () => {});
+			const { container } = render(<MessageInput sessionId="test-session" onSend={onSend} />);
+			const textarea = container.querySelector('textarea')!;
+
+			fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+
+			expect(onSend).toHaveBeenCalledOnce();
+		});
+
+		it('Enter key does NOT submit when reference autocomplete handles it', () => {
+			mockReferenceHandleKeyDown.mockReturnValue(true);
+			mockDraftContent = 'hello @task';
+
+			const onSend = vi.fn(async () => {});
+			const { container } = render(<MessageInput sessionId="test-session" onSend={onSend} />);
+			const textarea = container.querySelector('textarea')!;
+
+			fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+
+			expect(onSend).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('reference selection — content replacement', () => {
+		it('replaces @query at end of content with @ref token', async () => {
+			// The hook's handleSelect calls the onSelect callback which is handleReferenceSelect
+			// We test it indirectly by checking setContent was called with the right value
+			// Since the hook is mocked, we simulate what handleReferenceSelect would do
+			// by calling it directly via the component internals.
+			//
+			// However since hooks are mocked, we test the real handleReferenceSelect logic
+			// separately via the extractActiveAtQuery integration below.
+
+			// The hook handleSelect is provided; we verify the onSelect wiring by
+			// checking that the reference autocomplete's handleSelect prop is connected.
+			// This is covered by the keyboard event tests above.
+			// Here we test content replacement via a direct re-render with content set.
+			expect(true).toBe(true); // placeholder - see below for integration
+		});
+	});
+
+	describe('InputTextarea receives reference autocomplete props', () => {
+		it('passes showReferenceAutocomplete=false when autocomplete is hidden', () => {
+			mockReferenceShowAutocomplete = false;
+			mockReferenceResults = [];
+
+			const { container } = renderInput();
+
+			// ReferenceAutocomplete renders nothing when results is empty,
+			// so we check that the "References" header is absent
+			expect(container.textContent).not.toContain('References');
+		});
+
+		it('passes showReferenceAutocomplete=true and renders menu when results are present', () => {
+			mockReferenceShowAutocomplete = true;
+			mockReferenceResults = [
+				{
+					type: 'task',
+					id: 't-42',
+					shortId: 't-42',
+					displayText: 'Fix the login bug',
+					subtitle: 'in progress',
+				},
+			];
+
+			const { getByText } = renderInput();
+
+			expect(getByText('References')).toBeTruthy();
+			expect(getByText('Fix the login bug')).toBeTruthy();
+		});
+
+		it('passes selectedReferenceIndex to the autocomplete menu', () => {
+			mockReferenceShowAutocomplete = true;
+			mockReferenceSelectedIndex = 1;
+			mockReferenceResults = [
+				{ type: 'task', id: 't-1', displayText: 'First task' },
+				{ type: 'task', id: 't-2', displayText: 'Second task' },
+			];
+
+			const { getAllByRole } = renderInput();
+
+			const buttons = getAllByRole('button');
+			// Find the two task buttons (may have more buttons for other UI)
+			const taskButtons = buttons.filter(
+				(b) => b.textContent?.includes('First task') || b.textContent?.includes('Second task')
+			);
+			// The second task button (index 1) should have the selected style
+			expect(taskButtons[1].className).toContain('border-blue-500');
+			expect(taskButtons[0].className).not.toContain('border-blue-500');
+		});
+	});
+});

--- a/packages/web/src/components/__tests__/MessageInput.reference-autocomplete.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.reference-autocomplete.test.tsx
@@ -347,14 +347,19 @@ describe('MessageInput reference autocomplete', () => {
 				{ type: 'task', id: 't-2', displayText: 'Second task' },
 			];
 
-			const { getAllByRole } = renderInput();
+			const { container } = renderInput();
 
-			const buttons = getAllByRole('button');
-			const taskButtons = buttons.filter(
+			// The grouped component renders buttons with type="button"
+			const resultButtons = container.querySelectorAll('button[type="button"]');
+			// Exclude the send/stop button (last one, inside the pill border)
+			// The reference buttons are the first N buttons rendered by ReferenceAutocomplete
+			const refButtons = Array.from(resultButtons).filter(
 				(b) => b.textContent?.includes('First task') || b.textContent?.includes('Second task')
 			);
-			expect(taskButtons[1].className).toContain('border-blue-500');
-			expect(taskButtons[0].className).not.toContain('border-blue-500');
+			// selectedIndex=1 → second result is highlighted
+			expect(refButtons).toHaveLength(2);
+			expect(refButtons[1].className).toContain('border-blue-500');
+			expect(refButtons[0].className).not.toContain('border-blue-500');
 		});
 	});
 });

--- a/packages/web/src/components/__tests__/ReferenceAutocomplete.test.tsx
+++ b/packages/web/src/components/__tests__/ReferenceAutocomplete.test.tsx
@@ -1,278 +1,190 @@
 // @ts-nocheck
-/**
- * Tests for ReferenceAutocomplete Component
- */
-
-import { render, fireEvent } from '@testing-library/preact';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ReferenceAutocomplete from '../ReferenceAutocomplete';
 import type { ReferenceSearchResult } from '@neokai/shared';
 
-const taskResult: ReferenceSearchResult = {
+const TASK_RESULT: ReferenceSearchResult = {
 	type: 'task',
-	id: 't-1',
-	displayText: 'Fix login bug',
-	subtitle: 'in-progress',
+	id: 't-42',
+	shortId: 't-42',
+	displayText: 'Fix the login bug',
+	subtitle: 'in progress',
 };
 
-const goalResult: ReferenceSearchResult = {
-	type: 'goal',
-	id: 'g-1',
-	displayText: 'Launch v2',
-	subtitle: 'active',
-};
-
-const fileResult: ReferenceSearchResult = {
+const FILE_RESULT: ReferenceSearchResult = {
 	type: 'file',
-	id: 'src/app.ts',
-	displayText: 'app.ts',
-	subtitle: 'src/app.ts',
+	id: 'src/auth.ts',
+	displayText: 'src/auth.ts',
 };
 
-const folderResult: ReferenceSearchResult = {
+const GOAL_RESULT: ReferenceSearchResult = {
+	type: 'goal',
+	id: 'g-7',
+	shortId: 'g-7',
+	displayText: 'Launch v2',
+	subtitle: 'measurable',
+};
+
+const FOLDER_RESULT: ReferenceSearchResult = {
 	type: 'folder',
 	id: 'src',
 	displayText: 'src',
-	subtitle: 'src/',
-};
-
-const defaultProps = {
-	results: [taskResult, goalResult, fileResult, folderResult],
-	selectedIndex: 0,
-	onSelect: vi.fn(),
-	onClose: vi.fn(),
 };
 
 describe('ReferenceAutocomplete', () => {
 	beforeEach(() => {
-		vi.resetAllMocks();
+		cleanup();
 	});
 
 	afterEach(() => {
-		vi.restoreAllMocks();
+		cleanup();
 	});
 
-	describe('Rendering', () => {
+	describe('rendering', () => {
 		it('renders nothing when results is empty', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} results={[]} />);
+			const { container } = render(
+				<ReferenceAutocomplete
+					results={[]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={vi.fn()}
+				/>
+			);
 			expect(container.firstChild).toBeNull();
 		});
 
-		it('renders the container when results are present', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			expect(container.querySelector('div')).toBeTruthy();
-		});
-
-		it('shows "References" header when results include tasks or goals', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			expect(container.textContent).toContain('References');
-		});
-
-		it('shows "Files & Folders" header when results contain only file/folder types', () => {
-			const { container } = render(
-				<ReferenceAutocomplete {...defaultProps} results={[fileResult, folderResult]} />
+		it('renders all result items', () => {
+			const { getAllByRole } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT, FILE_RESULT]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={vi.fn()}
+				/>
 			);
-			expect(container.textContent).toContain('Files & Folders');
+			const buttons = getAllByRole('button');
+			expect(buttons).toHaveLength(2);
 		});
 
-		it('shows "Files & Folders" header for file-only results', () => {
-			const { container } = render(
-				<ReferenceAutocomplete {...defaultProps} results={[fileResult]} />
+		it('renders display text for each result', () => {
+			const { getByText } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT, FILE_RESULT]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={vi.fn()}
+				/>
 			);
-			expect(container.textContent).toContain('Files & Folders');
+			expect(getByText('Fix the login bug')).toBeTruthy();
+			expect(getByText('src/auth.ts')).toBeTruthy();
 		});
 
-		it('shows "Files & Folders" header for folder-only results', () => {
-			const { container } = render(
-				<ReferenceAutocomplete {...defaultProps} results={[folderResult]} />
+		it('renders subtitle when present', () => {
+			const { getByText } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={vi.fn()}
+				/>
 			);
-			expect(container.textContent).toContain('Files & Folders');
+			expect(getByText('in progress')).toBeTruthy();
 		});
 
-		it('shows "References" header when task results are present alongside files', () => {
-			const { container } = render(
-				<ReferenceAutocomplete {...defaultProps} results={[taskResult, fileResult]} />
+		it('renders shortId when present', () => {
+			const { getByText } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={vi.fn()}
+				/>
 			);
-			expect(container.textContent).toContain('References');
+			expect(getByText('t-42')).toBeTruthy();
 		});
 
-		it('renders displayText for each result', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			expect(container.textContent).toContain('Fix login bug');
-			expect(container.textContent).toContain('Launch v2');
-			expect(container.textContent).toContain('app.ts');
-			expect(container.textContent).toContain('src');
-		});
-
-		it('renders subtitle for results that have it', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			expect(container.textContent).toContain('in-progress');
-			expect(container.textContent).toContain('active');
-			expect(container.textContent).toContain('src/app.ts');
-		});
-
-		it('does not render subtitle element when subtitle is absent', () => {
-			const resultNoSubtitle: ReferenceSearchResult = {
-				type: 'file',
-				id: 'readme.md',
-				displayText: 'README.md',
-			};
-			const { container } = render(
-				<ReferenceAutocomplete {...defaultProps} results={[resultNoSubtitle]} />
+		it('renders header with @ References label', () => {
+			const { getByText } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={vi.fn()}
+				/>
 			);
-			// Only one text span inside the button (displayText), no subtitle span
-			const buttons = container.querySelectorAll('button[type="button"]');
-			expect(buttons.length).toBe(1);
-			const spans = buttons[0].querySelectorAll('span > span');
-			// inner column has one child: displayText only
-			expect(spans.length).toBe(1);
+			expect(getByText('References')).toBeTruthy();
 		});
 
-		it('renders group section labels', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			expect(container.textContent).toContain('Tasks');
-			expect(container.textContent).toContain('Goals');
-			expect(container.textContent).toContain('Files');
-			expect(container.textContent).toContain('Folders');
-		});
-
-		it('does not render empty group section labels', () => {
-			const { container } = render(
-				<ReferenceAutocomplete {...defaultProps} results={[taskResult]} />
+		it('applies selected style to the active item', () => {
+			const { getAllByRole } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT, FILE_RESULT]}
+					selectedIndex={1}
+					onSelect={vi.fn()}
+					onClose={vi.fn()}
+				/>
 			);
-			expect(container.textContent).toContain('Tasks');
-			expect(container.textContent).not.toContain('Goals');
-			expect(container.textContent).not.toContain('Files');
-			expect(container.textContent).not.toContain('Folders');
+			const buttons = getAllByRole('button');
+			expect(buttons[1].className).toContain('border-blue-500');
+			expect(buttons[0].className).not.toContain('border-blue-500');
 		});
 
-		it('renders keyboard hint footer', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			expect(container.textContent).toContain('↑↓');
-			expect(container.textContent).toContain('Enter');
-			expect(container.textContent).toContain('Esc');
+		it('renders all four reference types', () => {
+			const { getAllByRole } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT, GOAL_RESULT, FILE_RESULT, FOLDER_RESULT]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={vi.fn()}
+				/>
+			);
+			expect(getAllByRole('button')).toHaveLength(4);
 		});
 	});
 
-	describe('Selection highlighting', () => {
-		it('applies selected styling to the item at selectedIndex', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			expect(buttons[0].className).toContain('bg-blue-500/20');
-			expect(buttons[0].className).toContain('border-blue-500');
-		});
-
-		it('does not apply selected styling to non-selected items', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			for (let i = 1; i < buttons.length; i++) {
-				expect(buttons[i].className).not.toContain('bg-blue-500/20');
-			}
-		});
-
-		it('applies selected styling to the correct item when selectedIndex changes', () => {
-			const { container, rerender } = render(
-				<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />
+	describe('interaction', () => {
+		it('calls onSelect with the result when a button is clicked', () => {
+			const onSelect = vi.fn();
+			const { getAllByRole } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT, FILE_RESULT]}
+					selectedIndex={0}
+					onSelect={onSelect}
+					onClose={vi.fn()}
+				/>
 			);
-			rerender(<ReferenceAutocomplete {...defaultProps} selectedIndex={2} />);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			expect(buttons[2].className).toContain('bg-blue-500/20');
-			expect(buttons[0].className).not.toContain('bg-blue-500/20');
-		});
-	});
-
-	describe('Click selection', () => {
-		it('calls onSelect with the correct result when a button is clicked', () => {
-			const onSelect = vi.fn();
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			fireEvent.click(buttons[0]);
-			expect(onSelect).toHaveBeenCalledTimes(1);
-			expect(onSelect).toHaveBeenCalledWith(taskResult);
+			fireEvent.click(getAllByRole('button')[1]);
+			expect(onSelect).toHaveBeenCalledOnce();
+			expect(onSelect).toHaveBeenCalledWith(FILE_RESULT);
 		});
 
-		it('calls onSelect with the goal result when goal button is clicked', () => {
-			const onSelect = vi.fn();
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			fireEvent.click(buttons[1]);
-			expect(onSelect).toHaveBeenCalledWith(goalResult);
-		});
-
-		it('calls onSelect with the file result when file button is clicked', () => {
-			const onSelect = vi.fn();
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			fireEvent.click(buttons[2]);
-			expect(onSelect).toHaveBeenCalledWith(fileResult);
-		});
-	});
-
-	describe('Click outside', () => {
-		it('calls onClose when clicking outside the component', () => {
+		it('calls onClose when clicking outside the menu', () => {
 			const onClose = vi.fn();
-			const { container } = render(
-				<div>
-					<ReferenceAutocomplete {...defaultProps} onClose={onClose} />
-					<div data-testid="outside">Outside</div>
-				</div>
+			render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={onClose}
+				/>
 			);
-			const outside = container.querySelector('[data-testid="outside"]');
-			fireEvent.mouseDown(outside!);
-			expect(onClose).toHaveBeenCalledTimes(1);
+			fireEvent.mouseDown(document.body);
+			expect(onClose).toHaveBeenCalledOnce();
 		});
 
-		it('does not call onClose when clicking inside the component', () => {
+		it('does not call onClose when clicking inside the menu', () => {
 			const onClose = vi.fn();
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} onClose={onClose} />);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			fireEvent.mouseDown(buttons[0]);
+			const { getAllByRole } = render(
+				<ReferenceAutocomplete
+					results={[TASK_RESULT]}
+					selectedIndex={0}
+					onSelect={vi.fn()}
+					onClose={onClose}
+				/>
+			);
+			fireEvent.mouseDown(getAllByRole('button')[0]);
 			expect(onClose).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('Positioning', () => {
-		it('defaults to bottom positioning (above textarea) when no position is given', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			const dropdown = container.querySelector('div');
-			// style should have marginBottom set and no top
-			expect(dropdown?.style.marginBottom).toBe('8px');
-			expect(dropdown?.style.top).toBe('');
-		});
-
-		it('applies explicit top/left position when position prop is provided', () => {
-			const { container } = render(
-				<ReferenceAutocomplete {...defaultProps} position={{ top: 100, left: 50 }} />
-			);
-			const dropdown = container.querySelector('div');
-			expect(dropdown?.style.top).toBe('100px');
-			expect(dropdown?.style.left).toBe('50px');
-		});
-	});
-
-	describe('Group ordering', () => {
-		it('renders groups in order: Tasks, Goals, Files, Folders', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			const sectionLabels = Array.from(container.querySelectorAll('span.text-\\[10px\\]')).map(
-				(el) => el.textContent?.trim()
-			);
-			expect(sectionLabels).toEqual(['Tasks', 'Goals', 'Files', 'Folders']);
-		});
-	});
-
-	describe('Result count', () => {
-		it('renders the correct number of result buttons', () => {
-			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			expect(buttons.length).toBe(4);
-		});
-
-		it('renders only matching buttons for single-type results', () => {
-			const { container } = render(
-				<ReferenceAutocomplete {...defaultProps} results={[taskResult]} />
-			);
-			const buttons = container.querySelectorAll('button[type="button"]');
-			expect(buttons.length).toBe(1);
 		});
 	});
 });

--- a/packages/web/src/components/__tests__/ReferenceAutocomplete.test.tsx
+++ b/packages/web/src/components/__tests__/ReferenceAutocomplete.test.tsx
@@ -1,190 +1,278 @@
 // @ts-nocheck
-import { cleanup, fireEvent, render } from '@testing-library/preact';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+/**
+ * Tests for ReferenceAutocomplete Component
+ */
+
+import { render, fireEvent } from '@testing-library/preact';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ReferenceAutocomplete from '../ReferenceAutocomplete';
 import type { ReferenceSearchResult } from '@neokai/shared';
 
-const TASK_RESULT: ReferenceSearchResult = {
+const taskResult: ReferenceSearchResult = {
 	type: 'task',
-	id: 't-42',
-	shortId: 't-42',
-	displayText: 'Fix the login bug',
-	subtitle: 'in progress',
+	id: 't-1',
+	displayText: 'Fix login bug',
+	subtitle: 'in-progress',
 };
 
-const FILE_RESULT: ReferenceSearchResult = {
-	type: 'file',
-	id: 'src/auth.ts',
-	displayText: 'src/auth.ts',
-};
-
-const GOAL_RESULT: ReferenceSearchResult = {
+const goalResult: ReferenceSearchResult = {
 	type: 'goal',
-	id: 'g-7',
-	shortId: 'g-7',
+	id: 'g-1',
 	displayText: 'Launch v2',
-	subtitle: 'measurable',
+	subtitle: 'active',
 };
 
-const FOLDER_RESULT: ReferenceSearchResult = {
+const fileResult: ReferenceSearchResult = {
+	type: 'file',
+	id: 'src/app.ts',
+	displayText: 'app.ts',
+	subtitle: 'src/app.ts',
+};
+
+const folderResult: ReferenceSearchResult = {
 	type: 'folder',
 	id: 'src',
 	displayText: 'src',
+	subtitle: 'src/',
+};
+
+const defaultProps = {
+	results: [taskResult, goalResult, fileResult, folderResult],
+	selectedIndex: 0,
+	onSelect: vi.fn(),
+	onClose: vi.fn(),
 };
 
 describe('ReferenceAutocomplete', () => {
 	beforeEach(() => {
-		cleanup();
+		vi.resetAllMocks();
 	});
 
 	afterEach(() => {
-		cleanup();
+		vi.restoreAllMocks();
 	});
 
-	describe('rendering', () => {
+	describe('Rendering', () => {
 		it('renders nothing when results is empty', () => {
-			const { container } = render(
-				<ReferenceAutocomplete
-					results={[]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={vi.fn()}
-				/>
-			);
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} results={[]} />);
 			expect(container.firstChild).toBeNull();
 		});
 
-		it('renders all result items', () => {
-			const { getAllByRole } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT, FILE_RESULT]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={vi.fn()}
-				/>
-			);
-			const buttons = getAllByRole('button');
-			expect(buttons).toHaveLength(2);
+		it('renders the container when results are present', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.querySelector('div')).toBeTruthy();
 		});
 
-		it('renders display text for each result', () => {
-			const { getByText } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT, FILE_RESULT]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={vi.fn()}
-				/>
-			);
-			expect(getByText('Fix the login bug')).toBeTruthy();
-			expect(getByText('src/auth.ts')).toBeTruthy();
+		it('shows "References" header when results include tasks or goals', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('References');
 		});
 
-		it('renders subtitle when present', () => {
-			const { getByText } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={vi.fn()}
-				/>
+		it('shows "Files & Folders" header when results contain only file/folder types', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[fileResult, folderResult]} />
 			);
-			expect(getByText('in progress')).toBeTruthy();
+			expect(container.textContent).toContain('Files & Folders');
 		});
 
-		it('renders shortId when present', () => {
-			const { getByText } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={vi.fn()}
-				/>
+		it('shows "Files & Folders" header for file-only results', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[fileResult]} />
 			);
-			expect(getByText('t-42')).toBeTruthy();
+			expect(container.textContent).toContain('Files & Folders');
 		});
 
-		it('renders header with @ References label', () => {
-			const { getByText } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={vi.fn()}
-				/>
+		it('shows "Files & Folders" header for folder-only results', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[folderResult]} />
 			);
-			expect(getByText('References')).toBeTruthy();
+			expect(container.textContent).toContain('Files & Folders');
 		});
 
-		it('applies selected style to the active item', () => {
-			const { getAllByRole } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT, FILE_RESULT]}
-					selectedIndex={1}
-					onSelect={vi.fn()}
-					onClose={vi.fn()}
-				/>
+		it('shows "References" header when task results are present alongside files', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[taskResult, fileResult]} />
 			);
-			const buttons = getAllByRole('button');
-			expect(buttons[1].className).toContain('border-blue-500');
-			expect(buttons[0].className).not.toContain('border-blue-500');
+			expect(container.textContent).toContain('References');
 		});
 
-		it('renders all four reference types', () => {
-			const { getAllByRole } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT, GOAL_RESULT, FILE_RESULT, FOLDER_RESULT]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={vi.fn()}
-				/>
+		it('renders displayText for each result', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('Fix login bug');
+			expect(container.textContent).toContain('Launch v2');
+			expect(container.textContent).toContain('app.ts');
+			expect(container.textContent).toContain('src');
+		});
+
+		it('renders subtitle for results that have it', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('in-progress');
+			expect(container.textContent).toContain('active');
+			expect(container.textContent).toContain('src/app.ts');
+		});
+
+		it('does not render subtitle element when subtitle is absent', () => {
+			const resultNoSubtitle: ReferenceSearchResult = {
+				type: 'file',
+				id: 'readme.md',
+				displayText: 'README.md',
+			};
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[resultNoSubtitle]} />
 			);
-			expect(getAllByRole('button')).toHaveLength(4);
+			// Only one text span inside the button (displayText), no subtitle span
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons.length).toBe(1);
+			const spans = buttons[0].querySelectorAll('span > span');
+			// inner column has one child: displayText only
+			expect(spans.length).toBe(1);
+		});
+
+		it('renders group section labels', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('Tasks');
+			expect(container.textContent).toContain('Goals');
+			expect(container.textContent).toContain('Files');
+			expect(container.textContent).toContain('Folders');
+		});
+
+		it('does not render empty group section labels', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[taskResult]} />
+			);
+			expect(container.textContent).toContain('Tasks');
+			expect(container.textContent).not.toContain('Goals');
+			expect(container.textContent).not.toContain('Files');
+			expect(container.textContent).not.toContain('Folders');
+		});
+
+		it('renders keyboard hint footer', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			expect(container.textContent).toContain('↑↓');
+			expect(container.textContent).toContain('Enter');
+			expect(container.textContent).toContain('Esc');
 		});
 	});
 
-	describe('interaction', () => {
-		it('calls onSelect with the result when a button is clicked', () => {
+	describe('Selection highlighting', () => {
+		it('applies selected styling to the item at selectedIndex', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons[0].className).toContain('bg-blue-500/20');
+			expect(buttons[0].className).toContain('border-blue-500');
+		});
+
+		it('does not apply selected styling to non-selected items', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			for (let i = 1; i < buttons.length; i++) {
+				expect(buttons[i].className).not.toContain('bg-blue-500/20');
+			}
+		});
+
+		it('applies selected styling to the correct item when selectedIndex changes', () => {
+			const { container, rerender } = render(
+				<ReferenceAutocomplete {...defaultProps} selectedIndex={0} />
+			);
+			rerender(<ReferenceAutocomplete {...defaultProps} selectedIndex={2} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons[2].className).toContain('bg-blue-500/20');
+			expect(buttons[0].className).not.toContain('bg-blue-500/20');
+		});
+	});
+
+	describe('Click selection', () => {
+		it('calls onSelect with the correct result when a button is clicked', () => {
 			const onSelect = vi.fn();
-			const { getAllByRole } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT, FILE_RESULT]}
-					selectedIndex={0}
-					onSelect={onSelect}
-					onClose={vi.fn()}
-				/>
-			);
-			fireEvent.click(getAllByRole('button')[1]);
-			expect(onSelect).toHaveBeenCalledOnce();
-			expect(onSelect).toHaveBeenCalledWith(FILE_RESULT);
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			fireEvent.click(buttons[0]);
+			expect(onSelect).toHaveBeenCalledTimes(1);
+			expect(onSelect).toHaveBeenCalledWith(taskResult);
 		});
 
-		it('calls onClose when clicking outside the menu', () => {
-			const onClose = vi.fn();
-			render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={onClose}
-				/>
-			);
-			fireEvent.mouseDown(document.body);
-			expect(onClose).toHaveBeenCalledOnce();
+		it('calls onSelect with the goal result when goal button is clicked', () => {
+			const onSelect = vi.fn();
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			fireEvent.click(buttons[1]);
+			expect(onSelect).toHaveBeenCalledWith(goalResult);
 		});
 
-		it('does not call onClose when clicking inside the menu', () => {
+		it('calls onSelect with the file result when file button is clicked', () => {
+			const onSelect = vi.fn();
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} onSelect={onSelect} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			fireEvent.click(buttons[2]);
+			expect(onSelect).toHaveBeenCalledWith(fileResult);
+		});
+	});
+
+	describe('Click outside', () => {
+		it('calls onClose when clicking outside the component', () => {
 			const onClose = vi.fn();
-			const { getAllByRole } = render(
-				<ReferenceAutocomplete
-					results={[TASK_RESULT]}
-					selectedIndex={0}
-					onSelect={vi.fn()}
-					onClose={onClose}
-				/>
+			const { container } = render(
+				<div>
+					<ReferenceAutocomplete {...defaultProps} onClose={onClose} />
+					<div data-testid="outside">Outside</div>
+				</div>
 			);
-			fireEvent.mouseDown(getAllByRole('button')[0]);
+			const outside = container.querySelector('[data-testid="outside"]');
+			fireEvent.mouseDown(outside!);
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not call onClose when clicking inside the component', () => {
+			const onClose = vi.fn();
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} onClose={onClose} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			fireEvent.mouseDown(buttons[0]);
 			expect(onClose).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Positioning', () => {
+		it('defaults to bottom positioning (above textarea) when no position is given', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			const dropdown = container.querySelector('div');
+			// style should have marginBottom set and no top
+			expect(dropdown?.style.marginBottom).toBe('8px');
+			expect(dropdown?.style.top).toBe('');
+		});
+
+		it('applies explicit top/left position when position prop is provided', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} position={{ top: 100, left: 50 }} />
+			);
+			const dropdown = container.querySelector('div');
+			expect(dropdown?.style.top).toBe('100px');
+			expect(dropdown?.style.left).toBe('50px');
+		});
+	});
+
+	describe('Group ordering', () => {
+		it('renders groups in order: Tasks, Goals, Files, Folders', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			const sectionLabels = Array.from(container.querySelectorAll('span.text-\\[10px\\]')).map(
+				(el) => el.textContent?.trim()
+			);
+			expect(sectionLabels).toEqual(['Tasks', 'Goals', 'Files', 'Folders']);
+		});
+	});
+
+	describe('Result count', () => {
+		it('renders the correct number of result buttons', () => {
+			const { container } = render(<ReferenceAutocomplete {...defaultProps} />);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons.length).toBe(4);
+		});
+
+		it('renders only matching buttons for single-type results', () => {
+			const { container } = render(
+				<ReferenceAutocomplete {...defaultProps} results={[taskResult]} />
+			);
+			const buttons = container.querySelectorAll('button[type="button"]');
+			expect(buttons.length).toBe(1);
 		});
 	});
 });


### PR DESCRIPTION
- Create ReferenceAutocomplete component with type icons (task/goal/file/folder),
  display text, subtitle, shortId, and keyboard navigation hints
- Extend InputTextarea with showReferenceAutocomplete, referenceResults,
  selectedReferenceIndex, onReferenceSelect, onReferenceClose props and
  optional textareaRef forwarding for post-selection focus
- Wire useReferenceAutocomplete into MessageInput: handleReferenceSelect
  replaces @query with @ref{type:id} token and refocuses textarea
- Reference autocomplete takes keyboard event precedence over command autocomplete
- Supports combining / commands and @ references (e.g. /agent @task-t-42 fix)
- Add 20 new tests: ReferenceAutocomplete component and MessageInput integration
- Fix MessageInput.queue-mode test mock to include useReferenceAutocomplete
