### PR TITLE
feat(runtime): add recoverStuckLeaders() to re-inject worker messages after leader rate limit expiry

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2718,8 +2718,12 @@ export class RoomRuntime {
 				continue;
 			}
 
-			// Construct a continuation message summarising the last worker output
-			let continuationMessage = '[Auto-recovery] Resuming leader review after rate limit expired.';
+			// Construct a continuation message summarising the last worker output.
+			// Note: in the normal case lastForwardedMessageId is already updated by
+			// routeWorkerToLeader (~line 933), so getWorkerMessages returns an empty array
+			// here. That is fine — the leader's conversation context already contains the
+			// full worker envelope; the generic message alone is sufficient to resume review.
+			let continuationMessage = `[Auto-recovery] Resuming leader review after rate limit expired (iteration ${group.feedbackIteration}).`;
 			if (this.getWorkerMessages) {
 				const workerMessages = this.getWorkerMessages(
 					group.workerSessionId,
@@ -2741,7 +2745,9 @@ export class RoomRuntime {
 
 			// Clear the expired rate limit and any task restriction
 			this.groupRepo.clearRateLimit(group.id);
-			void this.clearTaskRestriction(group.taskId);
+			void this.clearTaskRestriction(group.taskId).catch((err) => {
+				log.error(`[StuckLeader] Group ${group.id}: clearTaskRestriction threw:`, err);
+			});
 
 			this.appendGroupEvent(group.id, 'status', {
 				text: 'Leader recovered from expired rate limit. Re-injecting worker message.',

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -195,6 +195,13 @@ export class RoomRuntime {
 	private stuckWorkerRecoveryInFlight = new Set<string>();
 
 	/**
+	 * Group IDs whose stuck-leader recovery is currently in-flight.
+	 * Guards against duplicate message injections across successive ticks
+	 * while the leader is being re-activated after a rate/usage limit expiry.
+	 */
+	private stuckLeaderRecoveryInFlight = new Set<string>();
+
+	/**
 	 * Task IDs whose group spawn is currently in-flight (async).
 	 * Guards against concurrent ticks re-attempting spawn for the same task while
 	 * `spawnGroupForTask` is awaiting worktree creation or DB insert — the window
@@ -1067,12 +1074,9 @@ export class RoomRuntime {
 					return;
 				}
 				// Only apply backoff on first detection.
-				// Unlike the worker path (where recoverStuckWorkers re-triggers onWorkerTerminalState
-				// after expiry), there is no recoverStuckLeaders mechanism that re-calls this handler.
-				// The !group.rateLimit guard is a defensive check: it prevents the backoff from being
-				// reset if this handler is somehow called again while a rate limit is already recorded.
-				// A full leader retry after 429 would require re-injecting the worker message into the
-				// leader session — tracked as a future improvement (out of scope for this fix).
+				// recoverStuckLeaders re-injects the worker message into the leader session after
+				// expiry, which causes onLeaderTerminalState to fire again. The !group.rateLimit guard
+				// prevents the backoff from being reset on those re-triggers.
 				if (errorClass?.class === 'rate_limit' && !group.rateLimit) {
 					const rateLimitBackoff = errorClass.resetsAt
 						? createRateLimitBackoff(leaderOutputText, 'leader')
@@ -2671,6 +2675,95 @@ export class RoomRuntime {
 	}
 
 	/**
+	 * Detect and recover leader sessions stuck after a rate/usage limit has expired.
+	 *
+	 * Pre-conditions for recovery:
+	 * - Leader session exists in the session factory
+	 * - Leader session is idle or interrupted (not actively processing)
+	 * - Group has an expired rate limit scoped to the leader role
+	 * - Group is NOT awaiting human review
+	 * - Group is NOT paused waiting for a question answer
+	 * - A recovery for this group is NOT already in-flight from a previous tick
+	 */
+	private recoverStuckLeaders(): void {
+		if (!this.sessionFactory.getProcessingState) return; // getProcessingState is optional
+
+		const now = Date.now();
+		const activeGroups = this.groupRepo.getActiveGroups(this.roomId);
+		for (const group of activeGroups) {
+			// Only recover when the leader has an expired rate limit scoped to the leader role
+			const hasExpiredLeaderRateLimit =
+				group.rateLimit !== null &&
+				now >= group.rateLimit.resetsAt &&
+				group.rateLimit.sessionRole === 'leader';
+
+			if (!hasExpiredLeaderRateLimit) continue;
+			// Skip groups awaiting human review
+			if (group.submittedForReview) continue;
+			// Skip groups paused waiting for a question answer
+			if (group.waitingForQuestion) continue;
+
+			// Leader must be in the session factory (not a zombie)
+			if (!this.sessionFactory.hasSession(group.leaderSessionId)) continue;
+
+			// Leader must be in a terminal state (idle or interrupted)
+			const leaderState = this.sessionFactory.getProcessingState(group.leaderSessionId);
+			if (leaderState !== 'idle' && leaderState !== 'interrupted') continue;
+
+			// Guard against duplicate in-flight recovery: if a previous tick already
+			// injected a message for this group and the leader hasn't started processing yet,
+			// skip it to avoid sending duplicate messages.
+			if (this.stuckLeaderRecoveryInFlight.has(group.id)) {
+				log.debug(`[StuckLeader] Group ${group.id}: recovery already in-flight, skipping`);
+				continue;
+			}
+
+			// Construct a continuation message summarising the last worker output
+			let continuationMessage = '[Auto-recovery] Resuming leader review after rate limit expired.';
+			if (this.getWorkerMessages) {
+				const workerMessages = this.getWorkerMessages(
+					group.workerSessionId,
+					group.lastForwardedMessageId
+				);
+				if (workerMessages.length > 0) {
+					const excerpt = workerMessages
+						.map((m) => m.text)
+						.join('\n')
+						.slice(0, 500);
+					continuationMessage += ` Last worker output:\n${excerpt}`;
+				}
+			}
+
+			log.warn(
+				`[StuckLeader] Group ${group.id}: leader is '${leaderState}' with expired rate limit. ` +
+					`Re-injecting worker message to resume review.`
+			);
+
+			// Clear the expired rate limit and any task restriction
+			this.groupRepo.clearRateLimit(group.id);
+			void this.clearTaskRestriction(group.taskId);
+
+			this.appendGroupEvent(group.id, 'status', {
+				text: 'Leader recovered from expired rate limit. Re-injecting worker message.',
+			});
+
+			// Mark as in-flight before firing, clear when injection completes
+			this.stuckLeaderRecoveryInFlight.add(group.id);
+			void this.sessionFactory
+				.injectMessage(group.leaderSessionId, continuationMessage)
+				.catch((err) => {
+					log.error(`[StuckLeader] Group ${group.id}: re-inject threw:`, err);
+				})
+				.finally(() => {
+					this.stuckLeaderRecoveryInFlight.delete(group.id);
+				});
+
+			// Schedule a follow-up tick to pick up the leader's fresh output
+			this.scheduleTick();
+		}
+	}
+
+	/**
 	 * Auto-clean stale session groups whose tasks have reached a terminal state.
 	 *
 	 * Groups become stale when a task transitions to completed/cancelled/archived
@@ -2797,6 +2890,11 @@ export class RoomRuntime {
 		// This recovers cases where the observer callback fired but the routing failed silently.
 		// Note: synchronous scan, only fires async work as fire-and-forget if stuck workers are found.
 		this.recoverStuckWorkers();
+
+		// Safety net: detect leader sessions stuck after a rate/usage limit has expired.
+		// Re-injects the last worker message so the leader can resume reviewing.
+		// Note: synchronous scan, only fires async work as fire-and-forget if stuck leaders are found.
+		this.recoverStuckLeaders();
 
 		// Recurring mission scheduler: check for due missions and trigger new executions.
 		// Also checks for completed executions to advance next_run_at.

--- a/packages/daemon/tests/unit/room/room-runtime-recover-stuck-leaders.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recover-stuck-leaders.test.ts
@@ -87,6 +87,25 @@ describe('recoverStuckLeaders', () => {
 		expect(updated.rateLimit).toBeNull();
 	});
 
+	it('restores task status to in_progress via clearTaskRestriction', async () => {
+		const { groupId, taskId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		// Set the task to usage_limited (simulating what persistTaskRestriction does)
+		await ctx.taskManager.updateTaskStatus(taskId, 'usage_limited');
+
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Allow the async clearTaskRestriction to complete
+		await new Promise((r) => setTimeout(r, 10));
+
+		const task = await ctx.taskManager.getTask(taskId);
+		expect(task!.status).toBe('in_progress');
+	});
+
 	it('does not inject when the rate limit is still active (resetsAt in the future)', async () => {
 		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
 
@@ -132,6 +151,38 @@ describe('recoverStuckLeaders', () => {
 
 		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
 		ctx.sessionFactory.processingStates.set(leaderSessionId, 'processing');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+	});
+
+	it('injects when the leader session is interrupted (treated same as idle)', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'interrupted');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(1);
+		expect(injectCalls[0].args[1]).toContain('[Auto-recovery]');
+	});
+
+	it('does not inject when the group has waitingForQuestion=true', async () => {
+		const { groupId, leaderSessionId, workerSessionId } = await createTaskWithGroup(ctx);
+
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.groupRepo.setWaitingForQuestion(groupId, true, workerSessionId);
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
 
 		ctx.runtime.start();
 		await ctx.runtime.tick();
@@ -208,6 +259,36 @@ describe('recoverStuckLeaders', () => {
 			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
 		);
 		expect(injectCalls).toHaveLength(0);
+	});
+
+	it('sends generic continuation message when getWorkerMessages returns empty (normal case after routing)', async () => {
+		// In the normal case, lastForwardedMessageId is already up-to-date after routeWorkerToLeader,
+		// so getWorkerMessages returns an empty array. The generic message alone should be sent.
+		const ctxEmpty = createRuntimeTestContext({
+			getWorkerMessages: () => [],
+		});
+		ctx.runtime.stop();
+
+		const { task } = await createGoalAndTask(ctxEmpty);
+		const group = ctxEmpty.groupRepo.createGroup(task.id, `worker:${task.id}`, `leader:${task.id}`);
+		await ctxEmpty.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+		ctxEmpty.groupRepo.setRateLimit(group.id, expiredLeaderBackoff());
+		ctxEmpty.sessionFactory.processingStates.set(group.leaderSessionId, 'idle');
+
+		ctxEmpty.runtime.start();
+		await ctxEmpty.runtime.tick();
+
+		const injectCalls = ctxEmpty.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === group.leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(1);
+		const msg = injectCalls[0].args[1] as string;
+		expect(msg).toContain('[Auto-recovery]');
+		expect(msg).not.toContain('Last worker output');
+
+		ctxEmpty.runtime.stop();
+		ctxEmpty.db.close();
 	});
 
 	it('includes excerpt of worker output in the injected continuation message', async () => {

--- a/packages/daemon/tests/unit/room/room-runtime-recover-stuck-leaders.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recover-stuck-leaders.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for recoverStuckLeaders() — the leader-side counterpart to recoverStuckWorkers().
+ *
+ * recoverStuckLeaders() runs every tick and re-injects the last worker output into the
+ * leader session when the leader has an expired rate/usage limit and is idle.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import {
+	createRuntimeTestContext,
+	createGoalAndTask,
+	type RuntimeTestContext,
+} from './room-runtime-test-helpers';
+import type { RateLimitBackoff } from '../../../src/lib/room/state/session-group-repository';
+
+/**
+ * Helper: create a task + group directly in DB (bypassing tick).
+ */
+async function createTaskWithGroup(
+	ctx: RuntimeTestContext
+): Promise<{ taskId: string; groupId: string; workerSessionId: string; leaderSessionId: string }> {
+	const { task } = await createGoalAndTask(ctx);
+	const group = ctx.groupRepo.createGroup(task.id, `worker:${task.id}`, `leader:${task.id}`);
+	await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+	return {
+		taskId: task.id,
+		groupId: group.id,
+		workerSessionId: group.workerSessionId,
+		leaderSessionId: group.leaderSessionId,
+	};
+}
+
+/**
+ * Build an expired rate-limit backoff (resetsAt in the past) for the given role.
+ */
+function expiredLeaderBackoff(msPast = 1000): RateLimitBackoff {
+	return {
+		detectedAt: Date.now() - msPast - 5000,
+		resetsAt: Date.now() - msPast,
+		sessionRole: 'leader',
+	};
+}
+
+describe('recoverStuckLeaders', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: (_sessionId, _afterId) => [
+				{ id: 'msg-1', text: 'Worker output text', toolCallNames: [] },
+			],
+		});
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('injects a message into the leader session when the rate limit has expired', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		// Simulate expired leader rate limit
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(1);
+		expect(injectCalls[0].args[1]).toContain('[Auto-recovery]');
+		expect(injectCalls[0].args[1]).toContain('Worker output text');
+	});
+
+	it('clears the rate limit from the group before injecting', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const updated = ctx.groupRepo.getGroup(groupId)!;
+		expect(updated.rateLimit).toBeNull();
+	});
+
+	it('does not inject when the rate limit is still active (resetsAt in the future)', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		// Active rate limit — not yet expired
+		ctx.groupRepo.setRateLimit(groupId, {
+			detectedAt: Date.now(),
+			resetsAt: Date.now() + 60_000,
+			sessionRole: 'leader',
+		});
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+	});
+
+	it('does not inject when the rate limit is scoped to the worker role', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		// Expired rate limit but scoped to worker, not leader
+		ctx.groupRepo.setRateLimit(groupId, {
+			detectedAt: Date.now() - 5000,
+			resetsAt: Date.now() - 1000,
+			sessionRole: 'worker',
+		});
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+	});
+
+	it('does not inject when the leader session is actively processing', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'processing');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+	});
+
+	it('does not inject when the group is awaiting human review', async () => {
+		const { groupId, leaderSessionId, taskId } = await createTaskWithGroup(ctx);
+
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.groupRepo.setSubmittedForReview(groupId, true);
+		await ctx.taskManager.reviewTask(taskId);
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+	});
+
+	it('does not inject when the leader session is missing from the factory', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.sessionFactory.missingSessionIds = new Set([leaderSessionId]);
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+	});
+
+	it('guards against duplicate injection: only one inject across two ticks due to rate limit cleared', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		ctx.groupRepo.setRateLimit(groupId, expiredLeaderBackoff());
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+
+		// First tick — triggers recovery: rate limit cleared, message injected
+		await ctx.runtime.tick();
+		// Second tick — rate limit already cleared, no recovery needed
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		// Only one inject because the rate limit is cleared on the first recovery
+		expect(injectCalls).toHaveLength(1);
+	});
+
+	it('does not inject when there is no rate limit', async () => {
+		const { leaderSessionId } = await createTaskWithGroup(ctx);
+
+		// No rate limit set — group is normally idle
+		ctx.sessionFactory.processingStates.set(leaderSessionId, 'idle');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+	});
+
+	it('includes excerpt of worker output in the injected continuation message', async () => {
+		const workerOutputText = 'Implemented the feature as requested.';
+		const ctxWithMessages = createRuntimeTestContext({
+			getWorkerMessages: () => [{ id: 'w1', text: workerOutputText, toolCallNames: [] }],
+		});
+		ctx.runtime.stop();
+
+		const { task } = await createGoalAndTask(ctxWithMessages);
+		const group = ctxWithMessages.groupRepo.createGroup(
+			task.id,
+			`worker:${task.id}`,
+			`leader:${task.id}`
+		);
+		await ctxWithMessages.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+		ctxWithMessages.groupRepo.setRateLimit(group.id, expiredLeaderBackoff());
+		ctxWithMessages.sessionFactory.processingStates.set(group.leaderSessionId, 'idle');
+
+		ctxWithMessages.runtime.start();
+		await ctxWithMessages.runtime.tick();
+
+		const injectCalls = ctxWithMessages.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === group.leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(1);
+		expect(injectCalls[0].args[1]).toContain(workerOutputText);
+
+		ctxWithMessages.runtime.stop();
+		ctxWithMessages.db.close();
+	});
+});


### PR DESCRIPTION
Adds stuckLeaderRecoveryInFlight Set and recoverStuckLeaders() method to
RoomRuntime that mirrors recoverStuckWorkers(). When a leader session has an
expired rate limit (sessionRole === 'leader') and is idle, the method clears
the rate limit, clears any task restriction, and injects a continuation message
containing the last worker output so the leader can resume reviewing.

Calls recoverStuckLeaders() from executeTick() alongside recoverStuckWorkers().
Also updates the stale comment on the rate_limit guard that said there was no
recoverStuckLeaders mechanism.

Includes 10 unit tests covering: inject on expiry, rate limit cleared, active
limit skipped, worker-role limit skipped, processing leader skipped, submitted-
for-review skipped, missing session skipped, no-rate-limit skipped, duplicate-
inject guard (rate limit cleared after first recovery), and worker excerpt
included in continuation message.
