### PR TITLE
fix: add re-detection guard to usage_limit handler in onWorkerTerminalState

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -727,44 +727,55 @@ export class RoomRuntime {
 				// Fall through to the worktree check so the worker can attempt cleanup/retry.
 			}
 			if (errorClass?.class === 'usage_limit') {
-				// Usage limit (daily/weekly cap) — do NOT wait. Try fallback model immediately.
-				// If no fallback is configured, fall through to rate_limit behavior (pause + backoff).
-				log.info(
-					`Usage limit detected in worker output for group ${groupId}: ${errorClass.reason}`
-				);
-				const switched = await this.trySwitchToFallbackModel(
-					groupId,
-					group.workerSessionId,
-					'worker'
-				);
-				if (!switched) {
-					// No fallback available — fall through to rate_limit behavior (backoff + pause)
-					// Parse reset time from the usage limit message, or use 1-minute default
-					const rateLimitBackoff = errorClass.resetsAt
-						? createRateLimitBackoff(workerOutputText, 'worker')
-						: null;
-					const backoff: RateLimitBackoff = rateLimitBackoff ?? {
-						detectedAt: Date.now(),
-						resetsAt: Date.now() + 60 * 1000,
-						sessionRole: 'worker',
-					};
-					this.groupRepo.setRateLimit(groupId, backoff);
-					this.appendGroupEvent(groupId, 'rate_limited', {
-						text: `Usage limit reached. Pausing until ${new Date(backoff.resetsAt).toLocaleTimeString()}.`,
-						resetsAt: backoff.resetsAt,
-						sessionRole: 'worker',
-					});
-					await this.persistTaskRestriction(
-						group.taskId,
-						backoff,
-						'usage_limit',
-						`Daily/weekly usage cap`
+				// Only attempt fallback / backoff on first detection (group.rateLimit is null).
+				// After the initial backoff expires, recoverStuckWorkers re-triggers this handler
+				// with the same old "You've hit your limit" text still in the worker output.
+				// Skipping re-detection here lets the worker fall through to the worktree check
+				// and attempt cleanup/retry instead of re-applying a stale backoff indefinitely.
+				// (group.rateLimit is intentionally NOT cleared by the timer — it acts as a
+				// sentinel so that re-triggers caused by recoverStuckWorkers never loop.)
+				if (!group.rateLimit) {
+					// Usage limit (daily/weekly cap) — do NOT wait. Try fallback model immediately.
+					// If no fallback is configured, fall through to rate_limit behavior (pause + backoff).
+					log.info(
+						`Usage limit detected in worker output for group ${groupId}: ${errorClass.reason}`
 					);
-					this.scheduleTickAfterRateLimitReset(groupId);
-					return;
+					const switched = await this.trySwitchToFallbackModel(
+						groupId,
+						group.workerSessionId,
+						'worker'
+					);
+					if (!switched) {
+						// No fallback available — fall through to rate_limit behavior (backoff + pause)
+						// Parse reset time from the usage limit message, or use 1-minute default
+						const rateLimitBackoff = errorClass.resetsAt
+							? createRateLimitBackoff(workerOutputText, 'worker')
+							: null;
+						const backoff: RateLimitBackoff = rateLimitBackoff ?? {
+							detectedAt: Date.now(),
+							resetsAt: Date.now() + 60 * 1000,
+							sessionRole: 'worker',
+						};
+						this.groupRepo.setRateLimit(groupId, backoff);
+						this.appendGroupEvent(groupId, 'rate_limited', {
+							text: `Usage limit reached. Pausing until ${new Date(backoff.resetsAt).toLocaleTimeString()}.`,
+							resetsAt: backoff.resetsAt,
+							sessionRole: 'worker',
+						});
+						await this.persistTaskRestriction(
+							group.taskId,
+							backoff,
+							'usage_limit',
+							`Daily/weekly usage cap`
+						);
+						this.scheduleTickAfterRateLimitReset(groupId);
+						return;
+					}
+					// Fall through to normal routing — fallback model switch event was already appended
+					// in trySwitchToFallbackModel so the UI shows the switch clearly.
 				}
-				// Fall through to normal routing — fallback model switch event was already appended
-				// in trySwitchToFallbackModel so the UI shows the switch clearly.
+				// group.rateLimit already set (even if expired): re-trigger after expiry.
+				// Fall through to the worktree check so the worker can attempt cleanup/retry.
 			}
 		}
 

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -309,5 +309,45 @@ describe('RoomRuntime - terminal error detection', () => {
 			const payload = JSON.parse(rateLimitedEvents[0].payloadJson ?? '{}');
 			expect(payload.text).toContain('Usage limit');
 		});
+
+		it('does NOT re-set rate limit when group.rateLimit is already set (usage_limit re-trigger after expiry)', async () => {
+			// Production flow:
+			//   1. Initial usage_limit → setRateLimit(resetsAt) → scheduleTickAfterRateLimitReset
+			//   2. Timer fires after reset time → does NOT clear rateLimit (sentinel remains)
+			//   3. recoverStuckWorkers → onWorkerTerminalState called again with same usage_limit text
+			//   4. group.rateLimit is non-null (expired but present) → guard skips re-detection
+			//   5. Falls through to worktree check → routes to leader — no infinite loop
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
+				],
+			});
+
+			const { group } = await spawnAndSimulateWorkerOutput('');
+
+			// Simulate the limit having already expired (timer fired, resetsAt now in past,
+			// but rateLimit is still non-null because the sentinel is never cleared by the timer).
+			const expiredRateLimit = {
+				detectedAt: Date.now() - 120_000,
+				resetsAt: Date.now() - 1, // already expired
+				sessionRole: 'worker' as const,
+			};
+			ctx.groupRepo.setRateLimit(group.id, expiredRateLimit);
+
+			// Re-trigger as recoverStuckWorkers would
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			// Rate limit must NOT have been pushed to a new future timestamp —
+			// the guard should have skipped re-detection.
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.rateLimit!.resetsAt).toBeLessThanOrEqual(Date.now());
+
+			// Worker should have been routed to leader (worktree is clean in tests).
+			// Routing is confirmed by feedbackIteration incrementing.
+			expect(updatedGroup!.feedbackIteration).toBeGreaterThan(0);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Add `!group.rateLimit` guard to the `usage_limit` block in `onWorkerTerminalState()`, matching the existing `rate_limit` guard pattern at line 693. This prevents infinite loops when usage limits expire and `recoverStuckWorkers` re-triggers with stale error text.
- Add unit test verifying re-trigger behavior: when `group.rateLimit` is already set (even if expired), the `usage_limit` handler is skipped and falls through to normal routing.

## Context

Without this guard, every time `onWorkerTerminalState` is called with old usage-limit text in the output (e.g., after `recoverStuckWorkers` fires post-expiry), it re-applies the backoff and returns early — even if the limit has already expired. This caused permanent deadlocks.

Part of the "Fix usage limit handling and fallback model auto-switch gaps" goal.

## Test plan

- [x] New unit test: `does NOT re-set rate limit when group.rateLimit is already set (usage_limit re-trigger after expiry)`
- [x] All 16 terminal-error tests pass
- [x] Full test suite passes (1521 tests)