### PR TITLE
fix(goals): auto-compute nextRunAt in patchGoal when schedule is updated

### DIFF
--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -337,13 +337,44 @@ export class GoalManager {
 	 * General-purpose patch for editable fields (title, description, missionType,
 	 * autonomyLevel, structuredMetrics, schedule, priority, and similar).
 	 * Does NOT change status or recalculate progress.
+	 *
+	 * Auto-computes nextRunAt when schedule is set for a recurring mission,
+	 * mirroring the same logic in createGoal(). This ensures that updating a
+	 * goal's cron expression via goal.update also persists nextRunAt so the
+	 * scheduler (tickRecurringMissions Phase 2) can fire the goal.
 	 */
 	async patchGoal(goalId: string, patch: UpdateGoalParams): Promise<RoomGoal> {
 		const goal = await this.getGoal(goalId);
 		if (!goal) {
 			throw new Error(`Goal not found: ${goalId}`);
 		}
-		const updatedGoal = this.goalRepo.updateGoal(goalId, patch);
+
+		// Auto-compute nextRunAt when schedule is being set for a recurring mission.
+		// The effective mission type is the patched type (if changing) or the existing type.
+		const effectiveMissionType = patch.missionType ?? goal.missionType;
+		let computedPatch: UpdateGoalParams = patch;
+		if (
+			effectiveMissionType === 'recurring' &&
+			patch.schedule != null &&
+			patch.nextRunAt === undefined
+		) {
+			if (!isValidCronExpression(patch.schedule.expression)) {
+				throw new Error(
+					`Invalid cron expression "${patch.schedule.expression}" for recurring mission. ` +
+						'Use 5-field cron or presets (@daily, @weekly, @hourly, @monthly).'
+				);
+			}
+			const tz = patch.schedule.timezone ?? getSystemTimezone();
+			const nextRunAt = getNextRunAt(patch.schedule.expression, tz);
+			if (nextRunAt === null) {
+				throw new Error(
+					`Cron expression "${patch.schedule.expression}" produces no future run times.`
+				);
+			}
+			computedPatch = { ...patch, nextRunAt };
+		}
+
+		const updatedGoal = this.goalRepo.updateGoal(goalId, computedPatch);
 		if (!updatedGoal) {
 			throw new Error(`Failed to update goal: ${goalId}`);
 		}

--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -865,3 +865,144 @@ describe('GoalManager ShortIdAllocator wiring', () => {
 		expect(g2.shortId).toBe('g-2');
 	});
 });
+
+describe('GoalManager.patchGoal — schedule nextRunAt auto-computation', () => {
+	let db: Database;
+	let goalManager: GoalManager;
+	let roomId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createTables(db);
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS goals (
+				id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'active',
+				priority TEXT NOT NULL DEFAULT 'normal', progress INTEGER DEFAULT 0,
+				linked_task_ids TEXT DEFAULT '[]', metrics TEXT DEFAULT '{}',
+				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER,
+				planning_attempts INTEGER DEFAULT 0, goal_review_attempts INTEGER DEFAULT 0,
+				mission_type TEXT, autonomy_level TEXT, structured_metrics TEXT, schedule TEXT,
+				schedule_paused INTEGER DEFAULT 0, next_run_at INTEGER,
+				max_consecutive_failures INTEGER, max_planning_attempts INTEGER,
+				consecutive_failures INTEGER DEFAULT 0, replan_count INTEGER DEFAULT 0,
+				short_id TEXT,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			);
+		`);
+
+		const roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({ name: 'Test Room', allowedPaths: [] });
+		roomId = room.id;
+		goalManager = new GoalManager(db, roomId, noOpReactiveDb);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('auto-computes nextRunAt when updating schedule on a recurring mission', async () => {
+		const goal = await goalManager.createGoal({
+			title: 'Recurring',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+		expect(goal.nextRunAt).toBeDefined();
+		const originalNextRunAt = goal.nextRunAt!;
+
+		// Patch the schedule to a new expression
+		const before = Math.floor(Date.now() / 1000);
+		const patched = await goalManager.patchGoal(goal.id, {
+			schedule: { expression: '@hourly', timezone: 'UTC' },
+		});
+		const after = Math.floor(Date.now() / 1000) + 3700; // up to 1 hour + buffer
+
+		expect(patched.schedule?.expression).toBe('@hourly');
+		expect(patched.nextRunAt).toBeDefined();
+		expect(patched.nextRunAt!).toBeGreaterThan(before);
+		// @hourly fires within the next hour
+		expect(patched.nextRunAt!).toBeLessThanOrEqual(after);
+		// nextRunAt should change when the cron expression changes
+		expect(patched.nextRunAt!).not.toBe(originalNextRunAt);
+	});
+
+	it('auto-computes nextRunAt when changing missionType to recurring with a schedule', async () => {
+		const goal = await goalManager.createGoal({
+			title: 'One-shot',
+			missionType: 'one_shot',
+		});
+		expect(goal.nextRunAt).toBeUndefined();
+
+		const before = Math.floor(Date.now() / 1000);
+		const patched = await goalManager.patchGoal(goal.id, {
+			missionType: 'recurring',
+			schedule: { expression: '@weekly', timezone: 'UTC' },
+		});
+		const after = Math.floor(Date.now() / 1000) + 7 * 24 * 3600 + 100;
+
+		expect(patched.missionType).toBe('recurring');
+		expect(patched.schedule?.expression).toBe('@weekly');
+		expect(patched.nextRunAt).toBeDefined();
+		expect(patched.nextRunAt!).toBeGreaterThan(before);
+		expect(patched.nextRunAt!).toBeLessThanOrEqual(after);
+	});
+
+	it('does NOT overwrite nextRunAt when caller explicitly passes it', async () => {
+		const goal = await goalManager.createGoal({
+			title: 'Recurring',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+
+		const explicitNextRunAt = Math.floor(Date.now() / 1000) + 9999;
+		const patched = await goalManager.patchGoal(goal.id, {
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: explicitNextRunAt,
+		});
+
+		expect(patched.nextRunAt).toBe(explicitNextRunAt);
+	});
+
+	it('does NOT compute nextRunAt when setting schedule on a non-recurring goal', async () => {
+		const goal = await goalManager.createGoal({
+			title: 'One-shot',
+			missionType: 'one_shot',
+		});
+
+		// Patching schedule on a one_shot goal should NOT compute nextRunAt
+		const patched = await goalManager.patchGoal(goal.id, {
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+
+		expect(patched.nextRunAt).toBeUndefined();
+	});
+
+	it('throws on invalid cron expression during patchGoal', async () => {
+		const goal = await goalManager.createGoal({
+			title: 'Recurring',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+
+		await expect(
+			goalManager.patchGoal(goal.id, {
+				schedule: { expression: 'not-a-cron', timezone: 'UTC' },
+			})
+		).rejects.toThrow(/Invalid cron expression/);
+	});
+
+	it('preserves existing nextRunAt when patching non-schedule fields', async () => {
+		const goal = await goalManager.createGoal({
+			title: 'Recurring',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+		const originalNextRunAt = goal.nextRunAt!;
+		expect(originalNextRunAt).toBeDefined();
+
+		const patched = await goalManager.patchGoal(goal.id, { title: 'Updated Title' });
+
+		expect(patched.title).toBe('Updated Title');
+		expect(patched.nextRunAt).toBe(originalNextRunAt);
+	});
+});

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -875,3 +875,72 @@ describe('Recurring Missions: plan reuse for subsequent executions', () => {
 		expect(planningCalls.length).toBeGreaterThan(0);
 	});
 });
+
+describe('Recurring Missions: schedule updated via patchGoal triggers execution', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('recurring goal whose schedule was set via patchGoal fires when nextRunAt passes', async () => {
+		// Simulate a user creating a one-shot goal, then editing it to become recurring.
+		// patchGoal must auto-compute nextRunAt for the goal to ever trigger.
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Edited to recurring',
+			description: 'Was one-shot, now recurring',
+			missionType: 'one_shot',
+		});
+
+		// patchGoal now auto-computes nextRunAt; immediately advance it to the past
+		// so the scheduler fires in the next tick.
+		const patched = await ctx.goalManager.patchGoal(goal.id, {
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+		// patchGoal must have set nextRunAt (the bug was that it didn't)
+		expect(patched.nextRunAt).toBeDefined();
+
+		// Simulate time passing: move nextRunAt into the past
+		await ctx.goalManager.updateNextRunAt(goal.id, Math.floor(Date.now() / 1000) - 60);
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Scheduler should have started a new execution
+		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeExecution).not.toBeNull();
+		expect(activeExecution?.status).toBe('running');
+
+		// nextRunAt should have been advanced to the future
+		const updated = await ctx.goalManager.getGoal(goal.id);
+		expect(updated?.nextRunAt).not.toBeNull();
+		expect(updated!.nextRunAt!).toBeGreaterThan(Math.floor(Date.now() / 1000));
+	});
+
+	test('createGoal auto-computes nextRunAt and scheduler fires without manual override', async () => {
+		// createGoal already auto-computes nextRunAt — verify it, then simulate time passing.
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Auto nextRunAt',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+
+		expect(goal.nextRunAt).toBeDefined();
+		expect(goal.nextRunAt!).toBeGreaterThan(Math.floor(Date.now() / 1000));
+
+		// Advance nextRunAt to past so scheduler fires
+		await ctx.goalManager.updateNextRunAt(goal.id, Math.floor(Date.now() / 1000) - 60);
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeExecution).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- **Bug**: editing a recurring goal's schedule via the UI called `patchGoal()`, which saved the cron expression but left `nextRunAt` as null. The scheduler (`tickRecurringMissions` Phase 2) skips goals with `null` nextRunAt, so the goal never triggered.
- **Fix**: `patchGoal()` now mirrors `createGoal()` — when the effective mission type is `recurring` and `schedule` is being set without an explicit `nextRunAt`, it calls `getNextRunAt()` to compute and persist the value.
- **Tests**: added 6 unit tests to `goal-manager.test.ts` covering patchGoal schedule scenarios, and 2 integration tests to `recurring-missions.test.ts` verifying the full flow (patchGoal → scheduler → execution).