### PR TITLE
task/41 add usagelimit detection to the mirroring callb

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2328,8 +2328,12 @@ export class RoomRuntime {
 						if (!freshGroup) return;
 						if (freshGroup.rateLimit !== null) return;
 
-						// Duplicate fallback guard: only attempt once per session per detection cycle
+						// Duplicate fallback guard: added synchronously BEFORE the async call so
+						// that two distinct messages arriving before the first .then() resolves
+						// cannot both pass the guard and trigger duplicate trySwitchToFallbackModel
+						// calls.
 						if (fallbackAttempted.has(fallbackKey)) return;
+						fallbackAttempted.add(fallbackKey);
 
 						log.info(
 							`Usage limit detected in ${role} message for group ${group.id} (real-time). ` +
@@ -2343,7 +2347,6 @@ export class RoomRuntime {
 										`Fallback model switch succeeded for ${sessionRole} session ${sessionId} ` +
 											`in group ${group.id} (mirroring).`
 									);
-									fallbackAttempted.add(fallbackKey);
 									// Clear any stale task restriction so the UI reflects the new model
 									this.clearTaskRestriction(freshGroup.taskId).catch((err: unknown) => {
 										log.error(
@@ -2354,9 +2357,8 @@ export class RoomRuntime {
 									// No fallback available — apply backoff and restrict the task
 									log.info(
 										`No fallback model available for ${sessionRole} session ${sessionId}. ` +
-											`Applying usage limit backoff for group ${group.id}.`
+											`Applying usage limit backoff for group ${freshGroup.id}.`
 									);
-									fallbackAttempted.add(fallbackKey);
 									const rateLimitBackoff = msgErrorClass.resetsAt
 										? createRateLimitBackoff(messageContent, sessionRole)
 										: null;
@@ -2365,8 +2367,8 @@ export class RoomRuntime {
 										resetsAt: Date.now() + 60 * 1000,
 										sessionRole,
 									};
-									this.groupRepo.setRateLimit(group.id, backoff);
-									this.appendGroupEvent(group.id, 'rate_limited', {
+									this.groupRepo.setRateLimit(freshGroup.id, backoff);
+									this.appendGroupEvent(freshGroup.id, 'rate_limited', {
 										text: `Usage limit reached. Pausing until ${new Date(backoff.resetsAt).toLocaleTimeString()}.`,
 										resetsAt: backoff.resetsAt,
 										sessionRole,
@@ -2381,10 +2383,12 @@ export class RoomRuntime {
 											`Failed to persist usage limit restriction for task ${freshGroup.taskId}: ${String(err)}`
 										);
 									});
-									this.scheduleTickAfterRateLimitReset(group.id);
+									this.scheduleTickAfterRateLimitReset(freshGroup.id);
 								}
 							})
 							.catch((err: unknown) => {
+								// fallbackAttempted was already set synchronously above, so even
+								// unexpected throws won't leave the guard open for retry loops.
 								log.error(
 									`Error attempting fallback model switch for session ${sessionId}: ${String(err)}`
 								);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2274,6 +2274,10 @@ export class RoomRuntime {
 		if (!this.daemonHub) return;
 
 		const mirroredUuids = new Set<string>();
+		// Tracks (groupId:sessionId) keys for which a fallback switch has already been attempted
+		// (either succeeded or failed). Prevents duplicate trySwitchToFallbackModel calls when
+		// multiple mirroring callbacks fire for the same usage_limit message.
+		const fallbackAttempted = new Set<string>();
 
 		const mirrorSession = (sessionId: string, role: string) => {
 			return this.daemonHub!.on(
@@ -2288,30 +2292,103 @@ export class RoomRuntime {
 					const messageContent = JSON.stringify(event.message);
 					const msgErrorClass = classifyError(messageContent);
 					if (msgErrorClass?.class === 'rate_limit') {
+						// Use immutable group.id / group.taskId from closure; read fresh state for mutable fields
+						const freshGroup = this.groupRepo.getGroup(group.id);
+						if (!freshGroup) return;
 						const sessionRole = sessionId === group.workerSessionId ? 'worker' : 'leader';
 						const rateLimitBackoff = createRateLimitBackoff(messageContent, sessionRole);
 						if (rateLimitBackoff) {
-							this.groupRepo.setRateLimit(group.id, rateLimitBackoff);
+							this.groupRepo.setRateLimit(freshGroup.id, rateLimitBackoff);
 							log.info(
-								`Rate limit detected in ${role} message for group ${group.id}. ` +
+								`Rate limit detected in ${role} message for group ${freshGroup.id}. ` +
 									`Backoff until ${new Date(rateLimitBackoff.resetsAt).toLocaleTimeString()}.`
 							);
-							this.appendGroupEvent(group.id, 'rate_limited', {
+							this.appendGroupEvent(freshGroup.id, 'rate_limited', {
 								text: `Rate limit detected in ${role} output. Pausing until ${new Date(rateLimitBackoff.resetsAt).toLocaleTimeString()}.`,
 								resetsAt: rateLimitBackoff.resetsAt,
 								sessionRole,
 							});
 							this.persistTaskRestriction(
-								group.taskId,
+								freshGroup.taskId,
 								rateLimitBackoff,
 								'rate_limit',
 								`API rate limit (HTTP 429) in ${role}`
 							).catch((err: unknown) => {
 								log.error(
-									`Failed to persist rate limit restriction for task ${group.taskId}: ${String(err)}`
+									`Failed to persist rate limit restriction for task ${freshGroup.taskId}: ${String(err)}`
 								);
 							});
 						}
+					} else if (msgErrorClass?.class === 'usage_limit') {
+						const sessionRole = sessionId === group.workerSessionId ? 'worker' : 'leader';
+						const fallbackKey = `${group.id}:${sessionId}`;
+
+						// Re-detection guard: if backoff already set, a prior handler is managing this
+						const freshGroup = this.groupRepo.getGroup(group.id);
+						if (!freshGroup) return;
+						if (freshGroup.rateLimit !== null) return;
+
+						// Duplicate fallback guard: only attempt once per session per detection cycle
+						if (fallbackAttempted.has(fallbackKey)) return;
+
+						log.info(
+							`Usage limit detected in ${role} message for group ${group.id} (real-time). ` +
+								`Attempting fallback model switch for ${sessionRole} session ${sessionId}.`
+						);
+
+						this.trySwitchToFallbackModel(group.id, sessionId, sessionRole)
+							.then((switched) => {
+								if (switched) {
+									log.info(
+										`Fallback model switch succeeded for ${sessionRole} session ${sessionId} ` +
+											`in group ${group.id} (mirroring).`
+									);
+									fallbackAttempted.add(fallbackKey);
+									// Clear any stale task restriction so the UI reflects the new model
+									this.clearTaskRestriction(freshGroup.taskId).catch((err: unknown) => {
+										log.error(
+											`Failed to clear task restriction for task ${freshGroup.taskId}: ${String(err)}`
+										);
+									});
+								} else {
+									// No fallback available — apply backoff and restrict the task
+									log.info(
+										`No fallback model available for ${sessionRole} session ${sessionId}. ` +
+											`Applying usage limit backoff for group ${group.id}.`
+									);
+									fallbackAttempted.add(fallbackKey);
+									const rateLimitBackoff = msgErrorClass.resetsAt
+										? createRateLimitBackoff(messageContent, sessionRole)
+										: null;
+									const backoff: RateLimitBackoff = rateLimitBackoff ?? {
+										detectedAt: Date.now(),
+										resetsAt: Date.now() + 60 * 1000,
+										sessionRole,
+									};
+									this.groupRepo.setRateLimit(group.id, backoff);
+									this.appendGroupEvent(group.id, 'rate_limited', {
+										text: `Usage limit reached. Pausing until ${new Date(backoff.resetsAt).toLocaleTimeString()}.`,
+										resetsAt: backoff.resetsAt,
+										sessionRole,
+									});
+									this.persistTaskRestriction(
+										freshGroup.taskId,
+										backoff,
+										'usage_limit',
+										`Daily/weekly usage cap`
+									).catch((err: unknown) => {
+										log.error(
+											`Failed to persist usage limit restriction for task ${freshGroup.taskId}: ${String(err)}`
+										);
+									});
+									this.scheduleTickAfterRateLimitReset(group.id);
+								}
+							})
+							.catch((err: unknown) => {
+								log.error(
+									`Error attempting fallback model switch for session ${sessionId}: ${String(err)}`
+								);
+							});
 					}
 
 					// Canonical timeline rows are persisted by the SDK/session layer into
@@ -2328,6 +2405,7 @@ export class RoomRuntime {
 			unsubWorker();
 			unsubLeader();
 			mirroredUuids.clear();
+			fallbackAttempted.clear();
 		});
 	}
 

--- a/packages/daemon/tests/unit/room/room-runtime-mirroring-usage-limit.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-mirroring-usage-limit.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Tests for real-time usage_limit detection in setupMirroring().
+ *
+ * Verifies:
+ * - usage_limit message fires fallback attempt when fallback configured
+ * - successful fallback: model_fallback event appended, task restriction cleared
+ * - failed fallback (no models): backoff set, task restricted to usage_limited
+ * - re-detection guard: second usage_limit message for same session skips duplicate attempt
+ * - fresh state reads: stale closure group object is never used for mutable state
+ */
+
+import { describe, expect, it, afterEach } from 'bun:test';
+import {
+	createRuntimeTestContext,
+	createGoalAndTask,
+	type RuntimeTestContext,
+} from './room-runtime-test-helpers';
+import type { MessageHub } from '@neokai/shared';
+import type { GlobalSettings } from '@neokai/shared';
+
+const USAGE_LIMIT_MSG = "You've hit your limit · resets 11pm (America/New_York)";
+
+/** Wrap a message in a JSON string the way the SDK serializes it to sdk.message events */
+function makeSdkMessage(text: string, uuid = 'msg-uuid-1') {
+	return JSON.stringify({ uuid, type: 'text', text });
+}
+
+/** Build a minimal MessageHub mock that responds to session.model.get */
+function makeMessageHubMock(opts: {
+	model?: string;
+	provider?: string;
+	failModelGet?: boolean;
+}): MessageHub {
+	return {
+		request: async (method: string, _params: unknown) => {
+			if (method === 'session.model.get') {
+				if (opts.failModelGet) throw new Error('model get failed');
+				return {
+					currentModel: opts.model ?? 'claude-3-5-sonnet-20241022',
+					modelInfo: { provider: opts.provider ?? 'anthropic' },
+				};
+			}
+			return undefined;
+		},
+	} as unknown as MessageHub;
+}
+
+/** Global settings with one fallback model configured */
+function withFallbackModel(
+	fallbackModel = 'claude-haiku-4-5-20251001',
+	provider = 'anthropic'
+): () => GlobalSettings {
+	return () =>
+		({
+			fallbackModels: [{ model: fallbackModel, provider }],
+		}) as GlobalSettings;
+}
+
+describe('setupMirroring - usage_limit real-time detection', () => {
+	let ctx: RuntimeTestContext;
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	async function spawnGroup() {
+		const { task } = await createGoalAndTask(ctx);
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		const group = groups[0];
+		await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+		return { group, task };
+	}
+
+	describe('no fallback model configured', () => {
+		it('applies backoff when usage_limit is detected and no fallback available', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			// Allow async .then() chain to settle
+			await new Promise((r) => setTimeout(r, 10));
+
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(true);
+		});
+
+		it('sets task to usage_limited when no fallback available', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group, task } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('usage_limited');
+			expect(updatedTask!.restrictions?.type).toBe('usage_limit');
+		});
+
+		it('appends rate_limited event when no fallback available', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			const events = ctx.db
+				.prepare(`SELECT kind, payload_json FROM task_group_events WHERE group_id = ? ORDER BY id`)
+				.all(group.id) as Array<{ kind: string; payload_json: string }>;
+
+			const rateLimitedEvent = events.find((e) => e.kind === 'rate_limited');
+			expect(rateLimitedEvent).toBeDefined();
+			const payload = JSON.parse(rateLimitedEvent!.payload_json);
+			expect(payload.sessionRole).toBe('worker');
+		});
+	});
+
+	describe('fallback model configured', () => {
+		it('calls trySwitchToFallbackModel when usage_limit detected', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: withFallbackModel(),
+				messageHub: makeMessageHubMock({}),
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			expect(switchCalls.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('appends model_fallback event on successful switch', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: withFallbackModel(),
+				messageHub: makeMessageHubMock({}),
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			const events = ctx.db
+				.prepare(`SELECT kind, payload_json FROM task_group_events WHERE group_id = ? ORDER BY id`)
+				.all(group.id) as Array<{ kind: string; payload_json: string }>;
+
+			const fallbackEvent = events.find((e) => e.kind === 'model_fallback');
+			expect(fallbackEvent).toBeDefined();
+		});
+
+		it('does NOT set group.rateLimit on successful switch', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: withFallbackModel(),
+				messageHub: makeMessageHubMock({}),
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(false);
+		});
+
+		it('clears task restriction when task was usage_limited before successful switch', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: withFallbackModel(),
+				messageHub: makeMessageHubMock({}),
+			});
+
+			const { group, task } = await spawnGroup();
+			// Pre-set restriction to simulate prior detection
+			await ctx.taskManager.updateTaskStatus(task.id, 'usage_limited', {
+				restrictions: {
+					type: 'usage_limit',
+					limit: 'Daily/weekly usage cap',
+					resetAt: Date.now() + 60_000,
+					sessionRole: 'worker',
+				},
+			});
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+			expect(updatedTask!.restrictions).toBeNull();
+		});
+	});
+
+	describe('re-detection guard', () => {
+		it('does not attempt fallback twice for the same session+message', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: withFallbackModel(),
+				messageHub: makeMessageHubMock({}),
+			});
+
+			const { group } = await spawnGroup();
+
+			// Fire the SAME message UUID twice — second should be deduplicated by mirroredUuids
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-same', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-same', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Should have been called exactly once despite two events
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			expect(switchCalls).toHaveLength(1);
+		});
+
+		it('does not attempt fallback twice for different UUIDs but after fallbackAttempted is set', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: withFallbackModel(),
+				messageHub: makeMessageHubMock({}),
+			});
+
+			const { group } = await spawnGroup();
+
+			// First message triggers fallback
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Second message with different UUID (not deduped by mirroredUuids)
+			// but fallbackAttempted should guard against it
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-2', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Only one switchModel call total
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			expect(switchCalls).toHaveLength(1);
+		});
+
+		it('skips when group.rateLimit is already set (re-detection guard)', async () => {
+			ctx = createRuntimeTestContext({
+				// No fallback configured so first detection sets a backoff
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group } = await spawnGroup();
+
+			// First event sets backoff
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(true);
+
+			// Second event with different UUID — rateLimit guard should skip it
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-2', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			// No duplicate events: only one rate_limited event
+			const events = ctx.db
+				.prepare(`SELECT kind FROM task_group_events WHERE group_id = ? AND kind = 'rate_limited'`)
+				.all(group.id) as Array<{ kind: string }>;
+			expect(events).toHaveLength(1);
+		});
+	});
+
+	describe('message content parsing', () => {
+		it('handles usage_limit in JSON-wrapped message content', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group } = await spawnGroup();
+
+			// The mirroring callback stringifies the entire event.message, so
+			// a nested text field containing the usage_limit string is still detected.
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: {
+					uuid: 'msg-json-1',
+					type: 'assistant',
+					content: [{ type: 'text', text: USAGE_LIMIT_MSG }],
+				},
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(true);
+		});
+
+		it('does not trigger on normal non-error messages', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-ok', type: 'text', text: 'Task completed successfully.' },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(false);
+		});
+	});
+
+	describe('leader session mirroring', () => {
+		it('detects usage_limit in leader messages when no fallback', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.leaderSessionId,
+				message: { uuid: 'leader-msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(true);
+
+			const events = ctx.db
+				.prepare(
+					`SELECT kind, payload_json FROM task_group_events WHERE group_id = ? AND kind = 'rate_limited'`
+				)
+				.all(group.id) as Array<{ kind: string; payload_json: string }>;
+			expect(events).toHaveLength(1);
+			const payload = JSON.parse(events[0].payload_json);
+			expect(payload.sessionRole).toBe('leader');
+		});
+	});
+
+	describe('cleanup', () => {
+		it('clears fallbackAttempted set when mirroring is cleaned up', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: withFallbackModel(),
+				messageHub: makeMessageHubMock({}),
+			});
+
+			const { group } = await spawnGroup();
+
+			// Trigger fallback
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Cleanup mirroring (normally done when group is completed)
+			ctx.runtime.stop();
+
+			// No errors thrown — cleanup ran successfully
+			expect(true).toBe(true);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-mirroring-usage-limit.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-mirroring-usage-limit.test.ts
@@ -20,11 +20,6 @@ import type { GlobalSettings } from '@neokai/shared';
 
 const USAGE_LIMIT_MSG = "You've hit your limit · resets 11pm (America/New_York)";
 
-/** Wrap a message in a JSON string the way the SDK serializes it to sdk.message events */
-function makeSdkMessage(text: string, uuid = 'msg-uuid-1') {
-	return JSON.stringify({ uuid, type: 'text', text });
-}
-
 /** Build a minimal MessageHub mock that responds to session.model.get */
 function makeMessageHubMock(opts: {
 	model?: string;
@@ -176,8 +171,9 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 				.prepare(`SELECT kind, payload_json FROM task_group_events WHERE group_id = ? ORDER BY id`)
 				.all(group.id) as Array<{ kind: string; payload_json: string }>;
 
-			const fallbackEvent = events.find((e) => e.kind === 'model_fallback');
-			expect(fallbackEvent).toBeDefined();
+			const fallbackEvents = events.filter((e) => e.kind === 'model_fallback');
+			// Exactly one model_fallback event — synchronous guard prevents duplicates
+			expect(fallbackEvents).toHaveLength(1);
 		});
 
 		it('does NOT set group.rateLimit on successful switch', async () => {
@@ -254,7 +250,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 			expect(switchCalls).toHaveLength(1);
 		});
 
-		it('does not attempt fallback twice for different UUIDs but after fallbackAttempted is set', async () => {
+		it('does not attempt fallback twice for different UUIDs (race condition: both fired before .then() resolves)', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
 				messageHub: makeMessageHubMock({}),
@@ -262,16 +258,14 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 
 			const { group } = await spawnGroup();
 
-			// First message triggers fallback
+			// Fire both messages SYNCHRONOUSLY before any await — simulates the race where
+			// two distinct usage_limit messages arrive before the first .then() resolves.
+			// The guard must be set synchronously (not inside .then()) to prevent both from
+			// passing through.
 			ctx.hub.fire('sdk.message', {
 				sessionId: group.workerSessionId,
 				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
 			});
-
-			await new Promise((r) => setTimeout(r, 10));
-
-			// Second message with different UUID (not deduped by mirroredUuids)
-			// but fallbackAttempted should guard against it
 			ctx.hub.fire('sdk.message', {
 				sessionId: group.workerSessionId,
 				message: { uuid: 'msg-2', type: 'text', text: USAGE_LIMIT_MSG },
@@ -279,7 +273,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 
 			await new Promise((r) => setTimeout(r, 10));
 
-			// Only one switchModel call total
+			// Only one switchModel call total — synchronous guard blocked the second
 			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
 			expect(switchCalls).toHaveLength(1);
 		});
@@ -389,7 +383,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 	});
 
 	describe('cleanup', () => {
-		it('clears fallbackAttempted set when mirroring is cleaned up', async () => {
+		it('resetting mirroring clears fallbackAttempted so a new setup can attempt fallback again', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
 				messageHub: makeMessageHubMock({}),
@@ -397,19 +391,38 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 
 			const { group } = await spawnGroup();
 
-			// Trigger fallback
+			// First detection triggers fallback and marks fallbackAttempted
 			ctx.hub.fire('sdk.message', {
 				sessionId: group.workerSessionId,
 				message: { uuid: 'msg-1', type: 'text', text: USAGE_LIMIT_MSG },
 			});
-
 			await new Promise((r) => setTimeout(r, 10));
 
-			// Cleanup mirroring (normally done when group is completed)
-			ctx.runtime.stop();
+			const switchCallsAfterFirst = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'switchModel'
+			).length;
+			expect(switchCallsAfterFirst).toBe(1);
 
-			// No errors thrown — cleanup ran successfully
-			expect(true).toBe(true);
+			// Simulate cleanup + re-setup of mirroring (as happens when a group is
+			// restarted). Access via any to call private methods.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const runtimeAny = ctx.runtime as any;
+			runtimeAny.cleanupMirroring(group.id);
+			runtimeAny.setupMirroring(group);
+
+			// After re-setup, the fresh fallbackAttempted set allows a new attempt
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				// Different UUID so mirroredUuids doesn't deduplicate it
+				message: { uuid: 'msg-2', type: 'text', text: USAGE_LIMIT_MSG },
+			});
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Should have triggered a second switch attempt
+			const switchCallsAfterSecond = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'switchModel'
+			).length;
+			expect(switchCallsAfterSecond).toBe(2);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -10,12 +10,32 @@ import { noOpReactiveDb } from '../../helpers/reactive-database';
 import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 import type { HookOptions } from '../../../src/lib/room/runtime/lifecycle-hooks';
+import type { MessageHub } from '@neokai/shared';
 
 export function createMockDaemonHub() {
 	const handlers = new Map<string, Map<string | undefined, Array<(data: unknown) => void>>>();
 	const emittedEvents: Array<{ event: string; data: unknown }> = [];
+
+	/** Dispatch an event synchronously to all registered handlers for that event/sessionId. */
+	function fire(event: string, data: Record<string, unknown> & { sessionId?: string }): void {
+		const eventHandlers = handlers.get(event);
+		if (!eventHandlers) return;
+		// Call handlers registered with no sessionId filter (wildcard)
+		for (const handler of eventHandlers.get(undefined) ?? []) {
+			handler(data);
+		}
+		// Call handlers registered for this specific sessionId
+		if (data.sessionId) {
+			for (const handler of eventHandlers.get(data.sessionId) ?? []) {
+				handler(data);
+			}
+		}
+	}
+
 	return {
 		emittedEvents,
+		/** Fire event to registered handlers (for testing real-time callbacks like mirroring). */
+		fire,
 		on(
 			event: string,
 			handler: (data: unknown) => void,
@@ -53,6 +73,16 @@ export function createMockSessionFactory() {
 	>();
 	/** Session IDs that should appear missing from cache — configurable in tests */
 	let missingSessionIds: Set<string> | undefined;
+	/** Override for switchModel — tests can replace this to control fallback behavior */
+	let switchModelImpl: (
+		sessionId: string,
+		model: string,
+		provider: string
+	) => Promise<{ success: boolean; model: string; error?: string }> = async (
+		_sessionId,
+		model,
+		_provider
+	) => ({ success: true, model });
 	return {
 		calls,
 		processingStates,
@@ -61,6 +91,14 @@ export function createMockSessionFactory() {
 		},
 		set missingSessionIds(v: Set<string> | undefined) {
 			missingSessionIds = v;
+		},
+		/** Override to control switchModel responses in tests */
+		set switchModelImpl(fn: (
+			sessionId: string,
+			model: string,
+			provider: string
+		) => Promise<{ success: boolean; model: string; error?: string }>) {
+			switchModelImpl = fn;
 		},
 		async createAndStartSession(init: unknown, role: string) {
 			calls.push({ method: 'createAndStartSession', args: [init, role] });
@@ -109,7 +147,7 @@ export function createMockSessionFactory() {
 		},
 		async switchModel(sessionId: string, model: string, provider: string) {
 			calls.push({ method: 'switchModel', args: [sessionId, model, provider] });
-			return { success: true, model };
+			return switchModelImpl(sessionId, model, provider);
 		},
 	} satisfies SessionFactory & {
 		calls: Array<{ method: string; args: unknown[] }>;
@@ -260,8 +298,8 @@ export interface RuntimeTestContextOptions {
 	) => Array<{ id: string; text: string; toolCallNames: string[] }>;
 	/** Get global settings for testing fallback model logic */
 	getGlobalSettings?: () => GlobalSettings;
-	/** Optional mock messageHub for testing fallback model switch logic */
-	messageHub?: { request: (method: string, data?: unknown) => Promise<unknown> };
+	/** Optional MessageHub mock for testing trySwitchToFallbackModel (session.model.get RPC) */
+	messageHub?: MessageHub;
 }
 
 export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): RuntimeTestContext {
@@ -302,7 +340,7 @@ export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): Runt
 		getGoal: (goalId) => goalManager.getGoal(goalId),
 		getGlobalSettings: opts?.getGlobalSettings ?? (() => ({}) as GlobalSettings),
 		daemonHub: mockHub as unknown as DaemonHub,
-		messageHub: opts?.messageHub as never,
+		messageHub: opts?.messageHub,
 	});
 
 	return {


### PR DESCRIPTION
Add real-time `usage_limit` detection to the `setupMirroring()` callback in `room-runtime.ts`.

## Changes

- **Real-time detection**: mirroring callback now handles `usage_limit` errors alongside `rate_limit`
- **Fallback switch**: immediately attempts `trySwitchToFallbackModel()` on detection
  - Success: appends `model_fallback` event, clears stale task restriction
  - Failure: sets backoff, persists `usage_limited` task status, schedules tick
- **Race condition guard**: `fallbackAttempted.add()` called synchronously before the async call — prevents duplicate `switchModel` calls if two messages arrive before the first `.then()` resolves
- **Re-detection guard**: skips if `freshGroup.rateLimit !== null` (prior handler already active)
- **Fresh state reads**: all mutable state reads use `groupRepo.getGroup()` instead of closure-captured `group`
- **Cleanup**: `fallbackAttempted.clear()` added to the mirroring cleanup callback
- **Consistency**: `rate_limit` handler updated to use `freshGroup` references

## Tests

14 new unit tests in `room-runtime-mirroring-usage-limit.test.ts` covering:
- No-fallback path: backoff set, task restricted to `usage_limited`
- Fallback success: `model_fallback` event (exactly 1), task restriction cleared
- Race condition: two messages fired synchronously → only one `switchModel` call
- Re-detection guard: second message skipped when `rateLimit` already set
- Leader session detection
- Cleanup reset: after `cleanupMirroring` + `setupMirroring`, fresh guard allows new attempt

Also adds `hub.fire()` to mock daemon hub and `switchModel` + `messageHub` support to test helpers.