### PR TITLE
feat(shared): add AppSkill type family to shared package

### DIFF
--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -20,6 +20,7 @@ export * from './types/space.ts';
 export * from './types/space-utils.ts';
 export * from './types/tools.ts';
 export * from './types/app-mcp-server.ts';
+export * from './types/skills.ts';
 export * from './types/reference.ts';
 export * from './live-query-types.ts';
 export * from './prompts/index.ts';

--- a/packages/shared/src/types/skills.test.ts
+++ b/packages/shared/src/types/skills.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'bun:test';
+import type {
+	AppSkill,
+	AppSkillConfig,
+	BuiltinSkillConfig,
+	CreateSkillParams,
+	McpServerSkillConfig,
+	PluginSkillConfig,
+	SkillSourceType,
+	SkillValidationStatus,
+	UpdateSkillParams,
+} from './skills.ts';
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+function isBuiltinSkillConfig(config: AppSkillConfig): config is BuiltinSkillConfig {
+	return 'commandName' in config;
+}
+
+function isPluginSkillConfig(config: AppSkillConfig): config is PluginSkillConfig {
+	return 'pluginPath' in config;
+}
+
+function isMcpServerSkillConfig(config: AppSkillConfig): config is McpServerSkillConfig {
+	return 'appMcpServerId' in config;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const builtinConfig: BuiltinSkillConfig = { commandName: 'update-config' };
+const pluginConfig: PluginSkillConfig = { pluginPath: '/home/user/.neokai/skills/my-skill' };
+const mcpConfig: McpServerSkillConfig = { appMcpServerId: 'mcp-uuid-1234' };
+
+const baseSkill: AppSkill = {
+	id: 'skill-uuid-1',
+	name: 'web-search',
+	displayName: 'Web Search',
+	description: 'Searches the web using Brave API',
+	sourceType: 'mcp_server',
+	config: mcpConfig,
+	enabled: true,
+	builtIn: false,
+	validationStatus: 'valid',
+	createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SkillSourceType', () => {
+	it('accepts valid source types', () => {
+		const types: SkillSourceType[] = ['builtin', 'plugin', 'mcp_server'];
+		expect(types).toHaveLength(3);
+	});
+});
+
+describe('SkillValidationStatus', () => {
+	it('accepts all valid statuses', () => {
+		const statuses: SkillValidationStatus[] = ['pending', 'valid', 'invalid', 'unknown'];
+		expect(statuses).toHaveLength(4);
+	});
+});
+
+describe('AppSkillConfig discriminated union', () => {
+	it('identifies BuiltinSkillConfig correctly', () => {
+		const config: AppSkillConfig = builtinConfig;
+		expect(isBuiltinSkillConfig(config)).toBe(true);
+		expect(isPluginSkillConfig(config)).toBe(false);
+		expect(isMcpServerSkillConfig(config)).toBe(false);
+	});
+
+	it('identifies PluginSkillConfig correctly', () => {
+		const config: AppSkillConfig = pluginConfig;
+		expect(isBuiltinSkillConfig(config)).toBe(false);
+		expect(isPluginSkillConfig(config)).toBe(true);
+		expect(isMcpServerSkillConfig(config)).toBe(false);
+	});
+
+	it('identifies McpServerSkillConfig correctly', () => {
+		const config: AppSkillConfig = mcpConfig;
+		expect(isBuiltinSkillConfig(config)).toBe(false);
+		expect(isPluginSkillConfig(config)).toBe(false);
+		expect(isMcpServerSkillConfig(config)).toBe(true);
+	});
+});
+
+describe('AppSkill', () => {
+	it('has all required fields', () => {
+		expect(baseSkill.id).toBe('skill-uuid-1');
+		expect(baseSkill.name).toBe('web-search');
+		expect(baseSkill.displayName).toBe('Web Search');
+		expect(baseSkill.description).toBeTruthy();
+		expect(baseSkill.sourceType).toBe('mcp_server');
+		expect(baseSkill.enabled).toBe(true);
+		expect(baseSkill.builtIn).toBe(false);
+		expect(baseSkill.validationStatus).toBe('valid');
+		expect(baseSkill.createdAt).toBeTruthy();
+	});
+
+	it('config is accessible as McpServerSkillConfig when sourceType is mcp_server', () => {
+		if (isMcpServerSkillConfig(baseSkill.config)) {
+			expect(baseSkill.config.appMcpServerId).toBe('mcp-uuid-1234');
+		} else {
+			throw new Error('Expected McpServerSkillConfig');
+		}
+	});
+
+	it('supports builtin sourceType with BuiltinSkillConfig', () => {
+		const skill: AppSkill = {
+			...baseSkill,
+			id: 'skill-builtin-1',
+			sourceType: 'builtin',
+			config: builtinConfig,
+			builtIn: true,
+		};
+		expect(skill.sourceType).toBe('builtin');
+		if (isBuiltinSkillConfig(skill.config)) {
+			expect(skill.config.commandName).toBe('update-config');
+		} else {
+			throw new Error('Expected BuiltinSkillConfig');
+		}
+	});
+
+	it('supports plugin sourceType with PluginSkillConfig', () => {
+		const skill: AppSkill = {
+			...baseSkill,
+			id: 'skill-plugin-1',
+			sourceType: 'plugin',
+			config: pluginConfig,
+		};
+		expect(skill.sourceType).toBe('plugin');
+		if (isPluginSkillConfig(skill.config)) {
+			expect(skill.config.pluginPath).toBe('/home/user/.neokai/skills/my-skill');
+		} else {
+			throw new Error('Expected PluginSkillConfig');
+		}
+	});
+});
+
+describe('CreateSkillParams', () => {
+	it('excludes id, createdAt, builtIn', () => {
+		const params: CreateSkillParams = {
+			name: 'my-skill',
+			displayName: 'My Skill',
+			description: 'Does something useful',
+			sourceType: 'plugin',
+			config: pluginConfig,
+			enabled: true,
+			validationStatus: 'pending',
+		};
+		// TypeScript would error if id/createdAt/builtIn were required — verify shape at runtime
+		expect('id' in params).toBe(false);
+		expect('createdAt' in params).toBe(false);
+		expect('builtIn' in params).toBe(false);
+		expect(params.name).toBe('my-skill');
+	});
+});
+
+describe('UpdateSkillParams', () => {
+	it('allows partial updates', () => {
+		const patch: UpdateSkillParams = { enabled: false };
+		expect(patch.enabled).toBe(false);
+	});
+
+	it('allows empty update object', () => {
+		const patch: UpdateSkillParams = {};
+		expect(Object.keys(patch)).toHaveLength(0);
+	});
+
+	it('allows updating multiple fields', () => {
+		const patch: UpdateSkillParams = {
+			displayName: 'Updated Name',
+			validationStatus: 'invalid',
+			enabled: false,
+		};
+		expect(patch.displayName).toBe('Updated Name');
+		expect(patch.validationStatus).toBe('invalid');
+		expect(patch.enabled).toBe(false);
+	});
+});

--- a/packages/shared/src/types/skills.test.ts
+++ b/packages/shared/src/types/skills.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { isBuiltinSkillConfig, isMcpServerSkillConfig, isPluginSkillConfig } from './skills.ts';
 import type {
 	AppSkill,
 	AppSkillConfig,
@@ -12,28 +13,15 @@ import type {
 } from './skills.ts';
 
 // ---------------------------------------------------------------------------
-// Type guards
-// ---------------------------------------------------------------------------
-
-function isBuiltinSkillConfig(config: AppSkillConfig): config is BuiltinSkillConfig {
-	return 'commandName' in config;
-}
-
-function isPluginSkillConfig(config: AppSkillConfig): config is PluginSkillConfig {
-	return 'pluginPath' in config;
-}
-
-function isMcpServerSkillConfig(config: AppSkillConfig): config is McpServerSkillConfig {
-	return 'appMcpServerId' in config;
-}
-
-// ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const builtinConfig: BuiltinSkillConfig = { commandName: 'update-config' };
-const pluginConfig: PluginSkillConfig = { pluginPath: '/home/user/.neokai/skills/my-skill' };
-const mcpConfig: McpServerSkillConfig = { appMcpServerId: 'mcp-uuid-1234' };
+const builtinConfig: BuiltinSkillConfig = { type: 'builtin', commandName: 'update-config' };
+const pluginConfig: PluginSkillConfig = {
+	type: 'plugin',
+	pluginPath: '/home/user/.neokai/skills/my-skill',
+};
+const mcpConfig: McpServerSkillConfig = { type: 'mcp_server', appMcpServerId: 'mcp-uuid-1234' };
 
 const baseSkill: AppSkill = {
 	id: 'skill-uuid-1',
@@ -45,7 +33,7 @@ const baseSkill: AppSkill = {
 	enabled: true,
 	builtIn: false,
 	validationStatus: 'valid',
-	createdAt: '2026-01-01T00:00:00.000Z',
+	createdAt: 1735689600000, // 2026-01-01T00:00:00.000Z in Unix ms
 };
 
 // ---------------------------------------------------------------------------
@@ -66,26 +54,50 @@ describe('SkillValidationStatus', () => {
 	});
 });
 
-describe('AppSkillConfig discriminated union', () => {
-	it('identifies BuiltinSkillConfig correctly', () => {
+describe('AppSkillConfig discriminated union — type guards', () => {
+	it('identifies BuiltinSkillConfig via type discriminator', () => {
 		const config: AppSkillConfig = builtinConfig;
 		expect(isBuiltinSkillConfig(config)).toBe(true);
 		expect(isPluginSkillConfig(config)).toBe(false);
 		expect(isMcpServerSkillConfig(config)).toBe(false);
 	});
 
-	it('identifies PluginSkillConfig correctly', () => {
+	it('identifies PluginSkillConfig via type discriminator', () => {
 		const config: AppSkillConfig = pluginConfig;
 		expect(isBuiltinSkillConfig(config)).toBe(false);
 		expect(isPluginSkillConfig(config)).toBe(true);
 		expect(isMcpServerSkillConfig(config)).toBe(false);
 	});
 
-	it('identifies McpServerSkillConfig correctly', () => {
+	it('identifies McpServerSkillConfig via type discriminator', () => {
 		const config: AppSkillConfig = mcpConfig;
 		expect(isBuiltinSkillConfig(config)).toBe(false);
 		expect(isPluginSkillConfig(config)).toBe(false);
 		expect(isMcpServerSkillConfig(config)).toBe(true);
+	});
+
+	it('BuiltinSkillConfig has commandName', () => {
+		if (isBuiltinSkillConfig(builtinConfig)) {
+			expect(builtinConfig.commandName).toBe('update-config');
+		} else {
+			throw new Error('Expected BuiltinSkillConfig');
+		}
+	});
+
+	it('PluginSkillConfig has pluginPath', () => {
+		if (isPluginSkillConfig(pluginConfig)) {
+			expect(pluginConfig.pluginPath).toBe('/home/user/.neokai/skills/my-skill');
+		} else {
+			throw new Error('Expected PluginSkillConfig');
+		}
+	});
+
+	it('McpServerSkillConfig has appMcpServerId', () => {
+		if (isMcpServerSkillConfig(mcpConfig)) {
+			expect(mcpConfig.appMcpServerId).toBe('mcp-uuid-1234');
+		} else {
+			throw new Error('Expected McpServerSkillConfig');
+		}
 	});
 });
 
@@ -99,7 +111,11 @@ describe('AppSkill', () => {
 		expect(baseSkill.enabled).toBe(true);
 		expect(baseSkill.builtIn).toBe(false);
 		expect(baseSkill.validationStatus).toBe('valid');
-		expect(baseSkill.createdAt).toBeTruthy();
+	});
+
+	it('createdAt is a number (Unix ms)', () => {
+		expect(typeof baseSkill.createdAt).toBe('number');
+		expect(baseSkill.createdAt).toBe(1735689600000);
 	});
 
 	it('config is accessible as McpServerSkillConfig when sourceType is mcp_server', () => {
@@ -153,17 +169,38 @@ describe('CreateSkillParams', () => {
 			enabled: true,
 			validationStatus: 'pending',
 		};
-		// TypeScript would error if id/createdAt/builtIn were required — verify shape at runtime
 		expect('id' in params).toBe(false);
 		expect('createdAt' in params).toBe(false);
 		expect('builtIn' in params).toBe(false);
 		expect(params.name).toBe('my-skill');
 	});
+
+	it('includes name, sourceType, and validationStatus (immutable post-creation fields)', () => {
+		const params: CreateSkillParams = {
+			name: 'my-skill',
+			displayName: 'My Skill',
+			description: 'Desc',
+			sourceType: 'builtin',
+			config: builtinConfig,
+			enabled: true,
+			validationStatus: 'pending',
+		};
+		expect(params.name).toBe('my-skill');
+		expect(params.sourceType).toBe('builtin');
+		expect(params.validationStatus).toBe('pending');
+	});
 });
 
 describe('UpdateSkillParams', () => {
-	it('allows partial updates', () => {
-		const patch: UpdateSkillParams = { enabled: false };
+	it('restricts to user-editable fields only', () => {
+		const patch: UpdateSkillParams = {
+			displayName: 'New Name',
+			description: 'New description',
+			enabled: false,
+			config: pluginConfig,
+		};
+		expect(patch.displayName).toBe('New Name');
+		expect(patch.description).toBe('New description');
 		expect(patch.enabled).toBe(false);
 	});
 
@@ -172,14 +209,17 @@ describe('UpdateSkillParams', () => {
 		expect(Object.keys(patch)).toHaveLength(0);
 	});
 
-	it('allows updating multiple fields', () => {
-		const patch: UpdateSkillParams = {
-			displayName: 'Updated Name',
-			validationStatus: 'invalid',
-			enabled: false,
-		};
-		expect(patch.displayName).toBe('Updated Name');
-		expect(patch.validationStatus).toBe('invalid');
+	it('allows partial update with only enabled', () => {
+		const patch: UpdateSkillParams = { enabled: false };
 		expect(patch.enabled).toBe(false);
+	});
+
+	it('does not include name, sourceType, or validationStatus', () => {
+		// TypeScript would error if these were set — verify at runtime that
+		// a valid patch object does not contain immutable fields
+		const patch: UpdateSkillParams = { displayName: 'Test' };
+		expect('name' in patch).toBe(false);
+		expect('sourceType' in patch).toBe(false);
+		expect('validationStatus' in patch).toBe(false);
 	});
 });

--- a/packages/shared/src/types/skills.ts
+++ b/packages/shared/src/types/skills.ts
@@ -1,0 +1,81 @@
+/**
+ * Application-level Skills Registry Types
+ *
+ * These types define the schema for Skills registered at the application level.
+ * Registered skills are available to any room or session that enables them.
+ *
+ * Source type guide:
+ * - 'builtin'    — references a slash command in .claude/commands/
+ * - 'plugin'     — references a local plugin directory on disk
+ * - 'mcp_server' — references an existing app_mcp_servers entry by ID;
+ *                  avoids duplicating MCP server config that is already
+ *                  managed by the app-level MCP registry
+ */
+
+export type SkillSourceType = 'builtin' | 'plugin' | 'mcp_server';
+
+/** Config for a built-in skill backed by a .claude/commands/ slash command. */
+export interface BuiltinSkillConfig {
+	/** The slash-command name (e.g. "update-config", "claude-api"). */
+	commandName: string;
+}
+
+/** Config for a skill backed by a local plugin directory. */
+export interface PluginSkillConfig {
+	/** Absolute path to the plugin directory on disk. */
+	pluginPath: string;
+}
+
+/**
+ * Config for a skill backed by an existing app-level MCP server.
+ * References the server by its UUID in app_mcp_servers — no config duplication.
+ */
+export interface McpServerSkillConfig {
+	/** UUID of the corresponding `app_mcp_servers` row. */
+	appMcpServerId: string;
+}
+
+/** Discriminated union of all possible skill configurations. */
+export type AppSkillConfig = BuiltinSkillConfig | PluginSkillConfig | McpServerSkillConfig;
+
+/** Lifecycle validation state of a skill. */
+export type SkillValidationStatus = 'pending' | 'valid' | 'invalid' | 'unknown';
+
+/**
+ * A skill registered at the application level.
+ * Skills can originate from built-in commands, local plugins, or MCP servers.
+ */
+export interface AppSkill {
+	/** Unique identifier (UUID). */
+	id: string;
+	/** Internal unique name (slug-style, e.g. "web-search"). */
+	name: string;
+	/** Human-readable display name shown in the UI. */
+	displayName: string;
+	/** Short description of what the skill does (used for agent discovery). */
+	description: string;
+	/** Where the skill comes from. */
+	sourceType: SkillSourceType;
+	/** Source-type-specific configuration. */
+	config: AppSkillConfig;
+	/** Whether this skill is globally enabled. */
+	enabled: boolean;
+	/** True when the skill is shipped with NeoKai and cannot be deleted. */
+	builtIn: boolean;
+	/** Current validation state (set by the async validation job). */
+	validationStatus: SkillValidationStatus;
+	/** ISO-8601 timestamp when the record was created. */
+	createdAt: string;
+}
+
+/**
+ * Payload for creating a new skill entry.
+ * `id`, `createdAt`, and `builtIn` are generated / set server-side.
+ */
+export type CreateSkillParams = Omit<AppSkill, 'id' | 'createdAt' | 'builtIn'>;
+
+/**
+ * Payload for updating an existing skill entry.
+ * All CreateSkillParams fields are optional.
+ */
+export type UpdateSkillParams = Partial<CreateSkillParams>;

--- a/packages/shared/src/types/skills.ts
+++ b/packages/shared/src/types/skills.ts
@@ -14,14 +14,22 @@
 
 export type SkillSourceType = 'builtin' | 'plugin' | 'mcp_server';
 
-/** Config for a built-in skill backed by a .claude/commands/ slash command. */
+/**
+ * Config for a built-in skill backed by a .claude/commands/ slash command.
+ * The `type` discriminator enables safe JSON round-tripping from SQLite.
+ */
 export interface BuiltinSkillConfig {
+	type: 'builtin';
 	/** The slash-command name (e.g. "update-config", "claude-api"). */
 	commandName: string;
 }
 
-/** Config for a skill backed by a local plugin directory. */
+/**
+ * Config for a skill backed by a local plugin directory.
+ * The `type` discriminator enables safe JSON round-tripping from SQLite.
+ */
 export interface PluginSkillConfig {
+	type: 'plugin';
 	/** Absolute path to the plugin directory on disk. */
 	pluginPath: string;
 }
@@ -29,8 +37,10 @@ export interface PluginSkillConfig {
 /**
  * Config for a skill backed by an existing app-level MCP server.
  * References the server by its UUID in app_mcp_servers — no config duplication.
+ * The `type` discriminator enables safe JSON round-tripping from SQLite.
  */
 export interface McpServerSkillConfig {
+	type: 'mcp_server';
 	/** UUID of the corresponding `app_mcp_servers` row. */
 	appMcpServerId: string;
 }
@@ -48,13 +58,13 @@ export type SkillValidationStatus = 'pending' | 'valid' | 'invalid' | 'unknown';
 export interface AppSkill {
 	/** Unique identifier (UUID). */
 	id: string;
-	/** Internal unique name (slug-style, e.g. "web-search"). */
+	/** Internal unique name (slug-style, e.g. "web-search"). Immutable after creation. */
 	name: string;
 	/** Human-readable display name shown in the UI. */
 	displayName: string;
 	/** Short description of what the skill does (used for agent discovery). */
 	description: string;
-	/** Where the skill comes from. */
+	/** Where the skill comes from. Immutable after creation. */
 	sourceType: SkillSourceType;
 	/** Source-type-specific configuration. */
 	config: AppSkillConfig;
@@ -62,10 +72,12 @@ export interface AppSkill {
 	enabled: boolean;
 	/** True when the skill is shipped with NeoKai and cannot be deleted. */
 	builtIn: boolean;
-	/** Current validation state (set by the async validation job). */
+	/**
+	 * Current validation state (set by the async validation job — not user-editable).
+	 */
 	validationStatus: SkillValidationStatus;
-	/** ISO-8601 timestamp when the record was created. */
-	createdAt: string;
+	/** Unix timestamp (ms) when the record was created. Consistent with other NeoKai tables. */
+	createdAt: number;
 }
 
 /**
@@ -76,6 +88,32 @@ export type CreateSkillParams = Omit<AppSkill, 'id' | 'createdAt' | 'builtIn'>;
 
 /**
  * Payload for updating an existing skill entry.
- * All CreateSkillParams fields are optional.
+ * Restricted to user-editable fields only:
+ * - `name` and `sourceType` are immutable after creation
+ * - `validationStatus` is managed by the async validation job
  */
-export type UpdateSkillParams = Partial<CreateSkillParams>;
+export interface UpdateSkillParams {
+	displayName?: string;
+	description?: string;
+	enabled?: boolean;
+	config?: AppSkillConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+/** Returns true when `config` is a {@link BuiltinSkillConfig}. */
+export function isBuiltinSkillConfig(config: AppSkillConfig): config is BuiltinSkillConfig {
+	return config.type === 'builtin';
+}
+
+/** Returns true when `config` is a {@link PluginSkillConfig}. */
+export function isPluginSkillConfig(config: AppSkillConfig): config is PluginSkillConfig {
+	return config.type === 'plugin';
+}
+
+/** Returns true when `config` is a {@link McpServerSkillConfig}. */
+export function isMcpServerSkillConfig(config: AppSkillConfig): config is McpServerSkillConfig {
+	return config.type === 'mcp_server';
+}


### PR DESCRIPTION
Add `AppSkill` type family and related interfaces to `packages/shared/src/types/skills.ts`, exported from the shared barrel.

**New types:**
- `SkillSourceType` — `'builtin' | 'plugin' | 'mcp_server'`
- `BuiltinSkillConfig`, `PluginSkillConfig`, `McpServerSkillConfig` — source-specific config
- `AppSkillConfig` — discriminated union of the three configs
- `SkillValidationStatus` — `'pending' | 'valid' | 'invalid' | 'unknown'`
- `AppSkill` — full skill record interface
- `CreateSkillParams` / `UpdateSkillParams` — CRUD payload types

Unit tests cover type guards for all three union branches, field presence checks, and partial update shapes (13 tests, all passing).