### PR TITLE
fix(daemon): skip error classification for tool result messages

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -63,6 +63,7 @@ import {
 } from './message-routing';
 import { createRateLimitBackoff } from './rate-limit-utils';
 import { classifyError } from './error-classifier';
+import { isSDKUserMessage } from '@neokai/shared/sdk/type-guards';
 import { Logger } from '../../logger';
 import {
 	runWorkerExitGate,
@@ -2346,6 +2347,11 @@ export class RoomRuntime {
 					const uuid = 'uuid' in event.message ? (event.message.uuid as string) : null;
 					if (uuid && mirroredUuids.has(uuid)) return;
 					if (uuid) mirroredUuids.add(uuid);
+
+					// Skip tool results — they contain arbitrary file content that can match error
+					// patterns (e.g. test fixtures like "You've hit your limit · resets 11pm") but
+					// are not actual errors from the model
+					if (isSDKUserMessage(event.message)) return;
 
 					// Check for rate limit errors in real-time for both Worker and Leader sessions
 					const messageContent = JSON.stringify(event.message);

--- a/packages/daemon/tests/unit/room/room-runtime-mirroring-usage-limit.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-mirroring-usage-limit.test.ts
@@ -354,6 +354,99 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		});
 	});
 
+	describe('tool result messages (user type) should not trigger false positives', () => {
+		it('does not detect usage_limit in user message (tool result content)', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group } = await spawnGroup();
+
+			// Simulate a tool result containing the usage_limit text as fixture data
+			// This should NOT trigger the usage_limit detection because user messages
+			// are tool results, not actual model error output
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: {
+					uuid: 'tool-result-1',
+					type: 'user',
+					role: 'user',
+					content: [
+						{
+							type: 'tool_result',
+							tool_use_id: 'tool_123',
+							content: `File content: const USAGE_LIMIT_MSG = "${USAGE_LIMIT_MSG}"`,
+						},
+					],
+				},
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Should NOT be rate limited — tool result content is not an actual error
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(false);
+		});
+
+		it('does not detect usage_limit in user message for leader session', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: () => ({}) as GlobalSettings,
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.leaderSessionId,
+				message: {
+					uuid: 'tool-result-leader-1',
+					type: 'user',
+					role: 'user',
+					content: [
+						{
+							type: 'tool_result',
+							tool_use_id: 'tool_456',
+							content: `Reading test fixture: "${USAGE_LIMIT_MSG}"`,
+						},
+					],
+				},
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			expect(ctx.groupRepo.isRateLimited(group.id)).toBe(false);
+		});
+
+		it('does not trigger fallback switch for user message with usage_limit text', async () => {
+			ctx = createRuntimeTestContext({
+				getGlobalSettings: withFallbackModel(),
+				messageHub: makeMessageHubMock({}),
+			});
+
+			const { group } = await spawnGroup();
+
+			ctx.hub.fire('sdk.message', {
+				sessionId: group.workerSessionId,
+				message: {
+					uuid: 'tool-result-2',
+					type: 'user',
+					role: 'user',
+					content: [
+						{
+							type: 'tool_result',
+							tool_use_id: 'tool_789',
+							content: `"You've hit your limit · resets 11pm (America/New_York)"`,
+						},
+					],
+				},
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Should NOT have attempted any model switch
+			const switchCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'switchModel');
+			expect(switchCalls).toHaveLength(0);
+		});
+	});
+
 	describe('leader session mirroring', () => {
 		it('detects usage_limit in leader messages when no fallback', async () => {
 			ctx = createRuntimeTestContext({


### PR DESCRIPTION
## Summary

- The `setupMirroring` handler was running `classifyError()` on ALL `sdk.message` events, including user messages that are tool results
- Tool results can contain arbitrary text from file reads, including test fixtures like `"You've hit your limit · resets 11pm (America/New_York)"` which would falsely trigger usage_limit detection
- Now skips error classification for user messages (`type: 'user'`) since tool results are data returned from tool calls, not actual model errors

## Test plan

- [x] Added 3 unit tests to verify user messages with usage_limit text don't trigger false positives
- [x] All existing tests pass (21 tests in room-runtime-mirroring-usage-limit.test.ts, 37 tests in error-classifier.test.ts)