### PR TITLE
feat(space): extend ChannelRouter with gate evaluation and cyclic iteration tracking (Task 3.1)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -383,14 +383,18 @@ export class ChannelRouter {
 		}
 
 		// ── 5. Increment iteration count for cyclic channels ──────────────────
-		// Re-read the run to get the freshest iterationCount before incrementing
-		// (another concurrent delivery may have already incremented it).
+		// Use the atomic incrementIterationCount() which runs a single SQL UPDATE
+		// with a WHERE guard (iteration_count < max_iterations), eliminating any
+		// TOCTOU race between the cap check above and this write. If another
+		// concurrent delivery already pushed the count to the cap, the atomic
+		// increment will return false — we throw to surface the cap violation even
+		// though message delivery already succeeded at this point.
 		if (channel?.isCyclic) {
-			const freshRun = this.config.workflowRunRepo.getRun(runId);
-			if (freshRun) {
-				this.config.workflowRunRepo.updateRun(runId, {
-					iterationCount: freshRun.iterationCount + 1,
-				});
+			const incremented = this.config.workflowRunRepo.incrementIterationCount(runId);
+			if (!incremented) {
+				throw new ActivationError(
+					`Cyclic channel from "${fromRole}" to "${toTarget}" reached the maximum iteration count during delivery (cap enforced atomically). Message was delivered but the cycle was not counted.`
+				);
 			}
 		}
 

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -1,12 +1,17 @@
 /**
- * ChannelRouter — lazy node activation for agent-centric workflow execution.
+ * ChannelRouter — message delivery with gate enforcement and lazy node activation.
  *
- * When a message arrives for a target agent role whose node has no active tasks,
- * the router creates pending SpaceTask records on-demand (lazy activation).
- * This replaces the step-centric model where the executor always pre-created
- * tasks for the next node eagerly.
+ * Handles all message delivery within a workflow run:
+ * - Within-node DMs (same node, agent-to-agent)
+ * - Cross-node DMs (target resolved by agent role)
+ * - Fan-out (target resolved by node name → all agents in that node)
  *
- * Key design decisions:
+ * Gate enforcement:
+ * - canDeliver() evaluates gates and iteration caps without side effects
+ * - deliverMessage() performs gate evaluation, cyclic iteration tracking,
+ *   and lazy node activation in one atomic operation
+ *
+ * Lazy node activation:
  * - activateNode() is idempotent: if tasks already exist for the node the
  *   existing tasks are returned unchanged.
  * - Concurrency is handled via a DB UNIQUE partial index on
@@ -17,12 +22,24 @@
  *   ChannelRouter only creates SpaceTask DB records.
  */
 
-import type { SpaceTask, SpaceTaskType, SpaceWorkflow, WorkflowNode } from '@neokai/shared';
+import type {
+	SpaceTask,
+	SpaceTaskType,
+	SpaceWorkflow,
+	WorkflowChannel,
+	WorkflowNode,
+} from '@neokai/shared';
 import { resolveNodeAgents } from '@neokai/shared';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
+import { ChannelGateEvaluator, ChannelGateBlockedError } from './channel-gate-evaluator';
+import type { ChannelGateContext, GateResult } from './channel-gate-evaluator';
+
+// Re-export for callers that only need to import from channel-router
+export { ChannelGateBlockedError };
+export type { ChannelGateContext, GateResult };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -43,12 +60,20 @@ export interface DeliveredMessage {
 	runId: string;
 	/** Role of the sending agent */
 	fromRole: string;
-	/** Role of the receiving agent */
+	/**
+	 * Role of the receiving agent, or node name for fan-out deliveries.
+	 * When isFanOut is true this is the node name, not an individual agent role.
+	 */
 	toRole: string;
 	/** The message content */
 	message: string;
 	/** Node ID of the target agent */
 	targetNodeId: string;
+	/**
+	 * True when the delivery targeted a node name (fan-out to all agents in the
+	 * node) rather than a specific agent role (point-to-point DM).
+	 */
+	isFanOut: boolean;
 	/**
 	 * Tasks created by lazy activation, or undefined when the node was already active.
 	 * An empty array is never returned — either undefined (already active) or ≥1 tasks.
@@ -64,6 +89,9 @@ export interface DeliveredMessage {
  * Thrown by activateNode() for unrecoverable problems such as a missing run
  * or workflow, a node that does not exist, or an attempted activation on a
  * run that has already reached a terminal state.
+ *
+ * Also thrown by deliverMessage() when the iteration cap is exceeded on a
+ * cyclic channel (an unrecoverable limit — not a retryable gate block).
  */
 export class ActivationError extends Error {
 	constructor(
@@ -88,6 +116,11 @@ export interface ChannelRouterConfig {
 	workflowManager: SpaceWorkflowManager;
 	/** Agent manager for resolving agent roles → task types */
 	agentManager: SpaceAgentManager;
+	/**
+	 * Injectable gate evaluator — omit to use the real evaluator (Bun.spawn).
+	 * Inject a mock in tests to avoid real subprocess calls.
+	 */
+	gateEvaluator?: ChannelGateEvaluator;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,7 +128,11 @@ export interface ChannelRouterConfig {
 // ---------------------------------------------------------------------------
 
 export class ChannelRouter {
-	constructor(private readonly config: ChannelRouterConfig) {}
+	private readonly gateEvaluator: ChannelGateEvaluator;
+
+	constructor(private readonly config: ChannelRouterConfig) {
+		this.gateEvaluator = config.gateEvaluator ?? new ChannelGateEvaluator();
+	}
 
 	// -------------------------------------------------------------------------
 	// Public API
@@ -197,24 +234,94 @@ export class ChannelRouter {
 	}
 
 	/**
-	 * Deliver a message from one agent role to another within a workflow run.
+	 * Check whether delivery of a message from `fromRole` to `toTarget` is currently
+	 * permitted — without performing any delivery or state mutations.
 	 *
-	 * If the target role's node has no active tasks the node is lazily activated
-	 * (pending SpaceTask records created) before returning.
+	 * Evaluation order:
+	 * 1. **Open topology** — when no channel is declared for the pair, delivery is
+	 *    always allowed (no restriction).
+	 * 2. **Iteration cap** — for cyclic channels, blocks when
+	 *    `run.iterationCount >= run.maxIterations`.
+	 * 3. **Gate condition** — evaluates the channel's gate using the provided context.
+	 *
+	 * @param runId     - Workflow run ID
+	 * @param fromRole  - Sending agent role name
+	 * @param toTarget  - Receiving agent role name, or node name for fan-out
+	 * @param context   - Gate evaluation context (workspace path, human approval, task result)
+	 * @returns GateResult — `{ allowed: true }` or `{ allowed: false, reason }` when blocked
+	 * @throws ActivationError when the run or workflow is not found
+	 */
+	async canDeliver(
+		runId: string,
+		fromRole: string,
+		toTarget: string,
+		context: ChannelGateContext
+	): Promise<GateResult> {
+		const run = this.config.workflowRunRepo.getRun(runId);
+		if (!run) throw new ActivationError(`Run not found: ${runId}`);
+
+		const workflow = this.config.workflowManager.getWorkflow(run.workflowId);
+		if (!workflow) throw new ActivationError(`Workflow not found: ${run.workflowId}`);
+
+		const channel = this.findMatchingWorkflowChannel(workflow, fromRole, toTarget);
+		if (!channel) {
+			// Open topology — no declared channel for this pair; delivery is unrestricted
+			return { allowed: true };
+		}
+
+		// ── Iteration cap check ──────────────────────────────────────────────
+		if (channel.isCyclic && run.iterationCount >= run.maxIterations) {
+			return {
+				allowed: false,
+				reason: `Cyclic channel from "${fromRole}" to "${toTarget}" has reached the maximum iteration count (${run.iterationCount}/${run.maxIterations}). Increase maxIterations to allow more cycles.`,
+			};
+		}
+
+		// ── Gate condition evaluation ────────────────────────────────────────
+		if (!channel.gate) return { allowed: true };
+		return this.gateEvaluator.evaluateCondition(channel.gate, context);
+	}
+
+	/**
+	 * Deliver a message from one agent role to another (or to a node for fan-out)
+	 * within a workflow run.
+	 *
+	 * **Target resolution:**
+	 * - `toTarget` is an agent role name → DM to the agent's node (lazy-activated
+	 *   if not already active)
+	 * - `toTarget` is a node name → fan-out to the node; all agent slots are
+	 *   activated (lazy-activated if not already active)
+	 *
+	 * **Gate evaluation (when `context` is provided):**
+	 * - Locates the matching `WorkflowChannel` for the from/to pair
+	 * - Throws `ChannelGateBlockedError` if the gate blocks delivery
+	 * - When no context is given, gates are not evaluated (backward-compatible)
+	 *
+	 * **Cyclic iteration tracking:**
+	 * - If the matching channel has `isCyclic: true`, `run.iterationCount` is
+	 *   incremented after successful delivery, regardless of whether `context` is
+	 *   provided.
+	 * - If the iteration cap has already been reached, throws `ActivationError`
+	 *   (unrecoverable hard limit, not a retryable gate condition).
 	 *
 	 * @param runId    - Workflow run ID
 	 * @param fromRole - Role name of the sending agent (WorkflowNodeAgent.name)
-	 * @param toRole   - Role name of the receiving agent (WorkflowNodeAgent.name)
+	 * @param toTarget - Role name of the receiving agent, or node name for fan-out
 	 * @param message  - Message content to deliver
+	 * @param context  - Optional gate evaluation context; omit to skip gate checks
 	 * @returns DeliveredMessage descriptor; `activatedTasks` is set when the
 	 *   target node was lazily activated, undefined when it was already active
-	 * @throws ActivationError when the run, workflow, or target role is not found
+	 * @throws ActivationError when the run, workflow, or target role/node is not
+	 *   found, or the cyclic iteration cap is exceeded
+	 * @throws ChannelGateBlockedError when a gate condition blocks delivery
+	 *   (only when `context` is provided)
 	 */
 	async deliverMessage(
 		runId: string,
 		fromRole: string,
-		toRole: string,
-		message: string
+		toTarget: string,
+		message: string,
+		context?: ChannelGateContext
 	): Promise<DeliveredMessage> {
 		// ── 1. Load the run and workflow ───────────────────────────────────────
 		const run = this.config.workflowRunRepo.getRun(runId);
@@ -227,15 +334,47 @@ export class ChannelRouter {
 			throw new ActivationError(`Workflow not found: ${run.workflowId}`);
 		}
 
-		// ── 2. Locate the node that owns the target role ───────────────────────
-		const targetNode = this.findNodeByAgentRole(workflow, toRole);
-		if (!targetNode) {
-			throw new ActivationError(
-				`No node found with agent role "${toRole}" in workflow "${run.workflowId}"`
-			);
+		// ── 2. Gate evaluation and iteration cap ───────────────────────────────
+		const channel = this.findMatchingWorkflowChannel(workflow, fromRole, toTarget);
+
+		if (channel) {
+			// Always enforce the iteration cap for cyclic channels (even without context)
+			if (channel.isCyclic && run.iterationCount >= run.maxIterations) {
+				throw new ActivationError(
+					`Cyclic channel from "${fromRole}" to "${toTarget}" has reached the maximum iteration count (${run.iterationCount}/${run.maxIterations}). Increase maxIterations to allow more cycles.`
+				);
+			}
+
+			// Gate evaluation — only when the caller supplies evaluation context
+			if (context && channel.gate) {
+				const gateResult = await this.gateEvaluator.evaluateCondition(channel.gate, context);
+				if (!gateResult.allowed) {
+					throw new ChannelGateBlockedError(
+						gateResult.reason ?? `Gate blocked delivery from "${fromRole}" to "${toTarget}"`,
+						channel.gate.type
+					);
+				}
+			}
 		}
 
-		// ── 3. Lazy activation ─────────────────────────────────────────────────
+		// ── 3. Target resolution: agent role → DM, node name → fan-out ────────
+		let targetNode = this.findNodeByAgentRole(workflow, toTarget);
+		let isFanOut = false;
+
+		if (!targetNode) {
+			// Try node name for fan-out delivery
+			const byName = workflow.nodes.find((n) => n.name === toTarget);
+			if (byName) {
+				targetNode = byName;
+				isFanOut = true;
+			} else {
+				throw new ActivationError(
+					`No node found with agent role or node name "${toTarget}" in workflow "${run.workflowId}"`
+				);
+			}
+		}
+
+		// ── 4. Lazy activation ─────────────────────────────────────────────────
 		const activeTasks = this.getActiveTasksForNode(runId, targetNode.id);
 		let activatedTasks: SpaceTask[] | undefined;
 
@@ -243,7 +382,27 @@ export class ChannelRouter {
 			activatedTasks = await this.activateNode(runId, targetNode.id);
 		}
 
-		return { runId, fromRole, toRole, message, targetNodeId: targetNode.id, activatedTasks };
+		// ── 5. Increment iteration count for cyclic channels ──────────────────
+		// Re-read the run to get the freshest iterationCount before incrementing
+		// (another concurrent delivery may have already incremented it).
+		if (channel?.isCyclic) {
+			const freshRun = this.config.workflowRunRepo.getRun(runId);
+			if (freshRun) {
+				this.config.workflowRunRepo.updateRun(runId, {
+					iterationCount: freshRun.iterationCount + 1,
+				});
+			}
+		}
+
+		return {
+			runId,
+			fromRole,
+			toRole: toTarget,
+			message,
+			targetNodeId: targetNode.id,
+			isFanOut,
+			activatedTasks,
+		};
 	}
 
 	// -------------------------------------------------------------------------
@@ -295,6 +454,37 @@ export class ChannelRouter {
 			}
 		}
 		return undefined;
+	}
+
+	/**
+	 * Finds the first WorkflowChannel in the workflow that matches the given
+	 * fromRole → toTarget pair.
+	 *
+	 * Matching rules:
+	 * - `channel.from` must equal `fromRole` (wildcard `'*'` matches any sender)
+	 * - `channel.to` must equal `toTarget`, or contain it in an array
+	 *   (wildcard `'*'` matches any target)
+	 *
+	 * `toTarget` may be either an agent role name or a node name — the raw
+	 * WorkflowChannel declaration is not resolved; the caller is responsible for
+	 * knowing the target type.
+	 *
+	 * Returns undefined when no channel is found (open topology).
+	 */
+	private findMatchingWorkflowChannel(
+		workflow: SpaceWorkflow,
+		fromRole: string,
+		toTarget: string
+	): WorkflowChannel | undefined {
+		const channels = workflow.channels ?? [];
+		return channels.find((ch) => {
+			// Match the from side
+			if (ch.from !== '*' && ch.from !== fromRole) return false;
+			// Match the to side
+			if (ch.to === '*' || ch.to === toTarget) return true;
+			if (Array.isArray(ch.to)) return ch.to.includes(toTarget);
+			return false;
+		});
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -180,6 +180,26 @@ export class SpaceWorkflowRunRepository {
 	}
 
 	/**
+	 * Atomically increment the iteration counter for a run, respecting the cap.
+	 *
+	 * Uses a single SQL UPDATE with a WHERE guard so the read-check-write is atomic:
+	 *   UPDATE ... SET iteration_count = iteration_count + 1
+	 *   WHERE id = ? AND iteration_count < max_iterations
+	 *
+	 * @returns true when the counter was incremented (below cap),
+	 *          false when the cap was already reached (no change applied)
+	 */
+	incrementIterationCount(id: string): boolean {
+		const stmt = this.db.prepare(
+			`UPDATE space_workflow_runs
+			 SET iteration_count = iteration_count + 1, updated_at = ?
+			 WHERE id = ? AND iteration_count < max_iterations`
+		);
+		const result = stmt.run(Date.now(), id);
+		return result.changes > 0;
+	}
+
+	/**
 	 * Delete a workflow run by ID
 	 */
 	deleteRun(id: string): boolean {

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -1390,5 +1390,241 @@ describe('ChannelRouter', () => {
 				router.canDeliver('nonexistent-run', 'coder', 'planner', { workspacePath: '/tmp/ws' })
 			).rejects.toBeInstanceOf(ActivationError);
 		});
+
+		test('canDeliver: throws ActivationError when workflow not found', async () => {
+			// Create a run, then point it to a nonexistent workflow by bypassing FK checks.
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{ id: NODE_A, name: 'Node A', agentId: AGENT_CODER },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Orphaned Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// Disable FK enforcement, remap workflow_id to a nonexistent ID, then re-enable.
+			db.exec('PRAGMA foreign_keys = OFF');
+			db.prepare('UPDATE space_workflow_runs SET workflow_id = ? WHERE id = ?').run(
+				'nonexistent-workflow-id',
+				run.id
+			);
+			db.exec('PRAGMA foreign_keys = ON');
+
+			await expect(
+				router.canDeliver(run.id, 'coder', 'planner', { workspacePath: '/tmp/ws' })
+			).rejects.toBeInstanceOf(ActivationError);
+			await expect(
+				router.canDeliver(run.id, 'coder', 'planner', { workspacePath: '/tmp/ws' })
+			).rejects.toThrow(/Workflow not found/);
+		});
+
+		test('canDeliver: condition gate — allowed via mock evaluator (exit 0)', async () => {
+			const allowingRouter = new ChannelRouter({
+				taskRepo,
+				workflowRunRepo,
+				workflowManager,
+				agentManager,
+				gateEvaluator: makeAllowingEvaluator(),
+			});
+
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'condition', expression: 'test -f /some/file' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Condition Gate Allowed Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await allowingRouter.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.allowed).toBe(true);
+		});
+
+		test('canDeliver: condition gate — blocked via mock evaluator (exit 1)', async () => {
+			const blockingRouter = new ChannelRouter({
+				taskRepo,
+				workflowRunRepo,
+				workflowManager,
+				agentManager,
+				gateEvaluator: makeBlockingEvaluator(),
+			});
+
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'condition', expression: 'test -f /nonexistent' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Condition Gate Blocked Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await blockingRouter.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toMatch(/condition expression exited/);
+		});
+
+		// -----------------------------------------------------------------------
+		// Wildcard channel matching
+		// -----------------------------------------------------------------------
+
+		test('wildcard from: channel with from="*" matches any sender', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: '*',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'human' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Wildcard From Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// 'coder' is not the declared sender, but '*' should match it
+			const blocked = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+				humanApproved: false,
+			});
+			expect(blocked.allowed).toBe(false);
+			expect(blocked.reason).toMatch(/human approval/);
+		});
+
+		test('wildcard to: channel with to="*" matches any target', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: '*',
+					direction: 'one-way',
+					gate: { type: 'task_result', expression: 'pass' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Wildcard To Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// 'planner' should be matched by '*'
+			const blocked = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+				taskResult: 'fail',
+			});
+			expect(blocked.allowed).toBe(false);
+
+			const allowed = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+				taskResult: 'pass: all tests green',
+			});
+			expect(allowed.allowed).toBe(true);
+		});
+
+		test('wildcard to: deliverMessage uses wildcard channel gate', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: '*',
+					direction: 'one-way',
+					gate: { type: 'human' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Wildcard Delivery Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// Wildcard channel gate blocks delivery without approval
+			await expect(
+				router.deliverMessage(run.id, 'coder', 'planner', 'msg', {
+					workspacePath: '/tmp/ws',
+					humanApproved: false,
+				})
+			).rejects.toBeInstanceOf(ChannelGateBlockedError);
+
+			// Wildcard channel gate allows delivery with approval
+			const result = await router.deliverMessage(run.id, 'coder', 'planner', 'msg', {
+				workspacePath: '/tmp/ws',
+				humanApproved: true,
+			});
+			expect(result.fromRole).toBe('coder');
+		});
 	});
 });

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -15,6 +15,22 @@
  * - deliverMessage(): does not re-activate when target node is already active
  * - deliverMessage(): sets activatedTasks only on first activation
  * - deliverMessage(): throws when target role not found in workflow
+ * - deliverMessage(): fan-out — node name target activates all agents in that node
+ * - deliverMessage(): within-node DM — same-node agent-to-agent
+ * - deliverMessage(): isFanOut flag set for node-name targets
+ * - deliverMessage(): isFanOut false for agent-role targets
+ * - deliverMessage(): gate blocked throws ChannelGateBlockedError
+ * - deliverMessage(): gate allowed delivers successfully
+ * - deliverMessage(): cyclic channel increments iterationCount
+ * - deliverMessage(): cyclic iteration cap throws ActivationError
+ * - deliverMessage(): no context — gates skipped, delivery succeeds
+ * - canDeliver(): open topology allows all deliveries
+ * - canDeliver(): gate 'always' — always allowed
+ * - canDeliver(): gate 'human' — blocked without approval, allowed with approval
+ * - canDeliver(): gate 'task_result' — blocked on mismatch, allowed on match
+ * - canDeliver(): cyclic channel — blocked when iterationCount >= maxIterations
+ * - canDeliver(): cyclic channel — allowed when below cap
+ * - canDeliver(): no gate on channel — allowed
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -28,8 +44,13 @@ import { SpaceTaskRepository } from '../../../src/storage/repositories/space-tas
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
-import { ChannelRouter, ActivationError } from '../../../src/lib/space/runtime/channel-router.ts';
-import type { SpaceWorkflow } from '@neokai/shared';
+import {
+	ChannelRouter,
+	ActivationError,
+	ChannelGateBlockedError,
+} from '../../../src/lib/space/runtime/channel-router.ts';
+import { ChannelGateEvaluator } from '../../../src/lib/space/runtime/channel-gate-evaluator.ts';
+import type { SpaceWorkflow, WorkflowChannel } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // DB helpers
@@ -82,7 +103,8 @@ function buildWorkflow(
 		name: string;
 		agentId?: string;
 		agents?: Array<{ agentId: string; name: string }>;
-	}>
+	}>,
+	channels?: WorkflowChannel[]
 ): SpaceWorkflow {
 	return workflowManager.createWorkflow({
 		spaceId,
@@ -98,7 +120,22 @@ function buildWorkflow(
 		startNodeId: nodes[0].id,
 		rules: [],
 		tags: [],
+		channels: channels ?? [],
 	});
+}
+
+// ---------------------------------------------------------------------------
+// Mock gate evaluator helpers
+// ---------------------------------------------------------------------------
+
+/** Creates a ChannelGateEvaluator that always allows delivery */
+function makeAllowingEvaluator(): ChannelGateEvaluator {
+	return new ChannelGateEvaluator(async () => ({ exitCode: 0 }));
+}
+
+/** Creates a ChannelGateEvaluator that always fails shell conditions */
+function makeBlockingEvaluator(): ChannelGateEvaluator {
+	return new ChannelGateEvaluator(async () => ({ exitCode: 1 }));
 }
 
 // ---------------------------------------------------------------------------
@@ -402,7 +439,7 @@ describe('ChannelRouter', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// deliverMessage
+	// deliverMessage — basic routing
 	// -------------------------------------------------------------------------
 
 	describe('deliverMessage', () => {
@@ -434,6 +471,7 @@ describe('ChannelRouter', () => {
 			expect(result.toRole).toBe('planner');
 			expect(result.message).toBe('hello planner');
 			expect(result.targetNodeId).toBe(NODE_B);
+			expect(result.isFanOut).toBe(false);
 			// activatedTasks should be set since NODE_B had no tasks
 			expect(result.activatedTasks).toBeDefined();
 			expect(result.activatedTasks).toHaveLength(1);
@@ -512,7 +550,7 @@ describe('ChannelRouter', () => {
 			).rejects.toBeInstanceOf(ActivationError);
 			await expect(
 				router.deliverMessage(run.id, 'coder', 'nonexistent-role', 'hello')
-			).rejects.toThrow(/No node found with agent role/);
+			).rejects.toThrow(/No node found/);
 		});
 
 		test('returns correct targetNodeId in result', async () => {
@@ -539,6 +577,818 @@ describe('ChannelRouter', () => {
 
 			const result = await router.deliverMessage(run.id, 'sender', 'receiver', 'test');
 			expect(result.targetNodeId).toBe(NODE_B);
+		});
+
+		// -----------------------------------------------------------------------
+		// Fan-out — node name targeting
+		// -----------------------------------------------------------------------
+
+		test('fan-out: node name activates all agents in the target node', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Sender Node',
+					agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+				},
+				{
+					id: NODE_B,
+					name: 'Receiver Node',
+					agents: [
+						{ agentId: AGENT_CODER, name: 'coder-b' },
+						{ agentId: AGENT_PLANNER, name: 'planner-b' },
+					],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Fan-out Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// Use node name 'Receiver Node' as target (fan-out)
+			const result = await router.deliverMessage(run.id, 'coder', 'Receiver Node', 'broadcast');
+
+			expect(result.targetNodeId).toBe(NODE_B);
+			expect(result.isFanOut).toBe(true);
+			// Both agents in NODE_B should be activated
+			expect(result.activatedTasks).toBeDefined();
+			expect(result.activatedTasks).toHaveLength(2);
+			const roles = result.activatedTasks!.map((t) => t.slotRole).sort();
+			expect(roles).toEqual(['coder-b', 'planner-b']);
+		});
+
+		test('fan-out: isFanOut is false when targeting by agent role', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Sender Node',
+					agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+				},
+				{
+					id: NODE_B,
+					name: 'Receiver Node',
+					agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'DM Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await router.deliverMessage(run.id, 'coder', 'planner', 'dm message');
+
+			expect(result.isFanOut).toBe(false);
+		});
+
+		test('within-node DM: agent can message another agent in the same node', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Collaboration Node',
+					agents: [
+						{ agentId: AGENT_CODER, name: 'coder' },
+						{ agentId: AGENT_PLANNER, name: 'planner' },
+					],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Within-node Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// Both agents are in NODE_A; 'planner' is in the same node as 'coder'
+			const result = await router.deliverMessage(run.id, 'coder', 'planner', 'hey planner');
+
+			expect(result.targetNodeId).toBe(NODE_A);
+			expect(result.isFanOut).toBe(false);
+		});
+
+		// -----------------------------------------------------------------------
+		// Gate evaluation
+		// -----------------------------------------------------------------------
+
+		test('gate blocked: throws ChannelGateBlockedError for human gate without approval', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'human', description: 'Needs human review' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Human Gate Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			await expect(
+				router.deliverMessage(run.id, 'coder', 'planner', 'needs review', {
+					workspacePath: '/tmp/ws',
+					humanApproved: false,
+				})
+			).rejects.toBeInstanceOf(ChannelGateBlockedError);
+		});
+
+		test('gate allowed: human gate with approval delivers successfully', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'human' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Human Gate Approved Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await router.deliverMessage(run.id, 'coder', 'planner', 'approved message', {
+				workspacePath: '/tmp/ws',
+				humanApproved: true,
+			});
+
+			expect(result.fromRole).toBe('coder');
+			expect(result.toRole).toBe('planner');
+		});
+
+		test('gate blocked: task_result gate blocks on mismatch', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'task_result', expression: 'success' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Task Result Gate Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			await expect(
+				router.deliverMessage(run.id, 'coder', 'planner', 'msg', {
+					workspacePath: '/tmp/ws',
+					taskResult: 'failure',
+				})
+			).rejects.toBeInstanceOf(ChannelGateBlockedError);
+		});
+
+		test('gate allowed: task_result gate passes on match', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'task_result', expression: 'success' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Task Result Match Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await router.deliverMessage(run.id, 'coder', 'planner', 'msg', {
+				workspacePath: '/tmp/ws',
+				taskResult: 'success: all tests passed',
+			});
+
+			expect(result.fromRole).toBe('coder');
+		});
+
+		test('no context: gates are skipped and delivery succeeds', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'human' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'No Context Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// No context provided — gate is not evaluated
+			const result = await router.deliverMessage(run.id, 'coder', 'planner', 'msg');
+			expect(result.fromRole).toBe('coder');
+		});
+
+		test('condition gate: uses injected evaluator (allowed)', async () => {
+			const allowingRouter = new ChannelRouter({
+				taskRepo,
+				workflowRunRepo,
+				workflowManager,
+				agentManager,
+				gateEvaluator: makeAllowingEvaluator(),
+			});
+
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'condition', expression: 'exit 0' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Condition Gate Allowed',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await allowingRouter.deliverMessage(run.id, 'coder', 'planner', 'msg', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.fromRole).toBe('coder');
+		});
+
+		test('condition gate: uses injected evaluator (blocked)', async () => {
+			const blockingRouter = new ChannelRouter({
+				taskRepo,
+				workflowRunRepo,
+				workflowManager,
+				agentManager,
+				gateEvaluator: makeBlockingEvaluator(),
+			});
+
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'condition', expression: 'exit 1' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Condition Gate Blocked',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			await expect(
+				blockingRouter.deliverMessage(run.id, 'coder', 'planner', 'msg', {
+					workspacePath: '/tmp/ws',
+				})
+			).rejects.toBeInstanceOf(ChannelGateBlockedError);
+		});
+
+		// -----------------------------------------------------------------------
+		// Cyclic channels — iteration tracking
+		// -----------------------------------------------------------------------
+
+		test('cyclic channel: increments iterationCount on successful delivery', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					isCyclic: true,
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Cyclic Run',
+				currentNodeId: NODE_A,
+				maxIterations: 5,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// First delivery
+			await router.deliverMessage(run.id, 'coder', 'planner', 'message 1');
+			let freshRun = workflowRunRepo.getRun(run.id)!;
+			expect(freshRun.iterationCount).toBe(1);
+
+			// Cancel existing tasks to allow re-activation
+			for (const t of taskRepo.listByWorkflowRun(run.id)) {
+				taskRepo.updateTask(t.id, { status: 'cancelled' });
+			}
+
+			// Second delivery
+			await router.deliverMessage(run.id, 'coder', 'planner', 'message 2');
+			freshRun = workflowRunRepo.getRun(run.id)!;
+			expect(freshRun.iterationCount).toBe(2);
+		});
+
+		test('cyclic channel: throws ActivationError when iteration cap is reached', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					isCyclic: true,
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Iteration Cap Run',
+				currentNodeId: NODE_A,
+				maxIterations: 2,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// Manually set iterationCount to the cap
+			workflowRunRepo.updateRun(run.id, { iterationCount: 2 });
+
+			await expect(
+				router.deliverMessage(run.id, 'coder', 'planner', 'over the limit')
+			).rejects.toBeInstanceOf(ActivationError);
+			await expect(
+				router.deliverMessage(run.id, 'coder', 'planner', 'over the limit')
+			).rejects.toThrow(/maximum iteration count/);
+		});
+
+		test('non-cyclic channel: iterationCount stays unchanged', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					// isCyclic is NOT set
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Non-cyclic Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			await router.deliverMessage(run.id, 'coder', 'planner', 'non-cyclic message');
+
+			const freshRun = workflowRunRepo.getRun(run.id)!;
+			expect(freshRun.iterationCount).toBe(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// canDeliver
+	// -------------------------------------------------------------------------
+
+	describe('canDeliver', () => {
+		test('open topology: always allowed when no channels declared', async () => {
+			// No channels on workflow
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Open Topology Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.allowed).toBe(true);
+		});
+
+		test("open topology: allowed even when channels exist but don't match the pair", async () => {
+			const channels: WorkflowChannel[] = [{ from: 'coder', to: 'reviewer', direction: 'one-way' }];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'No Match Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			// coder→planner not declared; open topology for this pair
+			const result = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.allowed).toBe(true);
+		});
+
+		test('channel with no gate: always allowed', async () => {
+			const channels: WorkflowChannel[] = [{ from: 'coder', to: 'planner', direction: 'one-way' }];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'No Gate Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.allowed).toBe(true);
+		});
+
+		test('gate always: allowed', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'always' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Always Gate Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const result = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.allowed).toBe(true);
+		});
+
+		test('gate human: blocked without approval', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'human' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Human Gate Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const blocked = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+				humanApproved: false,
+			});
+			expect(blocked.allowed).toBe(false);
+			expect(blocked.reason).toMatch(/human approval/);
+		});
+
+		test('gate human: allowed with approval', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'human' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Human Gate Approved Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const allowed = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+				humanApproved: true,
+			});
+			expect(allowed.allowed).toBe(true);
+		});
+
+		test('gate task_result: blocked on mismatch, allowed on match', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					gate: { type: 'task_result', expression: 'success' },
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Task Result Gate Run',
+				currentNodeId: NODE_A,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+
+			const blocked = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+				taskResult: 'failure',
+			});
+			expect(blocked.allowed).toBe(false);
+			expect(blocked.reason).toMatch(/failure/);
+
+			const allowed = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+				taskResult: 'success: all tests passed',
+			});
+			expect(allowed.allowed).toBe(true);
+		});
+
+		test('cyclic channel: blocked when iterationCount >= maxIterations', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					isCyclic: true,
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Iteration Cap Run',
+				currentNodeId: NODE_A,
+				maxIterations: 3,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+			workflowRunRepo.updateRun(run.id, { iterationCount: 3 });
+
+			const result = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toMatch(/maximum iteration count/);
+		});
+
+		test('cyclic channel: allowed when below the cap', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					isCyclic: true,
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Below Cap Run',
+				currentNodeId: NODE_A,
+				maxIterations: 5,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+			workflowRunRepo.updateRun(run.id, { iterationCount: 2 });
+
+			const result = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			expect(result.allowed).toBe(true);
+		});
+
+		test('non-cyclic channel: iteration count does not block delivery', async () => {
+			const channels: WorkflowChannel[] = [
+				{
+					from: 'coder',
+					to: 'planner',
+					direction: 'one-way',
+					// isCyclic NOT set
+				},
+			];
+			const workflow = buildWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Non-cyclic Cap Run',
+				currentNodeId: NODE_A,
+				maxIterations: 1,
+			});
+			workflowRunRepo.updateStatus(run.id, 'in_progress');
+			// Set iterationCount above maxIterations
+			workflowRunRepo.updateRun(run.id, { iterationCount: 100 });
+
+			const result = await router.canDeliver(run.id, 'coder', 'planner', {
+				workspacePath: '/tmp/ws',
+			});
+			// Non-cyclic channel is not affected by iteration count
+			expect(result.allowed).toBe(true);
+		});
+
+		test('canDeliver: throws ActivationError when run not found', async () => {
+			await expect(
+				router.canDeliver('nonexistent-run', 'coder', 'planner', { workspacePath: '/tmp/ws' })
+			).rejects.toBeInstanceOf(ActivationError);
 		});
 	});
 });


### PR DESCRIPTION
- Add canDeliver() — pure gate+iteration-cap check without side effects
  - Finds matching WorkflowChannel for from/to pair (open topology returns allowed)
  - Blocks on cyclic channel when iterationCount >= maxIterations
  - Evaluates all gate types (always, human, condition, task_result)

- Update deliverMessage() with optional gate context parameter
  - Evaluates gate via ChannelGateEvaluator when context is provided
  - Throws ChannelGateBlockedError for gate-blocked deliveries (retryable)
  - Throws ActivationError for iteration cap exceeded (hard limit)
  - Increments run.iterationCount for cyclic channels after delivery
  - Adds fan-out support: node name targets activate all agents in that node
  - Sets isFanOut flag on DeliveredMessage for node-name vs agent-role distinction

- Add gateEvaluator to ChannelRouterConfig (injectable for tests)
- Re-export ChannelGateBlockedError, ChannelGateContext, GateResult from channel-router

- 38 unit tests (25 new + 13 existing) covering all new features
