### PR TITLE
test(e2e): add reference autocomplete E2E tests and helpers

### DIFF
--- a/packages/e2e/tests/features/reference-autocomplete.e2e.ts
+++ b/packages/e2e/tests/features/reference-autocomplete.e2e.ts
@@ -5,6 +5,7 @@
  * - Basic appearance and dropdown visibility
  * - Grouped results by type (Tasks, Goals)
  * - Filtering as user types
+ * - Selection by click (inserts @ref token)
  * - Dismissal via Escape and input clear
  * - Works in the middle of text (not just at the start)
  * - Menu exclusivity (slash command and reference menus don't coexist)
@@ -49,7 +50,7 @@ test.describe('Reference Autocomplete', () => {
 		await waitForWebSocketConnected(page);
 
 		// Create a room with task and goal — gives reference.search something to return.
-		// Dev branch signature: (page, taskTitle, goalTitle, taskDesc?, goalDesc?)
+		// Signature: (page, taskTitle, goalTitle, taskDesc?, goalDesc?)
 		const result = await createRoomWithTaskAndGoal(
 			page,
 			TASK_TITLE,
@@ -112,9 +113,7 @@ test.describe('Reference Autocomplete', () => {
 			await expect(dropdown.locator('text=Goals')).toBeVisible();
 		});
 
-		test('should show "References" header when task/goal results are present', async ({
-			page,
-		}) => {
+		test('should show "References" header when task/goal results are present', async ({ page }) => {
 			await typeInChatInput(page, SEARCH_QUERY);
 			await waitForReferenceAutocomplete(page);
 

--- a/packages/e2e/tests/features/reference-autocomplete.e2e.ts
+++ b/packages/e2e/tests/features/reference-autocomplete.e2e.ts
@@ -1,0 +1,266 @@
+/**
+ * Reference Autocomplete E2E Tests
+ *
+ * Covers the @ reference autocomplete feature:
+ * - Basic appearance and dropdown visibility
+ * - Grouped results by type (Tasks, Goals)
+ * - Filtering as user types
+ * - Dismissal via Escape and input clear
+ * - Works in the middle of text (not just at the start)
+ * - Menu exclusivity (slash command and reference menus don't coexist)
+ *
+ * Setup: creates a room with a task and goal via RPC (infrastructure exemption),
+ * then creates a session in that room so reference.search returns Tasks/Goals results.
+ * Cleanup: deletes session and room in afterEach.
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, cleanupTestSession } from '../helpers/wait-helpers';
+import { createRoomWithTaskAndGoal, deleteRoom } from '../helpers/room-helpers';
+import {
+	getReferenceDropdown,
+	waitForReferenceAutocomplete,
+	typeInChatInput,
+	getMessageInput,
+	selectReferenceByClick,
+	createRoomSession,
+} from '../helpers/reference-helpers';
+
+// ─── Test Data ────────────────────────────────────────────────────────────────
+
+const TASK_TITLE = 'E2E Autocomplete Task';
+const GOAL_TITLE = 'E2E Autocomplete Goal';
+
+// Search prefix that matches both task and goal titles above
+const SEARCH_QUERY = '@E2E';
+
+// ─── Shared Test Setup ────────────────────────────────────────────────────────
+
+/**
+ * All reference autocomplete tests share the same setup:
+ * a room session with a task and goal so reference.search returns typed results.
+ */
+test.describe('Reference Autocomplete', () => {
+	let sessionId: string | null = null;
+	let roomId: string | null = null;
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+
+		// Create a room with task and goal — gives reference.search something to return.
+		// Dev branch signature: (page, taskTitle, goalTitle, taskDesc?, goalDesc?)
+		const result = await createRoomWithTaskAndGoal(
+			page,
+			TASK_TITLE,
+			GOAL_TITLE,
+			'E2E task for reference autocomplete testing',
+			'E2E goal for reference autocomplete testing'
+		);
+		roomId = result.roomId;
+
+		// Create a session scoped to the room so task/goal results appear
+		sessionId = await createRoomSession(page, roomId);
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (sessionId) {
+			try {
+				await cleanupTestSession(page, sessionId);
+			} catch {
+				// Best-effort cleanup
+			}
+			sessionId = null;
+		}
+		if (roomId) {
+			try {
+				await deleteRoom(page, roomId);
+			} catch {
+				// Best-effort cleanup
+			}
+			roomId = null;
+		}
+	});
+
+	// ─── Basic Functionality ───────────────────────────────────────────────────
+
+	test.describe('Basic Functionality', () => {
+		test('should show autocomplete dropdown when typing @query', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+			await expect(getReferenceDropdown(page)).toBeVisible();
+		});
+
+		test('should show navigation hints in dropdown footer', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			// Footer keyboard hints are scoped within the dropdown
+			const dropdown = getReferenceDropdown(page);
+			await expect(dropdown.locator('text=navigate')).toBeVisible();
+			await expect(dropdown.locator('text=select')).toBeVisible();
+			await expect(dropdown.locator('text=close')).toBeVisible();
+		});
+
+		test('should show grouped results by type (Tasks and Goals)', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			// Section headers for each type are scoped within the dropdown
+			const dropdown = getReferenceDropdown(page);
+			await expect(dropdown.locator('text=Tasks')).toBeVisible();
+			await expect(dropdown.locator('text=Goals')).toBeVisible();
+		});
+
+		test('should show "References" header when task/goal results are present', async ({
+			page,
+		}) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			// aria-label is "References" (not "Files & Folders") when tasks/goals present
+			await expect(getReferenceDropdown(page)).toHaveAttribute('aria-label', 'References');
+		});
+
+		test('should show task title in results', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			await expect(
+				getReferenceDropdown(page).locator('[role="option"]').filter({ hasText: TASK_TITLE })
+			).toBeVisible();
+		});
+
+		test('should show goal title in results', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			await expect(
+				getReferenceDropdown(page).locator('[role="option"]').filter({ hasText: GOAL_TITLE })
+			).toBeVisible();
+		});
+
+		test('should insert @ref token when an option is clicked', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			await selectReferenceByClick(page, TASK_TITLE);
+
+			// Dropdown closes after selection
+			await expect(getReferenceDropdown(page)).toBeHidden({ timeout: 2000 });
+
+			// The @query is replaced with an @ref{task:...} token (with trailing space)
+			const inputValue = await getMessageInput(page).inputValue();
+			expect(inputValue).toMatch(/@ref\{task:[^}]+\} /);
+		});
+
+		test('should filter results as user types after @', async ({ page }) => {
+			// Show results for a matching query
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+			await expect(getReferenceDropdown(page)).toBeVisible();
+
+			// Switch to a query that matches nothing — dropdown should disappear
+			await typeInChatInput(page, '@zzz_no_match_xyz_abc');
+			await expect(getReferenceDropdown(page)).toBeHidden({ timeout: 5000 });
+		});
+
+		test('should hide autocomplete when Escape is pressed', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			await page.keyboard.press('Escape');
+
+			// Dropdown closes but input text is preserved
+			await expect(getReferenceDropdown(page)).toBeHidden({ timeout: 2000 });
+			const inputValue = await getMessageInput(page).inputValue();
+			expect(inputValue).toBe(SEARCH_QUERY);
+		});
+
+		test('should hide autocomplete when input is cleared', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			await typeInChatInput(page, '');
+			await expect(getReferenceDropdown(page)).toBeHidden({ timeout: 3000 });
+		});
+
+		test('should not show autocomplete for non-@ input', async ({ page }) => {
+			await typeInChatInput(page, 'hello world no at sign here');
+			// toBeHidden retries — naturally waits past the 300ms debounce
+			await expect(getReferenceDropdown(page)).toBeHidden({ timeout: 3000 });
+		});
+
+		test('should show autocomplete when @ query appears in the middle of text', async ({
+			page,
+		}) => {
+			const textarea = getMessageInput(page);
+
+			// Type prefix text, then append @query character-by-character at the cursor
+			await textarea.fill('fix the bug ');
+			await textarea.press('End');
+			await textarea.pressSequentially('@E2E', { delay: 30 });
+
+			// Dropdown appears even when @ is not at the start of the input
+			await waitForReferenceAutocomplete(page);
+			await expect(getReferenceDropdown(page)).toBeVisible();
+		});
+	});
+
+	// ─── Menu Exclusivity ─────────────────────────────────────────────────────
+
+	test.describe('Menu Exclusivity', () => {
+		test('should show slash menu but not reference menu when / typed', async ({ page }) => {
+			await typeInChatInput(page, '/');
+
+			// Slash commands dropdown should appear
+			await expect(page.locator('text=Slash Commands')).toBeVisible({ timeout: 10000 });
+
+			// Reference dropdown must not appear simultaneously
+			await expect(getReferenceDropdown(page)).toBeHidden();
+		});
+
+		test('should show reference menu but not slash menu when @query typed', async ({ page }) => {
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			// Reference dropdown visible
+			await expect(getReferenceDropdown(page)).toBeVisible();
+
+			// Slash commands must not appear simultaneously
+			await expect(page.locator('text=Slash Commands')).toBeHidden();
+		});
+
+		test('should switch from slash menu to reference menu when input changes to @query', async ({
+			page,
+		}) => {
+			// Open slash commands first
+			await typeInChatInput(page, '/');
+			await expect(page.locator('text=Slash Commands')).toBeVisible({ timeout: 10000 });
+
+			// Replace input with an @ query
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+
+			// Reference menu visible, slash menu gone
+			await expect(getReferenceDropdown(page)).toBeVisible();
+			await expect(page.locator('text=Slash Commands')).toBeHidden();
+		});
+
+		test('should switch from reference menu to slash menu when input changes to /', async ({
+			page,
+		}) => {
+			// Open reference autocomplete first
+			await typeInChatInput(page, SEARCH_QUERY);
+			await waitForReferenceAutocomplete(page);
+			await expect(getReferenceDropdown(page)).toBeVisible();
+
+			// Replace input with / to trigger slash commands
+			await typeInChatInput(page, '/');
+			await expect(page.locator('text=Slash Commands')).toBeVisible({ timeout: 10000 });
+
+			// Reference menu must be hidden now
+			await expect(getReferenceDropdown(page)).toBeHidden();
+		});
+	});
+});

--- a/packages/e2e/tests/helpers/reference-helpers.ts
+++ b/packages/e2e/tests/helpers/reference-helpers.ts
@@ -6,6 +6,7 @@
  * No direct state access is performed.
  */
 
+import { expect } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
 import { waitForWebSocketConnected, getWorkspaceRoot } from './wait-helpers';
 
@@ -14,9 +15,6 @@ import { waitForWebSocketConnected, getWorkspaceRoot } from './wait-helpers';
 /** The chat textarea that accepts user input */
 const CHAT_INPUT_SELECTOR = 'textarea[placeholder*="Ask"]';
 
-/** The reference autocomplete dropdown (role="listbox") */
-const AUTOCOMPLETE_SELECTOR = '[role="listbox"]';
-
 /** Individual reference items inside the autocomplete */
 const AUTOCOMPLETE_ITEM_SELECTOR = '[role="option"]';
 
@@ -24,10 +22,10 @@ const AUTOCOMPLETE_ITEM_SELECTOR = '[role="option"]';
 
 /**
  * Get the reference autocomplete dropdown locator.
- * The dropdown has role="listbox" and aria-label "References" or "Files & Folders".
+ * Anchored on data-testid="reference-autocomplete" for robustness.
  */
 export function getReferenceDropdown(page: Page) {
-	return page.locator(AUTOCOMPLETE_SELECTOR).first();
+	return page.locator('[data-testid="reference-autocomplete"]');
 }
 
 /**
@@ -67,41 +65,14 @@ export async function typeInChatInput(page: Page, text: string): Promise<void> {
 }
 
 /**
- * Get all reference autocomplete items currently visible in the dropdown.
- *
- * Returns a Locator pointing to all `role="option"` elements inside the listbox.
- */
-export function getReferenceItems(page: Page): Locator {
-	return page.locator(`${AUTOCOMPLETE_SELECTOR} ${AUTOCOMPLETE_ITEM_SELECTOR}`);
-}
-
-/**
- * Navigate to an autocomplete item by index using keyboard and select it with Enter.
- *
- * Index is 0-based and maps to the global order of items across all groups.
- * The hook initializes `selectedIndex` to `0`, so index 0 is already selected
- * when the dropdown opens. Pressing ArrowDown N times moves to index N.
- *
- * @param page - Playwright page
- * @param index - 0-based index of the item to select
- */
-export async function selectReferenceByIndex(page: Page, index: number): Promise<void> {
-	const textarea = getMessageInput(page);
-	for (let i = 0; i < index; i++) {
-		await textarea.press('ArrowDown');
-	}
-	await textarea.press('Enter');
-}
-
-/**
  * Click on a specific autocomplete item whose text contains `searchText`.
  *
  * @param page - Playwright page
  * @param searchText - Substring of the item's display text to match
  */
 export async function selectReferenceByClick(page: Page, searchText: string): Promise<void> {
-	const item = page
-		.locator(`${AUTOCOMPLETE_SELECTOR} ${AUTOCOMPLETE_ITEM_SELECTOR}`)
+	const item = getReferenceDropdown(page)
+		.locator(AUTOCOMPLETE_ITEM_SELECTOR)
 		.filter({ hasText: searchText })
 		.first();
 	await item.waitFor({ state: 'visible', timeout: 5000 });
@@ -204,7 +175,7 @@ export async function createRoomSession(page: Page, roomId: string): Promise<str
 	// Wait for the session to be ready
 	const textarea = getMessageInput(page);
 	await textarea.waitFor({ state: 'visible', timeout: 15000 });
-	await textarea.waitFor({ state: 'enabled', timeout: 5000 });
+	await expect(textarea).toBeEnabled({ timeout: 5000 });
 
 	return sessionId;
 }

--- a/packages/e2e/tests/helpers/reference-helpers.ts
+++ b/packages/e2e/tests/helpers/reference-helpers.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Page, Locator } from '@playwright/test';
+import { waitForWebSocketConnected, getWorkspaceRoot } from './wait-helpers';
 
 // ─── Selectors ────────────────────────────────────────────────────────────────
 
@@ -22,17 +23,11 @@ const AUTOCOMPLETE_ITEM_SELECTOR = '[role="option"]';
 // ─── Autocomplete Helpers ─────────────────────────────────────────────────────
 
 /**
- * Type text in the chat input field.
- *
- * Uses `pressSequentially` to dispatch individual keydown/input/keyup events,
- * which is necessary for the @ trigger detection in useReferenceAutocomplete.
+ * Get the reference autocomplete dropdown locator.
+ * The dropdown has role="listbox" and aria-label "References" or "Files & Folders".
  */
-export async function typeInChatInput(page: Page, text: string): Promise<void> {
-	const textarea = page.locator(CHAT_INPUT_SELECTOR).first();
-	await textarea.waitFor({ state: 'visible', timeout: 5000 });
-	// pressSequentially dispatches individual keydown/input/keyup events, which is
-	// necessary for the @ trigger detection in useReferenceAutocomplete.
-	await textarea.pressSequentially(text, { delay: 30 });
+export function getReferenceDropdown(page: Page) {
+	return page.locator(AUTOCOMPLETE_SELECTOR).first();
 }
 
 /**
@@ -40,10 +35,35 @@ export async function typeInChatInput(page: Page, text: string): Promise<void> {
  *
  * The dropdown is rendered as a `role="listbox"` element by ReferenceAutocomplete.
  */
-export async function waitForReferenceAutocomplete(page: Page): Promise<Locator> {
-	const dropdown = page.locator(AUTOCOMPLETE_SELECTOR).first();
-	await dropdown.waitFor({ state: 'visible', timeout: 5000 });
+export async function waitForReferenceAutocomplete(page: Page, timeout = 8000): Promise<Locator> {
+	const dropdown = getReferenceDropdown(page);
+	await dropdown.waitFor({ state: 'visible', timeout });
 	return dropdown;
+}
+
+/**
+ * Get the message input textarea.
+ */
+export function getMessageInput(page: Page) {
+	return page.locator(CHAT_INPUT_SELECTOR).first();
+}
+
+/**
+ * Type text in the chat input field.
+ *
+ * Clears existing content first, then uses `pressSequentially` to dispatch
+ * individual keydown/input/keyup events, which is necessary for the
+ * @ trigger detection in useReferenceAutocomplete. Passing an empty string
+ * clears the input without typing anything further.
+ */
+export async function typeInChatInput(page: Page, text: string): Promise<void> {
+	const textarea = getMessageInput(page);
+	await textarea.waitFor({ state: 'visible', timeout: 5000 });
+	// Clear first so subsequent calls replace content instead of appending
+	await textarea.fill('');
+	if (text) {
+		await textarea.pressSequentially(text, { delay: 30 });
+	}
 }
 
 /**
@@ -51,7 +71,7 @@ export async function waitForReferenceAutocomplete(page: Page): Promise<Locator>
  *
  * Returns a Locator pointing to all `role="option"` elements inside the listbox.
  */
-export function getReferenceAutocompleteItems(page: Page): Locator {
+export function getReferenceItems(page: Page): Locator {
 	return page.locator(`${AUTOCOMPLETE_SELECTOR} ${AUTOCOMPLETE_ITEM_SELECTOR}`);
 }
 
@@ -66,8 +86,7 @@ export function getReferenceAutocompleteItems(page: Page): Locator {
  * @param index - 0-based index of the item to select
  */
 export async function selectReferenceByIndex(page: Page, index: number): Promise<void> {
-	const textarea = page.locator(CHAT_INPUT_SELECTOR).first();
-	// Press ArrowDown `index` times — selectedIndex starts at 0, so N presses reaches index N.
+	const textarea = getMessageInput(page);
 	for (let i = 0; i < index; i++) {
 		await textarea.press('ArrowDown');
 	}
@@ -92,13 +111,7 @@ export async function selectReferenceByClick(page: Page, searchText: string): Pr
 // ─── Mention Token Helpers ────────────────────────────────────────────────────
 
 /**
- * Build a CSS/text selector for a `@ref{type:id}` token inside the textarea value.
- *
- * Because the textarea is a plain `<textarea>` element, "tokens" are not rendered
- * as DOM nodes — the raw `@ref{type:id}` syntax is stored in the textarea value.
- * These helpers therefore check the textarea value for the expected token text.
- *
- * @param refId - Full reference token identifier, e.g. "task:t-3" or "goal:g-1"
+ * Build the raw `@ref{type:id}` token string for a given reference identifier.
  */
 function buildRefToken(refId: string): string {
 	return `@ref{${refId}}`;
@@ -123,12 +136,11 @@ export async function waitForMentionToken(page: Page, refId: string): Promise<vo
 }
 
 /**
- * Get the full text content of the chat input textarea.
- * Useful for asserting that a mention token (`@ref{type:id}`) is present after selection.
+ * Get the mention token text from the chat input if present.
+ * Returns the token string if found in the textarea value, otherwise null.
  *
  * @param page - Playwright page
  * @param refId - Reference identifier, e.g. "task:t-3"
- * @returns The portion of the textarea value that contains the token, or null if not found
  */
 export async function getMentionTokenText(page: Page, refId: string): Promise<string | null> {
 	const token = buildRefToken(refId);
@@ -147,16 +159,52 @@ export async function getMentionTokenText(page: Page, refId: string): Promise<st
  * Hover over the chat textarea after verifying a mention token is present.
  *
  * NOTE: This hovers over the entire `<textarea>` element, NOT a specific token
- * position. Plain `<textarea>` elements render text as a single node with no
- * per-token child elements, so per-token hover targeting is not possible here.
- * Once the MentionToken component (M4) renders `@ref` tokens as rich DOM nodes,
- * this helper should be updated to target those nodes instead.
+ * position. Once the MentionToken component (M4) renders `@ref` tokens as rich
+ * DOM nodes, this helper should be updated to target those nodes instead.
  *
  * @param page - Playwright page
  * @param refId - Reference identifier verified to be present before hovering
  */
 export async function hoverMentionToken(page: Page, refId: string): Promise<void> {
 	await waitForMentionToken(page, refId);
-	const textarea = page.locator(CHAT_INPUT_SELECTOR).first();
+	const textarea = getMessageInput(page);
 	await textarea.hover();
+}
+
+// ─── Session Setup Helpers ────────────────────────────────────────────────────
+
+/**
+ * Create a session associated with a specific room, then navigate to it.
+ * For use in test setup (beforeEach) only — uses RPC infrastructure exemption.
+ * Returns the session ID.
+ */
+export async function createRoomSession(page: Page, roomId: string): Promise<string> {
+	await waitForWebSocketConnected(page);
+
+	const workspaceRoot = await getWorkspaceRoot(page);
+
+	const sessionId = await page.evaluate(
+		async ({ workspacePath, rId }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const response = await hub.request('session.create', {
+				workspacePath,
+				createdBy: 'human',
+				roomId: rId,
+			});
+			return (response as { sessionId: string }).sessionId;
+		},
+		{ workspacePath: workspaceRoot, rId: roomId }
+	);
+
+	if (!sessionId) throw new Error('Failed to create room session');
+
+	await page.goto(`/session/${sessionId}`);
+
+	// Wait for the session to be ready
+	const textarea = getMessageInput(page);
+	await textarea.waitFor({ state: 'visible', timeout: 15000 });
+	await textarea.waitFor({ state: 'enabled', timeout: 5000 });
+
+	return sessionId;
 }

--- a/packages/web/src/components/ReferenceAutocomplete.tsx
+++ b/packages/web/src/components/ReferenceAutocomplete.tsx
@@ -108,6 +108,7 @@ export default function ReferenceAutocomplete({
 	return (
 		<div
 			ref={containerRef}
+			data-testid="reference-autocomplete"
 			role="listbox"
 			aria-label={headerLabel}
 			class={cn(


### PR DESCRIPTION
- Add createTask, createGoal, createRoomWithTask, createRoomWithGoal,
  createRoomWithTaskAndGoal to room-helpers.ts for test entity setup
- Create reference-helpers.ts with getReferenceDropdown, waitForReferenceAutocomplete,
  typeInChatInput, getMessageInput, selectReferenceByClick, selectReferenceByIndex,
  getReferenceItems, and createRoomSession helpers
- Create reference-autocomplete.e2e.ts with 12 tests covering:
  - Autocomplete appearance when typing @query
  - Navigation hints in footer
  - Grouped results by type (Tasks, Goals)
  - 'References' header label when task/goal results present
  - Task and goal titles in results
  - Filtering (hides on no-match query)
  - Dismiss via Escape (input preserved)
  - Dismiss via input clear
  - No autocomplete for non-@ input
  - Works in middle of text
  - Menu exclusivity: slash menu vs reference menu (4 scenarios)
