### PR TITLE
feat(daemon): Skills RPC handlers

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -304,6 +304,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		reactiveDb,
 		liveQueries,
 		appMcpManager,
+		skillsManager,
 	});
 
 	// Create WebSocket handlers

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -78,6 +78,8 @@ import { FileIndex } from '../file-index';
 import { LiveQueryEngine } from '../../storage/live-query';
 import type { AppMcpLifecycleManager } from '../mcp';
 import { registerAppMcpHandlers, setupAppMcpHandlers } from './app-mcp-handlers';
+import { registerSkillHandlers } from './skill-handlers';
+import type { SkillsManager } from '../skills-manager';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -108,6 +110,8 @@ export interface RPCHandlerDependencies {
 	liveQueries: LiveQueryEngine;
 	/** Application-level MCP lifecycle manager */
 	appMcpManager: AppMcpLifecycleManager;
+	/** Application-level Skills manager */
+	skillsManager: SkillsManager;
 }
 
 const log = new Logger('rpc-handlers');
@@ -300,6 +304,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Per-room MCP enablement RPC handlers
 	setupAppMcpHandlers(deps.messageHub, deps.daemonHub, deps.db);
+
+	// Skills registry RPC handlers
+	registerSkillHandlers(deps.messageHub, deps.skillsManager, deps.daemonHub);
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/skill-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/skill-handlers.ts
@@ -1,0 +1,123 @@
+/**
+ * Skills RPC Handlers
+ *
+ * Exposes the application-level Skills registry via RPC:
+ * - skill.list       — list all skills
+ * - skill.get        — get a single skill by id
+ * - skill.create     — add a new skill, emit skills.changed
+ * - skill.update     — update a skill, emit skills.changed
+ * - skill.delete     — remove a skill, emit skills.changed
+ * - skill.setEnabled — toggle enabled flag, emit skills.changed
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type { AppSkill, CreateSkillParams, UpdateSkillParams } from '@neokai/shared';
+import type { DaemonHub } from '../daemon-hub';
+import type { SkillsManager } from '../skills-manager';
+import { Logger } from '../logger';
+
+const log = new Logger('skill-handlers');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emitChanged(daemonHub: DaemonHub): void {
+	daemonHub.emit('skills.changed', { sessionId: 'global' }).catch((err) => {
+		log.warn('Failed to emit skills.changed:', err);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Handler registration
+// ---------------------------------------------------------------------------
+
+export function registerSkillHandlers(
+	messageHub: MessageHub,
+	skillsManager: SkillsManager,
+	daemonHub: DaemonHub
+): void {
+	// skill.list — returns AppSkill[]
+	messageHub.onRequest('skill.list', async () => {
+		const skills = skillsManager.listSkills();
+		return { skills } satisfies { skills: AppSkill[] };
+	});
+
+	// skill.get — fetch a single skill by id
+	messageHub.onRequest('skill.get', async (data) => {
+		const { id } = data as { id: string };
+
+		if (!id) {
+			throw new Error('id is required');
+		}
+
+		const skill = skillsManager.getSkill(id);
+		return { skill } satisfies { skill: AppSkill | null };
+	});
+
+	// skill.create — validates input via SkillsManager, creates skill, emits event
+	messageHub.onRequest('skill.create', async (data) => {
+		const { params } = data as { params: CreateSkillParams };
+
+		if (!params) {
+			throw new Error('params is required');
+		}
+
+		const skill = skillsManager.addSkill(params);
+		emitChanged(daemonHub);
+		log.info(`skill.create: created "${skill.name}" (${skill.id})`);
+		return { skill } satisfies { skill: AppSkill };
+	});
+
+	// skill.update — updates skill, emits event, returns updated skill
+	messageHub.onRequest('skill.update', async (data) => {
+		const { id, params } = data as { id: string; params: UpdateSkillParams };
+
+		if (!id) {
+			throw new Error('id is required');
+		}
+		if (!params) {
+			throw new Error('params is required');
+		}
+
+		const skill = skillsManager.updateSkill(id, params);
+		emitChanged(daemonHub);
+		log.info(`skill.update: updated "${skill.name}" (${id})`);
+		return { skill } satisfies { skill: AppSkill };
+	});
+
+	// skill.delete — removes skill, emits event
+	messageHub.onRequest('skill.delete', async (data) => {
+		const { id } = data as { id: string };
+
+		if (!id) {
+			throw new Error('id is required');
+		}
+
+		const removed = skillsManager.removeSkill(id);
+		if (!removed) {
+			throw new Error(`Skill not found or cannot be removed: ${id}`);
+		}
+
+		emitChanged(daemonHub);
+		log.info(`skill.delete: deleted ${id}`);
+		return { success: true } satisfies { success: boolean };
+	});
+
+	// skill.setEnabled — convenience toggle for the enabled field
+	messageHub.onRequest('skill.setEnabled', async (data) => {
+		const { id, enabled } = data as { id: string; enabled: boolean };
+
+		if (!id) {
+			throw new Error('id is required');
+		}
+		if (typeof enabled !== 'boolean') {
+			throw new Error('enabled must be a boolean');
+		}
+
+		const skill = skillsManager.setSkillEnabled(id, enabled);
+		emitChanged(daemonHub);
+		log.info(`skill.setEnabled: set ${id} enabled=${enabled}`);
+		return { skill } satisfies { skill: AppSkill };
+	});
+}

--- a/packages/daemon/tests/unit/rpc-handlers/skill-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/skill-handlers.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for Skills RPC Handlers
+ *
+ * Tests the RPC handlers for Skills registry operations:
+ * - skill.list       — list all skills
+ * - skill.get        — get a single skill by id
+ * - skill.create     — add a new skill
+ * - skill.update     — update a skill
+ * - skill.delete     — remove a skill
+ * - skill.setEnabled — toggle enabled flag
+ */
+
+import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import { registerSkillHandlers } from '../../../src/lib/rpc-handlers/skill-handlers';
+import type { SkillsManager } from '../../../src/lib/skills-manager';
+import type { AppSkill, CreateSkillParams, UpdateSkillParams } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const mockSkill: AppSkill = {
+	id: 'skill-1',
+	name: 'test-skill',
+	displayName: 'Test Skill',
+	description: 'A test skill',
+	sourceType: 'builtin',
+	config: { type: 'builtin', commandName: '/test' },
+	enabled: true,
+	builtIn: false,
+	validationStatus: 'valid',
+	createdAt: Date.now(),
+};
+
+const createSkillParams: CreateSkillParams = {
+	name: 'new-skill',
+	displayName: 'New Skill',
+	description: 'A new skill',
+	sourceType: 'builtin',
+	config: { type: 'builtin', commandName: '/new' },
+	enabled: true,
+	validationStatus: 'pending',
+};
+
+const updateSkillParams: UpdateSkillParams = {
+	displayName: 'Updated Skill',
+	description: 'Updated description',
+};
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+
+	return { hub, handlers };
+}
+
+function createMockSkillsManager() {
+	return {
+		listSkills: mock(() => [mockSkill]),
+		getSkill: mock((id: string) => (id === mockSkill.id ? mockSkill : null)),
+		addSkill: mock((params: CreateSkillParams) => ({
+			...mockSkill,
+			id: 'skill-new',
+			name: params.name,
+			displayName: params.displayName,
+		})),
+		updateSkill: mock((id: string, params: UpdateSkillParams) => ({
+			...mockSkill,
+			...params,
+		})),
+		removeSkill: mock((id: string) => id === mockSkill.id),
+		setSkillEnabled: mock((id: string, enabled: boolean) => ({
+			...mockSkill,
+			enabled,
+		})),
+	} as unknown as SkillsManager;
+}
+
+function createMockDaemonHub() {
+	return {
+		emit: mock(() => Promise.resolve()),
+		on: mock(() => () => {}),
+	} as unknown as import('../../../src/lib/daemon-hub').DaemonHub;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Skill RPC Handlers', () => {
+	let hubData: ReturnType<typeof createMockMessageHub>;
+	let skillsManager: ReturnType<typeof createMockSkillsManager>;
+	let daemonHub: ReturnType<typeof createMockDaemonHub>;
+
+	beforeEach(() => {
+		hubData = createMockMessageHub();
+		skillsManager = createMockSkillsManager();
+		daemonHub = createMockDaemonHub();
+
+		registerSkillHandlers(hubData.hub, skillsManager, daemonHub);
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	describe('skill.list', () => {
+		it('returns all skills', async () => {
+			const handler = hubData.handlers.get('skill.list');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({}, {})) as { skills: AppSkill[] };
+			expect(result.skills).toHaveLength(1);
+			expect(result.skills[0].id).toBe('skill-1');
+			expect(skillsManager.listSkills).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('skill.get', () => {
+		it('returns a skill by id', async () => {
+			const handler = hubData.handlers.get('skill.get');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ id: 'skill-1' }, {})) as { skill: AppSkill };
+			expect(result.skill).toBeDefined();
+			expect(result.skill!.id).toBe('skill-1');
+			expect(skillsManager.getSkill).toHaveBeenCalledWith('skill-1');
+		});
+
+		it('returns null for non-existent skill', async () => {
+			const handler = hubData.handlers.get('skill.get');
+			const result = (await handler!({ id: 'nonexistent' }, {})) as { skill: AppSkill | null };
+			expect(result.skill).toBeNull();
+		});
+
+		it('throws if id is missing', async () => {
+			const handler = hubData.handlers.get('skill.get');
+			await expect(handler!({}, {})).rejects.toThrow('id is required');
+		});
+	});
+
+	describe('skill.create', () => {
+		it('creates a skill and emits skills.changed', async () => {
+			const handler = hubData.handlers.get('skill.create');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ params: createSkillParams }, {})) as { skill: AppSkill };
+			expect(result.skill).toBeDefined();
+			expect(result.skill.name).toBe('new-skill');
+			expect(result.skill.id).toBe('skill-new');
+			expect(skillsManager.addSkill).toHaveBeenCalledWith(createSkillParams);
+			expect(daemonHub.emit).toHaveBeenCalledWith('skills.changed', { sessionId: 'global' });
+		});
+
+		it('throws if params is missing', async () => {
+			const handler = hubData.handlers.get('skill.create');
+			await expect(handler!({}, {})).rejects.toThrow('params is required');
+		});
+
+		it('surfaces validation errors from SkillsManager', async () => {
+			skillsManager.addSkill = mock(() => {
+				throw new Error('sourceType "plugin" must match config.type "builtin"');
+			}) as unknown as SkillsManager['addSkill'];
+
+			const handler = hubData.handlers.get('skill.create');
+			await expect(handler!({ params: createSkillParams }, {})).rejects.toThrow(
+				'sourceType "plugin" must match config.type "builtin"'
+			);
+		});
+
+		it('surfaces duplicate name error from SkillsManager', async () => {
+			skillsManager.addSkill = mock(() => {
+				throw new Error('A skill named "new-skill" already exists');
+			}) as unknown as SkillsManager['addSkill'];
+
+			const handler = hubData.handlers.get('skill.create');
+			await expect(handler!({ params: createSkillParams }, {})).rejects.toThrow(
+				'A skill named "new-skill" already exists'
+			);
+		});
+	});
+
+	describe('skill.update', () => {
+		it('updates a skill and emits skills.changed', async () => {
+			const handler = hubData.handlers.get('skill.update');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ id: 'skill-1', params: updateSkillParams }, {})) as {
+				skill: AppSkill;
+			};
+			expect(result.skill).toBeDefined();
+			expect(result.skill.displayName).toBe('Updated Skill');
+			expect(skillsManager.updateSkill).toHaveBeenCalledWith('skill-1', updateSkillParams);
+			expect(daemonHub.emit).toHaveBeenCalledWith('skills.changed', { sessionId: 'global' });
+		});
+
+		it('throws if id is missing', async () => {
+			const handler = hubData.handlers.get('skill.update');
+			await expect(handler!({ params: updateSkillParams }, {})).rejects.toThrow('id is required');
+		});
+
+		it('throws if params is missing', async () => {
+			const handler = hubData.handlers.get('skill.update');
+			await expect(handler!({ id: 'skill-1' }, {})).rejects.toThrow('params is required');
+		});
+
+		it('surfaces "not found" error from SkillsManager', async () => {
+			skillsManager.updateSkill = mock(() => {
+				throw new Error('Skill not found: nonexistent-id');
+			}) as unknown as SkillsManager['updateSkill'];
+
+			const handler = hubData.handlers.get('skill.update');
+			await expect(
+				handler!({ id: 'nonexistent-id', params: updateSkillParams }, {})
+			).rejects.toThrow('Skill not found: nonexistent-id');
+		});
+	});
+
+	describe('skill.delete', () => {
+		it('removes a skill and emits skills.changed', async () => {
+			const handler = hubData.handlers.get('skill.delete');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ id: 'skill-1' }, {})) as { success: boolean };
+			expect(result.success).toBe(true);
+			expect(skillsManager.removeSkill).toHaveBeenCalledWith('skill-1');
+			expect(daemonHub.emit).toHaveBeenCalledWith('skills.changed', { sessionId: 'global' });
+		});
+
+		it('throws if id is missing', async () => {
+			const handler = hubData.handlers.get('skill.delete');
+			await expect(handler!({}, {})).rejects.toThrow('id is required');
+		});
+
+		it('throws if skill cannot be removed (not found or built-in)', async () => {
+			skillsManager.removeSkill = mock(() => false);
+
+			const handler = hubData.handlers.get('skill.delete');
+			await expect(handler!({ id: 'nonexistent' }, {})).rejects.toThrow(
+				'Skill not found or cannot be removed: nonexistent'
+			);
+		});
+	});
+
+	describe('skill.setEnabled', () => {
+		it('enables a skill and emits skills.changed', async () => {
+			const handler = hubData.handlers.get('skill.setEnabled');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ id: 'skill-1', enabled: false }, {})) as {
+				skill: AppSkill;
+			};
+			expect(result.skill).toBeDefined();
+			expect(result.skill.enabled).toBe(false);
+			expect(skillsManager.setSkillEnabled).toHaveBeenCalledWith('skill-1', false);
+			expect(daemonHub.emit).toHaveBeenCalledWith('skills.changed', { sessionId: 'global' });
+		});
+
+		it('throws if id is missing', async () => {
+			const handler = hubData.handlers.get('skill.setEnabled');
+			await expect(handler!({ enabled: true }, {})).rejects.toThrow('id is required');
+		});
+
+		it('throws if enabled is not a boolean', async () => {
+			const handler = hubData.handlers.get('skill.setEnabled');
+			await expect(handler!({ id: 'skill-1', enabled: 'yes' }, {})).rejects.toThrow(
+				'enabled must be a boolean'
+			);
+		});
+
+		it('surfaces "not found" error from SkillsManager', async () => {
+			skillsManager.setSkillEnabled = mock(() => {
+				throw new Error('Skill not found: nonexistent');
+			}) as unknown as SkillsManager['setSkillEnabled'];
+
+			const handler = hubData.handlers.get('skill.setEnabled');
+			await expect(handler!({ id: 'nonexistent', enabled: true }, {})).rejects.toThrow(
+				'Skill not found: nonexistent'
+			);
+		});
+	});
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -30,6 +30,7 @@ import type {
 	CreateAppMcpServerRequest,
 	UpdateAppMcpServerRequest,
 } from './types/app-mcp-server.ts';
+import type { AppSkill, CreateSkillParams, UpdateSkillParams } from './types/skills.ts';
 
 // Request types
 export interface CreateSessionRequest {
@@ -718,4 +719,72 @@ export interface McpRegistryError {
 /** Response from mcp.registry.listErrors */
 export interface McpRegistryListErrorsResponse {
 	errors: McpRegistryError[];
+}
+
+// ---------------------------------------------------------------------------
+// Skills RPC types (skill.*)
+//
+// Request/Response types for the application-level Skills registry RPC methods.
+// ---------------------------------------------------------------------------
+
+export type { AppSkill, CreateSkillParams, UpdateSkillParams };
+
+/** Request for skill.list */
+export interface SkillListRequest {}
+
+/** Response from skill.list */
+export interface SkillListResponse {
+	skills: AppSkill[];
+}
+
+/** Request for skill.get */
+export interface SkillGetRequest {
+	id: string;
+}
+
+/** Response from skill.get */
+export interface SkillGetResponse {
+	skill: AppSkill | null;
+}
+
+/** Request for skill.create */
+export interface SkillCreateRequest {
+	params: CreateSkillParams;
+}
+
+/** Response from skill.create */
+export interface SkillCreateResponse {
+	skill: AppSkill;
+}
+
+/** Request for skill.update */
+export interface SkillUpdateRequest {
+	id: string;
+	params: UpdateSkillParams;
+}
+
+/** Response from skill.update */
+export interface SkillUpdateResponse {
+	skill: AppSkill;
+}
+
+/** Request for skill.delete */
+export interface SkillDeleteRequest {
+	id: string;
+}
+
+/** Response from skill.delete */
+export interface SkillDeleteResponse {
+	success: boolean;
+}
+
+/** Request for skill.setEnabled */
+export interface SkillSetEnabledRequest {
+	id: string;
+	enabled: boolean;
+}
+
+/** Response from skill.setEnabled */
+export interface SkillSetEnabledResponse {
+	skill: AppSkill;
 }


### PR DESCRIPTION
Add 6 RPC handlers for Skills CRUD operations, enabling the web UI to manage skills via MessageHub.

**Handlers:** `skill.list`, `skill.get`, `skill.create`, `skill.update`, `skill.delete`, `skill.setEnabled`

- Request/response types in `packages/shared/src/api.ts`
- Handlers in `packages/daemon/src/lib/rpc-handlers/skill-handlers.ts` using `SkillsManager`
- `skillsManager` wired through `RPCHandlerDependencies` → `setupRPCHandlers()`
- Each mutating handler emits `skills.changed` event on `DaemonHub`
- Validation errors from `SkillsManager` surfaced as RPC error responses
- 19 unit tests covering success and error paths for all 6 handlers