### PR TITLE
task/task 71 update visual workflow editor for channels

### DIFF
--- a/packages/web/src/components/space/ChannelEditor.tsx
+++ b/packages/web/src/components/space/ChannelEditor.tsx
@@ -1,0 +1,524 @@
+/**
+ * ChannelEditor
+ *
+ * Unified CRUD editor for WorkflowChannel entries with gate configuration.
+ * Supports all 4 gate condition types: always, human, condition, task_result.
+ *
+ * This component manages workflow-level channels (not node-level).
+ * Channels connect agents by role name across nodes in the workflow graph.
+ *
+ * Usage:
+ *   <ChannelEditor channels={channels} onChange={setChannels} agentRoles={roles} />
+ */
+
+import { useState, useCallback, useEffect } from 'preact/hooks';
+import type { WorkflowChannel, WorkflowConditionType } from '@neokai/shared';
+import { GateConfig, CONDITION_LABELS } from './visual-editor/GateConfig';
+import type { ConditionDraft } from './visual-editor/GateConfig';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ChannelEditorProps {
+	/** Workflow-level channels */
+	channels: WorkflowChannel[];
+	onChange: (channels: WorkflowChannel[]) => void;
+	/** Known agent role names for from/to dropdowns (from step.agents[].name) */
+	agentRoles?: string[];
+	/** Index of the channel to pre-expand (e.g. when selected via canvas click) */
+	highlightIndex?: number | null;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function conditionToGate(cond: ConditionDraft): WorkflowChannel['gate'] {
+	if (cond.type === 'always') return undefined;
+	return { type: cond.type as WorkflowConditionType, expression: cond.expression };
+}
+
+function gateToCondition(gate: WorkflowChannel['gate']): ConditionDraft {
+	if (!gate || gate.type === 'always') return { type: 'always' };
+	return { type: gate.type as WorkflowConditionType, expression: gate.expression };
+}
+
+function formatTo(to: string | string[]): string {
+	return Array.isArray(to) ? to.join(', ') : to;
+}
+
+function parseToField(raw: string): string | string[] {
+	const parts = raw
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean);
+	return parts.length > 1 ? parts : (parts[0] ?? '');
+}
+
+function gateLabel(gate: WorkflowChannel['gate']): string | null {
+	if (!gate || gate.type === 'always') return null;
+	return CONDITION_LABELS[gate.type as WorkflowConditionType] ?? gate.type;
+}
+
+// ============================================================================
+// ChannelEntry — single expandable channel row
+// ============================================================================
+
+interface ChannelEntryProps {
+	channel: WorkflowChannel;
+	index: number;
+	agentRoles: string[];
+	expanded: boolean;
+	highlighted: boolean;
+	onToggle: () => void;
+	onChange: (index: number, channel: WorkflowChannel) => void;
+	onDelete: (index: number) => void;
+}
+
+function ChannelEntry({
+	channel,
+	index,
+	agentRoles,
+	expanded,
+	highlighted,
+	onToggle,
+	onChange,
+	onDelete,
+}: ChannelEntryProps) {
+	const gate = gateToCondition(channel.gate);
+	const hasGate = !!channel.gate && channel.gate.type !== 'always';
+	const directionSymbol = channel.direction === 'bidirectional' ? '↔' : '→';
+	const toText = formatTo(channel.to);
+	const gateLbl = gateLabel(channel.gate);
+
+	function updateField<K extends keyof WorkflowChannel>(key: K, value: WorkflowChannel[K]) {
+		onChange(index, { ...channel, [key]: value });
+	}
+
+	function handleGateChange(cond: ConditionDraft) {
+		onChange(index, { ...channel, gate: conditionToGate(cond) });
+	}
+
+	const borderClass = highlighted
+		? 'border-teal-500 ring-1 ring-teal-500/40'
+		: hasGate
+			? 'border-teal-700/50 bg-teal-950/20'
+			: 'border-dark-600 bg-dark-800';
+
+	return (
+		<div
+			class={`rounded border ${borderClass}`}
+			data-testid="channel-entry"
+			data-has-gate={hasGate ? 'true' : undefined}
+			data-channel-index={index}
+		>
+			{/* Summary row */}
+			<div class="flex items-center gap-2 px-2 py-1.5">
+				<button
+					type="button"
+					onClick={onToggle}
+					class="flex-1 flex items-center gap-2 text-left min-w-0"
+					data-testid="channel-toggle-button"
+				>
+					<span class="text-xs text-gray-300 font-mono truncate">
+						<span class="text-gray-400">{channel.from}</span>
+						<span class="text-teal-500 mx-1">{directionSymbol}</span>
+						<span class="text-gray-400">{toText}</span>
+					</span>
+					{gateLbl && (
+						<span
+							class="text-xs text-teal-400 bg-teal-900/40 border border-teal-700/50 rounded px-1 py-0.5 flex-shrink-0"
+							data-testid="gate-badge"
+						>
+							{gateLbl}
+						</span>
+					)}
+					{channel.label && (
+						<span class="text-xs text-gray-600 italic truncate flex-shrink-0">
+							&ldquo;{channel.label}&rdquo;
+						</span>
+					)}
+				</button>
+				<button
+					type="button"
+					onClick={onToggle}
+					class="text-gray-600 hover:text-gray-300 transition-colors flex-shrink-0"
+					title={expanded ? 'Collapse' : 'Edit'}
+					data-testid="channel-expand-button"
+					aria-expanded={expanded}
+				>
+					<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						{expanded ? (
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M5 15l7-7 7 7"
+							/>
+						) : (
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M19 9l-7 7-7-7"
+							/>
+						)}
+					</svg>
+				</button>
+				<button
+					type="button"
+					onClick={() => onDelete(index)}
+					class="text-gray-600 hover:text-red-400 transition-colors flex-shrink-0"
+					title="Delete channel"
+					data-testid="delete-channel-button"
+				>
+					<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M6 18L18 6M6 6l12 12"
+						/>
+					</svg>
+				</button>
+			</div>
+
+			{/* Edit form */}
+			{expanded && (
+				<div
+					class="px-2 pb-2 space-y-2 border-t border-dark-700 pt-2"
+					data-testid="channel-edit-form"
+				>
+					{/* From */}
+					<div class="space-y-0.5">
+						<label class="text-xs text-gray-500">From</label>
+						{agentRoles.length > 0 ? (
+							<select
+								data-testid="channel-from-select"
+								value={channel.from}
+								onChange={(e) => updateField('from', (e.currentTarget as HTMLSelectElement).value)}
+								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+							>
+								<option value="">— Select source —</option>
+								<option value="task-agent">task-agent</option>
+								<option value="*">* (all agents)</option>
+								{agentRoles.map((r) => (
+									<option key={r} value={r}>
+										{r}
+									</option>
+								))}
+							</select>
+						) : (
+							<input
+								type="text"
+								data-testid="channel-from-input"
+								value={channel.from}
+								onInput={(e) => updateField('from', (e.currentTarget as HTMLInputElement).value)}
+								placeholder="e.g. task-agent, coder, *"
+								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+							/>
+						)}
+					</div>
+
+					{/* Direction */}
+					<div class="space-y-0.5">
+						<label class="text-xs text-gray-500">Direction</label>
+						<select
+							data-testid="channel-direction-select"
+							value={channel.direction}
+							onChange={(e) =>
+								updateField(
+									'direction',
+									(e.currentTarget as HTMLSelectElement).value as 'one-way' | 'bidirectional'
+								)
+							}
+							class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+						>
+							<option value="one-way">→ One-way</option>
+							<option value="bidirectional">↔ Bidirectional</option>
+						</select>
+					</div>
+
+					{/* To */}
+					<div class="space-y-0.5">
+						<label class="text-xs text-gray-500">To (comma-separated for fan-out)</label>
+						{agentRoles.length > 0 ? (
+							<select
+								data-testid="channel-to-select"
+								value={typeof channel.to === 'string' ? channel.to : ''}
+								onChange={(e) => updateField('to', (e.currentTarget as HTMLSelectElement).value)}
+								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+							>
+								<option value="">— Select target —</option>
+								<option value="task-agent">task-agent</option>
+								<option value="*">* (all agents)</option>
+								{agentRoles.map((r) => (
+									<option key={r} value={r}>
+										{r}
+									</option>
+								))}
+							</select>
+						) : (
+							<input
+								type="text"
+								data-testid="channel-to-input"
+								value={formatTo(channel.to)}
+								onInput={(e) =>
+									updateField('to', parseToField((e.currentTarget as HTMLInputElement).value))
+								}
+								placeholder="e.g. reviewer, coder (comma for fan-out)"
+								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+							/>
+						)}
+					</div>
+
+					{/* Label */}
+					<div class="space-y-0.5">
+						<label class="text-xs text-gray-500">Label (optional)</label>
+						<input
+							type="text"
+							data-testid="channel-label-input"
+							value={channel.label ?? ''}
+							onInput={(e) =>
+								updateField('label', (e.currentTarget as HTMLInputElement).value || undefined)
+							}
+							placeholder="e.g. PR ready for review"
+							class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+						/>
+					</div>
+
+					{/* Gate — supports all 4 condition types */}
+					<GateConfig
+						label="Gate condition"
+						condition={gate}
+						onChange={handleGateChange}
+						testId={`channel-gate-select-${index}`}
+					/>
+
+					{/* Cyclic flag */}
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input
+							type="checkbox"
+							data-testid="channel-cyclic-checkbox"
+							checked={!!channel.isCyclic}
+							onChange={(e) =>
+								updateField('isCyclic', (e.currentTarget as HTMLInputElement).checked || undefined)
+							}
+							class="rounded border-dark-600 text-teal-500 focus:ring-teal-500"
+						/>
+						<span class="text-xs text-gray-400">
+							Cyclic (increments iteration counter on delivery)
+						</span>
+					</label>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ============================================================================
+// AddChannelForm — inline form to add a new channel
+// ============================================================================
+
+interface AddChannelFormProps {
+	agentRoles: string[];
+	onAdd: (channel: WorkflowChannel) => void;
+}
+
+function AddChannelForm({ agentRoles, onAdd }: AddChannelFormProps) {
+	const [from, setFrom] = useState('');
+	const [to, setTo] = useState('');
+	const [direction, setDirection] = useState<'one-way' | 'bidirectional'>('one-way');
+	const [label, setLabel] = useState('');
+
+	function handleAdd() {
+		if (!from.trim() || !to.trim()) return;
+		onAdd({
+			from: from.trim(),
+			to: parseToField(to),
+			direction,
+			label: label.trim() || undefined,
+		});
+		setFrom('');
+		setTo('');
+		setDirection('one-way');
+		setLabel('');
+	}
+
+	const disabled = !from.trim() || !to.trim();
+
+	return (
+		<div
+			class="space-y-2 bg-dark-850 border border-dashed border-dark-600 rounded p-2"
+			data-testid="add-channel-form"
+		>
+			<p class="text-xs text-gray-600 font-medium">Add channel</p>
+			<div class="flex gap-2">
+				{agentRoles.length > 0 ? (
+					<select
+						data-testid="new-channel-from-select"
+						value={from}
+						onChange={(e) => setFrom((e.currentTarget as HTMLSelectElement).value)}
+						class="flex-1 text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+					>
+						<option value="">From…</option>
+						<option value="task-agent">task-agent</option>
+						<option value="*">* (all)</option>
+						{agentRoles.map((r) => (
+							<option key={r} value={r}>
+								{r}
+							</option>
+						))}
+					</select>
+				) : (
+					<input
+						type="text"
+						data-testid="new-channel-from-input"
+						value={from}
+						onInput={(e) => setFrom((e.currentTarget as HTMLInputElement).value)}
+						placeholder="From…"
+						class="flex-1 text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+					/>
+				)}
+				<select
+					data-testid="new-channel-direction-select"
+					value={direction}
+					onChange={(e) =>
+						setDirection(
+							(e.currentTarget as HTMLSelectElement).value as 'one-way' | 'bidirectional'
+						)
+					}
+					class="text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+				>
+					<option value="one-way">→</option>
+					<option value="bidirectional">↔</option>
+				</select>
+			</div>
+			{agentRoles.length > 0 ? (
+				<select
+					data-testid="new-channel-to-select"
+					value={to}
+					onChange={(e) => setTo((e.currentTarget as HTMLSelectElement).value)}
+					class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+				>
+					<option value="">To…</option>
+					<option value="task-agent">task-agent</option>
+					<option value="*">* (all)</option>
+					{agentRoles.map((r) => (
+						<option key={r} value={r}>
+							{r}
+						</option>
+					))}
+				</select>
+			) : (
+				<input
+					type="text"
+					data-testid="new-channel-to-input"
+					value={to}
+					onInput={(e) => setTo((e.currentTarget as HTMLInputElement).value)}
+					placeholder="To… (comma-separated for fan-out)"
+					class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+				/>
+			)}
+			<input
+				type="text"
+				data-testid="new-channel-label-input"
+				value={label}
+				onInput={(e) => setLabel((e.currentTarget as HTMLInputElement).value)}
+				placeholder="Label (optional)"
+				class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
+			/>
+			<button
+				type="button"
+				data-testid="add-channel-submit-button"
+				onClick={handleAdd}
+				disabled={disabled}
+				class="w-full text-xs py-1 rounded bg-teal-700/50 hover:bg-teal-700 disabled:opacity-40 disabled:cursor-not-allowed text-teal-300 transition-colors"
+			>
+				Add Channel
+			</button>
+		</div>
+	);
+}
+
+// ============================================================================
+// ChannelEditor
+// ============================================================================
+
+export function ChannelEditor({
+	channels,
+	onChange,
+	agentRoles = [],
+	highlightIndex = null,
+}: ChannelEditorProps) {
+	const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+	// Auto-expand the highlighted channel (e.g. selected from canvas)
+	useEffect(() => {
+		if (highlightIndex !== null) {
+			setExpandedIndex(highlightIndex);
+		}
+	}, [highlightIndex]);
+
+	const handleToggle = useCallback((index: number) => {
+		setExpandedIndex((prev) => (prev === index ? null : index));
+	}, []);
+
+	const handleChange = useCallback(
+		(index: number, updated: WorkflowChannel) => {
+			const next = channels.map((ch, i) => (i === index ? updated : ch));
+			onChange(next);
+		},
+		[channels, onChange]
+	);
+
+	const handleDelete = useCallback(
+		(index: number) => {
+			const next = channels.filter((_, i) => i !== index);
+			onChange(next);
+			setExpandedIndex((prev) => {
+				if (prev === null) return null;
+				if (prev === index) return null;
+				if (prev > index) return prev - 1;
+				return prev;
+			});
+		},
+		[channels, onChange]
+	);
+
+	const handleAdd = useCallback(
+		(channel: WorkflowChannel) => {
+			onChange([...channels, channel]);
+			// Auto-expand the newly added channel
+			setExpandedIndex(channels.length);
+		},
+		[channels, onChange]
+	);
+
+	return (
+		<div class="space-y-2" data-testid="channel-editor">
+			{channels.length === 0 && (
+				<p class="text-xs text-gray-600 text-center py-2">No channels — agents are isolated.</p>
+			)}
+
+			<div class="space-y-1.5" data-testid="channels-list">
+				{channels.map((ch, i) => (
+					<ChannelEntry
+						key={i}
+						channel={ch}
+						index={i}
+						agentRoles={agentRoles}
+						expanded={expandedIndex === i}
+						highlighted={highlightIndex === i && expandedIndex !== i}
+						onToggle={() => handleToggle(i)}
+						onChange={handleChange}
+						onDelete={handleDelete}
+					/>
+				))}
+			</div>
+
+			<AddChannelForm agentRoles={agentRoles} onAdd={handleAdd} />
+		</div>
+	);
+}

--- a/packages/web/src/components/space/ChannelEditor.tsx
+++ b/packages/web/src/components/space/ChannelEditor.tsx
@@ -243,10 +243,10 @@ function ChannelEntry({
 					{/* To */}
 					<div class="space-y-0.5">
 						<label class="text-xs text-gray-500">To (comma-separated for fan-out)</label>
-						{agentRoles.length > 0 ? (
+						{agentRoles.length > 0 && typeof channel.to === 'string' ? (
 							<select
 								data-testid="channel-to-select"
-								value={typeof channel.to === 'string' ? channel.to : ''}
+								value={channel.to}
 								onChange={(e) => updateField('to', (e.currentTarget as HTMLSelectElement).value)}
 								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
 							>

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState } from 'preact/hooks';
-import type { SpaceWorkflow, SpaceAgent } from '@neokai/shared';
+import type { SpaceWorkflow, SpaceAgent, WorkflowChannel } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 import { WorkflowNodeCard } from './WorkflowNodeCard';
@@ -20,6 +20,7 @@ import type { NodeDraft, ConditionDraft } from './WorkflowNodeCard';
 import { WorkflowRulesEditor } from './WorkflowRulesEditor';
 import type { RuleDraft } from './WorkflowRulesEditor';
 import { rulesToDrafts } from './WorkflowRulesEditor';
+import { ChannelEditor } from './ChannelEditor';
 
 // ============================================================================
 // Tags constants
@@ -101,6 +102,7 @@ export function initFromWorkflow(wf: SpaceWorkflow): {
 	transitions: ConditionDraft[];
 	rules: RuleDraft[];
 	tags: string[];
+	channels: WorkflowChannel[];
 } {
 	const stepMap = new Map(wf.nodes.map((s) => [s.id, s]));
 	const ordered: NodeDraft[] = [];
@@ -154,6 +156,7 @@ export function initFromWorkflow(wf: SpaceWorkflow): {
 		transitions: conditions,
 		rules: rulesToDrafts(wf.rules ?? []),
 		tags: wf.tags ?? [],
+		channels: wf.channels ?? [],
 	};
 }
 
@@ -177,6 +180,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 	const [description, setDescription] = useState(workflow?.description ?? '');
 	const [steps, setSteps] = useState<NodeDraft[]>(initial?.steps ?? [makeEmptyStep()]);
 	const [transitions, setTransitions] = useState<ConditionDraft[]>(initial?.transitions ?? []);
+	const [channels, setChannels] = useState<WorkflowChannel[]>(initial?.channels ?? []);
 	const [rules, setRules] = useState<RuleDraft[]>(initial?.rules ?? []);
 	const [tags, setTags] = useState<string[]>(initial?.tags ?? []);
 	const [tagInput, setTagInput] = useState('');
@@ -377,6 +381,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 					startNodeId: stepIds[0],
 					rules: updateRules,
 					tags,
+					channels: channels.length > 0 ? channels : [],
 				});
 			} else {
 				// Create uses WorkflowRuleInput (no id)
@@ -394,6 +399,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 					startNodeId: stepIds[0],
 					rules: createRules,
 					tags,
+					channels: channels.length > 0 ? channels : undefined,
 				});
 			}
 
@@ -556,6 +562,16 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 						</svg>
 						Add Step
 					</button>
+				</div>
+
+				{/* Channels */}
+				<div class="space-y-3">
+					<h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Channels</h2>
+					<ChannelEditor
+						channels={channels}
+						onChange={setChannels}
+						agentRoles={agents.map((a) => a.role).filter(Boolean)}
+					/>
 				</div>
 
 				{/* Tags */}

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -794,6 +794,7 @@ export function WorkflowNodeCard({
 						condition={exitCondition ?? { type: 'always' }}
 						onChange={onUpdateExitCondition}
 						terminalMessage={isLast ? 'Workflow ends here' : undefined}
+						testId="exit-gate-select"
 					/>
 
 					{/* Instructions */}

--- a/packages/web/src/components/space/__tests__/ChannelEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/ChannelEditor.test.tsx
@@ -1,0 +1,312 @@
+/**
+ * Unit tests for ChannelEditor
+ *
+ * Tests:
+ * - Renders empty state when no channels
+ * - Renders channel entries with from/direction/to summary
+ * - Toggle expand/collapse a channel entry
+ * - Delete a channel calls onChange with filtered list
+ * - Add channel form: disabled when from/to empty, calls onChange on add
+ * - Gate badge rendered when channel has a non-always gate
+ * - highlightIndex auto-expands the matching channel
+ * - With agentRoles: renders dropdowns for from/to
+ * - Without agentRoles: renders text inputs for from/to
+ * - Updating direction, label, gate calls onChange with updated channel
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import type { WorkflowChannel } from '@neokai/shared';
+import { ChannelEditor } from '../ChannelEditor';
+
+const DEFAULT_ROLES = ['coder', 'reviewer', 'planner'];
+
+function makeChannel(overrides: Partial<WorkflowChannel> = {}): WorkflowChannel {
+	return {
+		from: 'task-agent',
+		to: 'coder',
+		direction: 'one-way',
+		...overrides,
+	};
+}
+
+describe('ChannelEditor', () => {
+	beforeEach(() => {
+		cleanup();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	// -------------------------------------------------------------------------
+	// Empty state
+	// -------------------------------------------------------------------------
+
+	it('shows empty state message when no channels', () => {
+		const onChange = vi.fn();
+		const { getByTestId, getByText } = render(<ChannelEditor channels={[]} onChange={onChange} />);
+		expect(getByTestId('channel-editor')).toBeTruthy();
+		expect(getByText(/no channels/i)).toBeTruthy();
+	});
+
+	it('does not show empty state when channels exist', () => {
+		const onChange = vi.fn();
+		const { queryByText } = render(
+			<ChannelEditor channels={[makeChannel()]} onChange={onChange} />
+		);
+		expect(queryByText(/no channels/i)).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// Channel list rendering
+	// -------------------------------------------------------------------------
+
+	it('renders channel entries with from/to summary', () => {
+		const onChange = vi.fn();
+		const channels = [
+			makeChannel({ from: 'coder', to: 'reviewer', direction: 'one-way' }),
+			makeChannel({ from: 'task-agent', to: 'coder', direction: 'bidirectional' }),
+		];
+		const { getAllByTestId } = render(<ChannelEditor channels={channels} onChange={onChange} />);
+		const entries = getAllByTestId('channel-entry');
+		expect(entries).toHaveLength(2);
+	});
+
+	it('shows gate badge when channel has a non-always gate', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel({ gate: { type: 'human' } })];
+		const { getByTestId } = render(<ChannelEditor channels={channels} onChange={onChange} />);
+		expect(getByTestId('gate-badge')).toBeTruthy();
+	});
+
+	it('does not show gate badge for ungated channel', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { queryByTestId } = render(<ChannelEditor channels={channels} onChange={onChange} />);
+		expect(queryByTestId('gate-badge')).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// Expand / collapse
+	// -------------------------------------------------------------------------
+
+	it('collapses all entries initially', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { queryByTestId } = render(<ChannelEditor channels={channels} onChange={onChange} />);
+		expect(queryByTestId('channel-edit-form')).toBeNull();
+	});
+
+	it('expands a channel entry when toggle button is clicked', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		const toggleBtn = getAllByTestId('channel-toggle-button')[0];
+		fireEvent.click(toggleBtn);
+		expect(getByTestId('channel-edit-form')).toBeTruthy();
+	});
+
+	it('collapses an already-expanded entry on second click', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { getAllByTestId, queryByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		const toggleBtn = getAllByTestId('channel-toggle-button')[0];
+		fireEvent.click(toggleBtn);
+		fireEvent.click(toggleBtn);
+		expect(queryByTestId('channel-edit-form')).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// highlightIndex
+	// -------------------------------------------------------------------------
+
+	it('auto-expands the channel at highlightIndex', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel(), makeChannel({ from: 'reviewer', to: 'coder' })];
+		const { getAllByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} highlightIndex={1} />
+		);
+		// The second entry (index 1) should be expanded
+		const editForms = getAllByTestId('channel-edit-form');
+		expect(editForms).toHaveLength(1);
+		// The expanded entry should be the second one (index 1)
+		const entries = getAllByTestId('channel-entry');
+		expect(entries[1].querySelector('[data-testid="channel-edit-form"]')).toBeTruthy();
+	});
+
+	// -------------------------------------------------------------------------
+	// Delete
+	// -------------------------------------------------------------------------
+
+	it('calls onChange with channel removed when delete is clicked', () => {
+		const onChange = vi.fn();
+		const channels = [
+			makeChannel({ from: 'coder', to: 'reviewer' }),
+			makeChannel({ from: 'task-agent', to: 'coder' }),
+		];
+		const { getAllByTestId } = render(<ChannelEditor channels={channels} onChange={onChange} />);
+		const deleteButtons = getAllByTestId('delete-channel-button');
+		fireEvent.click(deleteButtons[0]);
+		expect(onChange).toHaveBeenCalledOnce();
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(result).toHaveLength(1);
+		expect(result[0].from).toBe('task-agent');
+	});
+
+	// -------------------------------------------------------------------------
+	// Add channel form — no agentRoles (text inputs)
+	// -------------------------------------------------------------------------
+
+	it('renders text inputs when no agentRoles provided', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(<ChannelEditor channels={[]} onChange={onChange} />);
+		expect(getByTestId('new-channel-from-input')).toBeTruthy();
+		expect(getByTestId('new-channel-to-input')).toBeTruthy();
+	});
+
+	it('add-channel button is disabled when from/to are empty', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(<ChannelEditor channels={[]} onChange={onChange} />);
+		const addBtn = getByTestId('add-channel-submit-button') as HTMLButtonElement;
+		expect(addBtn.disabled).toBe(true);
+	});
+
+	it('add-channel button calls onChange with new channel when from and to are filled', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(<ChannelEditor channels={[]} onChange={onChange} />);
+		fireEvent.input(getByTestId('new-channel-from-input'), { target: { value: 'coder' } });
+		fireEvent.input(getByTestId('new-channel-to-input'), { target: { value: 'reviewer' } });
+		fireEvent.click(getByTestId('add-channel-submit-button'));
+		expect(onChange).toHaveBeenCalledOnce();
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(result).toHaveLength(1);
+		expect(result[0].from).toBe('coder');
+		expect(result[0].to).toBe('reviewer');
+		expect(result[0].direction).toBe('one-way');
+	});
+
+	it('parses comma-separated to field into array on add', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(<ChannelEditor channels={[]} onChange={onChange} />);
+		fireEvent.input(getByTestId('new-channel-from-input'), { target: { value: 'coder' } });
+		fireEvent.input(getByTestId('new-channel-to-input'), {
+			target: { value: 'reviewer, planner' },
+		});
+		fireEvent.click(getByTestId('add-channel-submit-button'));
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(Array.isArray(result[0].to)).toBe(true);
+		expect(result[0].to).toEqual(['reviewer', 'planner']);
+	});
+
+	it('clears add-channel form after add', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(<ChannelEditor channels={[]} onChange={onChange} />);
+		const fromInput = getByTestId('new-channel-from-input') as HTMLInputElement;
+		const toInput = getByTestId('new-channel-to-input') as HTMLInputElement;
+		fireEvent.input(fromInput, { target: { value: 'coder' } });
+		fireEvent.input(toInput, { target: { value: 'reviewer' } });
+		fireEvent.click(getByTestId('add-channel-submit-button'));
+		expect(fromInput.value).toBe('');
+		expect(toInput.value).toBe('');
+	});
+
+	// -------------------------------------------------------------------------
+	// Add channel form — with agentRoles (dropdowns)
+	// -------------------------------------------------------------------------
+
+	it('renders dropdowns when agentRoles are provided', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(
+			<ChannelEditor channels={[]} onChange={onChange} agentRoles={DEFAULT_ROLES} />
+		);
+		expect(getByTestId('new-channel-from-select')).toBeTruthy();
+		expect(getByTestId('new-channel-to-select')).toBeTruthy();
+	});
+
+	it('add via dropdowns calls onChange with correct channel', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(
+			<ChannelEditor channels={[]} onChange={onChange} agentRoles={DEFAULT_ROLES} />
+		);
+		fireEvent.change(getByTestId('new-channel-from-select'), { target: { value: 'coder' } });
+		fireEvent.change(getByTestId('new-channel-to-select'), { target: { value: 'reviewer' } });
+		fireEvent.click(getByTestId('add-channel-submit-button'));
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(result[0].from).toBe('coder');
+		expect(result[0].to).toBe('reviewer');
+	});
+
+	// -------------------------------------------------------------------------
+	// Channel editing
+	// -------------------------------------------------------------------------
+
+	it('updating direction calls onChange with updated channel', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel({ direction: 'one-way' })];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		// Expand the entry
+		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
+		// Change direction
+		fireEvent.change(getByTestId('channel-direction-select'), {
+			target: { value: 'bidirectional' },
+		});
+		expect(onChange).toHaveBeenCalledOnce();
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(result[0].direction).toBe('bidirectional');
+	});
+
+	it('updating label calls onChange with updated channel', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
+		fireEvent.input(getByTestId('channel-label-input'), { target: { value: 'PR ready' } });
+		expect(onChange).toHaveBeenCalledOnce();
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(result[0].label).toBe('PR ready');
+	});
+
+	it('cyclic checkbox updates isCyclic on channel', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
+		fireEvent.change(getByTestId('channel-cyclic-checkbox'), {
+			target: { checked: true },
+		});
+		expect(onChange).toHaveBeenCalledOnce();
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(result[0].isCyclic).toBe(true);
+	});
+
+	// -------------------------------------------------------------------------
+	// Multi-channel add appends to existing list
+	// -------------------------------------------------------------------------
+
+	it('adds channel to existing list without replacing it', () => {
+		let currentChannels: WorkflowChannel[] = [makeChannel({ from: 'coder', to: 'reviewer' })];
+		const onChange = vi.fn((updated: WorkflowChannel[]) => {
+			currentChannels = updated;
+		});
+		const { getByTestId, rerender } = render(
+			<ChannelEditor channels={currentChannels} onChange={onChange} />
+		);
+		fireEvent.input(getByTestId('new-channel-from-input'), { target: { value: 'planner' } });
+		fireEvent.input(getByTestId('new-channel-to-input'), { target: { value: 'coder' } });
+		fireEvent.click(getByTestId('add-channel-submit-button'));
+		expect(currentChannels).toHaveLength(2);
+		expect(currentChannels[0].from).toBe('coder');
+		expect(currentChannels[1].from).toBe('planner');
+	});
+});

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -384,10 +384,10 @@ describe('WorkflowEditor', () => {
 			// Click step 1 header to expand it
 			const stepHeaders = container.querySelectorAll('.cursor-pointer');
 			fireEvent.click(stepHeaders[0]);
-			// Now find the exit gate select (selects[2] = exit gate when entry+agent are visible)
-			const selects = container.querySelectorAll('select');
-			// Find exit gate select — it's labeled 'Exit Gate', the last condition select
-			const exitGateSelect = selects[selects.length - 1] as HTMLSelectElement;
+			// Find exit gate select via testid (more robust than positional select indexing)
+			const exitGateSelect = container.querySelector(
+				'[data-testid="exit-gate-select"]'
+			) as HTMLSelectElement;
 			fireEvent.change(exitGateSelect, { target: { value: 'condition' } });
 			// Leave expression empty and try to save
 			fireEvent.click(getByText('Create Workflow'));

--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -437,7 +437,10 @@ export function EdgeRenderer({
 							stroke="transparent"
 							strokeWidth={HITBOX_STROKE_WIDTH}
 							fill="none"
-							style={{ cursor: onChannelSelect ? 'pointer' : 'default', pointerEvents: 'stroke' }}
+							style={{
+								cursor: onChannelSelect && channel.id != null ? 'pointer' : 'default',
+								pointerEvents: 'stroke',
+							}}
 							onClick={
 								onChannelSelect && channel.id != null
 									? (e: MouseEvent) => {

--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -8,9 +8,9 @@
  * by CONTROL_OFFSET px for a smooth curve.
  *
  * Edge color reflects the condition type:
- *   always   → blue  (#3b82f6)
- *   human    → yellow (#facc15)
- *   condition → purple (#c084fc)
+ *   always    -> blue  (#3b82f6)
+ *   human     -> yellow (#facc15)
+ *   condition -> purple (#c084fc)
  *
  * A wider invisible hitbox path (stroke-width 12px) is rendered behind each
  * visible edge to make clicking easier. An arrowhead marker indicates direction.
@@ -21,15 +21,17 @@
  * collisions when multiple EdgeRenderer instances are mounted simultaneously.
  *
  * Channel edges are also rendered (via the channels prop). Channel edges connect
- * between side ports (left/right) of nodes with a distinct dashed teal style.
- * Bidirectional channels show double arrowheads; one-way channels show a single arrowhead.
+ * between side ports (left/right) of nodes with a distinct teal style.
+ * Gated channels (gate condition != always) use solid lines for visual distinction.
+ * Ungated channels use dashed lines. Bidirectional channels show double arrowheads.
+ * Channels are selectable by clicking; the selected channel highlights in white.
  */
 
 import { useEffect, useRef } from 'preact/hooks';
 import type { WorkflowTransition, WorkflowConditionType } from '@neokai/shared';
 import type { NodePosition } from './types';
 
-// Module-level counter — increments on each EdgeRenderer mount, giving every
+// Module-level counter -- increments on each EdgeRenderer mount, giving every
 // instance a unique marker ID prefix even when multiple instances are on the
 // same page (e.g. split-view or comparison mode).
 let _instanceCounter = 0;
@@ -66,12 +68,21 @@ export interface ResolvedWorkflowChannel {
 	fromStepId: string;
 	toStepId: string;
 	direction: 'one-way' | 'bidirectional';
+	/**
+	 * Gate condition type -- when present (and not 'always'), the channel has a gate.
+	 * Gated channels render as solid lines; ungated channels render as dashed lines.
+	 */
+	gateType?: 'human' | 'condition' | 'task_result';
+	/** Stable ID for selection -- typically the workflow-level channel array index as a string. */
+	id?: string;
+	/** Optional display label from WorkflowChannel.label */
+	label?: string;
 }
 
-/** Channel edge color — teal, distinct from transition edge colors */
+/** Channel edge color -- teal, distinct from transition edge colors */
 export const CHANNEL_EDGE_COLOR = '#14b8a6'; // teal-500
 
-/** Channel edge stroke dash pattern for visual distinction */
+/** Channel edge stroke dash pattern for ungated channels */
 export const CHANNEL_EDGE_DASH_ARRAY = '6 4';
 
 /** Control point horizontal offset for channel edge bezier curves */
@@ -89,6 +100,10 @@ export interface EdgeRendererProps {
 	onEdgeDelete?: (transitionId: string) => void;
 	/** Channel edges to render between nodes (with resolved source/target node IDs). */
 	channels?: ResolvedWorkflowChannel[];
+	/** Selected channel ID -- highlights the matching channel edge. */
+	selectedChannelId?: string | null;
+	/** Called when the user clicks a channel edge. Receives the channel's `id` field. */
+	onChannelSelect?: (channelId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -207,6 +222,8 @@ export function EdgeRenderer({
 	onEdgeSelect,
 	onEdgeDelete,
 	channels = [],
+	selectedChannelId,
+	onChannelSelect,
 }: EdgeRendererProps) {
 	// Stable per-instance prefix to prevent marker ID collisions across instances
 	const markerPrefixRef = useRef<string | null>(null);
@@ -243,7 +260,7 @@ export function EdgeRenderer({
 
 	return (
 		<>
-			{/* Arrowhead marker definitions — one per condition type + one for selected state.
+			{/* Arrowhead marker definitions -- one per condition type + one for selected state.
 			    IDs are prefixed with instanceId to prevent collisions between multiple instances. */}
 			<defs>
 				{(Object.entries(EDGE_COLORS) as [WorkflowConditionType, string][]).map(([type, color]) => (
@@ -271,32 +288,55 @@ export function EdgeRenderer({
 				>
 					<path d="M 0 0 L 10 5 L 0 10 z" fill="white" />
 				</marker>
-				{/* Channel edge arrowhead markers — only render when channels are present */}
+				{/* Channel edge arrowhead markers -- rendered when channels are present */}
 				{channels.length > 0 && (
-					<marker
-						id={`${markerPrefix}-channel-end`}
-						viewBox="0 0 10 10"
-						refX="10"
-						refY="5"
-						markerWidth="6"
-						markerHeight="6"
-						orient="auto-start-reverse"
-					>
-						<path d="M 0 0 L 10 5 L 0 10 z" fill={CHANNEL_EDGE_COLOR} />
-					</marker>
-				)}
-				{channels.length > 0 && (
-					<marker
-						id={`${markerPrefix}-channel-start`}
-						viewBox="0 0 10 10"
-						refX="0"
-						refY="5"
-						markerWidth="6"
-						markerHeight="6"
-						orient="auto-start-reverse"
-					>
-						<path d="M 10 0 L 0 5 L 10 10 z" fill={CHANNEL_EDGE_COLOR} />
-					</marker>
+					<>
+						<marker
+							id={`${markerPrefix}-channel-end`}
+							viewBox="0 0 10 10"
+							refX="10"
+							refY="5"
+							markerWidth="6"
+							markerHeight="6"
+							orient="auto-start-reverse"
+						>
+							<path d="M 0 0 L 10 5 L 0 10 z" fill={CHANNEL_EDGE_COLOR} />
+						</marker>
+						<marker
+							id={`${markerPrefix}-channel-start`}
+							viewBox="0 0 10 10"
+							refX="0"
+							refY="5"
+							markerWidth="6"
+							markerHeight="6"
+							orient="auto-start-reverse"
+						>
+							<path d="M 10 0 L 0 5 L 10 10 z" fill={CHANNEL_EDGE_COLOR} />
+						</marker>
+						{/* White markers for selected channel state */}
+						<marker
+							id={`${markerPrefix}-channel-selected`}
+							viewBox="0 0 10 10"
+							refX="10"
+							refY="5"
+							markerWidth="6"
+							markerHeight="6"
+							orient="auto-start-reverse"
+						>
+							<path d="M 0 0 L 10 5 L 0 10 z" fill="white" />
+						</marker>
+						<marker
+							id={`${markerPrefix}-channel-selected-start`}
+							viewBox="0 0 10 10"
+							refX="0"
+							refY="5"
+							markerWidth="6"
+							markerHeight="6"
+							orient="auto-start-reverse"
+						>
+							<path d="M 10 0 L 0 5 L 10 10 z" fill="white" />
+						</marker>
+					</>
 				)}
 			</defs>
 
@@ -351,43 +391,75 @@ export function EdgeRenderer({
 				);
 			})}
 
-			{/* Channel edges — dashed teal edges connecting side ports of nodes */}
-			{channels.map((channel) => {
+			{/* Channel edges -- teal edges connecting nodes.
+			    Gated channels (gateType present) render as solid lines for visual distinction.
+			    Ungated channels render as dashed lines.
+			    Selected channels are highlighted in white. */}
+			{channels.map((channel, idx) => {
 				const pts = computeChannelEdgePoints(channel, nodePositions);
 				if (!pts) return null;
 
 				const d = buildPathD(pts);
 				const isBidirectional = channel.direction === 'bidirectional';
-				const markerEndId = `${markerPrefix}-channel-end`;
-				const markerStartId = `${markerPrefix}-channel-start`;
+				const isGated = !!channel.gateType;
+				const isSelected = channel.id != null && channel.id === selectedChannelId;
+
+				const strokeColor = isSelected ? 'white' : CHANNEL_EDGE_COLOR;
+				const strokeWidth = isSelected ? SELECTED_STROKE_WIDTH : NORMAL_STROKE_WIDTH;
+				// Gated channels render as solid lines; ungated as dashed
+				const strokeDasharray = isSelected || isGated ? undefined : CHANNEL_EDGE_DASH_ARRAY;
+				const strokeOpacity = isSelected ? 1 : 0.85;
+
+				// Use white markers when selected, teal otherwise
+				const markerEndId = isSelected
+					? `${markerPrefix}-channel-selected`
+					: `${markerPrefix}-channel-end`;
+				const markerStartId = isSelected
+					? `${markerPrefix}-channel-selected-start`
+					: `${markerPrefix}-channel-start`;
+
+				const channelKey = channel.id ?? `${channel.fromStepId}-${channel.toStepId}-${idx}`;
 
 				return (
 					<g
-						key={`channel-${channel.fromStepId}-${channel.toStepId}`}
+						key={channelKey}
 						data-testid={`channel-edge-${channel.fromStepId}-${channel.toStepId}`}
 						data-channel-edge="true"
 						data-channel-direction={channel.direction}
+						data-channel-id={channel.id}
+						data-channel-gated={isGated ? 'true' : undefined}
+						data-selected={isSelected ? 'true' : 'false'}
+						style={{ pointerEvents: 'auto' }}
 					>
-						{/* Invisible hitbox for easier interaction */}
+						{/* Invisible wider hitbox for easier click selection */}
 						<path
 							d={d}
 							stroke="transparent"
 							strokeWidth={HITBOX_STROKE_WIDTH}
 							fill="none"
-							style={{ cursor: 'pointer', pointerEvents: 'stroke' }}
+							style={{ cursor: onChannelSelect ? 'pointer' : 'default', pointerEvents: 'stroke' }}
+							onClick={
+								onChannelSelect && channel.id != null
+									? (e: MouseEvent) => {
+											e.stopPropagation();
+											onChannelSelect(channel.id!);
+										}
+									: undefined
+							}
 						/>
-						{/* Visible dashed channel edge */}
+						{/* Visible channel edge path */}
 						<path
 							d={d}
-							stroke={CHANNEL_EDGE_COLOR}
-							strokeWidth={NORMAL_STROKE_WIDTH}
-							strokeDasharray={CHANNEL_EDGE_DASH_ARRAY}
-							strokeOpacity={0.8}
+							stroke={strokeColor}
+							strokeWidth={strokeWidth}
+							strokeDasharray={strokeDasharray}
+							strokeOpacity={strokeOpacity}
 							fill="none"
 							markerEnd={`url(#${markerEndId})`}
 							markerStart={isBidirectional ? `url(#${markerStartId})` : undefined}
-							data-stroke-color={CHANNEL_EDGE_COLOR}
-							data-stroke-width={String(NORMAL_STROKE_WIDTH)}
+							data-stroke-color={strokeColor}
+							data-stroke-width={String(strokeWidth)}
+							data-channel-gated={isGated ? 'true' : undefined}
 							style={{ pointerEvents: 'none' }}
 						/>
 					</g>

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'preact/hooks';
-import type { SpaceAgent, WorkflowNodeAgent, WorkflowChannel } from '@neokai/shared';
+import type { SpaceAgent, WorkflowNodeAgent } from '@neokai/shared';
 import type { NodeDraft } from '../WorkflowNodeCard';
 import { isMultiAgentNode } from '../WorkflowNodeCard';
 import { GateConfig } from './GateConfig';
@@ -82,17 +82,6 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 		onUpdate({ ...step, agents: next, agentId: '' });
 	}
 
-	/**
-	 * Auto-create Task Agent channels for a step that just got agents assigned.
-	 * Called from event handlers (agent dropdown onChange, addAgent) to avoid
-	 * mount-time side effects that corrupt existing workflow data.
-	 */
-	function buildTaskAgentChannels(agentsToChannel: WorkflowNodeAgent[]): WorkflowChannel[] {
-		return agentsToChannel.map((sa) => {
-			return { from: 'task-agent', to: sa.name, direction: 'bidirectional' };
-		});
-	}
-
 	function addAgent(agentId: string) {
 		if (!agentId) return;
 		const agentInfo = agents.find((a) => a.id === agentId);
@@ -106,9 +95,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 			role = `${baseRole}-${i}`;
 		}
 		const next = [...stepAgents, { agentId, name: role }];
-		// Merge agents + channels into a single onUpdate call to avoid stale-reference overwrites
-		const newChannels = step.channels === undefined ? buildTaskAgentChannels(next) : step.channels;
-		onUpdate({ ...step, agents: next, agentId: '', channels: newChannels });
+		onUpdate({ ...step, agents: next, agentId: '' });
 	}
 
 	function removeAgent(role: string) {
@@ -182,17 +169,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 					value={step.agentId}
 					onChange={(e) => {
 						const newAgentId = (e.currentTarget as HTMLSelectElement).value;
-						const nextStep = { ...step, agentId: newAgentId };
-						// Auto-create task-agent channel when a single agent is assigned
-						if (newAgentId && step.channels === undefined) {
-							const agentInfo = agents.find((a) => a.id === newAgentId);
-							if (agentInfo) {
-								nextStep.channels = [
-									{ from: 'task-agent', to: agentInfo.role, direction: 'bidirectional' },
-								];
-							}
-						}
-						onUpdate(nextStep);
+						onUpdate({ ...step, agentId: newAgentId });
 					}}
 					class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
 				>
@@ -397,172 +374,6 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 }
 
 // ============================================================================
-// ChannelsPanelSection — manages messaging channels in the config panel
-// ============================================================================
-
-interface ChannelsPanelSectionProps {
-	step: NodeDraft;
-	agents: SpaceAgent[];
-	onUpdate: (step: NodeDraft) => void;
-}
-
-function ChannelsPanelSection({ step, onUpdate }: ChannelsPanelSectionProps) {
-	const channels = step.channels ?? [];
-	const stepAgents = step.agents ?? [];
-
-	// Collect known roles from step agents (+ wildcard)
-	const knownRoles = ['*', ...stepAgents.map((sa) => sa.name)];
-
-	const [newFrom, setNewFrom] = useState('');
-	const [newTo, setNewTo] = useState('');
-	const [newDirection, setNewDirection] = useState<'one-way' | 'bidirectional'>('one-way');
-	const [newLabel, setNewLabel] = useState('');
-
-	// Reset add-channel form fields when the selected node changes, so stale values
-	// from one node don't bleed into the form for the next selected node.
-	useEffect(() => {
-		setNewFrom('');
-		setNewTo('');
-		setNewDirection('one-way');
-		setNewLabel('');
-	}, [step.localId]);
-
-	function updateChannels(next: WorkflowChannel[]) {
-		onUpdate({ ...step, channels: next.length > 0 ? next : undefined });
-	}
-
-	function removeChannel(index: number) {
-		updateChannels(channels.filter((_, i) => i !== index));
-	}
-
-	function addChannel() {
-		if (!newFrom || !newTo) return;
-		const toValue: string | string[] = newTo.includes(',')
-			? newTo
-					.split(',')
-					.map((s) => s.trim())
-					.filter(Boolean)
-			: newTo.trim();
-		const ch: WorkflowChannel = {
-			from: newFrom,
-			to: toValue,
-			direction: newDirection,
-			label: newLabel.trim() || undefined,
-		};
-		updateChannels([...channels, ch]);
-		setNewFrom('');
-		setNewTo('');
-		setNewDirection('one-way');
-		setNewLabel('');
-	}
-
-	const formatTo = (to: string | string[]) => (Array.isArray(to) ? `[${to.join(', ')}]` : to);
-
-	return (
-		<div class="space-y-2 pt-3 border-t border-dark-700" data-testid="channels-section">
-			<label class="text-xs font-medium text-gray-400">
-				Channels <span class="text-gray-600 font-normal">(messaging topology)</span>
-			</label>
-
-			{channels.length === 0 && (
-				<p class="text-xs text-gray-600">No channels — agents are isolated.</p>
-			)}
-
-			<div class="space-y-1" data-testid="channels-list">
-				{channels.map((ch, i) => (
-					<div
-						key={i}
-						class="flex items-center gap-2 bg-dark-800 border border-dark-600 rounded px-2 py-1.5"
-						data-testid="channel-entry"
-					>
-						<span class="text-xs text-gray-300 font-mono flex-1">
-							{ch.from} {ch.direction === 'bidirectional' ? '↔' : '→'} {formatTo(ch.to)}
-							{ch.label && <span class="text-gray-500 ml-1">"{ch.label}"</span>}
-						</span>
-						<button
-							type="button"
-							data-testid="remove-channel-button"
-							onClick={() => removeChannel(i)}
-							class="text-gray-600 hover:text-red-400 transition-colors flex-shrink-0"
-							title="Remove channel"
-						>
-							<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width={2}
-									d="M6 18L18 6M6 6l12 12"
-								/>
-							</svg>
-						</button>
-					</div>
-				))}
-			</div>
-
-			{/* Add channel form */}
-			<div
-				class="space-y-2 bg-dark-800 border border-dark-600 rounded p-2"
-				data-testid="add-channel-form"
-			>
-				<div class="flex gap-2">
-					<select
-						data-testid="channel-from-select"
-						value={newFrom}
-						onChange={(e) => setNewFrom((e.currentTarget as HTMLSelectElement).value)}
-						class="flex-1 text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500"
-					>
-						<option value="">From…</option>
-						{knownRoles.map((r) => (
-							<option key={r} value={r}>
-								{r}
-							</option>
-						))}
-					</select>
-					<select
-						data-testid="channel-direction-select"
-						value={newDirection}
-						onChange={(e) =>
-							setNewDirection(
-								(e.currentTarget as HTMLSelectElement).value as 'one-way' | 'bidirectional'
-							)
-						}
-						class="text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500"
-					>
-						<option value="one-way">→ one-way</option>
-						<option value="bidirectional">↔ bidirectional</option>
-					</select>
-				</div>
-				<input
-					data-testid="channel-to-input"
-					type="text"
-					value={newTo}
-					onInput={(e) => setNewTo((e.currentTarget as HTMLInputElement).value)}
-					placeholder="To role(s) — comma-separated, * for all"
-					class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-600"
-				/>
-				<input
-					data-testid="channel-label-input"
-					type="text"
-					value={newLabel}
-					onInput={(e) => setNewLabel((e.currentTarget as HTMLInputElement).value)}
-					placeholder="Label (optional)"
-					class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-600"
-				/>
-				<button
-					type="button"
-					data-testid="add-channel-button"
-					onClick={addChannel}
-					disabled={!newFrom || !newTo}
-					class="w-full text-xs py-1 rounded bg-dark-700 hover:bg-dark-600 disabled:opacity-40 disabled:cursor-not-allowed text-gray-300 transition-colors"
-				>
-					Add channel
-				</button>
-			</div>
-		</div>
-	);
-}
-
-// ============================================================================
 // Component
 // ============================================================================
 
@@ -680,11 +491,6 @@ export function NodeConfigPanel({
 
 				{/* Agent(s) */}
 				<AgentsSection step={step} agents={agents} onUpdate={onUpdate} />
-
-				{/* Channels (shown when node has agents or has existing channels) */}
-				{(!!step.agentId || isMultiAgentNode(step) || step.channels) && (
-					<ChannelsPanelSection step={step} agents={agents} onUpdate={onUpdate} />
-				)}
 
 				{/* Entry Gate */}
 				<GateConfig

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -49,6 +49,7 @@ import { computeFitToView } from './CanvasToolbar';
 import { autoLayout, TASK_AGENT_INITIAL_POSITION } from './layout';
 import type { NodePosition } from './types';
 import { NodeConfigPanel } from './NodeConfigPanel';
+import { ChannelEditor } from '../ChannelEditor';
 import { EdgeConfigPanel } from './EdgeConfigPanel';
 
 // ============================================================================
@@ -114,7 +115,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const [rules, setRules] = useState<RuleDraft[]>(() => initState?.rules ?? []);
 	const [tags, setTags] = useState<string[]>(() => initState?.tags ?? []);
 	const [startNodeId, setStartStepId] = useState<string>(() => initState?.startNodeId ?? '');
-	const [channels, _setChannels] = useState<WorkflowChannel[]>(() => initState?.channels ?? []);
+	const [channels, setChannels] = useState<WorkflowChannel[]>(() => initState?.channels ?? []);
 	const [viewportState, setViewportState] = useState<ViewportState>({
 		offsetX: 0,
 		offsetY: 0,
@@ -128,6 +129,9 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	// colons, so the first ':' unambiguously splits from/to.
 	const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
 
+	const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
+	const [showChannels, setShowChannels] = useState(true);
+
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [showRules, setShowRules] = useState(false);
@@ -138,23 +142,23 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 
 	const agents = filterAgents(spaceStore.agents.value);
 
+	// Collect all agent slot names from nodes for ChannelEditor from/to suggestions
+	const agentRoles = useMemo(() => {
+		const roles = new Set<string>();
+		for (const node of nodes) {
+			if (node.step.id === TASK_AGENT_NODE_ID || node.step.localId === TASK_AGENT_NODE_ID) continue;
+			if (node.step.agents) {
+				for (const agent of node.step.agents) {
+					if (agent.name) roles.add(agent.name);
+				}
+			}
+		}
+		return Array.from(roles);
+	}, [nodes]);
+
 	// ------------------------------------------------------------------
 	// Key-resolution maps
 	// ------------------------------------------------------------------
-
-	/**
-	 * Maps step.id or step.localId -> step.localId.
-	 * Used when converting VisualEdge (keyed by step.id for existing steps) to
-	 * WorkflowTransition (keyed by localId, which is what WorkflowCanvas uses).
-	 */
-	const stepKeyToLocalId = useMemo(() => {
-		const map = new Map<string, string>();
-		for (const node of nodes) {
-			if (node.step.id) map.set(node.step.id, node.step.localId);
-			map.set(node.step.localId, node.step.localId);
-		}
-		return map;
-	}, [nodes]);
 
 	/** Maps step.localId -> step key used in VisualEdge (step.id ?? step.localId). */
 	const localIdToStepKey = useMemo(() => {
@@ -166,63 +170,97 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	}, [nodes]);
 
 	// ------------------------------------------------------------------
-	// Derived: WorkflowTransition[] for WorkflowCanvas
-	// WorkflowCanvas / EdgeRenderer use localIds as node keys, so we re-map
-	// VisualEdge's step.id-based keys to localIds here.
-	// ------------------------------------------------------------------
-
-	const transitions = useMemo<WorkflowTransition[]>(() => {
-		return edges.map((e, i) => {
-			const fromLocalId = stepKeyToLocalId.get(e.fromStepKey) ?? e.fromStepKey;
-			const toLocalId = stepKeyToLocalId.get(e.toStepKey) ?? e.toStepKey;
-			return {
-				id: `${fromLocalId}:${toLocalId}`,
-				from: fromLocalId,
-				to: toLocalId,
-				condition: e.condition ?? { type: 'always' },
-				order: i,
-			};
-		});
-	}, [edges, stepKeyToLocalId]);
-
-	// ------------------------------------------------------------------
-	// Derived: ResolvedWorkflowChannel[] for Task Agent channel connections
-	// Task Agent channels are stored at the workflow level (channels).
-	// We extract edges from task-agent to each connected step.
+	// Derived: ResolvedWorkflowChannel[] for workflow-level channel connections.
+	// Resolves channel from/to agent role names to node localIds so EdgeRenderer
+	// can render the edges. Includes gate type and ID for visual distinction + selection.
 	// ------------------------------------------------------------------
 
 	const channelEdges = useMemo<
-		{ fromStepId: string; toStepId: string; direction: 'one-way' | 'bidirectional' }[]
+		{
+			fromStepId: string;
+			toStepId: string;
+			direction: 'one-way' | 'bidirectional';
+			gateType?: 'human' | 'condition' | 'task_result';
+			id?: string;
+			label?: string;
+		}[]
 	>(() => {
 		const result: {
 			fromStepId: string;
 			toStepId: string;
 			direction: 'one-way' | 'bidirectional';
+			gateType?: 'human' | 'condition' | 'task_result';
+			id?: string;
+			label?: string;
 		}[] = [];
-		// Build a localId lookup from step.localId to the actual step localId
-		// (for new unsaved steps, step.localId === step.id; for saved steps, step.localId may differ)
-		const _nodeLocalIds = new Set(nodes.map((n) => n.step.localId));
-		for (const channel of channels) {
-			// Only include channels where task-agent is the source
+
+		// Build agent name -> node localId lookup for cross-node channel resolution
+		const nameToNodeId = new Map<string, string>();
+		for (const node of nodes) {
+			if (node.step.id === TASK_AGENT_NODE_ID || node.step.localId === TASK_AGENT_NODE_ID) continue;
+			// Map agent slot names (from WorkflowNodeAgent.name)
+			if (node.step.agents) {
+				for (const agent of node.step.agents) {
+					if (agent.name) nameToNodeId.set(agent.name, node.step.localId);
+				}
+			}
+			// Also map node name itself for convenience
+			if (node.step.name) nameToNodeId.set(node.step.name, node.step.localId);
+		}
+
+		const nodeLocalIds = new Set(nodes.map((n) => n.step.localId));
+
+		channels.forEach((channel, i) => {
+			const channelId = String(i);
+			const gateType =
+				channel.gate && channel.gate.type !== 'always'
+					? (channel.gate.type as 'human' | 'condition' | 'task_result')
+					: undefined;
+
 			if (channel.from === 'task-agent') {
-				// The 'to' field may be a step localId or id - find the matching node
-				const toStr = Array.isArray(channel.to) ? channel.to[0] : channel.to;
-				// Find a node whose localId or id matches the to field
-				const targetNode = nodes.find(
-					(n) =>
-						n.step.localId === toStr ||
-						n.step.id === toStr ||
-						(n.step.localId === n.step.id && n.step.localId === toStr)
-				);
-				if (targetNode) {
+				// task-agent -> node channel: resolve 'to' to a node localId
+				const toTargets = Array.isArray(channel.to) ? channel.to : [channel.to];
+				for (const toStr of toTargets) {
+					const targetNode = nodes.find(
+						(n) =>
+							n.step.localId === toStr ||
+							n.step.id === toStr ||
+							nameToNodeId.get(toStr) === n.step.localId
+					);
+					if (targetNode) {
+						result.push({
+							fromStepId: 'task-agent',
+							toStepId: targetNode.step.localId,
+							direction: channel.direction,
+							gateType,
+							id: channelId,
+							label: channel.label,
+						});
+					}
+				}
+			} else {
+				// Cross-node channel: resolve from agent name to node localId
+				const fromNodeId =
+					nameToNodeId.get(channel.from) ?? (nodeLocalIds.has(channel.from) ? channel.from : null);
+				if (!fromNodeId) return;
+
+				const toTargets = Array.isArray(channel.to) ? channel.to : [channel.to];
+				for (const toStr of toTargets) {
+					if (toStr === '*') continue; // wildcard: no specific edge to render
+					const toNodeId = nameToNodeId.get(toStr) ?? (nodeLocalIds.has(toStr) ? toStr : null);
+					if (!toNodeId || toNodeId === fromNodeId) continue;
 					result.push({
-						fromStepId: 'task-agent',
-						toStepId: targetNode.step.localId,
+						fromStepId: fromNodeId,
+						toStepId: toNodeId,
 						direction: channel.direction,
+						gateType,
+						id: channelId,
+						label: channel.label,
 					});
 				}
 			}
-		}
+		});
+
 		return result;
 	}, [channels, nodes]);
 
@@ -429,7 +467,20 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 
 	const handleEdgeSelect = useCallback((edgeId: string | null) => {
 		setSelectedEdgeId(edgeId);
-		if (edgeId) setSelectedNodeId(null);
+		if (edgeId) {
+			setSelectedNodeId(null);
+			setSelectedChannelId(null);
+		}
+	}, []);
+
+	const handleChannelSelect = useCallback((channelId: string | null) => {
+		setSelectedChannelId(channelId);
+		if (channelId) {
+			setSelectedNodeId(null);
+			setSelectedEdgeId(null);
+			// Auto-expand the Channels section when a channel is selected via canvas
+			setShowChannels(true);
+		}
 	}, []);
 
 	const handleCreateTransition = useCallback(
@@ -838,7 +889,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					nodes={nodeData}
 					viewportState={viewportState}
 					onViewportChange={setViewportState}
-					transitions={transitions}
+					transitions={[]}
 					channels={channelEdges}
 					onNodeSelect={handleNodeSelect}
 					onDeleteNode={handleDeleteNode}
@@ -846,6 +897,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					onCreateTransition={handleCreateTransition}
 					onEdgeSelect={handleEdgeSelect}
 					onDeleteEdge={handleDeleteEdge}
+					onChannelSelect={handleChannelSelect}
+					selectedChannelId={selectedChannelId}
 				/>
 
 				{/* NodeConfigPanel — anchored to the right of the canvas.
@@ -949,6 +1002,43 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 							))}
 						</div>
 					</div>
+				</div>
+
+				{/* Channels — collapsible section for workflow-level channel management */}
+				<div class="px-4 py-2 border-b border-dark-800">
+					<button
+						onClick={() => setShowChannels((v) => !v)}
+						class="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-300 transition-colors"
+						data-testid="toggle-channels-button"
+					>
+						<svg
+							class={`w-3 h-3 transition-transform ${showChannels ? 'rotate-90' : ''}`}
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M9 5l7 7-7 7"
+							/>
+						</svg>
+						<span class="font-semibold uppercase tracking-wider">
+							Channels {channels.length > 0 ? `(${channels.length})` : ''}
+						</span>
+					</button>
+
+					{showChannels && (
+						<div class="mt-3" data-testid="channels-section">
+							<ChannelEditor
+								channels={channels}
+								onChange={setChannels}
+								agentRoles={agentRoles}
+								highlightIndex={selectedChannelId != null ? parseInt(selectedChannelId, 10) : null}
+							/>
+						</div>
+					)}
 				</div>
 
 				{/* Rules — collapsible */}

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -322,8 +322,13 @@ export function WorkflowCanvas({
 	// Compute channel edges from nodes' channel declarations.
 	// Also merges with any explicitly passed channels prop (for backward compatibility).
 	const computedChannelEdges = useMemo(() => computeChannelEdges(nodes), [nodes]);
-	const effectiveChannels =
-		channels.length > 0 ? [...computedChannelEdges, ...channels] : computedChannelEdges;
+	// Merge computed channel edges with explicitly passed channels, deduplicating by fromStepId+toStepId.
+	const effectiveChannels = (() => {
+		if (channels.length === 0) return computedChannelEdges;
+		const seen = new Set(computedChannelEdges.map((c) => `${c.fromStepId}:${c.toStepId}`));
+		const deduped = channels.filter((c) => !seen.has(`${c.fromStepId}:${c.toStepId}`));
+		return [...computedChannelEdges, ...deduped];
+	})();
 
 	// Clear selection if the selected node is removed externally (e.g. parent deletes it
 	// from the nodes array). Without this, a node re-added with the same stepId would

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -76,6 +76,10 @@ export interface WorkflowCanvasProps {
 	onEdgeSelect?: (transitionId: string | null) => void;
 	/** Called when Delete/Backspace is pressed with an edge selected. */
 	onDeleteEdge?: (transitionId: string) => void;
+	/** Called when a channel edge is clicked. Receives the channel's id. */
+	onChannelSelect?: (channelId: string | null) => void;
+	/** Currently selected channel ID for highlighting. */
+	selectedChannelId?: string | null;
 }
 
 // ---- Ghost edge rendering ----
@@ -262,6 +266,8 @@ export function WorkflowCanvas({
 	onCreateTransition,
 	onEdgeSelect,
 	onDeleteEdge,
+	onChannelSelect,
+	selectedChannelId,
 }: WorkflowCanvasProps) {
 	const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 	const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
@@ -437,6 +443,8 @@ export function WorkflowCanvas({
 					onEdgeSelect={handleEdgeSelect}
 					onEdgeDelete={handleEdgeDelete}
 					channels={effectiveChannels}
+					selectedChannelId={selectedChannelId}
+					onChannelSelect={onChannelSelect ?? undefined}
 				/>
 				{dragState.active && dragState.fromPos && dragState.currentPos && (
 					<GhostEdge from={dragState.fromPos} to={dragState.currentPos} />
@@ -451,6 +459,8 @@ export function WorkflowCanvas({
 			handleEdgeSelect,
 			handleEdgeDelete,
 			dragState,
+			selectedChannelId,
+			onChannelSelect,
 		]
 	);
 

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -467,7 +467,7 @@ describe('NodeConfigPanel', () => {
 			expect(select.textContent).toContain('Coder');
 		});
 
-		it('auto-creates task-agent channels when adding an agent in multi-agent mode', () => {
+		it('does not auto-create channels when adding an agent (channels are managed at workflow level)', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
@@ -476,145 +476,9 @@ describe('NodeConfigPanel', () => {
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
 			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
 			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
-			// Should have 2 agents and 2 task-agent channels (one per agent)
+			// 2 agents added, but no auto-created channels (channels are workflow-level now)
 			expect(updatedStep.agents).toHaveLength(2);
-			expect(updatedStep.channels?.length).toBe(2);
-			expect(
-				updatedStep.channels?.every(
-					(c: { from: string; direction: string }) =>
-						c.from === 'task-agent' && c.direction === 'bidirectional'
-				)
-			).toBe(true);
-		});
-
-		it('preserves existing channels when adding an agent if channels are already set', () => {
-			const onUpdate = vi.fn();
-			const step = makeStep({
-				agentId: '',
-				agents: [{ agentId: 'agent-1', name: 'planner' }],
-				channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' as const }],
-			});
-			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
-			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
-			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
-			// Should have 2 agents, and existing channels should be preserved
-			expect(updatedStep.agents).toHaveLength(2);
-			expect(updatedStep.channels?.length).toBe(1);
-			expect(updatedStep.channels?.[0].from).toBe('coder');
-		});
-
-		it('shows channels section in multi-agent mode', () => {
-			const step = makeStep({
-				agentId: '',
-				agents: [
-					{ agentId: 'agent-1', name: 'planner' },
-					{ agentId: 'agent-2', name: 'coder' },
-				],
-			});
-			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
-			expect(getByTestId('channels-section')).toBeTruthy();
-		});
-
-		it('shows channels section for single-agent node with agent', () => {
-			// Channels section is always shown so users can manage Task Agent channels.
-			const { queryByTestId } = render(<NodeConfigPanel {...makeProps()} />);
-			expect(queryByTestId('channels-section')).toBeTruthy();
-		});
-
-		it('renders existing channels in channels list', () => {
-			const step = makeStep({
-				agentId: '',
-				agents: [
-					{ agentId: 'agent-1', name: 'planner' },
-					{ agentId: 'agent-2', name: 'coder' },
-				],
-				channels: [
-					{ from: 'coder', to: 'reviewer', direction: 'one-way' },
-					{ from: 'reviewer', to: 'coder', direction: 'bidirectional' },
-				],
-			});
-			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
-			expect(getAllByTestId('channel-entry')).toHaveLength(2);
-		});
-
-		it('remove channel button calls onUpdate without that channel', () => {
-			const onUpdate = vi.fn();
-			const step = makeStep({
-				agentId: '',
-				agents: [
-					{ agentId: 'agent-1', name: 'planner' },
-					{ agentId: 'agent-2', name: 'coder' },
-				],
-				channels: [
-					{ from: 'coder', to: 'reviewer', direction: 'one-way' },
-					{ from: 'reviewer', to: 'coder', direction: 'bidirectional' },
-				],
-			});
-			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
-			fireEvent.click(getAllByTestId('remove-channel-button')[0]);
-			const updatedStep = onUpdate.mock.calls[0][0];
-			expect(updatedStep.channels).toHaveLength(1);
-			expect(updatedStep.channels[0].from).toBe('reviewer');
-		});
-
-		it('add channel button is disabled when from or to is empty', () => {
-			const step = makeStep({
-				agentId: '',
-				agents: [
-					{ agentId: 'agent-1', name: 'planner' },
-					{ agentId: 'agent-2', name: 'coder' },
-				],
-			});
-			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
-			const addBtn = getByTestId('add-channel-button');
-			expect(addBtn.hasAttribute('disabled')).toBe(true);
-		});
-
-		it('add channel adds a new channel entry', () => {
-			const onUpdate = vi.fn();
-			const step = makeStep({
-				agentId: '',
-				agents: [
-					{ agentId: 'agent-1', name: 'planner' },
-					{ agentId: 'agent-2', name: 'coder' },
-				],
-			});
-			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
-			// Set from
-			act(() => {
-				fireEvent.change(getByTestId('channel-from-select'), { target: { value: 'coder' } });
-			});
-			// Set to
-			act(() => {
-				fireEvent.input(getByTestId('channel-to-input'), { target: { value: 'reviewer' } });
-			});
-			// Click add
-			act(() => {
-				fireEvent.click(getByTestId('add-channel-button'));
-			});
-			expect(onUpdate).toHaveBeenCalled();
-			const updatedStep = onUpdate.mock.calls[0][0];
-			expect(updatedStep.channels).toHaveLength(1);
-			expect(updatedStep.channels[0].from).toBe('coder');
-			expect(updatedStep.channels[0].to).toBe('reviewer');
-			expect(updatedStep.channels[0].direction).toBe('one-way');
-		});
-
-		it('channel-from-select dropdown options are slot roles (WorkflowNodeAgent.role), not SpaceAgent.role', () => {
-			// When the same agent is added twice with roles "coder" and "coder-2",
-			// both slot roles must appear as distinct options in the channel dropdown.
-			const step = makeStep({
-				agentId: '',
-				agents: [
-					{ agentId: 'agent-2', name: 'coder' },
-					{ agentId: 'agent-2', name: 'coder-2' },
-				],
-			});
-			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
-			const fromSelect = getByTestId('channel-from-select');
-			// Both slot-specific roles must be present as options
-			expect(fromSelect.textContent).toContain('coder');
-			expect(fromSelect.textContent).toContain('coder-2');
+			expect(updatedStep.channels).toBeUndefined();
 		});
 
 		it('adding the same agent twice generates a unique slot role with numeric suffix', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -352,8 +352,6 @@ describe('VisualWorkflowEditor', () => {
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
 			);
 			const nodesBefore = getAllByTestId(/^workflow-node-/).length;
-			// The workflow has one edge (step-1 → step-2); confirm it renders before deletion
-			expect(container.querySelector('[data-edge-id]')).toBeTruthy();
 
 			// Select step-2 (the non-start regular node).
 			// Skip the Task Agent virtual node (data-testid="workflow-node-__task_agent__")
@@ -372,8 +370,7 @@ describe('VisualWorkflowEditor', () => {
 
 			expect(getAllByTestId(/^workflow-node-/).length).toBe(nodesBefore - 1);
 			expect(queryByTestId('node-config-panel')).toBeNull();
-			// Edges referencing the deleted node must also be removed
-			expect(container.querySelector('[data-edge-id]')).toBeNull();
+			// Transitions are hidden on canvas (channels are primary connections).
 		});
 
 		it('Task Agent never receives the start badge after any node deletion', () => {
@@ -515,100 +512,18 @@ describe('VisualWorkflowEditor', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// Edge selection → EdgeConfigPanel
-	// -------------------------------------------------------------------------
-
-	describe('Edge selection — EdgeConfigPanel', () => {
-		it('clicking an edge hitbox opens EdgeConfigPanel', () => {
-			const { container, queryByTestId } = render(
-				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
-			);
-			expect(queryByTestId('edge-config-panel')).toBeNull();
-
-			// EdgeRenderer renders a <g data-edge-id="..."> with a hitbox <path> as first child
-			const hitboxPath = container.querySelector('[data-edge-id] > path');
-			expect(hitboxPath).toBeTruthy();
-			fireEvent.click(hitboxPath!);
-
-			expect(queryByTestId('edge-config-panel')).toBeTruthy();
-		});
-
-		it('EdgeConfigPanel close button dismisses the panel', () => {
-			const { container, queryByTestId } = render(
-				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
-			);
-			const hitboxPath = container.querySelector('[data-edge-id] > path')!;
-			fireEvent.click(hitboxPath);
-			expect(queryByTestId('edge-config-panel')).toBeTruthy();
-
-			// The close button inside EdgeConfigPanel
-			const closeBtn = queryByTestId('close-button');
-			expect(closeBtn).toBeTruthy();
-			fireEvent.click(closeBtn!);
-			expect(queryByTestId('edge-config-panel')).toBeNull();
-		});
-
-		it('deleting an edge via EdgeConfigPanel removes it and hides the panel', () => {
-			const { container, queryByTestId, getByTestId } = render(
-				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
-			);
-			const hitboxBefore = container.querySelector('[data-edge-id] > path')!;
-			fireEvent.click(hitboxBefore);
-
-			fireEvent.click(getByTestId('delete-transition-button'));
-
-			// After deletion the edge element should be gone
-			expect(container.querySelector('[data-edge-id]')).toBeNull();
-			// And the panel should be dismissed
-			expect(queryByTestId('edge-config-panel')).toBeNull();
-		});
-
-		it('changing edge condition type updates the panel', () => {
-			const { container, getByTestId } = render(
-				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
-			);
-			fireEvent.click(container.querySelector('[data-edge-id] > path')!);
-
-			const select = getByTestId('condition-type-select') as HTMLSelectElement;
-			fireEvent.change(select, { target: { value: 'human' } });
-
-			expect(select.value).toBe('human');
-		});
-
-		it('selecting an edge clears the node selection', () => {
-			const { container, getAllByTestId, queryByTestId } = render(
-				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
-			);
-
-			// First select a regular node ([0] is Task Agent, not selectable; use [1])
-			fireEvent.click(getAllByTestId(/^workflow-node-/)[1]);
-			expect(queryByTestId('node-config-panel')).toBeTruthy();
-
-			// Then click an edge
-			const hitbox = container.querySelector('[data-edge-id] > path')!;
-			fireEvent.click(hitbox);
-
-			expect(queryByTestId('node-config-panel')).toBeNull();
-			expect(queryByTestId('edge-config-panel')).toBeTruthy();
-		});
-	});
-
-	// -------------------------------------------------------------------------
 	// handleCreateTransition
 	// -------------------------------------------------------------------------
 
 	describe('handleCreateTransition', () => {
-		it('renders exactly one edge for the single transition in the workflow', () => {
-			// Smoke test: makeWorkflow has one transition (step-1 → step-2); confirm
-			// exactly one edge element is rendered. The port-drag dedup logic in
-			// handleCreateTransition cannot be exercised in JSDOM (requires real
-			// mousemove/mouseup across port elements), so this test only validates
-			// the initial render state.
+		it('renders no visible edges (transitions hidden; channels are primary connections)', () => {
+			// Transitions are stored in state but not passed to EdgeRenderer (channels
+			// replaced them as the primary visual connections in Task 7.1).
 			const { container } = render(
 				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
 			);
-			// EdgeRenderer wraps each edge in a <g data-edge-id="..."> element
-			expect(container.querySelectorAll('[data-edge-id]').length).toBe(1);
+			// Transitions are hidden: no [data-edge-id] elements expected
+			expect(container.querySelectorAll('[data-edge-id]').length).toBe(0);
 		});
 	});
 
@@ -898,7 +813,7 @@ describe('VisualWorkflowEditor', () => {
 			expect(getAllByTestId(/^workflow-node-/).length).toBe(3);
 		});
 
-		it('selecting a template creates edges between nodes', () => {
+		it('selecting a template creates nodes but no visible edges (transitions hidden)', () => {
 			const { getByTestId, getAllByTestId, container } = render(
 				<VisualWorkflowEditor {...makeProps()} />
 			);
@@ -909,8 +824,8 @@ describe('VisualWorkflowEditor', () => {
 			);
 			fireEvent.click(codingOption!);
 
-			// Should have 1 edge connecting the 2 nodes (EdgeRenderer uses data-edge-id attribute)
-			expect(container.querySelectorAll('[data-edge-id]').length).toBe(1);
+			// Transitions hidden; channels are the primary visual connections.
+			expect(container.querySelectorAll('[data-edge-id]').length).toBe(0);
 		});
 
 		it('selecting a template assigns autoLayout positions (non-zero for at least one node)', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
@@ -141,21 +141,21 @@ describe('VisualWorkflowEditor handleCreateTransition Task Agent guard', () => {
 		expect(container.querySelectorAll('[data-edge-id]').length).toBe(edgesBefore);
 	});
 
-	it('does add an edge for two regular node IDs (positive case)', () => {
+	it('does add a transition for two regular node IDs (positive case — transitions stored in state but hidden on canvas)', () => {
 		const { container } = render(
 			<VisualWorkflowEditor workflow={makeWorkflow()} onSave={vi.fn()} onCancel={vi.fn()} />
 		);
 
 		expect(capturedOnCreateTransition).toBeTruthy();
 
-		// makeWorkflow has no transitions, so edges start at 0
+		// Transitions are hidden on the canvas (channels are primary visual connections).
 		expect(container.querySelectorAll('[data-edge-id]').length).toBe(0);
 
 		act(() => {
 			capturedOnCreateTransition!('step-1', 'step-2');
 		});
 
-		// A real edge should be created
-		expect(container.querySelectorAll('[data-edge-id]').length).toBe(1);
+		// Transition is stored in state but still not rendered as an edge
+		expect(container.querySelectorAll('[data-edge-id]').length).toBe(0);
 	});
 });


### PR DESCRIPTION
- **feat(tasks): make failed state non-terminal (allow messages + retry)**
- **fix: pass taskManager as parameter to avoid accessing private field**
- **fix: align needs_attention handling between RPC and agent-tool paths**
- **ci: add setup-devproxy composite action with caching to fix CI install failures**
- **fix(ci): use jq + GITHUB_TOKEN auth to resolve devproxy version in setup action**
- **fix(ci): inject github.token into composite action step env for API auth**
- **fix: resolve leftover conflict markers in human-message-routing tests**
- **ci: simplify CI pipeline by removing intermediate gate jobs and extracting Dev Proxy action**
- **fix: restore runner.os guard on setup-devproxy, add startup timeout failure**
- **fix: always set archivedAt when archiving task without active runtime**
- **fix: correct comment about orphaned worktree cleanup, add review state test**
- **fix(ci): use nc -z TCP check for devproxy readiness instead of curl**
- **feat: add draft message auto-save to task view input**
- **fix: address review feedback on task draft auto-save**
- **feat: persist task input draft to server-side storage**
- **fix: address review feedback on task draft RPC handler**
- **ci: add rpc-task-draft-handlers.test.ts to rpc-1 CI matrix shard**
- **ci: register rpc-task-draft-handlers.test.ts in validate-online-test-matrix script**
- **fix: address review feedback on task draft hook (round 2)**
- **fix: add cancelled flag to loadDraft to prevent cross-task data corruption**
- **fix(test): mock Bun.spawn in dialog-handlers tests to prevent system folder picker**
- **test(dialog-handlers): fix platform-agnostic test and cover error-handling path**
- **fix: address round-7 review feedback on task draft hook**
- **ci: retrigger CI after base branch corrected to dev**
- **ci: retrigger CI (rpc-remove-output flaky timeout)**
- **feat: raise draft/message char limit from 100k to 200k**
- **fix: correct too-long test repeat count and JSDoc after 200k limit raise**
- **chore: bump version to 0.7.1 (#357)**
- **fix: skip max feedback iterations limit when task is in review state (#358)**
- **docs: Goal V2 (Mission System) plan for autonomous agent workflows (#322)**
- **fix: preserve PR data on runtime escalation and show PR in task view header (#360)**
- **chore: update deps to latest minor versions (except claude agent SDK) (#362)**
- **chore: upgrade @anthropic-ai/claude-agent-sdk from 0.2.55 to 0.2.76 (#363)**
- **feat: order tasks by most recently updated within each status (#365)**
- **feat: add GLM-5-Turbo model support (#367)**
- **fix: prevent API error bounce loops for all agents in runtime (#366)**
- **feat: Anthropic-compatible HTTP bridge backed by codex app-server (#339)**
- **feat: GitHub Copilot as transparent AgentSession backend via embedded Anthropic-compatible server (#340)**
- **feat: add mission metadata schema and types for Goal V2 (#369)**
- **docs: Goal V2 Mission System -- Autonomous Agent Workflows plan (#368)**
- **fix: show PR link for all task statuses once created (#372)**
- **Plan: Full first-class anthropic-copilot and anthropic-codex provider support (#370)**
- **feat: tighten leader agent tool permissions to read-only context subset (#371)**
- **feat: define V2 mission types and extend RoomGoal (Task 1.1) (#374)**
- **chore: remove pi-mono approach dead code (#364)**
- **feat: widen Provider type union to include anthropic-copilot and anthropic-codex (#373)**
- **fix: remove unsafe provider casts in daemon, use widened Provider type (#377)**
- **fix: Enter to send in task HumanInputArea, default target to leader (#387)**
- **fix: inject room chat system prompt to prevent premature task creation (#379)**
- **feat: add anthropic-codex Codex entry to PROVIDER_LABELS (#375)**
- **feat: make provider routing fully deterministic via explicit (modelId, providerId) pairs (#376)**
- **fix: parse /context response from assistant messages (new SDK format) (#381)**
- **fix: prevent agent from creating duplicate PRs on re-dispatch (#392)**
- **fix: remove merge method flag from human approval message (#393)**
- **feat: iterate all tool results in codex bridge continuation (#378)**
- **feat: replace copy toast with inline green check mark (#394)**
- **feat: require explicit provider ID for all model resolution (#388)**
- **test: add provider routing tests for copilot/cross-provider model switches (#395)**
- **feat: provider-grouped model picker with availability dots (#398)**
- **feat: replace plain-text error bodies with Anthropic JSON error envelopes in codex bridge (#380)**
- **feat: improve error mapping in copilot bridge (Task 5.1) (#384)**
- **fix: render leader questions as interactive forms in task conversation (#400)**
- **feat: wire thread/tokenUsage/updated into SSE message_delta token counts (#383)**
- **feat: recurring missions — scheduling with execution identity and recovery (Task 3) (#390)**
- **feat: UI terminology — rename Goal to Mission (Task 5) (#397)**
- **feat: implement semi-autonomous mode for coder/general tasks (Task 4) (#396)**
- **feat: measurable missions — structured metrics and adaptive replanning (Task 2) (#382)**
- **fix: call queryObject.close() before clearing transport reference (#403)**
- **fix: scope message locator in persistence e2e test to avoid strict mode violation (#402)**
- **feat: provider-aware session creation (#399) (#401)**
- **feat: add provider badge in session status bar next to model icon (#391)**
- **feat: heuristic token accounting for copilot bridge (#385)**
- **test: unit tests for provider routing and type safety (Task 7.1) (#399)**
- **feat: log warning when tool_choice is provided but not honored in both bridges (#386)**
- **task/task 72 update online provider test shards (#409)**
- **feat: graceful degradation on provider unavailability (#408)**
- **test: add E2E tests for provider model switching UI (#406)**
- **feat: eager leader initialization and fix observer race in TaskGroupManager (#411)**
- **feat: filter unauthenticated providers from model picker (#410)**
- **Fix SQLITE_BUSY retries and closed SSE controller handling (#415)**
- **fix: resolve leader questions routing to dead session instances (#404)**
- **feat: add OpenAI token refresh/login in settings for Codex (#416)**
- **fix: use correct /room/:id route in mission-terminology e2e tests (#419)**
- **fix: restore dead worker sessions before routing leader feedback (#418)**
- **feat: UI — type-specific mission creation and detail views (Task 6) (#405)**
- **fix: capture assistant.message.content when Copilot SDK skips streaming deltas (#421)**
- **fix: set ANTHROPIC_DEFAULT_*_MODEL in Codex provider to prevent Anthropic model fallback (#412)**
- **fix: support Agent tool name for subagent blocks (SDK 0.2.76+ renamed Task to Agent) (#424)**
- **fix(codex-bridge): persist Codex sessions across turns (#420)**
- **docs: add final provider parity report (#413)**
- **docs: plan for Multi-Agent V2 customizable agents and workflows (#359)**
- **task/fix logout button not working for openai and copil (#423)**
- **feat: define Space shared types in @neokai/shared (#425)**
- **feat: add Migration 29 — create all Space system tables (#427)**
- **feat: add SpaceAgent and workflow types to space.ts (Task 3.1) (#426)**
- **feat: custom agent types, repository, and manager (Task 2.1) (#428)**
- **feat: add Space repositories and managers (Task 1.3) (#429)**
- **feat: SpaceWorkflowRepository and SpaceWorkflowManager (Task 3.2) (#430)**
- **feat: Space RPC handlers and DaemonEventMap registration (Task 1.4) (#433)**
- **docs: add provider setup documentation for anthropic-copilot and anthropic-codex (#414)**
- **test: integration testing and documentation for Mission System V2 (Task 7) (#422)**
- **feat: add task management tools to leader role (#435)**
- **feat: add spaceAgent RPC handlers and DaemonEventMap entries (Task 2.2) (#431)**
- **feat: simplify multi-agent space — explicit workflowId or AI auto-select only (#434)**
- **feat: add leader progress summary at end of each turn (#436)**
- **feat: custom agent session init factory and SpaceAgent tools (Task 2.3) (#432)**
- **docs: update multi-agent space task docs with simplified workflow selection design (#439)**
- **docs: NeoKai UI/UX 1.0.0 upgrade plan (#442)**
- **docs: add NeoKai UI/UX 1.0.0 upgrade specification (#444)**
- **feat: extend CSS custom properties vocabulary in styles.css (#445)**
- **feat: Workflow RPC handlers and DaemonEventMap registration (Task 3.3) (#437)**
- **feat: built-in workflow templates and seedBuiltInWorkflows (Task 3.4) (#440)**
- **feat: Space navigation, routing, and signals (Task 5.1) (#438)**
- **feat: add WorkflowExecutor core for Space workflow run progression (Task 4.1) (#443)**
- **feat: define Space export/import JSON format (Task 8.1) (#441)**
- **docs: align Milestone 4 planning docs with transition/condition implementation (#447)**
- **feat: SpaceRuntime — workflow orchestration, task-type assignment, seedDefaultWorkflow wiring (Task 4.2) (#450)**
- **fix: make CreateWorkflowRunParams.currentStepId optional (#449)**
- **feat: add SpaceStore reactive state management (Task 5.2) (#446)**
- **fix: fix failing E2E tests for mission creation routes and persistence (#451)**
- **feat: add Space export/import RPC handlers (Task 8.2) (#452)**
- **feat: workflow selection logic and Space agent tools (Task 7.1) (#453)**
- **fix: sync space_agents columns in space-test-db.ts with migration schema (#448)**
- **feat: Space creation UX and 3-column layout (Task 5.3) (#455)**
- **task/make turn summary card use bigger font and render  (#460)**
- **feat: SpaceRuntimeService, workflow run RPC handlers, and session group metadata (Task 4.3) (#454)**
- **feat: Task 8.3 — Frontend Export/Import UI for Space agents and workflows**
- **fix: fetch real Copilot model IDs dynamically via client.listModels() (#464)**
- **task/fix agent session crash when switching modelprovid (#459)**
- **task/add support for minimax m27 highspeed model (#458)**
- **feat: Task 6.1 - Custom Agent List and Editor**
- **task/task 72 space agent prompt enhancement (#457)**
- **feat: workflow step builder (Task 6.2) (#463)**
- **fix: handle thinking blocks in SDK title generation (#461)**
- **refactor: remove detectProvider heuristic entirely (#467)**
- **feat: Task 6.3 - Workflow Rules Editor and Space integration (#468)**
- **feat: add structured tokens object to design-tokens module (#469)**
- **test: add tokens unified namespace tests for Task 1.2 (#470)**
- **feat: typography and global prose refinements (Task 1.3) (#471)**
- **fix: ensure onError cleanup runs on subprocess crash in codex bridge (#473)**
- **fix: clear stale sdkSessionId when SDK session file no longer exists (#474)**
- **fix: display Copilot quota errors as UI error blocks and stop retrying (#476)**
- **feat: display API retry errors in UI during SDK retry attempts (#475)**
- **fix: use unique workspace paths and correct delete params in space E2E tests (#477)**
- **feat: Button/IconButton/NavIconButton unification (Task 2.1) (#472)**
- **fix: clean up stale spaces before creating in E2E tests (#478)**
- **fix: correct space.list response shape in E2E stale-space cleanup (#481)**
- **fix: use correct space.create response shape in E2E tests (#482)**
- **ci: skip unstable space E2E tests (export-import, workflow-rules) (#483)**
- **docs: plan for workflow visual editor implementation (#479)**
- **feat: add VisualCanvas component with pan and zoom (Task 1.2) (#484)**
- **feat: add layout column to space_workflows for visual editor (Task 1.1) (#485)**
- **feat: replace hidden dropdown with inline Cancel/Complete buttons in TaskView (Task 2.2) (#480)**
- **feat: add SVG overlay layer for edges in VisualCanvas (Task 1.3) (#488)**
- **feat: add WorkflowNode canvas component (Task 2.1) (#490)**
- **fix: sync room chat session model when defaultModel changes to prevent glm-5-turbo errors (#486)**
- **feat: DAG auto-layout algorithm for workflow visual editor (Task 5.1) (#487)**
- **feat: add CanvasToolbar with zoom controls and fit-to-view (Task 1.4) (#489)**
- **feat: add node selection and multi-select to visual editor (Task 2.3) (#491)**
- **feat: implement WorkflowNode with drag-and-drop support (Task 2.2) (#492)**
- **fix: always set provider in createCustomAgentInit for Space custom agents (#495)**
- **feat: create connections by dragging from output to input ports (Task 3.2) (#496)**
- **feat: implement NodeConfigPanel and extract GateConfig (Task 4.1) (#497)**
- **feat: add Spaces UI with global agent and context panel (#493)**
- **task/task 31 render edges as svg bezier curves (#494)**
- **feat: implement EdgeConfigPanel component for transition editing (Task 4.2) (#498)**
- **feat: serialize visual state to SpaceWorkflow data model (Task 5.2) (#499)**
- **Plan: Task Agent session orchestrator for Space tasks (#501)**
- **feat: add VisualWorkflowEditor orchestrator component (Task 6.1) (#500)**
- **feat: add space_task_agent session type and taskAgentSessionId to SpaceTask (#502)**
- **feat: define Task Agent MCP tool schemas (Task 1.3) (#503)**
- **feat: add List/Visual toggle in SpaceIsland workflow editor (Task 6.2) (#505)**
- **feat: add template support to visual workflow editor (Task 5.3) (#506)**
- **test: add performance validation for large workflows (Task 7.3) (#504)**
- **feat: build Task Agent system prompt and initial message builders (#507)**
- **feat: add task_agent_session_id to space_tasks schema and repository (#508)**
- **docs: plan for Space Agent Coordinator reactive event-driven task coordination (Layer 4a) (#512)**
- **feat: implement createTaskAgentInit factory for Task Agent sessions (Task 2.2) (#510)**
- **feat: implement Task Agent MCP tool handlers (Task 3.1) (#513)**
- **test: add E2E tests for visual workflow editor (Task 7.1) (#509)**
- **feat: define NotificationSink interface and SpaceNotificationEvent types (Task 2.1) (#515)**
- **feat: add retryTask and reassignTask methods to SpaceTaskManager (#514)**
- **feat: implement SessionNotificationSink for Space Agent event injection (#519)**
- **test: fix pre-existing test failures for compatibility (Task 7.2) (#511)**
- **feat: add SpaceAutonomyLevel, SpaceConfig types, and autonomy_level DB column (#516)**
- **feat: add coordination tools to space-agent-tools (Task 3.2) (#520)**
- **test: add MCP server factory tests for createTaskAgentMcpServer (#517)**
- **feat: update space-chat-agent prompt with coordinator behavior (Task 4.1) (#523)**
- **feat: update SpaceManager and RPC handlers for autonomy level (Task 1.2) (#524)**
- **feat: integrate NotificationSink into SpaceRuntime tick loop (Task 2.2) (#525)**
- **fix: use worktree path for SDK session file lookups (#518)**
- **task/review pr 518 (#527)**
- **feat: update global-spaces-agent prompt with coordination guidance (#522)**
- **test: autonomy level behavior tests for space agent (Task 6.2) (#526)**
- **feat: add needs_attention detection for standalone tasks in SpaceRuntime (#529)**
- **feat: add coordination tools to global-spaces-tools.ts (Task 3.3) (#521)**
- **feat: implement TaskAgentManager core (Task 4.1) (#528)**
- **test: add full pipeline integration tests for concurrent notification events (Task 6.1) (#531)**
- **feat: wire SessionNotificationSink into provisionGlobalSpacesAgent (Task 5.2) (#530)**
- **feat: wire TaskAgentManager into DaemonApp (Task 4.3) (#532)**
- **test: edge case and resilience tests for notification system (Task 6.3) (#537)**
- **feat: add human message routing to Task Agent via space.task.sendMessage/getMessages (#536)**
- **feat: add Task Agent spawning to SpaceRuntime tick loop (Task 5.1) (#538)**
- **test: verify all MCP tools registered in global-spaces provisioning (Task 5.3) (#534)**
- **feat: add send_message_to_task tool to Space Agent (#535)**
- **feat: wire TaskAgentManager into SpaceRuntimeService (Task 5.2) (#540)**
- **feat: add task completion notification to Space Agent (Task 6.2) (#541)**
- **test: online tests with dev proxy for space agent coordination (Task 6.4) (#539)**
- **feat: add toast semantic methods and ConfirmModal enhancements (Task 2.3) (#543)**
- **feat: add Task Agent session rehydration on daemon restart (Task 5.3) (#542)**
- **feat: add semantic status border and inline reject form to RoomTasks (Task 2.4) (#544)**
- **feat: add Inbox navigation infrastructure (Task 3.1) (#545)**
- **feat: add Inbox view (inbox-store + Inbox.tsx + MainContent routing) (Task 3.2) (#546)**
- **test: add end-to-end online test for Task Agent lifecycle (Task 6.3) (#547)**
- **feat: add direct approve/reject to Inbox without TaskView navigation (Task 4.3) (#548)**
- **feat: hide ContextPanel when inbox is active (Task 4.2) (#550)**
- **fix: remove premature task_agent_session_id index from migration 29 (#551)**
- **feat: auto-expand review TaskCards with Approve button and worker summary (Task 4.4) (#553)**
- **docs: plan for workflow iteration loop with agent-driven cyclic transitions (#552)**
- **docs: plan to fix E2E test failures on dev branch CI (#556)**
- **docs: plan for task status lifecycle redesign (#555)**
- **feat: add goalId column to space_tasks and types (Task 3.1) (#561)**
- **fix: replace fixed sleep with Playwright auto-retrying assertion in worktree-isolation E2E test (#557)**
- **fix: rewrite task-actions-dropdown E2E tests to match actual inline button UI (#558)**
- **Plan: Redesign RoomContextPanel goal-centric sidebar (#563)**
- **feat: add iteration tracking columns to DB and types (Task 2.1) (#564)**
- **fix: remove stale sessions from RoomContextPanel on session delete/update (#554)**
- **fix: update space-creation E2E test assertions to match actual tabbed UI (#559)**
- **feat: add ActionBar component and replace inline HeaderReviewBar in TaskView (Task 4.5) (#560)**
- **feat: propagate goalId through workflow task creation (Task 3.2) (#565)**
- **feat: add task_result condition type and isCyclic to workflow transitions (#562)**
- **fix: fix visual-workflow-editor E2E tests — space URL sync + navigateToSpace wait (#567)**
- **feat: add CollapsibleSection component for sidebar sections (#568)**
- **feat: add /room/:roomId/agent route pattern and navigation (#570)**
- **feat: add mobile BottomTabBar with iOS-style navigation (Task 4.6) (#571)**
- **feat: add computed signals for goal-task grouping and orphan tasks (#569)**
- **test: unit tests for goalId propagation (Task 5.3) (#572)**
- **feat: add archived status to TaskStatus and SpaceTaskStatus unions (#566)**
- **feat: add Verify & Test step to Coding Workflow template (#573)**
- **feat: implement task_result evaluation in WorkflowExecutor (#574)**
- **chore: trigger PR creation for task 5.1 (#583)**
- **feat(workflow): implement iteration detection and capping in WorkflowExecutor (#585)**
- **fix: replace crypto.randomUUID with browser-compatible generateUUID (#587)**
- **feat: wire step_result through advance_workflow to executor (Task 1.3) (#586)**
- **feat: rewrite RoomContextPanel with goal-centric sidebar layout (#577)**
- **test: unit tests for archived status transitions and archival filtering (#580)**
- **test: add unit tests for router room agent route (#575)**
- **test: add reactivity and edge case tests for room store computed signals (#576)**
- **fix: stop worktree cleanup on complete and cancel in task-group-manager (#578)**
- **test: add space task manager tests for archival and reactivation lifecycle (#579)**
- **test: add archive and reactivation RPC handler tests for space tasks (#593)**
- **fix: fix flaky online tests in CI (#582)**
- **feat: Phase 4 micro-animations — badge pop, card approve/reject, panel & page fade-in (#590)**
- **test: add missing draft/pending Active tab and sessions count badge tests for RoomContextPanel (#591)**
- **feat: update task tab grouping to Active/Review/Done/Archived (#581)**
- **feat: add model switching in TaskView and auto-fallback on rate/usage limits (#589)**
- **test: add end-to-end cyclic workflow integration test (Task 5.5) (#598)**
- **test: validate Room.tsx integration with room agent routes (#592)**
- **feat: update room-runtime and RPC handlers for new lifecycle (#594)**
- **feat: add reactivate and archive actions to TaskView (#601)**
- **test: add E2E tests for room sidebar sections (goal expand/collapse and task tab filtering) (#602)**
- **feat: allow cancelled → completed status transition (#600)**
- **test: add E2E tests for room sidebar URL navigation and persistence (#603)**
- **fix: update room-agent-tools guards and comments for new task lifecycle (#599)**
- **test: add web unit tests for archived status and reactivate/archive button visibility (#604)**
- **fix: recover rate-limited workers stuck in later iterations (feedbackIteration > 0) (#596)**
- **test: add unit tests for room-runtime lifecycle changes (#605)**
- **test: add online integration tests for task reactivation and archive lifecycle (#608)**
- **test: add edge-case tests for cyclic transition condition evaluation and iterationCount (#609)**
- **test: add E2E tests for task reactivate and archive UI actions (#611)**
- **fix: sync root repo after PR merge via lifecycle gate (#610)**
- **docs: plan for Space Agent Groups flexible multi-agent collaboration (#606)**
- **feat: add migration 40 for flexible session groups (#614)**
- **feat: extend WorkflowStep with agents array and WorkflowChannel topology (#613)**
- **docs: implementation plan for persistent job queue adoption (#612)**
- **feat: update shared types for flexible SpaceSessionGroup model (#615)**
- **feat: extend listJobs to accept status arrays (#618)**
- **feat: add resolveTaskTypesForStep for multi-agent per-agent type resolution (#616)**
- **docs(plans): SQL LiveQuery adoption plan (#205)**
- **feat: add channel and multi-agent step validation to SpaceWorkflowManager (#617)**
- **feat: extend export/import format for multi-agent steps and channels (#620)**
- **task/task 13 update spacesessiongrouprepository for new (#619)**
- **ci: skip Codex bridge tests + fix multi-agent import test (#627)**
- **test: add export/import round-trip tests for multi-agent workflows (#624)**
- **feat: update WorkflowExecutor for multi-agent parallel step execution (#621)**
- **feat: create job queue constants, wire processor into app lifecycle (#622)**
- **test: unit tests for updated SpaceSessionGroupRepository schema (#625)**
- **feat: thread reactiveDb through dependency interfaces (#623)**
- **feat: show associated goal on room task list and task view (#629)**
- **feat: wire SpaceSessionGroupRepository into TaskAgentManager (#628)**
- **test: add JobQueueProcessor lifecycle integration tests (#632)**
- **feat: add session title generation job handler (#630)**
- **feat: add job_queue.cleanup handler and wire into daemon startup (#635)**
- **test: verify eager stale job reclamation on processor restart (#633)**
- **test: unit tests for updated Coding Workflow template (Task 5.4) (#584)**
- **feat: expose triggerPoll and create github.poll job handler (#631)**
- **test: add comprehensive unit tests for multi-agent workflow executor (#636)**
- **feat: inject ReactiveDatabase into TaskManager and fire notifyChange after writes (#642)**
- **feat: update visual workflow editor for multi-agent steps and channel topology (#637)**
- **feat: add room.tick job handler, enqueueRoomTick, and cancelPendingTickJobs (#634)**
- **feat: add notifyChange to GoalRepository and wire through GoalManager (#641)**
- **feat: rehydrate group map on daemon restart via dedicated rehydrateGroupMaps() (#639)**
- **feat: add sub-session members to groups (Task 2.2) (#638)**
- **feat: wire session title handler into SessionManager and remove pendingBackgroundTasks (#640)**
- **test: add E2E tests for multi-agent step editor and channel topology (#645)**
- **feat: remove setInterval from GitHubPollingService and wire handler into GitHubService (#644)**
- **feat: add notifyChange to SessionGroupRepository (#643)**
- **feat: replace setInterval/queueMicrotask with job queue in RoomRuntime (#646)**
- **test: add online test for session title generation via job queue (#647)**
- **feat: emit session group events via DaemonHub (Task 2.3) (#648)**
- **feat: add shared LiveQuery protocol types (#651)**
- **test: add online test for GitHub polling via job queue (#650)**
- **feat: add MessageHub.onClientDisconnect forwarding method (#652)**
- **feat: plumb clientId into CallContext (#653)**
- **fix: model switch now always restarts query when queryObject exists (#657)**
- **feat: add ChannelResolver, list_group_members and relay_message tools to Task Agent (#649)**
- **feat: wire room.tick handler into RoomRuntimeService and fix stopRuntime bug (#660)**
- **feat: hide completed tasks under Goals in sidebar with show/hide toggle (#656)**
- **feat: define named-query registry with column aliasing and JSON parsing (#655)**
- **feat: redesign task view with action dropdown and circular progress (#658)**
- **feat: add space session group RPC handlers and SpaceStore signals (#659)**
- **test: add unit tests for TaskAgentManager group persistence and events (#654)**
- **fix: enqueueRoomTick replaces pending tick when new request is sooner (#661)**
- **test: add online test for room tick via job queue (Task 4.4) (#670)**
- **feat: display active agents in SpaceTaskPane (#663)**
- **feat: implement liveQuery.subscribe and liveQuery.unsubscribe RPC handlers (#672)**
- **feat: step agent peer communication tools (send_feedback, request_peer_input, list_peers) (#675)**
- **test: add integration tests for job queue crash/restart recovery (#671)**
- **fix: use try/finally in test 1 so daemon1 is always stopped on assertion failure (#682)**
- **fix: revert task view gear button to expanded-down panel UX (#681)**
- **fix: prevent duplicate group spawning for same task during concurrent ticks (#687)**
- **test: add disconnect cleanup unit test and online LiveQuery pipeline test (Task 2.6) (#680)**
- **test: add reactive signal update tests for SpaceTaskPane working agents (#679)**
- **fix: remove emitTaskUpdate from task.fail RPC handler (Task 3.1) (#688)**
- **ci: split rpc online tests into 4 balanced shards (#685)**
- **feat: add E2E test for active agents display in SpaceTaskPane (#683)**
- **docs: document out-of-scope setInterval users after job-queue migration (#693)**
- **test: add comprehensive unit tests for cross-agent messaging (#684)**
- **feat: add git branch and session status to TaskInfoPanel expanded view (#691)**
- **feat: add step agent peer communication tools (send_feedback, request_peer_input, list_peers) (#678)**
- **test(e2e): add job queue background tasks E2E test for session title generation (#692)**
- **test: add integration tests for cross-group isolation and channel enforcement (#686)**
- **feat: add useGroupMessages hook for LiveQuery group message streaming (#690)**
- **feat: add force-stop session group RPC + auto-clean stale groups in tick (#694)**
- **fix: address root causes of duplicate and stale session groups (#696)**
- **feat: replace state.groupMessages.delta listener with useGroupMessages hook (#698)**
- **fix: remove emitGoalUpdated/emitGoalProgressUpdated from goal RPC handlers (Task 3.2) (#695)**
- **feat: redesign Goals tab with two-step create wizard and improved cards (#703)**
- **fix: fix task cancellation cascade and allow manual UI state transitions (#702)**
- **feat: remove daemon-side state.groupMessages.delta emissions and add reconnect handling (#700)**
- **feat: migrate TaskConversationRenderer to liveQuery and add E2E streaming tests (#701)**
- **feat: replace room.task.update listener with tasks.byRoom LiveQuery (Task 3.3) (#705)**
- **test: add reconnect resync guard test for review-status toast (Task 3.4) (#709)**
- **fix: reuse existing dev proxy instance instead of failing on startup (#706)**
- **fix: fix TaskView not showing messages after daemon restart (#707)**
- **feat: expand TaskView info panel with task ID, group ID, full session IDs, model switcher, and metadata (#708)**
- **feat: create useRoomLiveQuery hook and integrate with Room.tsx (Task 3.5) (#711)**
- **fix: prevent UNIQUE constraint crash in spawnGroupForTask and handle race gracefully (#710)**
- **feat: add stale-event guard for LiveQuery subscriptions (Task 3.6) (#712)**
- **test(e2e): add LiveQuery task/goal update E2E tests (Task 3.7) (#713)**
- **docs: add dev branch e2e tests health check plan (#704)**
- **feat: enable Bash and full MCP access for Room Agent session (#715)**
- **fix: prevent full conversation reload when sending a message in TaskView (#716)**
- **Fix TaskView recovery after server restart (#718)**
- **refactor: canonical TaskView timeline + runtime startup state persistence (#720)**
- **feat: audit and fix room agent MCP tools parity vs backend capabilities (#719)**
- **fix: propagate reactiveDb to TaskRepository for LiveQuery notifications + rename Goals to Missions (#717)**
- **test: fix pre-existing test failures uncovered during Task 6.2 verification (#721)**
- **task/bug task view message timestamps show current time (#722)**
- **fix(e2e): disambiguate Missions tab locator to avoid sidebar button clash (#723)**
- **fix: use reactive db facade for sdk message write paths (#724)**
- **fix(e2e): update mission-creation selectors for two-step wizard flow (#725)**
- **refactor: unify message delivery semantics + align TaskView pending UX (#726)**
- **docs: document Task 4 verification - all E2E tests pass on dev CI (#729)**
- **chore: bump version to 0.8.0 (#728)**
- **docs: document Task 4 verification - all E2E tests pass on dev CI (#731)**
- **docs: update verification doc with final CI run info (#732)**
- **chore(release): sync main history + release automation for v0.8.0 (#733)**
- **chore: update dependencies and pin all versions to exact (#736)**
- **plan: TaskViewV2 turn-based conversation summary with slide-out panels (#666)**
- **chore: update @anthropic-ai/claude-agent-sdk to 0.2.81 (#737)**
- **feat: implement ReadonlySessionChat and SlideOutPanel components (#739)**
- **test: unit tests for ReadonlySessionChat and SlideOutPanel (#741)**
- **feat: extract shared hooks, sub-components, constants from TaskView/TaskConversationRenderer (#740)**
- **feat: define TurnBlock types and implement useTurnBlocks hook (#742)**
- **test: add real-time delta tests for useTurnBlocks (#743)**
- **feat: implement TurnSummaryBlock component (#744)**
- **feat: implement RuntimeMessageRenderer component with unit tests (#745)**
- **test: unit tests for TurnSummaryBlock component (#746)**
- **feat: add client-side pagination to TaskView message list (#738)**
- **feat: implement TaskViewV2 component with turn-based conversation view (#747)**
- **feat: implement TaskViewToggle and integrate into Room.tsx (#748)**
- **test: E2E tests for TaskViewV2 toggle, persistence, and structural presence**
- **docs: plan for unifying agent communication and workflow graph model (#750)**
- **refactor: rename send_feedback to send_message in step agent tools (#751)**
- **test: clarify send_message rename from send_feedback in step-agent-tools.test.ts (#754)**
- **refactor: remove request_peer_input tool from step agent tools (#756)**
- **refactor: remove relay_message from Task Agent tool set (#755)**
- **test: add Task Agent channel topology tests to cross-agent messaging (#757)**
- **feat: give Task Agent the send_message tool via channel topology (#758)**
- **feat: add migration 45 to rename step to node in workflow tables (#752)**
- **fix: route human message to correct agent based on target parameter (#762)**
- **fix: prevent TaskView error on tab resume due to race condition (#761)**
- **feat: auto-create Task Agent channels on node addition (#760)**
- **test: add E2E tests for Task Agent visible node in visual editor (#759)**
- **feat: add channel edge rendering to EdgeRenderer (#763)**
- **test(e2e): add E2E tests for channel direction visualization (#764)**
- **feat: integrate channel edges into WorkflowCanvas (#765)**
- **task/task 21 rename shared types in spacets and space u (#753)**
- **refactor: rename step → node in storage repositories (#767)**
- **feat(TaskViewV2): UI/UX review — fix turn splitting, task-dispatch context, and renderable message window (#766)**
- **refactor: update step→node terminology in runtime comments and export-format (#768)**
- **feat: rename WorkflowStepCard to WorkflowNodeCard and update all references (#769)**
- **test: update all tests for step→node rename (#770)**
- **fix: reduce redundant concurrent tick spawn attempts (#771)**
- **fix: delete stale branch instead of falling back to UUID in worktree-manager (#772)**
- **fix: improve SDK startup timeout — exponential backoff, more retries, better diagnostics (#773)**
- **feat(TaskViewV2): AgentTurnBlock UI/UX polish + performance optimizations (#776)**
- **test: add unit tests for recurring mission schedule tools (set_schedule, pause_schedule, resume_schedule) (#778)**
- **fix(e2e): use exact text match for 'Message number 1' selector (#779)**
- **feat(visual-editor): add Task Agent virtual node to data model (#774)**
- **feat: extend WorkflowNodeAgent schema with role, model, systemPrompt fields (#777)**
- **feat(visual-editor): render Task Agent as distinct pinned node on canvas (#780)**
- **feat(visual-editor): add per-slot agent override UI with visual indicators (#783)**
- **test(space): add per-slot override tests for export/import pipeline (#782)**
- **feat(space): resolve base + override config at runtime when spawning agent sessions (#784)**
- **plan: simplify ID and folder path system (#787)**
- **feat(shared): add short ID utilities and prefix constants (#788)**
- **feat(storage): add migration 47 — short_id columns and short_id_counters table (#789)**
- **feat(daemon): add ShortIdAllocator service with atomic counter allocation (#790)**
- **feat(shared): add shortId field to NeoTask and RoomGoal interfaces (#791)**
- **feat(worktree): add getProjectShortKey and sentinel-based collision detection (#792)**
- **test(worktree): add TEST_WORKTREE_BASE_DIR override and old-path verifyWorktree tests (#794)**
- **feat(storage): add short ID assignment and backfill in TaskRepository (#793)**
- **feat(storage): add short ID assignment and backfill in GoalRepository (#task-23) (#795)**
- **feat(storage): wire ShortIdAllocator into TaskManager and GoalManager at all instantiation sites (#796)**
- **test(short-id): add multi-tenant isolation unit tests for scoped counters (#798)**
- **feat(lib): add ID resolution helpers for task and goal UUID/short-ID lookup (#800)**
- **docs: add agent memory research report with phased FTS5 + vector recommendation (#785)**
- **docs: add LSP integration research — Claude Agent SDK and native LSP options (#786)**
- **feat(web): replace flat progress bar with circular indicator in task list items (#801)**
- **fix(task): transition review task to in_progress when human sends a message (#802)**
- **fix(recurring): auto-compute nextRunAt and implement plan reuse (#781)**
- **feat(web): remove approve and cancel buttons from task list items (#803)**
- **feat(web): show room-specific bottom tabs on mobile when in room context (#804)**
- **feat(rpc): accept short IDs in goal handlers and expose shortId in responses (#805)**
- **fix(web): fix goal timestamp always showing "now", improve list item layout (#807)**
- **feat(leader): verify PR mergeability before submit_for_review (#808)**
- **feat(rpc): accept short IDs in task handlers and return shortId in responses (#task-32) (#806)**
- **feat(room): include shortId in TaskSummary for room.overview (#810)**
- **feat(web): update task URL route patterns to accept short IDs (#811)**
- **docs(plan): comprehensive MCP support review and external MCP integration (#797)**
- **feat(web): display short IDs in task cards with click-to-copy badge (#812)**
- **docs: document Planner web search capability (#815)**
- **test(short-id): add backward compatibility unit tests for legacy rows (#813)**
- **docs: add MCP architecture audit report (#816)**
- **feat(web): display short IDs in goals editor with click-to-copy badge (#817)**
- **feat(storage): add app_mcp_servers table, types, and repository (#818)**
- **test(short-id): add online integration test for full short ID lifecycle (#819)**
- **test(e2e): add short ID display and copy test; fix LiveQuery SQL missing short_id (#821)**
- **feat(mcp): add AppMcpLifecycleManager class and wire mcp.registry.listErrors RPC (#820)**
- **feat(mcp): seed default fetch-mcp and brave-search entries on daemon startup (#823)**
- **feat(task): make rate/usage limits first-class task concerns with persistence and auto-retry (#809)**
- **task/allow changing worker and leader model in task exp (#826)**
- **docs: Space V2 vs Room Gap Analysis (#828)**
- **fix(agent): always restart query when switching models mid-session (#827)**
- **docs: System-wide @ referencing system plan (#830)**
- **fix(goal-handlers): resolve short task IDs to full UUIDs in task.approve (#831)**
- **fix(web): fix pre-existing test regressions in final regression pass (#824)**
- **refactor(ui): reduce task list info density and update mobile room bottom nav (#829)**
- **feat(shared): define reference types for @ referencing system (#835)**
- **feat(web): add useReferenceAutocomplete hook for @ reference system (#836)**
- **feat(file-index): implement workspace file index with polling-based cache refresh (#837)**
- **feat(reference): implement reference.resolve RPC handler with shared types (#839)**
- **fix(agent): clear models cache on restart/reset to fix mid-turn model switch (#834)**
- **feat(web): add ReferenceAutocomplete component for @ reference system (#843)**
- **feat(references): implement file/folder resolvers and shared reference types (#842)**
- **feat(reference): implement reference.search RPC handler with FileIndex (#841)**
- **feat(web): integrate reference autocomplete with InputTextarea (#846)**
- **feat(agent): create ReferenceResolver service and shared reference types (#838)**
- **feat(session): implement message preprocessing with @ reference resolution (#844)**
- **feat(web): integrate reference autocomplete with MessageInput (#845)**
- **feat(web): add MentionToken component for @ reference rendering (#850)**
- **feat(web): integrate @ref token rendering in SDKUserMessage (#852)**
- **feat(e2e): add room entity and reference autocomplete helpers (#851)**
- **task/mobile ux and touch support (#849)**
- **feat(agent): implement agent context injection for @ references (#3.4) (#848)**
- **test(e2e): add reference autocomplete E2E tests and helpers (#854)**
- **feat(references): apply faded strikethrough visual state for deleted @ref entities (#853)**
- **feat(web,e2e): integrate MentionToken rendering and add reference autocomplete E2E tests (#855)**
- **test(e2e): add edge cases, mobile, and accessibility tests for reference autocomplete (#856)**
- **feat(rpc): add MCP registry CRUD handlers and mcpServers.global LiveQuery (#822)**
- **feat(room): integrate AppMcpLifecycleManager into RoomRuntimeService (Task 3.2) (#858)**
- **feat(room): inject merged MCP servers into worker sessions via setRuntimeMcpServers() (Task 3.3) (#860)**
- **task/task 34 integrate lifecycle manager into space mod (#861)**
- **Plan: Refactor Space Workflow from Step-Centric to Agent-Centric Collaboration Model (#857)**
- **feat(space): add completion_summary to space_tasks for agent completion state (#862)**
- **feat(space): add report_done MCP tool to step agents (#863)**
- **feat(space): unified channel resolution with resolveChannels() and validateChannels() (#864)**
- **feat(storage+rpc): add per-room MCP enablement storage and RPC (Task 4.1) (#825)**
- **feat(mcp): wire per-room enablement into AppMcpLifecycleManager (Task 4.2) (#872)**
- **feat(web): add MCP registry API helpers and LiveQuery store (Task 5.1) (#873)**
- **feat(web): add Application-Level MCP Settings Panel (Task 5.2) (#875)**
- **feat(web): add per-room MCP enablement UI in RoomSettings (Task 5.3) (#874)**
- **test(e2e): add MCP registry UI and per-room enable/disable E2E test (Task 7.1) (#876)**
- **fix(room): route task session model switches through RoomRuntimeService (#871)**
- **test(space): add report_done tool and unit tests for agent completion signaling (#865)**
- **feat(space): extend WorkflowChannel type and rename WorkflowNodeAgent.role to .name (#868)**
- **feat(space): add agent liveness guard with report_done timeout (Task 2.6) (#878)**
- **feat(space): add ChannelGateEvaluator for agent-centric channel gate enforcement (#881)**
- **feat(shared): extend ResolvedChannel with gate field for policy enforcement (#880)**
- **feat(db): add unified channels column to space_workflows (Migration 53) (#882)**
- **feat(web): update visual workflow editor to display and configure channels (Task 7.1)**
