### PR TITLE
fix(error-classifier): only pause on actual API errors, not SDK info messages

### DIFF
--- a/packages/daemon/src/lib/room/runtime/error-classifier.ts
+++ b/packages/daemon/src/lib/room/runtime/error-classifier.ts
@@ -4,19 +4,19 @@
  * Single point of truth for classifying API errors from agent output:
  * - terminal:    unrecoverable errors (4xx) → fail task immediately
  * - rate_limit:  HTTP 429 rate limits with parseable retry-after → pause with backoff
- * - usage_limit: daily/weekly usage cap limits (e.g. "You've hit your limit · resets 2pm")
- *                → immediately attempt fallback model, skip backoff
+ * - usage_limit: daily/weekly usage cap limits → immediately attempt fallback model, skip backoff
+ *                Detected via: SDK rate_limit_event (status:'rejected') OR
+ *                Anthropic usage-limit text "You've hit your limit · resets …"
  * - recoverable: transient errors (5xx) → bounce/retry
  *
- * Detection strategy: match only structured "API Error: NNN" messages from the
- * Claude Agent SDK. Free-form text patterns are intentionally avoided because
- * they cause false positives when workers discuss error handling in prose
- * (e.g. "implemented handling for invalid model errors").
+ * Detection strategy:
+ * 1. Structured "API Error: NNN" messages from the Claude Agent SDK (HTTP status code determines class)
+ * 2. SDK rate_limit_event JSON: only 'rejected' status is an actual error;
+ *    'allowed' / 'allowed_warning' are informational (orange badge in UI) → returns null
+ * 3. Anthropic usage-limit text pattern "You've hit your limit · resets …" (actual 4xx response)
  *
- * The Anthropic usage-limit text pattern ("You've hit your limit · resets …")
- * is classified as usage_limit (not rate_limit) because waiting for the reset
- * can mean hours of downtime. Falling back to an alternative model keeps the
- * task moving without requiring the user to wait.
+ * Free-form prose does NOT trigger classification to avoid false positives
+ * (e.g. "implemented handling for invalid model errors").
  */
 
 import { parseRateLimitReset } from './rate-limit-utils';
@@ -63,18 +63,17 @@ function extractHttpStatus(message: string): number | undefined {
 /**
  * Classify an error message from agent output.
  *
- * Only matches structured "API Error: NNN" messages produced by the Claude
- * Agent SDK, plus the Anthropic usage-limit text for usage_limit detection.
- * Free-form prose does NOT trigger classification.
- *
  * Evaluation order (first match wins):
  * 1. "API Error: NNN" — HTTP status code determines class
  *    - 400/401/403/404/422 → terminal
  *    - 429               → rate_limit (with resetsAt if parseable)
  *    - 5xx              → recoverable
- * 2. Anthropic usage-limit text → usage_limit (immediate fallback, no backoff)
+ * 2. SDK rate_limit_event JSON (from mirrorSession event streaming):
+ *    - status 'rejected'              → usage_limit (actual limit hit, trigger fallback)
+ *    - status 'allowed'/'allowed_warning' → null (informational only, do NOT pause)
+ * 3. Anthropic usage-limit text "You've hit your limit · resets …" → usage_limit
  *
- * Returns null when the message is not an API error.
+ * Returns null when the message is not an API error (including SDK info messages).
  *
  * @example
  * classifyError('API Error: 400 {"error":{"message":"Invalid model: xyz"}}')
@@ -88,6 +87,12 @@ function extractHttpStatus(message: string): number | undefined {
  *
  * classifyError('API Error: 500 Internal Server Error')
  * // → { class: 'recoverable', reason: '...', statusCode: 500 }
+ *
+ * classifyError('{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1749600000},...}')
+ * // → null  (SDK info message — orange badge in UI, agent can continue)
+ *
+ * classifyError('{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1749600000},...}')
+ * // → { class: 'usage_limit', reason: '...', resetsAt: 1749600000000 }
  *
  * classifyError('implemented handling for invalid model errors')
  * // → null  (prose — no false positive)
@@ -125,7 +130,35 @@ export function classifyError(message: string): ErrorClassification | null {
 		}
 	}
 
-	// ── 2. Anthropic usage-limit text (specific, cannot appear in normal prose).
+	// ── 2. SDK rate_limit_event JSON (from mirrorSession event streaming) ────
+	//     These messages are emitted for ALL rate limit state changes, not just errors.
+	//     Only 'rejected' status means the API actually blocked the request.
+	//     'allowed' / 'allowed_warning' are informational (orange badge in UI) — never pause.
+	if (message.includes('"type":"rate_limit_event"')) {
+		try {
+			const parsed = JSON.parse(message) as {
+				type?: string;
+				rate_limit_info?: { status?: string; resetsAt?: number };
+			};
+			if (parsed.type === 'rate_limit_event') {
+				const info = parsed.rate_limit_info;
+				if (info?.status === 'rejected') {
+					const resetsAt = typeof info.resetsAt === 'number' ? info.resetsAt * 1000 : undefined;
+					return {
+						class: 'usage_limit',
+						reason: `Usage limit reached (rate_limit_event: rejected)${resetsAt ? ` — resets at ${new Date(resetsAt).toLocaleTimeString()}` : ''}`,
+						resetsAt,
+					};
+				}
+				// 'allowed' / 'allowed_warning' → informational, not an error; skip all text matching
+				return null;
+			}
+		} catch {
+			// JSON parse failed — fall through to text patterns
+		}
+	}
+
+	// ── 3. Anthropic usage-limit text (specific, cannot appear in normal prose).
 	//     Classified as usage_limit — falling back to an alternative model keeps the
 	//     task moving instead of waiting hours until the daily/weekly cap resets.
 	const usageLimitResetsAt = parseRateLimitReset(message);

--- a/packages/daemon/src/lib/room/runtime/rate-limit-utils.ts
+++ b/packages/daemon/src/lib/room/runtime/rate-limit-utils.ts
@@ -17,14 +17,55 @@ const RATE_LIMIT_PATTERN =
 /**
  * Parse rate limit reset time from error message.
  *
- * @param errorMessage - The rate limit error message
- * @returns The reset timestamp in ms, or null if not parseable
+ * Handles two input formats:
+ *
+ * 1. SDK `rate_limit_event` JSON (e.g. from `mirrorSession`):
+ *    Only returns a timestamp for `status: 'rejected'` — the actual limit hit.
+ *    `status: 'allowed'` / `'allowed_warning'` events are informational (orange badge
+ *    in the UI) and must NOT trigger pause/backoff, so null is returned immediately.
+ *
+ * 2. Anthropic usage-limit text pattern:
+ *    "You've hit your limit · resets 1pm (America/New_York)"
+ *    (from actual 4xx API error responses)
+ *
+ * @param errorMessage - The rate limit error message (text or JSON string)
+ * @returns The reset timestamp in ms, or null if not parseable / not an actual limit hit
  *
  * @example
  * parseRateLimitReset("You've hit your limit · resets 1pm (America/New_York)")
  * // Returns timestamp for 1pm in America/New_York timezone
+ *
+ * parseRateLimitReset(JSON.stringify({type:'rate_limit_event',rate_limit_info:{status:'rejected',resetsAt:1749600000}}))
+ * // Returns 1749600000 * 1000 (resetsAt in ms)
+ *
+ * parseRateLimitReset(JSON.stringify({type:'rate_limit_event',rate_limit_info:{status:'allowed',resetsAt:1749600000}}))
+ * // Returns null — informational only, not an actual error
  */
 export function parseRateLimitReset(errorMessage: string): number | null {
+	// ── Structured SDK rate_limit_event JSON ─────────────────────────────────
+	// These messages are emitted for ALL rate limit state changes, not just errors.
+	// Only 'rejected' status means the API actually blocked the request.
+	if (errorMessage.includes('"type":"rate_limit_event"')) {
+		try {
+			const parsed = JSON.parse(errorMessage) as {
+				type?: string;
+				rate_limit_info?: { status?: string; resetsAt?: number };
+			};
+			if (parsed.type === 'rate_limit_event') {
+				const info = parsed.rate_limit_info;
+				if (info?.status === 'rejected' && typeof info.resetsAt === 'number') {
+					// SDK resetsAt is in seconds; convert to ms for callers
+					return info.resetsAt * 1000;
+				}
+				// 'allowed' / 'allowed_warning' → informational, not a limit hit
+				return null;
+			}
+		} catch {
+			// JSON parse failed — fall through to text pattern below
+		}
+	}
+
+	// ── Anthropic usage-limit text (from actual 4xx API responses) ───────────
 	const match = errorMessage.match(RATE_LIMIT_PATTERN);
 	if (!match) return null;
 
@@ -168,10 +209,30 @@ export function parseRateLimitReset(errorMessage: string): number | null {
 /**
  * Check if a message contains a rate limit error.
  *
+ * Returns true for:
+ * - Anthropic usage-limit text matching RATE_LIMIT_PATTERN
+ * - SDK `rate_limit_event` JSON with `status: 'rejected'`
+ *
+ * Returns false for SDK `rate_limit_event` JSON with non-rejected status
+ * (those are informational, not actual errors).
+ *
  * @param message - The message to check
- * @returns true if the message is a rate limit error
+ * @returns true if the message represents an actual rate limit hit
  */
 export function isRateLimitError(message: string): boolean {
+	if (message.includes('"type":"rate_limit_event"')) {
+		try {
+			const parsed = JSON.parse(message) as {
+				type?: string;
+				rate_limit_info?: { status?: string };
+			};
+			if (parsed.type === 'rate_limit_event') {
+				return parsed.rate_limit_info?.status === 'rejected';
+			}
+		} catch {
+			// fall through to text pattern
+		}
+	}
 	return RATE_LIMIT_PATTERN.test(message);
 }
 

--- a/packages/daemon/tests/unit/room/rate-limit-utils.test.ts
+++ b/packages/daemon/tests/unit/room/rate-limit-utils.test.ts
@@ -112,6 +112,90 @@ describe('rate-limit-utils', () => {
 		});
 	});
 
+	describe('SDK rate_limit_event JSON handling', () => {
+		it('returns null for rate_limit_event with status allowed (informational)', () => {
+			const json = JSON.stringify({
+				type: 'rate_limit_event',
+				rate_limit_info: { status: 'allowed', rateLimitType: 'five_hour', resetsAt: 1749600000 },
+				uuid: 'abc',
+				session_id: 'def',
+			});
+			expect(parseRateLimitReset(json)).toBeNull();
+		});
+
+		it('returns null for rate_limit_event with status allowed_warning (informational)', () => {
+			const json = JSON.stringify({
+				type: 'rate_limit_event',
+				rate_limit_info: {
+					status: 'allowed_warning',
+					rateLimitType: 'five_hour',
+					resetsAt: 1749600000,
+				},
+				uuid: 'abc',
+				session_id: 'def',
+			});
+			expect(parseRateLimitReset(json)).toBeNull();
+		});
+
+		it('returns resetsAt * 1000 for rate_limit_event with status rejected', () => {
+			const resetsAtSeconds = 1749600000;
+			const json = JSON.stringify({
+				type: 'rate_limit_event',
+				rate_limit_info: {
+					status: 'rejected',
+					rateLimitType: 'five_hour',
+					resetsAt: resetsAtSeconds,
+				},
+				uuid: 'abc',
+				session_id: 'def',
+			});
+			const result = parseRateLimitReset(json);
+			expect(result).toBe(resetsAtSeconds * 1000);
+		});
+
+		it('returns null for rate_limit_event with status rejected but no resetsAt', () => {
+			const json = JSON.stringify({
+				type: 'rate_limit_event',
+				rate_limit_info: { status: 'rejected', rateLimitType: 'five_hour' },
+				uuid: 'abc',
+				session_id: 'def',
+			});
+			expect(parseRateLimitReset(json)).toBeNull();
+		});
+	});
+
+	describe('isRateLimitError — SDK rate_limit_event JSON', () => {
+		it('returns false for rate_limit_event with status allowed', () => {
+			const json = JSON.stringify({
+				type: 'rate_limit_event',
+				rate_limit_info: { status: 'allowed', resetsAt: 1749600000 },
+				uuid: 'abc',
+				session_id: 'def',
+			});
+			expect(isRateLimitError(json)).toBe(false);
+		});
+
+		it('returns false for rate_limit_event with status allowed_warning', () => {
+			const json = JSON.stringify({
+				type: 'rate_limit_event',
+				rate_limit_info: { status: 'allowed_warning', resetsAt: 1749600000 },
+				uuid: 'abc',
+				session_id: 'def',
+			});
+			expect(isRateLimitError(json)).toBe(false);
+		});
+
+		it('returns true for rate_limit_event with status rejected', () => {
+			const json = JSON.stringify({
+				type: 'rate_limit_event',
+				rate_limit_info: { status: 'rejected', resetsAt: 1749600000 },
+				uuid: 'abc',
+				session_id: 'def',
+			});
+			expect(isRateLimitError(json)).toBe(true);
+		});
+	});
+
 	describe('createRateLimitBackoff', () => {
 		let originalDateNow: typeof Date.now;
 		const mockDetectedAt = 1709508000000; // Fixed timestamp

--- a/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
@@ -107,6 +107,84 @@ describe('error-classifier', () => {
 			});
 		});
 
+		describe('SDK rate_limit_event JSON messages', () => {
+			it('returns null for rate_limit_event with status allowed (informational — orange badge)', () => {
+				const json = JSON.stringify({
+					type: 'rate_limit_event',
+					rate_limit_info: {
+						status: 'allowed',
+						rateLimitType: 'five_hour',
+						resetsAt: 1749600000,
+					},
+					uuid: 'abc',
+					session_id: 'def',
+				});
+				expect(classifyError(json)).toBeNull();
+			});
+
+			it('returns null for rate_limit_event with status allowed_warning (informational)', () => {
+				const json = JSON.stringify({
+					type: 'rate_limit_event',
+					rate_limit_info: {
+						status: 'allowed_warning',
+						rateLimitType: 'five_hour',
+						resetsAt: 1749600000,
+					},
+					uuid: 'abc',
+					session_id: 'def',
+				});
+				expect(classifyError(json)).toBeNull();
+			});
+
+			it('classifies rate_limit_event with status rejected as usage_limit with correct resetsAt', () => {
+				const resetsAtSeconds = 1749600000;
+				const json = JSON.stringify({
+					type: 'rate_limit_event',
+					rate_limit_info: {
+						status: 'rejected',
+						rateLimitType: 'five_hour',
+						resetsAt: resetsAtSeconds,
+					},
+					uuid: 'abc',
+					session_id: 'def',
+				});
+				const result = classifyError(json);
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('usage_limit');
+				expect(result!.resetsAt).toBe(resetsAtSeconds * 1000);
+			});
+
+			it('classifies rate_limit_event with status rejected and no resetsAt as usage_limit', () => {
+				const json = JSON.stringify({
+					type: 'rate_limit_event',
+					rate_limit_info: { status: 'rejected', rateLimitType: 'five_hour' },
+					uuid: 'abc',
+					session_id: 'def',
+				});
+				const result = classifyError(json);
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('usage_limit');
+				expect(result!.resetsAt).toBeUndefined();
+			});
+
+			it('does NOT classify rate_limit_event with allowed even if JSON contains time-like strings', () => {
+				// The SDK info message "Rate limit Five Hour — allowed Resets at 01:00 AM" when
+				// serialized should never trigger the classifier — only rejected status should.
+				const json = JSON.stringify({
+					type: 'rate_limit_event',
+					rate_limit_info: {
+						status: 'allowed',
+						rateLimitType: 'five_hour',
+						resetsAt: 1749603600,
+						overageDisabledReason: 'org_level_disabled',
+					},
+					uuid: 'abc',
+					session_id: 'def',
+				});
+				expect(classifyError(json)).toBeNull();
+			});
+		});
+
 		describe('prose / explanatory text does NOT trigger false positives', () => {
 			it('returns null for "implemented handling for invalid model errors"', () => {
 				expect(


### PR DESCRIPTION
## Summary

SDK `rate_limit_event` messages with `status: 'allowed'` or `'allowed_warning'` are informational (orange badge in UI) — the agent can continue working. Only `status: 'rejected'` is an actual limit hit requiring pause/fallback.

Previously, `classifyError()` could classify these informational events as `usage_limit`, incorrectly triggering pause and backoff.

### Changes

- **`error-classifier.ts`**: Add early guard for `rate_limit_event` JSON — returns `null` for non-rejected events; returns `usage_limit` with correct `resetsAt` (seconds→ms) for rejected events
- **`rate-limit-utils.ts`**: `parseRateLimitReset` skips non-rejected rate_limit_events immediately; extracts `resetsAt * 1000` for rejected events. `isRateLimitError` consistently checks status field for JSON messages
- **Tests**: New cases for `allowed`/`allowed_warning` (→ `null`) and `rejected` (→ `usage_limit`) in both test files