### PR TITLE
feat(space): add ChannelGateEvaluator for agent-centric channel gate enforcement

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-gate-evaluator.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-gate-evaluator.ts
@@ -1,0 +1,263 @@
+/**
+ * ChannelGateEvaluator
+ *
+ * Evaluates whether a WorkflowChannel's gate condition allows message delivery.
+ *
+ * Gate types supported:
+ *   always      — channel is always open; delivery is never blocked
+ *   human       — delivery requires explicit human approval (context.humanApproved === true)
+ *   condition   — shell expression; delivery allowed when expression exits with code 0
+ *   task_result — delivery allowed when context.taskResult starts with gate.expression
+ *
+ * Usage:
+ *   const evaluator = new ChannelGateEvaluator(workspacePath);
+ *   const result = await evaluator.evaluate(channel, { humanApproved: false });
+ *   if (!result.allowed) throw new ChannelGateBlockedError(result.reason!);
+ */
+
+import type { WorkflowChannel, WorkflowCondition } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Context provided to gate evaluation.
+ * Callers populate only the fields relevant to the gate type being evaluated.
+ */
+export interface ChannelGateContext {
+	/** Absolute path to the workspace root (cwd for `condition`-type shell expressions). */
+	workspacePath: string;
+	/**
+	 * Whether a human has explicitly approved delivery on this channel.
+	 * Required for `human` gate type — delivery is blocked until this is true.
+	 */
+	humanApproved?: boolean;
+	/**
+	 * Task result string for `task_result` gate type.
+	 * Delivery is allowed when this value starts with `gate.expression`.
+	 */
+	taskResult?: string;
+}
+
+/** Result of a single gate evaluation attempt. */
+export interface GateResult {
+	/** Whether delivery is allowed. */
+	allowed: boolean;
+	/** Human-readable explanation when delivery is blocked. */
+	reason?: string;
+}
+
+/**
+ * Thrown by evaluate() when the gate condition blocks message delivery.
+ * Callers may catch this to provide user-visible feedback or to queue the message.
+ */
+export class ChannelGateBlockedError extends Error {
+	constructor(
+		message: string,
+		/** The gate type that caused the block (for programmatic handling). */
+		public readonly gateType: WorkflowCondition['type']
+	) {
+		super(message);
+		this.name = 'ChannelGateBlockedError';
+	}
+}
+
+/**
+ * Injectable command runner — the default uses Bun.spawn; tests inject a mock.
+ * Signature mirrors CommandRunner in workflow-executor.ts.
+ */
+export type ChannelCommandRunner = (
+	args: string[],
+	cwd: string,
+	timeoutMs: number
+) => Promise<{ exitCode: number | null; timedOut?: boolean; stderr?: string }>;
+
+// ---------------------------------------------------------------------------
+// Default timeout constants (matches WorkflowExecutor values)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONDITION_TIMEOUT_MS = 60_000;
+const MAX_CONDITION_TIMEOUT_MS = 300_000;
+
+// ---------------------------------------------------------------------------
+// Default command runner (real Bun.spawn)
+// ---------------------------------------------------------------------------
+
+const defaultCommandRunner: ChannelCommandRunner = async (args, cwd, timeoutMs) => {
+	const proc = Bun.spawn(args, {
+		cwd,
+		stdout: 'ignore',
+		stderr: 'pipe',
+	});
+
+	let killed = false;
+	let killTimer: ReturnType<typeof setTimeout> | undefined;
+
+	if (timeoutMs > 0) {
+		killTimer = setTimeout(() => {
+			killed = true;
+			proc.kill();
+		}, timeoutMs);
+	}
+
+	const [stderr] = await Promise.all([
+		new Response(proc.stderr).text().catch(() => ''),
+		proc.exited,
+	]);
+
+	if (killTimer !== undefined) clearTimeout(killTimer);
+
+	if (killed) {
+		return { exitCode: null, timedOut: true, stderr };
+	}
+	return { exitCode: proc.exitCode, stderr };
+};
+
+// ---------------------------------------------------------------------------
+// ChannelGateEvaluator
+// ---------------------------------------------------------------------------
+
+export class ChannelGateEvaluator {
+	constructor(private readonly commandRunner: ChannelCommandRunner = defaultCommandRunner) {}
+
+	/**
+	 * Evaluates whether the channel's gate allows message delivery.
+	 *
+	 * - If the channel has no `gate` field, delivery is always allowed.
+	 * - If the gate type is `always`, delivery is always allowed.
+	 * - Otherwise, returns `{ allowed: false, reason }` when the gate blocks.
+	 *
+	 * Does NOT throw on blocked gates — callers may throw ChannelGateBlockedError
+	 * themselves when appropriate. This keeps the evaluator pure and composable.
+	 */
+	async evaluate(channel: WorkflowChannel, context: ChannelGateContext): Promise<GateResult> {
+		if (!channel.gate) {
+			return { allowed: true };
+		}
+		return this.evaluateCondition(channel.gate, context);
+	}
+
+	/**
+	 * Evaluates a single WorkflowCondition against the given context.
+	 *
+	 * Exposed as a public method so callers can evaluate conditions outside of a
+	 * channel (e.g. for testing individual gate expressions in isolation).
+	 */
+	async evaluateCondition(
+		condition: WorkflowCondition,
+		context: ChannelGateContext
+	): Promise<GateResult> {
+		switch (condition.type) {
+			case 'always':
+				return { allowed: true };
+
+			case 'human':
+				if (context.humanApproved) {
+					return { allowed: true };
+				}
+				return {
+					allowed: false,
+					reason: 'Gate blocked: waiting for human approval before message delivery',
+				};
+
+			case 'condition': {
+				if (!condition.expression || !condition.expression.trim()) {
+					return {
+						allowed: false,
+						reason: 'Gate blocked: condition gate requires a non-empty expression',
+					};
+				}
+				return this.runConditionExpression(
+					condition.expression,
+					context.workspacePath,
+					condition.timeoutMs
+				);
+			}
+
+			case 'task_result': {
+				if (!condition.expression || !condition.expression.trim()) {
+					return {
+						allowed: false,
+						reason: 'Gate blocked: task_result gate requires a non-empty expression',
+					};
+				}
+				if (context.taskResult === undefined) {
+					return {
+						allowed: false,
+						reason: 'Gate blocked: no task result available for task_result gate evaluation',
+					};
+				}
+				if (context.taskResult.startsWith(condition.expression)) {
+					return { allowed: true };
+				}
+				return {
+					allowed: false,
+					reason: `Gate blocked: task result "${context.taskResult}" does not match expected "${condition.expression}"`,
+				};
+			}
+
+			default: {
+				const _exhaustive: never = condition.type;
+				return {
+					allowed: false,
+					reason: `Gate blocked: unknown gate type "${_exhaustive}"`,
+				};
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Executes a condition expression via the shell and returns whether it exited with code 0.
+	 * The expression is passed to `sh -c` so shell semantics work as expected.
+	 */
+	private async runConditionExpression(
+		expression: string,
+		cwd: string,
+		timeoutMs?: number
+	): Promise<GateResult> {
+		const effectiveTimeout = resolveTimeout(timeoutMs);
+		const args = ['sh', '-c', expression.trim()];
+
+		let result: { exitCode: number | null; timedOut?: boolean; stderr?: string };
+		try {
+			result = await this.commandRunner(args, cwd, effectiveTimeout);
+		} catch (err) {
+			return {
+				allowed: false,
+				reason: `Gate blocked: expression execution error: ${(err as Error).message}`,
+			};
+		}
+
+		if (result.timedOut) {
+			return {
+				allowed: false,
+				reason: `Gate blocked: condition expression timed out after ${effectiveTimeout}ms`,
+			};
+		}
+
+		if (result.exitCode !== 0) {
+			const stderrSnippet = result.stderr?.trim() ? `: ${result.stderr.slice(-500).trim()}` : '';
+			return {
+				allowed: false,
+				reason: `Gate blocked: condition expression exited with code ${result.exitCode ?? 'null'}${stderrSnippet}`,
+			};
+		}
+
+		return { allowed: true };
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Module-level helpers
+// ---------------------------------------------------------------------------
+
+/** Clamps/resolves the condition timeout to the valid range. */
+function resolveTimeout(timeoutMs?: number): number {
+	if (!timeoutMs || timeoutMs <= 0) return DEFAULT_CONDITION_TIMEOUT_MS;
+	return Math.min(timeoutMs, MAX_CONDITION_TIMEOUT_MS);
+}

--- a/packages/daemon/tests/unit/space/channel-gate-evaluator.test.ts
+++ b/packages/daemon/tests/unit/space/channel-gate-evaluator.test.ts
@@ -1,0 +1,412 @@
+/**
+ * ChannelGateEvaluator Unit Tests
+ *
+ * Covers all 4 gate types:
+ *   always      — always allows delivery
+ *   human       — blocks until humanApproved === true
+ *   condition   — shell expression; allowed on exit code 0
+ *   task_result — prefix match on taskResult string
+ *
+ * Also covers:
+ *   - No gate field → always allowed
+ *   - Empty expression → blocked with clear message
+ *   - Command execution error → blocked with error message
+ *   - Timeout → blocked with timeout message
+ *   - ChannelGateBlockedError construction and properties
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+	ChannelGateEvaluator,
+	ChannelGateBlockedError,
+} from '../../../src/lib/space/runtime/channel-gate-evaluator.ts';
+import type {
+	ChannelCommandRunner,
+	ChannelGateContext,
+} from '../../../src/lib/space/runtime/channel-gate-evaluator.ts';
+import type { WorkflowChannel } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeChannel(overrides: Partial<WorkflowChannel> = {}): WorkflowChannel {
+	return {
+		from: 'agent-a',
+		to: 'agent-b',
+		direction: 'one-way',
+		...overrides,
+	};
+}
+
+function makeContext(overrides: Partial<ChannelGateContext> = {}): ChannelGateContext {
+	return {
+		workspacePath: '/tmp/test-workspace',
+		...overrides,
+	};
+}
+
+function makeOkRunner(): ChannelCommandRunner {
+	return async () => ({ exitCode: 0 });
+}
+
+function makeFailRunner(exitCode = 1, stderr = ''): ChannelCommandRunner {
+	return async () => ({ exitCode, stderr });
+}
+
+function makeTimeoutRunner(): ChannelCommandRunner {
+	return async () => ({ exitCode: null, timedOut: true });
+}
+
+function makeThrowRunner(message: string): ChannelCommandRunner {
+	return async () => {
+		throw new Error(message);
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests: no gate
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateEvaluator — no gate', () => {
+	test('channel without gate is always allowed', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const result = await evaluator.evaluate(makeChannel(), makeContext());
+		expect(result.allowed).toBe(true);
+		expect(result.reason).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: always gate
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateEvaluator — always gate', () => {
+	test('always gate allows delivery unconditionally', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'always' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(true);
+	});
+
+	test('always gate allows delivery even with no humanApproved', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'always' } });
+		const result = await evaluator.evaluate(channel, makeContext({ humanApproved: false }));
+		expect(result.allowed).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: human gate
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateEvaluator — human gate', () => {
+	test('human gate blocks when humanApproved is absent', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'human' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('human approval');
+	});
+
+	test('human gate blocks when humanApproved is false', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'human' } });
+		const result = await evaluator.evaluate(channel, makeContext({ humanApproved: false }));
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('human approval');
+	});
+
+	test('human gate allows delivery when humanApproved is true', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'human' } });
+		const result = await evaluator.evaluate(channel, makeContext({ humanApproved: true }));
+		expect(result.allowed).toBe(true);
+		expect(result.reason).toBeUndefined();
+	});
+
+	test('human gate reason contains "Gate blocked" prefix', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'human' } });
+		const result = await evaluator.evaluate(channel, makeContext({ humanApproved: false }));
+		expect(result.reason).toMatch(/^Gate blocked:/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: condition gate
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateEvaluator — condition gate', () => {
+	test('condition gate allows delivery when command exits with code 0', async () => {
+		const evaluator = new ChannelGateEvaluator(makeOkRunner());
+		const channel = makeChannel({ gate: { type: 'condition', expression: 'true' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(true);
+	});
+
+	test('condition gate blocks when command exits with non-zero code', async () => {
+		const evaluator = new ChannelGateEvaluator(makeFailRunner(1));
+		const channel = makeChannel({ gate: { type: 'condition', expression: 'false' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('exit');
+	});
+
+	test('condition gate blocks when command exits with non-zero and includes stderr', async () => {
+		const evaluator = new ChannelGateEvaluator(makeFailRunner(2, 'some error output'));
+		const channel = makeChannel({ gate: { type: 'condition', expression: 'bad-cmd' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('some error output');
+	});
+
+	test('condition gate blocks on empty expression', async () => {
+		const evaluator = new ChannelGateEvaluator(makeOkRunner());
+		const channel = makeChannel({ gate: { type: 'condition', expression: '' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('non-empty expression');
+	});
+
+	test('condition gate blocks on whitespace-only expression', async () => {
+		const evaluator = new ChannelGateEvaluator(makeOkRunner());
+		const channel = makeChannel({ gate: { type: 'condition', expression: '   ' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('non-empty expression');
+	});
+
+	test('condition gate blocks on missing expression', async () => {
+		const evaluator = new ChannelGateEvaluator(makeOkRunner());
+		const channel = makeChannel({ gate: { type: 'condition' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('non-empty expression');
+	});
+
+	test('condition gate blocks when command runner throws', async () => {
+		const evaluator = new ChannelGateEvaluator(makeThrowRunner('spawn failed'));
+		const channel = makeChannel({ gate: { type: 'condition', expression: 'test -f /some/path' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('spawn failed');
+	});
+
+	test('condition gate blocks on timeout', async () => {
+		const evaluator = new ChannelGateEvaluator(makeTimeoutRunner());
+		const channel = makeChannel({ gate: { type: 'condition', expression: 'sleep 999' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('timed out');
+	});
+
+	test('condition gate reason contains "Gate blocked" prefix on failure', async () => {
+		const evaluator = new ChannelGateEvaluator(makeFailRunner());
+		const channel = makeChannel({ gate: { type: 'condition', expression: 'false' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.reason).toMatch(/^Gate blocked:/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: task_result gate
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateEvaluator — task_result gate', () => {
+	test('task_result gate allows delivery on exact match', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'task_result', expression: 'passed' } });
+		const result = await evaluator.evaluate(channel, makeContext({ taskResult: 'passed' }));
+		expect(result.allowed).toBe(true);
+	});
+
+	test('task_result gate allows delivery on prefix match', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'task_result', expression: 'pass' } });
+		const result = await evaluator.evaluate(
+			channel,
+			makeContext({ taskResult: 'passed with details' })
+		);
+		expect(result.allowed).toBe(true);
+	});
+
+	test('task_result gate blocks when result does not match', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'task_result', expression: 'passed' } });
+		const result = await evaluator.evaluate(channel, makeContext({ taskResult: 'failed' }));
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('"failed"');
+		expect(result.reason).toContain('"passed"');
+	});
+
+	test('task_result gate blocks when taskResult is undefined', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'task_result', expression: 'passed' } });
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('no task result available');
+	});
+
+	test('task_result gate blocks on empty expression', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'task_result', expression: '' } });
+		const result = await evaluator.evaluate(channel, makeContext({ taskResult: 'passed' }));
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('non-empty expression');
+	});
+
+	test('task_result gate blocks on missing expression', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'task_result' } });
+		const result = await evaluator.evaluate(channel, makeContext({ taskResult: 'passed' }));
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain('non-empty expression');
+	});
+
+	test('task_result gate reason contains "Gate blocked" prefix on failure', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'task_result', expression: 'passed' } });
+		const result = await evaluator.evaluate(channel, makeContext({ taskResult: 'failed' }));
+		expect(result.reason).toMatch(/^Gate blocked:/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: evaluateCondition (public method, direct access)
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateEvaluator.evaluateCondition', () => {
+	test('evaluates always condition directly', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const result = await evaluator.evaluateCondition({ type: 'always' }, makeContext());
+		expect(result.allowed).toBe(true);
+	});
+
+	test('evaluates human condition directly — blocked', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const result = await evaluator.evaluateCondition(
+			{ type: 'human' },
+			makeContext({ humanApproved: false })
+		);
+		expect(result.allowed).toBe(false);
+	});
+
+	test('evaluates human condition directly — allowed', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const result = await evaluator.evaluateCondition(
+			{ type: 'human' },
+			makeContext({ humanApproved: true })
+		);
+		expect(result.allowed).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: ChannelGateBlockedError
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateBlockedError', () => {
+	test('has correct name', () => {
+		const err = new ChannelGateBlockedError('delivery blocked', 'human');
+		expect(err.name).toBe('ChannelGateBlockedError');
+	});
+
+	test('stores gateType', () => {
+		const err = new ChannelGateBlockedError('blocked by condition', 'condition');
+		expect(err.gateType).toBe('condition');
+	});
+
+	test('is an instance of Error', () => {
+		const err = new ChannelGateBlockedError('msg', 'always');
+		expect(err).toBeInstanceOf(Error);
+	});
+
+	test('message is accessible', () => {
+		const err = new ChannelGateBlockedError('gate is blocked', 'task_result');
+		expect(err.message).toBe('gate is blocked');
+	});
+
+	test('can be thrown and caught', () => {
+		expect(() => {
+			throw new ChannelGateBlockedError('blocked', 'human');
+		}).toThrow(ChannelGateBlockedError);
+	});
+
+	test('can be caught as Error', () => {
+		expect(() => {
+			throw new ChannelGateBlockedError('blocked', 'human');
+		}).toThrow(Error);
+	});
+
+	test('caller pattern: throw on blocked delivery', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel = makeChannel({ gate: { type: 'human' } });
+		const result = await evaluator.evaluate(channel, makeContext({ humanApproved: false }));
+
+		const tryDeliver = () => {
+			if (!result.allowed) {
+				throw new ChannelGateBlockedError(result.reason!, channel.gate!.type);
+			}
+		};
+
+		expect(tryDeliver).toThrow(ChannelGateBlockedError);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: bidirectional channel with gate
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateEvaluator — channel variants', () => {
+	test('bidirectional channel with always gate is allowed', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel: WorkflowChannel = {
+			from: 'coder',
+			to: 'reviewer',
+			direction: 'bidirectional',
+			gate: { type: 'always' },
+		};
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(true);
+	});
+
+	test('fan-out channel (array to) with human gate blocks correctly', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel: WorkflowChannel = {
+			from: 'leader',
+			to: ['worker-a', 'worker-b', 'worker-c'],
+			direction: 'one-way',
+			gate: { type: 'human' },
+		};
+		const result = await evaluator.evaluate(channel, makeContext({ humanApproved: false }));
+		expect(result.allowed).toBe(false);
+	});
+
+	test('channel with isCyclic and task_result gate evaluates correctly', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const channel: WorkflowChannel = {
+			from: 'coder',
+			to: 'reviewer',
+			direction: 'one-way',
+			isCyclic: true,
+			gate: { type: 'task_result', expression: 'ci_passed' },
+		};
+		const result = await evaluator.evaluate(channel, makeContext({ taskResult: 'ci_passed' }));
+		expect(result.allowed).toBe(true);
+	});
+
+	test('channel with label and condition gate passes through correctly', async () => {
+		const evaluator = new ChannelGateEvaluator(makeOkRunner());
+		const channel: WorkflowChannel = {
+			from: 'coder',
+			to: 'reviewer',
+			direction: 'one-way',
+			label: 'Submit for review',
+			gate: { type: 'condition', expression: 'test -f pr.md' },
+		};
+		const result = await evaluator.evaluate(channel, makeContext());
+		expect(result.allowed).toBe(true);
+	});
+});


### PR DESCRIPTION
Implements Task 1.4: gate evaluation engine that checks whether a WorkflowChannel
allows message delivery based on its gate condition.

Supports all 4 gate types:
- always: channel is always open
- human: blocks until humanApproved === true in context
- condition: shell expression; allowed on exit code 0
- task_result: prefix match on taskResult string

Design:
- Injectable CommandRunner for testability (no real subprocesses in tests)
- ChannelGateBlockedError carries gateType for programmatic handling
- evaluateCondition() exposed as public for isolated condition testing
- Clear "Gate blocked: ..." prefix on all failure reasons
- Timeout/error handling mirrors WorkflowExecutor pattern

37 unit tests covering all gate types, edge cases (empty expression, missing
taskResult, throw/timeout runners), ChannelGateBlockedError properties, and
channel variants (bidirectional, fan-out, isCyclic).
