### PR TITLE
feat(planner): add web search guidance to plan-writer and planner prompts

### DIFF
--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -155,6 +155,14 @@ Task(subagent_type: "Explore", prompt: "Explore [area]. I need: [questions]. Ret
 \`\`\`
 Spawn multiple Explore agents **in parallel** to cover different areas. Gather enough context to understand existing patterns, affected areas, dependencies, and overall complexity.
 
+## Optional: Web Research
+
+When the goal involves integrating external technologies, APIs, or libraries that may have recent changes (e.g., after your knowledge cutoff), use \`WebSearch\` to look up current documentation or changelog entries before planning.
+
+- Use \`WebSearch\` for: finding latest API patterns, library versions, breaking changes, or community best practices.
+- Use \`WebFetch\` for: fetching a specific documentation page or GitHub release notes by URL.
+- Do NOT search for general coding patterns you already know — only search when external, up-to-date information would improve plan accuracy.
+
 ## Step 2: Scope Assessment
 
 Based on your exploration, determine the plan structure:
@@ -278,6 +286,8 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@
 git fetch origin && git rebase origin/$DEFAULT_BRANCH
 \`\`\`
 **If the rebase fails with conflicts, stop immediately and report the error** — do NOT plan against a stale codebase
+
+You may also use \`WebSearch\` to verify current technology choices or check for recent breaking changes before spawning the plan-writer.
 
 ## Phase 1: Planning
 

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -131,6 +131,19 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null');
 		});
 
+		it('should mention WebSearch in pre-planning setup section', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			expect(prompt).toContain('WebSearch');
+			// The note should appear in the Pre-Planning Setup section (before Phase 1)
+			const setupIdx = prompt.indexOf('Pre-Planning Setup (MANDATORY)');
+			const webSearchIdx = prompt.indexOf('WebSearch');
+			const phase1Idx = prompt.indexOf('Phase 1: Planning');
+			expect(setupIdx).toBeGreaterThanOrEqual(0);
+			expect(webSearchIdx).toBeGreaterThanOrEqual(0);
+			expect(webSearchIdx).toBeGreaterThan(setupIdx);
+			expect(webSearchIdx).toBeLessThan(phase1Idx);
+		});
+
 		it('should place pre-planning setup before Phase 1 planning', () => {
 			const prompt = buildPlannerSystemPrompt('Build stock app');
 			const syncIdx = prompt.indexOf('Pre-Planning Setup (MANDATORY)');
@@ -243,6 +256,30 @@ describe('planner-agent', () => {
 		it('should instruct to create a feature branch with plan slug', () => {
 			const prompt = buildPlanWriterPrompt();
 			expect(prompt).toContain('git checkout -b plan/<plan_slug>');
+		});
+
+		it('should include optional web research section', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('Optional: Web Research');
+			expect(prompt).toContain('WebSearch');
+			expect(prompt).toContain('WebFetch');
+		});
+
+		it('should position web research section after codebase exploration and before scope assessment', () => {
+			const prompt = buildPlanWriterPrompt();
+			const explorationIdx = prompt.indexOf('Step 1: Codebase Exploration');
+			const webResearchIdx = prompt.indexOf('Optional: Web Research');
+			const scopeIdx = prompt.indexOf('Step 2: Scope Assessment');
+			expect(explorationIdx).toBeGreaterThanOrEqual(0);
+			expect(webResearchIdx).toBeGreaterThanOrEqual(0);
+			expect(scopeIdx).toBeGreaterThanOrEqual(0);
+			expect(explorationIdx).toBeLessThan(webResearchIdx);
+			expect(webResearchIdx).toBeLessThan(scopeIdx);
+		});
+
+		it('should clarify when NOT to use web search', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('Do NOT search');
 		});
 	});
 


### PR DESCRIPTION
Add explicit `WebSearch`/`WebFetch` guidance to both planner prompts:

- `buildPlanWriterPrompt()`: new "Optional: Web Research" section between codebase exploration and scope assessment, explaining when to use each tool and when not to search
- `buildPlannerSystemPrompt()`: one-liner note in the Pre-Planning Setup section so the planner can verify technology choices before spawning the plan-writer

Unit tests added for both prompt changes (positioning + content checks).