### PR TITLE
refactor(daemon): remove auto-recovery logic from query-runner

### DIFF
--- a/packages/daemon/.env.example
+++ b/packages/daemon/.env.example
@@ -66,17 +66,6 @@ MAX_SESSIONS=10
 # running many concurrent sessions.
 # Default: 15000
 # NEOKAI_SDK_STARTUP_TIMEOUT_MS=15000
-#
-# Base delay (ms) before the first auto-recovery attempt after a startup
-# timeout. Each subsequent attempt doubles this (exponential backoff).
-# Example: 3000 → attempt 1 waits 3s, attempt 2 waits 6s.
-# Default: 3000
-# NEOKAI_SDK_STARTUP_RECOVERY_DELAY_MS=3000
-#
-# Maximum number of auto-recovery attempts before surfacing the error to
-# the user. Set to 0 to disable auto-recovery entirely.
-# Default: 2
-# NEOKAI_SDK_STARTUP_MAX_RETRIES=2
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # File Index Configuration

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -221,7 +221,6 @@ export class AgentSession
 	queryAbortController: AbortController | null = null;
 	firstMessageReceived = false;
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
-	startupTimeoutAutoRecoverAttempts = 0;
 	originalEnvVars: OriginalEnvVars = {};
 	// Whether to auto-queue /context after each turn (default: true)
 	// Disabled for room-managed agents to prevent interleaved messages after terminal state
@@ -801,12 +800,6 @@ export class AgentSession
 
 	async onMarkApiSuccess(): Promise<void> {
 		this.errorManager.markApiSuccess();
-	}
-
-	async onStartupTimeoutAutoRecover(): Promise<void> {
-		if (this.isCleaningUp()) return;
-		this.logger.warn('Auto-recovering after SDK startup timeout — starting fresh without resume.');
-		await this.startStreamingQuery();
 	}
 
 	// ============================================================================

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -25,10 +25,6 @@ import type { QueryOptionsBuilder } from './query-options-builder';
 import type { AskUserQuestionHandler } from './ask-user-question-handler';
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
-/** Base delay before the first auto-recovery attempt. Each subsequent attempt doubles this. */
-const DEFAULT_STARTUP_RECOVERY_DELAY_MS = 3000;
-/** Maximum number of auto-recovery attempts before surfacing the error to the user. */
-const DEFAULT_STARTUP_MAX_RETRIES = 2;
 
 function getStartupTimeoutMs(): number {
 	const raw = process.env.NEOKAI_SDK_STARTUP_TIMEOUT_MS;
@@ -37,26 +33,10 @@ function getStartupTimeoutMs(): number {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STARTUP_TIMEOUT_MS;
 }
 
-function getStartupRecoveryDelayMs(): number {
-	const raw = process.env.NEOKAI_SDK_STARTUP_RECOVERY_DELAY_MS;
-	if (!raw) return DEFAULT_STARTUP_RECOVERY_DELAY_MS;
-	const parsed = Number.parseInt(raw, 10);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STARTUP_RECOVERY_DELAY_MS;
-}
-
-function getStartupMaxRetries(): number {
-	const raw = process.env.NEOKAI_SDK_STARTUP_MAX_RETRIES;
-	if (!raw) return DEFAULT_STARTUP_MAX_RETRIES;
-	const parsed = Number.parseInt(raw, 10);
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_STARTUP_MAX_RETRIES;
-}
-
 // Read once at module load — consistent with the original STARTUP_TIMEOUT_MS pattern.
 // Env vars set after the process starts will not be picked up; the values displayed
 // in user-facing error messages reflect these module-load-time snapshots.
 const STARTUP_TIMEOUT_MS = getStartupTimeoutMs();
-const STARTUP_RECOVERY_DELAY_MS = getStartupRecoveryDelayMs();
-const STARTUP_MAX_RETRIES = getStartupMaxRetries();
 
 /**
  * Original environment variables for restoration after SDK query
@@ -95,10 +75,6 @@ export interface QueryRunnerContext {
 	queryAbortController: AbortController | null;
 	firstMessageReceived: boolean;
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null;
-	// Tracks consecutive auto-recovery attempts for the current query.
-	// Reset to 0 when a query receives its first message (successful startup).
-	// Prevents infinite retry loops when the SDK is permanently broken.
-	startupTimeoutAutoRecoverAttempts: number;
 	originalEnvVars: OriginalEnvVars;
 	// Methods for state coordination
 	incrementQueryGeneration(): number;
@@ -110,12 +86,6 @@ export interface QueryRunnerContext {
 	onSlashCommandsFetched(): Promise<void>;
 	onModelsFetched(): Promise<void>;
 	onMarkApiSuccess(): Promise<void>;
-
-	// Optional auto-recovery callback invoked when the SDK startup timer fires.
-	// If set, the catch block skips messageQueue.clear() (preserving queued messages
-	// for transparent retry) and schedules a fresh startStreamingQuery() call
-	// instead of surfacing an error to the user.
-	onStartupTimeoutAutoRecover?(): Promise<void>;
 }
 
 /**
@@ -270,7 +240,6 @@ export class QueryRunner {
 							(isRootWorkspace
 								? ' — running on root workspace (not a worktree); check for other Claude Code sessions using this path'
 								: '') +
-							`. Attempt ${this.ctx.startupTimeoutAutoRecoverAttempts + 1} of ${STARTUP_MAX_RETRIES + 1}.` +
 							` (Hint: set NEOKAI_SDK_STARTUP_TIMEOUT_MS to increase timeout, currently ${STARTUP_TIMEOUT_MS}ms)`
 					);
 
@@ -314,8 +283,6 @@ export class QueryRunner {
 				if (timer && messageCount === 1) {
 					clearTimeout(timer);
 					this.ctx.startupTimeoutTimer = null;
-					// Reset auto-recovery counter: query started successfully.
-					this.ctx.startupTimeoutAutoRecoverAttempts = 0;
 				}
 
 				this.ctx.firstMessageReceived = true;
@@ -353,17 +320,8 @@ export class QueryRunner {
 			const isStartupTimeout = errorMessage.includes('SDK startup timeout');
 			const isConversationNotFound = errorMessage.includes('No conversation found');
 
-			// Preserve queued messages for transparent retry when auto-recovery is
-			// registered (startup timeout / conversation not found + provider switch).
-			// In all other cases, clear the queue so stale messages don't bleed
-			// into the next session.
-			if (
-				!(isStartupTimeout || isConversationNotFound) ||
-				isAbortError ||
-				!this.ctx.onStartupTimeoutAutoRecover
-			) {
-				messageQueue.clear();
-			}
+			// Always clear the queue on error so stale messages don't bleed into the next session.
+			messageQueue.clear();
 
 			// If startup timed out or conversation not found while trying to resume a session,
 			// clear sdkSessionId so the next attempt starts a fresh SDK session instead of
@@ -378,153 +336,104 @@ export class QueryRunner {
 			}
 
 			if (!isAbortError) {
-				// On startup timeout or conversation not found, attempt transparent auto-recovery
-				// (up to STARTUP_MAX_RETRIES): restart the query without the old resume handle
-				// (sdkSessionId already cleared above). Queued messages are preserved so
-				// the user's pending send is retried automatically without any visible error.
-				// Uses exponential backoff: delay doubles with each attempt to give the SDK
-				// process time to fully exit before the next spawn.
-				// The retry limit prevents infinite loops when the SDK is permanently broken:
-				// after all retries are exhausted, the error surfaces normally.
-				const startupRecoverAttempts = this.ctx.startupTimeoutAutoRecoverAttempts + 1;
-				const canAutoRecover =
-					(isStartupTimeout || isConversationNotFound) &&
-					!this.ctx.isCleaningUp() &&
-					!!this.ctx.onStartupTimeoutAutoRecover &&
-					startupRecoverAttempts <= STARTUP_MAX_RETRIES;
+				const apiErrorHandled = await this.handleApiValidationError(error);
 
-				if (canAutoRecover) {
-					this.ctx.startupTimeoutAutoRecoverAttempts = startupRecoverAttempts;
-					// Exponential backoff: base * 2^(attempt-1), capped at 30s.
-					// e.g. with default 3s base: attempt 1 → 3s, attempt 2 → 6s
-					const delayMs = Math.min(
-						STARTUP_RECOVERY_DELAY_MS * Math.pow(2, startupRecoverAttempts - 1),
-						30000
-					);
-					logger.warn(
-						`SDK ${isConversationNotFound ? 'conversation not found' : 'startup timeout'} — ` +
-							`scheduling auto-recovery attempt ${startupRecoverAttempts}/${STARTUP_MAX_RETRIES} ` +
-							`(fresh query without resume) in ${delayMs}ms`
-					);
-					// Defer until after finally{} completes so shared state is reset first.
-					setTimeout(() => {
-						this.ctx.onStartupTimeoutAutoRecover!().catch((err: unknown) => {
-							logger.error('Auto-recovery after SDK startup timeout failed:', err);
-						});
-					}, delayMs);
-					// setIdle is handled by the finally block; skipping here avoids a double call.
-				} else {
-					// Reset counter so a future successfully-started session can recover again.
-					if (isStartupTimeout || isConversationNotFound) {
-						this.ctx.startupTimeoutAutoRecoverAttempts = 0;
-					}
-					const apiErrorHandled = await this.handleApiValidationError(error);
+				if (!apiErrorHandled) {
+					let category = ErrorCategory.SYSTEM;
+					const providerId = session.config.provider as string | undefined;
 
-					if (!apiErrorHandled) {
-						let category = ErrorCategory.SYSTEM;
-						const providerId = session.config.provider as string | undefined;
+					// Detect provider-specific errors before general categorization
+					const isProviderSession =
+						providerId && providerId !== 'anthropic' && providerId !== 'glm';
 
-						// Detect provider-specific errors before general categorization
-						const isProviderSession =
-							providerId && providerId !== 'anthropic' && providerId !== 'glm';
-
-						if (
-							isProviderSession &&
-							(errorMessage.includes('401') ||
-								errorMessage.includes('403') ||
-								errorMessage.includes('unauthorized') ||
-								errorMessage.includes('Unauthorized') ||
-								errorMessage.includes('token expired') ||
-								errorMessage.includes('token_expired') ||
-								errorMessage.includes('not authenticated') ||
-								errorMessage.includes('invalid_api_key'))
-						) {
-							category = ErrorCategory.PROVIDER_AUTH_ERROR;
-						} else if (
-							isProviderSession &&
-							(errorMessage.includes('ECONNREFUSED') ||
-								errorMessage.includes('ENOTFOUND') ||
-								errorMessage.includes('EHOSTUNREACH') ||
-								errorMessage.includes('service unavailable') ||
-								errorMessage.includes('503') ||
-								errorMessage.includes('502'))
-						) {
-							category = ErrorCategory.PROVIDER_UNAVAILABLE;
-						} else if (
-							errorMessage.includes('401') ||
+					if (
+						isProviderSession &&
+						(errorMessage.includes('401') ||
+							errorMessage.includes('403') ||
 							errorMessage.includes('unauthorized') ||
-							errorMessage.includes('invalid_api_key')
-						) {
-							category = ErrorCategory.AUTHENTICATION;
-						} else if (
-							errorMessage.includes('ECONNREFUSED') ||
-							errorMessage.includes('ENOTFOUND')
-						) {
-							category = ErrorCategory.CONNECTION;
-						} else if (
-							errorMessage.includes('429') ||
-							errorMessage.includes('rate limit') ||
-							errorMessage.includes('402') ||
-							errorMessage.toLowerCase().includes('no quota') ||
-							errorMessage.toLowerCase().includes('quota exceeded') ||
-							errorMessage.toLowerCase().includes('insufficient_quota')
-						) {
-							category = ErrorCategory.RATE_LIMIT;
-						} else if (errorMessage.includes('timeout')) {
-							category = ErrorCategory.TIMEOUT;
-						} else if (errorMessage.includes('model_not_found')) {
-							category = ErrorCategory.MODEL;
-						} else if (
-							errorMessage.includes('cannot be run as root') ||
-							errorMessage.includes('dangerously-skip-permissions') ||
-							errorMessage.includes('permission') ||
-							errorMessage.includes('Exit code: 1')
-						) {
-							category = ErrorCategory.PERMISSION;
-						}
-
-						const processingState = stateManager.getState();
-
-						// For startup timeouts / conversation-not-found that exhausted all retries,
-						// provide actionable recovery hints. Both error types are handled symmetrically
-						// (same retry gate, same sdkSessionId clearing), so both deserve a hint.
-						// Keep the hints distinct: NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a
-						// missing/corrupt session file — the session ID was already cleared above,
-						// so the next message will automatically start a fresh session.
-						const startupTimeoutUserMessage = isStartupTimeout
-							? `The AI session failed to start after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
-								`(workspace: ${session.workspacePath}). ` +
-								`Common causes: another Claude Code session is using the same workspace, ` +
-								`a stale lock file in .claude/, or the workspace is under heavy load. ` +
-								`Try: closing other Claude sessions on this workspace, ` +
-								`then resend your message. ` +
-								`You can also increase the timeout with NEOKAI_SDK_STARTUP_TIMEOUT_MS (current: ${STARTUP_TIMEOUT_MS}ms).`
-							: isConversationNotFound
-								? `The AI session could not be resumed after ${STARTUP_MAX_RETRIES + 1} attempt(s) ` +
-									`(workspace: ${session.workspacePath}). ` +
-									`The previous session file could not be found or is corrupt. ` +
-									`The session has been reset automatically — please resend your message to start fresh.`
-								: undefined;
-
-						await errorManager.handleError(
-							session.id,
-							error as Error,
-							category,
-							startupTimeoutUserMessage,
-							processingState,
-							{
-								errorMessage,
-								queueSize: messageQueue.size(),
-								providerId: providerId ?? 'anthropic',
-								workspacePath: session.workspacePath,
-								isRootWorkspace: !session.worktree,
-								startupTimeoutMs: STARTUP_TIMEOUT_MS,
-								startupMaxRetries: STARTUP_MAX_RETRIES,
-							}
-						);
+							errorMessage.includes('Unauthorized') ||
+							errorMessage.includes('token expired') ||
+							errorMessage.includes('token_expired') ||
+							errorMessage.includes('not authenticated') ||
+							errorMessage.includes('invalid_api_key'))
+					) {
+						category = ErrorCategory.PROVIDER_AUTH_ERROR;
+					} else if (
+						isProviderSession &&
+						(errorMessage.includes('ECONNREFUSED') ||
+							errorMessage.includes('ENOTFOUND') ||
+							errorMessage.includes('EHOSTUNREACH') ||
+							errorMessage.includes('service unavailable') ||
+							errorMessage.includes('503') ||
+							errorMessage.includes('502'))
+					) {
+						category = ErrorCategory.PROVIDER_UNAVAILABLE;
+					} else if (
+						errorMessage.includes('401') ||
+						errorMessage.includes('unauthorized') ||
+						errorMessage.includes('invalid_api_key')
+					) {
+						category = ErrorCategory.AUTHENTICATION;
+					} else if (errorMessage.includes('ECONNREFUSED') || errorMessage.includes('ENOTFOUND')) {
+						category = ErrorCategory.CONNECTION;
+					} else if (
+						errorMessage.includes('429') ||
+						errorMessage.includes('rate limit') ||
+						errorMessage.includes('402') ||
+						errorMessage.toLowerCase().includes('no quota') ||
+						errorMessage.toLowerCase().includes('quota exceeded') ||
+						errorMessage.toLowerCase().includes('insufficient_quota')
+					) {
+						category = ErrorCategory.RATE_LIMIT;
+					} else if (errorMessage.includes('timeout')) {
+						category = ErrorCategory.TIMEOUT;
+					} else if (errorMessage.includes('model_not_found')) {
+						category = ErrorCategory.MODEL;
+					} else if (
+						errorMessage.includes('cannot be run as root') ||
+						errorMessage.includes('dangerously-skip-permissions') ||
+						errorMessage.includes('permission') ||
+						errorMessage.includes('Exit code: 1')
+					) {
+						category = ErrorCategory.PERMISSION;
 					}
-					await stateManager.setIdle();
+
+					const processingState = stateManager.getState();
+
+					// For startup timeouts / conversation-not-found, provide actionable recovery hints.
+					// Keep the hints distinct: NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a
+					// missing/corrupt session file — the session ID was already cleared above,
+					// so the next message will automatically start a fresh session.
+					const startupTimeoutUserMessage = isStartupTimeout
+						? `The AI session failed to start (workspace: ${session.workspacePath}). ` +
+							`Common causes: another Claude Code session is using the same workspace, ` +
+							`a stale lock file in .claude/, or the workspace is under heavy load. ` +
+							`Try: closing other Claude sessions on this workspace, ` +
+							`then resend your message. ` +
+							`You can also increase the timeout with NEOKAI_SDK_STARTUP_TIMEOUT_MS (current: ${STARTUP_TIMEOUT_MS}ms).`
+						: isConversationNotFound
+							? `The AI session could not be resumed (workspace: ${session.workspacePath}). ` +
+								`The previous session file could not be found or is corrupt. ` +
+								`The session has been reset automatically — please resend your message to start fresh.`
+							: undefined;
+
+					await errorManager.handleError(
+						session.id,
+						error as Error,
+						category,
+						startupTimeoutUserMessage,
+						processingState,
+						{
+							errorMessage,
+							queueSize: messageQueue.size(),
+							providerId: providerId ?? 'anthropic',
+							workspacePath: session.workspacePath,
+							isRootWorkspace: !session.worktree,
+							startupTimeoutMs: STARTUP_TIMEOUT_MS,
+						}
+					);
 				}
+				await stateManager.setIdle();
 			}
 		} finally {
 			// Check for stale query FIRST to avoid race conditions.

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -185,7 +185,6 @@ describe('QueryRunner', () => {
 			queryAbortController: null,
 			firstMessageReceived: false,
 			startupTimeoutTimer: null,
-			startupTimeoutAutoRecoverAttempts: 0,
 			originalEnvVars: {},
 
 			// Methods for state coordination
@@ -717,7 +716,7 @@ describe('QueryRunner', () => {
 		});
 	});
 
-	describe('startup timeout auto-recovery', () => {
+	describe('startup timeout error surfacing', () => {
 		// Integration tests: exercise the runQuery() catch block when a startup-timeout
 		// error is thrown.  buildSpy throws 'SDK startup timeout - query aborted' so the
 		// test never waits for the real 15-second timer.
@@ -741,18 +740,7 @@ describe('QueryRunner', () => {
 			}
 		});
 
-		it('should NOT call messageQueue.clear() when onStartupTimeoutAutoRecover is registered', async () => {
-			const ctx = createContext({
-				onStartupTimeoutAutoRecover: mock(async () => {}),
-			});
-			runner = new QueryRunner(ctx);
-			runner.start();
-			await ctx.queryPromise?.catch(() => {});
-
-			expect(clearSpy).not.toHaveBeenCalled();
-		});
-
-		it('should call messageQueue.clear() when onStartupTimeoutAutoRecover is absent', async () => {
+		it('should always call messageQueue.clear() on startup timeout error', async () => {
 			const ctx = createContext();
 			runner = new QueryRunner(ctx);
 			runner.start();
@@ -761,17 +749,12 @@ describe('QueryRunner', () => {
 			expect(clearSpy).toHaveBeenCalled();
 		});
 
-		it('should call messageQueue.clear() on startup-timeout AbortError even when handler is registered', async () => {
-			// Guard: if the throw site ever becomes an AbortError, queue must still be
-			// cleared because the recovery path is gated behind !isAbortError and will
-			// not run — leaving stale preserved messages would be wrong.
+		it('should call messageQueue.clear() on startup-timeout AbortError', async () => {
 			const abortError = new Error('SDK startup timeout - query aborted');
 			abortError.name = 'AbortError';
 			buildSpy.mockRejectedValue(abortError);
 
-			const ctx = createContext({
-				onStartupTimeoutAutoRecover: mock(async () => {}),
-			});
+			const ctx = createContext();
 			runner = new QueryRunner(ctx);
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
@@ -779,137 +762,17 @@ describe('QueryRunner', () => {
 			expect(clearSpy).toHaveBeenCalled();
 		});
 
-		it('should schedule onStartupTimeoutAutoRecover after the recovery delay (not immediately)', async () => {
-			jest.useFakeTimers();
-			const recoverSpy = mock(async () => {});
-			const ctx = createContext({
-				onStartupTimeoutAutoRecover: recoverSpy,
-			});
+		it('should surface error immediately via handleError on startup timeout', async () => {
+			const ctx = createContext();
 			runner = new QueryRunner(ctx);
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
 
-			// Not yet called — deferred by setTimeout
-			expect(recoverSpy).not.toHaveBeenCalled();
-			// startupTimeoutAutoRecoverAttempts was incremented (recovery is scheduled)
-			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(1);
-
-			// Advance timers past the base recovery delay (default 3000ms)
-			jest.runAllTimers();
-			// Allow microtasks to flush
-			await new Promise((resolve) => setImmediate(resolve));
-			expect(recoverSpy).toHaveBeenCalledTimes(1);
-			jest.useRealTimers();
-		});
-
-		it('should NOT invoke onStartupTimeoutAutoRecover when isCleaningUp returns true', async () => {
-			jest.useFakeTimers();
-			const recoverSpy = mock(async () => {});
-			const ctx = createContext({
-				isCleaningUp: () => true,
-				onStartupTimeoutAutoRecover: recoverSpy,
-			});
-			runner = new QueryRunner(ctx);
-			runner.start();
-			await ctx.queryPromise?.catch(() => {});
-
-			jest.runAllTimers();
-			await new Promise((resolve) => setImmediate(resolve));
-			expect(recoverSpy).not.toHaveBeenCalled();
-			jest.useRealTimers();
-		});
-
-		it('should surface error normally and NOT recover when retry limit (2) is already reached', async () => {
-			const recoverSpy = mock(async () => {});
-			const ctx = createContext({
-				startupTimeoutAutoRecoverAttempts: 2, // already at limit (default STARTUP_MAX_RETRIES=2)
-				onStartupTimeoutAutoRecover: recoverSpy,
-			});
-			runner = new QueryRunner(ctx);
-			runner.start();
-			await ctx.queryPromise?.catch(() => {});
-
-			await new Promise((resolve) => setTimeout(resolve, 100));
-			expect(recoverSpy).not.toHaveBeenCalled();
 			expect(handleErrorSpy).toHaveBeenCalled();
 		});
 
-		it('should still recover on second attempt (attempts=1, limit=2)', async () => {
-			jest.useFakeTimers();
-			const recoverSpy = mock(async () => {});
-			const ctx = createContext({
-				startupTimeoutAutoRecoverAttempts: 1, // first retry already done, second still allowed
-				onStartupTimeoutAutoRecover: recoverSpy,
-			});
-			runner = new QueryRunner(ctx);
-			runner.start();
-			await ctx.queryPromise?.catch(() => {});
-
-			expect(recoverSpy).not.toHaveBeenCalled();
-			// Second attempt increments to 2 (still ≤ STARTUP_MAX_RETRIES=2)
-			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(2);
-
-			jest.runAllTimers();
-			await new Promise((resolve) => setImmediate(resolve));
-			expect(recoverSpy).toHaveBeenCalledTimes(1);
-			jest.useRealTimers();
-		});
-
-		it('should use exponential backoff: second attempt delay is 2× the first', async () => {
-			// First attempt: delay = BASE * 2^(1-1) = BASE * 1
-			// Second attempt: delay = BASE * 2^(2-1) = BASE * 2
-			const capturedDelays: number[] = [];
-			const originalSetTimeout = globalThis.setTimeout;
-			// Spy on setTimeout to capture delay arguments for recovery calls
-			const setTimeoutSpy = mock((fn: () => void, delay?: number) => {
-				capturedDelays.push(delay ?? 0);
-				return originalSetTimeout(fn, 0); // fire immediately to avoid slow tests
-			});
-			globalThis.setTimeout = setTimeoutSpy as unknown as typeof setTimeout;
-
-			try {
-				const ctx1 = createContext({
-					startupTimeoutAutoRecoverAttempts: 0, // first attempt
-					onStartupTimeoutAutoRecover: mock(async () => {}),
-				});
-				new QueryRunner(ctx1).start();
-				await ctx1.queryPromise?.catch(() => {});
-
-				const ctx2 = createContext({
-					startupTimeoutAutoRecoverAttempts: 1, // second attempt
-					onStartupTimeoutAutoRecover: mock(async () => {}),
-				});
-				new QueryRunner(ctx2).start();
-				await ctx2.queryPromise?.catch(() => {});
-			} finally {
-				globalThis.setTimeout = originalSetTimeout;
-			}
-
-			// Each QueryRunner run produces exactly one setTimeout (the recovery defer).
-			// Asserting === 2 guards against accidental extra calls shifting the indices.
-			expect(capturedDelays.length).toBe(2);
-			const delay1 = capturedDelays[0];
-			const delay2 = capturedDelays[1];
-			expect(delay1).toBeGreaterThan(0);
-			expect(delay2).toBe(delay1 * 2);
-		});
-
-		it('should increment startupTimeoutAutoRecoverAttempts when recovery is scheduled', async () => {
-			const ctx = createContext({
-				startupTimeoutAutoRecoverAttempts: 0,
-				onStartupTimeoutAutoRecover: mock(async () => {}),
-			});
-			runner = new QueryRunner(ctx);
-			runner.start();
-			await ctx.queryPromise?.catch(() => {});
-
-			expect(ctx.startupTimeoutAutoRecoverAttempts).toBe(1);
-		});
-
-		it('should pass actionable user message to handleError when all retries exhausted (startup timeout)', async () => {
-			const ctx = createContext({
-				startupTimeoutAutoRecoverAttempts: 2, // at limit, no handler needed
-			});
+		it('should pass actionable user message with timeout hint to handleError (startup timeout)', async () => {
+			const ctx = createContext();
 			runner = new QueryRunner(ctx);
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
@@ -922,13 +785,14 @@ describe('QueryRunner', () => {
 				expect.anything(),
 				expect.objectContaining({ isRootWorkspace: expect.any(Boolean) })
 			);
+			// Should NOT contain retry count language
+			const userMessage = handleErrorSpy.mock.calls[0][3] as string;
+			expect(userMessage).not.toContain('attempt(s)');
 		});
 
-		it('should pass session-reset hint (no timeout mention) when conversation-not-found retries exhausted', async () => {
+		it('should pass session-reset hint (no timeout mention) for conversation-not-found', async () => {
 			buildSpy.mockRejectedValue(new Error('No conversation found for session abc123'));
-			const ctx = createContext({
-				startupTimeoutAutoRecoverAttempts: 2, // at limit
-			});
+			const ctx = createContext();
 			runner = new QueryRunner(ctx);
 			runner.start();
 			await ctx.queryPromise?.catch(() => {});
@@ -944,6 +808,28 @@ describe('QueryRunner', () => {
 			// NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a missing session file
 			const userMessage = handleErrorSpy.mock.calls[0][3] as string;
 			expect(userMessage).not.toContain('NEOKAI_SDK_STARTUP_TIMEOUT_MS');
+			// Should NOT contain retry count language
+			expect(userMessage).not.toContain('attempt(s)');
+		});
+
+		it('should call stateManager.setIdle after handling startup timeout error', async () => {
+			const ctx = createContext();
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(setIdleSpy).toHaveBeenCalled();
+		});
+
+		it('should NOT pass startupMaxRetries in handleError metadata', async () => {
+			const ctx = createContext();
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(handleErrorSpy).toHaveBeenCalled();
+			const metadata = handleErrorSpy.mock.calls[0][5] as Record<string, unknown>;
+			expect(metadata.startupMaxRetries).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
Remove the silent auto-recovery code path from `query-runner.ts`. Startup timeout and conversation-not-found errors are now surfaced immediately to the user instead of being retried transparently.

**Changes:**
- Remove `onStartupTimeoutAutoRecover` callback and `startupTimeoutAutoRecoverAttempts` tracking from `QueryRunnerContext`
- Remove `STARTUP_RECOVERY_DELAY_MS` / `STARTUP_MAX_RETRIES` constants, env vars, and reader functions
- Simplify catch block: always clear message queue, always surface error via `errorManager.handleError()`
- Update error messages to remove "after N attempt(s)" language; keep actionable recovery hints
- Remove `startupMaxRetries` from `handleError()` metadata
- Clean up `agent-session.ts` (remove field + method) and `.env.example`
- Rewrite tests to verify immediate error surfacing (74 tests pass)

Part of: fix model switching bugs (#929) — Task 2.1