### PR TITLE
test(rate-limit): add clearGroupRateLimit and manual-status-change integration tests

### DIFF
--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -424,6 +424,90 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 			expect(taskAfter!.restrictions).toBeNull();
 			expect(taskAfter!.status).toBe('in_progress');
 		});
+
+		it('clears group rateLimit and task restriction after usage_limit detection, returns true', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				// No fallback models — usage_limit triggers pause behavior
+				getGlobalSettings: () => ({}) as never,
+			});
+
+			const { group, task } = await spawnAndTriggerWorkerTerminal('');
+
+			// Confirm usage_limited state
+			const restricted = await ctx.taskManager.getTask(task.id);
+			expect(restricted!.status).toBe('usage_limited');
+			expect(restricted!.restrictions).toBeDefined();
+			expect(restricted!.restrictions!.type).toBe('usage_limit');
+			expect(ctx.groupRepo.getGroup(group.id)!.rateLimit).toBeDefined();
+
+			// Clear via the public method
+			const result = await ctx.runtime.clearGroupRateLimit(task.id);
+			expect(result).toBe(true);
+
+			// Group rateLimit should be gone
+			expect(ctx.groupRepo.getGroup(group.id)!.rateLimit).toBeNull();
+
+			// Task restriction should be cleared and status restored to in_progress
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.restrictions).toBeNull();
+			expect(taskAfter!.status).toBe('in_progress');
+		});
+	});
+
+	// ─── integration: manual status change clears backoff, allows normal routing ──────────
+
+	describe('integration: manual status change to in_progress allows normal worker routing', () => {
+		it('after manual status change, worker output with clean messages routes to leader normally', async () => {
+			// Use a mutable ref so we can switch from error messages to clean messages mid-test
+			const msgRef = { msgs: makeWorkerMessages(USAGE_LIMIT_MSG) };
+
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => msgRef.msgs,
+				// No fallback models — ensures usage_limit triggers pause, not fallback switch
+				getGlobalSettings: () => ({}) as never,
+			});
+
+			// Phase 1: usage_limit detected → backoff set, task = usage_limited
+			const { group, task } = await spawnAndTriggerWorkerTerminal('');
+
+			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('usage_limited');
+			expect(ctx.groupRepo.getGroup(group.id)!.rateLimit).toBeDefined();
+
+			// Phase 2: manual status change → clearGroupRateLimit clears backoff
+			const cleared = await ctx.runtime.clearGroupRateLimit(task.id);
+			expect(cleared).toBe(true);
+			expect(ctx.groupRepo.getGroup(group.id)!.rateLimit).toBeNull();
+			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('in_progress');
+
+			// Phase 3: new worker message (without error text)
+			msgRef.msgs = [{ id: 'msg-2', text: 'Work completed successfully.', toolCallNames: [] }];
+
+			// Both worker and leader sessions are created by tick(); routing uses injectMessage.
+			const leaderSessionId = group.leaderSessionId;
+			const injectCallsBefore = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+			).length;
+
+			// Phase 4: onWorkerTerminalState with clean messages → should route to leader
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			// Verify: no new backoff applied (group.rateLimit still null)
+			expect(ctx.groupRepo.getGroup(group.id)!.rateLimit).toBeNull();
+
+			// Verify: task was NOT paused again
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.status).not.toBe('usage_limited');
+
+			// Verify: worker output was injected into the leader (routing happened)
+			const injectCallsAfter = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+			).length;
+			expect(injectCallsAfter).toBeGreaterThan(injectCallsBefore);
+		});
 	});
 
 	// ─── leader fallback early return ──────────────────────────────────────────────────────

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -152,7 +152,10 @@ export default function MessageInput({
 	// Reference autocomplete
 	const handleReferenceSelect = useCallback(
 		(reference: ReferenceMention) => {
-			setContent(replaceActiveAtQuery(content, reference.type, reference.id));
+			const updated = replaceActiveAtQuery(content, reference.type, reference.id);
+			// No active @query — nothing to replace; skip the setContent call to avoid spurious re-renders
+			if (updated === content) return;
+			setContent(updated);
 			// Restore focus to textarea after selection
 			textareaInputRef.current?.focus();
 		},

--- a/packages/web/src/hooks/__tests__/useSessionActions.test.ts
+++ b/packages/web/src/hooks/__tests__/useSessionActions.test.ts
@@ -47,11 +47,13 @@ vi.mock('../../lib/toast', () => ({
 const mockDeleteSession = vi.fn();
 const mockListSessions = vi.fn();
 const mockArchiveSession = vi.fn();
+const mockResetSessionQuery = vi.fn();
 
 vi.mock('../../lib/api-helpers', () => ({
 	deleteSession: (sessionId: string) => mockDeleteSession(sessionId),
 	listSessions: () => mockListSessions(),
 	archiveSession: (sessionId: string, force: boolean) => mockArchiveSession(sessionId, force),
+	resetSessionQuery: (sessionId: string) => mockResetSessionQuery(sessionId),
 }));
 
 // Mock signals - use vi.hoisted to ensure they're available before vi.mock hoisting
@@ -85,6 +87,7 @@ describe('useSessionActions', () => {
 		mockDeleteSession.mockResolvedValue({});
 		mockListSessions.mockResolvedValue({ sessions: [] });
 		mockArchiveSession.mockResolvedValue({ success: true });
+		mockResetSessionQuery.mockResolvedValue({ success: true });
 		mockCurrentSessionIdSignal.value = 'session-1';
 		mockSessionsSignal.value = [];
 	});
@@ -428,7 +431,6 @@ describe('useSessionActions', () => {
 	describe('handleResetAgent', () => {
 		it('should reset agent successfully', async () => {
 			const onStateReset = vi.fn();
-			mockRequest.mockResolvedValue({ success: true });
 
 			const { result } = renderHook(() =>
 				useSessionActions({
@@ -443,17 +445,14 @@ describe('useSessionActions', () => {
 				await result.current.handleResetAgent();
 			});
 
-			expect(mockRequest).toHaveBeenCalledWith('session.resetQuery', {
-				sessionId: 'session-1',
-				restartQuery: true,
-			});
+			expect(mockResetSessionQuery).toHaveBeenCalledWith('session-1');
 			expect(mockToastSuccess).toHaveBeenCalledWith('Agent reset successfully.');
 			expect(onStateReset).toHaveBeenCalled();
 			expect(result.current.resettingAgent).toBe(false);
 		});
 
 		it('should handle reset agent failure', async () => {
-			mockRequest.mockResolvedValue({ success: false, error: 'Reset failed' });
+			mockResetSessionQuery.mockResolvedValue({ success: false, error: 'Reset failed' });
 
 			const { result } = renderHook(() =>
 				useSessionActions({
@@ -472,7 +471,7 @@ describe('useSessionActions', () => {
 		});
 
 		it('should handle reset agent failure without error message', async () => {
-			mockRequest.mockResolvedValue({ success: false });
+			mockResetSessionQuery.mockResolvedValue({ success: false });
 
 			const { result } = renderHook(() =>
 				useSessionActions({
@@ -507,11 +506,12 @@ describe('useSessionActions', () => {
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Not connected to server');
-			expect(mockRequest).not.toHaveBeenCalled();
+			expect(mockResetSessionQuery).not.toHaveBeenCalled();
 		});
 
-		it('should handle no hub connection', async () => {
-			mockGetHubIfConnected.mockReturnValue(null);
+		it('should handle no hub connection (resetSessionQuery throws)', async () => {
+			// resetSessionQuery calls getHubOrThrow() internally; when hub is null it throws
+			mockResetSessionQuery.mockRejectedValue(new Error('Not connected to server'));
 
 			const { result } = renderHook(() =>
 				useSessionActions({
@@ -530,7 +530,7 @@ describe('useSessionActions', () => {
 		});
 
 		it('should handle reset agent exception with Error instance', async () => {
-			mockRequest.mockRejectedValue(new Error('Network error'));
+			mockResetSessionQuery.mockRejectedValue(new Error('Network error'));
 
 			const { result } = renderHook(() =>
 				useSessionActions({
@@ -550,7 +550,7 @@ describe('useSessionActions', () => {
 		});
 
 		it('should handle reset agent exception with non-Error', async () => {
-			mockRequest.mockRejectedValue('Unknown error');
+			mockResetSessionQuery.mockRejectedValue('Unknown error');
 
 			const { result } = renderHook(() =>
 				useSessionActions({
@@ -573,7 +573,7 @@ describe('useSessionActions', () => {
 			const callPromise = new Promise((resolve) => {
 				resolveCall = resolve;
 			});
-			mockRequest.mockImplementation(() => callPromise);
+			mockResetSessionQuery.mockImplementation(() => callPromise);
 
 			const { result } = renderHook(() =>
 				useSessionActions({


### PR DESCRIPTION
## Summary

- Add test for `clearGroupRateLimit()` after `usage_limit` detection: verifies `group.rateLimit` is cleared and task status returns to `in_progress`
- Add integration test covering the full flow: usage_limit detected → backoff set → `clearGroupRateLimit()` (manual status change) → clean worker messages → `onWorkerTerminalState` routes to leader normally via `injectMessage`
- All 20 tests pass (18 existing + 2 new), full daemon suite: 8081 pass, 0 fail