### PR TITLE
fix(room): clear task restriction on stuck worker recovery after rate limit expiry

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2814,6 +2814,10 @@ export class RoomRuntime {
 			// When recovering after rate/usage limit expiry, clear the task restriction
 			// so the task status returns to in_progress.  Without this the task stays stuck
 			// in rate_limited/usage_limited even though the work has resumed.
+			// Note: groupRepo.clearRateLimit is intentionally NOT called here — the expired
+			// but non-null rateLimit acts as a re-detection sentinel so that the re-triggered
+			// onWorkerTerminalState does not re-classify the stale error and re-apply the backoff.
+			// The sentinel is only cleared when send_to_worker starts a genuinely new iteration.
 			if (hasExpiredRateLimit) {
 				void this.clearTaskRestriction(group.taskId).catch((err) => {
 					log.error(`[StuckWorker] Group ${group.id}: clearTaskRestriction threw:`, err);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2811,6 +2811,15 @@ export class RoomRuntime {
 				text: `Worker found in ${workerState} state with routing not yet complete — re-triggering routing to Leader.`,
 			});
 
+			// When recovering after rate/usage limit expiry, clear the task restriction
+			// so the task status returns to in_progress.  Without this the task stays stuck
+			// in rate_limited/usage_limited even though the work has resumed.
+			if (hasExpiredRateLimit) {
+				void this.clearTaskRestriction(group.taskId).catch((err) => {
+					log.error(`[StuckWorker] Group ${group.id}: clearTaskRestriction threw:`, err);
+				});
+			}
+
 			// Mark as in-flight before firing, clear when done (success or error)
 			this.stuckWorkerRecoveryInFlight.add(group.id);
 			void this.onWorkerTerminalState(group.id, {

--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -194,6 +194,76 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 			// Some routing call should have been made
 			expect(callsAfter).toBeGreaterThanOrEqual(callsBefore);
 		});
+
+		it('restores task status to in_progress after rate limit expiry recovery', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(RATE_LIMIT_MSG),
+			});
+
+			const { group, task } = await spawnAndTriggerWorkerTerminal('');
+
+			// Verify task is rate_limited
+			const rateLimited = await ctx.taskManager.getTask(task.id);
+			expect(rateLimited!.status).toBe('rate_limited');
+			expect(rateLimited!.restrictions).toBeDefined();
+
+			// Set the actual worker session to idle so recoverStuckWorkers picks it up
+			ctx.sessionFactory.processingStates.set(group.workerSessionId, 'idle');
+
+			// Manually set an expired rate limit
+			ctx.groupRepo.setRateLimit(group.id, {
+				detectedAt: Date.now() - 120_000,
+				resetsAt: Date.now() - 60_000, // expired
+				sessionRole: 'worker',
+			});
+
+			// Trigger recovery via tick
+			await ctx.runtime.tick();
+
+			// Allow the fire-and-forget clearTaskRestriction to resolve
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Task status must be restored to in_progress with restrictions cleared
+			const resumed = await ctx.taskManager.getTask(task.id);
+			expect(resumed!.status).toBe('in_progress');
+			expect(resumed!.restrictions).toBeNull();
+		});
+
+		it('restores task status to in_progress after usage_limit expiry recovery', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
+				// No fallback models — ensures usage_limit triggers pause
+				getGlobalSettings: () => ({}) as never,
+			});
+
+			const { group, task } = await spawnAndTriggerWorkerTerminal('');
+
+			// Verify task is usage_limited
+			const usageLimited = await ctx.taskManager.getTask(task.id);
+			expect(usageLimited!.status).toBe('usage_limited');
+			expect(usageLimited!.restrictions).toBeDefined();
+
+			// Set the actual worker session to idle so recoverStuckWorkers picks it up
+			ctx.sessionFactory.processingStates.set(group.workerSessionId, 'idle');
+
+			// Manually set an expired rate limit (simulating timer expiry)
+			ctx.groupRepo.setRateLimit(group.id, {
+				detectedAt: Date.now() - 120_000,
+				resetsAt: Date.now() - 60_000, // expired
+				sessionRole: 'worker',
+			});
+
+			// Trigger recovery via tick
+			await ctx.runtime.tick();
+
+			// Allow the fire-and-forget clearTaskRestriction to resolve
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Task status must be restored to in_progress with restrictions cleared
+			const resumed = await ctx.taskManager.getTask(task.id);
+			expect(resumed!.status).toBe('in_progress');
+			expect(resumed!.restrictions).toBeNull();
+		});
 	});
 
 	// ─── Leader rate/usage limit paths ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- Call `clearTaskRestriction()` in `recoverStuckWorkers()` when recovering after rate/usage limit expiry, restoring task status to `in_progress`
- Previously, `recoverStuckLeaders` correctly called `clearTaskRestriction` but the worker recovery path did not, leaving tasks stuck in `rate_limited`/`usage_limited` status even after work resumed
- Add two unit tests verifying task status restoration for both `rate_limit` and `usage_limit` expiry scenarios

## Test plan

- [x] Unit tests pass (24/24 in rate-limit-persistence, 1652/1652 in room suite)
- [x] Typecheck passes
- [x] Lint/format pass