### PR TITLE
task/task 34 integrate lifecycle manager into space mod

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -378,6 +378,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		getApiKey: () => deps.authManager.getCurrentApiKey(),
 		defaultModel: deps.config.defaultModel,
 		sessionGroupRepo: spaceSessionGroupRepo,
+		appMcpManager: deps.appMcpManager,
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn
@@ -465,6 +466,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			db: deps.db.getDatabase(),
 			state: globalSpacesState,
 			daemonHub: deps.daemonHub,
+			appMcpManager: deps.appMcpManager,
 		}).catch((error) => {
 			log.error('Failed to provision global spaces agent:', error);
 		});

--- a/packages/daemon/src/lib/space/provision-global-agent.ts
+++ b/packages/daemon/src/lib/space/provision-global-agent.ts
@@ -10,6 +10,7 @@
 
 import type { McpServerConfig } from '@neokai/shared';
 import type { Database as BunDatabase } from 'bun:sqlite';
+import type { AppMcpLifecycleManager } from '../mcp/app-mcp-lifecycle-manager';
 import type { SessionManager } from '../session-manager';
 import type { SpaceManager } from './managers/space-manager';
 import type { SpaceAgentManager } from './managers/space-agent-manager';
@@ -66,6 +67,13 @@ export interface ProvisionGlobalSpacesAgentDeps {
 	 * message includes the spaceId and taskId so the agent can act on specific tasks.
 	 */
 	daemonHub?: DaemonHub;
+	/**
+	 * Application-level MCP lifecycle manager.
+	 * When provided, registry-sourced MCP servers are merged into the global spaces agent
+	 * session's MCP map. The in-process global-spaces-tools server takes precedence over
+	 * registry entries on name collision.
+	 */
+	appMcpManager?: AppMcpLifecycleManager;
 }
 
 /**
@@ -90,6 +98,7 @@ export async function provisionGlobalSpacesAgent(
 		db,
 		state,
 		daemonHub,
+		appMcpManager,
 	} = deps;
 
 	// Get the shared runtime (no specific space context needed for the global agent)
@@ -143,7 +152,20 @@ export async function provisionGlobalSpacesAgent(
 		state
 	);
 
+	// Merge registry-sourced MCP servers from AppMcpLifecycleManager alongside the
+	// in-process global-spaces-tools server. The in-process server always wins on collision
+	// since it provides the core space management tools required for the global agent.
+	const registryMcpServers = appMcpManager?.getEnabledMcpConfigs() ?? {};
+	for (const name of Object.keys(registryMcpServers)) {
+		if (name === 'global-spaces-tools') {
+			log.warn(
+				`Global spaces agent: MCP server name collision on 'global-spaces-tools' — ` +
+					`in-process server takes precedence over registry entry.`
+			);
+		}
+	}
 	existingSession.setRuntimeMcpServers({
+		...registryMcpServers,
 		'global-spaces-tools': mcpServer as unknown as McpServerConfig,
 	});
 	existingSession.setRuntimeSystemPrompt(buildGlobalSpacesAgentPrompt());

--- a/packages/daemon/src/lib/space/provision-global-agent.ts
+++ b/packages/daemon/src/lib/space/provision-global-agent.ts
@@ -155,6 +155,13 @@ export async function provisionGlobalSpacesAgent(
 	// Merge registry-sourced MCP servers from AppMcpLifecycleManager alongside the
 	// in-process global-spaces-tools server. The in-process server always wins on collision
 	// since it provides the core space management tools required for the global agent.
+	//
+	// Note: unlike RoomRuntimeService, this function does NOT subscribe to mcp.registry.changed
+	// events. The global spaces agent is a daemon-lifetime singleton provisioned once at startup.
+	// Registry changes while it is running will NOT be hot-reloaded; they take effect only on
+	// the next daemon restart. This is a deliberate omission: the hot-reload complexity is not
+	// warranted for a singleton session, and the room module pattern (room-runtime-service.ts)
+	// covers the more common per-room case.
 	const registryMcpServers = appMcpManager?.getEnabledMcpConfigs() ?? {};
 	for (const name of Object.keys(registryMcpServers)) {
 		if (name === 'global-spaces-tools') {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -46,6 +46,7 @@ import type {
 	MessageHub,
 	McpServerConfig,
 } from '@neokai/shared';
+import type { AppMcpLifecycleManager } from '../../mcp/app-mcp-lifecycle-manager';
 import type { UUID } from 'crypto';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { AgentSessionInit } from '../../../lib/agent/agent-session';
@@ -104,6 +105,13 @@ export interface TaskAgentManagerConfig {
 	defaultModel: string;
 	/** Session group repository — used to persist SpaceSessionGroup records per task */
 	sessionGroupRepo: SpaceSessionGroupRepository;
+	/**
+	 * Application-level MCP lifecycle manager.
+	 * When provided, registry-sourced MCP servers are merged into the Task Agent session's
+	 * MCP map via setRuntimeMcpServers(). The in-process task-agent server takes precedence
+	 * over registry entries on name collision.
+	 */
+	appMcpManager?: AppMcpLifecycleManager;
 }
 
 // ---------------------------------------------------------------------------
@@ -307,7 +315,21 @@ export class TaskAgentManager {
 			// the `server` property for the live Server instance. The cast is safe because
 			// createTaskAgentMcpServer returns { server, cleanup } which satisfies the
 			// runtime shape used inside AgentSession.setRuntimeMcpServers().
+			//
+			// Merge registry-sourced MCP servers from AppMcpLifecycleManager alongside the
+			// in-process task-agent server. The task-agent server always wins on collision
+			// since it provides the core orchestration tools required for task management.
+			const registryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
+			for (const name of Object.keys(registryMcpServers)) {
+				if (name === 'task-agent') {
+					log.warn(
+						`Task agent session ${sessionId}: MCP server name collision on 'task-agent' — ` +
+							`in-process task-agent server takes precedence over registry entry.`
+					);
+				}
+			}
 			agentSession.setRuntimeMcpServers({
+				...registryMcpServers,
 				'task-agent': mcpServer as unknown as McpServerConfig,
 			});
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -319,6 +319,10 @@ export class TaskAgentManager {
 			// Merge registry-sourced MCP servers from AppMcpLifecycleManager alongside the
 			// in-process task-agent server. The task-agent server always wins on collision
 			// since it provides the core orchestration tools required for task management.
+			//
+			// Note: task agent sessions are short-lived (one per task), so there is no
+			// mcp.registry.changed subscription here. Registry changes during a running task
+			// are not hot-reloaded; they take effect when the next task agent is spawned.
 			const registryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
 			for (const name of Object.keys(registryMcpServers)) {
 				if (name === 'task-agent') {
@@ -1154,7 +1158,20 @@ export class TaskAgentManager {
 				) as unknown as McpServerConfig,
 		});
 
+		// Merge registry-sourced MCP servers alongside the in-process task-agent server,
+		// mirroring the same logic in spawnTaskAgent() so rehydrated sessions have the
+		// same MCP configuration as freshly spawned ones.
+		const rehydrateRegistryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
+		for (const name of Object.keys(rehydrateRegistryMcpServers)) {
+			if (name === 'task-agent') {
+				log.warn(
+					`Rehydrating task agent session ${sessionId}: MCP server name collision on 'task-agent' — ` +
+						`in-process task-agent server takes precedence over registry entry.`
+				);
+			}
+		}
 		agentSession.setRuntimeMcpServers({
+			...rehydrateRegistryMcpServers,
 			'task-agent': mcpServer as unknown as McpServerConfig,
 		});
 

--- a/packages/daemon/tests/unit/space/provision-global-agent-mcp.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent-mcp.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for provisionGlobalSpacesAgent + AppMcpLifecycleManager integration (Task 3.4).
+ *
+ * Verifies that:
+ * 1. Registry-sourced MCP servers are merged alongside the in-process
+ *    'global-spaces-tools' server in the setRuntimeMcpServers() call.
+ * 2. The in-process 'global-spaces-tools' server takes precedence over a registry
+ *    entry with the same name.
+ * 3. appMcpManager is optional — omitting it does not throw; only the in-process
+ *    server is injected.
+ * 4. Multiple registry servers are all included in the merged map.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import {
+	provisionGlobalSpacesAgent,
+	type ProvisionGlobalSpacesAgentDeps,
+} from '../../../src/lib/space/provision-global-agent.ts';
+import { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import type { McpServerConfig } from '@neokai/shared';
+import type { SessionManager } from '../../../src/lib/session-manager.ts';
+import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager.ts';
+import type { GlobalSpacesState } from '../../../src/lib/space/tools/global-spaces-tools.ts';
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-provision-global-mcp',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+// ---------------------------------------------------------------------------
+// Session stub that captures setRuntimeMcpServers calls
+// ---------------------------------------------------------------------------
+
+interface SessionStub {
+	setRuntimeMcpServers: ReturnType<typeof mock>;
+	setRuntimeSystemPrompt: ReturnType<typeof mock>;
+	/** All maps passed to setRuntimeMcpServers, in call order */
+	capturedMcpMaps: Array<Record<string, McpServerConfig>>;
+}
+
+function makeSessionStub(): SessionStub {
+	const capturedMcpMaps: Array<Record<string, McpServerConfig>> = [];
+	return {
+		capturedMcpMaps,
+		setRuntimeMcpServers: mock((map: Record<string, McpServerConfig>) => {
+			capturedMcpMaps.push(map);
+		}),
+		setRuntimeSystemPrompt: mock(() => {}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Session manager that returns a controlled stub
+// ---------------------------------------------------------------------------
+
+function makeSessionManager(stub: SessionStub): SessionManager {
+	let callCount = 0;
+	return {
+		getSessionAsync: mock(async () => {
+			callCount++;
+			// First call: session does not exist (trigger createSession)
+			if (callCount === 1) return null;
+			// Subsequent calls: return stub
+			return stub as never;
+		}),
+		createSession: mock(async () => {}),
+	} as unknown as SessionManager;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal session factory
+// ---------------------------------------------------------------------------
+
+function makeSessionFactory(): SessionFactory {
+	return {
+		createAndStartSession: async () => {},
+		injectMessage: async () => {},
+		hasSession: () => true,
+		answerQuestion: async () => false as const,
+		createWorktree: async () => null,
+		restoreSession: async () => false as const,
+		startSession: async () => false as const,
+		setSessionMcpServers: () => false as const,
+		removeWorktree: async () => null,
+		getProcessingState: () => undefined,
+	} as unknown as SessionFactory;
+}
+
+// ---------------------------------------------------------------------------
+// Build minimal deps for provisionGlobalSpacesAgent
+// ---------------------------------------------------------------------------
+
+function buildDeps(
+	db: BunDatabase,
+	opts: {
+		registryMcpServers?: Record<string, McpServerConfig>;
+		hasAppMcpManager?: boolean;
+		stub?: SessionStub;
+	} = {}
+): { deps: ProvisionGlobalSpacesAgentDeps; stub: SessionStub } {
+	const { registryMcpServers = {}, hasAppMcpManager = true } = opts;
+	const stub = opts.stub ?? makeSessionStub();
+
+	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const taskRepo = new SpaceTaskRepository(db);
+	const agentRepo = new SpaceAgentRepository(db);
+	const agentManager = new SpaceAgentManager(agentRepo);
+	const workflowRepo = new SpaceWorkflowRepository(db);
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+	const spaceManager = new SpaceManager(db);
+
+	const spaceRuntimeService = new SpaceRuntimeService({
+		db,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		workflowRunRepo,
+		taskRepo,
+		tickIntervalMs: 100_000,
+	});
+
+	const appMcpManager = hasAppMcpManager
+		? { getEnabledMcpConfigs: () => registryMcpServers }
+		: undefined;
+
+	const state: GlobalSpacesState = { activeSpaceId: null };
+
+	const deps: ProvisionGlobalSpacesAgentDeps = {
+		sessionManager: makeSessionManager(stub),
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		spaceRuntimeService,
+		sessionFactory: makeSessionFactory(),
+		taskRepo,
+		workflowRunRepo,
+		db,
+		state,
+		appMcpManager: appMcpManager as never,
+	};
+
+	return { deps, stub };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('provisionGlobalSpacesAgent — registry MCP merge (Task 3.4)', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('registry servers are merged into setRuntimeMcpServers alongside global-spaces-tools', async () => {
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
+		const { deps, stub } = buildDeps(db, {
+			registryMcpServers: { 'registry-mcp': registryServer },
+		});
+
+		await provisionGlobalSpacesAgent(deps);
+
+		expect(stub.capturedMcpMaps.length).toBe(1);
+		const merged = stub.capturedMcpMaps[0]!;
+		expect(merged['registry-mcp']).toBeDefined();
+		expect(merged['global-spaces-tools']).toBeDefined();
+	});
+
+	test('in-process global-spaces-tools takes precedence over registry entry with same name', async () => {
+		// A registry entry named 'global-spaces-tools' must NOT override the in-process server.
+		const impostor: McpServerConfig = { type: 'stdio', command: 'impostor' };
+		const { deps, stub } = buildDeps(db, {
+			registryMcpServers: { 'global-spaces-tools': impostor },
+		});
+
+		await provisionGlobalSpacesAgent(deps);
+
+		expect(stub.capturedMcpMaps.length).toBe(1);
+		const merged = stub.capturedMcpMaps[0]!;
+		const server = merged['global-spaces-tools'] as McpServerConfig & { command?: string };
+		// The impostor has command: 'impostor'; the real in-process server is an MCP SDK Server
+		// object (no .command property), so if command is missing or different the real server won.
+		expect(server.command).not.toBe('impostor');
+	});
+
+	test('works without appMcpManager — only global-spaces-tools is injected', async () => {
+		const { deps, stub } = buildDeps(db, { hasAppMcpManager: false });
+
+		await provisionGlobalSpacesAgent(deps);
+
+		expect(stub.capturedMcpMaps.length).toBe(1);
+		const merged = stub.capturedMcpMaps[0]!;
+		expect(merged['global-spaces-tools']).toBeDefined();
+		expect(Object.keys(merged)).toEqual(['global-spaces-tools']);
+	});
+
+	test('multiple registry servers are all present in the merged map', async () => {
+		const serverA: McpServerConfig = { type: 'stdio', command: 'cmd-a' };
+		const serverB: McpServerConfig = { type: 'stdio', command: 'cmd-b' };
+		const { deps, stub } = buildDeps(db, {
+			registryMcpServers: { 'mcp-a': serverA, 'mcp-b': serverB },
+		});
+
+		await provisionGlobalSpacesAgent(deps);
+
+		expect(stub.capturedMcpMaps.length).toBe(1);
+		const merged = stub.capturedMcpMaps[0]!;
+		expect(merged['mcp-a']).toBeDefined();
+		expect(merged['mcp-b']).toBeDefined();
+		expect(merged['global-spaces-tools']).toBeDefined();
+	});
+});

--- a/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Tests for TaskAgentManager + AppMcpLifecycleManager integration (Task 3.4).
+ *
+ * Verifies that:
+ * 1. Task agent sessions receive registry-sourced MCP servers merged into their
+ *    setRuntimeMcpServers() call alongside the in-process task-agent server.
+ * 2. The in-process task-agent server always takes precedence over registry entries
+ *    on name collision.
+ * 3. The merged map is complete — registry entries are not dropped.
+ * 4. appMcpManager is optional — omitting it does not throw; task-agent server is
+ *    still injected.
+ * 5. Multiple registry servers are all included in the merged map.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager.ts';
+import { AgentSession } from '../../../src/lib/agent/agent-session.ts';
+import type { Space, SpaceTask, McpServerConfig } from '@neokai/shared';
+import type { AgentProcessingState } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Minimal in-process DaemonHub
+// ---------------------------------------------------------------------------
+
+type EventHandler = (data: Record<string, unknown>) => void;
+
+class TestDaemonHub {
+	private listeners = new Map<string, Map<string, EventHandler>>();
+
+	on(event: string, handler: EventHandler, opts?: { sessionId?: string }): () => void {
+		const key = opts?.sessionId ? `${event}:${opts.sessionId}` : `${event}:*`;
+		if (!this.listeners.has(key)) this.listeners.set(key, new Map());
+		const id = Math.random().toString(36).slice(2);
+		this.listeners.get(key)!.set(id, handler);
+		return () => {
+			this.listeners.get(key)?.delete(id);
+		};
+	}
+
+	emit(event: string, data: Record<string, unknown>): Promise<void> {
+		const sessionId = (data as { sessionId?: string }).sessionId;
+		if (sessionId) {
+			for (const h of this.listeners.get(`${event}:${sessionId}`)?.values() ?? []) h(data);
+		}
+		for (const h of this.listeners.get(`${event}:*`)?.values() ?? []) h(data);
+		return Promise.resolve();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock AgentSession
+// ---------------------------------------------------------------------------
+
+interface MockAgentSession {
+	session: { id: string };
+	getProcessingState: () => AgentProcessingState;
+	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	setRuntimeSystemPrompt: (sp: unknown) => void;
+	startStreamingQuery: () => Promise<void>;
+	ensureQueryStarted: () => Promise<void>;
+	handleInterrupt: () => Promise<void>;
+	cleanup: () => Promise<void>;
+	messageQueue: { enqueueWithId: (id: string, msg: string) => Promise<void> };
+	_mcpServers: Record<string, unknown>;
+}
+
+function makeMockSession(sessionId: string): MockAgentSession {
+	const m: MockAgentSession = {
+		session: { id: sessionId },
+		_mcpServers: {},
+		getProcessingState: () => ({ status: 'idle' }) as AgentProcessingState,
+		setRuntimeMcpServers(servers) {
+			m._mcpServers = servers;
+		},
+		setRuntimeSystemPrompt(_sp: unknown) {},
+		async startStreamingQuery() {},
+		async ensureQueryStarted() {},
+		async handleInterrupt() {},
+		async cleanup() {},
+		messageQueue: {
+			async enqueueWithId(_id: string, _msg: string) {},
+		},
+	};
+	return m;
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-tam-mcp',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {
+	return {
+		id: spaceId,
+		workspacePath,
+		name: `Space ${spaceId}`,
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Build TaskAgentManager with optional appMcpManager
+// ---------------------------------------------------------------------------
+
+function buildManager(opts: {
+	registryMcpServers?: Record<string, McpServerConfig>;
+	hasAppMcpManager?: boolean;
+}): {
+	manager: TaskAgentManager;
+	createdSessions: Map<string, MockAgentSession>;
+	fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
+	bunDb: BunDatabase;
+	dir: string;
+	taskRepo: SpaceTaskRepository;
+	taskManager: SpaceTaskManager;
+	space: Space;
+} {
+	const { registryMcpServers = {}, hasAppMcpManager = true } = opts;
+	const { db: bunDb, dir } = makeDb();
+	const spaceId = 'space-mcp-test';
+	seedSpaceRow(bunDb, spaceId);
+
+	const agentRepo = new SpaceAgentRepository(bunDb);
+	const agentManager = new SpaceAgentManager(agentRepo);
+	const sessionGroupRepo = new SpaceSessionGroupRepository(bunDb);
+	const workflowRepo = new SpaceWorkflowRepository(bunDb);
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+	const workflowRunRepo = new SpaceWorkflowRunRepository(bunDb);
+	const taskRepo = new SpaceTaskRepository(bunDb);
+	const spaceManager = new SpaceManager(bunDb);
+	const taskManager = new SpaceTaskManager(bunDb, spaceId);
+	const runtime = new SpaceRuntime({
+		db: bunDb,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		workflowRunRepo,
+		taskRepo,
+	});
+	const daemonHub = new TestDaemonHub();
+	const space = makeSpace(spaceId);
+
+	const createdSessions = new Map<string, MockAgentSession>();
+	const dbSessions = new Map<string, unknown>();
+
+	const mockDb = {
+		getSession: (id: string) => (dbSessions.has(id) ? dbSessions.get(id) : null),
+		createSession: (session: unknown) => {
+			dbSessions.set((session as { id: string }).id, session);
+		},
+		deleteSession: (id: string) => dbSessions.delete(id),
+		saveUserMessage: () => 'msg-id',
+		updateSession: () => {},
+		getDatabase: () => bunDb,
+	};
+
+	const fromInitSpy = spyOn(AgentSession, 'fromInit').mockImplementation(
+		(
+			init: unknown,
+			_db: unknown,
+			_hub: unknown,
+			_dHub: unknown,
+			_key: unknown,
+			_model: unknown
+		) => {
+			const { sessionId } = init as { sessionId: string };
+			const mockSession = makeMockSession(sessionId);
+			createdSessions.set(sessionId, mockSession);
+			mockDb.createSession({ id: sessionId, type: 'space_task_agent' });
+			return mockSession as unknown as AgentSession;
+		}
+	);
+
+	const appMcpManager = hasAppMcpManager
+		? { getEnabledMcpConfigs: () => registryMcpServers }
+		: undefined;
+
+	const manager = new TaskAgentManager({
+		db: mockDb as unknown as import('../../../src/storage/database.ts').Database,
+		sessionManager: {
+			deleteSession: async () => {},
+			registerSession: () => {},
+		} as unknown as import('../../../src/lib/session-manager.ts').SessionManager,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		spaceRuntimeService: {
+			createOrGetRuntime: async (_spaceId: string) => runtime,
+		} as unknown as import('../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
+		taskRepo,
+		workflowRunRepo,
+		daemonHub: daemonHub as unknown as import('../../../src/lib/daemon-hub.ts').DaemonHub,
+		messageHub: {} as unknown as import('@neokai/shared').MessageHub,
+		getApiKey: async () => 'test-key',
+		defaultModel: 'claude-sonnet-4-5-20250929',
+		sessionGroupRepo,
+		appMcpManager: appMcpManager as never,
+	});
+
+	return { manager, createdSessions, fromInitSpy, bunDb, dir, taskRepo, taskManager, space };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
+	const spies: Array<{ mockRestore: () => void }> = [];
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		for (const spy of spies.splice(0)) spy.mockRestore();
+		for (const dir of dirs.splice(0)) {
+			try {
+				rmSync(dir, { recursive: true });
+			} catch {
+				// best-effort cleanup
+			}
+		}
+	});
+
+	test('task agent session receives registry MCP servers merged with task-agent server', async () => {
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
+		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+			registryMcpServers: { 'registry-mcp': registryServer },
+		});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const task = await taskManager.createTask({
+			title: 'Test task',
+			description: 'desc',
+			taskType: 'coding',
+			status: 'pending',
+		});
+
+		await manager.spawnTaskAgent(task, space, null, null);
+
+		// Find the created session — it will be the task agent session
+		const sessions = [...createdSessions.values()];
+		expect(sessions.length).toBeGreaterThan(0);
+		const taskAgentSession = sessions[0]!;
+
+		const mcpServers = taskAgentSession._mcpServers;
+		// Must have both registry server and in-process task-agent server
+		expect(mcpServers['registry-mcp']).toBeDefined();
+		expect(mcpServers['task-agent']).toBeDefined();
+	});
+
+	test('in-process task-agent server takes precedence over registry entry with same name', async () => {
+		// A registry entry named 'task-agent' should NOT override the in-process server.
+		const impostor: McpServerConfig = { type: 'stdio', command: 'impostor-cmd' };
+		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+			registryMcpServers: { 'task-agent': impostor },
+		});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const task = await taskManager.createTask({
+			title: 'Collision task',
+			description: 'desc',
+			taskType: 'coding',
+			status: 'pending',
+		});
+
+		await manager.spawnTaskAgent(task, space, null, null);
+
+		const session = [...createdSessions.values()][0]!;
+		const mcpServers = session._mcpServers;
+		// The task-agent entry must be the real MCP server object, not the registry impostor
+		const taskAgentServer = mcpServers['task-agent'] as McpServerConfig & { command?: string };
+		// The impostor has command: 'impostor-cmd'; real server won't have that property
+		expect(taskAgentServer.command).not.toBe('impostor-cmd');
+	});
+
+	test('merged map contains all registry servers — none are dropped', async () => {
+		const serverA: McpServerConfig = { type: 'stdio', command: 'server-a' };
+		const serverB: McpServerConfig = { type: 'stdio', command: 'server-b' };
+		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+			registryMcpServers: { 'mcp-a': serverA, 'mcp-b': serverB },
+		});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const task = await taskManager.createTask({
+			title: 'Multi-registry task',
+			description: 'desc',
+			taskType: 'coding',
+			status: 'pending',
+		});
+
+		await manager.spawnTaskAgent(task, space, null, null);
+
+		const session = [...createdSessions.values()][0]!;
+		const mcpServers = session._mcpServers;
+		expect(mcpServers['mcp-a']).toBeDefined();
+		expect(mcpServers['mcp-b']).toBeDefined();
+		expect(mcpServers['task-agent']).toBeDefined();
+	});
+
+	test('works without appMcpManager — task-agent server is still injected', async () => {
+		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+			hasAppMcpManager: false,
+		});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const task = await taskManager.createTask({
+			title: 'No registry task',
+			description: 'desc',
+			taskType: 'coding',
+			status: 'pending',
+		});
+
+		await manager.spawnTaskAgent(task, space, null, null);
+
+		const session = [...createdSessions.values()][0]!;
+		const mcpServers = session._mcpServers;
+		// task-agent server must still be present even without appMcpManager
+		expect(mcpServers['task-agent']).toBeDefined();
+	});
+
+	test('works with empty registry — task-agent server is still injected', async () => {
+		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+			registryMcpServers: {},
+		});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const task = await taskManager.createTask({
+			title: 'Empty registry task',
+			description: 'desc',
+			taskType: 'coding',
+			status: 'pending',
+		});
+
+		await manager.spawnTaskAgent(task, space, null, null);
+
+		const session = [...createdSessions.values()][0]!;
+		const mcpServers = session._mcpServers;
+		expect(mcpServers['task-agent']).toBeDefined();
+		// Only the task-agent server should be present
+		expect(Object.keys(mcpServers)).toEqual(['task-agent']);
+	});
+});

--- a/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
@@ -12,7 +12,7 @@
  * 5. Multiple registry servers are all included in the merged map.
  */
 
-import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import { describe, test, expect, afterEach, spyOn, beforeEach } from 'bun:test';
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
@@ -155,6 +155,8 @@ function buildManager(opts: {
 	taskRepo: SpaceTaskRepository;
 	taskManager: SpaceTaskManager;
 	space: Space;
+	/** Seed a session in the mock DB (used to simulate sessions that existed before restart). */
+	seedSession: (id: string, type: string) => void;
 } {
 	const { registryMcpServers = {}, hasAppMcpManager = true } = opts;
 	const { db: bunDb, dir } = makeDb();
@@ -238,7 +240,19 @@ function buildManager(opts: {
 		appMcpManager: appMcpManager as never,
 	});
 
-	return { manager, createdSessions, fromInitSpy, bunDb, dir, taskRepo, taskManager, space };
+	return {
+		manager,
+		createdSessions,
+		fromInitSpy,
+		bunDb,
+		dir,
+		taskRepo,
+		taskManager,
+		space,
+		seedSession: (id: string, type: string) => {
+			mockDb.createSession({ id, type });
+		},
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -382,5 +396,69 @@ describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
 		expect(mcpServers['task-agent']).toBeDefined();
 		// Only the task-agent server should be present
 		expect(Object.keys(mcpServers)).toEqual(['task-agent']);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Rehydration tests — registry MCP merge on daemon restart (P1 fix)
+// ---------------------------------------------------------------------------
+
+describe('TaskAgentManager.rehydrate — registry MCP merge (Task 3.4)', () => {
+	const spies: Array<{ mockRestore: () => void }> = [];
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		for (const spy of spies.splice(0)) spy.mockRestore();
+		for (const dir of dirs.splice(0)) {
+			try {
+				rmSync(dir, { recursive: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('rehydrated task agent session receives registry MCP servers alongside task-agent server', async () => {
+		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
+		const { manager, createdSessions, fromInitSpy, bunDb, dir, taskManager, space, seedSession } =
+			buildManager({ registryMcpServers: { 'registry-mcp': registryServer } });
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		// Create a task that was in progress before the daemon restart
+		const task = await taskManager.createTask({
+			title: 'Rehydration task',
+			description: 'desc',
+			taskType: 'coding',
+			status: 'in_progress',
+		});
+		const agentSessionId = `space:${space.id}:task:${task.id}`;
+
+		// Persist session ID on task (simulates state after first spawnTaskAgent)
+		bunDb
+			.prepare(`UPDATE space_tasks SET task_agent_session_id = ?, updated_at = ? WHERE id = ?`)
+			.run(agentSessionId, Date.now(), task.id);
+
+		// Seed a mock DB record for the session so rehydrate filter passes type check
+		seedSession(agentSessionId, 'space_task_agent');
+
+		// Spy on AgentSession.restore (used by rehydrateTaskAgent, unlike spawnTaskAgent)
+		const agentSessionModule = await import('../../../src/lib/agent/agent-session.ts');
+		const restoreSpy = spyOn(agentSessionModule.AgentSession, 'restore').mockImplementation(
+			(sessionId: string) => {
+				const mockSession = makeMockSession(sessionId);
+				createdSessions.set(sessionId, mockSession);
+				return mockSession as unknown as AgentSession;
+			}
+		);
+		spies.push(restoreSpy);
+
+		await manager.rehydrate();
+
+		const session = createdSessions.get(agentSessionId);
+		expect(session).toBeDefined();
+		const mcpServers = session!._mcpServers;
+		expect(mcpServers['registry-mcp']).toBeDefined();
+		expect(mcpServers['task-agent']).toBeDefined();
 	});
 });


### PR DESCRIPTION
- **feat(tasks): make failed state non-terminal (allow messages + retry)**
- **fix: pass taskManager as parameter to avoid accessing private field**
- **fix: align needs_attention handling between RPC and agent-tool paths**
- **ci: add setup-devproxy composite action with caching to fix CI install failures**
- **fix(ci): use jq + GITHUB_TOKEN auth to resolve devproxy version in setup action**
- **fix(ci): inject github.token into composite action step env for API auth**
- **fix: resolve leftover conflict markers in human-message-routing tests**
- **ci: simplify CI pipeline by removing intermediate gate jobs and extracting Dev Proxy action**
- **fix: restore runner.os guard on setup-devproxy, add startup timeout failure**
- **fix: always set archivedAt when archiving task without active runtime**
- **fix: correct comment about orphaned worktree cleanup, add review state test**
- **fix(ci): use nc -z TCP check for devproxy readiness instead of curl**
- **feat: add draft message auto-save to task view input**
- **fix: address review feedback on task draft auto-save**
- **feat: persist task input draft to server-side storage**
- **fix: address review feedback on task draft RPC handler**
- **ci: add rpc-task-draft-handlers.test.ts to rpc-1 CI matrix shard**
- **ci: register rpc-task-draft-handlers.test.ts in validate-online-test-matrix script**
- **fix: address review feedback on task draft hook (round 2)**
- **fix: add cancelled flag to loadDraft to prevent cross-task data corruption**
- **fix(test): mock Bun.spawn in dialog-handlers tests to prevent system folder picker**
- **test(dialog-handlers): fix platform-agnostic test and cover error-handling path**
- **fix: address round-7 review feedback on task draft hook**
- **ci: retrigger CI after base branch corrected to dev**
- **ci: retrigger CI (rpc-remove-output flaky timeout)**
- **feat: raise draft/message char limit from 100k to 200k**
- **fix: correct too-long test repeat count and JSDoc after 200k limit raise**
- **chore: bump version to 0.7.1 (#357)**
- **fix: skip max feedback iterations limit when task is in review state (#358)**
- **docs: Goal V2 (Mission System) plan for autonomous agent workflows (#322)**
- **fix: preserve PR data on runtime escalation and show PR in task view header (#360)**
- **chore: update deps to latest minor versions (except claude agent SDK) (#362)**
- **chore: upgrade @anthropic-ai/claude-agent-sdk from 0.2.55 to 0.2.76 (#363)**
- **feat: order tasks by most recently updated within each status (#365)**
- **feat: add GLM-5-Turbo model support (#367)**
- **fix: prevent API error bounce loops for all agents in runtime (#366)**
- **feat: Anthropic-compatible HTTP bridge backed by codex app-server (#339)**
- **feat: GitHub Copilot as transparent AgentSession backend via embedded Anthropic-compatible server (#340)**
- **feat: add mission metadata schema and types for Goal V2 (#369)**
- **docs: Goal V2 Mission System -- Autonomous Agent Workflows plan (#368)**
- **fix: show PR link for all task statuses once created (#372)**
- **Plan: Full first-class anthropic-copilot and anthropic-codex provider support (#370)**
- **feat: tighten leader agent tool permissions to read-only context subset (#371)**
- **feat: define V2 mission types and extend RoomGoal (Task 1.1) (#374)**
- **chore: remove pi-mono approach dead code (#364)**
- **feat: widen Provider type union to include anthropic-copilot and anthropic-codex (#373)**
- **fix: remove unsafe provider casts in daemon, use widened Provider type (#377)**
- **fix: Enter to send in task HumanInputArea, default target to leader (#387)**
- **fix: inject room chat system prompt to prevent premature task creation (#379)**
- **feat: add anthropic-codex Codex entry to PROVIDER_LABELS (#375)**
- **feat: make provider routing fully deterministic via explicit (modelId, providerId) pairs (#376)**
- **fix: parse /context response from assistant messages (new SDK format) (#381)**
- **fix: prevent agent from creating duplicate PRs on re-dispatch (#392)**
- **fix: remove merge method flag from human approval message (#393)**
- **feat: iterate all tool results in codex bridge continuation (#378)**
- **feat: replace copy toast with inline green check mark (#394)**
- **feat: require explicit provider ID for all model resolution (#388)**
- **test: add provider routing tests for copilot/cross-provider model switches (#395)**
- **feat: provider-grouped model picker with availability dots (#398)**
- **feat: replace plain-text error bodies with Anthropic JSON error envelopes in codex bridge (#380)**
- **feat: improve error mapping in copilot bridge (Task 5.1) (#384)**
- **fix: render leader questions as interactive forms in task conversation (#400)**
- **feat: wire thread/tokenUsage/updated into SSE message_delta token counts (#383)**
- **feat: recurring missions — scheduling with execution identity and recovery (Task 3) (#390)**
- **feat: UI terminology — rename Goal to Mission (Task 5) (#397)**
- **feat: implement semi-autonomous mode for coder/general tasks (Task 4) (#396)**
- **feat: measurable missions — structured metrics and adaptive replanning (Task 2) (#382)**
- **fix: call queryObject.close() before clearing transport reference (#403)**
- **fix: scope message locator in persistence e2e test to avoid strict mode violation (#402)**
- **feat: provider-aware session creation (#399) (#401)**
- **feat: add provider badge in session status bar next to model icon (#391)**
- **feat: heuristic token accounting for copilot bridge (#385)**
- **test: unit tests for provider routing and type safety (Task 7.1) (#399)**
- **feat: log warning when tool_choice is provided but not honored in both bridges (#386)**
- **task/task 72 update online provider test shards (#409)**
- **feat: graceful degradation on provider unavailability (#408)**
- **test: add E2E tests for provider model switching UI (#406)**
- **feat: eager leader initialization and fix observer race in TaskGroupManager (#411)**
- **feat: filter unauthenticated providers from model picker (#410)**
- **Fix SQLITE_BUSY retries and closed SSE controller handling (#415)**
- **fix: resolve leader questions routing to dead session instances (#404)**
- **feat: add OpenAI token refresh/login in settings for Codex (#416)**
- **fix: use correct /room/:id route in mission-terminology e2e tests (#419)**
- **fix: restore dead worker sessions before routing leader feedback (#418)**
- **feat: UI — type-specific mission creation and detail views (Task 6) (#405)**
- **fix: capture assistant.message.content when Copilot SDK skips streaming deltas (#421)**
- **fix: set ANTHROPIC_DEFAULT_*_MODEL in Codex provider to prevent Anthropic model fallback (#412)**
- **fix: support Agent tool name for subagent blocks (SDK 0.2.76+ renamed Task to Agent) (#424)**
- **fix(codex-bridge): persist Codex sessions across turns (#420)**
- **docs: add final provider parity report (#413)**
- **docs: plan for Multi-Agent V2 customizable agents and workflows (#359)**
- **task/fix logout button not working for openai and copil (#423)**
- **feat: define Space shared types in @neokai/shared (#425)**
- **feat: add Migration 29 — create all Space system tables (#427)**
- **feat: add SpaceAgent and workflow types to space.ts (Task 3.1) (#426)**
- **feat: custom agent types, repository, and manager (Task 2.1) (#428)**
- **feat: add Space repositories and managers (Task 1.3) (#429)**
- **feat: SpaceWorkflowRepository and SpaceWorkflowManager (Task 3.2) (#430)**
- **feat: Space RPC handlers and DaemonEventMap registration (Task 1.4) (#433)**
- **docs: add provider setup documentation for anthropic-copilot and anthropic-codex (#414)**
- **test: integration testing and documentation for Mission System V2 (Task 7) (#422)**
- **feat: add task management tools to leader role (#435)**
- **feat: add spaceAgent RPC handlers and DaemonEventMap entries (Task 2.2) (#431)**
- **feat: simplify multi-agent space — explicit workflowId or AI auto-select only (#434)**
- **feat: add leader progress summary at end of each turn (#436)**
- **feat: custom agent session init factory and SpaceAgent tools (Task 2.3) (#432)**
- **docs: update multi-agent space task docs with simplified workflow selection design (#439)**
- **docs: NeoKai UI/UX 1.0.0 upgrade plan (#442)**
- **docs: add NeoKai UI/UX 1.0.0 upgrade specification (#444)**
- **feat: extend CSS custom properties vocabulary in styles.css (#445)**
- **feat: Workflow RPC handlers and DaemonEventMap registration (Task 3.3) (#437)**
- **feat: built-in workflow templates and seedBuiltInWorkflows (Task 3.4) (#440)**
- **feat: Space navigation, routing, and signals (Task 5.1) (#438)**
- **feat: add WorkflowExecutor core for Space workflow run progression (Task 4.1) (#443)**
- **feat: define Space export/import JSON format (Task 8.1) (#441)**
- **docs: align Milestone 4 planning docs with transition/condition implementation (#447)**
- **feat: SpaceRuntime — workflow orchestration, task-type assignment, seedDefaultWorkflow wiring (Task 4.2) (#450)**
- **fix: make CreateWorkflowRunParams.currentStepId optional (#449)**
- **feat: add SpaceStore reactive state management (Task 5.2) (#446)**
- **fix: fix failing E2E tests for mission creation routes and persistence (#451)**
- **feat: add Space export/import RPC handlers (Task 8.2) (#452)**
- **feat: workflow selection logic and Space agent tools (Task 7.1) (#453)**
- **fix: sync space_agents columns in space-test-db.ts with migration schema (#448)**
- **feat: Space creation UX and 3-column layout (Task 5.3) (#455)**
- **task/make turn summary card use bigger font and render  (#460)**
- **feat: SpaceRuntimeService, workflow run RPC handlers, and session group metadata (Task 4.3) (#454)**
- **feat: Task 8.3 — Frontend Export/Import UI for Space agents and workflows**
- **fix: fetch real Copilot model IDs dynamically via client.listModels() (#464)**
- **task/fix agent session crash when switching modelprovid (#459)**
- **task/add support for minimax m27 highspeed model (#458)**
- **feat: Task 6.1 - Custom Agent List and Editor**
- **task/task 72 space agent prompt enhancement (#457)**
- **feat: workflow step builder (Task 6.2) (#463)**
- **fix: handle thinking blocks in SDK title generation (#461)**
- **refactor: remove detectProvider heuristic entirely (#467)**
- **feat: Task 6.3 - Workflow Rules Editor and Space integration (#468)**
- **feat: add structured tokens object to design-tokens module (#469)**
- **test: add tokens unified namespace tests for Task 1.2 (#470)**
- **feat: typography and global prose refinements (Task 1.3) (#471)**
- **fix: ensure onError cleanup runs on subprocess crash in codex bridge (#473)**
- **fix: clear stale sdkSessionId when SDK session file no longer exists (#474)**
- **fix: display Copilot quota errors as UI error blocks and stop retrying (#476)**
- **feat: display API retry errors in UI during SDK retry attempts (#475)**
- **fix: use unique workspace paths and correct delete params in space E2E tests (#477)**
- **feat: Button/IconButton/NavIconButton unification (Task 2.1) (#472)**
- **fix: clean up stale spaces before creating in E2E tests (#478)**
- **fix: correct space.list response shape in E2E stale-space cleanup (#481)**
- **fix: use correct space.create response shape in E2E tests (#482)**
- **ci: skip unstable space E2E tests (export-import, workflow-rules) (#483)**
- **docs: plan for workflow visual editor implementation (#479)**
- **feat: add VisualCanvas component with pan and zoom (Task 1.2) (#484)**
- **feat: add layout column to space_workflows for visual editor (Task 1.1) (#485)**
- **feat: replace hidden dropdown with inline Cancel/Complete buttons in TaskView (Task 2.2) (#480)**
- **feat: add SVG overlay layer for edges in VisualCanvas (Task 1.3) (#488)**
- **feat: add WorkflowNode canvas component (Task 2.1) (#490)**
- **fix: sync room chat session model when defaultModel changes to prevent glm-5-turbo errors (#486)**
- **feat: DAG auto-layout algorithm for workflow visual editor (Task 5.1) (#487)**
- **feat: add CanvasToolbar with zoom controls and fit-to-view (Task 1.4) (#489)**
- **feat: add node selection and multi-select to visual editor (Task 2.3) (#491)**
- **feat: implement WorkflowNode with drag-and-drop support (Task 2.2) (#492)**
- **fix: always set provider in createCustomAgentInit for Space custom agents (#495)**
- **feat: create connections by dragging from output to input ports (Task 3.2) (#496)**
- **feat: implement NodeConfigPanel and extract GateConfig (Task 4.1) (#497)**
- **feat: add Spaces UI with global agent and context panel (#493)**
- **task/task 31 render edges as svg bezier curves (#494)**
- **feat: implement EdgeConfigPanel component for transition editing (Task 4.2) (#498)**
- **feat: serialize visual state to SpaceWorkflow data model (Task 5.2) (#499)**
- **Plan: Task Agent session orchestrator for Space tasks (#501)**
- **feat: add VisualWorkflowEditor orchestrator component (Task 6.1) (#500)**
- **feat: add space_task_agent session type and taskAgentSessionId to SpaceTask (#502)**
- **feat: define Task Agent MCP tool schemas (Task 1.3) (#503)**
- **feat: add List/Visual toggle in SpaceIsland workflow editor (Task 6.2) (#505)**
- **feat: add template support to visual workflow editor (Task 5.3) (#506)**
- **test: add performance validation for large workflows (Task 7.3) (#504)**
- **feat: build Task Agent system prompt and initial message builders (#507)**
- **feat: add task_agent_session_id to space_tasks schema and repository (#508)**
- **docs: plan for Space Agent Coordinator reactive event-driven task coordination (Layer 4a) (#512)**
- **feat: implement createTaskAgentInit factory for Task Agent sessions (Task 2.2) (#510)**
- **feat: implement Task Agent MCP tool handlers (Task 3.1) (#513)**
- **test: add E2E tests for visual workflow editor (Task 7.1) (#509)**
- **feat: define NotificationSink interface and SpaceNotificationEvent types (Task 2.1) (#515)**
- **feat: add retryTask and reassignTask methods to SpaceTaskManager (#514)**
- **feat: implement SessionNotificationSink for Space Agent event injection (#519)**
- **test: fix pre-existing test failures for compatibility (Task 7.2) (#511)**
- **feat: add SpaceAutonomyLevel, SpaceConfig types, and autonomy_level DB column (#516)**
- **feat: add coordination tools to space-agent-tools (Task 3.2) (#520)**
- **test: add MCP server factory tests for createTaskAgentMcpServer (#517)**
- **feat: update space-chat-agent prompt with coordinator behavior (Task 4.1) (#523)**
- **feat: update SpaceManager and RPC handlers for autonomy level (Task 1.2) (#524)**
- **feat: integrate NotificationSink into SpaceRuntime tick loop (Task 2.2) (#525)**
- **fix: use worktree path for SDK session file lookups (#518)**
- **task/review pr 518 (#527)**
- **feat: update global-spaces-agent prompt with coordination guidance (#522)**
- **test: autonomy level behavior tests for space agent (Task 6.2) (#526)**
- **feat: add needs_attention detection for standalone tasks in SpaceRuntime (#529)**
- **feat: add coordination tools to global-spaces-tools.ts (Task 3.3) (#521)**
- **feat: implement TaskAgentManager core (Task 4.1) (#528)**
- **test: add full pipeline integration tests for concurrent notification events (Task 6.1) (#531)**
- **feat: wire SessionNotificationSink into provisionGlobalSpacesAgent (Task 5.2) (#530)**
- **feat: wire TaskAgentManager into DaemonApp (Task 4.3) (#532)**
- **test: edge case and resilience tests for notification system (Task 6.3) (#537)**
- **feat: add human message routing to Task Agent via space.task.sendMessage/getMessages (#536)**
- **feat: add Task Agent spawning to SpaceRuntime tick loop (Task 5.1) (#538)**
- **test: verify all MCP tools registered in global-spaces provisioning (Task 5.3) (#534)**
- **feat: add send_message_to_task tool to Space Agent (#535)**
- **feat: wire TaskAgentManager into SpaceRuntimeService (Task 5.2) (#540)**
- **feat: add task completion notification to Space Agent (Task 6.2) (#541)**
- **test: online tests with dev proxy for space agent coordination (Task 6.4) (#539)**
- **feat: add toast semantic methods and ConfirmModal enhancements (Task 2.3) (#543)**
- **feat: add Task Agent session rehydration on daemon restart (Task 5.3) (#542)**
- **feat: add semantic status border and inline reject form to RoomTasks (Task 2.4) (#544)**
- **feat: add Inbox navigation infrastructure (Task 3.1) (#545)**
- **feat: add Inbox view (inbox-store + Inbox.tsx + MainContent routing) (Task 3.2) (#546)**
- **test: add end-to-end online test for Task Agent lifecycle (Task 6.3) (#547)**
- **feat: add direct approve/reject to Inbox without TaskView navigation (Task 4.3) (#548)**
- **feat: hide ContextPanel when inbox is active (Task 4.2) (#550)**
- **fix: remove premature task_agent_session_id index from migration 29 (#551)**
- **feat: auto-expand review TaskCards with Approve button and worker summary (Task 4.4) (#553)**
- **docs: plan for workflow iteration loop with agent-driven cyclic transitions (#552)**
- **docs: plan to fix E2E test failures on dev branch CI (#556)**
- **docs: plan for task status lifecycle redesign (#555)**
- **feat: add goalId column to space_tasks and types (Task 3.1) (#561)**
- **fix: replace fixed sleep with Playwright auto-retrying assertion in worktree-isolation E2E test (#557)**
- **fix: rewrite task-actions-dropdown E2E tests to match actual inline button UI (#558)**
- **Plan: Redesign RoomContextPanel goal-centric sidebar (#563)**
- **feat: add iteration tracking columns to DB and types (Task 2.1) (#564)**
- **fix: remove stale sessions from RoomContextPanel on session delete/update (#554)**
- **fix: update space-creation E2E test assertions to match actual tabbed UI (#559)**
- **feat: add ActionBar component and replace inline HeaderReviewBar in TaskView (Task 4.5) (#560)**
- **feat: propagate goalId through workflow task creation (Task 3.2) (#565)**
- **feat: add task_result condition type and isCyclic to workflow transitions (#562)**
- **fix: fix visual-workflow-editor E2E tests — space URL sync + navigateToSpace wait (#567)**
- **feat: add CollapsibleSection component for sidebar sections (#568)**
- **feat: add /room/:roomId/agent route pattern and navigation (#570)**
- **feat: add mobile BottomTabBar with iOS-style navigation (Task 4.6) (#571)**
- **feat: add computed signals for goal-task grouping and orphan tasks (#569)**
- **test: unit tests for goalId propagation (Task 5.3) (#572)**
- **feat: add archived status to TaskStatus and SpaceTaskStatus unions (#566)**
- **feat: add Verify & Test step to Coding Workflow template (#573)**
- **feat: implement task_result evaluation in WorkflowExecutor (#574)**
- **chore: trigger PR creation for task 5.1 (#583)**
- **feat(workflow): implement iteration detection and capping in WorkflowExecutor (#585)**
- **fix: replace crypto.randomUUID with browser-compatible generateUUID (#587)**
- **feat: wire step_result through advance_workflow to executor (Task 1.3) (#586)**
- **feat: rewrite RoomContextPanel with goal-centric sidebar layout (#577)**
- **test: unit tests for archived status transitions and archival filtering (#580)**
- **test: add unit tests for router room agent route (#575)**
- **test: add reactivity and edge case tests for room store computed signals (#576)**
- **fix: stop worktree cleanup on complete and cancel in task-group-manager (#578)**
- **test: add space task manager tests for archival and reactivation lifecycle (#579)**
- **test: add archive and reactivation RPC handler tests for space tasks (#593)**
- **fix: fix flaky online tests in CI (#582)**
- **feat: Phase 4 micro-animations — badge pop, card approve/reject, panel & page fade-in (#590)**
- **test: add missing draft/pending Active tab and sessions count badge tests for RoomContextPanel (#591)**
- **feat: update task tab grouping to Active/Review/Done/Archived (#581)**
- **feat: add model switching in TaskView and auto-fallback on rate/usage limits (#589)**
- **test: add end-to-end cyclic workflow integration test (Task 5.5) (#598)**
- **test: validate Room.tsx integration with room agent routes (#592)**
- **feat: update room-runtime and RPC handlers for new lifecycle (#594)**
- **feat: add reactivate and archive actions to TaskView (#601)**
- **test: add E2E tests for room sidebar sections (goal expand/collapse and task tab filtering) (#602)**
- **feat: allow cancelled → completed status transition (#600)**
- **test: add E2E tests for room sidebar URL navigation and persistence (#603)**
- **fix: update room-agent-tools guards and comments for new task lifecycle (#599)**
- **test: add web unit tests for archived status and reactivate/archive button visibility (#604)**
- **fix: recover rate-limited workers stuck in later iterations (feedbackIteration > 0) (#596)**
- **test: add unit tests for room-runtime lifecycle changes (#605)**
- **test: add online integration tests for task reactivation and archive lifecycle (#608)**
- **test: add edge-case tests for cyclic transition condition evaluation and iterationCount (#609)**
- **test: add E2E tests for task reactivate and archive UI actions (#611)**
- **fix: sync root repo after PR merge via lifecycle gate (#610)**
- **docs: plan for Space Agent Groups flexible multi-agent collaboration (#606)**
- **feat: add migration 40 for flexible session groups (#614)**
- **feat: extend WorkflowStep with agents array and WorkflowChannel topology (#613)**
- **docs: implementation plan for persistent job queue adoption (#612)**
- **feat: update shared types for flexible SpaceSessionGroup model (#615)**
- **feat: extend listJobs to accept status arrays (#618)**
- **feat: add resolveTaskTypesForStep for multi-agent per-agent type resolution (#616)**
- **docs(plans): SQL LiveQuery adoption plan (#205)**
- **feat: add channel and multi-agent step validation to SpaceWorkflowManager (#617)**
- **feat: extend export/import format for multi-agent steps and channels (#620)**
- **task/task 13 update spacesessiongrouprepository for new (#619)**
- **ci: skip Codex bridge tests + fix multi-agent import test (#627)**
- **test: add export/import round-trip tests for multi-agent workflows (#624)**
- **feat: update WorkflowExecutor for multi-agent parallel step execution (#621)**
- **feat: create job queue constants, wire processor into app lifecycle (#622)**
- **test: unit tests for updated SpaceSessionGroupRepository schema (#625)**
- **feat: thread reactiveDb through dependency interfaces (#623)**
- **feat: show associated goal on room task list and task view (#629)**
- **feat: wire SpaceSessionGroupRepository into TaskAgentManager (#628)**
- **test: add JobQueueProcessor lifecycle integration tests (#632)**
- **feat: add session title generation job handler (#630)**
- **feat: add job_queue.cleanup handler and wire into daemon startup (#635)**
- **test: verify eager stale job reclamation on processor restart (#633)**
- **test: unit tests for updated Coding Workflow template (Task 5.4) (#584)**
- **feat: expose triggerPoll and create github.poll job handler (#631)**
- **test: add comprehensive unit tests for multi-agent workflow executor (#636)**
- **feat: inject ReactiveDatabase into TaskManager and fire notifyChange after writes (#642)**
- **feat: update visual workflow editor for multi-agent steps and channel topology (#637)**
- **feat: add room.tick job handler, enqueueRoomTick, and cancelPendingTickJobs (#634)**
- **feat: add notifyChange to GoalRepository and wire through GoalManager (#641)**
- **feat: rehydrate group map on daemon restart via dedicated rehydrateGroupMaps() (#639)**
- **feat: add sub-session members to groups (Task 2.2) (#638)**
- **feat: wire session title handler into SessionManager and remove pendingBackgroundTasks (#640)**
- **test: add E2E tests for multi-agent step editor and channel topology (#645)**
- **feat: remove setInterval from GitHubPollingService and wire handler into GitHubService (#644)**
- **feat: add notifyChange to SessionGroupRepository (#643)**
- **feat: replace setInterval/queueMicrotask with job queue in RoomRuntime (#646)**
- **test: add online test for session title generation via job queue (#647)**
- **feat: emit session group events via DaemonHub (Task 2.3) (#648)**
- **feat: add shared LiveQuery protocol types (#651)**
- **test: add online test for GitHub polling via job queue (#650)**
- **feat: add MessageHub.onClientDisconnect forwarding method (#652)**
- **feat: plumb clientId into CallContext (#653)**
- **fix: model switch now always restarts query when queryObject exists (#657)**
- **feat: add ChannelResolver, list_group_members and relay_message tools to Task Agent (#649)**
- **feat: wire room.tick handler into RoomRuntimeService and fix stopRuntime bug (#660)**
- **feat: hide completed tasks under Goals in sidebar with show/hide toggle (#656)**
- **feat: define named-query registry with column aliasing and JSON parsing (#655)**
- **feat: redesign task view with action dropdown and circular progress (#658)**
- **feat: add space session group RPC handlers and SpaceStore signals (#659)**
- **test: add unit tests for TaskAgentManager group persistence and events (#654)**
- **fix: enqueueRoomTick replaces pending tick when new request is sooner (#661)**
- **test: add online test for room tick via job queue (Task 4.4) (#670)**
- **feat: display active agents in SpaceTaskPane (#663)**
- **feat: implement liveQuery.subscribe and liveQuery.unsubscribe RPC handlers (#672)**
- **feat: step agent peer communication tools (send_feedback, request_peer_input, list_peers) (#675)**
- **test: add integration tests for job queue crash/restart recovery (#671)**
- **fix: use try/finally in test 1 so daemon1 is always stopped on assertion failure (#682)**
- **fix: revert task view gear button to expanded-down panel UX (#681)**
- **fix: prevent duplicate group spawning for same task during concurrent ticks (#687)**
- **test: add disconnect cleanup unit test and online LiveQuery pipeline test (Task 2.6) (#680)**
- **test: add reactive signal update tests for SpaceTaskPane working agents (#679)**
- **fix: remove emitTaskUpdate from task.fail RPC handler (Task 3.1) (#688)**
- **ci: split rpc online tests into 4 balanced shards (#685)**
- **feat: add E2E test for active agents display in SpaceTaskPane (#683)**
- **docs: document out-of-scope setInterval users after job-queue migration (#693)**
- **test: add comprehensive unit tests for cross-agent messaging (#684)**
- **feat: add git branch and session status to TaskInfoPanel expanded view (#691)**
- **feat: add step agent peer communication tools (send_feedback, request_peer_input, list_peers) (#678)**
- **test(e2e): add job queue background tasks E2E test for session title generation (#692)**
- **test: add integration tests for cross-group isolation and channel enforcement (#686)**
- **feat: add useGroupMessages hook for LiveQuery group message streaming (#690)**
- **feat: add force-stop session group RPC + auto-clean stale groups in tick (#694)**
- **fix: address root causes of duplicate and stale session groups (#696)**
- **feat: replace state.groupMessages.delta listener with useGroupMessages hook (#698)**
- **fix: remove emitGoalUpdated/emitGoalProgressUpdated from goal RPC handlers (Task 3.2) (#695)**
- **feat: redesign Goals tab with two-step create wizard and improved cards (#703)**
- **fix: fix task cancellation cascade and allow manual UI state transitions (#702)**
- **feat: remove daemon-side state.groupMessages.delta emissions and add reconnect handling (#700)**
- **feat: migrate TaskConversationRenderer to liveQuery and add E2E streaming tests (#701)**
- **feat: replace room.task.update listener with tasks.byRoom LiveQuery (Task 3.3) (#705)**
- **test: add reconnect resync guard test for review-status toast (Task 3.4) (#709)**
- **fix: reuse existing dev proxy instance instead of failing on startup (#706)**
- **fix: fix TaskView not showing messages after daemon restart (#707)**
- **feat: expand TaskView info panel with task ID, group ID, full session IDs, model switcher, and metadata (#708)**
- **feat: create useRoomLiveQuery hook and integrate with Room.tsx (Task 3.5) (#711)**
- **fix: prevent UNIQUE constraint crash in spawnGroupForTask and handle race gracefully (#710)**
- **feat: add stale-event guard for LiveQuery subscriptions (Task 3.6) (#712)**
- **test(e2e): add LiveQuery task/goal update E2E tests (Task 3.7) (#713)**
- **docs: add dev branch e2e tests health check plan (#704)**
- **feat: enable Bash and full MCP access for Room Agent session (#715)**
- **fix: prevent full conversation reload when sending a message in TaskView (#716)**
- **Fix TaskView recovery after server restart (#718)**
- **refactor: canonical TaskView timeline + runtime startup state persistence (#720)**
- **feat: audit and fix room agent MCP tools parity vs backend capabilities (#719)**
- **fix: propagate reactiveDb to TaskRepository for LiveQuery notifications + rename Goals to Missions (#717)**
- **test: fix pre-existing test failures uncovered during Task 6.2 verification (#721)**
- **task/bug task view message timestamps show current time (#722)**
- **fix(e2e): disambiguate Missions tab locator to avoid sidebar button clash (#723)**
- **fix: use reactive db facade for sdk message write paths (#724)**
- **fix(e2e): update mission-creation selectors for two-step wizard flow (#725)**
- **refactor: unify message delivery semantics + align TaskView pending UX (#726)**
- **docs: document Task 4 verification - all E2E tests pass on dev CI (#729)**
- **chore: bump version to 0.8.0 (#728)**
- **docs: document Task 4 verification - all E2E tests pass on dev CI (#731)**
- **docs: update verification doc with final CI run info (#732)**
- **chore(release): sync main history + release automation for v0.8.0 (#733)**
- **chore: update dependencies and pin all versions to exact (#736)**
- **plan: TaskViewV2 turn-based conversation summary with slide-out panels (#666)**
- **chore: update @anthropic-ai/claude-agent-sdk to 0.2.81 (#737)**
- **feat: implement ReadonlySessionChat and SlideOutPanel components (#739)**
- **test: unit tests for ReadonlySessionChat and SlideOutPanel (#741)**
- **feat: extract shared hooks, sub-components, constants from TaskView/TaskConversationRenderer (#740)**
- **feat: define TurnBlock types and implement useTurnBlocks hook (#742)**
- **test: add real-time delta tests for useTurnBlocks (#743)**
- **feat: implement TurnSummaryBlock component (#744)**
- **feat: implement RuntimeMessageRenderer component with unit tests (#745)**
- **test: unit tests for TurnSummaryBlock component (#746)**
- **feat: add client-side pagination to TaskView message list (#738)**
- **feat: implement TaskViewV2 component with turn-based conversation view (#747)**
- **feat: implement TaskViewToggle and integrate into Room.tsx (#748)**
- **test: E2E tests for TaskViewV2 toggle, persistence, and structural presence**
- **docs: plan for unifying agent communication and workflow graph model (#750)**
- **refactor: rename send_feedback to send_message in step agent tools (#751)**
- **test: clarify send_message rename from send_feedback in step-agent-tools.test.ts (#754)**
- **refactor: remove request_peer_input tool from step agent tools (#756)**
- **refactor: remove relay_message from Task Agent tool set (#755)**
- **test: add Task Agent channel topology tests to cross-agent messaging (#757)**
- **feat: give Task Agent the send_message tool via channel topology (#758)**
- **feat: add migration 45 to rename step to node in workflow tables (#752)**
- **fix: route human message to correct agent based on target parameter (#762)**
- **fix: prevent TaskView error on tab resume due to race condition (#761)**
- **feat: auto-create Task Agent channels on node addition (#760)**
- **test: add E2E tests for Task Agent visible node in visual editor (#759)**
- **feat: add channel edge rendering to EdgeRenderer (#763)**
- **test(e2e): add E2E tests for channel direction visualization (#764)**
- **feat: integrate channel edges into WorkflowCanvas (#765)**
- **task/task 21 rename shared types in spacets and space u (#753)**
- **refactor: rename step → node in storage repositories (#767)**
- **feat(TaskViewV2): UI/UX review — fix turn splitting, task-dispatch context, and renderable message window (#766)**
- **refactor: update step→node terminology in runtime comments and export-format (#768)**
- **feat: rename WorkflowStepCard to WorkflowNodeCard and update all references (#769)**
- **test: update all tests for step→node rename (#770)**
- **fix: reduce redundant concurrent tick spawn attempts (#771)**
- **fix: delete stale branch instead of falling back to UUID in worktree-manager (#772)**
- **fix: improve SDK startup timeout — exponential backoff, more retries, better diagnostics (#773)**
- **feat(TaskViewV2): AgentTurnBlock UI/UX polish + performance optimizations (#776)**
- **test: add unit tests for recurring mission schedule tools (set_schedule, pause_schedule, resume_schedule) (#778)**
- **fix(e2e): use exact text match for 'Message number 1' selector (#779)**
- **feat(visual-editor): add Task Agent virtual node to data model (#774)**
- **feat: extend WorkflowNodeAgent schema with role, model, systemPrompt fields (#777)**
- **feat(visual-editor): render Task Agent as distinct pinned node on canvas (#780)**
- **feat(visual-editor): add per-slot agent override UI with visual indicators (#783)**
- **test(space): add per-slot override tests for export/import pipeline (#782)**
- **feat(space): resolve base + override config at runtime when spawning agent sessions (#784)**
- **plan: simplify ID and folder path system (#787)**
- **feat(shared): add short ID utilities and prefix constants (#788)**
- **feat(storage): add migration 47 — short_id columns and short_id_counters table (#789)**
- **feat(daemon): add ShortIdAllocator service with atomic counter allocation (#790)**
- **feat(shared): add shortId field to NeoTask and RoomGoal interfaces (#791)**
- **feat(worktree): add getProjectShortKey and sentinel-based collision detection (#792)**
- **test(worktree): add TEST_WORKTREE_BASE_DIR override and old-path verifyWorktree tests (#794)**
- **feat(storage): add short ID assignment and backfill in TaskRepository (#793)**
- **feat(storage): add short ID assignment and backfill in GoalRepository (#task-23) (#795)**
- **feat(storage): wire ShortIdAllocator into TaskManager and GoalManager at all instantiation sites (#796)**
- **test(short-id): add multi-tenant isolation unit tests for scoped counters (#798)**
- **feat(lib): add ID resolution helpers for task and goal UUID/short-ID lookup (#800)**
- **docs: add agent memory research report with phased FTS5 + vector recommendation (#785)**
- **docs: add LSP integration research — Claude Agent SDK and native LSP options (#786)**
- **feat(web): replace flat progress bar with circular indicator in task list items (#801)**
- **fix(task): transition review task to in_progress when human sends a message (#802)**
- **fix(recurring): auto-compute nextRunAt and implement plan reuse (#781)**
- **feat(web): remove approve and cancel buttons from task list items (#803)**
- **feat(web): show room-specific bottom tabs on mobile when in room context (#804)**
- **feat(rpc): accept short IDs in goal handlers and expose shortId in responses (#805)**
- **fix(web): fix goal timestamp always showing "now", improve list item layout (#807)**
- **feat(leader): verify PR mergeability before submit_for_review (#808)**
- **feat(rpc): accept short IDs in task handlers and return shortId in responses (#task-32) (#806)**
- **feat(room): include shortId in TaskSummary for room.overview (#810)**
- **feat(web): update task URL route patterns to accept short IDs (#811)**
- **docs(plan): comprehensive MCP support review and external MCP integration (#797)**
- **feat(web): display short IDs in task cards with click-to-copy badge (#812)**
- **docs: document Planner web search capability (#815)**
- **test(short-id): add backward compatibility unit tests for legacy rows (#813)**
- **docs: add MCP architecture audit report (#816)**
- **feat(web): display short IDs in goals editor with click-to-copy badge (#817)**
- **feat(storage): add app_mcp_servers table, types, and repository (#818)**
- **test(short-id): add online integration test for full short ID lifecycle (#819)**
- **test(e2e): add short ID display and copy test; fix LiveQuery SQL missing short_id (#821)**
- **feat(mcp): add AppMcpLifecycleManager class and wire mcp.registry.listErrors RPC (#820)**
- **feat(mcp): seed default fetch-mcp and brave-search entries on daemon startup (#823)**
- **feat(task): make rate/usage limits first-class task concerns with persistence and auto-retry (#809)**
- **task/allow changing worker and leader model in task exp (#826)**
- **docs: Space V2 vs Room Gap Analysis (#828)**
- **fix(agent): always restart query when switching models mid-session (#827)**
- **docs: System-wide @ referencing system plan (#830)**
- **fix(goal-handlers): resolve short task IDs to full UUIDs in task.approve (#831)**
- **fix(web): fix pre-existing test regressions in final regression pass (#824)**
- **refactor(ui): reduce task list info density and update mobile room bottom nav (#829)**
- **feat(shared): define reference types for @ referencing system (#835)**
- **feat(web): add useReferenceAutocomplete hook for @ reference system (#836)**
- **feat(file-index): implement workspace file index with polling-based cache refresh (#837)**
- **feat(reference): implement reference.resolve RPC handler with shared types (#839)**
- **fix(agent): clear models cache on restart/reset to fix mid-turn model switch (#834)**
- **feat(web): add ReferenceAutocomplete component for @ reference system (#843)**
- **feat(references): implement file/folder resolvers and shared reference types (#842)**
- **feat(reference): implement reference.search RPC handler with FileIndex (#841)**
- **feat(web): integrate reference autocomplete with InputTextarea (#846)**
- **feat(agent): create ReferenceResolver service and shared reference types (#838)**
- **feat(session): implement message preprocessing with @ reference resolution (#844)**
- **feat(web): integrate reference autocomplete with MessageInput (#845)**
- **feat(web): add MentionToken component for @ reference rendering (#850)**
- **feat(web): integrate @ref token rendering in SDKUserMessage (#852)**
- **feat(e2e): add room entity and reference autocomplete helpers (#851)**
- **task/mobile ux and touch support (#849)**
- **feat(agent): implement agent context injection for @ references (#3.4) (#848)**
- **test(e2e): add reference autocomplete E2E tests and helpers (#854)**
- **feat(references): apply faded strikethrough visual state for deleted @ref entities (#853)**
- **feat(web,e2e): integrate MentionToken rendering and add reference autocomplete E2E tests (#855)**
- **test(e2e): add edge cases, mobile, and accessibility tests for reference autocomplete (#856)**
- **feat(rpc): add MCP registry CRUD handlers and mcpServers.global LiveQuery (#822)**
- **feat(room): integrate AppMcpLifecycleManager into RoomRuntimeService (Task 3.2) (#858)**
- **feat(room): inject merged MCP servers into worker sessions via setRuntimeMcpServers() (Task 3.3) (#860)**
- **feat(space): integrate AppMcpLifecycleManager into space module agents (Task 3.4)**
