### PR TITLE
feat(room): add leader task review step after planner creates tasks

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -209,7 +209,11 @@ For planning tasks the planner must run a second phase to create tasks.
    2. Read the plan file under docs/plans/
    3. Create all tasks 1:1 from the plan using the \`create_task\` tool
    4. Finish your response after all tasks are created"
-2. **After planner exits with tasks created** — When you next receive \`[PLANNER OUTPUT]\` showing "Phase 2 (task creation)" and "Tasks created: N", call \`complete_task\` with a summary.
+2. **After planner exits with tasks created** — When you next receive \`[PLANNER OUTPUT]\` showing "Phase 2 (task creation)" and "Tasks created: N":
+   a. Read the plan document under \`docs/plans/\` in the workspace.
+   b. Review each listed task against the plan: verify title, description, dependencies, priority, completeness, and no scope creep.
+   c. Use \`update_task\` to fix any discrepancies found.
+   d. Call \`complete_task\` with a summary after all tasks are verified.
 
 **IMPORTANT**: The planner must use the \`create_task\` tool to register tasks. You cannot call \`complete_task\` until tasks are created — the runtime gate will reject it.`;
 	}
@@ -338,7 +342,11 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 
 ${prMergeabilityCheckBlock('Step 5', false)}
 
-Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first. After the planner runs Phase 2 and you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\`, call \`complete_task\`.`;
+Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first. After the planner runs Phase 2 and you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\`:
+1. Read the plan document under \`docs/plans/\` in the workspace.
+2. Review each listed task against the plan for accuracy, completeness, correct dependencies, and no scope creep.
+3. Use \`update_task\` to fix any discrepancies found.
+4. Call \`complete_task\` with a summary after all tasks are verified.`;
 }
 
 function leaderPlanReviewSimpleSection(helperNames: string[]): string {
@@ -361,7 +369,17 @@ ${helperSection}## Plan Review Guidelines
 6. **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`.
 7. Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first.
 
-**Phase 2 (task creation)**: When you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\` showing "Tasks created: N", call \`complete_task\` with a summary of the tasks created.`;
+**Phase 2 (task review + completion)**: When you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\` showing "Tasks created: N":
+1. Read the plan document under \`docs/plans/\` in the workspace.
+2. Review each listed task against the plan. For each task, verify:
+   - **Title** — accurately reflects the scope and intent from the plan
+   - **Description** — covers all relevant details (root cause, fix approach, files)
+   - **Dependencies** — correctly reflect the dependency order in the plan
+   - **Priority** — matches the priority assigned in the plan
+   - **Completeness** — no plan items were missed or incorrectly merged
+   - **No scope creep** — tasks contain only work from their plan section
+3. Use \`update_task\` to fix any discrepancies found.
+4. Call \`complete_task\` with a summary after all tasks are verified.`;
 }
 
 function leaderCodeReviewGuidelinesSection(reviewerNames: string[], helperNames: string[]): string {

--- a/packages/daemon/src/lib/room/runtime/message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/message-routing.ts
@@ -56,7 +56,9 @@ export interface PlanEnvelopeParams {
 	/** The actual planner assistant output */
 	workerOutput: string;
 	/** Draft tasks created by the planner */
-	draftTasks: Array<Pick<NeoTask, 'id' | 'title' | 'description' | 'priority' | 'assignedAgent'>>;
+	draftTasks: Array<
+		Pick<NeoTask, 'id' | 'title' | 'description' | 'priority' | 'assignedAgent' | 'dependsOn'>
+	>;
 	/** Whether the plan has been approved (phase 2) */
 	approved?: boolean;
 }
@@ -92,9 +94,32 @@ export function formatPlanEnvelope(params: PlanEnvelopeParams): string {
 				`${i + 1}. **${t.title}** (agent: ${t.assignedAgent ?? 'coder'}, priority: ${t.priority})`
 			);
 			lines.push(`   ${t.description}`);
+			if (t.dependsOn && t.dependsOn.length > 0) {
+				lines.push(`   Depends on: ${t.dependsOn.join(', ')}`);
+			}
 			lines.push(`   _Task ID: ${t.id}_`);
 			lines.push('');
 		}
+	}
+
+	if (params.approved && params.draftTasks.length > 0) {
+		lines.push('## Review Instructions');
+		lines.push('');
+		lines.push(
+			'Before calling `complete_task`, review each task above against the plan document (available under `docs/plans/` in the workspace). For each task verify:'
+		);
+		lines.push('- **Title** — accurately reflects the scope and intent from the plan');
+		lines.push(
+			'- **Description** — covers all relevant details from the plan section (root cause, fix approach, files)'
+		);
+		lines.push('- **Dependencies** — correctly reflect the dependency order specified in the plan');
+		lines.push('- **Priority** — matches the priority assigned in the plan');
+		lines.push('- **Completeness** — no plan items were missed or incorrectly merged');
+		lines.push('- **No scope creep** — tasks contain only work from their plan section');
+		lines.push('');
+		lines.push(
+			'Use `update_task` to fix any discrepancies, then call `complete_task` with a summary.'
+		);
 	}
 
 	return lines.join('\n');

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -225,6 +225,20 @@ describe('Leader Agent', () => {
 			expect(prompt).toContain('complete_task');
 		});
 
+		it('should include task review step in Phase 2 guidance for simple plan review', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
+			// Leader must review tasks against plan before completing
+			expect(prompt).toContain('docs/plans/');
+			expect(prompt).toContain('update_task');
+			expect(prompt).toContain('No scope creep');
+		});
+
+		it('should include task review step in Phase 2 guidance for post-approval section', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
+			// Post-approval section must mention review step
+			expect(prompt).toContain('verify title, description, dependencies');
+		});
+
 		it('should use planning-specific post-approval workflow for plan_review', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
 			// Should instruct leader to send planner back — NOT merge the PR itself

--- a/packages/daemon/tests/unit/room/message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/message-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
 	formatWorkerToLeaderEnvelope,
+	formatPlanEnvelope,
 	formatLeaderToWorkerFeedback,
 	formatLeaderContractNudge,
 	priorityOrder,
@@ -69,6 +70,107 @@ describe('Message Routing', () => {
 			});
 
 			expect(result).toContain('Terminal state: interrupted');
+		});
+	});
+
+	describe('formatPlanEnvelope', () => {
+		it('should format Phase 1 envelope without review instructions', () => {
+			const result = formatPlanEnvelope({
+				iteration: 1,
+				goalTitle: 'Build auth system',
+				terminalState: 'idle',
+				workerOutput: 'Created plan PR #42',
+				draftTasks: [],
+				approved: false,
+			});
+
+			expect(result).toContain('[PLANNER OUTPUT] Iteration: 1');
+			expect(result).toContain('Phase 1 (plan document)');
+			expect(result).toContain('Goal: Build auth system');
+			expect(result).toContain('Plan PR created — ready for review');
+			expect(result).not.toContain('Review Instructions');
+		});
+
+		it('should format Phase 2 envelope with task details and review instructions', () => {
+			const result = formatPlanEnvelope({
+				iteration: 2,
+				goalTitle: 'Build auth system',
+				terminalState: 'idle',
+				workerOutput: 'Created 2 tasks',
+				draftTasks: [
+					{
+						id: 'task-1',
+						title: 'Add login endpoint',
+						description: 'Create POST /login',
+						priority: 'high',
+						assignedAgent: 'coder',
+						dependsOn: [],
+					},
+					{
+						id: 'task-2',
+						title: 'Add logout endpoint',
+						description: 'Create POST /logout',
+						priority: 'normal',
+						assignedAgent: 'coder',
+						dependsOn: ['task-1'],
+					},
+				],
+				approved: true,
+			});
+
+			expect(result).toContain('Phase 2 (task creation)');
+			expect(result).toContain('Tasks created: 2');
+			expect(result).toContain('Add login endpoint');
+			expect(result).toContain('Add logout endpoint');
+			expect(result).toContain('Task ID: task-1');
+			expect(result).toContain('Task ID: task-2');
+			expect(result).toContain('Review Instructions');
+			expect(result).toContain('update_task');
+			expect(result).toContain('complete_task');
+		});
+
+		it('should show dependencies for tasks that have them', () => {
+			const result = formatPlanEnvelope({
+				iteration: 2,
+				goalTitle: 'Build feature',
+				terminalState: 'idle',
+				workerOutput: 'Tasks created',
+				draftTasks: [
+					{
+						id: 'task-1',
+						title: 'Task A',
+						description: 'First task',
+						priority: 'normal',
+						assignedAgent: 'coder',
+						dependsOn: [],
+					},
+					{
+						id: 'task-2',
+						title: 'Task B',
+						description: 'Second task',
+						priority: 'normal',
+						assignedAgent: 'coder',
+						dependsOn: ['task-1'],
+					},
+				],
+				approved: true,
+			});
+
+			expect(result).not.toMatch(/Depends on:.*\n.*Task A/);
+			expect(result).toContain('Depends on: task-1');
+		});
+
+		it('should not show review instructions for Phase 2 with no tasks', () => {
+			const result = formatPlanEnvelope({
+				iteration: 2,
+				goalTitle: 'Build feature',
+				terminalState: 'idle',
+				workerOutput: 'No tasks created',
+				draftTasks: [],
+				approved: true,
+			});
+
+			expect(result).not.toContain('Review Instructions');
 		});
 	});
 


### PR DESCRIPTION
After the planner completes Phase 2 (task creation), the leader now reviews each created task against the plan document before calling `complete_task`.

## Changes

- **`formatPlanEnvelope`**: Include `dependsOn` in the task listing; add a **Review Instructions** block to Phase 2 envelopes that tells the leader to verify title, description, dependencies, priority, completeness, and no scope creep for each task before completing
- **`leader-agent`**: Update Post-Approval Workflow and Plan Review Guidelines (both simple and orchestration paths) to require reading `docs/plans/` and using `update_task` to fix discrepancies before calling `complete_task`
- **Tests**: New `formatPlanEnvelope` tests for Phase 2 structure, dependency display, and review instructions; new leader-agent tests verifying Phase 2 review guidance is present in the system prompt