### PR TITLE
fix(runtime): add !group.rateLimit re-detection guard to leader usage_limit handler

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1092,42 +1092,51 @@ export class RoomRuntime {
 					return;
 				}
 				if (errorClass?.class === 'usage_limit') {
-					// Usage limit (daily/weekly cap) — do NOT wait. Try fallback model immediately.
-					// If no fallback is configured, fall through to rate_limit behavior (backoff + pause).
-					log.info(
-						`Usage limit detected in leader output for group ${groupId}: ${errorClass.reason}`
-					);
-					const switched = await this.trySwitchToFallbackModel(
-						groupId,
-						group.leaderSessionId,
-						'leader'
-					);
-					if (!switched) {
-						// No fallback available — fall through to rate_limit behavior (backoff + pause)
-						const rateLimitBackoff = errorClass.resetsAt
-							? createRateLimitBackoff(leaderOutputText, 'leader')
-							: null;
-						const backoff: RateLimitBackoff = rateLimitBackoff ?? {
-							detectedAt: Date.now(),
-							resetsAt: Date.now() + 60 * 1000,
-							sessionRole: 'leader',
-						};
-						this.groupRepo.setRateLimit(groupId, backoff);
-						this.appendGroupEvent(groupId, 'rate_limited', {
-							text: `Usage limit reached in leader. Pausing until ${new Date(backoff.resetsAt).toLocaleTimeString()}.`,
-							resetsAt: backoff.resetsAt,
-							sessionRole: 'leader',
-						});
-						await this.persistTaskRestriction(
-							group.taskId,
-							backoff,
-							'usage_limit',
-							`Daily/weekly usage cap in leader`
+					// Only act on first detection. If group.rateLimit is already set (even if expired),
+					// the limit was already handled — skip re-detection and fall through to normal
+					// completion. This prevents an infinite loop when recoverStuckLeaders re-triggers
+					// onLeaderTerminalState after the limit has reset but the old output still contains
+					// the usage-limit text.
+					if (!group.rateLimit) {
+						// Usage limit (daily/weekly cap) — do NOT wait. Try fallback model immediately.
+						// If no fallback is configured, fall through to rate_limit behavior (backoff + pause).
+						log.info(
+							`Usage limit detected in leader output for group ${groupId}: ${errorClass.reason}`
 						);
-						this.scheduleTickAfterRateLimitReset(groupId);
-						return;
+						const switched = await this.trySwitchToFallbackModel(
+							groupId,
+							group.leaderSessionId,
+							'leader'
+						);
+						if (!switched) {
+							// No fallback available — fall through to rate_limit behavior (backoff + pause)
+							const rateLimitBackoff = errorClass.resetsAt
+								? createRateLimitBackoff(leaderOutputText, 'leader')
+								: null;
+							const backoff: RateLimitBackoff = rateLimitBackoff ?? {
+								detectedAt: Date.now(),
+								resetsAt: Date.now() + 60 * 1000,
+								sessionRole: 'leader',
+							};
+							this.groupRepo.setRateLimit(groupId, backoff);
+							this.appendGroupEvent(groupId, 'rate_limited', {
+								text: `Usage limit reached in leader. Pausing until ${new Date(backoff.resetsAt).toLocaleTimeString()}.`,
+								resetsAt: backoff.resetsAt,
+								sessionRole: 'leader',
+							});
+							await this.persistTaskRestriction(
+								group.taskId,
+								backoff,
+								'usage_limit',
+								`Daily/weekly usage cap in leader`
+							);
+							this.scheduleTickAfterRateLimitReset(groupId);
+							return;
+						}
+						// Fall through to normal completion — fallback model switch event was already appended
 					}
-					// Fall through to normal completion — fallback model switch event was already appended
+					// group.rateLimit already set (even if expired): re-trigger after expiry.
+					// Fall through to normal completion so the leader can finish cleanly.
 				}
 			}
 		}

--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -287,4 +287,90 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 			expect(updated!.restrictions!.sessionRole).toBe('leader');
 		});
 	});
+
+	describe('leader usage_limit re-detection guard (!group.rateLimit)', () => {
+		it('skips usage_limit handler when group.rateLimit is already set (active)', async () => {
+			// Scenario: usage_limit was already detected (group.rateLimit set).
+			// Re-triggering onLeaderTerminalState with the same usage-limit output must NOT
+			// re-apply the backoff or return early — it must fall through to normal completion.
+			let leaderSessionId: string | null = null;
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: (sessionId) => {
+					if (leaderSessionId && sessionId === leaderSessionId) {
+						return makeWorkerMessages(USAGE_LIMIT_MSG);
+					}
+					return [];
+				},
+				getGlobalSettings: () => ({}) as never,
+			});
+
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+			leaderSessionId = group.leaderSessionId;
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			// Simulate a rateLimit that is already set (first detection already occurred)
+			const existingBackoff = {
+				detectedAt: Date.now() - 10_000,
+				resetsAt: Date.now() + 60_000, // still active
+				sessionRole: 'leader' as const,
+			};
+			ctx.groupRepo.setRateLimit(group.id, existingBackoff);
+
+			// Re-trigger onLeaderTerminalState — the guard must prevent re-applying backoff
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// group.rateLimit must remain unchanged (not re-applied)
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.rateLimit).toEqual(existingBackoff);
+
+			// Task should still be in_progress (no new restriction persisted)
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+		});
+
+		it('skips usage_limit handler when group.rateLimit is expired (re-trigger after reset)', async () => {
+			// Scenario: usage_limit was detected, rateLimit set, then the reset timer fired.
+			// group.rateLimit is expired but still non-null.
+			// onLeaderTerminalState must NOT re-apply backoff — fall through to completion.
+			let leaderSessionId: string | null = null;
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: (sessionId) => {
+					if (leaderSessionId && sessionId === leaderSessionId) {
+						return makeWorkerMessages(USAGE_LIMIT_MSG);
+					}
+					return [];
+				},
+				getGlobalSettings: () => ({}) as never,
+			});
+
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+			leaderSessionId = group.leaderSessionId;
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			// Expired rate limit — simulates the reset timer having fired
+			const expiredBackoff = {
+				detectedAt: Date.now() - 120_000,
+				resetsAt: Date.now() - 10_000, // expired 10s ago
+				sessionRole: 'leader' as const,
+			};
+			ctx.groupRepo.setRateLimit(group.id, expiredBackoff);
+
+			// Re-trigger onLeaderTerminalState
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// group.rateLimit must remain the expired backoff — not overwritten with a new one
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.rateLimit).toEqual(expiredBackoff);
+
+			// Task must not transition to usage_limited again
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+		});
+	});
 });


### PR DESCRIPTION
Wraps the usage_limit detection block in onLeaderTerminalState() with the
same `!group.rateLimit` guard already used by the rate_limit handler. When
group.rateLimit is already set (even if expired), re-triggers skip the
fallback/backoff logic and fall through to normal completion. This prevents
an infinite loop when recoverStuckLeaders (Gap F) re-triggers
onLeaderTerminalState after the usage limit has reset but the old session
output still contains the usage-limit text.

Adds two new unit tests covering both the active and expired rateLimit cases.
