### PR TITLE
fix(model-switch): clear sdkSessionId before restart to ensure fresh query

### DIFF
--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -184,9 +184,10 @@ export class ModelSwitchHandler {
 				// newProviderInstance is guaranteed non-null here (we returned early above).
 				session.config.provider = newProviderInstance.id as Provider;
 
-				// FIX: Clear sdkSessionId before restart to ensure the new query starts fresh.
-				// The old SDK session file was created with the old model. The SDK may use the
-				// session-file model over the options model, so the model switch wouldn't take effect.
+				// FIX: Clear sdkSessionId before restart so the new query starts fresh with the
+				// new model. The old SDK session file was created with the old model. The SDK may
+				// use the session-file model over the options model, so the model switch wouldn't
+				// take effect without this.
 				session.sdkSessionId = undefined;
 
 				// Only pass serializable fields — session.config may contain runtime-only
@@ -229,9 +230,10 @@ export class ModelSwitchHandler {
 				// newProviderInstance is guaranteed non-null here (we returned early above).
 				session.config.provider = newProviderInstance.id as Provider;
 
-				// FIX: Clear sdkSessionId before restart to ensure the new query starts fresh.
-				// The old SDK session file was created with the old model. The SDK may use the
-				// session-file model over the options model, so the model switch wouldn't take effect.
+				// FIX: Clear sdkSessionId before restart so the new query starts fresh with the
+				// new model. The old SDK session file was created with the old model. The SDK may
+				// use the session-file model over the options model, so the model switch wouldn't
+				// take effect without this.
 				session.sdkSessionId = undefined;
 
 				// Only pass serializable fields — session.config may contain runtime-only

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -183,10 +183,17 @@ export class ModelSwitchHandler {
 				session.config.model = resolvedModel;
 				// newProviderInstance is guaranteed non-null here (we returned early above).
 				session.config.provider = newProviderInstance.id as Provider;
+
+				// FIX: Clear sdkSessionId before restart to ensure the new query starts fresh.
+				// The old SDK session file was created with the old model. The SDK may use the
+				// session-file model over the options model, so the model switch wouldn't take effect.
+				session.sdkSessionId = undefined;
+
 				// Only pass serializable fields — session.config may contain runtime-only
 				// objects (mcpServers with closures, agents, spawnClaudeCodeProcess) that
 				// cannot be JSON-stringified and would cause a cyclic structure error.
 				db.updateSession(session.id, {
+					sdkSessionId: undefined,
 					config: {
 						model: resolvedModel,
 						provider: newProviderInstance.id as Provider,
@@ -221,10 +228,17 @@ export class ModelSwitchHandler {
 				session.config.model = resolvedModel;
 				// newProviderInstance is guaranteed non-null here (we returned early above).
 				session.config.provider = newProviderInstance.id as Provider;
+
+				// FIX: Clear sdkSessionId before restart to ensure the new query starts fresh.
+				// The old SDK session file was created with the old model. The SDK may use the
+				// session-file model over the options model, so the model switch wouldn't take effect.
+				session.sdkSessionId = undefined;
+
 				// Only pass serializable fields — session.config may contain runtime-only
 				// objects (mcpServers with closures, agents, spawnClaudeCodeProcess) that
 				// cannot be JSON-stringified and would cause a cyclic structure error.
 				db.updateSession(session.id, {
+					sdkSessionId: undefined,
 					config: {
 						model: resolvedModel,
 						provider: newProviderInstance.id as Provider,

--- a/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
@@ -321,10 +321,10 @@ describe('ModelSwitchHandler', () => {
 				expect(restartSpy).toHaveBeenCalled();
 			});
 
-			it('should clear sdkSessionId before restart when query not started', async () => {
+			it('should clear sdkSessionId when query not started', async () => {
 				// FIX: sdkSessionId must be cleared before restart so the new query starts fresh
-				// with the new model. The old SDK session file was created with the old model,
-				// and the SDK may use the session-file model over the options model.
+				// with the new model. The old SDK session file was created with the old model, and
+				// the SDK may use the session-file model over the options model.
 				handler = createHandler({ queryObject: null });
 				await handler.switchModel(VALID_MODEL, 'anthropic');
 
@@ -457,10 +457,10 @@ describe('ModelSwitchHandler', () => {
 				);
 			});
 
-			it('should clear sdkSessionId before restart when query is running', async () => {
+			it('should clear sdkSessionId when query is running', async () => {
 				// FIX: sdkSessionId must be cleared before restart so the new query starts fresh
-				// with the new model. The old SDK session file was created with the old model,
-				// and the SDK may use the session-file model over the options model.
+				// with the new model. The old SDK session file was created with the old model, and
+				// the SDK may use the session-file model over the options model.
 				handler = createHandler();
 				await handler.switchModel(VALID_MODEL, 'anthropic');
 

--- a/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
@@ -162,6 +162,7 @@ describe('ModelSwitchHandler', () => {
 				totalCost: 0,
 				toolCallCount: 0,
 			},
+			sdkSessionId: 'old-sdk-session-id',
 		};
 
 		// Create mocks
@@ -320,6 +321,24 @@ describe('ModelSwitchHandler', () => {
 				expect(restartSpy).toHaveBeenCalled();
 			});
 
+			it('should clear sdkSessionId before restart when query not started', async () => {
+				// FIX: sdkSessionId must be cleared before restart so the new query starts fresh
+				// with the new model. The old SDK session file was created with the old model,
+				// and the SDK may use the session-file model over the options model.
+				handler = createHandler({ queryObject: null });
+				await handler.switchModel(VALID_MODEL, 'anthropic');
+
+				// Verify sdkSessionId was cleared in the session object
+				expect(mockSession.sdkSessionId).toBeUndefined();
+				// Verify sdkSessionId was cleared in the database update
+				expect(updateSessionSpy).toHaveBeenCalledWith(
+					mockSession.id,
+					expect.objectContaining({
+						sdkSessionId: undefined,
+					})
+				);
+			});
+
 			it('should pass only serializable config fields (no closures or cyclic refs)', async () => {
 				// Simulate a room agent session config with runtime-only non-serializable fields
 				const mockCallback = () => {};
@@ -434,6 +453,24 @@ describe('ModelSwitchHandler', () => {
 					mockSession.id,
 					expect.objectContaining({
 						config: expect.objectContaining({ model: 'opus', provider: expect.any(String) }),
+					})
+				);
+			});
+
+			it('should clear sdkSessionId before restart when query is running', async () => {
+				// FIX: sdkSessionId must be cleared before restart so the new query starts fresh
+				// with the new model. The old SDK session file was created with the old model,
+				// and the SDK may use the session-file model over the options model.
+				handler = createHandler();
+				await handler.switchModel(VALID_MODEL, 'anthropic');
+
+				// Verify sdkSessionId was cleared in the session object
+				expect(mockSession.sdkSessionId).toBeUndefined();
+				// Verify sdkSessionId was cleared in the database update
+				expect(updateSessionSpy).toHaveBeenCalledWith(
+					mockSession.id,
+					expect.objectContaining({
+						sdkSessionId: undefined,
 					})
 				);
 			});


### PR DESCRIPTION
The old SDK session file was created with the old model. When switching
models, the SDK may use the session-file model over the options model,
so the model switch wouldn't take effect.

Fix: Before calling lifecycleManager.restart(), clear sdkSessionId
and persist to DB so the new query starts completely fresh with the new
model. This applies to ALL sessions (normal and task).

Added unit tests to verify sdkSessionId is cleared in both cases:
- query not started (queryObject is null)
- query is running (queryObject exists)
