### PR TITLE
test(e2e): E2E tests for agent-centric workflow model

### DIFF
--- a/packages/e2e/tests/features/space-agent-centric-workflow.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-centric-workflow.e2e.ts
@@ -1,0 +1,349 @@
+/**
+ * Agent-Centric Workflow E2E Tests
+ *
+ * Tests the agent-centric collaboration workflow model features:
+ * - Create workflow with workflow-level channels between agents
+ * - Add gate condition to a channel in the visual editor
+ * - Agent completion state indicators on multi-agent canvas nodes
+ *
+ * Setup: creates a Space with two agents via RPC in beforeEach (infrastructure).
+ * Cleanup: deletes the Space via RPC in afterEach.
+ *
+ * E2E Rules:
+ * - All test actions go through the UI (clicks, inputs, navigation)
+ * - All assertions check visible DOM state
+ * - RPC is only used in beforeEach/afterEach for test infrastructure
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import {
+	createSpace,
+	deleteSpace,
+	navigateToSpace,
+	resetEditorModeStorage,
+	openNewWorkflowEditor,
+	switchToVisualMode,
+	openWorkflowForEdit,
+	setupMultiAgentStep,
+	ensureChannelsSectionOpen,
+	addWorkflowChannel,
+	expandChannelEntry,
+	setChannelGate,
+} from '../helpers/workflow-editor-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+
+// ─── Agent roles used across tests ────────────────────────────────────────────
+
+const ROLE_A = 'coder';
+const ROLE_B = 'reviewer';
+const AGENT_A_NAME = 'Coder Agent';
+const AGENT_B_NAME = 'Reviewer Agent';
+const AGENT_A_OPTION = `${AGENT_A_NAME} (${ROLE_A})`;
+const AGENT_B_OPTION = `${AGENT_B_NAME} (${ROLE_B})`;
+
+// ─── RPC helpers (infrastructure only) ────────────────────────────────────────
+
+/**
+ * Creates a space and two agents (coder, reviewer) for agent-centric test scenarios.
+ */
+async function createTestSpace(page: Page): Promise<string> {
+	await waitForWebSocketConnected(page);
+	const spaceName = `E2E Agent-Centric Workflow ${Date.now()}`;
+	const spaceId = await createSpace(page, spaceName);
+
+	await page.evaluate(
+		async ({ sid, roleA, roleB, agentAName, agentBName }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			await hub.request('spaceAgent.create', {
+				spaceId: sid,
+				name: agentAName,
+				role: roleA,
+				description: '',
+			});
+			await hub.request('spaceAgent.create', {
+				spaceId: sid,
+				name: agentBName,
+				role: roleB,
+				description: '',
+			});
+		},
+		{
+			sid: spaceId,
+			roleA: ROLE_A,
+			roleB: ROLE_B,
+			agentAName: AGENT_A_NAME,
+			agentBName: AGENT_B_NAME,
+		}
+	);
+
+	return spaceId;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Agent-Centric Workflow', () => {
+	test.describe.configure({ mode: 'serial' });
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let spaceId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await resetEditorModeStorage(page);
+		spaceId = await createTestSpace(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (spaceId) {
+			await deleteSpace(page, spaceId);
+			spaceId = '';
+		}
+	});
+
+	// ─── Test 1: Create workflow with workflow-level channels ─────────────────
+
+	test('Add workflow-level channels between agents and verify channel list', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill('Agent Channel Test');
+
+		// Add a node and configure two agents so agentRoles is populated,
+		// which gives the ChannelEditor select dropdowns instead of text inputs.
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]').filter({
+			hasNot: page.locator('[data-task-agent="true"]'),
+		});
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('step-name-input').fill('Parallel Step');
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		// Channels section is visible by default — ensure it's open
+		await ensureChannelsSectionOpen(editor);
+		const channelsSection = editor.getByTestId('channels-section');
+		await expect(channelsSection).toBeVisible({ timeout: 3000 });
+
+		// Add a one-way channel: coder → reviewer
+		await addWorkflowChannel(editor, ROLE_A, ROLE_B, 'one-way');
+
+		// Verify channel entry appears with correct from/to/direction
+		const channelsList = channelsSection.getByTestId('channels-list');
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(1, { timeout: 3000 });
+		const entry = channelsList.getByTestId('channel-entry').first();
+		await expect(entry).toContainText(ROLE_A);
+		await expect(entry).toContainText('→');
+		await expect(entry).toContainText(ROLE_B);
+
+		// Add a bidirectional channel: reviewer ↔ coder
+		await addWorkflowChannel(editor, ROLE_B, ROLE_A, 'bidirectional');
+
+		// Two entries should now be in the channels list
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(2, { timeout: 3000 });
+		const secondEntry = channelsList.getByTestId('channel-entry').nth(1);
+		await expect(secondEntry).toContainText(ROLE_B);
+		await expect(secondEntry).toContainText('↔');
+		await expect(secondEntry).toContainText(ROLE_A);
+	});
+
+	// ─── Test 2: Add gate condition to a workflow channel ─────────────────────
+
+	test('Configure human-approval gate on workflow channel — gate badge appears', async ({
+		page,
+	}) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill('Gate Config Test');
+
+		// Add a node with two agents so agentRoles is populated
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]').filter({
+			hasNot: page.locator('[data-task-agent="true"]'),
+		});
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('step-name-input').fill('Gate Step');
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		// Ensure channels section is open and add a channel
+		await ensureChannelsSectionOpen(editor);
+		const channelsSection = editor.getByTestId('channels-section');
+		await addWorkflowChannel(editor, ROLE_A, ROLE_B);
+
+		const channelsList = channelsSection.getByTestId('channels-list');
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(1, { timeout: 3000 });
+
+		// Expand the channel entry to edit its gate condition
+		await expandChannelEntry(channelsList, 0);
+
+		// Gate defaults to "Automatic" (always). Switch to Human Approval.
+		await setChannelGate(channelsList, 0, 'human');
+
+		// Gate badge should appear in the channel entry summary
+		const entry = channelsList.getByTestId('channel-entry').first();
+		const gateBadge = entry.getByTestId('gate-badge');
+		await expect(gateBadge).toBeVisible({ timeout: 3000 });
+		await expect(gateBadge).toContainText('Human Approval');
+
+		// The entry should also have data-has-gate="true" attribute
+		await expect(entry).toHaveAttribute('data-has-gate', 'true');
+	});
+
+	// ─── Test 3: Agent completion state indicators ────────────────────────────
+
+	test('Multi-agent node renders agent badges and completion state structure', async ({ page }) => {
+		const WORKFLOW_NAME = `Completion State Test ${Date.now()}`;
+
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill(WORKFLOW_NAME);
+
+		// Add a step with two agents
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]').filter({
+			hasNot: page.locator('[data-task-agent="true"]'),
+		});
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('step-name-input').fill('Parallel Agents');
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		// The canvas node should show agent-badges with both agent names
+		const node = nodes.first();
+		const agentBadges = node.getByTestId('agent-badges');
+		await expect(agentBadges).toBeVisible({ timeout: 3000 });
+		await expect(agentBadges.locator(`text=${AGENT_A_NAME}`)).toBeVisible({ timeout: 2000 });
+		await expect(agentBadges.locator(`text=${AGENT_B_NAME}`)).toBeVisible({ timeout: 2000 });
+
+		// Without an active workflow run, no completion state icons should be visible
+		// (no agent-status-spinner, agent-status-check, or agent-status-fail)
+		await expect(node.getByTestId('agent-status-spinner')).toHaveCount(0);
+		await expect(node.getByTestId('agent-status-check')).toHaveCount(0);
+		await expect(node.getByTestId('agent-status-fail')).toHaveCount(0);
+
+		// Save the workflow so it can be reopened
+		await editor.getByTestId('save-button').click();
+		await expect(page.getByTestId('editor-mode-toggle')).not.toBeVisible({ timeout: 5000 });
+		await expect(page.locator(`text=${WORKFLOW_NAME}`)).toBeVisible({ timeout: 5000 });
+
+		// ── Reopen and verify agent badges persist ──────────────────────────────
+
+		await openWorkflowForEdit(page, WORKFLOW_NAME);
+		await switchToVisualMode(page);
+
+		const editorReopen = page.getByTestId('visual-workflow-editor');
+		const reopenedNodes = editorReopen.locator('[data-testid^="workflow-node-"]').filter({
+			hasNot: page.locator('[data-task-agent="true"]'),
+		});
+		await expect(reopenedNodes).toHaveCount(1, { timeout: 5000 });
+
+		// Agent badges should be visible after reload
+		const reopenedNode = reopenedNodes.first();
+		const reopenedBadges = reopenedNode.getByTestId('agent-badges');
+		await expect(reopenedBadges).toBeVisible({ timeout: 3000 });
+		await expect(reopenedBadges.locator(`text=${AGENT_A_NAME}`)).toBeVisible({ timeout: 2000 });
+		await expect(reopenedBadges.locator(`text=${AGENT_B_NAME}`)).toBeVisible({ timeout: 2000 });
+
+		// Still no completion state icons (no active run)
+		await expect(reopenedNode.getByTestId('agent-status-spinner')).toHaveCount(0);
+		await expect(reopenedNode.getByTestId('agent-status-check')).toHaveCount(0);
+	});
+
+	// ─── Test 4: Workflow channels persist after save and reopen ─────────────
+
+	test('Workflow-level channels and gate configuration persist after save', async ({ page }) => {
+		const WORKFLOW_NAME = `Channel Persist Test ${Date.now()}`;
+
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill(WORKFLOW_NAME);
+
+		// Add step with two agents
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]').filter({
+			hasNot: page.locator('[data-task-agent="true"]'),
+		});
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('step-name-input').fill('Collab Step');
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		// Add a workflow-level channel with a human-approval gate
+		await ensureChannelsSectionOpen(editor);
+		await addWorkflowChannel(editor, ROLE_A, ROLE_B);
+		const channelsSection = editor.getByTestId('channels-section');
+		const channelsList = channelsSection.getByTestId('channels-list');
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(1, { timeout: 3000 });
+
+		// Set gate to human approval
+		await expandChannelEntry(channelsList, 0);
+		await setChannelGate(channelsList, 0, 'human');
+		const entry = channelsList.getByTestId('channel-entry').first();
+		await expect(entry.getByTestId('gate-badge')).toBeVisible({ timeout: 2000 });
+
+		// Save workflow
+		await editor.getByTestId('save-button').click();
+		await expect(page.getByTestId('editor-mode-toggle')).not.toBeVisible({ timeout: 5000 });
+		await expect(page.locator(`text=${WORKFLOW_NAME}`)).toBeVisible({ timeout: 5000 });
+
+		// ── Reopen and verify channel + gate persist ────────────────────────────
+
+		await openWorkflowForEdit(page, WORKFLOW_NAME);
+		await switchToVisualMode(page);
+
+		const editorReopen = page.getByTestId('visual-workflow-editor');
+
+		// Channels section should be open with the persisted channel
+		await ensureChannelsSectionOpen(editorReopen);
+		const reopenedChannelsSection = editorReopen.getByTestId('channels-section');
+		const reopenedChannelsList = reopenedChannelsSection.getByTestId('channels-list');
+		await expect(reopenedChannelsList.getByTestId('channel-entry')).toHaveCount(1, {
+			timeout: 5000,
+		});
+
+		// Persisted channel should show coder → reviewer
+		const persistedEntry = reopenedChannelsList.getByTestId('channel-entry').first();
+		await expect(persistedEntry).toContainText(ROLE_A);
+		await expect(persistedEntry).toContainText('→');
+		await expect(persistedEntry).toContainText(ROLE_B);
+
+		// Gate badge should be visible (human approval gate was persisted)
+		await expect(persistedEntry.getByTestId('gate-badge')).toBeVisible({ timeout: 3000 });
+		await expect(persistedEntry.getByTestId('gate-badge')).toContainText('Human Approval');
+	});
+});

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -136,7 +136,7 @@ export async function openWorkflowForEdit(page: Page, workflowName: string): Pro
  * Configure a node config panel to have two agents in multi-agent mode.
  *
  * Precondition: the NodeConfigPanel is already open (panel locator is visible).
- * Postcondition: agents-list has 2 agent-entry items and channels-section is visible.
+ * Postcondition: agents-list has 2 agent-entry items.
  *
  * @param panel - Locator scoped to the `node-config-panel` element
  * @param agentAOption - Exact option label for the first agent (e.g. "Coder Agent (coder)")
@@ -161,4 +161,101 @@ export async function setupMultiAgentStep(
 	await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
 		timeout: 3000,
 	});
+}
+
+// ─── Workflow-level channel helpers ───────────────────────────────────────────
+
+/**
+ * Ensure the Channels collapsible section is expanded in the visual editor.
+ * The section is open by default (showChannels = true), but this helper
+ * will click the toggle if it was previously collapsed.
+ *
+ * @param editor - Locator scoped to the `visual-workflow-editor` element
+ */
+export async function ensureChannelsSectionOpen(editor: Locator): Promise<void> {
+	const section = editor.getByTestId('channels-section');
+	const isVisible = await section.isVisible().catch(() => false);
+	if (!isVisible) {
+		await editor.getByTestId('toggle-channels-button').click();
+		await expect(section).toBeVisible({ timeout: 3000 });
+	}
+}
+
+/**
+ * Add a workflow-level channel using the AddChannelForm inside the ChannelEditor.
+ *
+ * When the editor has agentRoles (nodes with multi-agent config), select elements
+ * are shown — pass `from`/`to` as agent role names.
+ * When agentRoles is empty (single-agent nodes), text inputs are used instead.
+ *
+ * @param editor - Locator scoped to the `visual-workflow-editor` element
+ * @param from - Source agent role name (e.g. "coder", "task-agent", "*")
+ * @param to - Target agent role name (e.g. "reviewer")
+ * @param direction - Channel direction ('one-way' | 'bidirectional'), defaults to 'one-way'
+ */
+export async function addWorkflowChannel(
+	editor: Locator,
+	from: string,
+	to: string,
+	direction: 'one-way' | 'bidirectional' = 'one-way'
+): Promise<void> {
+	const form = editor.getByTestId('add-channel-form');
+
+	// From — prefer select, fall back to text input
+	const fromSelect = form.getByTestId('new-channel-from-select');
+	if (await fromSelect.isVisible().catch(() => false)) {
+		await fromSelect.selectOption({ value: from });
+	} else {
+		await form.getByTestId('new-channel-from-input').fill(from);
+	}
+
+	// Direction (only change if not default one-way)
+	if (direction !== 'one-way') {
+		await form.getByTestId('new-channel-direction-select').selectOption({ value: direction });
+	}
+
+	// To — prefer select, fall back to text input
+	const toSelect = form.getByTestId('new-channel-to-select');
+	if (await toSelect.isVisible().catch(() => false)) {
+		await toSelect.selectOption({ value: to });
+	} else {
+		await form.getByTestId('new-channel-to-input').fill(to);
+	}
+
+	await form.getByTestId('add-channel-submit-button').click();
+}
+
+/**
+ * Expand a channel entry at the given (zero-based) index for inline editing.
+ *
+ * @param channelsList - Locator scoped to the `channels-list` element
+ * @param index - Zero-based index of the channel to expand
+ */
+export async function expandChannelEntry(channelsList: Locator, index: number): Promise<void> {
+	const entry = channelsList.getByTestId('channel-entry').nth(index);
+	const editForm = entry.getByTestId('channel-edit-form');
+	const isAlreadyExpanded = await editForm.isVisible().catch(() => false);
+	if (!isAlreadyExpanded) {
+		await entry.getByTestId('channel-expand-button').click();
+		await expect(editForm).toBeVisible({ timeout: 2000 });
+	}
+}
+
+/**
+ * Set the gate condition type on an expanded channel entry.
+ *
+ * Precondition: the channel entry at `index` is already expanded (channel-edit-form visible).
+ *
+ * @param channelsList - Locator scoped to the `channels-list` element
+ * @param index - Zero-based channel index (used to target the correct gate select)
+ * @param gateType - Gate condition type: 'always' | 'human' | 'condition' | 'task_result'
+ */
+export async function setChannelGate(
+	channelsList: Locator,
+	index: number,
+	gateType: 'always' | 'human' | 'condition' | 'task_result'
+): Promise<void> {
+	const gateSelect = channelsList.getByTestId(`channel-gate-select-${index}`);
+	await expect(gateSelect).toBeVisible({ timeout: 3000 });
+	await gateSelect.selectOption({ value: gateType });
 }


### PR DESCRIPTION
Add 4 Playwright E2E tests for the agent-centric workflow collaboration model and 4 new channel operation helpers.

**Tests** (`space-agent-centric-workflow.e2e.ts`):
- Create workflow with workflow-level channels between agents (via ChannelEditor)
- Configure human-approval gate on a channel and verify gate-badge renders
- Multi-agent node shows agent-badges and correct completion state structure (no icons without active run)
- Workflow channels and gate configuration persist after save/reopen

**Helpers** (`workflow-editor-helpers.ts`):
- `ensureChannelsSectionOpen` — opens Channels collapsible if collapsed
- `addWorkflowChannel` — adds a workflow-level channel; handles both select (agentRoles present) and text input
- `expandChannelEntry` — expands channel for inline editing
- `setChannelGate` — selects gate condition type on an expanded channel