### PR TITLE
feat(space): add ChannelRouter with lazy node activation (Task 3.0)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -173,6 +173,13 @@ export class ChannelRouter {
 			} catch (err) {
 				// Detect DB UNIQUE constraint violation caused by a concurrent activateNode() call.
 				// The winning writer already created the tasks — re-read and return them.
+				//
+				// Note on partial-activation tradeoff: when the violation occurs on the nth
+				// agent slot (n > 1), the tasks already pushed to `tasks` earlier in this
+				// loop are silently discarded in favour of the re-read set. This is safe
+				// because both callers resolved task metadata from the same DB state, so the
+				// winning writer's tasks are equivalent. The returned set is guaranteed to be
+				// a superset of what this caller created so far, so no task is lost.
 				if (isDuplicateConstraintError(err)) {
 					const concurrentTasks = this.getActiveTasksForNode(runId, nodeId);
 					if (concurrentTasks.length > 0) {
@@ -253,6 +260,13 @@ export class ChannelRouter {
 	 *
 	 * Terminal tasks (completed, cancelled, needs_attention, archived) are
 	 * excluded so cyclic workflows can re-activate a node after its tasks complete.
+	 *
+	 * `draft` is intentionally excluded even though it is a valid `SpaceTaskStatus`.
+	 * The ChannelRouter always creates tasks with `status: 'pending'` — `draft` is
+	 * reserved for tasks created by external callers that are not yet ready to run.
+	 * The Migration 54 index matches this exclusion, meaning two draft tasks for the
+	 * same (run, node, slot) are allowed to coexist. Callers that create draft tasks
+	 * outside ChannelRouter must manage uniqueness themselves.
 	 */
 	private getActiveTasksForNode(runId: string, nodeId: string): SpaceTask[] {
 		const ACTIVE_STATUSES = new Set([

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -1,0 +1,312 @@
+/**
+ * ChannelRouter — lazy node activation for agent-centric workflow execution.
+ *
+ * When a message arrives for a target agent role whose node has no active tasks,
+ * the router creates pending SpaceTask records on-demand (lazy activation).
+ * This replaces the step-centric model where the executor always pre-created
+ * tasks for the next node eagerly.
+ *
+ * Key design decisions:
+ * - activateNode() is idempotent: if tasks already exist for the node the
+ *   existing tasks are returned unchanged.
+ * - Concurrency is handled via a DB UNIQUE partial index on
+ *   (workflow_run_id, workflow_node_id, slot_role). A duplicate INSERT throws
+ *   a SQLiteError; the handler re-reads and returns the tasks created by the
+ *   winning writer.
+ * - No session group creation — that is the responsibility of TaskAgentManager.
+ *   ChannelRouter only creates SpaceTask DB records.
+ */
+
+import type { SpaceTask, SpaceTaskType, SpaceWorkflow, WorkflowNode } from '@neokai/shared';
+import { resolveNodeAgents } from '@neokai/shared';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import type { SpaceAgentManager } from '../managers/space-agent-manager';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Resolved task-type metadata for a single agent slot */
+interface ResolvedTaskType {
+	taskType: SpaceTaskType;
+	customAgentId: string | undefined;
+}
+
+/**
+ * Return value from deliverMessage().
+ * Callers can inspect `activatedTasks` to know whether a lazy activation occurred.
+ */
+export interface DeliveredMessage {
+	/** Workflow run ID */
+	runId: string;
+	/** Role of the sending agent */
+	fromRole: string;
+	/** Role of the receiving agent */
+	toRole: string;
+	/** The message content */
+	message: string;
+	/** Node ID of the target agent */
+	targetNodeId: string;
+	/**
+	 * Tasks created by lazy activation, or undefined when the node was already active.
+	 * An empty array is never returned — either undefined (already active) or ≥1 tasks.
+	 */
+	activatedTasks?: SpaceTask[];
+}
+
+// ---------------------------------------------------------------------------
+// ActivationError
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by activateNode() for unrecoverable problems such as a missing run
+ * or workflow, a node that does not exist, or an attempted activation on a
+ * run that has already reached a terminal state.
+ */
+export class ActivationError extends Error {
+	constructor(
+		message: string,
+		public readonly cause?: unknown
+	) {
+		super(message);
+		this.name = 'ActivationError';
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface ChannelRouterConfig {
+	/** Task repository for creating and querying SpaceTask records */
+	taskRepo: SpaceTaskRepository;
+	/** Workflow run repository for reading run metadata */
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Workflow manager for loading workflow definitions */
+	workflowManager: SpaceWorkflowManager;
+	/** Agent manager for resolving agent roles → task types */
+	agentManager: SpaceAgentManager;
+}
+
+// ---------------------------------------------------------------------------
+// ChannelRouter
+// ---------------------------------------------------------------------------
+
+export class ChannelRouter {
+	constructor(private readonly config: ChannelRouterConfig) {}
+
+	// -------------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Lazily activate a workflow node by creating a pending SpaceTask for each
+	 * agent declared on the node.
+	 *
+	 * Idempotency rules (checked in order):
+	 * 1. If non-cancelled tasks already exist for (runId, nodeId) → return them.
+	 * 2. If a concurrent writer beats this call (UNIQUE constraint violation) →
+	 *    re-read and return the tasks created by the winning writer.
+	 *
+	 * @param runId  - ID of the SpaceWorkflowRun that owns the node
+	 * @param nodeId - ID of the WorkflowNode to activate
+	 * @returns Array of created (or pre-existing) SpaceTask records (≥ 1)
+	 * @throws ActivationError when the run/workflow/node is not found, or the
+	 *   run is in a terminal state (cancelled / completed)
+	 */
+	async activateNode(runId: string, nodeId: string): Promise<SpaceTask[]> {
+		// ── 1. Load the run ────────────────────────────────────────────────────
+		const run = this.config.workflowRunRepo.getRun(runId);
+		if (!run) {
+			throw new ActivationError(`Run not found: ${runId}`);
+		}
+		if (run.status === 'cancelled' || run.status === 'completed') {
+			throw new ActivationError(`Cannot activate node for run in status "${run.status}": ${runId}`);
+		}
+
+		// ── 2. Idempotency check — return existing active tasks if present ─────
+		const existingTasks = this.getActiveTasksForNode(runId, nodeId);
+		if (existingTasks.length > 0) {
+			return existingTasks;
+		}
+
+		// ── 3. Resolve the workflow and node ───────────────────────────────────
+		const workflow = this.config.workflowManager.getWorkflow(run.workflowId);
+		if (!workflow) {
+			throw new ActivationError(`Workflow not found: ${run.workflowId}`);
+		}
+		const node = workflow.nodes.find((n) => n.id === nodeId);
+		if (!node) {
+			throw new ActivationError(`Node "${nodeId}" not found in workflow "${run.workflowId}"`);
+		}
+
+		// ── 4. Resolve agent slots and create one task per slot ───────────────
+		let agents: ReturnType<typeof resolveNodeAgents>;
+		try {
+			agents = resolveNodeAgents(node);
+		} catch (err) {
+			throw new ActivationError(
+				`Cannot resolve agents for node "${nodeId}": ${err instanceof Error ? err.message : String(err)}`,
+				err
+			);
+		}
+
+		const tasks: SpaceTask[] = [];
+		for (const agentEntry of agents) {
+			const resolved = this.resolveTaskTypeForAgent(agentEntry.agentId);
+			try {
+				const task = this.config.taskRepo.createTask({
+					spaceId: run.spaceId,
+					title: node.name,
+					description: agentEntry.instructions ?? node.instructions ?? '',
+					workflowRunId: runId,
+					workflowNodeId: nodeId,
+					taskType: resolved.taskType,
+					customAgentId: resolved.customAgentId,
+					slotRole: agentEntry.name,
+					status: 'pending',
+					goalId: run.goalId,
+				});
+				tasks.push(task);
+			} catch (err) {
+				// Detect DB UNIQUE constraint violation caused by a concurrent activateNode() call.
+				// The winning writer already created the tasks — re-read and return them.
+				if (isDuplicateConstraintError(err)) {
+					const concurrentTasks = this.getActiveTasksForNode(runId, nodeId);
+					if (concurrentTasks.length > 0) {
+						return concurrentTasks;
+					}
+				}
+				throw new ActivationError(
+					`Failed to create task for agent "${agentEntry.name}" on node "${nodeId}": ${err instanceof Error ? err.message : String(err)}`,
+					err
+				);
+			}
+		}
+
+		return tasks;
+	}
+
+	/**
+	 * Deliver a message from one agent role to another within a workflow run.
+	 *
+	 * If the target role's node has no active tasks the node is lazily activated
+	 * (pending SpaceTask records created) before returning.
+	 *
+	 * @param runId    - Workflow run ID
+	 * @param fromRole - Role name of the sending agent (WorkflowNodeAgent.name)
+	 * @param toRole   - Role name of the receiving agent (WorkflowNodeAgent.name)
+	 * @param message  - Message content to deliver
+	 * @returns DeliveredMessage descriptor; `activatedTasks` is set when the
+	 *   target node was lazily activated, undefined when it was already active
+	 * @throws ActivationError when the run, workflow, or target role is not found
+	 */
+	async deliverMessage(
+		runId: string,
+		fromRole: string,
+		toRole: string,
+		message: string
+	): Promise<DeliveredMessage> {
+		// ── 1. Load the run and workflow ───────────────────────────────────────
+		const run = this.config.workflowRunRepo.getRun(runId);
+		if (!run) {
+			throw new ActivationError(`Run not found: ${runId}`);
+		}
+
+		const workflow = this.config.workflowManager.getWorkflow(run.workflowId);
+		if (!workflow) {
+			throw new ActivationError(`Workflow not found: ${run.workflowId}`);
+		}
+
+		// ── 2. Locate the node that owns the target role ───────────────────────
+		const targetNode = this.findNodeByAgentRole(workflow, toRole);
+		if (!targetNode) {
+			throw new ActivationError(
+				`No node found with agent role "${toRole}" in workflow "${run.workflowId}"`
+			);
+		}
+
+		// ── 3. Lazy activation ─────────────────────────────────────────────────
+		const activeTasks = this.getActiveTasksForNode(runId, targetNode.id);
+		let activatedTasks: SpaceTask[] | undefined;
+
+		if (activeTasks.length === 0) {
+			activatedTasks = await this.activateNode(runId, targetNode.id);
+		}
+
+		return { runId, fromRole, toRole, message, targetNodeId: targetNode.id, activatedTasks };
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns all in-flight tasks for a given (runId, nodeId) pair.
+	 *
+	 * "In-flight" means the task is in an active (non-terminal) status:
+	 * pending, in_progress, review, rate_limited, or usage_limited.
+	 * This mirrors the partial index constraint in Migration 54 so the
+	 * application-level check stays consistent with the DB-level constraint.
+	 *
+	 * Terminal tasks (completed, cancelled, needs_attention, archived) are
+	 * excluded so cyclic workflows can re-activate a node after its tasks complete.
+	 */
+	private getActiveTasksForNode(runId: string, nodeId: string): SpaceTask[] {
+		const ACTIVE_STATUSES = new Set([
+			'pending',
+			'in_progress',
+			'review',
+			'rate_limited',
+			'usage_limited',
+		]);
+		return this.config.taskRepo
+			.listByWorkflowRun(runId)
+			.filter((t) => t.workflowNodeId === nodeId && ACTIVE_STATUSES.has(t.status));
+	}
+
+	/**
+	 * Searches workflow nodes for the first node that has an agent slot with the
+	 * given role name. Returns undefined when no node matches.
+	 */
+	private findNodeByAgentRole(workflow: SpaceWorkflow, role: string): WorkflowNode | undefined {
+		for (const node of workflow.nodes) {
+			try {
+				const agents = resolveNodeAgents(node);
+				if (agents.some((a) => a.name === role)) return node;
+			} catch {
+				// Skip malformed nodes (neither agentId nor agents defined)
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Resolves the SpaceTaskType and optional customAgentId for an agent ID.
+	 * Mirrors SpaceRuntime.resolveTaskTypeForAgent() so task creation is consistent.
+	 */
+	private resolveTaskTypeForAgent(agentId: string): ResolvedTaskType {
+		const agent = this.config.agentManager.getById(agentId);
+		if (!agent) return { taskType: 'coding', customAgentId: agentId };
+		if (agent.role === 'planner') return { taskType: 'planning', customAgentId: undefined };
+		if (agent.role === 'coder' || agent.role === 'general') {
+			return { taskType: 'coding', customAgentId: undefined };
+		}
+		// Custom role
+		return { taskType: 'coding', customAgentId: agentId };
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when `err` is a SQLite UNIQUE constraint violation.
+ * Bun's SQLite driver throws an Error whose message contains "UNIQUE constraint failed".
+ */
+function isDuplicateConstraintError(err: unknown): boolean {
+	return err instanceof Error && err.message.includes('UNIQUE constraint failed');
+}

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -449,7 +449,19 @@ export class WorkflowExecutor {
 		// Create one pending SpaceTask per agent. All tasks share the same workflowRunId
 		// and workflowNodeId so SpaceRuntime can track them as a group.
 		// Per-agent instructions override step-level instructions when present.
+		//
+		// Idempotency: if the target node already has active tasks for a given agent slot
+		// (detected via UNIQUE constraint violation on workflow_run_id+workflow_node_id+slot_role),
+		// reuse the existing task. This handles both cyclic re-activation and concurrent
+		// activateNode() calls racing with followTransition().
 		const tasks: SpaceTask[] = [];
+		const ACTIVE_STATUSES = new Set([
+			'pending',
+			'in_progress',
+			'review',
+			'rate_limited',
+			'usage_limited',
+		]);
 		for (const agentEntry of stepAgents) {
 			// Resolve task metadata per agent so each task is created complete in one DB write.
 			// When a taskTypeResolver is provided it fully controls taskType AND customAgentId —
@@ -457,17 +469,36 @@ export class WorkflowExecutor {
 			// Without a resolver (backward-compat), fall back to agentEntry.agentId.
 			const resolved = this.taskTypeResolver?.(nextStep, agentEntry);
 
-			const task = await this.taskManager.createTask({
-				title: nextStep.name,
-				description: agentEntry.instructions ?? nextStep.instructions ?? '',
-				workflowRunId: this.run.id,
-				workflowNodeId: nextStep.id,
-				taskType: resolved?.taskType as import('@neokai/shared').SpaceTaskType | undefined,
-				customAgentId: resolved !== undefined ? resolved.customAgentId : agentEntry.agentId,
-				slotRole: agentEntry.name,
-				status: 'pending',
-				goalId: this.run.goalId,
-			});
+			let task: SpaceTask;
+			try {
+				task = await this.taskManager.createTask({
+					title: nextStep.name,
+					description: agentEntry.instructions ?? nextStep.instructions ?? '',
+					workflowRunId: this.run.id,
+					workflowNodeId: nextStep.id,
+					taskType: resolved?.taskType as import('@neokai/shared').SpaceTaskType | undefined,
+					customAgentId: resolved !== undefined ? resolved.customAgentId : agentEntry.agentId,
+					slotRole: agentEntry.name,
+					status: 'pending',
+					goalId: this.run.goalId,
+				});
+			} catch (err) {
+				// UNIQUE constraint violation: another writer already created a task for this slot.
+				// Re-read and return the existing active task rather than failing.
+				if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+					const existingTasks = (await this.taskManager.listTasksByWorkflowRun(this.run.id)).filter(
+						(t) =>
+							t.workflowNodeId === nextStep.id &&
+							t.slotRole === agentEntry.name &&
+							ACTIVE_STATUSES.has(t.status)
+					);
+					if (existingTasks.length > 0) {
+						tasks.push(existingTasks[0]);
+						continue;
+					}
+				}
+				throw err;
+			}
 
 			tasks.push(task);
 		}

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -214,6 +214,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// WorkflowChannel[]). Existing rows that have channels embedded in config are migrated
 	// in-place so no data is lost.
 	runMigration53(db);
+
+	// Migration 54: Add unique partial index on space_tasks (workflow_run_id, workflow_node_id,
+	// slot_role) to enforce at-most-one task per agent slot per workflow node per run.
+	// Prevents duplicate tasks from concurrent ChannelRouter.activateNode() calls.
+	runMigration54(db);
 }
 
 /**
@@ -3263,4 +3268,44 @@ export function runMigration53(db: BunDatabase): void {
 			);
 		}
 	}
+}
+
+/**
+ * Migration 54: Add unique partial index on space_tasks for lazy node activation.
+ *
+ * Enforces at-most-one in-flight task per (workflow_run_id, workflow_node_id, slot_role)
+ * tuple, preventing duplicate tasks when multiple concurrent ChannelRouter.activateNode()
+ * calls race to activate the same node.
+ *
+ * The partial WHERE clause restricts the uniqueness guarantee to "active" statuses only
+ * (pending, in_progress, review, rate_limited, usage_limited). Terminal statuses
+ * (completed, cancelled, needs_attention, archived, draft) are excluded so that:
+ * - Cyclic workflows can re-activate a node after its tasks complete
+ * - Failed/cancelled activations can be retried without hitting the constraint
+ *
+ * The NULL exclusions preserve backward-compat with legacy tasks that predate the
+ * channel/slot system (agentId-shorthand tasks with NULL workflow_node_id or slot_role).
+ *
+ * Idempotent via CREATE UNIQUE INDEX IF NOT EXISTS.
+ */
+export function runMigration54(db: BunDatabase): void {
+	// Guard: only create the index when the required columns exist.
+	// `workflow_node_id` may still be named `workflow_step_id` on DBs whose migration 39
+	// rebuild ran after migration 45's rename (an uncommon but valid test-fixture path).
+	// `slot_role` was added by migration 46; guard prevents failure on older DB states.
+	if (
+		!tableExists(db, 'space_tasks') ||
+		!tableHasColumn(db, 'space_tasks', 'workflow_node_id') ||
+		!tableHasColumn(db, 'space_tasks', 'slot_role')
+	) {
+		return;
+	}
+	db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_space_tasks_run_node_agent
+    ON space_tasks (workflow_run_id, workflow_node_id, slot_role)
+    WHERE workflow_run_id IS NOT NULL
+      AND workflow_node_id IS NOT NULL
+      AND slot_role IS NOT NULL
+      AND status IN ('pending', 'in_progress', 'review', 'rate_limited', 'usage_limited')
+  `);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -3277,11 +3277,16 @@ export function runMigration53(db: BunDatabase): void {
  * tuple, preventing duplicate tasks when multiple concurrent ChannelRouter.activateNode()
  * calls race to activate the same node.
  *
- * The partial WHERE clause restricts the uniqueness guarantee to "active" statuses only
- * (pending, in_progress, review, rate_limited, usage_limited). Terminal statuses
- * (completed, cancelled, needs_attention, archived, draft) are excluded so that:
- * - Cyclic workflows can re-activate a node after its tasks complete
- * - Failed/cancelled activations can be retried without hitting the constraint
+ * The partial WHERE clause restricts the uniqueness guarantee to "active" statuses only:
+ * pending, in_progress, review, rate_limited, usage_limited.
+ *
+ * Excluded statuses and rationale:
+ * - completed / cancelled / needs_attention / archived: terminal statuses excluded so
+ *   cyclic workflows can re-activate a node after tasks finish, and failed activations
+ *   can be retried.
+ * - draft: intentionally excluded because ChannelRouter never creates draft tasks and
+ *   draft is reserved for externally-managed tasks not yet ready to run. Two draft
+ *   tasks for the same slot may coexist; external callers own their uniqueness.
  *
  * The NULL exclusions preserve backward-compat with legacy tasks that predate the
  * channel/slot system (agentId-shorthand tasks with NULL workflow_node_id or slot_role).

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -1,0 +1,544 @@
+/**
+ * ChannelRouter Unit Tests
+ *
+ * Covers:
+ * - activateNode(): first activation creates tasks for each agent slot
+ * - activateNode(): idempotent — returns existing tasks on repeated calls
+ * - activateNode(): concurrent activation (UNIQUE constraint) handled gracefully
+ * - activateNode(): cancelled run throws ActivationError
+ * - activateNode(): completed run throws ActivationError
+ * - activateNode(): missing run throws ActivationError
+ * - activateNode(): missing workflow throws ActivationError
+ * - activateNode(): missing node throws ActivationError
+ * - activateNode(): multi-agent node creates one task per agent slot
+ * - deliverMessage(): auto-activates target node when no active tasks
+ * - deliverMessage(): does not re-activate when target node is already active
+ * - deliverMessage(): sets activatedTasks only on first activation
+ * - deliverMessage(): throws when target role not found in workflow
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { ChannelRouter, ActivationError } from '../../../src/lib/space/runtime/channel-router.ts';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-channel-router',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpace(db: BunDatabase, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function seedAgent(
+	db: BunDatabase,
+	agentId: string,
+	spaceId: string,
+	role: 'coder' | 'planner' | 'general' | string
+): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, role, description, model, tools, system_prompt,
+     config, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '', null, '[]', '', null, ?, ?)`
+	).run(agentId, spaceId, `Agent ${agentId}`, role, Date.now(), Date.now());
+}
+
+// ---------------------------------------------------------------------------
+// Workflow builder helpers
+// ---------------------------------------------------------------------------
+
+function buildWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	nodes: Array<{
+		id: string;
+		name: string;
+		agentId?: string;
+		agents?: Array<{ agentId: string; name: string }>;
+	}>
+): SpaceWorkflow {
+	return workflowManager.createWorkflow({
+		spaceId,
+		name: `Test Workflow ${Date.now()}`,
+		description: '',
+		nodes: nodes.map((n) => ({
+			id: n.id,
+			name: n.name,
+			agentId: n.agentId,
+			agents: n.agents,
+		})),
+		transitions: [],
+		startNodeId: nodes[0].id,
+		rules: [],
+		tags: [],
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('ChannelRouter', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	let taskRepo: SpaceTaskRepository;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let workflowManager: SpaceWorkflowManager;
+	let agentManager: SpaceAgentManager;
+	let router: ChannelRouter;
+
+	const SPACE_ID = 'space-cr-1';
+	const AGENT_CODER = 'agent-coder';
+	const AGENT_PLANNER = 'agent-planner';
+	const AGENT_CUSTOM = 'agent-custom';
+
+	const NODE_A = 'node-a';
+	const NODE_B = 'node-b';
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+
+		seedSpace(db, SPACE_ID);
+		seedAgent(db, AGENT_CODER, SPACE_ID, 'coder');
+		seedAgent(db, AGENT_PLANNER, SPACE_ID, 'planner');
+		seedAgent(db, AGENT_CUSTOM, SPACE_ID, 'my-custom-role');
+
+		taskRepo = new SpaceTaskRepository(db);
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+
+		const agentRepo = new SpaceAgentRepository(db);
+		agentManager = new SpaceAgentManager(agentRepo);
+
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		workflowManager = new SpaceWorkflowManager(workflowRepo);
+
+		router = new ChannelRouter({ taskRepo, workflowRunRepo, workflowManager, agentManager });
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	// -------------------------------------------------------------------------
+	// activateNode — first activation
+	// -------------------------------------------------------------------------
+
+	describe('activateNode', () => {
+		test('creates one pending task for a single-agent node', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{ id: NODE_A, name: 'Node A', agentId: AGENT_CODER },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Test Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const tasks = await router.activateNode(run.id, NODE_A);
+
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].status).toBe('pending');
+			expect(tasks[0].workflowRunId).toBe(run.id);
+			expect(tasks[0].workflowNodeId).toBe(NODE_A);
+			expect(tasks[0].slotRole).toBe(AGENT_CODER); // resolveNodeAgents uses agentId as name for shorthand
+			expect(tasks[0].taskType).toBe('coding');
+			expect(tasks[0].customAgentId).toBeFalsy();
+		});
+
+		test('creates one task per agent for a multi-agent node', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Multi Agent Node',
+					agents: [
+						{ agentId: AGENT_CODER, name: 'coder-slot' },
+						{ agentId: AGENT_PLANNER, name: 'planner-slot' },
+					],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Multi Agent Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const tasks = await router.activateNode(run.id, NODE_A);
+
+			expect(tasks).toHaveLength(2);
+			const slotRoles = tasks.map((t) => t.slotRole).sort();
+			expect(slotRoles).toEqual(['coder-slot', 'planner-slot']);
+
+			// task types are resolved per-agent
+			const coderTask = tasks.find((t) => t.slotRole === 'coder-slot')!;
+			const plannerTask = tasks.find((t) => t.slotRole === 'planner-slot')!;
+			expect(coderTask.taskType).toBe('coding');
+			expect(plannerTask.taskType).toBe('planning');
+		});
+
+		test('sets correct taskType for custom-role agent', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Custom Node',
+					agents: [{ agentId: AGENT_CUSTOM, name: 'custom-slot' }],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Custom Role Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const tasks = await router.activateNode(run.id, NODE_A);
+
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].taskType).toBe('coding');
+			expect(tasks[0].customAgentId).toBe(AGENT_CUSTOM);
+		});
+
+		// -----------------------------------------------------------------------
+		// Idempotent activation
+		// -----------------------------------------------------------------------
+
+		test('returns existing tasks on repeated activation (idempotent)', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{ id: NODE_A, name: 'Node A', agentId: AGENT_CODER },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Idempotent Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const firstResult = await router.activateNode(run.id, NODE_A);
+			const secondResult = await router.activateNode(run.id, NODE_A);
+
+			// Second call must return the same tasks (same IDs, no duplicates)
+			expect(secondResult).toHaveLength(1);
+			expect(secondResult[0].id).toBe(firstResult[0].id);
+
+			// Only one task exists in the DB
+			const allTasks = taskRepo
+				.listByWorkflowRun(run.id)
+				.filter((t) => t.workflowNodeId === NODE_A);
+			expect(allTasks).toHaveLength(1);
+		});
+
+		test('re-activates if the only existing task is cancelled', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{ id: NODE_A, name: 'Node A', agentId: AGENT_CODER },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Cancelled Task Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// First activation
+			const firstTasks = await router.activateNode(run.id, NODE_A);
+			expect(firstTasks).toHaveLength(1);
+
+			// Cancel the task
+			taskRepo.updateTask(firstTasks[0].id, { status: 'cancelled' });
+
+			// Second activation should create fresh tasks (cancelled tasks are excluded)
+			const secondTasks = await router.activateNode(run.id, NODE_A);
+			expect(secondTasks).toHaveLength(1);
+			expect(secondTasks[0].id).not.toBe(firstTasks[0].id);
+			expect(secondTasks[0].status).toBe('pending');
+		});
+
+		// -----------------------------------------------------------------------
+		// Concurrent activation — DB uniqueness
+		// -----------------------------------------------------------------------
+
+		test('handles concurrent activation via UNIQUE constraint gracefully', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Node A',
+					agents: [{ agentId: AGENT_CODER, name: 'coder-slot' }],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Concurrent Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// Simulate a concurrent activation by directly inserting a task with the
+			// same (workflow_run_id, workflow_node_id, slot_role) before the router
+			// creates its task — triggering the UNIQUE constraint path.
+			const firstTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: NODE_A,
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: NODE_A,
+				slotRole: 'coder-slot',
+				status: 'pending',
+			});
+
+			// The router's activateNode() should detect the UNIQUE constraint violation
+			// and return the already-inserted task instead of throwing.
+			const tasks = await router.activateNode(run.id, NODE_A);
+
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].id).toBe(firstTask.id);
+		});
+
+		// -----------------------------------------------------------------------
+		// Error cases
+		// -----------------------------------------------------------------------
+
+		test('throws ActivationError when run is cancelled', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{ id: NODE_A, name: 'Node A', agentId: AGENT_CODER },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Cancelled Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'cancelled');
+
+			await expect(router.activateNode(run.id, NODE_A)).rejects.toBeInstanceOf(ActivationError);
+			await expect(router.activateNode(run.id, NODE_A)).rejects.toThrow(/cancelled/);
+		});
+
+		test('throws ActivationError when run is completed', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{ id: NODE_A, name: 'Node A', agentId: AGENT_CODER },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Completed Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'completed');
+
+			await expect(router.activateNode(run.id, NODE_A)).rejects.toBeInstanceOf(ActivationError);
+			await expect(router.activateNode(run.id, NODE_A)).rejects.toThrow(/completed/);
+		});
+
+		test('throws ActivationError when run does not exist', async () => {
+			await expect(router.activateNode('nonexistent-run', NODE_A)).rejects.toBeInstanceOf(
+				ActivationError
+			);
+			await expect(router.activateNode('nonexistent-run', NODE_A)).rejects.toThrow(/Run not found/);
+		});
+
+		test('throws ActivationError when node does not exist in workflow', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{ id: NODE_A, name: 'Node A', agentId: AGENT_CODER },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Bad Node Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			await expect(router.activateNode(run.id, 'nonexistent-node')).rejects.toBeInstanceOf(
+				ActivationError
+			);
+			await expect(router.activateNode(run.id, 'nonexistent-node')).rejects.toThrow(
+				/not found in workflow/
+			);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// deliverMessage
+	// -------------------------------------------------------------------------
+
+	describe('deliverMessage', () => {
+		test('auto-activates target node when no active tasks exist', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Sender Node',
+					agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+				},
+				{
+					id: NODE_B,
+					name: 'Receiver Node',
+					agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Deliver Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await router.deliverMessage(run.id, 'coder', 'planner', 'hello planner');
+
+			expect(result.fromRole).toBe('coder');
+			expect(result.toRole).toBe('planner');
+			expect(result.message).toBe('hello planner');
+			expect(result.targetNodeId).toBe(NODE_B);
+			// activatedTasks should be set since NODE_B had no tasks
+			expect(result.activatedTasks).toBeDefined();
+			expect(result.activatedTasks).toHaveLength(1);
+			expect(result.activatedTasks![0].workflowNodeId).toBe(NODE_B);
+			expect(result.activatedTasks![0].slotRole).toBe('planner');
+		});
+
+		test('does not re-activate when target node already has active tasks', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Sender Node',
+					agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+				},
+				{
+					id: NODE_B,
+					name: 'Receiver Node',
+					agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Already Active Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// Pre-create a task for NODE_B so it is already active
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Planner Task',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: NODE_B,
+				slotRole: 'planner',
+				status: 'in_progress',
+			});
+
+			const beforeCount = taskRepo
+				.listByWorkflowRun(run.id)
+				.filter((t) => t.workflowNodeId === NODE_B).length;
+
+			const result = await router.deliverMessage(run.id, 'coder', 'planner', 'hi again');
+
+			// activatedTasks should be undefined (node was already active)
+			expect(result.activatedTasks).toBeUndefined();
+
+			// No new tasks should have been created
+			const afterCount = taskRepo
+				.listByWorkflowRun(run.id)
+				.filter((t) => t.workflowNodeId === NODE_B).length;
+			expect(afterCount).toBe(beforeCount);
+		});
+
+		test('throws ActivationError when target role is not found in workflow', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Sender Node',
+					agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Missing Role Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			await expect(
+				router.deliverMessage(run.id, 'coder', 'nonexistent-role', 'hello')
+			).rejects.toBeInstanceOf(ActivationError);
+			await expect(
+				router.deliverMessage(run.id, 'coder', 'nonexistent-role', 'hello')
+			).rejects.toThrow(/No node found with agent role/);
+		});
+
+		test('returns correct targetNodeId in result', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Node A',
+					agents: [{ agentId: AGENT_CODER, name: 'sender' }],
+				},
+				{
+					id: NODE_B,
+					name: 'Node B',
+					agents: [{ agentId: AGENT_PLANNER, name: 'receiver' }],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Target Node Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await router.deliverMessage(run.id, 'sender', 'receiver', 'test');
+			expect(result.targetNodeId).toBe(NODE_B);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/migrations/migration-54_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-54_test.ts
@@ -1,0 +1,271 @@
+/**
+ * Migration 54 Tests
+ *
+ * Covers:
+ * - Index is created on a fresh DB (workflow_node_id + slot_role present)
+ * - Index is skipped when workflow_node_id is absent (graceful guard)
+ * - Index is skipped when slot_role is absent (graceful guard)
+ * - Index enforces uniqueness for active-status tuples
+ * - Index allows duplicate (run, node, agent) when old row is completed
+ * - Index allows duplicate (run, node, agent) when old row is cancelled
+ * - Index allows NULL workflow_run_id / workflow_node_id / slot_role (legacy compat)
+ * - Idempotent: calling runMigration54 twice does not error
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { runMigration54 } from '../../../../src/storage/schema/migrations.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-migration-54',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function getIndexNames(db: BunDatabase, table: string): string[] {
+	const rows = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?`)
+		.all(table) as { name: string }[];
+	return rows.map((r) => r.name);
+}
+
+function seedSpace(db: BunDatabase, spaceId = 'sp-1'): void {
+	db.prepare(
+		`INSERT OR IGNORE INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function insertTask(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		spaceId?: string;
+		runId?: string | null;
+		nodeId?: string | null;
+		slotRole?: string | null;
+		status?: string;
+	}
+): void {
+	const now = Date.now();
+	// Disable FK checks for test fixture inserts so we can use arbitrary run/node IDs
+	// without needing to create all referenced parent rows.
+	db.exec('PRAGMA foreign_keys = OFF');
+	try {
+		db.prepare(
+			`INSERT INTO space_tasks
+		 (id, space_id, title, description, status, priority, depends_on, workflow_run_id, workflow_node_id, slot_role, created_at, updated_at)
+		 VALUES (?, ?, 'Task', '', ?, 'normal', '[]', ?, ?, ?, ?, ?)`
+		).run(
+			opts.id,
+			opts.spaceId ?? 'sp-1',
+			opts.status ?? 'pending',
+			opts.runId ?? null,
+			opts.nodeId ?? null,
+			opts.slotRole ?? null,
+			now,
+			now
+		);
+	} finally {
+		db.exec('PRAGMA foreign_keys = ON');
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedSpace(db);
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test('index is created on a fresh migrated DB', () => {
+		const indexes = getIndexNames(db, 'space_tasks');
+		expect(indexes).toContain('uq_space_tasks_run_node_agent');
+	});
+
+	test('idempotent: calling runMigration54 again does not error', () => {
+		expect(() => runMigration54(db)).not.toThrow();
+		const indexes = getIndexNames(db, 'space_tasks');
+		expect(indexes).toContain('uq_space_tasks_run_node_agent');
+	});
+
+	test('enforces uniqueness for two pending tasks with same run+node+slot', () => {
+		insertTask(db, {
+			id: 't-1',
+			runId: 'run-1',
+			nodeId: 'node-1',
+			slotRole: 'coder',
+			status: 'pending',
+		});
+		expect(() =>
+			insertTask(db, {
+				id: 't-2',
+				runId: 'run-1',
+				nodeId: 'node-1',
+				slotRole: 'coder',
+				status: 'pending',
+			})
+		).toThrow(/UNIQUE constraint failed/);
+	});
+
+	test('enforces uniqueness for in_progress duplicate', () => {
+		insertTask(db, {
+			id: 't-1',
+			runId: 'run-1',
+			nodeId: 'node-1',
+			slotRole: 'coder',
+			status: 'in_progress',
+		});
+		expect(() =>
+			insertTask(db, {
+				id: 't-2',
+				runId: 'run-1',
+				nodeId: 'node-1',
+				slotRole: 'coder',
+				status: 'pending',
+			})
+		).toThrow(/UNIQUE constraint failed/);
+	});
+
+	test('allows second pending task after first is completed', () => {
+		insertTask(db, {
+			id: 't-1',
+			runId: 'run-1',
+			nodeId: 'node-1',
+			slotRole: 'coder',
+			status: 'completed',
+		});
+		expect(() =>
+			insertTask(db, {
+				id: 't-2',
+				runId: 'run-1',
+				nodeId: 'node-1',
+				slotRole: 'coder',
+				status: 'pending',
+			})
+		).not.toThrow();
+	});
+
+	test('allows second pending task after first is cancelled', () => {
+		insertTask(db, {
+			id: 't-1',
+			runId: 'run-1',
+			nodeId: 'node-1',
+			slotRole: 'coder',
+			status: 'cancelled',
+		});
+		expect(() =>
+			insertTask(db, {
+				id: 't-2',
+				runId: 'run-1',
+				nodeId: 'node-1',
+				slotRole: 'coder',
+				status: 'pending',
+			})
+		).not.toThrow();
+	});
+
+	test('allows second pending task after first is needs_attention', () => {
+		insertTask(db, {
+			id: 't-1',
+			runId: 'run-1',
+			nodeId: 'node-1',
+			slotRole: 'coder',
+			status: 'needs_attention',
+		});
+		expect(() =>
+			insertTask(db, {
+				id: 't-2',
+				runId: 'run-1',
+				nodeId: 'node-1',
+				slotRole: 'coder',
+				status: 'pending',
+			})
+		).not.toThrow();
+	});
+
+	test('allows multiple legacy tasks with NULL workflow_run_id', () => {
+		insertTask(db, { id: 't-1', runId: null, nodeId: null, slotRole: null, status: 'pending' });
+		expect(() =>
+			insertTask(db, { id: 't-2', runId: null, nodeId: null, slotRole: null, status: 'pending' })
+		).not.toThrow();
+	});
+
+	test('different slot roles on same run+node are allowed simultaneously', () => {
+		insertTask(db, {
+			id: 't-1',
+			runId: 'run-1',
+			nodeId: 'node-1',
+			slotRole: 'coder',
+			status: 'pending',
+		});
+		expect(() =>
+			insertTask(db, {
+				id: 't-2',
+				runId: 'run-1',
+				nodeId: 'node-1',
+				slotRole: 'planner',
+				status: 'pending',
+			})
+		).not.toThrow();
+	});
+
+	test('skips gracefully when workflow_node_id column is absent', () => {
+		// Create a minimal space_tasks table WITHOUT workflow_node_id
+		const db2Dir = join(process.cwd(), 'tmp', 'test-migration-54', `no-col-${Date.now()}`);
+		mkdirSync(db2Dir, { recursive: true });
+		const db2 = new BunDatabase(join(db2Dir, 'test2.db'));
+		try {
+			db2.exec(`
+				CREATE TABLE space_tasks (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					title TEXT NOT NULL DEFAULT '',
+					description TEXT NOT NULL DEFAULT '',
+					status TEXT NOT NULL DEFAULT 'pending',
+					priority TEXT NOT NULL DEFAULT 'normal',
+					slot_role TEXT,
+					workflow_run_id TEXT,
+					depends_on TEXT NOT NULL DEFAULT '[]',
+					created_at INTEGER NOT NULL DEFAULT 0,
+					updated_at INTEGER NOT NULL DEFAULT 0
+				)
+			`);
+			// runMigration54 should skip without throwing
+			expect(() => runMigration54(db2)).not.toThrow();
+			// Index should NOT exist since workflow_node_id is absent
+			const indexes = getIndexNames(db2, 'space_tasks');
+			expect(indexes).not.toContain('uq_space_tasks_run_node_agent');
+		} finally {
+			db2.close();
+			rmSync(db2Dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/daemon/tests/unit/storage/migrations/migration-54_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-54_test.ts
@@ -211,6 +211,28 @@ describe('Migration 54: uq_space_tasks_run_node_agent unique index', () => {
 		).not.toThrow();
 	});
 
+	test('allows two draft tasks with the same run+node+slot (draft excluded from index)', () => {
+		// draft is intentionally excluded from the partial index so that external callers
+		// can create draft tasks without being constrained by ChannelRouter's uniqueness guarantee.
+		// Two draft tasks for the same (run, node, slot) must NOT trigger a UNIQUE violation.
+		insertTask(db, {
+			id: 't-1',
+			runId: 'run-1',
+			nodeId: 'node-1',
+			slotRole: 'coder',
+			status: 'draft',
+		});
+		expect(() =>
+			insertTask(db, {
+				id: 't-2',
+				runId: 'run-1',
+				nodeId: 'node-1',
+				slotRole: 'coder',
+				status: 'draft',
+			})
+		).not.toThrow();
+	});
+
 	test('allows multiple legacy tasks with NULL workflow_run_id', () => {
 		insertTask(db, { id: 't-1', runId: null, nodeId: null, slotRole: null, status: 'pending' });
 		expect(() =>


### PR DESCRIPTION
Implements lazy activation of target nodes in the channel routing layer.
When a message is delivered to an agent role whose node has no active tasks,
the router creates pending SpaceTask records on-demand rather than requiring
upfront activation at workflow start.

Key changes:

- ChannelRouter (channel-router.ts): New class with activateNode() and
  deliverMessage() for lazy on-demand node activation
- Migration 54: Unique partial index on (workflow_run_id, workflow_node_id,
  slot_role) for active statuses only; terminal statuses excluded for cyclic
  workflow support; guarded by column-existence for forward-compat
- WorkflowExecutor: followTransition() made idempotent via UNIQUE constraint
  error handling; cyclic workflows reuse existing tasks instead of throwing
- 14 unit tests for ChannelRouter covering activation scenarios
- 10 unit tests for Migration 54 covering index behavior
