### PR TITLE
feat(daemon): remind leader to re-submit review after human feedback

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -1073,9 +1073,11 @@ export function setupTaskHandlers(
 		// review tasks: transition to in_progress before routing the human message.
 		// The group is still active (sessions running), so no revival is needed — just
 		// update the status so the task reflects that work is ongoing again.
+		let wasInReview = false;
 		if (task.status === 'review') {
 			try {
 				await taskManager.setTaskStatus(taskId, 'in_progress');
+				wasInReview = true;
 			} catch (err) {
 				throw new Error(
 					`Failed to transition task ${taskId} from review to in_progress: ${String(err)}`
@@ -1092,13 +1094,20 @@ export function setupTaskHandlers(
 			await runtime.clearGroupRateLimit(taskId);
 		}
 
+		// When the task was in review, prepend a context note so the leader knows to
+		// re-submit for review after addressing the human's feedback.
+		const reviewReminder = wasInReview
+			? `[Context: This task was in \`review\` status. The message below is human feedback. After addressing the feedback, call \`set_task_status\` with status \`review\` to re-submit for human approval.]\n\n`
+			: '';
+		const messageToRoute = reviewReminder + params.message.trim();
+
 		const groupRepo = makeGroupRepo();
 		const result = await routeHumanMessageToGroup(
 			runtime,
 			groupRepo,
 			taskManager,
 			taskId,
-			params.message.trim(),
+			messageToRoute,
 			target
 		);
 

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -1097,7 +1097,7 @@ export function setupTaskHandlers(
 		// When the task was in review, prepend a context note so the leader knows to
 		// re-submit for review after addressing the human's feedback.
 		const reviewReminder = wasInReview
-			? `[Context: This task was in \`review\` status. The message below is human feedback. After addressing the feedback, call \`set_task_status\` with status \`review\` to re-submit for human approval.]\n\n`
+			? `[Context: This task was in \`review\` status. The message below is human feedback. After addressing the feedback, call \`submit_for_review\` to re-submit for human approval.]\n\n`
 			: '';
 		const messageToRoute = reviewReminder + params.message.trim();
 

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -555,7 +555,10 @@ describe('task.sendHumanMessage RPC Handler', () => {
 
 			expect(result).toEqual({ success: true });
 			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'in_progress');
-			expect(runtime.injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, 'add error handling');
+			// Message should include review reminder prepended
+			const injectedMsg = (runtime.injectMessageToWorker.mock.calls[0] as [string, string])[1];
+			expect(injectedMsg).toContain('add error handling');
+			expect(injectedMsg).toContain('[Context: This task was in `review` status.');
 		});
 
 		it('transitions to in_progress and routes message to leader', async () => {
@@ -568,7 +571,10 @@ describe('task.sendHumanMessage RPC Handler', () => {
 
 			expect(result).toEqual({ success: true });
 			expect(setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'in_progress');
-			expect(runtime.injectMessageToLeader).toHaveBeenCalledWith(TASK_UUID, 'approve and merge');
+			// Message should include review reminder prepended
+			const injectedMsg = (runtime.injectMessageToLeader.mock.calls[0] as [string, string])[1];
+			expect(injectedMsg).toContain('approve and merge');
+			expect(injectedMsg).toContain('[Context: This task was in `review` status.');
 		});
 
 		it('throws when status transition from review to in_progress fails', async () => {

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -70,6 +70,19 @@ const mockTaskManager = {
 				updatedAt: Date.now(),
 			}) as NeoTask
 	),
+	setTaskStatus: mock(
+		async () =>
+			({
+				id: TASK_UUID,
+				roomId: 'room-123',
+				title: 'Test Task',
+				description: 'Test description',
+				status: 'in_progress' as TaskStatus,
+				priority: 'medium' as TaskPriority,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}) as NeoTask
+	),
 };
 
 const createMockTaskManager = (): TaskManagerLike => mockTaskManager as unknown as TaskManagerLike;
@@ -245,6 +258,7 @@ describe('Task RPC Handlers', () => {
 		mockTaskManager.getTask.mockClear();
 		mockTaskManager.listTasks.mockClear();
 		mockTaskManager.failTask.mockClear();
+		mockTaskManager.setTaskStatus.mockClear();
 
 		setupTaskHandlers(
 			messageHubData.hub,
@@ -725,5 +739,79 @@ describe('task.sendHumanMessage handler', () => {
 
 		expect(injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, maxMessage);
 		expect(result.success).toBe(true);
+	});
+
+	it('prepends review reminder when task was in review status', async () => {
+		const { runtimeService, injectMessageToLeader } = createMockRuntimeService(true);
+		const db = createMockDatabaseWithGroup('awaiting_leader');
+
+		// Override getTask to return a task in 'review' status
+		mockTaskManager.getTask.mockResolvedValueOnce({
+			id: TASK_UUID,
+			roomId: 'room-123',
+			title: 'Test Task',
+			description: 'Test description',
+			status: 'review' as TaskStatus,
+			priority: 'medium' as TaskPriority,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		} as NeoTask);
+		// Second call (for emitTaskUpdate after routing) returns in_progress
+		mockTaskManager.getTask.mockResolvedValueOnce({
+			id: TASK_UUID,
+			roomId: 'room-123',
+			title: 'Test Task',
+			description: 'Test description',
+			status: 'in_progress' as TaskStatus,
+			priority: 'medium' as TaskPriority,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		} as NeoTask);
+
+		setupTaskHandlers(
+			messageHubData.hub,
+			roomManagerData.roomManager,
+			daemonHubData.daemonHub,
+			db,
+			{ notifyChange: () => {} } as never,
+			createMockTaskManager,
+			runtimeService
+		);
+
+		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
+		const result = (await handler!(
+			{ roomId: 'room-123', taskId: TASK_UUID, message: 'Please fix the typo', target: 'leader' },
+			{}
+		)) as { success: boolean };
+
+		expect(result.success).toBe(true);
+		// setTaskStatus should have been called to transition review → in_progress
+		expect(mockTaskManager.setTaskStatus).toHaveBeenCalledWith(TASK_UUID, 'in_progress');
+		// The injected message should include the review reminder
+		const injectedMessage = (injectMessageToLeader.mock.calls[0] as [string, string])[1];
+		expect(injectedMessage).toContain('[Context: This task was in `review` status.');
+		expect(injectedMessage).toContain('set_task_status');
+		expect(injectedMessage).toContain('Please fix the typo');
+	});
+
+	it('does not prepend review reminder for non-review tasks', async () => {
+		const { runtimeService, injectMessageToWorker } = createMockRuntimeService(true);
+		const db = createMockDatabaseWithGroup('awaiting_leader');
+
+		// Default getTask returns status 'pending'
+		setupTaskHandlers(
+			messageHubData.hub,
+			roomManagerData.roomManager,
+			daemonHubData.daemonHub,
+			db,
+			{ notifyChange: () => {} } as never,
+			createMockTaskManager,
+			runtimeService
+		);
+
+		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
+		await handler!({ roomId: 'room-123', taskId: TASK_UUID, message: 'hello there' }, {});
+
+		expect(injectMessageToWorker).toHaveBeenCalledWith(TASK_UUID, 'hello there');
 	});
 });

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -790,7 +790,7 @@ describe('task.sendHumanMessage handler', () => {
 		// The injected message should include the review reminder
 		const injectedMessage = (injectMessageToLeader.mock.calls[0] as [string, string])[1];
 		expect(injectedMessage).toContain('[Context: This task was in `review` status.');
-		expect(injectedMessage).toContain('set_task_status');
+		expect(injectedMessage).toContain('submit_for_review');
 		expect(injectedMessage).toContain('Please fix the typo');
 	});
 


### PR DESCRIPTION
When a human sends a message to a task in `review` status, the system transitions it to `in_progress`. Previously, the leader had no signal that it needed to re-submit for review after addressing the feedback.

## Changes

- In `task.sendHumanMessage` handler: when the task was in `review` status before the transition, prepend a context note to the injected message telling the leader to call `set_task_status` back to `review` after addressing the feedback
- Updated existing tests in `rpc-handlers/task-handlers.test.ts` that checked exact message content (now check for `toContain`)
- Added two new tests in `rpc/task-handlers.test.ts`: one verifying the reminder is prepended for review tasks, one verifying non-review tasks are unaffected