### PR TITLE
feat(space): add ExportedWorkflowChannel and validate channel references on import

### DIFF
--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -23,6 +23,7 @@ import type {
 	SpaceWorkflow,
 	ExportedSpaceAgent,
 	ExportedSpaceWorkflow,
+	ExportedWorkflowChannel,
 	ExportedWorkflowNode,
 	ExportedWorkflowNodeAgent,
 	ExportedWorkflowTransition,
@@ -67,22 +68,18 @@ const exportedWorkflowNodeAgentSchema = z.object({
 	instructions: z.string().optional(),
 });
 
-const workflowChannelSchema = z.object({
-	id: z.string().optional(),
+/**
+ * Zod schema for an exported workflow channel.
+ * Differs from the runtime WorkflowChannel schema: `id` is intentionally absent
+ * since channel IDs are space-specific and stripped during export.
+ */
+const exportedWorkflowChannelSchema = z.object({
 	from: z.string().min(1),
 	to: z.union([z.string().min(1), z.array(z.string().min(1))]),
 	direction: z.enum(['one-way', 'bidirectional']),
 	isCyclic: z.boolean().optional(),
 	label: z.string().optional(),
-	gate: z
-		.object({
-			type: z.enum(['always', 'human', 'condition', 'task_result']),
-			expression: z.string().optional(),
-			description: z.string().optional(),
-			maxRetries: z.number().int().nonnegative().optional(),
-			timeoutMs: z.number().int().nonnegative().optional(),
-		})
-		.optional(),
+	gate: workflowConditionSchema.optional(),
 });
 
 const exportedWorkflowNodeSchema = z
@@ -151,7 +148,7 @@ const exportedWorkflowBaseSchema = z.object({
 	rules: z.array(exportedWorkflowRuleSchema),
 	tags: z.array(z.string()),
 	config: z.record(z.string(), z.unknown()).optional(),
-	channels: z.array(workflowChannelSchema).optional(),
+	channels: z.array(exportedWorkflowChannelSchema).optional(),
 });
 
 const exportBundleBaseSchema = z.object({
@@ -314,7 +311,21 @@ export function exportWorkflow(
 	};
 	if (workflow.description !== undefined) result.description = workflow.description;
 	if (workflow.config !== undefined) result.config = workflow.config;
-	if (workflow.channels && workflow.channels.length > 0) result.channels = workflow.channels;
+	// Export channels — strip `id` (space-specific) and convert to portable ExportedWorkflowChannel format
+	if (workflow.channels && workflow.channels.length > 0) {
+		const exportedChannels: ExportedWorkflowChannel[] = workflow.channels.map((ch) => {
+			const exported: ExportedWorkflowChannel = {
+				from: ch.from,
+				to: ch.to,
+				direction: ch.direction,
+			};
+			if (ch.isCyclic !== undefined) exported.isCyclic = ch.isCyclic;
+			if (ch.label !== undefined) exported.label = ch.label;
+			if (ch.gate !== undefined) exported.gate = ch.gate;
+			return exported;
+		});
+		result.channels = exportedChannels;
+	}
 	return result;
 }
 
@@ -415,6 +426,40 @@ export function validateExportedWorkflow(data: unknown): ValidationResult<Export
 				ok: false,
 				error: `invalid: transitions[${i}].toNode "${t.toNode}" does not reference a known node name`,
 			};
+		}
+	}
+
+	// Channel from/to must reference known node names, agent slot names, or '*' wildcard.
+	// Build valid name set: '*' + all node names + all agent slot names (agents[].name).
+	// Single-agent nodes (agentRef shorthand) use the node name for fan-out targeting.
+	if (result.data.channels && result.data.channels.length > 0) {
+		const validChannelNames = new Set<string>(['*']);
+		for (const node of result.data.nodes) {
+			validChannelNames.add(node.name);
+			if (node.agents) {
+				for (const a of node.agents) {
+					validChannelNames.add(a.name);
+				}
+			}
+		}
+		for (let ci = 0; ci < result.data.channels.length; ci++) {
+			const ch = result.data.channels[ci];
+			const loc = `channels[${ci}]`;
+			if (!validChannelNames.has(ch.from)) {
+				return {
+					ok: false,
+					error: `invalid: ${loc}.from "${ch.from}" does not reference a known agent slot name or node name`,
+				};
+			}
+			const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
+			for (let ti = 0; ti < toList.length; ti++) {
+				if (!validChannelNames.has(toList[ti])) {
+					return {
+						ok: false,
+						error: `invalid: ${loc}.to[${ti}] "${toList[ti]}" does not reference a known agent slot name or node name`,
+					};
+				}
+			}
 		}
 	}
 

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -1994,3 +1994,352 @@ describe('round-trip: multi-agent + channels', () => {
 		}
 	});
 });
+
+// ---------------------------------------------------------------------------
+// ExportedWorkflowChannel — export strips `id`, validateExportedWorkflow
+// validates channel references
+// ---------------------------------------------------------------------------
+
+describe('ExportedWorkflowChannel — export and validation', () => {
+	function makeWorkflowWithChannelId(): SpaceWorkflow {
+		return {
+			id: 'wf-ch',
+			spaceId: 'space-1',
+			name: 'Channel Workflow',
+			nodes: [
+				{
+					id: 'node-1',
+					name: 'Code and Review',
+					agents: [
+						{ agentId: 'agent-uuid-1', name: 'coder' },
+						{ agentId: 'agent-uuid-3', name: 'reviewer' },
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 'node-1',
+			rules: [],
+			tags: [],
+			channels: [
+				{
+					id: 'ch-uuid-1',
+					from: 'coder',
+					to: 'reviewer',
+					direction: 'bidirectional',
+					label: 'feedback',
+				},
+			],
+			createdAt: 1000,
+			updatedAt: 2000,
+		};
+	}
+
+	test('exportWorkflow strips channel id', () => {
+		const workflow = makeWorkflowWithChannelId();
+		const exported = exportWorkflow(workflow, [makeAgent(), makeReviewerAgent()]);
+
+		expect(exported.channels).toHaveLength(1);
+		const ch = exported.channels![0] as Record<string, unknown>;
+		expect('id' in ch).toBe(false);
+	});
+
+	test('exportWorkflow preserves channel fields except id', () => {
+		const workflow = makeWorkflowWithChannelId();
+		const exported = exportWorkflow(workflow, [makeAgent(), makeReviewerAgent()]);
+
+		const ch = exported.channels![0];
+		expect(ch.from).toBe('coder');
+		expect(ch.to).toBe('reviewer');
+		expect(ch.direction).toBe('bidirectional');
+		expect(ch.label).toBe('feedback');
+	});
+
+	test('exportWorkflow strips id from channel with gate', () => {
+		const workflow: SpaceWorkflow = {
+			id: 'wf-gate',
+			spaceId: 'space-1',
+			name: 'Gated Workflow',
+			nodes: [
+				{
+					id: 'node-1',
+					name: 'Work',
+					agents: [
+						{ agentId: 'agent-uuid-1', name: 'coder' },
+						{ agentId: 'agent-uuid-3', name: 'reviewer' },
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 'node-1',
+			rules: [],
+			tags: [],
+			channels: [
+				{
+					id: 'ch-gate-uuid',
+					from: 'coder',
+					to: 'reviewer',
+					direction: 'one-way',
+					gate: { type: 'human', description: 'Needs human approval' },
+				},
+			],
+			createdAt: 1000,
+			updatedAt: 2000,
+		};
+		const exported = exportWorkflow(workflow, [makeAgent(), makeReviewerAgent()]);
+
+		const ch = exported.channels![0] as Record<string, unknown>;
+		expect('id' in ch).toBe(false);
+		expect(ch.gate).toEqual({ type: 'human', description: 'Needs human approval' });
+	});
+
+	test('exportWorkflow strips id from channel with isCyclic', () => {
+		const workflow: SpaceWorkflow = {
+			id: 'wf-cyclic',
+			spaceId: 'space-1',
+			name: 'Cyclic Workflow',
+			nodes: [
+				{
+					id: 'node-1',
+					name: 'Loop',
+					agents: [
+						{ agentId: 'agent-uuid-1', name: 'coder' },
+						{ agentId: 'agent-uuid-3', name: 'reviewer' },
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: 'node-1',
+			rules: [],
+			tags: [],
+			channels: [
+				{
+					id: 'ch-cyclic-uuid',
+					from: 'coder',
+					to: 'reviewer',
+					direction: 'one-way',
+					isCyclic: true,
+				},
+			],
+			createdAt: 1000,
+			updatedAt: 2000,
+		};
+		const exported = exportWorkflow(workflow, [makeAgent(), makeReviewerAgent()]);
+
+		const ch = exported.channels![0] as Record<string, unknown>;
+		expect('id' in ch).toBe(false);
+		expect(ch.isCyclic).toBe(true);
+	});
+
+	test('channel id does not appear in exported JSON', () => {
+		const workflow = makeWorkflowWithChannelId();
+		const exported = exportWorkflow(workflow, [makeAgent(), makeReviewerAgent()]);
+		const json = JSON.stringify(exported);
+
+		expect(json).not.toContain('ch-uuid-1');
+	});
+
+	test('validateExportedWorkflow accepts channels with valid slot name references', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [
+						{ agentRef: 'Coder', name: 'coder' },
+						{ agentRef: 'Reviewer', name: 'reviewer' },
+					],
+					name: 'Collab',
+				},
+			],
+			transitions: [],
+			startNode: 'Collab',
+			rules: [],
+			tags: [],
+			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+	});
+
+	test('validateExportedWorkflow accepts channels referencing node name (fan-out)', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [{ agentRef: 'Coder', name: 'coder' }],
+					name: 'Code',
+				},
+				{
+					agents: [{ agentRef: 'Reviewer', name: 'reviewer' }],
+					name: 'Review',
+				},
+			],
+			transitions: [{ fromNode: 'Code', toNode: 'Review' }],
+			startNode: 'Code',
+			rules: [],
+			tags: [],
+			channels: [{ from: 'coder', to: 'Review', direction: 'one-way' }],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+	});
+
+	test('validateExportedWorkflow accepts wildcard * references', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [{ agentRef: 'Coder', name: 'coder' }],
+					name: 'Work',
+				},
+			],
+			transitions: [],
+			startNode: 'Work',
+			rules: [],
+			tags: [],
+			channels: [{ from: '*', to: '*', direction: 'bidirectional' }],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+	});
+
+	test('validateExportedWorkflow rejects channel with unknown from reference', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [
+						{ agentRef: 'Coder', name: 'coder' },
+						{ agentRef: 'Reviewer', name: 'reviewer' },
+					],
+					name: 'Collab',
+				},
+			],
+			transitions: [],
+			startNode: 'Collab',
+			rules: [],
+			tags: [],
+			channels: [{ from: 'unknown-agent', to: 'reviewer', direction: 'one-way' }],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('channels[0].from');
+			expect(result.error).toContain('"unknown-agent"');
+		}
+	});
+
+	test('validateExportedWorkflow rejects channel with unknown to reference', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [
+						{ agentRef: 'Coder', name: 'coder' },
+						{ agentRef: 'Reviewer', name: 'reviewer' },
+					],
+					name: 'Collab',
+				},
+			],
+			transitions: [],
+			startNode: 'Collab',
+			rules: [],
+			tags: [],
+			channels: [{ from: 'coder', to: 'ghost', direction: 'one-way' }],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('channels[0].to');
+			expect(result.error).toContain('"ghost"');
+		}
+	});
+
+	test('validateExportedWorkflow rejects channel with unknown to in array', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [
+						{ agentRef: 'Hub', name: 'hub' },
+						{ agentRef: 'Spoke1', name: 'spoke1' },
+					],
+					name: 'Fan-out',
+				},
+			],
+			transitions: [],
+			startNode: 'Fan-out',
+			rules: [],
+			tags: [],
+			channels: [{ from: 'hub', to: ['spoke1', 'missing-spoke'], direction: 'one-way' }],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('channels[0].to');
+			expect(result.error).toContain('"missing-spoke"');
+		}
+	});
+
+	test('validateExportedWorkflow rejects channel id present in input (schema excludes id)', () => {
+		// The exported channel schema does not accept `id` — it will be dropped silently
+		// by Zod strict parsing, OR pass through if not explicitly rejected.
+		// This test verifies the channel still validates correctly (id stripped by schema).
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [
+						{ agentRef: 'Coder', name: 'coder' },
+						{ agentRef: 'Reviewer', name: 'reviewer' },
+					],
+					name: 'Step',
+				},
+			],
+			transitions: [],
+			startNode: 'Step',
+			rules: [],
+			tags: [],
+			channels: [{ id: 'ch-123', from: 'coder', to: 'reviewer', direction: 'one-way' }],
+		};
+		const result = validateExportedWorkflow(data);
+		// Channel id is stripped by the schema (not included in exportedWorkflowChannelSchema)
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const ch = result.value.channels![0] as Record<string, unknown>;
+			expect('id' in ch).toBe(false);
+		}
+	});
+
+	test('round-trip: export strips channel id, validate passes', () => {
+		const workflow = makeWorkflowWithChannelId();
+		const agents = [makeAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.channels).toHaveLength(1);
+			const ch = result.value.channels![0] as Record<string, unknown>;
+			expect('id' in ch).toBe(false);
+			expect(ch.from).toBe('coder');
+			expect(ch.to).toBe('reviewer');
+			expect(ch.direction).toBe('bidirectional');
+		}
+	});
+});

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -924,6 +924,31 @@ export interface UpdateSpaceWorkflowParams {
 // ============================================================================
 
 /**
+ * A directed messaging channel in the portable export format.
+ *
+ * Differences from `WorkflowChannel`:
+ * - `id` is stripped (space-specific, regenerated on import if needed)
+ * - `from`/`to` use agent slot name strings (`WorkflowNodeAgent.name`), node names,
+ *   or `'*'` for broadcast — all portable across Space instances.
+ */
+export interface ExportedWorkflowChannel {
+	/**
+	 * Source agent slot name (`WorkflowNodeAgent.name`), node name for fan-out,
+	 * or `'*'` for all agents in the workflow.
+	 */
+	from: string;
+	/**
+	 * Target agent slot name(s), node name for fan-out, or `'*'` for all agents.
+	 * An array enables fan-out or hub-spoke topologies.
+	 */
+	to: string | string[];
+	direction: 'one-way' | 'bidirectional';
+	isCyclic?: boolean;
+	label?: string;
+	gate?: WorkflowCondition;
+}
+
+/**
  * A single agent entry within a multi-agent exported workflow node.
  * Mirrors `WorkflowNodeAgent` but uses a portable `agentRef` name instead of a UUID.
  */
@@ -1103,10 +1128,11 @@ export interface ExportedSpaceWorkflow {
 	config?: Record<string, unknown>;
 	/**
 	 * Directed messaging channels for the workflow.
-	 * Uses agent name strings (portable — not UUIDs). Exported and imported as-is.
+	 * Uses agent slot name strings and node names (portable — not UUIDs).
+	 * Channel `id` fields are stripped during export and omitted here.
 	 * Absent or empty means agents are fully isolated (no messaging constraints).
 	 */
-	channels?: WorkflowChannel[];
+	channels?: ExportedWorkflowChannel[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `ExportedWorkflowChannel` type to `packages/shared/src/types/space.ts` — mirrors `WorkflowChannel` but strips the `id` field (space-specific, not portable)
- Update `ExportedSpaceWorkflow.channels` from `WorkflowChannel[]` to `ExportedWorkflowChannel[]`
- In `export-format.ts`: replace `workflowChannelSchema` with `exportedWorkflowChannelSchema` (no `id` field), update `exportWorkflow()` to explicitly strip `id` from channels
- In `validateExportedWorkflow()`: add referential integrity check for channel `from`/`to` — each value must be `'*'`, a known node name, or a known agent slot name (`agents[].name`); catches missing references with clear error messages
- 11 new unit tests in `export-format.test.ts` covering all new behaviors

## Test plan

- [x] `bun test packages/daemon/tests/unit/space/export-format.test.ts` — 119 tests pass
- [x] `bun test packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts` — 78 tests pass
- [x] Lint, typecheck, knip — all clean