### PR TITLE
feat(daemon): SKILL_VALIDATE job queue for async skill validation

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -23,7 +23,8 @@ import type { TaskAgentManager } from './lib/space/runtime/task-agent-manager';
 import { JobQueueRepository } from './storage/repositories/job-queue-repository';
 import { JobQueueProcessor } from './storage/job-queue-processor';
 import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
-import { JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
+import { createSkillValidateHandler } from './lib/job-handlers/skill-validate.handler';
+import { JOB_QUEUE_CLEANUP, SKILL_VALIDATE } from './lib/job-queue-constants';
 import { AppMcpLifecycleManager, seedDefaultMcpEntries } from './lib/mcp';
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
@@ -276,7 +277,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	seedDefaultMcpEntries(db);
 
 	// Instantiate Skills manager and initialize built-in skills
-	const skillsManager = new SkillsManager(db.skills, db.appMcpServers);
+	const skillsManager = new SkillsManager(db.skills, db.appMcpServers, jobQueue);
 	skillsManager.initializeBuiltins();
 
 	// Initialize workspace file index (non-blocking — init runs in the background)
@@ -422,6 +423,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Register job handlers BEFORE starting the processor so no pending job
 	// from a previous run is dequeued without a handler available.
+	jobProcessor.register(
+		SKILL_VALIDATE,
+		createSkillValidateHandler(skillsManager, db.appMcpServers)
+	);
 	jobProcessor.register(JOB_QUEUE_CLEANUP, createCleanupHandler(jobQueue));
 
 	// Enqueue the initial cleanup job if none is already pending.

--- a/packages/daemon/src/lib/job-handlers/skill-validate.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/skill-validate.handler.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants } from 'node:fs';
+import { access, constants } from 'node:fs/promises';
 import type { Job } from '../../storage/repositories/job-queue-repository';
 import type { SkillsManager } from '../skills-manager';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
@@ -25,21 +25,24 @@ export function createSkillValidateHandler(
 			throw new Error(`Skill not found: ${skillId}`);
 		}
 
-		if (isPluginSkillConfig(skill.config)) {
-			// Check that the plugin path exists and is accessible
-			accessSync(skill.config.pluginPath, constants.R_OK);
-		} else if (isMcpServerSkillConfig(skill.config)) {
-			// Check that the referenced app_mcp_servers entry still exists
-			const server = appMcpServerRepo.get(skill.config.appMcpServerId);
-			if (!server) {
-				throw new Error(
-					`mcp_server skill "${skill.name}": app_mcp_servers entry not found for id "${skill.config.appMcpServerId}"`
-				);
+		try {
+			if (isPluginSkillConfig(skill.config)) {
+				await access(skill.config.pluginPath, constants.R_OK);
+			} else if (isMcpServerSkillConfig(skill.config)) {
+				const server = appMcpServerRepo.get(skill.config.appMcpServerId);
+				if (!server) {
+					throw new Error(
+						`mcp_server skill "${skill.name}": app_mcp_servers entry not found for id "${skill.config.appMcpServerId}"`
+					);
+				}
 			}
-		}
-		// builtin skills are always valid — no-op
+			// builtin skills are always valid — no-op
 
-		skillsManager.setSkillValidationStatus(skillId, 'valid');
-		return { valid: true, skillId };
+			skillsManager.setSkillValidationStatus(skillId, 'valid');
+			return { valid: true, skillId };
+		} catch (error) {
+			skillsManager.setSkillValidationStatus(skillId, 'invalid');
+			throw error;
+		}
 	};
 }

--- a/packages/daemon/src/lib/job-handlers/skill-validate.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/skill-validate.handler.ts
@@ -1,0 +1,45 @@
+import { accessSync, constants } from 'node:fs';
+import type { Job } from '../../storage/repositories/job-queue-repository';
+import type { SkillsManager } from '../skills-manager';
+import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
+import { isPluginSkillConfig, isMcpServerSkillConfig } from '@neokai/shared';
+
+export interface SkillValidateResult extends Record<string, unknown> {
+	valid: boolean;
+	skillId: string;
+}
+
+export function createSkillValidateHandler(
+	skillsManager: SkillsManager,
+	appMcpServerRepo: AppMcpServerRepository
+) {
+	return async function handleSkillValidate(job: Job): Promise<SkillValidateResult> {
+		const { skillId } = job.payload as { skillId: string };
+
+		if (!skillId || typeof skillId !== 'string') {
+			throw new Error('Job payload missing required field: skillId');
+		}
+
+		const skill = skillsManager.getSkill(skillId);
+		if (!skill) {
+			throw new Error(`Skill not found: ${skillId}`);
+		}
+
+		if (isPluginSkillConfig(skill.config)) {
+			// Check that the plugin path exists and is accessible
+			accessSync(skill.config.pluginPath, constants.R_OK);
+		} else if (isMcpServerSkillConfig(skill.config)) {
+			// Check that the referenced app_mcp_servers entry still exists
+			const server = appMcpServerRepo.get(skill.config.appMcpServerId);
+			if (!server) {
+				throw new Error(
+					`mcp_server skill "${skill.name}": app_mcp_servers entry not found for id "${skill.config.appMcpServerId}"`
+				);
+			}
+		}
+		// builtin skills are always valid — no-op
+
+		skillsManager.setSkillValidationStatus(skillId, 'valid');
+		return { valid: true, skillId };
+	};
+}

--- a/packages/daemon/src/lib/job-queue-constants.ts
+++ b/packages/daemon/src/lib/job-queue-constants.ts
@@ -7,3 +7,4 @@ export const SESSION_TITLE_GENERATION = 'session.title_generation';
 export const GITHUB_POLL = 'github.poll';
 export const ROOM_TICK = 'room.tick';
 export const JOB_QUEUE_CLEANUP = 'job_queue.cleanup';
+export const SKILL_VALIDATE = 'skill.validate';

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -38,14 +38,6 @@ export class SkillsManager {
 		return this.repo.get(id);
 	}
 
-	/**
-	 * Set the job queue for async validation enqueuing.
-	 * Called by the daemon app after both SkillsManager and JobQueue are created.
-	 */
-	setJobQueue(jobQueue: JobQueueRepository): void {
-		this.jobQueue = jobQueue;
-	}
-
 	addSkill(params: CreateSkillParams): AppSkill {
 		// Validate sourceType/config consistency and security-sensitive fields
 		this.validateSkillConfig(params.sourceType, params.config);
@@ -90,6 +82,7 @@ export class SkillsManager {
 
 		this.repo.update(id, params);
 		if (params.config !== undefined) {
+			this.repo.setValidationStatus(id, 'pending');
 			this.enqueueValidation(id);
 		}
 		return this.repo.get(id)!;

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -16,12 +16,19 @@ import type {
 } from '@neokai/shared';
 import type { SkillRepository } from '../storage/repositories/skill-repository';
 import type { AppMcpServerRepository } from '../storage/repositories/app-mcp-server-repository';
+import type { JobQueueRepository } from '../storage/repositories/job-queue-repository';
+import { SKILL_VALIDATE } from './job-queue-constants';
 
 export class SkillsManager {
+	private jobQueue: JobQueueRepository | null = null;
+
 	constructor(
 		private repo: SkillRepository,
-		private appMcpServerRepo: AppMcpServerRepository
-	) {}
+		private appMcpServerRepo: AppMcpServerRepository,
+		jobQueue?: JobQueueRepository
+	) {
+		if (jobQueue) this.jobQueue = jobQueue;
+	}
 
 	listSkills(): AppSkill[] {
 		return this.repo.findAll();
@@ -29,6 +36,14 @@ export class SkillsManager {
 
 	getSkill(id: string): AppSkill | null {
 		return this.repo.get(id);
+	}
+
+	/**
+	 * Set the job queue for async validation enqueuing.
+	 * Called by the daemon app after both SkillsManager and JobQueue are created.
+	 */
+	setJobQueue(jobQueue: JobQueueRepository): void {
+		this.jobQueue = jobQueue;
 	}
 
 	addSkill(params: CreateSkillParams): AppSkill {
@@ -55,6 +70,7 @@ export class SkillsManager {
 		};
 
 		this.repo.insert(skill);
+		this.enqueueValidation(skill.id);
 		const inserted = this.repo.get(skill.id);
 		if (!inserted) {
 			throw new Error(`Failed to insert skill "${params.name}"`);
@@ -73,6 +89,9 @@ export class SkillsManager {
 		}
 
 		this.repo.update(id, params);
+		if (params.config !== undefined) {
+			this.enqueueValidation(id);
+		}
 		return this.repo.get(id)!;
 	}
 
@@ -126,6 +145,15 @@ export class SkillsManager {
 	// ---------------------------------------------------------------------------
 	// Private helpers
 	// ---------------------------------------------------------------------------
+
+	/**
+	 * Enqueue an async validation job for a skill.
+	 * No-op if jobQueue is not set (e.g. during tests or before full app init).
+	 */
+	private enqueueValidation(skillId: string): void {
+		if (!this.jobQueue) return;
+		this.jobQueue.enqueue({ queue: SKILL_VALIDATE, payload: { skillId } });
+	}
 
 	/**
 	 * Validate source-type-specific config fields for security.

--- a/packages/daemon/tests/unit/job-handlers/skill-validate.handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/skill-validate.handler.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { createSkillValidateHandler } from '../../../src/lib/job-handlers/skill-validate.handler';
+import { SKILL_VALIDATE } from '../../../src/lib/job-queue-constants';
+import type { Job } from '../../../src/storage/repositories/job-queue-repository';
+import type { SkillsManager } from '../../../src/lib/skills-manager';
+import type { AppMcpServerRepository } from '../../../src/storage/repositories/app-mcp-server-repository';
+import type { AppSkill } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJob(payload: Record<string, unknown>): Job {
+	return {
+		id: 'test-job-id',
+		queue: SKILL_VALIDATE,
+		status: 'processing',
+		payload,
+		result: null,
+		error: null,
+		priority: 0,
+		maxRetries: 3,
+		retryCount: 0,
+		runAt: Date.now(),
+		createdAt: Date.now(),
+		startedAt: Date.now(),
+		completedAt: null,
+	};
+}
+
+function makeSkill(overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id: 'skill-1',
+		name: 'test-skill',
+		displayName: 'Test Skill',
+		description: 'A test skill',
+		sourceType: 'builtin',
+		config: { type: 'builtin', commandName: 'test-cmd' },
+		enabled: true,
+		builtIn: false,
+		validationStatus: 'pending',
+		createdAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeSkillsManager(
+	impl?: Partial<Pick<SkillsManager, 'getSkill' | 'setSkillValidationStatus'>>
+): SkillsManager {
+	return {
+		getSkill: impl?.getSkill ?? mock(() => makeSkill()),
+		setSkillValidationStatus: impl?.setSkillValidationStatus ?? mock(() => makeSkill()),
+	} as unknown as SkillsManager;
+}
+
+function makeAppMcpServerRepo(
+	impl?: Partial<Pick<AppMcpServerRepository, 'get'>>
+): AppMcpServerRepository {
+	return {
+		get: impl?.get ?? mock(() => null),
+	} as unknown as AppMcpServerRepository;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createSkillValidateHandler', () => {
+	let handler: ReturnType<typeof createSkillValidateHandler>;
+
+	beforeEach(() => {
+		handler = createSkillValidateHandler(makeSkillsManager(), makeAppMcpServerRepo());
+	});
+
+	it('throws when skillId is missing from payload', async () => {
+		const job = makeJob({});
+		await expect(handler(job)).rejects.toThrow('Job payload missing required field: skillId');
+	});
+
+	it('throws when skillId is not a string', async () => {
+		const job = makeJob({ skillId: 42 });
+		await expect(handler(job)).rejects.toThrow('Job payload missing required field: skillId');
+	});
+
+	it('throws when skill is not found', async () => {
+		const mgr = makeSkillsManager({ getSkill: mock(() => null) });
+		handler = createSkillValidateHandler(mgr, makeAppMcpServerRepo());
+
+		const job = makeJob({ skillId: 'nonexistent' });
+		await expect(handler(job)).rejects.toThrow('Skill not found: nonexistent');
+	});
+
+	it('passes validation for builtin skill and returns { valid: true, skillId }', async () => {
+		const skill = makeSkill({
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'update-config' },
+		});
+		const setStatusMock = mock(() => makeSkill({ validationStatus: 'valid' }));
+		const mgr = makeSkillsManager({
+			getSkill: mock(() => skill),
+			setSkillValidationStatus: setStatusMock,
+		});
+		handler = createSkillValidateHandler(mgr, makeAppMcpServerRepo());
+
+		const job = makeJob({ skillId: 'skill-1' });
+		const result = await handler(job);
+
+		expect(result).toEqual({ valid: true, skillId: 'skill-1' });
+		expect(setStatusMock).toHaveBeenCalledWith('skill-1', 'valid');
+	});
+
+	it('passes validation for plugin skill with accessible path', async () => {
+		// Use a path that always exists
+		const pluginPath = '/';
+		const skill = makeSkill({
+			sourceType: 'plugin',
+			config: { type: 'plugin', pluginPath },
+		});
+		const setStatusMock = mock(() => makeSkill({ validationStatus: 'valid' }));
+		const mgr = makeSkillsManager({
+			getSkill: mock(() => skill),
+			setSkillValidationStatus: setStatusMock,
+		});
+		handler = createSkillValidateHandler(mgr, makeAppMcpServerRepo());
+
+		const job = makeJob({ skillId: 'skill-1' });
+		const result = await handler(job);
+
+		expect(result).toEqual({ valid: true, skillId: 'skill-1' });
+		expect(setStatusMock).toHaveBeenCalledWith('skill-1', 'valid');
+	});
+
+	it('fails validation for plugin skill with non-existent path', async () => {
+		const pluginPath = '/nonexistent/path/that/does/not/exist';
+		const skill = makeSkill({
+			sourceType: 'plugin',
+			config: { type: 'plugin', pluginPath },
+		});
+		const setStatusMock = mock(() => makeSkill());
+		const mgr = makeSkillsManager({
+			getSkill: mock(() => skill),
+			setSkillValidationStatus: setStatusMock,
+		});
+		handler = createSkillValidateHandler(mgr, makeAppMcpServerRepo());
+
+		const job = makeJob({ skillId: 'skill-1' });
+		await expect(handler(job)).rejects.toThrow();
+		expect(setStatusMock).not.toHaveBeenCalled();
+	});
+
+	it('fails validation for mcp_server skill referencing non-existent MCP server', async () => {
+		const skill = makeSkill({
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: 'missing-server-id' },
+			name: 'my-mcp-skill',
+		});
+		const setStatusMock = mock(() => makeSkill());
+		const mcpRepo = makeAppMcpServerRepo({ get: mock(() => null) });
+		const mgr = makeSkillsManager({
+			getSkill: mock(() => skill),
+			setSkillValidationStatus: setStatusMock,
+		});
+		handler = createSkillValidateHandler(mgr, mcpRepo);
+
+		const job = makeJob({ skillId: 'skill-1' });
+		await expect(handler(job)).rejects.toThrow(
+			'mcp_server skill "my-mcp-skill": app_mcp_servers entry not found for id "missing-server-id"'
+		);
+		expect(setStatusMock).not.toHaveBeenCalled();
+	});
+
+	it('passes validation for mcp_server skill when MCP server exists', async () => {
+		const skill = makeSkill({
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: 'existing-server-id' },
+		});
+		const setStatusMock = mock(() => makeSkill({ validationStatus: 'valid' }));
+		const mcpRepo = makeAppMcpServerRepo({
+			get: mock(() => ({ id: 'existing-server-id' }) as never),
+		});
+		const mgr = makeSkillsManager({
+			getSkill: mock(() => skill),
+			setSkillValidationStatus: setStatusMock,
+		});
+		handler = createSkillValidateHandler(mgr, mcpRepo);
+
+		const job = makeJob({ skillId: 'skill-1' });
+		const result = await handler(job);
+
+		expect(result).toEqual({ valid: true, skillId: 'skill-1' });
+		expect(setStatusMock).toHaveBeenCalledWith('skill-1', 'valid');
+	});
+});

--- a/packages/daemon/tests/unit/job-handlers/skill-validate.handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/skill-validate.handler.test.ts
@@ -5,6 +5,9 @@ import type { Job } from '../../../src/storage/repositories/job-queue-repository
 import type { SkillsManager } from '../../../src/lib/skills-manager';
 import type { AppMcpServerRepository } from '../../../src/storage/repositories/app-mcp-server-repository';
 import type { AppSkill } from '@neokai/shared';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -110,8 +113,8 @@ describe('createSkillValidateHandler', () => {
 	});
 
 	it('passes validation for plugin skill with accessible path', async () => {
-		// Use a path that always exists
-		const pluginPath = '/';
+		// Use a temp directory that is guaranteed to exist and be readable
+		const pluginPath = mkdtempSync(join(tmpdir(), 'neokai-test-'));
 		const skill = makeSkill({
 			sourceType: 'plugin',
 			config: { type: 'plugin', pluginPath },
@@ -130,7 +133,7 @@ describe('createSkillValidateHandler', () => {
 		expect(setStatusMock).toHaveBeenCalledWith('skill-1', 'valid');
 	});
 
-	it('fails validation for plugin skill with non-existent path', async () => {
+	it('fails validation for plugin skill with non-existent path and sets status to invalid', async () => {
 		const pluginPath = '/nonexistent/path/that/does/not/exist';
 		const skill = makeSkill({
 			sourceType: 'plugin',
@@ -145,10 +148,10 @@ describe('createSkillValidateHandler', () => {
 
 		const job = makeJob({ skillId: 'skill-1' });
 		await expect(handler(job)).rejects.toThrow();
-		expect(setStatusMock).not.toHaveBeenCalled();
+		expect(setStatusMock).toHaveBeenCalledWith('skill-1', 'invalid');
 	});
 
-	it('fails validation for mcp_server skill referencing non-existent MCP server', async () => {
+	it('fails validation for mcp_server skill referencing non-existent MCP server and sets status to invalid', async () => {
 		const skill = makeSkill({
 			sourceType: 'mcp_server',
 			config: { type: 'mcp_server', appMcpServerId: 'missing-server-id' },
@@ -166,7 +169,7 @@ describe('createSkillValidateHandler', () => {
 		await expect(handler(job)).rejects.toThrow(
 			'mcp_server skill "my-mcp-skill": app_mcp_servers entry not found for id "missing-server-id"'
 		);
-		expect(setStatusMock).not.toHaveBeenCalled();
+		expect(setStatusMock).toHaveBeenCalledWith('skill-1', 'invalid');
 	});
 
 	it('passes validation for mcp_server skill when MCP server exists', async () => {


### PR DESCRIPTION
## Summary
- Add `SKILL_VALIDATE` job queue constant and `createSkillValidateHandler` that validates skills asynchronously after add/update
- Handler checks plugin path accessibility (`fs.accessSync`) and MCP server reference existence (`AppMcpServerRepository.get`)
- Builtin skills pass validation as no-op
- `SkillsManager` enqueues a validation job in `addSkill()` and `updateSkill()` (when config changes) via optional `jobQueue` dependency
- Handler registered in `app.ts` before `jobProcessor.start()`
- 8 unit tests covering all skill types and error cases

## Test plan
- [x] `bun test packages/daemon/tests/unit/job-handlers/skill-validate.handler.test.ts` — 8/8 pass
- [x] `bun test packages/daemon/tests/unit/skills-manager.test.ts` — 38/38 pass (no regression)
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — 0 errors