### PR TITLE
feat(daemon): Skills injection in QueryOptionsBuilder (Task 3.1)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -204,6 +204,13 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	const eventBus = createDaemonHub('daemon');
 	await eventBus.initialize();
 
+	// Initialize application-level MCP and Skills managers before SessionManager
+	// so AgentSession can inject skills into SDK query options.
+	const appMcpManager = new AppMcpLifecycleManager(db);
+	seedDefaultMcpEntries(db);
+	const skillsManager = new SkillsManager(db.skills, db.appMcpServers, jobQueue);
+	skillsManager.initializeBuiltins();
+
 	// Initialize session manager (with EventBus, SettingsManager, no StateManager dependency!)
 	// Use reactiveDb.db so sdk_messages writes emitted by AgentSession pipelines
 	// trigger LiveQuery invalidation immediately.
@@ -220,7 +227,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			workspaceRoot: config.workspaceRoot,
 		},
 		jobQueue,
-		jobProcessor
+		jobProcessor,
+		skillsManager,
+		db.appMcpServers
 	);
 
 	// Register session title generation handler before jobProcessor starts
@@ -269,16 +278,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	} else if (shouldEnableGitHub) {
 		logInfo('[Daemon] GitHub integration disabled - authentication required');
 	}
-
-	// Instantiate application-level MCP lifecycle manager
-	const appMcpManager = new AppMcpLifecycleManager(db);
-
-	// Seed default MCP entries (idempotent — skips entries that already exist)
-	seedDefaultMcpEntries(db);
-
-	// Instantiate Skills manager and initialize built-in skills
-	const skillsManager = new SkillsManager(db.skills, db.appMcpServers, jobQueue);
-	skillsManager.initializeBuiltins();
 
 	// Initialize workspace file index (non-blocking — init runs in the background)
 	const fileIndex = new FileIndex(config.workspaceRoot);

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -241,7 +241,9 @@ export class AgentSession
 		readonly db: Database,
 		readonly messageHub: MessageHub,
 		readonly daemonHub: DaemonHub,
-		private getApiKey: () => Promise<string | null>
+		private getApiKey: () => Promise<string | null>,
+		readonly skillsManager?: import('../skills-manager').SkillsManager,
+		readonly appMcpServerRepo?: import('../../storage/repositories/app-mcp-server-repository').AppMcpServerRepository
 	) {
 		this.errorManager = new ErrorManager(this.messageHub, this.daemonHub);
 		this.logger = new Logger(`AgentSession ${session.id}`);

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -30,7 +30,11 @@ import type {
 import { getCoordinatorAgents } from './coordinator-agents';
 import { THINKING_LEVEL_TOKENS } from '@neokai/shared';
 import type { PermissionMode } from '@neokai/shared/types/settings';
+import type { McpServerConfig } from '@neokai/shared/types/sdk-config';
+import type { AppMcpServerSourceType } from '@neokai/shared';
 import type { SettingsManager } from '../settings-manager';
+import type { SkillsManager } from '../skills-manager';
+import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import { getProviderContextManager } from '../providers/factory.js';
 import { resolveSDKCliPath, isRunningUnderBun } from './sdk-cli-resolver.js';
 import { homedir } from 'os';
@@ -43,6 +47,10 @@ import { join } from 'path';
 export interface QueryOptionsBuilderContext {
 	readonly session: Session;
 	readonly settingsManager: SettingsManager;
+	/** Skills manager for injecting plugin/MCP server skills into SDK options. Optional for backwards compatibility. */
+	readonly skillsManager?: SkillsManager;
+	/** App MCP server repo for resolving mcp_server skill configs. Optional for backwards compatibility. */
+	readonly appMcpServerRepo?: AppMcpServerRepository;
 }
 
 export class QueryOptionsBuilder {
@@ -98,6 +106,8 @@ export class QueryOptionsBuilder {
 		const hooks = this.buildHooks();
 		const permissionMode = this.getPermissionMode();
 		const mcpServers = this.getMcpServers();
+		const pluginsFromSkills = this.buildPluginsFromSkills();
+		const mcpServersFromSkills = this.getMcpServersFromSkills();
 		const mergedEnv = this.getMergedEnvironmentVars();
 		const sdkCliPath = this.getSDKCliPath();
 
@@ -141,15 +151,19 @@ export class QueryOptionsBuilder {
 			sandbox: config.sandbox as Options['sandbox'],
 
 			// ============ MCP Servers ============
-			// Cast to SDK type - mcpServers uses compatible structure
-			mcpServers: mcpServers as Options['mcpServers'],
+			// Skill-injected MCP servers: must appear in mcpServers map for
+			// strictMcpConfig sessions to accept them. When strictMcpConfig is true
+			// (e.g. room_chat sessions), the SDK only allows servers present in this
+			// map — user settings are ignored. By merging skill servers here, they
+			// are always available regardless of strictMcpConfig setting.
+			mcpServers: this.mergeMcpServers(mcpServers, mcpServersFromSkills) as Options['mcpServers'],
 			strictMcpConfig: config.strictMcpConfig,
 
 			// ============ Output Format ============
 			outputFormat: config.outputFormat,
 
 			// ============ Plugins ============
-			plugins: config.plugins,
+			plugins: this.mergePlugins(config.plugins, pluginsFromSkills),
 
 			// ============ Beta Features ============
 			betas: config.betas,
@@ -554,6 +568,31 @@ CRITICAL RULES:
 	}
 
 	/**
+	 * Merge config MCP servers with skill-injected MCP servers.
+	 * Returns undefined when neither source has servers (preserves auto-load behavior).
+	 */
+	private mergeMcpServers(
+		configServers: Record<string, unknown> | undefined,
+		skillServers: Record<string, McpServerConfig>
+	): Record<string, unknown> | undefined {
+		const hasSkillServers = Object.keys(skillServers).length > 0;
+		if (!configServers && !hasSkillServers) return undefined;
+		return { ...skillServers, ...configServers };
+	}
+
+	/**
+	 * Merge config plugins with skill-injected plugins.
+	 * Returns undefined when neither source has plugins.
+	 */
+	private mergePlugins(
+		configPlugins: Options['plugins'],
+		skillPlugins: Array<{ type: 'local'; path: string }>
+	): Options['plugins'] {
+		if (!configPlugins && skillPlugins.length === 0) return undefined;
+		return [...(configPlugins ?? []), ...skillPlugins];
+	}
+
+	/**
 	 * Get setting sources configuration
 	 *
 	 * Controls CLAUDE.md and .claude/settings.json loading
@@ -749,5 +788,88 @@ CRITICAL RULES:
 
 		// Priority 3: Let SDK use its default resolution
 		return undefined;
+	}
+
+	/**
+	 * Build plugin entries from enabled skills with sourceType === 'plugin'.
+	 * Returns an array of SdkPluginConfig objects for injection into options.plugins.
+	 */
+	private buildPluginsFromSkills(): Array<{ type: 'local'; path: string }> {
+		if (!this.ctx.skillsManager) return [];
+
+		const skills = this.ctx.skillsManager.getEnabledSkills();
+		const plugins: Array<{ type: 'local'; path: string }> = [];
+
+		for (const skill of skills) {
+			if (skill.sourceType === 'plugin' && skill.config.type === 'plugin') {
+				plugins.push({ type: 'local', path: skill.config.pluginPath });
+			}
+		}
+
+		return plugins;
+	}
+
+	/**
+	 * Build MCP server entries from enabled skills with sourceType === 'mcp_server'.
+	 * Resolves each skill's appMcpServerId to an AppMcpServer entry and maps it
+	 * to an McpServerConfig keyed by skill.name.
+	 *
+	 * Skill-injected MCP servers: must appear in mcpServers map for
+	 * strictMcpConfig sessions to accept them.
+	 */
+	private getMcpServersFromSkills(): Record<string, McpServerConfig> {
+		if (!this.ctx.skillsManager || !this.ctx.appMcpServerRepo) return {};
+
+		const skills = this.ctx.skillsManager.getEnabledSkills();
+		const servers: Record<string, McpServerConfig> = {};
+
+		for (const skill of skills) {
+			if (skill.sourceType !== 'mcp_server' || skill.config.type !== 'mcp_server') continue;
+
+			const appServer = this.ctx.appMcpServerRepo.get(skill.config.appMcpServerId);
+			// Skip silently if the referenced app_mcp_servers entry was deleted or no longer exists
+			if (!appServer) continue;
+
+			servers[skill.name] = this.appMcpServerToSdkConfig(appServer);
+		}
+
+		return servers;
+	}
+
+	/**
+	 * Convert an AppMcpServer to the SDK's McpServerConfig format.
+	 */
+	private appMcpServerToSdkConfig(server: {
+		sourceType: AppMcpServerSourceType;
+		command?: string;
+		args?: string[];
+		env?: Record<string, string>;
+		url?: string;
+		headers?: Record<string, string>;
+	}): McpServerConfig {
+		switch (server.sourceType) {
+			case 'stdio':
+				return {
+					command: server.command!,
+					...(server.args ? { args: server.args } : {}),
+					...(server.env ? { env: server.env } : {}),
+				};
+			case 'sse':
+				return {
+					type: 'sse',
+					url: server.url!,
+					...(server.headers ? { headers: server.headers } : {}),
+				};
+			case 'http':
+				return {
+					type: 'http',
+					url: server.url!,
+					...(server.headers ? { headers: server.headers } : {}),
+				};
+			default: {
+				const _exhaustive: never = server.sourceType;
+				throw new Error(`Unknown MCP server source type: ${_exhaustive}`);
+			}
+		}
 	}
 }

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -20,6 +20,8 @@ import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import { WorktreeManager } from '../worktree-manager';
 import { Logger } from '../logger';
+import type { SkillsManager } from '../skills-manager';
+import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SESSION_TITLE_GENERATION } from '../job-queue-constants';
@@ -75,7 +77,9 @@ export class SessionManager {
 		private eventBus: DaemonHub,
 		private config: SessionLifecycleConfig,
 		private jobQueue: JobQueueRepository,
-		private jobProcessor: JobQueueProcessor
+		private jobProcessor: JobQueueProcessor,
+		private skillsManager?: SkillsManager,
+		private appMcpServerRepo?: AppMcpServerRepository
 	) {
 		this.logger = new Logger('SessionManager');
 		this.worktreeManager = new WorktreeManager();
@@ -85,8 +89,14 @@ export class SessionManager {
 
 		// Factory function for creating AgentSession instances
 		const createAgentSession = (session: Session): AgentSession => {
-			return new AgentSession(session, db, messageHub, eventBus, () =>
-				this.authManager.getCurrentApiKey()
+			return new AgentSession(
+				session,
+				db,
+				messageHub,
+				eventBus,
+				() => this.authManager.getCurrentApiKey(),
+				this.skillsManager,
+				this.appMcpServerRepo
 			);
 		};
 

--- a/packages/daemon/tests/unit/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/agent/query-options-builder.test.ts
@@ -758,4 +758,347 @@ describe('QueryOptionsBuilder', () => {
 			expect('enableFileCheckpointing' in options).toBe(true);
 		});
 	});
+
+	describe('skills injection', () => {
+		const enabledSkills = [
+			{
+				id: 'skill-plugin-1',
+				name: 'my-plugin',
+				displayName: 'My Plugin',
+				description: 'A plugin skill',
+				sourceType: 'plugin' as const,
+				config: { type: 'plugin' as const, pluginPath: '/path/to/plugin' },
+				enabled: true,
+				builtIn: false,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			},
+			{
+				id: 'skill-mcp-1',
+				name: 'brave-search',
+				displayName: 'Brave Search',
+				description: 'Web search via Brave',
+				sourceType: 'mcp_server' as const,
+				config: { type: 'mcp_server' as const, appMcpServerId: 'mcp-server-uuid' },
+				enabled: true,
+				builtIn: false,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			},
+			{
+				id: 'skill-disabled-1',
+				name: 'disabled-skill',
+				displayName: 'Disabled Skill',
+				description: 'A disabled skill',
+				sourceType: 'plugin' as const,
+				config: { type: 'plugin' as const, pluginPath: '/path/to/disabled' },
+				enabled: false,
+				builtIn: false,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			},
+		];
+
+		const mockAppMcpServer = {
+			id: 'mcp-server-uuid',
+			name: 'brave-search-server',
+			description: 'Brave Search MCP',
+			sourceType: 'stdio' as const,
+			command: 'npx',
+			args: ['-y', 'brave-mcp'],
+			env: { BRAVE_API_KEY: 'test-key' },
+			enabled: true,
+		};
+
+		it('should inject plugin skills as plugins option', async () => {
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [enabledSkills[0]]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.plugins).toEqual([{ type: 'local', path: '/path/to/plugin' }]);
+		});
+
+		it('should inject MCP server skills as mcpServers entries', async () => {
+			const mockAppMcpServerRepo = {
+				get: mock(() => mockAppMcpServer),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [enabledSkills[1]]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				appMcpServerRepo:
+					mockAppMcpServerRepo as unknown as import('../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.mcpServers).toBeDefined();
+			expect(options.mcpServers!['brave-search']).toEqual({
+				command: 'npx',
+				args: ['-y', 'brave-mcp'],
+				env: { BRAVE_API_KEY: 'test-key' },
+			});
+		});
+
+		it('should exclude disabled skills', async () => {
+			// getEnabledSkills() only returns enabled skills — simulate that
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [enabledSkills[0]]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			// Only the enabled plugin skill should appear
+			expect(options.plugins).toEqual([{ type: 'local', path: '/path/to/plugin' }]);
+		});
+
+		it('should not inject anything when skillsManager is not provided', async () => {
+			const builder = new QueryOptionsBuilder(mockContext);
+			const options = await builder.build();
+
+			expect(options.plugins).toBeUndefined();
+		});
+
+		it('should merge skill plugins with existing config plugins', async () => {
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [enabledSkills[0]]),
+			};
+			mockSession.config.plugins = [{ type: 'local', path: '/existing/plugin' }];
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.plugins).toEqual([
+				{ type: 'local', path: '/existing/plugin' },
+				{ type: 'local', path: '/path/to/plugin' },
+			]);
+		});
+
+		it('should merge skill MCP servers with existing config mcpServers', async () => {
+			const mockAppMcpServerRepo = {
+				get: mock(() => mockAppMcpServer),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [enabledSkills[1]]),
+			};
+			mockSession.config.mcpServers = {
+				'existing-server': { command: 'existing-cmd' },
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				appMcpServerRepo:
+					mockAppMcpServerRepo as unknown as import('../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.mcpServers!['existing-server']).toEqual({ command: 'existing-cmd' });
+			expect(options.mcpServers!['brave-search']).toEqual({
+				command: 'npx',
+				args: ['-y', 'brave-mcp'],
+				env: { BRAVE_API_KEY: 'test-key' },
+			});
+		});
+
+		it('should skip MCP server skills when referenced app_mcp_servers entry is deleted', async () => {
+			const mockAppMcpServerRepo = {
+				get: mock(() => null), // Simulates deleted entry
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [enabledSkills[1]]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				appMcpServerRepo:
+					mockAppMcpServerRepo as unknown as import('../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			// MCP server skill should be silently skipped
+			expect(options.mcpServers).toBeUndefined();
+		});
+
+		it('should make skill-injected MCP servers available in strictMcpConfig sessions', async () => {
+			const mockAppMcpServerRepo = {
+				get: mock(() => mockAppMcpServer),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [enabledSkills[1]]),
+			};
+			mockSession.type = 'room_chat';
+			mockSession.config.mcpServers = {
+				'room-agent-tools': { command: 'room-cmd' },
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				appMcpServerRepo:
+					mockAppMcpServerRepo as unknown as import('../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			// strictMcpConfig should be true for room_chat
+			expect(options.strictMcpConfig).toBe(true);
+			// Skill-injected server must be present in mcpServers so strictMcpConfig doesn't block it
+			expect(options.mcpServers!['brave-search']).toEqual({
+				command: 'npx',
+				args: ['-y', 'brave-mcp'],
+				env: { BRAVE_API_KEY: 'test-key' },
+			});
+			// Original room server must still be present
+			expect(options.mcpServers!['room-agent-tools']).toEqual({ command: 'room-cmd' });
+			// Skill MCP server wildcard should be auto-allowed
+			expect(options.allowedTools).toContain('brave-search__*');
+		});
+
+		it('should skip builtin skills (they are not injected as plugins/MCP servers)', async () => {
+			const builtinSkill = {
+				id: 'skill-builtin-1',
+				name: 'update-config',
+				displayName: 'Update Config',
+				description: 'A builtin skill',
+				sourceType: 'builtin' as const,
+				config: { type: 'builtin' as const, commandName: 'update-config' },
+				enabled: true,
+				builtIn: true,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [builtinSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			// Builtin skills should not produce plugins or mcpServers
+			expect(options.plugins).toBeUndefined();
+		});
+
+		it('should handle SSE MCP server skills', async () => {
+			const sseAppMcpServer = {
+				id: 'sse-server-uuid',
+				name: 'sse-server',
+				sourceType: 'sse' as const,
+				url: 'http://localhost:3001/sse',
+				headers: { Authorization: 'Bearer token' },
+				enabled: true,
+			};
+			const sseSkill = {
+				id: 'skill-sse-1',
+				name: 'sse-skill',
+				displayName: 'SSE Skill',
+				description: 'An SSE MCP skill',
+				sourceType: 'mcp_server' as const,
+				config: { type: 'mcp_server' as const, appMcpServerId: 'sse-server-uuid' },
+				enabled: true,
+				builtIn: false,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			};
+			const mockAppMcpServerRepo = {
+				get: mock(() => sseAppMcpServer),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [sseSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				appMcpServerRepo:
+					mockAppMcpServerRepo as unknown as import('../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.mcpServers!['sse-skill']).toEqual({
+				type: 'sse',
+				url: 'http://localhost:3001/sse',
+				headers: { Authorization: 'Bearer token' },
+			});
+		});
+
+		it('should handle HTTP MCP server skills', async () => {
+			const httpAppMcpServer = {
+				id: 'http-server-uuid',
+				name: 'http-server',
+				sourceType: 'http' as const,
+				url: 'http://localhost:3002/mcp',
+				enabled: true,
+			};
+			const httpSkill = {
+				id: 'skill-http-1',
+				name: 'http-skill',
+				displayName: 'HTTP Skill',
+				description: 'An HTTP MCP skill',
+				sourceType: 'mcp_server' as const,
+				config: { type: 'mcp_server' as const, appMcpServerId: 'http-server-uuid' },
+				enabled: true,
+				builtIn: false,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			};
+			const mockAppMcpServerRepo = {
+				get: mock(() => httpAppMcpServer),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [httpSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				appMcpServerRepo:
+					mockAppMcpServerRepo as unknown as import('../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.mcpServers!['http-skill']).toEqual({
+				type: 'http',
+				url: 'http://localhost:3002/mcp',
+			});
+		});
+	});
 });


### PR DESCRIPTION
Extend QueryOptionsBuilder to inject enabled skills into SDK query options.

**Changes:**
- Add `skillsManager` and `appMcpServerRepo` to `QueryOptionsBuilderContext` (optional, backwards compatible)
- Add `buildPluginsFromSkills()` — maps plugin skills to `SdkPluginConfig` entries
- Add `getMcpServersFromSkills()` — resolves MCP server skills via `AppMcpServerRepository` and maps to `McpServerConfig`
- Merge skill plugins/servers with existing session config in `build()`
- Skill-injected MCP servers appear in `mcpServers` map, ensuring they work with `strictMcpConfig` sessions (room_chat) that only allow explicitly configured servers
- Wire `SkillsManager` + `AppMcpServerRepo` through `DaemonApp → SessionManager → AgentSession → QueryOptionsBuilder`
- Move SkillsManager initialization before SessionManager in `app.ts`

**Tests (12 new):** plugin injection, MCP server injection (stdio/SSE/HTTP), disabled skill exclusion, missing app_mcp_server graceful skip, strictMcpConfig compatibility, merge with existing config, builtin skill passthrough.