### PR TITLE
feat(daemon): room-level skill enablement persistence (room_skill_overrides table)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -181,7 +181,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.daemonHub,
 		deps.config.workspaceRoot,
 		deps.sessionManager,
-		deps.jobQueue
+		deps.jobQueue,
+		deps.db
 	);
 
 	// Room Runtime Service (must be created before task/goal handlers — messaging + task approval need it)

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -275,6 +275,34 @@ function mapMcpEnablementRow(row: Record<string, unknown>): Record<string, unkno
 	};
 }
 
+const SKILLS_BY_ROOM_SQL = `
+SELECT
+  s.id,
+  s.name,
+  s.display_name AS displayName,
+  s.description,
+  s.source_type AS sourceType,
+  s.config,
+  s.built_in AS builtIn,
+  s.validation_status AS validationStatus,
+  s.created_at AS createdAt,
+  CASE WHEN rso.enabled IS NOT NULL THEN rso.enabled ELSE s.enabled END AS enabled,
+  CASE WHEN rso.skill_id IS NOT NULL THEN 1 ELSE 0 END AS overriddenByRoom
+FROM skills s
+LEFT JOIN room_skill_overrides rso ON rso.skill_id = s.id AND rso.room_id = ?
+ORDER BY s.built_in DESC, s.created_at ASC, s.id ASC
+`.trim();
+
+function mapSkillByRoomRow(row: Record<string, unknown>): Record<string, unknown> {
+	return {
+		...row,
+		config: JSON.parse(row.config as string),
+		enabled: row.enabled === 1,
+		builtIn: row.builtIn === 1,
+		overriddenByRoom: row.overriddenByRoom === 1,
+	};
+}
+
 /**
  * Canonical task timeline query (no projection table):
  * - SDK messages are read directly from sdk_messages joined through session_group_members.
@@ -390,6 +418,14 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			mapRow: mapMcpEnablementRow,
 		},
 	],
+	[
+		'skills.byRoom',
+		{
+			sql: SKILLS_BY_ROOM_SQL,
+			paramCount: 1,
+			mapRow: mapSkillByRoomRow,
+		},
+	],
 ]);
 
 // ============================================================================
@@ -453,7 +489,8 @@ export function setupLiveQueryHandlers(
 		if (
 			queryName === 'tasks.byRoom' ||
 			queryName === 'goals.byRoom' ||
-			queryName === 'mcpEnablement.byRoom'
+			queryName === 'mcpEnablement.byRoom' ||
+			queryName === 'skills.byRoom'
 		) {
 			const roomId = params[0] as string;
 			if (!stmtRoom.get(roomId)) {

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -19,6 +19,7 @@ import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import type { SessionManager } from '../session-manager';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { Database } from '../../storage/database';
 import { getCliAgents, refresh as refreshCliAgents } from '../room/agents/cli-agent-registry';
 import { inferProviderForModel } from '../providers/registry';
 import { Logger } from '../logger';
@@ -32,7 +33,8 @@ export function setupRoomHandlers(
 	daemonHub: DaemonHub,
 	workspaceRoot?: string,
 	sessionManager?: SessionManager,
-	jobQueue?: JobQueueRepository
+	jobQueue?: JobQueueRepository,
+	db?: Database
 ): void {
 	// room.create - Create a new room
 	messageHub.onRequest('room.create', async (data) => {
@@ -281,6 +283,38 @@ export function setupRoomHandlers(
 		}
 		return { agents: getCliAgents() };
 	});
+
+	// --- Per-Room Skill Override Handlers ---
+	if (db) {
+		// room.getSkillOverrides - Get all skill overrides for a room
+		messageHub.onRequest('room.getSkillOverrides', (data) => {
+			const params = data as { roomId: string };
+			if (!params.roomId) throw new Error('Room ID is required');
+			const overrides = db.roomSkillOverrides.getOverrides(params.roomId);
+			return { overrides } satisfies {
+				overrides: Array<{ skillId: string; roomId: string; enabled: boolean }>;
+			};
+		});
+
+		// room.setSkillOverride - Set (upsert) a skill override for a room
+		messageHub.onRequest('room.setSkillOverride', (data) => {
+			const params = data as { roomId: string; skillId: string; enabled: boolean };
+			if (!params.roomId) throw new Error('Room ID is required');
+			if (!params.skillId) throw new Error('Skill ID is required');
+			if (typeof params.enabled !== 'boolean') throw new Error('enabled must be a boolean');
+			db.roomSkillOverrides.upsertOverride(params.roomId, params.skillId, params.enabled);
+			return { success: true } satisfies { success: boolean };
+		});
+
+		// room.clearSkillOverride - Remove a skill override for a room (revert to global)
+		messageHub.onRequest('room.clearSkillOverride', (data) => {
+			const params = data as { roomId: string; skillId: string };
+			if (!params.roomId) throw new Error('Room ID is required');
+			if (!params.skillId) throw new Error('Skill ID is required');
+			db.roomSkillOverrides.deleteOverride(params.roomId, params.skillId);
+			return { success: true } satisfies { success: boolean };
+		});
+	}
 }
 
 export function setupRoomRuntimeHandlers(

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -37,6 +37,7 @@ import { AppMcpServerRepository } from './repositories/app-mcp-server-repository
 import { TaskRepository } from './repositories/task-repository';
 import { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
 import { SkillRepository } from './repositories/skill-repository';
+import { RoomSkillOverrideRepository } from './repositories/room-skill-override-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -61,6 +62,7 @@ export { SpaceAgentRepository } from './repositories/space-agent-repository';
 export { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 export { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
 export { SkillRepository } from './repositories/skill-repository';
+export { RoomSkillOverrideRepository } from './repositories/room-skill-override-repository';
 
 /**
  * Database facade class that maintains backward compatibility with the original Database class.
@@ -81,6 +83,7 @@ export class Database {
 	private taskRepo!: TaskRepository;
 	private roomMcpEnablementRepo!: RoomMcpEnablementRepository;
 	private skillRepo!: SkillRepository;
+	private roomSkillOverrideRepo!: RoomSkillOverrideRepository;
 	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
@@ -105,6 +108,7 @@ export class Database {
 		this.appMcpServerRepo = new AppMcpServerRepository(db, reactiveDb);
 		this.roomMcpEnablementRepo = new RoomMcpEnablementRepository(db, reactiveDb);
 		this.skillRepo = new SkillRepository(db, reactiveDb);
+		this.roomSkillOverrideRepo = new RoomSkillOverrideRepository(db, reactiveDb);
 	}
 
 	// ============================================================================
@@ -468,6 +472,13 @@ export class Database {
 	 */
 	get skills(): SkillRepository {
 		return this.skillRepo;
+	}
+
+	/**
+	 * Get the per-room skill override repository
+	 */
+	get roomSkillOverrides(): RoomSkillOverrideRepository {
+		return this.roomSkillOverrideRepo;
 	}
 
 	close(): void {

--- a/packages/daemon/src/storage/repositories/room-skill-override-repository.ts
+++ b/packages/daemon/src/storage/repositories/room-skill-override-repository.ts
@@ -1,0 +1,84 @@
+/**
+ * RoomSkillOverrideRepository
+ *
+ * Stores per-room overrides for which skills are enabled.
+ * Each write calls reactiveDb.notifyChange('room_skill_overrides') so that
+ * LiveQueryEngine can invalidate frontend subscriptions on every change.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type { RoomSkillOverride } from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+
+// ---------------------------------------------------------------------------
+// Internal row type
+// ---------------------------------------------------------------------------
+
+interface OverrideRow {
+	skill_id: string;
+	room_id: string;
+	enabled: number;
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+export class RoomSkillOverrideRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb: ReactiveDatabase
+	) {}
+
+	/**
+	 * Get all overrides for a room.
+	 */
+	getOverrides(roomId: string): RoomSkillOverride[] {
+		const rows = this.db
+			.prepare(
+				`SELECT skill_id, room_id, enabled
+         FROM room_skill_overrides
+         WHERE room_id = ?`
+			)
+			.all(roomId) as OverrideRow[];
+		return rows.map((r) => ({
+			skillId: r.skill_id,
+			roomId: r.room_id,
+			enabled: r.enabled === 1,
+		}));
+	}
+
+	/**
+	 * Upsert an override for a single skill in a room.
+	 * Calling with enabled=true or enabled=false sets an explicit override.
+	 * Use deleteOverride() to remove an override and revert to global.
+	 */
+	upsertOverride(roomId: string, skillId: string, enabled: boolean): void {
+		this.db
+			.prepare(
+				`INSERT INTO room_skill_overrides (skill_id, room_id, enabled)
+         VALUES (?, ?, ?)
+         ON CONFLICT(skill_id, room_id) DO UPDATE SET enabled = excluded.enabled`
+			)
+			.run(skillId, roomId, enabled ? 1 : 0);
+		this.reactiveDb.notifyChange('room_skill_overrides');
+	}
+
+	/**
+	 * Remove a single override, reverting to global default.
+	 */
+	deleteOverride(roomId: string, skillId: string): void {
+		this.db
+			.prepare(`DELETE FROM room_skill_overrides WHERE room_id = ? AND skill_id = ?`)
+			.run(roomId, skillId);
+		this.reactiveDb.notifyChange('room_skill_overrides');
+	}
+
+	/**
+	 * Remove all overrides for a room, reverting all skills to global defaults.
+	 */
+	deleteAllForRoom(roomId: string): void {
+		this.db.prepare(`DELETE FROM room_skill_overrides WHERE room_id = ?`).run(roomId);
+		this.reactiveDb.notifyChange('room_skill_overrides');
+	}
+}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -384,6 +384,16 @@ export function createTables(db: BunDatabase): void {
       )
     `);
 
+	// Per-room skill enablement overrides
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS room_skill_overrides (
+        skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+        room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        PRIMARY KEY (skill_id, room_id)
+      )
+    `);
+
 	db.exec(`
       CREATE TABLE IF NOT EXISTS job_queue (
         id TEXT PRIMARY KEY,

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -31,6 +31,8 @@ export { runMigration55 } from './migrations';
 export { runMigration56 } from './migrations';
 // knip-ignore-next-line
 export { runMigration57 } from './migrations';
+// knip-ignore-next-line
+export { runMigration58 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -233,6 +233,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 57: Create skills table for application-level Skills registry.
 	// Idempotent via CREATE TABLE IF NOT EXISTS.
 	runMigration57(db);
+
+	// Migration 58: Create room_skill_overrides table for per-room skill enablement.
+	// Mirrors the room_mcp_enablement pattern (migration 52) but references skills(id).
+	// Idempotent via CREATE TABLE IF NOT EXISTS.
+	runMigration58(db);
 }
 
 /**
@@ -3730,6 +3735,22 @@ export function runMigration57(db: BunDatabase): void {
       built_in INTEGER NOT NULL DEFAULT 0,
       validation_status TEXT NOT NULL DEFAULT 'pending',
       created_at INTEGER NOT NULL
+    )
+  `);
+}
+
+/**
+ * Migration 58: Create room_skill_overrides table for per-room skill enablement.
+ * Mirrors the room_mcp_enablement pattern (migration 52) but references skills(id).
+ * Idempotent via CREATE TABLE IF NOT EXISTS.
+ */
+export function runMigration58(db: BunDatabase): void {
+	db.exec(`
+    CREATE TABLE IF NOT EXISTS room_skill_overrides (
+      skill_id TEXT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+      room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      PRIMARY KEY (skill_id, room_id)
     )
   `);
 }

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
@@ -48,12 +48,14 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		expect(NAMED_QUERY_REGISTRY.has('tasks.byRoom')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('goals.byRoom')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('sessionGroupMessages.byGroup')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('skills.byRoom')).toBe(true);
 	});
 
 	test('all registry entries have correct paramCount', () => {
 		expect(NAMED_QUERY_REGISTRY.get('tasks.byRoom')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('goals.byRoom')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!.paramCount).toBe(1);
+		expect(NAMED_QUERY_REGISTRY.get('skills.byRoom')!.paramCount).toBe(1);
 	});
 
 	// -------------------------------------------------------------------------
@@ -366,6 +368,122 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		test('ORDER BY is createdAt ASC, id ASC (deterministic tiebreaker)', () => {
 			const sql = NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!.sql;
 			expect(sql).toContain('ORDER BY createdAt ASC, id ASC');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// skills.byRoom — global skills with per-room override via LEFT JOIN
+	// -------------------------------------------------------------------------
+
+	describe('skills.byRoom', () => {
+		function insertSkill(
+			id: string,
+			name: string,
+			opts: { enabled?: boolean; builtIn?: boolean } = {}
+		): void {
+			const enabled = opts.enabled ?? true;
+			const builtIn = opts.builtIn ? 1 : 0;
+			const config = JSON.stringify({ type: 'builtin', commandName: name });
+			db.exec(`
+				INSERT INTO skills (id, name, display_name, description, source_type, config, enabled, built_in, validation_status, created_at)
+				VALUES ('${id}', '${name}', '${name}', '${name} skill', 'builtin', '${config}', ${enabled ? 1 : 0}, ${builtIn}, 'valid', ${now})
+			`);
+		}
+
+		function setOverride(roomId: string, skillId: string, enabled: boolean): void {
+			db.exec(`
+				INSERT INTO room_skill_overrides (skill_id, room_id, enabled)
+				VALUES ('${skillId}', '${roomId}', ${enabled ? 1 : 0})
+			`);
+		}
+
+		function queryAndMap(): Record<string, unknown>[] {
+			const entry = NAMED_QUERY_REGISTRY.get('skills.byRoom')!;
+			const rows = db.prepare(entry.sql).all(roomId) as Record<string, unknown>[];
+			return entry.mapRow ? rows.map(entry.mapRow) : rows;
+		}
+
+		test('returns global enabled when no room override row exists', () => {
+			insertSkill('s-1', 'alpha', { enabled: true });
+			insertSkill('s-2', 'beta', { enabled: false });
+
+			const rows = queryAndMap();
+			expect(rows).toHaveLength(2);
+			const alpha = rows.find((r) => r.name === 'alpha')!;
+			const beta = rows.find((r) => r.name === 'beta')!;
+			expect(alpha.enabled).toBe(true);
+			expect(beta.enabled).toBe(false);
+			expect(alpha.overriddenByRoom).toBe(false);
+			expect(beta.overriddenByRoom).toBe(false);
+		});
+
+		test('returns room override enabled when override row exists', () => {
+			insertSkill('s-1', 'alpha', { enabled: true });
+			insertSkill('s-2', 'beta', { enabled: true });
+
+			// Override alpha to disabled in the room
+			setOverride(roomId, 's-1', false);
+
+			const rows = queryAndMap();
+			const alpha = rows.find((r) => r.name === 'alpha')!;
+			const beta = rows.find((r) => r.name === 'beta')!;
+			expect(alpha.enabled).toBe(false);
+			expect(alpha.overriddenByRoom).toBe(true);
+			expect(beta.enabled).toBe(true);
+			expect(beta.overriddenByRoom).toBe(false);
+		});
+
+		test('room override can enable a globally disabled skill', () => {
+			insertSkill('s-1', 'alpha', { enabled: false });
+			setOverride(roomId, 's-1', true);
+
+			const [row] = queryAndMap();
+			expect(row.enabled).toBe(true);
+			expect(row.overriddenByRoom).toBe(true);
+		});
+
+		test('config is parsed as JSON object', () => {
+			insertSkill('s-1', 'alpha');
+			const [row] = queryAndMap();
+			expect(typeof row.config).toBe('object');
+			expect(row.config).toEqual({ type: 'builtin', commandName: 'alpha' });
+		});
+
+		test('builtIn is converted from SQLite integer to boolean', () => {
+			insertSkill('s-1', 'builtin-skill', { builtIn: true });
+			insertSkill('s-2', 'custom-skill', { builtIn: false });
+
+			const rows = queryAndMap();
+			const builtin = rows.find((r) => r.name === 'builtin-skill')!;
+			const custom = rows.find((r) => r.name === 'custom-skill')!;
+			expect(builtin.builtIn).toBe(true);
+			expect(custom.builtIn).toBe(false);
+		});
+
+		test('displayName and sourceType are camelCase aliases', () => {
+			insertSkill('s-1', 'alpha');
+			const [row] = queryAndMap();
+			expect(row).toHaveProperty('displayName', 'alpha');
+			expect(row).toHaveProperty('sourceType', 'builtin');
+			expect(row).not.toHaveProperty('display_name');
+			expect(row).not.toHaveProperty('source_type');
+		});
+
+		test('ORDER BY is built_in DESC, created_at ASC, id ASC (deterministic)', () => {
+			const sql = NAMED_QUERY_REGISTRY.get('skills.byRoom')!.sql;
+			expect(sql).toContain('ORDER BY s.built_in DESC, s.created_at ASC, s.id ASC');
+		});
+
+		test('LEFT JOIN preserves skills with no override row', () => {
+			insertSkill('s-1', 'no-override');
+			const rows = queryAndMap();
+			expect(rows).toHaveLength(1);
+			expect(rows[0].overriddenByRoom).toBe(false);
+		});
+
+		test('has mapRow function', () => {
+			const entry = NAMED_QUERY_REGISTRY.get('skills.byRoom')!;
+			expect(typeof entry.mapRow).toBe('function');
 		});
 	});
 

--- a/packages/daemon/tests/unit/storage/room-skill-override-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/room-skill-override-repository.test.ts
@@ -1,0 +1,252 @@
+/**
+ * RoomSkillOverrideRepository Unit Tests
+ *
+ * Covers getOverrides, upsertOverride, deleteOverride, deleteAllForRoom,
+ * notifyChange calls, cascade deletes, and per-room isolation.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import { RoomSkillOverrideRepository } from '../../../src/storage/repositories/room-skill-override-repository';
+import { SkillRepository } from '../../../src/storage/repositories/skill-repository';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+import type { AppSkill } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('RoomSkillOverrideRepository', () => {
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let repo: RoomSkillOverrideRepository;
+	let skillRepo: SkillRepository;
+	let notifyChangeSpy: ReturnType<typeof mock>;
+
+	const ROOM_A = 'room-aaa';
+	const ROOM_B = 'room-bbb';
+
+	function insertRoom(id: string): void {
+		const now = Date.now();
+		bunDb
+			.prepare(`INSERT INTO rooms (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)`)
+			.run(id, id, now, now);
+	}
+
+	function insertSkill(name: string, enabled = true): string {
+		const id = `skill-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		const skill: AppSkill = {
+			id,
+			name,
+			displayName: name,
+			description: `${name} skill`,
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: name },
+			enabled,
+			builtIn: false,
+			validationStatus: 'pending',
+			createdAt: Date.now(),
+		};
+		skillRepo.insert(skill);
+		return id;
+	}
+
+	beforeEach(() => {
+		bunDb = new BunDatabase(':memory:');
+		bunDb.exec('PRAGMA foreign_keys = ON');
+		createTables(bunDb);
+
+		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+		notifyChangeSpy = mock(() => {});
+		reactiveDb.notifyChange = notifyChangeSpy;
+
+		skillRepo = new SkillRepository(bunDb, reactiveDb);
+		repo = new RoomSkillOverrideRepository(bunDb, reactiveDb);
+
+		insertRoom(ROOM_A);
+		insertRoom(ROOM_B);
+	});
+
+	afterEach(() => {
+		bunDb.close();
+	});
+
+	// ---------------------------------------------------------------------------
+	// getOverrides
+	// ---------------------------------------------------------------------------
+
+	describe('getOverrides', () => {
+		test('returns empty array when no overrides exist', () => {
+			expect(repo.getOverrides(ROOM_A)).toEqual([]);
+		});
+
+		test('returns all overrides for a room', () => {
+			const skillId1 = insertSkill('alpha');
+			const skillId2 = insertSkill('beta');
+			repo.upsertOverride(ROOM_A, skillId1, true);
+			repo.upsertOverride(ROOM_A, skillId2, false);
+
+			const overrides = repo.getOverrides(ROOM_A);
+			expect(overrides).toHaveLength(2);
+			expect(overrides).toContainEqual({ skillId: skillId1, roomId: ROOM_A, enabled: true });
+			expect(overrides).toContainEqual({ skillId: skillId2, roomId: ROOM_A, enabled: false });
+		});
+
+		test('per-room isolation — ROOM_A overrides do not appear in ROOM_B', () => {
+			const skillId = insertSkill('isolated');
+			repo.upsertOverride(ROOM_A, skillId, true);
+
+			expect(repo.getOverrides(ROOM_A)).toHaveLength(1);
+			expect(repo.getOverrides(ROOM_B)).toHaveLength(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// upsertOverride
+	// ---------------------------------------------------------------------------
+
+	describe('upsertOverride', () => {
+		test('inserts an enabled override', () => {
+			const skillId = insertSkill('enabled-skill');
+			repo.upsertOverride(ROOM_A, skillId, true);
+
+			const overrides = repo.getOverrides(ROOM_A);
+			expect(overrides).toEqual([{ skillId, roomId: ROOM_A, enabled: true }]);
+		});
+
+		test('inserts a disabled override', () => {
+			const skillId = insertSkill('disabled-skill');
+			repo.upsertOverride(ROOM_A, skillId, false);
+
+			const overrides = repo.getOverrides(ROOM_A);
+			expect(overrides).toEqual([{ skillId, roomId: ROOM_A, enabled: false }]);
+		});
+
+		test('upserts — flipping from disabled to enabled', () => {
+			const skillId = insertSkill('flipper');
+			repo.upsertOverride(ROOM_A, skillId, false);
+			repo.upsertOverride(ROOM_A, skillId, true);
+
+			const overrides = repo.getOverrides(ROOM_A);
+			expect(overrides).toEqual([{ skillId, roomId: ROOM_A, enabled: true }]);
+		});
+
+		test('calls notifyChange after each write', () => {
+			const skillId = insertSkill('notifier');
+			notifyChangeSpy.mockClear();
+			repo.upsertOverride(ROOM_A, skillId, true);
+
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('room_skill_overrides');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// deleteOverride
+	// ---------------------------------------------------------------------------
+
+	describe('deleteOverride', () => {
+		test('removes a single override', () => {
+			const skillId = insertSkill('removable');
+			repo.upsertOverride(ROOM_A, skillId, true);
+			expect(repo.getOverrides(ROOM_A)).toHaveLength(1);
+
+			repo.deleteOverride(ROOM_A, skillId);
+			expect(repo.getOverrides(ROOM_A)).toHaveLength(0);
+		});
+
+		test('does not affect other overrides in the same room', () => {
+			const skillId1 = insertSkill('keep');
+			const skillId2 = insertSkill('remove');
+			repo.upsertOverride(ROOM_A, skillId1, true);
+			repo.upsertOverride(ROOM_A, skillId2, true);
+
+			repo.deleteOverride(ROOM_A, skillId2);
+			const overrides = repo.getOverrides(ROOM_A);
+			expect(overrides).toHaveLength(1);
+			expect(overrides[0].skillId).toBe(skillId1);
+		});
+
+		test('calls notifyChange after delete', () => {
+			const skillId = insertSkill('delete-notify');
+			repo.upsertOverride(ROOM_A, skillId, true);
+			notifyChangeSpy.mockClear();
+
+			repo.deleteOverride(ROOM_A, skillId);
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('room_skill_overrides');
+		});
+
+		test('no-op when override does not exist', () => {
+			const skillId = insertSkill('nonexistent');
+			expect(() => repo.deleteOverride(ROOM_A, skillId)).not.toThrow();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// deleteAllForRoom
+	// ---------------------------------------------------------------------------
+
+	describe('deleteAllForRoom', () => {
+		test('removes all overrides for a room', () => {
+			const skillId1 = insertSkill('all-1');
+			const skillId2 = insertSkill('all-2');
+			repo.upsertOverride(ROOM_A, skillId1, true);
+			repo.upsertOverride(ROOM_A, skillId2, false);
+
+			repo.deleteAllForRoom(ROOM_A);
+			expect(repo.getOverrides(ROOM_A)).toEqual([]);
+		});
+
+		test('does not affect other rooms', () => {
+			const skillId = insertSkill('cross-room-delete');
+			repo.upsertOverride(ROOM_A, skillId, true);
+			repo.upsertOverride(ROOM_B, skillId, false);
+
+			repo.deleteAllForRoom(ROOM_A);
+			expect(repo.getOverrides(ROOM_A)).toEqual([]);
+			expect(repo.getOverrides(ROOM_B)).toHaveLength(1);
+		});
+
+		test('calls notifyChange after delete', () => {
+			const skillId = insertSkill('all-notify');
+			repo.upsertOverride(ROOM_A, skillId, true);
+			notifyChangeSpy.mockClear();
+
+			repo.deleteAllForRoom(ROOM_A);
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('room_skill_overrides');
+		});
+
+		test('no-op when room has no overrides', () => {
+			expect(() => repo.deleteAllForRoom('nonexistent-room')).not.toThrow();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Cascade deletes
+	// ---------------------------------------------------------------------------
+
+	describe('cascade deletes', () => {
+		test('deleting a room removes its overrides (ON DELETE CASCADE)', () => {
+			const skillId = insertSkill('cascade-room');
+			repo.upsertOverride(ROOM_A, skillId, true);
+
+			bunDb.prepare(`DELETE FROM rooms WHERE id = ?`).run(ROOM_A);
+			expect(repo.getOverrides(ROOM_A)).toEqual([]);
+		});
+
+		test('deleting a skill removes its overrides (ON DELETE CASCADE)', () => {
+			const skillId = insertSkill('cascade-skill');
+			repo.upsertOverride(ROOM_A, skillId, true);
+			repo.upsertOverride(ROOM_B, skillId, false);
+
+			// Delete the skill row directly (FK cascade should clean up overrides)
+			bunDb.prepare(`DELETE FROM skills WHERE id = ?`).run(skillId);
+			expect(repo.getOverrides(ROOM_A)).toEqual([]);
+			expect(repo.getOverrides(ROOM_B)).toEqual([]);
+		});
+	});
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -397,6 +397,35 @@ export interface McpRoomResetToGlobalResponse {
 	ok: boolean;
 }
 
+// --- Per-Room Skill Enablement ---
+
+export interface SkillRoomGetOverridesRequest {
+	roomId: string;
+}
+
+export interface SkillRoomGetOverridesResponse {
+	overrides: Array<{ skillId: string; roomId: string; enabled: boolean }>;
+}
+
+export interface SkillRoomSetOverrideRequest {
+	roomId: string;
+	skillId: string;
+	enabled: boolean;
+}
+
+export interface SkillRoomSetOverrideResponse {
+	success: boolean;
+}
+
+export interface SkillRoomClearOverrideRequest {
+	roomId: string;
+	skillId: string;
+}
+
+export interface SkillRoomClearOverrideResponse {
+	success: boolean;
+}
+
 // --- Output Format ---
 
 export interface GetOutputFormatRequest {

--- a/packages/shared/src/types/skills.ts
+++ b/packages/shared/src/types/skills.ts
@@ -99,6 +99,17 @@ export interface UpdateSkillParams {
 	config?: AppSkillConfig;
 }
 
+/**
+ * Per-room override for a skill's enabled state.
+ * When an override exists for a (skillId, roomId) pair, the `enabled` field
+ * takes precedence over the skill's global `enabled` value.
+ */
+export interface RoomSkillOverride {
+	skillId: string;
+	roomId: string;
+	enabled: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Type guards
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `room_skill_overrides` table with composite PK `(skill_id, room_id)` and CASCADE FKs to `skills` and `rooms`
- Add `RoomSkillOverrideRepository` with `getOverrides`, `upsertOverride`, `deleteOverride`, `deleteAllForRoom` — all write methods call `reactiveDb.notifyChange('room_skill_overrides')`
- Add `RoomSkillOverride` type to shared package
- Add three RPC handlers: `room.getSkillOverrides`, `room.setSkillOverride`, `room.clearSkillOverride`
- Add `skills.byRoom` named query (LEFT JOIN `room_skill_overrides`) with room-level `enabled` and `overriddenByRoom` fields
- Add `skills.byRoom` to LiveQuery auth guard allow-list

## Test plan
- [x] 17 unit tests for `RoomSkillOverrideRepository` (CRUD, notifyChange, per-room isolation, cascade deletes)
- [x] 10 unit tests for `skills.byRoom` named query (global enabled, room override, JSON parsing, boolean coercion, camelCase aliases)
- [x] `bun run typecheck` passes
- [x] All 8225 existing unit tests pass with no regressions