### PR TITLE
feat(shared): extend ResolvedChannel with gate field for policy enforcement

### DIFF
--- a/packages/daemon/tests/unit/space/channel-resolution.test.ts
+++ b/packages/daemon/tests/unit/space/channel-resolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import type { SpaceAgent, SpaceWorkflow, WorkflowNode } from '@neokai/shared';
+import type { SpaceAgent, SpaceWorkflow, WorkflowCondition, WorkflowNode } from '@neokai/shared';
 import { resolveChannels, validateChannels } from '@neokai/shared';
 
 // ============================================================================
@@ -476,5 +476,93 @@ describe('resolveChannels edge cases', () => {
 		expect(result[0].toRole).toBe('coder');
 		expect(result[0].toAgentId).toBe('agent-coder');
 		expect(result[0].isFanOut).toBeFalsy();
+	});
+});
+
+// ============================================================================
+// gate field propagation
+// ============================================================================
+
+describe('resolveChannels — gate field', () => {
+	const gate: WorkflowCondition = {
+		type: 'condition',
+		expression: 'ci-passing',
+		description: 'CI must pass',
+	};
+
+	test('gate is propagated from WorkflowChannel to ResolvedChannel', () => {
+		const node = makeNode('n1', 'Node1', [
+			{ name: 'coder', agentId: 'agent-coder' },
+			{ name: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way', gate }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].gate).toEqual(gate);
+	});
+
+	test('gate is absent when WorkflowChannel has no gate', () => {
+		const node = makeNode('n1', 'Node1', [
+			{ name: 'coder', agentId: 'agent-coder' },
+			{ name: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow([node], [{ from: 'coder', to: 'reviewer', direction: 'one-way' }]);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].gate).toBeUndefined();
+	});
+
+	test('gate is propagated to both directions in a bidirectional channel', () => {
+		const node = makeNode('n1', 'Node1', [
+			{ name: 'coder', agentId: 'agent-coder' },
+			{ name: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'coder', to: 'reviewer', direction: 'bidirectional', gate }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].gate).toEqual(gate);
+		expect(result[1].gate).toEqual(gate);
+	});
+
+	test('gate is propagated to all fan-out entries', () => {
+		const nodeA = makeNode('n1', 'NodeA', [{ name: 'coder', agentId: 'agent-coder' }]);
+		const nodeB = makeNode('n2', 'NodeB', [
+			{ name: 'reviewer', agentId: 'agent-reviewer' },
+			{ name: 'qa', agentId: 'agent-qa' },
+		]);
+		const wf = makeWorkflow(
+			[nodeA, nodeB],
+			[{ from: 'coder', to: 'NodeB', direction: 'one-way', gate }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(2);
+		expect(result.every((r) => r.isFanOut === true)).toBe(true);
+		expect(result[0].gate).toEqual(gate);
+		expect(result[1].gate).toEqual(gate);
+	});
+
+	test('gate with human type is propagated correctly', () => {
+		const humanGate: WorkflowCondition = { type: 'human', description: 'Human must approve' };
+		const node = makeNode('n1', 'Node1', [
+			{ name: 'coder', agentId: 'agent-coder' },
+			{ name: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way', gate: humanGate }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result[0].gate).toEqual(humanGate);
 	});
 });

--- a/packages/daemon/tests/unit/space/channel-resolver.test.ts
+++ b/packages/daemon/tests/unit/space/channel-resolver.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import { ChannelResolver } from '../../../src/lib/space/runtime/channel-resolver.ts';
-import type { ResolvedChannel } from '@neokai/shared';
+import type { ResolvedChannel, WorkflowCondition } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Test data helpers
@@ -275,5 +275,52 @@ describe('ChannelResolver.isEmpty', () => {
 
 	test('false when at least one channel', () => {
 		expect(new ChannelResolver([oneWayChannel('a', 'b')]).isEmpty()).toBe(false);
+	});
+});
+
+// ===========================================================================
+// gate field
+// ===========================================================================
+
+describe('ChannelResolver — gate field', () => {
+	const gate: WorkflowCondition = { type: 'condition', expression: 'ci-passing' };
+
+	function gatedChannel(fromRole: string, toRole: string, g: WorkflowCondition): ResolvedChannel {
+		return {
+			fromRole,
+			toRole,
+			fromAgentId: `agent-${fromRole}`,
+			toAgentId: `agent-${toRole}`,
+			direction: 'one-way',
+			isHubSpoke: false,
+			gate: g,
+		};
+	}
+
+	test('gate field is preserved through getResolvedChannels()', () => {
+		const ch = gatedChannel('coder', 'reviewer', gate);
+		const resolver = new ChannelResolver([ch]);
+		const [result] = resolver.getResolvedChannels();
+		expect(result.gate).toEqual(gate);
+	});
+
+	test('channel with gate passes structural validation in fromRunConfig()', () => {
+		const ch = gatedChannel('coder', 'reviewer', gate);
+		const resolver = ChannelResolver.fromRunConfig({ _resolvedChannels: [ch] });
+		expect(resolver.isEmpty()).toBe(false);
+		expect(resolver.getResolvedChannels()[0].gate).toEqual(gate);
+	});
+
+	test('channel without gate has undefined gate field', () => {
+		const ch = oneWayChannel('coder', 'reviewer');
+		const resolver = new ChannelResolver([ch]);
+		expect(resolver.getResolvedChannels()[0].gate).toBeUndefined();
+	});
+
+	test('canSend still works correctly for channels with gate', () => {
+		// canSend checks routing permission only — gate evaluation is a separate concern
+		const resolver = new ChannelResolver([gatedChannel('coder', 'reviewer', gate)]);
+		expect(resolver.canSend('coder', 'reviewer')).toBe(true);
+		expect(resolver.canSend('reviewer', 'coder')).toBe(false);
 	});
 });

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -12,6 +12,7 @@ import type {
 	SpaceAgent,
 	SpaceWorkflow,
 	WorkflowChannel,
+	WorkflowCondition,
 	WorkflowNode,
 	WorkflowNodeAgent,
 } from './space.ts';
@@ -57,6 +58,12 @@ export interface ResolvedChannel {
 	 * In hub-spoke, spokes may only reply to the hub — no spoke-to-spoke messaging.
 	 */
 	isHubSpoke: boolean;
+	/**
+	 * Optional gate condition inherited from the source WorkflowChannel.
+	 * When present, the message must pass this condition before delivery.
+	 * Absent means the channel is always open (no gate enforcement).
+	 */
+	gate?: WorkflowCondition;
 }
 
 // ============================================================================
@@ -165,7 +172,7 @@ function expandChannel(
 	nameToAgentId: Map<string, string>,
 	out: ResolvedChannel[]
 ): void {
-	const { from, to, direction, label } = channel;
+	const { from, to, direction, label, gate } = channel;
 
 	// Resolve concrete from-names.
 	const fromNames: string[] = from === '*' ? allNames : [from];
@@ -197,6 +204,7 @@ function expandChannel(
 				toAgentId,
 				direction: 'one-way',
 				label,
+				gate,
 				isHubSpoke,
 			});
 
@@ -211,6 +219,7 @@ function expandChannel(
 					toAgentId: fromAgentId,
 					direction: 'one-way',
 					label,
+					gate,
 					isHubSpoke,
 				});
 			}
@@ -390,8 +399,7 @@ function expandUnifiedChannel(
 	nodeNameToAgents: Map<string, Array<{ name: string; agentId: string }>>,
 	out: ResolvedChannel[]
 ): void {
-	const { from, to, direction, label } = channel;
-	const isCyclic = channel.isCyclic;
+	const { from, to, direction, label, gate, isCyclic } = channel;
 
 	// Resolve from-agents
 	const fromAgents = resolveAgentRef(from, allAgentNames, nameToAgent, nodeNameToAgents);
@@ -434,6 +442,7 @@ function expandUnifiedChannel(
 				toAgentId: toAgent.agentId,
 				direction: 'one-way',
 				label,
+				gate,
 				isFanOut,
 				isCyclic,
 				isHubSpoke,
@@ -447,6 +456,7 @@ function expandUnifiedChannel(
 					toAgentId: fromAgent.agentId,
 					direction: 'one-way',
 					label,
+					gate,
 					isFanOut,
 					isCyclic,
 					isHubSpoke,


### PR DESCRIPTION
Add `gate?: WorkflowCondition` to `ResolvedChannel` so gate policy
information from `WorkflowChannel` is preserved after resolution.
Propagate gate through both `expandChannel` (deprecated path) and
`expandUnifiedChannel` (unified path).

Also ensures only one resolved channel type exists (no separate
ResolvedCrossNodeChannel) — ResolvedChannel already captures all
info needed for routing and gate evaluation.

Tests: 9 new tests covering gate propagation for one-way, bidirectional,
fan-out channels, and ChannelResolver behaviour with gated channels.
