### PR TITLE
feat(space): unified channel resolution with resolveChannels() and validateChannels()

### DIFF
--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -68,9 +68,11 @@ const exportedWorkflowNodeAgentSchema = z.object({
 });
 
 const workflowChannelSchema = z.object({
+	id: z.string().optional(),
 	from: z.string().min(1),
 	to: z.union([z.string().min(1), z.array(z.string().min(1))]),
 	direction: z.enum(['one-way', 'bidirectional']),
+	isCyclic: z.boolean().optional(),
 	label: z.string().optional(),
 });
 
@@ -141,6 +143,7 @@ const exportedWorkflowBaseSchema = z.object({
 	rules: z.array(exportedWorkflowRuleSchema),
 	tags: z.array(z.string()),
 	config: z.record(z.string(), z.unknown()).optional(),
+	channels: z.array(workflowChannelSchema).optional(),
 });
 
 const exportBundleBaseSchema = z.object({
@@ -304,6 +307,8 @@ export function exportWorkflow(
 	};
 	if (workflow.description !== undefined) result.description = workflow.description;
 	if (workflow.config !== undefined) result.config = workflow.config;
+	// Workflow-level channels use role strings and node names — no UUID remapping needed.
+	if (workflow.channels && workflow.channels.length > 0) result.channels = workflow.channels;
 	return result;
 }
 

--- a/packages/daemon/tests/unit/space/channel-resolution.test.ts
+++ b/packages/daemon/tests/unit/space/channel-resolution.test.ts
@@ -433,4 +433,136 @@ describe('validateChannels', () => {
 		const errors = validateChannels(wf, agents);
 		expect(errors).toHaveLength(0);
 	});
+
+	test('node-name/role-name collision: ambiguity error reported for from', () => {
+		// Node named "coder" and an agent with role "coder" in a different node
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const nodeA = makeNode('coder', 'coder', [{ role: 'reviewer', agentId: 'agent-reviewer' }]);
+		const nodeB = makeNode('n2', 'NodeB', [{ role: 'coder', agentId: 'agent-coder' }]);
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way' }]
+		);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.includes('ambiguous'))).toBe(true);
+	});
+
+	test('node-name/role-name collision: ambiguity error reported for to', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const nodeA = makeNode('n1', 'reviewer', [{ role: 'coder', agentId: 'agent-coder' }]);
+		const nodeB = makeNode('n2', 'NodeB', [{ role: 'reviewer', agentId: 'agent-reviewer' }]);
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way' }]
+		);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.includes('ambiguous'))).toBe(true);
+	});
+
+	test('invalid direction value: error reported', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const node = makeNode('n1', 'Node1', [
+			{ role: 'coder', agentId: 'agent-coder' },
+			{ role: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			[{ from: 'coder', to: 'reviewer', direction: 'invalid' as any }]
+		);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.includes('direction'))).toBe(true);
+	});
+});
+
+// ============================================================================
+// resolveChannels edge cases
+// ============================================================================
+
+describe('resolveChannels edge cases', () => {
+	test('wildcard from (*): expands to all agents sending to target', () => {
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'coder', agentId: 'agent-coder' },
+				{ role: 'reviewer', agentId: 'agent-reviewer' },
+				{ role: 'tester', agentId: 'agent-tester' },
+			],
+			[{ from: '*', to: 'reviewer', direction: 'one-way' }]
+		);
+		const wf = makeWorkflow([node]);
+		const result = resolveChannels(wf);
+
+		// coder→reviewer and tester→reviewer (self-loop reviewer→reviewer skipped)
+		expect(result).toHaveLength(2);
+		expect(result.every((r) => r.toRole === 'reviewer')).toBe(true);
+		const fromRoles = result.map((r) => r.fromRole).sort();
+		expect(fromRoles).toEqual(['coder', 'tester']);
+	});
+
+	test('from as node name: each agent in node gets a sender entry', () => {
+		const nodeA = makeNode('n1', 'Coders', [
+			{ role: 'coder1', agentId: 'agent-coder1' },
+			{ role: 'coder2', agentId: 'agent-coder2' },
+		]);
+		const nodeB = makeNode('n2', 'NodeB', [{ role: 'reviewer', agentId: 'agent-reviewer' }]);
+		// "Coders" node as from — all agents in Coders send to reviewer
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'Coders', to: 'reviewer', direction: 'one-way' }]
+		);
+		const result = resolveChannels(wf);
+
+		// coder1→reviewer + coder2→reviewer
+		expect(result).toHaveLength(2);
+		expect(result.every((r) => r.toRole === 'reviewer')).toBe(true);
+		// isFanOut is false for individual entries even though from was a node name
+		expect(result.every((r) => !r.isFanOut)).toBe(true);
+	});
+
+	test('bidirectional with fan-out to node name: expands with isFanOut on forward entries', () => {
+		const nodeA = makeNode('n1', 'NodeA', [{ role: 'planner', agentId: 'agent-planner' }]);
+		const nodeB = makeNode('n2', 'NodeB', [
+			{ role: 'coder1', agentId: 'agent-coder1' },
+			{ role: 'coder2', agentId: 'agent-coder2' },
+		]);
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'planner', to: 'NodeB', direction: 'bidirectional' }]
+		);
+		const result = resolveChannels(wf);
+
+		// forward: planner→coder1, planner→coder2 (isFanOut: true)
+		// reverse: coder1→planner, coder2→planner (isFanOut: true, same channel)
+		expect(result).toHaveLength(4);
+		const forward = result.filter((r) => r.fromRole === 'planner');
+		const reverse = result.filter((r) => r.toRole === 'planner');
+		expect(forward).toHaveLength(2);
+		expect(reverse).toHaveLength(2);
+		// All are marked isFanOut since to was a node name
+		expect(forward.every((r) => r.isFanOut === true)).toBe(true);
+		// isHubSpoke: true because single from + multiple to + bidirectional
+		expect(result.every((r) => r.isHubSpoke === true)).toBe(true);
+	});
+
+	test('node-name/role-name collision: resolver prefers role over node name for to', () => {
+		// "coder" is both an agent role in nodeB and the name of nodeA
+		const nodeA = makeNode('coder', 'coder', [{ role: 'planner', agentId: 'agent-planner' }]);
+		const nodeB = makeNode('n2', 'NodeB', [{ role: 'coder', agentId: 'agent-coder' }]);
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'planner', to: 'coder', direction: 'one-way' }]
+		);
+		const result = resolveChannels(wf);
+
+		// Resolver prefers role match → single DM to coder agent, NOT fan-out to node "coder"
+		expect(result).toHaveLength(1);
+		expect(result[0].toRole).toBe('coder');
+		expect(result[0].toAgentId).toBe('agent-coder');
+		expect(result[0].isFanOut).toBeFalsy();
+	});
 });

--- a/packages/daemon/tests/unit/space/channel-resolution.test.ts
+++ b/packages/daemon/tests/unit/space/channel-resolution.test.ts
@@ -1,0 +1,436 @@
+import { describe, test, expect } from 'bun:test';
+import type { SpaceAgent, SpaceWorkflow, WorkflowNode } from '@neokai/shared';
+import { resolveChannels, validateChannels } from '@neokai/shared';
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+function makeAgent(id: string): SpaceAgent {
+	return { id, spaceId: 'space-1', name: id, role: 'coder', createdAt: 0, updatedAt: 0 };
+}
+
+function makeNode(
+	id: string,
+	name: string,
+	agents: Array<{ role: string; agentId: string }>,
+	channels?: WorkflowNode['channels']
+): WorkflowNode {
+	return {
+		id,
+		name,
+		agents: agents.map((a) => ({ agentId: a.agentId, role: a.role })),
+		channels,
+	};
+}
+
+function makeWorkflow(nodes: WorkflowNode[], channels?: SpaceWorkflow['channels']): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		spaceId: 'space-1',
+		name: 'Test Workflow',
+		nodes,
+		transitions: [],
+		startNodeId: nodes[0]?.id ?? '',
+		rules: [],
+		tags: [],
+		createdAt: 0,
+		updatedAt: 0,
+		channels,
+	};
+}
+
+// ============================================================================
+// resolveChannels tests
+// ============================================================================
+
+describe('resolveChannels', () => {
+	test('within-node DM: two agents in same node, one-way channel between them', () => {
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'coder', agentId: 'agent-coder' },
+				{ role: 'reviewer', agentId: 'agent-reviewer' },
+			],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way' }]
+		);
+		const wf = makeWorkflow([node]);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			fromRole: 'coder',
+			toRole: 'reviewer',
+			fromAgentId: 'agent-coder',
+			toAgentId: 'agent-reviewer',
+			direction: 'one-way',
+			isHubSpoke: false,
+			isFanOut: false,
+		});
+	});
+
+	test('within-node broadcast: agent sends to node name (fan-out, isFanOut: true)', () => {
+		const node = makeNode('n1', 'Node1', [
+			{ role: 'hub', agentId: 'agent-hub' },
+			{ role: 'worker1', agentId: 'agent-w1' },
+			{ role: 'worker2', agentId: 'agent-w2' },
+		]);
+		const wf = makeWorkflow([node], [{ from: 'hub', to: 'Node1', direction: 'one-way' }]);
+		const result = resolveChannels(wf);
+
+		// hub sends to worker1 and worker2 (not itself — self-loops skipped)
+		expect(result).toHaveLength(2);
+		for (const r of result) {
+			expect(r.fromRole).toBe('hub');
+			expect(r.isFanOut).toBe(true);
+			expect(r.isHubSpoke).toBe(false);
+			expect(r.direction).toBe('one-way');
+		}
+		const toRoles = result.map((r) => r.toRole).sort();
+		expect(toRoles).toEqual(['worker1', 'worker2']);
+	});
+
+	test('cross-node DM: agent in node A sends to agent in node B', () => {
+		const nodeA = makeNode('n1', 'NodeA', [{ role: 'coder', agentId: 'agent-coder' }]);
+		const nodeB = makeNode('n2', 'NodeB', [{ role: 'reviewer', agentId: 'agent-reviewer' }]);
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way' }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			fromRole: 'coder',
+			toRole: 'reviewer',
+			fromAgentId: 'agent-coder',
+			toAgentId: 'agent-reviewer',
+			direction: 'one-way',
+			isFanOut: false,
+			isHubSpoke: false,
+		});
+	});
+
+	test('cross-node fan-out: agent in node A sends to node B name (all agents)', () => {
+		const nodeA = makeNode('n1', 'NodeA', [{ role: 'planner', agentId: 'agent-planner' }]);
+		const nodeB = makeNode('n2', 'NodeB', [
+			{ role: 'coder1', agentId: 'agent-coder1' },
+			{ role: 'coder2', agentId: 'agent-coder2' },
+		]);
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'planner', to: 'NodeB', direction: 'one-way' }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(2);
+		for (const r of result) {
+			expect(r.fromRole).toBe('planner');
+			expect(r.isFanOut).toBe(true);
+		}
+		const toRoles = result.map((r) => r.toRole).sort();
+		expect(toRoles).toEqual(['coder1', 'coder2']);
+	});
+
+	test('bidirectional point-to-point: expands to two one-way entries', () => {
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'alice', agentId: 'agent-alice' },
+				{ role: 'bob', agentId: 'agent-bob' },
+			],
+			[{ from: 'alice', to: 'bob', direction: 'bidirectional' }]
+		);
+		const wf = makeWorkflow([node]);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(2);
+		const aliceToBob = result.find((r) => r.fromRole === 'alice' && r.toRole === 'bob');
+		const bobToAlice = result.find((r) => r.fromRole === 'bob' && r.toRole === 'alice');
+		expect(aliceToBob).toBeDefined();
+		expect(bobToAlice).toBeDefined();
+		expect(aliceToBob!.isHubSpoke).toBe(false);
+		expect(bobToAlice!.isHubSpoke).toBe(false);
+	});
+
+	test('bidirectional hub-spoke: one sender, multiple receivers bidirectionally', () => {
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'hub', agentId: 'agent-hub' },
+				{ role: 'spoke1', agentId: 'agent-spoke1' },
+				{ role: 'spoke2', agentId: 'agent-spoke2' },
+			],
+			[{ from: 'hub', to: ['spoke1', 'spoke2'], direction: 'bidirectional' }]
+		);
+		const wf = makeWorkflow([node]);
+		const result = resolveChannels(wf);
+
+		// hub→spoke1, hub→spoke2, spoke1→hub, spoke2→hub = 4 entries
+		expect(result).toHaveLength(4);
+		for (const r of result) {
+			expect(r.isHubSpoke).toBe(true);
+		}
+		const hubToSpoke = result.filter((r) => r.fromRole === 'hub');
+		const spokeToHub = result.filter((r) => r.toRole === 'hub');
+		expect(hubToSpoke).toHaveLength(2);
+		expect(spokeToHub).toHaveLength(2);
+	});
+
+	test('self-loop skipped: from === to generates no entry', () => {
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[{ role: 'coder', agentId: 'agent-coder' }],
+			[{ from: 'coder', to: 'coder', direction: 'one-way' }]
+		);
+		const wf = makeWorkflow([node]);
+		const result = resolveChannels(wf);
+		expect(result).toHaveLength(0);
+	});
+
+	test('unresolvable references silently skipped', () => {
+		const node = makeNode('n1', 'Node1', [{ role: 'coder', agentId: 'agent-coder' }]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'unknown-role', to: 'also-unknown', direction: 'one-way' }]
+		);
+		const result = resolveChannels(wf);
+		expect(result).toHaveLength(0);
+	});
+
+	test('wildcard from/to: backward compat with * syntax', () => {
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'coder', agentId: 'agent-coder' },
+				{ role: 'reviewer', agentId: 'agent-reviewer' },
+				{ role: 'tester', agentId: 'agent-tester' },
+			],
+			[{ from: 'coder', to: '*', direction: 'one-way' }]
+		);
+		const wf = makeWorkflow([node]);
+		const result = resolveChannels(wf);
+
+		// coder→reviewer, coder→tester (self-loop skipped)
+		expect(result).toHaveLength(2);
+		for (const r of result) {
+			expect(r.fromRole).toBe('coder');
+		}
+	});
+
+	test('empty workflow: returns empty array', () => {
+		const wf = makeWorkflow([]);
+		const result = resolveChannels(wf);
+		expect(result).toHaveLength(0);
+	});
+
+	test('workflow.channels and node.channels both combined', () => {
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'coder', agentId: 'agent-coder' },
+				{ role: 'reviewer', agentId: 'agent-reviewer' },
+			],
+			[
+				// node-level channel
+				{ from: 'reviewer', to: 'coder', direction: 'one-way', label: 'node-channel' },
+			]
+		);
+		const wf = makeWorkflow(
+			[node],
+			[
+				// workflow-level channel
+				{ from: 'coder', to: 'reviewer', direction: 'one-way', label: 'wf-channel' },
+			]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(2);
+		const wfCh = result.find((r) => r.label === 'wf-channel');
+		const nodeCh = result.find((r) => r.label === 'node-channel');
+		expect(wfCh).toBeDefined();
+		expect(nodeCh).toBeDefined();
+	});
+
+	test('channelId is propagated from source WorkflowChannel', () => {
+		const node = makeNode('n1', 'Node1', [
+			{ role: 'coder', agentId: 'agent-coder' },
+			{ role: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ id: 'ch-001', from: 'coder', to: 'reviewer', direction: 'one-way' }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].channelId).toBe('ch-001');
+	});
+
+	test('isCyclic is propagated from source WorkflowChannel', () => {
+		const node = makeNode('n1', 'Node1', [
+			{ role: 'coder', agentId: 'agent-coder' },
+			{ role: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way', isCyclic: true }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].isCyclic).toBe(true);
+	});
+});
+
+// ============================================================================
+// validateChannels tests
+// ============================================================================
+
+describe('validateChannels', () => {
+	test('valid channels pass: no errors', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const node = makeNode('n1', 'Node1', [
+			{ role: 'coder', agentId: 'agent-coder' },
+			{ role: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow([node], [{ from: 'coder', to: 'reviewer', direction: 'one-way' }]);
+		const errors = validateChannels(wf, agents);
+		expect(errors).toHaveLength(0);
+	});
+
+	test('invalid from reference: error about unknown role/node', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const node = makeNode('n1', 'Node1', [
+			{ role: 'coder', agentId: 'agent-coder' },
+			{ role: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'unknown-role', to: 'reviewer', direction: 'one-way' }]
+		);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('unknown-role');
+	});
+
+	test('invalid to reference: error about unknown role/node', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const node = makeNode('n1', 'Node1', [
+			{ role: 'coder', agentId: 'agent-coder' },
+			{ role: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'coder', to: 'unknown-target', direction: 'one-way' }]
+		);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('unknown-target');
+	});
+
+	test('duplicate roles across nodes: error reported', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-coder2')];
+		const nodeA = makeNode('n1', 'NodeA', [{ role: 'coder', agentId: 'agent-coder' }]);
+		const nodeB = makeNode('n2', 'NodeB', [{ role: 'coder', agentId: 'agent-coder2' }]);
+		// Need at least one channel so validation runs
+		const wf = makeWorkflow([nodeA, nodeB], [{ from: 'coder', to: 'coder', direction: 'one-way' }]);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		const dupeError = errors.find((e) => e.includes('globally unique'));
+		expect(dupeError).toBeDefined();
+	});
+
+	test('wildcard mixed in array to: error reported', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const node = makeNode('n1', 'Node1', [
+			{ role: 'coder', agentId: 'agent-coder' },
+			{ role: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'coder', to: ['reviewer', '*'], direction: 'one-way' }]
+		);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.includes("mixes wildcard '*'"))).toBe(true);
+	});
+
+	test('agent not in space agents: error reported', () => {
+		// Space agents list does not include agent-coder
+		const agents = [makeAgent('agent-reviewer')];
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'coder', agentId: 'agent-coder' },
+				{ role: 'reviewer', agentId: 'agent-reviewer' },
+			],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way' }]
+		);
+		const wf = makeWorkflow([node]);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.includes('agent-coder'))).toBe(true);
+	});
+
+	test('empty channels: returns empty array', () => {
+		const agents = [makeAgent('agent-coder')];
+		const node = makeNode('n1', 'Node1', [{ role: 'coder', agentId: 'agent-coder' }]);
+		// No channels on workflow or node
+		const wf = makeWorkflow([node]);
+		const errors = validateChannels(wf, agents);
+		expect(errors).toHaveLength(0);
+	});
+
+	test('node-level channel references valid role: no errors', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'coder', agentId: 'agent-coder' },
+				{ role: 'reviewer', agentId: 'agent-reviewer' },
+			],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way' }]
+		);
+		const wf = makeWorkflow([node]);
+		const errors = validateChannels(wf, agents);
+		expect(errors).toHaveLength(0);
+	});
+
+	test('node-level channel with invalid role: error reported', () => {
+		const agents = [makeAgent('agent-coder'), makeAgent('agent-reviewer')];
+		const node = makeNode(
+			'n1',
+			'Node1',
+			[
+				{ role: 'coder', agentId: 'agent-coder' },
+				{ role: 'reviewer', agentId: 'agent-reviewer' },
+			],
+			[{ from: 'coder', to: 'nonexistent', direction: 'one-way' }]
+		);
+		const wf = makeWorkflow([node]);
+		const errors = validateChannels(wf, agents);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.includes('nonexistent'))).toBe(true);
+	});
+
+	test('cross-node fan-out via node name: valid when node name exists', () => {
+		const agents = [makeAgent('agent-planner'), makeAgent('agent-coder')];
+		const nodeA = makeNode('n1', 'NodeA', [{ role: 'planner', agentId: 'agent-planner' }]);
+		const nodeB = makeNode('n2', 'NodeB', [{ role: 'coder', agentId: 'agent-coder' }]);
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'planner', to: 'NodeB', direction: 'one-way' }]
+		);
+		const errors = validateChannels(wf, agents);
+		expect(errors).toHaveLength(0);
+	});
+});

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -40,8 +40,13 @@ export interface ResolvedChannel {
 	/** Always `'one-way'` after resolution — bidirectional is split into two entries */
 	direction: 'one-way';
 	/**
-	 * True when this channel fans out to all agents in a target node
-	 * (i.e. `to` in the source WorkflowChannel was a node name, not an agent role).
+	 * True when the `to` side of the source WorkflowChannel resolved to a node name
+	 * (fan-out delivery to all agents in that node), not an individual agent role.
+	 *
+	 * Note: `isFanOut` specifically describes **to-side** fan-out. When `from` in the
+	 * source channel is a node name, the resolver creates one `ResolvedChannel` entry
+	 * per agent in that node, each with `isFanOut: false` — the individual entries are
+	 * point-to-point even though they originated from a node-addressed source.
 	 */
 	isFanOut?: boolean;
 	/** Optional label inherited from the source WorkflowChannel */
@@ -540,11 +545,27 @@ export function validateChannels(workflow: SpaceWorkflow, agents: SpaceAgent[]):
 	];
 
 	for (const { ch, loc } of allChannels) {
-		if (ch.from !== '*' && !knownRoles.has(ch.from) && !knownNodeNames.has(ch.from)) {
+		// Validate direction field
+		if (ch.direction !== 'one-way' && ch.direction !== 'bidirectional') {
 			errors.push(
-				`${loc}.from "${ch.from}" does not match any agent role or node name in the workflow. ` +
-					`Known roles: [${[...knownRoles].join(', ')}]. Known nodes: [${[...knownNodeNames].join(', ')}].`
+				`${loc}.direction "${ch.direction}" is not valid. Must be 'one-way' or 'bidirectional'.`
 			);
+		}
+
+		if (ch.from !== '*') {
+			if (!knownRoles.has(ch.from) && !knownNodeNames.has(ch.from)) {
+				errors.push(
+					`${loc}.from "${ch.from}" does not match any agent role or node name in the workflow. ` +
+						`Known roles: [${[...knownRoles].join(', ')}]. Known nodes: [${[...knownNodeNames].join(', ')}].`
+				);
+			} else if (knownRoles.has(ch.from) && knownNodeNames.has(ch.from)) {
+				// Ambiguous: matches both an agent role and a node name.
+				// The resolver always prefers the role — flag this so the user can rename to avoid confusion.
+				errors.push(
+					`${loc}.from "${ch.from}" is ambiguous: it matches both an agent role and a node name. ` +
+						'Rename the node or the agent role to avoid misrouting.'
+				);
+			}
 		}
 
 		const toList: string[] = Array.isArray(ch.to) ? ch.to : [ch.to];
@@ -557,10 +578,18 @@ export function validateChannels(workflow: SpaceWorkflow, agents: SpaceAgent[]):
 		}
 
 		for (const toRef of toList) {
-			if (toRef !== '*' && !knownRoles.has(toRef) && !knownNodeNames.has(toRef)) {
+			if (toRef === '*') continue;
+			if (!knownRoles.has(toRef) && !knownNodeNames.has(toRef)) {
 				errors.push(
 					`${loc}.to "${toRef}" does not match any agent role or node name in the workflow. ` +
 						`Known roles: [${[...knownRoles].join(', ')}]. Known nodes: [${[...knownNodeNames].join(', ')}].`
+				);
+			} else if (knownRoles.has(toRef) && knownNodeNames.has(toRef)) {
+				// Ambiguous: matches both an agent role and a node name.
+				// The resolver always prefers the role — flag this so the user can rename to avoid confusion.
+				errors.push(
+					`${loc}.to "${toRef}" is ambiguous: it matches both an agent role and a node name. ` +
+						'Rename the node or the agent role to avoid misrouting.'
 				);
 			}
 		}

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -8,7 +8,13 @@
  * - `validateNodeChannels` checks that channel role references are valid.
  */
 
-import type { SpaceAgent, WorkflowChannel, WorkflowNode, WorkflowNodeAgent } from './space.ts';
+import type {
+	SpaceAgent,
+	SpaceWorkflow,
+	WorkflowChannel,
+	WorkflowNode,
+	WorkflowNodeAgent,
+} from './space.ts';
 
 // ============================================================================
 // ResolvedChannel
@@ -21,6 +27,8 @@ import type { SpaceAgent, WorkflowChannel, WorkflowNode, WorkflowNodeAgent } fro
  * Wildcard and array `to` declarations are expanded into one entry per resolved pair.
  */
 export interface ResolvedChannel {
+	/** ID of the source WorkflowChannel, if provided */
+	channelId?: string;
 	/** Role of the sending agent (matches WorkflowNodeAgent.role) */
 	fromRole: string;
 	/** Role of the receiving agent (matches WorkflowNodeAgent.role) */
@@ -31,8 +39,15 @@ export interface ResolvedChannel {
 	toAgentId: string;
 	/** Always `'one-way'` after resolution — bidirectional is split into two entries */
 	direction: 'one-way';
+	/**
+	 * True when this channel fans out to all agents in a target node
+	 * (i.e. `to` in the source WorkflowChannel was a node name, not an agent role).
+	 */
+	isFanOut?: boolean;
 	/** Optional label inherited from the source WorkflowChannel */
 	label?: string;
+	/** Inherited from the source WorkflowChannel */
+	isCyclic?: boolean;
 	/**
 	 * True when this channel belongs to a hub-spoke topology
 	 * (bidirectional source with an array `to` containing more than one role).
@@ -113,6 +128,8 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
  * @returns Array of concrete `ResolvedChannel` routing rules. Empty when no channels are defined.
  * @throws {Error} When neither `agentId` nor `agents` is provided on the node
  *   (propagated from `resolveNodeAgents`). Callers should validate nodes before calling this.
+ * @deprecated Use `resolveChannels()` instead, which operates at the workflow level
+ *   and handles all channel types uniformly. This function will be removed in a future milestone.
  */
 export function resolveNodeChannels(node: WorkflowNode): ResolvedChannel[] {
 	if (!node.channels || node.channels.length === 0) return [];
@@ -213,6 +230,8 @@ function expandChannel(
  * @param agents - All `SpaceAgent` records in the Space (used to verify agentId existence).
  * @returns Array of human-readable error strings. Empty array means no errors.
  * @public
+ * @deprecated Use `validateChannels()` instead, which operates at the workflow level
+ *   and handles all channel types uniformly. This function will be removed in a future milestone.
  */
 export function validateNodeChannels(node: WorkflowNode, agents: SpaceAgent[]): string[] {
 	const errors: string[] = [];
@@ -276,6 +295,272 @@ export function validateNodeChannels(node: WorkflowNode, agents: SpaceAgent[]): 
 				errors.push(
 					`channels[${i}].to "${toRole}" does not match any agent role in node "${node.name}". ` +
 						`Known roles: [${[...knownRoles].join(', ')}].`
+				);
+			}
+		}
+	}
+
+	return errors;
+}
+
+// ============================================================================
+// resolveChannels
+// ============================================================================
+
+/**
+ * Unified workflow-level channel resolver.
+ *
+ * Resolves all channels in the workflow (from both `workflow.channels` and
+ * `workflow.nodes[].channels`) into concrete, directional `ResolvedChannel` entries.
+ *
+ * This is the single resolution path for all channel types — within-node,
+ * cross-node, DM, and fan-out. There is no separate resolveNodeChannels call needed.
+ *
+ * Addressing semantics:
+ * - `from`/`to` values are looked up globally against `WorkflowNodeAgent.role` strings
+ *   (which must be unique across all nodes in the workflow for correct routing).
+ * - When `to` matches a **node name** (from `WorkflowNode.name`), the channel
+ *   fans out to all agents in that node (`isFanOut: true`).
+ * - When `to` matches an **agent role**, the channel is a point-to-point DM (`isFanOut: false`).
+ * - The wildcard `'*'` for `from` or `to` (as sole element) expands to all agent roles,
+ *   preserving backward compatibility with node-level channel declarations.
+ * - Bidirectional channels expand to two one-way entries.
+ * - Self-loops are skipped.
+ * - Unresolvable references are silently skipped; use `validateChannels` to surface them.
+ *
+ * @param workflow - The workflow whose channels are to be resolved.
+ * @param _agents  - Space agents (reserved for future gate/context use; not used by resolver).
+ * @returns Array of concrete `ResolvedChannel` routing rules.
+ */
+export function resolveChannels(
+	workflow: SpaceWorkflow,
+	_agents?: SpaceAgent[]
+): ResolvedChannel[] {
+	// Collect channels from workflow-level and node-level
+	const allChannels: WorkflowChannel[] = [
+		...(workflow.channels ?? []),
+		...workflow.nodes.flatMap((n) => n.channels ?? []),
+	];
+	if (allChannels.length === 0) return [];
+
+	// Build global role → agent info map and node name → agents map
+	const roleToAgent = new Map<string, { agentId: string }>();
+	const nodeNameToAgents = new Map<string, Array<{ role: string; agentId: string }>>();
+
+	for (const node of workflow.nodes) {
+		let nodeAgents: WorkflowNodeAgent[];
+		try {
+			nodeAgents = resolveNodeAgents(node);
+		} catch {
+			continue; // invalid node — validateChannels handles this
+		}
+
+		const nodeAgentList: Array<{ role: string; agentId: string }> = [];
+		for (const na of nodeAgents) {
+			roleToAgent.set(na.role, { agentId: na.agentId });
+			nodeAgentList.push({ role: na.role, agentId: na.agentId });
+		}
+		nodeNameToAgents.set(node.name, nodeAgentList);
+	}
+
+	const allRoles = [...roleToAgent.keys()];
+	const results: ResolvedChannel[] = [];
+
+	for (const channel of allChannels) {
+		expandUnifiedChannel(channel, allRoles, roleToAgent, nodeNameToAgents, results);
+	}
+
+	return results;
+}
+
+function expandUnifiedChannel(
+	channel: WorkflowChannel,
+	allRoles: string[],
+	roleToAgent: Map<string, { agentId: string }>,
+	nodeNameToAgents: Map<string, Array<{ role: string; agentId: string }>>,
+	out: ResolvedChannel[]
+): void {
+	const { from, to, direction, label } = channel;
+	const channelId = channel.id;
+	const isCyclic = channel.isCyclic;
+
+	// Resolve from-agents
+	const fromAgents = resolveAgentRef(from, allRoles, roleToAgent, nodeNameToAgents);
+
+	// Resolve to-agents and determine isFanOut
+	const toList: string[] = Array.isArray(to) ? to : [to];
+	let isFanOut = false;
+	let toAgents: Array<{ role: string; agentId: string }>;
+
+	if (toList.length === 1 && toList[0] === '*') {
+		// Wildcard: all roles (backward compat with node-level channels)
+		toAgents = allRoles.map((r) => ({ role: r, agentId: roleToAgent.get(r)!.agentId }));
+	} else if (
+		toList.length === 1 &&
+		nodeNameToAgents.has(toList[0]) &&
+		!roleToAgent.has(toList[0])
+	) {
+		// Node name (not an agent role): fan-out to all agents in that node
+		toAgents = nodeNameToAgents.get(toList[0])!;
+		isFanOut = true;
+	} else {
+		// Explicit role(s) or array: look up each individually
+		toAgents = toList.flatMap((t) => resolveAgentRef(t, allRoles, roleToAgent, nodeNameToAgents));
+	}
+
+	// Hub-spoke: single named from-agent + multiple to-agents + bidirectional
+	const isHubSpoke =
+		direction === 'bidirectional' && fromAgents.length === 1 && toAgents.length > 1;
+
+	for (const fromAgent of fromAgents) {
+		for (const toAgent of toAgents) {
+			if (fromAgent.role === toAgent.role) continue; // skip self-loops
+
+			out.push({
+				channelId,
+				fromRole: fromAgent.role,
+				toRole: toAgent.role,
+				fromAgentId: fromAgent.agentId,
+				toAgentId: toAgent.agentId,
+				direction: 'one-way',
+				label,
+				isFanOut,
+				isCyclic,
+				isHubSpoke,
+			});
+
+			if (direction === 'bidirectional') {
+				out.push({
+					channelId,
+					fromRole: toAgent.role,
+					toRole: fromAgent.role,
+					fromAgentId: toAgent.agentId,
+					toAgentId: fromAgent.agentId,
+					direction: 'one-way',
+					label,
+					isFanOut,
+					isCyclic,
+					isHubSpoke,
+				});
+			}
+		}
+	}
+}
+
+function resolveAgentRef(
+	ref: string,
+	allRoles: string[],
+	roleToAgent: Map<string, { agentId: string }>,
+	nodeNameToAgents: Map<string, Array<{ role: string; agentId: string }>>
+): Array<{ role: string; agentId: string }> {
+	if (ref === '*') {
+		return allRoles.map((r) => ({ role: r, agentId: roleToAgent.get(r)!.agentId }));
+	}
+	const agentInfo = roleToAgent.get(ref);
+	if (agentInfo) {
+		return [{ role: ref, agentId: agentInfo.agentId }];
+	}
+	const nodeAgents = nodeNameToAgents.get(ref);
+	if (nodeAgents) {
+		return [...nodeAgents];
+	}
+	return []; // unresolvable — validateChannels handles this
+}
+
+// ============================================================================
+// validateChannels
+// ============================================================================
+
+/**
+ * Validates all channel declarations in a workflow.
+ *
+ * Checks both `workflow.channels` (workflow-level) and each node's `channels` (node-level).
+ *
+ * Checks:
+ * - All node agents have `agentId` values present in the provided `agents` list.
+ * - All `WorkflowNodeAgent.role` values are globally unique across the workflow
+ *   (required for unambiguous cross-node channel routing).
+ * - `from`/`to` role strings reference either a known agent role, a known node name,
+ *   or the wildcard `'*'`.
+ * - `'*'` is not mixed with other roles in an array `to`.
+ *
+ * @param workflow - The workflow to validate.
+ * @param agents   - All `SpaceAgent` records in the Space (used to verify agentId existence).
+ * @returns Array of human-readable error strings. Empty array means no errors.
+ */
+export function validateChannels(workflow: SpaceWorkflow, agents: SpaceAgent[]): string[] {
+	const errors: string[] = [];
+
+	const workflowChannels = workflow.channels ?? [];
+	const nodeChannels = workflow.nodes.flatMap((n) => n.channels ?? []);
+	if (workflowChannels.length === 0 && nodeChannels.length === 0) return errors;
+
+	const agentIdSet = new Set(agents.map((a) => a.id));
+	const knownRoles = new Set<string>();
+	const seenRoles = new Set<string>();
+	const knownNodeNames = new Set<string>();
+
+	for (const node of workflow.nodes) {
+		knownNodeNames.add(node.name);
+
+		let nodeAgents: WorkflowNodeAgent[];
+		try {
+			nodeAgents = resolveNodeAgents(node);
+		} catch (err) {
+			errors.push((err as Error).message);
+			continue;
+		}
+
+		for (const na of nodeAgents) {
+			if (!agentIdSet.has(na.agentId)) {
+				errors.push(
+					`Agent with id "${na.agentId}" in node "${node.name}" not found in space agents.`
+				);
+			}
+			if (seenRoles.has(na.role)) {
+				errors.push(
+					`Agent role "${na.role}" appears in multiple workflow nodes. ` +
+						'Roles must be globally unique across the workflow for unambiguous channel routing.'
+				);
+			} else {
+				seenRoles.add(na.role);
+				knownRoles.add(na.role);
+			}
+		}
+	}
+
+	const allChannels: Array<{ ch: WorkflowChannel; loc: string }> = [
+		...workflowChannels.map((ch, i) => ({ ch, loc: `workflow.channels[${i}]` })),
+		...workflow.nodes.flatMap((n, ni) =>
+			(n.channels ?? []).map((ch, ci) => ({
+				ch,
+				loc: `workflow.nodes[${ni}].channels[${ci}]`,
+			}))
+		),
+	];
+
+	for (const { ch, loc } of allChannels) {
+		if (ch.from !== '*' && !knownRoles.has(ch.from) && !knownNodeNames.has(ch.from)) {
+			errors.push(
+				`${loc}.from "${ch.from}" does not match any agent role or node name in the workflow. ` +
+					`Known roles: [${[...knownRoles].join(', ')}]. Known nodes: [${[...knownNodeNames].join(', ')}].`
+			);
+		}
+
+		const toList: string[] = Array.isArray(ch.to) ? ch.to : [ch.to];
+
+		if (toList.length > 1 && toList.includes('*')) {
+			errors.push(
+				`${loc}.to mixes wildcard '*' with explicit roles. ` +
+					"Use a plain '*' string (not an array) to target all agents."
+			);
+		}
+
+		for (const toRef of toList) {
+			if (toRef !== '*' && !knownRoles.has(toRef) && !knownNodeNames.has(toRef)) {
+				errors.push(
+					`${loc}.to "${toRef}" does not match any agent role or node name in the workflow. ` +
+						`Known roles: [${[...knownRoles].join(', ')}]. Known nodes: [${[...knownNodeNames].join(', ')}].`
 				);
 			}
 		}

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1088,6 +1088,11 @@ export interface ExportedSpaceWorkflow {
 	tags: string[];
 	/** Additional runtime configuration */
 	config?: Record<string, unknown>;
+	/**
+	 * Workflow-level messaging channels. Exported as-is — they already use role strings
+	 * and node names, not UUIDs, so no remapping is needed on import.
+	 */
+	channels?: WorkflowChannel[];
 }
 
 /**

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -631,6 +631,8 @@ export const TASK_AGENT_NODE_ID = '__task_agent__';
  * No channels = no messaging constraints (agents are fully isolated).
  */
 export interface WorkflowChannel {
+	/** Optional stable identifier for this channel */
+	id?: string;
 	/**
 	 * Source role string (matches `WorkflowNodeAgent.role`) or `'*'` for all agents in the node.
 	 */
@@ -649,6 +651,11 @@ export interface WorkflowChannel {
 	 *   spoke may reply to hub only (no spoke-to-spoke messaging).
 	 */
 	direction: 'one-way' | 'bidirectional';
+	/**
+	 * When true, each delivery on this channel increments the run's iteration counter.
+	 * Used for cyclic workflows — channel-level analogue of WorkflowTransition.isCyclic.
+	 */
+	isCyclic?: boolean;
 	/** Optional human-readable label for display in the visual editor */
 	label?: string;
 }
@@ -776,6 +783,14 @@ export interface SpaceWorkflow {
 	/** Rules that govern agent behavior during this workflow */
 	rules: WorkflowRule[];
 	/**
+	 * Workflow-level directed messaging channels between agents.
+	 * Use `from`/`to` to reference `WorkflowNodeAgent.role` values (globally unique across
+	 * the workflow) or node names (for fan-out to all agents in a node).
+	 * Channels defined here take precedence over node-level channels.
+	 * No channels = no messaging constraints (agents are fully isolated).
+	 */
+	channels?: WorkflowChannel[];
+	/**
 	 * @deprecated isDefault is no longer used for workflow selection.
 	 * Workflow selection uses only two modes: explicit workflowId or AI auto-select.
 	 * This field is retained for backward compatibility but has no runtime effect.
@@ -822,6 +837,10 @@ export interface CreateSpaceWorkflowParams {
 	 */
 	rules?: WorkflowRuleInput[];
 	/**
+	 * Workflow-level messaging channels. `id` is optional — backend generates one when omitted.
+	 */
+	channels?: WorkflowChannel[];
+	/**
 	 * @deprecated isDefault has no runtime effect. Workflow selection uses only explicit workflowId or AI auto-select.
 	 */
 	isDefault?: boolean;
@@ -862,6 +881,10 @@ export interface UpdateSpaceWorkflowParams {
 	 * Replaces the entire rule list. Pass `[]` or `null` to clear all rules.
 	 */
 	rules?: WorkflowRule[] | null;
+	/**
+	 * Replaces the entire channel list. Pass `[]` or `null` to clear all channels.
+	 */
+	channels?: WorkflowChannel[] | null;
 	/**
 	 * @deprecated isDefault has no runtime effect. Workflow selection uses only explicit workflowId or AI auto-select.
 	 */


### PR DESCRIPTION
- Add resolveChannels(workflow, agents) as single resolution path for all channel
  types (within-node DM, cross-node DM, fan-out by node name, wildcard broadcast)
- Add validateChannels(workflow, agents) for workflow-level validation including
  globally-unique role checks and agent/node reference validation
- Add isFanOut?, channelId?, isCyclic? fields to ResolvedChannel (backward compat)
- Add id?, isCyclic? fields to WorkflowChannel
- Add channels?: WorkflowChannel[] to SpaceWorkflow, CreateSpaceWorkflowParams,
  UpdateSpaceWorkflowParams for workflow-level channel declarations
- Deprecate resolveNodeChannels() and validateNodeChannels() — no breaking changes
- 23 new tests covering all resolution and validation scenarios
