### PR TITLE
feat(db): add unified channels column to space_workflows (Migration 53)

### DIFF
--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -4,11 +4,12 @@
  * Data access layer for SpaceWorkflow, SpaceWorkflowNode, and SpaceWorkflowTransition records.
  *
  * Storage layout:
- *   space_workflows             — id, space_id, name, description, start_node_id, config (JSON), layout (JSON), created_at, updated_at
+ *   space_workflows             — id, space_id, name, description, start_node_id, config (JSON), channels (JSON), layout (JSON), created_at, updated_at
  *   space_workflow_nodes        — id, workflow_id, name, agent_id, order_index, config (JSON), created_at, updated_at
  *   space_workflow_transitions  — id, workflow_id, from_node_id, to_node_id, condition (JSON), order_index, is_cyclic, created_at, updated_at
  *
  * The `config` column on space_workflows stores: { tags, rules, ...extra }
+ * The `channels` column on space_workflows stores: WorkflowChannel[] JSON (unified channel topology)
  * The `config` column on space_workflow_nodes stores: { instructions? }
  * The `condition` column on space_workflow_transitions stores: WorkflowCondition JSON or null
  */
@@ -41,6 +42,7 @@ interface WorkflowRow {
 	description: string;
 	start_node_id: string | null;
 	config: string | null;
+	channels: string | null;
 	layout: string | null;
 	max_iterations: number | null;
 	created_at: number;
@@ -74,8 +76,6 @@ interface TransitionRow {
 interface WorkflowConfigJson {
 	tags?: string[];
 	rules?: WorkflowRule[];
-	/** Workflow-level channel topology declarations */
-	channels?: WorkflowChannel[];
 	extra?: Record<string, unknown>;
 }
 
@@ -144,6 +144,8 @@ function rowToWorkflow(
 	// Derive startNodeId: use explicit column, fall back to first node
 	const startNodeId = row.start_node_id ?? nodes[0]?.id ?? '';
 	const layout = parseJson<Record<string, { x: number; y: number }> | null>(row.layout, null);
+	// Read channels from the dedicated column (Migration 53+).
+	const channels = parseJson<WorkflowChannel[] | null>(row.channels, null);
 	return {
 		id: row.id,
 		spaceId: row.space_id,
@@ -154,7 +156,7 @@ function rowToWorkflow(
 		startNodeId,
 		rules: cfg.rules ?? [],
 		tags: cfg.tags ?? [],
-		channels: cfg.channels && cfg.channels.length > 0 ? cfg.channels : undefined,
+		channels: channels && channels.length > 0 ? channels : undefined,
 		config: cfg.extra,
 		maxIterations: row.max_iterations ?? undefined,
 		layout: layout ?? undefined,
@@ -193,16 +195,17 @@ export class SpaceWorkflowRepository {
 		const cfg: WorkflowConfigJson = {
 			tags: params.tags ?? [],
 			rules: this.assignRuleIds(params.rules ?? []),
-			channels: params.channels && params.channels.length > 0 ? params.channels : undefined,
 			extra: params.config,
 		};
 
+		const channelsJson =
+			params.channels && params.channels.length > 0 ? JSON.stringify(params.channels) : null;
 		const layoutJson = params.layout ? JSON.stringify(params.layout) : null;
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, max_iterations, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, channels, layout, max_iterations, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				workflowId,
@@ -211,6 +214,7 @@ export class SpaceWorkflowRepository {
 				params.description ?? '',
 				startNodeId,
 				JSON.stringify(cfg),
+				channelsJson,
 				layoutJson,
 				params.maxIterations ?? null,
 				now,
@@ -293,10 +297,6 @@ export class SpaceWorkflowRepository {
 			newCfg.rules = params.rules ?? [];
 			cfgChanged = true;
 		}
-		if (params.channels !== undefined) {
-			newCfg.channels = params.channels && params.channels.length > 0 ? params.channels : undefined;
-			cfgChanged = true;
-		}
 		if (params.config !== undefined) {
 			newCfg.extra = params.config ?? undefined;
 			cfgChanged = true;
@@ -305,6 +305,13 @@ export class SpaceWorkflowRepository {
 		if (cfgChanged) {
 			fields.push('config = ?');
 			values.push(JSON.stringify(newCfg));
+		}
+
+		if (params.channels !== undefined) {
+			fields.push('channels = ?');
+			values.push(
+				params.channels && params.channels.length > 0 ? JSON.stringify(params.channels) : null
+			);
 		}
 
 		if (params.maxIterations !== undefined) {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -208,6 +208,12 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 52: Create room_mcp_enablement table for per-room MCP enablement overrides.
 	runMigration52(db);
+
+	// Migration 53: Add channels column to space_workflows for unified channel topology storage.
+	// Channels move from the config JSON blob to a dedicated TEXT column (JSON-serialized
+	// WorkflowChannel[]). Existing rows that have channels embedded in config are migrated
+	// in-place so no data is lost.
+	runMigration53(db);
 }
 
 /**
@@ -3214,4 +3220,47 @@ export function runMigration52(db: BunDatabase): void {
       PRIMARY KEY (room_id, server_id)
     )
   `);
+}
+
+/**
+ * Migration 53: Add channels column to space_workflows.
+ *
+ * Channels move out of the config JSON blob into a dedicated TEXT column that stores a
+ * JSON-serialized WorkflowChannel[] array. This makes the channel topology a first-class
+ * column rather than a nested JSON field, simplifying repository reads/writes.
+ *
+ * For existing rows, channels are extracted from the config JSON and written to the new
+ * column so that no data is lost. The config JSON is updated in-place with channels removed.
+ *
+ * Idempotent via tableHasColumn guard.
+ */
+export function runMigration53(db: BunDatabase): void {
+	if (!tableHasColumn(db, 'space_workflows', 'channels')) {
+		db.exec(`ALTER TABLE space_workflows ADD COLUMN channels TEXT`);
+
+		// Migrate existing rows: pull channels out of config JSON into the new column.
+		const rows = db
+			.prepare(`SELECT id, config FROM space_workflows WHERE config IS NOT NULL`)
+			.all() as Array<{ id: string; config: string }>;
+
+		for (const row of rows) {
+			let cfg: Record<string, unknown>;
+			try {
+				cfg = JSON.parse(row.config) as Record<string, unknown>;
+			} catch {
+				continue;
+			}
+			if (!cfg.channels) continue;
+
+			const channelsJson = JSON.stringify(cfg.channels);
+			delete cfg.channels;
+			const updatedConfig = JSON.stringify(cfg);
+
+			db.prepare(`UPDATE space_workflows SET channels = ?, config = ? WHERE id = ?`).run(
+				channelsJson,
+				updatedConfig,
+				row.id
+			);
+		}
+	}
 }

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -57,6 +57,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			description TEXT NOT NULL DEFAULT '',
 			start_node_id TEXT,
 			config TEXT,
+			channels TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -64,6 +64,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			description TEXT NOT NULL DEFAULT '',
 			start_node_id TEXT,
 			config TEXT,
+			channels TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -76,6 +76,7 @@ function createSchema(db: Database): void {
 			description TEXT NOT NULL DEFAULT '',
 			start_node_id TEXT,
 			config TEXT,
+			channels TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,

--- a/packages/daemon/tests/unit/storage/migrations/migration-53_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-53_test.ts
@@ -1,0 +1,301 @@
+/**
+ * Migration 53 Tests
+ *
+ * Migration 53 adds a dedicated `channels TEXT` column to `space_workflows`.
+ * Channels are moved from the `config` JSON blob to this first-class column
+ * (JSON-serialized WorkflowChannel[]).
+ *
+ * Covers:
+ * - channels column exists after migration on a fresh DB
+ * - Migration is idempotent (running twice does not throw)
+ * - New rows without channels have NULL in the channels column
+ * - Channels round-trip correctly through create/read via the repository
+ * - Channels are NOT stored inside config JSON after create
+ * - Channels are updated correctly via the repository
+ * - Clearing channels via update sets the column to NULL
+ * - Data migration: existing rows with channels in config JSON get migrated to the column
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { runMigration53 } from '../../../../src/storage/schema/migrations.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const info = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+	return info.some((c) => c.name === column);
+}
+
+/** Create a minimal space_workflows table without the channels column, simulating pre-M53 state. */
+function createMinimalWorkflowsTable(db: BunDatabase): void {
+	db.exec('PRAGMA foreign_keys = OFF');
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflows (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			start_node_id TEXT,
+			config TEXT,
+			layout TEXT,
+			max_iterations INTEGER,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('Migration 53: channels column on space_workflows', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-53', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('space_workflows has channels column after migration', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'space_workflows', 'channels')).toBe(true);
+	});
+
+	test('migration is idempotent — running twice does not throw', () => {
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+	});
+
+	test('new rows without channels have NULL in the channels column', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-no-ch', '/workspace/m53a', 'Space A', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
+			 VALUES ('wf-no-ch', 'sp-no-ch', 'No Channels', ${now}, ${now})`
+		);
+
+		const row = db.prepare(`SELECT channels FROM space_workflows WHERE id = 'wf-no-ch'`).get() as {
+			channels: string | null;
+		};
+		expect(row.channels).toBeNull();
+	});
+
+	test('channels round-trip correctly via repository create and get', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-rt', '/workspace/m53b', 'Space B', ${now}, ${now})`
+		);
+
+		const repo = new SpaceWorkflowRepository(db);
+		const wf = repo.createWorkflow({
+			spaceId: 'sp-rt',
+			name: 'Round-Trip',
+			nodes: [
+				{ id: 'node-a', name: 'Alpha' },
+				{ id: 'node-b', name: 'Beta' },
+			],
+			channels: [
+				{ from: 'node-a', to: 'node-b', direction: 'one-way', label: 'alpha to beta' },
+				{ from: 'node-b', to: 'node-a', direction: 'bidirectional' },
+			],
+		});
+
+		// Verify the channels column is written at the DB level
+		const raw = db.prepare(`SELECT channels FROM space_workflows WHERE id = ?`).get(wf.id) as {
+			channels: string | null;
+		};
+		expect(raw.channels).not.toBeNull();
+		const stored = JSON.parse(raw.channels!) as unknown[];
+		expect(stored).toHaveLength(2);
+
+		// Verify round-trip via repository read
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched).not.toBeNull();
+		expect(fetched!.channels).toHaveLength(2);
+		expect(fetched!.channels![0]).toMatchObject({
+			from: 'node-a',
+			to: 'node-b',
+			direction: 'one-way',
+			label: 'alpha to beta',
+		});
+		expect(fetched!.channels![1]).toMatchObject({
+			from: 'node-b',
+			to: 'node-a',
+			direction: 'bidirectional',
+		});
+	});
+
+	test('channels are NOT stored inside config JSON', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-cfg', '/workspace/m53c', 'Space C', ${now}, ${now})`
+		);
+
+		const repo = new SpaceWorkflowRepository(db);
+		const wf = repo.createWorkflow({
+			spaceId: 'sp-cfg',
+			name: 'Config Check',
+			channels: [{ from: 'a', to: 'b', direction: 'one-way' }],
+		});
+
+		const raw = db.prepare(`SELECT config FROM space_workflows WHERE id = ?`).get(wf.id) as {
+			config: string | null;
+		};
+		const cfg = JSON.parse(raw.config ?? '{}') as Record<string, unknown>;
+		expect(cfg.channels).toBeUndefined();
+	});
+
+	test('updating channels via repository writes to the channels column', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-upd', '/workspace/m53d', 'Space D', ${now}, ${now})`
+		);
+
+		const repo = new SpaceWorkflowRepository(db);
+		const wf = repo.createWorkflow({
+			spaceId: 'sp-upd',
+			name: 'Update Test',
+			channels: [{ from: 'x', to: 'y', direction: 'one-way' }],
+		});
+
+		repo.updateWorkflow(wf.id, {
+			channels: [
+				{ from: 'x', to: 'y', direction: 'one-way' },
+				{ from: 'y', to: 'x', direction: 'one-way', label: 'reply' },
+			],
+		});
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched!.channels).toHaveLength(2);
+		expect(fetched!.channels![1].label).toBe('reply');
+	});
+
+	test('setting channels to null clears the channels column', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-clr', '/workspace/m53e', 'Space E', ${now}, ${now})`
+		);
+
+		const repo = new SpaceWorkflowRepository(db);
+		const wf = repo.createWorkflow({
+			spaceId: 'sp-clr',
+			name: 'Clear Test',
+			channels: [{ from: 'a', to: 'b', direction: 'one-way' }],
+		});
+
+		repo.updateWorkflow(wf.id, { channels: null });
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched!.channels).toBeUndefined();
+
+		const raw = db.prepare(`SELECT channels FROM space_workflows WHERE id = ?`).get(wf.id) as {
+			channels: string | null;
+		};
+		expect(raw.channels).toBeNull();
+	});
+
+	test('data migration: existing rows with channels in config JSON are migrated to the channels column', () => {
+		// Set up a minimal pre-M53 DB: space_workflows table without the channels column.
+		createMinimalWorkflowsTable(db);
+
+		const now = Date.now();
+		const legacyConfig = JSON.stringify({
+			tags: ['legacy'],
+			rules: [],
+			channels: [{ from: 'old-a', to: 'old-b', direction: 'one-way', label: 'legacy link' }],
+		});
+		db.exec(
+			`INSERT INTO space_workflows (id, space_id, name, config, created_at, updated_at)
+			 VALUES ('wf-legacy', 'sp-legacy', 'Legacy WF', '${legacyConfig}', ${now}, ${now})`
+		);
+
+		// The column should not exist yet
+		expect(columnExists(db, 'space_workflows', 'channels')).toBe(false);
+
+		// Run the migration
+		runMigration53(db);
+
+		// Column now exists
+		expect(columnExists(db, 'space_workflows', 'channels')).toBe(true);
+
+		// The channels were migrated from config to the channels column
+		const raw = db
+			.prepare(`SELECT channels, config FROM space_workflows WHERE id = 'wf-legacy'`)
+			.get() as { channels: string | null; config: string };
+
+		expect(raw.channels).not.toBeNull();
+		const migratedChannels = JSON.parse(raw.channels!) as Array<Record<string, unknown>>;
+		expect(migratedChannels).toHaveLength(1);
+		expect(migratedChannels[0]).toMatchObject({
+			from: 'old-a',
+			to: 'old-b',
+			direction: 'one-way',
+			label: 'legacy link',
+		});
+
+		// config JSON must no longer contain channels
+		const migratedCfg = JSON.parse(raw.config) as Record<string, unknown>;
+		expect(migratedCfg.channels).toBeUndefined();
+		expect(migratedCfg.tags).toEqual(['legacy']);
+	});
+
+	test('data migration: rows without channels in config are left with NULL in channels column', () => {
+		createMinimalWorkflowsTable(db);
+
+		const now = Date.now();
+		const configNoCh = JSON.stringify({ tags: ['no-channels'], rules: [] });
+		db.exec(
+			`INSERT INTO space_workflows (id, space_id, name, config, created_at, updated_at)
+			 VALUES ('wf-noch', 'sp-noch', 'No Ch WF', '${configNoCh}', ${now}, ${now})`
+		);
+
+		runMigration53(db);
+
+		const raw = db.prepare(`SELECT channels FROM space_workflows WHERE id = 'wf-noch'`).get() as {
+			channels: string | null;
+		};
+		expect(raw.channels).toBeNull();
+	});
+});


### PR DESCRIPTION
Move WorkflowChannel[] from the config JSON blob to a dedicated
`channels TEXT` column on space_workflows. This makes channel topology
a first-class column rather than a nested JSON field.

- Migration 53: ALTER TABLE space_workflows ADD COLUMN channels TEXT,
  with an idempotent tableHasColumn guard. Existing rows whose config
  JSON contains channels are data-migrated in-place (channels extracted
  from config and written to the new column).
- SpaceWorkflowRepository: read channels from row.channels (dedicated
  column), write channels to channels column on create/update, remove
  channels from WorkflowConfigJson.
- Update space-test-db.ts and space-export-import-handlers.test.ts to
  include the channels column in their hardcoded schemas.
- Add migration-53_test.ts: 9 tests covering column existence,
  idempotency, round-trips, config JSON exclusion, update, clear,
  and the data migration path from legacy config JSON rows.
