### PR TITLE
feat(reference): implement task and goal resolvers

### DIFF
--- a/packages/daemon/src/lib/agent/reference-resolver.ts
+++ b/packages/daemon/src/lib/agent/reference-resolver.ts
@@ -2,8 +2,7 @@
  * ReferenceResolver — Core service for parsing and resolving @ references
  *
  * Handles extracting @ref{} mentions from text and resolving them to their
- * full entity data. Currently implements file and folder resolvers.
- * Task and goal resolvers are stubbed (see Task 3.1).
+ * full entity data. Implements file, folder, task, and goal resolvers.
  *
  * Path validation enforced for file/folder references:
  *   - Empty paths are rejected
@@ -37,7 +36,11 @@ import type {
 	ResolvedReference,
 	ResolvedFileReference,
 	ResolvedFolderReference,
+	ResolvedTaskReference,
+	ResolvedGoalReference,
 	ReferenceType,
+	NeoTask,
+	RoomGoal,
 } from '@neokai/shared';
 import { REFERENCE_PATTERN } from '@neokai/shared';
 import { Logger } from '../logger.ts';
@@ -51,9 +54,39 @@ const MAX_FILE_SIZE = 50 * 1024;
 const MAX_FOLDER_ENTRIES = 200;
 
 /**
+ * Minimal structural interface for TaskRepository — only the method(s) used here.
+ * Using a structural interface (not importing the class) avoids pulling in SQLite.
+ */
+export interface TaskRepoLike {
+	getTaskByShortId(roomId: string, shortId: string): NeoTask | null;
+}
+
+/**
+ * Minimal structural interface for GoalRepository — only the method(s) used here.
+ */
+export interface GoalRepoLike {
+	getGoalByShortId(roomId: string, shortId: string): RoomGoal | null;
+}
+
+/**
+ * Minimal structural interface for SpaceTaskRepository — only the method(s) used here.
+ */
+export interface SpaceTaskRepoLike {
+	getTask(id: string): { id: string; spaceId: string; [key: string]: unknown } | null;
+}
+
+/** Optional repository dependencies injected at construction time. */
+export interface ReferenceResolverDeps {
+	taskRepo?: TaskRepoLike;
+	goalRepo?: GoalRepoLike;
+	spaceTaskRepo?: SpaceTaskRepoLike;
+}
+
+/**
  * Context for resolving references — provides session-scoped information.
  * File/folder resolution only requires workspacePath.
- * Task/goal resolution (Task 3.1) will use roomId and spaceId.
+ * Task resolution uses roomId (room tasks) or spaceId (space tasks).
+ * Goal resolution uses roomId.
  */
 export interface ResolutionContext {
 	roomId?: string;
@@ -62,6 +95,15 @@ export interface ResolutionContext {
 }
 
 export class ReferenceResolver {
+	private readonly taskRepo?: TaskRepoLike;
+	private readonly goalRepo?: GoalRepoLike;
+	private readonly spaceTaskRepo?: SpaceTaskRepoLike;
+
+	constructor(deps: ReferenceResolverDeps = {}) {
+		this.taskRepo = deps.taskRepo;
+		this.goalRepo = deps.goalRepo;
+		this.spaceTaskRepo = deps.spaceTaskRepo;
+	}
 	/**
 	 * Extract all @ref{} mentions from a text string.
 	 * Returns deduplicated mentions in order of appearance.
@@ -108,9 +150,9 @@ export class ReferenceResolver {
 			case 'folder':
 				return this.resolveFolder(mention.id, context);
 			case 'task':
+				return this.resolveTask(mention.id, context);
 			case 'goal':
-				// Implemented by Task 3.1 — task/goal resolvers
-				return null;
+				return this.resolveGoal(mention.id, context);
 			default: {
 				const _exhaustive: never = mention.type;
 				log.warn(`Unknown reference type: ${_exhaustive}`);
@@ -381,6 +423,97 @@ export class ReferenceResolver {
 				entries,
 			},
 		};
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Task resolver
+	// ────────────────────────────────────────────────────────────────────────────
+
+	private async resolveTask(
+		id: string,
+		context: ResolutionContext
+	): Promise<ResolvedTaskReference | null> {
+		if (id.startsWith('st-')) {
+			return this.resolveSpaceTask(id, context);
+		}
+		if (id.startsWith('t-')) {
+			return this.resolveRoomTask(id, context);
+		}
+		log.warn(`Unrecognized task reference format: "${id}" (expected t- or st- prefix)`);
+		return null;
+	}
+
+	private resolveRoomTask(
+		shortId: string,
+		context: ResolutionContext
+	): ResolvedTaskReference | null {
+		if (!context.roomId) {
+			log.warn(`Cannot resolve room task "${shortId}": session has no room context`);
+			return null;
+		}
+		if (!this.taskRepo) {
+			log.warn('Cannot resolve room task: TaskRepository not injected');
+			return null;
+		}
+		const task = this.taskRepo.getTaskByShortId(context.roomId, shortId);
+		if (!task) {
+			log.warn(`Room task not found: "${shortId}" in room "${context.roomId}"`);
+			return null;
+		}
+		// Defensive cross-room check in case the repo isn't scoped
+		if (task.roomId !== context.roomId) {
+			log.warn(
+				`Cross-room reference rejected: task "${shortId}" belongs to room "${task.roomId}", not "${context.roomId}"`
+			);
+			return null;
+		}
+		return { type: 'task', id: task.id, data: task };
+	}
+
+	private resolveSpaceTask(id: string, context: ResolutionContext): ResolvedTaskReference | null {
+		if (!context.spaceId) {
+			log.warn(`Cannot resolve space task "${id}": session has no space context`);
+			return null;
+		}
+		if (!this.spaceTaskRepo) {
+			log.warn('Cannot resolve space task: SpaceTaskRepository not injected');
+			return null;
+		}
+		// id is "st-<uuid>"; strip the prefix to get the UUID
+		const uuid = id.slice('st-'.length);
+		const task = this.spaceTaskRepo.getTask(uuid);
+		if (!task) {
+			log.warn(`Space task not found: UUID "${uuid}" (from reference "${id}")`);
+			return null;
+		}
+		if (task.spaceId !== context.spaceId) {
+			log.warn(
+				`Cross-space reference rejected: task "${id}" belongs to space "${task.spaceId}", not "${context.spaceId}"`
+			);
+			return null;
+		}
+		return { type: 'task', id: task.id, data: task as unknown as NeoTask };
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Goal resolver
+	// ────────────────────────────────────────────────────────────────────────────
+
+	private resolveGoal(shortId: string, context: ResolutionContext): ResolvedGoalReference | null {
+		if (!context.roomId) {
+			log.warn(`Cannot resolve goal "${shortId}": session has no room context`);
+			return null;
+		}
+		if (!this.goalRepo) {
+			log.warn('Cannot resolve goal: GoalRepository not injected');
+			return null;
+		}
+		const goal = this.goalRepo.getGoalByShortId(context.roomId, shortId);
+		if (!goal) {
+			log.warn(`Goal not found: "${shortId}" in room "${context.roomId}"`);
+			return null;
+		}
+		return { type: 'goal', id: goal.id, data: goal };
 	}
 
 	// ────────────────────────────────────────────────────────────────────────────

--- a/packages/daemon/src/lib/agent/reference-resolver.ts
+++ b/packages/daemon/src/lib/agent/reference-resolver.ts
@@ -41,6 +41,7 @@ import type {
 	ReferenceType,
 	NeoTask,
 	RoomGoal,
+	SpaceTask,
 } from '@neokai/shared';
 import { REFERENCE_PATTERN } from '@neokai/shared';
 import { Logger } from '../logger.ts';
@@ -52,6 +53,10 @@ const MAX_FILE_SIZE = 50 * 1024;
 
 /** Max number of directory entries returned for folder references */
 const MAX_FOLDER_ENTRIES = 200;
+
+/** Reference prefixes */
+const ROOM_TASK_PREFIX = 't-';
+const SPACE_TASK_PREFIX = 'st-';
 
 /**
  * Minimal structural interface for TaskRepository — only the method(s) used here.
@@ -72,7 +77,7 @@ export interface GoalRepoLike {
  * Minimal structural interface for SpaceTaskRepository — only the method(s) used here.
  */
 export interface SpaceTaskRepoLike {
-	getTask(id: string): { id: string; spaceId: string; [key: string]: unknown } | null;
+	getTask(id: string): SpaceTask | null;
 }
 
 /** Optional repository dependencies injected at construction time. */
@@ -152,7 +157,7 @@ export class ReferenceResolver {
 			case 'task':
 				return this.resolveTask(mention.id, context);
 			case 'goal':
-				return this.resolveGoal(mention.id, context);
+				return Promise.resolve(this.resolveGoal(mention.id, context));
 			default: {
 				const _exhaustive: never = mention.type;
 				log.warn(`Unknown reference type: ${_exhaustive}`);
@@ -429,17 +434,16 @@ export class ReferenceResolver {
 	// Task resolver
 	// ────────────────────────────────────────────────────────────────────────────
 
-	private async resolveTask(
-		id: string,
-		context: ResolutionContext
-	): Promise<ResolvedTaskReference | null> {
-		if (id.startsWith('st-')) {
+	private resolveTask(id: string, context: ResolutionContext): ResolvedTaskReference | null {
+		if (id.startsWith(SPACE_TASK_PREFIX)) {
 			return this.resolveSpaceTask(id, context);
 		}
-		if (id.startsWith('t-')) {
+		if (id.startsWith(ROOM_TASK_PREFIX)) {
 			return this.resolveRoomTask(id, context);
 		}
-		log.warn(`Unrecognized task reference format: "${id}" (expected t- or st- prefix)`);
+		log.warn(
+			`Unrecognized task reference format: "${id}" (expected ${ROOM_TASK_PREFIX} or ${SPACE_TASK_PREFIX} prefix)`
+		);
 		return null;
 	}
 
@@ -480,7 +484,7 @@ export class ReferenceResolver {
 			return null;
 		}
 		// id is "st-<uuid>"; strip the prefix to get the UUID
-		const uuid = id.slice('st-'.length);
+		const uuid = id.slice(SPACE_TASK_PREFIX.length);
 		const task = this.spaceTaskRepo.getTask(uuid);
 		if (!task) {
 			log.warn(`Space task not found: UUID "${uuid}" (from reference "${id}")`);
@@ -492,7 +496,7 @@ export class ReferenceResolver {
 			);
 			return null;
 		}
-		return { type: 'task', id: task.id, data: task as unknown as NeoTask };
+		return { type: 'task', id: task.id, data: task };
 	}
 
 	// ────────────────────────────────────────────────────────────────────────────
@@ -511,6 +515,13 @@ export class ReferenceResolver {
 		const goal = this.goalRepo.getGoalByShortId(context.roomId, shortId);
 		if (!goal) {
 			log.warn(`Goal not found: "${shortId}" in room "${context.roomId}"`);
+			return null;
+		}
+		// Defensive cross-room check in case the repo isn't scoped
+		if (goal.roomId !== context.roomId) {
+			log.warn(
+				`Cross-room reference rejected: goal "${shortId}" belongs to room "${goal.roomId}", not "${context.roomId}"`
+			);
 			return null;
 		}
 		return { type: 'goal', id: goal.id, data: goal };

--- a/packages/daemon/tests/unit/reference-resolver.test.ts
+++ b/packages/daemon/tests/unit/reference-resolver.test.ts
@@ -10,12 +10,17 @@
  *   - task/goal references return null (stubs pending Task 3.1)
  */
 
-import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { describe, expect, it, test, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdir, writeFile, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ReferenceResolver } from '../../src/lib/agent/reference-resolver';
-import type { ResolutionContext } from '../../src/lib/agent/reference-resolver';
+import type {
+	ResolutionContext,
+	TaskRepoLike,
+	GoalRepoLike,
+	SpaceTaskRepoLike,
+} from '../../src/lib/agent/reference-resolver';
 import type { ResolvedFileReference, ResolvedFolderReference } from '@neokai/shared';
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -502,19 +507,19 @@ describe('ReferenceResolver', () => {
 	// Task / goal references (stubs)
 	// ──────────────────────────────────────────────────────────────────────────
 
-	describe('task and goal references', () => {
-		it('returns null for task references (not yet implemented)', async () => {
+	describe('task and goal references without injected repos', () => {
+		it('returns null for task references when no repo injected', async () => {
 			const result = await resolver.resolveReference(
 				{ type: 'task', id: 't-42', displayText: '@ref{task:t-42}' },
-				ctx
+				{ ...ctx, roomId: 'room-1' }
 			);
 			expect(result).toBeNull();
 		});
 
-		it('returns null for goal references (not yet implemented)', async () => {
+		it('returns null for goal references when no repo injected', async () => {
 			const result = await resolver.resolveReference(
 				{ type: 'goal', id: 'g-7', displayText: '@ref{goal:g-7}' },
-				ctx
+				{ ...ctx, roomId: 'room-1' }
 			);
 			expect(result).toBeNull();
 		});
@@ -560,5 +565,310 @@ describe('ReferenceResolver', () => {
 			expect(result['@ref{file:good.txt}']).toBeDefined();
 			expect(result['@ref{file:bad.txt}']).toBeUndefined();
 		});
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Mock helpers for task / goal tests — no SQLite, no repositories
+// ────────────────────────────────────────────────────────────────────────────
+
+const ROOM_ID = 'room-abc';
+const OTHER_ROOM_ID = 'room-xyz';
+const SPACE_ID = 'space-111';
+const OTHER_SPACE_ID = 'space-222';
+const WORKSPACE = '/workspace';
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'task-uuid-1',
+		shortId: 't-1',
+		roomId: ROOM_ID,
+		title: 'Default Task',
+		description: '',
+		status: 'pending',
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeSpaceTask(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'space-task-uuid-1',
+		spaceId: SPACE_ID,
+		title: 'Default Space Task',
+		description: '',
+		status: 'pending',
+		priority: 'normal',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeGoal(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'goal-uuid-1',
+		shortId: 'g-1',
+		roomId: ROOM_ID,
+		title: 'Default Goal',
+		description: '',
+		status: 'active',
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function mockTaskRepo(returnValue?: ReturnType<typeof makeTask>): TaskRepoLike {
+	return { getTaskByShortId: mock(() => returnValue ?? null) };
+}
+
+function mockGoalRepo(returnValue?: ReturnType<typeof makeGoal>): GoalRepoLike {
+	return { getGoalByShortId: mock(() => returnValue ?? null) };
+}
+
+function mockSpaceTaskRepo(returnValue?: ReturnType<typeof makeSpaceTask>): SpaceTaskRepoLike {
+	return { getTask: mock(() => returnValue ?? null) };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Room task resolution
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('ReferenceResolver — room task resolution', () => {
+	test('resolves a room task by shortId', async () => {
+		const task = makeTask({ shortId: 't-1', title: 'Implement auth', priority: 'high' });
+		const resolver = new ReferenceResolver({ taskRepo: mockTaskRepo(task) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: 't-1', displayText: '@ref{task:t-1}' },
+			{ roomId: ROOM_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).not.toBeNull();
+		expect(result!.type).toBe('task');
+		expect(result!.id).toBe(task.id);
+		const data = result!.data as typeof task;
+		expect(data.shortId).toBe('t-1');
+		expect(data.title).toBe('Implement auth');
+		expect(data.roomId).toBe(ROOM_ID);
+	});
+
+	test('returns null when session has no room context', async () => {
+		const resolver = new ReferenceResolver({ taskRepo: mockTaskRepo(makeTask()) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: 't-1', displayText: '@ref{task:t-1}' },
+			{ workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('returns null for unrecognized task ID format (no t- or st- prefix)', async () => {
+		const resolver = new ReferenceResolver({ taskRepo: mockTaskRepo(makeTask()) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: 'abc123', displayText: '@ref{task:abc123}' },
+			{ roomId: ROOM_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('returns null when task does not exist', async () => {
+		const resolver = new ReferenceResolver({ taskRepo: mockTaskRepo() });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: 't-999', displayText: '@ref{task:t-999}' },
+			{ roomId: ROOM_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('cross-room check: rejects task whose roomId differs from context', async () => {
+		const task = makeTask({ roomId: OTHER_ROOM_ID });
+		const resolver = new ReferenceResolver({ taskRepo: mockTaskRepo(task) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: 't-1', displayText: '@ref{task:t-1}' },
+			{ roomId: ROOM_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Space task resolution
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('ReferenceResolver — space task resolution', () => {
+	test('resolves a space task by st-<uuid> reference', async () => {
+		const task = makeSpaceTask({ id: 'uuid-aaa', title: 'Deploy service' });
+		const resolver = new ReferenceResolver({ spaceTaskRepo: mockSpaceTaskRepo(task) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: `st-${task.id}`, displayText: `@ref{task:st-${task.id}}` },
+			{ spaceId: SPACE_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).not.toBeNull();
+		expect(result!.type).toBe('task');
+		expect(result!.id).toBe(task.id);
+		expect((result!.data as typeof task).title).toBe('Deploy service');
+	});
+
+	test('returns null when session has no space context', async () => {
+		const task = makeSpaceTask();
+		const resolver = new ReferenceResolver({ spaceTaskRepo: mockSpaceTaskRepo(task) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: `st-${task.id}`, displayText: `@ref{task:st-${task.id}}` },
+			{ workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('returns null when space task UUID does not exist', async () => {
+		const resolver = new ReferenceResolver({ spaceTaskRepo: mockSpaceTaskRepo() });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: 'st-nonexistent-uuid', displayText: '@ref{task:st-nonexistent-uuid}' },
+			{ spaceId: SPACE_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('returns null for cross-space reference', async () => {
+		const task = makeSpaceTask({ spaceId: OTHER_SPACE_ID });
+		const resolver = new ReferenceResolver({ spaceTaskRepo: mockSpaceTaskRepo(task) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: `st-${task.id}`, displayText: `@ref{task:st-${task.id}}` },
+			{ spaceId: SPACE_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('returns null gracefully for st-<non-uuid> value', async () => {
+		const resolver = new ReferenceResolver({ spaceTaskRepo: mockSpaceTaskRepo() });
+
+		const result = await resolver.resolveReference(
+			{ type: 'task', id: 'st-not-a-uuid', displayText: '@ref{task:st-not-a-uuid}' },
+			{ spaceId: SPACE_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Goal resolution
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('ReferenceResolver — goal resolution', () => {
+	test('resolves a goal by shortId', async () => {
+		const goal = makeGoal({ shortId: 'g-1', title: 'Q1 Revenue Target', progress: 75 });
+		const resolver = new ReferenceResolver({ goalRepo: mockGoalRepo(goal) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'goal', id: 'g-1', displayText: '@ref{goal:g-1}' },
+			{ roomId: ROOM_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).not.toBeNull();
+		expect(result!.type).toBe('goal');
+		expect(result!.id).toBe(goal.id);
+		const data = result!.data as typeof goal;
+		expect(data.shortId).toBe('g-1');
+		expect(data.title).toBe('Q1 Revenue Target');
+		expect(data.progress).toBe(75);
+	});
+
+	test('returns null when session has no room context', async () => {
+		const resolver = new ReferenceResolver({ goalRepo: mockGoalRepo(makeGoal()) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'goal', id: 'g-1', displayText: '@ref{goal:g-1}' },
+			{ workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('returns null when goal does not exist', async () => {
+		const resolver = new ReferenceResolver({ goalRepo: mockGoalRepo() });
+
+		const result = await resolver.resolveReference(
+			{ type: 'goal', id: 'g-999', displayText: '@ref{goal:g-999}' },
+			{ roomId: ROOM_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('resolves goal with missionType and autonomyLevel fields', async () => {
+		const goal = makeGoal({ missionType: 'measurable', autonomyLevel: 'semi_autonomous' });
+		const resolver = new ReferenceResolver({ goalRepo: mockGoalRepo(goal) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'goal', id: 'g-1', displayText: '@ref{goal:g-1}' },
+			{ roomId: ROOM_ID, workspacePath: WORKSPACE }
+		);
+
+		const data = result!.data as typeof goal;
+		expect(data.missionType).toBe('measurable');
+		expect(data.autonomyLevel).toBe('semi_autonomous');
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// resolveAllReferences with task/goal mocks
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('ReferenceResolver.resolveAllReferences — task/goal', () => {
+	test('resolves task and goal references together', async () => {
+		const task = makeTask({ shortId: 't-1' });
+		const goal = makeGoal({ shortId: 'g-1' });
+		const resolver = new ReferenceResolver({
+			taskRepo: mockTaskRepo(task),
+			goalRepo: mockGoalRepo(goal),
+		});
+
+		const text = 'Work on @ref{task:t-1} toward @ref{goal:g-1}';
+		const result = await resolver.resolveAllReferences(text, {
+			roomId: ROOM_ID,
+			workspacePath: WORKSPACE,
+		});
+
+		expect(Object.keys(result)).toHaveLength(2);
+		expect(result['@ref{task:t-1}']).toBeDefined();
+		expect(result['@ref{goal:g-1}']).toBeDefined();
+	});
+
+	test('omits unresolvable task references', async () => {
+		const task = makeTask({ shortId: 't-1' });
+		const tRepo: TaskRepoLike = {
+			getTaskByShortId: mock((_, shortId: string) => (shortId === 't-1' ? task : null)),
+		};
+		const resolver = new ReferenceResolver({ taskRepo: tRepo });
+
+		const result = await resolver.resolveAllReferences('@ref{task:t-1} @ref{task:t-999}', {
+			roomId: ROOM_ID,
+			workspacePath: WORKSPACE,
+		});
+
+		expect(Object.keys(result)).toHaveLength(1);
+		expect(result['@ref{task:t-1}']).toBeDefined();
 	});
 });

--- a/packages/daemon/tests/unit/reference-resolver.test.ts
+++ b/packages/daemon/tests/unit/reference-resolver.test.ts
@@ -830,6 +830,18 @@ describe('ReferenceResolver — goal resolution', () => {
 		expect(data.missionType).toBe('measurable');
 		expect(data.autonomyLevel).toBe('semi_autonomous');
 	});
+
+	test('cross-room check: rejects goal whose roomId differs from context', async () => {
+		const goal = makeGoal({ roomId: OTHER_ROOM_ID });
+		const resolver = new ReferenceResolver({ goalRepo: mockGoalRepo(goal) });
+
+		const result = await resolver.resolveReference(
+			{ type: 'goal', id: 'g-1', displayText: '@ref{goal:g-1}' },
+			{ roomId: ROOM_ID, workspacePath: WORKSPACE }
+		);
+
+		expect(result).toBeNull();
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/shared/src/types/reference.ts
+++ b/packages/shared/src/types/reference.ts
@@ -7,6 +7,7 @@
  */
 
 import type { NeoTask, RoomGoal } from './neo.ts';
+import type { SpaceTask } from './space.ts';
 
 /**
  * The type of entity being referenced.
@@ -52,7 +53,8 @@ export interface ResolvedReference {
 
 export interface ResolvedTaskReference extends ResolvedReference {
 	type: 'task';
-	data: NeoTask;
+	/** Room tasks (t- prefix) carry NeoTask; space tasks (st- prefix) carry SpaceTask */
+	data: NeoTask | SpaceTask;
 }
 
 export interface ResolvedGoalReference extends ResolvedReference {


### PR DESCRIPTION
## Summary

- Add task resolution (room tasks via `t-` prefix, space tasks via `st-` prefix) to `ReferenceResolver`
- Add goal resolution (`g-` prefix) to `ReferenceResolver`
- Repository dependencies injected as minimal structural interfaces (`TaskRepoLike`, `GoalRepoLike`, `SpaceTaskRepoLike`) — no SQLite imports in the resolver
- Tests use pure mock objects only — no in-memory SQLite, no DB setup

## Test plan

- [ ] `bun test packages/daemon/tests/unit/reference-resolver.test.ts` — 61 tests pass
- [ ] `make test-daemon` — full daemon suite passes (8272 pass)
- [ ] Verify no OOM: mock-only tests have negligible memory footprint