### PR TITLE
feat(space): add completion_summary to space_tasks for agent completion state

### DIFF
--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -248,6 +248,10 @@ export class SpaceTaskRepository {
 			fields.push('goal_id = ?');
 			values.push(params.goalId ?? null);
 		}
+		if (params.completionSummary !== undefined) {
+			fields.push('completion_summary = ?');
+			values.push(params.completionSummary ?? null);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -371,6 +375,7 @@ export class SpaceTaskRepository {
 			prNumber: (row.pr_number as number | null) ?? undefined,
 			prCreatedAt: (row.pr_created_at as number | null) ?? undefined,
 			archivedAt: (row.archived_at as number | null) ?? undefined,
+			completionSummary: (row.completion_summary as string | null) ?? undefined,
 			createdAt: row.created_at as number,
 			startedAt: (row.started_at as number | null) ?? undefined,
 			completedAt: (row.completed_at as number | null) ?? undefined,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -199,6 +199,12 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// This table stores MCP server configurations that are available globally.
 	// Idempotent via CREATE TABLE IF NOT EXISTS.
 	runMigration50(db);
+
+	// Migration 51: Add completion_summary column to space_tasks.
+	// Stores the agent's done report — the human-readable summary an agent writes when
+	// it marks a task completed. This is the canonical location for agent completion state
+	// (alongside the existing status, completed_at, and task_agent_session_id columns).
+	runMigration51(db);
 }
 
 /**
@@ -3143,6 +3149,24 @@ export function runMigration49(db: BunDatabase): void {
 	db.exec(
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_room_short_id ON tasks(room_id, short_id) WHERE short_id IS NOT NULL`
 	);
+}
+
+/**
+ * Migration 51: Add completion_summary column to space_tasks.
+ *
+ * Agent completion state is tracked entirely on space_tasks — not on session group members.
+ * The three columns that together represent agent completion state are:
+ *   - status            — existing, set to 'completed' (or 'needs_attention' / 'cancelled')
+ *   - completed_at      — existing, timestamp stamped automatically on terminal status change
+ *   - completion_summary — NEW, free-text summary written by the agent when it finishes
+ *
+ * SpaceSessionGroupMember is NOT extended because that table is being removed entirely
+ * in the agent-centric refactor (Task 8.2).
+ *
+ * Uses ADD COLUMN IF NOT EXISTS (SQLite 3.37+) for idempotency.
+ */
+export function runMigration51(db: BunDatabase): void {
+	db.exec(`ALTER TABLE space_tasks ADD COLUMN IF NOT EXISTS completion_summary TEXT`);
 }
 
 /**

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -3166,7 +3166,9 @@ export function runMigration49(db: BunDatabase): void {
  * Uses ADD COLUMN IF NOT EXISTS (SQLite 3.37+) for idempotency.
  */
 export function runMigration51(db: BunDatabase): void {
-	db.exec(`ALTER TABLE space_tasks ADD COLUMN IF NOT EXISTS completion_summary TEXT`);
+	if (!tableHasColumn(db, 'space_tasks', 'completion_summary')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN completion_summary TEXT`);
+	}
 }
 
 /**

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -160,6 +160,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			pr_number INTEGER,
 			pr_created_at INTEGER,
 			archived_at INTEGER,
+			completion_summary TEXT,
 			created_at INTEGER NOT NULL,
 			started_at INTEGER,
 			completed_at INTEGER,

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -393,6 +393,38 @@ describe('SpaceTaskRepository', () => {
 		});
 	});
 
+	describe('completionSummary', () => {
+		it('is undefined when not set', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			expect(task.completionSummary).toBeUndefined();
+		});
+
+		it('sets completionSummary via updateTask', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			const updated = repo.updateTask(task.id, {
+				status: 'completed',
+				completionSummary: 'Implemented the feature and added tests.',
+			});
+			expect(updated!.completionSummary).toBe('Implemented the feature and added tests.');
+			expect(updated!.status).toBe('completed');
+			expect(updated!.completedAt).toBeDefined();
+		});
+
+		it('clears completionSummary with null', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			repo.updateTask(task.id, { completionSummary: 'Done.' });
+			const cleared = repo.updateTask(task.id, { completionSummary: null });
+			expect(cleared!.completionSummary).toBeUndefined();
+		});
+
+		it('persists completionSummary across reads', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			repo.updateTask(task.id, { completionSummary: 'All done!' });
+			const fetched = repo.getTask(task.id);
+			expect(fetched!.completionSummary).toBe('All done!');
+		});
+	});
+
 	describe('findByGoalId', () => {
 		it('returns tasks for a given goal', () => {
 			repo.createTask({ spaceId, title: 'A', description: '', goalId: 'goal-1' });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -207,6 +207,15 @@ export interface SpaceTask {
 	 * session is created. Null when no Task Agent has been spawned yet.
 	 */
 	taskAgentSessionId?: string | null;
+	/**
+	 * Human-readable summary written by the agent when it marks the task as done.
+	 *
+	 * This field, together with `status` (set to 'completed') and `completedAt`
+	 * (auto-stamped on terminal status change), forms the complete agent completion
+	 * state. All three live on space_tasks — not on SpaceSessionGroupMember, which
+	 * is being removed in the agent-centric refactor.
+	 */
+	completionSummary?: string | null;
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Start timestamp (milliseconds since epoch) */
@@ -282,6 +291,11 @@ export interface UpdateSpaceTaskParams {
 	 * Set when spawning a Task Agent; null to clear the reference.
 	 */
 	taskAgentSessionId?: string | null;
+	/**
+	 * Human-readable summary written by the agent when it marks the task as done.
+	 * Set alongside `status: 'completed'`; null to clear.
+	 */
+	completionSummary?: string | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
Agent completion state is now fully tracked on space_tasks:
- status (existing): set to 'completed' on agent done
- completed_at (existing): auto-stamped on terminal status change
- completion_summary (new): free-text done report written by the agent

Adds Migration 51 (ALTER TABLE ADD COLUMN IF NOT EXISTS), updates the
SpaceTask type and UpdateSpaceTaskParams, maps the new column in
rowToSpaceTask, and adds repository tests.

SpaceSessionGroupMember is not extended — that table is being removed
entirely in the agent-centric refactor (Task 8.2).
