### PR TITLE
feat(room): integrate AppMcpLifecycleManager into RoomRuntimeService (Task 3.2)

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -183,6 +183,9 @@ export class RoomRuntimeService {
 			}
 			this.runtimes.delete(roomId);
 			this.observers.delete(roomId);
+			// Clear the cached room-agent-tools server; createOrGetRuntime() →
+			// setupRoomAgentSession() will repopulate it for the fresh runtime.
+			this.roomAgentMcpServers.delete(roomId);
 		}
 
 		// Create a fresh runtime - autoStart=true starts it immediately
@@ -643,9 +646,13 @@ export class RoomRuntimeService {
 		const unsubMcpChanged = this.ctx.daemonHub.on(
 			'mcp.registry.changed',
 			() => {
-				const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
+				// Re-read both sources inside the handler (not hoisted above the loop) so
+				// that if getEnabledMcpServersConfig() ever becomes room-scoped, it will
+				// be called per-room consistently with the initial setupRoomAgentSession path.
+				// Registry configs are global and read once — the call is cheap.
 				const registryMcpServers = this.ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
 				for (const [roomId] of this.runtimes) {
+					const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
 					const roomChatSessionId = `room:chat:${roomId}`;
 					void this.ctx.sessionManager
 						.getSessionAsync(roomChatSessionId)

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -10,6 +10,7 @@
 
 import type { Room, McpServerConfig, RuntimeState, GlobalSettings } from '@neokai/shared';
 import type { SettingsManager } from '../../settings-manager';
+import type { AppMcpLifecycleManager } from '../../mcp/app-mcp-lifecycle-manager';
 import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../../storage/job-queue-processor';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
@@ -53,6 +54,8 @@ export interface RoomRuntimeServiceConfig {
 	getGlobalSettings: () => GlobalSettings;
 	/** Settings manager for reading project-configured MCP servers */
 	settingsManager: SettingsManager;
+	/** Application-level MCP lifecycle manager — provides registry-sourced MCP configs */
+	appMcpManager?: AppMcpLifecycleManager;
 	/** Reactive database wrapper for change event emission */
 	reactiveDb: ReactiveDatabase;
 	/**
@@ -72,6 +75,8 @@ export class RoomRuntimeService {
 	private observers = new Map<string, SessionObserver>();
 	private agentSessions = new Map<string, AgentSession>();
 	private unsubscribers: Array<() => void> = [];
+	/** Stores the room-agent-tools McpServerConfig per room for hot-reload on registry changes */
+	private roomAgentMcpServers = new Map<string, McpServerConfig>();
 
 	constructor(private ctx: RoomRuntimeServiceConfig) {}
 
@@ -157,6 +162,7 @@ export class RoomRuntimeService {
 		runtime.stop();
 		this.runtimes.delete(roomId);
 		this.observers.delete(roomId);
+		this.roomAgentMcpServers.delete(roomId);
 		this.persistRuntimePreference(roomId, 'stopped');
 		return true;
 	}
@@ -192,6 +198,7 @@ export class RoomRuntimeService {
 		this.runtimes.clear();
 		this.observers.clear();
 		this.agentSessions.clear();
+		this.roomAgentMcpServers.clear();
 
 		for (const unsub of this.unsubscribers) {
 			unsub();
@@ -505,6 +512,10 @@ export class RoomRuntimeService {
 			runtimeService: this,
 		}) as unknown as McpServerConfig;
 
+		// Cache the room-agent-tools server so the mcp.registry.changed handler can
+		// include it when re-applying MCP configs to live sessions.
+		this.roomAgentMcpServers.set(room.id, roomAgentMcpServer);
+
 		// Reuse the SessionManager-owned room chat AgentSession to avoid duplicate
 		// DaemonHub subscriptions and duplicate query execution.
 		void this.ctx.sessionManager
@@ -535,12 +546,23 @@ export class RoomRuntimeService {
 					}
 				}
 
-				// Merge user/project-configured MCP servers with the room-agent-tools server so the
-				// room agent can use GitHub MCP, etc. for coordination tasks.
-				// room-agent-tools is placed last to ensure it always takes precedence.
-				const enabledMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
+				// Merge MCP servers from three sources into a single map for the room chat session:
+				//   1. File-based servers (from .mcp.json / settings.json via SettingsManager)
+				//   2. Registry-based servers (application-level entries from AppMcpLifecycleManager)
+				//   3. room-agent-tools (in-process server for room coordination)
+				//
+				// Merge order: file-based first, registry-based second (wins over file-based on
+				// name collision), then room-agent-tools last so it ALWAYS takes precedence.
+				// This guarantees room coordination tools are never shadowed by user-configured servers.
+				//
+				// Note: setRuntimeMcpServers() replaces the config used for the NEXT query; it does
+				// NOT restart any in-flight query. This is intentional — MCP server changes between
+				// queries are the expected use case, and disrupting an active query is not safe.
+				const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
+				const registryMcpServers = this.ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
 				roomChatSession.setRuntimeMcpServers({
-					...enabledMcpServers,
+					...fileMcpServers,
+					...registryMcpServers,
 					'room-agent-tools': roomAgentMcpServer,
 				});
 				// Inject the room chat system prompt so the agent knows the proper
@@ -611,6 +633,44 @@ export class RoomRuntimeService {
 			this.runtimes.get(event.roomId)?.onTaskStatusChanged(event.task.id);
 		});
 		this.unsubscribers.push(unsubTaskUpdate);
+
+		// mcp.registry.changed — re-apply MCP configs to all live room chat sessions when the
+		// application-level registry changes (entry created/updated/deleted/toggled).
+		//
+		// Note: setRuntimeMcpServers() updates the config used for subsequent queries only;
+		// it does NOT interrupt a query that is already in-flight. This is sufficient because
+		// MCP server changes between queries are the expected use case.
+		const unsubMcpChanged = this.ctx.daemonHub.on(
+			'mcp.registry.changed',
+			() => {
+				const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
+				const registryMcpServers = this.ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
+				for (const [roomId] of this.runtimes) {
+					const roomChatSessionId = `room:chat:${roomId}`;
+					void this.ctx.sessionManager
+						.getSessionAsync(roomChatSessionId)
+						.then((session) => {
+							if (!session) return;
+							// Merge: file-based, then registry (wins on collision), then
+							// room-agent-tools last so it ALWAYS takes precedence.
+							const merged: Record<string, McpServerConfig> = {
+								...fileMcpServers,
+								...registryMcpServers,
+							};
+							const roomAgentMcpServer = this.roomAgentMcpServers.get(roomId);
+							if (roomAgentMcpServer) {
+								merged['room-agent-tools'] = roomAgentMcpServer;
+							}
+							session.setRuntimeMcpServers(merged);
+						})
+						.catch((error) => {
+							log.warn(`Failed to re-apply MCP servers for room ${roomId}:`, error);
+						});
+				}
+			},
+			{ sessionId: 'global' }
+		);
+		this.unsubscribers.push(unsubMcpChanged);
 	}
 
 	private async initializeExistingRooms(): Promise<void> {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -198,6 +198,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		defaultModel: deps.config.defaultModel,
 		getGlobalSettings: () => deps.settingsManager.getGlobalSettings(),
 		settingsManager: deps.settingsManager,
+		appMcpManager: deps.appMcpManager,
 		reactiveDb: deps.reactiveDb,
 		jobQueue: deps.jobQueue,
 		jobProcessor: deps.jobProcessor,

--- a/packages/daemon/tests/unit/room/room-runtime-service-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-mcp.test.ts
@@ -8,7 +8,7 @@
  * 3. On mcp.registry.changed, all live room chat sessions are updated.
  */
 
-import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import {
 	RoomRuntimeService,
 	type RoomRuntimeServiceConfig,

--- a/packages/daemon/tests/unit/room/room-runtime-service-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-mcp.test.ts
@@ -1,0 +1,642 @@
+/**
+ * Tests for RoomRuntimeService MCP integration.
+ *
+ * Verifies that:
+ * 1. Registry-sourced MCP servers are merged into the final mcpServers map
+ *    passed to setRuntimeMcpServers() alongside file-based servers.
+ * 2. room-agent-tools always takes precedence (applied last).
+ * 3. On mcp.registry.changed, all live room chat sessions are updated.
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import {
+	RoomRuntimeService,
+	type RoomRuntimeServiceConfig,
+} from '../../../src/lib/room/runtime/room-runtime-service';
+import type { McpServerConfig, Room } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type DaemonHubListener = (event: Record<string, unknown>) => void;
+
+/** Minimal daemonHub mock that tracks subscriptions and allows manual event emission */
+function makeDaemonHub() {
+	const listeners = new Map<string, DaemonHubListener[]>();
+
+	return {
+		on: (event: string, handler: DaemonHubListener) => {
+			if (!listeners.has(event)) listeners.set(event, []);
+			listeners.get(event)!.push(handler);
+			return () => {
+				const arr = listeners.get(event);
+				if (arr) {
+					const idx = arr.indexOf(handler);
+					if (idx !== -1) arr.splice(idx, 1);
+				}
+			};
+		},
+		emit: async (event: string, payload: Record<string, unknown>) => {
+			for (const handler of listeners.get(event) ?? []) {
+				handler(payload);
+			}
+		},
+	};
+}
+
+function makeRoomManager(rooms: Room[] = []) {
+	const byId = new Map(rooms.map((r) => [r.id, r]));
+	return {
+		listRooms: () => rooms,
+		getRoom: (id: string) => byId.get(id) ?? null,
+		updateRoom: () => null,
+	};
+}
+
+function makeRoom(id: string): Room {
+	return {
+		id,
+		name: `Room ${id}`,
+		allowedPaths: [{ path: '/tmp' }],
+		defaultPath: '/tmp',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+function makeConfig(overrides: Partial<RoomRuntimeServiceConfig> = {}): RoomRuntimeServiceConfig {
+	return {
+		db: {} as never,
+		messageHub: {} as never,
+		daemonHub: makeDaemonHub() as never,
+		getApiKey: async () => null,
+		roomManager: makeRoomManager() as never,
+		sessionManager: {} as never,
+		defaultWorkspacePath: '/tmp',
+		defaultModel: 'test-model',
+		getGlobalSettings: () => ({}) as never,
+		settingsManager: { getEnabledMcpServersConfig: () => ({}) } as never,
+		reactiveDb: {} as never,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests: initial MCP merge in setupRoomAgentSession
+// ---------------------------------------------------------------------------
+
+describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
+	it('includes registry-sourced servers in the map passed to setRuntimeMcpServers', async () => {
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'npx', args: ['my-mcp'] };
+
+		const appMcpManager = {
+			getEnabledMcpConfigs: () => ({ 'registry-server': registryServer }),
+		};
+
+		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
+
+		const roomChatSession = {
+			setRuntimeMcpServers: (map: Record<string, McpServerConfig>) => {
+				setRuntimeMcpServersCalls.push(map);
+			},
+			setRuntimeSystemPrompt: () => {},
+			getSessionData: () => ({
+				config: { model: 'test-model', provider: 'anthropic' },
+			}),
+		};
+
+		const sessionManager = {
+			getSessionAsync: async (id: string) => {
+				if (id.startsWith('room:chat:')) return roomChatSession;
+				return null;
+			},
+			updateSession: async () => {},
+		};
+
+		const room = makeRoom('room-1');
+		const roomManager = makeRoomManager([room]);
+
+		const service = new RoomRuntimeService(
+			makeConfig({
+				appMcpManager: appMcpManager as never,
+				sessionManager: sessionManager as never,
+				roomManager: roomManager as never,
+			})
+		);
+
+		// Call setupRoomAgentSession via the private method (test-only access)
+		const serviceAny = service as unknown as {
+			setupRoomAgentSession: (
+				room: Room,
+				groupRepo: unknown,
+				taskManager: unknown,
+				goalManager: unknown
+			) => void;
+		};
+
+		// Provide minimal stubs for the repos/managers passed into setupRoomAgentSession
+		const groupRepo = {
+			getActiveGroups: () => [],
+		};
+		const taskManager = {
+			getTask: () => null,
+			listTasks: () => [],
+		};
+		const goalManager = {
+			getGoal: () => null,
+			listGoals: () => [],
+		};
+
+		serviceAny.setupRoomAgentSession(room, groupRepo, taskManager, goalManager);
+
+		// Wait for the async getSessionAsync promise to resolve
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(setRuntimeMcpServersCalls.length).toBeGreaterThanOrEqual(1);
+		const finalMap = setRuntimeMcpServersCalls[setRuntimeMcpServersCalls.length - 1]!;
+
+		// Registry server must be present
+		expect(finalMap['registry-server']).toEqual(registryServer);
+		// room-agent-tools must always be present (in-process server)
+		expect(finalMap['room-agent-tools']).toBeDefined();
+	});
+
+	it('room-agent-tools takes precedence over a registry entry with the same name', async () => {
+		// Simulate a registry entry with the reserved name 'room-agent-tools'
+		const conflictingServer: McpServerConfig = {
+			type: 'stdio',
+			command: 'should-be-overridden',
+		};
+
+		const appMcpManager = {
+			getEnabledMcpConfigs: () => ({ 'room-agent-tools': conflictingServer }),
+		};
+
+		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
+
+		const roomChatSession = {
+			setRuntimeMcpServers: (map: Record<string, McpServerConfig>) => {
+				setRuntimeMcpServersCalls.push(map);
+			},
+			setRuntimeSystemPrompt: () => {},
+			getSessionData: () => ({
+				config: { model: 'test-model', provider: 'anthropic' },
+			}),
+		};
+
+		const sessionManager = {
+			getSessionAsync: async (id: string) => {
+				if (id.startsWith('room:chat:')) return roomChatSession;
+				return null;
+			},
+			updateSession: async () => {},
+		};
+
+		const room = makeRoom('room-2');
+		const roomManager = makeRoomManager([room]);
+
+		const service = new RoomRuntimeService(
+			makeConfig({
+				appMcpManager: appMcpManager as never,
+				sessionManager: sessionManager as never,
+				roomManager: roomManager as never,
+			})
+		);
+
+		const serviceAny = service as unknown as {
+			setupRoomAgentSession: (
+				room: Room,
+				groupRepo: unknown,
+				taskManager: unknown,
+				goalManager: unknown
+			) => void;
+		};
+
+		serviceAny.setupRoomAgentSession(
+			room,
+			{ getActiveGroups: () => [] },
+			{ getTask: () => null, listTasks: () => [] },
+			{ getGoal: () => null, listGoals: () => [] }
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(setRuntimeMcpServersCalls.length).toBeGreaterThanOrEqual(1);
+		const finalMap = setRuntimeMcpServersCalls[setRuntimeMcpServersCalls.length - 1]!;
+
+		// room-agent-tools must NOT be the conflicting registry entry
+		expect(
+			(finalMap['room-agent-tools'] as McpServerConfig & { command?: string }).command
+		).not.toBe('should-be-overridden');
+	});
+
+	it('merges file-based servers alongside registry servers', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-server' };
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-server' };
+
+		const appMcpManager = {
+			getEnabledMcpConfigs: () => ({ 'registry-mcp': registryServer }),
+		};
+
+		const settingsManager = {
+			getEnabledMcpServersConfig: () => ({ 'file-mcp': fileServer }),
+		};
+
+		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
+
+		const roomChatSession = {
+			setRuntimeMcpServers: (map: Record<string, McpServerConfig>) => {
+				setRuntimeMcpServersCalls.push(map);
+			},
+			setRuntimeSystemPrompt: () => {},
+			getSessionData: () => ({
+				config: { model: 'test-model', provider: 'anthropic' },
+			}),
+		};
+
+		const sessionManager = {
+			getSessionAsync: async (id: string) => {
+				if (id.startsWith('room:chat:')) return roomChatSession;
+				return null;
+			},
+			updateSession: async () => {},
+		};
+
+		const room = makeRoom('room-3');
+		const roomManager = makeRoomManager([room]);
+
+		const service = new RoomRuntimeService(
+			makeConfig({
+				appMcpManager: appMcpManager as never,
+				settingsManager: settingsManager as never,
+				sessionManager: sessionManager as never,
+				roomManager: roomManager as never,
+			})
+		);
+
+		const serviceAny = service as unknown as {
+			setupRoomAgentSession: (
+				room: Room,
+				groupRepo: unknown,
+				taskManager: unknown,
+				goalManager: unknown
+			) => void;
+		};
+
+		serviceAny.setupRoomAgentSession(
+			room,
+			{ getActiveGroups: () => [] },
+			{ getTask: () => null, listTasks: () => [] },
+			{ getGoal: () => null, listGoals: () => [] }
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(setRuntimeMcpServersCalls.length).toBeGreaterThanOrEqual(1);
+		const finalMap = setRuntimeMcpServersCalls[setRuntimeMcpServersCalls.length - 1]!;
+
+		expect(finalMap['file-mcp']).toEqual(fileServer);
+		expect(finalMap['registry-mcp']).toEqual(registryServer);
+		expect(finalMap['room-agent-tools']).toBeDefined();
+	});
+
+	it('works without appMcpManager (optional field)', async () => {
+		// No appMcpManager provided — should not throw and file-based + room-agent-tools still applied
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-server' };
+
+		const settingsManager = {
+			getEnabledMcpServersConfig: () => ({ 'file-mcp': fileServer }),
+		};
+
+		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
+
+		const roomChatSession = {
+			setRuntimeMcpServers: (map: Record<string, McpServerConfig>) => {
+				setRuntimeMcpServersCalls.push(map);
+			},
+			setRuntimeSystemPrompt: () => {},
+			getSessionData: () => ({
+				config: { model: 'test-model', provider: 'anthropic' },
+			}),
+		};
+
+		const sessionManager = {
+			getSessionAsync: async (id: string) => {
+				if (id.startsWith('room:chat:')) return roomChatSession;
+				return null;
+			},
+			updateSession: async () => {},
+		};
+
+		const room = makeRoom('room-4');
+		const roomManager = makeRoomManager([room]);
+
+		const service = new RoomRuntimeService(
+			makeConfig({
+				// appMcpManager intentionally omitted
+				settingsManager: settingsManager as never,
+				sessionManager: sessionManager as never,
+				roomManager: roomManager as never,
+			})
+		);
+
+		const serviceAny = service as unknown as {
+			setupRoomAgentSession: (
+				room: Room,
+				groupRepo: unknown,
+				taskManager: unknown,
+				goalManager: unknown
+			) => void;
+		};
+
+		serviceAny.setupRoomAgentSession(
+			room,
+			{ getActiveGroups: () => [] },
+			{ getTask: () => null, listTasks: () => [] },
+			{ getGoal: () => null, listGoals: () => [] }
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(setRuntimeMcpServersCalls.length).toBeGreaterThanOrEqual(1);
+		const finalMap = setRuntimeMcpServersCalls[setRuntimeMcpServersCalls.length - 1]!;
+
+		expect(finalMap['file-mcp']).toEqual(fileServer);
+		expect(finalMap['room-agent-tools']).toBeDefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: mcp.registry.changed hot-reload
+// ---------------------------------------------------------------------------
+
+describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
+	it('re-applies MCP configs to live room chat sessions when registry changes', async () => {
+		const daemonHub = makeDaemonHub();
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'new-registry-server' };
+
+		const appMcpManager = {
+			getEnabledMcpConfigs: () => ({ 'hot-server': registryServer }),
+		};
+
+		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
+
+		const roomChatSession = {
+			setRuntimeMcpServers: (map: Record<string, McpServerConfig>) => {
+				setRuntimeMcpServersCalls.push(map);
+			},
+			setRuntimeSystemPrompt: () => {},
+			getSessionData: () => ({
+				config: { model: 'test-model', provider: 'anthropic' },
+			}),
+		};
+
+		const sessionManager = {
+			getSessionAsync: async (id: string) => {
+				if (id.startsWith('room:chat:')) return roomChatSession;
+				return null;
+			},
+			updateSession: async () => {},
+		};
+
+		const room = makeRoom('room-hot');
+		const roomManager = makeRoomManager([room]);
+
+		const service = new RoomRuntimeService(
+			makeConfig({
+				appMcpManager: appMcpManager as never,
+				sessionManager: sessionManager as never,
+				roomManager: roomManager as never,
+				daemonHub: daemonHub as never,
+			})
+		);
+
+		// Manually inject the runtime and room-agent-tools server into the private maps
+		// so the registry.changed handler sees a live room without going through full startup.
+		const serviceAny = service as unknown as {
+			runtimes: Map<string, unknown>;
+			roomAgentMcpServers: Map<string, McpServerConfig>;
+		};
+
+		const mockRuntime = {
+			start: () => {},
+			stop: () => {},
+			getState: () => 'running',
+		};
+		serviceAny.runtimes.set('room-hot', mockRuntime);
+
+		const roomAgentToolsServer: McpServerConfig = {
+			type: 'stdio',
+			command: 'room-agent-tools-cmd',
+		};
+		serviceAny.roomAgentMcpServers.set('room-hot', roomAgentToolsServer);
+
+		// Subscribe to events (wires up the mcp.registry.changed listener)
+		const servicePrivate = service as unknown as { subscribeToEvents: () => void };
+		servicePrivate.subscribeToEvents();
+
+		// Emit mcp.registry.changed
+		await daemonHub.emit('mcp.registry.changed', { sessionId: 'global' });
+
+		// Wait for the async session lookup to resolve
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(setRuntimeMcpServersCalls.length).toBeGreaterThanOrEqual(1);
+		const updatedMap = setRuntimeMcpServersCalls[setRuntimeMcpServersCalls.length - 1]!;
+
+		// Registry-sourced server must be in the updated map
+		expect(updatedMap['hot-server']).toEqual(registryServer);
+		// room-agent-tools must be included from the cached server
+		expect(updatedMap['room-agent-tools']).toEqual(roomAgentToolsServer);
+	});
+
+	it('skips rooms that have no cached room-agent-tools server but still applies other servers', async () => {
+		const daemonHub = makeDaemonHub();
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'reg-server' };
+
+		const appMcpManager = {
+			getEnabledMcpConfigs: () => ({ 'reg-server': registryServer }),
+		};
+
+		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
+
+		const roomChatSession = {
+			setRuntimeMcpServers: (map: Record<string, McpServerConfig>) => {
+				setRuntimeMcpServersCalls.push(map);
+			},
+			setRuntimeSystemPrompt: () => {},
+			getSessionData: () => ({
+				config: { model: 'test-model', provider: 'anthropic' },
+			}),
+		};
+
+		const sessionManager = {
+			getSessionAsync: async (id: string) => {
+				if (id.startsWith('room:chat:')) return roomChatSession;
+				return null;
+			},
+			updateSession: async () => {},
+		};
+
+		const room = makeRoom('room-no-agent-tools');
+		const roomManager = makeRoomManager([room]);
+
+		const service = new RoomRuntimeService(
+			makeConfig({
+				appMcpManager: appMcpManager as never,
+				sessionManager: sessionManager as never,
+				roomManager: roomManager as never,
+				daemonHub: daemonHub as never,
+			})
+		);
+
+		const serviceAny = service as unknown as {
+			runtimes: Map<string, unknown>;
+			roomAgentMcpServers: Map<string, McpServerConfig>;
+		};
+
+		// Inject a runtime but NO room-agent-tools entry in the cache
+		serviceAny.runtimes.set('room-no-agent-tools', {
+			start: () => {},
+			stop: () => {},
+			getState: () => 'running',
+		});
+		// roomAgentMcpServers map is intentionally left empty for this room
+
+		const servicePrivate = service as unknown as { subscribeToEvents: () => void };
+		servicePrivate.subscribeToEvents();
+
+		await daemonHub.emit('mcp.registry.changed', { sessionId: 'global' });
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(setRuntimeMcpServersCalls.length).toBeGreaterThanOrEqual(1);
+		const updatedMap = setRuntimeMcpServersCalls[setRuntimeMcpServersCalls.length - 1]!;
+
+		// Registry server is still applied
+		expect(updatedMap['reg-server']).toEqual(registryServer);
+		// room-agent-tools is absent because it's not cached
+		expect(updatedMap['room-agent-tools']).toBeUndefined();
+	});
+
+	it('does not call setRuntimeMcpServers for rooms with no live session', async () => {
+		const daemonHub = makeDaemonHub();
+
+		const sessionManager = {
+			// Always returns null — no session found
+			getSessionAsync: async () => null,
+		};
+
+		const room = makeRoom('room-no-session');
+		const roomManager = makeRoomManager([room]);
+
+		const appMcpManager = {
+			getEnabledMcpConfigs: () => ({}),
+		};
+
+		const service = new RoomRuntimeService(
+			makeConfig({
+				appMcpManager: appMcpManager as never,
+				sessionManager: sessionManager as never,
+				roomManager: roomManager as never,
+				daemonHub: daemonHub as never,
+			})
+		);
+
+		const serviceAny = service as unknown as {
+			runtimes: Map<string, unknown>;
+		};
+		serviceAny.runtimes.set('room-no-session', {
+			start: () => {},
+			stop: () => {},
+			getState: () => 'running',
+		});
+
+		const servicePrivate = service as unknown as { subscribeToEvents: () => void };
+		servicePrivate.subscribeToEvents();
+
+		// Should not throw even if session is missing
+		await daemonHub.emit('mcp.registry.changed', { sessionId: 'global' });
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		// No assertion on calls — just verifying no error is thrown
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: registry wins over file on name collision
+// ---------------------------------------------------------------------------
+
+describe('RoomRuntimeService MCP merge — collision resolution', () => {
+	it('registry-sourced server wins over file-based server on same name', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-cmd' };
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
+
+		const appMcpManager = {
+			getEnabledMcpConfigs: () => ({ 'shared-name': registryServer }),
+		};
+
+		const settingsManager = {
+			getEnabledMcpServersConfig: () => ({ 'shared-name': fileServer }),
+		};
+
+		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
+
+		const roomChatSession = {
+			setRuntimeMcpServers: (map: Record<string, McpServerConfig>) => {
+				setRuntimeMcpServersCalls.push(map);
+			},
+			setRuntimeSystemPrompt: () => {},
+			getSessionData: () => ({
+				config: { model: 'test-model', provider: 'anthropic' },
+			}),
+		};
+
+		const sessionManager = {
+			getSessionAsync: async (id: string) => {
+				if (id.startsWith('room:chat:')) return roomChatSession;
+				return null;
+			},
+			updateSession: async () => {},
+		};
+
+		const room = makeRoom('room-collision');
+		const roomManager = makeRoomManager([room]);
+
+		const service = new RoomRuntimeService(
+			makeConfig({
+				appMcpManager: appMcpManager as never,
+				settingsManager: settingsManager as never,
+				sessionManager: sessionManager as never,
+				roomManager: roomManager as never,
+			})
+		);
+
+		const serviceAny = service as unknown as {
+			setupRoomAgentSession: (
+				room: Room,
+				groupRepo: unknown,
+				taskManager: unknown,
+				goalManager: unknown
+			) => void;
+		};
+
+		serviceAny.setupRoomAgentSession(
+			room,
+			{ getActiveGroups: () => [] },
+			{ getTask: () => null, listTasks: () => [] },
+			{ getGoal: () => null, listGoals: () => [] }
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(setRuntimeMcpServersCalls.length).toBeGreaterThanOrEqual(1);
+		const finalMap = setRuntimeMcpServersCalls[setRuntimeMcpServersCalls.length - 1]!;
+
+		// Registry wins on name collision with file-based
+		expect((finalMap['shared-name'] as McpServerConfig & { command?: string }).command).toBe(
+			'registry-cmd'
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Injects `AppMcpLifecycleManager` (optional) into `RoomRuntimeServiceConfig` as `appMcpManager`
- Merges three MCP sources in `setupRoomAgentSession`: file-based (`SettingsManager.getEnabledMcpServersConfig()`), registry-based (`appMcpManager.getEnabledMcpConfigs()`), then `room-agent-tools` last (always wins on collision)
- Caches the per-room `room-agent-tools` McpServerConfig in a `roomAgentMcpServers` map for hot-reload support
- Subscribes to `mcp.registry.changed` in `subscribeToEvents()` — re-applies merged MCP configs to all live room chat sessions; documents that `setRuntimeMcpServers()` is between-query only and does not disrupt in-flight queries
- Passes `appMcpManager` from the `RoomRuntimeService` construction site in `rpc-handlers/index.ts`
- Cleans up `roomAgentMcpServers` entries on `stopRuntime()` and `stop()`

## Test plan

- [x] 8 new unit tests in `room-runtime-service-mcp.test.ts` covering:
  - Registry servers appear in the merged map
  - `room-agent-tools` takes precedence over any registry entry with the same name
  - File-based and registry servers are both present in the merged map
  - Works correctly without `appMcpManager` (optional field, fallback to `{}`)
  - `mcp.registry.changed` triggers `setRuntimeMcpServers()` on all live sessions
  - Missing `room-agent-tools` cache entry doesn't prevent other servers from applying
  - No error thrown when session is not found during hot-reload
  - Registry-sourced server wins over file-based server on name collision
- [x] Existing wiring tests (26 tests) still pass
- [x] TypeScript typecheck clean
- [x] Lint clean (0 warnings/errors)