### PR TITLE
fix(room): route task session model switches through RoomRuntimeService

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -140,6 +140,37 @@ export class RoomRuntimeService {
 		return this.agentSessions.get(sessionId);
 	}
 
+	/**
+	 * Get the current model for a task session.
+	 * Returns the model info or null if the session is not found.
+	 */
+	async modelGet(sessionId: string): Promise<{ currentModel: string; provider: string } | null> {
+		const session = this.agentSessions.get(sessionId);
+		if (!session) return null;
+		const sessionData = session.getSessionData();
+		return {
+			currentModel: sessionData.config.model,
+			provider: sessionData.config.provider ?? '',
+		};
+	}
+
+	/**
+	 * Switch the model for a task session.
+	 * This operates on the runtime's own AgentSession instances to avoid
+	 * creating duplicate sessions via SessionManager.
+	 */
+	async modelSwitch(
+		sessionId: string,
+		model: string,
+		provider: string
+	): Promise<{ success: boolean; model: string; error?: string }> {
+		const session = this.agentSessions.get(sessionId);
+		if (!session) {
+			return { success: false, model: '', error: 'Session not found in runtime' };
+		}
+		return session.handleModelSwitch(model, provider);
+	}
+
 	pauseRuntime(roomId: string): boolean {
 		const runtime = this.runtimes.get(roomId);
 		if (!runtime) return false;

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -505,6 +505,13 @@ export class RoomRuntimeService {
 					return false;
 				}
 			},
+			switchModel: async (sessionId, model, provider) => {
+				const session = agentSessions.get(sessionId);
+				if (!session) {
+					return { success: false, model: '', error: 'Session not found in runtime' };
+				}
+				return session.handleModelSwitch(model, provider);
+			},
 		};
 	}
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -39,7 +39,6 @@ import type { SessionObserver, TerminalState } from '../state/session-observer';
 import type { SessionFactory, WorkerConfig } from './task-group-manager';
 import { TaskGroupManager } from './task-group-manager';
 import type { DaemonHub } from '../../daemon-hub';
-import type { ModelSwitchResult } from '../../agent/model-switch-handler';
 import type { LeaderToolCallbacks, LeaderToolResult } from '../agents/leader-agent';
 import { createLeaderMcpServer } from '../agents/leader-agent';
 import type {
@@ -395,11 +394,11 @@ export class RoomRuntime {
 		}
 
 		try {
-			const result = (await this.messageHub?.request('session.model.switch', {
+			const result = await this.sessionFactory.switchModel(
 				sessionId,
-				model: fallback.model,
-				provider: fallback.provider,
-			})) as ModelSwitchResult | undefined;
+				fallback.model,
+				fallback.provider
+			);
 
 			if (result?.success) {
 				log.info(

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -114,6 +114,16 @@ export interface SessionFactory {
 	 * Returns true if worktree was removed, false if it didn't exist or was main repo.
 	 */
 	removeWorktree(workspacePath: string): Promise<boolean>;
+	/**
+	 * Switch the model for a session directly without going through RPC.
+	 * This avoids creating duplicate AgentSession instances via SessionManager.
+	 * Returns the result of the model switch operation.
+	 */
+	switchModel(
+		sessionId: string,
+		model: string,
+		provider: string
+	): Promise<{ success: boolean; model: string; error?: string }>;
 }
 
 /**

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -455,6 +455,11 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			setSessionMcpServers: () => false as const,
 			removeWorktree: async () => false as const,
 			getProcessingState: (_sessionId: string) => undefined,
+			switchModel: async (_sessionId: string, _model: string, _provider: string) => ({
+				success: false,
+				model: '',
+				error: 'switchModel not supported for global session factory',
+			}),
 		};
 
 		provisionGlobalSpacesAgent({

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -329,6 +329,13 @@ export function setupRoomRuntimeHandlers(
 		if (!result.success) {
 			throw new Error(result.error ?? 'Model switch failed');
 		}
+		// Emit session.updated event for parity with session.model.switch handler.
+		// This allows listeners to react to model changes on task sessions.
+		messageHub.event(
+			'session.updated',
+			{ sessionId: params.sessionId, model: result.model },
+			{ channel: `session:${params.sessionId}` }
+		);
 		return result;
 	});
 

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -306,6 +306,32 @@ export function setupRoomRuntimeHandlers(
 		return { leaderModel, workerModel };
 	});
 
+	// room.runtime.model.get - Get current model for a task session
+	messageHub.onRequest('room.runtime.model.get', async (data) => {
+		const params = data as { sessionId: string };
+		if (!params.sessionId) throw new Error('Session ID is required');
+		const result = await roomRuntimeService.modelGet(params.sessionId);
+		if (!result) throw new Error('Session not found in runtime');
+		return result;
+	});
+
+	// room.runtime.model.switch - Switch model for a task session
+	messageHub.onRequest('room.runtime.model.switch', async (data) => {
+		const params = data as { sessionId: string; model: string; provider: string };
+		if (!params.sessionId) throw new Error('Session ID is required');
+		if (!params.model) throw new Error('Model is required');
+		if (!params.provider) throw new Error('Provider is required');
+		const result = await roomRuntimeService.modelSwitch(
+			params.sessionId,
+			params.model,
+			params.provider
+		);
+		if (!result.success) {
+			throw new Error(result.error ?? 'Model switch failed');
+		}
+		return result;
+	});
+
 	// room.runtime.pause - Pause runtime
 	messageHub.onRequest('room.runtime.pause', async (data) => {
 		const params = data as { roomId: string };

--- a/packages/daemon/tests/unit/rpc/room-runtime-model-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-runtime-model-handlers.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for Room Runtime Model Handlers
+ *
+ * Tests the RPC handlers for room runtime model operations:
+ * - room.runtime.model.get - Get current model for a task session
+ * - room.runtime.model.switch - Switch model for a task session
+ */
+
+import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import type { MessageHub, DaemonHub } from '@neokai/shared';
+import { setupRoomRuntimeHandlers } from '../../../src/lib/rpc-handlers/room-handlers';
+import type { RoomRuntimeService } from '../../../src/lib/room/runtime/room-runtime-service';
+import type { AgentSession } from '../../../src/lib/agent/agent-session';
+
+// Type for captured request handlers
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+// Helper to create a minimal mock MessageHub that captures handlers
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+
+	return { hub, handlers };
+}
+
+// Helper to create mock DaemonHub
+function createMockDaemonHub(): {
+	daemonHub: DaemonHub;
+	emitMock: ReturnType<typeof mock>;
+} {
+	const emitMock = mock(async () => {});
+	const daemonHub = {
+		emit: emitMock,
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+
+	return { daemonHub, emitMock };
+}
+
+describe('RoomRuntimeModel Handlers', () => {
+	let messageHubData: ReturnType<typeof createMockMessageHub>;
+	let daemonHubData: ReturnType<typeof createMockDaemonHub>;
+	let mockAgentSession: AgentSession;
+	let mockRoomRuntimeService: RoomRuntimeService;
+
+	beforeEach(() => {
+		messageHubData = createMockMessageHub();
+		daemonHubData = createMockDaemonHub();
+
+		// Create mock AgentSession
+		mockAgentSession = {
+			getSessionData: mock(() => ({
+				id: 'test-session-123',
+				config: {
+					model: 'claude-sonnet-4-6',
+					provider: 'anthropic',
+				},
+			})),
+			handleModelSwitch: mock(async (model: string, provider: string) => ({
+				success: true,
+				model,
+				provider,
+			})),
+		} as unknown as AgentSession;
+
+		// Create mock RoomRuntimeService
+		mockRoomRuntimeService = {
+			modelGet: mock(async (sessionId: string) => {
+				if (sessionId === 'non-existent') return null;
+				return {
+					currentModel: 'claude-sonnet-4-6',
+					provider: 'anthropic',
+				};
+			}),
+			modelSwitch: mock(
+				async (
+					sessionId: string,
+					model: string,
+					provider: string
+				): Promise<{ success: boolean; model: string; error?: string }> => {
+					if (sessionId === 'non-existent') {
+						return { success: false, model: '', error: 'Session not found in runtime' };
+					}
+					if (sessionId === 'switch-error') {
+						return { success: false, model: '', error: 'Model switch failed' };
+					}
+					return { success: true, model };
+				}
+			),
+		} as unknown as RoomRuntimeService;
+
+		// Setup handlers with mocked dependencies
+		setupRoomRuntimeHandlers(messageHubData.hub, daemonHubData.daemonHub, mockRoomRuntimeService);
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	describe('room.runtime.model.get', () => {
+		it('returns model info for existing session', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.get');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ sessionId: 'test-session-123' }, {})) as {
+				currentModel: string;
+				provider: string;
+			};
+
+			expect(result.currentModel).toBe('claude-sonnet-4-6');
+			expect(result.provider).toBe('anthropic');
+		});
+
+		it('throws error when sessionId is missing', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.get');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({}, {})).rejects.toThrow('Session ID is required');
+		});
+
+		it('throws error when session not found', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.get');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ sessionId: 'non-existent' }, {})).rejects.toThrow(
+				'Session not found in runtime'
+			);
+		});
+	});
+
+	describe('room.runtime.model.switch', () => {
+		it('switches model successfully', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.switch');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!(
+				{ sessionId: 'test-session-123', model: 'claude-opus-4', provider: 'anthropic' },
+				{}
+			)) as { success: boolean; model: string };
+
+			expect(result.success).toBe(true);
+			expect(result.model).toBe('claude-opus-4');
+		});
+
+		it('throws error when sessionId is missing', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.switch');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ model: 'claude-opus-4', provider: 'anthropic' }, {})).rejects.toThrow(
+				'Session ID is required'
+			);
+		});
+
+		it('throws error when model is missing', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.switch');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ sessionId: 'test-session-123', provider: 'anthropic' }, {})
+			).rejects.toThrow('Model is required');
+		});
+
+		it('throws error when provider is missing', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.switch');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ sessionId: 'test-session-123', model: 'claude-opus-4' }, {})
+			).rejects.toThrow('Provider is required');
+		});
+
+		it('throws error when session not found', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.switch');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ sessionId: 'non-existent', model: 'claude-opus-4', provider: 'anthropic' }, {})
+			).rejects.toThrow('Session not found in runtime');
+		});
+
+		it('throws error when model switch fails', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.switch');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ sessionId: 'switch-error', model: 'claude-opus-4', provider: 'anthropic' }, {})
+			).rejects.toThrow('Model switch failed');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/rpc/room-runtime-model-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-runtime-model-handlers.test.ts
@@ -211,5 +211,34 @@ describe('RoomRuntimeModel Handlers', () => {
 				handler!({ sessionId: 'switch-error', model: 'claude-opus-4', provider: 'anthropic' }, {})
 			).rejects.toThrow('Model switch failed');
 		});
+
+		it('emits session.updated event with correct payload on success', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.switch');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!(
+				{ sessionId: 'test-session-123', model: 'claude-opus-4', provider: 'anthropic' },
+				{}
+			)) as { success: boolean; model: string };
+
+			expect(result.success).toBe(true);
+			expect(messageHubData.hub.event).toHaveBeenCalledTimes(1);
+			expect(messageHubData.hub.event).toHaveBeenCalledWith(
+				'session.updated',
+				{ sessionId: 'test-session-123', model: 'claude-opus-4' },
+				{ channel: 'session:test-session-123' }
+			);
+		});
+
+		it('does not emit session.updated event when model switch fails', async () => {
+			const handler = messageHubData.handlers.get('room.runtime.model.switch');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ sessionId: 'switch-error', model: 'claude-opus-4', provider: 'anthropic' }, {})
+			).rejects.toThrow('Model switch failed');
+
+			expect(messageHubData.hub.event).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -59,6 +59,8 @@ function formatTimestamp(ms: number): string {
 
 export interface TaskInfoPanelProps {
 	isOpen: boolean;
+	/** Room ID for routing task session model switches through RoomRuntimeService */
+	roomId?: string;
 	/** Full task ID */
 	taskId?: string;
 	/** Full session group ID */
@@ -108,6 +110,7 @@ export interface TaskInfoPanelProps {
 
 export function TaskInfoPanel({
 	isOpen,
+	roomId,
 	taskId,
 	groupId,
 	feedbackIteration,
@@ -265,6 +268,7 @@ export function TaskInfoPanel({
 									<span class="text-xs text-gray-400">Model:</span>
 									<TaskViewModelSelector
 										sessionId={workerSession.id}
+										roomId={roomId}
 										currentModel={workerSession.config.model ?? ''}
 										currentProvider={workerSession.config.provider}
 									/>
@@ -278,6 +282,7 @@ export function TaskInfoPanel({
 									<span class="text-xs text-gray-400">Model:</span>
 									<TaskViewModelSelector
 										sessionId={leaderSession.id}
+										roomId={roomId}
 										currentModel={leaderSession.config.model ?? ''}
 										currentProvider={leaderSession.config.provider}
 									/>

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -283,6 +283,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 			{/* Info panel — expands below header when gear is clicked */}
 			<TaskInfoPanel
 				isOpen={isInfoPanelOpen}
+				roomId={roomId}
 				taskId={task.id}
 				groupId={group?.id}
 				feedbackIteration={group?.feedbackIteration}

--- a/packages/web/src/components/room/TaskViewModelSelector.tsx
+++ b/packages/web/src/components/room/TaskViewModelSelector.tsx
@@ -30,6 +30,8 @@ interface RawModelEntry {
 
 export interface TaskViewModelSelectorProps {
 	sessionId: string;
+	/** Room ID for routing task session model switches through RoomRuntimeService */
+	roomId?: string;
 	currentModel: string;
 	currentProvider?: string;
 	disabled?: boolean;
@@ -39,6 +41,7 @@ export interface TaskViewModelSelectorProps {
 
 export function TaskViewModelSelector({
 	sessionId,
+	roomId,
 	currentModel,
 	currentProvider,
 	disabled = false,
@@ -102,15 +105,28 @@ export function TaskViewModelSelector({
 					return;
 				}
 
-				const result = (await hub.request('session.model.switch', {
-					sessionId,
-					model: model.id,
-					provider: model.provider,
-				})) as {
-					success: boolean;
-					model: string;
-					error?: string;
-				};
+				// Use room.runtime.model.switch for task sessions when roomId is available.
+				// This routes through RoomRuntimeService which owns the AgentSession instances
+				// for worker/leader sessions, avoiding duplicate session creation via SessionManager.
+				const result = roomId
+					? ((await hub.request('room.runtime.model.switch', {
+							sessionId,
+							model: model.id,
+							provider: model.provider,
+						})) as {
+							success: boolean;
+							model: string;
+							error?: string;
+						})
+					: ((await hub.request('session.model.switch', {
+							sessionId,
+							model: model.id,
+							provider: model.provider,
+						})) as {
+							success: boolean;
+							model: string;
+							error?: string;
+						});
 
 				if (result.success) {
 					toast.success(`Switched to ${model.name}`);
@@ -125,7 +141,7 @@ export function TaskViewModelSelector({
 				setSwitching(false);
 			}
 		},
-		[sessionId]
+		[sessionId, roomId]
 	);
 
 	// Get current model info

--- a/packages/web/src/components/room/TaskViewV2.tsx
+++ b/packages/web/src/components/room/TaskViewV2.tsx
@@ -299,6 +299,7 @@ export function TaskViewV2({ roomId, taskId }: TaskViewV2Props) {
 			{/* Info panel */}
 			<TaskInfoPanel
 				isOpen={isInfoPanelOpen}
+				roomId={roomId}
 				taskId={task.id}
 				groupId={group?.id}
 				feedbackIteration={group?.feedbackIteration}

--- a/packages/web/src/hooks/useTaskViewData.ts
+++ b/packages/web/src/hooks/useTaskViewData.ts
@@ -96,10 +96,15 @@ export function useTaskViewData(roomId: string, taskId: string): UseTaskViewData
 		let cancelled = false;
 		let fetchGroupSeq = 0;
 
+		// Track current session IDs for session.updated event subscriptions
+		const currentSessionIds = { worker: '', leader: '' };
+
 		const fetchSessionInfo = async (grp: TaskGroupInfo | null) => {
 			if (!grp) {
 				setWorkerSession(null);
 				setLeaderSession(null);
+				currentSessionIds.worker = '';
+				currentSessionIds.leader = '';
 				return;
 			}
 			try {
@@ -114,6 +119,8 @@ export function useTaskViewData(roomId: string, taskId: string): UseTaskViewData
 				if (!cancelled) {
 					setWorkerSession(workerRes?.session ?? null);
 					setLeaderSession(leaderRes?.session ?? null);
+					currentSessionIds.worker = workerRes?.session?.id ?? '';
+					currentSessionIds.leader = leaderRes?.session?.id ?? '';
 				}
 			} catch {
 				// Session fetch failure is non-fatal
@@ -178,16 +185,39 @@ export function useTaskViewData(roomId: string, taskId: string): UseTaskViewData
 		load();
 
 		// Re-fetch group whenever the task status changes (e.g. group spawned or completed)
-		const unsub = onEvent<{ roomId: string; task: NeoTask }>('room.task.update', (event) => {
-			if (event.task.id === taskId && !cancelled) {
-				setTask(event.task);
-				void fetchGroup();
+		const unsubTaskUpdate = onEvent<{ roomId: string; task: NeoTask }>(
+			'room.task.update',
+			(event) => {
+				if (event.task.id === taskId && !cancelled) {
+					setTask(event.task);
+					void fetchGroup();
+				}
 			}
-		});
+		);
+
+		// Update session model when session.updated event is received for worker or leader.
+		// This ensures the model label in TaskInfoPanel updates immediately after a model switch.
+		const unsubSessionUpdate = onEvent<{ sessionId: string; model?: string }>(
+			'session.updated',
+			(event) => {
+				if (cancelled) return;
+				if (event.sessionId === currentSessionIds.worker && event.model) {
+					setWorkerSession((prev) =>
+						prev ? { ...prev, config: { ...prev.config, model: event.model! } } : null
+					);
+				}
+				if (event.sessionId === currentSessionIds.leader && event.model) {
+					setLeaderSession((prev) =>
+						prev ? { ...prev, config: { ...prev.config, model: event.model! } } : null
+					);
+				}
+			}
+		);
 
 		return () => {
 			cancelled = true;
-			unsub();
+			unsubTaskUpdate();
+			unsubSessionUpdate();
 			leaveRoom(channel);
 		};
 	}, [roomId, taskId, isConnected]);


### PR DESCRIPTION
When session.model.switch is called for a task session (worker/leader),
SessionCache creates a NEW AgentSession via new AgentSession(...) (not
AgentSession.restore()). This new instance calls restart() ->
startStreamingQuery(), creating a new query loop. Meanwhile,
RoomRuntimeService still has its own AgentSession running with the old
model. Two concurrent query loops for the same session cause conflicts.

This fix adds room.runtime.model.get and room.runtime.model.switch
handlers to RoomRuntimeService that operate on the runtime's own
AgentSession instances. The TaskViewModelSelector now uses
room.runtime.model.switch when roomId is available, routing through
RoomRuntimeService instead of SessionManager.

Files changed:
- RoomRuntimeService: Added modelGet() and modelSwitch() methods
- room-handlers: Added room.runtime.model.get and room.runtime.model.switch handlers
- TaskViewModelSelector: Added roomId prop, uses room.runtime.model.switch when roomId is provided
- TaskInfoPanel: Added roomId prop and passes it to TaskViewModelSelector
- TaskView/TaskViewV2: Pass roomId to TaskInfoPanel
- Added unit tests for new handlers

Fixes: Bug 1 - Task view model switching not taking effect mid-task
