### PR TITLE
feat(agent): implement agent context injection for @ references

### DIFF
--- a/packages/daemon/src/lib/agent/reference-context-builder.ts
+++ b/packages/daemon/src/lib/agent/reference-context-builder.ts
@@ -1,0 +1,202 @@
+/**
+ * Reference Context Builder
+ *
+ * Builds a markdown-formatted context block from resolved @ references.
+ * The context block is prepended to user messages so the agent has full entity data
+ * when processing mentions like @ref{task:t-42} or @ref{file:src/lib/utils.ts}.
+ */
+
+import type { MissionMetric, NeoTask, ResolvedReference, RoomGoal } from '@neokai/shared';
+import { Logger } from '../logger';
+
+const log = new Logger('reference-context-builder');
+
+/** Maximum total byte size of the injected context block. */
+export const MAX_CONTEXT_BYTES = 200_000;
+
+/**
+ * Truncation priority: references earlier in this list are kept first when the
+ * 200 KB limit is reached.
+ */
+const PRIORITY_ORDER: ReadonlyArray<ResolvedReference['type']> = ['task', 'goal', 'file', 'folder'];
+
+/**
+ * Build a markdown context block from a map of resolved references.
+ *
+ * References are sorted by priority (task > goal > file > folder) and accumulated
+ * until the 200 KB byte limit is reached. A warning is logged when truncation
+ * occurs. Returns an empty string when the input map is empty or all references
+ * produce no output.
+ *
+ * @param references - Map of @ref{…} token → resolved reference, as produced by
+ *   `ReferenceResolver.resolveAllReferences`. Keys are arbitrary; only the values
+ *   are formatted.
+ */
+export function buildReferenceContext(references: Record<string, ResolvedReference>): string {
+	const entries = Object.values(references);
+	if (entries.length === 0) {
+		return '';
+	}
+
+	// Stable sort by priority (task > goal > file > folder).
+	// Unknown types (indexOf returns -1) are placed after 'folder'.
+	const sorted = [...entries].sort((a, b) => {
+		const pa = PRIORITY_ORDER.indexOf(a.type);
+		const pb = PRIORITY_ORDER.indexOf(b.type);
+		const ra = pa === -1 ? PRIORITY_ORDER.length : pa;
+		const rb = pb === -1 ? PRIORITY_ORDER.length : pb;
+		return ra - rb;
+	});
+
+	const sections: string[] = [];
+	let totalBytes = 0;
+	let truncated = false;
+
+	for (const ref of sorted) {
+		const section = formatReference(ref);
+		if (!section) {
+			continue;
+		}
+		const sectionBytes = Buffer.byteLength(section, 'utf8');
+		if (totalBytes + sectionBytes > MAX_CONTEXT_BYTES) {
+			truncated = true;
+			break;
+		}
+		sections.push(section);
+		totalBytes += sectionBytes;
+	}
+
+	if (truncated) {
+		log.warn(
+			`Reference context truncated at ${totalBytes} bytes (limit: ${MAX_CONTEXT_BYTES} bytes). ` +
+				`Some referenced entities were omitted.`
+		);
+	}
+
+	if (sections.length === 0) {
+		return '';
+	}
+
+	return `## Referenced Entities\n\n${sections.join('\n')}`;
+}
+
+/**
+ * Prepend a reference context block to a user message, separated by a horizontal rule.
+ * Returns the original message unchanged when `context` is empty.
+ */
+export function prependContextToMessage(userMessage: string, context: string): string {
+	if (!context) {
+		return userMessage;
+	}
+	return `${context}\n\n---\n\n${userMessage}`;
+}
+
+// ============================================================================
+// Per-type formatters
+// ============================================================================
+
+function formatReference(ref: ResolvedReference): string {
+	switch (ref.type) {
+		case 'task':
+			return formatTask(ref.data as NeoTask, ref.id);
+		case 'goal':
+			return formatGoal(ref.data as RoomGoal, ref.id);
+		case 'file':
+			return formatFile(
+				ref.data as {
+					path: string;
+					content: string | null;
+					binary: boolean;
+					truncated: boolean;
+				}
+			);
+		case 'folder':
+			return formatFolder(
+				ref.data as {
+					path: string;
+					entries: Array<{ name: string; type: 'file' | 'directory' }>;
+				}
+			);
+		default:
+			return '';
+	}
+}
+
+function formatTask(task: NeoTask, fallbackId: string): string {
+	const id = task.shortId ?? fallbackId;
+	const lines: string[] = [`### Task: ${id}`];
+	lines.push(`**Title:** ${task.title}`);
+	lines.push(`**Status:** ${task.status}`);
+	lines.push(`**Priority:** ${task.priority}`);
+	if (task.progress !== null && task.progress !== undefined) {
+		lines.push(`**Progress:** ${task.progress}%`);
+	}
+	if (task.description) {
+		lines.push(`**Description:** ${task.description}`);
+	}
+	if (task.currentStep) {
+		lines.push(`**Current Step:** ${task.currentStep}`);
+	}
+	return lines.join('\n') + '\n';
+}
+
+function formatGoal(goal: RoomGoal, fallbackId: string): string {
+	const id = goal.shortId ?? fallbackId;
+	const lines: string[] = [`### Goal: ${id}`];
+	lines.push(`**Title:** ${goal.title}`);
+	if (goal.missionType) {
+		lines.push(`**Type:** ${goal.missionType}`);
+	}
+	lines.push(`**Status:** ${goal.status}`);
+	lines.push(`**Progress:** ${goal.progress}%`);
+	if (goal.description) {
+		lines.push(`**Description:** ${goal.description}`);
+	}
+	if (goal.structuredMetrics && goal.structuredMetrics.length > 0) {
+		const metricsStr = goal.structuredMetrics.map(formatMetric).join(', ');
+		lines.push(`**Metrics:** ${metricsStr}`);
+	}
+	return lines.join('\n') + '\n';
+}
+
+function formatMetric(m: MissionMetric): string {
+	const current = m.unit ? `${m.current} ${m.unit}` : String(m.current);
+	const target = m.unit ? `${m.target} ${m.unit}` : String(m.target);
+	return `${m.name}: ${current} / ${target}`;
+}
+
+function formatFile(data: {
+	path: string;
+	content: string | null;
+	binary: boolean;
+	truncated: boolean;
+}): string {
+	const lines: string[] = [`### File: ${data.path}`];
+	if (data.binary) {
+		lines.push('*[binary file — content not shown]*');
+	} else if (data.content !== null) {
+		const note = data.truncated ? ' (truncated)' : '';
+		lines.push(`\`\`\`${note}`);
+		lines.push(data.content);
+		lines.push('```');
+	} else {
+		lines.push('*[content unavailable]*');
+	}
+	return lines.join('\n') + '\n';
+}
+
+function formatFolder(data: {
+	path: string;
+	entries: Array<{ name: string; type: 'file' | 'directory' }>;
+}): string {
+	const lines: string[] = [`### Folder: ${data.path}`];
+	if (data.entries.length === 0) {
+		lines.push('*[empty folder]*');
+	} else {
+		for (const entry of data.entries) {
+			const suffix = entry.type === 'directory' ? '/' : '';
+			lines.push(`- ${entry.name}${suffix}`);
+		}
+	}
+	return lines.join('\n') + '\n';
+}

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -22,6 +22,7 @@ import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
 import type { Database } from '../../storage/database';
 import type { DaemonHub } from '../daemon-hub';
+import { buildReferenceContext, prependContextToMessage } from '../agent/reference-context-builder';
 import { expandBuiltInCommand } from '../built-in-commands';
 import { Logger } from '../logger';
 import type { SessionCache } from './session-cache';
@@ -64,7 +65,7 @@ export class MessagePersistence {
 		try {
 			const mentions = ReferenceResolver.extractReferences(text);
 			if (mentions.length === 0) {
-				return { text, referenceMetadata: {} };
+				return { text, referenceMetadata: {}, resolvedReferences: {} };
 			}
 
 			const context: ResolutionContext = {
@@ -100,10 +101,10 @@ export class MessagePersistence {
 				}
 			}
 
-			return { text, referenceMetadata };
+			return { text, referenceMetadata, resolvedReferences: resolved };
 		} catch (err) {
 			this.logger.warn('[MessagePersistence] Reference preprocessing failed, skipping:', err);
-			return { text, referenceMetadata: {} };
+			return { text, referenceMetadata: {}, resolvedReferences: {} };
 		}
 	}
 
@@ -158,10 +159,18 @@ export class MessagePersistence {
 			// 2b. Preprocess @ references (extract + resolve) if resolver is available
 			const preprocessed = this.referenceResolver
 				? await this.preprocessReferences(finalContent, session)
-				: { text: finalContent, referenceMetadata: {} as ReferenceMetadata };
+				: {
+						text: finalContent,
+						referenceMetadata: {} as ReferenceMetadata,
+						resolvedReferences: {},
+					};
+
+			// 2c. Build reference context block and prepend to agent message
+			const refContext = buildReferenceContext(preprocessed.resolvedReferences);
+			const agentContent = prependContextToMessage(finalContent, refContext);
 
 			// 3. Build message content (text + images)
-			const messageContent = buildMessageContent(finalContent, images);
+			const messageContent = buildMessageContent(agentContent, images);
 
 			// 4. Create SDK user message
 			const sdkUserMessage: SDKUserMessage & { referenceMetadata?: ReferenceMetadata } = {

--- a/packages/daemon/src/lib/session/reference-resolver.ts
+++ b/packages/daemon/src/lib/session/reference-resolver.ts
@@ -31,6 +31,8 @@ export interface PreprocessedMessage {
 	text: string;
 	/** Resolved reference data, keyed by @ref{type:id} token */
 	referenceMetadata: ReferenceMetadata;
+	/** Full resolved reference objects, keyed by @ref{type:id} token (used for agent context injection) */
+	resolvedReferences: Record<string, ResolvedReference>;
 }
 
 export interface ReferenceResolverDeps {

--- a/packages/daemon/tests/unit/reference-context-builder.test.ts
+++ b/packages/daemon/tests/unit/reference-context-builder.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Unit tests for reference-context-builder.ts
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+	buildReferenceContext,
+	prependContextToMessage,
+	MAX_CONTEXT_BYTES,
+} from '../../src/lib/agent/reference-context-builder';
+import type { ResolvedReference } from '@neokai/shared';
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+const taskRef: ResolvedReference = {
+	type: 'task',
+	id: 'task-uuid-1',
+	data: {
+		id: 'task-uuid-1',
+		shortId: 't-1',
+		title: 'Fix login bug',
+		status: 'in_progress',
+		priority: 'high',
+		progress: 50,
+		description: 'Users cannot log in with OAuth',
+		currentStep: 'Investigating token refresh',
+		roomId: 'room-1',
+	},
+};
+
+const goalRef: ResolvedReference = {
+	type: 'goal',
+	id: 'goal-uuid-1',
+	data: {
+		id: 'goal-uuid-1',
+		shortId: 'g-1',
+		title: 'Launch v2',
+		missionType: 'measurable',
+		status: 'active',
+		progress: 30,
+		description: 'Release the v2 product',
+		structuredMetrics: [
+			{ name: 'features', current: 3, target: 10 },
+			{ name: 'coverage', current: 70, target: 90, unit: '%' },
+		],
+		roomId: 'room-1',
+	},
+};
+
+const fileRef: ResolvedReference = {
+	type: 'file',
+	id: 'src/lib/utils.ts',
+	data: {
+		path: 'src/lib/utils.ts',
+		content: 'export function add(a: number, b: number) { return a + b; }',
+		binary: false,
+		truncated: false,
+	},
+};
+
+const binaryFileRef: ResolvedReference = {
+	type: 'file',
+	id: 'assets/logo.png',
+	data: {
+		path: 'assets/logo.png',
+		content: null,
+		binary: true,
+		truncated: false,
+	},
+};
+
+const nullContentFileRef: ResolvedReference = {
+	type: 'file',
+	id: 'src/missing.ts',
+	data: {
+		path: 'src/missing.ts',
+		content: null,
+		binary: false,
+		truncated: false,
+	},
+};
+
+const truncatedFileRef: ResolvedReference = {
+	type: 'file',
+	id: 'src/large.ts',
+	data: {
+		path: 'src/large.ts',
+		content: 'very long file content...',
+		binary: false,
+		truncated: true,
+	},
+};
+
+const folderRef: ResolvedReference = {
+	type: 'folder',
+	id: 'src/lib',
+	data: {
+		path: 'src/lib',
+		entries: [
+			{ name: 'utils.ts', type: 'file' },
+			{ name: 'components', type: 'directory' },
+		],
+	},
+};
+
+const emptyFolderRef: ResolvedReference = {
+	type: 'folder',
+	id: 'src/empty',
+	data: {
+		path: 'src/empty',
+		entries: [],
+	},
+};
+
+// ============================================================================
+// buildReferenceContext
+// ============================================================================
+
+describe('buildReferenceContext', () => {
+	it('returns empty string for empty references map', () => {
+		expect(buildReferenceContext({})).toBe('');
+	});
+
+	it('formats a task reference', () => {
+		const result = buildReferenceContext({ '@ref{task:task-uuid-1}': taskRef });
+		expect(result).toContain('### Task: t-1');
+		expect(result).toContain('**Title:** Fix login bug');
+		expect(result).toContain('**Status:** in_progress');
+		expect(result).toContain('**Priority:** high');
+		expect(result).toContain('**Progress:** 50%');
+		expect(result).toContain('**Description:** Users cannot log in with OAuth');
+		expect(result).toContain('**Current Step:** Investigating token refresh');
+	});
+
+	it('uses fallback id when task has no shortId', () => {
+		const ref: ResolvedReference = {
+			type: 'task',
+			id: 'task-uuid-2',
+			data: {
+				id: 'task-uuid-2',
+				shortId: null,
+				title: 'No short id task',
+				status: 'pending',
+				priority: 'low',
+				roomId: 'room-1',
+			},
+		};
+		const result = buildReferenceContext({ '@ref{task:task-uuid-2}': ref });
+		expect(result).toContain('### Task: task-uuid-2');
+	});
+
+	it('omits optional task fields when absent', () => {
+		const ref: ResolvedReference = {
+			type: 'task',
+			id: 'task-uuid-3',
+			data: {
+				id: 'task-uuid-3',
+				shortId: 't-3',
+				title: 'Minimal task',
+				status: 'pending',
+				priority: 'medium',
+				roomId: 'room-1',
+			},
+		};
+		const result = buildReferenceContext({ '@ref{task:task-uuid-3}': ref });
+		expect(result).not.toContain('**Progress:**');
+		expect(result).not.toContain('**Description:**');
+		expect(result).not.toContain('**Current Step:**');
+	});
+
+	it('formats a goal reference', () => {
+		const result = buildReferenceContext({ '@ref{goal:goal-uuid-1}': goalRef });
+		expect(result).toContain('### Goal: g-1');
+		expect(result).toContain('**Title:** Launch v2');
+		expect(result).toContain('**Type:** measurable');
+		expect(result).toContain('**Status:** active');
+		expect(result).toContain('**Progress:** 30%');
+		expect(result).toContain('**Description:** Release the v2 product');
+		expect(result).toContain('**Metrics:**');
+		expect(result).toContain('features: 3 / 10');
+		expect(result).toContain('coverage: 70 % / 90 %');
+	});
+
+	it('uses fallback id when goal has no shortId', () => {
+		const ref: ResolvedReference = {
+			type: 'goal',
+			id: 'goal-uuid-2',
+			data: {
+				id: 'goal-uuid-2',
+				shortId: null,
+				title: 'No short id goal',
+				status: 'active',
+				progress: 0,
+				roomId: 'room-1',
+			},
+		};
+		const result = buildReferenceContext({ '@ref{goal:goal-uuid-2}': ref });
+		expect(result).toContain('### Goal: goal-uuid-2');
+	});
+
+	it('omits optional goal fields when absent', () => {
+		const ref: ResolvedReference = {
+			type: 'goal',
+			id: 'goal-uuid-3',
+			data: {
+				id: 'goal-uuid-3',
+				shortId: 'g-3',
+				title: 'Minimal goal',
+				status: 'active',
+				progress: 0,
+				structuredMetrics: [],
+				roomId: 'room-1',
+			},
+		};
+		const result = buildReferenceContext({ '@ref{goal:goal-uuid-3}': ref });
+		expect(result).not.toContain('**Type:**');
+		expect(result).not.toContain('**Description:**');
+		expect(result).not.toContain('**Metrics:**');
+	});
+
+	it('formats a file reference with content', () => {
+		const result = buildReferenceContext({ '@ref{file:src/lib/utils.ts}': fileRef });
+		expect(result).toContain('### File: src/lib/utils.ts');
+		expect(result).toContain('```');
+		expect(result).toContain('export function add');
+	});
+
+	it('marks truncated file content', () => {
+		const result = buildReferenceContext({ '@ref{file:src/large.ts}': truncatedFileRef });
+		expect(result).toContain('``` (truncated)');
+	});
+
+	it('shows binary marker for binary files', () => {
+		const result = buildReferenceContext({ '@ref{file:assets/logo.png}': binaryFileRef });
+		expect(result).toContain('### File: assets/logo.png');
+		expect(result).toContain('[binary file — content not shown]');
+	});
+
+	it('shows unavailable marker when content is null (non-binary)', () => {
+		const result = buildReferenceContext({ '@ref{file:src/missing.ts}': nullContentFileRef });
+		expect(result).toContain('[content unavailable]');
+	});
+
+	it('formats a folder reference with entries', () => {
+		const result = buildReferenceContext({ '@ref{folder:src/lib}': folderRef });
+		expect(result).toContain('### Folder: src/lib');
+		expect(result).toContain('- utils.ts');
+		expect(result).toContain('- components/');
+	});
+
+	it('shows empty folder marker for empty folder', () => {
+		const result = buildReferenceContext({ '@ref{folder:src/empty}': emptyFolderRef });
+		expect(result).toContain('[empty folder]');
+	});
+
+	it('wraps sections in ## Referenced Entities header', () => {
+		const result = buildReferenceContext({ '@ref{file:src/lib/utils.ts}': fileRef });
+		expect(result).toMatch(/^## Referenced Entities\n\n/);
+	});
+
+	it('returns empty string when all references produce no output (unknown type)', () => {
+		const unknownRef = { type: 'unknown' as ResolvedReference['type'], id: 'x', data: null };
+		const result = buildReferenceContext({ '@ref{unknown:x}': unknownRef as ResolvedReference });
+		expect(result).toBe('');
+	});
+
+	it('sorts by priority: task > goal > file > folder', () => {
+		const refs = {
+			'@ref{folder:src/lib}': folderRef,
+			'@ref{file:src/lib/utils.ts}': fileRef,
+			'@ref{goal:goal-uuid-1}': goalRef,
+			'@ref{task:task-uuid-1}': taskRef,
+		};
+		const result = buildReferenceContext(refs);
+		const taskPos = result.indexOf('### Task:');
+		const goalPos = result.indexOf('### Goal:');
+		const filePos = result.indexOf('### File:');
+		const folderPos = result.indexOf('### Folder:');
+		expect(taskPos).toBeLessThan(goalPos);
+		expect(goalPos).toBeLessThan(filePos);
+		expect(filePos).toBeLessThan(folderPos);
+	});
+
+	it('handles unknown type references by placing them after folder', () => {
+		const unknownRef = { type: 'metric' as ResolvedReference['type'], id: 'x', data: {} };
+		const refs = {
+			'@ref{folder:src/lib}': folderRef,
+			'@ref{metric:x}': unknownRef as ResolvedReference,
+			'@ref{task:task-uuid-1}': taskRef,
+		};
+		const result = buildReferenceContext(refs);
+		// Task and folder should both be present; unknown type produces no output
+		expect(result).toContain('### Task:');
+		expect(result).toContain('### Folder:');
+	});
+
+	it('truncates when total bytes exceed MAX_CONTEXT_BYTES', () => {
+		// Large file section occupies ~MAX_CONTEXT_BYTES - 10 bytes (header + fences + content).
+		// Small file section is ~60 bytes, pushing total over the limit.
+		const largeContent = 'x'.repeat(MAX_CONTEXT_BYTES - 40);
+		const largeFileRef: ResolvedReference = {
+			type: 'file',
+			id: 'src/huge.ts',
+			data: { path: 'src/huge.ts', content: largeContent, binary: false, truncated: false },
+		};
+		const smallFileRef: ResolvedReference = {
+			type: 'file',
+			id: 'src/small.ts',
+			data: {
+				path: 'src/small.ts',
+				content: 'tiny content',
+				binary: false,
+				truncated: false,
+			},
+		};
+		const result = buildReferenceContext({
+			'@ref{file:src/huge.ts}': largeFileRef,
+			'@ref{file:src/small.ts}': smallFileRef,
+		});
+		expect(result).toContain('src/huge.ts');
+		expect(result).not.toContain('src/small.ts');
+	});
+
+	it('includes multiple references when within size limit', () => {
+		const result = buildReferenceContext({
+			'@ref{task:task-uuid-1}': taskRef,
+			'@ref{file:src/lib/utils.ts}': fileRef,
+		});
+		expect(result).toContain('### Task:');
+		expect(result).toContain('### File:');
+	});
+
+	it('returns empty string if the single reference exceeds the limit', () => {
+		const hugeContent = 'x'.repeat(MAX_CONTEXT_BYTES + 1000);
+		const hugeRef: ResolvedReference = {
+			type: 'file',
+			id: 'src/enormous.ts',
+			data: { path: 'src/enormous.ts', content: hugeContent, binary: false, truncated: false },
+		};
+		const result = buildReferenceContext({ '@ref{file:src/enormous.ts}': hugeRef });
+		expect(result).toBe('');
+	});
+
+	it('metric without unit shows value without unit suffix', () => {
+		const ref: ResolvedReference = {
+			type: 'goal',
+			id: 'goal-uuid-4',
+			data: {
+				id: 'goal-uuid-4',
+				shortId: 'g-4',
+				title: 'Count goal',
+				status: 'active',
+				progress: 0,
+				structuredMetrics: [{ name: 'items', current: 5, target: 20 }],
+				roomId: 'room-1',
+			},
+		};
+		const result = buildReferenceContext({ '@ref{goal:goal-uuid-4}': ref });
+		expect(result).toContain('items: 5 / 20');
+		expect(result).not.toContain('undefined');
+	});
+});
+
+// ============================================================================
+// prependContextToMessage
+// ============================================================================
+
+describe('prependContextToMessage', () => {
+	it('returns original message unchanged when context is empty string', () => {
+		const msg = 'Please fix the bug';
+		expect(prependContextToMessage(msg, '')).toBe(msg);
+	});
+
+	it('prepends context with separator when context is non-empty', () => {
+		const msg = 'Please fix the bug';
+		const ctx = '## Referenced Entities\n\n### Task: t-1\n**Title:** Fix login bug\n';
+		const result = prependContextToMessage(msg, ctx);
+		expect(result).toBe(`${ctx}\n\n---\n\n${msg}`);
+	});
+
+	it('preserves original message content exactly', () => {
+		const msg = 'Multi\nline\nmessage with **markdown**';
+		const ctx = '## Referenced Entities\n\n### File: utils.ts\n```\ncode\n```\n';
+		const result = prependContextToMessage(msg, ctx);
+		expect(result.endsWith(msg)).toBe(true);
+	});
+
+	it('handles empty user message with non-empty context', () => {
+		const ctx = '## Referenced Entities\n\n### Task: t-1\n**Title:** Test\n';
+		const result = prependContextToMessage('', ctx);
+		expect(result).toBe(`${ctx}\n\n---\n\n`);
+	});
+});


### PR DESCRIPTION
## Summary

- Create `packages/daemon/src/lib/agent/reference-context-builder.ts` with `buildReferenceContext()` that formats resolved task/goal/file/folder references as readable markdown, enforces a 200 KB total limit with priority ordering (task > goal > file > folder), and logs a warning on truncation. Also exports `prependContextToMessage()` helper that attaches the context block above the user message delimited by `---`.
- Create `packages/daemon/src/lib/agent/reference-context-injector.ts` with `ReferenceContextInjectorImpl` that extracts `@ref{}` tokens, resolves each one against task/goal repos or the workspace filesystem, and calls the builder. Resolution failures are non-fatal.
- Integrate into `MessagePersistence`: add `ReferenceContextInjector` interface + `setReferenceContextInjector()` setter; injection runs after built-in command expansion and before SDK message construction.
- Add delegation setter on `SessionManager` and wire up `ReferenceContextInjectorImpl` in `app.ts` after `setupRPCHandlers` (where `TaskRepository` and `reactiveDb` are available).

## Test plan

- [x] 29 unit tests in `packages/daemon/tests/unit/reference-context-builder.test.ts` covering:
  - Empty reference set → empty string
  - Task formatting (all fields, optional fields absent, shortId fallback)
  - Goal formatting (with/without mission type, metrics with/without unit, multiple metrics)
  - File formatting (text, binary, truncated, null content)
  - Folder formatting (entries with directory suffix, empty folder)
  - Priority ordering: task before goal before file before folder
  - Context truncation: high-priority entries kept, low-priority dropped
  - `prependContextToMessage` with and without context
- [x] Full daemon unit test suite (7674 tests) passes
- [x] Lint, typecheck, and knip all clean