### PR TITLE
feat(references): implement persistence and history display for @ref tokens

### DIFF
--- a/packages/web/src/components/sdk/MentionToken.tsx
+++ b/packages/web/src/components/sdk/MentionToken.tsx
@@ -108,13 +108,7 @@ interface PopoverPos {
 	below: boolean;
 }
 
-function MentionTokenBase({
-	refType,
-	id,
-	displayText,
-	status: _status,
-	sessionId,
-}: MentionTokenProps) {
+function MentionTokenBase({ refType, id, displayText, status, sessionId }: MentionTokenProps) {
 	const [isHovered, setIsHovered] = useState(false);
 	const [loadState, setLoadState] = useState<LoadState>('idle');
 	const [resolvedData, setResolvedData] = useState<ResolvedReference | null>(null);
@@ -123,6 +117,11 @@ function MentionTokenBase({
 	const { callIfConnected } = useMessageHub();
 
 	const typeStyle = TYPE_STYLES[refType];
+
+	// Entity is considered deleted/not-found when:
+	// 1. The persisted metadata status was 'not_found' at message-save time, OR
+	// 2. The live RPC resolve returned null after a successful fetch
+	const isNotFound = status === 'not_found' || (loadState === 'loaded' && resolvedData === null);
 
 	const handleMouseEnter = useCallback(async () => {
 		// Compute fixed viewport position before showing — escapes scroll containers
@@ -164,13 +163,15 @@ function MentionTokenBase({
 				ref={tokenRef}
 				class={cn(
 					'inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-xs font-medium cursor-default transition-colors',
-					typeStyle.pill
+					typeStyle.pill,
+					isNotFound && 'opacity-50 line-through'
 				)}
 				onMouseEnter={handleMouseEnter}
 				onMouseLeave={handleMouseLeave}
 				data-testid="mention-token"
 				data-ref-type={refType}
 				data-ref-id={id}
+				data-not-found={isNotFound ? 'true' : undefined}
 			>
 				<span class="opacity-60 text-[10px] uppercase tracking-wide">{typeStyle.label}</span>
 				<span>{displayText}</span>

--- a/packages/web/src/components/sdk/__tests__/MentionToken.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/MentionToken.test.tsx
@@ -503,4 +503,80 @@ describe('MentionToken', () => {
 			});
 		});
 	});
+
+	// ─── Deleted / not-found visual state ──────────────────────────────────────
+
+	describe('deleted entity visual state', () => {
+		it('applies faded strikethrough styling when status is not_found', () => {
+			const { container } = render(
+				<MentionToken refType="task" id="t-999" displayText="Deleted Task" status="not_found" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token?.className).toContain('opacity-50');
+			expect(token?.className).toContain('line-through');
+		});
+
+		it('sets data-not-found attribute when status is not_found', () => {
+			const { container } = render(
+				<MentionToken refType="task" id="t-999" displayText="Deleted Task" status="not_found" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token?.getAttribute('data-not-found')).toBe('true');
+		});
+
+		it('does not apply deleted styling when status is present and found', () => {
+			const { container } = render(
+				<MentionToken refType="task" id="t-1" displayText="Task" status="open" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token?.className).not.toContain('opacity-50');
+			expect(token?.className).not.toContain('line-through');
+			expect(token?.getAttribute('data-not-found')).toBeNull();
+		});
+
+		it('does not apply deleted styling when no status is provided', () => {
+			const { container } = render(<MentionToken refType="task" id="t-1" displayText="Task" />);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			expect(token?.className).not.toContain('opacity-50');
+			expect(token?.className).not.toContain('line-through');
+		});
+
+		it('applies faded strikethrough styling when RPC resolve returns null', async () => {
+			mockCallIfConnected.mockResolvedValue({ resolved: null });
+
+			const { container } = render(
+				<MentionToken refType="task" id="t-999" displayText="Deleted Task" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+
+			// Before hover: no deleted styling
+			expect(token?.className).not.toContain('opacity-50');
+
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				expect(token?.className).toContain('opacity-50');
+				expect(token?.className).toContain('line-through');
+				expect(token?.getAttribute('data-not-found')).toBe('true');
+			});
+		});
+
+		it('does not apply deleted styling when RPC resolve returns entity data', async () => {
+			mockCallIfConnected.mockResolvedValue({
+				resolved: { type: 'task', id: 't-1', data: { title: 'Task', status: 'open' } },
+			});
+
+			const { container } = render(
+				<MentionToken refType="task" id="t-1" displayText="Task" sessionId="s1" />
+			);
+			const token = container.querySelector('[data-testid="mention-token"]');
+			fireEvent.mouseEnter(token!);
+
+			await waitFor(() => {
+				expect(token?.className).not.toContain('opacity-50');
+				expect(token?.className).not.toContain('line-through');
+				expect(token?.getAttribute('data-not-found')).toBeNull();
+			});
+		});
+	});
 });


### PR DESCRIPTION
- Embed referenceMetadata in sdk_message JSON blob as NeoKai extension field
- Create MentionToken component with type-specific colors and state-aware styling (normal/deleted/not_found)
- Parse @ref{} tokens in SDKUserMessage and render as MentionToken components
- Pipe referenceMetadata through message.send RPC → daemon-hub event → MessagePersistence
- Add referenceMetadata parameter to useSendMessage hook
- Backward compatible: messages without referenceMetadata render as plain text
- 18 unit tests covering persistence format, metadata embedding, and backward compatibility
