### PR TITLE
feat(task-handlers): call clearGroupRateLimit when resuming from rate/usage limited status

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -485,6 +485,19 @@ export function setupTaskHandlers(
 			}
 		}
 
+		// Clear group rate limit when resuming from a rate/usage limited state.
+		// This is a separate block (not inside the restart block above) because
+		// rate_limited/usage_limited tasks are NOT covered by the restart block.
+		if (
+			(task.status === 'usage_limited' || task.status === 'rate_limited') &&
+			(params.status === 'in_progress' || params.status === 'pending')
+		) {
+			const runtime = runtimeService?.getRuntime(params.roomId);
+			if (runtime) {
+				runtime.clearGroupRateLimit(taskId);
+			}
+		}
+
 		// Apply status change
 		const updatedTask = await taskManager.setTaskStatus(taskId, params.status, {
 			result: params.result,

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -488,13 +488,15 @@ export function setupTaskHandlers(
 		// Clear group rate limit when resuming from a rate/usage limited state.
 		// This is a separate block (not inside the restart block above) because
 		// rate_limited/usage_limited tasks are NOT covered by the restart block.
+		// Note: pending is only reachable from these statuses in manual mode
+		// (VALID_STATUS_TRANSITIONS only allows in_progress in runtime mode).
 		if (
 			(task.status === 'usage_limited' || task.status === 'rate_limited') &&
 			(params.status === 'in_progress' || params.status === 'pending')
 		) {
 			const runtime = runtimeService?.getRuntime(params.roomId);
 			if (runtime) {
-				runtime.clearGroupRateLimit(taskId);
+				await runtime.clearGroupRateLimit(taskId);
 			}
 		}
 

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -1416,6 +1416,168 @@ describe('task.setStatus RPC Handler', () => {
 			);
 		});
 	});
+
+	describe('clearGroupRateLimit on resume from rate/usage limited', () => {
+		/** Build a runtime service that also exposes clearGroupRateLimit. */
+		function makeRuntimeServiceWithClearRateLimit(clearResult = true) {
+			const clearGroupRateLimit = mock(async () => clearResult);
+			const cancelTask = mock(async () => ({
+				success: true,
+				cancelledTaskIds: [TASK_UUID],
+			}));
+			const terminateTaskGroup = mock(async () => true);
+			const runtime = { clearGroupRateLimit, cancelTask, terminateTaskGroup };
+			const service = {
+				getRuntime: mock(() => runtime),
+			} as unknown as RoomRuntimeService;
+			return { service, runtime, clearGroupRateLimit };
+		}
+
+		it('calls clearGroupRateLimit when transitioning usage_limited → in_progress', async () => {
+			const usageLimitedTask = { ...mockTask, status: 'usage_limited' as const };
+			const { service, clearGroupRateLimit } = makeRuntimeServiceWithClearRateLimit();
+			const factory = makeSetStatusTaskManagerFactory(usageLimitedTask);
+			setup({ task: usageLimitedTask, runtimeService: service, taskManagerFactory: factory });
+
+			await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'in_progress', mode: 'manual' },
+				{}
+			);
+
+			expect(clearGroupRateLimit).toHaveBeenCalledWith(TASK_UUID);
+		});
+
+		it('calls clearGroupRateLimit when transitioning usage_limited → pending', async () => {
+			const usageLimitedTask = { ...mockTask, status: 'usage_limited' as const };
+			const { service, clearGroupRateLimit } = makeRuntimeServiceWithClearRateLimit();
+			const factory = makeSetStatusTaskManagerFactory(usageLimitedTask);
+			setup({ task: usageLimitedTask, runtimeService: service, taskManagerFactory: factory });
+
+			await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'pending', mode: 'manual' },
+				{}
+			);
+
+			expect(clearGroupRateLimit).toHaveBeenCalledWith(TASK_UUID);
+		});
+
+		it('calls clearGroupRateLimit when transitioning rate_limited → in_progress', async () => {
+			const rateLimitedTask = { ...mockTask, status: 'rate_limited' as const };
+			const { service, clearGroupRateLimit } = makeRuntimeServiceWithClearRateLimit();
+			const factory = makeSetStatusTaskManagerFactory(rateLimitedTask);
+			setup({ task: rateLimitedTask, runtimeService: service, taskManagerFactory: factory });
+
+			await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'in_progress', mode: 'manual' },
+				{}
+			);
+
+			expect(clearGroupRateLimit).toHaveBeenCalledWith(TASK_UUID);
+		});
+
+		it('calls clearGroupRateLimit when transitioning rate_limited → pending', async () => {
+			const rateLimitedTask = { ...mockTask, status: 'rate_limited' as const };
+			const { service, clearGroupRateLimit } = makeRuntimeServiceWithClearRateLimit();
+			const factory = makeSetStatusTaskManagerFactory(rateLimitedTask);
+			setup({ task: rateLimitedTask, runtimeService: service, taskManagerFactory: factory });
+
+			await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'pending', mode: 'manual' },
+				{}
+			);
+
+			expect(clearGroupRateLimit).toHaveBeenCalledWith(TASK_UUID);
+		});
+
+		it('does NOT call clearGroupRateLimit when transitioning usage_limited → completed', async () => {
+			const usageLimitedTask = { ...mockTask, status: 'usage_limited' as const };
+			const { service, clearGroupRateLimit } = makeRuntimeServiceWithClearRateLimit();
+			const factory = makeSetStatusTaskManagerFactory(usageLimitedTask);
+			setup({ task: usageLimitedTask, runtimeService: service, taskManagerFactory: factory });
+
+			await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'completed', mode: 'manual' },
+				{}
+			);
+
+			expect(clearGroupRateLimit).not.toHaveBeenCalled();
+		});
+
+		it('does NOT call clearGroupRateLimit when transitioning in_progress → pending', async () => {
+			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
+			const { service, clearGroupRateLimit } = makeRuntimeServiceWithClearRateLimit();
+			const factory = makeSetStatusTaskManagerFactory(inProgressTask);
+			setup({ task: inProgressTask, runtimeService: service, taskManagerFactory: factory });
+
+			await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'pending', mode: 'manual' },
+				{}
+			);
+
+			expect(clearGroupRateLimit).not.toHaveBeenCalled();
+		});
+
+		it('continues normally when no runtime is available for the room', async () => {
+			const usageLimitedTask = { ...mockTask, status: 'usage_limited' as const };
+			// getRuntime() returns null — no runtime for this room
+			const service = { getRuntime: mock(() => null) } as unknown as RoomRuntimeService;
+			const factory = makeSetStatusTaskManagerFactory(usageLimitedTask);
+			setup({ task: usageLimitedTask, runtimeService: service, taskManagerFactory: factory });
+
+			// Should not throw — handler continues and calls setTaskStatus
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'in_progress', mode: 'manual' },
+				{}
+			);
+
+			expect(result).toEqual({ task: { ...usageLimitedTask, status: 'in_progress' } });
+		});
+
+		it('calls clearGroupRateLimit BEFORE setTaskStatus', async () => {
+			const usageLimitedTask = { ...mockTask, status: 'usage_limited' as const };
+			const callOrder: string[] = [];
+			const clearGroupRateLimit = mock(async () => {
+				callOrder.push('clearGroupRateLimit');
+				return true;
+			});
+			const cancelTask = mock(async () => ({ success: true, cancelledTaskIds: [TASK_UUID] }));
+			const terminateTaskGroup = mock(async () => true);
+			const runtime = { clearGroupRateLimit, cancelTask, terminateTaskGroup };
+			const service = { getRuntime: mock(() => runtime) } as unknown as RoomRuntimeService;
+
+			const setTaskStatusMock = mock(async () => {
+				callOrder.push('setTaskStatus');
+				return { ...usageLimitedTask, status: 'in_progress' as const };
+			});
+			const manager = {
+				createTask: mock(async () => usageLimitedTask),
+				getTask: mock(async () => usageLimitedTask),
+				listTasks: mock(async () => []),
+				failTask: mock(async () => usageLimitedTask),
+				cancelTask: mock(async () => ({ ...usageLimitedTask, status: 'cancelled' as const })),
+				setTaskStatus: setTaskStatusMock,
+				archiveTask: mock(async () => ({ ...usageLimitedTask })),
+			};
+			const factory = mock(() => manager) as unknown as TaskManagerFactory;
+
+			setupTaskHandlers(
+				hub,
+				mockRoomManager,
+				createMockDaemonHub(),
+				makeDb(makeGroupRow()),
+				{ notifyChange: () => {} } as never,
+				factory,
+				service
+			);
+
+			await handlers.get('task.setStatus')!(
+				{ roomId: 'room-1', taskId: TASK_UUID, status: 'in_progress', mode: 'manual' },
+				{}
+			);
+
+			expect(callOrder).toEqual(['clearGroupRateLimit', 'setTaskStatus']);
+		});
+	});
 });
 
 // ─── task.interruptSession Tests ───


### PR DESCRIPTION
In the task.setStatus RPC handler, add a new top-level conditional block
that calls runtime.clearGroupRateLimit(taskId) when transitioning from
usage_limited or rate_limited to in_progress or pending. This clears the
group.rateLimit state before setTaskStatus() runs so the runtime is
consistent after manual status changes. No error is thrown if no runtime
is available.
