### PR TITLE
feat(review-tab): show needs_attention and rate/usage-limited tasks prominently

### DIFF
--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -3,7 +3,8 @@
  *
  * Tests task filter tabs, tab switching, task grouping by status,
  * empty states, click handling, and section rendering for all tabs:
- * Active (draft + pending + in_progress), Review (review + needs_attention),
+ * Active (draft + pending + in_progress),
+ * Review (needs_attention → rate_limited/usage_limited → review),
  * Done (completed + cancelled), Archived (archived, hidden by default).
  */
 
@@ -106,6 +107,24 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Active');
 			expect(container.textContent).toContain('3');
 		});
+
+		it('should include rate_limited and usage_limited in review tab count', () => {
+			const tasks = [
+				createTask('t1', 'review'),
+				createTask('t2', 'needs_attention'),
+				createTask('t3', 'rate_limited'),
+				createTask('t4', 'usage_limited'),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// Review tab count: 4 (review + needs_attention + rate_limited + usage_limited)
+			const tabBar = container.querySelector('.border-b.border-dark-700');
+			const reviewTabBtn = Array.from(tabBar?.querySelectorAll('button') ?? []).find((b) =>
+				b.textContent?.includes('Review')
+			);
+			expect(reviewTabBtn?.textContent).toContain('4');
+		});
 	});
 
 	describe('Active Tab', () => {
@@ -176,6 +195,67 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Needs Attention');
 			expect(container.textContent).toContain('Review task');
 			expect(container.textContent).toContain('Attention task');
+		});
+
+		it('should show rate_limited tasks under Review tab with orange styling', () => {
+			const tasks = [createTask('t1', 'rate_limited', { title: 'Rate limited task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Rate / Usage Limited');
+			expect(container.textContent).toContain('Rate limited task');
+			const header = container.querySelector('.text-orange-400');
+			expect(header).toBeTruthy();
+		});
+
+		it('should show usage_limited tasks under Review tab with orange styling', () => {
+			const tasks = [createTask('t1', 'usage_limited', { title: 'Usage limited task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Rate / Usage Limited');
+			expect(container.textContent).toContain('Usage limited task');
+		});
+
+		it('should show rate_limited and usage_limited tasks together in the same group', () => {
+			const tasks = [
+				createTask('t1', 'rate_limited', { title: 'Rate task' }),
+				createTask('t2', 'usage_limited', { title: 'Usage task' }),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Rate / Usage Limited (2)');
+		});
+
+		it('should display rate_limited error message in orange', () => {
+			const tasks = [
+				createTask('t1', 'rate_limited', { title: 'Rate task', error: 'API rate limit hit' }),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const errorEl = container.querySelector('p.text-orange-400');
+			expect(errorEl).toBeTruthy();
+			expect(errorEl?.textContent).toContain('API rate limit hit');
+		});
+
+		it('should display visual order: needs_attention above rate/usage limited above review', () => {
+			const tasks = [
+				createTask('t1', 'review', { title: 'Normal review' }),
+				createTask('t2', 'rate_limited', { title: 'Rate limited' }),
+				createTask('t3', 'needs_attention', { title: 'Needs attention' }),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const headers = Array.from(container.querySelectorAll('h3')).map((h) => h.textContent ?? '');
+			const needsIdx = headers.findIndex((t) => t.includes('Needs Attention'));
+			const rateIdx = headers.findIndex((t) => t.includes('Rate / Usage Limited'));
+			const reviewIdx = headers.findIndex((t) => t.includes('Awaiting Review'));
+
+			expect(needsIdx).toBeLessThan(rateIdx);
+			expect(rateIdx).toBeLessThan(reviewIdx);
 		});
 
 		it('should show empty state when no review tasks', () => {
@@ -631,6 +711,27 @@ describe('RoomTasks', () => {
 
 			expect(container.textContent).toContain('Draft (1)');
 			expect(container.textContent).toContain('Draft task');
+		});
+
+		it('rate_limited tasks appear under review tab, not active tab', () => {
+			selectedTabSignal.value = 'active';
+			const tasks = [createTask('t1', 'rate_limited', { title: 'Rate limited task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// Active tab should show empty state since rate_limited is not active
+			expect(container.textContent).toContain('No active tasks');
+			expect(container.textContent).not.toContain('Rate limited task');
+		});
+
+		it('usage_limited tasks appear under review tab, not active tab', () => {
+			selectedTabSignal.value = 'active';
+			const tasks = [createTask('t1', 'usage_limited', { title: 'Usage limited task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('No active tasks');
+			expect(container.textContent).not.toContain('Usage limited task');
 		});
 
 		it('there is no needs_attention tab button in the tab bar', () => {

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -53,7 +53,13 @@ function getTabCounts(tasks: TaskSummary[]) {
 		active: tasks.filter(
 			(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
 		).length,
-		review: tasks.filter((t) => t.status === 'review' || t.status === 'needs_attention').length,
+		review: tasks.filter(
+			(t) =>
+				t.status === 'review' ||
+				t.status === 'needs_attention' ||
+				t.status === 'rate_limited' ||
+				t.status === 'usage_limited'
+		).length,
 		done: tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled').length,
 		archived: tasks.filter((t) => t.status === 'archived').length,
 	};
@@ -67,7 +73,13 @@ function getFilteredTasks(tasks: TaskSummary[], tab: TaskFilterTab): TaskSummary
 				(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
 			);
 		case 'review':
-			return tasks.filter((t) => t.status === 'review' || t.status === 'needs_attention');
+			return tasks.filter(
+				(t) =>
+					t.status === 'review' ||
+					t.status === 'needs_attention' ||
+					t.status === 'rate_limited' ||
+					t.status === 'usage_limited'
+			);
 		case 'done':
 			return tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled');
 		case 'archived':
@@ -348,23 +360,14 @@ function TaskList({
 	}
 
 	if (tab === 'review') {
-		const reviewTasks = tasks.filter((t) => t.status === 'review');
 		const needsAttention = tasks.filter((t) => t.status === 'needs_attention');
+		const rateLimited = tasks.filter(
+			(t) => t.status === 'rate_limited' || t.status === 'usage_limited'
+		);
+		const reviewTasks = tasks.filter((t) => t.status === 'review');
 
 		return (
 			<div class="space-y-4">
-				{reviewTasks.length > 0 && (
-					<TaskGroup
-						title="Awaiting Review"
-						count={reviewTasks.length}
-						variant="purple"
-						tasks={reviewTasks}
-						allTasks={allTasks}
-						goalByTaskId={goalByTaskId}
-						onTaskClick={onTaskClick}
-						onGoalClick={onGoalClick}
-					/>
-				)}
 				{needsAttention.length > 0 && (
 					<TaskGroup
 						title="Needs Attention"
@@ -376,6 +379,31 @@ function TaskList({
 						onTaskClick={onTaskClick}
 						onGoalClick={onGoalClick}
 						showAlert
+					/>
+				)}
+				{rateLimited.length > 0 && (
+					<TaskGroup
+						title="Rate / Usage Limited"
+						count={rateLimited.length}
+						variant="orange"
+						tasks={rateLimited}
+						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
+						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
+						showClock
+					/>
+				)}
+				{reviewTasks.length > 0 && (
+					<TaskGroup
+						title="Awaiting Review"
+						count={reviewTasks.length}
+						variant="purple"
+						tasks={reviewTasks}
+						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
+						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
 					/>
 				)}
 			</div>
@@ -447,10 +475,11 @@ function TaskGroup({
 	onGoalClick,
 	onReactivate,
 	showAlert = false,
+	showClock = false,
 }: {
 	title: string;
 	count: number;
-	variant: 'default' | 'yellow' | 'purple' | 'green' | 'red' | 'gray';
+	variant: 'default' | 'yellow' | 'purple' | 'green' | 'red' | 'orange' | 'gray';
 	tasks: TaskSummary[];
 	allTasks: TaskSummary[];
 	goalByTaskId?: Map<string, RoomGoal>;
@@ -458,6 +487,7 @@ function TaskGroup({
 	onGoalClick?: () => void;
 	onReactivate?: (taskId: string) => void;
 	showAlert?: boolean;
+	showClock?: boolean;
 }) {
 	const headerStyles: Record<string, string> = {
 		default: '',
@@ -465,6 +495,7 @@ function TaskGroup({
 		purple: 'bg-purple-900/20',
 		green: 'bg-green-900/20',
 		red: 'bg-red-900/20',
+		orange: 'bg-orange-900/20',
 		gray: 'bg-dark-800',
 	};
 
@@ -474,6 +505,7 @@ function TaskGroup({
 		purple: 'text-purple-400',
 		green: 'text-green-400',
 		red: 'text-red-400',
+		orange: 'text-orange-400',
 		gray: 'text-gray-500',
 	};
 
@@ -483,6 +515,7 @@ function TaskGroup({
 		purple: 'border-dark-700',
 		green: 'border-dark-700',
 		red: 'border-red-800/60',
+		orange: 'border-orange-800/60',
 		gray: 'border-dark-700',
 	};
 
@@ -503,6 +536,21 @@ function TaskGroup({
 							stroke-linejoin="round"
 							stroke-width={1.5}
 							d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+						/>
+					</svg>
+				)}
+				{showClock && (
+					<svg
+						class="w-4 h-4 text-orange-400 flex-shrink-0"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={1.5}
+							d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
 						/>
 					</svg>
 				)}
@@ -669,6 +717,11 @@ function TaskItem({
 			)}
 			{task.status === 'needs_attention' && task.error && (
 				<p class="text-xs text-red-400 mt-1.5 line-clamp-2" title={task.error}>
+					{task.error}
+				</p>
+			)}
+			{(task.status === 'rate_limited' || task.status === 'usage_limited') && task.error && (
+				<p class="text-xs text-orange-400 mt-1.5 line-clamp-2" title={task.error}>
 					{task.error}
 				</p>
 			)}

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -3,7 +3,7 @@
  * - tasksByGoalId: Map of goal ID → linked TaskSummary[]
  * - orphanTasks: Tasks not linked to any goal
  * - orphanTasksActive: Orphan tasks with draft/pending/in_progress
- * - orphanTasksReview: Orphan tasks with review/needs_attention
+ * - orphanTasksReview: Orphan tasks with review/needs_attention/rate_limited/usage_limited
  * - orphanTasksDone: Orphan tasks with completed/cancelled
  * - orphanTasksArchived: Orphan tasks with archived
  */
@@ -170,16 +170,18 @@ describe('RoomStore — computed goal/task signals', () => {
 	});
 
 	describe('orphanTasksReview', () => {
-		it('includes review and needs_attention orphan tasks', () => {
+		it('includes review, needs_attention, rate_limited, and usage_limited orphan tasks', () => {
 			roomStore.tasks.value = [
 				makeTask('t1', 'draft'),
 				makeTask('t2', 'review'),
 				makeTask('t3', 'needs_attention'),
 				makeTask('t4', 'completed'),
+				makeTask('t5', 'rate_limited'),
+				makeTask('t6', 'usage_limited'),
 			];
 			roomStore.goals.value = [];
 			const ids = roomStore.orphanTasksReview.value.map((t) => t.id);
-			expect(ids).toEqual(['t2', 't3']);
+			expect(ids).toEqual(['t2', 't3', 't5', 't6']);
 		});
 	});
 
@@ -246,10 +248,10 @@ describe('RoomStore — computed goal/task signals', () => {
 				}
 			}
 
-			// All covered — rate_limited and usage_limited fall into the active bucket
+			// All covered — rate_limited and usage_limited fall into the review bucket
 			expect(active.size + review.size + done.size + archived.size).toBe(10);
-			expect(active.has('rate_limited')).toBe(true);
-			expect(active.has('usage_limited')).toBe(true);
+			expect(review.has('rate_limited')).toBe(true);
+			expect(review.has('usage_limited')).toBe(true);
 		});
 	});
 

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -192,21 +192,22 @@ class RoomStore {
 		return this.tasks.value.filter((t) => !linkedIds.has(t.id));
 	});
 
-	/** Orphan tasks that are active (draft, pending, in_progress, rate_limited, or usage_limited) */
+	/** Orphan tasks that are active (draft, pending, or in_progress) */
 	readonly orphanTasksActive = computed(() =>
 		this.orphanTasks.value.filter(
-			(t) =>
-				t.status === 'draft' ||
-				t.status === 'pending' ||
-				t.status === 'in_progress' ||
-				t.status === 'rate_limited' ||
-				t.status === 'usage_limited'
+			(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
 		)
 	);
 
-	/** Orphan tasks in review (review or needs_attention) */
+	/** Orphan tasks in review (review, needs_attention, rate_limited, or usage_limited) */
 	readonly orphanTasksReview = computed(() =>
-		this.orphanTasks.value.filter((t) => t.status === 'review' || t.status === 'needs_attention')
+		this.orphanTasks.value.filter(
+			(t) =>
+				t.status === 'review' ||
+				t.status === 'needs_attention' ||
+				t.status === 'rate_limited' ||
+				t.status === 'usage_limited'
+		)
 	);
 
 	/** Orphan tasks that are done (completed or cancelled) */
@@ -368,13 +369,19 @@ class RoomStore {
 				}
 				if (event.updated?.length) {
 					const updatedTasks = event.updated as TaskSummary[];
-					// Show toast when a known task transitions into review status.
+					// Show toast when a known task transitions into review/rate-limited/usage-limited status.
 					// Skip when prevTask is absent to avoid spurious toasts during hydration.
 					for (const updatedTask of updatedTasks) {
-						if (updatedTask.status === 'review') {
-							const prevTask = current.find((t) => t.id === updatedTask.id);
-							if (prevTask && prevTask.status !== 'review') {
+						const prevTask = current.find((t) => t.id === updatedTask.id);
+						if (prevTask) {
+							if (updatedTask.status === 'review' && prevTask.status !== 'review') {
 								toast.info(`Task ready for review: ${updatedTask.title}`);
+							} else if (
+								(updatedTask.status === 'rate_limited' || updatedTask.status === 'usage_limited') &&
+								prevTask.status !== updatedTask.status
+							) {
+								const limitType = updatedTask.status === 'rate_limited' ? 'rate' : 'usage';
+								toast.warning(`Task paused (${limitType} limit): ${updatedTask.title}`);
 							}
 						}
 					}


### PR DESCRIPTION
## Summary

- `rate_limited` and `usage_limited` tasks moved from Active tab to Review tab
- Review tab now shows a strict priority order: **Needs Attention** → **Rate / Usage Limited** → **Awaiting Review**
- Orange styling (clock icon, border, error text) for rate/usage limited group
- `toast.warning` fires when a task transitions into rate/usage limited status
- `orphanTasksReview` now includes rate/usage limited; `orphanTasksActive` no longer does