### PR TITLE
feat(daemon): SkillRepository (SQLite) and SkillsManager

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -26,6 +26,7 @@ import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
 import { JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
 import { AppMcpLifecycleManager, seedDefaultMcpEntries } from './lib/mcp';
 import { FileIndex } from './lib/file-index';
+import { SkillsManager } from './lib/skills-manager';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -75,6 +76,8 @@ export interface DaemonAppContext {
 	jobProcessor: JobQueueProcessor;
 	/** Application-level MCP lifecycle manager — converts registry entries to SDK configs */
 	appMcpManager: AppMcpLifecycleManager;
+	/** Application-level Skills manager — registry CRUD and validation */
+	skillsManager: SkillsManager;
 	/** Workspace file index for fast fuzzy file/folder search */
 	fileIndex: FileIndex;
 	/**
@@ -271,6 +274,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Seed default MCP entries (idempotent — skips entries that already exist)
 	seedDefaultMcpEntries(db);
+
+	// Instantiate Skills manager and initialize built-in skills
+	const skillsManager = new SkillsManager(db.skills, db.appMcpServers);
+	skillsManager.initializeBuiltins();
 
 	// Initialize workspace file index (non-blocking — init runs in the background)
 	const fileIndex = new FileIndex(config.workspaceRoot);
@@ -552,6 +559,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		jobQueue,
 		jobProcessor,
 		appMcpManager,
+		skillsManager,
 		fileIndex,
 		cleanup,
 	};

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -32,7 +32,14 @@ export class SkillsManager {
 	}
 
 	addSkill(params: CreateSkillParams): AppSkill {
+		// Validate sourceType/config consistency and security-sensitive fields
 		this.validateSkillConfig(params.sourceType, params.config);
+
+		// Enforce name uniqueness with a user-friendly error
+		const existing = this.repo.getByName(params.name);
+		if (existing) {
+			throw new Error(`A skill named "${params.name}" already exists`);
+		}
 
 		const skill: AppSkill = {
 			id: generateUUID(),
@@ -48,7 +55,11 @@ export class SkillsManager {
 		};
 
 		this.repo.insert(skill);
-		return this.repo.get(skill.id)!;
+		const inserted = this.repo.get(skill.id);
+		if (!inserted) {
+			throw new Error(`Failed to insert skill "${params.name}"`);
+		}
+		return inserted;
 	}
 
 	updateSkill(id: string, params: UpdateSkillParams): AppSkill {
@@ -74,8 +85,17 @@ export class SkillsManager {
 		return this.repo.get(id)!;
 	}
 
-	setSkillValidationStatus(id: string, status: SkillValidationStatus): void {
+	/**
+	 * Set the validation status for a skill (called by the async validation job).
+	 * Throws if the skill does not exist so job failures are surfaced, not silenced.
+	 */
+	setSkillValidationStatus(id: string, status: SkillValidationStatus): AppSkill {
+		const existing = this.repo.get(id);
+		if (!existing) {
+			throw new Error(`Skill not found: ${id}`);
+		}
 		this.repo.setValidationStatus(id, status);
+		return this.repo.get(id)!;
 	}
 
 	/**
@@ -110,8 +130,17 @@ export class SkillsManager {
 	/**
 	 * Validate source-type-specific config fields for security.
 	 * Throws a descriptive Error on validation failure.
+	 *
+	 * Checks performed:
+	 * 1. sourceType must match config.type (prevents mismatched payloads)
+	 * 2. Source-type-specific field constraints
 	 */
 	private validateSkillConfig(sourceType: SkillSourceType, config: AppSkillConfig): void {
+		// Explicit sourceType/config.type consistency check
+		if (sourceType !== config.type) {
+			throw new Error(`sourceType "${sourceType}" must match config.type "${config.type}"`);
+		}
+
 		if (config.type === 'plugin') {
 			const { pluginPath } = config;
 			if (!pluginPath || pluginPath.trim() === '') {
@@ -120,7 +149,8 @@ export class SkillsManager {
 			if (!pluginPath.startsWith('/')) {
 				throw new Error('plugin skill: pluginPath must be an absolute path (starts with /)');
 			}
-			if (pluginPath.includes('../')) {
+			// Reject any path that contains '..' as a segment (handles /a/../b and /a/b/..)
+			if (pluginPath.split('/').some((seg) => seg === '..')) {
 				throw new Error('plugin skill: pluginPath must not contain path traversal sequences (../)');
 			}
 		} else if (config.type === 'mcp_server') {
@@ -140,9 +170,9 @@ export class SkillsManager {
 				throw new Error('builtin skill: commandName must not be empty');
 			}
 		} else {
-			// Exhaustive check — sourceType drives config.type in valid usage
-			const _: never = config;
-			throw new Error(`Unknown skill config type: ${sourceType}`);
+			// Exhaustive type guard
+			const _exhaustive: never = config;
+			throw new Error(`Unknown skill config type: ${(_exhaustive as AppSkillConfig).type}`);
 		}
 	}
 }

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -1,0 +1,148 @@
+/**
+ * SkillsManager
+ *
+ * Service layer for the application-level Skills registry.
+ * Enforces input validation for security-sensitive fields before persisting.
+ */
+
+import { generateUUID } from '@neokai/shared';
+import type {
+	AppSkill,
+	AppSkillConfig,
+	CreateSkillParams,
+	UpdateSkillParams,
+	SkillSourceType,
+	SkillValidationStatus,
+} from '@neokai/shared';
+import type { SkillRepository } from '../storage/repositories/skill-repository';
+import type { AppMcpServerRepository } from '../storage/repositories/app-mcp-server-repository';
+
+export class SkillsManager {
+	constructor(
+		private repo: SkillRepository,
+		private appMcpServerRepo: AppMcpServerRepository
+	) {}
+
+	listSkills(): AppSkill[] {
+		return this.repo.findAll();
+	}
+
+	getSkill(id: string): AppSkill | null {
+		return this.repo.get(id);
+	}
+
+	addSkill(params: CreateSkillParams): AppSkill {
+		this.validateSkillConfig(params.sourceType, params.config);
+
+		const skill: AppSkill = {
+			id: generateUUID(),
+			name: params.name,
+			displayName: params.displayName,
+			description: params.description,
+			sourceType: params.sourceType,
+			config: params.config,
+			enabled: params.enabled,
+			builtIn: false,
+			validationStatus: params.validationStatus ?? 'pending',
+			createdAt: Date.now(),
+		};
+
+		this.repo.insert(skill);
+		return this.repo.get(skill.id)!;
+	}
+
+	updateSkill(id: string, params: UpdateSkillParams): AppSkill {
+		const existing = this.repo.get(id);
+		if (!existing) {
+			throw new Error(`Skill not found: ${id}`);
+		}
+
+		if (params.config !== undefined) {
+			this.validateSkillConfig(existing.sourceType, params.config);
+		}
+
+		this.repo.update(id, params);
+		return this.repo.get(id)!;
+	}
+
+	setSkillEnabled(id: string, enabled: boolean): AppSkill {
+		const existing = this.repo.get(id);
+		if (!existing) {
+			throw new Error(`Skill not found: ${id}`);
+		}
+		this.repo.setEnabled(id, enabled);
+		return this.repo.get(id)!;
+	}
+
+	setSkillValidationStatus(id: string, status: SkillValidationStatus): void {
+		this.repo.setValidationStatus(id, status);
+	}
+
+	/**
+	 * Remove a skill by ID.
+	 * Returns false if the skill is built-in or not found.
+	 */
+	removeSkill(id: string): boolean {
+		const existing = this.repo.get(id);
+		if (!existing) return false;
+		if (existing.builtIn) return false;
+		return this.repo.delete(id);
+	}
+
+	getEnabledSkills(): AppSkill[] {
+		return this.repo.findEnabled();
+	}
+
+	/**
+	 * Upsert default built-in skills on startup.
+	 * For mcp_server type built-ins, ensures backing app_mcp_servers entries exist.
+	 */
+	initializeBuiltins(): void {
+		// No default built-in skills defined yet — reserved for future use.
+		// Implementors: call this.repo.findAll() to check for existing entries,
+		// then this.repo.insert() for any that are missing.
+	}
+
+	// ---------------------------------------------------------------------------
+	// Private helpers
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Validate source-type-specific config fields for security.
+	 * Throws a descriptive Error on validation failure.
+	 */
+	private validateSkillConfig(sourceType: SkillSourceType, config: AppSkillConfig): void {
+		if (config.type === 'plugin') {
+			const { pluginPath } = config;
+			if (!pluginPath || pluginPath.trim() === '') {
+				throw new Error('plugin skill: pluginPath must not be empty');
+			}
+			if (!pluginPath.startsWith('/')) {
+				throw new Error('plugin skill: pluginPath must be an absolute path (starts with /)');
+			}
+			if (pluginPath.includes('../')) {
+				throw new Error('plugin skill: pluginPath must not contain path traversal sequences (../)');
+			}
+		} else if (config.type === 'mcp_server') {
+			const { appMcpServerId } = config;
+			if (!appMcpServerId || appMcpServerId.trim() === '') {
+				throw new Error('mcp_server skill: appMcpServerId must not be empty');
+			}
+			const server = this.appMcpServerRepo.get(appMcpServerId);
+			if (!server) {
+				throw new Error(
+					`mcp_server skill: app_mcp_servers entry not found for id "${appMcpServerId}"`
+				);
+			}
+		} else if (config.type === 'builtin') {
+			const { commandName } = config;
+			if (!commandName || commandName.trim() === '') {
+				throw new Error('builtin skill: commandName must not be empty');
+			}
+		} else {
+			// Exhaustive check — sourceType drives config.type in valid usage
+			const _: never = config;
+			throw new Error(`Unknown skill config type: ${sourceType}`);
+		}
+	}
+}

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -36,6 +36,7 @@ import { JobQueueRepository } from './repositories/job-queue-repository';
 import { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 import { TaskRepository } from './repositories/task-repository';
 import { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
+import { SkillRepository } from './repositories/skill-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -59,6 +60,7 @@ export { TaskRepository } from './repositories/task-repository';
 export { SpaceAgentRepository } from './repositories/space-agent-repository';
 export { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 export { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
+export { SkillRepository } from './repositories/skill-repository';
 
 /**
  * Database facade class that maintains backward compatibility with the original Database class.
@@ -78,6 +80,7 @@ export class Database {
 	private appMcpServerRepo!: AppMcpServerRepository;
 	private taskRepo!: TaskRepository;
 	private roomMcpEnablementRepo!: RoomMcpEnablementRepository;
+	private skillRepo!: SkillRepository;
 	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
@@ -101,6 +104,7 @@ export class Database {
 		this.jobQueueRepo = new JobQueueRepository(db);
 		this.appMcpServerRepo = new AppMcpServerRepository(db, reactiveDb);
 		this.roomMcpEnablementRepo = new RoomMcpEnablementRepository(db, reactiveDb);
+		this.skillRepo = new SkillRepository(db, reactiveDb);
 	}
 
 	// ============================================================================
@@ -457,6 +461,13 @@ export class Database {
 	 */
 	get roomMcpEnablement(): RoomMcpEnablementRepository {
 		return this.roomMcpEnablementRepo;
+	}
+
+	/**
+	 * Get the application-level Skills repository
+	 */
+	get skills(): SkillRepository {
+		return this.skillRepo;
 	}
 
 	close(): void {

--- a/packages/daemon/src/storage/repositories/skill-repository.ts
+++ b/packages/daemon/src/storage/repositories/skill-repository.ts
@@ -1,0 +1,202 @@
+/**
+ * SkillRepository
+ *
+ * CRUD operations for the application-level Skills registry.
+ * Each write method calls reactiveDb.notifyChange('skills') so that
+ * LiveQueryEngine can invalidate frontend subscriptions on every registry change.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type {
+	AppSkill,
+	AppSkillConfig,
+	SkillSourceType,
+	SkillValidationStatus,
+} from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+
+// ---------------------------------------------------------------------------
+// Internal row type (mirrors SQLite columns)
+// ---------------------------------------------------------------------------
+
+interface SkillRow {
+	id: string;
+	name: string;
+	display_name: string;
+	description: string;
+	source_type: string;
+	config: string;
+	enabled: number;
+	built_in: number;
+	validation_status: string;
+	created_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToSkill(row: SkillRow): AppSkill {
+	return {
+		id: row.id,
+		name: row.name,
+		displayName: row.display_name,
+		description: row.description,
+		sourceType: row.source_type as SkillSourceType,
+		config: JSON.parse(row.config) as AppSkillConfig,
+		enabled: row.enabled === 1,
+		builtIn: row.built_in === 1,
+		validationStatus: row.validation_status as SkillValidationStatus,
+		createdAt: row.created_at,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+export class SkillRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb: ReactiveDatabase
+	) {}
+
+	/**
+	 * Ensure the skills table exists. Called during DB initialization.
+	 * Idempotent via CREATE TABLE IF NOT EXISTS.
+	 */
+	ensureTable(): void {
+		this.db.exec(`
+      CREATE TABLE IF NOT EXISTS skills (
+        id TEXT PRIMARY KEY,
+        name TEXT UNIQUE NOT NULL,
+        display_name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        source_type TEXT NOT NULL,
+        config TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        built_in INTEGER NOT NULL DEFAULT 0,
+        validation_status TEXT NOT NULL DEFAULT 'pending',
+        created_at INTEGER NOT NULL
+      )
+    `);
+	}
+
+	/**
+	 * List all skills, ordered by created_at ascending.
+	 */
+	findAll(): AppSkill[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM skills ORDER BY created_at ASC`)
+			.all() as SkillRow[];
+		return rows.map(rowToSkill);
+	}
+
+	/**
+	 * Get a skill by ID. Returns null if not found.
+	 */
+	get(id: string): AppSkill | null {
+		const row = this.db.prepare(`SELECT * FROM skills WHERE id = ?`).get(id) as
+			| SkillRow
+			| undefined;
+		return row ? rowToSkill(row) : null;
+	}
+
+	/**
+	 * List only enabled skills, ordered by created_at ascending.
+	 */
+	findEnabled(): AppSkill[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM skills WHERE enabled = 1 ORDER BY created_at ASC`)
+			.all() as SkillRow[];
+		return rows.map(rowToSkill);
+	}
+
+	/**
+	 * Insert a new skill record.
+	 */
+	insert(skill: AppSkill): void {
+		this.db
+			.prepare(
+				`INSERT INTO skills
+         (id, name, display_name, description, source_type, config, enabled, built_in, validation_status, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				skill.id,
+				skill.name,
+				skill.displayName,
+				skill.description,
+				skill.sourceType,
+				JSON.stringify(skill.config),
+				skill.enabled ? 1 : 0,
+				skill.builtIn ? 1 : 0,
+				skill.validationStatus,
+				skill.createdAt
+			);
+		this.reactiveDb.notifyChange('skills');
+	}
+
+	/**
+	 * Update mutable fields on an existing skill.
+	 */
+	update(id: string, fields: Partial<AppSkill>): void {
+		const setClauses: string[] = [];
+		const values: (string | number | null)[] = [];
+
+		if (fields.displayName !== undefined) {
+			setClauses.push('display_name = ?');
+			values.push(fields.displayName);
+		}
+		if (fields.description !== undefined) {
+			setClauses.push('description = ?');
+			values.push(fields.description);
+		}
+		if (fields.enabled !== undefined) {
+			setClauses.push('enabled = ?');
+			values.push(fields.enabled ? 1 : 0);
+		}
+		if (fields.config !== undefined) {
+			setClauses.push('config = ?');
+			values.push(JSON.stringify(fields.config));
+		}
+		if (fields.validationStatus !== undefined) {
+			setClauses.push('validation_status = ?');
+			values.push(fields.validationStatus);
+		}
+
+		if (setClauses.length === 0) return;
+
+		values.push(id);
+		this.db.prepare(`UPDATE skills SET ${setClauses.join(', ')} WHERE id = ?`).run(...values);
+		this.reactiveDb.notifyChange('skills');
+	}
+
+	/**
+	 * Toggle the enabled flag for a skill. Targeted single-column UPDATE.
+	 */
+	setEnabled(id: string, enabled: boolean): void {
+		this.db.prepare(`UPDATE skills SET enabled = ? WHERE id = ?`).run(enabled ? 1 : 0, id);
+		this.reactiveDb.notifyChange('skills');
+	}
+
+	/**
+	 * Set the validation_status for a skill. Used by the async validation job.
+	 */
+	setValidationStatus(id: string, status: SkillValidationStatus): void {
+		this.db.prepare(`UPDATE skills SET validation_status = ? WHERE id = ?`).run(status, id);
+		this.reactiveDb.notifyChange('skills');
+	}
+
+	/**
+	 * Delete a skill by ID. Returns true if a row was deleted.
+	 */
+	delete(id: string): boolean {
+		const result = this.db.prepare(`DELETE FROM skills WHERE id = ?`).run(id);
+		const deleted = result.changes > 0;
+		if (deleted) {
+			this.reactiveDb.notifyChange('skills');
+		}
+		return deleted;
+	}
+}

--- a/packages/daemon/src/storage/repositories/skill-repository.ts
+++ b/packages/daemon/src/storage/repositories/skill-repository.ts
@@ -12,6 +12,7 @@ import type {
 	AppSkillConfig,
 	SkillSourceType,
 	SkillValidationStatus,
+	UpdateSkillParams,
 } from '@neokai/shared';
 import type { ReactiveDatabase } from '../reactive-database';
 
@@ -62,27 +63,6 @@ export class SkillRepository {
 	) {}
 
 	/**
-	 * Ensure the skills table exists. Called during DB initialization.
-	 * Idempotent via CREATE TABLE IF NOT EXISTS.
-	 */
-	ensureTable(): void {
-		this.db.exec(`
-      CREATE TABLE IF NOT EXISTS skills (
-        id TEXT PRIMARY KEY,
-        name TEXT UNIQUE NOT NULL,
-        display_name TEXT NOT NULL,
-        description TEXT NOT NULL,
-        source_type TEXT NOT NULL,
-        config TEXT NOT NULL,
-        enabled INTEGER NOT NULL DEFAULT 1,
-        built_in INTEGER NOT NULL DEFAULT 0,
-        validation_status TEXT NOT NULL DEFAULT 'pending',
-        created_at INTEGER NOT NULL
-      )
-    `);
-	}
-
-	/**
 	 * List all skills, ordered by created_at ascending.
 	 */
 	findAll(): AppSkill[] {
@@ -97,6 +77,16 @@ export class SkillRepository {
 	 */
 	get(id: string): AppSkill | null {
 		const row = this.db.prepare(`SELECT * FROM skills WHERE id = ?`).get(id) as
+			| SkillRow
+			| undefined;
+		return row ? rowToSkill(row) : null;
+	}
+
+	/**
+	 * Get a skill by name. Returns null if not found.
+	 */
+	getByName(name: string): AppSkill | null {
+		const row = this.db.prepare(`SELECT * FROM skills WHERE name = ?`).get(name) as
 			| SkillRow
 			| undefined;
 		return row ? rowToSkill(row) : null;
@@ -138,9 +128,10 @@ export class SkillRepository {
 	}
 
 	/**
-	 * Update mutable fields on an existing skill.
+	 * Update user-editable fields on an existing skill (mirrors UpdateSkillParams).
+	 * Immutable fields (name, sourceType, builtIn, createdAt) are not settable here.
 	 */
-	update(id: string, fields: Partial<AppSkill>): void {
+	update(id: string, fields: UpdateSkillParams): void {
 		const setClauses: string[] = [];
 		const values: (string | number | null)[] = [];
 
@@ -160,10 +151,6 @@ export class SkillRepository {
 			setClauses.push('config = ?');
 			values.push(JSON.stringify(fields.config));
 		}
-		if (fields.validationStatus !== undefined) {
-			setClauses.push('validation_status = ?');
-			values.push(fields.validationStatus);
-		}
 
 		if (setClauses.length === 0) return;
 
@@ -182,10 +169,17 @@ export class SkillRepository {
 
 	/**
 	 * Set the validation_status for a skill. Used by the async validation job.
+	 * Only fires notifyChange when a row was actually updated.
 	 */
-	setValidationStatus(id: string, status: SkillValidationStatus): void {
-		this.db.prepare(`UPDATE skills SET validation_status = ? WHERE id = ?`).run(status, id);
-		this.reactiveDb.notifyChange('skills');
+	setValidationStatus(id: string, status: SkillValidationStatus): boolean {
+		const result = this.db
+			.prepare(`UPDATE skills SET validation_status = ? WHERE id = ?`)
+			.run(status, id);
+		const changed = result.changes > 0;
+		if (changed) {
+			this.reactiveDb.notifyChange('skills');
+		}
+		return changed;
 	}
 
 	/**

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -29,6 +29,8 @@ export { runMigration51 } from './migrations';
 export { runMigration55 } from './migrations';
 // knip-ignore-next-line
 export { runMigration56 } from './migrations';
+// knip-ignore-next-line
+export { runMigration57 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -363,6 +365,22 @@ export function createTables(db: BunDatabase): void {
         server_id TEXT NOT NULL REFERENCES app_mcp_servers(id) ON DELETE CASCADE,
         enabled INTEGER NOT NULL DEFAULT 1,
         PRIMARY KEY (room_id, server_id)
+      )
+    `);
+
+	// Application-level Skills registry
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS skills (
+        id TEXT PRIMARY KEY,
+        name TEXT UNIQUE NOT NULL,
+        display_name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        source_type TEXT NOT NULL,
+        config TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        built_in INTEGER NOT NULL DEFAULT 0,
+        validation_status TEXT NOT NULL DEFAULT 'pending',
+        created_at INTEGER NOT NULL
       )
     `);
 

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -229,6 +229,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 56: Expand assigned_agent CHECK constraint to include 'planner'.
 	// SQLite cannot ALTER a CHECK constraint directly, so we recreate the table.
 	runMigration56(db);
+
+	// Migration 57: Create skills table for application-level Skills registry.
+	// Idempotent via CREATE TABLE IF NOT EXISTS.
+	runMigration57(db);
 }
 
 /**
@@ -3706,4 +3710,26 @@ export function runMigration56(db: BunDatabase): void {
 	db.exec(
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_room_short_id ON tasks(room_id, short_id) WHERE short_id IS NOT NULL`
 	);
+}
+
+/**
+ * Migration 57: Create skills table for application-level Skills registry.
+ * Skills are available globally to any room or session that enables them.
+ * Idempotent via CREATE TABLE IF NOT EXISTS.
+ */
+export function runMigration57(db: BunDatabase): void {
+	db.exec(`
+    CREATE TABLE IF NOT EXISTS skills (
+      id TEXT PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL,
+      display_name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      source_type TEXT NOT NULL,
+      config TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      built_in INTEGER NOT NULL DEFAULT 0,
+      validation_status TEXT NOT NULL DEFAULT 'pending',
+      created_at INTEGER NOT NULL
+    )
+  `);
 }

--- a/packages/daemon/tests/unit/skills-manager.test.ts
+++ b/packages/daemon/tests/unit/skills-manager.test.ts
@@ -1,0 +1,589 @@
+/**
+ * Unit Tests for SkillRepository and SkillsManager
+ *
+ * Covers:
+ * - CRUD operations with in-memory SQLite
+ * - Built-in skill deletion protection
+ * - Persistence across load cycles
+ * - getEnabledSkills() filtering
+ * - All validation rules (plugin path traversal, mcp_server ref, builtin commandName)
+ * - Valid configs pass validation
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../src/storage/schema';
+import { SkillRepository } from '../../src/storage/repositories/skill-repository';
+import { AppMcpServerRepository } from '../../src/storage/repositories/app-mcp-server-repository';
+import { SkillsManager } from '../../src/lib/skills-manager';
+import { noOpReactiveDb } from '../helpers/reactive-database';
+import type { AppSkill } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	createTables(db);
+	return db;
+}
+
+function makeRepo(db: BunDatabase): SkillRepository {
+	return new SkillRepository(db, noOpReactiveDb);
+}
+
+function makeMcpRepo(db: BunDatabase): AppMcpServerRepository {
+	return new AppMcpServerRepository(db, noOpReactiveDb);
+}
+
+function makeManager(db: BunDatabase): { mgr: SkillsManager; mcpRepo: AppMcpServerRepository } {
+	const mcpRepo = makeMcpRepo(db);
+	const skillRepo = makeRepo(db);
+	const mgr = new SkillsManager(skillRepo, mcpRepo);
+	return { mgr, mcpRepo };
+}
+
+// ---------------------------------------------------------------------------
+// SkillRepository tests
+// ---------------------------------------------------------------------------
+
+describe('SkillRepository', () => {
+	let db: BunDatabase;
+	let repo: SkillRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		repo = makeRepo(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('findAll returns empty array on fresh DB', () => {
+		expect(repo.findAll()).toEqual([]);
+	});
+
+	test('insert and get round-trip', () => {
+		const skill: AppSkill = {
+			id: 'skill-1',
+			name: 'test-skill',
+			displayName: 'Test Skill',
+			description: 'A test skill',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'test-cmd' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'pending',
+			createdAt: Date.now(),
+		};
+		repo.insert(skill);
+
+		const found = repo.get('skill-1');
+		expect(found).not.toBeNull();
+		expect(found!.id).toBe('skill-1');
+		expect(found!.name).toBe('test-skill');
+		expect(found!.displayName).toBe('Test Skill');
+		expect(found!.config).toEqual({ type: 'builtin', commandName: 'test-cmd' });
+		expect(found!.enabled).toBe(true);
+		expect(found!.builtIn).toBe(false);
+		expect(found!.validationStatus).toBe('pending');
+	});
+
+	test('get returns null for unknown id', () => {
+		expect(repo.get('nonexistent')).toBeNull();
+	});
+
+	test('findAll returns all inserted skills', () => {
+		const base = {
+			description: 'd',
+			sourceType: 'builtin' as const,
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'pending' as const,
+			createdAt: 1,
+		};
+		repo.insert({
+			...base,
+			id: 'a',
+			name: 'skill-a',
+			displayName: 'A',
+			config: { type: 'builtin', commandName: 'cmd-a' },
+		});
+		repo.insert({
+			...base,
+			id: 'b',
+			name: 'skill-b',
+			displayName: 'B',
+			config: { type: 'builtin', commandName: 'cmd-b' },
+		});
+
+		const all = repo.findAll();
+		expect(all).toHaveLength(2);
+		expect(all.map((s) => s.id)).toContain('a');
+		expect(all.map((s) => s.id)).toContain('b');
+	});
+
+	test('findEnabled returns only enabled skills', () => {
+		const base = {
+			description: 'd',
+			sourceType: 'builtin' as const,
+			builtIn: false,
+			validationStatus: 'pending' as const,
+			createdAt: 1,
+		};
+		repo.insert({
+			...base,
+			id: 'e1',
+			name: 'enabled-1',
+			displayName: 'E1',
+			config: { type: 'builtin', commandName: 'c1' },
+			enabled: true,
+		});
+		repo.insert({
+			...base,
+			id: 'e2',
+			name: 'disabled-1',
+			displayName: 'D1',
+			config: { type: 'builtin', commandName: 'c2' },
+			enabled: false,
+		});
+
+		const enabled = repo.findEnabled();
+		expect(enabled).toHaveLength(1);
+		expect(enabled[0].id).toBe('e1');
+	});
+
+	test('update modifies displayName and description', () => {
+		const skill: AppSkill = {
+			id: 'upd-1',
+			name: 'upd',
+			displayName: 'Old',
+			description: 'Old desc',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'pending',
+			createdAt: 1,
+		};
+		repo.insert(skill);
+		repo.update('upd-1', { displayName: 'New Name', description: 'New desc' });
+
+		const found = repo.get('upd-1');
+		expect(found!.displayName).toBe('New Name');
+		expect(found!.description).toBe('New desc');
+	});
+
+	test('setEnabled toggles enabled flag', () => {
+		const skill: AppSkill = {
+			id: 'tog-1',
+			name: 'tog',
+			displayName: 'Tog',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'pending',
+			createdAt: 1,
+		};
+		repo.insert(skill);
+		repo.setEnabled('tog-1', false);
+		expect(repo.get('tog-1')!.enabled).toBe(false);
+		repo.setEnabled('tog-1', true);
+		expect(repo.get('tog-1')!.enabled).toBe(true);
+	});
+
+	test('setValidationStatus updates validation_status', () => {
+		const skill: AppSkill = {
+			id: 'val-1',
+			name: 'val',
+			displayName: 'Val',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'pending',
+			createdAt: 1,
+		};
+		repo.insert(skill);
+		repo.setValidationStatus('val-1', 'valid');
+		expect(repo.get('val-1')!.validationStatus).toBe('valid');
+	});
+
+	test('delete removes a skill and returns true', () => {
+		const skill: AppSkill = {
+			id: 'del-1',
+			name: 'del',
+			displayName: 'Del',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'pending',
+			createdAt: 1,
+		};
+		repo.insert(skill);
+		expect(repo.delete('del-1')).toBe(true);
+		expect(repo.get('del-1')).toBeNull();
+	});
+
+	test('delete returns false for unknown id', () => {
+		expect(repo.delete('ghost')).toBe(false);
+	});
+
+	test('persistence across load cycles — re-open same DB path', () => {
+		// Use a temp file path to test actual persistence
+		const tmpPath = `/tmp/skills-test-${Date.now()}.db`;
+		const db1 = new BunDatabase(tmpPath);
+		createTables(db1);
+		const repo1 = new SkillRepository(db1, noOpReactiveDb);
+		repo1.insert({
+			id: 'persist-1',
+			name: 'persist',
+			displayName: 'Persist',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'p-cmd' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'valid',
+			createdAt: 42,
+		});
+		db1.close();
+
+		// Re-open
+		const db2 = new BunDatabase(tmpPath);
+		const repo2 = new SkillRepository(db2, noOpReactiveDb);
+		const found = repo2.get('persist-1');
+		expect(found).not.toBeNull();
+		expect(found!.name).toBe('persist');
+		expect(found!.validationStatus).toBe('valid');
+		db2.close();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// SkillsManager tests
+// ---------------------------------------------------------------------------
+
+describe('SkillsManager', () => {
+	let db: BunDatabase;
+	let mgr: SkillsManager;
+	let mcpRepo: AppMcpServerRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		({ mgr, mcpRepo } = makeManager(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// --- CRUD ---
+
+	test('addSkill creates a skill with generated id and createdAt', () => {
+		const skill = mgr.addSkill({
+			name: 'my-skill',
+			displayName: 'My Skill',
+			description: 'Does something',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'my-cmd' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+
+		expect(skill.id).toBeTruthy();
+		expect(skill.name).toBe('my-skill');
+		expect(skill.builtIn).toBe(false);
+		expect(skill.createdAt).toBeGreaterThan(0);
+	});
+
+	test('listSkills returns all skills', () => {
+		mgr.addSkill({
+			name: 's1',
+			displayName: 'S1',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'c1' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		mgr.addSkill({
+			name: 's2',
+			displayName: 'S2',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'c2' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		expect(mgr.listSkills()).toHaveLength(2);
+	});
+
+	test('getSkill returns null for unknown id', () => {
+		expect(mgr.getSkill('unknown')).toBeNull();
+	});
+
+	test('updateSkill modifies displayName', () => {
+		const skill = mgr.addSkill({
+			name: 'upd',
+			displayName: 'Old',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		const updated = mgr.updateSkill(skill.id, { displayName: 'New' });
+		expect(updated.displayName).toBe('New');
+	});
+
+	test('updateSkill throws for unknown id', () => {
+		expect(() => mgr.updateSkill('ghost', { displayName: 'x' })).toThrow('not found');
+	});
+
+	test('setSkillEnabled toggles enabled', () => {
+		const skill = mgr.addSkill({
+			name: 'toggle',
+			displayName: 'T',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		const disabled = mgr.setSkillEnabled(skill.id, false);
+		expect(disabled.enabled).toBe(false);
+	});
+
+	test('setSkillValidationStatus updates status', () => {
+		const skill = mgr.addSkill({
+			name: 'valst',
+			displayName: 'V',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		mgr.setSkillValidationStatus(skill.id, 'valid');
+		expect(mgr.getSkill(skill.id)!.validationStatus).toBe('valid');
+	});
+
+	test('getEnabledSkills filters disabled skills', () => {
+		mgr.addSkill({
+			name: 'on',
+			displayName: 'On',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'c1' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		const off = mgr.addSkill({
+			name: 'off',
+			displayName: 'Off',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'c2' },
+			enabled: false,
+			validationStatus: 'pending',
+		});
+		const enabled = mgr.getEnabledSkills();
+		expect(enabled.map((s) => s.id)).not.toContain(off.id);
+		expect(enabled).toHaveLength(1);
+	});
+
+	// --- Built-in protection ---
+
+	test('removeSkill returns false for built-in skill', () => {
+		// Insert a built-in skill directly via repo
+		const repo = makeRepo(db);
+		repo.insert({
+			id: 'builtin-1',
+			name: 'bi',
+			displayName: 'BI',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			builtIn: true,
+			validationStatus: 'valid',
+			createdAt: Date.now(),
+		});
+		expect(mgr.removeSkill('builtin-1')).toBe(false);
+		expect(mgr.getSkill('builtin-1')).not.toBeNull();
+	});
+
+	test('removeSkill returns false for unknown id', () => {
+		expect(mgr.removeSkill('ghost')).toBe(false);
+	});
+
+	test('removeSkill deletes non-built-in skill', () => {
+		const skill = mgr.addSkill({
+			name: 'rem',
+			displayName: 'R',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		expect(mgr.removeSkill(skill.id)).toBe(true);
+		expect(mgr.getSkill(skill.id)).toBeNull();
+	});
+
+	// --- Validation: plugin ---
+
+	test('addSkill with plugin: valid absolute path passes', () => {
+		const skill = mgr.addSkill({
+			name: 'plugin-ok',
+			displayName: 'P',
+			description: 'd',
+			sourceType: 'plugin',
+			config: { type: 'plugin', pluginPath: '/usr/local/plugins/myplugin' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		expect(skill.name).toBe('plugin-ok');
+	});
+
+	test('addSkill with plugin: empty pluginPath throws', () => {
+		expect(() =>
+			mgr.addSkill({
+				name: 'plugin-empty',
+				displayName: 'P',
+				description: 'd',
+				sourceType: 'plugin',
+				config: { type: 'plugin', pluginPath: '' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('pluginPath must not be empty');
+	});
+
+	test('addSkill with plugin: relative path throws', () => {
+		expect(() =>
+			mgr.addSkill({
+				name: 'plugin-rel',
+				displayName: 'P',
+				description: 'd',
+				sourceType: 'plugin',
+				config: { type: 'plugin', pluginPath: 'relative/path' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('absolute path');
+	});
+
+	test('addSkill with plugin: path traversal throws', () => {
+		expect(() =>
+			mgr.addSkill({
+				name: 'plugin-traverse',
+				displayName: 'P',
+				description: 'd',
+				sourceType: 'plugin',
+				config: { type: 'plugin', pluginPath: '/plugins/../etc/passwd' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('../');
+	});
+
+	// --- Validation: mcp_server ---
+
+	test('addSkill with mcp_server: valid appMcpServerId passes', () => {
+		const server = mcpRepo.create({ name: 'brave', sourceType: 'stdio', command: 'npx' });
+		const skill = mgr.addSkill({
+			name: 'mcp-ok',
+			displayName: 'MCP',
+			description: 'd',
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: server.id },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		expect(skill.name).toBe('mcp-ok');
+	});
+
+	test('addSkill with mcp_server: non-existent appMcpServerId throws', () => {
+		expect(() =>
+			mgr.addSkill({
+				name: 'mcp-bad',
+				displayName: 'MCP',
+				description: 'd',
+				sourceType: 'mcp_server',
+				config: { type: 'mcp_server', appMcpServerId: 'does-not-exist' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('not found');
+	});
+
+	test('addSkill with mcp_server: empty appMcpServerId throws', () => {
+		expect(() =>
+			mgr.addSkill({
+				name: 'mcp-empty',
+				displayName: 'MCP',
+				description: 'd',
+				sourceType: 'mcp_server',
+				config: { type: 'mcp_server', appMcpServerId: '' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('appMcpServerId must not be empty');
+	});
+
+	// --- Validation: builtin ---
+
+	test('addSkill with builtin: valid commandName passes', () => {
+		const skill = mgr.addSkill({
+			name: 'bi-ok',
+			displayName: 'BI',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'update-config' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		expect(skill.name).toBe('bi-ok');
+	});
+
+	test('addSkill with builtin: empty commandName throws', () => {
+		expect(() =>
+			mgr.addSkill({
+				name: 'bi-empty',
+				displayName: 'BI',
+				description: 'd',
+				sourceType: 'builtin',
+				config: { type: 'builtin', commandName: '' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('commandName must not be empty');
+	});
+
+	// --- Validation on updateSkill ---
+
+	test('updateSkill validates new config', () => {
+		const skill = mgr.addSkill({
+			name: 'upd-val',
+			displayName: 'U',
+			description: 'd',
+			sourceType: 'plugin',
+			config: { type: 'plugin', pluginPath: '/good/path' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+
+		expect(() =>
+			mgr.updateSkill(skill.id, { config: { type: 'plugin', pluginPath: 'bad/relative' } })
+		).toThrow('absolute path');
+	});
+});

--- a/packages/daemon/tests/unit/skills-manager.test.ts
+++ b/packages/daemon/tests/unit/skills-manager.test.ts
@@ -7,9 +7,12 @@
  * - Persistence across load cycles
  * - getEnabledSkills() filtering
  * - All validation rules (plugin path traversal, mcp_server ref, builtin commandName)
+ * - sourceType / config.type consistency enforcement
+ * - Name uniqueness enforcement
  * - Valid configs pass validation
  */
 
+import { unlinkSync } from 'node:fs';
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { createTables } from '../../src/storage/schema';
@@ -93,6 +96,24 @@ describe('SkillRepository', () => {
 
 	test('get returns null for unknown id', () => {
 		expect(repo.get('nonexistent')).toBeNull();
+	});
+
+	test('getByName returns skill by name', () => {
+		const skill: AppSkill = {
+			id: 'gbn-1',
+			name: 'by-name',
+			displayName: 'By Name',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'pending',
+			createdAt: 1,
+		};
+		repo.insert(skill);
+		expect(repo.getByName('by-name')).not.toBeNull();
+		expect(repo.getByName('nonexistent')).toBeNull();
 	});
 
 	test('findAll returns all inserted skills', () => {
@@ -196,7 +217,7 @@ describe('SkillRepository', () => {
 		expect(repo.get('tog-1')!.enabled).toBe(true);
 	});
 
-	test('setValidationStatus updates validation_status', () => {
+	test('setValidationStatus updates validation_status and returns true', () => {
 		const skill: AppSkill = {
 			id: 'val-1',
 			name: 'val',
@@ -210,8 +231,13 @@ describe('SkillRepository', () => {
 			createdAt: 1,
 		};
 		repo.insert(skill);
-		repo.setValidationStatus('val-1', 'valid');
+		const changed = repo.setValidationStatus('val-1', 'valid');
+		expect(changed).toBe(true);
 		expect(repo.get('val-1')!.validationStatus).toBe('valid');
+	});
+
+	test('setValidationStatus returns false for unknown id', () => {
+		expect(repo.setValidationStatus('ghost', 'valid')).toBe(false);
 	});
 
 	test('delete removes a skill and returns true', () => {
@@ -237,7 +263,6 @@ describe('SkillRepository', () => {
 	});
 
 	test('persistence across load cycles — re-open same DB path', () => {
-		// Use a temp file path to test actual persistence
 		const tmpPath = `/tmp/skills-test-${Date.now()}.db`;
 		const db1 = new BunDatabase(tmpPath);
 		createTables(db1);
@@ -256,7 +281,7 @@ describe('SkillRepository', () => {
 		});
 		db1.close();
 
-		// Re-open
+		// Re-open — data must still be there
 		const db2 = new BunDatabase(tmpPath);
 		const repo2 = new SkillRepository(db2, noOpReactiveDb);
 		const found = repo2.get('persist-1');
@@ -264,6 +289,9 @@ describe('SkillRepository', () => {
 		expect(found!.name).toBe('persist');
 		expect(found!.validationStatus).toBe('valid');
 		db2.close();
+
+		// Clean up temp file
+		unlinkSync(tmpPath);
 	});
 });
 
@@ -362,7 +390,7 @@ describe('SkillsManager', () => {
 		expect(disabled.enabled).toBe(false);
 	});
 
-	test('setSkillValidationStatus updates status', () => {
+	test('setSkillValidationStatus updates status and returns updated skill', () => {
 		const skill = mgr.addSkill({
 			name: 'valst',
 			displayName: 'V',
@@ -372,8 +400,12 @@ describe('SkillsManager', () => {
 			enabled: true,
 			validationStatus: 'pending',
 		});
-		mgr.setSkillValidationStatus(skill.id, 'valid');
-		expect(mgr.getSkill(skill.id)!.validationStatus).toBe('valid');
+		const updated = mgr.setSkillValidationStatus(skill.id, 'valid');
+		expect(updated.validationStatus).toBe('valid');
+	});
+
+	test('setSkillValidationStatus throws for unknown id', () => {
+		expect(() => mgr.setSkillValidationStatus('ghost', 'valid')).toThrow('not found');
 	});
 
 	test('getEnabledSkills filters disabled skills', () => {
@@ -400,10 +432,35 @@ describe('SkillsManager', () => {
 		expect(enabled).toHaveLength(1);
 	});
 
+	// --- Name uniqueness ---
+
+	test('addSkill throws a friendly error on duplicate name', () => {
+		mgr.addSkill({
+			name: 'dupe',
+			displayName: 'Dupe',
+			description: 'd',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'cmd' },
+			enabled: true,
+			validationStatus: 'pending',
+		});
+		expect(() =>
+			mgr.addSkill({
+				name: 'dupe',
+				displayName: 'Dupe 2',
+				description: 'd',
+				sourceType: 'builtin',
+				config: { type: 'builtin', commandName: 'cmd2' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('already exists');
+	});
+
 	// --- Built-in protection ---
 
 	test('removeSkill returns false for built-in skill', () => {
-		// Insert a built-in skill directly via repo
+		// Insert a built-in skill directly via repo (bypasses manager's addSkill)
 		const repo = makeRepo(db);
 		repo.insert({
 			id: 'builtin-1',
@@ -437,6 +494,23 @@ describe('SkillsManager', () => {
 		});
 		expect(mgr.removeSkill(skill.id)).toBe(true);
 		expect(mgr.getSkill(skill.id)).toBeNull();
+	});
+
+	// --- Validation: sourceType / config.type mismatch ---
+
+	test('addSkill rejects mismatched sourceType and config.type', () => {
+		expect(() =>
+			mgr.addSkill({
+				name: 'mismatch',
+				displayName: 'M',
+				description: 'd',
+				sourceType: 'builtin',
+				// @ts-expect-error — intentional mismatch for testing runtime guard
+				config: { type: 'plugin', pluginPath: '/some/path' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('must match config.type');
 	});
 
 	// --- Validation: plugin ---
@@ -482,7 +556,7 @@ describe('SkillsManager', () => {
 		).toThrow('absolute path');
 	});
 
-	test('addSkill with plugin: path traversal throws', () => {
+	test('addSkill with plugin: path traversal with ../ throws', () => {
 		expect(() =>
 			mgr.addSkill({
 				name: 'plugin-traverse',
@@ -493,7 +567,21 @@ describe('SkillsManager', () => {
 				enabled: true,
 				validationStatus: 'pending',
 			})
-		).toThrow('../');
+		).toThrow('traversal');
+	});
+
+	test('addSkill with plugin: path traversal at end (/foo/..) throws', () => {
+		expect(() =>
+			mgr.addSkill({
+				name: 'plugin-traverse-end',
+				displayName: 'P',
+				description: 'd',
+				sourceType: 'plugin',
+				config: { type: 'plugin', pluginPath: '/plugins/foo/..' },
+				enabled: true,
+				validationStatus: 'pending',
+			})
+		).toThrow('traversal');
 	});
 
 	// --- Validation: mcp_server ---


### PR DESCRIPTION
## Summary

- `SkillRepository` — SQLite CRUD for `skills` table (migration 57 + schema/index.ts), using the shared DB instance. Implements `findAll`, `get`, `findEnabled`, `insert`, `update`, `setEnabled`, `setValidationStatus`, `delete`. All writes call `reactiveDb.notifyChange('skills')`.
- `SkillsManager` — service layer wrapping the repo. Enforces input validation before every insert/update: plugin `pluginPath` must be absolute and traversal-free; `mcp_server` `appMcpServerId` must reference an existing `app_mcp_servers` row; `builtin` `commandName` must be non-empty. `removeSkill` returns `false` for built-in skills.
- `app.ts` — instantiates `SkillsManager(db.skills, db.appMcpServers)` and calls `initializeBuiltins()` at startup.
- 32 unit tests: CRUD, built-in deletion protection, persistence across DB reopen, `getEnabledSkills` filtering, and all validation boundary cases.

Closes task 2.2 of the Skills Registry milestone.