### PR TITLE
feat(web): add MentionToken component for @ reference rendering

### DIFF
--- a/packages/web/src/components/MentionToken.tsx
+++ b/packages/web/src/components/MentionToken.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'preact/hooks';
+import { cn } from '../lib/utils.ts';
+import type { ReferenceMention, ReferenceMetadata, ReferenceType } from '@neokai/shared';
+
+export interface MentionTokenProps {
+	mention: ReferenceMention;
+	metadata?: ReferenceMetadata;
+	onClick?: () => void;
+}
+
+const TYPE_STYLES: Record<ReferenceType, { container: string; icon: string; label: string }> = {
+	task: {
+		container: 'bg-blue-500/15 text-blue-300 hover:bg-blue-500/25',
+		icon: 'text-blue-400',
+		label: 'task',
+	},
+	goal: {
+		container: 'bg-purple-500/15 text-purple-300 hover:bg-purple-500/25',
+		icon: 'text-purple-400',
+		label: 'goal',
+	},
+	file: {
+		container: 'bg-green-500/15 text-green-300 hover:bg-green-500/25',
+		icon: 'text-green-400',
+		label: 'file',
+	},
+	folder: {
+		container: 'bg-yellow-500/15 text-yellow-300 hover:bg-yellow-500/25',
+		icon: 'text-yellow-400',
+		label: 'folder',
+	},
+};
+
+function TokenIcon({ type, className }: { type: ReferenceType; className?: string }) {
+	if (type === 'task') {
+		return (
+			<svg
+				class={cn('w-3 h-3 shrink-0', className)}
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+				/>
+			</svg>
+		);
+	}
+	if (type === 'goal') {
+		return (
+			<svg
+				class={cn('w-3 h-3 shrink-0', className)}
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"
+				/>
+			</svg>
+		);
+	}
+	if (type === 'folder') {
+		return (
+			<svg
+				class={cn('w-3 h-3 shrink-0', className)}
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+				/>
+			</svg>
+		);
+	}
+	// file
+	return (
+		<svg
+			class={cn('w-3 h-3 shrink-0', className)}
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+			/>
+		</svg>
+	);
+}
+
+/**
+ * Renders a single @ reference as a styled, interactive pill token.
+ *
+ * Display text is resolved from `metadata` first (by the @ref{type:id} key),
+ * falling back to `mention.displayText`, then to `mention.id`.
+ */
+export default function MentionToken({ mention, metadata, onClick }: MentionTokenProps) {
+	const [showTooltip, setShowTooltip] = useState(false);
+
+	const tokenKey = `@ref{${mention.type}:${mention.id}}`;
+	const metaEntry = metadata?.[tokenKey];
+	const displayText = metaEntry?.displayText || mention.displayText || mention.id;
+	const status = metaEntry?.status;
+
+	const styles = TYPE_STYLES[mention.type];
+	const ariaLabel = `${styles.label} reference: ${displayText}`;
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		if (e.key === 'Enter' && onClick) {
+			e.preventDefault();
+			onClick();
+		}
+	};
+
+	return (
+		<span class="relative inline-flex">
+			<span
+				role={onClick ? 'button' : undefined}
+				tabIndex={0}
+				aria-label={ariaLabel}
+				onClick={onClick}
+				onKeyDown={handleKeyDown}
+				onMouseEnter={() => setShowTooltip(true)}
+				onMouseLeave={() => setShowTooltip(false)}
+				onFocus={() => setShowTooltip(true)}
+				onBlur={() => setShowTooltip(false)}
+				class={cn(
+					'rounded-full px-2 py-0.5 text-xs font-medium inline-flex items-center gap-1',
+					'transition-colors duration-100',
+					onClick ? 'cursor-pointer' : 'cursor-default',
+					styles.container
+				)}
+			>
+				<TokenIcon type={mention.type} className={styles.icon} />
+				<span class="max-w-[160px] truncate">{displayText}</span>
+			</span>
+
+			{showTooltip && (
+				<span
+					role="tooltip"
+					class={cn(
+						'absolute z-50 bottom-full left-0 mb-1.5',
+						'bg-dark-800 border border-gray-700 rounded-lg shadow-xl',
+						'px-3 py-2 text-xs text-gray-200 whitespace-nowrap',
+						'pointer-events-none'
+					)}
+				>
+					<span class="flex flex-col gap-0.5 min-w-0">
+						<span class="font-medium text-gray-100">{displayText}</span>
+						{status && <span class="text-gray-400">{status}</span>}
+						<span class="text-gray-500">
+							{mention.type}: {mention.id}
+						</span>
+					</span>
+				</span>
+			)}
+		</span>
+	);
+}

--- a/packages/web/src/components/MentionToken.tsx
+++ b/packages/web/src/components/MentionToken.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'preact/hooks';
+import { useId, useState } from 'preact/hooks';
 import { cn } from '../lib/utils.ts';
 import type { ReferenceMention, ReferenceMetadata, ReferenceType } from '@neokai/shared';
+import ReferenceTypeIcon from './ReferenceTypeIcon.tsx';
 
 export interface MentionTokenProps {
 	mention: ReferenceMention;
@@ -11,99 +12,25 @@ export interface MentionTokenProps {
 const TYPE_STYLES: Record<ReferenceType, { container: string; icon: string; label: string }> = {
 	task: {
 		container: 'bg-blue-500/15 text-blue-300 hover:bg-blue-500/25',
-		icon: 'text-blue-400',
+		icon: 'w-3 h-3 text-blue-400',
 		label: 'task',
 	},
 	goal: {
 		container: 'bg-purple-500/15 text-purple-300 hover:bg-purple-500/25',
-		icon: 'text-purple-400',
+		icon: 'w-3 h-3 text-purple-400',
 		label: 'goal',
 	},
 	file: {
 		container: 'bg-green-500/15 text-green-300 hover:bg-green-500/25',
-		icon: 'text-green-400',
+		icon: 'w-3 h-3 text-green-400',
 		label: 'file',
 	},
 	folder: {
 		container: 'bg-yellow-500/15 text-yellow-300 hover:bg-yellow-500/25',
-		icon: 'text-yellow-400',
+		icon: 'w-3 h-3 text-yellow-400',
 		label: 'folder',
 	},
 };
-
-function TokenIcon({ type, className }: { type: ReferenceType; className?: string }) {
-	if (type === 'task') {
-		return (
-			<svg
-				class={cn('w-3 h-3 shrink-0', className)}
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke="currentColor"
-				aria-hidden="true"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-				/>
-			</svg>
-		);
-	}
-	if (type === 'goal') {
-		return (
-			<svg
-				class={cn('w-3 h-3 shrink-0', className)}
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke="currentColor"
-				aria-hidden="true"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"
-				/>
-			</svg>
-		);
-	}
-	if (type === 'folder') {
-		return (
-			<svg
-				class={cn('w-3 h-3 shrink-0', className)}
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke="currentColor"
-				aria-hidden="true"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
-				/>
-			</svg>
-		);
-	}
-	// file
-	return (
-		<svg
-			class={cn('w-3 h-3 shrink-0', className)}
-			fill="none"
-			viewBox="0 0 24 24"
-			stroke="currentColor"
-			aria-hidden="true"
-		>
-			<path
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				stroke-width={2}
-				d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-			/>
-		</svg>
-	);
-}
 
 /**
  * Renders a single @ reference as a styled, interactive pill token.
@@ -113,6 +40,7 @@ function TokenIcon({ type, className }: { type: ReferenceType; className?: strin
  */
 export default function MentionToken({ mention, metadata, onClick }: MentionTokenProps) {
 	const [showTooltip, setShowTooltip] = useState(false);
+	const tooltipId = useId();
 
 	const tokenKey = `@ref{${mention.type}:${mention.id}}`;
 	const metaEntry = metadata?.[tokenKey];
@@ -123,7 +51,7 @@ export default function MentionToken({ mention, metadata, onClick }: MentionToke
 	const ariaLabel = `${styles.label} reference: ${displayText}`;
 
 	const handleKeyDown = (e: KeyboardEvent) => {
-		if (e.key === 'Enter' && onClick) {
+		if ((e.key === 'Enter' || e.key === ' ') && onClick) {
 			e.preventDefault();
 			onClick();
 		}
@@ -133,8 +61,9 @@ export default function MentionToken({ mention, metadata, onClick }: MentionToke
 		<span class="relative inline-flex">
 			<span
 				role={onClick ? 'button' : undefined}
-				tabIndex={0}
+				tabIndex={onClick ? 0 : undefined}
 				aria-label={ariaLabel}
+				aria-describedby={showTooltip ? tooltipId : undefined}
 				onClick={onClick}
 				onKeyDown={handleKeyDown}
 				onMouseEnter={() => setShowTooltip(true)}
@@ -148,12 +77,13 @@ export default function MentionToken({ mention, metadata, onClick }: MentionToke
 					styles.container
 				)}
 			>
-				<TokenIcon type={mention.type} className={styles.icon} />
+				<ReferenceTypeIcon type={mention.type} className={styles.icon} />
 				<span class="max-w-[160px] truncate">{displayText}</span>
 			</span>
 
 			{showTooltip && (
 				<span
+					id={tooltipId}
 					role="tooltip"
 					class={cn(
 						'absolute z-50 bottom-full left-0 mb-1.5',

--- a/packages/web/src/components/ReferenceAutocomplete.tsx
+++ b/packages/web/src/components/ReferenceAutocomplete.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'preact/hooks';
 import { cn } from '../lib/utils.ts';
 import { borderColors } from '../lib/design-tokens.ts';
 import type { ReferenceSearchResult, ReferenceType } from '@neokai/shared';
+import ReferenceTypeIcon from './ReferenceTypeIcon.tsx';
 
 export interface ReferenceAutocompleteProps {
 	results: ReferenceSearchResult[];
@@ -20,74 +21,15 @@ const TYPE_LABELS: Record<ReferenceType, string> = {
 	folder: 'Folders',
 };
 
+const TYPE_ICON_CLASS: Record<ReferenceType, string> = {
+	task: 'w-3.5 h-3.5 text-indigo-400',
+	goal: 'w-3.5 h-3.5 text-amber-400',
+	file: 'w-3.5 h-3.5 text-blue-400',
+	folder: 'w-3.5 h-3.5 text-yellow-400',
+};
+
 function TypeIcon({ type }: { type: ReferenceType }) {
-	if (type === 'task') {
-		return (
-			<svg
-				class="w-3.5 h-3.5 text-indigo-400 shrink-0"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke="currentColor"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-				/>
-			</svg>
-		);
-	}
-	if (type === 'goal') {
-		return (
-			<svg
-				class="w-3.5 h-3.5 text-amber-400 shrink-0"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke="currentColor"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"
-				/>
-			</svg>
-		);
-	}
-	if (type === 'folder') {
-		return (
-			<svg
-				class="w-3.5 h-3.5 text-yellow-400 shrink-0"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke="currentColor"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
-				/>
-			</svg>
-		);
-	}
-	// file
-	return (
-		<svg
-			class="w-3.5 h-3.5 text-blue-400 shrink-0"
-			fill="none"
-			viewBox="0 0 24 24"
-			stroke="currentColor"
-		>
-			<path
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				stroke-width={2}
-				d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-			/>
-		</svg>
-	);
+	return <ReferenceTypeIcon type={type} className={TYPE_ICON_CLASS[type]} />;
 }
 
 /**

--- a/packages/web/src/components/ReferenceTypeIcon.tsx
+++ b/packages/web/src/components/ReferenceTypeIcon.tsx
@@ -1,0 +1,86 @@
+import { cn } from '../lib/utils.ts';
+import type { ReferenceType } from '@neokai/shared';
+
+export interface ReferenceTypeIconProps {
+	type: ReferenceType;
+	/** Tailwind classes for size and color, e.g. "w-3.5 h-3.5 text-indigo-400 shrink-0" */
+	className?: string;
+}
+
+/**
+ * Shared SVG icon for a reference type.
+ * Used by both MentionToken and ReferenceAutocomplete.
+ */
+export default function ReferenceTypeIcon({ type, className }: ReferenceTypeIconProps) {
+	if (type === 'task') {
+		return (
+			<svg
+				class={cn('shrink-0', className)}
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+				/>
+			</svg>
+		);
+	}
+	if (type === 'goal') {
+		return (
+			<svg
+				class={cn('shrink-0', className)}
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"
+				/>
+			</svg>
+		);
+	}
+	if (type === 'folder') {
+		return (
+			<svg
+				class={cn('shrink-0', className)}
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+				/>
+			</svg>
+		);
+	}
+	// file
+	return (
+		<svg
+			class={cn('shrink-0', className)}
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+			/>
+		</svg>
+	);
+}

--- a/packages/web/src/components/__tests__/MentionToken.test.tsx
+++ b/packages/web/src/components/__tests__/MentionToken.test.tsx
@@ -151,10 +151,32 @@ describe('MentionToken', () => {
 			expect(token).toBeNull();
 		});
 
-		it('is focusable via tabIndex=0', () => {
-			const { container } = render(<MentionToken mention={taskMention} />);
+		it('is focusable via tabIndex=0 when onClick is provided', () => {
+			const { container } = render(<MentionToken mention={taskMention} onClick={vi.fn()} />);
 			const token = container.querySelector('[tabindex="0"]');
 			expect(token).toBeTruthy();
+		});
+
+		it('is not focusable when onClick is not provided', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[tabindex="0"]');
+			expect(token).toBeNull();
+		});
+
+		it('sets aria-describedby to tooltip id when tooltip is visible', () => {
+			const { container } = render(<MentionToken mention={taskMention} onClick={vi.fn()} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.mouseEnter(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			const tooltipId = tooltip?.getAttribute('id');
+			expect(tooltipId).toBeTruthy();
+			expect(token?.getAttribute('aria-describedby')).toBe(tooltipId);
+		});
+
+		it('does not set aria-describedby when tooltip is hidden', () => {
+			const { container } = render(<MentionToken mention={taskMention} onClick={vi.fn()} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.getAttribute('aria-describedby')).toBeNull();
 		});
 
 		it('uses metadata displayText in aria-label when available', () => {
@@ -204,11 +226,19 @@ describe('MentionToken', () => {
 			expect(onClick).toHaveBeenCalledTimes(1);
 		});
 
+		it('calls onClick when Space key is pressed', () => {
+			const onClick = vi.fn();
+			const { container } = render(<MentionToken mention={taskMention} onClick={onClick} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.keyDown(token!, { key: ' ' });
+			expect(onClick).toHaveBeenCalledTimes(1);
+		});
+
 		it('does not call onClick when other keys are pressed', () => {
 			const onClick = vi.fn();
 			const { container } = render(<MentionToken mention={taskMention} onClick={onClick} />);
 			const token = container.querySelector('[aria-label]');
-			fireEvent.keyDown(token!, { key: 'Space' });
+			fireEvent.keyDown(token!, { key: 'Tab' });
 			fireEvent.keyDown(token!, { key: 'a' });
 			expect(onClick).not.toHaveBeenCalled();
 		});

--- a/packages/web/src/components/__tests__/MentionToken.test.tsx
+++ b/packages/web/src/components/__tests__/MentionToken.test.tsx
@@ -1,0 +1,329 @@
+// @ts-nocheck
+/**
+ * Tests for MentionToken Component
+ */
+
+import { render, fireEvent } from '@testing-library/preact';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import MentionToken from '../MentionToken';
+import type { ReferenceMention, ReferenceMetadata } from '@neokai/shared';
+
+const taskMention: ReferenceMention = {
+	type: 'task',
+	id: 't-42',
+	displayText: 'Fix login bug',
+};
+
+const goalMention: ReferenceMention = {
+	type: 'goal',
+	id: 'g-7',
+	displayText: 'Launch v2',
+};
+
+const fileMention: ReferenceMention = {
+	type: 'file',
+	id: 'src/app.ts',
+	displayText: 'app.ts',
+};
+
+const folderMention: ReferenceMention = {
+	type: 'folder',
+	id: 'src',
+	displayText: 'src',
+};
+
+describe('MentionToken', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('Rendering', () => {
+		it('renders displayText from mention when no metadata is provided', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			expect(container.textContent).toContain('Fix login bug');
+		});
+
+		it('renders displayText from metadata when available', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-42}': { type: 'task', id: 't-42', displayText: 'Updated Task Title' },
+			};
+			const { container } = render(<MentionToken mention={taskMention} metadata={metadata} />);
+			expect(container.textContent).toContain('Updated Task Title');
+		});
+
+		it('prefers metadata displayText over mention displayText', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-42}': { type: 'task', id: 't-42', displayText: 'Meta Title' },
+			};
+			const { container } = render(<MentionToken mention={taskMention} metadata={metadata} />);
+			expect(container.textContent).toContain('Meta Title');
+			expect(container.textContent).not.toContain('Fix login bug');
+		});
+
+		it('falls back to mention.id when displayText is empty string', () => {
+			const mention: ReferenceMention = { type: 'task', id: 't-99', displayText: '' };
+			const { container } = render(<MentionToken mention={mention} />);
+			// empty string is falsy, falls back to id
+			expect(container.textContent).toContain('t-99');
+		});
+
+		it('renders task mention with blue styling', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.className).toContain('bg-blue-500/15');
+			expect(token?.className).toContain('text-blue-300');
+		});
+
+		it('renders goal mention with purple styling', () => {
+			const { container } = render(<MentionToken mention={goalMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.className).toContain('bg-purple-500/15');
+			expect(token?.className).toContain('text-purple-300');
+		});
+
+		it('renders file mention with green styling', () => {
+			const { container } = render(<MentionToken mention={fileMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.className).toContain('bg-green-500/15');
+			expect(token?.className).toContain('text-green-300');
+		});
+
+		it('renders folder mention with yellow styling', () => {
+			const { container } = render(<MentionToken mention={folderMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.className).toContain('bg-yellow-500/15');
+			expect(token?.className).toContain('text-yellow-300');
+		});
+
+		it('renders a pill shape (rounded-full)', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.className).toContain('rounded-full');
+		});
+
+		it('renders an SVG icon for each type', () => {
+			const types = [taskMention, goalMention, fileMention, folderMention];
+			for (const mention of types) {
+				const { container } = render(<MentionToken mention={mention} />);
+				expect(container.querySelector('svg')).toBeTruthy();
+			}
+		});
+	});
+
+	describe('ARIA accessibility', () => {
+		it('sets aria-label with type and displayText for task', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.getAttribute('aria-label')).toBe('task reference: Fix login bug');
+		});
+
+		it('sets aria-label with type and displayText for goal', () => {
+			const { container } = render(<MentionToken mention={goalMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.getAttribute('aria-label')).toBe('goal reference: Launch v2');
+		});
+
+		it('sets aria-label with type and displayText for file', () => {
+			const { container } = render(<MentionToken mention={fileMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.getAttribute('aria-label')).toBe('file reference: app.ts');
+		});
+
+		it('sets aria-label with type and displayText for folder', () => {
+			const { container } = render(<MentionToken mention={folderMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.getAttribute('aria-label')).toBe('folder reference: src');
+		});
+
+		it('sets role="button" when onClick is provided', () => {
+			const { container } = render(<MentionToken mention={taskMention} onClick={vi.fn()} />);
+			const token = container.querySelector('[role="button"]');
+			expect(token).toBeTruthy();
+		});
+
+		it('does not set role="button" when onClick is not provided', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[role="button"]');
+			expect(token).toBeNull();
+		});
+
+		it('is focusable via tabIndex=0', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[tabindex="0"]');
+			expect(token).toBeTruthy();
+		});
+
+		it('uses metadata displayText in aria-label when available', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-42}': { type: 'task', id: 't-42', displayText: 'Meta Label' },
+			};
+			const { container } = render(<MentionToken mention={taskMention} metadata={metadata} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.getAttribute('aria-label')).toBe('task reference: Meta Label');
+		});
+	});
+
+	describe('Click interaction', () => {
+		it('calls onClick when the token is clicked', () => {
+			const onClick = vi.fn();
+			const { container } = render(<MentionToken mention={taskMention} onClick={onClick} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.click(token!);
+			expect(onClick).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not throw when clicked without onClick handler', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(() => fireEvent.click(token!)).not.toThrow();
+		});
+
+		it('applies cursor-pointer class when onClick is provided', () => {
+			const { container } = render(<MentionToken mention={taskMention} onClick={vi.fn()} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.className).toContain('cursor-pointer');
+		});
+
+		it('applies cursor-default class when onClick is not provided', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(token?.className).toContain('cursor-default');
+		});
+	});
+
+	describe('Keyboard accessibility', () => {
+		it('calls onClick when Enter key is pressed', () => {
+			const onClick = vi.fn();
+			const { container } = render(<MentionToken mention={taskMention} onClick={onClick} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.keyDown(token!, { key: 'Enter' });
+			expect(onClick).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not call onClick when other keys are pressed', () => {
+			const onClick = vi.fn();
+			const { container } = render(<MentionToken mention={taskMention} onClick={onClick} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.keyDown(token!, { key: 'Space' });
+			fireEvent.keyDown(token!, { key: 'a' });
+			expect(onClick).not.toHaveBeenCalled();
+		});
+
+		it('does not throw on Enter key press when onClick is absent', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			expect(() => fireEvent.keyDown(token!, { key: 'Enter' })).not.toThrow();
+		});
+	});
+
+	describe('Tooltip', () => {
+		it('shows tooltip on mouse enter', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.mouseEnter(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			expect(tooltip).toBeTruthy();
+		});
+
+		it('hides tooltip on mouse leave', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.mouseEnter(token!);
+			fireEvent.mouseLeave(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			expect(tooltip).toBeNull();
+		});
+
+		it('shows tooltip on focus', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.focus(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			expect(tooltip).toBeTruthy();
+		});
+
+		it('hides tooltip on blur', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.focus(token!);
+			fireEvent.blur(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			expect(tooltip).toBeNull();
+		});
+
+		it('tooltip shows displayText', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.mouseEnter(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			expect(tooltip?.textContent).toContain('Fix login bug');
+		});
+
+		it('tooltip shows type and id', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.mouseEnter(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			expect(tooltip?.textContent).toContain('task');
+			expect(tooltip?.textContent).toContain('t-42');
+		});
+
+		it('tooltip shows status when present in metadata', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-42}': {
+					type: 'task',
+					id: 't-42',
+					displayText: 'Fix login bug',
+					status: 'in-progress',
+				},
+			};
+			const { container } = render(<MentionToken mention={taskMention} metadata={metadata} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.mouseEnter(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			expect(tooltip?.textContent).toContain('in-progress');
+		});
+
+		it('tooltip does not show status when absent', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const token = container.querySelector('[aria-label]');
+			fireEvent.mouseEnter(token!);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			// No status span: inner container has only displayText + type:id children
+			const innerContainer = tooltip?.querySelector('span');
+			const childSpans = innerContainer?.querySelectorAll(':scope > span');
+			// Only two: displayText and type:id (no status span)
+			expect(childSpans?.length).toBe(2);
+		});
+
+		it('tooltip is not rendered initially', () => {
+			const { container } = render(<MentionToken mention={taskMention} />);
+			const tooltip = container.querySelector('[role="tooltip"]');
+			expect(tooltip).toBeNull();
+		});
+	});
+
+	describe('Metadata fallback', () => {
+		it('falls back to mention.displayText when metadata key does not match', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-99}': { type: 'task', id: 't-99', displayText: 'Other Task' },
+			};
+			const { container } = render(<MentionToken mention={taskMention} metadata={metadata} />);
+			expect(container.textContent).toContain('Fix login bug');
+		});
+
+		it('falls back to mention.id when both metadata and displayText are unavailable', () => {
+			const mention: ReferenceMention = { type: 'file', id: 'src/foo.ts', displayText: '' };
+			const { container } = render(<MentionToken mention={mention} />);
+			expect(container.textContent).toContain('src/foo.ts');
+		});
+
+		it('renders without metadata prop', () => {
+			expect(() => render(<MentionToken mention={taskMention} />)).not.toThrow();
+		});
+	});
+});


### PR DESCRIPTION
Renders a single @ref{type:id} token as a styled pill with type-specific
colors (task=blue, goal=purple, file=green, folder=yellow), an SVG icon,
hover/focus tooltip showing full entity details, click/keyboard handlers,
and ARIA accessibility labels.

37 unit tests cover rendering, type styles, aria labels, click, keyboard
(Enter key), tooltip show/hide, status display, and metadata fallback.
