### PR TITLE
test(space): add comprehensive tests for unified channels and gates

### DIFF
--- a/packages/daemon/tests/unit/space/channel-gate-evaluator.test.ts
+++ b/packages/daemon/tests/unit/space/channel-gate-evaluator.test.ts
@@ -64,6 +64,18 @@ function makeThrowRunner(message: string): ChannelCommandRunner {
 	};
 }
 
+/** Returns a runner that records the timeoutMs argument it was called with. */
+function makeCapturingRunner(): { runner: ChannelCommandRunner; getTimeout: () => number } {
+	let capturedTimeout = -1;
+	return {
+		runner: async (_args, _cwd, timeoutMs) => {
+			capturedTimeout = timeoutMs;
+			return { exitCode: 0 };
+		},
+		getTimeout: () => capturedTimeout,
+	};
+}
+
 // ---------------------------------------------------------------------------
 // Tests: no gate
 // ---------------------------------------------------------------------------
@@ -275,6 +287,12 @@ describe('ChannelGateEvaluator — task_result gate', () => {
 
 // ---------------------------------------------------------------------------
 // Tests: evaluateCondition (public method, direct access)
+//
+// These tests intentionally exercise evaluateCondition() as a public API
+// contract — callers can evaluate conditions outside of a channel (e.g.
+// testing individual gate expressions in isolation).  The condition/task_result
+// cases intentionally overlap with the evaluate() tests above to confirm the
+// public method returns the same results regardless of call path.
 // ---------------------------------------------------------------------------
 
 describe('ChannelGateEvaluator.evaluateCondition', () => {
@@ -302,6 +320,8 @@ describe('ChannelGateEvaluator.evaluateCondition', () => {
 		expect(result.allowed).toBe(true);
 	});
 
+	// These confirm evaluateCondition() returns the same result as evaluate()
+	// for condition/task_result, verifying the public API is a faithful delegate.
 	test('evaluates condition gate directly — allowed on exit 0', async () => {
 		const evaluator = new ChannelGateEvaluator(makeOkRunner());
 		const result = await evaluator.evaluateCondition(
@@ -347,71 +367,53 @@ describe('ChannelGateEvaluator.evaluateCondition', () => {
 
 describe('ChannelGateEvaluator — condition gate timeoutMs', () => {
 	test('default timeout (60 000 ms) is used when no timeoutMs specified', async () => {
-		let capturedTimeout = -1;
-		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
-			capturedTimeout = timeoutMs;
-			return { exitCode: 0 };
-		};
-		const evaluator = new ChannelGateEvaluator(capturingRunner);
-		const channel = makeChannel({ gate: { type: 'condition', expression: 'true' } });
-		await evaluator.evaluate(channel, makeContext());
-		expect(capturedTimeout).toBe(60_000);
+		const { runner, getTimeout } = makeCapturingRunner();
+		const evaluator = new ChannelGateEvaluator(runner);
+		await evaluator.evaluate(
+			makeChannel({ gate: { type: 'condition', expression: 'true' } }),
+			makeContext()
+		);
+		expect(getTimeout()).toBe(60_000);
 	});
 
 	test('custom timeoutMs within valid range is passed to the command runner', async () => {
-		let capturedTimeout = -1;
-		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
-			capturedTimeout = timeoutMs;
-			return { exitCode: 0 };
-		};
-		const evaluator = new ChannelGateEvaluator(capturingRunner);
-		const channel = makeChannel({
-			gate: { type: 'condition', expression: 'true', timeoutMs: 5_000 },
-		});
-		await evaluator.evaluate(channel, makeContext());
-		expect(capturedTimeout).toBe(5_000);
+		const { runner, getTimeout } = makeCapturingRunner();
+		const evaluator = new ChannelGateEvaluator(runner);
+		await evaluator.evaluate(
+			makeChannel({ gate: { type: 'condition', expression: 'true', timeoutMs: 5_000 } }),
+			makeContext()
+		);
+		expect(getTimeout()).toBe(5_000);
 	});
 
 	test('timeoutMs above 300 000 ms is clamped to 300 000', async () => {
-		let capturedTimeout = -1;
-		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
-			capturedTimeout = timeoutMs;
-			return { exitCode: 0 };
-		};
-		const evaluator = new ChannelGateEvaluator(capturingRunner);
-		const channel = makeChannel({
-			gate: { type: 'condition', expression: 'true', timeoutMs: 999_999 },
-		});
-		await evaluator.evaluate(channel, makeContext());
-		expect(capturedTimeout).toBe(300_000);
+		const { runner, getTimeout } = makeCapturingRunner();
+		const evaluator = new ChannelGateEvaluator(runner);
+		await evaluator.evaluate(
+			makeChannel({ gate: { type: 'condition', expression: 'true', timeoutMs: 999_999 } }),
+			makeContext()
+		);
+		expect(getTimeout()).toBe(300_000);
 	});
 
 	test('timeoutMs of 0 falls back to default 60 000 ms', async () => {
-		let capturedTimeout = -1;
-		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
-			capturedTimeout = timeoutMs;
-			return { exitCode: 0 };
-		};
-		const evaluator = new ChannelGateEvaluator(capturingRunner);
-		const channel = makeChannel({
-			gate: { type: 'condition', expression: 'true', timeoutMs: 0 },
-		});
-		await evaluator.evaluate(channel, makeContext());
-		expect(capturedTimeout).toBe(60_000);
+		const { runner, getTimeout } = makeCapturingRunner();
+		const evaluator = new ChannelGateEvaluator(runner);
+		await evaluator.evaluate(
+			makeChannel({ gate: { type: 'condition', expression: 'true', timeoutMs: 0 } }),
+			makeContext()
+		);
+		expect(getTimeout()).toBe(60_000);
 	});
 
 	test('negative timeoutMs falls back to default 60 000 ms', async () => {
-		let capturedTimeout = -1;
-		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
-			capturedTimeout = timeoutMs;
-			return { exitCode: 0 };
-		};
-		const evaluator = new ChannelGateEvaluator(capturingRunner);
-		const channel = makeChannel({
-			gate: { type: 'condition', expression: 'true', timeoutMs: -100 },
-		});
-		await evaluator.evaluate(channel, makeContext());
-		expect(capturedTimeout).toBe(60_000);
+		const { runner, getTimeout } = makeCapturingRunner();
+		const evaluator = new ChannelGateEvaluator(runner);
+		await evaluator.evaluate(
+			makeChannel({ gate: { type: 'condition', expression: 'true', timeoutMs: -100 } }),
+			makeContext()
+		);
+		expect(getTimeout()).toBe(60_000);
 	});
 });
 

--- a/packages/daemon/tests/unit/space/channel-gate-evaluator.test.ts
+++ b/packages/daemon/tests/unit/space/channel-gate-evaluator.test.ts
@@ -301,6 +301,118 @@ describe('ChannelGateEvaluator.evaluateCondition', () => {
 		);
 		expect(result.allowed).toBe(true);
 	});
+
+	test('evaluates condition gate directly — allowed on exit 0', async () => {
+		const evaluator = new ChannelGateEvaluator(makeOkRunner());
+		const result = await evaluator.evaluateCondition(
+			{ type: 'condition', expression: 'echo ok' },
+			makeContext()
+		);
+		expect(result.allowed).toBe(true);
+	});
+
+	test('evaluates condition gate directly — blocked on non-zero exit', async () => {
+		const evaluator = new ChannelGateEvaluator(makeFailRunner(1));
+		const result = await evaluator.evaluateCondition(
+			{ type: 'condition', expression: 'false' },
+			makeContext()
+		);
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toMatch(/^Gate blocked:/);
+	});
+
+	test('evaluates task_result gate directly — allowed on prefix match', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const result = await evaluator.evaluateCondition(
+			{ type: 'task_result', expression: 'ci_passed' },
+			makeContext({ taskResult: 'ci_passed: all 42 checks green' })
+		);
+		expect(result.allowed).toBe(true);
+	});
+
+	test('evaluates task_result gate directly — blocked on mismatch', async () => {
+		const evaluator = new ChannelGateEvaluator();
+		const result = await evaluator.evaluateCondition(
+			{ type: 'task_result', expression: 'ci_passed' },
+			makeContext({ taskResult: 'ci_failed' })
+		);
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toMatch(/^Gate blocked:/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: condition gate timeoutMs propagation
+// ---------------------------------------------------------------------------
+
+describe('ChannelGateEvaluator — condition gate timeoutMs', () => {
+	test('default timeout (60 000 ms) is used when no timeoutMs specified', async () => {
+		let capturedTimeout = -1;
+		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
+			capturedTimeout = timeoutMs;
+			return { exitCode: 0 };
+		};
+		const evaluator = new ChannelGateEvaluator(capturingRunner);
+		const channel = makeChannel({ gate: { type: 'condition', expression: 'true' } });
+		await evaluator.evaluate(channel, makeContext());
+		expect(capturedTimeout).toBe(60_000);
+	});
+
+	test('custom timeoutMs within valid range is passed to the command runner', async () => {
+		let capturedTimeout = -1;
+		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
+			capturedTimeout = timeoutMs;
+			return { exitCode: 0 };
+		};
+		const evaluator = new ChannelGateEvaluator(capturingRunner);
+		const channel = makeChannel({
+			gate: { type: 'condition', expression: 'true', timeoutMs: 5_000 },
+		});
+		await evaluator.evaluate(channel, makeContext());
+		expect(capturedTimeout).toBe(5_000);
+	});
+
+	test('timeoutMs above 300 000 ms is clamped to 300 000', async () => {
+		let capturedTimeout = -1;
+		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
+			capturedTimeout = timeoutMs;
+			return { exitCode: 0 };
+		};
+		const evaluator = new ChannelGateEvaluator(capturingRunner);
+		const channel = makeChannel({
+			gate: { type: 'condition', expression: 'true', timeoutMs: 999_999 },
+		});
+		await evaluator.evaluate(channel, makeContext());
+		expect(capturedTimeout).toBe(300_000);
+	});
+
+	test('timeoutMs of 0 falls back to default 60 000 ms', async () => {
+		let capturedTimeout = -1;
+		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
+			capturedTimeout = timeoutMs;
+			return { exitCode: 0 };
+		};
+		const evaluator = new ChannelGateEvaluator(capturingRunner);
+		const channel = makeChannel({
+			gate: { type: 'condition', expression: 'true', timeoutMs: 0 },
+		});
+		await evaluator.evaluate(channel, makeContext());
+		expect(capturedTimeout).toBe(60_000);
+	});
+
+	test('negative timeoutMs falls back to default 60 000 ms', async () => {
+		let capturedTimeout = -1;
+		const capturingRunner: ChannelCommandRunner = async (_args, _cwd, timeoutMs) => {
+			capturedTimeout = timeoutMs;
+			return { exitCode: 0 };
+		};
+		const evaluator = new ChannelGateEvaluator(capturingRunner);
+		const channel = makeChannel({
+			gate: { type: 'condition', expression: 'true', timeoutMs: -100 },
+		});
+		await evaluator.evaluate(channel, makeContext());
+		expect(capturedTimeout).toBe(60_000);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/space/channel-resolution.test.ts
+++ b/packages/daemon/tests/unit/space/channel-resolution.test.ts
@@ -565,4 +565,58 @@ describe('resolveChannels — gate field', () => {
 
 		expect(result[0].gate).toEqual(humanGate);
 	});
+
+	test('gate with always type is propagated correctly', () => {
+		const alwaysGate: WorkflowCondition = { type: 'always' };
+		const node = makeNode('n1', 'Node1', [
+			{ name: 'coder', agentId: 'agent-coder' },
+			{ name: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way', gate: alwaysGate }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result[0].gate).toEqual(alwaysGate);
+	});
+
+	test('gate with task_result type is propagated correctly', () => {
+		const taskResultGate: WorkflowCondition = { type: 'task_result', expression: 'ci_passed' };
+		const node = makeNode('n1', 'Node1', [
+			{ name: 'coder', agentId: 'agent-coder' },
+			{ name: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const wf = makeWorkflow(
+			[node],
+			[{ from: 'coder', to: 'reviewer', direction: 'one-way', gate: taskResultGate }]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result[0].gate).toEqual(taskResultGate);
+	});
+
+	test('multiple channels with different gate types all propagated correctly', () => {
+		const node = makeNode('n1', 'Node1', [
+			{ name: 'planner', agentId: 'agent-planner' },
+			{ name: 'coder', agentId: 'agent-coder' },
+			{ name: 'reviewer', agentId: 'agent-reviewer' },
+		]);
+		const plannerGate: WorkflowCondition = { type: 'always' };
+		const reviewGate: WorkflowCondition = { type: 'task_result', expression: 'tests_pass' };
+		const wf = makeWorkflow(
+			[node],
+			[
+				{ from: 'planner', to: 'coder', direction: 'one-way', gate: plannerGate },
+				{ from: 'coder', to: 'reviewer', direction: 'one-way', gate: reviewGate },
+			]
+		);
+		const result = resolveChannels(wf);
+
+		expect(result).toHaveLength(2);
+		const plannerToCoder = result.find((r) => r.fromRole === 'planner');
+		const coderToReviewer = result.find((r) => r.fromRole === 'coder');
+		expect(plannerToCoder?.gate).toEqual(plannerGate);
+		expect(coderToReviewer?.gate).toEqual(reviewGate);
+	});
 });


### PR DESCRIPTION
Adds 12 new tests across two test files to fill coverage gaps:

channel-gate-evaluator.test.ts (+9 tests):
- evaluateCondition() direct tests for condition and task_result gate types
- timeoutMs propagation: default (60s), custom within range, clamped at max
  (300s), zero falls back to default, negative falls back to default

channel-resolution.test.ts (+3 tests):
- Gate propagation for 'always' type
- Gate propagation for 'task_result' type
- Multiple channels with different gate types all propagated correctly

Total: 112 tests pass across channel-resolution, channel-gate-evaluator, and
channel-resolver test suites (was 100).
