### PR TITLE
fix(space): Phase 1 critical gap fixes for Space system reliability

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -497,8 +497,11 @@ export class SpaceRuntime {
 		const spaces = await this.config.spaceManager.listSpaces(false);
 
 		for (const space of spaces) {
-			// getRehydratableRuns returns 'in_progress' AND 'needs_attention' runs.
-			// 'pending' is still excluded — it's transient (task creation may have failed).
+			// getRehydratableRuns returns 'pending', 'in_progress' AND 'needs_attention' runs.
+			// 'pending' runs may exist if the daemon crashed between createRun() and
+			// updateStatus('in_progress'). We check whether tasks were already created:
+			//   - Tasks exist  → transition to in_progress and build executor normally
+			//   - No tasks     → transition to cancelled (task creation never happened)
 			// 'needs_attention' runs are included so a human-gate-blocked run gets its
 			// executor reloaded on restart, allowing it to advance once the gate is resolved.
 			const activeRuns = this.config.workflowRunRepo.getRehydratableRuns(space.id);
@@ -514,6 +517,30 @@ export class SpaceRuntime {
 					continue;
 				}
 
+				// Handle 'pending' runs that were interrupted before updateStatus('in_progress').
+				// We need to determine whether task creation completed before the crash.
+				if (run.status === 'pending') {
+					const existingTasks = this.config.taskRepo.listByWorkflowRun(run.id);
+					if (existingTasks.length === 0) {
+						// No tasks exist — the crash happened before task creation started.
+						// Cancel the run since we cannot safely resume without knowing what
+						// was supposed to be created.
+						log.info(
+							`SpaceRuntime: recovering orphaned 'pending' run ${run.id} — ` +
+								`no tasks found, cancelling run`
+						);
+						this.config.workflowRunRepo.updateStatus(run.id, 'cancelled');
+						continue;
+					}
+					// Tasks exist — the crash happened after task creation but before
+					// updateStatus('in_progress'). Complete the transition now.
+					log.info(
+						`SpaceRuntime: recovering 'pending' run ${run.id} — ` +
+							`${existingTasks.length} task(s) found, promoting to in_progress`
+					);
+					this.config.workflowRunRepo.updateStatus(run.id, 'in_progress');
+				}
+
 				const meta: ExecutorMeta = {
 					workflow,
 					spaceId: space.id,
@@ -521,7 +548,9 @@ export class SpaceRuntime {
 				};
 				this.executorMeta.set(run.id, meta);
 
-				const executor = this.buildExecutor(workflow, run, space.id, space.workspacePath);
+				// Re-read the run from DB to pick up the status transition above
+				const freshRun = this.config.workflowRunRepo.getRun(run.id)!;
+				const executor = this.buildExecutor(workflow, freshRun, space.id, space.workspacePath);
 				this.executors.set(run.id, executor);
 			}
 		}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -70,8 +70,6 @@ import { createStepAgentMcpServer } from '../tools/step-agent-tools';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
 import { Logger } from '../../logger';
 import { SpaceTaskManager } from '../managers/space-task-manager';
-import { GoalRepository } from '../../../storage/repositories/goal-repository';
-import type { ReactiveDatabase } from '../../../storage/reactive-database';
 
 const log = new Logger('task-agent-manager');
 
@@ -911,10 +909,7 @@ export class TaskAgentManager {
 					// Recalculate goal progress if this task is linked to a goal
 					if (stepTask.goalId) {
 						try {
-							const goalRepo = new GoalRepository(
-								this.config.db.getDatabase(),
-								this.config.db as unknown as ReactiveDatabase
-							);
+							const goalRepo = this.config.db.getGoalRepo();
 							goalRepo.recalculateProgressFromSpaceTasks(stepTask.goalId, this.config.taskRepo);
 						} catch (err) {
 							log.warn(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -70,6 +70,8 @@ import { createStepAgentMcpServer } from '../tools/step-agent-tools';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
 import { Logger } from '../../logger';
 import { SpaceTaskManager } from '../managers/space-task-manager';
+import { GoalRepository } from '../../../storage/repositories/goal-repository';
+import type { ReactiveDatabase } from '../../../storage/reactive-database';
 
 const log = new Logger('task-agent-manager');
 
@@ -905,6 +907,22 @@ export class TaskAgentManager {
 				if (spaceId) {
 					const taskManager = new SpaceTaskManager(this.config.db.getDatabase(), spaceId);
 					await taskManager.setTaskStatus(stepTask.id, 'completed');
+
+					// Recalculate goal progress if this task is linked to a goal
+					if (stepTask.goalId) {
+						try {
+							const goalRepo = new GoalRepository(
+								this.config.db.getDatabase(),
+								this.config.db as unknown as ReactiveDatabase
+							);
+							goalRepo.recalculateProgressFromSpaceTasks(stepTask.goalId, this.config.taskRepo);
+						} catch (err) {
+							log.warn(
+								`TaskAgentManager: failed to recalculate goal progress for goal ${stepTask.goalId}:`,
+								err
+							);
+						}
+					}
 				}
 			} catch (err) {
 				log.warn(`TaskAgentManager: failed to mark step task ${stepTask.id} as completed:`, err);
@@ -1216,6 +1234,16 @@ export class TaskAgentManager {
 					this.subSessions.set(taskId, new Map());
 				}
 				this.subSessions.get(taskId)!.set(subSessionId, subSession);
+
+				// Restart streaming for the restored sub-session.
+				// Errors are non-fatal — log a warning and continue.
+				try {
+					await subSession.startStreamingQuery();
+				} catch (err) {
+					log.warn(
+						`TaskAgentManager.rehydrate: startStreamingQuery failed for sub-session ${subSessionId}: ${err}`
+					);
+				}
 			}
 		}
 

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -638,6 +638,59 @@ export class GoalRepository {
 	}
 
 	// =========================================================================
+	// Space Goal Progress
+	// =========================================================================
+
+	/**
+	 * Recalculate goal progress from Space tasks (not Room tasks).
+	 *
+	 * Uses the same algorithm as GoalManager.calculateProgressFromTasks():
+	 * - completed → 100%
+	 * - needs_attention/cancelled → 0% (terminal, no contribution)
+	 * - otherwise → task.progress ?? 0
+	 * - Average of all tasks
+	 *
+	 * Returns the calculated progress value (0-100).
+	 */
+	recalculateProgressFromSpaceTasks(
+		goalId: string,
+		spaceTaskRepo: {
+			findByGoalId(goalId: string): Array<{ status: string; progress?: number | null }>;
+		}
+	): number {
+		const tasks = spaceTaskRepo.findByGoalId(goalId);
+
+		if (tasks.length === 0) {
+			this.updateGoal(goalId, { progress: 0 });
+			return 0;
+		}
+
+		let totalProgress = 0;
+		let taskCount = 0;
+
+		for (const task of tasks) {
+			if (task.status === 'completed') {
+				totalProgress += 100;
+			} else if (task.status === 'needs_attention' || task.status === 'cancelled') {
+				// Terminal tasks don't contribute to progress
+				totalProgress += 0;
+			} else {
+				totalProgress += task.progress ?? 0;
+			}
+			taskCount++;
+		}
+
+		if (taskCount === 0) {
+			this.updateGoal(goalId, { progress: 0 });
+			return 0;
+		}
+
+		const progress = Math.round(totalProgress / taskCount);
+		this.updateGoal(goalId, { progress });
+		return progress;
+	}
+
+	// =========================================================================
 	// Private helpers
 	// =========================================================================
 

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -680,11 +680,6 @@ export class GoalRepository {
 			taskCount++;
 		}
 
-		if (taskCount === 0) {
-			this.updateGoal(goalId, { progress: 0 });
-			return 0;
-		}
-
 		const progress = Math.round(totalProgress / taskCount);
 		this.updateGoal(goalId, { progress });
 		return progress;

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -94,18 +94,22 @@ export class SpaceWorkflowRunRepository {
 	}
 
 	/**
-	 * List runs that need an executor on startup: in_progress and needs_attention.
+	 * List runs that need an executor on startup: pending, in_progress, and needs_attention.
 	 *
 	 * This superset of getActiveRuns() is used exclusively by rehydrateExecutors()
 	 * so that runs blocked at a human gate (needs_attention) get an executor
 	 * reloaded on restart. Without this, a run waiting for human approval would
 	 * be permanently stuck after a process restart.
 	 *
-	 * `pending` is still excluded for the same reason as in getActiveRuns().
+	 * `pending` runs are included because a crash between createRun() and
+	 * updateStatus('in_progress') leaves a 'pending' run with no tasks. On restart,
+	 * rehydrateExecutors() checks whether tasks exist for the run:
+	 *   - Tasks exist  → transition to in_progress and build the executor
+	 *   - No tasks     → transition to cancelled (was interrupted before task creation)
 	 */
 	getRehydratableRuns(spaceId: string): SpaceWorkflowRun[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_workflow_runs WHERE space_id = ? AND status IN ('in_progress', 'needs_attention') ORDER BY created_at ASC`
+			`SELECT * FROM space_workflow_runs WHERE space_id = ? AND status IN ('pending', 'in_progress', 'needs_attention') ORDER BY created_at ASC`
 		);
 		const rows = stmt.all(spaceId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToRun(r));

--- a/packages/daemon/tests/unit/space/goal-repository-space-goal-progress.test.ts
+++ b/packages/daemon/tests/unit/space/goal-repository-space-goal-progress.test.ts
@@ -1,0 +1,389 @@
+/**
+ * GoalRepository.recalculateProgressFromSpaceTasks() Unit Tests
+ *
+ * Covers:
+ * - Empty tasks list returns 0 progress
+ * - completed task → 100%
+ * - needs_attention/cancelled → 0% (terminal, no contribution)
+ * - in_progress with progress value contributes its progress
+ * - pending task with no progress → 0%
+ * - Average of all non-terminal tasks
+ * - Mix of terminal and non-terminal tasks
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables, runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { GoalRepository } from '../../../src/storage/repositories/goal-repository.ts';
+import { noOpReactiveDb } from '../../helpers/reactive-database';
+
+// ---------------------------------------------------------------------------
+// Test DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-space-goal-progress',
+		`t-${Date.now()}-${Math.random()}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	createTables(db);
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+const SPACE_ID = 'space-1';
+const GOAL_ID = 'goal-test-1';
+
+function seedSpaceAndGoal(db: BunDatabase): void {
+	// Disable FK constraints when seeding — goals table has FK to rooms which
+	// isn't created in this isolated test DB. Re-enable after both inserts.
+	db.exec('PRAGMA foreign_keys = OFF');
+
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(SPACE_ID, '/tmp/ws', 'Test Space', Date.now(), Date.now());
+
+	db.prepare(
+		`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids,
+     metrics, created_at, updated_at, mission_type, autonomy_level, schedule, schedule_paused, next_run_at,
+     structured_metrics, max_consecutive_failures, max_planning_attempts, consecutive_failures,
+     replan_count, short_id)
+     VALUES (?, ?, ?, '', 'active', 'normal', 0, '[]', '{}', ?, ?, 'one_shot', 'supervised', NULL, 0, NULL,
+     NULL, 3, 0, 0, 0, NULL)`
+	).run(GOAL_ID, 'room-1', 'Test Goal', Date.now(), Date.now());
+
+	db.exec('PRAGMA foreign_keys = ON');
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('GoalRepository.recalculateProgressFromSpaceTasks', () => {
+	let db: BunDatabase;
+	let dir: string;
+	let spaceTaskRepo: SpaceTaskRepository;
+	let goalRepo: GoalRepository;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedSpaceAndGoal(db);
+		spaceTaskRepo = new SpaceTaskRepository(db);
+		goalRepo = new GoalRepository(db, noOpReactiveDb);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('returns 0 progress when no tasks exist for goal', () => {
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(0);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(0);
+	});
+
+	test('completed task contributes 100%', () => {
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Completed Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'completed',
+		});
+
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(100);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(100);
+	});
+
+	test('needs_attention task contributes 0% (terminal)', () => {
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Needs Attention Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'needs_attention',
+		});
+
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(0);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(0);
+	});
+
+	test('cancelled task contributes 0% (terminal)', () => {
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Cancelled Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'cancelled',
+		});
+
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(0);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(0);
+	});
+
+	test('in_progress task with progress contributes its progress value', () => {
+		const task = spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'In Progress Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'in_progress',
+		});
+		spaceTaskRepo.updateTask(task.id, { progress: 50 });
+
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(50);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(50);
+	});
+
+	test('pending task with no progress contributes 0%', () => {
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Pending Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'pending',
+			// progress not set → undefined/null
+		});
+
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(0);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(0);
+	});
+
+	test('multiple tasks returns average progress', () => {
+		// Task 1: completed → 100%
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Completed Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'completed',
+		});
+		// Task 2: in_progress with 50% → 50%
+		const halfDoneTask = spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Half Done Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'in_progress',
+		});
+		spaceTaskRepo.updateTask(halfDoneTask.id, { progress: 50 });
+		// Task 3: pending, no progress → 0%
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Not Started Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'pending',
+		});
+
+		// (100 + 50 + 0) / 3 = 50
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(50);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(50);
+	});
+
+	test('all completed tasks returns 100%', () => {
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Task 1',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'completed',
+		});
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Task 2',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'completed',
+		});
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Task 3',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'completed',
+		});
+
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(100);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(100);
+	});
+
+	test('mix of terminal and non-terminal tasks calculates correctly', () => {
+		// completed → 100%
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Completed',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'completed',
+		});
+		// needs_attention → 0% (terminal)
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Needs Attention',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'needs_attention',
+		});
+		// cancelled → 0% (terminal)
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Cancelled',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'cancelled',
+		});
+		// in_progress with 75% → 75%
+		const almostDoneTask = spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Almost Done',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'in_progress',
+		});
+		spaceTaskRepo.updateTask(almostDoneTask.id, { progress: 75 });
+
+		// (100 + 0 + 0 + 75) / 4 = 43.75 → rounded to 44
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(44);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(44);
+	});
+
+	test('only terminal tasks returns 0%', () => {
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Needs Attention',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'needs_attention',
+		});
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Cancelled',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'cancelled',
+		});
+
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(0);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(0);
+	});
+
+	test('progress is rounded to nearest integer', () => {
+		// Three tasks each at 33% → (33 + 33 + 33) / 3 = 33
+		const task1 = spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Task 1',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'in_progress',
+		});
+		spaceTaskRepo.updateTask(task1.id, { progress: 33 });
+
+		const task2 = spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Task 2',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'in_progress',
+		});
+		spaceTaskRepo.updateTask(task2.id, { progress: 33 });
+
+		const task3 = spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Task 3',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'in_progress',
+		});
+		spaceTaskRepo.updateTask(task3.id, { progress: 33 });
+
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(33);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(33);
+	});
+
+	test('tasks without matching goalId are excluded', () => {
+		// Create a task with different goalId
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Other Goal Task',
+			description: 'desc',
+			goalId: 'other-goal',
+			status: 'completed', // Would be 100% if included
+		});
+		// Create a task with no goalId
+		spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'No Goal Task',
+			description: 'desc',
+			// goalId intentionally omitted
+			status: 'completed', // Would be 100% if included
+		});
+		// Create a task with matching goalId
+		const ourGoalTask = spaceTaskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Our Goal Task',
+			description: 'desc',
+			goalId: GOAL_ID,
+			status: 'in_progress',
+		});
+		spaceTaskRepo.updateTask(ourGoalTask.id, { progress: 25 });
+
+		// Only our goal's task counts → 25
+		const progress = goalRepo.recalculateProgressFromSpaceTasks(GOAL_ID, spaceTaskRepo);
+		expect(progress).toBe(25);
+
+		const goal = goalRepo.getGoal(GOAL_ID);
+		expect(goal?.progress).toBe(25);
+	});
+});

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -1316,6 +1316,152 @@ describe('SpaceRuntime', () => {
 			const stepBTask = taskRepo.listByWorkflowRun(run.id).find((t) => t.workflowNodeId === STEP_B);
 			expect(stepBTask).toBeDefined();
 		});
+
+		test('rehydrates pending run with tasks: transitions to in_progress and builds executor', async () => {
+			// Simulates a crash between updateStatus('in_progress') and task creation completing.
+			// Tasks exist in DB, so the run should be promoted to in_progress and rehydrated.
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+				{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+			]);
+
+			// Create a 'pending' run (as if createRun() succeeded but updateStatus('in_progress') never ran)
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Interrupted Run',
+				currentNodeId: STEP_A,
+			});
+			expect(pendingRun.status).toBe('pending');
+
+			// Create the start step task as if task creation completed before the crash
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Plan',
+				description: '',
+				workflowRunId: pendingRun.id,
+				workflowNodeId: STEP_A,
+				status: 'pending',
+			});
+
+			// Fresh runtime should recover the pending run
+			const freshRuntime = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+			});
+
+			await freshRuntime.executeTick();
+
+			// Run should be promoted to in_progress
+			const recoveredRun = workflowRunRepo.getRun(pendingRun.id)!;
+			expect(recoveredRun.status).toBe('in_progress');
+
+			// Executor should be registered
+			expect(freshRuntime.getExecutor(pendingRun.id)).toBeDefined();
+
+			// Subsequent tick should process the existing task normally
+			const tasks = taskRepo.listByWorkflowRun(pendingRun.id);
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].status).toBe('pending');
+		});
+
+		test('rehydrates pending run without tasks: transitions to cancelled', async () => {
+			// Simulates a crash between createRun() and task creation.
+			// No tasks exist, so the run cannot be safely resumed — cancel it.
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			// Create a 'pending' run with no tasks (crash happened before task creation)
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Orphaned Pending Run',
+				currentNodeId: STEP_A,
+			});
+			expect(pendingRun.status).toBe('pending');
+
+			// No tasks created — simulating crash before task creation
+
+			// Fresh runtime should cancel the orphaned pending run
+			const freshRuntime = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+			});
+
+			await freshRuntime.executeTick();
+
+			// Run should be cancelled
+			const cancelledRun = workflowRunRepo.getRun(pendingRun.id)!;
+			expect(cancelledRun.status).toBe('cancelled');
+
+			// No executor should be registered
+			expect(freshRuntime.getExecutor(pendingRun.id)).toBeUndefined();
+			expect(freshRuntime.executorCount).toBe(0);
+		});
+
+		test('pending run recovery: pending run with tasks can advance on subsequent tick', async () => {
+			// Verify that a recovered pending run (with tasks) can actually advance.
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			// Create pending run with one task (simulating mid-creation crash)
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recoverable Run',
+				currentNodeId: STEP_A,
+			});
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Plan',
+				description: '',
+				workflowRunId: pendingRun.id,
+				workflowNodeId: STEP_A,
+				status: 'completed', // task was already done when crash happened
+			});
+
+			// Fresh runtime rehydrates and promotes the run
+			const freshRuntime = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+			});
+
+			// First tick: rehydrates executor and transitions pending → in_progress
+			await freshRuntime.executeTick();
+
+			const runAfterRehydrate = workflowRunRepo.getRun(pendingRun.id)!;
+			expect(runAfterRehydrate.status).toBe('in_progress');
+			expect(freshRuntime.getExecutor(pendingRun.id)).toBeDefined();
+
+			// Second tick: should advance to step B since task is completed
+			await freshRuntime.executeTick();
+
+			const stepBTask = taskRepo
+				.listByWorkflowRun(pendingRun.id)
+				.find((t) => t.workflowNodeId === STEP_B);
+			expect(stepBTask).toBeDefined();
+			expect(stepBTask!.status).toBe('pending');
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -21,12 +21,13 @@ import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from 'bun:
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { createTables, runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository.ts';
+import { GoalRepository } from '../../../src/storage/repositories/goal-repository.ts';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
@@ -36,6 +37,7 @@ import { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-mana
 import { AgentSession } from '../../../src/lib/agent/agent-session.ts';
 import type { Space, SpaceWorkflow, SpaceWorkflowRun, SpaceTask } from '@neokai/shared';
 import type { AgentProcessingState } from '@neokai/shared';
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 
 // ---------------------------------------------------------------------------
 // Minimal in-process DaemonHub for tests
@@ -162,6 +164,7 @@ function makeDb(): { db: BunDatabase; dir: string } {
 	mkdirSync(dir, { recursive: true });
 	const db = new BunDatabase(join(dir, 'test.db'));
 	db.exec('PRAGMA foreign_keys = ON');
+	createTables(db);
 	runMigrations(db, () => {});
 	return { db, dir };
 }
@@ -232,6 +235,7 @@ interface TestCtx {
 		saveUserMessage: () => string;
 		updateSession: () => void;
 		getDatabase: () => BunDatabase;
+		getGoalRepo: () => GoalRepository;
 	};
 	sessionGroupRepo: SpaceSessionGroupRepository;
 	manager: TaskAgentManager;
@@ -276,6 +280,9 @@ function makeCtx(): TestCtx {
 	// Track DB sessions created (to simulate fromInit check)
 	const dbSessions = new Map<string, unknown>();
 
+	// GoalRepository for goal progress integration tests
+	const goalRepo = new GoalRepository(bunDb, noOpReactiveDb);
+
 	const mockDb = {
 		getSession: (id: string) => (dbSessions.has(id) ? dbSessions.get(id) : null),
 		createSession: (session: unknown) => {
@@ -287,6 +294,7 @@ function makeCtx(): TestCtx {
 		saveUserMessage: (_sessionId: string, _msg: unknown, _status: string) => 'msg-id',
 		updateSession: () => {},
 		getDatabase: () => bunDb,
+		getGoalRepo: () => goalRepo,
 	};
 
 	const mockSpaceRuntimeService = {
@@ -1032,6 +1040,89 @@ describe('TaskAgentManager', () => {
 			await expect(
 				callHandleSubSessionComplete(ctx.manager, parentTask.id, 'nonexistent-step', 'session-xyz')
 			).resolves.toBeUndefined();
+		});
+
+		test('recalculates goal progress when step task with goalId completes', async () => {
+			const goalId = 'test-goal-progress';
+			const stepId = 'step-goal-test';
+
+			// Seed a goal (FK to rooms disabled via PRAGMA in tests)
+			ctx.bunDb.exec('PRAGMA foreign_keys = OFF');
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO goals (id, room_id, title, description, status, priority, progress,
+           linked_task_ids, metrics, created_at, updated_at, mission_type, autonomy_level,
+           schedule, schedule_paused, next_run_at, structured_metrics, max_consecutive_failures,
+           max_planning_attempts, consecutive_failures, replan_count, short_id)
+           VALUES (?, ?, ?, '', 'active', 'normal', 0, '[]', '{}', ?, ?, 'one_shot', 'supervised',
+           NULL, 0, NULL, NULL, 3, 0, 0, 0, NULL)`
+				)
+				.run(goalId, 'room-test', 'Test Goal', Date.now(), Date.now());
+			ctx.bunDb.exec('PRAGMA foreign_keys = ON');
+
+			// Create workflow and step to satisfy FK constraints
+			const wfId = 'wf-goal-test';
+			const wfRunId = 'wf-run-goal-test';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, created_at, updated_at)
+           VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'Test WF', now, now);
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, order_index, created_at, updated_at)
+           VALUES (?, ?, ?, '', 0, ?, ?)`
+				)
+				.run(stepId, wfId, 'Step 1', now, now);
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_node_id, created_at, updated_at)
+           VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+
+			// Create parent task with workflow run
+			const parentTask = await ctx.taskManager.createTask({
+				title: 'Parent task',
+				description: 'Orchestrator task',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+
+			// Create step task with goalId
+			const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:step:${stepId}`;
+			const stepTask = await ctx.taskManager.createTask({
+				title: 'Step task with goal',
+				description: 'A step task linked to a goal',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+				workflowNodeId: stepId,
+				taskAgentSessionId: subSessionId,
+				goalId: goalId,
+			});
+
+			// Spawn Task Agent so internal state is ready
+			await ctx.manager.spawnTaskAgent(
+				{ ...parentTask, workflowRunId: wfRunId },
+				ctx.space,
+				null,
+				null
+			);
+
+			// Verify initial goal progress is 0
+			const goalBefore = ctx.mockDb.getGoalRepo().getGoal(goalId);
+			expect(goalBefore?.progress).toBe(0);
+
+			// Call handleSubSessionComplete to complete the step
+			await callHandleSubSessionComplete(ctx.manager, parentTask.id, stepId, subSessionId);
+
+			// Goal progress should now be 100 (completed task contributes 100%)
+			const goalAfter = ctx.mockDb.getGoalRepo().getGoal(goalId);
+			expect(goalAfter?.progress).toBe(100);
 		});
 	});
 

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -1921,18 +1921,18 @@ describe('TaskAgentManager', () => {
 			void stepTask;
 		});
 
-		test('does not restart streaming for sub-sessions during rehydration', async () => {
-			// Sub-sessions in the map after rehydration should NOT have _startCalled = true
-			// (they are stubs that the Task Agent will re-spawn as needed)
-			const wfId = 'wf-rehydrate-no-start';
+		test('restarts streaming for sub-sessions during rehydration', async () => {
+			// After rehydration, sub-sessions should have startStreamingQuery called
+			// so they can resume streaming immediately.
+			const wfId = 'wf-rehydrate-sub-start';
 			const now = Date.now();
 			ctx.bunDb
 				.prepare(
 					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, created_at, updated_at)
            VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
 				)
-				.run(wfId, ctx.spaceId, 'WF Sub No Start', now, now);
-			const wfRunId = 'run-rehydrate-no-start';
+				.run(wfId, ctx.spaceId, 'WF Sub Start', now, now);
+			const wfRunId = 'run-rehydrate-sub-start';
 			ctx.bunDb
 				.prepare(
 					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_node_id, created_at, updated_at)
@@ -1941,7 +1941,7 @@ describe('TaskAgentManager', () => {
 				.run(wfRunId, ctx.spaceId, wfId, now, now);
 
 			const mainTask = await ctx.taskManager.createTask({
-				title: 'Main task no-start',
+				title: 'Main task sub-start',
 				description: '',
 				taskType: 'coding',
 				status: 'in_progress',
@@ -1951,7 +1951,7 @@ describe('TaskAgentManager', () => {
 			ctx.taskRepo.updateTask(mainTask.id, { taskAgentSessionId: mainSessionId });
 			ctx.mockDb.createSession({ id: mainSessionId, type: 'space_task_agent' });
 
-			const subSessionId = '550e8400-e29b-41d4-a716-nostart-sub-01';
+			const subSessionId = '550e8400-e29b-41d4-a716-sub-start-01';
 			await ctx.taskManager.createTask({
 				title: 'Sub task',
 				description: '',
@@ -1970,11 +1970,76 @@ describe('TaskAgentManager', () => {
 
 			await ctx.manager.rehydrate();
 
-			// The sub-session stub should NOT have startStreamingQuery called
+			// The sub-session should have startStreamingQuery called on rehydration
 			const subSession = ctx.createdSessions.get(subSessionId);
-			if (subSession) {
-				expect(subSession._startCalled).toBe(false);
-			}
+			expect(subSession).toBeDefined();
+			expect(subSession!._startCalled).toBe(true);
+
+			restoreSpy.mockRestore();
+		});
+
+		test('streaming restart failure for sub-session is non-fatal during rehydration', async () => {
+			// If startStreamingQuery throws for a sub-session, rehydration should
+			// continue without failing the entire task.
+			const wfId = 'wf-rehydrate-sub-error';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, created_at, updated_at)
+           VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'WF Sub Error', now, now);
+			const wfRunId = 'run-rehydrate-sub-error';
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_node_id, created_at, updated_at)
+           VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+
+			const mainTask = await ctx.taskManager.createTask({
+				title: 'Main task sub-error',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+			const mainSessionId = `space:${ctx.spaceId}:task:${mainTask.id}`;
+			ctx.taskRepo.updateTask(mainTask.id, { taskAgentSessionId: mainSessionId });
+			ctx.mockDb.createSession({ id: mainSessionId, type: 'space_task_agent' });
+
+			const subSessionId = '550e8400-e29b-41d4-a716-sub-error-01';
+			await ctx.taskManager.createTask({
+				title: 'Sub task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+				taskAgentSessionId: subSessionId,
+			});
+			ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+			// First restore call returns a session whose startStreamingQuery throws
+			const failingSession = makeMockSession(subSessionId);
+			failingSession.startStreamingQuery = async () => {
+				throw new Error('streaming restart failed');
+			};
+
+			const restoreSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+				if (sessionId === subSessionId) {
+					ctx.createdSessions.set(sessionId, failingSession);
+					return failingSession as unknown as AgentSession;
+				}
+				const session = makeMockSession(sessionId);
+				ctx.createdSessions.set(sessionId, session);
+				return session as unknown as AgentSession;
+			});
+
+			// rehydrate() should not throw even though the sub-session streaming fails
+			await expect(ctx.manager.rehydrate()).resolves.toBeUndefined();
+
+			// The sub-session should still be in the map despite the error
+			expect(ctx.manager.getSubSession(subSessionId)).toBeDefined();
 
 			restoreSpy.mockRestore();
 		});

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -115,9 +115,10 @@ describe('SpaceWorkflowRunRepository', () => {
 	});
 
 	describe('getRehydratableRuns', () => {
-		it('returns in_progress and needs_attention runs; excludes pending, completed, cancelled', () => {
-			// 'pending' — excluded (transient creation state)
-			repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Pending' });
+		it('returns pending, in_progress, and needs_attention runs; excludes completed and cancelled', () => {
+			// 'pending' — included (crash recovery: pending runs with no tasks are cancelled,
+			// pending runs with tasks are promoted to in_progress by rehydrateExecutors)
+			const r1 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Pending' });
 
 			// 'in_progress' — included
 			const r2 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'InProgress' });
@@ -136,9 +137,9 @@ describe('SpaceWorkflowRunRepository', () => {
 			repo.updateStatus(r5.id, 'cancelled');
 
 			const rehydratable = repo.getRehydratableRuns(spaceId);
-			expect(rehydratable).toHaveLength(2);
+			expect(rehydratable).toHaveLength(3);
 			const titles = rehydratable.map((r) => r.title).sort();
-			expect(titles).toEqual(['InProgress', 'NeedsAttention']);
+			expect(titles).toEqual(['InProgress', 'NeedsAttention', 'Pending']);
 		});
 	});
 


### PR DESCRIPTION
Three Phase 1 critical fixes from the Space V2 gap analysis:

1. Goal Management Integration: Wire Space task completion to goal progress
   recalculation. Added recalculateProgressFromSpaceTasks() to GoalRepository
   and integrated it into TaskAgentManager.handleSubSessionComplete() so
   completing a Space task with a goalId updates the goal's progress.

2. Sub-session Streaming Restart: Fixed TaskAgentManager.rehydrateTaskAgent()
   to call startStreamingQuery() on restored sub-sessions. Previously sub-sessions
   were restored to memory but not actively streaming, leaving them dormant.

3. Pending Run Rehydration: Fixed space-workflow-run-repository.getRehydratableRuns()
   to include 'pending' runs, and updated rehydrateExecutors() to handle them:
   - Pending runs with existing tasks are transitioned to 'in_progress' and rebuilt
   - Pending runs without tasks (crash before task creation) are safely cancelled

Tests added for all three fixes.
