### PR TITLE
Plan: Fix model switching bugs in NeoKai

### DIFF
--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -46,7 +46,7 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 
 **Approach**: Write an online integration test (using dev proxy) that performs a model switch mid-session and observes the `system:init` message from the SDK subprocess. The `system:init` message's `model` field is the authoritative source for which model the SDK is actually using. By comparing the `model` field before and after the switch, we can determine whether the new model takes effect.
 
-**Observability mechanism**: Subscribe to `state.sdkMessages.delta` events on the session channel via WebSocket. Listen for `type === 'system' && subtype === 'init'` messages and read the `.model` field. This pattern is already used in `packages/daemon/tests/online/agent/agent-session-sdk.test.ts` (lines 300-326).
+**Observability mechanism**: Subscribe to `state.sdkMessages.delta` events on the session channel via `daemon.messageHub.onEvent()`. Listen for `type === 'system' && subtype === 'init'` messages and read the `.model` field. Use the `waitForSystemInit()` helper pattern from `packages/daemon/tests/online/coordinator/coordinator-mode-switch.test.ts` (lines 54-97), which joins the session channel via `daemon.messageHub.joinChannel('session:' + sessionId)`, parses the `added` array from the delta payload, and matches on `msg.type === 'system' && msg.subtype === 'init'`. Adapt this helper to also extract and return the `model` field.
 
 **Decision point**: After this investigation task completes, the human reviewer will decide the Bug 2 approach based on the evidence:
 - **If the test passes** (new model appears in `system:init` after switch): model switching works without forking — the bug may be elsewhere (e.g., UI-only, race condition in restart, or already fixed). No `forkSession` implementation needed.
@@ -62,20 +62,24 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 
 **File**: `packages/daemon/tests/online/rpc/rpc-model-switching.test.ts` (append to existing file)
 
-**Key observability mechanism**: The SDK's `system:init` message (first message emitted by a new query) carries a `model` field that is the authoritative source for which model the subprocess is using. By subscribing to `state.sdkMessages.delta` events on the session channel and listening for `system:init` messages before and after the switch, we can determine whether the new model takes effect. This pattern is already used in `packages/daemon/tests/online/agent/agent-session-sdk.test.ts` (lines 300-326).
+**Key observability mechanism**: The SDK's `system:init` message (first message emitted by a new query) carries a `model` field that is the authoritative source for which model the subprocess is using. By subscribing to `state.sdkMessages.delta` events on the session channel and listening for `system:init` messages before and after the switch, we can determine whether the new model takes effect. Use the `waitForSystemInit()` helper pattern from `packages/daemon/tests/online/coordinator/coordinator-mode-switch.test.ts` (lines 54-97) — it uses `daemon.messageHub.onEvent('state.sdkMessages.delta', ...)` and `daemon.messageHub.joinChannel(...)`, which is the modern API (the old raw WebSocket `SUBSCRIBE` pattern in `agent-session-sdk.test.ts` is inside a `describe.skip` block marked "DEPRECATED").
 
 **Subtasks**:
-1. Create a helper that subscribes to `state.sdkMessages.delta` on a session channel and returns a Promise that resolves with the next `system:init` message's `model` field. Use the WebSocket subscription pattern from `agent-session-sdk.test.ts`.
+1. Create a `waitForSystemInit(sessionId)` helper adapted from `packages/daemon/tests/online/coordinator/coordinator-mode-switch.test.ts` (lines 54-97). It should:
+   - Join the session channel via `daemon.messageHub.joinChannel('session:' + sessionId)`
+   - Return a Promise that resolves with the `model` field from the next `system:init` delta event
+   - Listen via `daemon.messageHub.onEvent('state.sdkMessages.delta', ...)` and parse the `added` array
+   - Match on `msg.type === 'system' && msg.subtype === 'init'`
+   - Clean up the event listener after resolving
 
 2. Write a test (using dev proxy via `NEOKAI_USE_DEV_PROXY=1`) that:
    - Creates a session and sends a message to start a query.
-   - Captures the first `system:init` message's `model` field → `initialModel`.
-   - Waits for the query response to confirm the agent is working.
-   - Calls `session.model.switch` with a different model (e.g., `claude-sonnet-4-20250514` → `claude-haiku-4-5-20251001`).
-   - Waits for the model switch RPC to complete (the restart should happen automatically).
-   - Captures the next `system:init` message's `model` field → `postSwitchModel`.
+   - **Before sending**: call `waitForSystemInit(sessionId)` to capture the initial `model` field → `initialModel`. Wait for the query response to confirm the agent is working.
+   - Calls `session.model.switch` with a different model (e.g., `claude-sonnet-4-20250514` → `claude-haiku-4-5-20251001`) and awaits completion. The `restart()` happens internally — the RPC returns after the old query is stopped.
+   - **After the RPC returns, before sending the next message**: call `waitForSystemInit(sessionId)` to capture the post-switch `model` field → `postSwitchModel`. Do NOT subscribe before the RPC call — `restart()` may emit teardown-related events that could race with the subscription. The subscription must be set up after the RPC completes but before the post-switch message triggers a new query turn.
+   - Sends another message (this triggers the new query turn, which emits the `system:init` that `waitForSystemInit` is waiting for).
    - Asserts that `postSwitchModel !== initialModel` (the SDK subprocess is using the new model).
-   - Sends another message and waits for a response (verifying the agent is not stuck after the switch).
+   - Waits for the response (verifying the agent is not stuck after the switch).
 
 3. If the dev proxy does not support observing different models (it mocks all responses uniformly), the test can still verify that a NEW `system:init` is emitted after the switch (the `session_id` may or may not change). Document the limitation clearly.
 
@@ -192,7 +196,7 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 - Restore path also registers sessions.
 - No regression in existing SessionCache tests.
 
-**Dependencies**: Task 3
+**Dependencies**: Task 2
 
 **Agent type**: coder
 

--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -20,15 +20,15 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 
 **Fix — two registration paths**: Room sessions enter `RoomRuntimeService.agentSessions` through two distinct code paths, both of which must register in `SessionCache`:
 
-1. **New session creation** (`createAndStartSession` at line ~250): After `agentSessions.set(init.sessionId, session)`, call `ctx.sessionManager.registerSession(session)`.
+1. **New session creation** (`createAndStartSession` at line 272): After `agentSessions.set(init.sessionId, session)` (line 281), call `ctx.sessionManager.registerSession(session)`.
 
-2. **Session restoration after daemon restart** (`restoreSession` at line ~380): After `agentSessions.set(sessionId, session)`, call `ctx.sessionManager.registerSession(session)`. This is critical -- without it, the fix would only work until the first daemon restart.
+2. **Session restoration after daemon restart** (`restoreSession` at line 398): After `agentSessions.set(sessionId, session)` (line 411), call `ctx.sessionManager.registerSession(session)`. This is critical -- without it, the fix would only work until the first daemon restart.
 
 **Cleanup — all teardown paths**: Room sessions are removed from `agentSessions` through multiple code paths, each of which must unregister from `SessionCache`:
 
-1. **`stopSession()`** (line ~442, `finally` block): Called during task cancellation/completion. Add `ctx.sessionManager.unregisterSession(sessionId)`.
+1. **`stopSession()`** (line 458, `finally` block): Called during task cancellation/completion. After `agentSessions.delete(sessionId)` (line 473), add `ctx.sessionManager.unregisterSession(sessionId)`.
 
-2. **`RoomRuntimeService.stop()`** (line ~197): Called during daemon shutdown. After `this.agentSessions.clear()`, iterate the previously-cleared entries and call `ctx.sessionManager.unregisterSession()` for each. Alternatively, refactor to iterate and unregister before clearing.
+2. **`RoomRuntimeService.stop()`** (line 228): Called during daemon shutdown. Before `this.agentSessions.clear()` (line 234), iterate all entries and call `ctx.sessionManager.unregisterSession()` for each.
 
 **Why add `unregisterSession` to `SessionManager`**: `SessionManager.sessionCache` is `private`. Adding `unregisterSession(sessionId: string): void` as a thin wrapper over `this.sessionCache.remove(sessionId)` mirrors the existing `registerSession()` which wraps `this.sessionCache.set()`, maintaining API symmetry.
 
@@ -200,23 +200,23 @@ The fix requires three coordinated changes:
 
 1. Add `unregisterSession(sessionId: string): void` to `SessionManager` that delegates to `this.sessionCache.remove(sessionId)`. This mirrors `registerSession()` which delegates to `this.sessionCache.set()`.
 
-2. **Registration path 1 — new session creation**: In `createSessionFactory().createAndStartSession()` (line ~250), after `agentSessions.set(init.sessionId, session)`, add:
+2. **Registration path 1 — new session creation**: In `createSessionFactory().createAndStartSession()` (line 272), after `agentSessions.set(init.sessionId, session)` (line 281), add:
    ```ts
    ctx.sessionManager.registerSession(session);
    ```
 
-3. **Registration path 2 — daemon restart restoration**: In `createSessionFactory().restoreSession()` (line ~380), after `agentSessions.set(sessionId, session)`, add:
+3. **Registration path 2 — daemon restart restoration**: In `createSessionFactory().restoreSession()` (line 398), after `agentSessions.set(sessionId, session)` (line 411), add:
    ```ts
    ctx.sessionManager.registerSession(session);
    ```
    This is critical. Without this, sessions restored after a daemon restart would NOT be in SessionCache, and Bug 1 would reoccur on every restart. The `restoreSession()` path uses `AgentSession.restore()` instead of `AgentSession.fromInit()`, but the result is the same `AgentSession` instance that needs to be findable via `sessionManager.getSessionAsync()`.
 
-4. **Teardown path 1 — individual session stop**: In `stopSession()` (line ~442, in the `finally` block after `agentSessions.delete(sessionId)`), add:
+4. **Teardown path 1 — individual session stop**: In `stopSession()` (line 458, in the `finally` block after `agentSessions.delete(sessionId)` at line 473), add:
    ```ts
    ctx.sessionManager.unregisterSession(sessionId);
    ```
 
-5. **Teardown path 2 — service shutdown**: In `RoomRuntimeService.stop()` (line ~197), before `this.agentSessions.clear()`, iterate all entries and unregister each:
+5. **Teardown path 2 — service shutdown**: In `RoomRuntimeService.stop()` (line 228), before `this.agentSessions.clear()` (line 234), iterate all entries and unregister each:
    ```ts
    for (const sessionId of this.agentSessions.keys()) {
        ctx.sessionManager.unregisterSession(sessionId);
@@ -225,7 +225,7 @@ The fix requires three coordinated changes:
    ```
    This prevents stale room session references from remaining in SessionCache after daemon shutdown.
 
-6. Verify that the `SessionCache.getAsync()` guard (line ~100 of `session-cache.ts`) correctly prefers the registered instance if a concurrent `getAsync()` call is in-flight during registration.
+6. Verify that the `SessionCache.getAsync()` guard (line 99 of `session-cache.ts`) correctly prefers the registered instance if a concurrent `getAsync()` call is in-flight during registration.
 7. Document the namespace invariant: room role strings must never equal `"space"` (add a comment in the role definition code where roles are enumerated).
 
 **Acceptance criteria**:

--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -5,7 +5,7 @@
 Fix two model switching bugs that prevent model changes from taking effect:
 
 1. **Bug 1 (Task View)**: When switching models in the Task View, `session.model.switch` creates a NEW `AgentSession` via `SessionCache` (a separate instance from `RoomRuntimeService.agentSessions`), causing duplicate/conflicting concurrent queries for the same session.
-2. **Bug 2 (Normal Session)**: When switching models on a normal session, `sdkSessionId` is NOT cleared during the restart, so the new query resumes the old SDK session file (created with the old model). The SDK may use the session-file model over the options model, making the switch ineffective.
+2. **Bug 2 (Normal Session)**: When switching models on a normal session, the agent may stop responding or may not use the new model. Root cause is unverified — an investigation task (Task 1) will determine whether the issue actually exists and what fix is needed.
 
 ## Approach
 
@@ -38,107 +38,58 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 
 **Namespace invariant**: The disjoint namespace guarantee relies on an invariant that must be preserved: **room role strings (e.g., `coder`, `general`, `planner`, `leader`) must never equal the literal string `"space"`**. If a role named `"space"` were introduced, session IDs like `space:{roomId}:...` could collide with Space session IDs like `space:{spaceId}:task:{taskId}`. This constraint should be documented in the role definition code (where roles are defined/enumerated) to prevent future violations.
 
-### Bug 2 Fix: Use `forkSession: true` on model switch restart
+### Bug 2: Investigation — does model switching actually work?
 
-**Revised root cause**: The original analysis assumed the SDK uses the model stored in the session file when resuming, but investigation reveals the model is **NOT** stored in the session file (`.jsonl` files contain only messages, not model metadata). The SDK receives both `--model` and `--resume` as CLI flags and **should** honor the new model. However, the agent still stops responding after a model switch, suggesting the issue is likely that:
+**Observation**: Model switching worked before without forking. The original root-cause analysis assumed the SDK uses a stale model from the session file, but the model is NOT stored in the session file — `.jsonl` files contain only messages. The SDK receives `--model` and `--resume` as CLI flags and should honor the new model.
 
-1. The SDK's `setModel()` has a known issue: it doesn't update the cached `system:init` message (documented in `model-switch-handler.ts` lines 13-16). While NeoKai already restarts the query to work around this, the restart resumes the **same** session, and the SDK may still carry stale internal state from the old session.
-2. The 100ms delay in `restart()` may not be sufficient for the old subprocess to fully exit before the new one starts, causing conflicts.
+**Uncertainty**: The previous plan proposed using `forkSession: true` to work around potential stale state, but this was never verified. We need concrete evidence before committing to any fix approach.
 
-**Fix — use SDK's `forkSession: true` option**: The Claude Agent SDK supports `forkSession: true` as a query option (`packages/shared/src/sdk/sdk.d.ts:906`). When combined with `resume`, it forks the session to a **new session ID** while preserving the full conversation history. The old session file remains intact and resumable.
+**Approach**: Write an online integration test (using dev proxy) that performs a model switch mid-session and observes the `system:init` message from the SDK subprocess. The `system:init` message's `model` field is the authoritative source for which model the SDK is actually using. By comparing the `model` field before and after the switch, we can determine whether the new model takes effect.
 
-The fix requires three coordinated changes:
+**Observability mechanism**: Subscribe to `state.sdkMessages.delta` events on the session channel via WebSocket. Listen for `type === 'system' && subtype === 'init'` messages and read the `.model` field. This pattern is already used in `packages/daemon/tests/online/agent/agent-session-sdk.test.ts` (lines 300-326).
 
-1. In `ModelSwitchHandler.switchModel()`, after updating the model/provider config, set a transient flag on the session: `session._forkOnNextQuery = true`. This flag is NOT persisted to DB (it's a runtime-only signal).
-2. In `QueryOptionsBuilder.addSessionStateOptions()` (line 323 of `query-options-builder.ts`), when building options:
-   - If `session.sdkSessionId` is set AND `session._forkOnNextQuery` is true:
-     - Set `result.resume = session.sdkSessionId` (carry forward conversation history)
-     - Set `result.forkSession = true` (fork to new session, old one preserved)
-     - Clear `session._forkOnNextQuery = false` (consume the flag)
-   - Otherwise, behave as before (just set `resume` if `sdkSessionId` exists)
-3. **Critical**: Update `sdk-message-handler.ts` `handleSystemMessage()` (line 650) to allow overwriting `sdkSessionId` when it changes. The current guard `!session.sdkSessionId` prevents this — after a fork, the SDK emits a `system:init` with a NEW `session_id`, but the guard drops it because the old ID is still set. Without this fix, future restarts would resume the old (pre-fork) session instead of the forked one.
-
-**Why this preserves session resumability**:
-- The old `sdkSessionId` remains valid — the old session file is untouched and can be resumed via `--resume <old-id>` at any time.
-- The new `sdkSessionId` (from the fork) becomes the active session ID. Future queries resume the forked session (which has the full conversation history up to the fork point).
-- `forkSession` is a first-class, documented SDK feature (`Options.forkSession?: boolean`).
-
-**Why a transient flag instead of clearing sdkSessionId**:
-- Clearing `sdkSessionId` would lose the ability to resume the old session (the reviewer's concern).
-- Using `forkSession: true` preserves the old session AND starts a clean new session with the new model.
-- The SDK handles the fork atomically — no race conditions between old and new sessions.
-
-**Type-safe flag**: Add `_forkOnNextQuery?: boolean` with a `/** @internal */` JSDoc tag to the `Session` interface in `packages/shared/src/types.ts` (line ~157, near `sdkSessionId`). This avoids `(session as any)` casts scattered across multiple files, lets the TypeScript compiler catch typos, and signals the field should not be serialized to DB. The `@internal` tag marks it as private to the daemon runtime.
-
-**Error handling edge cases**:
-- If `restart()` throws after the flag is set, the flag remains but is harmless — the next successful `startStreamingQuery()` call will see the flag and apply `forkSession: true`. Note: `session.config.model` was already persisted to DB, so the next query uses the correct new model. The flag being set on retry is actually correct — the retry should fork with the new model.
-- If the user switches models multiple times before any query starts (e.g., A → B → C), each call sets `_forkOnNextQuery = true` (idempotent) and updates `session.config.model`. On the next query start, it forks to model C with the correct resume history. This is correct behavior.
-- If the SDK fork operation itself fails (e.g., corrupted session file), the SDK will likely emit an error message. The `QueryRunner` handles startup errors via its timeout/retry mechanism (lines 354-414 of `query-runner.ts`). If the fork fails, `_forkOnNextQuery` was already consumed, so the next restart attempt would resume without forking — which is acceptable since the model config is already persisted.
+**Decision point**: After this investigation task completes, the human reviewer will decide the Bug 2 approach based on the evidence:
+- **If the test passes** (new model appears in `system:init` after switch): model switching works without forking — the bug may be elsewhere (e.g., UI-only, race condition in restart, or already fixed). No `forkSession` implementation needed.
+- **If the test fails** (old model still appears in `system:init`): we have concrete proof of the issue, and can investigate further (forkSession, clearing sdkSessionId, or other approaches).
 
 ---
 
 ## Tasks
 
-### Task 1: Add `forkSession: true` support on model switch (Bug 2)
+### Task 1: Investigate whether model switching takes effect without code changes (Bug 2)
 
-**Description**: Modify `ModelSwitchHandler.switchModel()` to set a transient flag that causes the next query to fork the SDK session. Modify `QueryOptionsBuilder.addSessionStateOptions()` to detect this flag and pass `forkSession: true` alongside `resume` to the SDK. **Critical**: Update `sdk-message-handler.ts` to allow overwriting `sdkSessionId` when it changes (fork produces a new session ID).
+**Description**: Write an online integration test that performs a model switch mid-session and observes the SDK's `system:init` message to verify whether the new model actually takes effect. This task produces evidence to guide the Bug 2 fix approach — it does NOT implement any fix.
 
-**Files**:
-- `packages/shared/src/types.ts` — add `_forkOnNextQuery` to `Session` interface
-- `packages/daemon/src/lib/agent/model-switch-handler.ts` — set `_forkOnNextQuery` flag
-- `packages/daemon/src/lib/agent/query-options-builder.ts` — read flag, add `forkSession: true` to options
-- `packages/daemon/src/lib/agent/sdk-message-handler.ts` — update `sdkSessionId` capture guard to allow overwriting on fork
+**File**: `packages/daemon/tests/online/rpc/rpc-model-switching.test.ts` (append to existing file)
+
+**Key observability mechanism**: The SDK's `system:init` message (first message emitted by a new query) carries a `model` field that is the authoritative source for which model the subprocess is using. By subscribing to `state.sdkMessages.delta` events on the session channel and listening for `system:init` messages before and after the switch, we can determine whether the new model takes effect. This pattern is already used in `packages/daemon/tests/online/agent/agent-session-sdk.test.ts` (lines 300-326).
 
 **Subtasks**:
-0. Add `/** @internal */ _forkOnNextQuery?: boolean;` to the `Session` interface in `packages/shared/src/types.ts` (near `sdkSessionId` at line ~157). The `@internal` tag signals it should not be serialized to DB or exposed to clients. This avoids `as any` casts and gives the TypeScript compiler type-safety.
+1. Create a helper that subscribes to `state.sdkMessages.delta` on a session channel and returns a Promise that resolves with the next `system:init` message's `model` field. Use the WebSocket subscription pattern from `agent-session-sdk.test.ts`.
 
-1. In `ModelSwitchHandler.switchModel()`, after updating `session.config.model` and `session.config.provider` and persisting to DB (both the `!queryObject` and `queryObject` branches), set the transient flag:
-   ```ts
-   session._forkOnNextQuery = true;
-   ```
-   This is set in both branches (after the existing `db.updateSession` calls that update model/provider). The flag is NOT persisted to DB — it's a runtime-only signal.
+2. Write a test (using dev proxy via `NEOKAI_USE_DEV_PROXY=1`) that:
+   - Creates a session and sends a message to start a query.
+   - Captures the first `system:init` message's `model` field → `initialModel`.
+   - Waits for the query response to confirm the agent is working.
+   - Calls `session.model.switch` with a different model (e.g., `claude-sonnet-4-20250514` → `claude-haiku-4-5-20251001`).
+   - Waits for the model switch RPC to complete (the restart should happen automatically).
+   - Captures the next `system:init` message's `model` field → `postSwitchModel`.
+   - Asserts that `postSwitchModel !== initialModel` (the SDK subprocess is using the new model).
+   - Sends another message and waits for a response (verifying the agent is not stuck after the switch).
 
-2. In `QueryOptionsBuilder.addSessionStateOptions()` (line 323 of `query-options-builder.ts`), add logic after the `resume` block:
-   ```ts
-   // If a model switch requested a fork, use forkSession to create a new session
-   // while preserving conversation history. The old session remains resumable.
-   if (result.resume && this.ctx.session._forkOnNextQuery) {
-       result.forkSession = true;
-       this.ctx.session._forkOnNextQuery = false; // consume the flag
-   }
-   ```
-   This ensures that when `restart()` calls `startStreamingQuery()` → `runQuery()`, the query options include both `resume` (old session for history) and `forkSession: true` (create new session with new model).
+3. If the dev proxy does not support observing different models (it mocks all responses uniformly), the test can still verify that a NEW `system:init` is emitted after the switch (the `session_id` may or may not change). Document the limitation clearly.
 
-3. **Critical — update `sdk-message-handler.ts` guard**: The current guard at line 650 is `if (isSDKSystemInit(message) && !session.sdkSessionId && message.session_id)`. The `!session.sdkSessionId` condition means "only capture if we don't already have a session ID." After a fork, `session.sdkSessionId` still holds the OLD session ID, so the NEW `system:init` message (with the forked session ID) is silently dropped. This causes future restarts to resume the wrong session branch.
+4. Run the test and record the results. The test outcome determines next steps:
+   - **Pass**: Model switching works — the SDK honors `--model` even when `--resume` is set. Bug 2 may not exist as described, or the fix may be simpler than `forkSession`.
+   - **Fail**: The SDK uses the old model after a switch → we have proof that forking or another approach is needed.
 
-   Change the guard to also allow overwriting when the session ID has changed (indicating a fork):
-   ```ts
-   if (isSDKSystemInit(message) && message.session_id) {
-       const isNewSession = !session.sdkSessionId || session.sdkSessionId !== message.session_id;
-       if (isNewSession) {
-           session.sdkSessionId = message.session_id;
-           db.updateSession(session.id, { sdkSessionId: message.session_id });
-           await daemonHub.emit('session.updated', {
-               sessionId: session.id,
-               source: 'sdk-session',
-               session: { sdkSessionId: message.session_id },
-           });
-       }
-   }
-   ```
-   This preserves the existing behavior (capture on first init) while also handling session ID changes from forks or any future mechanism. The `isSDKSystemInit` guard on line 650 still ensures that other system subtypes (api_retry, status, etc.) cannot accidentally overwrite the field.
-
-4. Verify that `session.config.model` is correctly read by `QueryRunner.runQuery()` (line 159) after the model update, ensuring the new model is passed to the SDK.
+**Dev proxy considerations**: The dev proxy mock system does NOT distinguish between models — all requests get the same mock response regardless of the `model` field. The `system:init` message's `model` field is emitted by the SDK subprocess BEFORE any API request, so it reflects the CLI flag, not the mock response. The test should still be able to observe the model field from `system:init` even with dev proxy.
 
 **Acceptance criteria**:
-- `_forkOnNextQuery` is a typed field on `Session` (no `as any` casts).
-- After a model switch, the query options include both `resume` (old session ID) and `forkSession: true`.
-- The `_forkOnNextQuery` flag is consumed (set to false) after being used, so it doesn't leak into subsequent queries.
-- The old `sdkSessionId` remains in DB and can be used for resumption (not deleted).
-- A new `sdkSessionId` is captured from the `system:init` message after the fork (the guard in `sdk-message-handler.ts` allows overwriting).
-- After a fork, `session.get` returns the new (forked) `sdkSessionId`, not the old one.
-- Existing unit tests for `ModelSwitchHandler` still pass.
-- New unit test confirms `forkSession: true` is set in options on model switch (see Task 2).
+- Test produces a clear pass/fail result.
+- The `system:init` `model` field is captured before and after the switch.
+- Results are documented (pass → model switching works; fail → `forkSession` or alternative approach needed).
+- Test passes with `NEOKAI_USE_DEV_PROXY=1`.
 
 **Dependencies**: None
 
@@ -146,39 +97,11 @@ The fix requires three coordinated changes:
 
 ---
 
-### Task 2: Add unit tests for Bug 2 fix (forkSession on model switch)
-
-**Description**: Add unit tests to verify that `forkSession: true` is set in query options when a model switch occurs.
-
-**File**: `packages/daemon/tests/unit/agent/model-switch-handler.test.ts` (existing file, ~615 lines)
-
-**Subtasks**:
-1. Add a new `describe('forkSession on model switch')` block within the existing test file.
-2. Test that `_forkOnNextQuery` flag is set on the session after a successful model switch in both branches:
-   - When `queryObject` is `null` (no running query): verify flag is set.
-   - When `queryObject` is present (query running): verify flag is set and `restart()` is called.
-3. Test that `QueryOptionsBuilder.addSessionStateOptions()` produces options with `forkSession: true` when the flag is set and `sdkSessionId` exists.
-4. Test that `addSessionStateOptions()` produces options with `forkSession: true` AND `resume` set (both must be present for the fork to work).
-5. Test that the `_forkOnNextQuery` flag is consumed (set to `false`) after `addSessionStateOptions()` uses it.
-6. Test that when `_forkOnNextQuery` is NOT set, `forkSession` is NOT included in options (normal behavior).
-7. Test error path: if `restart()` throws after the flag is set, verify the flag is still set (it will be consumed on the next successful query start).
-8. Test the `sdk-message-handler.ts` guard update: simulate a `system:init` message with a DIFFERENT `session_id` than the current `session.sdkSessionId`, and verify the new ID is captured (overwriting the old one). Also verify that a `system:init` with the SAME `session_id` does NOT trigger an overwrite.
-
-**Acceptance criteria**:
-- Test confirms `_forkOnNextQuery` is set on session after model switch.
-- Test confirms `addSessionStateOptions()` sets `forkSession: true` when flag is present.
-- Test confirms `resume` is also set (conversation history is preserved).
-- Test confirms the flag is consumed after use.
-- Test confirms normal queries (no model switch) do NOT include `forkSession`.
-- All existing model switch handler tests still pass.
-
-**Dependencies**: Task 1
-
-**Agent type**: coder
+> **Decision point**: After Task 1 completes, the human reviewer will decide the Bug 2 approach based on the evidence. If the test shows model switching already works, no further Bug 2 tasks are needed. If it fails, a new task will be created with the appropriate fix (possibly `forkSession: true`, clearing `sdkSessionId`, or another approach).
 
 ---
 
-### Task 3: Add `unregisterSession` to SessionManager and register room sessions in SessionCache (Bug 1)
+### Task 2: Add `unregisterSession` to SessionManager and register room sessions in SessionCache (Bug 1)
 
 **Description**: Add `unregisterSession()` to `SessionManager` for symmetry with the existing `registerSession()`, then register room worker/leader sessions in `SessionCache` through both creation paths and unregister them through all teardown paths.
 
@@ -245,7 +168,7 @@ The fix requires three coordinated changes:
 
 ---
 
-### Task 4: Add unit tests for room session registration in SessionCache (Bug 1 tests)
+### Task 3: Add unit tests for room session registration in SessionCache (Bug 1 tests)
 
 **Description**: Add unit tests to verify that room sessions are properly registered/unregistered in SessionCache, covering both creation and restoration paths.
 
@@ -273,64 +196,3 @@ The fix requires three coordinated changes:
 
 **Agent type**: coder
 
----
-
-### Task 5: Add online integration test for model switch with forkSession (Bug 2)
-
-**Description**: Add an online integration test that verifies model switch works end-to-end, specifically that `sdkSessionId` is updated (forked) after switching models and the agent responds.
-
-**File**: `packages/daemon/tests/online/rpc/rpc-model-switching.test.ts` (existing file)
-
-**Subtasks**:
-1. Add a test (using dev proxy via `NEOKAI_USE_DEV_PROXY=1`) that:
-   - Creates a session and sends a message to establish an `sdkSessionId`.
-   - Waits for the response, then calls `session.get` to verify `sdkSessionId` is non-null. Record the original ID.
-   - Calls `session.model.switch` to switch to a different model.
-   - Waits for the model switch to complete (restart finishes).
-   - Calls `session.get` to verify `sdkSessionId` is still non-null but has CHANGED to a new value (the forked session ID).
-   - Sends another message and waits for a response (verifying the agent is not stuck).
-
-**Dev proxy considerations**: The dev proxy mock system does NOT distinguish between models -- all requests to the same endpoint get the same mock response regardless of the `model` field in the request body. This is fine for our test because we are verifying the `forkSession` behavior (observable via `session.get` showing a new `sdkSessionId`), not the actual model used by the SDK. The mock response is sufficient to confirm the agent starts a new forked query after the switch.
-
-**Note on dev proxy `forkSession` support**: The dev proxy may not fully support the `forkSession` flow since it intercepts HTTP requests. If the SDK's `--resume` + `--fork-session` flags cause the subprocess to behave differently, the dev proxy mock may need adjustment. If the forkSession option causes issues with dev proxy, this test should be marked as requiring real credentials (like the GLM model switching test) or the dev proxy mocks may need to be updated. The unit tests (Task 2) provide adequate coverage regardless. The `sdk-message-handler.ts` guard fix (Task 1, subtask 3) is a prerequisite for this test to pass — without it, the new `sdkSessionId` would not be captured.
-
-**Acceptance criteria**:
-- Test verifies `sdkSessionId` is non-null after first query.
-- Test verifies `sdkSessionId` changes (new ID) after model switch (fork occurred).
-- Test verifies agent responds after model switch (no stuck state).
-- Test passes with `NEOKAI_USE_DEV_PROXY=1` if possible, or documented as requiring real credentials.
-
-**Dependencies**: Task 1, Task 2
-
-**Agent type**: coder
-
----
-
-### Task 6: E2E test for normal session model switching
-
-**Description**: Add a Playwright E2E test that verifies normal session model switching works without causing the agent to become unresponsive.
-
-**Files**:
-- `packages/e2e/tests/` (new test file, e.g., `model-switching.e2e.ts`)
-
-**Subtasks**:
-1. Create an E2E test for normal session model switching:
-   - Navigate to the app and create a new session via the UI.
-   - Open the model selector dropdown.
-   - Switch to a different model.
-   - Verify the model indicator in the UI updates to show the new model.
-   - Type and send a message.
-   - Verify the agent responds (not stuck/silent) by waiting for a response message to appear in the chat.
-2. This test covers Bug 2 (the `forkSession` fix). It does not need to verify the internal `sdkSessionId` state (which is invisible to the browser) -- it verifies the observable behavior: the agent continues to respond after a model switch.
-
-**Task view E2E test**: A full task view E2E test for Bug 1 is deferred because it requires complex room setup (room creation, mission configuration, worker spawning, task view navigation). The Bug 1 fix (Task 3) is adequately covered by unit tests (Task 4) that verify `sessionManager.getSessionAsync()` returns the correct instance for room sessions, including the restoration path. If a regression occurs, it would be caught by those unit tests. A task view E2E test can be added in a follow-up if needed.
-
-**Acceptance criteria**:
-- Normal session model switch works without causing the agent to become unresponsive.
-- The model indicator in the UI updates correctly.
-- Test passes consistently.
-- Test follows E2E rules (all actions through UI, no direct RPC calls for assertions).
-
-**Dependencies**: Task 1
-
-**Agent type**: coder

--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -32,7 +32,11 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 
 **Why add `unregisterSession` to `SessionManager`**: `SessionManager.sessionCache` is `private`. Adding `unregisterSession(sessionId: string): void` as a thin wrapper over `this.sessionCache.remove(sessionId)` mirrors the existing `registerSession()` which wraps `this.sessionCache.set()`, maintaining API symmetry.
 
+**Race condition in `SessionCache.remove()`**: The current `remove()` method (line 141-143 of `session-cache.ts`) only calls `this.sessions.delete(sessionId)` but does **NOT** clear `this.sessionLoadLocks`. This creates a race: if a concurrent `getAsync()` call has already passed the `sessions.has()` check and is awaiting an in-flight load lock, the load will eventually resolve, check `if (!this.sessions.has(sessionId))` → true (since we just removed it), and re-insert a stale DB-loaded duplicate into the cache. The fix must also clear the load lock in `remove()`, mirroring how `set()` clears it (line 135). Since `SessionCache` is a private dependency of `SessionManager`, the implementer should update `SessionCache.remove()` to also call `this.sessionLoadLocks.delete(sessionId)`. Existing callers of `sessionCache.remove()` (in `SessionLifecycle.delete()`) will benefit from this fix as well.
+
 **Space session collision risk**: Space session IDs use the `space:{uuid}:task:{uuid}` prefix, while Room session IDs use `{role}:{roomId}:{taskId}:{uuid}` or `room:chat:{roomId}`. These are structurally disjoint namespaces, making a collision practically impossible. `SessionCache.set()` has no overwrite guard, but the disjoint namespaces make this moot. No additional guard is needed.
+
+**Namespace invariant**: The disjoint namespace guarantee relies on an invariant that must be preserved: **room role strings (e.g., `coder`, `general`, `planner`, `leader`) must never equal the literal string `"space"`**. If a role named `"space"` were introduced, session IDs like `space:{roomId}:...` could collide with Space session IDs like `space:{spaceId}:task:{taskId}`. This constraint should be documented in the role definition code (where roles are defined/enumerated) to prevent future violations.
 
 ### Bug 2 Fix: Clear sdkSessionId during model switch restart
 
@@ -109,10 +113,20 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 **Description**: Add `unregisterSession()` to `SessionManager` for symmetry with the existing `registerSession()`, then register room worker/leader sessions in `SessionCache` through both creation paths and unregister them through all teardown paths.
 
 **Files**:
+- `packages/daemon/src/lib/session/session-cache.ts` — fix `remove()` to also clear `sessionLoadLocks`
 - `packages/daemon/src/lib/session/session-manager.ts` — add `unregisterSession()` method
 - `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` — add `registerSession` in `createAndStartSession()` AND `restoreSession()`, add `unregisterSession` in `stopSession()` and `stop()`
 
 **Subtasks**:
+
+0. **Fix `SessionCache.remove()` race condition**: In `session-cache.ts`, update the `remove()` method (line 141) to also clear the session load lock:
+   ```ts
+   remove(sessionId: string): void {
+       this.sessions.delete(sessionId);
+       this.sessionLoadLocks.delete(sessionId);
+   }
+   ```
+   This mirrors `set()` (line 132-136) which already clears `sessionLoadLocks`. Without this fix, a concurrent `getAsync()` call awaiting a load lock would re-insert a stale DB-loaded duplicate after `remove()` deletes the session from `sessions`. Existing callers of `sessionCache.remove()` (e.g., `SessionLifecycle.delete()`) will also benefit from this fix.
 
 1. Add `unregisterSession(sessionId: string): void` to `SessionManager` that delegates to `this.sessionCache.remove(sessionId)`. This mirrors `registerSession()` which delegates to `this.sessionCache.set()`.
 
@@ -142,8 +156,10 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
    This prevents stale room session references from remaining in SessionCache after daemon shutdown.
 
 6. Verify that the `SessionCache.getAsync()` guard (line ~100 of `session-cache.ts`) correctly prefers the registered instance if a concurrent `getAsync()` call is in-flight during registration.
+7. Document the namespace invariant: room role strings must never equal `"space"` (add a comment in the role definition code where roles are enumerated).
 
 **Acceptance criteria**:
+- `SessionCache.remove()` also clears `sessionLoadLocks` for the removed session ID (preventing concurrent `getAsync()` from re-inserting a stale duplicate).
 - `SessionManager.unregisterSession()` is available and delegates to `sessionCache.remove()`.
 - Room sessions are registered in `SessionCache` immediately after creation via `createAndStartSession()`.
 - Room sessions are registered in `SessionCache` after restoration via `restoreSession()` (daemon restart path).
@@ -167,11 +183,13 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 **Subtasks**:
 1. Test that `SessionManager.unregisterSession()` calls `sessionCache.remove()` with the correct session ID.
-2. Test that after `registerSession()` is called, `getSessionAsync()` returns the registered instance (not a DB-loaded duplicate).
-3. Test that after `unregisterSession()` is called, `getSessionAsync()` falls through to DB loading (the session is no longer in cache).
-4. Test the concurrent access guard: if `getAsync()` is called concurrently with `registerSession()`, the registered instance is preferred over the DB-loaded one (this tests the guard at `session-cache.ts:100`).
-5. Test that restoring a session (simulating `restoreSession()` flow) also registers it in SessionCache.
-6. If possible, add an integration test that simulates room session creation via `createAndStartSession()` and verifies the session is findable via `sessionManager.getSessionAsync()`.
+2. Test that `SessionCache.remove()` also clears `sessionLoadLocks` for the removed session ID.
+3. Test the unregister race condition: if `getAsync()` has an in-flight load lock, and `remove()` is called concurrently, the load lock is cleared so the in-flight load does NOT re-insert a stale session into `sessions`.
+4. Test that after `registerSession()` is called, `getSessionAsync()` returns the registered instance (not a DB-loaded duplicate).
+5. Test that after `unregisterSession()` is called, `getSessionAsync()` falls through to DB loading (the session is no longer in cache).
+6. Test the concurrent access guard: if `getAsync()` is called concurrently with `registerSession()`, the registered instance is preferred over the DB-loaded one (this tests the guard at `session-cache.ts:100`).
+7. Test that restoring a session (simulating `restoreSession()` flow) also registers it in SessionCache.
+8. If possible, add an integration test that simulates room session creation via `createAndStartSession()` and verifies the session is findable via `sessionManager.getSessionAsync()`.
 
 **Acceptance criteria**:
 - All tests pass.

--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -38,41 +38,79 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 
 **Namespace invariant**: The disjoint namespace guarantee relies on an invariant that must be preserved: **room role strings (e.g., `coder`, `general`, `planner`, `leader`) must never equal the literal string `"space"`**. If a role named `"space"` were introduced, session IDs like `space:{roomId}:...` could collide with Space session IDs like `space:{spaceId}:task:{taskId}`. This constraint should be documented in the role definition code (where roles are defined/enumerated) to prevent future violations.
 
-### Bug 2 Fix: Clear sdkSessionId during model switch restart
+### Bug 2 Fix: Use `forkSession: true` on model switch restart
 
-The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHandler.switchModel()`): it validates the SDK session file but does NOT clear `sdkSessionId`. Since `QueryOptionsBuilder.addSessionStateOptions()` sets `result.resume = session.sdkSessionId`, the new query resumes the old session file (created with the old model).
+**Revised root cause**: The original analysis assumed the SDK uses the model stored in the session file when resuming, but investigation reveals the model is **NOT** stored in the session file (`.jsonl` files contain only messages, not model metadata). The SDK receives both `--model` and `--resume` as CLI flags and **should** honor the new model. However, the agent still stops responding after a model switch, suggesting the issue is likely that:
 
-**Fix**: In `ModelSwitchHandler.switchModel()`, clear `session.sdkSessionId` and persist the change to DB before calling `lifecycleManager.restart()`. This ensures `addSessionStateOptions()` will not set `resume`, so the new query starts fresh with the new model.
+1. The SDK's `setModel()` has a known issue: it doesn't update the cached `system:init` message (documented in `model-switch-handler.ts` lines 13-16). While NeoKai already restarts the query to work around this, the restart resumes the **same** session, and the SDK may still carry stale internal state from the old session.
+2. The 100ms delay in `restart()` may not be sufficient for the old subprocess to fully exit before the new one starts, causing conflicts.
 
-**SDK session file cleanup**: After clearing `sdkSessionId`, the old `.jsonl` session file at `~/.claude/projects/{key}/{old-sdkSessionId}.jsonl` becomes orphaned. It will NOT be deleted immediately. The existing `sdk.scan` / `sdk.cleanup` RPC handlers (on-demand user action) can identify and clean up these files. No automatic periodic cleanup exists. This is acceptable because: (a) orphan files are harmless (they consume disk space but don't affect behavior), (b) `identifyOrphanedSDKFiles()` can detect them by checking if the extracted `kaiSessionIds` match an active/archived session, (c) the session will get a new `.jsonl` file on the next query start (the old model's file is simply abandoned). The old file will be cleaned up on next `sdk.cleanup` invocation or `session.delete` (which calls `deleteSDKSessionFiles()`).
+**Fix — use SDK's `forkSession: true` option**: The Claude Agent SDK supports `forkSession: true` as a query option (`packages/shared/src/sdk/sdk.d.ts:906`). When combined with `resume`, it forks the session to a **new session ID** while preserving the full conversation history. The old session file remains intact and resumable.
 
-**Error handling edge case**: In the `queryObject` branch, `restart()` may throw. By this point, `sdkSessionId` is cleared in both memory and DB, and model/provider are already persisted. The session is in a consistent state: new model in DB, no `sdkSessionId`, but the old query is stopped. The next `ensureQueryStarted()` call will start a fresh query with the correct model and no resume. The error should propagate to the UI, but the session state is not corrupted. The `ModelSwitchHandler` already wraps the `restart()` call in a try/catch that returns `{ success: false, error }` (line ~266), so the UI will show the switch failed but the session remains usable.
+The fix modifies `QueryOptionsBuilder.addSessionStateOptions()` to set `forkSession: true` when a model switch has occurred. The mechanism:
+
+1. In `ModelSwitchHandler.switchModel()`, after updating the model/provider config, set a transient flag on the session: `session._forkOnNextQuery = true`. This flag is NOT persisted to DB (it's a runtime-only signal).
+2. In `QueryOptionsBuilder.addSessionStateOptions()` (line 323 of `query-options-builder.ts`), when building options:
+   - If `session.sdkSessionId` is set AND `session._forkOnNextQuery` is true:
+     - Set `result.resume = session.sdkSessionId` (carry forward conversation history)
+     - Set `result.forkSession = true` (fork to new session, old one preserved)
+     - Clear `session._forkOnNextQuery = false` (consume the flag)
+   - Otherwise, behave as before (just set `resume` if `sdkSessionId` exists)
+3. After the SDK starts the forked session, it emits a `system:init` message with a **new** session ID. The existing `sdk-message-handler.ts` (line 641) captures this new ID: `session.sdkSessionId = message.session_id` and persists it to DB.
+
+**Why this preserves session resumability**:
+- The old `sdkSessionId` remains valid — the old session file is untouched and can be resumed via `--resume <old-id>` at any time.
+- The new `sdkSessionId` (from the fork) becomes the active session ID. Future queries resume the forked session (which has the full conversation history up to the fork point).
+- `forkSession` is a first-class, documented SDK feature (`Options.forkSession?: boolean`).
+
+**Why a transient flag instead of clearing sdkSessionId**:
+- Clearing `sdkSessionId` would lose the ability to resume the old session (the reviewer's concern).
+- Using `forkSession: true` preserves the old session AND starts a clean new session with the new model.
+- The SDK handles the fork atomically — no race conditions between old and new sessions.
+
+**Error handling edge case**: If `restart()` throws after the flag is set, the flag remains but is harmless — the next successful `startStreamingQuery()` call will see the flag and apply `forkSession: true`. If the user switches models again before a successful restart, the flag is already set (idempotent). The flag is consumed (cleared) when `addSessionStateOptions()` actually uses it, so it won't leak into subsequent queries.
+
+**Naming the flag**: Use `session._forkOnNextQuery` with an underscore prefix to indicate it's a private/runtime-only field, consistent with how session objects carry transient state. An alternative is to add it to `session.metadata`, but that would persist to DB unnecessarily. The underscore prefix signals "do not serialize".
 
 ---
 
 ## Tasks
 
-### Task 1: Clear sdkSessionId during model switch (Bug 2)
+### Task 1: Add `forkSession: true` support on model switch (Bug 2)
 
-**Description**: Modify `ModelSwitchHandler.switchModel()` to clear `sdkSessionId` before calling `lifecycleManager.restart()`. This prevents the SDK from resuming an old session file that was created with the previous model.
+**Description**: Modify `ModelSwitchHandler.switchModel()` to set a transient flag that causes the next query to fork the SDK session (instead of resuming the same session). Then modify `QueryOptionsBuilder.addSessionStateOptions()` to detect this flag and pass `forkSession: true` alongside `resume` to the SDK.
 
-**File**: `packages/daemon/src/lib/agent/model-switch-handler.ts`
+**Files**:
+- `packages/daemon/src/lib/agent/model-switch-handler.ts` — set `_forkOnNextQuery` flag
+- `packages/daemon/src/lib/agent/query-options-builder.ts` — read flag, add `forkSession: true` to options
+- `packages/shared/src/types.ts` — add `_forkOnNextQuery` to `Session` interface (or use type assertion)
 
 **Subtasks**:
-1. In `ModelSwitchHandler.switchModel()`, after updating `session.config.model` and `session.config.provider` and persisting to DB (both the `!queryObject` and `queryObject` branches), clear `session.sdkSessionId`:
+1. In `ModelSwitchHandler.switchModel()`, after updating `session.config.model` and `session.config.provider` and persisting to DB (both the `!queryObject` and `queryObject` branches), set the transient flag:
    ```ts
-   session.sdkSessionId = undefined;
-   db.updateSession(session.id, { sdkSessionId: undefined });
+   (session as any)._forkOnNextQuery = true;
    ```
-   This should be added in both branches (lines ~189 and ~228, after the existing `db.updateSession` calls that update model/provider) to ensure `sdkSessionId` is always cleared when switching models, regardless of whether a query is running.
-2. The existing `restart()` method in `QueryLifecycleManager` already validates and repairs the SDK session file if `sdkSessionId` is set. Since we clear `sdkSessionId` before calling `restart()`, that validation block will be skipped (which is the desired behavior -- we want a fresh start, not a repair).
-3. The old SDK session `.jsonl` file becomes orphaned. Document this as intentional: it will be cleaned up by the next `sdk.cleanup` user action or `session.delete`. No immediate deletion is needed.
+   This is set in both branches (after the existing `db.updateSession` calls that update model/provider). The flag is NOT persisted to DB — it's a runtime-only signal.
+2. In `QueryOptionsBuilder.addSessionStateOptions()` (line 323 of `query-options-builder.ts`), add logic after the `resume` block:
+   ```ts
+   // If a model switch requested a fork, use forkSession to create a new session
+   // while preserving conversation history. The old session remains resumable.
+   if (result.resume && (this.ctx.session as any)._forkOnNextQuery) {
+       result.forkSession = true;
+       (this.ctx.session as any)._forkOnNextQuery = false; // consume the flag
+   }
+   ```
+   This ensures that when `restart()` calls `startStreamingQuery()` → `runQuery()`, the query options include both `resume` (old session for history) and `forkSession: true` (create new session with new model).
+3. The existing `sdk-message-handler.ts` (line 641) captures the new session ID from the `system:init` message and updates `session.sdkSessionId` in memory and DB. This happens automatically — no change needed.
+4. Verify that `session.config.model` is correctly read by `QueryRunner.runQuery()` (line 159) after the model update, ensuring the new model is passed to the SDK.
 
 **Acceptance criteria**:
-- After a model switch, `sdkSessionId` is `undefined` in both memory and DB.
-- The new query starts without `resume` in its options (verified by `addSessionStateOptions`).
+- After a model switch, the query options include both `resume` (old session ID) and `forkSession: true`.
+- The `_forkOnNextQuery` flag is consumed (set to false) after being used, so it doesn't leak into subsequent queries.
+- The old `sdkSessionId` remains in DB and can be used for resumption (not deleted).
+- A new `sdkSessionId` is captured from the `system:init` message after the fork.
 - Existing unit tests for `ModelSwitchHandler` still pass.
-- New unit test confirms `sdkSessionId` is cleared on model switch (see Task 2).
+- New unit test confirms `forkSession: true` is set in options on model switch (see Task 2).
 
 **Dependencies**: None
 
@@ -80,26 +118,29 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ---
 
-### Task 2: Add unit tests for Bug 2 fix (sdkSessionId clearing)
+### Task 2: Add unit tests for Bug 2 fix (forkSession on model switch)
 
-**Description**: Add unit tests to verify that `sdkSessionId` is cleared during model switch.
+**Description**: Add unit tests to verify that `forkSession: true` is set in query options when a model switch occurs.
 
 **File**: `packages/daemon/tests/unit/agent/model-switch-handler.test.ts` (existing file, ~615 lines)
 
 **Subtasks**:
-1. Add a new `describe('sdkSessionId clearing')` block within the existing test file.
-2. Test that `sdkSessionId` is set on the session before the switch, and is cleared (`undefined`) after a successful switch in both branches:
-   - When `queryObject` is `null` (no running query): verify `sdkSessionId` is cleared.
-   - When `queryObject` is present (query running): verify `sdkSessionId` is cleared and `restart()` is called.
-3. Verify that `db.updateSession` is called with `{ sdkSessionId: undefined }` during model switch (check the additional call beyond the model/provider update).
-4. Verify that `restart()` is still called (the clearing does not prevent the restart).
-5. Test the error path: if `restart()` throws, verify `sdkSessionId` remains cleared (the clearing happens before `restart()` is called).
+1. Add a new `describe('forkSession on model switch')` block within the existing test file.
+2. Test that `_forkOnNextQuery` flag is set on the session after a successful model switch in both branches:
+   - When `queryObject` is `null` (no running query): verify flag is set.
+   - When `queryObject` is present (query running): verify flag is set and `restart()` is called.
+3. Test that `QueryOptionsBuilder.addSessionStateOptions()` produces options with `forkSession: true` when the flag is set and `sdkSessionId` exists.
+4. Test that `addSessionStateOptions()` produces options with `forkSession: true` AND `resume` set (both must be present for the fork to work).
+5. Test that the `_forkOnNextQuery` flag is consumed (set to `false`) after `addSessionStateOptions()` uses it.
+6. Test that when `_forkOnNextQuery` is NOT set, `forkSession` is NOT included in options (normal behavior).
+7. Test error path: if `restart()` throws after the flag is set, verify the flag is still set (it will be consumed on the next successful query start).
 
 **Acceptance criteria**:
-- Test confirms `session.sdkSessionId` is cleared to `undefined` after model switch.
-- Test confirms `db.updateSession` is called with `{ sdkSessionId: undefined }`.
-- Test confirms `restart()` is still called when query is running.
-- Test confirms error in `restart()` does not revert `sdkSessionId` clearing.
+- Test confirms `_forkOnNextQuery` is set on session after model switch.
+- Test confirms `addSessionStateOptions()` sets `forkSession: true` when flag is present.
+- Test confirms `resume` is also set (conversation history is preserved).
+- Test confirms the flag is consumed after use.
+- Test confirms normal queries (no model switch) do NOT include `forkSession`.
 - All existing model switch handler tests still pass.
 
 **Dependencies**: Task 1
@@ -205,27 +246,30 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ---
 
-### Task 5: Add online integration test for model switch sdkSessionId clearing (Bug 2)
+### Task 5: Add online integration test for model switch with forkSession (Bug 2)
 
-**Description**: Add an online integration test that verifies model switch works end-to-end, specifically that `sdkSessionId` is cleared after switching models and the agent responds with the new model.
+**Description**: Add an online integration test that verifies model switch works end-to-end, specifically that `sdkSessionId` is updated (forked) after switching models and the agent responds.
 
 **File**: `packages/daemon/tests/online/rpc/rpc-model-switching.test.ts` (existing file)
 
 **Subtasks**:
 1. Add a test (using dev proxy via `NEOKAI_USE_DEV_PROXY=1`) that:
    - Creates a session and sends a message to establish an `sdkSessionId`.
-   - Waits for the response, then calls `session.get` to verify `sdkSessionId` is non-null.
+   - Waits for the response, then calls `session.get` to verify `sdkSessionId` is non-null. Record the original ID.
    - Calls `session.model.switch` to switch to a different model.
-   - Calls `session.get` again to verify `sdkSessionId` is `null`/`undefined`.
+   - Waits for the model switch to complete (restart finishes).
+   - Calls `session.get` to verify `sdkSessionId` is still non-null but has CHANGED to a new value (the forked session ID).
    - Sends another message and waits for a response (verifying the agent is not stuck).
 
-**Dev proxy considerations**: The dev proxy mock system does NOT distinguish between models -- all requests to the same endpoint get the same mock response regardless of the `model` field in the request body. This is fine for our test because we are verifying the `sdkSessionId` clearing behavior (observable via `session.get`), not the actual model used by the SDK. The mock response is sufficient to confirm the agent starts a new query after the switch.
+**Dev proxy considerations**: The dev proxy mock system does NOT distinguish between models -- all requests to the same endpoint get the same mock response regardless of the `model` field in the request body. This is fine for our test because we are verifying the `forkSession` behavior (observable via `session.get` showing a new `sdkSessionId`), not the actual model used by the SDK. The mock response is sufficient to confirm the agent starts a new forked query after the switch.
+
+**Note on dev proxy `forkSession` support**: The dev proxy may not fully support the `forkSession` flow since it intercepts HTTP requests. If the SDK's `--resume` + `--fork-session` flags cause the subprocess to behave differently, the dev proxy mock may need adjustment. If the forkSession option causes issues with dev proxy, this test should be marked as requiring real credentials (like the GLM model switching test) or the dev proxy mocks may need to be updated. The unit tests (Task 2) provide adequate coverage regardless.
 
 **Acceptance criteria**:
 - Test verifies `sdkSessionId` is non-null after first query.
-- Test verifies `sdkSessionId` is null after model switch.
+- Test verifies `sdkSessionId` changes (new ID) after model switch (fork occurred).
 - Test verifies agent responds after model switch (no stuck state).
-- Test passes with `NEOKAI_USE_DEV_PROXY=1` and does not require real API credentials.
+- Test passes with `NEOKAI_USE_DEV_PROXY=1` if possible, or documented as requiring real credentials.
 
 **Dependencies**: Task 1, Task 2
 
@@ -248,7 +292,7 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
    - Verify the model indicator in the UI updates to show the new model.
    - Type and send a message.
    - Verify the agent responds (not stuck/silent) by waiting for a response message to appear in the chat.
-2. This test covers Bug 2 (the `sdkSessionId` clearing fix). It does not need to verify the internal `sdkSessionId` state (which is invisible to the browser) -- it verifies the observable behavior: the agent continues to respond after a model switch.
+2. This test covers Bug 2 (the `forkSession` fix). It does not need to verify the internal `sdkSessionId` state (which is invisible to the browser) -- it verifies the observable behavior: the agent continues to respond after a model switch.
 
 **Task view E2E test**: A full task view E2E test for Bug 1 is deferred because it requires complex room setup (room creation, mission configuration, worker spawning, task view navigation). The Bug 1 fix (Task 3) is adequately covered by unit tests (Task 4) that verify `sessionManager.getSessionAsync()` returns the correct instance for room sessions, including the restoration path. If a regression occurs, it would be caught by those unit tests. A task view E2E test can be added in a follow-up if needed.
 

--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -9,17 +9,28 @@ Fix two model switching bugs that prevent model changes from taking effect:
 
 ## Approach
 
-### Bug 1 Fix: Route task-view model switch through RoomRuntimeService
+### Bug 1 Fix: Register room sessions in SessionCache (matching Space pattern)
 
 The root cause is that `session.model.switch` RPC handler in `session-handlers.ts` calls `sessionManager.getSessionAsync(sessionId)`, which for room worker/leader sessions creates a brand new `AgentSession` from DB via `SessionCache.loadSessionAsync()` -- because those sessions live in `RoomRuntimeService.agentSessions`, not in `SessionManager.sessionCache`.
 
-**Fix**: Add `room.runtime.model.switch` and `room.runtime.model.get` RPC handlers that operate on `RoomRuntimeService.agentSessions` directly. The `TaskViewModelSelector` component should call these new RPCs when the session belongs to a room. The existing `session.model.switch` handler remains for non-room sessions.
+**Why `registerSession` over new RPC handlers**: Space sessions (via `TaskAgentManager`) already solve this exact problem by calling `sessionManager.registerSession()` after creating sessions via `AgentSession.fromInit()`. The `SessionCache.set()` method clears any pending load locks so new `getAsync()` callers immediately see the registered instance, and `getAsync()` has a guard that prefers the registered live instance over a DB-loaded duplicate. This approach:
+- Fixes the bug for **all** RPC handlers that use `sessionManager.getSessionAsync()` (not just model switching -- also `message.send`, `message.sdkMessages`, etc.)
+- Requires **zero** new RPC handlers, no new RPC method names, no UI changes
+- Is consistent with the existing Space architecture (`task-agent-manager.ts:398`)
+
+**Fix**: In `RoomRuntimeService.createSessionFactory().createAndStartSession()`, add `ctx.sessionManager.registerSession(session)` after storing in the local `agentSessions` Map (line ~250 of `room-runtime-service.ts`). In `stopSession()`, add `ctx.sessionManager.sessionCache.remove(sessionId)` in the `finally` block (since there is no `unregisterSession()` method on `SessionManager`, directly access the cache's `remove()`).
+
+**Why not add `unregisterSession` to `SessionManager`**: `SessionManager.sessionCache` is `private`. We have two options: (a) make `sessionCache` accessible (e.g., add a public `unregisterSession` method), or (b) expose `sessionCache` via a getter. Option (a) is preferred for symmetry with `registerSession()`. However, since `stopSession` has access to the `ctx` closure which includes `sessionManager`, we can add `unregisterSession()` as a thin wrapper.
 
 ### Bug 2 Fix: Clear sdkSessionId during model switch restart
 
 The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHandler.switchModel()`): it validates the SDK session file but does NOT clear `sdkSessionId`. Since `QueryOptionsBuilder.addSessionStateOptions()` sets `result.resume = session.sdkSessionId`, the new query resumes the old session file (created with the old model).
 
 **Fix**: In `ModelSwitchHandler.switchModel()`, clear `session.sdkSessionId` and persist the change to DB before calling `lifecycleManager.restart()`. This ensures `addSessionStateOptions()` will not set `resume`, so the new query starts fresh with the new model.
+
+**SDK session file cleanup**: After clearing `sdkSessionId`, the old `.jsonl` session file at `~/.claude/projects/{key}/{old-sdkSessionId}.jsonl` becomes orphaned. It will NOT be deleted immediately. The existing `sdk.scan` / `sdk.cleanup` RPC handlers (on-demand user action) can identify and clean up these files. No automatic periodic cleanup exists. This is acceptable because: (a) orphan files are harmless (they consume disk space but don't affect behavior), (b) `identifyOrphanedSDKFiles()` can detect them by checking if the extracted `kaiSessionIds` match an active/archived session, (c) the session will get a new `.jsonl` file on the next query start (the old model's file is simply abandoned). The old file will be cleaned up on next `sdk.cleanup` invocation or `session.delete` (which calls `deleteSDKSessionFiles()`).
+
+**Error handling edge case**: In the `queryObject` branch, `restart()` may throw. By this point, `sdkSessionId` is cleared in both memory and DB, and model/provider are already persisted. The session is in a consistent state: new model in DB, no `sdkSessionId`, but the old query is stopped. The next `ensureQueryStarted()` call will start a fresh query with the correct model and no resume. The error should propagate to the UI, but the session state is not corrupted. The `ModelSwitchHandler` already wraps the `restart()` call in a try/catch that returns `{ success: false, error }` (line ~266), so the UI will show the switch failed but the session remains usable.
 
 ---
 
@@ -39,12 +50,13 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
    ```
    This should be added in both branches (lines ~189 and ~228, after the existing `db.updateSession` calls that update model/provider) to ensure `sdkSessionId` is always cleared when switching models, regardless of whether a query is running.
 2. The existing `restart()` method in `QueryLifecycleManager` already validates and repairs the SDK session file if `sdkSessionId` is set. Since we clear `sdkSessionId` before calling `restart()`, that validation block will be skipped (which is the desired behavior -- we want a fresh start, not a repair).
+3. The old SDK session `.jsonl` file becomes orphaned. Document this as intentional: it will be cleaned up by the next `sdk.cleanup` user action or `session.delete`. No immediate deletion is needed.
 
 **Acceptance criteria**:
 - After a model switch, `sdkSessionId` is `undefined` in both memory and DB.
 - The new query starts without `resume` in its options (verified by `addSessionStateOptions`).
 - Existing unit tests for `ModelSwitchHandler` still pass.
-- New unit test confirms `sdkSessionId` is cleared on model switch.
+- New unit test confirms `sdkSessionId` is cleared on model switch (see Task 2).
 
 **Dependencies**: None
 
@@ -52,20 +64,26 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ---
 
-### Task 2: Add unit tests for Bug 2 fix
+### Task 2: Add unit tests for Bug 2 fix (sdkSessionId clearing)
 
 **Description**: Add unit tests to verify that `sdkSessionId` is cleared during model switch.
 
-**File**: `packages/daemon/tests/unit/agent/model-switch-handler.test.ts`
+**File**: `packages/daemon/tests/unit/agent/model-switch-handler.test.ts` (existing file, ~615 lines)
 
 **Subtasks**:
-1. Add a test case in the model switch handler tests that verifies `sdkSessionId` is set on the session before the switch, and is cleared (`undefined`) after a successful switch. The test should mock the `QueryLifecycleManager.restart()` method and the DB `updateSession` method.
-2. Verify that `db.updateSession` is called with `{ sdkSessionId: undefined }` during model switch.
-3. Verify that `restart()` is still called (the clearing does not prevent the restart).
+1. Add a new `describe('sdkSessionId clearing')` block within the existing test file.
+2. Test that `sdkSessionId` is set on the session before the switch, and is cleared (`undefined`) after a successful switch in both branches:
+   - When `queryObject` is `null` (no running query): verify `sdkSessionId` is cleared.
+   - When `queryObject` is present (query running): verify `sdkSessionId` is cleared and `restart()` is called.
+3. Verify that `db.updateSession` is called with `{ sdkSessionId: undefined }` during model switch (check the additional call beyond the model/provider update).
+4. Verify that `restart()` is still called (the clearing does not prevent the restart).
+5. Test the error path: if `restart()` throws, verify `sdkSessionId` remains cleared (the clearing happens before `restart()` is called).
 
 **Acceptance criteria**:
 - Test confirms `session.sdkSessionId` is cleared to `undefined` after model switch.
-- Test confirms `db.updateSession` is called with the correct params.
+- Test confirms `db.updateSession` is called with `{ sdkSessionId: undefined }`.
+- Test confirms `restart()` is still called when query is running.
+- Test confirms error in `restart()` does not revert `sdkSessionId` clearing.
 - All existing model switch handler tests still pass.
 
 **Dependencies**: Task 1
@@ -74,30 +92,35 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ---
 
-### Task 3: Add `room.runtime.model.switch` and `room.runtime.model.get` RPC handlers (Bug 1)
+### Task 3: Add `unregisterSession` to SessionManager and register room sessions in SessionCache (Bug 1)
 
-**Description**: Add new RPC handlers that operate on `RoomRuntimeService.agentSessions` directly, bypassing the `SessionManager.sessionCache`. These handlers will be used by the Task View model selector.
+**Description**: Add `unregisterSession()` to `SessionManager` for symmetry with the existing `registerSession()`, then register room worker/leader sessions in `SessionCache` when they are created and unregister them when stopped. This follows the same pattern as Space sessions (`TaskAgentManager` at `task-agent-manager.ts:398`).
 
 **Files**:
-- `packages/daemon/src/lib/rpc-handlers/room-handlers.ts` (or a new file)
-- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`
+- `packages/daemon/src/lib/session/session-manager.ts` — add `unregisterSession()` method
+- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` — add `registerSession` call in `createAndStartSession()` and `unregisterSession` call in `stopSession()`
 
 **Subtasks**:
-1. Add a `switchModel(sessionId, model, provider)` method to `RoomRuntimeService` that:
-   - Looks up the `AgentSession` from `this.agentSessions` map
-   - If found, calls `agentSession.handleModelSwitch(model, provider)` and returns the result
-   - If not found, returns an error indicating the session is not managed by the room runtime
-2. Add a `getModel(sessionId)` method to `RoomRuntimeService` that:
-   - Looks up the `AgentSession` from `this.agentSessions` map
-   - If found, returns `agentSession.getCurrentModel()` and the session's provider
-   - If not found, returns null/undefined
-3. Add `room.runtime.model.switch` and `room.runtime.model.get` RPC handler registrations. These should be registered in the RPC handlers setup, passing the `RoomRuntimeService` instance.
+1. Add `unregisterSession(sessionId: string): void` to `SessionManager` that delegates to `this.sessionCache.remove(sessionId)`. This mirrors `registerSession()` which delegates to `this.sessionCache.set()`.
+2. In `RoomRuntimeService.createSessionFactory().createAndStartSession()` (line ~250), after `agentSessions.set(init.sessionId, session)`, add:
+   ```ts
+   ctx.sessionManager.registerSession(session);
+   ```
+   This ensures any RPC handler calling `sessionManager.getSessionAsync(sessionId)` for this room session will get the live instance with MCP tools, not a DB-loaded duplicate.
+3. In `RoomRuntimeService.stopSession()` (line ~442, in the `finally` block after `agentSessions.delete(sessionId)`), add:
+   ```ts
+   ctx.sessionManager.unregisterSession(sessionId);
+   ```
+   This prevents stale references in the SessionCache after the room session is stopped.
+4. Verify that the `SessionCache.getAsync()` guard (line ~100 of `session-cache.ts`) correctly prefers the registered instance if a concurrent `getAsync()` call is in-flight during registration.
 
 **Acceptance criteria**:
-- `room.runtime.model.switch` operates on the correct `AgentSession` from `RoomRuntimeService.agentSessions`.
-- `room.runtime.model.get` returns the current model from the correct instance.
-- If the session is not in the runtime service's cache, appropriate error is returned.
-- No duplicate `AgentSession` is created.
+- `SessionManager.unregisterSession()` is available and delegates to `sessionCache.remove()`.
+- Room sessions are registered in `SessionCache` immediately after creation.
+- Room sessions are unregistered from `SessionCache` when stopped.
+- `sessionManager.getSessionAsync()` for a room session returns the live instance (same object reference as in `RoomRuntimeService.agentSessions`), not a DB-loaded duplicate.
+- No duplicate `AgentSession` is created for room sessions when `session.model.switch` or any other RPC handler calls `getSessionAsync()`.
+- Existing Space session tests still pass (no regression).
 
 **Dependencies**: None
 
@@ -105,46 +128,25 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ---
 
-### Task 4: Update TaskViewModelSelector to use room.runtime.model.switch (Bug 1 UI fix)
+### Task 4: Add unit tests for room session registration in SessionCache (Bug 1 tests)
 
-**Description**: Modify the `TaskViewModelSelector` component (and the task view code that renders it) to use the new `room.runtime.model.switch` and `room.runtime.model.get` RPCs when the session belongs to a room's task view.
+**Description**: Add unit tests to verify that room sessions are properly registered/unregistered in SessionCache.
 
-**File**: `packages/web/src/components/room/TaskViewModelSelector.tsx`
-
-**Subtasks**:
-1. Add a `roomId` prop to `TaskViewModelSelector`. When `roomId` is provided:
-   - Use `room.runtime.model.switch` instead of `session.model.switch`
-   - Use `room.runtime.model.get` instead of `session.model.get`
-2. When `roomId` is not provided, fall back to the existing `session.model.switch` / `session.model.get` behavior.
-3. Update the parent component that renders `TaskViewModelSelector` to pass the `roomId` prop. Check the task view rendering code to find where `TaskViewModelSelector` is instantiated and ensure `roomId` is available.
-
-**Acceptance criteria**:
-- Task view model switching uses `room.runtime.model.switch` when `roomId` is provided.
-- The model switch operates on the correct `AgentSession` (the one in `RoomRuntimeService.agentSessions`).
-- No duplicate queries are created.
-- Fallback to `session.model.switch` works when `roomId` is not provided.
-
-**Dependencies**: Task 3
-
-**Agent type**: coder
-
----
-
-### Task 5: Add unit tests for room.runtime.model.switch (Bug 1 tests)
-
-**Description**: Add unit tests for the new `RoomRuntimeService.switchModel()` and `RoomRuntimeService.getModel()` methods.
-
-**File**: `packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts` (or new test file)
+**File**: `packages/daemon/tests/unit/room/` (new test file or append to existing room test file)
 
 **Subtasks**:
-1. Test `switchModel()` with a session that exists in `agentSessions`: verify it calls `handleModelSwitch` on the correct `AgentSession` and returns the result.
-2. Test `switchModel()` with a session that does NOT exist in `agentSessions`: verify it returns an error.
-3. Test `getModel()` with a session that exists: verify it returns the current model info.
-4. Test `getModel()` with a session that does NOT exist: verify it returns null/undefined.
+1. Test that `SessionManager.unregisterSession()` calls `sessionCache.remove()` with the correct session ID.
+2. Test that after `registerSession()` is called, `getSessionAsync()` returns the registered instance (not a DB-loaded duplicate).
+3. Test that after `unregisterSession()` is called, `getSessionAsync()` falls through to DB loading (the session is no longer in cache).
+4. Test the concurrent access guard: if `getAsync()` is called concurrently with `registerSession()`, the registered instance is preferred over the DB-loaded one (this tests the guard at `session-cache.ts:100`).
+5. If possible, add an integration test that simulates room session creation via `createAndStartSession()` and verifies the session is findable via `sessionManager.getSessionAsync()`.
 
 **Acceptance criteria**:
 - All tests pass.
-- Tests cover the happy path and error paths.
+- `unregisterSession` correctly removes from cache.
+- Registered instances are returned by `getSessionAsync()`.
+- Concurrent access guard works correctly.
+- No regression in existing SessionCache tests.
 
 **Dependencies**: Task 3
 
@@ -152,25 +154,27 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ---
 
-### Task 6: Add online integration test for model switch sdkSessionId clearing
+### Task 5: Add online integration test for model switch sdkSessionId clearing (Bug 2)
 
 **Description**: Add an online integration test that verifies model switch works end-to-end, specifically that `sdkSessionId` is cleared after switching models and the agent responds with the new model.
 
-**File**: `packages/daemon/tests/online/rpc/rpc-model-switching.test.ts`
+**File**: `packages/daemon/tests/online/rpc/rpc-model-switching.test.ts` (existing file)
 
 **Subtasks**:
-1. Add a test that:
-   - Creates a session
-   - Sends a message to get a response (establishing an `sdkSessionId`)
-   - Verifies `sdkSessionId` is set
-   - Switches to a different model
-   - Verifies `sdkSessionId` is cleared (via `session.get`)
-   - Sends another message and verifies the agent responds (not stuck)
+1. Add a test (using dev proxy via `NEOKAI_USE_DEV_PROXY=1`) that:
+   - Creates a session and sends a message to establish an `sdkSessionId`.
+   - Waits for the response, then calls `session.get` to verify `sdkSessionId` is non-null.
+   - Calls `session.model.switch` to switch to a different model.
+   - Calls `session.get` again to verify `sdkSessionId` is `null`/`undefined`.
+   - Sends another message and waits for a response (verifying the agent is not stuck).
+
+**Dev proxy considerations**: The dev proxy mock system does NOT distinguish between models -- all requests to the same endpoint get the same mock response regardless of the `model` field in the request body. This is fine for our test because we are verifying the `sdkSessionId` clearing behavior (observable via `session.get`), not the actual model used by the SDK. The mock response is sufficient to confirm the agent starts a new query after the switch.
 
 **Acceptance criteria**:
 - Test verifies `sdkSessionId` is non-null after first query.
 - Test verifies `sdkSessionId` is null after model switch.
 - Test verifies agent responds after model switch (no stuck state).
+- Test passes with `NEOKAI_USE_DEV_PROXY=1` and does not require real API credentials.
 
 **Dependencies**: Task 1, Task 2
 
@@ -178,25 +182,31 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ---
 
-### Task 7: Verify fix with E2E test
+### Task 6: E2E test for normal session model switching
 
-**Description**: Verify the model switching fix works end-to-end in the browser for both normal sessions and task view sessions.
+**Description**: Add a Playwright E2E test that verifies normal session model switching works without causing the agent to become unresponsive.
 
 **Files**:
-- `packages/e2e/tests/` (new test file)
+- `packages/e2e/tests/` (new test file, e.g., `model-switching.e2e.ts`)
 
 **Subtasks**:
 1. Create an E2E test for normal session model switching:
-   - Create a session
-   - Switch model via the model selector
-   - Send a message
-   - Verify the agent responds (not stuck/silent)
-2. If feasible based on test infrastructure complexity, add a basic smoke test for task view model switching. If the task view requires complex room setup, this can be deferred.
+   - Navigate to the app and create a new session via the UI.
+   - Open the model selector dropdown.
+   - Switch to a different model.
+   - Verify the model indicator in the UI updates to show the new model.
+   - Type and send a message.
+   - Verify the agent responds (not stuck/silent) by waiting for a response message to appear in the chat.
+2. This test covers Bug 2 (the `sdkSessionId` clearing fix). It does not need to verify the internal `sdkSessionId` state (which is invisible to the browser) -- it verifies the observable behavior: the agent continues to respond after a model switch.
+
+**Task view E2E test**: A full task view E2E test for Bug 1 is deferred because it requires complex room setup (room creation, mission configuration, worker spawning, task view navigation). The Bug 1 fix (Task 3) is adequately covered by unit tests (Task 4) that verify `sessionManager.getSessionAsync()` returns the correct instance for room sessions. If a regression occurs, it would be caught by those unit tests. A task view E2E test can be added in a follow-up if needed.
 
 **Acceptance criteria**:
 - Normal session model switch works without causing the agent to become unresponsive.
+- The model indicator in the UI updates correctly.
 - Test passes consistently.
+- Test follows E2E rules (all actions through UI, no direct RPC calls for assertions).
 
-**Dependencies**: Task 1, Task 4
+**Dependencies**: Task 1
 
 **Agent type**: coder

--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -47,7 +47,7 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 
 **Fix — use SDK's `forkSession: true` option**: The Claude Agent SDK supports `forkSession: true` as a query option (`packages/shared/src/sdk/sdk.d.ts:906`). When combined with `resume`, it forks the session to a **new session ID** while preserving the full conversation history. The old session file remains intact and resumable.
 
-The fix modifies `QueryOptionsBuilder.addSessionStateOptions()` to set `forkSession: true` when a model switch has occurred. The mechanism:
+The fix requires three coordinated changes:
 
 1. In `ModelSwitchHandler.switchModel()`, after updating the model/provider config, set a transient flag on the session: `session._forkOnNextQuery = true`. This flag is NOT persisted to DB (it's a runtime-only signal).
 2. In `QueryOptionsBuilder.addSessionStateOptions()` (line 323 of `query-options-builder.ts`), when building options:
@@ -56,7 +56,7 @@ The fix modifies `QueryOptionsBuilder.addSessionStateOptions()` to set `forkSess
      - Set `result.forkSession = true` (fork to new session, old one preserved)
      - Clear `session._forkOnNextQuery = false` (consume the flag)
    - Otherwise, behave as before (just set `resume` if `sdkSessionId` exists)
-3. After the SDK starts the forked session, it emits a `system:init` message with a **new** session ID. The existing `sdk-message-handler.ts` (line 641) captures this new ID: `session.sdkSessionId = message.session_id` and persists it to DB.
+3. **Critical**: Update `sdk-message-handler.ts` `handleSystemMessage()` (line 650) to allow overwriting `sdkSessionId` when it changes. The current guard `!session.sdkSessionId` prevents this — after a fork, the SDK emits a `system:init` with a NEW `session_id`, but the guard drops it because the old ID is still set. Without this fix, future restarts would resume the old (pre-fork) session instead of the forked one.
 
 **Why this preserves session resumability**:
 - The old `sdkSessionId` remains valid — the old session file is untouched and can be resumed via `--resume <old-id>` at any time.
@@ -68,9 +68,12 @@ The fix modifies `QueryOptionsBuilder.addSessionStateOptions()` to set `forkSess
 - Using `forkSession: true` preserves the old session AND starts a clean new session with the new model.
 - The SDK handles the fork atomically — no race conditions between old and new sessions.
 
-**Error handling edge case**: If `restart()` throws after the flag is set, the flag remains but is harmless — the next successful `startStreamingQuery()` call will see the flag and apply `forkSession: true`. If the user switches models again before a successful restart, the flag is already set (idempotent). The flag is consumed (cleared) when `addSessionStateOptions()` actually uses it, so it won't leak into subsequent queries.
+**Type-safe flag**: Add `_forkOnNextQuery?: boolean` with a `/** @internal */` JSDoc tag to the `Session` interface in `packages/shared/src/types.ts` (line ~157, near `sdkSessionId`). This avoids `(session as any)` casts scattered across multiple files, lets the TypeScript compiler catch typos, and signals the field should not be serialized to DB. The `@internal` tag marks it as private to the daemon runtime.
 
-**Naming the flag**: Use `session._forkOnNextQuery` with an underscore prefix to indicate it's a private/runtime-only field, consistent with how session objects carry transient state. An alternative is to add it to `session.metadata`, but that would persist to DB unnecessarily. The underscore prefix signals "do not serialize".
+**Error handling edge cases**:
+- If `restart()` throws after the flag is set, the flag remains but is harmless — the next successful `startStreamingQuery()` call will see the flag and apply `forkSession: true`. Note: `session.config.model` was already persisted to DB, so the next query uses the correct new model. The flag being set on retry is actually correct — the retry should fork with the new model.
+- If the user switches models multiple times before any query starts (e.g., A → B → C), each call sets `_forkOnNextQuery = true` (idempotent) and updates `session.config.model`. On the next query start, it forks to model C with the correct resume history. This is correct behavior.
+- If the SDK fork operation itself fails (e.g., corrupted session file), the SDK will likely emit an error message. The `QueryRunner` handles startup errors via its timeout/retry mechanism (lines 354-414 of `query-runner.ts`). If the fork fails, `_forkOnNextQuery` was already consumed, so the next restart attempt would resume without forking — which is acceptable since the model config is already persisted.
 
 ---
 
@@ -78,37 +81,62 @@ The fix modifies `QueryOptionsBuilder.addSessionStateOptions()` to set `forkSess
 
 ### Task 1: Add `forkSession: true` support on model switch (Bug 2)
 
-**Description**: Modify `ModelSwitchHandler.switchModel()` to set a transient flag that causes the next query to fork the SDK session (instead of resuming the same session). Then modify `QueryOptionsBuilder.addSessionStateOptions()` to detect this flag and pass `forkSession: true` alongside `resume` to the SDK.
+**Description**: Modify `ModelSwitchHandler.switchModel()` to set a transient flag that causes the next query to fork the SDK session. Modify `QueryOptionsBuilder.addSessionStateOptions()` to detect this flag and pass `forkSession: true` alongside `resume` to the SDK. **Critical**: Update `sdk-message-handler.ts` to allow overwriting `sdkSessionId` when it changes (fork produces a new session ID).
 
 **Files**:
+- `packages/shared/src/types.ts` — add `_forkOnNextQuery` to `Session` interface
 - `packages/daemon/src/lib/agent/model-switch-handler.ts` — set `_forkOnNextQuery` flag
 - `packages/daemon/src/lib/agent/query-options-builder.ts` — read flag, add `forkSession: true` to options
-- `packages/shared/src/types.ts` — add `_forkOnNextQuery` to `Session` interface (or use type assertion)
+- `packages/daemon/src/lib/agent/sdk-message-handler.ts` — update `sdkSessionId` capture guard to allow overwriting on fork
 
 **Subtasks**:
+0. Add `/** @internal */ _forkOnNextQuery?: boolean;` to the `Session` interface in `packages/shared/src/types.ts` (near `sdkSessionId` at line ~157). The `@internal` tag signals it should not be serialized to DB or exposed to clients. This avoids `as any` casts and gives the TypeScript compiler type-safety.
+
 1. In `ModelSwitchHandler.switchModel()`, after updating `session.config.model` and `session.config.provider` and persisting to DB (both the `!queryObject` and `queryObject` branches), set the transient flag:
    ```ts
-   (session as any)._forkOnNextQuery = true;
+   session._forkOnNextQuery = true;
    ```
    This is set in both branches (after the existing `db.updateSession` calls that update model/provider). The flag is NOT persisted to DB — it's a runtime-only signal.
+
 2. In `QueryOptionsBuilder.addSessionStateOptions()` (line 323 of `query-options-builder.ts`), add logic after the `resume` block:
    ```ts
    // If a model switch requested a fork, use forkSession to create a new session
    // while preserving conversation history. The old session remains resumable.
-   if (result.resume && (this.ctx.session as any)._forkOnNextQuery) {
+   if (result.resume && this.ctx.session._forkOnNextQuery) {
        result.forkSession = true;
-       (this.ctx.session as any)._forkOnNextQuery = false; // consume the flag
+       this.ctx.session._forkOnNextQuery = false; // consume the flag
    }
    ```
    This ensures that when `restart()` calls `startStreamingQuery()` → `runQuery()`, the query options include both `resume` (old session for history) and `forkSession: true` (create new session with new model).
-3. The existing `sdk-message-handler.ts` (line 641) captures the new session ID from the `system:init` message and updates `session.sdkSessionId` in memory and DB. This happens automatically — no change needed.
+
+3. **Critical — update `sdk-message-handler.ts` guard**: The current guard at line 650 is `if (isSDKSystemInit(message) && !session.sdkSessionId && message.session_id)`. The `!session.sdkSessionId` condition means "only capture if we don't already have a session ID." After a fork, `session.sdkSessionId` still holds the OLD session ID, so the NEW `system:init` message (with the forked session ID) is silently dropped. This causes future restarts to resume the wrong session branch.
+
+   Change the guard to also allow overwriting when the session ID has changed (indicating a fork):
+   ```ts
+   if (isSDKSystemInit(message) && message.session_id) {
+       const isNewSession = !session.sdkSessionId || session.sdkSessionId !== message.session_id;
+       if (isNewSession) {
+           session.sdkSessionId = message.session_id;
+           db.updateSession(session.id, { sdkSessionId: message.session_id });
+           await daemonHub.emit('session.updated', {
+               sessionId: session.id,
+               source: 'sdk-session',
+               session: { sdkSessionId: message.session_id },
+           });
+       }
+   }
+   ```
+   This preserves the existing behavior (capture on first init) while also handling session ID changes from forks or any future mechanism. The `isSDKSystemInit` guard on line 650 still ensures that other system subtypes (api_retry, status, etc.) cannot accidentally overwrite the field.
+
 4. Verify that `session.config.model` is correctly read by `QueryRunner.runQuery()` (line 159) after the model update, ensuring the new model is passed to the SDK.
 
 **Acceptance criteria**:
+- `_forkOnNextQuery` is a typed field on `Session` (no `as any` casts).
 - After a model switch, the query options include both `resume` (old session ID) and `forkSession: true`.
 - The `_forkOnNextQuery` flag is consumed (set to false) after being used, so it doesn't leak into subsequent queries.
 - The old `sdkSessionId` remains in DB and can be used for resumption (not deleted).
-- A new `sdkSessionId` is captured from the `system:init` message after the fork.
+- A new `sdkSessionId` is captured from the `system:init` message after the fork (the guard in `sdk-message-handler.ts` allows overwriting).
+- After a fork, `session.get` returns the new (forked) `sdkSessionId`, not the old one.
 - Existing unit tests for `ModelSwitchHandler` still pass.
 - New unit test confirms `forkSession: true` is set in options on model switch (see Task 2).
 
@@ -134,6 +162,7 @@ The fix modifies `QueryOptionsBuilder.addSessionStateOptions()` to set `forkSess
 5. Test that the `_forkOnNextQuery` flag is consumed (set to `false`) after `addSessionStateOptions()` uses it.
 6. Test that when `_forkOnNextQuery` is NOT set, `forkSession` is NOT included in options (normal behavior).
 7. Test error path: if `restart()` throws after the flag is set, verify the flag is still set (it will be consumed on the next successful query start).
+8. Test the `sdk-message-handler.ts` guard update: simulate a `system:init` message with a DIFFERENT `session_id` than the current `session.sdkSessionId`, and verify the new ID is captured (overwriting the old one). Also verify that a `system:init` with the SAME `session_id` does NOT trigger an overwrite.
 
 **Acceptance criteria**:
 - Test confirms `_forkOnNextQuery` is set on session after model switch.
@@ -263,7 +292,7 @@ The fix modifies `QueryOptionsBuilder.addSessionStateOptions()` to set `forkSess
 
 **Dev proxy considerations**: The dev proxy mock system does NOT distinguish between models -- all requests to the same endpoint get the same mock response regardless of the `model` field in the request body. This is fine for our test because we are verifying the `forkSession` behavior (observable via `session.get` showing a new `sdkSessionId`), not the actual model used by the SDK. The mock response is sufficient to confirm the agent starts a new forked query after the switch.
 
-**Note on dev proxy `forkSession` support**: The dev proxy may not fully support the `forkSession` flow since it intercepts HTTP requests. If the SDK's `--resume` + `--fork-session` flags cause the subprocess to behave differently, the dev proxy mock may need adjustment. If the forkSession option causes issues with dev proxy, this test should be marked as requiring real credentials (like the GLM model switching test) or the dev proxy mocks may need to be updated. The unit tests (Task 2) provide adequate coverage regardless.
+**Note on dev proxy `forkSession` support**: The dev proxy may not fully support the `forkSession` flow since it intercepts HTTP requests. If the SDK's `--resume` + `--fork-session` flags cause the subprocess to behave differently, the dev proxy mock may need adjustment. If the forkSession option causes issues with dev proxy, this test should be marked as requiring real credentials (like the GLM model switching test) or the dev proxy mocks may need to be updated. The unit tests (Task 2) provide adequate coverage regardless. The `sdk-message-handler.ts` guard fix (Task 1, subtask 3) is a prerequisite for this test to pass — without it, the new `sdkSessionId` would not be captured.
 
 **Acceptance criteria**:
 - Test verifies `sdkSessionId` is non-null after first query.

--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -18,9 +18,21 @@ The root cause is that `session.model.switch` RPC handler in `session-handlers.t
 - Requires **zero** new RPC handlers, no new RPC method names, no UI changes
 - Is consistent with the existing Space architecture (`task-agent-manager.ts:398`)
 
-**Fix**: In `RoomRuntimeService.createSessionFactory().createAndStartSession()`, add `ctx.sessionManager.registerSession(session)` after storing in the local `agentSessions` Map (line ~250 of `room-runtime-service.ts`). In `stopSession()`, add `ctx.sessionManager.sessionCache.remove(sessionId)` in the `finally` block (since there is no `unregisterSession()` method on `SessionManager`, directly access the cache's `remove()`).
+**Fix — two registration paths**: Room sessions enter `RoomRuntimeService.agentSessions` through two distinct code paths, both of which must register in `SessionCache`:
 
-**Why not add `unregisterSession` to `SessionManager`**: `SessionManager.sessionCache` is `private`. We have two options: (a) make `sessionCache` accessible (e.g., add a public `unregisterSession` method), or (b) expose `sessionCache` via a getter. Option (a) is preferred for symmetry with `registerSession()`. However, since `stopSession` has access to the `ctx` closure which includes `sessionManager`, we can add `unregisterSession()` as a thin wrapper.
+1. **New session creation** (`createAndStartSession` at line ~250): After `agentSessions.set(init.sessionId, session)`, call `ctx.sessionManager.registerSession(session)`.
+
+2. **Session restoration after daemon restart** (`restoreSession` at line ~380): After `agentSessions.set(sessionId, session)`, call `ctx.sessionManager.registerSession(session)`. This is critical -- without it, the fix would only work until the first daemon restart.
+
+**Cleanup — all teardown paths**: Room sessions are removed from `agentSessions` through multiple code paths, each of which must unregister from `SessionCache`:
+
+1. **`stopSession()`** (line ~442, `finally` block): Called during task cancellation/completion. Add `ctx.sessionManager.unregisterSession(sessionId)`.
+
+2. **`RoomRuntimeService.stop()`** (line ~197): Called during daemon shutdown. After `this.agentSessions.clear()`, iterate the previously-cleared entries and call `ctx.sessionManager.unregisterSession()` for each. Alternatively, refactor to iterate and unregister before clearing.
+
+**Why add `unregisterSession` to `SessionManager`**: `SessionManager.sessionCache` is `private`. Adding `unregisterSession(sessionId: string): void` as a thin wrapper over `this.sessionCache.remove(sessionId)` mirrors the existing `registerSession()` which wraps `this.sessionCache.set()`, maintaining API symmetry.
+
+**Space session collision risk**: Space session IDs use the `space:{uuid}:task:{uuid}` prefix, while Room session IDs use `{role}:{roomId}:{taskId}:{uuid}` or `room:chat:{roomId}`. These are structurally disjoint namespaces, making a collision practically impossible. `SessionCache.set()` has no overwrite guard, but the disjoint namespaces make this moot. No additional guard is needed.
 
 ### Bug 2 Fix: Clear sdkSessionId during model switch restart
 
@@ -94,33 +106,52 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ### Task 3: Add `unregisterSession` to SessionManager and register room sessions in SessionCache (Bug 1)
 
-**Description**: Add `unregisterSession()` to `SessionManager` for symmetry with the existing `registerSession()`, then register room worker/leader sessions in `SessionCache` when they are created and unregister them when stopped. This follows the same pattern as Space sessions (`TaskAgentManager` at `task-agent-manager.ts:398`).
+**Description**: Add `unregisterSession()` to `SessionManager` for symmetry with the existing `registerSession()`, then register room worker/leader sessions in `SessionCache` through both creation paths and unregister them through all teardown paths.
 
 **Files**:
 - `packages/daemon/src/lib/session/session-manager.ts` — add `unregisterSession()` method
-- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` — add `registerSession` call in `createAndStartSession()` and `unregisterSession` call in `stopSession()`
+- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` — add `registerSession` in `createAndStartSession()` AND `restoreSession()`, add `unregisterSession` in `stopSession()` and `stop()`
 
 **Subtasks**:
+
 1. Add `unregisterSession(sessionId: string): void` to `SessionManager` that delegates to `this.sessionCache.remove(sessionId)`. This mirrors `registerSession()` which delegates to `this.sessionCache.set()`.
-2. In `RoomRuntimeService.createSessionFactory().createAndStartSession()` (line ~250), after `agentSessions.set(init.sessionId, session)`, add:
+
+2. **Registration path 1 — new session creation**: In `createSessionFactory().createAndStartSession()` (line ~250), after `agentSessions.set(init.sessionId, session)`, add:
    ```ts
    ctx.sessionManager.registerSession(session);
    ```
-   This ensures any RPC handler calling `sessionManager.getSessionAsync(sessionId)` for this room session will get the live instance with MCP tools, not a DB-loaded duplicate.
-3. In `RoomRuntimeService.stopSession()` (line ~442, in the `finally` block after `agentSessions.delete(sessionId)`), add:
+
+3. **Registration path 2 — daemon restart restoration**: In `createSessionFactory().restoreSession()` (line ~380), after `agentSessions.set(sessionId, session)`, add:
+   ```ts
+   ctx.sessionManager.registerSession(session);
+   ```
+   This is critical. Without this, sessions restored after a daemon restart would NOT be in SessionCache, and Bug 1 would reoccur on every restart. The `restoreSession()` path uses `AgentSession.restore()` instead of `AgentSession.fromInit()`, but the result is the same `AgentSession` instance that needs to be findable via `sessionManager.getSessionAsync()`.
+
+4. **Teardown path 1 — individual session stop**: In `stopSession()` (line ~442, in the `finally` block after `agentSessions.delete(sessionId)`), add:
    ```ts
    ctx.sessionManager.unregisterSession(sessionId);
    ```
-   This prevents stale references in the SessionCache after the room session is stopped.
-4. Verify that the `SessionCache.getAsync()` guard (line ~100 of `session-cache.ts`) correctly prefers the registered instance if a concurrent `getAsync()` call is in-flight during registration.
+
+5. **Teardown path 2 — service shutdown**: In `RoomRuntimeService.stop()` (line ~197), before `this.agentSessions.clear()`, iterate all entries and unregister each:
+   ```ts
+   for (const sessionId of this.agentSessions.keys()) {
+       ctx.sessionManager.unregisterSession(sessionId);
+   }
+   this.agentSessions.clear();
+   ```
+   This prevents stale room session references from remaining in SessionCache after daemon shutdown.
+
+6. Verify that the `SessionCache.getAsync()` guard (line ~100 of `session-cache.ts`) correctly prefers the registered instance if a concurrent `getAsync()` call is in-flight during registration.
 
 **Acceptance criteria**:
 - `SessionManager.unregisterSession()` is available and delegates to `sessionCache.remove()`.
-- Room sessions are registered in `SessionCache` immediately after creation.
-- Room sessions are unregistered from `SessionCache` when stopped.
+- Room sessions are registered in `SessionCache` immediately after creation via `createAndStartSession()`.
+- Room sessions are registered in `SessionCache` after restoration via `restoreSession()` (daemon restart path).
+- Room sessions are unregistered from `SessionCache` when stopped via `stopSession()`.
+- Room sessions are unregistered from `SessionCache` when the service shuts down via `stop()`.
 - `sessionManager.getSessionAsync()` for a room session returns the live instance (same object reference as in `RoomRuntimeService.agentSessions`), not a DB-loaded duplicate.
 - No duplicate `AgentSession` is created for room sessions when `session.model.switch` or any other RPC handler calls `getSessionAsync()`.
-- Existing Space session tests still pass (no regression).
+- Existing Space session tests still pass (no regression -- Space and Room session IDs use disjoint namespaces: `space:{uuid}:task:{uuid}` vs `{role}:{roomId}:{taskId}:{uuid}`).
 
 **Dependencies**: None
 
@@ -130,7 +161,7 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 
 ### Task 4: Add unit tests for room session registration in SessionCache (Bug 1 tests)
 
-**Description**: Add unit tests to verify that room sessions are properly registered/unregistered in SessionCache.
+**Description**: Add unit tests to verify that room sessions are properly registered/unregistered in SessionCache, covering both creation and restoration paths.
 
 **File**: `packages/daemon/tests/unit/room/` (new test file or append to existing room test file)
 
@@ -139,13 +170,15 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
 2. Test that after `registerSession()` is called, `getSessionAsync()` returns the registered instance (not a DB-loaded duplicate).
 3. Test that after `unregisterSession()` is called, `getSessionAsync()` falls through to DB loading (the session is no longer in cache).
 4. Test the concurrent access guard: if `getAsync()` is called concurrently with `registerSession()`, the registered instance is preferred over the DB-loaded one (this tests the guard at `session-cache.ts:100`).
-5. If possible, add an integration test that simulates room session creation via `createAndStartSession()` and verifies the session is findable via `sessionManager.getSessionAsync()`.
+5. Test that restoring a session (simulating `restoreSession()` flow) also registers it in SessionCache.
+6. If possible, add an integration test that simulates room session creation via `createAndStartSession()` and verifies the session is findable via `sessionManager.getSessionAsync()`.
 
 **Acceptance criteria**:
 - All tests pass.
 - `unregisterSession` correctly removes from cache.
 - Registered instances are returned by `getSessionAsync()`.
 - Concurrent access guard works correctly.
+- Restore path also registers sessions.
 - No regression in existing SessionCache tests.
 
 **Dependencies**: Task 3
@@ -199,7 +232,7 @@ The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHa
    - Verify the agent responds (not stuck/silent) by waiting for a response message to appear in the chat.
 2. This test covers Bug 2 (the `sdkSessionId` clearing fix). It does not need to verify the internal `sdkSessionId` state (which is invisible to the browser) -- it verifies the observable behavior: the agent continues to respond after a model switch.
 
-**Task view E2E test**: A full task view E2E test for Bug 1 is deferred because it requires complex room setup (room creation, mission configuration, worker spawning, task view navigation). The Bug 1 fix (Task 3) is adequately covered by unit tests (Task 4) that verify `sessionManager.getSessionAsync()` returns the correct instance for room sessions. If a regression occurs, it would be caught by those unit tests. A task view E2E test can be added in a follow-up if needed.
+**Task view E2E test**: A full task view E2E test for Bug 1 is deferred because it requires complex room setup (room creation, mission configuration, worker spawning, task view navigation). The Bug 1 fix (Task 3) is adequately covered by unit tests (Task 4) that verify `sessionManager.getSessionAsync()` returns the correct instance for room sessions, including the restoration path. If a regression occurs, it would be caught by those unit tests. A task view E2E test can be added in a follow-up if needed.
 
 **Acceptance criteria**:
 - Normal session model switch works without causing the agent to become unresponsive.

--- a/docs/plans/fix-model-switching-bugs-in-neokai.md
+++ b/docs/plans/fix-model-switching-bugs-in-neokai.md
@@ -1,0 +1,202 @@
+# Fix Model Switching Bugs in NeoKai
+
+## Goal Summary
+
+Fix two model switching bugs that prevent model changes from taking effect:
+
+1. **Bug 1 (Task View)**: When switching models in the Task View, `session.model.switch` creates a NEW `AgentSession` via `SessionCache` (a separate instance from `RoomRuntimeService.agentSessions`), causing duplicate/conflicting concurrent queries for the same session.
+2. **Bug 2 (Normal Session)**: When switching models on a normal session, `sdkSessionId` is NOT cleared during the restart, so the new query resumes the old SDK session file (created with the old model). The SDK may use the session-file model over the options model, making the switch ineffective.
+
+## Approach
+
+### Bug 1 Fix: Route task-view model switch through RoomRuntimeService
+
+The root cause is that `session.model.switch` RPC handler in `session-handlers.ts` calls `sessionManager.getSessionAsync(sessionId)`, which for room worker/leader sessions creates a brand new `AgentSession` from DB via `SessionCache.loadSessionAsync()` -- because those sessions live in `RoomRuntimeService.agentSessions`, not in `SessionManager.sessionCache`.
+
+**Fix**: Add `room.runtime.model.switch` and `room.runtime.model.get` RPC handlers that operate on `RoomRuntimeService.agentSessions` directly. The `TaskViewModelSelector` component should call these new RPCs when the session belongs to a room. The existing `session.model.switch` handler remains for non-room sessions.
+
+### Bug 2 Fix: Clear sdkSessionId during model switch restart
+
+The root cause is in `QueryLifecycleManager.restart()` (called by `ModelSwitchHandler.switchModel()`): it validates the SDK session file but does NOT clear `sdkSessionId`. Since `QueryOptionsBuilder.addSessionStateOptions()` sets `result.resume = session.sdkSessionId`, the new query resumes the old session file (created with the old model).
+
+**Fix**: In `ModelSwitchHandler.switchModel()`, clear `session.sdkSessionId` and persist the change to DB before calling `lifecycleManager.restart()`. This ensures `addSessionStateOptions()` will not set `resume`, so the new query starts fresh with the new model.
+
+---
+
+## Tasks
+
+### Task 1: Clear sdkSessionId during model switch (Bug 2)
+
+**Description**: Modify `ModelSwitchHandler.switchModel()` to clear `sdkSessionId` before calling `lifecycleManager.restart()`. This prevents the SDK from resuming an old session file that was created with the previous model.
+
+**File**: `packages/daemon/src/lib/agent/model-switch-handler.ts`
+
+**Subtasks**:
+1. In `ModelSwitchHandler.switchModel()`, after updating `session.config.model` and `session.config.provider` and persisting to DB (both the `!queryObject` and `queryObject` branches), clear `session.sdkSessionId`:
+   ```ts
+   session.sdkSessionId = undefined;
+   db.updateSession(session.id, { sdkSessionId: undefined });
+   ```
+   This should be added in both branches (lines ~189 and ~228, after the existing `db.updateSession` calls that update model/provider) to ensure `sdkSessionId` is always cleared when switching models, regardless of whether a query is running.
+2. The existing `restart()` method in `QueryLifecycleManager` already validates and repairs the SDK session file if `sdkSessionId` is set. Since we clear `sdkSessionId` before calling `restart()`, that validation block will be skipped (which is the desired behavior -- we want a fresh start, not a repair).
+
+**Acceptance criteria**:
+- After a model switch, `sdkSessionId` is `undefined` in both memory and DB.
+- The new query starts without `resume` in its options (verified by `addSessionStateOptions`).
+- Existing unit tests for `ModelSwitchHandler` still pass.
+- New unit test confirms `sdkSessionId` is cleared on model switch.
+
+**Dependencies**: None
+
+**Agent type**: coder
+
+---
+
+### Task 2: Add unit tests for Bug 2 fix
+
+**Description**: Add unit tests to verify that `sdkSessionId` is cleared during model switch.
+
+**File**: `packages/daemon/tests/unit/agent/model-switch-handler.test.ts`
+
+**Subtasks**:
+1. Add a test case in the model switch handler tests that verifies `sdkSessionId` is set on the session before the switch, and is cleared (`undefined`) after a successful switch. The test should mock the `QueryLifecycleManager.restart()` method and the DB `updateSession` method.
+2. Verify that `db.updateSession` is called with `{ sdkSessionId: undefined }` during model switch.
+3. Verify that `restart()` is still called (the clearing does not prevent the restart).
+
+**Acceptance criteria**:
+- Test confirms `session.sdkSessionId` is cleared to `undefined` after model switch.
+- Test confirms `db.updateSession` is called with the correct params.
+- All existing model switch handler tests still pass.
+
+**Dependencies**: Task 1
+
+**Agent type**: coder
+
+---
+
+### Task 3: Add `room.runtime.model.switch` and `room.runtime.model.get` RPC handlers (Bug 1)
+
+**Description**: Add new RPC handlers that operate on `RoomRuntimeService.agentSessions` directly, bypassing the `SessionManager.sessionCache`. These handlers will be used by the Task View model selector.
+
+**Files**:
+- `packages/daemon/src/lib/rpc-handlers/room-handlers.ts` (or a new file)
+- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`
+
+**Subtasks**:
+1. Add a `switchModel(sessionId, model, provider)` method to `RoomRuntimeService` that:
+   - Looks up the `AgentSession` from `this.agentSessions` map
+   - If found, calls `agentSession.handleModelSwitch(model, provider)` and returns the result
+   - If not found, returns an error indicating the session is not managed by the room runtime
+2. Add a `getModel(sessionId)` method to `RoomRuntimeService` that:
+   - Looks up the `AgentSession` from `this.agentSessions` map
+   - If found, returns `agentSession.getCurrentModel()` and the session's provider
+   - If not found, returns null/undefined
+3. Add `room.runtime.model.switch` and `room.runtime.model.get` RPC handler registrations. These should be registered in the RPC handlers setup, passing the `RoomRuntimeService` instance.
+
+**Acceptance criteria**:
+- `room.runtime.model.switch` operates on the correct `AgentSession` from `RoomRuntimeService.agentSessions`.
+- `room.runtime.model.get` returns the current model from the correct instance.
+- If the session is not in the runtime service's cache, appropriate error is returned.
+- No duplicate `AgentSession` is created.
+
+**Dependencies**: None
+
+**Agent type**: coder
+
+---
+
+### Task 4: Update TaskViewModelSelector to use room.runtime.model.switch (Bug 1 UI fix)
+
+**Description**: Modify the `TaskViewModelSelector` component (and the task view code that renders it) to use the new `room.runtime.model.switch` and `room.runtime.model.get` RPCs when the session belongs to a room's task view.
+
+**File**: `packages/web/src/components/room/TaskViewModelSelector.tsx`
+
+**Subtasks**:
+1. Add a `roomId` prop to `TaskViewModelSelector`. When `roomId` is provided:
+   - Use `room.runtime.model.switch` instead of `session.model.switch`
+   - Use `room.runtime.model.get` instead of `session.model.get`
+2. When `roomId` is not provided, fall back to the existing `session.model.switch` / `session.model.get` behavior.
+3. Update the parent component that renders `TaskViewModelSelector` to pass the `roomId` prop. Check the task view rendering code to find where `TaskViewModelSelector` is instantiated and ensure `roomId` is available.
+
+**Acceptance criteria**:
+- Task view model switching uses `room.runtime.model.switch` when `roomId` is provided.
+- The model switch operates on the correct `AgentSession` (the one in `RoomRuntimeService.agentSessions`).
+- No duplicate queries are created.
+- Fallback to `session.model.switch` works when `roomId` is not provided.
+
+**Dependencies**: Task 3
+
+**Agent type**: coder
+
+---
+
+### Task 5: Add unit tests for room.runtime.model.switch (Bug 1 tests)
+
+**Description**: Add unit tests for the new `RoomRuntimeService.switchModel()` and `RoomRuntimeService.getModel()` methods.
+
+**File**: `packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts` (or new test file)
+
+**Subtasks**:
+1. Test `switchModel()` with a session that exists in `agentSessions`: verify it calls `handleModelSwitch` on the correct `AgentSession` and returns the result.
+2. Test `switchModel()` with a session that does NOT exist in `agentSessions`: verify it returns an error.
+3. Test `getModel()` with a session that exists: verify it returns the current model info.
+4. Test `getModel()` with a session that does NOT exist: verify it returns null/undefined.
+
+**Acceptance criteria**:
+- All tests pass.
+- Tests cover the happy path and error paths.
+
+**Dependencies**: Task 3
+
+**Agent type**: coder
+
+---
+
+### Task 6: Add online integration test for model switch sdkSessionId clearing
+
+**Description**: Add an online integration test that verifies model switch works end-to-end, specifically that `sdkSessionId` is cleared after switching models and the agent responds with the new model.
+
+**File**: `packages/daemon/tests/online/rpc/rpc-model-switching.test.ts`
+
+**Subtasks**:
+1. Add a test that:
+   - Creates a session
+   - Sends a message to get a response (establishing an `sdkSessionId`)
+   - Verifies `sdkSessionId` is set
+   - Switches to a different model
+   - Verifies `sdkSessionId` is cleared (via `session.get`)
+   - Sends another message and verifies the agent responds (not stuck)
+
+**Acceptance criteria**:
+- Test verifies `sdkSessionId` is non-null after first query.
+- Test verifies `sdkSessionId` is null after model switch.
+- Test verifies agent responds after model switch (no stuck state).
+
+**Dependencies**: Task 1, Task 2
+
+**Agent type**: coder
+
+---
+
+### Task 7: Verify fix with E2E test
+
+**Description**: Verify the model switching fix works end-to-end in the browser for both normal sessions and task view sessions.
+
+**Files**:
+- `packages/e2e/tests/` (new test file)
+
+**Subtasks**:
+1. Create an E2E test for normal session model switching:
+   - Create a session
+   - Switch model via the model selector
+   - Send a message
+   - Verify the agent responds (not stuck/silent)
+2. If feasible based on test infrastructure complexity, add a basic smoke test for task view model switching. If the task view requires complex room setup, this can be deferred.
+
+**Acceptance criteria**:
+- Normal session model switch works without causing the agent to become unresponsive.
+- Test passes consistently.
+
+**Dependencies**: Task 1, Task 4
+
+**Agent type**: coder

--- a/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -10,6 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import * as fs from 'fs/promises';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'path';
 import * as os from 'os';
 import { AnthropicToCodexBridgeProvider } from '../../../src/lib/providers/anthropic-to-codex-bridge-provider';
@@ -33,24 +34,34 @@ const fakeCodexFound = () => '/usr/local/bin/codex';
 /** A codexFinder that always returns null — simulates codex not installed. */
 const fakeCodexMissing = () => null;
 
-/** Write a NeoKai auth.json with an openai entry to a temp dir. */
-async function writeNeokaiAuth(dir: string, credentials: Record<string, unknown>): Promise<void> {
-	await fs.mkdir(dir, { recursive: true });
-	await fs.writeFile(path.join(dir, 'auth.json'), JSON.stringify({ openai: credentials }), {
+/**
+ * Write a NeoKai auth.json with an openai entry to a temp dir.
+ *
+ * Uses synchronous I/O to ensure the file is fully written before the
+ * provider reads it — Bun 1.3.10 on Linux may resolve async writes before
+ * data is durable, causing immediate subsequent reads to fail.
+ */
+function writeNeokaiAuth(dir: string, credentials: Record<string, unknown>): void {
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(path.join(dir, 'auth.json'), JSON.stringify({ openai: credentials }), {
 		mode: 0o600,
 	});
 }
 
-/** Write a ~/.codex/auth.json format file to a temp dir. */
-async function writeCodexAuth(
+/**
+ * Write a ~/.codex/auth.json format file to a temp dir.
+ *
+ * Uses synchronous I/O for the same reason as writeNeokaiAuth.
+ */
+function writeCodexAuth(
 	dir: string,
 	data: {
 		OPENAI_API_KEY?: string | null;
 		tokens?: { access_token?: string; refresh_token?: string; account_id?: string };
 	}
-): Promise<void> {
-	await fs.mkdir(dir, { recursive: true });
-	await fs.writeFile(path.join(dir, 'auth.json'), JSON.stringify(data), { mode: 0o600 });
+): void {
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(path.join(dir, 'auth.json'), JSON.stringify(data), { mode: 0o600 });
 }
 
 // ---------------------------------------------------------------------------
@@ -67,17 +78,17 @@ describe('AnthropicToCodexBridgeProvider', () => {
 	describe('getAuthStatus()', () => {
 		let emptyDir: string;
 
-		beforeEach(async () => {
+		beforeEach(() => {
 			// Use isolated empty dirs so file-based auth doesn't interfere
-			emptyDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neokai-auth-test-'));
+			emptyDir = mkdtempSync(path.join(os.tmpdir(), 'neokai-auth-test-'));
 		});
 
-		afterEach(async () => {
-			await fs.rm(emptyDir, { recursive: true, force: true });
+		afterEach(() => {
+			rmSync(emptyDir, { recursive: true, force: true });
 		});
 
 		it('returns isAuthenticated=false when no credentials', async () => {
-			provider = makeProvider({}, emptyDir, emptyDir);
+			provider = makeProvider({}, emptyDir, emptyDir, fakeCodexMissing);
 			const result = await provider.getAuthStatus();
 			expect(result.isAuthenticated).toBe(false);
 			expect(result.error).toBeTruthy();
@@ -101,7 +112,12 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		});
 
 		it('returns isAuthenticated=false with descriptive error when env vars are empty', async () => {
-			provider = makeProvider({ OPENAI_API_KEY: '', CODEX_API_KEY: '' }, emptyDir, emptyDir);
+			provider = makeProvider(
+				{ OPENAI_API_KEY: '', CODEX_API_KEY: '' },
+				emptyDir,
+				emptyDir,
+				fakeCodexMissing
+			);
 			const result = await provider.getAuthStatus();
 			expect(result.isAuthenticated).toBe(false);
 			expect(result.error).toBeTruthy();
@@ -110,7 +126,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('returns isAuthenticated=false with binary-not-found error when NeoKai OAuth stored but codex missing', async () => {
 			const neokaiDir = path.join(emptyDir, 'neokai');
 			const codexDir = path.join(emptyDir, 'codex');
-			await writeNeokaiAuth(neokaiDir, {
+			writeNeokaiAuth(neokaiDir, {
 				type: 'oauth',
 				access: 'oauth-access-token',
 				refresh: 'oauth-refresh-token',
@@ -125,7 +141,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('returns isAuthenticated=true when NeoKai OAuth credentials in auth.json and codex found', async () => {
 			const neokaiDir = path.join(emptyDir, 'neokai');
 			const codexDir = path.join(emptyDir, 'codex');
-			await writeNeokaiAuth(neokaiDir, {
+			writeNeokaiAuth(neokaiDir, {
 				type: 'oauth',
 				access: 'oauth-access-token',
 				refresh: 'oauth-refresh-token',
@@ -141,7 +157,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('returns isAuthenticated=false for api_key type in auth.json (not NeoKai OAuth)', async () => {
 			const neokaiDir = path.join(emptyDir, 'neokai');
 			const codexDir = path.join(emptyDir, 'codex');
-			await writeNeokaiAuth(neokaiDir, { type: 'api_key', access: 'sk-imported-key' });
+			writeNeokaiAuth(neokaiDir, { type: 'api_key', access: 'sk-imported-key' });
 			provider = makeProvider({}, neokaiDir, codexDir, fakeCodexFound);
 			const result = await provider.getAuthStatus();
 			expect(result.isAuthenticated).toBe(false);
@@ -150,7 +166,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('sets needsRefresh when NeoKai OAuth token is expired', async () => {
 			const neokaiDir = path.join(emptyDir, 'neokai');
 			const codexDir = path.join(emptyDir, 'codex');
-			await writeNeokaiAuth(neokaiDir, {
+			writeNeokaiAuth(neokaiDir, {
 				type: 'oauth',
 				access: 'oauth-access-token',
 				refresh: 'oauth-refresh-token',
@@ -171,19 +187,19 @@ describe('AnthropicToCodexBridgeProvider', () => {
 	describe('getApiKey() credential discovery chain', () => {
 		let tmpDir: string;
 
-		beforeEach(async () => {
-			tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neokai-codex-test-'));
+		beforeEach(() => {
+			tmpDir = mkdtempSync(path.join(os.tmpdir(), 'neokai-codex-test-'));
 		});
 
-		afterEach(async () => {
-			await fs.rm(tmpDir, { recursive: true, force: true });
+		afterEach(() => {
+			rmSync(tmpDir, { recursive: true, force: true });
 		});
 
 		it('Priority 1: returns OPENAI_API_KEY env var immediately', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'neokai-token' });
-			await writeCodexAuth(codexDir, { tokens: { access_token: 'codex-token' } });
+			writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'neokai-token' });
+			writeCodexAuth(codexDir, { tokens: { access_token: 'codex-token' } });
 
 			provider = makeProvider({ OPENAI_API_KEY: 'env-api-key' }, neokaiDir, codexDir);
 			expect(await provider.getApiKey()).toBe('env-api-key');
@@ -197,8 +213,8 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('Priority 3: returns access token from ~/.neokai/auth.json when no env var', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'neokai-access-token' });
-			await writeCodexAuth(codexDir, { tokens: { access_token: 'should-not-be-used' } });
+			writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'neokai-access-token' });
+			writeCodexAuth(codexDir, { tokens: { access_token: 'should-not-be-used' } });
 
 			provider = makeProvider({}, neokaiDir, codexDir);
 			expect(await provider.getApiKey()).toBe('neokai-access-token');
@@ -207,7 +223,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('Priority 4a: returns OPENAI_API_KEY from ~/.codex/auth.json when no higher source', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai'); // no file written
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeCodexAuth(codexDir, { OPENAI_API_KEY: 'codex-file-api-key' });
+			writeCodexAuth(codexDir, { OPENAI_API_KEY: 'codex-file-api-key' });
 
 			provider = makeProvider({}, neokaiDir, codexDir);
 			expect(await provider.getApiKey()).toBe('codex-file-api-key');
@@ -216,7 +232,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('Priority 4b: returns access_token from ~/.codex/auth.json when OPENAI_API_KEY is null', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai'); // no file written
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeCodexAuth(codexDir, {
+			writeCodexAuth(codexDir, {
 				OPENAI_API_KEY: null,
 				tokens: { access_token: 'codex-oauth-token' },
 			});
@@ -236,7 +252,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('empty-string env var falls through to file-based auth', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'neokai-fallback-token' });
+			writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'neokai-fallback-token' });
 
 			// OPENAI_API_KEY='' is falsy — should not block file-based lookup
 			provider = makeProvider({ OPENAI_API_KEY: '' }, neokaiDir, codexDir);
@@ -246,8 +262,8 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('env var takes priority over both auth files', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'neokai-token' });
-			await writeCodexAuth(codexDir, {
+			writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'neokai-token' });
+			writeCodexAuth(codexDir, {
 				OPENAI_API_KEY: 'codex-api-key',
 				tokens: { access_token: 'codex-bearer' },
 			});
@@ -263,7 +279,12 @@ describe('AnthropicToCodexBridgeProvider', () => {
 
 	describe('buildSdkConfig() workspace isolation', () => {
 		beforeEach(() => {
-			provider = makeProvider({ OPENAI_API_KEY: 'sk-placeholder' });
+			provider = makeProvider(
+				{ OPENAI_API_KEY: 'sk-placeholder' },
+				undefined,
+				undefined,
+				fakeCodexFound
+			);
 		});
 
 		it('starts separate bridge servers for different workspace paths', () => {
@@ -295,11 +316,11 @@ describe('AnthropicToCodexBridgeProvider', () => {
 
 		it('buildSdkConfig() uses cached API key resolved by prior getApiKey() call', async () => {
 			// Set up a provider with only file-based auth (no env var)
-			const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neokai-build-cfg-test-'));
+			const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'neokai-build-cfg-test-'));
 			try {
 				const neokaiDir = path.join(tmpDir, 'neokai');
-				await writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'file-based-token' });
-				const p = makeProvider({}, neokaiDir, path.join(tmpDir, 'codex'));
+				writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'file-based-token' });
+				const p = makeProvider({}, neokaiDir, path.join(tmpDir, 'codex'), fakeCodexFound);
 				// Warm the cache as isAvailable() / getAuthStatus() would in QueryRunner
 				await p.getApiKey();
 				// buildSdkConfig() is synchronous but should use the cached key
@@ -308,24 +329,29 @@ describe('AnthropicToCodexBridgeProvider', () => {
 				expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
 				p.stopAllBridgeServers();
 			} finally {
-				await fs.rm(tmpDir, { recursive: true, force: true });
+				rmSync(tmpDir, { recursive: true, force: true });
 			}
 		});
 
 		it('buildSdkConfig() uses cached key even when OPENAI_API_KEY is empty string', async () => {
 			// Empty-string env var must not block the cached file-based key
-			const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neokai-build-cfg-empty-'));
+			const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'neokai-build-cfg-empty-'));
 			try {
 				const neokaiDir = path.join(tmpDir, 'neokai');
-				await writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'file-token-not-empty' });
-				const p = makeProvider({ OPENAI_API_KEY: '' }, neokaiDir, path.join(tmpDir, 'codex'));
+				writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'file-token-not-empty' });
+				const p = makeProvider(
+					{ OPENAI_API_KEY: '' },
+					neokaiDir,
+					path.join(tmpDir, 'codex'),
+					fakeCodexFound
+				);
 				await p.getApiKey(); // populates cachedApiKey
 				const cfg = p.buildSdkConfig('codex-1', { workspacePath: '/tmp/empty-env-ws' });
 				expect(cfg.isAnthropicCompatible).toBe(true);
 				expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
 				p.stopAllBridgeServers();
 			} finally {
-				await fs.rm(tmpDir, { recursive: true, force: true });
+				rmSync(tmpDir, { recursive: true, force: true });
 			}
 		});
 
@@ -383,7 +409,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 
 	describe('ownsModel()', () => {
 		beforeEach(() => {
-			provider = makeProvider({});
+			provider = makeProvider({}, undefined, undefined, fakeCodexFound);
 		});
 
 		it('owns models explicitly listed in the catalogue', () => {
@@ -425,12 +451,12 @@ describe('AnthropicToCodexBridgeProvider', () => {
 	describe('getModels()', () => {
 		let tmpDir: string;
 
-		beforeEach(async () => {
-			tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neokai-models-test-'));
+		beforeEach(() => {
+			tmpDir = mkdtempSync(path.join(os.tmpdir(), 'neokai-models-test-'));
 		});
 
-		afterEach(async () => {
-			await fs.rm(tmpDir, { recursive: true, force: true });
+		afterEach(() => {
+			rmSync(tmpDir, { recursive: true, force: true });
 		});
 
 		it('returns models when OPENAI_API_KEY env var is set (env vars still power API calls)', async () => {
@@ -443,7 +469,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 
 		it('returns models when NeoKai OAuth credentials are in auth.json', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
-			await writeNeokaiAuth(neokaiDir, {
+			writeNeokaiAuth(neokaiDir, {
 				type: 'oauth',
 				access: 'oauth-access-token',
 				refresh: 'oauth-refresh-token',
@@ -468,8 +494,8 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		let tmpDir: string;
 		let fetchSpy: ReturnType<typeof spyOn>;
 
-		beforeEach(async () => {
-			tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neokai-import-test-'));
+		beforeEach(() => {
+			tmpDir = mkdtempSync(path.join(os.tmpdir(), 'neokai-import-test-'));
 			// Spy on global fetch to intercept token refresh calls.
 			// Default: simulate a network error so tests that don't set up a mock fail clearly.
 			fetchSpy = spyOn(globalThis, 'fetch').mockRejectedValue(
@@ -477,15 +503,15 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			);
 		});
 
-		afterEach(async () => {
+		afterEach(() => {
 			fetchSpy.mockRestore();
-			await fs.rm(tmpDir, { recursive: true, force: true });
+			rmSync(tmpDir, { recursive: true, force: true });
 		});
 
 		it('Test 1: imports API key directly from ~/.codex/auth.json into ~/.neokai/auth.json', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeCodexAuth(codexDir, { OPENAI_API_KEY: 'sk-codex-api-key' });
+			writeCodexAuth(codexDir, { OPENAI_API_KEY: 'sk-codex-api-key' });
 
 			const p = makeProvider({}, neokaiDir, codexDir);
 			const key = await p.getApiKey();
@@ -493,9 +519,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			expect(key).toBe('sk-codex-api-key');
 
 			// Credentials should now be written to ~/.neokai/auth.json
-			const neokaiAuth = JSON.parse(
-				await fs.readFile(path.join(neokaiDir, 'auth.json'), 'utf-8')
-			) as { openai: { type: string; access: string } };
+			const neokaiAuth = JSON.parse(readFileSync(path.join(neokaiDir, 'auth.json'), 'utf-8')) as {
+				openai: { type: string; access: string };
+			};
 			expect(neokaiAuth.openai.type).toBe('api_key');
 			expect(neokaiAuth.openai.access).toBe('sk-codex-api-key');
 
@@ -507,7 +533,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('Test 2: refreshes expired token + imports into ~/.neokai/auth.json', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeCodexAuth(codexDir, {
+			writeCodexAuth(codexDir, {
 				tokens: { access_token: 'old-expired-token', refresh_token: 'valid-refresh-token' },
 			});
 
@@ -531,9 +557,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			expect(fetchSpy).toHaveBeenCalledTimes(1);
 
 			// Verify the refreshed token was written to ~/.neokai/auth.json
-			const neokaiAuth = JSON.parse(
-				await fs.readFile(path.join(neokaiDir, 'auth.json'), 'utf-8')
-			) as { openai: { type: string; access: string; refresh: string } };
+			const neokaiAuth = JSON.parse(readFileSync(path.join(neokaiDir, 'auth.json'), 'utf-8')) as {
+				openai: { type: string; access: string; refresh: string };
+			};
 			expect(neokaiAuth.openai.type).toBe('oauth');
 			expect(neokaiAuth.openai.access).toBe('new-fresh-token');
 			expect(neokaiAuth.openai.refresh).toBe('new-refresh-token');
@@ -543,7 +569,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('Test 3: falls back to importing existing token when refresh fails', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
 			const codexDir = path.join(tmpDir, 'codex');
-			await writeCodexAuth(codexDir, {
+			writeCodexAuth(codexDir, {
 				tokens: { access_token: 'expired-token', refresh_token: 'invalid-refresh' },
 			});
 
@@ -562,9 +588,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			expect(key).toBe('expired-token');
 			expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-			const neokaiAuth = JSON.parse(
-				await fs.readFile(path.join(neokaiDir, 'auth.json'), 'utf-8')
-			) as {
+			const neokaiAuth = JSON.parse(readFileSync(path.join(neokaiDir, 'auth.json'), 'utf-8')) as {
 				openai: { type: string; access: string; refresh?: string };
 			};
 			expect(neokaiAuth.openai.type).toBe('oauth');
@@ -578,7 +602,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			const codexDir = path.join(tmpDir, 'codex');
 
 			// Pre-populate ~/.neokai/auth.json (simulates already-imported state)
-			await writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'already-imported-token' });
+			writeNeokaiAuth(neokaiDir, { type: 'oauth', access: 'already-imported-token' });
 
 			const p = makeProvider({}, neokaiDir, codexDir);
 

--- a/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -10,7 +10,15 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import * as fs from 'fs/promises';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs';
 import * as path from 'path';
 import * as os from 'os';
 import { AnthropicToCodexBridgeProvider } from '../../../src/lib/providers/anthropic-to-codex-bridge-provider';
@@ -70,9 +78,66 @@ function writeCodexAuth(
 
 describe('AnthropicToCodexBridgeProvider', () => {
 	let provider: AnthropicToCodexBridgeProvider;
+	let fsSpies: ReturnType<typeof spyOn>[];
+
+	/**
+	 * Workaround for Bun 1.3.11 on Linux CI: `fs/promises.readFile` may not
+	 * see files written by `node:fs.writeFileSync` in rapid succession (likely a
+	 * kernel page-cache race on ext4).  Bridge all async fs operations through
+	 * their sync counterparts so that test fixtures are reliably visible to the
+	 * provider's internal `loadCredentials()` / `importFromCodexAuth()` methods.
+	 */
+	beforeEach(() => {
+		fsSpies = [
+			spyOn(fs, 'readFile').mockImplementation(
+				(
+					filePath: Parameters<typeof fs.readFile>[0],
+					options?: Parameters<typeof fs.readFile>[1]
+				) => {
+					const encoding =
+						typeof options === 'string'
+							? options
+							: (options as { encoding?: BufferEncoding })?.encoding;
+					return Promise.resolve(
+						readFileSync(filePath as Parameters<typeof readFileSync>[0], encoding as BufferEncoding)
+					);
+				}
+			),
+			spyOn(fs, 'writeFile').mockImplementation(
+				(
+					filePath: Parameters<typeof fs.writeFile>[0],
+					data: Parameters<typeof fs.writeFile>[1],
+					options?: Parameters<typeof fs.writeFile>[2]
+				) => {
+					const mode =
+						typeof options === 'object' ? (options as { mode?: number }).mode : undefined;
+					writeFileSync(
+						filePath as Parameters<typeof writeFileSync>[0],
+						data as Parameters<typeof writeFileSync>[1],
+						mode as Parameters<typeof writeFileSync>[2]
+					);
+					return Promise.resolve();
+				}
+			),
+			spyOn(fs, 'rename').mockImplementation(
+				(oldPath: Parameters<typeof fs.rename>[0], newPath: Parameters<typeof fs.rename>[1]) => {
+					renameSync(
+						oldPath as Parameters<typeof renameSync>[0],
+						newPath as Parameters<typeof renameSync>[1]
+					);
+					return Promise.resolve();
+				}
+			),
+			spyOn(fs, 'unlink').mockImplementation((filePath: Parameters<typeof fs.unlink>[0]) => {
+				unlinkSync(filePath as Parameters<typeof unlinkSync>[0]);
+				return Promise.resolve();
+			}),
+		];
+	});
 
 	afterEach(() => {
 		provider?.stopAllBridgeServers();
+		fsSpies.forEach((spy) => spy.mockRestore());
 	});
 
 	describe('getAuthStatus()', () => {


### PR DESCRIPTION
## Bug 1 (Task View) — implement now

`session.model.switch` creates a NEW `AgentSession` via `SessionCache`, separate from `RoomRuntimeService.agentSessions`, causing duplicate concurrent queries. **Fix:** Register room sessions in `SessionCache` via `registerSession()` in both `createAndStartSession` and `restoreSession` paths (matching the Space pattern), add `unregisterSession()` for cleanup, fix `SessionCache.remove()` race condition. Tasks 2–3.

## Bug 2 (Normal Session) — investigate first

The previous plan proposed `forkSession: true` but this was never verified. Replaced with a single investigation task (Task 1) that writes an online integration test observing the SDK's `system:init` message before/after a model switch to prove or disprove whether the new model takes effect. After results are in, the human reviewer will decide the approach.

## Test fix

Bridged async `fs/promises` calls to sync `node:fs` counterparts in `AnthropicToCodexBridgeProvider` tests to work around a Bun 1.3.11 Linux CI issue.

## Plan

See `docs/plans/fix-model-switching-bugs-in-neokai.md` for full details.