### PR TITLE
fix(runtime): return early after successful trySwitchToFallbackModel in leader path

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1148,7 +1148,12 @@ export class RoomRuntime {
 							this.scheduleTickAfterRateLimitReset(groupId);
 							return;
 						}
-						// Fall through to normal completion — fallback model switch event was already appended
+						// Fallback switch succeeded — clear stale restriction/rate-limit so the task
+						// shows the correct status, then return. The observer will fire again when the
+						// new-model query finishes, delivering clean output (no stale error text).
+						this.groupRepo.clearRateLimit(groupId);
+						await this.clearTaskRestriction(group.taskId);
+						return;
 					}
 					// group.rateLimit already set (even if expired): re-trigger after expiry.
 					// Fall through to normal completion so the leader can finish cleanly.

--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -425,4 +425,110 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 			expect(taskAfter!.status).toBe('in_progress');
 		});
 	});
+
+	// ─── leader fallback early return ──────────────────────────────────────────────────────
+
+	describe('leader usage_limit: return early after successful trySwitchToFallbackModel', () => {
+		/**
+		 * Creates a context where trySwitchToFallbackModel succeeds:
+		 * - getGlobalSettings returns a fallback model chain
+		 * - messageHub.request('session.model.get') returns a current model not in the chain
+		 *   (so the first fallback is selected)
+		 * - sessionFactory.switchModel returns success
+		 */
+		function createFallbackCtx(leaderSessionIdRef: { value: string | null }) {
+			return createRuntimeTestContext({
+				getWorkerMessages: (sessionId) => {
+					if (leaderSessionIdRef.value && sessionId === leaderSessionIdRef.value) {
+						return makeWorkerMessages(USAGE_LIMIT_MSG);
+					}
+					return [];
+				},
+				getGlobalSettings: () =>
+					({
+						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
+					}) as never,
+				messageHub: {
+					async request(method: string, _params: unknown) {
+						if (method === 'session.model.get') {
+							return {
+								currentModel: 'claude-sonnet-4-6',
+								modelInfo: { provider: 'anthropic' },
+							};
+						}
+						return undefined;
+					},
+				},
+			});
+		}
+
+		it('clears group rateLimit after successful fallback switch in leader path', async () => {
+			const leaderSessionIdRef: { value: string | null } = { value: null };
+			ctx = createFallbackCtx(leaderSessionIdRef);
+
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+			leaderSessionIdRef.value = group.leaderSessionId;
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			// Pre-condition: no rateLimit yet
+			expect(ctx.groupRepo.getGroup(group.id)!.rateLimit).toBeNull();
+
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// rateLimit must be cleared (not set) after a successful fallback switch
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.rateLimit).toBeNull();
+		});
+
+		it('clears task restriction after successful fallback switch in leader path', async () => {
+			const leaderSessionIdRef: { value: string | null } = { value: null };
+			ctx = createFallbackCtx(leaderSessionIdRef);
+
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+			leaderSessionIdRef.value = group.leaderSessionId;
+
+			// Simulate that a prior detection set a usage_limited restriction
+			await ctx.taskManager.updateTaskStatus(task.id, 'usage_limited', {
+				restrictions: {
+					type: 'usage_limit',
+					resetAt: Date.now() + 60_000,
+					sessionRole: 'leader',
+					reason: 'Daily/weekly usage cap in leader',
+				},
+			});
+
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// Task restriction must be cleared back to in_progress
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+			expect(updatedTask!.restrictions).toBeNull();
+		});
+
+		it('does not fall through to normal completion after successful fallback switch', async () => {
+			// If the function returned early, no further processing (e.g. group completion) happens.
+			// The group should still be active (not completed) because the new model query is ongoing.
+			const leaderSessionIdRef: { value: string | null } = { value: null };
+			ctx = createFallbackCtx(leaderSessionIdRef);
+
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+			leaderSessionIdRef.value = group.leaderSessionId;
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// Group must NOT be completed — the new-model query is still pending
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.completedAt).toBeNull();
+		});
+	});
 });


### PR DESCRIPTION
After trySwitchToFallbackModel succeeds in onLeaderTerminalState, clear the
group rate limit and task restriction, then return early instead of falling
through to normal completion. This prevents stale error text from being
processed and ensures the UI shows the correct status while the new-model
query is running.

- Clear group.rateLimit via groupRepo.clearRateLimit after successful switch
- Clear task restriction via clearTaskRestriction after successful switch
- Return early so the observer fires again with clean output from new model
- Add switchModel to mock SessionFactory in test helpers
- Add messageHub option to RuntimeTestContextOptions for fallback model tests
- Add 3 unit tests covering: rateLimit cleared, task restriction cleared,
  group not completed (early return verified)
