### PR TITLE
feat(space): rename slot_role→agent_name and add completion_summary on space_tasks

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -202,7 +202,7 @@ export class ChannelRouter {
 					workflowNodeId: nodeId,
 					taskType: resolved.taskType,
 					customAgentId: resolved.customAgentId,
-					slotRole: agentEntry.name,
+					agentName: agentEntry.name,
 					status: 'pending',
 					goalId: run.goalId,
 				});

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -15,7 +15,7 @@
  * - activateNode() is idempotent: if tasks already exist for the node the
  *   existing tasks are returned unchanged.
  * - Concurrency is handled via a DB UNIQUE partial index on
- *   (workflow_run_id, workflow_node_id, slot_role). A duplicate INSERT throws
+ *   (workflow_run_id, workflow_node_id, agent_name). A duplicate INSERT throws
  *   a SQLiteError; the handler re-reads and returns the tasks created by the
  *   winning writer.
  * - No session group creation — that is the responsibility of TaskAgentManager.

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -345,7 +345,7 @@ export class SpaceRuntime {
 					workflowNodeId: startStep.id,
 					taskType: resolved.taskType,
 					customAgentId: resolved.customAgentId,
-					slotRole: agentEntry.name,
+					agentName: agentEntry.name,
 					status: 'pending',
 					goalId: run.goalId,
 				});

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -451,7 +451,7 @@ export class WorkflowExecutor {
 		// Per-agent instructions override step-level instructions when present.
 		//
 		// Idempotency: if the target node already has active tasks for a given agent slot
-		// (detected via UNIQUE constraint violation on workflow_run_id+workflow_node_id+slot_role),
+		// (detected via UNIQUE constraint violation on workflow_run_id+workflow_node_id+agent_name),
 		// reuse the existing task. This handles both cyclic re-activation and concurrent
 		// activateNode() calls racing with followTransition().
 		const tasks: SpaceTask[] = [];

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -478,7 +478,7 @@ export class WorkflowExecutor {
 					workflowNodeId: nextStep.id,
 					taskType: resolved?.taskType as import('@neokai/shared').SpaceTaskType | undefined,
 					customAgentId: resolved !== undefined ? resolved.customAgentId : agentEntry.agentId,
-					slotRole: agentEntry.name,
+					agentName: agentEntry.name,
 					status: 'pending',
 					goalId: this.run.goalId,
 				});
@@ -489,7 +489,7 @@ export class WorkflowExecutor {
 					const existingTasks = (await this.taskManager.listTasksByWorkflowRun(this.run.id)).filter(
 						(t) =>
 							t.workflowNodeId === nextStep.id &&
-							t.slotRole === agentEntry.name &&
+							t.agentName === agentEntry.name &&
 							ACTIVE_STATUSES.has(t.status)
 					);
 					if (existingTasks.length > 0) {

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -316,20 +316,20 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			}
 
 			// Find the WorkflowNodeAgent slot that spawned this task.
-			// When slotRole is stored on the task (migration 46+), use it for an exact match.
+			// When agentName is stored on the task (migration 51+), use it for an exact match.
 			// This correctly handles nodes where the same agentId appears multiple times with
-			// different slot roles (e.g. "strict-reviewer" and "quick-reviewer"): each task
-			// was created with its own slotRole, so the lookup is unambiguous.
-			// For tasks created before migration 46 (no slotRole), fall back to find-by-agentId,
+			// different agent names (e.g. "strict-reviewer" and "quick-reviewer"): each task
+			// was created with its own agentName, so the lookup is unambiguous.
+			// For tasks created before migration 51 (no agentName), fall back to find-by-agentId,
 			// which always returns the first matching slot — acceptable for legacy data.
-			const agentSlot = effectiveTask.slotRole
-				? nodeAgents.find((a) => a.name === effectiveTask.slotRole)
+			const agentSlot = effectiveTask.agentName
+				? nodeAgents.find((a) => a.name === effectiveTask.agentName)
 				: nodeAgents.find((a) => a.agentId === effectiveTask.customAgentId);
 
 			// Extract slot-level overrides (model and systemPrompt) if present.
 			// Always construct the object; undefined values are handled downstream
 			// (createCustomAgentInit guards on !== undefined for each field).
-			// When agentSlot is undefined (stale slotRole: the workflow was edited after
+			// When agentSlot is undefined (stale agentName: the workflow was edited after
 			// the task was created and the slot no longer exists), both fields are undefined
 			// and no override is applied — the base agent config is used as-is.
 			const slotOverrides = { model: agentSlot?.model, systemPrompt: agentSlot?.systemPrompt };

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -25,7 +25,7 @@ export class SpaceTaskRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, slot_role, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
+			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, agent_name, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
@@ -39,7 +39,7 @@ export class SpaceTaskRepository {
 			params.taskType ?? null,
 			params.assignedAgent ?? 'coder',
 			params.customAgentId ?? null,
-			params.slotRole ?? null,
+			params.agentName ?? null,
 			params.workflowRunId ?? null,
 			params.workflowNodeId ?? null,
 			params.createdByTaskId ?? null,
@@ -358,7 +358,7 @@ export class SpaceTaskRepository {
 			taskType: (row.task_type as SpaceTask['taskType'] | null) ?? undefined,
 			assignedAgent: (row.assigned_agent as SpaceTask['assignedAgent'] | null) ?? undefined,
 			customAgentId: (row.custom_agent_id as string | null) ?? undefined,
-			slotRole: (row.slot_role as string | null) ?? undefined,
+			agentName: (row.agent_name as string | null) ?? undefined,
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
 			workflowNodeId: (row.workflow_node_id as string | null) ?? undefined,
 			createdByTaskId: (row.created_by_task_id as string | null) ?? undefined,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -200,10 +200,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Idempotent via CREATE TABLE IF NOT EXISTS.
 	runMigration50(db);
 
-	// Migration 51: Add completion_summary column to space_tasks.
-	// Stores the agent's done report — the human-readable summary an agent writes when
-	// it marks a task completed. This is the canonical location for agent completion state
-	// (alongside the existing status, completed_at, and task_agent_session_id columns).
+	// Migration 51: Rename space_tasks.slot_role -> agent_name and add completion_summary column.
+	// Part of the agent-centric refactor: "slot role" is replaced by a plain "agent name" that
+	// directly identifies the agent. completion_summary stores a brief human-readable summary
+	// written by the agent when a task reaches a terminal state.
 	runMigration51(db);
 
 	// Migration 52: Create room_mcp_enablement table for per-room MCP enablement overrides.
@@ -3166,22 +3166,160 @@ export function runMigration49(db: BunDatabase): void {
 }
 
 /**
- * Migration 51: Add completion_summary column to space_tasks.
+ * Migration 51: Rename space_tasks.slot_role → agent_name; add completion_summary column.
  *
- * Agent completion state is tracked entirely on space_tasks — not on session group members.
- * The three columns that together represent agent completion state are:
- *   - status            — existing, set to 'completed' (or 'needs_attention' / 'cancelled')
- *   - completed_at      — existing, timestamp stamped automatically on terminal status change
- *   - completion_summary — NEW, free-text summary written by the agent when it finishes
+ * As part of the agent-centric collaboration refactor:
+ * - `slot_role` is renamed to `agent_name` — the field now stores the plain agent name
+ *   that identifies which agent spawned this task, rather than a workflow-slot role label.
+ * - `completion_summary TEXT` is added — a brief human-readable summary written by the agent
+ *   when a task reaches a terminal state (completed/needs_attention/cancelled).
  *
- * SpaceSessionGroupMember is NOT extended because that table is being removed entirely
- * in the agent-centric refactor (Task 8.2).
+ * Renaming requires a full table recreate (SQLite has limited ALTER TABLE support).
+ * The INSERT SELECT maps slot_role → agent_name and sets completion_summary to NULL for
+ * existing rows (backward compatible).
  *
- * Uses ADD COLUMN IF NOT EXISTS (SQLite 3.37+) for idempotency.
+ * Idempotent: guarded by tableHasColumn() checks.
  */
 export function runMigration51(db: BunDatabase): void {
-	if (!tableHasColumn(db, 'space_tasks', 'completion_summary')) {
-		db.exec(`ALTER TABLE space_tasks ADD COLUMN completion_summary TEXT`);
+	if (!tableExists(db, 'space_tasks')) return;
+
+	const hasSlotRole = tableHasColumn(db, 'space_tasks', 'slot_role');
+	const hasAgentName = tableHasColumn(db, 'space_tasks', 'agent_name');
+	const hasCompletionSummary = tableHasColumn(db, 'space_tasks', 'completion_summary');
+
+	if (!hasSlotRole && hasAgentName && hasCompletionSummary) {
+		// Already fully migrated — nothing to do.
+		return;
+	}
+
+	db.exec(`PRAGMA foreign_keys = OFF`);
+	try {
+		db.exec(`BEGIN`);
+
+		if (hasSlotRole) {
+			// Recreate the table, mapping slot_role → agent_name and adding completion_summary.
+			db.exec(`DROP TABLE IF EXISTS space_tasks_m51_new`);
+			db.exec(`
+				CREATE TABLE space_tasks_m51_new (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					title TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					status TEXT NOT NULL DEFAULT 'pending'
+						CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+					priority TEXT NOT NULL DEFAULT 'normal'
+						CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+					task_type TEXT
+						CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+					assigned_agent TEXT
+						CHECK(assigned_agent IN ('coder', 'general')),
+					custom_agent_id TEXT,
+					agent_name TEXT,
+					workflow_run_id TEXT,
+					workflow_node_id TEXT,
+					created_by_task_id TEXT,
+					goal_id TEXT,
+					progress INTEGER,
+					current_step TEXT,
+					result TEXT,
+					error TEXT,
+					completion_summary TEXT,
+					depends_on TEXT NOT NULL DEFAULT '[]',
+					input_draft TEXT,
+					active_session TEXT
+						CHECK(active_session IN ('worker', 'leader')),
+					task_agent_session_id TEXT,
+					pr_url TEXT,
+					pr_number INTEGER,
+					pr_created_at INTEGER,
+					archived_at INTEGER,
+					created_at INTEGER NOT NULL,
+					started_at INTEGER,
+					completed_at INTEGER,
+					updated_at INTEGER NOT NULL,
+					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+					FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+					FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
+				)
+			`);
+
+			// Build the INSERT SELECT dynamically to handle optional columns that may be absent
+			// on databases created by very early migrations before certain ALTER TABLE additions.
+			const existingCols = new Set(
+				(db.prepare(`PRAGMA table_info(space_tasks)`).all() as Array<{ name: string }>).map(
+					(r) => r.name
+				)
+			);
+			const colOrNull = (col: string) => (existingCols.has(col) ? col : `NULL AS ${col}`);
+
+			db.exec(`
+				INSERT INTO space_tasks_m51_new
+				SELECT
+					id,
+					space_id,
+					title,
+					description,
+					status,
+					priority,
+					${colOrNull('task_type')},
+					${colOrNull('assigned_agent')},
+					${colOrNull('custom_agent_id')},
+					slot_role AS agent_name,
+					${colOrNull('workflow_run_id')},
+					${colOrNull('workflow_node_id')},
+					${colOrNull('created_by_task_id')},
+					${colOrNull('goal_id')},
+					${colOrNull('progress')},
+					${colOrNull('current_step')},
+					${colOrNull('result')},
+					${colOrNull('error')},
+					NULL AS completion_summary,
+					depends_on,
+					${colOrNull('input_draft')},
+					${colOrNull('active_session')},
+					${colOrNull('task_agent_session_id')},
+					${colOrNull('pr_url')},
+					${colOrNull('pr_number')},
+					${colOrNull('pr_created_at')},
+					${colOrNull('archived_at')},
+					created_at,
+					${colOrNull('started_at')},
+					${colOrNull('completed_at')},
+					updated_at
+				FROM space_tasks
+			`);
+
+			db.exec(`DROP TABLE space_tasks`);
+			db.exec(`ALTER TABLE space_tasks_m51_new RENAME TO space_tasks`);
+
+			// Restore indexes.
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`
+			);
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
+			);
+		} else if (!hasCompletionSummary) {
+			// agent_name already exists (partial migration or fresh DB scenario);
+			// just add the missing completion_summary column.
+			db.exec(`ALTER TABLE space_tasks ADD COLUMN completion_summary TEXT`);
+		}
+
+		db.exec(`COMMIT`);
+	} catch (e) {
+		db.exec(`ROLLBACK`);
+		throw e;
+	} finally {
+		db.exec(`PRAGMA foreign_keys = ON`);
 	}
 }
 
@@ -3273,7 +3411,7 @@ export function runMigration53(db: BunDatabase): void {
 /**
  * Migration 54: Add unique partial index on space_tasks for lazy node activation.
  *
- * Enforces at-most-one in-flight task per (workflow_run_id, workflow_node_id, slot_role)
+ * Enforces at-most-one in-flight task per (workflow_run_id, workflow_node_id, agent_name)
  * tuple, preventing duplicate tasks when multiple concurrent ChannelRouter.activateNode()
  * calls race to activate the same node.
  *
@@ -3289,7 +3427,7 @@ export function runMigration53(db: BunDatabase): void {
  *   tasks for the same slot may coexist; external callers own their uniqueness.
  *
  * The NULL exclusions preserve backward-compat with legacy tasks that predate the
- * channel/slot system (agentId-shorthand tasks with NULL workflow_node_id or slot_role).
+ * channel/slot system (agentId-shorthand tasks with NULL workflow_node_id or agent_name).
  *
  * Idempotent via CREATE UNIQUE INDEX IF NOT EXISTS.
  */
@@ -3297,20 +3435,21 @@ export function runMigration54(db: BunDatabase): void {
 	// Guard: only create the index when the required columns exist.
 	// `workflow_node_id` may still be named `workflow_step_id` on DBs whose migration 39
 	// rebuild ran after migration 45's rename (an uncommon but valid test-fixture path).
-	// `slot_role` was added by migration 46; guard prevents failure on older DB states.
+	// `agent_name` was added by migration 51 (renamed from slot_role added by migration 46);
+	// guard prevents failure on older DB states.
 	if (
 		!tableExists(db, 'space_tasks') ||
 		!tableHasColumn(db, 'space_tasks', 'workflow_node_id') ||
-		!tableHasColumn(db, 'space_tasks', 'slot_role')
+		!tableHasColumn(db, 'space_tasks', 'agent_name')
 	) {
 		return;
 	}
 	db.exec(`
     CREATE UNIQUE INDEX IF NOT EXISTS uq_space_tasks_run_node_agent
-    ON space_tasks (workflow_run_id, workflow_node_id, slot_role)
+    ON space_tasks (workflow_run_id, workflow_node_id, agent_name)
     WHERE workflow_run_id IS NOT NULL
       AND workflow_node_id IS NOT NULL
-      AND slot_role IS NOT NULL
+      AND agent_name IS NOT NULL
       AND status IN ('pending', 'in_progress', 'review', 'rate_limited', 'usage_limited')
   `);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -216,7 +216,7 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	runMigration53(db);
 
 	// Migration 54: Add unique partial index on space_tasks (workflow_run_id, workflow_node_id,
-	// slot_role) to enforce at-most-one task per agent slot per workflow node per run.
+	// agent_name) to enforce at-most-one task per agent slot per workflow node per run.
 	// Prevents duplicate tasks from concurrent ChannelRouter.activateNode() calls.
 	runMigration54(db);
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -143,7 +143,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			assigned_agent TEXT
 				CHECK(assigned_agent IN ('coder', 'general')),
 			custom_agent_id TEXT,
-			slot_role TEXT,
+			agent_name TEXT,
 			workflow_run_id TEXT,
 			workflow_node_id TEXT,
 			created_by_task_id TEXT,
@@ -152,6 +152,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			current_step TEXT,
 			result TEXT,
 			error TEXT,
+			completion_summary TEXT,
 			depends_on TEXT NOT NULL DEFAULT '[]',
 			input_draft TEXT,
 			active_session TEXT
@@ -161,7 +162,6 @@ export function createSpaceTables(db: BunDatabase): void {
 			pr_number INTEGER,
 			pr_created_at INTEGER,
 			archived_at INTEGER,
-			completion_summary TEXT,
 			created_at INTEGER NOT NULL,
 			started_at INTEGER,
 			completed_at INTEGER,

--- a/packages/daemon/tests/unit/space/agent-liveness.test.ts
+++ b/packages/daemon/tests/unit/space/agent-liveness.test.ts
@@ -221,24 +221,25 @@ describe('autoCompleteStuckAgents', () => {
 		expect(taskRepo.getTask('task-fresh')!.status).toBe('in_progress');
 	});
 
-	test('does NOT auto-complete at exact timeout boundary (elapsed === timeoutMs)', async () => {
-		// The guard uses `elapsedMs <= timeoutMs`, so exact-match is excluded.
-		// This test seeds the task with startedAt = now - AGENT_REPORT_DONE_TIMEOUT_MS
-		// so elapsed is essentially exactly at the boundary (may be a few ms over due
-		// to test execution time, but we use a custom timeout far larger to be safe).
-		const customTimeoutMs = 5000; // 5 seconds
+	test('does NOT auto-complete when elapsed is at or below the timeout boundary', async () => {
+		// The guard uses `elapsedMs <= timeoutMs`, so tasks within the window are excluded.
+		// We set startedAt = now - elapsedMs and timeoutMs = elapsedMs + 1000 (1-second buffer)
+		// so that even if a few ms pass during test execution, elapsed stays safely below
+		// the timeout threshold.
+		const elapsedMs = 4000; // 4 seconds ago
+		const customTimeoutMs = elapsedMs + 1000; // timeout is 5 seconds (1 s above elapsed)
 		seedTask(db, 'task-boundary', spaceId, {
 			status: 'in_progress',
 			taskAgentSessionId: 'session-boundary',
-			startedAt: Date.now() - customTimeoutMs, // exactly at the boundary
+			startedAt: Date.now() - elapsedMs,
 		});
 
 		const task = taskRepo.getTask('task-boundary')!;
 		const tam = makeMockTAM(new Set(['task-boundary']));
 		const spy = makeNotifySpy();
 
-		// Patch startedAt to be exactly now - customTimeoutMs so elapsed = customTimeoutMs
-		const patchedTask: SpaceTask = { ...task, startedAt: Date.now() - customTimeoutMs };
+		// Patch startedAt so elapsedMs ≈ 4 s, timeout = 5 s → clearly within window
+		const patchedTask: SpaceTask = { ...task, startedAt: Date.now() - elapsedMs };
 
 		const result = await autoCompleteStuckAgents(
 			[patchedTask],
@@ -249,7 +250,7 @@ describe('autoCompleteStuckAgents', () => {
 			customTimeoutMs
 		);
 
-		// elapsed <= timeoutMs → no auto-completion
+		// elapsed < timeoutMs → no auto-completion
 		expect(result).toHaveLength(0);
 		expect(spy.events).toHaveLength(0);
 		expect(taskRepo.getTask('task-boundary')!.status).toBe('in_progress');

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -616,8 +616,8 @@ describe('ChannelRouter', () => {
 			// Both agents in NODE_B should be activated
 			expect(result.activatedTasks).toBeDefined();
 			expect(result.activatedTasks).toHaveLength(2);
-			const roles = result.activatedTasks!.map((t) => t.slotRole).sort();
-			expect(roles).toEqual(['coder-b', 'planner-b']);
+			const agentNames = result.activatedTasks!.map((t) => t.agentName).sort();
+			expect(agentNames).toEqual(['coder-b', 'planner-b']);
 		});
 
 		test('fan-out: isFanOut is false when targeting by agent role', async () => {

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -209,7 +209,7 @@ describe('ChannelRouter', () => {
 			expect(tasks[0].status).toBe('pending');
 			expect(tasks[0].workflowRunId).toBe(run.id);
 			expect(tasks[0].workflowNodeId).toBe(NODE_A);
-			expect(tasks[0].slotRole).toBe(AGENT_CODER); // resolveNodeAgents uses agentId as name for shorthand
+			expect(tasks[0].agentName).toBe(AGENT_CODER); // resolveNodeAgents uses agentId as name for shorthand
 			expect(tasks[0].taskType).toBe('coding');
 			expect(tasks[0].customAgentId).toBeFalsy();
 		});
@@ -237,12 +237,12 @@ describe('ChannelRouter', () => {
 			const tasks = await router.activateNode(run.id, NODE_A);
 
 			expect(tasks).toHaveLength(2);
-			const slotRoles = tasks.map((t) => t.slotRole).sort();
-			expect(slotRoles).toEqual(['coder-slot', 'planner-slot']);
+			const agentNames = tasks.map((t) => t.agentName).sort();
+			expect(agentNames).toEqual(['coder-slot', 'planner-slot']);
 
 			// task types are resolved per-agent
-			const coderTask = tasks.find((t) => t.slotRole === 'coder-slot')!;
-			const plannerTask = tasks.find((t) => t.slotRole === 'planner-slot')!;
+			const coderTask = tasks.find((t) => t.agentName === 'coder-slot')!;
+			const plannerTask = tasks.find((t) => t.agentName === 'planner-slot')!;
 			expect(coderTask.taskType).toBe('coding');
 			expect(plannerTask.taskType).toBe('planning');
 		});
@@ -351,7 +351,7 @@ describe('ChannelRouter', () => {
 			workflowRunRepo.updateStatus(run.id, 'in_progress');
 
 			// Simulate a concurrent activation by directly inserting a task with the
-			// same (workflow_run_id, workflow_node_id, slot_role) before the router
+			// same (workflow_run_id, workflow_node_id, agent_name) before the router
 			// creates its task — triggering the UNIQUE constraint path.
 			const firstTask = taskRepo.createTask({
 				spaceId: SPACE_ID,
@@ -359,7 +359,7 @@ describe('ChannelRouter', () => {
 				description: '',
 				workflowRunId: run.id,
 				workflowNodeId: NODE_A,
-				slotRole: 'coder-slot',
+				agentName: 'coder-slot',
 				status: 'pending',
 			});
 
@@ -476,7 +476,7 @@ describe('ChannelRouter', () => {
 			expect(result.activatedTasks).toBeDefined();
 			expect(result.activatedTasks).toHaveLength(1);
 			expect(result.activatedTasks![0].workflowNodeId).toBe(NODE_B);
-			expect(result.activatedTasks![0].slotRole).toBe('planner');
+			expect(result.activatedTasks![0].agentName).toBe('planner');
 		});
 
 		test('does not re-activate when target node already has active tasks', async () => {
@@ -508,7 +508,7 @@ describe('ChannelRouter', () => {
 				description: '',
 				workflowRunId: run.id,
 				workflowNodeId: NODE_B,
-				slotRole: 'planner',
+				agentName: 'planner',
 				status: 'in_progress',
 			});
 

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -2073,11 +2073,11 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		expect(promptText).toContain(overridePrompt);
 	});
 
-	test('same agent twice in one node: last task uses its own slot role (not the first slot)', async () => {
+	test('same agent twice in one node: last task uses its own agent name (not the first slot)', async () => {
 		// Regression test for the slot disambiguation bug:
-		// When the same agentId appears twice in a node with different slot roles,
-		// spawn_step_agent must select the task's own slot role — not always the first match.
-		// The fix stores slotRole on the task at creation time so the lookup is exact.
+		// When the same agentId appears twice in a node with different agent names,
+		// spawn_step_agent must select the task's own agent name — not always the first match.
+		// The fix stores agentName on the task at creation time so the lookup is exact.
 		const agentId = ctx.agentId;
 		const stepId = `step-dual-${Math.random().toString(36).slice(2)}`;
 
@@ -2103,14 +2103,14 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		// The executor creates two tasks for this step (one per agent slot)
 		const { run, mainTask } = await startRun(ctx, wf);
 
-		// Verify two tasks were created with the correct slotRole each
+		// Verify two tasks were created with the correct agentName each
 		const stepTasks = ctx.taskRepo
 			.listByWorkflowRun(run.id)
 			.filter((t) => t.workflowNodeId === stepId)
 			.sort((a, b) => a.createdAt - b.createdAt);
 		expect(stepTasks).toHaveLength(2);
-		expect(stepTasks[0]?.slotRole).toBe('strict-reviewer');
-		expect(stepTasks[1]?.slotRole).toBe('quick-reviewer');
+		expect(stepTasks[0]?.agentName).toBe('strict-reviewer');
+		expect(stepTasks[1]?.agentName).toBe('quick-reviewer');
 
 		// spawn_step_agent picks stepTasks[last] = the quick-reviewer task
 		const factory = makeMockSessionFactory();
@@ -2120,7 +2120,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		expect(parsed.success).toBe(true);
 
 		// The spawned session must use 'quick-reviewer' — NOT 'strict-reviewer' (the first slot),
-		// confirming that slotRole-based lookup picks the correct slot.
+		// confirming that agentName-based lookup picks the correct slot.
 		// Note: this test only covers the last-created (quick-reviewer) task because
 		// spawn_step_agent selects stepTasks[last]. In practice the Task Agent calls
 		// spawn_step_agent once per task; the strict-reviewer task is covered by the
@@ -2133,7 +2133,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		expect(capturedInfo?.role).not.toBe('coder');
 	});
 
-	test('stale slotRole (slot removed after task creation) falls back to base agent config', async () => {
+	test('stale agentName (slot removed after task creation) falls back to base agent config', async () => {
 		// If the workflow is edited after a task was created and the slot no longer exists,
 		// agentSlot will be undefined. slotOverrides becomes { model: undefined, systemPrompt: undefined }
 		// so no override is applied — the base agent config is used as-is.
@@ -2157,12 +2157,12 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 
 		const { run, mainTask } = await startRun(ctx, wf);
 
-		// Inject a stale slotRole directly via raw SQL (no public API for this scenario —
+		// Inject a stale agentName directly via raw SQL (no public API for this scenario —
 		// it simulates the workflow definition being edited and removing the 'reviewer' slot
 		// after the task was already created).
 		ctx.db
-			.prepare(`UPDATE space_tasks SET slot_role = ? WHERE workflow_node_id = ?`)
-			.run('deleted-slot-role', stepId);
+			.prepare(`UPDATE space_tasks SET agent_name = ? WHERE workflow_node_id = ?`)
+			.run('deleted-agent-name', stepId);
 
 		// Capture the init to verify no model override is applied
 		let capturedInit: { model?: string } | null = null;
@@ -2177,7 +2177,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		const result = await handlers.spawn_step_agent({ step_id: stepId });
 		const parsed = JSON.parse(result.content[0].text);
 
-		// Spawn must succeed — stale slotRole is not a hard error
+		// Spawn must succeed — stale agentName is not a hard error
 		expect(parsed.success).toBe(true);
 		// The slot model override ('claude-opus-4-6') must NOT be applied because the slot
 		// was not found; base agent config is used instead (no model set → DEFAULT_CUSTOM_AGENT_MODEL)

--- a/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
@@ -382,7 +382,10 @@ describe('Migration 34: Add archived to status CHECK constraints', () => {
 		expect(indexes).toContain('idx_space_tasks_status');
 		expect(indexes).toContain('idx_space_tasks_workflow_run_id');
 		expect(indexes).toContain('idx_space_tasks_custom_agent_id');
-		expect(indexes).toContain('idx_space_tasks_workflow_step_id');
+		// Migration 39 rebuilds with workflow_step_id, but migration 51 later
+		// rebuilds with workflow_node_id (agent_name rename), so the final index name
+		// reflects the post-migration-51 schema.
+		expect(indexes).toContain('idx_space_tasks_workflow_node_id');
 		expect(indexes).toContain('idx_space_tasks_task_agent_session_id');
 	});
 

--- a/packages/daemon/tests/unit/storage/migrations/migration-51_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-51_test.ts
@@ -1,0 +1,333 @@
+/**
+ * Migration 51 Tests
+ *
+ * Migration 51 renames space_tasks.slot_role → agent_name and adds
+ * completion_summary TEXT column.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations, createTables } from '../../../../src/storage/schema/index.ts';
+import { runMigration51 } from '../../../../src/storage/schema/migrations.ts';
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM pragma_table_info('${table}') WHERE name = ?`)
+		.get(column);
+	return !!result;
+}
+
+function getIndexes(db: BunDatabase, table: string): string[] {
+	const rows = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? ORDER BY name`)
+		.all(table) as Array<{ name: string }>;
+	return rows.map((r) => r.name);
+}
+
+describe('Migration 51: slot_role → agent_name + completion_summary on space_tasks', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-51', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('fresh DB has agent_name column (not slot_role) and completion_summary', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		expect(columnExists(db, 'space_tasks', 'agent_name')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'completion_summary')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'slot_role')).toBe(false);
+	});
+
+	test('fresh DB has correct indexes after migration', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		const indexes = getIndexes(db, 'space_tasks');
+		expect(indexes).toContain('idx_space_tasks_space_id');
+		expect(indexes).toContain('idx_space_tasks_status');
+		expect(indexes).toContain('idx_space_tasks_workflow_run_id');
+		expect(indexes).toContain('idx_space_tasks_workflow_node_id');
+		expect(indexes).toContain('idx_space_tasks_goal_id');
+		expect(indexes).toContain('idx_space_tasks_custom_agent_id');
+		expect(indexes).toContain('idx_space_tasks_task_agent_session_id');
+	});
+
+	test('existing DB with slot_role gets renamed to agent_name', () => {
+		// Build a schema that looks like a pre-migration-51 DB (post-migration-46 schema)
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_runs (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				workflow_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				current_step_index INTEGER NOT NULL DEFAULT 0,
+				current_node_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending',
+				config TEXT,
+				iteration_count INTEGER NOT NULL DEFAULT 0,
+				max_iterations INTEGER NOT NULL DEFAULT 5,
+				goal_id TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				completed_at INTEGER,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_nodes (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal'
+					CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				task_type TEXT
+					CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+				assigned_agent TEXT
+					CHECK(assigned_agent IN ('coder', 'general')),
+				custom_agent_id TEXT,
+				slot_role TEXT,
+				workflow_run_id TEXT,
+				workflow_node_id TEXT,
+				created_by_task_id TEXT,
+				goal_id TEXT,
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				input_draft TEXT,
+				active_session TEXT
+					CHECK(active_session IN ('worker', 'leader')),
+				task_agent_session_id TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				archived_at INTEGER,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+				FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
+			)
+		`);
+		db.exec(`CREATE INDEX idx_space_tasks_space_id ON space_tasks(space_id)`);
+		db.exec(`CREATE INDEX idx_space_tasks_status ON space_tasks(status)`);
+		db.exec(`CREATE INDEX idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`);
+		db.exec(`CREATE INDEX idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`);
+		db.exec(`CREATE INDEX idx_space_tasks_goal_id ON space_tasks(goal_id)`);
+		db.exec(`CREATE INDEX idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`);
+		db.exec(
+			`CREATE INDEX idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
+		);
+
+		// Insert test data with slot_role
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/test', 'Test Space', now, now);
+
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, description, slot_role, depends_on, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('task-1', 'space-1', 'Task 1', 'Desc 1', 'coder-role', '[]', now, now);
+
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, description, slot_role, depends_on, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('task-2', 'space-1', 'Task 2', 'Desc 2', null, '[]', now, now);
+
+		// Run migration
+		runMigration51(db);
+
+		// Verify column rename
+		expect(columnExists(db, 'space_tasks', 'agent_name')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'completion_summary')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'slot_role')).toBe(false);
+	});
+
+	test('existing DB: slot_role values are preserved as agent_name', () => {
+		// Minimal setup: just spaces + space_tasks with slot_role
+		db.exec(`PRAGMA foreign_keys = OFF`);
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflow_runs (id TEXT PRIMARY KEY, space_id TEXT, workflow_id TEXT,
+				title TEXT, description TEXT DEFAULT '', current_step_index INTEGER DEFAULT 0,
+				current_node_id TEXT, status TEXT DEFAULT 'pending', config TEXT,
+				iteration_count INTEGER DEFAULT 0, max_iterations INTEGER DEFAULT 5,
+				goal_id TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflow_nodes (id TEXT PRIMARY KEY, workflow_id TEXT, name TEXT,
+				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)
+		`);
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending',
+				priority TEXT NOT NULL DEFAULT 'normal',
+				slot_role TEXT,
+				workflow_run_id TEXT,
+				workflow_node_id TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`PRAGMA foreign_keys = ON`);
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('s1', '/ws', 'S', now, now);
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, description, slot_role, depends_on, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('t1', 's1', 'Title', 'Desc', 'reviewer', '[]', now, now);
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, description, slot_role, depends_on, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('t2', 's1', 'Title2', 'Desc2', null, '[]', now, now);
+
+		runMigration51(db);
+
+		const t1 = db.prepare(`SELECT * FROM space_tasks WHERE id = ?`).get('t1') as Record<
+			string,
+			unknown
+		>;
+		const t2 = db.prepare(`SELECT * FROM space_tasks WHERE id = ?`).get('t2') as Record<
+			string,
+			unknown
+		>;
+
+		// slot_role value 'reviewer' should be in agent_name
+		expect(t1['agent_name']).toBe('reviewer');
+		expect(t1['completion_summary']).toBeNull();
+
+		// null slot_role → null agent_name
+		expect(t2['agent_name']).toBeNull();
+		expect(t2['completion_summary']).toBeNull();
+	});
+
+	test('migration is idempotent — running twice does not fail', () => {
+		// Create minimal schema without slot_role (already migrated state)
+		db.exec(`PRAGMA foreign_keys = OFF`);
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflow_runs (id TEXT PRIMARY KEY, space_id TEXT, workflow_id TEXT,
+				title TEXT, description TEXT DEFAULT '', current_step_index INTEGER DEFAULT 0,
+				current_node_id TEXT, status TEXT DEFAULT 'pending', config TEXT,
+				iteration_count INTEGER DEFAULT 0, max_iterations INTEGER DEFAULT 5,
+				goal_id TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflow_nodes (id TEXT PRIMARY KEY, workflow_id TEXT, name TEXT,
+				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)
+		`);
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending',
+				priority TEXT NOT NULL DEFAULT 'normal',
+				slot_role TEXT,
+				workflow_run_id TEXT,
+				workflow_node_id TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`PRAGMA foreign_keys = ON`);
+
+		// First run
+		expect(() => runMigration51(db)).not.toThrow();
+
+		// Second run should be a no-op (no error)
+		expect(() => runMigration51(db)).not.toThrow();
+
+		// Column state after double run
+		expect(columnExists(db, 'space_tasks', 'agent_name')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'completion_summary')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'slot_role')).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/storage/migrations/migration-54_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-54_test.ts
@@ -2,13 +2,13 @@
  * Migration 54 Tests
  *
  * Covers:
- * - Index is created on a fresh DB (workflow_node_id + slot_role present)
+ * - Index is created on a fresh DB (workflow_node_id + agent_name present)
  * - Index is skipped when workflow_node_id is absent (graceful guard)
- * - Index is skipped when slot_role is absent (graceful guard)
+ * - Index is skipped when agent_name is absent (graceful guard)
  * - Index enforces uniqueness for active-status tuples
  * - Index allows duplicate (run, node, agent) when old row is completed
  * - Index allows duplicate (run, node, agent) when old row is cancelled
- * - Index allows NULL workflow_run_id / workflow_node_id / slot_role (legacy compat)
+ * - Index allows NULL workflow_run_id / workflow_node_id / agent_name (legacy compat)
  * - Idempotent: calling runMigration54 twice does not error
  */
 
@@ -59,7 +59,7 @@ function insertTask(
 		spaceId?: string;
 		runId?: string | null;
 		nodeId?: string | null;
-		slotRole?: string | null;
+		agentName?: string | null;
 		status?: string;
 	}
 ): void {
@@ -70,7 +70,7 @@ function insertTask(
 	try {
 		db.prepare(
 			`INSERT INTO space_tasks
-		 (id, space_id, title, description, status, priority, depends_on, workflow_run_id, workflow_node_id, slot_role, created_at, updated_at)
+		 (id, space_id, title, description, status, priority, depends_on, workflow_run_id, workflow_node_id, agent_name, created_at, updated_at)
 		 VALUES (?, ?, 'Task', '', ?, 'normal', '[]', ?, ?, ?, ?, ?)`
 		).run(
 			opts.id,
@@ -78,7 +78,7 @@ function insertTask(
 			opts.status ?? 'pending',
 			opts.runId ?? null,
 			opts.nodeId ?? null,
-			opts.slotRole ?? null,
+			opts.agentName ?? null,
 			now,
 			now
 		);
@@ -121,7 +121,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 			id: 't-1',
 			runId: 'run-1',
 			nodeId: 'node-1',
-			slotRole: 'coder',
+			agentName: 'coder',
 			status: 'pending',
 		});
 		expect(() =>
@@ -129,7 +129,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 				id: 't-2',
 				runId: 'run-1',
 				nodeId: 'node-1',
-				slotRole: 'coder',
+				agentName: 'coder',
 				status: 'pending',
 			})
 		).toThrow(/UNIQUE constraint failed/);
@@ -140,7 +140,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 			id: 't-1',
 			runId: 'run-1',
 			nodeId: 'node-1',
-			slotRole: 'coder',
+			agentName: 'coder',
 			status: 'in_progress',
 		});
 		expect(() =>
@@ -148,7 +148,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 				id: 't-2',
 				runId: 'run-1',
 				nodeId: 'node-1',
-				slotRole: 'coder',
+				agentName: 'coder',
 				status: 'pending',
 			})
 		).toThrow(/UNIQUE constraint failed/);
@@ -159,7 +159,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 			id: 't-1',
 			runId: 'run-1',
 			nodeId: 'node-1',
-			slotRole: 'coder',
+			agentName: 'coder',
 			status: 'completed',
 		});
 		expect(() =>
@@ -167,7 +167,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 				id: 't-2',
 				runId: 'run-1',
 				nodeId: 'node-1',
-				slotRole: 'coder',
+				agentName: 'coder',
 				status: 'pending',
 			})
 		).not.toThrow();
@@ -178,7 +178,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 			id: 't-1',
 			runId: 'run-1',
 			nodeId: 'node-1',
-			slotRole: 'coder',
+			agentName: 'coder',
 			status: 'cancelled',
 		});
 		expect(() =>
@@ -186,7 +186,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 				id: 't-2',
 				runId: 'run-1',
 				nodeId: 'node-1',
-				slotRole: 'coder',
+				agentName: 'coder',
 				status: 'pending',
 			})
 		).not.toThrow();
@@ -197,7 +197,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 			id: 't-1',
 			runId: 'run-1',
 			nodeId: 'node-1',
-			slotRole: 'coder',
+			agentName: 'coder',
 			status: 'needs_attention',
 		});
 		expect(() =>
@@ -205,7 +205,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 				id: 't-2',
 				runId: 'run-1',
 				nodeId: 'node-1',
-				slotRole: 'coder',
+				agentName: 'coder',
 				status: 'pending',
 			})
 		).not.toThrow();
@@ -219,7 +219,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 			id: 't-1',
 			runId: 'run-1',
 			nodeId: 'node-1',
-			slotRole: 'coder',
+			agentName: 'coder',
 			status: 'draft',
 		});
 		expect(() =>
@@ -227,16 +227,16 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 				id: 't-2',
 				runId: 'run-1',
 				nodeId: 'node-1',
-				slotRole: 'coder',
+				agentName: 'coder',
 				status: 'draft',
 			})
 		).not.toThrow();
 	});
 
 	test('allows multiple legacy tasks with NULL workflow_run_id', () => {
-		insertTask(db, { id: 't-1', runId: null, nodeId: null, slotRole: null, status: 'pending' });
+		insertTask(db, { id: 't-1', runId: null, nodeId: null, agentName: null, status: 'pending' });
 		expect(() =>
-			insertTask(db, { id: 't-2', runId: null, nodeId: null, slotRole: null, status: 'pending' })
+			insertTask(db, { id: 't-2', runId: null, nodeId: null, agentName: null, status: 'pending' })
 		).not.toThrow();
 	});
 
@@ -245,7 +245,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 			id: 't-1',
 			runId: 'run-1',
 			nodeId: 'node-1',
-			slotRole: 'coder',
+			agentName: 'coder',
 			status: 'pending',
 		});
 		expect(() =>
@@ -253,7 +253,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 				id: 't-2',
 				runId: 'run-1',
 				nodeId: 'node-1',
-				slotRole: 'planner',
+				agentName: 'planner',
 				status: 'pending',
 			})
 		).not.toThrow();
@@ -273,7 +273,7 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 					description TEXT NOT NULL DEFAULT '',
 					status TEXT NOT NULL DEFAULT 'pending',
 					priority TEXT NOT NULL DEFAULT 'normal',
-					slot_role TEXT,
+					agent_name TEXT,
 					workflow_run_id TEXT,
 					depends_on TEXT NOT NULL DEFAULT '[]',
 					created_at INTEGER NOT NULL DEFAULT 0,

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -167,7 +167,12 @@ export interface SpaceTask {
 	 * Stored at task creation time so `spawn_step_agent` can unambiguously map the task
 	 * back to the correct slot even when the same `agentId` appears multiple times in the node.
 	 */
-	slotRole?: string;
+	agentName?: string;
+	/**
+	 * Brief human-readable summary written by the agent when the task reaches a terminal state
+	 * (completed, needs_attention, cancelled). Populated by the executing agent; null until set.
+	 */
+	completionSummary?: string | null;
 	/** ID of the workflow run that spawned this task (if any) */
 	workflowRunId?: string;
 	/** ID of the workflow node that spawned this task (if any) */
@@ -207,15 +212,6 @@ export interface SpaceTask {
 	 * session is created. Null when no Task Agent has been spawned yet.
 	 */
 	taskAgentSessionId?: string | null;
-	/**
-	 * Human-readable summary written by the agent when it marks the task as done.
-	 *
-	 * This field, together with `status` (set to 'completed') and `completedAt`
-	 * (auto-stamped on terminal status change), forms the complete agent completion
-	 * state. All three live on space_tasks — not on SpaceSessionGroupMember, which
-	 * is being removed in the agent-centric refactor.
-	 */
-	completionSummary?: string | null;
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Start timestamp (milliseconds since epoch) */
@@ -240,9 +236,9 @@ export interface CreateSpaceTaskParams {
 	customAgentId?: string;
 	/**
 	 * The `WorkflowNodeAgent.name` of the specific slot that spawned this task.
-	 * See `SpaceTask.slotRole` for details.
+	 * See `SpaceTask.agentName` for details.
 	 */
-	slotRole?: string;
+	agentName?: string;
 	/** Workflow run that spawned this task */
 	workflowRunId?: string;
 	/** Workflow node that spawned this task */
@@ -292,8 +288,8 @@ export interface UpdateSpaceTaskParams {
 	 */
 	taskAgentSessionId?: string | null;
 	/**
-	 * Human-readable summary written by the agent when it marks the task as done.
-	 * Set alongside `status: 'completed'`; null to clear.
+	 * Brief human-readable summary written by the agent at task completion.
+	 * Null to clear.
 	 */
 	completionSummary?: string | null;
 }
@@ -900,7 +896,7 @@ export interface UpdateSpaceWorkflowParams {
 	 */
 	rules?: WorkflowRule[] | null;
 	/**
-	 * Replaces the entire channel list. Pass `[]` or `null` to clear all channels.
+	 * Replaces the channel list. Pass `[]` or `null` to clear all channels.
 	 */
 	channels?: WorkflowChannel[] | null;
 	/**


### PR DESCRIPTION
Part of the agent-centric collaboration refactor:

- Migration 51: rename space_tasks.slot_role → agent_name; add
  completion_summary TEXT column for agent-written task summaries at
  terminal state

- SpaceTask, CreateSpaceTaskParams: rename slotRole → agentName;
  add completionSummary field

- UpdateSpaceTaskParams: add completionSummary for write support

- SpaceTaskRepository: update INSERT/SELECT to use agent_name;
  add completion_summary to rowToSpaceTask and updateTask

- SpaceRuntime.startWorkflowRun, WorkflowExecutor: update slotRole →
  agentName when creating tasks

- TaskAgentTools: update agentName-based slot lookup; update
  comments to reference agentName

- space-test-db: update schema to use agent_name and include
  completion_summary

- migration-34_test: fix expected index name (workflow_step_id →
  workflow_node_id reflects post-migration-51 final state)

- Add migration-51_test with 5 tests covering rename, data
  preservation, and idempotency
