### PR TITLE
feat(mcp): wire per-room enablement into AppMcpLifecycleManager (Task 4.2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,6 +205,9 @@ jobs:
           - module: rewind
             test_path: tests/online/rewind
             mock_sdk: true
+          - module: room-mcp
+            test_path: tests/online/room/room-mcp-enablement.test.ts
+            mock_sdk: true
           # Room tests temporarily disabled during refactoring
           # - module: room-1
           #   test_path: >-

--- a/packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts
@@ -69,12 +69,49 @@ export class AppMcpLifecycleManager {
 	/**
 	 * Returns SDK MCP configs for a specific room.
 	 *
-	 * Stub: Milestone 4 will add the `room_mcp_enablement` table and per-room
-	 * filtering. Until then this falls back to the global enabled set.
+	 * Per-room overrides take precedence:
+	 * - If the room has explicitly enabled servers (via room_mcp_enablement), return those.
+	 * - If the room has no overrides, fall back to globally-enabled servers, but exclude
+	 *   any that are explicitly disabled for this room via per-room override.
 	 */
-	getEnabledMcpConfigsForRoom(_roomId: string): Record<string, McpServerConfig> {
-		// TODO (Milestone 4): Query room_mcp_enablement for roomId and filter accordingly.
-		return this.getEnabledMcpConfigs();
+	getEnabledMcpConfigsForRoom(roomId: string): Record<string, McpServerConfig> {
+		const roomServers = this.db.roomMcpEnablement.getEnabledServers(roomId);
+
+		// If the room has per-room enabled servers, return those (filtered by validation).
+		if (roomServers.length > 0) {
+			const result: Record<string, McpServerConfig> = {};
+			for (const entry of roomServers) {
+				const validation = this.validateEntry(entry);
+				if (!validation.valid) {
+					continue;
+				}
+				result[entry.name] = this.convertEntry(entry);
+			}
+			return result;
+		}
+
+		// No per-room enabled servers. Fall back to global enabled set, but exclude
+		// any servers that are explicitly disabled for this room.
+		const globalServers = this.db.appMcpServers.listEnabled();
+		const result: Record<string, McpServerConfig> = {};
+
+		for (const entry of globalServers) {
+			// Check if this server is explicitly disabled for the room
+			const override = this.db.roomMcpEnablement.getOverride(roomId, entry.id);
+			if (override !== null && !override.enabled) {
+				// Server is explicitly disabled for this room — skip it
+				continue;
+			}
+
+			const validation = this.validateEntry(entry);
+			if (!validation.valid) {
+				continue;
+			}
+
+			result[entry.name] = this.convertEntry(entry);
+		}
+
+		return result;
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -601,7 +601,8 @@ export class RoomRuntimeService {
 
 				// Merge MCP servers from three sources into a single map for the room chat session:
 				//   1. File-based servers (from .mcp.json / settings.json via SettingsManager)
-				//   2. Registry-based servers (application-level entries from AppMcpLifecycleManager)
+				//   2. Registry-based servers (application-level entries from AppMcpLifecycleManager,
+				//      filtered by per-room enablement via getEnabledMcpConfigsForRoom)
 				//   3. room-agent-tools (in-process server for room coordination)
 				//
 				// Precedence (highest to lowest): room-agent-tools > registry > file-based.
@@ -618,7 +619,8 @@ export class RoomRuntimeService {
 				// NOT restart any in-flight query. This is intentional — MCP server changes between
 				// queries are the expected use case, and disrupting an active query is not safe.
 				const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
-				const registryMcpServers = this.ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
+				const registryMcpServers =
+					this.ctx.appMcpManager?.getEnabledMcpConfigsForRoom(room.id) ?? {};
 				roomChatSession.setRuntimeMcpServers({
 					...fileMcpServers,
 					...registryMcpServers,
@@ -702,13 +704,12 @@ export class RoomRuntimeService {
 		const unsubMcpChanged = this.ctx.daemonHub.on(
 			'mcp.registry.changed',
 			() => {
-				// Re-read both sources inside the handler (not hoisted above the loop) so
-				// that if getEnabledMcpServersConfig() ever becomes room-scoped, it will
-				// be called per-room consistently with the initial setupRoomAgentSession path.
-				// Registry configs are global and read once — the call is cheap.
-				const registryMcpServers = this.ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
 				for (const [roomId] of this.runtimes) {
+					// Read both sources inside the handler per-room so that per-room enablement
+					// is respected when re-applying configs after registry changes.
 					const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
+					const registryMcpServers =
+						this.ctx.appMcpManager?.getEnabledMcpConfigsForRoom(roomId) ?? {};
 					const roomChatSessionId = `room:chat:${roomId}`;
 					void this.ctx.sessionManager
 						.getSessionAsync(roomChatSessionId)

--- a/packages/daemon/tests/online/room/room-mcp-enablement.test.ts
+++ b/packages/daemon/tests/online/room/room-mcp-enablement.test.ts
@@ -7,16 +7,13 @@
  * - mcp.room RPC handlers (setEnabled, getEnabled, resetToGlobal)
  *
  * These tests use the full daemon server with real database and RPC handlers.
- *
- * REQUIREMENTS:
- * - Requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN
- * - Makes real API calls (costs money, uses rate limits)
- * - Tests will FAIL if credentials are not available (no skip)
+ * They use dev proxy (mock_sdk: true) so no real AI API calls are made.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
+import { createRoom } from './room-test-helpers';
 
 describe('Room MCP Enablement — Online', () => {
 	let daemon: DaemonServerContext;
@@ -65,121 +62,157 @@ describe('Room MCP Enablement — Online', () => {
 		return result.serverIds;
 	}
 
+	/**
+	 * Helper to delete a room via RPC.
+	 */
+	async function deleteRoom(roomId: string): Promise<void> {
+		await daemon.messageHub.request('room.delete', { roomId });
+	}
+
 	describe('mcp.room.setEnabled', () => {
 		test('enabling a server for a room adds it to the room enablement list', async () => {
+			// Create a real room so room_mcp_enablement FK constraint is satisfied
+			const roomId = await createRoom(daemon, 'test-enable');
 			const { id: serverId } = await createRegistryServer('test-server-enable');
 
-			// Initially not enabled for any room
-			const initial = await getEnabledForRoom('room-enable-test');
-			expect(initial).not.toContain(serverId);
+			try {
+				// Initially not enabled for any room
+				const initial = await getEnabledForRoom(roomId);
+				expect(initial).not.toContain(serverId);
 
-			// Enable for room
-			await enableForRoom('room-enable-test', serverId, true);
+				// Enable for room
+				await enableForRoom(roomId, serverId, true);
 
-			// Now enabled
-			const after = await getEnabledForRoom('room-enable-test');
-			expect(after).toContain(serverId);
+				// Now enabled
+				const after = await getEnabledForRoom(roomId);
+				expect(after).toContain(serverId);
+			} finally {
+				await deleteRoom(roomId);
+			}
 		});
 
 		test('disabling a server for a room removes it from the room enablement list', async () => {
+			const roomId = await createRoom(daemon, 'test-disable');
 			const { id: serverId } = await createRegistryServer('test-server-disable');
 
-			// Enable first
-			await enableForRoom('room-disable-test', serverId, true);
-			let enabled = await getEnabledForRoom('room-disable-test');
-			expect(enabled).toContain(serverId);
+			try {
+				// Enable first
+				await enableForRoom(roomId, serverId, true);
+				let enabled = await getEnabledForRoom(roomId);
+				expect(enabled).toContain(serverId);
 
-			// Disable
-			await enableForRoom('room-disable-test', serverId, false);
-			enabled = await getEnabledForRoom('room-disable-test');
-			expect(enabled).not.toContain(serverId);
+				// Disable
+				await enableForRoom(roomId, serverId, false);
+				enabled = await getEnabledForRoom(roomId);
+				expect(enabled).not.toContain(serverId);
+			} finally {
+				await deleteRoom(roomId);
+			}
 		});
 
 		test('server must exist in registry before it can be enabled for a room', async () => {
-			// Try to enable a non-existent server
-			await expect(
-				daemon.messageHub.request('mcp.room.setEnabled', {
-					roomId: 'room-missing-server',
-					serverId: 'non-existent-server-id',
-					enabled: true,
-				})
-			).rejects.toThrow();
+			const roomId = await createRoom(daemon, 'test-missing-server');
+
+			try {
+				// Try to enable a non-existent server — should throw
+				await expect(
+					daemon.messageHub.request('mcp.room.setEnabled', {
+						roomId,
+						serverId: 'non-existent-server-id',
+						enabled: true,
+					})
+				).rejects.toThrow();
+			} finally {
+				await deleteRoom(roomId);
+			}
 		});
 	});
 
 	describe('mcp.room.resetToGlobal', () => {
 		test('resetToGlobal removes all per-room overrides', async () => {
+			const roomId = await createRoom(daemon, 'test-reset');
 			const server1 = await createRegistryServer('reset-server-1');
 			const server2 = await createRegistryServer('reset-server-2');
 
-			// Enable both for a room
-			await enableForRoom('room-reset-global', server1.id, true);
-			await enableForRoom('room-reset-global', server2.id, true);
+			try {
+				// Enable both for the room
+				await enableForRoom(roomId, server1.id, true);
+				await enableForRoom(roomId, server2.id, true);
 
-			let enabled = await getEnabledForRoom('room-reset-global');
-			expect(enabled).toContain(server1.id);
-			expect(enabled).toContain(server2.id);
+				let enabled = await getEnabledForRoom(roomId);
+				expect(enabled).toContain(server1.id);
+				expect(enabled).toContain(server2.id);
 
-			// Reset to global
-			await daemon.messageHub.request('mcp.room.resetToGlobal', {
-				roomId: 'room-reset-global',
-			});
+				// Reset to global
+				await daemon.messageHub.request('mcp.room.resetToGlobal', {
+					roomId,
+				});
 
-			// After reset, getEnabled returns empty (no explicit overrides)
-			enabled = await getEnabledForRoom('room-reset-global');
-			expect(enabled).toHaveLength(0);
+				// After reset, getEnabled returns empty (no explicit overrides)
+				enabled = await getEnabledForRoom(roomId);
+				expect(enabled).toHaveLength(0);
+			} finally {
+				await deleteRoom(roomId);
+			}
 		});
 	});
 
 	describe('mcp.registry.changed event', () => {
 		test('changing registry emits mcp.registry.changed event', async () => {
+			const roomId = await createRoom(daemon, 'test-changed-event');
 			const server = await createRegistryServer('changed-event-server');
 
-			// Enable for room
-			await enableForRoom('room-changed-event', server.id, true);
-			let enabled = await getEnabledForRoom('room-changed-event');
-			expect(enabled).toContain(server.id);
+			try {
+				// Enable for room
+				await enableForRoom(roomId, server.id, true);
+				let enabled = await getEnabledForRoom(roomId);
+				expect(enabled).toContain(server.id);
 
-			// The enableForRoom handler emits mcp.registry.changed,
-			// which triggers hot-reload in RoomRuntimeService.
-			// We verify the state change persisted correctly.
+				// The enableForRoom handler emits mcp.registry.changed,
+				// which triggers hot-reload in RoomRuntimeService.
+				// We verify the state change persisted correctly.
+			} finally {
+				await deleteRoom(roomId);
+			}
 		});
 	});
 
 	describe('global fallback behavior', () => {
 		test('rooms with no overrides fall back to globally enabled servers', async () => {
-			// Create servers
-			const serverA = await createRegistryServer('global-alpha');
-			const serverB = await createRegistryServer('global-beta');
+			const roomId = await createRoom(daemon, 'test-global-fallback');
 
-			// Enable globally (all servers start enabled by default from seed)
-			// No per-room overrides set
-
-			// A room with no overrides should not appear in getEnabledForRoom
-			// (getEnabledForRoom only returns explicit overrides)
-			const noOverrideRoom = await getEnabledForRoom('room-no-override');
-			expect(noOverrideRoom).not.toContain(serverA.id);
-			expect(noOverrideRoom).not.toContain(serverB.id);
+			try {
+				// A room with no overrides should not appear in getEnabledForRoom
+				// (getEnabledForRoom only returns explicit overrides)
+				const enabled = await getEnabledForRoom(roomId);
+				expect(enabled).toHaveLength(0);
+			} finally {
+				await deleteRoom(roomId);
+			}
 		});
 	});
 
 	describe('integration with registry CRUD', () => {
 		test('creating and deleting a server updates room enablement state', async () => {
-			// Create a server
+			const roomId = await createRoom(daemon, 'test-crud');
 			const { id: serverId } = await createRegistryServer('crud-integration-server');
 
-			// Enable for room
-			await enableForRoom('room-crud-test', serverId, true);
-			let enabled = await getEnabledForRoom('room-crud-test');
-			expect(enabled).toContain(serverId);
+			try {
+				// Enable for room
+				await enableForRoom(roomId, serverId, true);
+				let enabled = await getEnabledForRoom(roomId);
+				expect(enabled).toContain(serverId);
 
-			// Delete the server
-			await daemon.messageHub.request('mcp.registry.delete', { id: serverId });
+				// Delete the server
+				await daemon.messageHub.request('mcp.registry.delete', { id: serverId });
 
-			// The override for the deleted server remains in room_mcp_enablement
-			// but the server no longer exists in app_mcp_servers.
-			// getEnabledServers joins with app_mcp_servers, so it won't return the deleted server.
-			// This is expected behavior - orphaned overrides are cleaned up on next access.
+				// The override for the deleted server remains in room_mcp_enablement
+				// but the server no longer exists in app_mcp_servers.
+				// getEnabledServers joins with app_mcp_servers, so it won't return the deleted server.
+				// This is expected behavior - orphaned overrides are cleaned up on next access.
+			} finally {
+				await deleteRoom(roomId);
+			}
 		});
 	});
 });

--- a/packages/daemon/tests/online/room/room-mcp-enablement.test.ts
+++ b/packages/daemon/tests/online/room/room-mcp-enablement.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Online tests for Per-Room MCP Enablement
+ *
+ * Tests the integration between:
+ * - AppMcpLifecycleManager.getEnabledMcpConfigsForRoom()
+ * - RoomMcpEnablementRepository (per-room overrides)
+ * - mcp.room RPC handlers (setEnabled, getEnabled, resetToGlobal)
+ *
+ * These tests use the full daemon server with real database and RPC handlers.
+ *
+ * REQUIREMENTS:
+ * - Requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN
+ * - Makes real API calls (costs money, uses rate limits)
+ * - Tests will FAIL if credentials are not available (no skip)
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import type { DaemonServerContext } from '../../helpers/daemon-server';
+import { createDaemonServer } from '../../helpers/daemon-server';
+
+describe('Room MCP Enablement — Online', () => {
+	let daemon: DaemonServerContext;
+
+	beforeEach(async () => {
+		daemon = await createDaemonServer();
+	}, 30000);
+
+	afterEach(async () => {
+		if (!daemon) return;
+		daemon.kill('SIGTERM');
+		await daemon.waitForExit();
+	}, 15000);
+
+	/**
+	 * Helper to create a registry MCP server via RPC.
+	 */
+	async function createRegistryServer(name: string): Promise<{ id: string; name: string }> {
+		const result = (await daemon.messageHub.request('mcp.registry.create', {
+			name,
+			sourceType: 'stdio',
+			command: 'echo',
+			args: [name],
+		})) as { server: { id: string; name: string } };
+		return result.server;
+	}
+
+	/**
+	 * Helper to enable a server for a room via RPC.
+	 */
+	async function enableForRoom(roomId: string, serverId: string, enabled: boolean): Promise<void> {
+		await daemon.messageHub.request('mcp.room.setEnabled', {
+			roomId,
+			serverId,
+			enabled,
+		});
+	}
+
+	/**
+	 * Helper to get enabled servers for a room via RPC.
+	 */
+	async function getEnabledForRoom(roomId: string): Promise<string[]> {
+		const result = (await daemon.messageHub.request('mcp.room.getEnabled', {
+			roomId,
+		})) as { serverIds: string[] };
+		return result.serverIds;
+	}
+
+	describe('mcp.room.setEnabled', () => {
+		test('enabling a server for a room adds it to the room enablement list', async () => {
+			const { id: serverId } = await createRegistryServer('test-server-enable');
+
+			// Initially not enabled for any room
+			const initial = await getEnabledForRoom('room-enable-test');
+			expect(initial).not.toContain(serverId);
+
+			// Enable for room
+			await enableForRoom('room-enable-test', serverId, true);
+
+			// Now enabled
+			const after = await getEnabledForRoom('room-enable-test');
+			expect(after).toContain(serverId);
+		});
+
+		test('disabling a server for a room removes it from the room enablement list', async () => {
+			const { id: serverId } = await createRegistryServer('test-server-disable');
+
+			// Enable first
+			await enableForRoom('room-disable-test', serverId, true);
+			let enabled = await getEnabledForRoom('room-disable-test');
+			expect(enabled).toContain(serverId);
+
+			// Disable
+			await enableForRoom('room-disable-test', serverId, false);
+			enabled = await getEnabledForRoom('room-disable-test');
+			expect(enabled).not.toContain(serverId);
+		});
+
+		test('server must exist in registry before it can be enabled for a room', async () => {
+			// Try to enable a non-existent server
+			await expect(
+				daemon.messageHub.request('mcp.room.setEnabled', {
+					roomId: 'room-missing-server',
+					serverId: 'non-existent-server-id',
+					enabled: true,
+				})
+			).rejects.toThrow();
+		});
+	});
+
+	describe('mcp.room.resetToGlobal', () => {
+		test('resetToGlobal removes all per-room overrides', async () => {
+			const server1 = await createRegistryServer('reset-server-1');
+			const server2 = await createRegistryServer('reset-server-2');
+
+			// Enable both for a room
+			await enableForRoom('room-reset-global', server1.id, true);
+			await enableForRoom('room-reset-global', server2.id, true);
+
+			let enabled = await getEnabledForRoom('room-reset-global');
+			expect(enabled).toContain(server1.id);
+			expect(enabled).toContain(server2.id);
+
+			// Reset to global
+			await daemon.messageHub.request('mcp.room.resetToGlobal', {
+				roomId: 'room-reset-global',
+			});
+
+			// After reset, getEnabled returns empty (no explicit overrides)
+			enabled = await getEnabledForRoom('room-reset-global');
+			expect(enabled).toHaveLength(0);
+		});
+	});
+
+	describe('mcp.registry.changed event', () => {
+		test('changing registry emits mcp.registry.changed event', async () => {
+			const server = await createRegistryServer('changed-event-server');
+
+			// Enable for room
+			await enableForRoom('room-changed-event', server.id, true);
+			let enabled = await getEnabledForRoom('room-changed-event');
+			expect(enabled).toContain(server.id);
+
+			// The enableForRoom handler emits mcp.registry.changed,
+			// which triggers hot-reload in RoomRuntimeService.
+			// We verify the state change persisted correctly.
+		});
+	});
+
+	describe('global fallback behavior', () => {
+		test('rooms with no overrides fall back to globally enabled servers', async () => {
+			// Create servers
+			const serverA = await createRegistryServer('global-alpha');
+			const serverB = await createRegistryServer('global-beta');
+
+			// Enable globally (all servers start enabled by default from seed)
+			// No per-room overrides set
+
+			// A room with no overrides should not appear in getEnabledForRoom
+			// (getEnabledForRoom only returns explicit overrides)
+			const noOverrideRoom = await getEnabledForRoom('room-no-override');
+			expect(noOverrideRoom).not.toContain(serverA.id);
+			expect(noOverrideRoom).not.toContain(serverB.id);
+		});
+	});
+
+	describe('integration with registry CRUD', () => {
+		test('creating and deleting a server updates room enablement state', async () => {
+			// Create a server
+			const { id: serverId } = await createRegistryServer('crud-integration-server');
+
+			// Enable for room
+			await enableForRoom('room-crud-test', serverId, true);
+			let enabled = await getEnabledForRoom('room-crud-test');
+			expect(enabled).toContain(serverId);
+
+			// Delete the server
+			await daemon.messageHub.request('mcp.registry.delete', { id: serverId });
+
+			// The override for the deleted server remains in room_mcp_enablement
+			// but the server no longer exists in app_mcp_servers.
+			// getEnabledServers joins with app_mcp_servers, so it won't return the deleted server.
+			// This is expected behavior - orphaned overrides are cleaned up on next access.
+		});
+	});
+});

--- a/packages/daemon/tests/unit/mcp/app-mcp-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/mcp/app-mcp-lifecycle-manager.test.ts
@@ -493,15 +493,17 @@ describe('AppMcpLifecycleManager', () => {
 				command: 'valid',
 				enabled: true,
 			});
-			repo.create({
+			const brokenServer = repo.create({
 				name: 'broken-server',
 				sourceType: 'stdio',
 				// missing command — invalid
 				enabled: true,
 			});
 
+			// Enable both servers for the room so validation is actually invoked on broken-server
+			// within the per-room loop (getEnabledServers returns both, broken-server is filtered out)
 			db.roomMcpEnablement.setEnabled('room-invalid', validServer.id, true);
-			// broken-server has no per-room override but is globally invalid
+			db.roomMcpEnablement.setEnabled('room-invalid', brokenServer.id, true);
 
 			const roomConfigs = manager.getEnabledMcpConfigsForRoom('room-invalid');
 

--- a/packages/daemon/tests/unit/mcp/app-mcp-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/mcp/app-mcp-lifecycle-manager.test.ts
@@ -6,6 +6,8 @@
  * - Disabled entries are excluded from getEnabledMcpConfigs().
  * - validateEntry() catches missing required fields.
  * - getStartupErrors() returns invalid entries with descriptive messages.
+ * - getEnabledMcpConfigsForRoom() returns per-room overrides when set,
+ *   falling back to global enabled set when no overrides exist.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -13,6 +15,7 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { createTables } from '../../../src/storage/schema';
 import { createReactiveDatabase } from '../../../src/storage/reactive-database';
 import { AppMcpServerRepository } from '../../../src/storage/repositories/app-mcp-server-repository';
+import { RoomMcpEnablementRepository } from '../../../src/storage/repositories/room-mcp-enablement-repository';
 import { AppMcpLifecycleManager } from '../../../src/lib/mcp';
 import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
 import type { Database } from '../../../src/storage/database';
@@ -25,11 +28,13 @@ function createTestDb(): { bunDb: BunDatabase; reactiveDb: ReactiveDatabase; db:
 	const bunDb = new BunDatabase(':memory:');
 	createTables(bunDb);
 	const reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
-	const repo = new AppMcpServerRepository(bunDb, reactiveDb);
+	const appMcpServerRepo = new AppMcpServerRepository(bunDb, reactiveDb);
+	const roomMcpEnablementRepo = new RoomMcpEnablementRepository(bunDb, reactiveDb);
 
-	// Build a minimal Database facade that exposes appMcpServers
+	// Build a minimal Database facade that exposes both repositories
 	const db = {
-		appMcpServers: repo,
+		appMcpServers: appMcpServerRepo,
+		roomMcpEnablement: roomMcpEnablementRepo,
 	} as unknown as Database;
 
 	return { bunDb, reactiveDb, db };
@@ -391,22 +396,140 @@ describe('AppMcpLifecycleManager', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// getEnabledMcpConfigsForRoom (stub)
+	// getEnabledMcpConfigsForRoom — per-room enablement
 	// -------------------------------------------------------------------------
 
 	describe('getEnabledMcpConfigsForRoom', () => {
-		test('falls back to global enabled configs (stub behavior)', () => {
-			repo.create({
+		test('falls back to global enabled configs when room has no overrides', () => {
+			const server = repo.create({
 				name: 'global-server',
 				sourceType: 'stdio',
 				command: 'my-server',
 				enabled: true,
 			});
 
+			// No per-room overrides set — should fall back to global
 			const globalConfigs = manager.getEnabledMcpConfigs();
 			const roomConfigs = manager.getEnabledMcpConfigsForRoom('room-123');
 
 			expect(roomConfigs).toEqual(globalConfigs);
+			expect(roomConfigs['global-server']).toBeDefined();
+			expect((roomConfigs['global-server'] as { type: string }).type).toBe('stdio');
+		});
+
+		test('returns only per-room enabled servers when overrides exist', () => {
+			const serverA = repo.create({
+				name: 'server-a',
+				sourceType: 'stdio',
+				command: 'server-a',
+				enabled: true,
+			});
+			const serverB = repo.create({
+				name: 'server-b',
+				sourceType: 'stdio',
+				command: 'server-b',
+				enabled: true,
+			});
+
+			// Enable only server-a for room-123
+			db.roomMcpEnablement.setEnabled('room-123', serverA.id, true);
+			// room-123 has an override, so it should NOT include server-b
+			// (even though server-b is globally enabled)
+
+			const roomConfigs = manager.getEnabledMcpConfigsForRoom('room-123');
+
+			expect(roomConfigs['server-a']).toBeDefined();
+			expect(roomConfigs['server-b']).toBeUndefined();
+		});
+
+		test('per-room disable takes precedence over global enable', () => {
+			const server = repo.create({
+				name: 'selective-server',
+				sourceType: 'stdio',
+				command: 'selective',
+				enabled: true,
+			});
+
+			// Globally enabled, but disabled for room-456
+			db.roomMcpEnablement.setEnabled('room-456', server.id, false);
+
+			const roomConfigs = manager.getEnabledMcpConfigsForRoom('room-456');
+
+			expect(roomConfigs['selective-server']).toBeUndefined();
+		});
+
+		test('different rooms can have different enabled servers', () => {
+			const serverA = repo.create({
+				name: 'alpha',
+				sourceType: 'stdio',
+				command: 'alpha',
+				enabled: true,
+			});
+			const serverB = repo.create({
+				name: 'beta',
+				sourceType: 'stdio',
+				command: 'beta',
+				enabled: true,
+			});
+
+			// room-1: only alpha enabled
+			db.roomMcpEnablement.setEnabled('room-1', serverA.id, true);
+			// room-2: only beta enabled
+			db.roomMcpEnablement.setEnabled('room-2', serverB.id, true);
+
+			const configs1 = manager.getEnabledMcpConfigsForRoom('room-1');
+			const configs2 = manager.getEnabledMcpConfigsForRoom('room-2');
+
+			expect(configs1['alpha']).toBeDefined();
+			expect(configs1['beta']).toBeUndefined();
+			expect(configs2['alpha']).toBeUndefined();
+			expect(configs2['beta']).toBeDefined();
+		});
+
+		test('invalid entries are excluded from per-room configs', () => {
+			const validServer = repo.create({
+				name: 'valid-server',
+				sourceType: 'stdio',
+				command: 'valid',
+				enabled: true,
+			});
+			repo.create({
+				name: 'broken-server',
+				sourceType: 'stdio',
+				// missing command — invalid
+				enabled: true,
+			});
+
+			db.roomMcpEnablement.setEnabled('room-invalid', validServer.id, true);
+			// broken-server has no per-room override but is globally invalid
+
+			const roomConfigs = manager.getEnabledMcpConfigsForRoom('room-invalid');
+
+			expect(roomConfigs['valid-server']).toBeDefined();
+			expect(roomConfigs['broken-server']).toBeUndefined();
+		});
+
+		test('resetToGlobal removes per-room overrides', () => {
+			const server = repo.create({
+				name: 'reset-test',
+				sourceType: 'stdio',
+				command: 'reset',
+				enabled: true,
+			});
+
+			// Set per-room override
+			db.roomMcpEnablement.setEnabled('room-reset', server.id, true);
+
+			// Verify per-room override is in effect
+			let configs = manager.getEnabledMcpConfigsForRoom('room-reset');
+			expect(configs['reset-test']).toBeDefined();
+
+			// Reset to global
+			db.roomMcpEnablement.resetToGlobal('room-reset');
+
+			// Now falls back to global (which includes reset-test since it's globally enabled)
+			configs = manager.getEnabledMcpConfigsForRoom('room-reset');
+			expect(configs['reset-test']).toBeDefined();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-service-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-mcp.test.ts
@@ -94,6 +94,7 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'registry-server': registryServer }),
+			getEnabledMcpConfigsForRoom: () => ({ 'registry-server': registryServer }),
 		};
 
 		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
@@ -173,6 +174,7 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'room-agent-tools': conflictingServer }),
+			getEnabledMcpConfigsForRoom: () => ({ 'room-agent-tools': conflictingServer }),
 		};
 
 		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
@@ -239,6 +241,7 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'registry-mcp': registryServer }),
+			getEnabledMcpConfigsForRoom: () => ({ 'registry-mcp': registryServer }),
 		};
 
 		const settingsManager = {
@@ -380,6 +383,7 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'hot-server': registryServer }),
+			getEnabledMcpConfigsForRoom: () => ({ 'hot-server': registryServer }),
 		};
 
 		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
@@ -459,6 +463,7 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'reg-server': registryServer }),
+			getEnabledMcpConfigsForRoom: () => ({ 'reg-server': registryServer }),
 		};
 
 		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
@@ -534,6 +539,7 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({}),
+			getEnabledMcpConfigsForRoom: () => ({}),
 		};
 
 		const service = new RoomRuntimeService(
@@ -575,6 +581,7 @@ describe('RoomRuntimeService MCP merge — collision resolution', () => {
 
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'shared-name': registryServer }),
+			getEnabledMcpConfigsForRoom: () => ({ 'shared-name': registryServer }),
 		};
 
 		const settingsManager = {

--- a/scripts/validate-online-test-matrix.sh
+++ b/scripts/validate-online-test-matrix.sh
@@ -51,6 +51,7 @@ ROOM_FILES=(
   room-advanced-scenarios.test.ts
   room-chat-agent-tools.test.ts
   room-chat-constraints.test.ts
+  room-mcp-enablement.test.ts
   room-multi-agent-flow.test.ts
   room-planner-two-phase.test.ts
   room-replan-recovery.test.ts


### PR DESCRIPTION
Implement getEnabledMcpConfigsForRoom() to use the room_mcp_enablement
table for per-room filtering, falling back to global registry defaults
when no room-specific overrides exist.

Changes:
- AppMcpLifecycleManager.getEnabledMcpConfigsForRoom(): query
  roomMcpEnablement.getEnabledServers(roomId) for per-room overrides;
  if empty, fall back to global listEnabled() but exclude any servers
  explicitly disabled for that room via getOverride()
- RoomRuntimeService.setupRoomAgentSession(): call
  getEnabledMcpConfigsForRoom(room.id) instead of getEnabledMcpConfigs()
- mcp.registry.changed handler: call getEnabledMcpConfigsForRoom(roomId)
  per-room instead of global getEnabledMcpConfigs()
- Unit tests: update appMcpLifecycleManager tests with 6 new cases for
  per-room enablement; update room-runtime-service-mcp tests to mock
  getEnabledMcpConfigsForRoom
- Online tests: add room-mcp-enablement.test.ts verifying
  mcp.room.setEnabled/getEnabled/resetToGlobal RPC behavior
