### PR TITLE
feat(room): inject merged MCP servers into worker sessions via setRuntimeMcpServers() (Task 3.3)

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -250,13 +250,27 @@ export class RoomRuntimeService {
 				agentSessions.set(init.sessionId, session);
 
 				// Inject merged MCP servers for worker sessions (coder / general).
-				// File-based servers take precedence over registry servers on name collision
-				// because local project config is considered more specific than the global
-				// application-level registry.
 				//
-				// Hot-reload for worker sessions is intentionally skipped: workers are
-				// short-lived (one task per session) so a registry change mid-task would
-				// not be useful. The updated map is applied on the next session creation.
+				// Precedence (highest to lowest): file-based > registry.
+				// File-based servers are project-local config (.mcp.json / settings.json) and are
+				// considered more specific than the global application-level registry. When the same
+				// server name appears in both sources, the project's local definition wins.
+				//
+				// Note: Room chat sessions use the OPPOSITE precedence (registry > file-based) because
+				// room chat does not use project-local tools and the app-level registry is intended to
+				// extend the room chat experience. Worker sessions operate in the project workspace, so
+				// the project's local config should take priority.
+				//
+				// Hot-reload for worker sessions is intentionally skipped: workers are short-lived
+				// (one task per session) so a registry change mid-task would not be useful. The
+				// updated map is applied on the next session creation.
+				//
+				// Known limitation after daemon restart: recovered worker sessions re-created by
+				// restoreSession() will NOT have the merged (file + registry) MCP map reapplied —
+				// restoreMcpServersForGroup() only restores role-specific in-process tools
+				// (planner-tools, leader-agent-tools). Workers resumed from a crash will therefore
+				// run without user-configured MCP servers for the remainder of their task. This is
+				// accepted given the short-lived nature of worker sessions.
 				if (role === 'coder' || role === 'general') {
 					const fileMcpServers = ctx.settingsManager.getEnabledMcpServersConfig();
 					const registryMcpServers = ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
@@ -271,12 +285,17 @@ export class RoomRuntimeService {
 						}
 					}
 
-					// Merge: registry first, then file-based overwrites on collision
+					// Merge: registry first, then file-based overwrites on collision.
+					// Only call setRuntimeMcpServers when there is at least one server to inject —
+					// an undefined config lets the SDK use its own default discovery, while an
+					// empty map would suppress it entirely with no benefit.
 					const merged: Record<string, McpServerConfig> = {
 						...registryMcpServers,
 						...fileMcpServers,
 					};
-					session.setRuntimeMcpServers(merged);
+					if (Object.keys(merged).length > 0) {
+						session.setRuntimeMcpServers(merged);
+					}
 				}
 
 				// Leader sessions are started lazily: injectMessage() calls ensureQueryStarted()
@@ -585,9 +604,15 @@ export class RoomRuntimeService {
 				//   2. Registry-based servers (application-level entries from AppMcpLifecycleManager)
 				//   3. room-agent-tools (in-process server for room coordination)
 				//
-				// Merge order: file-based first, registry-based second (wins over file-based on
-				// name collision), then room-agent-tools last so it ALWAYS takes precedence.
-				// This guarantees room coordination tools are never shadowed by user-configured servers.
+				// Precedence (highest to lowest): room-agent-tools > registry > file-based.
+				// Registry wins over file-based here because the room chat session does not operate
+				// inside a specific project workspace — the app-level registry is intended to
+				// enrich the room chat experience and takes precedence over project-local config.
+				// room-agent-tools is always last so it can never be shadowed.
+				//
+				// Note: Worker sessions (coder/general) use the OPPOSITE file vs. registry precedence
+				// because they run inside the project workspace where local config is more specific.
+				// See createSessionFactory() for the worker merge logic.
 				//
 				// Note: setRuntimeMcpServers() replaces the config used for the NEXT query; it does
 				// NOT restart any in-flight query. This is intentional — MCP server changes between
@@ -795,7 +820,12 @@ export class RoomRuntimeService {
 						// message is injected (rate-limit detection and compatibility hooks).
 						runtime.restoreRecoveredGroupMirroring(group);
 
-						// Restore MCP servers (planner-tools, leader-agent-tools)
+						// Restore role-specific in-process MCP servers (planner-tools, leader-agent-tools).
+						// Note: file-based and registry-sourced MCP servers are NOT restored here for
+						// worker sessions (coder/general). This is a known limitation — recovered workers
+						// run without user-configured MCP servers for the remainder of their task.
+						// Workers are short-lived (one task per session) so this is accepted behaviour;
+						// the merged map is applied on the next session creation via createSessionFactory().
 						await runtime.restoreMcpServersForGroup(group);
 
 						if (!resumeAgents) {

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -248,6 +248,37 @@ export class RoomRuntimeService {
 					ctx.defaultModel
 				);
 				agentSessions.set(init.sessionId, session);
+
+				// Inject merged MCP servers for worker sessions (coder / general).
+				// File-based servers take precedence over registry servers on name collision
+				// because local project config is considered more specific than the global
+				// application-level registry.
+				//
+				// Hot-reload for worker sessions is intentionally skipped: workers are
+				// short-lived (one task per session) so a registry change mid-task would
+				// not be useful. The updated map is applied on the next session creation.
+				if (role === 'coder' || role === 'general') {
+					const fileMcpServers = ctx.settingsManager.getEnabledMcpServersConfig();
+					const registryMcpServers = ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
+
+					// Detect and warn on name collisions (file-based wins)
+					for (const name of Object.keys(fileMcpServers)) {
+						if (Object.prototype.hasOwnProperty.call(registryMcpServers, name)) {
+							log.warn(
+								`Worker session ${init.sessionId}: MCP server name collision on '${name}' — ` +
+									`file-based config takes precedence over registry entry.`
+							);
+						}
+					}
+
+					// Merge: registry first, then file-based overwrites on collision
+					const merged: Record<string, McpServerConfig> = {
+						...registryMcpServers,
+						...fileMcpServers,
+					};
+					session.setRuntimeMcpServers(merged);
+				}
+
 				// Leader sessions are started lazily: injectMessage() calls ensureQueryStarted()
 				// before enqueuing the first message. Starting eagerly here would trigger the
 				// 15s SDK startup timeout because the leader has no queued message yet.

--- a/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
@@ -8,9 +8,10 @@
  * 3. The merged map is complete — neither source is dropped.
  * 4. Non-worker roles (leader, planner) do NOT get the worker MCP injection.
  * 5. appMcpManager is optional — missing it does not throw.
+ * 6. setRuntimeMcpServers is NOT called when both sources are empty (no-op guard).
  */
 
-import { describe, expect, it, mock, spyOn } from 'bun:test';
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import type { McpServerConfig } from '@neokai/shared';
 import type { AgentSessionInit } from '../../../src/lib/agent/agent-session';
 
@@ -61,7 +62,8 @@ function makeMinimalInit(sessionId = 'session-1'): AgentSessionInit {
 
 /**
  * Build a minimal SessionFactory that lets us observe calls to the underlying
- * AgentSession mock. Returns the factory and a collector for setRuntimeMcpServers calls.
+ * AgentSession mock. Returns the factory, a collector for setRuntimeMcpServers calls,
+ * and the spy so the caller can restore it in afterEach.
  *
  * We exercise createAndStartSession by extracting the factory from a configured
  * RoomRuntimeService instance via the private createSessionFactory() method.
@@ -76,7 +78,8 @@ async function buildSessionFactory(opts: {
 	// Capture setRuntimeMcpServers calls per session
 	const setRuntimeMcpServersCalls = new Map<string, Array<Record<string, McpServerConfig>>>();
 
-	// Mock AgentSession.fromInit to return a controllable stub
+	// Mock AgentSession.fromInit to return a controllable stub.
+	// The spy is returned so tests can restore it in afterEach even when assertions throw.
 	const agentSessionModule = await import('../../../src/lib/agent/agent-session');
 	const fromInitSpy = spyOn(agentSessionModule.AgentSession, 'fromInit').mockImplementation(((
 		init: AgentSessionInit
@@ -141,6 +144,16 @@ async function buildSessionFactory(opts: {
 // ---------------------------------------------------------------------------
 
 describe('RoomRuntimeService worker session MCP merge', () => {
+	// Track spies created in each test so we can restore them in afterEach
+	// even when a test assertion throws before the inline restore call.
+	const spies: Array<{ mockRestore: () => void }> = [];
+
+	afterEach(() => {
+		for (const spy of spies.splice(0)) {
+			spy.mockRestore();
+		}
+	});
+
 	it('injects merged MCP map into coder sessions', async () => {
 		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-cmd' };
 		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
@@ -149,10 +162,9 @@ describe('RoomRuntimeService worker session MCP merge', () => {
 			fileMcpServers: { 'file-mcp': fileServer },
 			registryMcpServers: { 'registry-mcp': registryServer },
 		});
+		spies.push(fromInitSpy);
 
 		await factory.createAndStartSession(makeMinimalInit('s1'), 'coder');
-
-		fromInitSpy.mockRestore();
 
 		const calls = setRuntimeMcpServersCalls.get('s1') ?? [];
 		expect(calls.length).toBe(1);
@@ -168,11 +180,10 @@ describe('RoomRuntimeService worker session MCP merge', () => {
 			fileMcpServers: { 'file-mcp': fileServer },
 			registryMcpServers: { 'registry-mcp': registryServer },
 		});
+		spies.push(fromInitSpy);
 
 		const init = { ...makeMinimalInit('s2'), type: 'general' as const };
 		await factory.createAndStartSession(init, 'general');
-
-		fromInitSpy.mockRestore();
 
 		const calls = setRuntimeMcpServersCalls.get('s2') ?? [];
 		expect(calls.length).toBe(1);
@@ -188,10 +199,9 @@ describe('RoomRuntimeService worker session MCP merge', () => {
 			fileMcpServers: { 'shared-name': fileServer },
 			registryMcpServers: { 'shared-name': registryServer },
 		});
+		spies.push(fromInitSpy);
 
 		await factory.createAndStartSession(makeMinimalInit('s3'), 'coder');
-
-		fromInitSpy.mockRestore();
 
 		const calls = setRuntimeMcpServersCalls.get('s3') ?? [];
 		expect(calls.length).toBe(1);
@@ -209,10 +219,9 @@ describe('RoomRuntimeService worker session MCP merge', () => {
 			fileMcpServers: { 'file-unique': fileServer },
 			registryMcpServers: { 'registry-unique': registryServer },
 		});
+		spies.push(fromInitSpy);
 
 		await factory.createAndStartSession(makeMinimalInit('s4'), 'coder');
-
-		fromInitSpy.mockRestore();
 
 		const calls = setRuntimeMcpServersCalls.get('s4') ?? [];
 		expect(calls.length).toBe(1);
@@ -229,10 +238,9 @@ describe('RoomRuntimeService worker session MCP merge', () => {
 			fileMcpServers: { 'file-mcp': fileServer },
 			registryMcpServers: { 'registry-mcp': registryServer },
 		});
+		spies.push(fromInitSpy);
 
 		await factory.createAndStartSession(makeMinimalInit('s5'), 'leader');
-
-		fromInitSpy.mockRestore();
 
 		const calls = setRuntimeMcpServersCalls.get('s5') ?? [];
 		// setRuntimeMcpServers should NOT be called for leader
@@ -245,10 +253,9 @@ describe('RoomRuntimeService worker session MCP merge', () => {
 		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
 			fileMcpServers: { 'file-mcp': fileServer },
 		});
+		spies.push(fromInitSpy);
 
 		await factory.createAndStartSession(makeMinimalInit('s6'), 'planner');
-
-		fromInitSpy.mockRestore();
 
 		const calls = setRuntimeMcpServersCalls.get('s6') ?? [];
 		expect(calls.length).toBe(0);
@@ -261,29 +268,28 @@ describe('RoomRuntimeService worker session MCP merge', () => {
 			fileMcpServers: { 'file-mcp': fileServer },
 			hasAppMcpManager: false,
 		});
+		spies.push(fromInitSpy);
 
 		await factory.createAndStartSession(makeMinimalInit('s7'), 'coder');
-
-		fromInitSpy.mockRestore();
 
 		const calls = setRuntimeMcpServersCalls.get('s7') ?? [];
 		expect(calls.length).toBe(1);
 		expect(calls[0]!['file-mcp']).toEqual(fileServer);
 	});
 
-	it('injects empty map when both sources are empty (no MCP servers configured)', async () => {
+	it('does NOT call setRuntimeMcpServers when both sources are empty', async () => {
+		// When neither file-based nor registry has any servers, setRuntimeMcpServers
+		// should be skipped entirely so the SDK can use its own default discovery
+		// instead of being handed an empty map that suppresses it.
 		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
 			fileMcpServers: {},
 			registryMcpServers: {},
 		});
+		spies.push(fromInitSpy);
 
 		await factory.createAndStartSession(makeMinimalInit('s8'), 'coder');
 
-		fromInitSpy.mockRestore();
-
 		const calls = setRuntimeMcpServersCalls.get('s8') ?? [];
-		// setRuntimeMcpServers is still called, but with an empty map
-		expect(calls.length).toBe(1);
-		expect(Object.keys(calls[0]!)).toHaveLength(0);
+		expect(calls.length).toBe(0);
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for RoomRuntimeService worker session MCP integration (Task 3.3).
+ *
+ * Verifies that:
+ * 1. Worker sessions (coder/general) receive the merged (file-based + registry) MCP map
+ *    via setRuntimeMcpServers() when createAndStartSession is called.
+ * 2. File-based servers take precedence over registry servers on name collision.
+ * 3. The merged map is complete — neither source is dropped.
+ * 4. Non-worker roles (leader, planner) do NOT get the worker MCP injection.
+ * 5. appMcpManager is optional — missing it does not throw.
+ */
+
+import { describe, expect, it, mock, spyOn } from 'bun:test';
+import type { McpServerConfig } from '@neokai/shared';
+import type { AgentSessionInit } from '../../../src/lib/agent/agent-session';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type DaemonHubListener = (event: Record<string, unknown>) => void;
+
+function makeDaemonHub() {
+	const listeners = new Map<string, DaemonHubListener[]>();
+	return {
+		on: (event: string, handler: DaemonHubListener) => {
+			if (!listeners.has(event)) listeners.set(event, []);
+			listeners.get(event)!.push(handler);
+			return () => {
+				const arr = listeners.get(event);
+				if (arr) {
+					const idx = arr.indexOf(handler);
+					if (idx !== -1) arr.splice(idx, 1);
+				}
+			};
+		},
+		emit: async (event: string, payload: Record<string, unknown>) => {
+			for (const handler of listeners.get(event) ?? []) {
+				handler(payload);
+			}
+		},
+	};
+}
+
+function makeMinimalInit(sessionId = 'session-1'): AgentSessionInit {
+	return {
+		sessionId,
+		workspacePath: '/tmp',
+		systemPrompt: { type: 'preset', preset: 'claude_code' },
+		features: {
+			rewind: false,
+			worktree: false,
+			coordinator: false,
+			archive: false,
+			sessionInfo: false,
+		},
+		type: 'coder',
+		model: 'test-model',
+	};
+}
+
+/**
+ * Build a minimal SessionFactory that lets us observe calls to the underlying
+ * AgentSession mock. Returns the factory and a collector for setRuntimeMcpServers calls.
+ *
+ * We exercise createAndStartSession by extracting the factory from a configured
+ * RoomRuntimeService instance via the private createSessionFactory() method.
+ */
+async function buildSessionFactory(opts: {
+	fileMcpServers?: Record<string, McpServerConfig>;
+	registryMcpServers?: Record<string, McpServerConfig>;
+	hasAppMcpManager?: boolean;
+}) {
+	const { fileMcpServers = {}, registryMcpServers = {}, hasAppMcpManager = true } = opts;
+
+	// Capture setRuntimeMcpServers calls per session
+	const setRuntimeMcpServersCalls = new Map<string, Array<Record<string, McpServerConfig>>>();
+
+	// Mock AgentSession.fromInit to return a controllable stub
+	const agentSessionModule = await import('../../../src/lib/agent/agent-session');
+	const fromInitSpy = spyOn(agentSessionModule.AgentSession, 'fromInit').mockImplementation(((
+		init: AgentSessionInit
+	) => {
+		const id = init.sessionId;
+		if (!setRuntimeMcpServersCalls.has(id)) {
+			setRuntimeMcpServersCalls.set(id, []);
+		}
+		return {
+			setRuntimeMcpServers: (map: Record<string, McpServerConfig>) => {
+				setRuntimeMcpServersCalls.get(id)!.push(map);
+			},
+			startStreamingQuery: mock(async () => {}),
+			getProcessingState: () => ({ status: 'idle' }),
+		} as never;
+	}) as typeof agentSessionModule.AgentSession.fromInit);
+
+	const settingsManager = {
+		getEnabledMcpServersConfig: () => fileMcpServers,
+	};
+
+	const appMcpManager = hasAppMcpManager
+		? { getEnabledMcpConfigs: () => registryMcpServers }
+		: undefined;
+
+	// Build a minimal RoomRuntimeService config
+	const { RoomRuntimeService } = await import('../../../src/lib/room/runtime/room-runtime-service');
+
+	const service = new RoomRuntimeService({
+		db: {} as never,
+		messageHub: {} as never,
+		daemonHub: makeDaemonHub() as never,
+		getApiKey: async () => null,
+		roomManager: {
+			listRooms: () => [],
+			getRoom: () => null,
+			updateRoom: () => null,
+		} as never,
+		sessionManager: {} as never,
+		defaultWorkspacePath: '/tmp',
+		defaultModel: 'test-model',
+		getGlobalSettings: () => ({}) as never,
+		settingsManager: settingsManager as never,
+		appMcpManager: appMcpManager as never,
+		reactiveDb: {} as never,
+	});
+
+	// Extract the private createSessionFactory method
+	const factory = (
+		service as unknown as {
+			createSessionFactory: () => {
+				createAndStartSession: (init: AgentSessionInit, role: string) => Promise<void>;
+			};
+		}
+	).createSessionFactory();
+
+	return { factory, setRuntimeMcpServersCalls, fromInitSpy };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RoomRuntimeService worker session MCP merge', () => {
+	it('injects merged MCP map into coder sessions', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-cmd' };
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
+
+		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
+			fileMcpServers: { 'file-mcp': fileServer },
+			registryMcpServers: { 'registry-mcp': registryServer },
+		});
+
+		await factory.createAndStartSession(makeMinimalInit('s1'), 'coder');
+
+		fromInitSpy.mockRestore();
+
+		const calls = setRuntimeMcpServersCalls.get('s1') ?? [];
+		expect(calls.length).toBe(1);
+		expect(calls[0]!['file-mcp']).toEqual(fileServer);
+		expect(calls[0]!['registry-mcp']).toEqual(registryServer);
+	});
+
+	it('injects merged MCP map into general sessions', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-cmd' };
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
+
+		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
+			fileMcpServers: { 'file-mcp': fileServer },
+			registryMcpServers: { 'registry-mcp': registryServer },
+		});
+
+		const init = { ...makeMinimalInit('s2'), type: 'general' as const };
+		await factory.createAndStartSession(init, 'general');
+
+		fromInitSpy.mockRestore();
+
+		const calls = setRuntimeMcpServersCalls.get('s2') ?? [];
+		expect(calls.length).toBe(1);
+		expect(calls[0]!['file-mcp']).toEqual(fileServer);
+		expect(calls[0]!['registry-mcp']).toEqual(registryServer);
+	});
+
+	it('file-based server takes precedence over registry on name collision', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-wins' };
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-loses' };
+
+		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
+			fileMcpServers: { 'shared-name': fileServer },
+			registryMcpServers: { 'shared-name': registryServer },
+		});
+
+		await factory.createAndStartSession(makeMinimalInit('s3'), 'coder');
+
+		fromInitSpy.mockRestore();
+
+		const calls = setRuntimeMcpServersCalls.get('s3') ?? [];
+		expect(calls.length).toBe(1);
+		const merged = calls[0]!;
+		expect((merged['shared-name'] as McpServerConfig & { command?: string }).command).toBe(
+			'file-wins'
+		);
+	});
+
+	it('merged map contains both sources — neither is dropped', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-only' };
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-only' };
+
+		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
+			fileMcpServers: { 'file-unique': fileServer },
+			registryMcpServers: { 'registry-unique': registryServer },
+		});
+
+		await factory.createAndStartSession(makeMinimalInit('s4'), 'coder');
+
+		fromInitSpy.mockRestore();
+
+		const calls = setRuntimeMcpServersCalls.get('s4') ?? [];
+		expect(calls.length).toBe(1);
+		const merged = calls[0]!;
+		expect(merged['file-unique']).toEqual(fileServer);
+		expect(merged['registry-unique']).toEqual(registryServer);
+	});
+
+	it('does NOT inject MCP servers for leader sessions', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-cmd' };
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
+
+		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
+			fileMcpServers: { 'file-mcp': fileServer },
+			registryMcpServers: { 'registry-mcp': registryServer },
+		});
+
+		await factory.createAndStartSession(makeMinimalInit('s5'), 'leader');
+
+		fromInitSpy.mockRestore();
+
+		const calls = setRuntimeMcpServersCalls.get('s5') ?? [];
+		// setRuntimeMcpServers should NOT be called for leader
+		expect(calls.length).toBe(0);
+	});
+
+	it('does NOT inject MCP servers for planner sessions', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-cmd' };
+
+		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
+			fileMcpServers: { 'file-mcp': fileServer },
+		});
+
+		await factory.createAndStartSession(makeMinimalInit('s6'), 'planner');
+
+		fromInitSpy.mockRestore();
+
+		const calls = setRuntimeMcpServersCalls.get('s6') ?? [];
+		expect(calls.length).toBe(0);
+	});
+
+	it('works without appMcpManager — file-based servers are still injected', async () => {
+		const fileServer: McpServerConfig = { type: 'stdio', command: 'file-only-cmd' };
+
+		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
+			fileMcpServers: { 'file-mcp': fileServer },
+			hasAppMcpManager: false,
+		});
+
+		await factory.createAndStartSession(makeMinimalInit('s7'), 'coder');
+
+		fromInitSpy.mockRestore();
+
+		const calls = setRuntimeMcpServersCalls.get('s7') ?? [];
+		expect(calls.length).toBe(1);
+		expect(calls[0]!['file-mcp']).toEqual(fileServer);
+	});
+
+	it('injects empty map when both sources are empty (no MCP servers configured)', async () => {
+		const { factory, setRuntimeMcpServersCalls, fromInitSpy } = await buildSessionFactory({
+			fileMcpServers: {},
+			registryMcpServers: {},
+		});
+
+		await factory.createAndStartSession(makeMinimalInit('s8'), 'coder');
+
+		fromInitSpy.mockRestore();
+
+		const calls = setRuntimeMcpServersCalls.get('s8') ?? [];
+		// setRuntimeMcpServers is still called, but with an empty map
+		expect(calls.length).toBe(1);
+		expect(Object.keys(calls[0]!)).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
In createSessionFactory(), worker sessions (coder/general) now receive a merged
MCP map of file-based + registry-sourced servers via setRuntimeMcpServers() before
the SDK query starts. File-based config takes precedence over the registry on name
collision (local project config is more specific than the global app-level registry).
A WARN log is emitted for each collision.

Hot-reload for worker sessions is intentionally skipped: workers are short-lived
(one task per session), so registry changes take effect on the next session creation.

Adds 8 unit tests covering merge correctness, collision precedence, neither source
being dropped, and non-worker roles (leader/planner) not receiving the injection.
