### PR TITLE
feat(web): integrate @ref token rendering in SDKUserMessage

### DIFF
--- a/packages/web/src/components/sdk/MentionToken.tsx
+++ b/packages/web/src/components/sdk/MentionToken.tsx
@@ -10,7 +10,7 @@
 
 import type { JSX } from 'preact';
 import { memo } from 'preact/compat';
-import { useState, useCallback } from 'preact/hooks';
+import { useState, useCallback, useRef } from 'preact/hooks';
 import { cn } from '../../lib/utils.ts';
 import { useMessageHub } from '../../hooks/useMessageHub.ts';
 import type { ReferenceType, ReferenceMetadata, ResolvedReference } from '@neokai/shared';
@@ -41,18 +41,8 @@ const TYPE_STYLES: Record<ReferenceType, { pill: string; label: string }> = {
 
 function renderResolvedContent(resolved: ResolvedReference): JSX.Element {
 	switch (resolved.type) {
-		case 'task': {
-			const d = resolved.data as { title?: string; status?: string; description?: string };
-			return (
-				<div>
-					{d.title && <div class="font-medium text-white">{d.title}</div>}
-					{d.status && <div class="text-xs text-gray-400 mt-0.5">Status: {d.status}</div>}
-					{d.description && (
-						<div class="text-xs text-gray-400 mt-1 line-clamp-2">{d.description}</div>
-					)}
-				</div>
-			);
-		}
+		// task and goal share the same shape
+		case 'task':
 		case 'goal': {
 			const d = resolved.data as { title?: string; status?: string; description?: string };
 			return (
@@ -91,6 +81,9 @@ function renderResolvedContent(resolved: ResolvedReference): JSX.Element {
 				</div>
 			);
 		}
+		default: {
+			return <div class="text-xs text-gray-400">Unknown reference type</div>;
+		}
 	}
 }
 
@@ -107,6 +100,14 @@ export interface MentionTokenProps {
 
 type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
 
+/** Popover position computed from getBoundingClientRect, used for fixed positioning. */
+interface PopoverPos {
+	top: number;
+	left: number;
+	/** True when the popover is rendered below the token (not enough space above). */
+	below: boolean;
+}
+
 function MentionTokenBase({
 	refType,
 	id,
@@ -117,12 +118,23 @@ function MentionTokenBase({
 	const [isHovered, setIsHovered] = useState(false);
 	const [loadState, setLoadState] = useState<LoadState>('idle');
 	const [resolvedData, setResolvedData] = useState<ResolvedReference | null>(null);
+	const [popoverPos, setPopoverPos] = useState<PopoverPos>({ top: 0, left: 0, below: false });
+	const tokenRef = useRef<HTMLSpanElement>(null);
 	const { callIfConnected } = useMessageHub();
 
 	const typeStyle = TYPE_STYLES[refType];
 
 	const handleMouseEnter = useCallback(async () => {
+		// Compute fixed viewport position before showing — escapes scroll containers
+		// and overflow:hidden ancestors that would clip an absolute popover.
+		if (tokenRef.current) {
+			const rect = tokenRef.current.getBoundingClientRect();
+			// Flip below the token when there is insufficient space above (< 160 px)
+			const below = rect.top < 160;
+			setPopoverPos({ top: below ? rect.bottom : rect.top, left: rect.left, below });
+		}
 		setIsHovered(true);
+
 		// Only fetch once; skip if already fetched or no sessionId to call with
 		if (loadState === 'idle' && sessionId) {
 			setLoadState('loading');
@@ -143,9 +155,13 @@ function MentionTokenBase({
 		setIsHovered(false);
 	}, []);
 
+	// Popover offset from the token edge (px)
+	const POPOVER_GAP = 6;
+
 	return (
-		<span class="relative inline-block align-baseline">
+		<span class="inline-block align-baseline">
 			<span
+				ref={tokenRef}
 				class={cn(
 					'inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-xs font-medium cursor-default transition-colors',
 					typeStyle.pill
@@ -162,7 +178,16 @@ function MentionTokenBase({
 
 			{isHovered && (
 				<div
-					class="absolute bottom-full left-0 mb-2 z-50 min-w-[180px] max-w-[280px] bg-dark-800 border border-gray-600/50 rounded-md shadow-lg p-3 text-sm pointer-events-none animate-fadeIn"
+					style={{
+						position: 'fixed',
+						left: `${popoverPos.left}px`,
+						top: popoverPos.below
+							? `${popoverPos.top + POPOVER_GAP}px`
+							: `${popoverPos.top - POPOVER_GAP}px`,
+						transform: popoverPos.below ? 'none' : 'translateY(-100%)',
+						zIndex: 9999,
+					}}
+					class="min-w-[180px] max-w-[280px] bg-dark-800 border border-gray-600/50 rounded-md shadow-lg p-3 text-sm pointer-events-none animate-fadeIn"
 					role="tooltip"
 					data-testid="mention-token-popover"
 				>
@@ -199,7 +224,13 @@ export type MentionSegment = {
 export type UnknownMentionSegment = { kind: 'unknown-mention'; content: string };
 export type Segment = TextSegment | MentionSegment | UnknownMentionSegment;
 
-const VALID_REF_TYPES = new Set<string>(['task', 'goal', 'file', 'folder']);
+// Use `satisfies` so the compiler catches any mismatch with the ReferenceType union
+const VALID_REF_TYPES: ReadonlySet<string> = new Set<string>([
+	'task',
+	'goal',
+	'file',
+	'folder',
+] satisfies readonly ReferenceType[]);
 
 /**
  * Parse text content into display segments, resolving @ref{type:id} tokens.

--- a/packages/web/src/components/sdk/MentionToken.tsx
+++ b/packages/web/src/components/sdk/MentionToken.tsx
@@ -1,0 +1,252 @@
+/**
+ * MentionToken Component
+ *
+ * Renders a styled inline pill token for @ref{type:id} mentions in user messages.
+ * On hover, lazily fetches full entity data via the reference.resolve RPC and
+ * shows a popover with entity details.
+ *
+ * Performance: wrapped in memo to prevent re-renders during message list scrolling.
+ */
+
+import type { JSX } from 'preact';
+import { memo } from 'preact/compat';
+import { useState, useCallback } from 'preact/hooks';
+import { cn } from '../../lib/utils.ts';
+import { useMessageHub } from '../../hooks/useMessageHub.ts';
+import type { ReferenceType, ReferenceMetadata, ResolvedReference } from '@neokai/shared';
+import { REFERENCE_PATTERN } from '@neokai/shared';
+
+// ─── Type-specific styles ────────────────────────────────────────────────────
+
+const TYPE_STYLES: Record<ReferenceType, { pill: string; label: string }> = {
+	task: {
+		pill: 'bg-indigo-500/20 text-indigo-300 border-indigo-500/40 hover:bg-indigo-500/30',
+		label: 'task',
+	},
+	goal: {
+		pill: 'bg-amber-500/20 text-amber-300 border-amber-500/40 hover:bg-amber-500/30',
+		label: 'goal',
+	},
+	file: {
+		pill: 'bg-blue-500/20 text-blue-300 border-blue-500/40 hover:bg-blue-500/30',
+		label: 'file',
+	},
+	folder: {
+		pill: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/40 hover:bg-yellow-500/30',
+		label: 'folder',
+	},
+};
+
+// ─── Popover content helpers ─────────────────────────────────────────────────
+
+function renderResolvedContent(resolved: ResolvedReference): JSX.Element {
+	switch (resolved.type) {
+		case 'task': {
+			const d = resolved.data as { title?: string; status?: string; description?: string };
+			return (
+				<div>
+					{d.title && <div class="font-medium text-white">{d.title}</div>}
+					{d.status && <div class="text-xs text-gray-400 mt-0.5">Status: {d.status}</div>}
+					{d.description && (
+						<div class="text-xs text-gray-400 mt-1 line-clamp-2">{d.description}</div>
+					)}
+				</div>
+			);
+		}
+		case 'goal': {
+			const d = resolved.data as { title?: string; status?: string; description?: string };
+			return (
+				<div>
+					{d.title && <div class="font-medium text-white">{d.title}</div>}
+					{d.status && <div class="text-xs text-gray-400 mt-0.5">Status: {d.status}</div>}
+					{d.description && (
+						<div class="text-xs text-gray-400 mt-1 line-clamp-2">{d.description}</div>
+					)}
+				</div>
+			);
+		}
+		case 'file': {
+			const d = resolved.data as {
+				path: string;
+				size: number;
+				binary: boolean;
+				truncated: boolean;
+			};
+			return (
+				<div>
+					<div class="font-medium text-white font-mono text-xs truncate">{d.path}</div>
+					<div class="text-xs text-gray-400 mt-0.5">
+						{d.binary ? 'Binary file' : `${Math.round(d.size / 1024)} KB`}
+						{d.truncated && ' (truncated)'}
+					</div>
+				</div>
+			);
+		}
+		case 'folder': {
+			const d = resolved.data as { path: string; entries: Array<{ name: string }> };
+			return (
+				<div>
+					<div class="font-medium text-white font-mono text-xs truncate">{d.path}</div>
+					<div class="text-xs text-gray-400 mt-0.5">{d.entries.length} entries</div>
+				</div>
+			);
+		}
+	}
+}
+
+// ─── MentionToken component ──────────────────────────────────────────────────
+
+export interface MentionTokenProps {
+	refType: ReferenceType;
+	id: string;
+	displayText: string;
+	status?: string;
+	/** Session ID used for reference.resolve RPC calls. Required for hover preview. */
+	sessionId?: string;
+}
+
+type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
+
+function MentionTokenBase({
+	refType,
+	id,
+	displayText,
+	status: _status,
+	sessionId,
+}: MentionTokenProps) {
+	const [isHovered, setIsHovered] = useState(false);
+	const [loadState, setLoadState] = useState<LoadState>('idle');
+	const [resolvedData, setResolvedData] = useState<ResolvedReference | null>(null);
+	const { callIfConnected } = useMessageHub();
+
+	const typeStyle = TYPE_STYLES[refType];
+
+	const handleMouseEnter = useCallback(async () => {
+		setIsHovered(true);
+		// Only fetch once; skip if already fetched or no sessionId to call with
+		if (loadState === 'idle' && sessionId) {
+			setLoadState('loading');
+			try {
+				const result = await callIfConnected<{ resolved: ResolvedReference | null }>(
+					'reference.resolve',
+					{ sessionId, type: refType, id }
+				);
+				setResolvedData(result?.resolved ?? null);
+				setLoadState('loaded');
+			} catch {
+				setLoadState('error');
+			}
+		}
+	}, [loadState, sessionId, refType, id, callIfConnected]);
+
+	const handleMouseLeave = useCallback(() => {
+		setIsHovered(false);
+	}, []);
+
+	return (
+		<span class="relative inline-block align-baseline">
+			<span
+				class={cn(
+					'inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-xs font-medium cursor-default transition-colors',
+					typeStyle.pill
+				)}
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
+				data-testid="mention-token"
+				data-ref-type={refType}
+				data-ref-id={id}
+			>
+				<span class="opacity-60 text-[10px] uppercase tracking-wide">{typeStyle.label}</span>
+				<span>{displayText}</span>
+			</span>
+
+			{isHovered && (
+				<div
+					class="absolute bottom-full left-0 mb-2 z-50 min-w-[180px] max-w-[280px] bg-dark-800 border border-gray-600/50 rounded-md shadow-lg p-3 text-sm pointer-events-none animate-fadeIn"
+					role="tooltip"
+					data-testid="mention-token-popover"
+				>
+					{loadState === 'loading' && <div class="text-xs text-gray-400">Loading...</div>}
+					{loadState === 'loaded' && resolvedData && renderResolvedContent(resolvedData)}
+					{loadState === 'loaded' && !resolvedData && (
+						<div class="text-xs text-gray-400">Not found</div>
+					)}
+					{loadState === 'error' && <div class="text-xs text-red-400">Failed to load</div>}
+					{loadState === 'idle' && (
+						<div class="text-xs text-gray-400">
+							{refType}/{id}
+						</div>
+					)}
+				</div>
+			)}
+		</span>
+	);
+}
+
+export const MentionToken = memo(MentionTokenBase);
+
+// ─── Text parsing ─────────────────────────────────────────────────────────────
+
+export type TextSegment = { kind: 'text'; content: string };
+export type MentionSegment = {
+	kind: 'mention';
+	raw: string;
+	refType: ReferenceType;
+	id: string;
+	displayText: string;
+	status?: string;
+};
+export type UnknownMentionSegment = { kind: 'unknown-mention'; content: string };
+export type Segment = TextSegment | MentionSegment | UnknownMentionSegment;
+
+const VALID_REF_TYPES = new Set<string>(['task', 'goal', 'file', 'folder']);
+
+/**
+ * Parse text content into display segments, resolving @ref{type:id} tokens.
+ *
+ * - Known type + metadata   → MentionSegment with displayText from metadata
+ * - Known type + no metadata → MentionSegment with raw id as displayText
+ * - Unknown type             → UnknownMentionSegment (rendered with warning styling)
+ * - Plain text / plain @     → TextSegment (rendered as-is)
+ */
+export function parseTextWithReferences(text: string, metadata: ReferenceMetadata): Segment[] {
+	const segments: Segment[] = [];
+	// Clone the regex to get a fresh lastIndex; never mutate the shared export
+	const pattern = new RegExp(REFERENCE_PATTERN.source, REFERENCE_PATTERN.flags);
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = pattern.exec(text)) !== null) {
+		const raw = match[0];
+		const type = match[1];
+		const id = match[2];
+		const start = match.index;
+
+		if (start > lastIndex) {
+			segments.push({ kind: 'text', content: text.slice(lastIndex, start) });
+		}
+
+		if (VALID_REF_TYPES.has(type)) {
+			const meta = metadata[raw];
+			segments.push({
+				kind: 'mention',
+				raw,
+				refType: type as ReferenceType,
+				id,
+				displayText: meta?.displayText ?? id,
+				status: meta?.status,
+			});
+		} else {
+			// Unrecognised type — render as plain text with a subtle warning indicator
+			segments.push({ kind: 'unknown-mention', content: raw });
+		}
+
+		lastIndex = pattern.lastIndex;
+	}
+
+	if (lastIndex < text.length) {
+		segments.push({ kind: 'text', content: text.slice(lastIndex) });
+	}
+
+	return segments;
+}

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -21,6 +21,7 @@ import { renderRewindCheckbox } from './RewindCheckbox.tsx';
 import { isHiddenCommandOutput, SlashCommandOutput } from './SlashCommandOutput.tsx';
 import { SyntheticMessageBlock } from './SyntheticMessageBlock.tsx';
 import type { JSX } from 'preact';
+import { Fragment } from 'preact';
 import type { ReferenceMetadata } from '@neokai/shared';
 
 /**
@@ -43,7 +44,9 @@ function renderMessageText(
 		<>
 			{segments.map((seg, idx) => {
 				if (seg.kind === 'text') {
-					return <span key={idx}>{seg.content}</span>;
+					// Use Fragment to emit text nodes without a DOM wrapper, preserving
+					// the original text-node structure for selection and layout.
+					return <Fragment key={idx}>{seg.content}</Fragment>;
 				}
 				if (seg.kind === 'mention') {
 					return (

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -14,11 +14,59 @@ import { IconButton } from '../ui/IconButton.tsx';
 import { Spinner } from '../ui/Spinner.tsx';
 import { Tooltip } from '../ui/Tooltip.tsx';
 import { ErrorOutput, hasErrorOutput } from './ErrorOutput.tsx';
+import { MentionToken, parseTextWithReferences } from './MentionToken.tsx';
 import { MessageInfoButton } from './MessageInfoButton.tsx';
 import { MessageInfoDropdown } from './MessageInfoDropdown.tsx';
 import { renderRewindCheckbox } from './RewindCheckbox.tsx';
 import { isHiddenCommandOutput, SlashCommandOutput } from './SlashCommandOutput.tsx';
 import { SyntheticMessageBlock } from './SyntheticMessageBlock.tsx';
+import type { JSX } from 'preact';
+import type { ReferenceMetadata } from '@neokai/shared';
+
+/**
+ * Render text content, replacing @ref{type:id} tokens with styled MentionToken
+ * components and leaving all other text (including plain @) unchanged.
+ */
+function renderMessageText(
+	text: string,
+	metadata: ReferenceMetadata,
+	sessionId?: string
+): JSX.Element {
+	// Fast path: skip parsing when there are no @ref tokens
+	if (!text.includes('@ref{')) {
+		return <>{text}</>;
+	}
+
+	const segments = parseTextWithReferences(text, metadata);
+
+	return (
+		<>
+			{segments.map((seg, idx) => {
+				if (seg.kind === 'text') {
+					return <span key={idx}>{seg.content}</span>;
+				}
+				if (seg.kind === 'mention') {
+					return (
+						<MentionToken
+							key={idx}
+							refType={seg.refType}
+							id={seg.id}
+							displayText={seg.displayText}
+							status={seg.status}
+							sessionId={sessionId}
+						/>
+					);
+				}
+				// unknown-mention: render the raw token string with warning styling
+				return (
+					<span key={idx} class="text-yellow-500/70 italic" title="Unknown reference type">
+						{seg.content}
+					</span>
+				);
+			})}
+		</>
+	);
+}
 
 type UserMessage = Extract<SDKMessage, { type: 'user' }> & { sendStatus?: string };
 type SystemInitMessage = Extract<SDKMessage, { type: 'system'; subtype: 'init' }>;
@@ -113,6 +161,10 @@ export function SDKUserMessage({
 
 	const textContent = getTextContent();
 	const imageBlocks = getImageBlocks();
+
+	// Extract reference metadata from the message blob for rendering @ref tokens
+	const referenceMetadata: ReferenceMetadata =
+		(message as typeof message & { referenceMetadata?: ReferenceMetadata }).referenceMetadata ?? {};
 
 	// For synthetic messages, extract all content blocks for detailed display
 	const getSyntheticContentBlocks = (): Array<Record<string, unknown>> | string | null => {
@@ -240,7 +292,7 @@ export function SDKUserMessage({
 		>
 			{/* Main Content */}
 			<div class={cn(messageColors.user.text, 'whitespace-pre-wrap break-words')}>
-				{textContent}
+				{renderMessageText(textContent, referenceMetadata, sessionId)}
 			</div>
 
 			{/* Attached images */}

--- a/packages/web/src/components/sdk/__tests__/MentionToken.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/MentionToken.test.tsx
@@ -275,7 +275,6 @@ describe('MentionToken', () => {
 		it('calls reference.resolve RPC on first hover when sessionId is provided', async () => {
 			mockCallIfConnected.mockResolvedValue({ resolved: null });
 
-			render(<MentionToken refType="task" id="t-42" displayText="Task" sessionId="session-123" />);
 			const { container } = render(
 				<MentionToken refType="task" id="t-42" displayText="Task" sessionId="session-123" />
 			);
@@ -291,7 +290,6 @@ describe('MentionToken', () => {
 		});
 
 		it('does not call RPC when sessionId is absent', async () => {
-			render(<MentionToken refType="task" id="t-1" displayText="Task" />);
 			const { container } = render(<MentionToken refType="task" id="t-1" displayText="Task" />);
 			const token = container.querySelector('[data-testid="mention-token"]');
 			fireEvent.mouseEnter(token!);

--- a/packages/web/src/components/sdk/__tests__/MentionToken.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/MentionToken.test.tsx
@@ -1,0 +1,508 @@
+// @ts-nocheck
+/**
+ * MentionToken Component Tests
+ *
+ * Tests for the MentionToken inline pill component and the parseTextWithReferences
+ * utility function.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
+import { MentionToken, parseTextWithReferences } from '../MentionToken';
+import type { ReferenceMetadata } from '@neokai/shared';
+
+// ─── Mock useMessageHub ──────────────────────────────────────────────────────
+
+const mockCallIfConnected = vi.fn();
+
+vi.mock('../../../hooks/useMessageHub', () => ({
+	useMessageHub: () => ({
+		isConnected: false,
+		state: 'disconnected',
+		getHub: () => null,
+		request: vi.fn(),
+		onEvent: vi.fn(() => () => {}),
+		joinRoom: vi.fn(),
+		leaveRoom: vi.fn(),
+		call: vi.fn(),
+		callIfConnected: mockCallIfConnected,
+		subscribe: vi.fn(() => () => {}),
+		waitForConnection: vi.fn(),
+		onConnected: vi.fn(() => () => {}),
+	}),
+}));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockCallIfConnected.mockResolvedValue(null);
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+// ─── parseTextWithReferences ─────────────────────────────────────────────────
+
+describe('parseTextWithReferences', () => {
+	describe('plain text', () => {
+		it('returns a single text segment for plain text', () => {
+			const result = parseTextWithReferences('Hello world', {});
+			expect(result).toEqual([{ kind: 'text', content: 'Hello world' }]);
+		});
+
+		it('returns a single text segment for empty string', () => {
+			const result = parseTextWithReferences('', {});
+			expect(result).toEqual([]);
+		});
+
+		it('passes plain @ text as-is (no token)', () => {
+			const result = parseTextWithReferences('Hello @user how are you', {});
+			expect(result).toEqual([{ kind: 'text', content: 'Hello @user how are you' }]);
+		});
+
+		it('passes @ref without braces as plain text', () => {
+			const result = parseTextWithReferences('see @ref plain text', {});
+			expect(result).toEqual([{ kind: 'text', content: 'see @ref plain text' }]);
+		});
+	});
+
+	describe('known reference types', () => {
+		it('parses @ref{task:t-42} with metadata', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-42}': {
+					type: 'task',
+					id: 't-42',
+					displayText: 'Fix login bug',
+					status: 'open',
+				},
+			};
+			const result = parseTextWithReferences('Fix @ref{task:t-42} now', metadata);
+			expect(result).toHaveLength(3);
+			expect(result[0]).toEqual({ kind: 'text', content: 'Fix ' });
+			expect(result[1]).toMatchObject({
+				kind: 'mention',
+				refType: 'task',
+				id: 't-42',
+				displayText: 'Fix login bug',
+				status: 'open',
+			});
+			expect(result[2]).toEqual({ kind: 'text', content: ' now' });
+		});
+
+		it('parses @ref{goal:g-7} with metadata', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{goal:g-7}': { type: 'goal', id: 'g-7', displayText: 'Ship v2' },
+			};
+			const result = parseTextWithReferences('Work on @ref{goal:g-7}', metadata);
+			expect(result).toHaveLength(2);
+			expect(result[1]).toMatchObject({ kind: 'mention', refType: 'goal', displayText: 'Ship v2' });
+		});
+
+		it('parses @ref{file:src/foo.ts} with metadata', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{file:src/foo.ts}': { type: 'file', id: 'src/foo.ts', displayText: 'src/foo.ts' },
+			};
+			const result = parseTextWithReferences('See @ref{file:src/foo.ts}', metadata);
+			expect(result[1]).toMatchObject({ kind: 'mention', refType: 'file', id: 'src/foo.ts' });
+		});
+
+		it('parses @ref{folder:src} with metadata', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{folder:src}': { type: 'folder', id: 'src', displayText: 'src/' },
+			};
+			const result = parseTextWithReferences('Browse @ref{folder:src} please', metadata);
+			expect(result[1]).toMatchObject({ kind: 'mention', refType: 'folder', displayText: 'src/' });
+		});
+
+		it('uses raw id as displayText when metadata is missing', () => {
+			const result = parseTextWithReferences('Fix @ref{task:t-99}', {});
+			expect(result[1]).toMatchObject({
+				kind: 'mention',
+				refType: 'task',
+				id: 't-99',
+				displayText: 't-99', // raw id fallback
+			});
+		});
+
+		it('parses multiple references in one message', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Task One' },
+				'@ref{file:a.ts}': { type: 'file', id: 'a.ts', displayText: 'a.ts' },
+			};
+			const text = 'Do @ref{task:t-1} and see @ref{file:a.ts} for details';
+			const result = parseTextWithReferences(text, metadata);
+			expect(result).toHaveLength(5);
+			expect(result[1]).toMatchObject({ kind: 'mention', refType: 'task' });
+			expect(result[3]).toMatchObject({ kind: 'mention', refType: 'file' });
+		});
+
+		it('handles reference at start of text', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Task One' },
+			};
+			const result = parseTextWithReferences('@ref{task:t-1} is done', metadata);
+			expect(result[0]).toMatchObject({ kind: 'mention', refType: 'task' });
+			expect(result[1]).toEqual({ kind: 'text', content: ' is done' });
+		});
+
+		it('handles reference at end of text', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Task One' },
+			};
+			const result = parseTextWithReferences('Check @ref{task:t-1}', metadata);
+			expect(result[0]).toEqual({ kind: 'text', content: 'Check ' });
+			expect(result[1]).toMatchObject({ kind: 'mention', refType: 'task' });
+		});
+
+		it('handles adjacent references with no text between them', () => {
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'T1' },
+				'@ref{task:t-2}': { type: 'task', id: 't-2', displayText: 'T2' },
+			};
+			const result = parseTextWithReferences('@ref{task:t-1}@ref{task:t-2}', metadata);
+			expect(result).toHaveLength(2);
+			expect(result[0]).toMatchObject({ kind: 'mention', id: 't-1' });
+			expect(result[1]).toMatchObject({ kind: 'mention', id: 't-2' });
+		});
+	});
+
+	describe('unknown reference type', () => {
+		it('renders unknown type as unknown-mention segment', () => {
+			const result = parseTextWithReferences('See @ref{widget:w-1}', {});
+			expect(result).toHaveLength(2);
+			expect(result[0]).toEqual({ kind: 'text', content: 'See ' });
+			expect(result[1]).toEqual({ kind: 'unknown-mention', content: '@ref{widget:w-1}' });
+		});
+
+		it('does not emit status for unknown type', () => {
+			const result = parseTextWithReferences('@ref{custom:abc}', {});
+			expect(result[0]).toMatchObject({ kind: 'unknown-mention' });
+			expect((result[0] as { kind: string }).kind).not.toBe('mention');
+		});
+	});
+
+	describe('idempotency', () => {
+		it('is safe to call multiple times on the same text (no shared regex state)', () => {
+			const text = 'Fix @ref{task:t-1}';
+			const metadata: ReferenceMetadata = {
+				'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Task One' },
+			};
+			const result1 = parseTextWithReferences(text, metadata);
+			const result2 = parseTextWithReferences(text, metadata);
+			expect(result1).toEqual(result2);
+		});
+	});
+});
+
+// ─── MentionToken rendering ──────────────────────────────────────────────────
+
+describe('MentionToken', () => {
+	describe('rendering', () => {
+		it('renders a token with the correct display text', () => {
+			const { container } = render(
+				<MentionToken refType="task" id="t-42" displayText="Fix login bug" />
+			);
+			expect(container.textContent).toContain('Fix login bug');
+		});
+
+		it('renders with data-ref-type attribute', () => {
+			const { container } = render(<MentionToken refType="goal" id="g-7" displayText="Ship v2" />);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token?.getAttribute('data-ref-type')).toBe('goal');
+		});
+
+		it('renders with data-ref-id attribute', () => {
+			const { container } = render(
+				<MentionToken refType="file" id="src/foo.ts" displayText="foo.ts" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token?.getAttribute('data-ref-id')).toBe('src/foo.ts');
+		});
+
+		it('shows type label for task', () => {
+			const { container } = render(<MentionToken refType="task" id="t-1" displayText="My Task" />);
+			expect(container.textContent).toContain('task');
+		});
+
+		it('shows type label for goal', () => {
+			const { container } = render(<MentionToken refType="goal" id="g-1" displayText="My Goal" />);
+			expect(container.textContent).toContain('goal');
+		});
+
+		it('shows type label for file', () => {
+			const { container } = render(<MentionToken refType="file" id="f.ts" displayText="f.ts" />);
+			expect(container.textContent).toContain('file');
+		});
+
+		it('shows type label for folder', () => {
+			const { container } = render(<MentionToken refType="folder" id="src" displayText="src/" />);
+			expect(container.textContent).toContain('folder');
+		});
+	});
+
+	describe('hover popover', () => {
+		it('does not show popover before hover', () => {
+			const { container } = render(
+				<MentionToken refType="task" id="t-1" displayText="Task" sessionId="s1" />
+			);
+			expect(container.querySelector('[data-testid="mention-token-popover"]')).toBeNull();
+		});
+
+		it('shows popover on mouse enter', async () => {
+			const { container } = render(
+				<MentionToken refType="task" id="t-1" displayText="Task" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				expect(container.querySelector('[data-testid="mention-token-popover"]')).toBeTruthy();
+			});
+		});
+
+		it('hides popover on mouse leave', async () => {
+			const { container } = render(
+				<MentionToken refType="task" id="t-1" displayText="Task" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+			await waitFor(() => {
+				expect(container.querySelector('[data-testid="mention-token-popover"]')).toBeTruthy();
+			});
+			fireEvent.mouseLeave(token!);
+			expect(container.querySelector('[data-testid="mention-token-popover"]')).toBeNull();
+		});
+
+		it('calls reference.resolve RPC on first hover when sessionId is provided', async () => {
+			mockCallIfConnected.mockResolvedValue({ resolved: null });
+
+			render(<MentionToken refType="task" id="t-42" displayText="Task" sessionId="session-123" />);
+			const { container } = render(
+				<MentionToken refType="task" id="t-42" displayText="Task" sessionId="session-123" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				expect(mockCallIfConnected).toHaveBeenCalledWith(
+					'reference.resolve',
+					expect.objectContaining({ sessionId: 'session-123', type: 'task', id: 't-42' })
+				);
+			});
+		});
+
+		it('does not call RPC when sessionId is absent', async () => {
+			render(<MentionToken refType="task" id="t-1" displayText="Task" />);
+			const { container } = render(<MentionToken refType="task" id="t-1" displayText="Task" />);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			// Give time for any async calls
+			await new Promise((r) => setTimeout(r, 20));
+			expect(mockCallIfConnected).not.toHaveBeenCalled();
+		});
+
+		it('does not call RPC again on second hover (result is cached)', async () => {
+			mockCallIfConnected.mockResolvedValue({
+				resolved: {
+					type: 'task',
+					id: 't-1',
+					data: { title: 'Fix login', status: 'open' },
+				},
+			});
+
+			const { container } = render(
+				<MentionToken refType="task" id="t-1" displayText="Task" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+
+			// First hover
+			fireEvent.mouseEnter(token!);
+			await waitFor(() => {
+				expect(mockCallIfConnected).toHaveBeenCalledTimes(1);
+			});
+			fireEvent.mouseLeave(token!);
+
+			// Second hover
+			fireEvent.mouseEnter(token!);
+			await new Promise((r) => setTimeout(r, 20));
+			expect(mockCallIfConnected).toHaveBeenCalledTimes(1); // not called again
+		});
+
+		it('shows resolved task data in popover', async () => {
+			mockCallIfConnected.mockResolvedValue({
+				resolved: {
+					type: 'task',
+					id: 't-1',
+					data: { title: 'Fix login bug', status: 'open' },
+				},
+			});
+
+			const { container } = render(
+				<MentionToken refType="task" id="t-1" displayText="Task" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				expect(popover?.textContent).toContain('Fix login bug');
+				expect(popover?.textContent).toContain('open');
+			});
+		});
+
+		it('shows resolved goal data in popover', async () => {
+			mockCallIfConnected.mockResolvedValue({
+				resolved: {
+					type: 'goal',
+					id: 'g-1',
+					data: { title: 'Ship v2', status: 'active' },
+				},
+			});
+
+			const { container } = render(
+				<MentionToken refType="goal" id="g-1" displayText="Goal" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				expect(popover?.textContent).toContain('Ship v2');
+			});
+		});
+
+		it('shows resolved file data in popover', async () => {
+			mockCallIfConnected.mockResolvedValue({
+				resolved: {
+					type: 'file',
+					id: 'src/foo.ts',
+					data: { path: 'src/foo.ts', size: 2048, binary: false, truncated: false },
+				},
+			});
+
+			const { container } = render(
+				<MentionToken refType="file" id="src/foo.ts" displayText="foo.ts" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				expect(popover?.textContent).toContain('src/foo.ts');
+				expect(popover?.textContent).toContain('2 KB');
+			});
+		});
+
+		it('shows binary file indicator in popover', async () => {
+			mockCallIfConnected.mockResolvedValue({
+				resolved: {
+					type: 'file',
+					id: 'img.png',
+					data: { path: 'img.png', size: 4096, binary: true, truncated: false },
+				},
+			});
+
+			const { container } = render(
+				<MentionToken refType="file" id="img.png" displayText="img.png" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				expect(popover?.textContent).toContain('Binary file');
+			});
+		});
+
+		it('shows resolved folder data in popover', async () => {
+			mockCallIfConnected.mockResolvedValue({
+				resolved: {
+					type: 'folder',
+					id: 'src',
+					data: {
+						path: 'src',
+						entries: [
+							{ name: 'foo.ts', path: 'src/foo.ts', type: 'file' },
+							{ name: 'bar.ts', path: 'src/bar.ts', type: 'file' },
+						],
+					},
+				},
+			});
+
+			const { container } = render(
+				<MentionToken refType="folder" id="src" displayText="src/" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				expect(popover?.textContent).toContain('src');
+				expect(popover?.textContent).toContain('2 entries');
+			});
+		});
+
+		it('shows "Not found" when resolved is null', async () => {
+			mockCallIfConnected.mockResolvedValue({ resolved: null });
+
+			const { container } = render(
+				<MentionToken refType="task" id="t-999" displayText="t-999" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				expect(popover?.textContent).toContain('Not found');
+			});
+		});
+
+		it('shows "Failed to load" on RPC error', async () => {
+			mockCallIfConnected.mockRejectedValue(new Error('Network error'));
+
+			const { container } = render(
+				<MentionToken refType="task" id="t-1" displayText="Task" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				expect(popover?.textContent).toContain('Failed to load');
+			});
+		});
+
+		it('shows idle state info when no sessionId provided', async () => {
+			const { container } = render(<MentionToken refType="task" id="t-1" displayText="Task" />);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				// idle state shows refType/id
+				expect(popover?.textContent).toContain('task/t-1');
+			});
+		});
+
+		it('shows truncated indicator in file popover', async () => {
+			mockCallIfConnected.mockResolvedValue({
+				resolved: {
+					type: 'file',
+					id: 'big.ts',
+					data: { path: 'big.ts', size: 60000, binary: false, truncated: true },
+				},
+			});
+
+			const { container } = render(
+				<MentionToken refType="file" id="big.ts" displayText="big.ts" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				const popover = container.querySelector('[data-testid="mention-token-popover"]');
+				expect(popover?.textContent).toContain('truncated');
+			});
+		});
+	});
+});

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -11,6 +11,24 @@ import { SDKUserMessage } from '../SDKUserMessage';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { UUID } from 'crypto';
 
+// Mock useMessageHub — MentionToken uses it for hover preview RPC calls
+vi.mock('../../../hooks/useMessageHub', () => ({
+	useMessageHub: () => ({
+		isConnected: false,
+		state: 'disconnected',
+		getHub: () => null,
+		request: vi.fn(),
+		onEvent: vi.fn(() => () => {}),
+		joinRoom: vi.fn(),
+		leaveRoom: vi.fn(),
+		call: vi.fn(),
+		callIfConnected: vi.fn().mockResolvedValue(null),
+		subscribe: vi.fn(() => () => {}),
+		waitForConnection: vi.fn(),
+		onConnected: vi.fn(() => () => {}),
+	}),
+}));
+
 // Mock the utils module for copyToClipboard
 vi.mock('../../../lib/utils.ts', async (importOriginal) => {
 	const original = await importOriginal<typeof import('../../../lib/utils.ts')>();
@@ -572,6 +590,96 @@ describe('SDKUserMessage', () => {
 			// Check for max-width classes
 			const wrapper = container.querySelector('.max-w-\\[85\\%\\]');
 			expect(wrapper).toBeTruthy();
+		});
+	});
+
+	describe('Reference Token Rendering', () => {
+		function createMessageWithRef(
+			text: string,
+			referenceMetadata: Record<string, unknown> = {}
+		): Extract<SDKMessage, { type: 'user' }> {
+			return {
+				...createTextMessage(text),
+				referenceMetadata,
+			} as unknown as Extract<SDKMessage, { type: 'user' }>;
+		}
+
+		it('renders plain text without @ref unchanged', () => {
+			const message = createTextMessage('Hello @user how are you?');
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			expect(container.textContent).toContain('Hello @user how are you?');
+			expect(container.querySelector('[data-testid="mention-token"]')).toBeNull();
+		});
+
+		it('renders @ref{task:t-1} as a MentionToken', () => {
+			const message = createMessageWithRef('Fix @ref{task:t-1} now', {
+				'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Login bug' },
+			});
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token).toBeTruthy();
+			expect(container.textContent).toContain('Login bug');
+		});
+
+		it('renders @ref{goal:g-1} as a MentionToken with correct type', () => {
+			const message = createMessageWithRef('Work on @ref{goal:g-1}', {
+				'@ref{goal:g-1}': { type: 'goal', id: 'g-1', displayText: 'Ship v2' },
+			});
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token?.getAttribute('data-ref-type')).toBe('goal');
+		});
+
+		it('falls back to raw id when referenceMetadata is absent', () => {
+			const message = createMessageWithRef('Fix @ref{task:t-99}');
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token).toBeTruthy();
+			// displayText falls back to raw id
+			expect(container.textContent).toContain('t-99');
+		});
+
+		it('renders unknown reference type as styled plain text (not a token)', () => {
+			const message = createTextMessage('See @ref{widget:w-1} here');
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			// Should not render as a mention-token
+			expect(container.querySelector('[data-testid="mention-token"]')).toBeNull();
+			// Should render the raw text
+			expect(container.textContent).toContain('@ref{widget:w-1}');
+		});
+
+		it('renders surrounding text around a token', () => {
+			const message = createMessageWithRef('Please fix @ref{task:t-1} urgently', {
+				'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Bug' },
+			});
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			expect(container.textContent).toContain('Please fix');
+			expect(container.textContent).toContain('urgently');
+			expect(container.querySelector('[data-testid="mention-token"]')).toBeTruthy();
+		});
+
+		it('renders multiple tokens in a single message', () => {
+			const message = createMessageWithRef('Fix @ref{task:t-1} and see @ref{file:src/foo.ts}', {
+				'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Bug' },
+				'@ref{file:src/foo.ts}': { type: 'file', id: 'src/foo.ts', displayText: 'foo.ts' },
+			});
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			const tokens = container.querySelectorAll('[data-testid="mention-token"]');
+			expect(tokens).toHaveLength(2);
+		});
+
+		it('does not render mention-token for empty message text', () => {
+			const message = createTextMessage('');
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			expect(container.querySelector('[data-testid="mention-token"]')).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
- Create MentionToken component with type-specific pill styling
  (indigo=task, amber=goal, blue=file, yellow=folder)
- Lazy-load hover popover via reference.resolve RPC; result cached
  after first fetch to avoid re-fetching on subsequent hovers
- parseTextWithReferences() splits text into text/mention/unknown
  segments; safe against shared REFERENCE_PATTERN lastIndex state
- SDKUserMessage renders @ref{type:id} tokens inline; plain @ text
  and unknown types pass through unchanged (warning styling for unknowns)
- Missing referenceMetadata falls back to raw id as display text
- MentionToken wrapped in memo() to prevent re-renders during scrolling
- 77 unit tests: parsing logic, all ref types, hover states, RPC calls,
  fallbacks, and SDKUserMessage integration
