### PR TITLE
feat(room-runtime): return early after successful trySwitchToFallbackModel() in onWorkerTerminalState

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -771,8 +771,12 @@ export class RoomRuntime {
 						this.scheduleTickAfterRateLimitReset(groupId);
 						return;
 					}
-					// Fall through to normal routing — fallback model switch event was already appended
-					// in trySwitchToFallbackModel so the UI shows the switch clearly.
+					// Fallback switch succeeded: clear stale restriction/rate-limit so the UI shows the
+					// task as in_progress with the new model, then return. When the new query finishes,
+					// onWorkerTerminalState fires again with clean output and routes normally.
+					await this.clearTaskRestriction(group.taskId);
+					this.groupRepo.clearRateLimit(groupId);
+					return;
 				}
 				// group.rateLimit already set (even if expired): re-trigger after expiry.
 				// Fall through to the worktree check so the worker can attempt cleanup/retry.

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -384,5 +384,87 @@ describe('RoomRuntime - terminal error detection', () => {
 			// feedbackIteration must NOT have incremented — no routing happened
 			expect(updatedGroup!.feedbackIteration).toBe(0);
 		});
+
+		it('returns early without routing to leader after successful fallback switch', async () => {
+			// Configure a fallback model and a mock messageHub that provides the current model
+			const mockMessageHub = {
+				request: async (method: string) => {
+					if (method === 'session.model.get') {
+						return { currentModel: 'claude-opus-4-5', modelInfo: { provider: 'anthropic' } };
+					}
+					return undefined;
+				},
+			};
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
+				],
+				getGlobalSettings: () =>
+					({
+						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
+					}) as never,
+				messageHub: mockMessageHub,
+			});
+
+			const { group, task } = await spawnAndSimulateWorkerOutput('');
+
+			// Task should NOT be paused — fallback switch succeeded, task stays in_progress
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).not.toBe('usage_limited');
+			expect(updatedTask!.status).not.toBe('rate_limited');
+			expect(updatedTask!.restrictions).toBeNull();
+
+			// Group rate limit must NOT be set
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.rateLimit).toBeNull();
+
+			// Leader must NOT have been injected with stale error output
+			const leaderInjectCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'injectMessage' && c.args[0] === group.leaderSessionId
+			);
+			expect(leaderInjectCalls).toHaveLength(0);
+
+			// switchModel should have been called on the session factory
+			const switchModelCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			expect(switchModelCalls).toHaveLength(1);
+			expect(switchModelCalls[0].args[1]).toBe('claude-haiku-4-5');
+		});
+
+		it('clears stale task restriction after successful fallback switch', async () => {
+			const mockMessageHub = {
+				request: async (method: string) => {
+					if (method === 'session.model.get') {
+						return { currentModel: 'claude-opus-4-5', modelInfo: { provider: 'anthropic' } };
+					}
+					return undefined;
+				},
+			};
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
+				],
+				getGlobalSettings: () =>
+					({
+						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
+					}) as never,
+				messageHub: mockMessageHub,
+			});
+
+			const { group, task } = await spawnAndSimulateWorkerOutput('');
+
+			// Trigger once more to simulate a re-trigger while restrictions might be stale
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			// Task restrictions should remain clear
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.restrictions).toBeNull();
+
+			// Group rate limit should remain cleared
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.rateLimit).toBeNull();
+		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -107,6 +107,10 @@ export function createMockSessionFactory() {
 			calls.push({ method: 'startSession', args: [sessionId] });
 			return true;
 		},
+		async switchModel(sessionId: string, model: string, provider: string) {
+			calls.push({ method: 'switchModel', args: [sessionId, model, provider] });
+			return { success: true, model };
+		},
 	} satisfies SessionFactory & {
 		calls: Array<{ method: string; args: unknown[] }>;
 		processingStates: Map<
@@ -256,6 +260,8 @@ export interface RuntimeTestContextOptions {
 	) => Array<{ id: string; text: string; toolCallNames: string[] }>;
 	/** Get global settings for testing fallback model logic */
 	getGlobalSettings?: () => GlobalSettings;
+	/** Optional mock messageHub for testing fallback model switch logic */
+	messageHub?: { request: (method: string, data?: unknown) => Promise<unknown> };
 }
 
 export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): RuntimeTestContext {
@@ -296,6 +302,7 @@ export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): Runt
 		getGoal: (goalId) => goalManager.getGoal(goalId),
 		getGlobalSettings: opts?.getGlobalSettings ?? (() => ({}) as GlobalSettings),
 		daemonHub: mockHub as unknown as DaemonHub,
+		messageHub: opts?.messageHub as never,
 	});
 
 	return {


### PR DESCRIPTION
After a successful fallback model switch, clear stale task restrictions and
group rate limit, then return early instead of falling through to normal
routing. This prevents stale error text from being sent to the leader and
ensures the UI shows the task as in_progress with the new model.

When the new query completes, onWorkerTerminalState fires again with clean
output and routes normally (Bug D + Gap H fix).

Also adds switchModel() to the mock session factory and a messageHub option
to RuntimeTestContextOptions to support fallback model tests.
