### PR TITLE
feat(room): add model-specific fallback mappings alongside default list

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -351,11 +351,6 @@ export class RoomRuntime {
 		sessionRole: 'worker' | 'leader'
 	): Promise<boolean> {
 		const settings = this.getGlobalSettings();
-		const fallbackModels = settings.fallbackModels ?? [];
-
-		if (fallbackModels.length === 0) {
-			return false;
-		}
 
 		// Get current model info from the session
 		let currentModel: string;
@@ -375,10 +370,24 @@ export class RoomRuntime {
 			return false;
 		}
 
-		// Find the index of the current model in the fallback chain
-		const currentIndex = fallbackModels.findIndex(
-			(f) => f.model === currentModel && f.provider === currentProvider
-		);
+		// Resolve fallback chain: model-specific map takes priority over default list
+		const modelKey = `${currentProvider}/${currentModel}`;
+		const fallbackModels =
+			(settings.modelFallbackMap && settings.modelFallbackMap[modelKey]) ??
+			settings.fallbackModels ??
+			[];
+
+		if (fallbackModels.length === 0) {
+			return false;
+		}
+
+		// When using a model-specific mapping, always start from index 0 (the whole list
+		// is already the tailored chain for this model). When using the default list,
+		// advance past the current model's position so we don't re-try it.
+		const usingModelMap = Boolean(settings.modelFallbackMap && settings.modelFallbackMap[modelKey]);
+		const currentIndex = usingModelMap
+			? -1
+			: fallbackModels.findIndex((f) => f.model === currentModel && f.provider === currentProvider);
 
 		// Determine the starting index for the search
 		const startIndex = currentIndex === -1 ? 0 : currentIndex + 1;

--- a/packages/daemon/tests/unit/room/room-runtime-model-fallback-map.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-model-fallback-map.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for model-specific fallback mappings in trySwitchToFallbackModel().
+ *
+ * Verifies:
+ * - When the current model has an entry in modelFallbackMap, that chain is used instead of
+ *   the default fallbackModels list
+ * - When the current model has NO entry in modelFallbackMap, the default fallbackModels list
+ *   is used as a catch-all
+ * - When neither modelFallbackMap nor fallbackModels is configured, no switch occurs
+ * - Model-specific chain always starts from index 0 (not from currentIndex + 1)
+ * - Provider availability checks still work for model-specific chains
+ * - Same-model skip guard still applies for model-specific chains
+ */
+
+import { describe, expect, it, afterEach } from 'bun:test';
+import {
+	createRuntimeTestContext,
+	createGoalAndTask,
+	type RuntimeTestContext,
+} from './room-runtime-test-helpers';
+import type { GlobalSettings } from '@neokai/shared';
+
+describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
+	let ctx: RuntimeTestContext;
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	const USAGE_LIMIT_MSG = "You've hit your limit · resets 11pm (America/New_York)";
+
+	function makeWorkerMessages(text: string) {
+		return [{ id: 'msg-1', text, toolCallNames: [] }];
+	}
+
+	function makeMessageHub(currentModel: string, provider: string = 'anthropic') {
+		return {
+			async request(method: string, _args: unknown): Promise<unknown> {
+				if (method === 'session.model.get') {
+					return {
+						currentModel,
+						modelInfo: { provider },
+					};
+				}
+				return undefined;
+			},
+		};
+	}
+
+	function makeGlobalSettings(overrides: Partial<GlobalSettings>): () => GlobalSettings {
+		return () => overrides as unknown as GlobalSettings;
+	}
+
+	async function spawnGroup() {
+		const { task } = await createGoalAndTask(ctx);
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		const group = groups[0];
+		await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+		return { group, task };
+	}
+
+	describe('model-specific map takes priority over default list', () => {
+		it('uses the model-specific chain when current model has a mapping', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings({
+					// Default list: haiku first
+					fallbackModels: [
+						{ model: 'haiku', provider: 'anthropic' },
+						{ model: 'glm-4', provider: 'glm' },
+					],
+					// Model-specific: sonnet → minimax first
+					modelFallbackMap: {
+						'anthropic/sonnet': [
+							{ model: 'minimax-turbo', provider: 'minimax' },
+							{ model: 'glm-4', provider: 'glm' },
+						],
+					},
+				}),
+				messageHub: makeMessageHub('sonnet', 'anthropic'),
+			});
+
+			const { group } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			// Should use model-specific chain (minimax first), NOT the default (haiku first)
+			expect(switchCalls.length).toBe(1);
+			expect(switchCalls[0].args[1]).toBe('minimax-turbo');
+			expect(switchCalls[0].args[2]).toBe('minimax');
+		});
+
+		it('uses default fallbackModels when current model has no mapping', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings({
+					fallbackModels: [
+						{ model: 'haiku', provider: 'anthropic' },
+						{ model: 'glm-4', provider: 'glm' },
+					],
+					modelFallbackMap: {
+						// Only opus has a mapping; current model is sonnet → no mapping
+						'anthropic/opus': [{ model: 'glm-4', provider: 'glm' }],
+					},
+				}),
+				messageHub: makeMessageHub('sonnet', 'anthropic'),
+			});
+
+			const { group } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			// No model-specific mapping for anthropic/sonnet → falls back to default list
+			expect(switchCalls.length).toBe(1);
+			expect(switchCalls[0].args[1]).toBe('haiku');
+			expect(switchCalls[0].args[2]).toBe('anthropic');
+		});
+	});
+
+	describe('model-specific chain always starts from index 0', () => {
+		it('starts at index 0 of model-specific chain regardless of current model position', async () => {
+			// Even though the current model matches chain[0], we should NOT advance past it
+			// (the model-specific chain is a dedicated replacement chain, always start fresh)
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings({
+					modelFallbackMap: {
+						'anthropic/sonnet': [
+							{ model: 'minimax-turbo', provider: 'minimax' },
+							{ model: 'glm-4', provider: 'glm' },
+						],
+					},
+				}),
+				messageHub: makeMessageHub('sonnet', 'anthropic'),
+			});
+
+			const { group } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			// Should start from minimax-turbo (index 0), not skip it
+			expect(switchCalls.length).toBe(1);
+			expect(switchCalls[0].args[1]).toBe('minimax-turbo');
+		});
+	});
+
+	describe('same-model skip guard still works for model-specific chain', () => {
+		it('skips a model-specific chain entry that matches the current model', async () => {
+			// chain[0] is sonnet (same as current) → should be skipped → use glm-4
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings({
+					modelFallbackMap: {
+						'anthropic/sonnet': [
+							{ model: 'sonnet', provider: 'anthropic' }, // same as current → skip
+							{ model: 'glm-4', provider: 'glm' },
+						],
+					},
+				}),
+				messageHub: makeMessageHub('sonnet', 'anthropic'),
+			});
+
+			const { group } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			// chain[0] is sonnet (same as current) → skipped; chain[1] glm-4 → used
+			expect(switchCalls.length).toBe(1);
+			expect(switchCalls[0].args[1]).toBe('glm-4');
+		});
+	});
+
+	describe('provider availability checks work for model-specific chains', () => {
+		it('skips unavailable providers in model-specific chain and uses the next one', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings({
+					modelFallbackMap: {
+						'anthropic/sonnet': [
+							{ model: 'minimax-turbo', provider: 'minimax' }, // unavailable
+							{ model: 'glm-4', provider: 'glm' }, // available
+						],
+					},
+				}),
+				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				isProviderAvailable: async (provider, model) => {
+					if (provider === 'minimax' && model === 'minimax-turbo') return false;
+					return true;
+				},
+			});
+
+			const { group } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			// minimax-turbo unavailable → skipped; glm-4 available → used
+			expect(switchCalls.length).toBe(1);
+			expect(switchCalls[0].args[1]).toBe('glm-4');
+		});
+
+		it('returns false when all model-specific chain entries are unavailable', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings({
+					// Default list has haiku available — but model-specific map should be used
+					// and all its entries are unavailable
+					fallbackModels: [{ model: 'haiku', provider: 'anthropic' }],
+					modelFallbackMap: {
+						'anthropic/sonnet': [
+							{ model: 'minimax-turbo', provider: 'minimax' },
+							{ model: 'glm-4', provider: 'glm' },
+						],
+					},
+				}),
+				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				isProviderAvailable: async () => false,
+			});
+
+			const { group, task } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			// Both model-specific entries unavailable → no switch, even though default list has haiku
+			expect(switchCalls.length).toBe(0);
+
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.status).toBe('usage_limited');
+		});
+	});
+
+	describe('fallback when modelFallbackMap is defined but empty', () => {
+		it('falls back to default fallbackModels when map is empty object', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings({
+					fallbackModels: [{ model: 'haiku', provider: 'anthropic' }],
+					modelFallbackMap: {}, // empty map, no matching key
+				}),
+				messageHub: makeMessageHub('sonnet', 'anthropic'),
+			});
+
+			const { group } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			// No mapping for anthropic/sonnet → uses default fallbackModels → haiku
+			expect(switchCalls.length).toBe(1);
+			expect(switchCalls[0].args[1]).toBe('haiku');
+		});
+	});
+
+	describe('no fallback configured at all', () => {
+		it('returns false immediately when neither modelFallbackMap nor fallbackModels is set', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				getGlobalSettings: makeGlobalSettings({}),
+				messageHub: makeMessageHub('sonnet', 'anthropic'),
+			});
+
+			const { group, task } = await spawnGroup();
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			expect(switchCalls.length).toBe(0);
+
+			const updated = await ctx.taskManager.getTask(task.id);
+			expect(updated!.status).toBe('usage_limited');
+		});
+	});
+});

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -150,6 +150,14 @@ export interface GlobalSettings extends SDKSupportedSettings, FileOnlySettings {
 
 	/** Ordered fallback model chain for automatic model switching on rate/usage limits */
 	fallbackModels?: FallbackModelEntry[];
+
+	/**
+	 * Model-specific fallback mappings. When a model hits a rate/usage limit,
+	 * its entry here takes priority over the default `fallbackModels` list.
+	 * Keys are `"provider/model"` strings (e.g. `"anthropic/claude-sonnet-4-20250514"`).
+	 * Values are ordered fallback chains, same format as `fallbackModels`.
+	 */
+	modelFallbackMap?: Record<string, FallbackModelEntry[]>;
 }
 
 /**

--- a/packages/web/src/components/settings/FallbackModelsSettings.tsx
+++ b/packages/web/src/components/settings/FallbackModelsSettings.tsx
@@ -3,6 +3,10 @@
  *
  * Allows configuring the fallback model chain for automatic model switching
  * when rate limits or usage limits are hit.
+ *
+ * Two sections:
+ * 1. Default fallback chain — applies to all models without a specific mapping
+ * 2. Model-specific overrides — per-source-model chains (modelFallbackMap)
  */
 
 import { useEffect, useState } from 'preact/hooks';
@@ -31,10 +35,415 @@ interface RawModelEntry {
 	provider?: string;
 }
 
+// ─── Shared icon helpers ──────────────────────────────────────────────────────
+
+function ChevronUpIcon() {
+	return (
+		<svg class="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+		</svg>
+	);
+}
+
+function ChevronDownIcon() {
+	return (
+		<svg class="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+		</svg>
+	);
+}
+
+function XIcon({ class: cls }: { class?: string }) {
+	return (
+		<svg
+			class={cls ?? 'w-4 h-4 text-gray-400'}
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="2"
+				d="M6 18L18 6M6 6l12 12"
+			/>
+		</svg>
+	);
+}
+
+function PlusIcon() {
+	return (
+		<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+		</svg>
+	);
+}
+
+function PencilIcon() {
+	return (
+		<svg class="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="2"
+				d="M15.232 5.232l3.536 3.536M9 11l6.536-6.536a2 2 0 012.828 2.828L11.828 13.828a2 2 0 01-1.414.586H8v-2.414a2 2 0 01.586-1.414z"
+			/>
+		</svg>
+	);
+}
+
+// ─── Model picker modal ───────────────────────────────────────────────────────
+
+interface ModelPickerModalProps {
+	title: string;
+	groupedModels: Map<string, ModelInfo[]>;
+	providerAuthStatuses: Map<string, ProviderAuthStatus>;
+	/** Models to exclude from the picker (already selected). */
+	excludeModels: FallbackModelEntry[];
+	onSelect: (model: ModelInfo) => void;
+	onClose: () => void;
+}
+
+function ModelPickerModal({
+	title,
+	groupedModels,
+	providerAuthStatuses,
+	excludeModels,
+	onSelect,
+	onClose,
+}: ModelPickerModalProps) {
+	const allModels = Array.from(groupedModels.values()).flat();
+	const remaining = allModels.filter(
+		(m) => !excludeModels.some((e) => e.model === m.id && e.provider === m.provider)
+	);
+
+	return (
+		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+			<div class="bg-dark-850 border border-dark-600 rounded-lg shadow-xl w-80 max-h-[80vh] overflow-hidden flex flex-col">
+				<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700">
+					<h3 class="text-sm font-medium text-gray-100">{title}</h3>
+					<button class="p-1 rounded hover:bg-dark-700" onClick={onClose}>
+						<XIcon />
+					</button>
+				</div>
+
+				<div class="flex-1 overflow-y-auto py-2">
+					{Array.from(groupedModels.entries()).map(([provider, models]) => {
+						const authStatus = providerAuthStatuses.get(provider);
+						const isAuthenticated = authStatus?.isAuthenticated ?? false;
+
+						return (
+							<div key={provider}>
+								<div class="px-4 py-1.5 text-xs font-semibold text-gray-400">
+									{PROVIDER_LABELS[provider] || provider}
+									{!isAuthenticated && <span class="text-gray-600 ml-1">(not authenticated)</span>}
+								</div>
+								{models.map((model) => {
+									if (
+										excludeModels.some((e) => e.model === model.id && e.provider === model.provider)
+									)
+										return null;
+									return (
+										<button
+											key={`${model.provider}:${model.id}`}
+											class="w-full text-left px-4 py-2 text-sm flex items-center gap-2 hover:bg-dark-700 transition-colors"
+											onClick={() => onSelect(model)}
+										>
+											<span class="text-base">{getModelFamilyIcon(model.family)}</span>
+											<span class="flex-1 text-gray-200 truncate">{model.name}</span>
+										</button>
+									);
+								})}
+							</div>
+						);
+					})}
+
+					{remaining.length === 0 && (
+						<div class="px-4 py-4 text-sm text-gray-500 text-center">
+							All available models are already selected
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ─── Ordered fallback chain editor (reused in both sections) ──────────────────
+
+interface FallbackChainEditorProps {
+	models: FallbackModelEntry[];
+	availableModels: ModelInfo[];
+	isUpdating: boolean;
+	onMove: (index: number, direction: 'up' | 'down') => void;
+	onRemove: (index: number) => void;
+}
+
+function FallbackChainEditor({
+	models,
+	availableModels,
+	isUpdating,
+	onMove,
+	onRemove,
+}: FallbackChainEditorProps) {
+	const getDisplayInfo = (entry: FallbackModelEntry) => {
+		const model = availableModels.find(
+			(m) => m.id === entry.model && m.provider === entry.provider
+		);
+		return { name: model?.name ?? entry.model, family: model?.family ?? 'sonnet' };
+	};
+
+	return (
+		<div class="space-y-2">
+			{models.map((entry, index) => {
+				const displayInfo = getDisplayInfo(entry);
+				return (
+					<div
+						key={`${entry.provider}:${entry.model}`}
+						class="flex items-center gap-2 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2"
+					>
+						<span class="text-xs text-gray-500 font-medium w-4">{index + 1}.</span>
+						<span class="text-base">{getModelFamilyIcon(displayInfo.family)}</span>
+						<div class="flex-1 min-w-0">
+							<div class="text-sm text-gray-200 truncate">{displayInfo.name}</div>
+							<div class="text-xs text-gray-500">
+								{PROVIDER_LABELS[entry.provider] || entry.provider}
+							</div>
+						</div>
+						<div class="flex items-center gap-1">
+							<button
+								class="p-1 rounded hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed"
+								onClick={() => onMove(index, 'up')}
+								disabled={index === 0 || isUpdating}
+								title="Move up"
+							>
+								<ChevronUpIcon />
+							</button>
+							<button
+								class="p-1 rounded hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed"
+								onClick={() => onMove(index, 'down')}
+								disabled={index === models.length - 1 || isUpdating}
+								title="Move down"
+							>
+								<ChevronDownIcon />
+							</button>
+						</div>
+						<button
+							class="p-1 rounded hover:bg-red-900/30 disabled:opacity-30 disabled:cursor-not-allowed"
+							onClick={() => onRemove(index)}
+							disabled={isUpdating}
+							title="Remove"
+						>
+							<XIcon class="w-4 h-4 text-red-400" />
+						</button>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+// ─── Model-specific override editor modal ────────────────────────────────────
+
+interface OverrideEditorModalProps {
+	/** When editing an existing entry, this is the key being edited ("provider/model"). */
+	editingKey: string | null;
+	availableModels: ModelInfo[];
+	groupedModels: Map<string, ModelInfo[]>;
+	providerAuthStatuses: Map<string, ProviderAuthStatus>;
+	existingMapKeys: string[];
+	initialChain: FallbackModelEntry[];
+	onSave: (sourceKey: string, chain: FallbackModelEntry[]) => void;
+	onClose: () => void;
+}
+
+function OverrideEditorModal({
+	editingKey,
+	availableModels,
+	groupedModels,
+	providerAuthStatuses,
+	existingMapKeys,
+	initialChain,
+	onSave,
+	onClose,
+}: OverrideEditorModalProps) {
+	const [sourceKey, setSourceKey] = useState<string>(editingKey ?? '');
+	const [chain, setChain] = useState<FallbackModelEntry[]>(initialChain);
+	const [showSourcePicker, setShowSourcePicker] = useState(editingKey === null);
+	const [showAddFallbackPicker, setShowAddFallbackPicker] = useState(false);
+
+	const getDisplayInfo = (key: string) => {
+		const [provider, ...rest] = key.split('/');
+		const modelId = rest.join('/');
+		const model = availableModels.find((m) => m.id === modelId && m.provider === provider);
+		return model
+			? { name: model.name, family: model.family, provider }
+			: { name: modelId || key, family: 'sonnet', provider };
+	};
+
+	const handleSelectSource = (model: ModelInfo) => {
+		const key = `${model.provider}/${model.id}`;
+		setSourceKey(key);
+		setShowSourcePicker(false);
+	};
+
+	const handleAddFallback = (model: ModelInfo) => {
+		if (chain.some((e) => e.model === model.id && e.provider === model.provider)) return;
+		setChain((prev) => [...prev, { model: model.id, provider: model.provider ?? 'anthropic' }]);
+		setShowAddFallbackPicker(false);
+	};
+
+	const handleMoveChain = (index: number, direction: 'up' | 'down') => {
+		const newIndex = direction === 'up' ? index - 1 : index + 1;
+		if (newIndex < 0 || newIndex >= chain.length) return;
+		const next = [...chain];
+		[next[index], next[newIndex]] = [next[newIndex], next[index]];
+		setChain(next);
+	};
+
+	const handleRemoveChain = (index: number) => {
+		setChain((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	const handleSave = () => {
+		if (!sourceKey) {
+			toast.error('Please select a source model');
+			return;
+		}
+		onSave(sourceKey, chain);
+	};
+
+	// Exclude already-mapped keys from the source picker (except the one being edited)
+	const excludeFromSourcePicker: FallbackModelEntry[] = existingMapKeys
+		.filter((k) => k !== editingKey)
+		.map((k) => {
+			const [provider, ...rest] = k.split('/');
+			return { provider, model: rest.join('/') };
+		});
+
+	const sourceInfo = sourceKey ? getDisplayInfo(sourceKey) : null;
+
+	return (
+		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+			<div class="bg-dark-850 border border-dark-600 rounded-lg shadow-xl w-96 max-h-[85vh] overflow-hidden flex flex-col">
+				<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700">
+					<h3 class="text-sm font-medium text-gray-100">
+						{editingKey ? 'Edit Override' : 'Add Model-Specific Override'}
+					</h3>
+					<button class="p-1 rounded hover:bg-dark-700" onClick={onClose}>
+						<XIcon />
+					</button>
+				</div>
+
+				<div class="flex-1 overflow-y-auto p-4 space-y-4">
+					{/* Source model selector */}
+					<div>
+						<label class="block text-xs font-medium text-gray-400 mb-1">Source model</label>
+						{sourceInfo ? (
+							<div class="flex items-center gap-2 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2">
+								<span class="text-base">{getModelFamilyIcon(sourceInfo.family)}</span>
+								<div class="flex-1 min-w-0">
+									<div class="text-sm text-gray-200 truncate">{sourceInfo.name}</div>
+									<div class="text-xs text-gray-500">
+										{PROVIDER_LABELS[sourceInfo.provider] || sourceInfo.provider}
+									</div>
+								</div>
+								{editingKey === null && (
+									<button
+										class="p-1 rounded hover:bg-dark-700"
+										onClick={() => setShowSourcePicker(true)}
+										title="Change"
+									>
+										<PencilIcon />
+									</button>
+								)}
+							</div>
+						) : (
+							<button
+								class="w-full flex items-center gap-2 px-3 py-2 text-sm text-blue-400 hover:text-blue-300 hover:bg-dark-800 rounded-lg border border-dashed border-dark-600 hover:border-dark-500 transition-colors"
+								onClick={() => setShowSourcePicker(true)}
+							>
+								<PlusIcon />
+								Select source model
+							</button>
+						)}
+					</div>
+
+					{/* Fallback chain */}
+					<div>
+						<label class="block text-xs font-medium text-gray-400 mb-1">Fallback chain</label>
+						{chain.length === 0 ? (
+							<p class="text-xs text-gray-500 italic mb-2">No fallback models in this chain</p>
+						) : (
+							<FallbackChainEditor
+								models={chain}
+								availableModels={availableModels}
+								isUpdating={false}
+								onMove={handleMoveChain}
+								onRemove={handleRemoveChain}
+							/>
+						)}
+						<button
+							class="mt-2 flex items-center gap-2 px-3 py-2 text-sm text-blue-400 hover:text-blue-300 hover:bg-dark-800 rounded-lg border border-dashed border-dark-600 hover:border-dark-500 transition-colors"
+							onClick={() => setShowAddFallbackPicker(true)}
+						>
+							<PlusIcon />
+							Add Fallback Model
+						</button>
+					</div>
+				</div>
+
+				<div class="px-4 py-3 border-t border-dark-700 flex justify-end gap-2">
+					<button
+						class="px-3 py-1.5 text-sm text-gray-400 hover:text-gray-200 rounded-lg hover:bg-dark-700 transition-colors"
+						onClick={onClose}
+					>
+						Cancel
+					</button>
+					<button
+						class="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors disabled:opacity-50"
+						onClick={handleSave}
+						disabled={!sourceKey}
+					>
+						Save
+					</button>
+				</div>
+			</div>
+
+			{showSourcePicker && (
+				<ModelPickerModal
+					title="Select Source Model"
+					groupedModels={groupedModels}
+					providerAuthStatuses={providerAuthStatuses}
+					excludeModels={excludeFromSourcePicker}
+					onSelect={handleSelectSource}
+					onClose={() => setShowSourcePicker(false)}
+				/>
+			)}
+
+			{showAddFallbackPicker && (
+				<ModelPickerModal
+					title="Add Fallback Model"
+					groupedModels={groupedModels}
+					providerAuthStatuses={providerAuthStatuses}
+					excludeModels={chain}
+					onSelect={handleAddFallback}
+					onClose={() => setShowAddFallbackPicker(false)}
+				/>
+			)}
+		</div>
+	);
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
 export function FallbackModelsSettings() {
 	const settings = globalSettings.value;
 	const [fallbackModels, setFallbackModels] = useState<FallbackModelEntry[]>(
 		settings?.fallbackModels ?? []
+	);
+	const [modelFallbackMap, setModelFallbackMap] = useState<Record<string, FallbackModelEntry[]>>(
+		settings?.modelFallbackMap ?? {}
 	);
 	const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
 	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, ProviderAuthStatus>>(
@@ -42,16 +451,25 @@ export function FallbackModelsSettings() {
 	);
 	const [loading, setLoading] = useState(true);
 	const [isUpdating, setIsUpdating] = useState(false);
+
+	// Default list modal
 	const [showAddModal, setShowAddModal] = useState(false);
+
+	// Override editor modal state
+	const [overrideModal, setOverrideModal] = useState<{
+		open: boolean;
+		editingKey: string | null;
+	}>({ open: false, editingKey: null });
 
 	// Sync with global settings when they change
 	useEffect(() => {
 		if (settings) {
 			setFallbackModels(settings.fallbackModels ?? []);
+			setModelFallbackMap(settings.modelFallbackMap ?? {});
 		}
 	}, [settings]);
 
-	// Fetch available models
+	// Fetch available models + auth statuses
 	useEffect(() => {
 		const fetchData = async () => {
 			setLoading(true);
@@ -81,7 +499,8 @@ export function FallbackModelsSettings() {
 		void fetchData();
 	}, []);
 
-	// Save fallback models to settings
+	// ── Default fallback list helpers ──────────────────────────────────────────
+
 	const saveFallbackModels = async (models: FallbackModelEntry[]) => {
 		setIsUpdating(true);
 		try {
@@ -95,14 +514,12 @@ export function FallbackModelsSettings() {
 		}
 	};
 
-	// Remove a fallback model
 	const handleRemove = async (index: number) => {
 		const newModels = [...fallbackModels];
 		newModels.splice(index, 1);
 		await saveFallbackModels(newModels);
 	};
 
-	// Move a fallback model up or down
 	const handleMove = async (index: number, direction: 'up' | 'down') => {
 		const newIndex = direction === 'up' ? index - 1 : index + 1;
 		if (newIndex < 0 || newIndex >= fallbackModels.length) return;
@@ -112,9 +529,7 @@ export function FallbackModelsSettings() {
 		await saveFallbackModels(newModels);
 	};
 
-	// Add a new fallback model
 	const handleAdd = async (model: ModelInfo) => {
-		// Check if model is already in the list
 		if (fallbackModels.some((m) => m.model === model.id && m.provider === model.provider)) {
 			toast.error('Model is already in the fallback chain');
 			return;
@@ -128,218 +543,211 @@ export function FallbackModelsSettings() {
 		setShowAddModal(false);
 	};
 
-	// Get model info for display
+	// ── Model-specific override helpers ────────────────────────────────────────
+
+	const saveModelFallbackMap = async (map: Record<string, FallbackModelEntry[]>) => {
+		setIsUpdating(true);
+		try {
+			await updateGlobalSettings({ modelFallbackMap: map });
+			setModelFallbackMap(map);
+			toast.success('Model overrides updated');
+		} catch {
+			toast.error('Failed to update model overrides');
+		} finally {
+			setIsUpdating(false);
+		}
+	};
+
+	const handleSaveOverride = async (sourceKey: string, chain: FallbackModelEntry[]) => {
+		const newMap = { ...modelFallbackMap, [sourceKey]: chain };
+		await saveModelFallbackMap(newMap);
+		setOverrideModal({ open: false, editingKey: null });
+	};
+
+	const handleDeleteOverride = async (key: string) => {
+		const newMap = { ...modelFallbackMap };
+		delete newMap[key];
+		await saveModelFallbackMap(newMap);
+	};
+
+	// ── Display helpers ────────────────────────────────────────────────────────
+
 	const getModelDisplayInfo = (entry: FallbackModelEntry): { name: string; family: string } => {
 		const model = availableModels.find(
 			(m) => m.id === entry.model && m.provider === entry.provider
 		);
-		return {
-			name: model?.name ?? entry.model,
-			family: model?.family ?? 'sonnet',
-		};
+		return { name: model?.name ?? entry.model, family: model?.family ?? 'sonnet' };
+	};
+
+	const getKeyDisplayInfo = (key: string) => {
+		const [provider, ...rest] = key.split('/');
+		const modelId = rest.join('/');
+		const model = availableModels.find((m) => m.id === modelId && m.provider === provider);
+		return model
+			? { name: model.name, family: model.family, provider }
+			: { name: modelId || key, family: 'sonnet', provider: provider ?? '' };
 	};
 
 	const filteredModels = filterModelsForPicker(availableModels, providerAuthStatuses, undefined);
 	const groupedModels = groupModelsByProvider(filteredModels);
+	const overrideEntries = Object.entries(modelFallbackMap);
 
 	return (
 		<SettingsSection title="Fallback Models">
-			<div class="space-y-3">
-				<p class="text-xs text-gray-500 mb-3">
-					Configure an ordered list of fallback models. When the primary model hits a rate limit or
-					usage limit, NeoKai will automatically switch to the next model in the chain.
-				</p>
-
-				{loading ? (
-					<div class="flex items-center gap-2 text-xs text-gray-500">
-						<Spinner size="xs" />
-						<span>Loading models...</span>
+			<div class="space-y-6">
+				{/* ── Section 1: Default fallback chain ──────────────────────────────── */}
+				<div class="space-y-3">
+					<div>
+						<h4 class="text-sm font-medium text-gray-300">Default Fallback Chain</h4>
+						<p class="text-xs text-gray-500 mt-0.5">
+							Applies to all models that don&apos;t have a specific override below.
+						</p>
 					</div>
-				) : fallbackModels.length === 0 ? (
-					<div class="text-xs text-gray-500 italic">No fallback models configured</div>
-				) : (
-					<div class="space-y-2">
-						{fallbackModels.map((entry, index) => {
-							const displayInfo = getModelDisplayInfo(entry);
-							return (
-								<div
-									key={`${entry.provider}:${entry.model}`}
-									class="flex items-center gap-2 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2"
-								>
-									{/* Priority number */}
-									<span class="text-xs text-gray-500 font-medium w-4">{index + 1}.</span>
 
-									{/* Model icon */}
-									<span class="text-base">{getModelFamilyIcon(displayInfo.family)}</span>
-
-									{/* Model name and provider */}
-									<div class="flex-1 min-w-0">
-										<div class="text-sm text-gray-200 truncate">{displayInfo.name}</div>
-										<div class="text-xs text-gray-500">
-											{PROVIDER_LABELS[entry.provider] || entry.provider}
-										</div>
-									</div>
-
-									{/* Move buttons */}
-									<div class="flex items-center gap-1">
-										<button
-											class="p-1 rounded hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed"
-											onClick={() => handleMove(index, 'up')}
-											disabled={index === 0 || isUpdating}
-											title="Move up"
-										>
-											<svg
-												class="w-4 h-4 text-gray-400"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke="currentColor"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width="2"
-													d="M5 15l7-7 7 7"
-												/>
-											</svg>
-										</button>
-										<button
-											class="p-1 rounded hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed"
-											onClick={() => handleMove(index, 'down')}
-											disabled={index === fallbackModels.length - 1 || isUpdating}
-											title="Move down"
-										>
-											<svg
-												class="w-4 h-4 text-gray-400"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke="currentColor"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width="2"
-													d="M19 9l-7 7-7-7"
-												/>
-											</svg>
-										</button>
-									</div>
-
-									{/* Remove button */}
-									<button
-										class="p-1 rounded hover:bg-red-900/30 disabled:opacity-30 disabled:cursor-not-allowed"
-										onClick={() => handleRemove(index)}
-										disabled={isUpdating}
-										title="Remove"
-									>
-										<svg
-											class="w-4 h-4 text-red-400"
-											fill="none"
-											viewBox="0 0 24 24"
-											stroke="currentColor"
-										>
-											<path
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												stroke-width="2"
-												d="M6 18L18 6M6 6l12 12"
-											/>
-										</svg>
-									</button>
-								</div>
-							);
-						})}
-					</div>
-				)}
-
-				{/* Add button */}
-				<button
-					class="flex items-center gap-2 px-3 py-2 text-sm text-blue-400 hover:text-blue-300 hover:bg-dark-800 rounded-lg border border-dashed border-dark-600 hover:border-dark-500 transition-colors disabled:opacity-50"
-					onClick={() => setShowAddModal(true)}
-					disabled={loading}
-				>
-					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-							d="M12 4v16m8-8H4"
-						/>
-					</svg>
-					Add Fallback Model
-				</button>
-			</div>
-
-			{/* Add Model Modal */}
-			{showAddModal && (
-				<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-					<div class="bg-dark-850 border border-dark-600 rounded-lg shadow-xl w-80 max-h-[80vh] overflow-hidden flex flex-col">
-						<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700">
-							<h3 class="text-sm font-medium text-gray-100">Add Fallback Model</h3>
-							<button class="p-1 rounded hover:bg-dark-700" onClick={() => setShowAddModal(false)}>
-								<svg
-									class="w-4 h-4 text-gray-400"
-									fill="none"
-									viewBox="0 0 24 24"
-									stroke="currentColor"
-								>
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="2"
-										d="M6 18L18 6M6 6l12 12"
-									/>
-								</svg>
-							</button>
+					{loading ? (
+						<div class="flex items-center gap-2 text-xs text-gray-500">
+							<Spinner size="xs" />
+							<span>Loading models...</span>
 						</div>
+					) : fallbackModels.length === 0 ? (
+						<div class="text-xs text-gray-500 italic">No fallback models configured</div>
+					) : (
+						<FallbackChainEditor
+							models={fallbackModels}
+							availableModels={availableModels}
+							isUpdating={isUpdating}
+							onMove={handleMove}
+							onRemove={handleRemove}
+						/>
+					)}
 
-						<div class="flex-1 overflow-y-auto py-2">
-							{Array.from(groupedModels.entries()).map(([provider, models]) => {
-								const authStatus = providerAuthStatuses.get(provider);
-								const isAuthenticated = authStatus?.isAuthenticated ?? false;
+					<button
+						class="flex items-center gap-2 px-3 py-2 text-sm text-blue-400 hover:text-blue-300 hover:bg-dark-800 rounded-lg border border-dashed border-dark-600 hover:border-dark-500 transition-colors disabled:opacity-50"
+						onClick={() => setShowAddModal(true)}
+						disabled={loading}
+					>
+						<PlusIcon />
+						Add Fallback Model
+					</button>
+				</div>
 
+				{/* ── Section 2: Model-specific overrides ────────────────────────────── */}
+				<div class="space-y-3">
+					<div>
+						<h4 class="text-sm font-medium text-gray-300">Model-Specific Overrides</h4>
+						<p class="text-xs text-gray-500 mt-0.5">
+							Override the default chain for a specific model. Takes priority when that model hits a
+							limit.
+						</p>
+					</div>
+
+					{loading ? (
+						<div class="flex items-center gap-2 text-xs text-gray-500">
+							<Spinner size="xs" />
+							<span>Loading models...</span>
+						</div>
+					) : overrideEntries.length === 0 ? (
+						<div class="text-xs text-gray-500 italic">
+							No model-specific overrides. Add one to override the default chain for a specific
+							model.
+						</div>
+					) : (
+						<div class="space-y-2">
+							{overrideEntries.map(([key, chain]) => {
+								const sourceInfo = getKeyDisplayInfo(key);
 								return (
-									<div key={provider}>
-										<div class="px-4 py-1.5 text-xs font-semibold text-gray-400">
-											{PROVIDER_LABELS[provider] || provider}
-											{!isAuthenticated && (
-												<span class="text-gray-600 ml-1">(not authenticated)</span>
-											)}
+									<div key={key} class="bg-dark-800 border border-dark-700 rounded-lg px-3 py-2">
+										{/* Source model row */}
+										<div class="flex items-center gap-2">
+											<span class="text-base">{getModelFamilyIcon(sourceInfo.family)}</span>
+											<div class="flex-1 min-w-0">
+												<div class="text-sm text-gray-200 truncate">{sourceInfo.name}</div>
+												<div class="text-xs text-gray-500">
+													{PROVIDER_LABELS[sourceInfo.provider] || sourceInfo.provider}
+												</div>
+											</div>
+											<button
+												class="p-1 rounded hover:bg-dark-700 disabled:opacity-30"
+												onClick={() => setOverrideModal({ open: true, editingKey: key })}
+												disabled={isUpdating}
+												title="Edit"
+											>
+												<PencilIcon />
+											</button>
+											<button
+												class="p-1 rounded hover:bg-red-900/30 disabled:opacity-30"
+												onClick={() => handleDeleteOverride(key)}
+												disabled={isUpdating}
+												title="Delete"
+											>
+												<XIcon class="w-4 h-4 text-red-400" />
+											</button>
 										</div>
-										{models.map((model) => {
-											// Don't show models already in fallback chain
-											if (
-												fallbackModels.some(
-													(m) => m.model === model.id && m.provider === model.provider
-												)
-											) {
-												return null;
-											}
 
-											return (
-												<button
-													key={`${model.provider}:${model.id}`}
-													class="w-full text-left px-4 py-2 text-sm flex items-center gap-2 hover:bg-dark-700 transition-colors"
-													onClick={() => handleAdd(model)}
-												>
-													<span class="text-base">{getModelFamilyIcon(model.family)}</span>
-													<span class="flex-1 text-gray-200 truncate">{model.name}</span>
-												</button>
-											);
-										})}
+										{/* Fallback chips */}
+										{chain.length > 0 && (
+											<div class="mt-2 flex flex-wrap gap-1.5">
+												{chain.map((entry, i) => {
+													const info = getModelDisplayInfo(entry);
+													return (
+														<span
+															key={`${entry.provider}:${entry.model}`}
+															class="inline-flex items-center gap-1 px-2 py-0.5 text-xs bg-dark-700 text-gray-300 rounded-full"
+														>
+															<span class="text-gray-500">{i + 1}.</span>
+															<span>{getModelFamilyIcon(info.family)}</span>
+															<span class="truncate max-w-[120px]">{info.name}</span>
+														</span>
+													);
+												})}
+											</div>
+										)}
+										{chain.length === 0 && (
+											<p class="mt-1.5 text-xs text-gray-600 italic">Empty chain</p>
+										)}
 									</div>
 								);
 							})}
-
-							{filteredModels.filter(
-								(m) => !fallbackModels.some((f) => f.model === m.id && f.provider === m.provider)
-							).length === 0 && (
-								<div class="px-4 py-4 text-sm text-gray-500 text-center">
-									All available models are already in the fallback chain
-								</div>
-							)}
 						</div>
-					</div>
+					)}
+
+					<button
+						class="flex items-center gap-2 px-3 py-2 text-sm text-blue-400 hover:text-blue-300 hover:bg-dark-800 rounded-lg border border-dashed border-dark-600 hover:border-dark-500 transition-colors disabled:opacity-50"
+						onClick={() => setOverrideModal({ open: true, editingKey: null })}
+						disabled={loading}
+					>
+						<PlusIcon />
+						Add Override
+					</button>
 				</div>
+			</div>
+
+			{/* Default list — add model modal */}
+			{showAddModal && (
+				<ModelPickerModal
+					title="Add Fallback Model"
+					groupedModels={groupedModels}
+					providerAuthStatuses={providerAuthStatuses}
+					excludeModels={fallbackModels}
+					onSelect={handleAdd}
+					onClose={() => setShowAddModal(false)}
+				/>
+			)}
+
+			{/* Override editor modal */}
+			{overrideModal.open && (
+				<OverrideEditorModal
+					editingKey={overrideModal.editingKey}
+					availableModels={availableModels}
+					groupedModels={groupedModels}
+					providerAuthStatuses={providerAuthStatuses}
+					existingMapKeys={Object.keys(modelFallbackMap)}
+					initialChain={
+						overrideModal.editingKey ? (modelFallbackMap[overrideModal.editingKey] ?? []) : []
+					}
+					onSave={handleSaveOverride}
+					onClose={() => setOverrideModal({ open: false, editingKey: null })}
+				/>
 			)}
 		</SettingsSection>
 	);


### PR DESCRIPTION
Add `modelFallbackMap` to `GlobalSettings` and update `trySwitchToFallbackModel()` to check model-specific chains before the default `fallbackModels` list.

**Changes:**
- `packages/shared/src/types/settings.ts` — new optional `modelFallbackMap: Record<string, FallbackModelEntry[]>` field on `GlobalSettings`
- `packages/daemon/src/lib/room/runtime/room-runtime.ts` — resolve fallback chain with model-specific map priority; model key is `"provider/model"`
- 8 new unit tests covering all priority/skip/availability scenarios

**Behaviour:**
- Model key: `"provider/model"` (e.g. `"anthropic/claude-sonnet-4-20250514"`)
- Model-specific chain always starts from index 0
- Same-model skip guard and `isProviderAvailable` checks still apply
- Existing `fallbackModels` default list is fully backward-compatible