### PR TITLE
feat(session): add unregisterSession and register room sessions in SessionCache

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -231,6 +231,9 @@ export class RoomRuntimeService {
 		}
 		this.runtimes.clear();
 		this.observers.clear();
+		for (const sessionId of this.agentSessions.keys()) {
+			this.ctx.sessionManager.unregisterSession(sessionId);
+		}
 		this.agentSessions.clear();
 		this.roomAgentMcpServers.clear();
 
@@ -279,6 +282,7 @@ export class RoomRuntimeService {
 					ctx.defaultModel
 				);
 				agentSessions.set(init.sessionId, session);
+				ctx.sessionManager.registerSession(session);
 
 				// Inject merged MCP servers for worker sessions (coder / general).
 				//
@@ -409,6 +413,7 @@ export class RoomRuntimeService {
 				if (!session) return false;
 
 				agentSessions.set(sessionId, session);
+				ctx.sessionManager.registerSession(session);
 				// Don't call startStreamingQuery() here — the SDK query will be
 				// started lazily when injectMessage() is called. Eagerly starting
 				// without a queued message causes a 15s startup timeout because the
@@ -471,6 +476,7 @@ export class RoomRuntimeService {
 					log.warn(`Failed to cleanup session ${sessionId}:`, error);
 				} finally {
 					agentSessions.delete(sessionId);
+					ctx.sessionManager.unregisterSession(sessionId);
 				}
 			},
 			removeWorktree: async (workspacePath: string): Promise<boolean> => {

--- a/packages/daemon/tests/unit/room/room-runtime-service-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-mcp.test.ts
@@ -115,6 +115,9 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 				return null;
 			},
 			updateSession: async () => {},
+
+			registerSession: () => {},
+			unregisterSession: () => {},
 		};
 
 		const room = makeRoom('room-1');
@@ -195,6 +198,9 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 				return null;
 			},
 			updateSession: async () => {},
+
+			registerSession: () => {},
+			unregisterSession: () => {},
 		};
 
 		const room = makeRoom('room-2');
@@ -266,6 +272,9 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 				return null;
 			},
 			updateSession: async () => {},
+
+			registerSession: () => {},
+			unregisterSession: () => {},
 		};
 
 		const room = makeRoom('room-3');
@@ -332,6 +341,9 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 				return null;
 			},
 			updateSession: async () => {},
+
+			registerSession: () => {},
+			unregisterSession: () => {},
 		};
 
 		const room = makeRoom('room-4');
@@ -404,6 +416,9 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 				return null;
 			},
 			updateSession: async () => {},
+
+			registerSession: () => {},
+			unregisterSession: () => {},
 		};
 
 		const room = makeRoom('room-hot');
@@ -484,6 +499,9 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 				return null;
 			},
 			updateSession: async () => {},
+
+			registerSession: () => {},
+			unregisterSession: () => {},
 		};
 
 		const room = makeRoom('room-no-agent-tools');
@@ -532,6 +550,9 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 		const sessionManager = {
 			// Always returns null — no session found
 			getSessionAsync: async () => null,
+
+			registerSession: () => {},
+			unregisterSession: () => {},
 		};
 
 		const room = makeRoom('room-no-session');
@@ -606,6 +627,9 @@ describe('RoomRuntimeService MCP merge — collision resolution', () => {
 				return null;
 			},
 			updateSession: async () => {},
+
+			registerSession: () => {},
+			unregisterSession: () => {},
 		};
 
 		const room = makeRoom('room-collision');

--- a/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
@@ -68,7 +68,7 @@ function makeConfig(overrides: Partial<RoomRuntimeServiceConfig> = {}): RoomRunt
 		daemonHub: makeDaemonHub() as never,
 		getApiKey: async () => null,
 		roomManager: makeRoomManager() as never,
-		sessionManager: {} as never,
+		sessionManager: { registerSession: () => {}, unregisterSession: () => {} } as never,
 		defaultWorkspacePath: '/tmp',
 		defaultModel: 'test-model',
 		getGlobalSettings: () => ({}) as never,

--- a/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
@@ -118,7 +118,7 @@ async function buildSessionFactory(opts: {
 			getRoom: () => null,
 			updateRoom: () => null,
 		} as never,
-		sessionManager: {} as never,
+		sessionManager: { registerSession: () => {}, unregisterSession: () => {} } as never,
 		defaultWorkspacePath: '/tmp',
 		defaultModel: 'test-model',
 		getGlobalSettings: () => ({}) as never,

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -52,7 +52,7 @@ describe('RoomRuntimeService', () => {
 			daemonHub: {} as never,
 			getApiKey: async () => null,
 			roomManager: mockRoomManager,
-			sessionManager: {} as never,
+			sessionManager: { registerSession: () => {}, unregisterSession: () => {} } as never,
 			defaultWorkspacePath: '/tmp',
 			defaultModel: 'global-default-model',
 			getGlobalSettings: () => ({}) as never,
@@ -205,6 +205,9 @@ describe('RoomRuntimeService', () => {
 			const sessionManager = {
 				getSessionAsync: mock(async () => mockAgentSession),
 				updateSession: mock(async () => {}),
+
+				registerSession: () => {},
+				unregisterSession: () => {},
 			};
 
 			// Mock settingsManager with project MCP servers
@@ -519,7 +522,7 @@ describe('RoomRuntimeService restart recovery', () => {
 			roomManager: {
 				getRoom: () => null,
 			} as unknown as RoomManager,
-			sessionManager: {} as never,
+			sessionManager: { registerSession: () => {}, unregisterSession: () => {} } as never,
 			defaultWorkspacePath: '/workspace',
 			defaultModel: 'test-model',
 			getGlobalSettings: () => ({}) as never,

--- a/packages/daemon/tests/unit/session/session-cache.test.ts
+++ b/packages/daemon/tests/unit/session/session-cache.test.ts
@@ -204,6 +204,38 @@ describe('SessionCache', () => {
 		it('should be idempotent for non-existent session', () => {
 			expect(() => cache.remove('nonexistent')).not.toThrow();
 		});
+
+		it('should allow fresh getAsync after remove (no stale lock)', async () => {
+			// Populate via set, then remove should clear any load locks too.
+			cache.set('test-session-id', mockAgentSession);
+			cache.remove('test-session-id');
+			// After remove, the session is gone and no load lock exists.
+			// A subsequent getAsync should fall through to loadFromDB.
+			const result = await cache.getAsync('test-session-id');
+			expect(mockLoadFromDB).toHaveBeenCalledWith('test-session-id');
+			expect(result).toBe(mockAgentSession);
+		});
+
+		it('should clear in-flight load lock so getAsync after remove does a fresh load', async () => {
+			// Start an async load that is in-flight (lock is set)
+			const firstLoadPromise = cache.getAsync('test-session-id');
+
+			// Remove the session while the load is in-flight — this clears the lock
+			cache.remove('test-session-id');
+
+			// The first load may still complete (lock was cleared from locks map but promise runs)
+			await firstLoadPromise;
+
+			// Now the cache may or may not have the session (depends on timing).
+			// The important thing is: a second getAsync after remove+first-completion should work.
+			// Reset the mock call count to verify a fresh load is attempted.
+			(mockLoadFromDB as ReturnType<typeof mock>).mockClear();
+			cache.remove('test-session-id'); // ensure clean state
+
+			const result = await cache.getAsync('test-session-id');
+			expect(result).toBe(mockAgentSession);
+			expect(mockLoadFromDB).toHaveBeenCalledWith('test-session-id');
+		});
 	});
 
 	describe('has', () => {

--- a/packages/daemon/tests/unit/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/session/session-manager.test.ts
@@ -284,6 +284,54 @@ describe('SessionManager', () => {
 		});
 	});
 
+	describe('registerSession / unregisterSession', () => {
+		it('registerSession makes session retrievable via getSessionAsync', async () => {
+			const mockSession: Session = {
+				id: 'room:1:task:2:abc',
+				title: 'Room Session',
+				workspacePath: '/test',
+				status: 'active',
+				config: {},
+				metadata: {},
+			};
+			const fakeAgentSession = {
+				getSessionData: mock(() => mockSession),
+				cleanup: mock(async () => {}),
+			} as unknown as import('../../../src/lib/agent/agent-session').AgentSession;
+
+			sessionManager.registerSession(fakeAgentSession);
+
+			const result = await sessionManager.getSessionAsync('room:1:task:2:abc');
+			// Should return the exact same instance, not a DB-loaded duplicate
+			expect(result).toBe(fakeAgentSession);
+			// DB should not have been called since the instance is already in cache
+			expect(mockDb.getSession).not.toHaveBeenCalled();
+		});
+
+		it('unregisterSession removes session from cache', async () => {
+			const mockSession: Session = {
+				id: 'room:1:task:2:xyz',
+				title: 'Room Session',
+				workspacePath: '/test',
+				status: 'active',
+				config: {},
+				metadata: {},
+			};
+			const fakeAgentSession = {
+				getSessionData: mock(() => mockSession),
+				cleanup: mock(async () => {}),
+			} as unknown as import('../../../src/lib/agent/agent-session').AgentSession;
+
+			sessionManager.registerSession(fakeAgentSession);
+			sessionManager.unregisterSession('room:1:task:2:xyz');
+
+			// After unregister, getSession should return null (not in cache, not in DB)
+			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(null);
+			const result = await sessionManager.getSessionAsync('room:1:task:2:xyz');
+			expect(result).toBeNull();
+		});
+	});
+
 	describe('listSessions', () => {
 		it('should return list from database', () => {
 			const mockSessions: Session[] = [


### PR DESCRIPTION
Fix Bug 1 (room session duplicate) by ensuring room worker/leader sessions are properly tracked in `SessionCache`.

## Changes

- **`SessionCache.remove()`**: Also clears `sessionLoadLocks` to prevent a concurrent `getAsync()` from re-inserting a stale DB-loaded duplicate after removal
- **`SessionManager.unregisterSession()`**: New method mirroring `registerSession()`, delegates to `sessionCache.remove()`
- **`RoomRuntimeService`**: Calls `registerSession()` after `agentSessions.set()` in both `createAndStartSession()` and `restoreSession()` (daemon restart path), and `unregisterSession()` in `stopSession()` and `stop()`
- **Tests**: Updated 4 room-runtime-service test files to add `registerSession`/`unregisterSession` stubs; added unit tests for `SessionCache.remove()` race condition fix and `SessionManager.unregisterSession()` round-trip