### PR TITLE
feat(room-runtime): add public clearGroupRateLimit() method

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1808,6 +1808,25 @@ export class RoomRuntime {
 	}
 
 	/**
+	 * Clear the rate limit backoff for the group associated with a task.
+	 *
+	 * Called when a user manually transitions a task from `usage_limited`/`rate_limited`
+	 * back to `in_progress` so that stale rate-limit state doesn't block the next worker
+	 * iteration from forwarding its output to the leader.
+	 *
+	 * Returns `true` if a group was found and cleared, `false` if no group exists.
+	 */
+	async clearGroupRateLimit(taskId: string): Promise<boolean> {
+		const group = this.groupRepo.getGroupByTaskId(taskId);
+		if (!group) return false;
+
+		this.groupRepo.clearRateLimit(group.id);
+		await this.clearTaskRestriction(taskId);
+		log.info(`Cleared rate limit for group ${group.id} (task ${taskId})`);
+		return true;
+	}
+
+	/**
 	 * Archive a task group - terminate active sessions, cleanup worktree, and set archived status.
 	 *
 	 * Called when user archives a task via UI. This:

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1814,11 +1814,11 @@ export class RoomRuntime {
 	 * back to `in_progress` so that stale rate-limit state doesn't block the next worker
 	 * iteration from forwarding its output to the leader.
 	 *
-	 * Returns `true` if a group was found and cleared, `false` if no group exists.
+	 * Returns `true` if an active group was found and cleared, `false` otherwise.
 	 */
 	async clearGroupRateLimit(taskId: string): Promise<boolean> {
 		const group = this.groupRepo.getGroupByTaskId(taskId);
-		if (!group) return false;
+		if (!group || group.completedAt !== null) return false;
 
 		this.groupRepo.clearRateLimit(group.id);
 		await this.clearTaskRestriction(taskId);

--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -287,4 +287,42 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 			expect(updated!.restrictions!.sessionRole).toBe('leader');
 		});
 	});
+
+	// ─── clearGroupRateLimit ────────────────────────────────────────────────────────────────
+
+	describe('clearGroupRateLimit(taskId)', () => {
+		it('returns false when no group exists for the task', async () => {
+			ctx = createRuntimeTestContext();
+			ctx.runtime.start();
+			const result = await ctx.runtime.clearGroupRateLimit('non-existent-task');
+			expect(result).toBe(false);
+		});
+
+		it('clears group rateLimit and task restriction, returns true', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			const { group, task } = await spawnAndTriggerWorkerTerminal('');
+
+			// Confirm the group is rate-limited and task restriction is set
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(true);
+			const restricted = await ctx.taskManager.getTask(task.id);
+			expect(restricted!.status).toBe('rate_limited');
+			expect(restricted!.restrictions).toBeDefined();
+
+			// Clear via the new public method
+			const result = await ctx.runtime.clearGroupRateLimit(task.id);
+			expect(result).toBe(true);
+
+			// Group rateLimit should be gone
+			const groupAfter = ctx.groupRepo.getActiveGroups('room-1').find((g) => g.id === group.id);
+			expect(groupAfter?.rateLimit).toBeNull();
+
+			// Task restriction should be cleared and status restored to in_progress
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.restrictions).toBeNull();
+			expect(taskAfter!.status).toBe('in_progress');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -298,6 +298,20 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 			expect(result).toBe(false);
 		});
 
+		it('returns false when the group is already completed', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			const { group, task } = await spawnAndTriggerWorkerTerminal('');
+
+			// Mark the group as completed
+			ctx.groupRepo.completeGroup(group.id, group.version);
+
+			const result = await ctx.runtime.clearGroupRateLimit(task.id);
+			expect(result).toBe(false);
+		});
+
 		it('clears group rateLimit and task restriction, returns true', async () => {
 			ctx = createRuntimeTestContext({
 				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),


### PR DESCRIPTION
Adds clearGroupRateLimit(taskId) to RoomRuntime which looks up the active
group for a task, clears its rate limit via groupRepo.clearRateLimit(), and
clears the task restriction via clearTaskRestriction(). Returns true if a
group was found and cleared, false otherwise.

This supports Bug B fix: when task.setStatus transitions a task from
usage_limited/rate_limited back to in_progress, the caller can also clear
the stale group.rateLimit so the next worker iteration is not blocked.
