### PR TITLE
test(room-runtime): add tests for fallback model availability verification

### DIFF
--- a/packages/daemon/tests/unit/room/room-runtime-provider-availability.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-provider-availability.test.ts
@@ -301,6 +301,39 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 		});
 	});
 
+	describe('switchModel() itself fails after availability check passes', () => {
+		it('returns false when switchModel returns success:false', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings([{ model: 'haiku', provider: 'anthropic' }]),
+				messageHub: makeMessageHub('not-in-chain', 'other'),
+				isProviderAvailable: async () => true, // provider is available
+			});
+
+			// Make switchModel report failure (e.g. API error during model switch)
+			ctx.sessionFactory.switchModelImpl = async (_sessionId, model, _provider) => ({
+				success: false,
+				model,
+				error: 'model switch rejected by server',
+			});
+
+			const { group, task } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			// switchModel was called (availability check passed), but it failed
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			expect(switchCalls.length).toBe(1);
+			expect(switchCalls[0].args[1]).toBe('haiku');
+
+			// trySwitchToFallbackModel returned false → task is usage_limited
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.status).toBe('usage_limited');
+		});
+	});
+
 	describe('same-model skip guard', () => {
 		it('skips a fallback entry that matches the current model even if not via chain index', async () => {
 			// Current model is NOT in chain (index -1), but chain[0] happens to be the same model


### PR DESCRIPTION
Add/confirm unit tests verifying that `trySwitchToFallbackModel()` respects provider availability.

The existing `room-runtime-provider-availability.test.ts` already covered subtasks 1–4 and 6 from the task spec (9 tests). This PR adds the missing subtask 5: when provider availability check passes but `switchModel()` itself returns `success: false`, `trySwitchToFallbackModel()` returns `false` and leaves the task in `usage_limited` state.

All 10 tests pass.