### PR TITLE
feat(web): add Application-Level MCP Settings Panel (Task 5.2)

### DIFF
--- a/packages/web/src/components/settings/AppMcpServersSettings.tsx
+++ b/packages/web/src/components/settings/AppMcpServersSettings.tsx
@@ -95,6 +95,8 @@ export function AppMcpServersSettings() {
 			// sse or http
 			if (!formData.url.trim()) {
 				errors.url = 'URL is required for SSE/HTTP servers';
+			} else if (!/^https?:\/\//i.test(formData.url.trim())) {
+				errors.url = 'URL must start with http:// or https://';
 			}
 		}
 
@@ -555,32 +557,30 @@ export function AppMcpServersSettings() {
 						</>
 					)}
 
-					{/* Env Vars (for stdio) */}
-					{formData.sourceType === 'stdio' && (
-						<div>
-							<label class="block text-sm font-medium text-gray-300 mb-1">
-								Environment Variables
-							</label>
-							<textarea
-								value={formData.envVars}
-								onChange={(e) =>
-									setFormData({ ...formData, envVars: (e.target as HTMLTextAreaElement).value })
-								}
-								class={cn(
-									'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
-									'focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none',
-									formErrors.envVars ? 'border-red-500' : 'border-dark-700'
-								)}
-								rows={3}
-								placeholder="e.g., BRAVE_API_KEY=BRAVE_API_KEY"
-							/>
-							{formErrors.envVars && <p class="text-xs text-red-400 mt-1">{formErrors.envVars}</p>}
-							<p class="text-xs text-gray-500 mt-1">
-								One env var per line in key=value format. For secrets, set the value in your system
-								environment and reference the env var name here.
-							</p>
-						</div>
-					)}
+					{/* Env Vars (for all source types) */}
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							Environment Variables
+						</label>
+						<textarea
+							value={formData.envVars}
+							onChange={(e) =>
+								setFormData({ ...formData, envVars: (e.target as HTMLTextAreaElement).value })
+							}
+							class={cn(
+								'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+								'focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none',
+								formErrors.envVars ? 'border-red-500' : 'border-dark-700'
+							)}
+							rows={3}
+							placeholder="e.g., BRAVE_API_KEY=BRAVE_API_KEY"
+						/>
+						{formErrors.envVars && <p class="text-xs text-red-400 mt-1">{formErrors.envVars}</p>}
+						<p class="text-xs text-gray-500 mt-1">
+							One env var per line in key=value format. For secrets, set the value in your system
+							environment and reference the env var name here.
+						</p>
+					</div>
 
 					{/* Form Actions */}
 					<div class="flex items-center justify-end gap-3 pt-2">

--- a/packages/web/src/components/settings/AppMcpServersSettings.tsx
+++ b/packages/web/src/components/settings/AppMcpServersSettings.tsx
@@ -1,0 +1,613 @@
+/**
+ * AppMcpServersSettings Component
+ *
+ * Settings panel for managing application-level MCP server registry.
+ * Allows users to add, edit, delete, and enable/disable MCP servers.
+ */
+
+import { useEffect, useState } from 'preact/hooks';
+import type { AppMcpServer, AppMcpServerSourceType } from '@neokai/shared';
+import {
+	createAppMcpServer,
+	updateAppMcpServer,
+	deleteAppMcpServer,
+	setAppMcpServerEnabled,
+} from '../../lib/api-helpers.ts';
+import { appMcpStore } from '../../lib/app-mcp-store.ts';
+import { toast } from '../../lib/toast.ts';
+import { SettingsSection, SettingsToggle } from './SettingsSection.tsx';
+import { Modal } from '../ui/Modal.tsx';
+import { ConfirmModal } from '../ui/ConfirmModal.tsx';
+import { Button } from '../ui/Button.tsx';
+import { cn } from '../../lib/utils.ts';
+
+interface FormData {
+	name: string;
+	description: string;
+	sourceType: AppMcpServerSourceType;
+	command: string;
+	args: string;
+	envVars: string;
+	url: string;
+	headers: string;
+}
+
+interface FormErrors {
+	name?: string;
+	sourceType?: string;
+	command?: string;
+	args?: string;
+	envVars?: string;
+	url?: string;
+	headers?: string;
+}
+
+const EMPTY_FORM: FormData = {
+	name: '',
+	description: '',
+	sourceType: 'stdio',
+	command: '',
+	args: '',
+	envVars: '',
+	url: '',
+	headers: '',
+};
+
+export function AppMcpServersSettings() {
+	const servers = appMcpStore.appMcpServers.value;
+	const loading = appMcpStore.loading.value;
+	const error = appMcpStore.error.value;
+
+	const [showForm, setShowForm] = useState(false);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+	const [editingServer, setEditingServer] = useState<AppMcpServer | null>(null);
+	const [deletingServer, setDeletingServer] = useState<AppMcpServer | null>(null);
+	const [formData, setFormData] = useState<FormData>(EMPTY_FORM);
+	const [formErrors, setFormErrors] = useState<FormErrors>({});
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [togglingId, setTogglingId] = useState<string | null>(null);
+
+	// Subscribe to the store on mount
+	useEffect(() => {
+		appMcpStore.subscribe().catch((err) => {
+			toast.error(
+				'Failed to load MCP servers: ' + (err instanceof Error ? err.message : 'Unknown error')
+			);
+		});
+
+		return () => {
+			appMcpStore.unsubscribe();
+		};
+	}, []);
+
+	const validateForm = (): boolean => {
+		const errors: FormErrors = {};
+
+		if (!formData.name.trim()) {
+			errors.name = 'Name is required';
+		}
+
+		if (formData.sourceType === 'stdio') {
+			if (!formData.command.trim()) {
+				errors.command = 'Command is required for stdio servers';
+			}
+		} else {
+			// sse or http
+			if (!formData.url.trim()) {
+				errors.url = 'URL is required for SSE/HTTP servers';
+			}
+		}
+
+		if (formData.args.trim()) {
+			// Validate that args are space-separated without quotes issues
+			const args = formData.args.trim().split(/\s+/);
+			if (args.some((a) => a.includes('"'))) {
+				errors.args = 'Args should be space-separated without quotes';
+			}
+		}
+
+		if (formData.envVars.trim()) {
+			// Validate key=value format
+			const lines = formData.envVars.trim().split('\n');
+			for (const line of lines) {
+				if (!line.includes('=')) {
+					errors.envVars = 'Each env var must be in key=value format';
+					break;
+				}
+				const [key] = line.split('=');
+				if (!key.trim()) {
+					errors.envVars = 'Each env var must be in key=value format';
+					break;
+				}
+			}
+		}
+
+		if (formData.headers.trim()) {
+			// Validate key=value format
+			const lines = formData.headers.trim().split('\n');
+			for (const line of lines) {
+				if (!line.includes('=')) {
+					errors.headers = 'Each header must be in key=value format';
+					break;
+				}
+				const [key] = line.split('=');
+				if (!key.trim()) {
+					errors.headers = 'Each header must be in key=value format';
+					break;
+				}
+			}
+		}
+
+		setFormErrors(errors);
+		return Object.keys(errors).length === 0;
+	};
+
+	const resetForm = () => {
+		setFormData(EMPTY_FORM);
+		setFormErrors({});
+		setEditingServer(null);
+	};
+
+	const openAddForm = () => {
+		resetForm();
+		setShowForm(true);
+	};
+
+	const openEditForm = (server: AppMcpServer) => {
+		setEditingServer(server);
+		setFormData({
+			name: server.name,
+			description: server.description ?? '',
+			sourceType: server.sourceType,
+			command: server.command ?? '',
+			args: server.args?.join(' ') ?? '',
+			envVars: server.env
+				? Object.entries(server.env)
+						.map(([k, v]) => `${k}=${v}`)
+						.join('\n')
+				: '',
+			url: server.url ?? '',
+			headers: server.headers
+				? Object.entries(server.headers)
+						.map(([k, v]) => `${k}=${v}`)
+						.join('\n')
+				: '',
+		});
+		setFormErrors({});
+		setShowForm(true);
+	};
+
+	const closeForm = () => {
+		setShowForm(false);
+		resetForm();
+	};
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+
+		if (!validateForm()) return;
+
+		setIsSubmitting(true);
+
+		try {
+			const parsedArgs = formData.args.trim() ? formData.args.trim().split(/\s+/) : undefined;
+			const parsedEnv = formData.envVars.trim()
+				? Object.fromEntries(
+						formData.envVars
+							.trim()
+							.split('\n')
+							.map((line) => {
+								const [key, ...valueParts] = line.split('=');
+								return [key.trim(), valueParts.join('=')];
+							})
+					)
+				: undefined;
+			const parsedHeaders = formData.headers.trim()
+				? Object.fromEntries(
+						formData.headers
+							.trim()
+							.split('\n')
+							.map((line) => {
+								const [key, ...valueParts] = line.split('=');
+								return [key.trim(), valueParts.join('=')];
+							})
+					)
+				: undefined;
+
+			if (editingServer) {
+				await updateAppMcpServer(editingServer.id, {
+					name: formData.name.trim(),
+					description: formData.description.trim() || undefined,
+					sourceType: formData.sourceType,
+					command:
+						formData.sourceType === 'stdio' ? formData.command.trim() || undefined : undefined,
+					args: formData.sourceType === 'stdio' ? parsedArgs : undefined,
+					env: parsedEnv,
+					url: formData.sourceType !== 'stdio' ? formData.url.trim() || undefined : undefined,
+					headers: formData.sourceType !== 'stdio' ? parsedHeaders : undefined,
+				});
+				toast.success(`Updated "${formData.name}"`);
+			} else {
+				await createAppMcpServer({
+					name: formData.name.trim(),
+					description: formData.description.trim() || undefined,
+					sourceType: formData.sourceType,
+					command:
+						formData.sourceType === 'stdio' ? formData.command.trim() || undefined : undefined,
+					args: formData.sourceType === 'stdio' ? parsedArgs : undefined,
+					env: parsedEnv,
+					url: formData.sourceType !== 'stdio' ? formData.url.trim() || undefined : undefined,
+					headers: formData.sourceType !== 'stdio' ? parsedHeaders : undefined,
+				});
+				toast.success(`Added "${formData.name}"`);
+			}
+
+			closeForm();
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'Failed to save MCP server';
+			toast.error(message);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (!deletingServer) return;
+
+		setIsSubmitting(true);
+		try {
+			await deleteAppMcpServer(deletingServer.id);
+			toast.success(`Deleted "${deletingServer.name}"`);
+			setShowDeleteConfirm(false);
+			setDeletingServer(null);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'Failed to delete MCP server';
+			toast.error(message);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleToggle = async (server: AppMcpServer, enabled: boolean) => {
+		setTogglingId(server.id);
+		try {
+			await setAppMcpServerEnabled(server.id, enabled);
+			toast.success(`${enabled ? 'Enabled' : 'Disabled'} "${server.name}"`);
+		} catch (err) {
+			const message =
+				err instanceof Error
+					? err.message
+					: `Failed to ${enabled ? 'enable' : 'disable'} MCP server`;
+			toast.error(message);
+		} finally {
+			setTogglingId(null);
+		}
+	};
+
+	if (loading && servers.length === 0) {
+		return (
+			<SettingsSection title="Application MCP Servers">
+				<div class="text-sm text-gray-500 py-2">Loading servers...</div>
+			</SettingsSection>
+		);
+	}
+
+	if (error) {
+		return (
+			<SettingsSection title="Application MCP Servers">
+				<div class="text-sm text-red-400 py-2">Error: {error}</div>
+			</SettingsSection>
+		);
+	}
+
+	return (
+		<>
+			<SettingsSection title="Application MCP Servers">
+				<div class="mb-4">
+					<p class="text-xs text-gray-500 mb-3">
+						Application MCP servers are available to any room or session. Configure external MCP
+						servers here. For API keys and secrets, set them in your system environment (e.g.,{' '}
+						<code class="text-xs bg-dark-800 px-1 py-0.5 rounded">export BRAVE_API_KEY=...</code>)
+						and reference them by name in the env vars field below. Values stored here are saved in
+						plain text.
+					</p>
+					<Button variant="primary" size="sm" onClick={openAddForm}>
+						Add MCP Server
+					</Button>
+				</div>
+
+				{servers.length === 0 ? (
+					<div class="text-sm text-gray-500 py-4">
+						No MCP servers configured. Click "Add MCP Server" to add one.
+					</div>
+				) : (
+					<div class="space-y-2">
+						{servers.map((server) => (
+							<div
+								key={server.id}
+								class={cn(
+									'flex items-center justify-between gap-3 py-3 px-3',
+									'bg-dark-800/50 rounded-lg border border-dark-700'
+								)}
+							>
+								<div class="flex-1 min-w-0">
+									<div class="text-sm text-gray-200 truncate font-medium">{server.name}</div>
+									<div class="text-xs text-gray-500 mt-0.5 flex items-center gap-2 flex-wrap">
+										<span
+											class={cn(
+												'px-1.5 py-0.5 rounded text-[10px] uppercase font-medium',
+												server.sourceType === 'stdio' && 'bg-green-500/20 text-green-400',
+												server.sourceType === 'sse' && 'bg-blue-500/20 text-blue-400',
+												server.sourceType === 'http' && 'bg-purple-500/20 text-purple-400'
+											)}
+										>
+											{server.sourceType}
+										</span>
+										{server.sourceType === 'stdio' && server.command && (
+											<span class="font-mono truncate max-w-[200px]">{server.command}</span>
+										)}
+										{server.sourceType !== 'stdio' && server.url && (
+											<span class="truncate max-w-[200px]">{server.url}</span>
+										)}
+									</div>
+									{server.description && (
+										<div class="text-xs text-gray-500 mt-1 truncate">{server.description}</div>
+									)}
+								</div>
+
+								<div class="flex items-center gap-2 flex-shrink-0">
+									<button
+										onClick={() => openEditForm(server)}
+										class="p-1.5 text-gray-400 hover:text-gray-200 hover:bg-dark-700 rounded transition-colors"
+										title="Edit"
+									>
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+											/>
+										</svg>
+									</button>
+									<button
+										onClick={() => {
+											setDeletingServer(server);
+											setShowDeleteConfirm(true);
+										}}
+										class="p-1.5 text-gray-400 hover:text-red-400 hover:bg-dark-700 rounded transition-colors"
+										title="Delete"
+									>
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+											/>
+										</svg>
+									</button>
+									<SettingsToggle
+										checked={server.enabled}
+										onChange={(enabled) => handleToggle(server, enabled)}
+										disabled={togglingId === server.id}
+									/>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</SettingsSection>
+
+			{/* Add/Edit Form Modal */}
+			<Modal
+				isOpen={showForm}
+				onClose={closeForm}
+				title={editingServer ? 'Edit MCP Server' : 'Add MCP Server'}
+				size="lg"
+			>
+				<form onSubmit={handleSubmit} class="space-y-4">
+					{/* Name */}
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							Name <span class="text-red-400">*</span>
+						</label>
+						<input
+							type="text"
+							value={formData.name}
+							onChange={(e) =>
+								setFormData({ ...formData, name: (e.target as HTMLInputElement).value })
+							}
+							class={cn(
+								'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200',
+								'focus:outline-none focus:ring-1 focus:ring-blue-500',
+								formErrors.name ? 'border-red-500' : 'border-dark-700'
+							)}
+							placeholder="e.g., brave-search"
+						/>
+						{formErrors.name && <p class="text-xs text-red-400 mt-1">{formErrors.name}</p>}
+					</div>
+
+					{/* Description */}
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">Description</label>
+						<input
+							type="text"
+							value={formData.description}
+							onChange={(e) =>
+								setFormData({ ...formData, description: (e.target as HTMLInputElement).value })
+							}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
+							placeholder="Optional description"
+						/>
+					</div>
+
+					{/* Source Type */}
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							Source Type <span class="text-red-400">*</span>
+						</label>
+						<select
+							value={formData.sourceType}
+							onChange={(e) =>
+								setFormData({
+									...formData,
+									sourceType: (e.target as HTMLSelectElement).value as AppMcpServerSourceType,
+								})
+							}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						>
+							<option value="stdio">Stdio (local process)</option>
+							<option value="sse">SSE (Server-Sent Events)</option>
+							<option value="http">HTTP</option>
+						</select>
+					</div>
+
+					{/* Stdio-specific fields */}
+					{formData.sourceType === 'stdio' && (
+						<>
+							<div>
+								<label class="block text-sm font-medium text-gray-300 mb-1">
+									Command <span class="text-red-400">*</span>
+								</label>
+								<input
+									type="text"
+									value={formData.command}
+									onChange={(e) =>
+										setFormData({ ...formData, command: (e.target as HTMLInputElement).value })
+									}
+									class={cn(
+										'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+										'focus:outline-none focus:ring-1 focus:ring-blue-500',
+										formErrors.command ? 'border-red-500' : 'border-dark-700'
+									)}
+									placeholder="e.g., npx"
+								/>
+								{formErrors.command && (
+									<p class="text-xs text-red-400 mt-1">{formErrors.command}</p>
+								)}
+							</div>
+
+							<div>
+								<label class="block text-sm font-medium text-gray-300 mb-1">Args</label>
+								<input
+									type="text"
+									value={formData.args}
+									onChange={(e) =>
+										setFormData({ ...formData, args: (e.target as HTMLInputElement).value })
+									}
+									class={cn(
+										'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+										'focus:outline-none focus:ring-1 focus:ring-blue-500',
+										formErrors.args ? 'border-red-500' : 'border-dark-700'
+									)}
+									placeholder="e.g., -y @modelcontextprotocol/server-brave-search"
+								/>
+								{formErrors.args && <p class="text-xs text-red-400 mt-1">{formErrors.args}</p>}
+								<p class="text-xs text-gray-500 mt-1">Space-separated arguments</p>
+							</div>
+						</>
+					)}
+
+					{/* SSE/HTTP-specific fields */}
+					{formData.sourceType !== 'stdio' && (
+						<>
+							<div>
+								<label class="block text-sm font-medium text-gray-300 mb-1">
+									URL <span class="text-red-400">*</span>
+								</label>
+								<input
+									type="text"
+									value={formData.url}
+									onChange={(e) =>
+										setFormData({ ...formData, url: (e.target as HTMLInputElement).value })
+									}
+									class={cn(
+										'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200',
+										'focus:outline-none focus:ring-1 focus:ring-blue-500',
+										formErrors.url ? 'border-red-500' : 'border-dark-700'
+									)}
+									placeholder="e.g., http://localhost:8080/sse"
+								/>
+								{formErrors.url && <p class="text-xs text-red-400 mt-1">{formErrors.url}</p>}
+							</div>
+
+							<div>
+								<label class="block text-sm font-medium text-gray-300 mb-1">Headers</label>
+								<textarea
+									value={formData.headers}
+									onChange={(e) =>
+										setFormData({ ...formData, headers: (e.target as HTMLTextAreaElement).value })
+									}
+									class={cn(
+										'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+										'focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none',
+										formErrors.headers ? 'border-red-500' : 'border-dark-700'
+									)}
+									rows={3}
+									placeholder="e.g., Authorization=Bearer token"
+								/>
+								{formErrors.headers && (
+									<p class="text-xs text-red-400 mt-1">{formErrors.headers}</p>
+								)}
+								<p class="text-xs text-gray-500 mt-1">One header per line in key=value format</p>
+							</div>
+						</>
+					)}
+
+					{/* Env Vars (for stdio) */}
+					{formData.sourceType === 'stdio' && (
+						<div>
+							<label class="block text-sm font-medium text-gray-300 mb-1">
+								Environment Variables
+							</label>
+							<textarea
+								value={formData.envVars}
+								onChange={(e) =>
+									setFormData({ ...formData, envVars: (e.target as HTMLTextAreaElement).value })
+								}
+								class={cn(
+									'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+									'focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none',
+									formErrors.envVars ? 'border-red-500' : 'border-dark-700'
+								)}
+								rows={3}
+								placeholder="e.g., BRAVE_API_KEY=BRAVE_API_KEY"
+							/>
+							{formErrors.envVars && <p class="text-xs text-red-400 mt-1">{formErrors.envVars}</p>}
+							<p class="text-xs text-gray-500 mt-1">
+								One env var per line in key=value format. For secrets, set the value in your system
+								environment and reference the env var name here.
+							</p>
+						</div>
+					)}
+
+					{/* Form Actions */}
+					<div class="flex items-center justify-end gap-3 pt-2">
+						<Button type="button" variant="secondary" size="sm" onClick={closeForm}>
+							Cancel
+						</Button>
+						<Button type="submit" variant="primary" size="sm" loading={isSubmitting}>
+							{editingServer ? 'Save Changes' : 'Add Server'}
+						</Button>
+					</div>
+				</form>
+			</Modal>
+
+			{/* Delete Confirmation Modal */}
+			<ConfirmModal
+				isOpen={showDeleteConfirm}
+				onClose={() => {
+					setShowDeleteConfirm(false);
+					setDeletingServer(null);
+				}}
+				onConfirm={handleDelete}
+				title="Delete MCP Server"
+				message={`Are you sure you want to delete "${deletingServer?.name}"? This action cannot be undone.`}
+				confirmText="Delete"
+				confirmButtonVariant="danger"
+				isLoading={isSubmitting}
+			/>
+		</>
+	);
+}

--- a/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
+++ b/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, screen } from '@testing-library/preact';
+import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/preact';
 import type { AppMcpServer } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
@@ -123,8 +123,8 @@ vi.mock('../ui/ConfirmModal.tsx', () => ({
 		) : null,
 }));
 
-// Mock SettingsSection component
-vi.mock('./SettingsSection.tsx', () => ({
+// Mock SettingsSection component - correct path is ../SettingsSection.tsx
+vi.mock('../SettingsSection.tsx', () => ({
 	SettingsSection: ({
 		title,
 		children,
@@ -157,8 +157,7 @@ vi.mock('./SettingsSection.tsx', () => ({
 	),
 }));
 
-// Mock Button component - use data-testid to find buttons
-let buttonClickHandler: (() => void) | null = null;
+// Mock Button component
 vi.mock('../ui/Button.tsx', () => ({
 	Button: ({
 		children,
@@ -176,24 +175,18 @@ vi.mock('../ui/Button.tsx', () => ({
 		onClick?: () => void;
 		disabled?: boolean;
 		loading?: boolean;
-	}) => {
-		// Store the click handler so tests can trigger it
-		if (onClick) {
-			buttonClickHandler = onClick;
-		}
-		return (
-			<button
-				data-testid={`button-${variant || 'primary'}`}
-				data-size={size}
-				data-type={type}
-				disabled={disabled || loading}
-				onClick={onClick}
-			>
-				{loading && <span data-testid="button-loading">Loading...</span>}
-				{children}
-			</button>
-		);
-	},
+	}) => (
+		<button
+			data-testid={`button-${variant || 'primary'}`}
+			data-size={size}
+			data-type={type}
+			disabled={disabled || loading}
+			onClick={onClick}
+		>
+			{loading && <span data-testid="button-loading">Loading...</span>}
+			{children}
+		</button>
+	),
 }));
 
 // Import the component after mocks are set up
@@ -225,7 +218,6 @@ describe('AppMcpServersSettings', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		cleanup();
-		buttonClickHandler = null;
 
 		// Reset store signals
 		appMcpStore.appMcpServers.value = [];
@@ -244,7 +236,6 @@ describe('AppMcpServersSettings', () => {
 	afterEach(() => {
 		cleanup();
 		vi.clearAllMocks();
-		buttonClickHandler = null;
 	});
 
 	describe('Server List Display', () => {
@@ -253,7 +244,7 @@ describe('AppMcpServersSettings', () => {
 
 			render(<AppMcpServersSettings />);
 
-			expect(screen.getByText('No MCP servers configured')).toBeTruthy();
+			expect(screen.getByText(/No MCP servers configured/)).toBeTruthy();
 		});
 
 		it('should show loading state when loading', () => {
@@ -300,8 +291,7 @@ describe('AppMcpServersSettings', () => {
 		it('should show the informational note about env vars', () => {
 			render(<AppMcpServersSettings />);
 
-			expect(screen.getByText(/Environment Variables/)).toBeTruthy();
-			expect(screen.getByText(/system environment/)).toBeTruthy();
+			expect(screen.getByText(/env vars field below/)).toBeTruthy();
 		});
 
 		it('should show Add MCP Server button', () => {
@@ -335,6 +325,85 @@ describe('AppMcpServersSettings', () => {
 			render(<AppMcpServersSettings />);
 
 			expect(mockSubscribe).toHaveBeenCalled();
+		});
+	});
+
+	describe('Add Server Form', () => {
+		it('should have Add MCP Server button', () => {
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByText('Add MCP Server')).toBeTruthy();
+		});
+	});
+
+	describe('Edit Server', () => {
+		it('should show edit and delete buttons for servers', () => {
+			const servers = [makeServer('1', { name: 'test-server' })];
+			appMcpStore.appMcpServers.value = servers;
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByTitle('Edit')).toBeTruthy();
+			expect(screen.getByTitle('Delete')).toBeTruthy();
+		});
+	});
+
+	describe('Delete Confirmation', () => {
+		it('should show delete button that triggers confirmation state', () => {
+			const servers = [makeServer('1', { name: 'test-server' })];
+			appMcpStore.appMcpServers.value = servers;
+
+			render(<AppMcpServersSettings />);
+
+			// Delete button exists and is clickable
+			const deleteButton = screen.getByTitle('Delete');
+			expect(deleteButton).toBeTruthy();
+		});
+	});
+
+	describe('Toggle', () => {
+		it('should render toggle for each server', () => {
+			const servers = [makeServer('1', { name: 'test-server', enabled: true })];
+			appMcpStore.appMcpServers.value = servers;
+
+			render(<AppMcpServersSettings />);
+
+			const toggle = screen.getByTestId('settings-toggle');
+			expect(toggle).toBeTruthy();
+			expect(toggle.getAttribute('data-checked')).toBe('true');
+		});
+
+		it('should render toggle as unchecked when server is disabled', () => {
+			const servers = [makeServer('1', { name: 'test-server', enabled: false })];
+			appMcpStore.appMcpServers.value = servers;
+
+			render(<AppMcpServersSettings />);
+
+			const toggle = screen.getByTestId('settings-toggle');
+			expect(toggle.getAttribute('data-checked')).toBe('false');
+		});
+	});
+
+	describe('API Mock Behavior', () => {
+		it('mock createAppMcpServer is a function', () => {
+			expect(typeof mockCreateAppMcpServer).toBe('function');
+		});
+
+		it('mock updateAppMcpServer is a function', () => {
+			expect(typeof mockUpdateAppMcpServer).toBe('function');
+		});
+
+		it('mock deleteAppMcpServer is a function', () => {
+			expect(typeof mockDeleteAppMcpServer).toBe('function');
+		});
+
+		it('mock setAppMcpServerEnabled is a function', () => {
+			expect(typeof mockSetAppMcpServerEnabled).toBe('function');
+		});
+
+		it('should have toast error and success mocks', () => {
+			expect(typeof mockToastError).toBe('function');
+			expect(typeof mockToastSuccess).toBe('function');
 		});
 	});
 });

--- a/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
+++ b/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
@@ -66,8 +66,8 @@ vi.mock('../../../lib/toast.ts', () => ({
 	},
 }));
 
-// Mock Modal component
-vi.mock('../ui/Modal.tsx', () => ({
+// Mock Modal component - correct path from __tests__/ is ../../ui/Modal.tsx
+vi.mock('../../ui/Modal.tsx', () => ({
 	Modal: ({
 		isOpen,
 		onClose,
@@ -90,8 +90,8 @@ vi.mock('../ui/Modal.tsx', () => ({
 		) : null,
 }));
 
-// Mock ConfirmModal component
-vi.mock('../ui/ConfirmModal.tsx', () => ({
+// Mock ConfirmModal component - correct path from __tests__/ is ../../ui/ConfirmModal.tsx
+vi.mock('../../ui/ConfirmModal.tsx', () => ({
 	ConfirmModal: ({
 		isOpen,
 		onClose,
@@ -157,8 +157,8 @@ vi.mock('../SettingsSection.tsx', () => ({
 	),
 }));
 
-// Mock Button component
-vi.mock('../ui/Button.tsx', () => ({
+// Mock Button component - correct path from __tests__/ is ../../ui/Button.tsx
+vi.mock('../../ui/Button.tsx', () => ({
 	Button: ({
 		children,
 		variant,
@@ -329,81 +329,411 @@ describe('AppMcpServersSettings', () => {
 	});
 
 	describe('Add Server Form', () => {
-		it('should have Add MCP Server button', () => {
+		it('should open add form modal when Add MCP Server button is clicked', () => {
+			appMcpStore.appMcpServers.value = [];
 			render(<AppMcpServersSettings />);
 
-			expect(screen.getByText('Add MCP Server')).toBeTruthy();
+			fireEvent.click(screen.getByText('Add MCP Server'));
+
+			expect(screen.getByTestId('modal')).toBeTruthy();
+			expect(screen.getByTestId('modal-title').textContent).toBe('Add MCP Server');
+		});
+
+		it('should close form when Cancel button is clicked', () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
+
+			fireEvent.click(screen.getByText('Add MCP Server'));
+			expect(screen.getByTestId('modal')).toBeTruthy();
+
+			// Use text content to find the cancel button inside the modal
+			fireEvent.click(screen.getByText('Cancel'));
+			expect(screen.queryByTestId('modal')).toBeNull();
+		});
+
+		it('should call createAppMcpServer with correct data when form is submitted', async () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
+
+			// Open form
+			fireEvent.click(screen.getByText('Add MCP Server'));
+
+			// Fill in name
+			const nameInput = screen.getByPlaceholderText('e.g., brave-search');
+			fireEvent.change(nameInput, { target: { value: 'test-server' } });
+
+			// Fill in command (stdio type is default)
+			const commandInput = screen.getByPlaceholderText('e.g., npx');
+			fireEvent.change(commandInput, { target: { value: 'npx' } });
+
+			// Submit form - use the text inside the modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(mockCreateAppMcpServer).toHaveBeenCalledWith(
+					expect.objectContaining({
+						name: 'test-server',
+						sourceType: 'stdio',
+						command: 'npx',
+					})
+				);
+			});
+		});
+
+		it('should show validation error when name is empty', async () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
+
+			// Open form
+			fireEvent.click(screen.getByText('Add MCP Server'));
+
+			// Try to submit without filling name - click Add Server inside modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Name is required')).toBeTruthy();
+			});
+			expect(mockCreateAppMcpServer).not.toHaveBeenCalled();
+		});
+
+		it('should show validation error when command is empty for stdio type', async () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
+
+			// Open form
+			fireEvent.click(screen.getByText('Add MCP Server'));
+
+			// Fill name but not command
+			const nameInput = screen.getByPlaceholderText('e.g., brave-search');
+			fireEvent.change(nameInput, { target: { value: 'test-server' } });
+
+			// Submit form - click Add Server inside modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Command is required for stdio servers')).toBeTruthy();
+			});
+			expect(mockCreateAppMcpServer).not.toHaveBeenCalled();
+		});
+
+		it('should show success toast after adding server', async () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
+
+			// Open form and fill required fields
+			fireEvent.click(screen.getByText('Add MCP Server'));
+			const nameInput = screen.getByPlaceholderText('e.g., brave-search');
+			fireEvent.change(nameInput, { target: { value: 'test-server' } });
+			const commandInput = screen.getByPlaceholderText('e.g., npx');
+			fireEvent.change(commandInput, { target: { value: 'npx' } });
+
+			// Submit form - click Add Server inside modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(mockToastSuccess).toHaveBeenCalledWith('Added "test-server"');
+			});
+		});
+
+		it('should close modal after successful add', async () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
+
+			// Open form and fill required fields
+			fireEvent.click(screen.getByText('Add MCP Server'));
+			const nameInput = screen.getByPlaceholderText('e.g., brave-search');
+			fireEvent.change(nameInput, { target: { value: 'test-server' } });
+			const commandInput = screen.getByPlaceholderText('e.g., npx');
+			fireEvent.change(commandInput, { target: { value: 'npx' } });
+
+			// Submit form - click Add Server inside modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(screen.queryByTestId('modal')).toBeNull();
+			});
+		});
+
+		it('should show error toast when add fails', async () => {
+			appMcpStore.appMcpServers.value = [];
+			mockCreateAppMcpServer.mockRejectedValueOnce(new Error('Failed to add server'));
+			render(<AppMcpServersSettings />);
+
+			// Open form and fill required fields
+			fireEvent.click(screen.getByText('Add MCP Server'));
+			const nameInput = screen.getByPlaceholderText('e.g., brave-search');
+			fireEvent.change(nameInput, { target: { value: 'test-server' } });
+			const commandInput = screen.getByPlaceholderText('e.g., npx');
+			fireEvent.change(commandInput, { target: { value: 'npx' } });
+
+			// Submit form - click Add Server inside modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith('Failed to add server');
+			});
 		});
 	});
 
 	describe('Edit Server', () => {
-		it('should show edit and delete buttons for servers', () => {
-			const servers = [makeServer('1', { name: 'test-server' })];
+		it('should open edit form with pre-populated data when Edit button is clicked', () => {
+			const servers = [
+				makeServer('1', { name: 'test-server', command: 'npx', description: 'Test desc' }),
+			];
 			appMcpStore.appMcpServers.value = servers;
-
 			render(<AppMcpServersSettings />);
 
-			expect(screen.getByTitle('Edit')).toBeTruthy();
-			expect(screen.getByTitle('Delete')).toBeTruthy();
+			fireEvent.click(screen.getByTitle('Edit'));
+
+			expect(screen.getByTestId('modal')).toBeTruthy();
+			expect(screen.getByTestId('modal-title').textContent).toBe('Edit MCP Server');
+			// Name should be pre-populated
+			expect((screen.getByDisplayValue('test-server') as HTMLInputElement).value).toBe(
+				'test-server'
+			);
+		});
+
+		it('should call updateAppMcpServer with correct data when form is submitted', async () => {
+			const servers = [makeServer('1', { name: 'old-name', command: 'npx' })];
+			appMcpStore.appMcpServers.value = servers;
+			render(<AppMcpServersSettings />);
+
+			// Open edit form
+			fireEvent.click(screen.getByTitle('Edit'));
+
+			// Change name
+			const nameInput = screen.getByDisplayValue('old-name');
+			fireEvent.change(nameInput, { target: { value: 'updated-name' } });
+
+			// Submit form - use Save Changes text inside modal
+			fireEvent.click(screen.getByText('Save Changes'));
+
+			await waitFor(() => {
+				expect(mockUpdateAppMcpServer).toHaveBeenCalledWith(
+					'1',
+					expect.objectContaining({
+						name: 'updated-name',
+					})
+				);
+			});
+		});
+
+		it('should show success toast after updating server', async () => {
+			const servers = [makeServer('1', { name: 'test-server', command: 'npx' })];
+			appMcpStore.appMcpServers.value = servers;
+			render(<AppMcpServersSettings />);
+
+			// Open edit form and change name
+			fireEvent.click(screen.getByTitle('Edit'));
+			const nameInput = screen.getByDisplayValue('test-server');
+			fireEvent.change(nameInput, { target: { value: 'new-name' } });
+
+			// Submit form - use Save Changes text inside modal
+			fireEvent.click(screen.getByText('Save Changes'));
+
+			await waitFor(() => {
+				expect(mockToastSuccess).toHaveBeenCalledWith('Updated "new-name"');
+			});
 		});
 	});
 
 	describe('Delete Confirmation', () => {
-		it('should show delete button that triggers confirmation state', () => {
+		it('should show delete confirmation modal when Delete button is clicked', () => {
 			const servers = [makeServer('1', { name: 'test-server' })];
 			appMcpStore.appMcpServers.value = servers;
-
 			render(<AppMcpServersSettings />);
 
-			// Delete button exists and is clickable
-			const deleteButton = screen.getByTitle('Delete');
-			expect(deleteButton).toBeTruthy();
+			fireEvent.click(screen.getByTitle('Delete'));
+
+			expect(screen.getByTestId('confirm-modal')).toBeTruthy();
+			expect(screen.getByTestId('confirm-title').textContent).toBe('Delete MCP Server');
+			expect(screen.getByTestId('confirm-message').textContent).toContain('test-server');
+		});
+
+		it('should close confirmation modal when Cancel is clicked', () => {
+			const servers = [makeServer('1', { name: 'test-server' })];
+			appMcpStore.appMcpServers.value = servers;
+			render(<AppMcpServersSettings />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			expect(screen.getByTestId('confirm-modal')).toBeTruthy();
+
+			fireEvent.click(screen.getByTestId('confirm-cancel'));
+			expect(screen.queryByTestId('confirm-modal')).toBeNull();
+		});
+
+		it('should call deleteAppMcpServer when confirm delete is clicked', async () => {
+			const servers = [makeServer('1', { name: 'test-server' })];
+			appMcpStore.appMcpServers.value = servers;
+			render(<AppMcpServersSettings />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			fireEvent.click(screen.getByTestId('confirm-ok'));
+
+			await waitFor(() => {
+				expect(mockDeleteAppMcpServer).toHaveBeenCalledWith('1');
+			});
+		});
+
+		it('should show success toast after deleting server', async () => {
+			const servers = [makeServer('1', { name: 'test-server' })];
+			appMcpStore.appMcpServers.value = servers;
+			render(<AppMcpServersSettings />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			fireEvent.click(screen.getByTestId('confirm-ok'));
+
+			await waitFor(() => {
+				expect(mockToastSuccess).toHaveBeenCalledWith('Deleted "test-server"');
+			});
+		});
+
+		it('should close confirmation modal after successful delete', async () => {
+			const servers = [makeServer('1', { name: 'test-server' })];
+			appMcpStore.appMcpServers.value = servers;
+			render(<AppMcpServersSettings />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			expect(screen.getByTestId('confirm-modal')).toBeTruthy();
+
+			fireEvent.click(screen.getByTestId('confirm-ok'));
+
+			await waitFor(() => {
+				expect(screen.queryByTestId('confirm-modal')).toBeNull();
+			});
+		});
+
+		it('should show error toast when delete fails', async () => {
+			const servers = [makeServer('1', { name: 'test-server' })];
+			appMcpStore.appMcpServers.value = servers;
+			mockDeleteAppMcpServer.mockRejectedValueOnce(new Error('Delete failed'));
+			render(<AppMcpServersSettings />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			fireEvent.click(screen.getByTestId('confirm-ok'));
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith('Delete failed');
+			});
 		});
 	});
 
 	describe('Toggle', () => {
-		it('should render toggle for each server', () => {
+		it('should call setAppMcpServerEnabled when toggle is clicked', async () => {
 			const servers = [makeServer('1', { name: 'test-server', enabled: true })];
 			appMcpStore.appMcpServers.value = servers;
-
 			render(<AppMcpServersSettings />);
 
 			const toggle = screen.getByTestId('settings-toggle');
-			expect(toggle).toBeTruthy();
-			expect(toggle.getAttribute('data-checked')).toBe('true');
+			fireEvent.click(toggle);
+
+			await waitFor(() => {
+				expect(mockSetAppMcpServerEnabled).toHaveBeenCalledWith('1', false);
+			});
 		});
 
-		it('should render toggle as unchecked when server is disabled', () => {
-			const servers = [makeServer('1', { name: 'test-server', enabled: false })];
+		it('should show success toast after toggling', async () => {
+			const servers = [makeServer('1', { name: 'test-server', enabled: true })];
 			appMcpStore.appMcpServers.value = servers;
-
 			render(<AppMcpServersSettings />);
 
 			const toggle = screen.getByTestId('settings-toggle');
-			expect(toggle.getAttribute('data-checked')).toBe('false');
+			fireEvent.click(toggle);
+
+			await waitFor(() => {
+				expect(mockToastSuccess).toHaveBeenCalledWith('Disabled "test-server"');
+			});
+		});
+
+		it('should show error toast when toggle fails', async () => {
+			const servers = [makeServer('1', { name: 'test-server', enabled: true })];
+			appMcpStore.appMcpServers.value = servers;
+			mockSetAppMcpServerEnabled.mockRejectedValueOnce(new Error('Toggle failed'));
+			render(<AppMcpServersSettings />);
+
+			const toggle = screen.getByTestId('settings-toggle');
+			fireEvent.click(toggle);
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith('Toggle failed');
+			});
 		});
 	});
 
-	describe('API Mock Behavior', () => {
-		it('mock createAppMcpServer is a function', () => {
-			expect(typeof mockCreateAppMcpServer).toBe('function');
+	describe('HTTP/SSE Server Validation', () => {
+		it('should require URL for SSE source type', async () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
+
+			// Open form
+			fireEvent.click(screen.getByText('Add MCP Server'));
+
+			// Select SSE type using the select element
+			const selectEl = screen.getByRole('combobox');
+			fireEvent.change(selectEl, { target: { value: 'sse' } });
+
+			// Fill name but not URL
+			const nameInput = screen.getByPlaceholderText('e.g., brave-search');
+			fireEvent.change(nameInput, { target: { value: 'sse-server' } });
+
+			// Submit form - click Add Server inside modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(screen.getByText('URL is required for SSE/HTTP servers')).toBeTruthy();
+			});
+			expect(mockCreateAppMcpServer).not.toHaveBeenCalled();
 		});
 
-		it('mock updateAppMcpServer is a function', () => {
-			expect(typeof mockUpdateAppMcpServer).toBe('function');
+		it('should require URL for HTTP source type', async () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
+
+			// Open form
+			fireEvent.click(screen.getByText('Add MCP Server'));
+
+			// Select HTTP type
+			const selectEl = screen.getByRole('combobox');
+			fireEvent.change(selectEl, { target: { value: 'http' } });
+
+			// Fill name but not URL
+			const nameInput = screen.getByPlaceholderText('e.g., brave-search');
+			fireEvent.change(nameInput, { target: { value: 'http-server' } });
+
+			// Submit form - click Add Server inside modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(screen.getByText('URL is required for SSE/HTTP servers')).toBeTruthy();
+			});
+			expect(mockCreateAppMcpServer).not.toHaveBeenCalled();
 		});
 
-		it('mock deleteAppMcpServer is a function', () => {
-			expect(typeof mockDeleteAppMcpServer).toBe('function');
-		});
+		it('should validate URL format for HTTP source type', async () => {
+			appMcpStore.appMcpServers.value = [];
+			render(<AppMcpServersSettings />);
 
-		it('mock setAppMcpServerEnabled is a function', () => {
-			expect(typeof mockSetAppMcpServerEnabled).toBe('function');
-		});
+			// Open form
+			fireEvent.click(screen.getByText('Add MCP Server'));
 
-		it('should have toast error and success mocks', () => {
-			expect(typeof mockToastError).toBe('function');
-			expect(typeof mockToastSuccess).toBe('function');
+			// Select HTTP type
+			const selectEl = screen.getByRole('combobox');
+			fireEvent.change(selectEl, { target: { value: 'http' } });
+
+			// Fill name and invalid URL
+			const nameInput = screen.getByPlaceholderText('e.g., brave-search');
+			fireEvent.change(nameInput, { target: { value: 'http-server' } });
+
+			const urlInput = screen.getByPlaceholderText('e.g., http://localhost:8080/sse');
+			fireEvent.change(urlInput, { target: { value: 'invalid-url' } });
+
+			// Submit form - click Add Server inside modal
+			fireEvent.click(screen.getByText('Add Server'));
+
+			await waitFor(() => {
+				expect(screen.getByText('URL must start with http:// or https://')).toBeTruthy();
+			});
+			expect(mockCreateAppMcpServer).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
+++ b/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
@@ -1,0 +1,340 @@
+/**
+ * Tests for AppMcpServersSettings Component
+ *
+ * Tests the application-level MCP server registry settings UI including:
+ * - Server list display
+ * - Add server form validation
+ * - Edit server functionality
+ * - Delete confirmation dialog
+ * - Enable/disable toggle
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/preact';
+import type { AppMcpServer } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mocks - must use vi.hoisted for proper hoisting with vi.mock
+// ---------------------------------------------------------------------------
+
+const {
+	mockCreateAppMcpServer,
+	mockUpdateAppMcpServer,
+	mockDeleteAppMcpServer,
+	mockSetAppMcpServerEnabled,
+	mockToastError,
+	mockToastSuccess,
+	mockSubscribe,
+	mockUnsubscribe,
+} = vi.hoisted(() => ({
+	mockCreateAppMcpServer: vi.fn(),
+	mockUpdateAppMcpServer: vi.fn(),
+	mockDeleteAppMcpServer: vi.fn(),
+	mockSetAppMcpServerEnabled: vi.fn(),
+	mockToastError: vi.fn(),
+	mockToastSuccess: vi.fn(),
+	mockSubscribe: vi.fn().mockResolvedValue(undefined),
+	mockUnsubscribe: vi.fn(),
+}));
+
+// Mock the appMcpStore
+vi.mock('../../../lib/app-mcp-store.ts', () => ({
+	appMcpStore: {
+		appMcpServers: { value: [] },
+		loading: { value: false },
+		error: { value: null },
+		subscribe: mockSubscribe,
+		unsubscribe: mockUnsubscribe,
+	},
+}));
+
+// Mock api-helpers module
+vi.mock('../../../lib/api-helpers.ts', () => ({
+	createAppMcpServer: (...args: unknown[]) => mockCreateAppMcpServer(...args),
+	updateAppMcpServer: (...args: unknown[]) => mockUpdateAppMcpServer(...args),
+	deleteAppMcpServer: (...args: unknown[]) => mockDeleteAppMcpServer(...args),
+	setAppMcpServerEnabled: (...args: unknown[]) => mockSetAppMcpServerEnabled(...args),
+}));
+
+// Mock toast module
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		error: (msg: string) => mockToastError(msg),
+		success: (msg: string) => mockToastSuccess(msg),
+		info: vi.fn(),
+		warning: vi.fn(),
+	},
+}));
+
+// Mock Modal component
+vi.mock('../ui/Modal.tsx', () => ({
+	Modal: ({
+		isOpen,
+		onClose,
+		title,
+		children,
+	}: {
+		isOpen: boolean;
+		onClose: () => void;
+		title: string;
+		children: import('preact').ComponentChildren;
+	}) =>
+		isOpen ? (
+			<div data-testid="modal">
+				<h2 data-testid="modal-title">{title}</h2>
+				<div data-testid="modal-content">{children}</div>
+				<button data-testid="modal-close" onClick={onClose}>
+					Close
+				</button>
+			</div>
+		) : null,
+}));
+
+// Mock ConfirmModal component
+vi.mock('../ui/ConfirmModal.tsx', () => ({
+	ConfirmModal: ({
+		isOpen,
+		onClose,
+		onConfirm,
+		title,
+		message,
+		confirmText,
+		isLoading,
+	}: {
+		isOpen: boolean;
+		onClose: () => void;
+		onConfirm: () => void;
+		title: string;
+		message: string;
+		confirmText?: string;
+		isLoading?: boolean;
+	}) =>
+		isOpen ? (
+			<div data-testid="confirm-modal">
+				<span data-testid="confirm-title">{title}</span>
+				<span data-testid="confirm-message">{message}</span>
+				<button data-testid="confirm-cancel" onClick={onClose}>
+					Cancel
+				</button>
+				<button data-testid="confirm-ok" onClick={onConfirm} disabled={isLoading}>
+					{confirmText ?? 'Confirm'}
+				</button>
+			</div>
+		) : null,
+}));
+
+// Mock SettingsSection component
+vi.mock('./SettingsSection.tsx', () => ({
+	SettingsSection: ({
+		title,
+		children,
+	}: {
+		title: string;
+		children: import('preact').ComponentChildren;
+	}) => (
+		<div data-testid="settings-section">
+			<h3>{title}</h3>
+			<div>{children}</div>
+		</div>
+	),
+	SettingsToggle: ({
+		checked,
+		onChange,
+		disabled,
+	}: {
+		checked: boolean;
+		onChange: (v: boolean) => void;
+		disabled?: boolean;
+	}) => (
+		<button
+			data-testid="settings-toggle"
+			data-checked={String(checked)}
+			disabled={disabled}
+			onClick={() => onChange(!checked)}
+		>
+			Toggle
+		</button>
+	),
+}));
+
+// Mock Button component - use data-testid to find buttons
+let buttonClickHandler: (() => void) | null = null;
+vi.mock('../ui/Button.tsx', () => ({
+	Button: ({
+		children,
+		variant,
+		size,
+		type,
+		onClick,
+		disabled,
+		loading,
+	}: {
+		children: import('preact').ComponentChildren;
+		variant?: string;
+		size?: string;
+		type?: 'button' | 'submit';
+		onClick?: () => void;
+		disabled?: boolean;
+		loading?: boolean;
+	}) => {
+		// Store the click handler so tests can trigger it
+		if (onClick) {
+			buttonClickHandler = onClick;
+		}
+		return (
+			<button
+				data-testid={`button-${variant || 'primary'}`}
+				data-size={size}
+				data-type={type}
+				disabled={disabled || loading}
+				onClick={onClick}
+			>
+				{loading && <span data-testid="button-loading">Loading...</span>}
+				{children}
+			</button>
+		);
+	},
+}));
+
+// Import the component after mocks are set up
+import { AppMcpServersSettings } from '../AppMcpServersSettings.tsx';
+import { appMcpStore } from '../../../lib/app-mcp-store.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeServer(id: string, overrides: Partial<AppMcpServer> = {}): AppMcpServer {
+	return {
+		id,
+		name: `Server ${id}`,
+		sourceType: 'stdio',
+		command: 'npx',
+		args: ['-y', '@some/server'],
+		env: {},
+		enabled: true,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AppMcpServersSettings', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		cleanup();
+		buttonClickHandler = null;
+
+		// Reset store signals
+		appMcpStore.appMcpServers.value = [];
+		appMcpStore.loading.value = false;
+		appMcpStore.error.value = null;
+
+		// Default mock implementations
+		mockCreateAppMcpServer.mockResolvedValue({
+			server: makeServer('new', { name: 'new-server' }),
+		});
+		mockUpdateAppMcpServer.mockResolvedValue({ ok: true });
+		mockDeleteAppMcpServer.mockResolvedValue({ success: true });
+		mockSetAppMcpServerEnabled.mockResolvedValue({ ok: true });
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		buttonClickHandler = null;
+	});
+
+	describe('Server List Display', () => {
+		it('should show empty state when no servers', () => {
+			appMcpStore.appMcpServers.value = [];
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByText('No MCP servers configured')).toBeTruthy();
+		});
+
+		it('should show loading state when loading', () => {
+			appMcpStore.loading.value = true;
+			appMcpStore.appMcpServers.value = [];
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByText('Loading servers...')).toBeTruthy();
+		});
+
+		it('should show error state when there is an error', () => {
+			appMcpStore.error.value = 'Failed to connect';
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByText(/Failed to connect/)).toBeTruthy();
+		});
+
+		it('should display server name and source type', () => {
+			const servers = [
+				makeServer('1', { name: 'brave-search', sourceType: 'stdio' }),
+				makeServer('2', { name: 'fetch-mcp', sourceType: 'http', url: 'http://localhost:8080' }),
+			];
+			appMcpStore.appMcpServers.value = servers;
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByText('brave-search')).toBeTruthy();
+			expect(screen.getByText('fetch-mcp')).toBeTruthy();
+			expect(screen.getByText('stdio')).toBeTruthy();
+			expect(screen.getByText('http')).toBeTruthy();
+		});
+
+		it('should show description if present', () => {
+			const servers = [makeServer('1', { name: 'test', description: 'A test server' })];
+			appMcpStore.appMcpServers.value = servers;
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByText('A test server')).toBeTruthy();
+		});
+
+		it('should show the informational note about env vars', () => {
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByText(/Environment Variables/)).toBeTruthy();
+			expect(screen.getByText(/system environment/)).toBeTruthy();
+		});
+
+		it('should show Add MCP Server button', () => {
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByText('Add MCP Server')).toBeTruthy();
+		});
+
+		it('should show delete and edit buttons for each server', () => {
+			const servers = [makeServer('1', { name: 'test-server' })];
+			appMcpStore.appMcpServers.value = servers;
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByTitle('Edit')).toBeTruthy();
+			expect(screen.getByTitle('Delete')).toBeTruthy();
+		});
+
+		it('should show toggle for each server', () => {
+			const servers = [makeServer('1', { name: 'test-server', enabled: true })];
+			appMcpStore.appMcpServers.value = servers;
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByTestId('settings-toggle')).toBeTruthy();
+		});
+	});
+
+	describe('Subscribe/Unsubscribe', () => {
+		it('should call subscribe on mount', () => {
+			render(<AppMcpServersSettings />);
+
+			expect(mockSubscribe).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -44,6 +44,7 @@ const SETTINGS_SECTIONS: Array<{
 	{ id: 'general', label: 'General', icon: 'settings' },
 	{ id: 'providers', label: 'Providers', icon: 'cloud' },
 	{ id: 'mcp-servers', label: 'MCP Servers', icon: 'server' },
+	{ id: 'app-mcp-servers', label: 'Application MCP Servers', icon: 'app-server' },
 	{ id: 'fallback-models', label: 'Fallback Models', icon: 'swap' },
 	{ id: 'usage', label: 'Usage', icon: 'chart' },
 	{ id: 'about', label: 'About', icon: 'info' },
@@ -122,6 +123,19 @@ function SectionIcon({ type }: { type: string }) {
 						stroke-width={2}
 						d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
 					/>
+				</svg>
+			);
+		case 'app-server':
+			return (
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width={2}
+						d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"
+					/>
+					<circle cx="8" cy="8" r="1" fill="currentColor" />
+					<circle cx="12" cy="8" r="1" fill="currentColor" />
 				</svg>
 			);
 		default:

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -17,6 +17,7 @@ import { SpacesPage } from './SpacesPage.tsx';
 import { GeneralSettings } from '../components/settings/GeneralSettings.tsx';
 import { ProvidersSettings } from '../components/settings/ProvidersSettings.tsx';
 import { McpServersSettings } from '../components/settings/McpServersSettings.tsx';
+import { AppMcpServersSettings } from '../components/settings/AppMcpServersSettings.tsx';
 import { FallbackModelsSettings } from '../components/settings/FallbackModelsSettings.tsx';
 import { UsageAnalytics } from '../components/settings/UsageAnalytics.tsx';
 import { AboutSection } from '../components/settings/AboutSection.tsx';
@@ -106,6 +107,7 @@ export default function MainContent() {
 						{settingsSection === 'general' && <GeneralSettings />}
 						{settingsSection === 'providers' && <ProvidersSettings />}
 						{settingsSection === 'mcp-servers' && <McpServersSettings />}
+						{settingsSection === 'app-mcp-servers' && <AppMcpServersSettings />}
 						{settingsSection === 'fallback-models' && <FallbackModelsSettings />}
 						{settingsSection === 'usage' && <UsageAnalytics />}
 						{settingsSection === 'about' && <AboutSection />}

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -59,6 +59,7 @@ export type SettingsSection =
 	| 'general'
 	| 'providers'
 	| 'mcp-servers'
+	| 'app-mcp-servers'
 	| 'fallback-models'
 	| 'usage'
 	| 'about';


### PR DESCRIPTION
Add AppMcpServersSettings component for managing application-level MCP
server registry. Features:

- List all registry entries from appMcpServers signal
- Add/Edit/Delete MCP servers with form validation
- Enable/disable toggle per entry
- Integration into global settings panel as new "Application MCP Servers" section
- Env vars editor with informational note about secret handling
- Confirmation dialog before delete

Files:
- AppMcpServersSettings.tsx: Main settings component
- AppMcpServersSettings.test.tsx: Unit tests
- signals.ts: Added 'app-mcp-servers' section type
- ContextPanel.tsx: Added new settings section
- MainContent.tsx: Wired up new component
