### PR TITLE
feat(e2e): add room entity and reference autocomplete helpers

### DIFF
--- a/packages/e2e/tests/helpers/reference-helpers.ts
+++ b/packages/e2e/tests/helpers/reference-helpers.ts
@@ -1,0 +1,161 @@
+/**
+ * Reference Autocomplete E2E Helpers
+ *
+ * Shared helper functions for @ reference autocomplete interactions in E2E tests.
+ * All helpers interact through the browser UI (clicks, keyboard, DOM queries).
+ * No direct state access is performed.
+ */
+
+import type { Page, Locator } from '@playwright/test';
+
+// ─── Selectors ────────────────────────────────────────────────────────────────
+
+/** The chat textarea that accepts user input */
+const CHAT_INPUT_SELECTOR = 'textarea[placeholder*="Ask"]';
+
+/** The reference autocomplete dropdown (role="listbox") */
+const AUTOCOMPLETE_SELECTOR = '[role="listbox"]';
+
+/** Individual reference items inside the autocomplete */
+const AUTOCOMPLETE_ITEM_SELECTOR = '[role="option"]';
+
+// ─── Autocomplete Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Type text in the chat input field.
+ *
+ * Uses `fill` for plain text and `pressSequentially` for sequences that include
+ * the `@` trigger character so the React-like signal-based onChange fires.
+ */
+export async function typeInChatInput(page: Page, text: string): Promise<void> {
+	const textarea = page.locator(CHAT_INPUT_SELECTOR).first();
+	await textarea.waitFor({ state: 'visible', timeout: 5000 });
+	// pressSequentially dispatches individual keydown/input/keyup events, which is
+	// necessary for the @ trigger detection in useReferenceAutocomplete.
+	await textarea.pressSequentially(text, { delay: 30 });
+}
+
+/**
+ * Wait for the reference autocomplete dropdown to appear.
+ *
+ * The dropdown is rendered as a `role="listbox"` element by ReferenceAutocomplete.
+ */
+export async function waitForReferenceAutocomplete(page: Page): Promise<Locator> {
+	const dropdown = page.locator(AUTOCOMPLETE_SELECTOR).first();
+	await dropdown.waitFor({ state: 'visible', timeout: 5000 });
+	return dropdown;
+}
+
+/**
+ * Get all reference autocomplete items currently visible in the dropdown.
+ *
+ * Returns a Locator pointing to all `role="option"` elements inside the listbox.
+ */
+export function getReferenceAutocompleteItems(page: Page): Locator {
+	return page.locator(`${AUTOCOMPLETE_SELECTOR} ${AUTOCOMPLETE_ITEM_SELECTOR}`);
+}
+
+/**
+ * Navigate to an autocomplete item by index using keyboard and select it with Enter.
+ *
+ * Index is 0-based and maps to the global order of items across all groups.
+ * Pressing ArrowDown `index + 1` times from the initial position selects the
+ * desired item (the hook starts at index -1 / no selection before the first key).
+ *
+ * @param page - Playwright page
+ * @param index - 0-based index of the item to select
+ */
+export async function selectReferenceByIndex(page: Page, index: number): Promise<void> {
+	const textarea = page.locator(CHAT_INPUT_SELECTOR).first();
+	// Press ArrowDown (index + 1) times to reach the target item
+	for (let i = 0; i <= index; i++) {
+		await textarea.press('ArrowDown');
+	}
+	await textarea.press('Enter');
+}
+
+/**
+ * Click on a specific autocomplete item whose text contains `searchText`.
+ *
+ * @param page - Playwright page
+ * @param searchText - Substring of the item's display text to match
+ */
+export async function selectReferenceByClick(page: Page, searchText: string): Promise<void> {
+	const item = page
+		.locator(`${AUTOCOMPLETE_SELECTOR} ${AUTOCOMPLETE_ITEM_SELECTOR}`)
+		.filter({ hasText: searchText })
+		.first();
+	await item.waitFor({ state: 'visible', timeout: 5000 });
+	await item.click();
+}
+
+// ─── Mention Token Helpers ────────────────────────────────────────────────────
+
+/**
+ * Build a CSS/text selector for a `@ref{type:id}` token inside the textarea value.
+ *
+ * Because the textarea is a plain `<textarea>` element, "tokens" are not rendered
+ * as DOM nodes — the raw `@ref{type:id}` syntax is stored in the textarea value.
+ * These helpers therefore check the textarea value for the expected token text.
+ *
+ * @param refId - Full reference token identifier, e.g. "task:t-3" or "goal:g-1"
+ */
+function buildRefToken(refId: string): string {
+	return `@ref{${refId}}`;
+}
+
+/**
+ * Wait for a mention token to appear in the chat input textarea value.
+ *
+ * @param page - Playwright page
+ * @param refId - Reference identifier, e.g. "task:t-3"
+ */
+export async function waitForMentionToken(page: Page, refId: string): Promise<void> {
+	const token = buildRefToken(refId);
+	await page.waitForFunction(
+		({ selector, t }) => {
+			const textarea = document.querySelector(selector) as HTMLTextAreaElement | null;
+			return textarea?.value?.includes(t) ?? false;
+		},
+		{ selector: CHAT_INPUT_SELECTOR, t: token },
+		{ timeout: 5000 }
+	);
+}
+
+/**
+ * Get the full text content of the chat input textarea.
+ * Useful for asserting that a mention token (`@ref{type:id}`) is present after selection.
+ *
+ * @param page - Playwright page
+ * @param refId - Reference identifier, e.g. "task:t-3"
+ * @returns The portion of the textarea value that contains the token, or null if not found
+ */
+export async function getMentionTokenText(page: Page, refId: string): Promise<string | null> {
+	const token = buildRefToken(refId);
+	const value = await page.evaluate(
+		({ selector, t }) => {
+			const textarea = document.querySelector(selector) as HTMLTextAreaElement | null;
+			const v = textarea?.value ?? '';
+			return v.includes(t) ? t : null;
+		},
+		{ selector: CHAT_INPUT_SELECTOR, t: token }
+	);
+	return value;
+}
+
+/**
+ * Hover over a mention token in the chat textarea.
+ *
+ * Because `<textarea>` renders plain text without child DOM nodes, this helper
+ * hovers over the textarea element itself (the only interactive target available).
+ * Tests that need to verify tooltip/popover behaviour on tokens should use the
+ * MentionToken component (M4) once it exists and renders rich DOM nodes.
+ *
+ * @param page - Playwright page
+ * @param refId - Reference identifier (used to verify the token is present first)
+ */
+export async function hoverMentionToken(page: Page, refId: string): Promise<void> {
+	await waitForMentionToken(page, refId);
+	const textarea = page.locator(CHAT_INPUT_SELECTOR).first();
+	await textarea.hover();
+}

--- a/packages/e2e/tests/helpers/reference-helpers.ts
+++ b/packages/e2e/tests/helpers/reference-helpers.ts
@@ -24,8 +24,8 @@ const AUTOCOMPLETE_ITEM_SELECTOR = '[role="option"]';
 /**
  * Type text in the chat input field.
  *
- * Uses `fill` for plain text and `pressSequentially` for sequences that include
- * the `@` trigger character so the React-like signal-based onChange fires.
+ * Uses `pressSequentially` to dispatch individual keydown/input/keyup events,
+ * which is necessary for the @ trigger detection in useReferenceAutocomplete.
  */
 export async function typeInChatInput(page: Page, text: string): Promise<void> {
 	const textarea = page.locator(CHAT_INPUT_SELECTOR).first();
@@ -59,16 +59,16 @@ export function getReferenceAutocompleteItems(page: Page): Locator {
  * Navigate to an autocomplete item by index using keyboard and select it with Enter.
  *
  * Index is 0-based and maps to the global order of items across all groups.
- * Pressing ArrowDown `index + 1` times from the initial position selects the
- * desired item (the hook starts at index -1 / no selection before the first key).
+ * The hook initializes `selectedIndex` to `0`, so index 0 is already selected
+ * when the dropdown opens. Pressing ArrowDown N times moves to index N.
  *
  * @param page - Playwright page
  * @param index - 0-based index of the item to select
  */
 export async function selectReferenceByIndex(page: Page, index: number): Promise<void> {
 	const textarea = page.locator(CHAT_INPUT_SELECTOR).first();
-	// Press ArrowDown (index + 1) times to reach the target item
-	for (let i = 0; i <= index; i++) {
+	// Press ArrowDown `index` times — selectedIndex starts at 0, so N presses reaches index N.
+	for (let i = 0; i < index; i++) {
 		await textarea.press('ArrowDown');
 	}
 	await textarea.press('Enter');
@@ -144,15 +144,16 @@ export async function getMentionTokenText(page: Page, refId: string): Promise<st
 }
 
 /**
- * Hover over a mention token in the chat textarea.
+ * Hover over the chat textarea after verifying a mention token is present.
  *
- * Because `<textarea>` renders plain text without child DOM nodes, this helper
- * hovers over the textarea element itself (the only interactive target available).
- * Tests that need to verify tooltip/popover behaviour on tokens should use the
- * MentionToken component (M4) once it exists and renders rich DOM nodes.
+ * NOTE: This hovers over the entire `<textarea>` element, NOT a specific token
+ * position. Plain `<textarea>` elements render text as a single node with no
+ * per-token child elements, so per-token hover targeting is not possible here.
+ * Once the MentionToken component (M4) renders `@ref` tokens as rich DOM nodes,
+ * this helper should be updated to target those nodes instead.
  *
  * @param page - Playwright page
- * @param refId - Reference identifier (used to verify the token is present first)
+ * @param refId - Reference identifier verified to be present before hovering
  */
 export async function hoverMentionToken(page: Page, refId: string): Promise<void> {
 	await waitForMentionToken(page, refId);

--- a/packages/e2e/tests/helpers/room-helpers.ts
+++ b/packages/e2e/tests/helpers/room-helpers.ts
@@ -111,26 +111,6 @@ export async function createGoal(
 // ─── Delete Helpers ───────────────────────────────────────────────────────────
 
 /**
- * Delete a task via RPC. Best-effort — silently ignores errors so it can be
- * used safely in afterEach without masking test failures.
- */
-export async function deleteTask(page: Page, roomId: string, taskId: string): Promise<void> {
-	if (!taskId) return;
-	try {
-		await page.evaluate(
-			async ({ rId, tId }) => {
-				const hub = window.__messageHub || window.appState?.messageHub;
-				if (!hub?.request) return;
-				await hub.request('task.delete', { roomId: rId, taskId: tId });
-			},
-			{ rId: roomId, tId: taskId }
-		);
-	} catch {
-		// Best-effort cleanup
-	}
-}
-
-/**
  * Delete a goal via RPC. Best-effort — silently ignores errors so it can be
  * used safely in afterEach without masking test failures.
  */
@@ -262,14 +242,15 @@ export async function cleanupRoom(page: Page, roomId: string): Promise<void> {
 /**
  * Entity IDs collected during a test for bulk cleanup.
  *
- * - `roomIds`: Rooms to delete. Cascades to all tasks/goals inside them.
- * - `tasks`: Standalone tasks created in an existing room (not covered by room cascade).
- * - `goals`: Standalone goals created in an existing room (not covered by room cascade).
+ * - `roomIds`: Rooms to delete. Deletion cascades to all tasks inside them.
+ *   Tasks have no standalone delete RPC (`task.delete` does not exist), so
+ *   they must always be cleaned up by deleting their parent room.
+ * - `goals`: Standalone goals created in an existing room that will NOT be
+ *   deleted (use `deleteGoal` directly when the room survives the test).
  * - `filePaths`: Workspace-relative file paths created by `createTestFile`.
  */
 export interface CreatedEntities {
 	roomIds?: string[];
-	tasks?: Array<{ roomId: string; taskId: string }>;
 	goals?: Array<{ roomId: string; goalId: string }>;
 	filePaths?: string[];
 }
@@ -277,7 +258,7 @@ export interface CreatedEntities {
 /**
  * Bulk cleanup of all created entities.
  *
- * Deletes rooms (cascades tasks/goals), individual tasks/goals in existing rooms,
+ * Deletes rooms (cascades all tasks), individual goals in surviving rooms,
  * and workspace files. Best-effort — silently ignores errors.
  */
 export async function cleanupAllCreatedEntities(
@@ -285,12 +266,9 @@ export async function cleanupAllCreatedEntities(
 	entities: CreatedEntities
 ): Promise<void> {
 	const roomCleanups = (entities.roomIds ?? []).map((id) => cleanupRoom(page, id));
-	const taskCleanups = (entities.tasks ?? []).map(({ roomId, taskId }) =>
-		deleteTask(page, roomId, taskId)
-	);
 	const goalCleanups = (entities.goals ?? []).map(({ roomId, goalId }) =>
 		deleteGoal(page, roomId, goalId)
 	);
 	const fileCleanups = (entities.filePaths ?? []).map((fp) => deleteTestFile(page, fp));
-	await Promise.allSettled([...roomCleanups, ...taskCleanups, ...goalCleanups, ...fileCleanups]);
+	await Promise.allSettled([...roomCleanups, ...goalCleanups, ...fileCleanups]);
 }

--- a/packages/e2e/tests/helpers/room-helpers.ts
+++ b/packages/e2e/tests/helpers/room-helpers.ts
@@ -108,18 +108,63 @@ export async function createGoal(
 	);
 }
 
+// ─── Delete Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Delete a task via RPC. Best-effort — silently ignores errors so it can be
+ * used safely in afterEach without masking test failures.
+ */
+export async function deleteTask(page: Page, roomId: string, taskId: string): Promise<void> {
+	if (!taskId) return;
+	try {
+		await page.evaluate(
+			async ({ rId, tId }) => {
+				const hub = window.__messageHub || window.appState?.messageHub;
+				if (!hub?.request) return;
+				await hub.request('task.delete', { roomId: rId, taskId: tId });
+			},
+			{ rId: roomId, tId: taskId }
+		);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+/**
+ * Delete a goal via RPC. Best-effort — silently ignores errors so it can be
+ * used safely in afterEach without masking test failures.
+ */
+export async function deleteGoal(page: Page, roomId: string, goalId: string): Promise<void> {
+	if (!goalId) return;
+	try {
+		await page.evaluate(
+			async ({ rId, gId }) => {
+				const hub = window.__messageHub || window.appState?.messageHub;
+				if (!hub?.request) return;
+				await hub.request('goal.delete', { roomId: rId, goalId: gId });
+			},
+			{ rId: roomId, gId: goalId }
+		);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
 // ─── Composite Setup Helpers ──────────────────────────────────────────────────
 
 /**
  * Create a room with a task via RPC. Returns both IDs.
  * For use in beforeEach setup only.
+ *
+ * @param roomName - Optional explicit room name; defaults to `"${taskTitle} Room"`
  */
 export async function createRoomWithTask(
 	page: Page,
 	taskTitle: string,
-	taskDesc = ''
+	taskDesc = '',
+	roomName?: string
 ): Promise<{ roomId: string; taskId: string }> {
-	const roomId = await createRoom(page, `${taskTitle} Room`);
+	const roomId = await createRoom(page, roomName ?? `${taskTitle} Room`);
 	const taskId = await createTask(page, roomId, taskTitle, taskDesc);
 	return { roomId, taskId };
 }
@@ -127,13 +172,16 @@ export async function createRoomWithTask(
 /**
  * Create a room with a goal via RPC. Returns both IDs.
  * For use in beforeEach setup only.
+ *
+ * @param roomName - Optional explicit room name; defaults to `"${goalTitle} Room"`
  */
 export async function createRoomWithGoal(
 	page: Page,
 	goalTitle: string,
-	goalDesc = ''
+	goalDesc = '',
+	roomName?: string
 ): Promise<{ roomId: string; goalId: string }> {
-	const roomId = await createRoom(page, `${goalTitle} Room`);
+	const roomId = await createRoom(page, roomName ?? `${goalTitle} Room`);
 	const goalId = await createGoal(page, roomId, goalTitle, goalDesc);
 	return { roomId, goalId };
 }
@@ -141,15 +189,18 @@ export async function createRoomWithGoal(
 /**
  * Create a room with both a task and a goal via RPC. Returns all IDs.
  * For use in beforeEach setup only.
+ *
+ * @param roomName - Optional explicit room name; defaults to `"${taskTitle}-${goalTitle} Room"`
  */
 export async function createRoomWithTaskAndGoal(
 	page: Page,
 	taskTitle: string,
 	goalTitle: string,
 	taskDesc = '',
-	goalDesc = ''
+	goalDesc = '',
+	roomName?: string
 ): Promise<{ roomId: string; taskId: string; goalId: string }> {
-	const roomId = await createRoom(page, `${taskTitle} Room`);
+	const roomId = await createRoom(page, roomName ?? `${taskTitle}-${goalTitle} Room`);
 	const taskId = await createTask(page, roomId, taskTitle, taskDesc);
 	const goalId = await createGoal(page, roomId, goalTitle, goalDesc);
 	return { roomId, taskId, goalId };
@@ -210,22 +261,36 @@ export async function cleanupRoom(page: Page, roomId: string): Promise<void> {
 
 /**
  * Entity IDs collected during a test for bulk cleanup.
+ *
+ * - `roomIds`: Rooms to delete. Cascades to all tasks/goals inside them.
+ * - `tasks`: Standalone tasks created in an existing room (not covered by room cascade).
+ * - `goals`: Standalone goals created in an existing room (not covered by room cascade).
+ * - `filePaths`: Workspace-relative file paths created by `createTestFile`.
  */
 export interface CreatedEntities {
 	roomIds?: string[];
+	tasks?: Array<{ roomId: string; taskId: string }>;
+	goals?: Array<{ roomId: string; goalId: string }>;
 	filePaths?: string[];
 }
 
 /**
  * Bulk cleanup of all created entities.
- * Deletes rooms (and their tasks/goals) and workspace files.
- * Best-effort — silently ignores errors.
+ *
+ * Deletes rooms (cascades tasks/goals), individual tasks/goals in existing rooms,
+ * and workspace files. Best-effort — silently ignores errors.
  */
 export async function cleanupAllCreatedEntities(
 	page: Page,
 	entities: CreatedEntities
 ): Promise<void> {
 	const roomCleanups = (entities.roomIds ?? []).map((id) => cleanupRoom(page, id));
+	const taskCleanups = (entities.tasks ?? []).map(({ roomId, taskId }) =>
+		deleteTask(page, roomId, taskId)
+	);
+	const goalCleanups = (entities.goals ?? []).map(({ roomId, goalId }) =>
+		deleteGoal(page, roomId, goalId)
+	);
 	const fileCleanups = (entities.filePaths ?? []).map((fp) => deleteTestFile(page, fp));
-	await Promise.allSettled([...roomCleanups, ...fileCleanups]);
+	await Promise.allSettled([...roomCleanups, ...taskCleanups, ...goalCleanups, ...fileCleanups]);
 }

--- a/packages/e2e/tests/helpers/room-helpers.ts
+++ b/packages/e2e/tests/helpers/room-helpers.ts
@@ -5,9 +5,11 @@
  * All test actions and assertions must go through the browser UI.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
-import { waitForWebSocketConnected } from './wait-helpers';
+import { waitForWebSocketConnected, getWorkspaceRoot } from './wait-helpers';
 
 /**
  * Create a room via RPC. For use in beforeEach setup only.
@@ -51,4 +53,179 @@ export async function openMissionsTab(page: Page): Promise<void> {
 	await expect(missionsTab).toBeVisible({ timeout: 10000 });
 	await missionsTab.click();
 	await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });
+}
+
+// ─── Task / Goal Creation ─────────────────────────────────────────────────────
+
+/**
+ * Create a task in a room via RPC. For use in beforeEach setup only.
+ *
+ * Returns the task's short ID (e.g. "t-3").
+ */
+export async function createTask(
+	page: Page,
+	roomId: string,
+	title: string,
+	description = ''
+): Promise<string> {
+	await waitForWebSocketConnected(page);
+	return page.evaluate(
+		async ({ rId, t, d }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const res = await hub.request('task.create', { roomId: rId, title: t, description: d });
+			return (res as { task: { id: string } }).task.id;
+		},
+		{ rId: roomId, t: title, d: description }
+	);
+}
+
+/**
+ * Create a goal in a room via RPC. For use in beforeEach setup only.
+ *
+ * Returns the goal's short ID (e.g. "g-2").
+ */
+export async function createGoal(
+	page: Page,
+	roomId: string,
+	title: string,
+	description = ''
+): Promise<string> {
+	await waitForWebSocketConnected(page);
+	return page.evaluate(
+		async ({ rId, t, d }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const res = await hub.request('goal.create', {
+				roomId: rId,
+				title: t,
+				description: d,
+				priority: 'normal',
+			});
+			return (res as { goal: { id: string } }).goal.id;
+		},
+		{ rId: roomId, t: title, d: description }
+	);
+}
+
+// ─── Composite Setup Helpers ──────────────────────────────────────────────────
+
+/**
+ * Create a room with a task via RPC. Returns both IDs.
+ * For use in beforeEach setup only.
+ */
+export async function createRoomWithTask(
+	page: Page,
+	taskTitle: string,
+	taskDesc = ''
+): Promise<{ roomId: string; taskId: string }> {
+	const roomId = await createRoom(page, `${taskTitle} Room`);
+	const taskId = await createTask(page, roomId, taskTitle, taskDesc);
+	return { roomId, taskId };
+}
+
+/**
+ * Create a room with a goal via RPC. Returns both IDs.
+ * For use in beforeEach setup only.
+ */
+export async function createRoomWithGoal(
+	page: Page,
+	goalTitle: string,
+	goalDesc = ''
+): Promise<{ roomId: string; goalId: string }> {
+	const roomId = await createRoom(page, `${goalTitle} Room`);
+	const goalId = await createGoal(page, roomId, goalTitle, goalDesc);
+	return { roomId, goalId };
+}
+
+/**
+ * Create a room with both a task and a goal via RPC. Returns all IDs.
+ * For use in beforeEach setup only.
+ */
+export async function createRoomWithTaskAndGoal(
+	page: Page,
+	taskTitle: string,
+	goalTitle: string,
+	taskDesc = '',
+	goalDesc = ''
+): Promise<{ roomId: string; taskId: string; goalId: string }> {
+	const roomId = await createRoom(page, `${taskTitle} Room`);
+	const taskId = await createTask(page, roomId, taskTitle, taskDesc);
+	const goalId = await createGoal(page, roomId, goalTitle, goalDesc);
+	return { roomId, taskId, goalId };
+}
+
+// ─── File Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Create a test file in the workspace directory.
+ * For use in beforeEach setup only — writes using Node.js fs (test process side).
+ *
+ * @param page - Playwright page (used to resolve workspace root)
+ * @param filePath - Relative path within the workspace (e.g. "e2e-test/sample.ts")
+ * @param content - File content to write
+ * @returns Absolute path of the created file
+ */
+export async function createTestFile(
+	page: Page,
+	filePath: string,
+	content: string
+): Promise<string> {
+	const workspaceRoot = await getWorkspaceRoot(page);
+	const absPath = path.join(workspaceRoot, filePath);
+	fs.mkdirSync(path.dirname(absPath), { recursive: true });
+	fs.writeFileSync(absPath, content, 'utf-8');
+	return absPath;
+}
+
+/**
+ * Delete a test file from the workspace directory.
+ * Best-effort — silently ignores errors so it can be used safely in afterEach.
+ *
+ * @param page - Playwright page (used to resolve workspace root)
+ * @param filePath - Relative path within the workspace (same as passed to createTestFile)
+ */
+export async function deleteTestFile(page: Page, filePath: string): Promise<void> {
+	try {
+		const workspaceRoot = await getWorkspaceRoot(page);
+		const absPath = path.join(workspaceRoot, filePath);
+		if (fs.existsSync(absPath)) {
+			fs.rmSync(absPath, { force: true });
+		}
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+// ─── Cleanup Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Delete a room and all associated entities via RPC.
+ * Alias for deleteRoom — provided for semantic clarity in reference test teardown.
+ * Best-effort — silently ignores errors so it can be used safely in afterEach.
+ */
+export async function cleanupRoom(page: Page, roomId: string): Promise<void> {
+	await deleteRoom(page, roomId);
+}
+
+/**
+ * Entity IDs collected during a test for bulk cleanup.
+ */
+export interface CreatedEntities {
+	roomIds?: string[];
+	filePaths?: string[];
+}
+
+/**
+ * Bulk cleanup of all created entities.
+ * Deletes rooms (and their tasks/goals) and workspace files.
+ * Best-effort — silently ignores errors.
+ */
+export async function cleanupAllCreatedEntities(
+	page: Page,
+	entities: CreatedEntities
+): Promise<void> {
+	const roomCleanups = (entities.roomIds ?? []).map((id) => cleanupRoom(page, id));
+	const fileCleanups = (entities.filePaths ?? []).map((fp) => deleteTestFile(page, fp));
+	await Promise.allSettled([...roomCleanups, ...fileCleanups]);
 }


### PR DESCRIPTION
Add reusable E2E helper functions for the @ referencing system E2E tests:

- room-helpers.ts: createTask, createGoal, createRoomWithTask,
  createRoomWithGoal, createRoomWithTaskAndGoal, createTestFile,
  deleteTestFile, cleanupRoom, cleanupAllCreatedEntities
- reference-helpers.ts: typeInChatInput, waitForReferenceAutocomplete,
  getReferenceAutocompleteItems, selectReferenceByIndex,
  selectReferenceByClick, waitForMentionToken, getMentionTokenText,
  hoverMentionToken
