### PR TITLE
feat(web): integrate reference autocomplete with InputTextarea

### DIFF
--- a/packages/web/src/components/InputTextarea.tsx
+++ b/packages/web/src/components/InputTextarea.tsx
@@ -29,6 +29,8 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import { cn } from '../lib/utils.ts';
 import { borderColors } from '../lib/design-tokens.ts';
 import CommandAutocomplete from './CommandAutocomplete.tsx';
+import ReferenceAutocomplete from './ReferenceAutocomplete.tsx';
+import type { ReferenceMention, ReferenceSearchResult } from '@neokai/shared';
 
 export interface InputTextareaProps {
 	content: string;
@@ -44,6 +46,12 @@ export interface InputTextareaProps {
 	selectedCommandIndex?: number;
 	onCommandSelect?: (command: string) => void;
 	onCommandClose?: () => void;
+	// Reference autocomplete
+	showReferenceAutocomplete?: boolean;
+	referenceResults?: ReferenceSearchResult[];
+	selectedReferenceIndex?: number;
+	onReferenceSelect?: (reference: ReferenceMention) => void;
+	onReferenceClose?: () => void;
 	// Agent state - passed as prop to avoid direct signal reads that cause re-renders
 	isAgentWorking?: boolean;
 	onStop?: () => void;
@@ -70,6 +78,11 @@ export function InputTextarea({
 	selectedCommandIndex = 0,
 	onCommandSelect,
 	onCommandClose,
+	showReferenceAutocomplete = false,
+	referenceResults,
+	selectedReferenceIndex,
+	onReferenceSelect,
+	onReferenceClose,
 	isAgentWorking = false,
 	onStop,
 	onPaste,
@@ -140,16 +153,30 @@ export function InputTextarea({
 	const showStop = isAgentWorking && !hasContent && !!onStop;
 	const textareaLeftPadding = leadingElement ? (leadingPaddingClass ?? 'pl-28') : 'pl-5';
 
+	// Count @ref{} tokens in content
+	const refCount = [...content.matchAll(/@ref\{[^}:]+:[^}]+\}/g)].length;
+
 	return (
 		<div class="relative flex-1">
-			{/* Command Autocomplete */}
-			{showCommandAutocomplete && onCommandSelect && onCommandClose && (
-				<CommandAutocomplete
-					commands={filteredCommands}
-					selectedIndex={selectedCommandIndex}
-					onSelect={onCommandSelect}
-					onClose={onCommandClose}
+			{/* Autocomplete menus — only one shown at a time; reference takes priority */}
+			{showReferenceAutocomplete && onReferenceSelect && onReferenceClose ? (
+				<ReferenceAutocomplete
+					results={referenceResults ?? []}
+					selectedIndex={selectedReferenceIndex ?? 0}
+					onSelect={onReferenceSelect}
+					onClose={onReferenceClose}
 				/>
+			) : (
+				showCommandAutocomplete &&
+				onCommandSelect &&
+				onCommandClose && (
+					<CommandAutocomplete
+						commands={filteredCommands}
+						selectedIndex={selectedCommandIndex}
+						onSelect={onCommandSelect}
+						onClose={onCommandClose}
+					/>
+				)
 			)}
 
 			<div
@@ -205,6 +232,31 @@ export function InputTextarea({
 						)}
 					>
 						{charCount}/{maxChars}
+					</div>
+				)}
+
+				{/* Reference Badge — shows count of @ref{} tokens in content */}
+				{refCount > 0 && (
+					<div
+						class="absolute -bottom-6 left-0 flex items-center gap-1 text-xs text-gray-400"
+						data-testid="reference-badge"
+					>
+						<svg
+							class="w-3 h-3"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							stroke-width={2}
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+							/>
+						</svg>
+						<span>
+							{refCount} {refCount === 1 ? 'reference' : 'references'}
+						</span>
 					</div>
 				)}
 

--- a/packages/web/src/components/InputTextarea.tsx
+++ b/packages/web/src/components/InputTextarea.tsx
@@ -30,7 +30,8 @@ import { cn } from '../lib/utils.ts';
 import { borderColors } from '../lib/design-tokens.ts';
 import CommandAutocomplete from './CommandAutocomplete.tsx';
 import ReferenceAutocomplete from './ReferenceAutocomplete.tsx';
-import type { ReferenceMention, ReferenceSearchResult } from '@neokai/shared';
+import type { ReferenceSearchResult } from '@neokai/shared';
+import { REFERENCE_PATTERN } from '@neokai/shared';
 
 export interface InputTextareaProps {
 	content: string;
@@ -50,7 +51,7 @@ export interface InputTextareaProps {
 	showReferenceAutocomplete?: boolean;
 	referenceResults?: ReferenceSearchResult[];
 	selectedReferenceIndex?: number;
-	onReferenceSelect?: (reference: ReferenceMention) => void;
+	onReferenceSelect?: (result: ReferenceSearchResult) => void;
 	onReferenceClose?: () => void;
 	// Agent state - passed as prop to avoid direct signal reads that cause re-renders
 	isAgentWorking?: boolean;
@@ -153,8 +154,9 @@ export function InputTextarea({
 	const showStop = isAgentWorking && !hasContent && !!onStop;
 	const textareaLeftPadding = leadingElement ? (leadingPaddingClass ?? 'pl-28') : 'pl-5';
 
-	// Count @ref{} tokens in content
-	const refCount = [...content.matchAll(/@ref\{[^}:]+:[^}]+\}/g)].length;
+	// Count @ref{} tokens in content — use REFERENCE_PATTERN.source to get a fresh regex
+	// instance each render, avoiding stale lastIndex from the shared global-flag regex.
+	const refCount = [...content.matchAll(new RegExp(REFERENCE_PATTERN.source, 'g'))].length;
 
 	return (
 		<div class="relative flex-1">

--- a/packages/web/src/components/ReferenceAutocomplete.tsx
+++ b/packages/web/src/components/ReferenceAutocomplete.tsx
@@ -153,6 +153,8 @@ export default function ReferenceAutocomplete({
 	return (
 		<div
 			ref={containerRef}
+			role="listbox"
+			aria-label={headerLabel}
 			class={cn(
 				`absolute z-50 bg-dark-800 border ${borderColors.ui.default} rounded-lg shadow-xl`,
 				'overflow-hidden max-h-72 overflow-y-auto',
@@ -198,6 +200,8 @@ export default function ReferenceAutocomplete({
 								key={`${result.type}:${result.id}`}
 								ref={globalIndex === selectedIndex ? selectedItemRef : null}
 								type="button"
+								role="option"
+								aria-selected={globalIndex === selectedIndex}
 								onClick={() => onSelect(result)}
 								class={cn(
 									'w-full px-3 py-2 text-left transition-colors flex items-start gap-2',

--- a/packages/web/src/components/__tests__/InputTextarea.test.tsx
+++ b/packages/web/src/components/__tests__/InputTextarea.test.tsx
@@ -677,6 +677,182 @@ describe('InputTextarea', () => {
 		});
 	});
 
+	describe('Reference Autocomplete', () => {
+		it('should render ReferenceAutocomplete when showReferenceAutocomplete is true with results', () => {
+			const results = [
+				{
+					type: 'task' as const,
+					id: 'task-1',
+					shortId: 't-1',
+					displayText: 'Fix the login bug',
+					subtitle: 'open',
+				},
+			];
+			const onReferenceSelect = vi.fn();
+			const onReferenceClose = vi.fn();
+
+			const { container } = render(
+				<InputTextarea
+					content="@fix"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					showReferenceAutocomplete={true}
+					referenceResults={results}
+					selectedReferenceIndex={0}
+					onReferenceSelect={onReferenceSelect}
+					onReferenceClose={onReferenceClose}
+				/>
+			);
+
+			expect(container.textContent).toContain('Fix the login bug');
+		});
+
+		it('should not render ReferenceAutocomplete when callbacks are missing', () => {
+			const results = [{ type: 'task' as const, id: 'task-1', displayText: 'Fix the login bug' }];
+
+			const { container } = render(
+				<InputTextarea
+					content="@fix"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					showReferenceAutocomplete={true}
+					referenceResults={results}
+					selectedReferenceIndex={0}
+				/>
+			);
+
+			expect(container.textContent).not.toContain('Fix the login bug');
+		});
+
+		it('should render CommandAutocomplete when only command autocomplete is active', () => {
+			const { container } = render(
+				<InputTextarea
+					content="/he"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					showCommandAutocomplete={true}
+					filteredCommands={['/help']}
+					selectedCommandIndex={0}
+					onCommandSelect={vi.fn()}
+					onCommandClose={vi.fn()}
+				/>
+			);
+
+			expect(container.textContent).toContain('/help');
+		});
+
+		it('should show only reference autocomplete when both are active (reference takes priority)', () => {
+			const onReferenceSelect = vi.fn();
+			const onReferenceClose = vi.fn();
+			const onCommandSelect = vi.fn();
+			const onCommandClose = vi.fn();
+			const results = [{ type: 'task' as const, id: 'task-1', displayText: 'A Task' }];
+
+			const { container } = render(
+				<InputTextarea
+					content="@task"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					showReferenceAutocomplete={true}
+					referenceResults={results}
+					selectedReferenceIndex={0}
+					onReferenceSelect={onReferenceSelect}
+					onReferenceClose={onReferenceClose}
+					showCommandAutocomplete={true}
+					filteredCommands={['/help']}
+					selectedCommandIndex={0}
+					onCommandSelect={onCommandSelect}
+					onCommandClose={onCommandClose}
+				/>
+			);
+
+			// Reference should be shown
+			expect(container.textContent).toContain('A Task');
+			// Command should NOT be shown
+			expect(container.textContent).not.toContain('/help');
+		});
+	});
+
+	describe('Reference Badge', () => {
+		it('should not show badge when content has no @ref{} tokens', () => {
+			const { container } = render(
+				<InputTextarea
+					content="hello world"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+				/>
+			);
+
+			expect(container.querySelector('[data-testid="reference-badge"]')).toBeNull();
+		});
+
+		it('should show badge with count when content has @ref{} tokens', () => {
+			const { container } = render(
+				<InputTextarea
+					content="check @ref{task:t-1} and @ref{file:src/foo.ts}"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+				/>
+			);
+
+			const badge = container.querySelector('[data-testid="reference-badge"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.textContent).toContain('2');
+			expect(badge?.textContent).toContain('references');
+		});
+
+		it('should show singular "reference" for a single @ref{} token', () => {
+			const { container } = render(
+				<InputTextarea
+					content="see @ref{goal:g-5} for details"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+				/>
+			);
+
+			const badge = container.querySelector('[data-testid="reference-badge"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.textContent).toContain('1');
+			expect(badge?.textContent).toContain('reference');
+			expect(badge?.textContent).not.toContain('references');
+		});
+
+		it('should update badge count when content changes', () => {
+			const { container, rerender } = render(
+				<InputTextarea
+					content="@ref{task:t-1}"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+				/>
+			);
+
+			expect(container.querySelector('[data-testid="reference-badge"]')?.textContent).toContain(
+				'1'
+			);
+
+			rerender(
+				<InputTextarea
+					content="@ref{task:t-1} and @ref{task:t-2} and @ref{file:src/x.ts}"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+				/>
+			);
+
+			expect(container.querySelector('[data-testid="reference-badge"]')?.textContent).toContain(
+				'3'
+			);
+		});
+	});
+
 	describe('Paste Event Forwarding', () => {
 		it('should call onPaste callback when paste event fires on textarea', () => {
 			const onPaste = vi.fn(() => {});

--- a/packages/web/src/hooks/__tests__/useReferenceAutocomplete.test.ts
+++ b/packages/web/src/hooks/__tests__/useReferenceAutocomplete.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { renderHook, act } from '@testing-library/preact';
-import { useReferenceAutocomplete, extractActiveAtQuery } from '../useReferenceAutocomplete.ts';
+import {
+	useReferenceAutocomplete,
+	extractActiveAtQuery,
+	insertReferenceMention,
+} from '../useReferenceAutocomplete.ts';
 
 // --------------------------------------------------------------------------
 // Mocks
@@ -89,6 +93,55 @@ describe('extractActiveAtQuery', () => {
 
 	it('returns empty string for trailing @', () => {
 		expect(extractActiveAtQuery('hello @')).toBe('');
+	});
+});
+
+// --------------------------------------------------------------------------
+// insertReferenceMention unit tests
+// --------------------------------------------------------------------------
+
+describe('insertReferenceMention', () => {
+	it('replaces @query at end of content with @ref token', () => {
+		const mention = { type: 'task' as const, id: 't-42', displayText: 'Fix bug' };
+		const result = insertReferenceMention('fix @bug', 'bug', mention);
+		expect(result).toBe('fix @ref{task:t-42} ');
+	});
+
+	it('replaces empty query (just @) with @ref token', () => {
+		const mention = { type: 'goal' as const, id: 'g-7', displayText: 'Goal' };
+		const result = insertReferenceMention('hello @', '', mention);
+		expect(result).toBe('hello @ref{goal:g-7} ');
+	});
+
+	it('returns content unchanged when @query is not at end', () => {
+		const mention = { type: 'task' as const, id: 't-1', displayText: 'Task' };
+		const result = insertReferenceMention('hello world', 'world', mention);
+		expect(result).toBe('hello world');
+	});
+
+	it('appends trailing space after token', () => {
+		const mention = { type: 'file' as const, id: 'src/foo.ts', displayText: 'foo.ts' };
+		const result = insertReferenceMention('@foo', 'foo', mention);
+		expect(result).toBe('@ref{file:src/foo.ts} ');
+	});
+
+	it('handles file references with path as id', () => {
+		const mention = { type: 'folder' as const, id: 'src/components', displayText: 'components' };
+		const result = insertReferenceMention('look at @comp', 'comp', mention);
+		expect(result).toBe('look at @ref{folder:src/components} ');
+	});
+
+	it('handles content with existing @ref tokens before the active query', () => {
+		const mention = { type: 'task' as const, id: 't-5', displayText: 'Task 5' };
+		const result = insertReferenceMention('@ref{task:t-1} fix @bug', 'bug', mention);
+		expect(result).toBe('@ref{task:t-1} fix @ref{task:t-5} ');
+	});
+
+	it('returns unchanged content when suffix does not match', () => {
+		const mention = { type: 'task' as const, id: 't-1', displayText: 'Task' };
+		// content ends with @query but query string doesn't match (different text)
+		const result = insertReferenceMention('hello @world', 'xyz', mention);
+		expect(result).toBe('hello @world');
 	});
 });
 

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -63,6 +63,7 @@ export {
 export {
 	useReferenceAutocomplete,
 	extractActiveAtQuery,
+	insertReferenceMention,
 	type UseReferenceAutocompleteOptions,
 	type UseReferenceAutocompleteResult,
 } from './useReferenceAutocomplete';

--- a/packages/web/src/hooks/useReferenceAutocomplete.ts
+++ b/packages/web/src/hooks/useReferenceAutocomplete.ts
@@ -77,6 +77,24 @@ export function extractActiveAtQuery(content: string): string | null {
 }
 
 /**
+ * Replace the active @query at the end of content with an @ref{type:id} token.
+ *
+ * Finds the suffix "@" + query at the end of content and replaces it with
+ * the formatted token followed by a space so the token does not re-trigger
+ * autocomplete. Returns content unchanged if the suffix is not found.
+ */
+export function insertReferenceMention(
+	content: string,
+	query: string,
+	mention: ReferenceMention
+): string {
+	const atQuery = '@' + query;
+	if (!content.endsWith(atQuery)) return content;
+	const token = `@ref{${mention.type}:${mention.id}} `;
+	return content.slice(0, content.length - atQuery.length) + token;
+}
+
+/**
  * Hook for managing @ reference autocomplete
  */
 export function useReferenceAutocomplete({


### PR DESCRIPTION
- Add ReferenceAutocomplete component with grouped results by type
  (Tasks, Goals, Files, Folders), icons, shortId display, and keyboard hints
- Add reference autocomplete props to InputTextarea: showReferenceAutocomplete,
  referenceResults, selectedReferenceIndex, onReferenceSelect, onReferenceClose
- Implement mutual exclusion: reference autocomplete takes priority over command
  autocomplete when both are active
- Add @ref{} token badge below textarea showing count of active references
- Export insertReferenceMention() utility for replacing @query with @ref{type:id}
  token in content (used by MessageInput in the next wiring task)
- 24 new tests covering component rendering, selection, click-outside, badge
  count updates, insertion logic, and menu switching
