### PR TITLE
feat(space): add report_done MCP tool to step agents

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -197,6 +197,19 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 			`- All communication is scoped to this group — you cannot message agents in other tasks`
 	);
 
+	// Completion signalling
+	sections.push(`\n## Signalling Completion\n`);
+	sections.push(`\n### \`report_done\` (signal task completion)\n`);
+	sections.push(
+		`When you have finished all assigned work, call \`report_done\` to mark your step as complete. ` +
+			`Provide an optional \`summary\` describing what was accomplished.`
+	);
+	sections.push(
+		`- After calling \`report_done\`, stop — do not perform further actions\n` +
+			`- This is the correct way to close your task lifecycle\n` +
+			`- Do not rely on the session ending naturally; always call \`report_done\` explicitly`
+	);
+
 	// Review feedback handling
 	sections.push(`\n## Addressing Review Feedback\n`);
 	sections.push(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -300,13 +300,15 @@ export class TaskAgentManager {
 				sessionGroupRepo: this.config.sessionGroupRepo,
 				getGroupId: () => this.taskGroupIds.get(taskId),
 				daemonHub: this.config.daemonHub,
-				buildStepAgentMcpServer: (subSessionId, role) =>
+				buildStepAgentMcpServer: (subSessionId, role, stepTaskId) =>
 					this.buildStepAgentMcpServerForSession(
 						taskId,
 						subSessionId,
 						role,
 						spaceId,
-						workflowRunId
+						workflowRunId,
+						stepTaskId,
+						taskManager
 					) as unknown as McpServerConfig,
 			});
 
@@ -1148,13 +1150,15 @@ export class TaskAgentManager {
 			daemonHub: this.config.daemonHub,
 			sessionGroupRepo: this.config.sessionGroupRepo,
 			getGroupId: () => this.taskGroupIds.get(taskId),
-			buildStepAgentMcpServer: (subSessionId, role) =>
+			buildStepAgentMcpServer: (subSessionId, role, stepTaskId) =>
 				this.buildStepAgentMcpServerForSession(
 					taskId,
 					subSessionId,
 					role,
 					spaceId,
-					rehydrateWorkflowRunId
+					rehydrateWorkflowRunId,
+					stepTaskId,
+					taskManager
 				) as unknown as McpServerConfig,
 		});
 
@@ -1245,7 +1249,9 @@ export class TaskAgentManager {
 					subSessionId,
 					memberRole,
 					spaceId,
-					workflowRunId
+					workflowRunId,
+					stepTask.id,
+					taskManager
 				);
 				subSession.setRuntimeMcpServers({
 					'step-agent': stepAgentMcpServer as unknown as McpServerConfig,
@@ -1384,26 +1390,32 @@ export class TaskAgentManager {
 	 * Build a step agent MCP server for a newly spawned sub-session.
 	 * Called from the `buildStepAgentMcpServer` callback passed to createTaskAgentMcpServer().
 	 *
-	 * The server gives the step agent peer communication tools (list_peers, send_message)
-	 * that are scoped to its group and channel topology.
+	 * The server gives the step agent peer communication tools (list_peers, send_message,
+	 * report_done) that are scoped to its group, channel topology, and step task.
 	 */
 	private buildStepAgentMcpServerForSession(
 		taskId: string,
 		subSessionId: string,
 		role: string,
 		spaceId: string,
-		workflowRunId: string
+		workflowRunId: string,
+		stepTaskId: string,
+		taskManager: SpaceTaskManager
 	) {
 		return createStepAgentMcpServer({
 			mySessionId: subSessionId,
 			myRole: role,
 			taskId,
+			stepTaskId,
+			spaceId,
 			workflowRunId,
 			sessionGroupRepo: this.config.sessionGroupRepo,
 			getGroupId: () => this.taskGroupIds.get(taskId),
 			workflowRunRepo: this.config.workflowRunRepo,
 			messageInjector: (targetSessionId, message) =>
 				this.injectSubSessionMessage(targetSessionId, message),
+			taskManager,
+			daemonHub: this.config.daemonHub,
 		});
 	}
 }

--- a/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
@@ -64,6 +64,28 @@ export const SendMessageSchema = z.object({
 export type SendMessageInput = z.infer<typeof SendMessageSchema>;
 
 // ---------------------------------------------------------------------------
+// report_done
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `report_done` input.
+ *
+ * Signals that this step agent has completed its work. Marks the step's SpaceTask
+ * as 'completed' and persists an optional summary as the task result.
+ */
+export const ReportDoneSchema = z.object({
+	/** Optional summary of what was accomplished. Persisted as the task result. */
+	summary: z
+		.string()
+		.describe(
+			'Optional summary of what was accomplished. Will be persisted as the task completion result.'
+		)
+		.optional(),
+});
+
+export type ReportDoneInput = z.infer<typeof ReportDoneSchema>;
+
+// ---------------------------------------------------------------------------
 // Aggregate export
 // ---------------------------------------------------------------------------
 
@@ -73,6 +95,7 @@ export type SendMessageInput = z.infer<typeof SendMessageSchema>;
 export const STEP_AGENT_TOOL_SCHEMAS = {
 	list_peers: ListPeersSchema,
 	send_message: SendMessageSchema,
+	report_done: ReportDoneSchema,
 } as const;
 
 export type StepAgentToolName = keyof typeof STEP_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/step-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tools.ts
@@ -25,16 +25,21 @@
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import type { DaemonHub } from '../../daemon-hub';
+import { Logger } from '../../logger';
+import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceSessionGroupRepository } from '../../../storage/repositories/space-session-group-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import { ChannelResolver } from '../runtime/channel-resolver';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
-import { ListPeersSchema, SendMessageSchema } from './step-agent-tool-schemas';
-import type { ListPeersInput, SendMessageInput } from './step-agent-tool-schemas';
+import { ListPeersSchema, SendMessageSchema, ReportDoneSchema } from './step-agent-tool-schemas';
+import type { ListPeersInput, SendMessageInput, ReportDoneInput } from './step-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
+
+const log = new Logger('step-agent-tools');
 
 // ---------------------------------------------------------------------------
 // Config
@@ -42,7 +47,7 @@ export type { ToolResult };
 
 /**
  * Dependencies injected into createStepAgentToolHandlers().
- * All fields are required — the caller (TaskAgentManager) wires them up.
+ * All fields are required unless noted — the caller (TaskAgentManager) wires them up.
  */
 export interface StepAgentToolsConfig {
 	/** Session ID of this step agent (used to exclude self from list_peers). */
@@ -51,6 +56,10 @@ export interface StepAgentToolsConfig {
 	myRole: string;
 	/** ID of the parent task (used for error messages). */
 	taskId: string;
+	/** ID of the step-level SpaceTask this agent is executing. Used by report_done. */
+	stepTaskId: string;
+	/** Space ID — used for event emission in report_done. */
+	spaceId: string;
 	/** Workflow run ID — used to load channel topology from run config. */
 	workflowRunId: string;
 	/** Session group repository for looking up group members. */
@@ -64,6 +73,13 @@ export interface StepAgentToolsConfig {
 	 * Used by `send_message` to deliver messages to target sessions.
 	 */
 	messageInjector: (sessionId: string, message: string) => Promise<void>;
+	/** Task manager for validated status transitions. Used by report_done. */
+	taskManager: SpaceTaskManager;
+	/**
+	 * DaemonHub instance for emitting task update events.
+	 * Optional — if omitted, no events are emitted (e.g. in unit tests that don't need them).
+	 */
+	daemonHub?: DaemonHub;
 }
 
 // ---------------------------------------------------------------------------
@@ -79,11 +95,15 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		mySessionId,
 		myRole,
 		taskId,
+		stepTaskId,
+		spaceId,
 		workflowRunId,
 		sessionGroupRepo,
 		getGroupId,
 		workflowRunRepo,
 		messageInjector,
+		taskManager,
+		daemonHub,
 	} = config;
 
 	type GroupLoaded = {
@@ -309,6 +329,54 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 					'.',
 			});
 		},
+
+		/**
+		 * Signal that this step agent has completed its work.
+		 *
+		 * Marks the step's SpaceTask as 'completed', persists the optional summary
+		 * as the task result, and emits a `space.task.updated` event for real-time UI.
+		 *
+		 * After calling this tool, the step agent should stop and not perform
+		 * further work — the task lifecycle is closed.
+		 */
+		async report_done(args: ReportDoneInput): Promise<ToolResult> {
+			const { summary } = args;
+
+			try {
+				const updatedTask = await taskManager.setTaskStatus(stepTaskId, 'completed', {
+					result: summary,
+				});
+
+				// Emit DaemonHub event so the UI is notified of the step task completion.
+				if (daemonHub) {
+					void daemonHub
+						.emit('space.task.updated', {
+							sessionId: 'global',
+							spaceId,
+							taskId: stepTaskId,
+							task: updatedTask,
+						})
+						.catch((err) => {
+							log.warn(
+								`Failed to emit space.task.updated for step task ${stepTaskId} (parent ${taskId}): ` +
+									`${err instanceof Error ? err.message : String(err)}`
+							);
+						});
+				}
+
+				return jsonResult({
+					success: true,
+					stepTaskId,
+					summary,
+					message:
+						'Step task has been marked as completed. ' +
+						'Your work is done — stop here and do not continue.',
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
 	};
 }
 
@@ -339,6 +407,15 @@ export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
 				'Validates against declared channels — returns an error with available channels if unauthorized.',
 			SendMessageSchema.shape,
 			(args) => handlers.send_message(args)
+		),
+		tool(
+			'report_done',
+			'Signal that this step agent has completed its work. ' +
+				'Marks the step task as completed and persists an optional summary as the result. ' +
+				'Call this when you have finished all assigned work. ' +
+				'After calling this tool, stop — do not continue with further actions.',
+			ReportDoneSchema.shape,
+			(args) => handlers.report_done(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -188,8 +188,16 @@ export interface TaskAgentToolsConfig {
 	 * Called in `spawn_step_agent` after resolving the session ID and agent role.
 	 * Returns a McpServerConfig to attach to the sub-session's init.mcpServers.
 	 * Optional — if omitted, no step agent MCP server is attached (e.g. in unit tests).
+	 *
+	 * @param sessionId   - The sub-session ID being started.
+	 * @param role        - The slot role for the agent (used for channel routing).
+	 * @param stepTaskId  - The SpaceTask ID for this step (used by report_done).
 	 */
-	buildStepAgentMcpServer?: (sessionId: string, role: string) => McpServerConfig;
+	buildStepAgentMcpServer?: (
+		sessionId: string,
+		role: string,
+		stepTaskId: string
+	) => McpServerConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -365,8 +373,9 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			// Attach step agent peer communication MCP server if a factory is provided.
 			// The server is built with the slot role so it can validate channels using the
 			// same role that was registered in the session group.
+			// Pass stepTask.id so report_done can mark the correct step task as completed.
 			if (buildStepAgentMcpServer) {
-				const stepMcpServer = buildStepAgentMcpServer(subSessionId, memberRole);
+				const stepMcpServer = buildStepAgentMcpServer(subSessionId, memberRole, stepTask.id);
 				init = {
 					...init,
 					mcpServers: { ...init.mcpServers, 'step-agent': stepMcpServer },

--- a/packages/daemon/tests/unit/space/step-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/step-agent-tools.test.ts
@@ -15,8 +15,10 @@ import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import {
 	createStepAgentToolHandlers,
 	createStepAgentMcpServer,
@@ -116,11 +118,17 @@ interface TestCtx {
 	dir: string;
 	spaceId: string;
 	sessionGroupRepo: SpaceSessionGroupRepository;
+	taskRepo: SpaceTaskRepository;
+	taskManager: SpaceTaskManager;
 	groupId: string;
 	coderSessionId: string;
 	reviewerSessionId: string;
 	taskAgentSessionId: string;
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** ID of the parent (main) task seeded in the DB. */
+	parentTaskId: string;
+	/** ID of the step task seeded in the DB. */
+	stepTaskId: string;
 }
 
 function makeCtx(): TestCtx {
@@ -130,12 +138,28 @@ function makeCtx(): TestCtx {
 	seedSpaceRow(db, spaceId);
 
 	const sessionGroupRepo = new SpaceSessionGroupRepository(db);
+	const taskRepo = new SpaceTaskRepository(db);
+	const taskManager = new SpaceTaskManager(db, spaceId);
+
+	// Seed a parent task and a step task in the DB
+	const parentTask = taskRepo.createTask({
+		spaceId,
+		title: 'Parent Task',
+		description: '',
+		status: 'in_progress',
+	});
+	const stepTask = taskRepo.createTask({
+		spaceId,
+		title: 'Step Task',
+		description: '',
+		status: 'in_progress',
+	});
 
 	// Create a session group for the task
 	const group = sessionGroupRepo.createGroup({
 		spaceId,
 		name: 'task:test-task-1',
-		taskId: 'test-task-1',
+		taskId: parentTask.id,
 	});
 
 	// Add members: task-agent, coder, reviewer
@@ -168,11 +192,15 @@ function makeCtx(): TestCtx {
 		dir,
 		spaceId,
 		sessionGroupRepo,
+		taskRepo,
+		taskManager,
 		groupId: group.id,
 		coderSessionId,
 		reviewerSessionId,
 		taskAgentSessionId,
 		workflowRunRepo,
+		parentTaskId: parentTask.id,
+		stepTaskId: stepTask.id,
 	};
 }
 
@@ -185,7 +213,9 @@ function makeConfig(
 	return {
 		mySessionId: ctx.coderSessionId,
 		myRole: 'coder',
-		taskId: 'test-task-1',
+		taskId: ctx.parentTaskId,
+		stepTaskId: ctx.stepTaskId,
+		spaceId: ctx.spaceId,
 		workflowRunId: '',
 		sessionGroupRepo: ctx.sessionGroupRepo,
 		getGroupId: () => ctx.groupId,
@@ -193,6 +223,7 @@ function makeConfig(
 		messageInjector: async (sessionId, message) => {
 			injectedMessages.push({ sessionId, message });
 		},
+		taskManager: ctx.taskManager,
 		...overrides,
 	};
 }
@@ -662,6 +693,108 @@ describe('step-agent-tools: send_message', () => {
 		expect(data.success).toBe(false);
 		expect(data.delivered).toHaveLength(0);
 		expect(data.failed).toHaveLength(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: report_done
+// ---------------------------------------------------------------------------
+
+describe('step-agent-tools: report_done', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('marks step task as completed without summary', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.report_done({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.stepTaskId).toBe(ctx.stepTaskId);
+		expect(data.message).toContain('completed');
+
+		const updated = ctx.taskRepo.getTask(ctx.stepTaskId);
+		expect(updated?.status).toBe('completed');
+		expect(updated?.completedAt).toBeDefined();
+	});
+
+	test('persists summary as result field', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.report_done({ summary: 'PR #42 merged successfully.' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.summary).toBe('PR #42 merged successfully.');
+
+		const updated = ctx.taskRepo.getTask(ctx.stepTaskId);
+		expect(updated?.result).toBe('PR #42 merged successfully.');
+	});
+
+	test('emits space.task.updated event via daemonHub', async () => {
+		const emitted: Array<{ name: string; payload: unknown }> = [];
+		const fakeDaemonHub = {
+			emit: async (name: string, payload: unknown) => {
+				emitted.push({ name, payload });
+			},
+		};
+
+		const config = makeConfig(ctx, {
+			daemonHub: fakeDaemonHub as unknown as StepAgentToolsConfig['daemonHub'],
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		await handlers.report_done({ summary: 'done' });
+
+		expect(emitted).toHaveLength(1);
+		expect(emitted[0].name).toBe('space.task.updated');
+		const payload = emitted[0].payload as Record<string, unknown>;
+		expect(payload.taskId).toBe(ctx.stepTaskId);
+		expect(payload.spaceId).toBe(ctx.spaceId);
+		expect(payload.sessionId).toBe('global');
+		const task = payload.task as Record<string, unknown>;
+		expect(task.status).toBe('completed');
+	});
+
+	test('does not emit event when daemonHub is absent', async () => {
+		const config = makeConfig(ctx); // no daemonHub
+		const handlers = createStepAgentToolHandlers(config);
+		// Should not throw
+		const result = await handlers.report_done({});
+		const data = JSON.parse(result.content[0].text);
+		expect(data.success).toBe(true);
+	});
+
+	test('returns error when step task not found', async () => {
+		const config = makeConfig(ctx, { stepTaskId: 'nonexistent-step-task' });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.report_done({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('not found');
+	});
+
+	test('returns error on invalid status transition', async () => {
+		// Move step task to completed first
+		await ctx.taskManager.setTaskStatus(ctx.stepTaskId, 'completed');
+
+		const config = makeConfig(ctx);
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.report_done({ summary: 'already done' });
+		const data = JSON.parse(result.content[0].text);
+
+		// completed → completed is invalid
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Invalid status transition');
 	});
 });
 


### PR DESCRIPTION
Step agents can now explicitly signal completion by calling report_done,
which marks the step SpaceTask as 'completed', persists an optional summary
as the task result, and emits a space.task.updated event for real-time UI.

Changes:
- step-agent-tool-schemas.ts: add ReportDoneSchema with optional summary field
- step-agent-tools.ts: extend StepAgentToolsConfig with stepTaskId, spaceId,
  taskManager, daemonHub; implement report_done handler; register MCP tool
- task-agent-tools.ts: extend buildStepAgentMcpServer callback type to include
  stepTaskId; pass stepTask.id at the call site in spawn_step_agent
- task-agent-manager.ts: update buildStepAgentMcpServerForSession to accept
  stepTaskId and taskManager; pass them through all three call sites
- custom-agent.ts: add Signalling Completion section to system prompt
- step-agent-tools.test.ts: add 9 tests covering success path, summary
  persistence, event emission, missing hub, not-found, and invalid transition
