### PR TITLE
feat(web): global Skills LiveQuery store and hook

### DIFF
--- a/packages/web/src/hooks/useSkills.ts
+++ b/packages/web/src/hooks/useSkills.ts
@@ -1,0 +1,58 @@
+/**
+ * useSkills Hook
+ *
+ * Lifecycle adapter that manages the global Skills registry LiveQuery subscription.
+ *
+ * Responsibilities:
+ * - On mount: call skillsStore.subscribe()
+ * - On unmount: call skillsStore.unsubscribe()
+ *
+ * The store owns the subscription handles and cleanup logic.
+ * This hook is purely a lifecycle adapter between the Preact component
+ * tree and the skills store's LiveQuery methods.
+ *
+ * @returns The store signals for use in components.
+ *
+ * @example
+ * ```tsx
+ * export default function SkillsRegistry() {
+ *   const { skills, isLoading, error } = useSkills();
+ *   if (isLoading.value) return <div>Loading...</div>;
+ *   return <ul>{skills.value.map(s => <li key={s.id}>{s.displayName}</li>)}</ul>;
+ * }
+ * ```
+ */
+
+import { useEffect } from 'preact/hooks';
+import type { Signal } from '@preact/signals';
+import type { AppSkill } from '@neokai/shared';
+import { skillsStore } from '../lib/skills-store';
+
+interface UseSkillsResult {
+	skills: Signal<AppSkill[]>;
+	isLoading: Signal<boolean>;
+	error: Signal<string | null>;
+}
+
+/**
+ * Subscribe to the global Skills registry and return reactive signals.
+ *
+ * Manages the LiveQuery subscription lifecycle:
+ * subscribe on mount, unsubscribe on unmount.
+ */
+export function useSkills(): UseSkillsResult {
+	useEffect(() => {
+		skillsStore.subscribe().catch(() => {
+			// Error is surfaced via skillsStore.error signal
+		});
+		return () => {
+			skillsStore.unsubscribe();
+		};
+	}, []);
+
+	return {
+		skills: skillsStore.skills,
+		isLoading: skillsStore.isLoading,
+		error: skillsStore.error,
+	};
+}

--- a/packages/web/src/lib/skills-store.test.ts
+++ b/packages/web/src/lib/skills-store.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Tests for SkillsStore
+ *
+ * Verifies:
+ * - LiveQuery snapshot populates skills signal
+ * - LiveQuery delta (added/removed/updated) updates signal correctly
+ * - WebSocket reconnect re-subscribes automatically
+ * - unsubscribe() calls liveQuery.unsubscribe and resets state
+ * - Idempotent subscribe/unsubscribe behavior
+ * - Stale-event guard discards events after unsubscribe
+ * - Post-await unsubscribe race guard prevents dangling handlers
+ * - Error propagation via subscribe() rejection and error signal
+ * - Mutation methods call the correct RPC endpoints
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AppSkill, LiveQuerySnapshotEvent, LiveQueryDeltaEvent } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+type EventHandler<T = unknown> = (data: T) => void;
+
+interface MockHub {
+	_handlers: Map<string, EventHandler[]>;
+	_connectionHandlers: EventHandler[];
+	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	onConnection: (handler: EventHandler<string>) => () => void;
+	request: ReturnType<typeof vi.fn>;
+	fire: <T>(method: string, data: T) => void;
+	fireConnection: (state: string) => void;
+}
+
+function createMockHub(): MockHub {
+	const _handlers = new Map<string, EventHandler[]>();
+	const _connectionHandlers: EventHandler[] = [];
+	return {
+		_handlers,
+		_connectionHandlers,
+		onEvent: <T>(method: string, handler: EventHandler<T>) => {
+			if (!_handlers.has(method)) _handlers.set(method, []);
+			_handlers.get(method)!.push(handler as EventHandler);
+			return () => {
+				const list = _handlers.get(method);
+				if (list) {
+					const i = list.indexOf(handler as EventHandler);
+					if (i >= 0) list.splice(i, 1);
+				}
+			};
+		},
+		onConnection: (handler: EventHandler<string>) => {
+			_connectionHandlers.push(handler as EventHandler);
+			return () => {
+				const i = _connectionHandlers.indexOf(handler as EventHandler);
+				if (i >= 0) _connectionHandlers.splice(i, 1);
+			};
+		},
+		request: vi.fn(),
+		fire: <T>(method: string, data: T) => {
+			for (const h of _handlers.get(method) ?? []) h(data);
+		},
+		fireConnection: (state: string) => {
+			for (const h of _connectionHandlers) h(state);
+		},
+	};
+}
+
+vi.mock('./connection-manager.ts', () => ({
+	connectionManager: {
+		getHub: vi.fn(),
+		getHubIfConnected: vi.fn(),
+	},
+}));
+
+import { connectionManager } from './connection-manager.js';
+import { skillsStore } from './skills-store.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSkill(id: string, overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id,
+		name: `skill-${id}`,
+		displayName: `Skill ${id}`,
+		description: `Description for skill ${id}`,
+		sourceType: 'builtin',
+		config: { type: 'builtin', commandName: `cmd-${id}` },
+		enabled: true,
+		builtIn: false,
+		validationStatus: 'valid',
+		createdAt: Date.now(),
+		...overrides,
+	};
+}
+
+const SUBSCRIPTION_ID = 'skills-global';
+
+// ---------------------------------------------------------------------------
+// SkillsStore Tests
+// ---------------------------------------------------------------------------
+
+describe('SkillsStore', () => {
+	let mockHub: MockHub;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockHub = createMockHub();
+
+		// Reset store signals
+		skillsStore.skills.value = [];
+		skillsStore.isLoading.value = false;
+		skillsStore.error.value = null;
+
+		vi.mocked(connectionManager.getHub).mockResolvedValue(mockHub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+		vi.mocked(mockHub.request).mockResolvedValue({ ok: true });
+	});
+
+	afterEach(() => {
+		skillsStore.unsubscribe();
+	});
+
+	// ---------------------------------------------------------------------------
+	// subscribe()
+	// ---------------------------------------------------------------------------
+
+	describe('subscribe()', () => {
+		it('should send liveQuery.subscribe request with skills.list query', async () => {
+			await skillsStore.subscribe();
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.subscribe', {
+				queryName: 'skills.list',
+				params: [],
+				subscriptionId: SUBSCRIPTION_ID,
+			});
+		});
+
+		it('should set isLoading true while awaiting snapshot', async () => {
+			let resolveHub: (hub: MockHub) => void;
+			const hubPromise = new Promise<MockHub>((resolve) => {
+				resolveHub = (hub) => resolve(hub);
+			});
+			vi.mocked(connectionManager.getHub).mockReturnValue(hubPromise as never);
+
+			const loadingValues: boolean[] = [];
+			const unsub = skillsStore.isLoading.subscribe((v) => loadingValues.push(v));
+
+			// Start subscribe but don't await — pauses at getHub()
+			const subPromise = skillsStore.subscribe();
+
+			// Resolve the hub
+			resolveHub!(mockHub);
+
+			// Flush microtasks so the continuation runs
+			await Promise.resolve();
+
+			expect(skillsStore.isLoading.value).toBe(true);
+
+			// Fire snapshot to complete
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [],
+				version: 1,
+			});
+
+			await subPromise;
+			expect(skillsStore.isLoading.value).toBe(false);
+
+			unsub();
+		});
+
+		it('should populate skills from snapshot rows', async () => {
+			const skills = [makeSkill('1'), makeSkill('2')];
+
+			await skillsStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: skills,
+				version: 1,
+			});
+
+			expect(skillsStore.skills.value).toHaveLength(2);
+			expect(skillsStore.skills.value[0].id).toBe('1');
+			expect(skillsStore.skills.value[1].id).toBe('2');
+		});
+
+		it('should be idempotent — second subscribe() call is no-op', async () => {
+			await skillsStore.subscribe();
+			mockHub.request.mockClear();
+			await skillsStore.subscribe();
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
+
+		it('should set error signal and re-throw when hub subscription fails', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('subscribe failed'));
+
+			await expect(skillsStore.subscribe()).rejects.toThrow('subscribe failed');
+			expect(skillsStore.error.value).toBe('subscribe failed');
+			expect(skillsStore.isLoading.value).toBe(false);
+		});
+
+		it('should clean up handlers and clear activeSubscriptionIds on subscribe failure', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('subscribe failed'));
+
+			await expect(skillsStore.subscribe()).rejects.toThrow('subscribe failed');
+
+			// Subscribe again after failure — fresh handlers, no leak
+			vi.mocked(mockHub.request).mockResolvedValue({ ok: true });
+			await skillsStore.subscribe();
+
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeSkill('fresh')],
+				version: 1,
+			});
+
+			// If handlers were leaked, count would be wrong
+			expect(skillsStore.skills.value).toHaveLength(1);
+			expect(skillsStore.skills.value[0].id).toBe('fresh');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// liveQuery.delta handling
+	// ---------------------------------------------------------------------------
+
+	describe('delta handling', () => {
+		beforeEach(async () => {
+			await skillsStore.subscribe();
+			// Populate initial state
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeSkill('1'), makeSkill('2')],
+				version: 1,
+			});
+			expect(skillsStore.skills.value).toHaveLength(2);
+		});
+
+		it('should add new skills from delta.added', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: SUBSCRIPTION_ID,
+				added: [makeSkill('3')],
+				version: 2,
+			});
+
+			expect(skillsStore.skills.value).toHaveLength(3);
+			expect(skillsStore.skills.value.find((s) => s.id === '3')).toBeDefined();
+		});
+
+		it('should remove skills from delta.removed', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: SUBSCRIPTION_ID,
+				removed: [makeSkill('1')],
+				version: 2,
+			});
+
+			expect(skillsStore.skills.value).toHaveLength(1);
+			expect(skillsStore.skills.value.find((s) => s.id === '1')).toBeUndefined();
+		});
+
+		it('should update existing skills from delta.updated', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: SUBSCRIPTION_ID,
+				updated: [makeSkill('1', { displayName: 'Updated Skill 1', enabled: false })],
+				version: 2,
+			});
+
+			const skill1 = skillsStore.skills.value.find((s) => s.id === '1');
+			expect(skill1?.displayName).toBe('Updated Skill 1');
+			expect(skill1?.enabled).toBe(false);
+		});
+
+		it('should ignore delta with wrong subscriptionId', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: 'other-subscription',
+				added: [makeSkill('99')],
+				version: 2,
+			});
+
+			expect(skillsStore.skills.value).toHaveLength(2);
+			expect(skillsStore.skills.value.find((s) => s.id === '99')).toBeUndefined();
+		});
+
+		it('should ignore snapshot with wrong subscriptionId', () => {
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: 'other-subscription',
+				rows: [makeSkill('99')],
+				version: 2,
+			});
+
+			expect(skillsStore.skills.value).toHaveLength(2);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Stale-event guard
+	// ---------------------------------------------------------------------------
+
+	describe('stale-event guard', () => {
+		it('should discard snapshot event fired after unsubscribe', async () => {
+			await skillsStore.subscribe();
+
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeSkill('pre-1')],
+				version: 1,
+			});
+			expect(skillsStore.skills.value).toHaveLength(1);
+
+			skillsStore.unsubscribe();
+
+			// Fire a stale snapshot — should be ignored
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeSkill('stale-skill')],
+				version: 2,
+			});
+
+			expect(skillsStore.skills.value).toHaveLength(0);
+		});
+
+		it('should discard delta event fired after unsubscribe', async () => {
+			await skillsStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeSkill('1'), makeSkill('2')],
+				version: 1,
+			});
+			expect(skillsStore.skills.value).toHaveLength(2);
+
+			skillsStore.unsubscribe();
+
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: SUBSCRIPTION_ID,
+				added: [makeSkill('stale-add')],
+				version: 2,
+			});
+
+			expect(skillsStore.skills.value).toHaveLength(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Post-await unsubscribe race guard
+	// ---------------------------------------------------------------------------
+
+	describe('post-await unsubscribe race guard', () => {
+		it('should not leave dangling handlers when unsubscribe races with hub resolution', async () => {
+			let resolveRequest: () => void;
+			const requestPromise = new Promise<void>((resolve) => {
+				resolveRequest = () => resolve();
+			});
+			vi.mocked(mockHub.request).mockReturnValue(requestPromise as never);
+			vi.mocked(connectionManager.getHub).mockResolvedValue(mockHub as never);
+
+			// Start subscribe but don't await — pauses at hub.request
+			const subPromise = skillsStore.subscribe();
+
+			// Unsubscribe while subscribe request is still in-flight
+			skillsStore.unsubscribe();
+
+			// Allow the request to resolve
+			resolveRequest!();
+
+			await subPromise;
+
+			expect(skillsStore.isLoading.value).toBe(false);
+			expect(skillsStore.skills.value).toHaveLength(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Reconnect handling
+	// ---------------------------------------------------------------------------
+
+	describe('WebSocket reconnect', () => {
+		it('should re-subscribe with same subscriptionId on reconnect', async () => {
+			await skillsStore.subscribe();
+
+			mockHub.fireConnection('connected');
+
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.subscribe', {
+				queryName: 'skills.list',
+				params: [],
+				subscriptionId: SUBSCRIPTION_ID,
+			});
+		});
+
+		it('should set isLoading true before re-subscribe on reconnect', async () => {
+			await skillsStore.subscribe();
+			mockHub.request.mockClear();
+
+			const loadingValues: boolean[] = [];
+			const unsub = skillsStore.isLoading.subscribe((v) => loadingValues.push(v));
+
+			mockHub.fireConnection('connected');
+
+			expect(loadingValues).toContain(true);
+
+			unsub();
+		});
+
+		it('should not re-subscribe for non-connected state changes', async () => {
+			await skillsStore.subscribe();
+			mockHub.request.mockClear();
+
+			mockHub.fireConnection('disconnected');
+
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// unsubscribe()
+	// ---------------------------------------------------------------------------
+
+	describe('unsubscribe()', () => {
+		it('should call liveQuery.unsubscribe', async () => {
+			await skillsStore.subscribe();
+			mockHub.request.mockClear();
+
+			skillsStore.unsubscribe();
+
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.unsubscribe', {
+				subscriptionId: SUBSCRIPTION_ID,
+			});
+		});
+
+		it('should clear skills signal', async () => {
+			await skillsStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeSkill('1')],
+				version: 1,
+			});
+			expect(skillsStore.skills.value).toHaveLength(1);
+
+			skillsStore.unsubscribe();
+
+			expect(skillsStore.skills.value).toHaveLength(0);
+		});
+
+		it('should clear error signal', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('fail'));
+			await expect(skillsStore.subscribe()).rejects.toThrow();
+			expect(skillsStore.error.value).not.toBeNull();
+
+			skillsStore.unsubscribe();
+			expect(skillsStore.error.value).toBeNull();
+		});
+
+		it('should be idempotent — second unsubscribe() call is no-op', async () => {
+			await skillsStore.subscribe();
+			skillsStore.unsubscribe();
+			mockHub.request.mockClear();
+
+			skillsStore.unsubscribe();
+
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
+
+		it('should be safe to call before subscribe()', () => {
+			expect(() => skillsStore.unsubscribe()).not.toThrow();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Mutation methods
+	// ---------------------------------------------------------------------------
+
+	describe('addSkill()', () => {
+		it('should call skill.create RPC with params', async () => {
+			const params = {
+				name: 'new-skill',
+				displayName: 'New Skill',
+				description: 'A new skill',
+				sourceType: 'builtin' as const,
+				config: { type: 'builtin' as const, commandName: 'new-cmd' },
+				enabled: true,
+				validationStatus: 'pending' as const,
+			};
+			const created = makeSkill('new-id', { name: 'new-skill' });
+			vi.mocked(mockHub.request).mockResolvedValue({ skill: created });
+
+			const result = await skillsStore.addSkill(params);
+
+			expect(mockHub.request).toHaveBeenCalledWith('skill.create', { params });
+			expect(result).toEqual(created);
+		});
+
+		it('should propagate errors from skill.create', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('create failed'));
+
+			await expect(
+				skillsStore.addSkill({
+					name: 'x',
+					displayName: 'X',
+					description: '',
+					sourceType: 'builtin',
+					config: { type: 'builtin', commandName: 'x' },
+					enabled: true,
+					validationStatus: 'pending',
+				})
+			).rejects.toThrow('create failed');
+		});
+	});
+
+	describe('updateSkill()', () => {
+		it('should call skill.update RPC with id and params', async () => {
+			const updated = makeSkill('skill-1', { displayName: 'Updated' });
+			vi.mocked(mockHub.request).mockResolvedValue({ skill: updated });
+
+			const result = await skillsStore.updateSkill('skill-1', { displayName: 'Updated' });
+
+			expect(mockHub.request).toHaveBeenCalledWith('skill.update', {
+				id: 'skill-1',
+				params: { displayName: 'Updated' },
+			});
+			expect(result.displayName).toBe('Updated');
+		});
+
+		it('should propagate errors from skill.update', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('update failed'));
+
+			await expect(skillsStore.updateSkill('skill-1', { displayName: 'X' })).rejects.toThrow(
+				'update failed'
+			);
+		});
+	});
+
+	describe('removeSkill()', () => {
+		it('should call skill.delete RPC with id and return success boolean', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ success: true });
+
+			const result = await skillsStore.removeSkill('skill-1');
+
+			expect(mockHub.request).toHaveBeenCalledWith('skill.delete', { id: 'skill-1' });
+			expect(result).toBe(true);
+		});
+
+		it('should propagate errors from skill.delete', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('delete failed'));
+
+			await expect(skillsStore.removeSkill('skill-1')).rejects.toThrow('delete failed');
+		});
+	});
+
+	describe('setEnabled()', () => {
+		it('should call skill.setEnabled RPC with id and enabled=true', async () => {
+			const updated = makeSkill('skill-1', { enabled: true });
+			vi.mocked(mockHub.request).mockResolvedValue({ skill: updated });
+
+			const result = await skillsStore.setEnabled('skill-1', true);
+
+			expect(mockHub.request).toHaveBeenCalledWith('skill.setEnabled', {
+				id: 'skill-1',
+				enabled: true,
+			});
+			expect(result.enabled).toBe(true);
+		});
+
+		it('should call skill.setEnabled RPC with id and enabled=false', async () => {
+			const updated = makeSkill('skill-1', { enabled: false });
+			vi.mocked(mockHub.request).mockResolvedValue({ skill: updated });
+
+			const result = await skillsStore.setEnabled('skill-1', false);
+
+			expect(mockHub.request).toHaveBeenCalledWith('skill.setEnabled', {
+				id: 'skill-1',
+				enabled: false,
+			});
+			expect(result.enabled).toBe(false);
+		});
+
+		it('should propagate errors from skill.setEnabled', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('setEnabled failed'));
+
+			await expect(skillsStore.setEnabled('skill-1', true)).rejects.toThrow('setEnabled failed');
+		});
+	});
+});

--- a/packages/web/src/lib/skills-store.ts
+++ b/packages/web/src/lib/skills-store.ts
@@ -1,0 +1,240 @@
+/**
+ * SkillsStore - Application-level Skills registry with LiveQuery subscriptions
+ *
+ * ARCHITECTURE: LiveQuery supersedes one-shot skill.list for frontend UI purposes
+ * - Initial state: Fetched via LiveQuery snapshot on subscribe
+ * - Updates: Real-time via liveQuery.delta events
+ * - Reconnect: Re-subscribes with same subscriptionId on hub reconnection
+ * - Teardown: Calls liveQuery.unsubscribe to clean up server-side subscription
+ *
+ * Signal (reactive state):
+ * - skills: List of all application-level Skills
+ */
+
+import { signal } from '@preact/signals';
+import type {
+	AppSkill,
+	CreateSkillParams,
+	UpdateSkillParams,
+	LiveQuerySnapshotEvent,
+	LiveQueryDeltaEvent,
+} from '@neokai/shared';
+import { Logger } from '@neokai/shared';
+import { connectionManager } from './connection-manager';
+
+const logger = new Logger('kai:web:skills-store');
+
+const SUBSCRIPTION_ID = 'skills-global';
+
+class SkillsStore {
+	/** All application-level Skills */
+	readonly skills = signal<AppSkill[]>([]);
+
+	/** Loading state */
+	readonly isLoading = signal<boolean>(false);
+
+	/** Error state — set when subscribe() fails */
+	readonly error = signal<string | null>(null);
+
+	/** Cleanup functions registered during subscribe() */
+	private cleanups: Array<() => void> = [];
+
+	/**
+	 * Stale-event guard: set of currently active subscriptionIds.
+	 * Cleared immediately in unsubscribe() before handler teardown so that
+	 * any in-flight events (queued in the JS event loop between unsubscribe and
+	 * handler removal) are discarded rather than applied to the wrong state.
+	 */
+	private activeSubscriptionIds = new Set<string>();
+
+	/** Guard: true once subscribe() has been called and not yet torn down */
+	private subscribed = false;
+
+	/**
+	 * Subscribe to the global Skills registry via LiveQuery.
+	 *
+	 * Idempotent: safe to call multiple times; subsequent calls are no-ops
+	 * until unsubscribe() is called.
+	 *
+	 * Re-throws errors so callers can handle failures (e.g., show a toast).
+	 */
+	async subscribe(): Promise<void> {
+		if (this.subscribed) return;
+		this.subscribed = true;
+
+		try {
+			const hub = await connectionManager.getHub();
+
+			// Guard: unsubscribe() was called before hub became available
+			if (!this.subscribed) return;
+
+			this.isLoading.value = true;
+			this.activeSubscriptionIds.add(SUBSCRIPTION_ID);
+
+			// --- Snapshot handler ---
+			const unsubSnapshot = hub.onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+				if (event.subscriptionId !== SUBSCRIPTION_ID) return;
+				if (!this.activeSubscriptionIds.has(SUBSCRIPTION_ID)) return; // stale-event guard
+				this.skills.value = event.rows as AppSkill[];
+				this.isLoading.value = false;
+			});
+			this.cleanups.push(unsubSnapshot);
+			this.cleanups.push(() => this.activeSubscriptionIds.delete(SUBSCRIPTION_ID));
+
+			// --- Delta handler ---
+			const unsubDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+				if (event.subscriptionId !== SUBSCRIPTION_ID) return;
+				if (!this.activeSubscriptionIds.has(SUBSCRIPTION_ID)) return; // stale-event guard
+				let current = this.skills.value;
+				if (event.removed?.length) {
+					const removedIds = new Set((event.removed as AppSkill[]).map((r) => r.id));
+					current = current.filter((s) => !removedIds.has(s.id));
+				}
+				if (event.updated?.length) {
+					const updatedMap = new Map((event.updated as AppSkill[]).map((u) => [u.id, u]));
+					current = current.map((s) => updatedMap.get(s.id) ?? s);
+				}
+				if (event.added?.length) {
+					current = [...current, ...(event.added as AppSkill[])];
+				}
+				this.skills.value = current;
+			});
+			this.cleanups.push(unsubDelta);
+
+			// --- Reconnect handler ---
+			// Re-subscribe with the same subscriptionId so we get a fresh snapshot
+			// after the WebSocket reconnects.
+			const unsubReconnect = hub.onConnection((state) => {
+				if (state !== 'connected') return;
+				if (!this.activeSubscriptionIds.has(SUBSCRIPTION_ID)) return;
+				this.isLoading.value = true;
+				hub
+					.request('liveQuery.subscribe', {
+						queryName: 'skills.list',
+						params: [],
+						subscriptionId: SUBSCRIPTION_ID,
+					})
+					.catch((err) => {
+						logger.warn('SkillsStore LiveQuery re-subscribe failed:', err);
+						this.isLoading.value = false;
+					});
+			});
+			this.cleanups.push(unsubReconnect);
+
+			// --- Subscribe to the named query ---
+			await hub.request('liveQuery.subscribe', {
+				queryName: 'skills.list',
+				params: [],
+				subscriptionId: SUBSCRIPTION_ID,
+			});
+
+			// Guard: abort if unsubscribed while the subscribe request was in flight
+			if (!this.subscribed) {
+				this.teardownCleanly();
+				return;
+			}
+		} catch (err) {
+			this.subscribed = false;
+			this.teardownCleanly();
+			this.error.value =
+				err instanceof Error ? err.message : 'Failed to subscribe to Skills registry';
+			logger.error('Failed to subscribe SkillsStore LiveQuery:', err);
+			throw err;
+		}
+	}
+
+	/**
+	 * Run all cleanup functions and reset state — used after subscribe() races
+	 * with unsubscribe().
+	 */
+	private teardownCleanly(): void {
+		this.activeSubscriptionIds.delete(SUBSCRIPTION_ID);
+		for (const fn of this.cleanups) {
+			try {
+				fn();
+			} catch {
+				/* ignore */
+			}
+		}
+		this.cleanups = [];
+		this.isLoading.value = false;
+		this.error.value = null;
+	}
+
+	/**
+	 * Unsubscribe and reset state.
+	 *
+	 * Calls liveQuery.unsubscribe so the server cleans up the subscription.
+	 * Safe to call even if subscribe() was never called.
+	 */
+	unsubscribe(): void {
+		if (!this.subscribed) {
+			// Still reset error signal even if we were never subscribed
+			// (e.g., subscribe() failed and set this.subscribed = false in its catch block)
+			this.error.value = null;
+			return;
+		}
+		this.subscribed = false;
+
+		// Stale-event guard: clear activeSubscriptionIds immediately so any events
+		// already queued in the JS event loop are discarded before handlers are removed.
+		this.activeSubscriptionIds.delete(SUBSCRIPTION_ID);
+
+		this.teardownCleanly();
+
+		// Tell the server to dispose the subscription.
+		const hub = connectionManager.getHubIfConnected();
+		if (hub) {
+			hub.request('liveQuery.unsubscribe', { subscriptionId: SUBSCRIPTION_ID }).catch(() => {});
+		}
+
+		this.skills.value = [];
+	}
+
+	// ---------------------------------------------------------------------------
+	// Mutation methods — these trigger LiveQuery deltas automatically
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Add a new skill. The LiveQuery subscription will push the created skill
+	 * back via a delta event automatically.
+	 */
+	async addSkill(params: CreateSkillParams): Promise<AppSkill> {
+		const hub = await connectionManager.getHub();
+		const response = await hub.request<{ skill: AppSkill }>('skill.create', { params });
+		return response.skill;
+	}
+
+	/**
+	 * Update an existing skill. The LiveQuery subscription will push the updated
+	 * skill back via a delta event automatically.
+	 */
+	async updateSkill(id: string, params: UpdateSkillParams): Promise<AppSkill> {
+		const hub = await connectionManager.getHub();
+		const response = await hub.request<{ skill: AppSkill }>('skill.update', { id, params });
+		return response.skill;
+	}
+
+	/**
+	 * Remove a skill. The LiveQuery subscription will push the removal
+	 * back via a delta event automatically.
+	 */
+	async removeSkill(id: string): Promise<boolean> {
+		const hub = await connectionManager.getHub();
+		const response = await hub.request<{ success: boolean }>('skill.delete', { id });
+		return response.success;
+	}
+
+	/**
+	 * Enable or disable a skill. The LiveQuery subscription will push the updated
+	 * skill back via a delta event automatically.
+	 */
+	async setEnabled(id: string, enabled: boolean): Promise<AppSkill> {
+		const hub = await connectionManager.getHub();
+		const response = await hub.request<{ skill: AppSkill }>('skill.setEnabled', { id, enabled });
+		return response.skill;
+	}
+}
+
+/** Singleton store instance */
+export const skillsStore = new SkillsStore();


### PR DESCRIPTION
Implements Task 5.1 — global Skills registry LiveQuery store and hook.

- `SkillsStore` subscribes to `skills.list` named query via `liveQuery.subscribe`, handles snapshot/delta events to keep `skills` signal up to date, and re-subscribes on reconnect
- Four mutation methods (`addSkill`, `updateSkill`, `removeSkill`, `setEnabled`) call the correct RPC endpoints (`skill.create`, `skill.update`, `skill.delete`, `skill.setEnabled`)
- Singleton `skillsStore` exported; `useSkills` hook manages subscribe/unsubscribe lifecycle
- 31 unit tests: snapshot, delta add/remove/update, wrong-subscriptionId guard, stale-event guard, race guard, reconnect, all mutations, error propagation