### PR TITLE
feat(ui): agent completion state indicators on WorkflowNodeCard and WorkflowNode

### DIFF
--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -192,6 +192,18 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 	const agents = filterAgents(spaceStore.agents.value);
 	const tasksByNodeId = spaceStore.tasksByNodeId.value;
 
+	// Determine which workflow run to use for completion indicators.
+	// Prefer an active run; fall back to the most recently updated run.
+	// When no run exists yet (e.g. new workflow), relevantRunId is null.
+	const relevantRunId = (() => {
+		if (!workflow?.id) return null;
+		const runs = spaceStore.workflowRuns.value.filter((r) => r.workflowId === workflow.id);
+		if (!runs.length) return null;
+		const active = runs.find((r) => r.status === 'pending' || r.status === 'in_progress');
+		if (active) return active.id;
+		return [...runs].sort((a, b) => b.updatedAt - a.updatedAt)[0].id;
+	})();
+
 	// ---- Step operations ----
 
 	function addStep() {
@@ -527,8 +539,13 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 
 					<div class="space-y-2">
 						{steps.map((step, i) => {
-							// Derive per-agent completion states from live task data for this node.
-							const nodeTasks = step.id ? (tasksByNodeId.get(step.id) ?? []) : [];
+							// Derive per-agent completion states from live task data for this node,
+							// scoped to the most relevant workflow run to avoid mixing state from
+							// past runs with the current one.
+							const allNodeTasks = step.id ? (tasksByNodeId.get(step.id) ?? []) : [];
+							const nodeTasks = relevantRunId
+								? allNodeTasks.filter((t) => t.workflowRunId === relevantRunId)
+								: allNodeTasks;
 							const nodeTaskStates: AgentTaskState[] = nodeTasks.map((t) => ({
 								agentName: t.agentName ?? null,
 								status: t.status,

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -16,7 +16,7 @@ import type { SpaceWorkflow, SpaceAgent, WorkflowChannel } from '@neokai/shared'
 import { generateUUID } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 import { WorkflowNodeCard } from './WorkflowNodeCard';
-import type { NodeDraft, ConditionDraft } from './WorkflowNodeCard';
+import type { NodeDraft, ConditionDraft, AgentTaskState } from './WorkflowNodeCard';
 import { WorkflowRulesEditor } from './WorkflowRulesEditor';
 import type { RuleDraft } from './WorkflowRulesEditor';
 import { rulesToDrafts } from './WorkflowRulesEditor';
@@ -190,6 +190,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 	const [showTemplates, setShowTemplates] = useState(false);
 
 	const agents = filterAgents(spaceStore.agents.value);
+	const tasksByNodeId = spaceStore.tasksByNodeId.value;
 
 	// ---- Step operations ----
 
@@ -525,27 +526,39 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 					)}
 
 					<div class="space-y-2">
-						{steps.map((step, i) => (
-							<WorkflowNodeCard
-								key={step.localId}
-								node={step}
-								nodeIndex={i}
-								isFirst={i === 0}
-								isLast={i === steps.length - 1}
-								expanded={expandedIndex === i}
-								entryCondition={i > 0 ? (transitions[i - 1] ?? { type: 'always' }) : null}
-								exitCondition={i < steps.length - 1 ? (transitions[i] ?? { type: 'always' }) : null}
-								agents={agents}
-								onToggleExpand={() => setExpandedIndex((prev) => (prev === i ? null : i))}
-								onUpdate={(s) => updateStep(i, s)}
-								onUpdateEntryCondition={(c) => updateEntryCondition(i, c)}
-								onUpdateExitCondition={(c) => updateExitCondition(i, c)}
-								onMoveUp={() => moveStep(i, 'up')}
-								onMoveDown={() => moveStep(i, 'down')}
-								onRemove={() => removeStep(i)}
-								disableRemove={steps.length === 1}
-							/>
-						))}
+						{steps.map((step, i) => {
+							// Derive per-agent completion states from live task data for this node.
+							const nodeTasks = step.id ? (tasksByNodeId.get(step.id) ?? []) : [];
+							const nodeTaskStates: AgentTaskState[] = nodeTasks.map((t) => ({
+								agentName: t.agentName ?? null,
+								status: t.status,
+								completionSummary: t.completionSummary,
+							}));
+							return (
+								<WorkflowNodeCard
+									key={step.localId}
+									node={step}
+									nodeIndex={i}
+									isFirst={i === 0}
+									isLast={i === steps.length - 1}
+									expanded={expandedIndex === i}
+									entryCondition={i > 0 ? (transitions[i - 1] ?? { type: 'always' }) : null}
+									exitCondition={
+										i < steps.length - 1 ? (transitions[i] ?? { type: 'always' }) : null
+									}
+									agents={agents}
+									onToggleExpand={() => setExpandedIndex((prev) => (prev === i ? null : i))}
+									onUpdate={(s) => updateStep(i, s)}
+									onUpdateEntryCondition={(c) => updateEntryCondition(i, c)}
+									onUpdateExitCondition={(c) => updateExitCondition(i, c)}
+									onMoveUp={() => moveStep(i, 'up')}
+									onMoveDown={() => moveStep(i, 'down')}
+									onRemove={() => removeStep(i)}
+									disableRemove={steps.length === 1}
+									nodeTaskStates={nodeTaskStates.length > 0 ? nodeTaskStates : undefined}
+								/>
+							);
+						})}
 					</div>
 
 					<button

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -9,7 +9,12 @@
  */
 
 import { useState, useCallback } from 'preact/hooks';
-import type { SpaceAgent, WorkflowNodeAgent, WorkflowChannel } from '@neokai/shared';
+import type {
+	SpaceAgent,
+	WorkflowNodeAgent,
+	WorkflowChannel,
+	SpaceTaskStatus,
+} from '@neokai/shared';
 import type { WorkflowConditionType } from '@neokai/shared';
 import { cn } from '../../lib/utils';
 import { GateConfig, CONDITION_LABELS } from './visual-editor/GateConfig';
@@ -45,6 +50,26 @@ export function isMultiAgentNode(node: NodeDraft): boolean {
 
 // Re-export ConditionDraft so existing importers don't break
 export type { ConditionDraft } from './visual-editor/GateConfig';
+
+// ============================================================================
+// Agent Completion State
+// ============================================================================
+
+/**
+ * Runtime completion state for a single agent slot within a workflow node.
+ * Derived from SpaceTask records filtered by workflowNodeId.
+ */
+export interface AgentTaskState {
+	/** Matches WorkflowNodeAgent.name; null means single-agent node */
+	agentName: string | null;
+	status: SpaceTaskStatus;
+	completionSummary?: string | null;
+}
+
+/** Returns true when all provided agent states have status === 'completed'. */
+export function isNodeFullyCompleted(states: AgentTaskState[]): boolean {
+	return states.length > 0 && states.every((s) => s.status === 'completed');
+}
 
 // ============================================================================
 // Icon Components
@@ -97,6 +122,97 @@ function GateIcon({ type }: { type: WorkflowConditionType }) {
 				d="M13 5l7 7-7 7M5 5l7 7-7 7"
 			/>
 		</svg>
+	);
+}
+
+/** Animated spinner for in-progress agents */
+function SpinnerIcon({ title }: { title?: string }) {
+	return (
+		<svg
+			class="w-3 h-3 animate-spin"
+			fill="none"
+			viewBox="0 0 24 24"
+			aria-label={title}
+			data-testid="agent-status-spinner"
+		>
+			<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+			<path
+				class="opacity-75"
+				fill="currentColor"
+				d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+			/>
+		</svg>
+	);
+}
+
+/** Green checkmark for completed agents */
+function CheckIcon({ title }: { title?: string }) {
+	return (
+		<svg
+			class="w-3 h-3"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+			aria-label={title}
+			data-testid="agent-status-check"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width={2.5} d="M5 13l4 4L19 7" />
+		</svg>
+	);
+}
+
+/** Red/gray X for failed/cancelled agents */
+function FailIcon({ title }: { title?: string }) {
+	return (
+		<svg
+			class="w-3 h-3"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+			aria-label={title}
+			data-testid="agent-status-fail"
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2.5}
+				d="M6 18L18 6M6 6l12 12"
+			/>
+		</svg>
+	);
+}
+
+/** Renders the appropriate icon for an agent's task status. */
+export function AgentStatusIcon({ state }: { state: AgentTaskState }) {
+	const summary = state.completionSummary ?? undefined;
+	if (state.status === 'completed') {
+		return (
+			<span class="text-green-400 flex-shrink-0" title={summary ?? 'Done'}>
+				<CheckIcon title={summary ?? 'Done'} />
+			</span>
+		);
+	}
+	if (state.status === 'in_progress') {
+		return (
+			<span class="text-blue-400 flex-shrink-0" title="In progress">
+				<SpinnerIcon title="In progress" />
+			</span>
+		);
+	}
+	if (state.status === 'needs_attention' || state.status === 'cancelled') {
+		return (
+			<span class="text-red-400 flex-shrink-0" title={summary ?? state.status}>
+				<FailIcon title={summary ?? state.status} />
+			</span>
+		);
+	}
+	// pending/draft/review/rate_limited/usage_limited — faint dot
+	return (
+		<span
+			class="w-1.5 h-1.5 rounded-full bg-gray-500 flex-shrink-0"
+			title={state.status}
+			data-testid="agent-status-pending"
+		/>
 	);
 }
 
@@ -593,6 +709,12 @@ interface WorkflowNodeCardProps {
 	onRemove: () => void;
 	/** When true, the Remove button is disabled (e.g. only one node remains) */
 	disableRemove?: boolean;
+	/**
+	 * Runtime agent completion states for this node.
+	 * Derived from SpaceTask records filtered by the node's ID.
+	 * When provided, per-agent status indicators are shown in the collapsed header.
+	 */
+	nodeTaskStates?: AgentTaskState[];
 }
 
 export function WorkflowNodeCard({
@@ -612,12 +734,24 @@ export function WorkflowNodeCard({
 	onMoveDown,
 	onRemove,
 	disableRemove = false,
+	nodeTaskStates,
 }: WorkflowNodeCardProps) {
 	const multi = isMultiAgentNode(node);
 	const agentName = agents.find((a) => a.id === node.agentId)?.name ?? node.agentId;
 
+	// Build a lookup: agentName → AgentTaskState (for multi-agent) or the first entry (for single-agent)
+	const taskStateByAgent = new Map<string | null, AgentTaskState>(
+		(nodeTaskStates ?? []).map((s) => [s.agentName, s])
+	);
+	const allDone = isNodeFullyCompleted(nodeTaskStates ?? []);
+
 	return (
-		<div class="border border-dark-700 rounded-lg overflow-hidden">
+		<div
+			class={cn(
+				'border rounded-lg overflow-hidden',
+				allDone ? 'border-green-700/60' : 'border-dark-700'
+			)}
+		>
 			{/* Collapsed header — always visible */}
 			<div
 				class={cn(
@@ -626,8 +760,14 @@ export function WorkflowNodeCard({
 				)}
 				onClick={onToggleExpand}
 			>
-				{/* Step number */}
-				<span class="w-5 h-5 flex items-center justify-center rounded-full bg-dark-700 text-xs font-semibold text-gray-400 flex-shrink-0">
+				{/* Step number — turns green when all agents done */}
+				<span
+					class={cn(
+						'w-5 h-5 flex items-center justify-center rounded-full text-xs font-semibold flex-shrink-0',
+						allDone ? 'bg-green-800 text-green-300' : 'bg-dark-700 text-gray-400'
+					)}
+					data-testid="node-step-badge"
+				>
 					{nodeIndex + 1}
 				</span>
 
@@ -643,27 +783,45 @@ export function WorkflowNodeCard({
 								{node.agents!.map((a) => {
 									const name = agents.find((ag) => ag.id === a.agentId)?.name ?? a.agentId;
 									const hasOverrides = !!(a.model || a.systemPrompt);
+									const taskState = taskStateByAgent.get(a.name);
 									return (
 										<span
 											key={a.name}
-											class={`text-xs border rounded px-1 py-0.5 flex items-center gap-0.5 ${hasOverrides ? 'bg-amber-950/30 border-amber-700/50 text-amber-300' : 'bg-dark-700 border-dark-600 text-gray-300'}`}
+											class={cn(
+												'text-xs border rounded px-1 py-0.5 flex items-center gap-0.5',
+												hasOverrides
+													? 'bg-amber-950/30 border-amber-700/50 text-amber-300'
+													: 'bg-dark-700 border-dark-600 text-gray-300'
+											)}
 											title={`${name} — slot: ${a.name}${hasOverrides ? ' (has overrides)' : ''}`}
 										>
 											<span>{a.name}</span>
-											{hasOverrides && (
+											{hasOverrides && !taskState && (
 												<span
 													data-testid="override-dot"
 													class="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0"
 												/>
 											)}
+											{taskState && <AgentStatusIcon state={taskState} />}
 										</span>
 									);
 								})}
 							</span>
 						) : (
-							<span class="text-xs text-gray-500 truncate flex-shrink-0">{agentName || '—'}</span>
+							<span class="flex items-center gap-1 text-xs text-gray-500 truncate flex-shrink-0">
+								<span>{agentName || '—'}</span>
+								{taskStateByAgent.get(null) && (
+									<AgentStatusIcon state={taskStateByAgent.get(null)!} />
+								)}
+							</span>
 						)}
 					</div>
+					{/* Completion summary — shown when the single-agent or any agent has a summary */}
+					{nodeTaskStates && nodeTaskStates.some((s) => s.completionSummary) && (
+						<p class="text-xs text-gray-500 truncate mt-0.5" data-testid="node-completion-summary">
+							{nodeTaskStates.find((s) => s.completionSummary)?.completionSummary}
+						</p>
+					)}
 				</div>
 
 				{/* Gate icons */}

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -26,6 +26,7 @@ import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
+const mockTasksByNodeId = signal(new Map<string, unknown[]>());
 
 const mockCreateWorkflow = vi.fn();
 const mockUpdateWorkflow = vi.fn();
@@ -35,6 +36,7 @@ vi.mock('../../../lib/space-store', () => ({
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
+			tasksByNodeId: mockTasksByNodeId,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,
 		};

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -27,6 +27,7 @@ import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
 const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+const mockWorkflowRuns = signal<unknown[]>([]);
 
 const mockCreateWorkflow = vi.fn();
 const mockUpdateWorkflow = vi.fn();
@@ -37,6 +38,7 @@ vi.mock('../../../lib/space-store', () => ({
 			agents: mockAgents,
 			workflows: mockWorkflows,
 			tasksByNodeId: mockTasksByNodeId,
+			workflowRuns: mockWorkflowRuns,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,
 		};

--- a/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
@@ -17,7 +17,7 @@ import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import { useState } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
 import { WorkflowNodeCard } from '../WorkflowNodeCard';
-import type { NodeDraft, ConditionDraft } from '../WorkflowNodeCard';
+import type { NodeDraft, ConditionDraft, AgentTaskState } from '../WorkflowNodeCard';
 
 vi.mock('../../../lib/utils', () => ({
 	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
@@ -501,5 +501,114 @@ describe('WorkflowNodeCard — expanded view per-slot override section', () => {
 		expect(onUpdate).toHaveBeenCalled();
 		const updated = onUpdate.mock.calls[0][0] as NodeDraft;
 		expect(updated.agents?.[0].model).toBe('claude-opus-4-6');
+	});
+});
+
+// ============================================================================
+// Agent completion state
+// ============================================================================
+
+describe('WorkflowNodeCard — agent completion state', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	function makeMultiAgentStep(): NodeDraft {
+		return {
+			localId: 'local-multi',
+			id: 'node-multi',
+			name: 'Multi Step',
+			agentId: '',
+			instructions: '',
+			agents: [
+				{ agentId: 'agent-1', name: 'coder' },
+				{ agentId: 'agent-2', name: 'reviewer' },
+			],
+		};
+	}
+
+	it('shows spinner for in_progress agent (single-agent)', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'in_progress' }];
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('agent-status-spinner')).toBeTruthy();
+	});
+
+	it('shows checkmark for completed agent (single-agent)', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'completed' }];
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('agent-status-check')).toBeTruthy();
+	});
+
+	it('shows fail icon for needs_attention agent (single-agent)', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'needs_attention' }];
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('agent-status-fail')).toBeTruthy();
+	});
+
+	it('shows fail icon for cancelled agent', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'cancelled' }];
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('agent-status-fail')).toBeTruthy();
+	});
+
+	it('shows pending dot for pending agent', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'pending' }];
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('agent-status-pending')).toBeTruthy();
+	});
+
+	it('applies green step badge when all agents done', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'completed' }];
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
+		const badge = getByTestId('node-step-badge');
+		expect(badge.className).toContain('green');
+	});
+
+	it('does NOT apply green step badge when not all done', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'in_progress' }];
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
+		const badge = getByTestId('node-step-badge');
+		expect(badge.className).not.toContain('green');
+	});
+
+	it('shows completion summary text when provided', () => {
+		const states: AgentTaskState[] = [
+			{ agentName: null, status: 'completed', completionSummary: 'All done nicely' },
+		];
+		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('node-completion-summary').textContent).toBe('All done nicely');
+	});
+
+	it('shows per-agent status for multi-agent nodes', () => {
+		const states: AgentTaskState[] = [
+			{ agentName: 'coder', status: 'completed' },
+			{ agentName: 'reviewer', status: 'in_progress' },
+		];
+		const { getAllByTestId } = render(
+			<WorkflowNodeCard {...makeProps({ node: makeMultiAgentStep(), nodeTaskStates: states })} />
+		);
+		// One checkmark for coder, one spinner for reviewer
+		expect(getAllByTestId('agent-status-check')).toHaveLength(1);
+		expect(getAllByTestId('agent-status-spinner')).toHaveLength(1);
+	});
+
+	it('does not show status icons when nodeTaskStates is not provided', () => {
+		const { container } = render(<WorkflowNodeCard {...makeProps()} />);
+		expect(container.querySelector('[data-testid="agent-status-check"]')).toBeNull();
+		expect(container.querySelector('[data-testid="agent-status-spinner"]')).toBeNull();
+		expect(container.querySelector('[data-testid="agent-status-fail"]')).toBeNull();
+	});
+
+	it('shows green border when all agents completed', () => {
+		const states: AgentTaskState[] = [
+			{ agentName: 'coder', status: 'completed' },
+			{ agentName: 'reviewer', status: 'completed' },
+		];
+		const { container } = render(
+			<WorkflowNodeCard {...makeProps({ node: makeMultiAgentStep(), nodeTaskStates: states })} />
+		);
+		// The outer border should include 'green'
+		const outer = container.firstElementChild as HTMLElement;
+		expect(outer.className).toContain('green');
 	});
 });

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -143,6 +143,17 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const agents = filterAgents(spaceStore.agents.value);
 	const tasksByNodeId = spaceStore.tasksByNodeId.value;
 
+	// Determine which workflow run to use for completion indicators.
+	// Prefer an active run; fall back to the most recently updated run.
+	const relevantRunId = (() => {
+		if (!workflow?.id) return null;
+		const runs = spaceStore.workflowRuns.value.filter((r) => r.workflowId === workflow.id);
+		if (!runs.length) return null;
+		const active = runs.find((r) => r.status === 'pending' || r.status === 'in_progress');
+		if (active) return active.id;
+		return [...runs].sort((a, b) => b.updatedAt - a.updatedAt)[0].id;
+	})();
+
 	// Collect all agent slot names from nodes for ChannelEditor from/to suggestions
 	const agentRoles = useMemo(() => {
 		const roles = new Set<string>();
@@ -304,7 +315,11 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const nodeData = useMemo<WorkflowNodeData[]>(() => {
 		return nodes.map((node, i) => {
 			const nodeId = node.step.id;
-			const nodeTasks = nodeId ? (tasksByNodeId.get(nodeId) ?? []) : [];
+			const allNodeTasks = nodeId ? (tasksByNodeId.get(nodeId) ?? []) : [];
+			// Filter to the most relevant run to avoid mixing state from past runs.
+			const nodeTasks = relevantRunId
+				? allNodeTasks.filter((t) => t.workflowRunId === relevantRunId)
+				: allNodeTasks;
 			const nodeTaskStates: AgentTaskState[] = nodeTasks.map((t) => ({
 				agentName: t.agentName ?? null,
 				status: t.status,
@@ -319,7 +334,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				nodeTaskStates: nodeTaskStates.length > 0 ? nodeTaskStates : undefined,
 			};
 		});
-	}, [nodes, agents, nodeIsStart, tasksByNodeId]);
+	}, [nodes, agents, nodeIsStart, tasksByNodeId, relevantRunId]);
 
 	// ------------------------------------------------------------------
 	// Derived: selected node / edge

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -34,7 +34,7 @@ import { filterAgents, TEMPLATES } from '../WorkflowEditor';
 import type { WorkflowTemplate } from '../WorkflowEditor';
 import { WorkflowRulesEditor } from '../WorkflowRulesEditor';
 import type { RuleDraft } from '../WorkflowRulesEditor';
-import type { NodeDraft } from '../WorkflowNodeCard';
+import type { NodeDraft, AgentTaskState } from '../WorkflowNodeCard';
 import type { ConditionDraft } from './GateConfig';
 import type { ViewportState, Point } from './types';
 import type { VisualNode, VisualEdge, VisualEditorState } from './serialization';
@@ -141,6 +141,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const canvasContainerRef = useRef<HTMLDivElement>(null);
 
 	const agents = filterAgents(spaceStore.agents.value);
+	const tasksByNodeId = spaceStore.tasksByNodeId.value;
 
 	// Collect all agent slot names from nodes for ChannelEditor from/to suggestions
 	const agentRoles = useMemo(() => {
@@ -301,14 +302,24 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	// ------------------------------------------------------------------
 
 	const nodeData = useMemo<WorkflowNodeData[]>(() => {
-		return nodes.map((node, i) => ({
-			stepIndex: i,
-			step: node.step,
-			position: node.position,
-			agents,
-			isStartNode: nodeIsStart(node),
-		}));
-	}, [nodes, agents, nodeIsStart]);
+		return nodes.map((node, i) => {
+			const nodeId = node.step.id;
+			const nodeTasks = nodeId ? (tasksByNodeId.get(nodeId) ?? []) : [];
+			const nodeTaskStates: AgentTaskState[] = nodeTasks.map((t) => ({
+				agentName: t.agentName ?? null,
+				status: t.status,
+				completionSummary: t.completionSummary,
+			}));
+			return {
+				stepIndex: i,
+				step: node.step,
+				position: node.position,
+				agents,
+				isStartNode: nodeIsStart(node),
+				nodeTaskStates: nodeTaskStates.length > 0 ? nodeTaskStates : undefined,
+			};
+		});
+	}, [nodes, agents, nodeIsStart, tasksByNodeId]);
 
 	// ------------------------------------------------------------------
 	// Derived: selected node / edge

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -17,8 +17,8 @@
 import { useEffect, useCallback, useRef } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
 import { TASK_AGENT_NODE_ID } from '@neokai/shared';
-import type { NodeDraft } from '../WorkflowNodeCard';
-import { isMultiAgentNode } from '../WorkflowNodeCard';
+import type { NodeDraft, AgentTaskState } from '../WorkflowNodeCard';
+import { isMultiAgentNode, isNodeFullyCompleted, AgentStatusIcon } from '../WorkflowNodeCard';
 import type { Point } from './types';
 
 // ============================================================================
@@ -83,6 +83,11 @@ export interface WorkflowNodeProps {
 	isDropTarget?: boolean;
 	/** Called when the card body is clicked (for selection) */
 	onClick?: (stepId: string) => void;
+	/**
+	 * Runtime agent completion states for this node.
+	 * When provided, per-agent status indicators are shown inside the node card.
+	 */
+	nodeTaskStates?: AgentTaskState[];
 }
 
 // ============================================================================
@@ -103,12 +108,19 @@ export function WorkflowNode({
 	onPortMouseEnter,
 	onPortMouseLeave,
 	onClick,
+	nodeTaskStates,
 }: WorkflowNodeProps) {
 	const stepId = step.localId;
 	const isTaskAgent = stepId === TASK_AGENT_NODE_ID;
 
 	const multi = isMultiAgentNode(step);
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
+
+	// Build a lookup: agentName → AgentTaskState
+	const taskStateByAgent = new Map<string | null, AgentTaskState>(
+		(nodeTaskStates ?? []).map((s) => [s.agentName, s])
+	);
+	const allDone = isNodeFullyCompleted(nodeTaskStates ?? []);
 
 	// ---- Drag state ----
 	const dragState = useRef<{
@@ -255,7 +267,9 @@ export function WorkflowNode({
 			? 'border-green-500'
 			: isSelected
 				? 'border-blue-500'
-				: 'border-gray-700';
+				: allDone
+					? 'border-green-600'
+					: 'border-gray-700';
 
 	const bgClass = isTaskAgent ? 'bg-amber-950' : 'bg-gray-800';
 
@@ -386,6 +400,7 @@ export function WorkflowNode({
 					<div data-testid="agent-badges" class="flex flex-wrap gap-1 mt-1">
 						{step.agents!.map((sa) => {
 							const hasOverrides = !!(sa.model || sa.systemPrompt);
+							const taskState = taskStateByAgent.get(sa.name);
 							return (
 								<span
 									key={sa.name}
@@ -393,20 +408,25 @@ export function WorkflowNode({
 									title={hasOverrides ? `${sa.name} (has overrides)` : sa.name}
 								>
 									{sa.name}
-									{hasOverrides && (
+									{hasOverrides && !taskState && (
 										<span
 											data-testid="override-indicator"
 											class="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0"
 										/>
 									)}
+									{taskState && <AgentStatusIcon state={taskState} />}
 								</span>
 							);
 						})}
 					</div>
 				) : (
-					<p data-testid="agent-name" class="text-xs text-gray-400 truncate mt-0.5">
-						{agentName}
-					</p>
+					<div
+						data-testid="agent-name"
+						class="flex items-center gap-1 text-xs text-gray-400 truncate mt-0.5"
+					>
+						<span class="truncate">{agentName}</span>
+						{taskStateByAgent.get(null) && <AgentStatusIcon state={taskStateByAgent.get(null)!} />}
+					</div>
 				)}
 
 				{/* Channel topology */}

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -70,6 +70,7 @@ import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
 const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+const mockWorkflowRuns = signal<unknown[]>([]);
 
 const mockCreateWorkflow = vi.fn();
 const mockUpdateWorkflow = vi.fn();
@@ -80,6 +81,7 @@ vi.mock('../../../../lib/space-store', () => ({
 			agents: mockAgents,
 			workflows: mockWorkflows,
 			tasksByNodeId: mockTasksByNodeId,
+			workflowRuns: mockWorkflowRuns,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,
 		};

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -69,6 +69,7 @@ import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
+const mockTasksByNodeId = signal(new Map<string, unknown[]>());
 
 const mockCreateWorkflow = vi.fn();
 const mockUpdateWorkflow = vi.fn();
@@ -78,6 +79,7 @@ vi.mock('../../../../lib/space-store', () => ({
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
+			tasksByNodeId: mockTasksByNodeId,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,
 		};

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../WorkflowCanvas', async (importOriginal) => {
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
 const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+const mockWorkflowRuns = signal<unknown[]>([]);
 const mockCreateWorkflow = vi.fn();
 const mockUpdateWorkflow = vi.fn();
 
@@ -47,6 +48,7 @@ vi.mock('../../../../lib/space-store', () => ({
 			agents: mockAgents,
 			workflows: mockWorkflows,
 			tasksByNodeId: mockTasksByNodeId,
+			workflowRuns: mockWorkflowRuns,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,
 		};

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
@@ -37,6 +37,7 @@ vi.mock('../WorkflowCanvas', async (importOriginal) => {
 
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
+const mockTasksByNodeId = signal(new Map<string, unknown[]>());
 const mockCreateWorkflow = vi.fn();
 const mockUpdateWorkflow = vi.fn();
 
@@ -45,6 +46,7 @@ vi.mock('../../../../lib/space-store', () => ({
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
+			tasksByNodeId: mockTasksByNodeId,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,
 		};

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -25,6 +25,7 @@ import { WorkflowNode } from '../WorkflowNode';
 import type { WorkflowNodeProps } from '../WorkflowNode';
 import type { SpaceAgent } from '@neokai/shared';
 import { TASK_AGENT_NODE_ID } from '@neokai/shared';
+import type { AgentTaskState } from '../../WorkflowNodeCard';
 import type { Point } from '../types';
 
 afterEach(() => cleanup());
@@ -640,5 +641,83 @@ describe('WorkflowNode Task Agent rendering', () => {
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
 		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
 		expect(node.style.cursor).toBe('default');
+	});
+});
+
+// ============================================================================
+// Agent completion state
+// ============================================================================
+
+describe('WorkflowNode — agent completion state', () => {
+	const MULTI_STEP = {
+		localId: 'step-multi',
+		id: 'node-multi',
+		name: 'Multi Agent Step',
+		agentId: '',
+		instructions: '',
+		agents: [
+			{ agentId: 'agent-1', name: 'coder' },
+			{ agentId: 'agent-2', name: 'reviewer' },
+		],
+	};
+
+	it('shows spinner for in_progress single-agent', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'in_progress' }];
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('agent-status-spinner')).toBeTruthy();
+	});
+
+	it('shows checkmark for completed single-agent', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'completed' }];
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('agent-status-check')).toBeTruthy();
+	});
+
+	it('shows fail icon for needs_attention single-agent', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'needs_attention' }];
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ nodeTaskStates: states })} />);
+		expect(getByTestId('agent-status-fail')).toBeTruthy();
+	});
+
+	it('shows per-agent status icons for multi-agent node', () => {
+		const states: AgentTaskState[] = [
+			{ agentName: 'coder', status: 'completed' },
+			{ agentName: 'reviewer', status: 'in_progress' },
+		];
+		const { getAllByTestId } = render(
+			<WorkflowNode {...makeProps({ step: MULTI_STEP, nodeTaskStates: states })} />
+		);
+		expect(getAllByTestId('agent-status-check')).toHaveLength(1);
+		expect(getAllByTestId('agent-status-spinner')).toHaveLength(1);
+	});
+
+	it('applies green border when all agents completed', () => {
+		const states: AgentTaskState[] = [
+			{ agentName: 'coder', status: 'completed' },
+			{ agentName: 'reviewer', status: 'completed' },
+		];
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ step: MULTI_STEP, nodeTaskStates: states })} />
+		);
+		const node = getByTestId('workflow-node-step-multi');
+		expect(node.className).toContain('green');
+	});
+
+	it('does not apply green border when not all done', () => {
+		const states: AgentTaskState[] = [
+			{ agentName: 'coder', status: 'completed' },
+			{ agentName: 'reviewer', status: 'in_progress' },
+		];
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ step: MULTI_STEP, nodeTaskStates: states })} />
+		);
+		const node = getByTestId('workflow-node-step-multi');
+		expect(node.className).not.toContain('green');
+	});
+
+	it('does not show status icons without nodeTaskStates', () => {
+		const { container } = render(<WorkflowNode {...makeProps()} />);
+		expect(container.querySelector('[data-testid="agent-status-check"]')).toBeNull();
+		expect(container.querySelector('[data-testid="agent-status-spinner"]')).toBeNull();
 	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
@@ -48,11 +48,14 @@ const mockAgents: Signal<SpaceAgent[]> = signal([
 ]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
 
+const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+
 vi.mock('../../../../lib/space-store', () => ({
 	get spaceStore() {
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
+			tasksByNodeId: mockTasksByNodeId,
 			createWorkflow: vi.fn(),
 			updateWorkflow: vi.fn(),
 		};

--- a/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
@@ -49,6 +49,7 @@ const mockAgents: Signal<SpaceAgent[]> = signal([
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
 
 const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+const mockWorkflowRuns = signal<unknown[]>([]);
 
 vi.mock('../../../../lib/space-store', () => ({
 	get spaceStore() {
@@ -56,6 +57,7 @@ vi.mock('../../../../lib/space-store', () => ({
 			agents: mockAgents,
 			workflows: mockWorkflows,
 			tasksByNodeId: mockTasksByNodeId,
+			workflowRuns: mockWorkflowRuns,
 			createWorkflow: vi.fn(),
 			updateWorkflow: vi.fn(),
 		};

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -128,8 +128,12 @@ class SpaceStore {
 		const map = new Map<string, SpaceTask[]>();
 		for (const task of this.tasks.value) {
 			if (task.workflowNodeId) {
-				const existing = map.get(task.workflowNodeId) ?? [];
-				map.set(task.workflowNodeId, [...existing, task]);
+				let arr = map.get(task.workflowNodeId);
+				if (!arr) {
+					arr = [];
+					map.set(task.workflowNodeId, arr);
+				}
+				arr.push(task);
 			}
 		}
 		return map;

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -123,6 +123,18 @@ class SpaceStore {
 	/** Tasks not associated with any workflow run */
 	readonly standaloneTasks = computed(() => this.tasks.value.filter((t) => !t.workflowRunId));
 
+	/** Tasks grouped by workflow node ID — used to show per-node agent completion state */
+	readonly tasksByNodeId = computed(() => {
+		const map = new Map<string, SpaceTask[]>();
+		for (const task of this.tasks.value) {
+			if (task.workflowNodeId) {
+				const existing = map.get(task.workflowNodeId) ?? [];
+				map.set(task.workflowNodeId, [...existing, task]);
+			}
+		}
+		return map;
+	});
+
 	/** Session groups indexed by taskId for O(1) lookup */
 	readonly sessionGroupsByTask = computed(() => {
 		const map = new Map<string, SpaceSessionGroup[]>();


### PR DESCRIPTION
## Summary

- Add `AgentTaskState` type + `AgentStatusIcon` / `isNodeFullyCompleted` helpers to `WorkflowNodeCard`
- Per-agent status icons (spinner for in-progress, checkmark for done, X for failed/cancelled, dim dot for pending) in collapsed node header for both single-agent and multi-agent nodes
- Green border + green step badge on nodes where all agents have completed
- Completion summary text shown below agent names when available
- Add `tasksByNodeId` computed to `SpaceStore` for O(1) node→tasks lookup (reacts to `space.task.updated` WS events in real-time)
- Wire task states in `WorkflowEditor` (list view) and `VisualWorkflowEditor` (canvas view) — both show live indicators from `spaceStore.tasksByNodeId`
- 20 new tests; 5 test mocks updated to include `tasksByNodeId`