### PR TITLE
feat(space): add list_reachable_agents tool to step agent MCP server (Task 3.4)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -364,7 +364,7 @@ jobs:
   test-daemon-shared-unit:
     name: Daemon + Shared Unit Tests (Coverage)
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 6
     if: github.event_name != 'push' || github.ref != 'refs/heads/dev'
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -284,7 +284,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -373,7 +373,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -426,7 +426,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -480,7 +480,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -636,7 +636,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -780,7 +780,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -887,7 +887,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
@@ -87,6 +87,20 @@ export const ReportDoneSchema = z.object({
 export type ReportDoneInput = z.infer<typeof ReportDoneSchema>;
 
 // ---------------------------------------------------------------------------
+// list_reachable_agents
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `list_reachable_agents` input.
+ * Lists all agents and nodes this agent can reach, grouped by within-node peers
+ * and cross-node targets. Includes gate status for cross-node targets.
+ * No arguments — the reachability graph is inferred from the agent's context.
+ */
+export const ListReachableAgentsSchema = z.object({});
+
+export type ListReachableAgentsInput = z.infer<typeof ListReachableAgentsSchema>;
+
+// ---------------------------------------------------------------------------
 // Aggregate export
 // ---------------------------------------------------------------------------
 
@@ -97,6 +111,7 @@ export const STEP_AGENT_TOOL_SCHEMAS = {
 	list_peers: ListPeersSchema,
 	send_message: SendMessageSchema,
 	report_done: ReportDoneSchema,
+	list_reachable_agents: ListReachableAgentsSchema,
 } as const;
 
 export type StepAgentToolName = keyof typeof STEP_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/step-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tools.ts
@@ -34,8 +34,18 @@ import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/s
 import { ChannelResolver } from '../runtime/channel-resolver';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
-import { ListPeersSchema, SendMessageSchema, ReportDoneSchema } from './step-agent-tool-schemas';
-import type { ListPeersInput, SendMessageInput, ReportDoneInput } from './step-agent-tool-schemas';
+import {
+	ListPeersSchema,
+	SendMessageSchema,
+	ReportDoneSchema,
+	ListReachableAgentsSchema,
+} from './step-agent-tool-schemas';
+import type {
+	ListPeersInput,
+	SendMessageInput,
+	ReportDoneInput,
+	ListReachableAgentsInput,
+} from './step-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
@@ -332,6 +342,87 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		},
 
 		/**
+		 * List all agents and nodes this agent can reach, grouped as:
+		 *   - withinNodePeers: agents in the same workflow node (current group members)
+		 *   - crossNodeTargets: agents/nodes reachable via declared cross-node paths
+		 *
+		 * Uses agent-friendly terminology — no mention of channels or policies.
+		 * Gate status is included for cross-node targets so agents know whether
+		 * a target may require conditions to be met before delivery is permitted.
+		 *
+		 * Does NOT include self or the task-agent coordinator.
+		 */
+		async list_reachable_agents(_args: ListReachableAgentsInput): Promise<ToolResult> {
+			const loaded = loadGroupAndResolver();
+			if (!loaded.ok) return loaded.error;
+			const { group, resolver } = loaded;
+
+			// Within-node peers: group members excluding self and the task-agent coordinator
+			const withinNodePeers = group.members
+				.filter((m) => m.sessionId !== mySessionId && m.role !== 'task-agent')
+				.map((m) => ({
+					agentName: m.role,
+					status: m.status,
+				}));
+
+			const reachabilityDeclared = !resolver.isEmpty();
+
+			// Cross-node targets: outgoing channel entries where the target role is NOT
+			// already in the current session group (i.e., it lives on a different node).
+			const withinNodeRoles = new Set(group.members.map((m) => m.role));
+
+			type CrossNodeTarget = {
+				agentName: string;
+				isFanOut: boolean;
+				gate: { type: string; isGated: boolean; description?: string };
+			};
+			const crossNodeTargets: CrossNodeTarget[] = [];
+
+			if (reachabilityDeclared) {
+				const seen = new Set<string>();
+				for (const ch of resolver.getResolvedChannels()) {
+					if (ch.fromRole !== myRole) continue;
+					if (withinNodeRoles.has(ch.toRole)) continue; // within-node — already listed above
+					if (seen.has(ch.toRole)) continue; // deduplicate (e.g. bidirectional split)
+					seen.add(ch.toRole);
+
+					const gate = ch.gate;
+					const gateType = gate?.type ?? 'none';
+					// A gate is "blocking" (isGated) when a condition must be evaluated at delivery
+					// time — i.e. anything other than no gate at all or an 'always' gate.
+					const isGated = gate !== undefined && gate.type !== 'always' && gate.type !== undefined;
+					const entry: CrossNodeTarget = {
+						agentName: ch.toRole,
+						isFanOut: ch.isFanOut ?? false,
+						gate: { type: gateType, isGated },
+					};
+					if (gate?.description) {
+						entry.gate.description = gate.description;
+					}
+					crossNodeTargets.push(entry);
+				}
+			}
+
+			const totalReachable = withinNodePeers.length + crossNodeTargets.length;
+			const crossNodeSummary =
+				crossNodeTargets.length > 0
+					? ` Cross-node targets: ${crossNodeTargets.map((t) => t.agentName).join(', ')}.`
+					: '';
+
+			return jsonResult({
+				success: true,
+				myAgentName: myRole,
+				withinNodePeers,
+				crossNodeTargets,
+				reachabilityDeclared,
+				message:
+					`You can reach ${totalReachable} agent(s) in total. ` +
+					`Within-node peers: ${withinNodePeers.length > 0 ? withinNodePeers.map((p) => p.agentName).join(', ') : 'none'}.` +
+					crossNodeSummary,
+			});
+		},
+
+		/**
 		 * Signal that this step agent has completed its work.
 		 *
 		 * Marks the step's SpaceTask as 'completed', persists the optional summary
@@ -400,6 +491,16 @@ export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
 				'Use this to discover which peers are active and what direct messaging channels are available.',
 			ListPeersSchema.shape,
 			(args) => handlers.list_peers(args)
+		),
+		tool(
+			'list_reachable_agents',
+			'List all agents and nodes this agent can reach, grouped as within-node peers ' +
+				'(agents in the same workflow node) and cross-node targets (agents/nodes on other nodes). ' +
+				'Gate status is included for each cross-node target so you know whether a condition ' +
+				'must pass before delivery is permitted. ' +
+				'Use this before sending a message to understand who you can reach and whether any gates apply.',
+			ListReachableAgentsSchema.shape,
+			(args) => handlers.list_reachable_agents(args)
 		),
 		tool(
 			'send_message',

--- a/packages/daemon/tests/unit/space/step-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/step-agent-tools.test.ts
@@ -98,7 +98,8 @@ function seedWorkflowRunWithChannels(
 function makeResolvedChannel(
 	fromRole: string,
 	toRole: string,
-	isHubSpoke = false
+	isHubSpoke = false,
+	overrides: Partial<ResolvedChannel> = {}
 ): ResolvedChannel {
 	return {
 		fromRole,
@@ -107,6 +108,7 @@ function makeResolvedChannel(
 		toAgentId: `agent-${toRole}`,
 		direction: 'one-way',
 		isHubSpoke,
+		...overrides,
 	};
 }
 
@@ -843,6 +845,213 @@ describe('step-agent-tools: report_done', () => {
 		expect(data.success).toBe(false);
 		// Hub should not have been called since the DB update never happened
 		expect(emitted).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: list_reachable_agents
+// ---------------------------------------------------------------------------
+
+describe('step-agent-tools: list_reachable_agents', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns within-node peers excluding self and task-agent', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.myAgentName).toBe('coder');
+		expect(data.withinNodePeers).toHaveLength(1);
+		expect(data.withinNodePeers[0].agentName).toBe('reviewer');
+		expect(data.withinNodePeers[0].status).toBe('active');
+	});
+
+	test('returns empty cross-node targets when no channels declared', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.reachabilityDeclared).toBe(false);
+		expect(data.crossNodeTargets).toHaveLength(0);
+	});
+
+	test('returns cross-node targets for channels to roles not in current group', async () => {
+		// 'tester' is not a member of the session group — cross-node target
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester'),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.reachabilityDeclared).toBe(true);
+		expect(data.crossNodeTargets).toHaveLength(1);
+		expect(data.crossNodeTargets[0].agentName).toBe('tester');
+		expect(data.crossNodeTargets[0].isFanOut).toBe(false);
+	});
+
+	test('within-node peer with a channel does not appear in cross-node targets', async () => {
+		// 'reviewer' is in the session group — stays in withinNodePeers, not crossNodeTargets
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.withinNodePeers).toHaveLength(1);
+		expect(data.withinNodePeers[0].agentName).toBe('reviewer');
+		expect(data.crossNodeTargets).toHaveLength(0);
+	});
+
+	test('gate type none when no gate on cross-node channel', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester'), // no gate
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets[0].gate.type).toBe('none');
+		expect(data.crossNodeTargets[0].gate.isGated).toBe(false);
+	});
+
+	test('gate type human: isGated true', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester', false, { gate: { type: 'human' } }),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets[0].gate.type).toBe('human');
+		expect(data.crossNodeTargets[0].gate.isGated).toBe(true);
+	});
+
+	test('gate type condition: isGated true', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester', false, {
+				gate: { type: 'condition', expression: 'test -f pr.txt' },
+			}),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets[0].gate.type).toBe('condition');
+		expect(data.crossNodeTargets[0].gate.isGated).toBe(true);
+	});
+
+	test('gate type task_result: isGated true', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester', false, {
+				gate: { type: 'task_result', expression: 'passed' },
+			}),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets[0].gate.type).toBe('task_result');
+		expect(data.crossNodeTargets[0].gate.isGated).toBe(true);
+	});
+
+	test('gate type always: isGated false (always passes)', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester', false, { gate: { type: 'always' } }),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets[0].gate.type).toBe('always');
+		expect(data.crossNodeTargets[0].gate.isGated).toBe(false);
+	});
+
+	test('gate description propagated when present', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester', false, {
+				gate: { type: 'human', description: 'Needs tech lead approval' },
+			}),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets[0].gate.description).toBe('Needs tech lead approval');
+	});
+
+	test('fan-out target marked as isFanOut true', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'qa-node', false, { isFanOut: true }),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets).toHaveLength(1);
+		expect(data.crossNodeTargets[0].agentName).toBe('qa-node');
+		expect(data.crossNodeTargets[0].isFanOut).toBe(true);
+	});
+
+	test('deduplicates cross-node targets from multiple channels to same role', async () => {
+		// Two channels to 'tester' (e.g. from bidirectional expansion) — should appear once
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester'),
+			makeResolvedChannel('coder', 'tester'), // duplicate
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets).toHaveLength(1);
+	});
+
+	test('only includes outgoing channels (fromRole matches myRole)', async () => {
+		// Channel from 'tester' → 'coder' should NOT appear as a cross-node target for coder
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('tester', 'coder'),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.crossNodeTargets).toHaveLength(0);
+	});
+
+	test('returns error when group not found', async () => {
+		const config = makeConfig(ctx, { getGroupId: () => undefined });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_reachable_agents({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('No session group found');
 	});
 });
 


### PR DESCRIPTION
Add list_reachable_agents tool to step agent MCP server (Task 3.4). Returns within-node peers and cross-node targets with gate status. Also upgrades Bun from 1.3.10 to 1.3.11 in CI to fix intermittent file I/O test failures.