### PR TITLE
refactor(space): complete step-agent → node-agent rename

### DIFF
--- a/.devproxy/mocks.json
+++ b/.devproxy/mocks.json
@@ -94,7 +94,7 @@
 			}
 		},
 		{
-			"comment": "Task Agent lifecycle — spawn_step_agent probe. Returns text-only (no tool_use blocks) to prevent the Claude Agent SDK from trying to dispatch the short tool name 'spawn_step_agent' (registered as 'mcp__task-agent__spawn_step_agent'). Tool dispatch with a non-matching name causes the SDK to loop indefinitely. The text mentions spawn_step_agent and step-code-lifecycle-001 so tests can assert on text content.",
+			"comment": "Task Agent lifecycle — spawn_node_agent probe. Returns text-only (no tool_use blocks) to prevent the Claude Agent SDK from trying to dispatch the short tool name 'spawn_node_agent' (registered as 'mcp__task-agent__spawn_node_agent'). Tool dispatch with a non-matching name causes the SDK to loop indefinitely. The text mentions spawn_node_agent and step-code-lifecycle-001 so tests can assert on text content.",
 			"request": {
 				"url": "http://127.0.0.1:8000/v1/messages?beta=true",
 				"method": "POST",
@@ -109,7 +109,7 @@
 					},
 					{
 						"name": "x-mocked-by",
-						"value": "Dev Proxy mocks.json (task-agent spawn_step_agent probe)"
+						"value": "Dev Proxy mocks.json (task-agent spawn_node_agent probe)"
 					}
 				],
 				"body": {
@@ -119,7 +119,7 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "[MOCKED LIFECYCLE] I will now call spawn_step_agent for step step-code-lifecycle-001 to create a sub-agent for the Code Implementation step."
+							"text": "[MOCKED LIFECYCLE] I will now call spawn_node_agent for step step-code-lifecycle-001 to create a sub-agent for the Code Implementation step."
 						}
 					],
 					"model": "claude-haiku-20250307",
@@ -136,7 +136,7 @@
 			}
 		},
 		{
-			"comment": "Task Agent lifecycle — check_step_status probe. Returns text-only (no tool_use blocks) to prevent the Claude Agent SDK from trying to dispatch the short tool name 'check_step_status'. The text mentions check_step_status and step-code-lifecycle-001 so tests can assert on text content.",
+			"comment": "Task Agent lifecycle — check_node_status probe. Returns text-only (no tool_use blocks) to prevent the Claude Agent SDK from trying to dispatch the short tool name 'check_node_status'. The text mentions check_node_status and step-code-lifecycle-001 so tests can assert on text content.",
 			"request": {
 				"url": "http://127.0.0.1:8000/v1/messages?beta=true",
 				"method": "POST",
@@ -151,7 +151,7 @@
 					},
 					{
 						"name": "x-mocked-by",
-						"value": "Dev Proxy mocks.json (task-agent check_step_status probe)"
+						"value": "Dev Proxy mocks.json (task-agent check_node_status probe)"
 					}
 				],
 				"body": {
@@ -161,7 +161,7 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "[MOCKED LIFECYCLE] I will now call check_step_status to monitor the running step agent for step-code-lifecycle-001."
+							"text": "[MOCKED LIFECYCLE] I will now call check_node_status to monitor the running node agent for step-code-lifecycle-001."
 						}
 					],
 					"model": "claude-haiku-20250307",

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -8,7 +8,7 @@
  * report_done — the Task Agent no longer calls advance_workflow.
  *
  * ## Behavioral contract
- * - The Task Agent does NOT execute code directly — it delegates to step agents.
+ * - The Task Agent does NOT execute code directly — it delegates to node agents.
  * - It does NOT bypass human gates — it surfaces them and waits.
  * - It does NOT make architectural decisions — the workflow defines the process.
  *
@@ -16,12 +16,12 @@
  * The prompt references the following MCP tools by name. They must be registered
  * in the MCP server(s) composed with this agent's session at runtime:
  *
- *   - spawn_step_agent      — Start a sub-session for a workflow step's assigned agent
- *   - check_step_status     — Poll the status/output of a running step agent session
+ *   - spawn_node_agent      — Start a sub-session for a workflow step's assigned agent
+ *   - check_node_status     — Poll the status/output of a running node agent session
  *   - report_result         — Mark the task complete/failed and record the result summary
  *   - request_human_input   — Surface a human gate and block until the user responds
  *   - list_group_members    — List all group members with session IDs and permitted channels
- *   - send_message          — Send a message to peer step agents via channel topology
+ *   - send_message          — Send a message to peer node agents via channel topology
  *
  * ## Content interpolation
  * All operator-supplied content (space.backgroundContext, space.instructions,
@@ -86,13 +86,13 @@ export interface TaskAgentContext {
 // ---------------------------------------------------------------------------
 
 function formatStep(step: WorkflowNode, agents: SpaceAgent[]): string {
-	const stepAgents = resolveNodeAgents(step);
+	const nodeAgents = resolveNodeAgents(step);
 	let agentLabel: string;
-	if (stepAgents.length === 1) {
-		const a = agents.find((ag) => ag.id === stepAgents[0].agentId);
-		agentLabel = a ? `${a.name} (role: ${a.role})` : `agent id: ${stepAgents[0].agentId}`;
+	if (nodeAgents.length === 1) {
+		const a = agents.find((ag) => ag.id === nodeAgents[0].agentId);
+		agentLabel = a ? `${a.name} (role: ${a.role})` : `agent id: ${nodeAgents[0].agentId}`;
 	} else {
-		const labels = stepAgents.map((sa) => {
+		const labels = nodeAgents.map((sa) => {
 			const a = agents.find((ag) => ag.id === sa.agentId);
 			return a ? `${a.name} (role: ${a.role})` : `agent id: ${sa.agentId}`;
 		});
@@ -175,14 +175,14 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push('');
 	sections.push(
-		`- **spawn_step_agent** — Start a sub-session for the current workflow step. ` +
+		`- **spawn_node_agent** — Start a sub-session for the current workflow step. ` +
 			`Pass the \`step_id\` and optional override instructions. ` +
 			`Returns a \`session_id\` for the spawned sub-session. ` +
 			`Call this when a new step task needs to be executed.`
 	);
 	sections.push(
-		`- **check_step_status** — Poll the status and output of a running step agent session. ` +
-			`Pass the \`session_id\` returned by \`spawn_step_agent\`. ` +
+		`- **check_node_status** — Poll the status and output of a running node agent session. ` +
+			`Pass the \`session_id\` returned by \`spawn_node_agent\`. ` +
 			`Returns the session's current status (\`running\`, \`completed\`, \`error\`) and output. ` +
 			`Call this to determine when a step has finished.`
 	);
@@ -195,7 +195,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 		`- **request_human_input** — Surface a human gate and block until the human responds. ` +
 			`Pass a \`question\` describing what decision or approval is needed. ` +
 			`Returns the human's response. ` +
-			`Call this when a step agent pauses for human input.`
+			`Call this when a node agent pauses for human input.`
 	);
 	sections.push(
 		`- **list_group_members** — List all members of the current task's session group. ` +
@@ -204,40 +204,40 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`Use this to discover active sub-sessions and their communication permissions.`
 	);
 	sections.push(
-		`- **send_message** — Send a message directly to one or more peer step agents via declared channel topology. ` +
+		`- **send_message** — Send a message directly to one or more peer node agents via declared channel topology. ` +
 			`Supports point-to-point (\`coder\`), broadcast (\`*\`), and multicast (\`[coder, reviewer]\`). ` +
 			`The Task Agent has default bidirectional channels to all node agents, so it can always ` +
-			`message any peer step agent. Use \`list_group_members\` to see permitted targets.`
+			`message any peer node agent. Use \`list_group_members\` to see permitted targets.`
 	);
 
 	// ---- Workflow execution instructions ------------------------------------
 	sections.push(`\n## Workflow Execution Instructions\n`);
 	sections.push(
-		`In the agent-centric model, step agents drive workflow progression themselves ` +
+		`In the agent-centric model, node agents drive workflow progression themselves ` +
 			`via \`send_message\` and \`report_done\`. Your role is to spawn agents and monitor ` +
 			`their completion — you do not manually advance the workflow.\n`
 	);
 	sections.push(`Follow this loop until all agents have completed:\n`);
 	sections.push(
-		`1. **Spawn pending step agents** — Call \`spawn_step_agent\` for each pending step task ` +
+		`1. **Spawn pending node agents** — Call \`spawn_node_agent\` for each pending step task ` +
 			`(visible in the task list). Multiple agents may run concurrently in the same node.\n` +
-			`2. **Monitor completion** — Call \`check_step_status\` periodically until agents reach ` +
+			`2. **Monitor completion** — Call \`check_node_status\` periodically until agents reach ` +
 			`a terminal state (\`completed\` or \`error\`).\n` +
-			`3. **Agents drive their own progression** — When a step agent sends a message to another ` +
+			`3. **Agents drive their own progression** — When a node agent sends a message to another ` +
 			`agent role via \`send_message\`, the target node is activated automatically. ` +
 			`New pending tasks will appear — spawn agents for them (return to step 1).\n` +
 			`4. **Detect completion** — When all agents have completed (no more pending or ` +
 			`in-progress tasks), call \`report_result\` to complete the task.\n` +
-			`5. **Handle errors** — If a step agent errors, call \`report_result\` with ` +
+			`5. **Handle errors** — If a node agent errors, call \`report_result\` with ` +
 			`\`status: "cancelled"\` and the error details.\n` +
-			`6. **Handle human gates** — If a step agent pauses for human input, call ` +
+			`6. **Handle human gates** — If a node agent pauses for human input, call ` +
 			`\`request_human_input\` to surface the question, then wait for the human's response.`
 	);
 
 	// ---- Human gate handling -------------------------------------------------
 	sections.push(`\n## Human Gate Handling\n`);
 	sections.push(
-		`When a step agent requires human input or approval:\n` +
+		`When a node agent requires human input or approval:\n` +
 			`1. Call \`request_human_input\` with a clear description of the decision needed.\n` +
 			`2. Wait — do not proceed until the tool returns the human's response.\n` +
 			`3. Use the human's response to guide next steps.\n` +
@@ -255,7 +255,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	sections.push(
 		`1. **Do not execute code directly.** You are an orchestrator, not an executor. ` +
 			`All code execution, file editing, and git operations must be delegated to ` +
-			`step agents via \`spawn_step_agent\`. You have no direct access to the filesystem.\n`
+			`node agents via \`spawn_node_agent\`. You have no direct access to the filesystem.\n`
 	);
 	sections.push(
 		`2. **Do not bypass human gates.** When a workflow transition requires human approval, ` +
@@ -285,11 +285,11 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push(
 		`Channel topology is enforced uniformly across all agents. ` +
-			`The Task Agent uses \`send_message\` for all inter-agent communication with step agents.\n`
+			`The Task Agent uses \`send_message\` for all inter-agent communication with node agents.\n`
 	);
 	sections.push(
 		`Default channels: the Task Agent has default bidirectional channels to all node agent roles, ` +
-			`so it can always reach any peer step agent. If a user removes a Task Agent channel, ` +
+			`so it can always reach any peer node agent. If a user removes a Task Agent channel, ` +
 			`the Task Agent can no longer message that node until the channel is restored.\n`
 	);
 
@@ -432,12 +432,12 @@ export function buildTaskAgentInitialMessage(context: TaskAgentContext): string 
 	if (context.workflow && context.workflow.nodes.length > 0) {
 		// Normal case: workflow with steps — spawn the start step's agent.
 		parts.push(
-			`Begin executing the workflow now. Start by calling \`spawn_step_agent\` ` +
+			`Begin executing the workflow now. Start by calling \`spawn_node_agent\` ` +
 				`for the start step (\`${context.workflow.startNodeId}\`).`
 		);
 	} else if (context.workflow && context.workflow.nodes.length === 0) {
 		// Degenerate case: workflow exists but defines no steps.
-		// spawn_step_agent requires a step_id, so there is nothing to execute.
+		// spawn_node_agent requires a step_id, so there is nothing to execute.
 		// Surface this as an immediate failure rather than leaving the agent in
 		// an impossible state trying to spawn a step with no ID.
 		parts.push(
@@ -449,7 +449,7 @@ export function buildTaskAgentInitialMessage(context: TaskAgentContext): string 
 		// No workflow assigned — spawn the most appropriate agent directly.
 		parts.push(
 			`Begin executing the task now. Spawn the most appropriate agent using ` +
-				`\`spawn_step_agent\` and monitor its completion.`
+				`\`spawn_node_agent\` and monitor its completion.`
 		);
 	}
 

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -90,15 +90,15 @@ export type {
 
 export {
 	TASK_AGENT_TOOL_SCHEMAS,
-	SpawnStepAgentSchema,
-	CheckStepStatusSchema,
+	SpawnNodeAgentSchema,
+	CheckNodeStatusSchema,
 	ReportResultSchema,
 	RequestHumanInputSchema,
 	TaskResultStatusSchema,
 } from './tools/task-agent-tool-schemas';
 export type {
-	SpawnStepAgentInput,
-	CheckStepStatusInput,
+	SpawnNodeAgentInput,
+	CheckNodeStatusInput,
 	ReportResultInput,
 	RequestHumanInputInput,
 	TaskResultStatus,

--- a/packages/daemon/src/lib/space/runtime/agent-message-router.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-message-router.ts
@@ -1,5 +1,5 @@
 /**
- * AgentMessageRouter — unified message delivery for step agents.
+ * AgentMessageRouter — unified message delivery for node agents.
  *
  * Handles all message routing through a single code path — no separate within-node
  * vs cross-node logic. Target resolution:
@@ -13,9 +13,9 @@
  *
  * Note: This is distinct from ChannelRouter (channel-router.ts), which handles
  * workflow-level orchestration (lazy node activation, gate evaluation). This class
- * is used by step-agent-tools to deliver messages between live sessions at runtime.
+ * is used by node-agent-tools to deliver messages between live sessions at runtime.
  * TODO: Remove once TaskAgentManager wires up the workflow-level ChannelRouter for
- *   all sub-sessions and step-agent-tools can delegate to it directly.
+ *   all sub-sessions and node-agent-tools can delegate to it directly.
  */
 
 import type { SpaceSessionGroupRepository } from '../../../storage/repositories/space-session-group-repository';

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -413,8 +413,8 @@ export class SpaceRuntime {
 	 *   agent not found                   → taskType: 'coding',    customAgentId: agentId
 	 */
 	resolveTaskTypesForStep(step: WorkflowNode): ResolvedTaskType[] {
-		const stepAgents = resolveNodeAgents(step);
-		return stepAgents.map((sa) => this.resolveTaskTypeForAgent(sa.agentId));
+		const nodeAgents = resolveNodeAgents(step);
+		return nodeAgents.map((sa) => this.resolveTaskTypeForAgent(sa.agentId));
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2,7 +2,7 @@
  * TaskAgentManager
  *
  * Central integration point that manages the lifecycle of Task Agent sessions
- * and their sub-sessions (step agents). Each SpaceTask gets exactly one Task
+ * and their sub-sessions (node agents). Each SpaceTask gets exactly one Task
  * Agent session, and that session spawns sub-sessions for each workflow step.
  *
  * ## Session hierarchy
@@ -67,7 +67,7 @@ import type {
 	SubSessionState,
 } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
-import { createStepAgentMcpServer } from '../tools/step-agent-tools';
+import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
 import { ChannelResolver } from './channel-resolver';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
 import { Logger } from '../../logger';
@@ -299,8 +299,8 @@ export class TaskAgentManager {
 				sessionGroupRepo: this.config.sessionGroupRepo,
 				getGroupId: () => this.taskGroupIds.get(taskId),
 				daemonHub: this.config.daemonHub,
-				buildStepAgentMcpServer: (subSessionId, role, stepTaskId) =>
-					this.buildStepAgentMcpServerForSession(
+				buildNodeAgentMcpServer: (subSessionId, role, stepTaskId) =>
+					this.buildNodeAgentMcpServerForSession(
 						taskId,
 						subSessionId,
 						role,
@@ -694,13 +694,13 @@ export class TaskAgentManager {
 	private createSubSessionFactory(taskId: string, spaceId: string): SubSessionFactory {
 		// Capture workflowRunId once at factory-creation time to avoid a DB round-trip
 		// on every spawn. The run ID is immutable once assigned, so this is safe.
-		// Log a warning if the task lacks a workflow run — step-agent tools will
+		// Log a warning if the task lacks a workflow run — node-agent tools will
 		// produce an empty ChannelResolver (no declared channels) in that case.
 		const taskWorkflowRunId = this.config.taskRepo.getTask(taskId)?.workflowRunId ?? '';
 		if (!taskWorkflowRunId) {
 			log.warn(
 				`TaskAgentManager.createSubSessionFactory: task ${taskId} has no workflowRunId — ` +
-					`step-agent channel topology will be unavailable`
+					`node-agent channel topology will be unavailable`
 			);
 		}
 
@@ -903,7 +903,7 @@ export class TaskAgentManager {
 	}
 
 	/**
-	 * Called by the MCP onSubSessionComplete callback (registered in spawn_step_agent).
+	 * Called by the MCP onSubSessionComplete callback (registered in spawn_node_agent).
 	 * Updates the step task status to 'completed' and notifies the Task Agent.
 	 */
 	private async handleSubSessionComplete(
@@ -990,7 +990,7 @@ export class TaskAgentManager {
 					: '';
 				await this.injectMessageIntoSession(
 					taskAgentSession,
-					`[STEP_COMPLETE] Step "${stepId}" sub-session (${subSessionId}) has completed.${resultSummary}\nCall check_step_status to verify completion status.`,
+					`[STEP_COMPLETE] Step "${stepId}" sub-session (${subSessionId}) has completed.${resultSummary}\nCall check_node_status to verify completion status.`,
 					'defer'
 				);
 			} catch (err) {
@@ -1147,8 +1147,8 @@ export class TaskAgentManager {
 			daemonHub: this.config.daemonHub,
 			sessionGroupRepo: this.config.sessionGroupRepo,
 			getGroupId: () => this.taskGroupIds.get(taskId),
-			buildStepAgentMcpServer: (subSessionId, role, stepTaskId) =>
-				this.buildStepAgentMcpServerForSession(
+			buildNodeAgentMcpServer: (subSessionId, role, stepTaskId) =>
+				this.buildNodeAgentMcpServerForSession(
 					taskId,
 					subSessionId,
 					role,
@@ -1197,11 +1197,11 @@ export class TaskAgentManager {
 		await agentSession.startStreamingQuery();
 
 		// --- Inject re-orientation message so the agent checks state and continues.
-		// For workflow tasks: ask the agent to use check_step_status to resume workflow execution.
+		// For workflow tasks: ask the agent to use check_node_status to resume workflow execution.
 		// For standalone tasks (no workflowRunId): ask the agent to check status and continue.
 		const reorientMessage = task.workflowRunId
 			? 'You are resuming after a daemon restart. Your previous conversation state has been restored. ' +
-				'Please use `check_step_status` to determine the current state of your workflow and continue from where you left off.'
+				'Please use `check_node_status` to determine the current state of your workflow and continue from where you left off.'
 			: 'You are resuming after a daemon restart. Your previous conversation state has been restored. ' +
 				'Please check the current task status and continue from where you left off.';
 		await this.injectMessageIntoSession(agentSession, reorientMessage);
@@ -1236,12 +1236,12 @@ export class TaskAgentManager {
 				);
 				if (!subSession) continue;
 
-				// Re-attach step-agent MCP tools (runtime-only, not persisted to DB).
+				// Re-attach node-agent MCP tools (runtime-only, not persisted to DB).
 				// Look up the member's role from the session group; fall back to 'agent'.
 				const memberRole =
 					group?.members.find((m) => m.sessionId === subSessionId)?.role ?? 'agent';
 
-				const stepAgentMcpServer = this.buildStepAgentMcpServerForSession(
+				const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(
 					taskId,
 					subSessionId,
 					memberRole,
@@ -1251,7 +1251,7 @@ export class TaskAgentManager {
 					taskManager
 				);
 				subSession.setRuntimeMcpServers({
-					'step-agent': stepAgentMcpServer as unknown as McpServerConfig,
+					'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
 				});
 
 				if (!this.subSessions.has(taskId)) {
@@ -1384,18 +1384,18 @@ export class TaskAgentManager {
 	}
 
 	/**
-	 * Build a step agent MCP server for a newly spawned sub-session.
-	 * Called from the `buildStepAgentMcpServer` callback passed to createTaskAgentMcpServer().
+	 * Build a node agent MCP server for a newly spawned sub-session.
+	 * Called from the `buildNodeAgentMcpServer` callback passed to createTaskAgentMcpServer().
 	 *
 	 * Creates a ChannelResolver from the workflow run's config at spawn time and injects
-	 * it directly into the step agent MCP server config. This avoids a per-call DB lookup
+	 * it directly into the node agent MCP server config. This avoids a per-call DB lookup
 	 * and ensures each sub-session has its own resolver scoped to the channels declared
 	 * at step-start (stored in the run config by SpaceRuntime.storeResolvedChannels()).
 	 *
-	 * The server gives the step agent peer communication tools (list_peers, send_message,
+	 * The server gives the node agent peer communication tools (list_peers, send_message,
 	 * report_done) that are scoped to its group, channel topology, and step task.
 	 */
-	private buildStepAgentMcpServerForSession(
+	private buildNodeAgentMcpServerForSession(
 		taskId: string,
 		subSessionId: string,
 		role: string,
@@ -1413,7 +1413,7 @@ export class TaskAgentManager {
 			run?.config as Record<string, unknown> | undefined
 		);
 
-		return createStepAgentMcpServer({
+		return createNodeAgentMcpServer({
 			mySessionId: subSessionId,
 			myRole: role,
 			taskId,

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -1,6 +1,6 @@
 /**
- * Step Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 3
- * peer communication tools available to step agent sub-sessions.
+ * Node Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 3
+ * peer communication tools available to node agent sub-sessions.
  *
  * Tools:
  *   list_peers   — list other group members with their roles, statuses, and permitted channels
@@ -23,7 +23,7 @@ import { z } from 'zod';
 /**
  * Schema for `list_peers` input.
  * Lists all other members of the current workflow step group.
- * No arguments — the group and self are inferred from the step agent context.
+ * No arguments — the group and self are inferred from the node agent context.
  */
 export const ListPeersSchema = z.object({});
 
@@ -36,7 +36,7 @@ export type ListPeersInput = z.infer<typeof ListPeersSchema>;
 /**
  * Schema for `send_message` input.
  *
- * Primary direct messaging tool for step agents. Validates against declared channel
+ * Primary direct messaging tool for node agents. Validates against declared channel
  * topology before routing. Supports four target forms:
  *   - Agent name (role): `target: 'coder'` — DM to the named agent
  *   - Node name: `target: 'node-name'` — fan-out to all agents in the named node
@@ -70,7 +70,7 @@ export type SendMessageInput = z.infer<typeof SendMessageSchema>;
 /**
  * Schema for `report_done` input.
  *
- * Signals that this step agent has completed its work. Marks the step's SpaceTask
+ * Signals that this node agent has completed its work. Marks the step's SpaceTask
  * as 'completed' and persists an optional summary as the task result.
  */
 export const ReportDoneSchema = z.object({
@@ -104,13 +104,13 @@ export type ListReachableAgentsInput = z.infer<typeof ListReachableAgentsSchema>
 // ---------------------------------------------------------------------------
 
 /**
- * All step agent tool schemas keyed by tool name.
+ * All node agent tool schemas keyed by tool name.
  */
-export const STEP_AGENT_TOOL_SCHEMAS = {
+export const NODE_AGENT_TOOL_SCHEMAS = {
 	list_peers: ListPeersSchema,
 	send_message: SendMessageSchema,
 	report_done: ReportDoneSchema,
 	list_reachable_agents: ListReachableAgentsSchema,
 } as const;
 
-export type StepAgentToolName = keyof typeof STEP_AGENT_TOOL_SCHEMAS;
+export type NodeAgentToolName = keyof typeof NODE_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -1,7 +1,7 @@
 /**
- * Step Agent Tools — MCP tool handlers for step agent sub-sessions.
+ * Node Agent Tools — MCP tool handlers for node agent sub-sessions.
  *
- * These handlers implement peer communication tools for step agents within
+ * These handlers implement peer communication tools for node agents within
  * the same workflow step group:
  *
  *   list_peers   — discover other group members with roles and permitted channels
@@ -9,7 +9,7 @@
  *   report_done  — signal that this agent has completed its step task
  *
  * Communication model:
- * - Step agents communicate via declared channel topology (`send_message`).
+ * - Node agents communicate via declared channel topology (`send_message`).
  * - `list_peers` reveals who is in the group and what channels are available.
  *
  * Channel topology patterns supported:
@@ -20,7 +20,7 @@
  *
  * Design:
  * - Handlers are pure functions tested independently of any MCP server layer.
- * - Dependencies are injected via `StepAgentToolsConfig`.
+ * - Dependencies are injected via `NodeAgentToolsConfig`.
  * - `messageInjector` is backed by `injectSubSessionMessage` → `injectMessageIntoSession`
  *   → `session.messageQueue.enqueueWithId()`, which provides per-session write ordering.
  */
@@ -40,31 +40,31 @@ import {
 	SendMessageSchema,
 	ReportDoneSchema,
 	ListReachableAgentsSchema,
-} from './step-agent-tool-schemas';
+} from './node-agent-tool-schemas';
 import type {
 	ListPeersInput,
 	SendMessageInput,
 	ReportDoneInput,
 	ListReachableAgentsInput,
-} from './step-agent-tool-schemas';
+} from './node-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
 
-const log = new Logger('step-agent-tools');
+const log = new Logger('node-agent-tools');
 
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
 /**
- * Dependencies injected into createStepAgentToolHandlers().
+ * Dependencies injected into createNodeAgentToolHandlers().
  * All fields are required unless noted — the caller (TaskAgentManager) wires them up.
  */
-export interface StepAgentToolsConfig {
-	/** Session ID of this step agent (used to exclude self from list_peers). */
+export interface NodeAgentToolsConfig {
+	/** Session ID of this node agent (used to exclude self from list_peers). */
 	mySessionId: string;
-	/** Role of this step agent (e.g., 'coder', 'reviewer'). */
+	/** Role of this node agent (e.g., 'coder', 'reviewer'). */
 	myRole: string;
 	/** ID of the parent task (used for error messages). */
 	taskId: string;
@@ -114,10 +114,10 @@ export interface StepAgentToolsConfig {
 // ---------------------------------------------------------------------------
 
 /**
- * Create handler functions for the step agent peer communication tools.
+ * Create handler functions for the node agent peer communication tools.
  * Returns a map of tool name → async handler function.
  */
-export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
+export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 	const {
 		mySessionId,
 		myRole,
@@ -496,12 +496,12 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		},
 
 		/**
-		 * Signal that this step agent has completed its work.
+		 * Signal that this node agent has completed its work.
 		 *
 		 * Marks the step's SpaceTask as 'completed', persists the optional summary
 		 * as the task result, and emits a `space.task.updated` event for real-time UI.
 		 *
-		 * After calling this tool, the step agent should stop and not perform
+		 * After calling this tool, the node agent should stop and not perform
 		 * further work — the task lifecycle is closed.
 		 */
 		async report_done(args: ReportDoneInput): Promise<ToolResult> {
@@ -550,11 +550,11 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 // ---------------------------------------------------------------------------
 
 /**
- * Create an MCP server exposing all step agent peer communication tools.
- * Pass the returned server to the AgentSessionInit.mcpServers for step agent sessions.
+ * Create an MCP server exposing all node agent peer communication tools.
+ * Pass the returned server to the AgentSessionInit.mcpServers for node agent sessions.
  */
-export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
-	const handlers = createStepAgentToolHandlers(config);
+export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
+	const handlers = createNodeAgentToolHandlers(config);
 
 	const tools = [
 		tool(
@@ -586,7 +586,7 @@ export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
 		),
 		tool(
 			'report_done',
-			'Signal that this step agent has completed its work. ' +
+			'Signal that this node agent has completed its work. ' +
 				'Marks the step task as completed and persists an optional summary as the result. ' +
 				'Call this when you have finished all assigned work. ' +
 				'After calling this tool, stop — do not continue with further actions.',
@@ -595,7 +595,7 @@ export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
 		),
 	];
 
-	return createSdkMcpServer({ name: 'step-agent', tools });
+	return createSdkMcpServer({ name: 'node-agent', tools });
 }
 
-export type StepAgentMcpServer = ReturnType<typeof createStepAgentMcpServer>;
+export type NodeAgentMcpServer = ReturnType<typeof createNodeAgentMcpServer>;

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -3,8 +3,8 @@
  * tools available to the Task Agent session.
  *
  * Tools:
- *   spawn_step_agent      — spawn a sub-session for a specific workflow step
- *   check_step_status     — check the status of the current or a specific step's sub-session
+ *   spawn_node_agent      — spawn a sub-session for a specific workflow node
+ *   check_node_status     — check the status of the current or a specific node's sub-session
  *   report_result         — report the final task result (terminal tool)
  *   request_human_input   — pause execution and surface a question to the human user
  *   list_group_members    — list all members of the current task's session group
@@ -21,35 +21,35 @@
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
-// spawn_step_agent
+// spawn_node_agent
 // ---------------------------------------------------------------------------
 
 /**
- * Schema for `spawn_step_agent` input.
- * Spawns a sub-session for the given workflow step.
+ * Schema for `spawn_node_agent` input.
+ * Spawns a sub-session for the given workflow node.
  */
-export const SpawnStepAgentSchema = z.object({
+export const SpawnNodeAgentSchema = z.object({
 	/** ID of the workflow step to execute. */
 	step_id: z.string().describe('ID of the workflow step to spawn a sub-session for'),
-	/** Optional override instructions to pass to the step agent. */
+	/** Optional override instructions to pass to the node agent. */
 	instructions: z
 		.string()
-		.describe('Optional instructions to pass to the step agent, overriding the default step prompt')
+		.describe('Optional instructions to pass to the node agent, overriding the default step prompt')
 		.optional(),
 });
 
-export type SpawnStepAgentInput = z.infer<typeof SpawnStepAgentSchema>;
+export type SpawnNodeAgentInput = z.infer<typeof SpawnNodeAgentSchema>;
 
 // ---------------------------------------------------------------------------
-// check_step_status
+// check_node_status
 // ---------------------------------------------------------------------------
 
 /**
- * Schema for `check_step_status` input.
+ * Schema for `check_node_status` input.
  * Checks the processing state, completion, and any errors for the current or
- * a specific step's sub-session.
+ * a specific node's sub-session.
  */
-export const CheckStepStatusSchema = z.object({
+export const CheckNodeStatusSchema = z.object({
 	/** Optional step ID to check. Omit to check the current active step. */
 	step_id: z
 		.string()
@@ -57,7 +57,7 @@ export const CheckStepStatusSchema = z.object({
 		.optional(),
 });
 
-export type CheckStepStatusInput = z.infer<typeof CheckStepStatusSchema>;
+export type CheckNodeStatusInput = z.infer<typeof CheckNodeStatusSchema>;
 
 // ---------------------------------------------------------------------------
 // report_result
@@ -132,8 +132,8 @@ export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
  * The MCP server factory can iterate this map to register tools.
  */
 export const TASK_AGENT_TOOL_SCHEMAS = {
-	spawn_step_agent: SpawnStepAgentSchema,
-	check_step_status: CheckStepStatusSchema,
+	spawn_node_agent: SpawnNodeAgentSchema,
+	check_node_status: CheckNodeStatusSchema,
 	report_result: ReportResultSchema,
 	request_human_input: RequestHumanInputSchema,
 	list_group_members: ListGroupMembersSchema,

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -2,20 +2,20 @@
  * Task Agent Tools — MCP tool handlers for the Task Agent session.
  *
  * These handlers implement the business logic for the 6 Task Agent tools:
- *   spawn_step_agent      — Spawn a sub-session for a workflow step's assigned agent
- *   check_step_status     — Poll the status of a running step agent sub-session
+ *   spawn_node_agent      — Spawn a sub-session for a workflow node's assigned agent
+ *   check_node_status     — Poll the status of a running node agent sub-session
  *   report_result         — Mark the task as completed/failed and record the result
  *   request_human_input   — Pause execution and surface a question to the human user
  *   list_group_members    — List all members of the current task's session group
- *   send_message          — Send a message to peer step agents via channel topology
+ *   send_message          — Send a message to peer node agents via channel topology
  *
  * Design:
  * - Handlers are pure functions tested independently of any MCP server layer.
  * - Dependencies are injected via `TaskAgentToolsConfig`.
  * - The `SubSessionFactory` abstraction allows tests to mock session creation/state.
  * - Session completion is signalled via two paths:
- *     1. Completion callback registered in spawn_step_agent (fires automatically)
- *     2. Polling via check_step_status (Task Agent polls this tool)
+ *     1. Completion callback registered in spawn_node_agent (fires automatically)
+ *     2. Polling via check_node_status (Task Agent polls this tool)
  *
  * Following the pattern established in space-agent-tools.ts.
  */
@@ -37,22 +37,22 @@ import { ChannelResolver } from '../runtime/channel-resolver';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
-	SpawnStepAgentSchema,
-	CheckStepStatusSchema,
+	SpawnNodeAgentSchema,
+	CheckNodeStatusSchema,
 	ReportResultSchema,
 	RequestHumanInputSchema,
 	ListGroupMembersSchema,
 } from './task-agent-tool-schemas';
-import { SendMessageSchema } from './step-agent-tool-schemas';
+import { SendMessageSchema } from './node-agent-tool-schemas';
 import { resolveNodeAgents } from '@neokai/shared';
 import type {
-	SpawnStepAgentInput,
-	CheckStepStatusInput,
+	SpawnNodeAgentInput,
+	CheckNodeStatusInput,
 	ReportResultInput,
 	RequestHumanInputInput,
 	ListGroupMembersInput,
 } from './task-agent-tool-schemas';
-import type { SendMessageInput } from './step-agent-tool-schemas';
+import type { SendMessageInput } from './node-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
@@ -142,7 +142,7 @@ export interface TaskAgentToolsConfig {
 	taskRepo: SpaceTaskRepository;
 	/** Workflow run repository for reading and updating runs. */
 	workflowRunRepo: SpaceWorkflowRunRepository;
-	/** Agent manager for resolving step agents. */
+	/** Agent manager for resolving node agents. */
 	agentManager: SpaceAgentManager;
 	/** Task manager for validated status transitions. */
 	taskManager: SpaceTaskManager;
@@ -177,16 +177,16 @@ export interface TaskAgentToolsConfig {
 	 */
 	daemonHub?: DaemonHub;
 	/**
-	 * Factory to build a step agent MCP server for a spawned sub-session.
-	 * Called in `spawn_step_agent` after resolving the session ID and agent role.
+	 * Factory to build a node agent MCP server for a spawned sub-session.
+	 * Called in `spawn_node_agent` after resolving the session ID and agent role.
 	 * Returns a McpServerConfig to attach to the sub-session's init.mcpServers.
-	 * Optional — if omitted, no step agent MCP server is attached (e.g. in unit tests).
+	 * Optional — if omitted, no node agent MCP server is attached (e.g. in unit tests).
 	 *
 	 * @param sessionId   - The sub-session ID being started.
 	 * @param role        - The slot role for the agent (used for channel routing).
 	 * @param stepTaskId  - The SpaceTask ID for this step (used by report_done).
 	 */
-	buildStepAgentMcpServer?: (
+	buildNodeAgentMcpServer?: (
 		sessionId: string,
 		role: string,
 		stepTaskId: string
@@ -218,7 +218,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		sessionGroupRepo,
 		getGroupId,
 		daemonHub,
-		buildStepAgentMcpServer,
+		buildNodeAgentMcpServer,
 	} = config;
 
 	return {
@@ -233,12 +233,12 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 * 5. Create the sub-session via sessionFactory.create()
 		 * 6. Register completion callback (onSubSessionComplete) via sessionFactory.onComplete()
 		 * 7. Record the sub-session ID on the step task (BEFORE message injection, so
-		 *    check_step_status can track the session even if injection later fails)
+		 *    check_node_status can track the session even if injection later fails)
 		 * 8. Transition main task from pending → in_progress if not already in_progress
 		 * 9. Build and inject the task context message via messageInjector
 		 *    (non-fatal if injection fails — sub-session is already running and trackable)
 		 */
-		async spawn_step_agent(args: SpawnStepAgentInput): Promise<ToolResult> {
+		async spawn_node_agent(args: SpawnNodeAgentInput): Promise<ToolResult> {
 			const { step_id, instructions } = args;
 
 			// Load the workflow run
@@ -279,7 +279,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 
 			// Idempotency guard: if this step already has a tracked sub-session, return it
 			// without creating a duplicate. Prevents double-spawning from orphaning the first
-			// session when the Task Agent retries a spawn_step_agent call.
+			// session when the Task Agent retries a spawn_node_agent call.
 			if (stepTask.taskAgentSessionId) {
 				return jsonResult({
 					success: true,
@@ -291,7 +291,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				});
 			}
 
-			// Ensure customAgentId is set — fall back to the primary step agent ID for preset agents.
+			// Ensure customAgentId is set — fall back to the primary node agent ID for preset agents.
 			// WorkflowExecutor sets customAgentId to undefined for coder/general preset roles,
 			// but those agents are still SpaceAgent records. Use resolveNodeAgents to get the
 			// correct primary agentId regardless of whether the step uses agentId or agents[].
@@ -363,15 +363,15 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			// Falls back to the base agent's role, then 'agent' if neither is available.
 			const memberRole = agentSlot?.name ?? agentForMember?.role ?? 'agent';
 
-			// Attach step agent peer communication MCP server if a factory is provided.
+			// Attach node agent peer communication MCP server if a factory is provided.
 			// The server is built with the slot role so it can validate channels using the
 			// same role that was registered in the session group.
 			// Pass stepTask.id so report_done can mark the correct step task as completed.
-			if (buildStepAgentMcpServer) {
-				const stepMcpServer = buildStepAgentMcpServer(subSessionId, memberRole, stepTask.id);
+			if (buildNodeAgentMcpServer) {
+				const stepMcpServer = buildNodeAgentMcpServer(subSessionId, memberRole, stepTask.id);
 				init = {
 					...init,
-					mcpServers: { ...init.mcpServers, 'step-agent': stepMcpServer },
+					mcpServers: { ...init.mcpServers, 'node-agent': stepMcpServer },
 				};
 			}
 
@@ -393,7 +393,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			});
 
 			// Record the sub-session ID on the step task BEFORE message injection.
-			// This ensures check_step_status can locate and track the session even if
+			// This ensures check_node_status can locate and track the session even if
 			// the subsequent message injection fails.
 			taskRepo.updateTask(stepTask.id, {
 				taskAgentSessionId: actualSessionId,
@@ -417,7 +417,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			// This is non-fatal: if injection fails the sub-session still runs (and is
 			// already trackable via taskAgentSessionId recorded above), just without its
 			// initial task context. Return success with a warning field so the Task Agent
-			// can still poll check_step_status.
+			// can still poll check_node_status.
 			try {
 				// resolveAgentInit() already validated that the agent exists, so this
 				// getById() call should always succeed. If it somehow returns null after
@@ -449,7 +449,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				const message = err instanceof Error ? err.message : String(err);
 				// Return success:true because the sub-session was created, the completion
 				// callback is registered, and taskAgentSessionId is persisted. The Task Agent
-				// can still track completion via check_step_status. The warning informs it
+				// can still track completion via check_node_status. The warning informs it
 				// that the sub-session started without its initial task context message.
 				return jsonResult({
 					success: true,
@@ -471,16 +471,16 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		},
 
 		/**
-		 * Check the processing state of a step's sub-session.
+		 * Check the processing state of a node's sub-session.
 		 *
 		 * This is the primary mechanism for the Task Agent to detect sub-session completion.
-		 * The Task Agent polls this tool after spawning a step agent.
+		 * The Task Agent polls this tool after spawning a node agent.
 		 *
 		 * If step_id is omitted, checks the workflow run's current step.
 		 * Returns status = 'completed' when the step task has been marked completed in the DB
-		 * (which happens via the completion callback registered in spawn_step_agent).
+		 * (which happens via the completion callback registered in spawn_node_agent).
 		 */
-		async check_step_status(args: CheckStepStatusInput): Promise<ToolResult> {
+		async check_node_status(args: CheckNodeStatusInput): Promise<ToolResult> {
 			// Resolve step ID — use provided step_id or fall back to current step on run
 			let stepId = args.step_id;
 			if (!stepId) {
@@ -494,7 +494,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				if (!run.currentNodeId) {
 					return jsonResult({
 						success: false,
-						error: 'No current step on the workflow run. Call spawn_step_agent first.',
+						error: 'No current step on the workflow run. Call spawn_node_agent first.',
 					});
 				}
 				stepId = run.currentNodeId;
@@ -511,7 +511,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					stepId,
 					taskStatus: 'not_found',
 					sessionStatus: 'not_started',
-					message: 'No task found for this step. Has spawn_step_agent been called?',
+					message: 'No task found for this step. Has spawn_node_agent been called?',
 				});
 			}
 
@@ -537,7 +537,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					taskId: stepTask.id,
 					taskStatus: stepTask.status,
 					sessionStatus: 'not_started',
-					message: 'Sub-session not yet started for this step. Call spawn_step_agent.',
+					message: 'Sub-session not yet started for this step. Call spawn_node_agent.',
 				});
 			}
 
@@ -660,7 +660,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					success: false,
 					error:
 						`No session group found for task ${taskId}. ` +
-						`The group may not have been created yet — try after spawn_step_agent.`,
+						`The group may not have been created yet — try after spawn_node_agent.`,
 				});
 			}
 
@@ -730,11 +730,11 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		},
 
 		/**
-		 * Send a message directly to one or more peer step agents.
+		 * Send a message directly to one or more peer node agents.
 		 *
 		 * Validates the requested direction(s) against the declared channel topology
 		 * before routing. The Task Agent uses `send_message` for all inter-agent
-		 * communication with step agents.
+		 * communication with node agents.
 		 *
 		 * Target forms:
 		 *   - `target: 'coder'` — point-to-point to a single role
@@ -754,7 +754,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					success: false,
 					error:
 						`No session group found for task ${taskId}. ` +
-						`The group may not have been created yet — try after spawn_step_agent.`,
+						`The group may not have been created yet — try after spawn_node_agent.`,
 				});
 			}
 
@@ -964,19 +964,19 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 
 	const tools = [
 		tool(
-			'spawn_step_agent',
-			"Start a sub-session for a workflow step's assigned agent. " +
+			'spawn_node_agent',
+			"Start a sub-session for a workflow node's assigned agent. " +
 				'Call this to execute each workflow step. ' +
 				'Returns the session ID of the spawned sub-session.',
-			SpawnStepAgentSchema.shape,
-			(args) => handlers.spawn_step_agent(args)
+			SpawnNodeAgentSchema.shape,
+			(args) => handlers.spawn_node_agent(args)
 		),
 		tool(
-			'check_step_status',
-			'Poll the status of a running step agent sub-session. ' +
-				'Call this periodically after spawn_step_agent to detect when a step has completed.',
-			CheckStepStatusSchema.shape,
-			(args) => handlers.check_step_status(args)
+			'check_node_status',
+			'Poll the status of a running node agent sub-session. ' +
+				'Call this periodically after spawn_node_agent to detect when a step has completed.',
+			CheckNodeStatusSchema.shape,
+			(args) => handlers.check_node_status(args)
 		),
 		tool(
 			'report_result',
@@ -1002,7 +1002,7 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 		),
 		tool(
 			'send_message',
-			'Send a message directly to one or more peer step agents via declared channel topology. ' +
+			'Send a message directly to one or more peer node agents via declared channel topology. ' +
 				"Supports point-to-point ('coder'), broadcast ('*'), and multicast (['coder','reviewer']). " +
 				'Validates against declared channels — returns an error with available channels if unauthorized. ' +
 				'The Task Agent has default bidirectional channels to all node agents.',

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2955,7 +2955,7 @@ function runMigration45(db: BunDatabase): void {
  * Migration 46: Add slot_role column to space_tasks.
  *
  * Stores the `WorkflowNodeAgent.role` of the specific agent slot that spawned a task.
- * This allows `spawn_step_agent` to unambiguously identify the correct slot even when
+ * This allows `spawn_node_agent` to unambiguously identify the correct slot even when
  * the same `agentId` appears multiple times in a node with different slot roles and overrides.
  *
  * Existing rows get NULL for slot_role (backward compatible — the old lookup-by-agentId

--- a/packages/daemon/tests/online/space/task-agent-lifecycle.test.ts
+++ b/packages/daemon/tests/online/space/task-agent-lifecycle.test.ts
@@ -5,7 +5,7 @@
  * 1. SpaceRuntime detects a pending task and spawns a Task Agent session
  * 2. Task Agent session has correct type, context, and MCP tools attached
  * 3. Task Agent processes its initial context message
- * 4. Task Agent can call each workflow tool (spawn_step_agent, check_step_status,
+ * 4. Task Agent can call each workflow tool (spawn_node_agent, check_node_status,
  *    report_result) verified via probe mocks
  * 5. When report_result is called (via full MCP name mock), task status becomes 'completed'
  * 6. Space Agent receives the completion notification event
@@ -19,11 +19,11 @@
  * bodyFragment (substring search on the serialized request body). Matching mocks
  * return a pre-configured response.
  *
- * Tool call verification tests (spawn_step_agent, check_step_status)
+ * Tool call verification tests (spawn_node_agent, check_node_status)
  * use TEXT-ONLY mock responses. We cannot use tool_use blocks with the Claude Agent SDK
  * because it dispatches ALL tool_use content blocks regardless of stop_reason. Since the
- * short tool names (e.g. "spawn_step_agent") don't match the registered MCP names (e.g.
- * "mcp__task-agent__spawn_step_agent"), dispatch fails and the SDK retries indefinitely
+ * short tool names (e.g. "spawn_node_agent") don't match the registered MCP names (e.g.
+ * "mcp__task-agent__spawn_node_agent"), dispatch fails and the SDK retries indefinitely
  * (each retry re-sends the probe phrase, matching the same mock — infinite loop). Instead,
  * the mocks return text mentioning the tool name and relevant IDs for test assertions.
  *
@@ -366,14 +366,14 @@ describe('Task Agent Lifecycle — Online Tests', () => {
 	);
 
 	// -------------------------------------------------------------------------
-	// Test 3: spawn_step_agent tool invocation
+	// Test 3: spawn_node_agent tool invocation
 	// -------------------------------------------------------------------------
 	test(
-		'Task Agent uses spawn_step_agent to create a sub-session for a workflow step',
+		'Task Agent uses spawn_node_agent to create a sub-session for a workflow step',
 		async () => {
 			// NOTE: The probe mock returns a text-only response (no tool_use blocks) to
 			// prevent the Claude Agent SDK from dispatching the short tool name
-			// "spawn_step_agent" (registered as "mcp__task-agent__spawn_step_agent").
+			// "spawn_node_agent" (registered as "mcp__task-agent__spawn_node_agent").
 			// Dispatching a non-matching tool name causes the SDK to retry indefinitely.
 			// We verify the mock was matched by checking the text content mentions the
 			// tool name and step ID.
@@ -398,17 +398,17 @@ describe('Task Agent Lifecycle — Online Tests', () => {
 			// Wait for initial message processing before injecting probe
 			await waitForIdle(daemon, taskAgentSessionId, IDLE_TIMEOUT);
 
-			// Inject a probe message that triggers the spawn_step_agent mock.
+			// Inject a probe message that triggers the spawn_node_agent mock.
 			// The probe phrase "probe_task_agent_spawn_step_001" is unique to this request
 			// body at this point (earlier conversation does not contain it).
 			await sendMessage(
 				daemon,
 				taskAgentSessionId,
-				'probe_task_agent_spawn_step_001: Please spawn the step agent for the first workflow step.'
+				'probe_task_agent_spawn_step_001: Please spawn the node agent for the first workflow step.'
 			);
 			await waitForIdle(daemon, taskAgentSessionId, IDLE_TIMEOUT);
 
-			// Verify the mock was matched: the probe response mentions spawn_step_agent and
+			// Verify the mock was matched: the probe response mentions spawn_node_agent and
 			// the pre-assigned step ID step-code-lifecycle-001
 			const { sdkMessages } = await waitForSdkMessages(daemon, taskAgentSessionId, {
 				minCount: 4, // initial user + initial assistant + probe user + probe assistant
@@ -418,20 +418,20 @@ describe('Task Agent Lifecycle — Online Tests', () => {
 			const assistantMsgs = getAssistantMessages(sdkMessages);
 			const textContent = extractTextContent(assistantMsgs);
 
-			expect(textContent).toContain('spawn_step_agent');
+			expect(textContent).toContain('spawn_node_agent');
 			expect(textContent).toContain(STEP_CODE_ID);
 		},
 		TEST_TIMEOUT
 	);
 
 	// -------------------------------------------------------------------------
-	// Test 4: check_step_status tool invocation
+	// Test 4: check_node_status tool invocation
 	// -------------------------------------------------------------------------
 	test(
-		'Task Agent uses check_step_status to monitor a spawned sub-session',
+		'Task Agent uses check_node_status to monitor a spawned sub-session',
 		async () => {
 			// NOTE: The probe mock returns text-only (no tool_use blocks) to prevent the
-			// SDK from dispatching the short tool name "check_step_status".
+			// SDK from dispatching the short tool name "check_node_status".
 			// We verify the mock was matched by checking the text content.
 			// See probe mock "probe_task_agent_check_step_001" in .devproxy/mocks.json.
 			const { space, workflow } = await createTestFixtures(daemon);
@@ -456,7 +456,7 @@ describe('Task Agent Lifecycle — Online Tests', () => {
 			await sendMessage(
 				daemon,
 				taskAgentSessionId,
-				'probe_task_agent_check_step_001: Please check the status of the running step agent.'
+				'probe_task_agent_check_step_001: Please check the status of the running node agent.'
 			);
 			await waitForIdle(daemon, taskAgentSessionId, IDLE_TIMEOUT);
 
@@ -468,7 +468,7 @@ describe('Task Agent Lifecycle — Online Tests', () => {
 			const assistantMsgs = getAssistantMessages(sdkMessages);
 			const textContent = extractTextContent(assistantMsgs);
 
-			expect(textContent).toContain('check_step_status');
+			expect(textContent).toContain('check_node_status');
 		},
 		TEST_TIMEOUT
 	);

--- a/packages/daemon/tests/unit/space/agent-completion.test.ts
+++ b/packages/daemon/tests/unit/space/agent-completion.test.ts
@@ -18,9 +18,9 @@ import { SpaceTaskRepository } from '../../../src/storage/repositories/space-tas
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import {
-	createStepAgentToolHandlers,
-	type StepAgentToolsConfig,
-} from '../../../src/lib/space/tools/step-agent-tools.ts';
+	createNodeAgentToolHandlers,
+	type NodeAgentToolsConfig,
+} from '../../../src/lib/space/tools/node-agent-tools.ts';
 import {
 	createTaskAgentToolHandlers,
 	type SubSessionFactory,
@@ -235,7 +235,7 @@ describe('Migration 51 — rename slot_role → agent_name, add completion_summa
 });
 
 // ---------------------------------------------------------------------------
-// Tests: list_peers — completion state (step-agent-tools.ts)
+// Tests: list_peers — completion state (node-agent-tools.ts)
 // ---------------------------------------------------------------------------
 
 describe('list_peers — completion state via SpaceTaskRepository', () => {
@@ -288,7 +288,7 @@ describe('list_peers — completion state via SpaceTaskRepository', () => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
-	function makeConfig(overrides: Partial<StepAgentToolsConfig> = {}): StepAgentToolsConfig {
+	function makeConfig(overrides: Partial<NodeAgentToolsConfig> = {}): NodeAgentToolsConfig {
 		return {
 			mySessionId: coderSessionId,
 			myRole: 'coder',
@@ -312,7 +312,7 @@ describe('list_peers — completion state via SpaceTaskRepository', () => {
 		const workflowRunId = seedWorkflowRun(db, spaceId);
 		seedSpaceTask(db, spaceId, workflowRunId, nodeId, 'reviewer', 'completed', 'Review passed');
 
-		const handlers = createStepAgentToolHandlers(
+		const handlers = createNodeAgentToolHandlers(
 			makeConfig({ workflowRunId, workflowNodeId: nodeId })
 		);
 		const result = await handlers.list_peers({});
@@ -333,7 +333,7 @@ describe('list_peers — completion state via SpaceTaskRepository', () => {
 		seedSpaceTask(db, spaceId, workflowRunId, nodeId, 'coder', 'in_progress', null);
 		seedSpaceTask(db, spaceId, workflowRunId, nodeId, 'reviewer', 'completed', 'Done');
 
-		const handlers = createStepAgentToolHandlers(
+		const handlers = createNodeAgentToolHandlers(
 			makeConfig({ workflowRunId, workflowNodeId: nodeId })
 		);
 		const result = await handlers.list_peers({});
@@ -351,7 +351,7 @@ describe('list_peers — completion state via SpaceTaskRepository', () => {
 	test('list_peers returns null completionState when no tasks on node', async () => {
 		const workflowRunId = seedWorkflowRun(db, spaceId);
 
-		const handlers = createStepAgentToolHandlers(
+		const handlers = createNodeAgentToolHandlers(
 			makeConfig({ workflowRunId, workflowNodeId: 'node-empty' })
 		);
 		const result = await handlers.list_peers({});
@@ -370,7 +370,7 @@ describe('list_peers — completion state via SpaceTaskRepository', () => {
 		const workflowRunId = seedWorkflowRun(db, spaceId);
 		seedSpaceTask(db, spaceId, workflowRunId, nodeId, 'unknown-role', 'completed', 'Done');
 
-		const handlers = createStepAgentToolHandlers(
+		const handlers = createNodeAgentToolHandlers(
 			makeConfig({ workflowRunId, workflowNodeId: nodeId })
 		);
 		const result = await handlers.list_peers({});

--- a/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -4,7 +4,7 @@
  * Tests use a real file-based SQLite database (via runMigrations) — not mocks and not
  * `:memory:` — to verify security boundaries that unit tests with mocks cannot fully cover.
  *
- * What is genuinely new here (beyond existing step-agent-tools.test.ts / task-agent-tools.test.ts):
+ * What is genuinely new here (beyond existing node-agent-tools.test.ts / task-agent-tools.test.ts):
  *   - Suite 1: Two simultaneous groups in the same DB — verifies group-scoped isolation
  *              holistically rather than per-tool. send_message test confirms that overlapping
  *              role names in different groups are never confused.
@@ -20,7 +20,7 @@
  *              channel in permittedTargets for both the sender and Task Agent.
  *
  * Suites 2–6 provide complementary coverage for the direction-enforcement and topology
- * patterns that also exist in step-agent-tools.test.ts, exercised here end-to-end through
+ * patterns that also exist in node-agent-tools.test.ts, exercised here end-to-end through
  * the full tool handler + repository + resolver stack.
  *
  *   1. Cross-group isolation     — messages never cross group boundaries
@@ -47,9 +47,9 @@ import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/s
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import {
-	createStepAgentToolHandlers,
-	type StepAgentToolsConfig,
-} from '../../../src/lib/space/tools/step-agent-tools.ts';
+	createNodeAgentToolHandlers,
+	type NodeAgentToolsConfig,
+} from '../../../src/lib/space/tools/node-agent-tools.ts';
 import { ChannelResolver } from '../../../src/lib/space/runtime/channel-resolver.ts';
 import type { ResolvedChannel } from '@neokai/shared';
 
@@ -179,7 +179,7 @@ function makeStepConfig(
 	groupId: string,
 	channelResolver: ChannelResolver,
 	injector: (sessionId: string, message: string) => Promise<void>
-): StepAgentToolsConfig {
+): NodeAgentToolsConfig {
 	return {
 		mySessionId: sessionId,
 		myRole: role,
@@ -254,7 +254,7 @@ describe('cross-group isolation', () => {
 
 		// Coder in group A sends to reviewer (group A's reviewer only)
 		const config = makeStepConfig(tdb, 'session-coder-d', 'coder', groupA.id, resolver, injector);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		const result = await handlers.send_message({ target: 'reviewer', message: 'review this' });
 		const data = JSON.parse(result.content[0].text);
@@ -307,7 +307,7 @@ describe('channel direction enforcement', () => {
 
 		const { messages, injector } = makeMessageCapture();
 		const config = makeStepConfig(tdb, 'session-coder', 'coder', group.id, resolver, injector);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		const result = await handlers.send_message({ target: 'reviewer', message: 'please review' });
 		const data = JSON.parse(result.content[0].text);
@@ -350,7 +350,7 @@ describe('channel direction enforcement', () => {
 			resolver,
 			injector
 		);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		const result = await handlers.send_message({ target: 'coder', message: 'feedback' });
 		const data = JSON.parse(result.content[0].text);
@@ -383,7 +383,7 @@ describe('channel direction enforcement', () => {
 
 		const { messages, injector } = makeMessageCapture();
 		const config = makeStepConfig(tdb, 'session-coder', 'coder', group.id, resolver, injector);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		const result = await handlers.send_message({ target: 'reviewer', message: 'hi' });
 		const data = JSON.parse(result.content[0].text);
@@ -438,7 +438,7 @@ describe('bidirectional point-to-point A↔B', () => {
 
 		// Alice → Bob
 		const aliceConfig = makeStepConfig(tdb, 'session-alice', 'alice', group.id, resolver, injector);
-		const aliceHandlers = createStepAgentToolHandlers(aliceConfig);
+		const aliceHandlers = createNodeAgentToolHandlers(aliceConfig);
 
 		const r1 = await aliceHandlers.send_message({ target: 'bob', message: 'hello bob' });
 		const d1 = JSON.parse(r1.content[0].text);
@@ -446,7 +446,7 @@ describe('bidirectional point-to-point A↔B', () => {
 
 		// Bob → Alice
 		const bobConfig = makeStepConfig(tdb, 'session-bob', 'bob', group.id, resolver, injector);
-		const bobHandlers = createStepAgentToolHandlers(bobConfig);
+		const bobHandlers = createNodeAgentToolHandlers(bobConfig);
 
 		const r2 = await bobHandlers.send_message({ target: 'alice', message: 'hello alice' });
 		const d2 = JSON.parse(r2.content[0].text);
@@ -491,13 +491,13 @@ describe('bidirectional point-to-point A↔B', () => {
 		const { messages, injector } = makeMessageCapture();
 
 		// Round 1: coder submits PR
-		const coderHandlers = createStepAgentToolHandlers(
+		const coderHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-coder', 'coder', group.id, resolver, injector)
 		);
 		await coderHandlers.send_message({ target: 'reviewer', message: 'PR ready for review' });
 
 		// Round 2: reviewer gives feedback
-		const reviewerHandlers = createStepAgentToolHandlers(
+		const reviewerHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-reviewer', 'reviewer', group.id, resolver, injector)
 		);
 		await reviewerHandlers.send_message({
@@ -580,7 +580,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 		]);
 
 		const { messages, injector } = makeMessageCapture();
-		const hubHandlers = createStepAgentToolHandlers(
+		const hubHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-hub', 'hub', group.id, resolver, injector)
 		);
 
@@ -615,7 +615,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 		const { messages, injector } = makeMessageCapture();
 
 		// Spoke B tries to send to hub — should be rejected
-		const spokeBHandlers = createStepAgentToolHandlers(
+		const spokeBHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-spoke-b', 'spoke-b', group.id, resolver, injector)
 		);
 
@@ -639,7 +639,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 		const { messages, injector } = makeMessageCapture();
 
 		// Spoke B tries to send to spoke C — should be rejected (no such channel)
-		const spokeBHandlers = createStepAgentToolHandlers(
+		const spokeBHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-spoke-b', 'spoke-b', group.id, resolver, injector)
 		);
 
@@ -664,7 +664,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 		]);
 
 		const { messages, injector } = makeMessageCapture();
-		const hubHandlers = createStepAgentToolHandlers(
+		const hubHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-hub', 'hub', group.id, resolver, injector)
 		);
 
@@ -747,7 +747,7 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 		]);
 
 		const { messages, injector } = makeMessageCapture();
-		const leadHandlers = createStepAgentToolHandlers(
+		const leadHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-lead', 'lead', group.id, resolver, injector)
 		);
 
@@ -781,21 +781,21 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 		const { messages, injector } = makeMessageCapture();
 
 		// Worker B replies
-		const workerBHandlers = createStepAgentToolHandlers(
+		const workerBHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-worker-b', 'worker-b', group.id, resolver, injector)
 		);
 		const r1 = await workerBHandlers.send_message({ target: 'lead', message: 'worker-b done' });
 		expect(JSON.parse(r1.content[0].text).success).toBe(true);
 
 		// Worker C replies
-		const workerCHandlers = createStepAgentToolHandlers(
+		const workerCHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-worker-c', 'worker-c', group.id, resolver, injector)
 		);
 		const r2 = await workerCHandlers.send_message({ target: 'lead', message: 'worker-c done' });
 		expect(JSON.parse(r2.content[0].text).success).toBe(true);
 
 		// Worker D replies
-		const workerDHandlers = createStepAgentToolHandlers(
+		const workerDHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-worker-d', 'worker-d', group.id, resolver, injector)
 		);
 		const r3 = await workerDHandlers.send_message({ target: 'lead', message: 'worker-d done' });
@@ -826,7 +826,7 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 		const { messages, injector } = makeMessageCapture();
 
 		// Worker B attempts to message Worker C (cross-spoke)
-		const workerBHandlers = createStepAgentToolHandlers(
+		const workerBHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-worker-b', 'worker-b', group.id, resolver, injector)
 		);
 
@@ -855,10 +855,10 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 
 		const { messages, injector } = makeMessageCapture();
 
-		const leadHandlers = createStepAgentToolHandlers(
+		const leadHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-lead', 'lead', group.id, resolver, injector)
 		);
-		const workerBHandlers = createStepAgentToolHandlers(
+		const workerBHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-worker-b', 'worker-b', group.id, resolver, injector)
 		);
 
@@ -935,10 +935,10 @@ describe('concurrent message injection — both messages delivered', () => {
 
 		const { messages, injector } = makeMessageCapture();
 
-		const senderAHandlers = createStepAgentToolHandlers(
+		const senderAHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-sender-a', 'sender-a', group.id, resolver, injector)
 		);
-		const senderBHandlers = createStepAgentToolHandlers(
+		const senderBHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-sender-b', 'sender-b', group.id, resolver, injector)
 		);
 
@@ -990,7 +990,7 @@ describe('concurrent message injection — both messages delivered', () => {
 
 		const { messages, injector } = makeMessageCapture();
 
-		const hubHandlers = createStepAgentToolHandlers(
+		const hubHandlers = createNodeAgentToolHandlers(
 			makeStepConfig(tdb, 'session-hub-c', 'hub-c', group.id, resolver, injector)
 		);
 
@@ -1133,7 +1133,7 @@ describe('data reload and DB-based validation', () => {
 			reloadedRun!.config as Record<string, unknown>
 		);
 
-		const config: StepAgentToolsConfig = {
+		const config: NodeAgentToolsConfig = {
 			mySessionId: 'session-coder-rs',
 			myRole: 'coder',
 			taskId: 'task-reload-send',
@@ -1143,7 +1143,7 @@ describe('data reload and DB-based validation', () => {
 			messageInjector: injector,
 		};
 
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({
 			target: 'reviewer',
 			message: 'post-reload check',
@@ -1202,7 +1202,7 @@ describe('data reload and DB-based validation', () => {
 // ===========================================================================
 // Test Suite 8: Error Paths — Missing Group ID
 // ===========================================================================
-// Covers step-agent-tools.ts lines 124–133 (loadGroupAndResolver error path)
+// Covers node-agent-tools.ts lines 124–133 (loadGroupAndResolver error path)
 // where getGroupId() returns undefined — a race condition that can occur before
 // the TaskAgentManager has finished persisting the group to DB.
 
@@ -1222,7 +1222,7 @@ describe('error paths — missing group ID', () => {
 		const { messages, injector } = makeMessageCapture();
 
 		// getGroupId returns undefined — simulates race before group is created
-		const config: StepAgentToolsConfig = {
+		const config: NodeAgentToolsConfig = {
 			mySessionId: 'session-coder-nogroup',
 			myRole: 'coder',
 			taskId: 'task-nogroup',
@@ -1232,7 +1232,7 @@ describe('error paths — missing group ID', () => {
 			messageInjector: injector,
 		};
 
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -1242,7 +1242,7 @@ describe('error paths — missing group ID', () => {
 	});
 
 	test('list_peers returns structured error when getGroupId returns undefined', async () => {
-		const config: StepAgentToolsConfig = {
+		const config: NodeAgentToolsConfig = {
 			mySessionId: 'session-coder-nogroup',
 			myRole: 'coder',
 			taskId: 'task-nogroup',
@@ -1252,7 +1252,7 @@ describe('error paths — missing group ID', () => {
 			messageInjector: async () => {},
 		};
 
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -1357,7 +1357,7 @@ describe('Task Agent channel participation', () => {
 
 		const { messages, injector } = makeMessageCapture();
 		const config = makeStepConfig(tdb, 'session-coder', 'coder', group.id, resolver, injector);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		const result = await handlers.send_message({ target: 'task-agent', message: 'Hello TA' });
 		const data = JSON.parse(result.content[0].text);
@@ -1395,14 +1395,14 @@ describe('Task Agent channel participation', () => {
 
 		const { messages, injector } = makeMessageCapture();
 		const config = makeStepConfig(tdb, 'session-coder', 'coder', group.id, resolver, injector);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		const result = await handlers.send_message({ target: 'task-agent', message: 'Hello TA' });
 		const data = JSON.parse(result.content[0].text);
 
 		// The channel resolver check passes (channel is declared), but send_message
 		// explicitly filters out task-agent from delivery targets, so no message is delivered.
-		// This exercises the filter at step-agent-tools.ts: .filter((m) => m.role !== 'task-agent')
+		// This exercises the filter at node-agent-tools.ts: .filter((m) => m.role !== 'task-agent')
 		expect(data.success).toBe(false);
 		expect((data.error as string).toLowerCase()).toContain('no active sessions');
 		expect(messages).toHaveLength(0);

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for cross-agent messaging.
  *
- * Exercises the step agent peer communication tools (send_message, list_peers)
+ * Exercises the node agent peer communication tools (send_message, list_peers)
  * and the Task Agent list_group_members tool in isolation with a real SQLite DB.
  *
  * Test patterns covered:
@@ -42,9 +42,9 @@ import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-man
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import {
-	createStepAgentToolHandlers,
-	type StepAgentToolsConfig,
-} from '../../../src/lib/space/tools/step-agent-tools.ts';
+	createNodeAgentToolHandlers,
+	type NodeAgentToolsConfig,
+} from '../../../src/lib/space/tools/node-agent-tools.ts';
 import {
 	createTaskAgentToolHandlers,
 	type SubSessionFactory,
@@ -158,8 +158,8 @@ function makeStepConfig(
 	ctx: StepCtx,
 	mySessionId: string,
 	myRole: string,
-	overrides: Partial<StepAgentToolsConfig> = {}
-): StepAgentToolsConfig & {
+	overrides: Partial<NodeAgentToolsConfig> = {}
+): NodeAgentToolsConfig & {
 	injectedMessages: Array<{ sessionId: string; message: string }>;
 } {
 	const injectedMessages: Array<{ sessionId: string; message: string }> = [];
@@ -361,7 +361,7 @@ describe('send_message — point-to-point (target: role)', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
 			channelResolver: new ChannelResolver([ch('coder', 'reviewer')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'LGTM' }));
 		expect(result.success).toBe(true);
@@ -380,7 +380,7 @@ describe('send_message — point-to-point (target: role)', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
 			channelResolver: new ChannelResolver([ch('reviewer', 'coder')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'Hello' }));
 		expect(result.success).toBe(false);
@@ -405,7 +405,7 @@ describe('send_message — broadcast (target: "*")', () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub', {
 			channelResolver: new ChannelResolver([ch('hub', 'B'), ch('hub', 'C')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: '*', message: 'Broadcast!' }));
 		expect(result.success).toBe(true);
@@ -422,7 +422,7 @@ describe('send_message — broadcast (target: "*")', () => {
 		const cfg = makeStepConfig(ctx, 'sess-spoke', 'spoke', {
 			channelResolver: new ChannelResolver([ch('hub', 'spoke')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: '*', message: 'Hi' }));
 		expect(result.success).toBe(false);
@@ -446,7 +446,7 @@ describe('send_message — multicast (target: [role1, role2])', () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub', {
 			channelResolver: new ChannelResolver([ch('hub', 'B'), ch('hub', 'C')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: ['B', 'C'], message: 'Multicast' }));
 		expect(result.success).toBe(true);
@@ -464,7 +464,7 @@ describe('send_message — multicast (target: [role1, role2])', () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub', {
 			channelResolver: new ChannelResolver([ch('hub', 'B')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: ['B', 'C'], message: 'Multicast' }));
 		expect(result.success).toBe(false);
@@ -487,7 +487,7 @@ describe('send_message — multicast (target: [role1, role2])', () => {
 				cfg.injectedMessages.push({ sessionId, message });
 			},
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(
 			await handlers.send_message({ target: ['B', 'C'], message: 'Multicast partial' })
@@ -524,7 +524,7 @@ describe('send_message — no channels declared', () => {
 		// No channels declared — empty topology (default empty resolver)
 
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'Hi' }));
 		expect(result.success).toBe(false);
@@ -556,14 +556,14 @@ describe('send_message — fan-out one-way: hub → spokes, spokes cannot reply'
 
 	test('hub can send to B', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: 'B', message: 'Go!' }));
 		expect(result.success).toBe(true);
 	});
 
 	test('hub broadcasts to all spokes via *', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: '*', message: 'All go!' }));
 		expect(result.success).toBe(true);
 		const delivered = (result.delivered as Array<{ sessionId: string }>).map((d) => d.sessionId);
@@ -572,7 +572,7 @@ describe('send_message — fan-out one-way: hub → spokes, spokes cannot reply'
 
 	test('spoke B cannot send back to hub (one-way enforcement)', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-B', 'B');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: 'hub', message: 'Hello hub' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('hub')).toBe(true);
@@ -580,7 +580,7 @@ describe('send_message — fan-out one-way: hub → spokes, spokes cannot reply'
 
 	test('spoke B cannot send to spoke C (spoke isolation)', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-B', 'B');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: 'C', message: 'Hi C' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('C')).toBe(true);
@@ -615,7 +615,7 @@ describe('send_message — hub-spoke bidirectional: hub broadcasts, spokes reply
 
 	test('hub can send to B', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: 'B', message: 'Review this' }));
 		expect(result.success).toBe(true);
 		expect(cfg.injectedMessages[0].sessionId).toBe('sess-B');
@@ -623,7 +623,7 @@ describe('send_message — hub-spoke bidirectional: hub broadcasts, spokes reply
 
 	test('hub can broadcast to all spokes via *', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: '*', message: 'Broadcast' }));
 		expect(result.success).toBe(true);
 		const delivered = (result.delivered as Array<{ sessionId: string }>).map((d) => d.sessionId);
@@ -632,7 +632,7 @@ describe('send_message — hub-spoke bidirectional: hub broadcasts, spokes reply
 
 	test('spoke B can reply to hub', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-B', 'B');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: 'hub', message: 'Reviewed, LGTM' }));
 		expect(result.success).toBe(true);
 		expect(cfg.injectedMessages[0].sessionId).toBe('sess-hub');
@@ -640,7 +640,7 @@ describe('send_message — hub-spoke bidirectional: hub broadcasts, spokes reply
 
 	test('spoke B cannot send to spoke C (spoke isolation enforced)', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-B', 'B');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: 'C', message: 'Hi C' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('C')).toBe(true);
@@ -648,7 +648,7 @@ describe('send_message — hub-spoke bidirectional: hub broadcasts, spokes reply
 
 	test('spoke C cannot send to spoke B (spoke isolation, other direction)', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-C', 'C');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 		const result = parse(await handlers.send_message({ target: 'B', message: 'Hi B' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('B')).toBe(true);
@@ -674,7 +674,7 @@ describe('list_peers — peer discovery with channel info', () => {
 		]);
 
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.list_peers({}));
 		expect(result.success).toBe(true);
@@ -693,7 +693,7 @@ describe('list_peers — peer discovery with channel info', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
 			channelResolver: new ChannelResolver([ch('coder', 'reviewer')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.list_peers({}));
 		expect(result.channelTopologyDeclared).toBe(true);
@@ -708,7 +708,7 @@ describe('list_peers — peer discovery with channel info', () => {
 		// No channels declared (default empty resolver)
 
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.list_peers({}));
 		expect(result.channelTopologyDeclared).toBe(false);
@@ -720,7 +720,7 @@ describe('list_peers — peer discovery with channel info', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
 			getGroupId: () => undefined,
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.list_peers({}));
 		expect(result.success).toBe(false);
@@ -839,7 +839,7 @@ describe('list_group_members — Task Agent group view', () => {
 //   - When a channel to/from Task Agent is declared, it appears in permittedTargets
 //   - When the channel is removed (topology changes), permittedTargets updates
 //
-// Note: Task Agent does not have a send_message tool. When a step agent calls
+// Note: Task Agent does not have a send_message tool. When a node agent calls
 // send_message targeting 'task-agent', the channel resolver check passes (if channel
 // declared), but the task-agent is filtered from delivery targets, so the message
 // is never delivered. This is by design — Task Agent communicates via its own mechanisms,
@@ -1060,7 +1060,7 @@ describe('Task Agent in channel topology — via list_group_members', () => {
 // ===========================================================================
 
 describe('Group scoping — messages cannot leak between task groups', () => {
-	test('send_message only delivers within the step agent own group', async () => {
+	test('send_message only delivers within the node agent own group', async () => {
 		// Two independent step contexts (different groups, different DBs)
 		const ctxA = makeStepCtx([
 			{ sessionId: 'sess-hub-A', role: 'hub' },
@@ -1076,7 +1076,7 @@ describe('Group scoping — messages cannot leak between task groups', () => {
 
 		try {
 			const cfgA = makeStepConfig(ctxA, 'sess-hub-A', 'hub');
-			const handlersA = createStepAgentToolHandlers(cfgA);
+			const handlersA = createNodeAgentToolHandlers(cfgA);
 
 			// Group A hub sends to its own B — succeeds
 			const resultA = parse(await handlersA.send_message({ target: 'B', message: 'To A.B' }));
@@ -1111,7 +1111,7 @@ describe('Error cases — non-existent targets and injection failures', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
 			channelResolver: new ChannelResolver([ch('coder', 'ghost')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: 'ghost', message: 'Hello ghost' }));
 		expect(result.success).toBe(false);
@@ -1129,7 +1129,7 @@ describe('Error cases — non-existent targets and injection failures', () => {
 				throw new Error('Session closed');
 			},
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'Hi' }));
 		expect(result.success).toBe(false);
@@ -1157,7 +1157,7 @@ describe('Step with no channels declared', () => {
 		// No channels declared — resolver is empty
 
 		const cfgA = makeStepConfig(ctx, 'sess-a', 'agent-a');
-		const handlersA = createStepAgentToolHandlers(cfgA);
+		const handlersA = createNodeAgentToolHandlers(cfgA);
 
 		const fbResult = parse(
 			await handlersA.send_message({ target: 'agent-b', message: 'Direct msg' })
@@ -1172,7 +1172,7 @@ describe('Step with no channels declared', () => {
 		]);
 
 		const cfg = makeStepConfig(ctx, 'sess-a', 'agent-a');
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		const result = parse(await handlers.list_peers({}));
 		expect(result.channelTopologyDeclared).toBe(false);
@@ -1199,7 +1199,7 @@ describe('send_message — sender attribution prefix', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
 			channelResolver: new ChannelResolver([ch('coder', 'reviewer')]),
 		});
-		const handlers = createStepAgentToolHandlers(cfg);
+		const handlers = createNodeAgentToolHandlers(cfg);
 
 		await handlers.send_message({ target: 'reviewer', message: 'Here is my patch' });
 

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -1,7 +1,7 @@
 /**
- * Unit tests for createStepAgentToolHandlers()
+ * Unit tests for createNodeAgentToolHandlers()
  *
- * Covers all step agent peer communication tools:
+ * Covers all node agent peer communication tools:
  *   list_peers   — list peers excluding self and task-agent
  *   send_message — channel-validated direct messaging
  *   report_done  — signal agent completion, persist summary, emit event
@@ -19,10 +19,10 @@ import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/s
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import {
-	createStepAgentToolHandlers,
-	createStepAgentMcpServer,
-	type StepAgentToolsConfig,
-} from '../../../src/lib/space/tools/step-agent-tools.ts';
+	createNodeAgentToolHandlers,
+	createNodeAgentMcpServer,
+	type NodeAgentToolsConfig,
+} from '../../../src/lib/space/tools/node-agent-tools.ts';
 import { ChannelResolver } from '../../../src/lib/space/runtime/channel-resolver.ts';
 import type { ResolvedChannel } from '@neokai/shared';
 
@@ -34,7 +34,7 @@ function makeDb(): { db: BunDatabase; dir: string } {
 	const dir = join(
 		process.cwd(),
 		'tmp',
-		'test-step-agent-tools',
+		'test-node-agent-tools',
 		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
 	);
 	mkdirSync(dir, { recursive: true });
@@ -131,7 +131,7 @@ interface TestCtx {
 
 function makeCtx(): TestCtx {
 	const { db, dir } = makeDb();
-	const spaceId = 'space-step-tools-test';
+	const spaceId = 'space-node-tools-test';
 
 	seedSpaceRow(db, spaceId);
 
@@ -203,8 +203,8 @@ function makeCtx(): TestCtx {
 
 function makeConfig(
 	ctx: TestCtx,
-	overrides: Partial<StepAgentToolsConfig> = {}
-): StepAgentToolsConfig {
+	overrides: Partial<NodeAgentToolsConfig> = {}
+): NodeAgentToolsConfig {
 	const injectedMessages: Array<{ sessionId: string; message: string }> = [];
 
 	return {
@@ -239,7 +239,7 @@ function makeResolver(channels: ResolvedChannel[]): ChannelResolver {
 // Tests: list_peers
 // ---------------------------------------------------------------------------
 
-describe('step-agent-tools: list_peers', () => {
+describe('node-agent-tools: list_peers', () => {
 	let ctx: TestCtx;
 
 	beforeEach(() => {
@@ -253,7 +253,7 @@ describe('step-agent-tools: list_peers', () => {
 
 	test('returns peers excluding self and task-agent', async () => {
 		const config = makeConfig(ctx);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -266,7 +266,7 @@ describe('step-agent-tools: list_peers', () => {
 
 	test('reports no channel topology when none declared', async () => {
 		const config = makeConfig(ctx);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -278,7 +278,7 @@ describe('step-agent-tools: list_peers', () => {
 		const config = makeConfig(ctx, {
 			channelResolver: makeResolver([makeResolvedChannel('coder', 'reviewer')]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -288,7 +288,7 @@ describe('step-agent-tools: list_peers', () => {
 
 	test('returns error when group not found', async () => {
 		const config = makeConfig(ctx, { getGroupId: () => undefined });
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -313,7 +313,7 @@ describe('step-agent-tools: list_peers', () => {
 		});
 
 		const config = makeConfig(ctx, { getGroupId: () => isolatedGroup.id });
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -326,7 +326,7 @@ describe('step-agent-tools: list_peers', () => {
 // Tests: send_message
 // ---------------------------------------------------------------------------
 
-describe('step-agent-tools: send_message', () => {
+describe('node-agent-tools: send_message', () => {
 	let ctx: TestCtx;
 
 	beforeEach(() => {
@@ -346,7 +346,7 @@ describe('step-agent-tools: send_message', () => {
 				injected.push({ sessionId: sid, message: msg });
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'LGTM!' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -362,7 +362,7 @@ describe('step-agent-tools: send_message', () => {
 		const config = makeConfig(ctx, {
 			channelResolver: makeResolver([makeResolvedChannel('reviewer', 'coder')]), // reverse direction only
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -373,7 +373,7 @@ describe('step-agent-tools: send_message', () => {
 
 	test('returns error when no channels declared at all (empty topology blocks send_message)', async () => {
 		const config = makeConfig(ctx); // no workflowRunId, no channels
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'test' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -390,7 +390,7 @@ describe('step-agent-tools: send_message', () => {
 				injected.push(sid);
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: '*', message: 'broadcast!' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -403,7 +403,7 @@ describe('step-agent-tools: send_message', () => {
 		const config = makeConfig(ctx, {
 			channelResolver: makeResolver([makeResolvedChannel('reviewer', 'coder')]), // coder has no outgoing channels
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: '*', message: 'broadcast' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -414,7 +414,7 @@ describe('step-agent-tools: send_message', () => {
 	test('broadcast (*) with empty topology returns error', async () => {
 		// No channels declared at all
 		const config = makeConfig(ctx);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: '*', message: 'broadcast' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -439,7 +439,7 @@ describe('step-agent-tools: send_message', () => {
 				injected.push(sid);
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({
 			target: ['reviewer', 'security'],
 			message: 'multicast!',
@@ -464,7 +464,7 @@ describe('step-agent-tools: send_message', () => {
 				// no coder → security channel
 			]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({
 			target: ['reviewer', 'security'],
 			message: 'msg',
@@ -485,7 +485,7 @@ describe('step-agent-tools: send_message', () => {
 				makeResolvedChannel('reviewer', 'hub', true),
 			]),
 		}); // myRole='coder'
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -509,7 +509,7 @@ describe('step-agent-tools: send_message', () => {
 				injected.push(sid);
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'hub', message: 'done!' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -530,7 +530,7 @@ describe('step-agent-tools: send_message', () => {
 				injectedToReviewer.push(sid);
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		// coder → reviewer
 		const r1 = await handlers.send_message({ target: 'reviewer', message: 'code ready' });
@@ -545,7 +545,7 @@ describe('step-agent-tools: send_message', () => {
 				injectedToReviewer.push(sid);
 			},
 		});
-		const handlersAsReviewer = createStepAgentToolHandlers(configAsReviewer);
+		const handlersAsReviewer = createNodeAgentToolHandlers(configAsReviewer);
 		const r2 = await handlersAsReviewer.send_message({ target: 'coder', message: 'approved' });
 		expect(JSON.parse(r2.content[0].text).success).toBe(true);
 	});
@@ -554,7 +554,7 @@ describe('step-agent-tools: send_message', () => {
 		const config = makeConfig(ctx, {
 			channelResolver: makeResolver([makeResolvedChannel('coder', 'tester')]), // 'tester' role not in group
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'tester', message: 'test pls' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -577,7 +577,7 @@ describe('step-agent-tools: send_message', () => {
 				// second call succeeds
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -596,7 +596,7 @@ describe('step-agent-tools: send_message', () => {
 				throw new Error('always fails');
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'test' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -607,7 +607,7 @@ describe('step-agent-tools: send_message', () => {
 
 	test('returns error when group not found', async () => {
 		const config = makeConfig(ctx, { getGroupId: () => undefined });
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'test' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -620,7 +620,7 @@ describe('step-agent-tools: send_message', () => {
 			channelResolver: makeResolver([makeResolvedChannel('coder', 'reviewer')]),
 			getGroupId: () => 'nonexistent-group-id',
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'Hello' });
 		const data = JSON.parse(result.content[0].text);
 		expect(data.success).toBe(false);
@@ -645,7 +645,7 @@ describe('step-agent-tools: send_message', () => {
 				if (callCount === 2) throw new Error('session not available');
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		const result = await handlers.send_message({
 			target: ['reviewer', 'security'],
@@ -669,7 +669,7 @@ describe('step-agent-tools: send_message', () => {
 				throw new Error('all sessions unavailable');
 			},
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 
 		const result = await handlers.send_message({ target: 'reviewer', message: 'Hello' });
 		const data = JSON.parse(result.content[0].text);
@@ -684,7 +684,7 @@ describe('step-agent-tools: send_message', () => {
 // Tests: report_done
 // ---------------------------------------------------------------------------
 
-describe('step-agent-tools: report_done', () => {
+describe('node-agent-tools: report_done', () => {
 	let ctx: TestCtx;
 
 	beforeEach(() => {
@@ -698,7 +698,7 @@ describe('step-agent-tools: report_done', () => {
 
 	test('marks step task as completed without summary', async () => {
 		const config = makeConfig(ctx);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.report_done({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -713,7 +713,7 @@ describe('step-agent-tools: report_done', () => {
 
 	test('persists summary as result field', async () => {
 		const config = makeConfig(ctx);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.report_done({ summary: 'PR #42 merged successfully.' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -733,9 +733,9 @@ describe('step-agent-tools: report_done', () => {
 		};
 
 		const config = makeConfig(ctx, {
-			daemonHub: fakeDaemonHub as unknown as StepAgentToolsConfig['daemonHub'],
+			daemonHub: fakeDaemonHub as unknown as NodeAgentToolsConfig['daemonHub'],
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		await handlers.report_done({ summary: 'done' });
 
 		expect(emitted).toHaveLength(1);
@@ -750,7 +750,7 @@ describe('step-agent-tools: report_done', () => {
 
 	test('does not emit event when daemonHub is absent', async () => {
 		const config = makeConfig(ctx); // no daemonHub
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		// Should not throw
 		const result = await handlers.report_done({});
 		const data = JSON.parse(result.content[0].text);
@@ -759,7 +759,7 @@ describe('step-agent-tools: report_done', () => {
 
 	test('returns error when step task not found', async () => {
 		const config = makeConfig(ctx, { stepTaskId: 'nonexistent-step-task' });
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.report_done({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -772,7 +772,7 @@ describe('step-agent-tools: report_done', () => {
 		await ctx.taskManager.setTaskStatus(ctx.stepTaskId, 'completed');
 
 		const config = makeConfig(ctx);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.report_done({ summary: 'already done' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -791,9 +791,9 @@ describe('step-agent-tools: report_done', () => {
 		};
 
 		const config = makeConfig(ctx, {
-			daemonHub: throwingHub as unknown as StepAgentToolsConfig['daemonHub'],
+			daemonHub: throwingHub as unknown as NodeAgentToolsConfig['daemonHub'],
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.report_done({ summary: 'done despite hub error' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -817,9 +817,9 @@ describe('step-agent-tools: report_done', () => {
 
 		const config = makeConfig(ctx, {
 			stepTaskId: 'nonexistent-step-task',
-			daemonHub: trackingHub as unknown as StepAgentToolsConfig['daemonHub'],
+			daemonHub: trackingHub as unknown as NodeAgentToolsConfig['daemonHub'],
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.report_done({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -833,7 +833,7 @@ describe('step-agent-tools: report_done', () => {
 // Tests: list_reachable_agents
 // ---------------------------------------------------------------------------
 
-describe('step-agent-tools: list_reachable_agents', () => {
+describe('node-agent-tools: list_reachable_agents', () => {
 	let ctx: TestCtx;
 
 	beforeEach(() => {
@@ -847,7 +847,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 
 	test('returns within-node peers excluding self and task-agent', async () => {
 		const config = makeConfig(ctx);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -860,7 +860,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 
 	test('returns empty cross-node targets when no channels declared', async () => {
 		const config = makeConfig(ctx);
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -874,7 +874,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 		const config = makeConfig(ctx, {
 			channelResolver: makeResolver([makeResolvedChannel('coder', 'tester')]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -890,7 +890,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 		const config = makeConfig(ctx, {
 			channelResolver: makeResolver([makeResolvedChannel('coder', 'reviewer')]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -903,7 +903,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 		const config = makeConfig(ctx, {
 			channelResolver: makeResolver([makeResolvedChannel('coder', 'tester')]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -917,7 +917,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 				makeResolvedChannel('coder', 'tester', false, { gate: { type: 'human' } }),
 			]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -933,7 +933,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 				}),
 			]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -949,7 +949,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 				}),
 			]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -963,7 +963,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 				makeResolvedChannel('coder', 'tester', false, { gate: { type: 'always' } }),
 			]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -979,7 +979,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 				}),
 			]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -992,7 +992,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 				makeResolvedChannel('coder', 'qa-node', false, { isFanOut: true }),
 			]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -1009,7 +1009,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 				makeResolvedChannel('coder', 'tester'), // duplicate
 			]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -1021,7 +1021,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 		const config = makeConfig(ctx, {
 			channelResolver: makeResolver([makeResolvedChannel('tester', 'coder')]),
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -1030,7 +1030,7 @@ describe('step-agent-tools: list_reachable_agents', () => {
 
 	test('returns error when group not found', async () => {
 		const config = makeConfig(ctx, { getGroupId: () => undefined });
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_reachable_agents({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -1040,10 +1040,10 @@ describe('step-agent-tools: list_reachable_agents', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: createStepAgentMcpServer (factory)
+// Tests: createNodeAgentMcpServer (factory)
 // ---------------------------------------------------------------------------
 
-describe('step-agent-tools: createStepAgentMcpServer', () => {
+describe('node-agent-tools: createNodeAgentMcpServer', () => {
 	let ctx: TestCtx;
 
 	beforeEach(() => {
@@ -1057,7 +1057,7 @@ describe('step-agent-tools: createStepAgentMcpServer', () => {
 
 	test('creates an MCP server with expected tools', () => {
 		const config = makeConfig(ctx);
-		const server = createStepAgentMcpServer(config);
+		const server = createNodeAgentMcpServer(config);
 
 		// Server should be an object with a server property (MCP SDK server)
 		expect(server).toBeDefined();
@@ -1066,10 +1066,10 @@ describe('step-agent-tools: createStepAgentMcpServer', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: step agent system prompt
+// Tests: node agent system prompt
 // ---------------------------------------------------------------------------
 
-describe('step-agent-tools: system prompt includes peer communication section', () => {
+describe('node-agent-tools: system prompt includes peer communication section', () => {
 	test('buildCustomAgentSystemPrompt includes Peer Communication section', async () => {
 		const { buildCustomAgentSystemPrompt } = await import(
 			'../../../src/lib/space/agents/custom-agent.ts'
@@ -1132,7 +1132,7 @@ describe('list_peers — completion state', () => {
 			workflowNodeId,
 			spaceTaskRepo: ctx.spaceTaskRepo,
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -1166,7 +1166,7 @@ describe('list_peers — completion state', () => {
 			workflowNodeId,
 			spaceTaskRepo: ctx.spaceTaskRepo,
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 
@@ -1198,7 +1198,7 @@ describe('list_peers — completion state', () => {
 			workflowNodeId,
 			spaceTaskRepo: ctx.spaceTaskRepo,
 		});
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_peers({});
 		const data = JSON.parse(result.content[0].text);
 

--- a/packages/daemon/tests/unit/space/send-message-unified.test.ts
+++ b/packages/daemon/tests/unit/space/send-message-unified.test.ts
@@ -21,9 +21,9 @@ import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/s
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import {
-	createStepAgentToolHandlers,
-	type StepAgentToolsConfig,
-} from '../../../src/lib/space/tools/step-agent-tools.ts';
+	createNodeAgentToolHandlers,
+	type NodeAgentToolsConfig,
+} from '../../../src/lib/space/tools/node-agent-tools.ts';
 import { AgentMessageRouter } from '../../../src/lib/space/runtime/agent-message-router.ts';
 import { ChannelResolver } from '../../../src/lib/space/runtime/channel-resolver.ts';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
@@ -168,7 +168,7 @@ function makeBaseConfig(
 	workflowRunId: string,
 	injected: Array<{ sessionId: string; message: string }>,
 	channelResolver: ChannelResolver = new ChannelResolver([])
-): StepAgentToolsConfig {
+): NodeAgentToolsConfig {
 	return {
 		mySessionId: ctx.coderSessionId,
 		myRole: 'coder',
@@ -219,7 +219,7 @@ describe('send_message with ChannelRouter injected', () => {
 			messageInjector: baseConfig.messageInjector,
 		});
 
-		const handlers = createStepAgentToolHandlers({ ...baseConfig, agentMessageRouter });
+		const handlers = createNodeAgentToolHandlers({ ...baseConfig, agentMessageRouter });
 		const result = await handlers.send_message({ target: 'reviewer', message: 'hello via router' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -244,7 +244,7 @@ describe('send_message with ChannelRouter injected', () => {
 			messageInjector: baseConfig.messageInjector,
 		});
 
-		const handlers = createStepAgentToolHandlers({ ...baseConfig, agentMessageRouter });
+		const handlers = createNodeAgentToolHandlers({ ...baseConfig, agentMessageRouter });
 		const result = await handlers.send_message({ target: 'ghost-agent', message: 'knock knock' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -267,7 +267,7 @@ describe('send_message with ChannelRouter injected', () => {
 			messageInjector: baseConfig.messageInjector,
 		});
 
-		const handlers = createStepAgentToolHandlers({ ...baseConfig, agentMessageRouter });
+		const handlers = createNodeAgentToolHandlers({ ...baseConfig, agentMessageRouter });
 		const result = await handlers.send_message({ target: 'reviewer', message: 'unauthorized' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -290,7 +290,7 @@ describe('send_message with ChannelRouter injected', () => {
 			messageInjector: baseConfig.messageInjector,
 		});
 
-		const handlers = createStepAgentToolHandlers({ ...baseConfig, agentMessageRouter });
+		const handlers = createNodeAgentToolHandlers({ ...baseConfig, agentMessageRouter });
 		const result = await handlers.send_message({ target: '*', message: 'broadcast via router' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -330,7 +330,7 @@ describe('send_message without ChannelRouter (legacy path)', () => {
 		);
 		// No agentMessageRouter — uses legacy path
 
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: 'reviewer', message: 'legacy DM' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -345,7 +345,7 @@ describe('send_message without ChannelRouter (legacy path)', () => {
 			makeResolvedChannel('coder', 'reviewer'),
 		]);
 		const injected: string[] = [];
-		const config: StepAgentToolsConfig = {
+		const config: NodeAgentToolsConfig = {
 			...makeBaseConfig(
 				ctx,
 				workflowRunId,
@@ -357,7 +357,7 @@ describe('send_message without ChannelRouter (legacy path)', () => {
 			},
 		};
 
-		const handlers = createStepAgentToolHandlers(config);
+		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.send_message({ target: '*', message: 'broadcast legacy' });
 		const data = JSON.parse(result.content[0].text);
 
@@ -396,7 +396,7 @@ describe('both paths produce same behavior for role-based DM', () => {
 			injectedLegacy,
 			new ChannelResolver([makeResolvedChannel('coder', 'reviewer')])
 		);
-		const legacyHandlers = createStepAgentToolHandlers(legacyConfig);
+		const legacyHandlers = createNodeAgentToolHandlers(legacyConfig);
 		const legacyResult = await legacyHandlers.send_message({
 			target: 'reviewer',
 			message: 'test message',
@@ -413,7 +413,7 @@ describe('both paths produce same behavior for role-based DM', () => {
 			workflowRunId,
 			messageInjector: routerBaseConfig.messageInjector,
 		});
-		const routerHandlers = createStepAgentToolHandlers({ ...routerBaseConfig, agentMessageRouter });
+		const routerHandlers = createNodeAgentToolHandlers({ ...routerBaseConfig, agentMessageRouter });
 		const routerResult = await routerHandlers.send_message({
 			target: 'reviewer',
 			message: 'test message',

--- a/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for TaskAgentManager + AppMcpLifecycleManager integration (Task 3.4).
- * Also covers ChannelResolver injection into step agent MCP servers (Task 3.3).
+ * Also covers ChannelResolver injection into node agent MCP servers (Task 3.3).
  *
  * Verifies that:
  * 1. Task agent sessions receive registry-sourced MCP servers merged into their
@@ -11,8 +11,8 @@
  * 4. appMcpManager is optional — omitting it does not throw; task-agent server is
  *    still injected.
  * 5. Multiple registry servers are all included in the merged map.
- * 6. buildStepAgentMcpServerForSession creates a ChannelResolver from the workflow
- *    run config and injects it into the step agent MCP server config (Task 3.3).
+ * 6. buildNodeAgentMcpServerForSession creates a ChannelResolver from the workflow
+ *    run config and injects it into the node agent MCP server config (Task 3.3).
  */
 
 import { describe, test, expect, afterEach, spyOn, beforeEach } from 'bun:test';
@@ -32,7 +32,7 @@ import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager.ts';
 import { AgentSession } from '../../../src/lib/agent/agent-session.ts';
-import * as stepAgentToolsModule from '../../../src/lib/space/tools/step-agent-tools.ts';
+import * as nodeAgentToolsModule from '../../../src/lib/space/tools/node-agent-tools.ts';
 import type { Space, SpaceTask, McpServerConfig, ResolvedChannel } from '@neokai/shared';
 import type { AgentProcessingState } from '@neokai/shared';
 
@@ -468,7 +468,7 @@ describe('TaskAgentManager.rehydrate — registry MCP merge (Task 3.4)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// ChannelResolver injection into step agent MCP servers (Task 3.3)
+// ChannelResolver injection into node agent MCP servers (Task 3.3)
 // ---------------------------------------------------------------------------
 
 /**
@@ -533,7 +533,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 		}
 	});
 
-	test('buildStepAgentMcpServerForSession injects ChannelResolver with declared channels', () => {
+	test('buildNodeAgentMcpServerForSession injects ChannelResolver with declared channels', () => {
 		const { manager, fromInitSpy, bunDb, dir, space } = buildManager({});
 		spies.push(fromInitSpy);
 		dirs.push(dir);
@@ -543,14 +543,14 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 			makeResolvedChannel('coder', 'reviewer'),
 		]);
 
-		// Spy on createStepAgentMcpServer to capture the config it receives
+		// Spy on createNodeAgentMcpServer to capture the config it receives
 		let capturedConfig: Record<string, unknown> | null = null;
-		const mcpServerSpy = spyOn(stepAgentToolsModule, 'createStepAgentMcpServer').mockImplementation(
+		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
 			(config) => {
 				capturedConfig = config as unknown as Record<string, unknown>;
 				// Return minimal stub
 				return { server: {}, cleanup: () => {} } as unknown as ReturnType<
-					typeof stepAgentToolsModule.createStepAgentMcpServer
+					typeof nodeAgentToolsModule.createNodeAgentMcpServer
 				>;
 			}
 		);
@@ -558,7 +558,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 
 		// Call the private method directly via cast
 		const mgr = manager as unknown as {
-			buildStepAgentMcpServerForSession(
+			buildNodeAgentMcpServerForSession(
 				taskId: string,
 				subSessionId: string,
 				role: string,
@@ -566,7 +566,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 				workflowRunId: string
 			): unknown;
 		};
-		mgr.buildStepAgentMcpServerForSession(
+		mgr.buildNodeAgentMcpServerForSession(
 			'task-1',
 			'sub-session-1',
 			'coder',
@@ -584,7 +584,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 		expect(resolver.canSend('reviewer', 'coder')).toBe(false);
 	});
 
-	test('buildStepAgentMcpServerForSession injects empty ChannelResolver when run has no channels', () => {
+	test('buildNodeAgentMcpServerForSession injects empty ChannelResolver when run has no channels', () => {
 		const { manager, fromInitSpy, bunDb, dir, space } = buildManager({});
 		spies.push(fromInitSpy);
 		dirs.push(dir);
@@ -593,18 +593,18 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 		const workflowRunId = seedWorkflowRunWithChannels(bunDb, space.id, []);
 
 		let capturedConfig: Record<string, unknown> | null = null;
-		const mcpServerSpy = spyOn(stepAgentToolsModule, 'createStepAgentMcpServer').mockImplementation(
+		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
 			(config) => {
 				capturedConfig = config as unknown as Record<string, unknown>;
 				return { server: {}, cleanup: () => {} } as unknown as ReturnType<
-					typeof stepAgentToolsModule.createStepAgentMcpServer
+					typeof nodeAgentToolsModule.createNodeAgentMcpServer
 				>;
 			}
 		);
 		spies.push(mcpServerSpy);
 
 		const mgr = manager as unknown as {
-			buildStepAgentMcpServerForSession(
+			buildNodeAgentMcpServerForSession(
 				taskId: string,
 				subSessionId: string,
 				role: string,
@@ -612,7 +612,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 				workflowRunId: string
 			): unknown;
 		};
-		mgr.buildStepAgentMcpServerForSession(
+		mgr.buildNodeAgentMcpServerForSession(
 			'task-1',
 			'sub-session-1',
 			'coder',
@@ -627,24 +627,24 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 		expect(resolver.isEmpty()).toBe(true);
 	});
 
-	test('buildStepAgentMcpServerForSession injects empty ChannelResolver when workflowRunId is empty', () => {
+	test('buildNodeAgentMcpServerForSession injects empty ChannelResolver when workflowRunId is empty', () => {
 		const { manager, fromInitSpy, dir, space } = buildManager({});
 		spies.push(fromInitSpy);
 		dirs.push(dir);
 
 		let capturedConfig: Record<string, unknown> | null = null;
-		const mcpServerSpy = spyOn(stepAgentToolsModule, 'createStepAgentMcpServer').mockImplementation(
+		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
 			(config) => {
 				capturedConfig = config as unknown as Record<string, unknown>;
 				return { server: {}, cleanup: () => {} } as unknown as ReturnType<
-					typeof stepAgentToolsModule.createStepAgentMcpServer
+					typeof nodeAgentToolsModule.createNodeAgentMcpServer
 				>;
 			}
 		);
 		spies.push(mcpServerSpy);
 
 		const mgr = manager as unknown as {
-			buildStepAgentMcpServerForSession(
+			buildNodeAgentMcpServerForSession(
 				taskId: string,
 				subSessionId: string,
 				role: string,
@@ -653,7 +653,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 			): unknown;
 		};
 		// Empty workflowRunId — no run will be found
-		mgr.buildStepAgentMcpServerForSession('task-1', 'sub-session-1', 'coder', space.id, '');
+		mgr.buildNodeAgentMcpServerForSession('task-1', 'sub-session-1', 'coder', space.id, '');
 
 		expect(capturedConfig).not.toBeNull();
 		const resolver = (capturedConfig as { channelResolver: { isEmpty: () => boolean } })
@@ -662,24 +662,24 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 		expect(resolver.isEmpty()).toBe(true);
 	});
 
-	test('buildStepAgentMcpServerForSession passes correct mySessionId, myRole, and taskId', () => {
+	test('buildNodeAgentMcpServerForSession passes correct mySessionId, myRole, and taskId', () => {
 		const { manager, fromInitSpy, dir, space } = buildManager({});
 		spies.push(fromInitSpy);
 		dirs.push(dir);
 
 		let capturedConfig: Record<string, unknown> | null = null;
-		const mcpServerSpy = spyOn(stepAgentToolsModule, 'createStepAgentMcpServer').mockImplementation(
+		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
 			(config) => {
 				capturedConfig = config as unknown as Record<string, unknown>;
 				return { server: {}, cleanup: () => {} } as unknown as ReturnType<
-					typeof stepAgentToolsModule.createStepAgentMcpServer
+					typeof nodeAgentToolsModule.createNodeAgentMcpServer
 				>;
 			}
 		);
 		spies.push(mcpServerSpy);
 
 		const mgr = manager as unknown as {
-			buildStepAgentMcpServerForSession(
+			buildNodeAgentMcpServerForSession(
 				taskId: string,
 				subSessionId: string,
 				role: string,
@@ -687,7 +687,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 				workflowRunId: string
 			): unknown;
 		};
-		mgr.buildStepAgentMcpServerForSession(
+		mgr.buildNodeAgentMcpServerForSession(
 			'my-task-id',
 			'my-sub-session-id',
 			'reviewer',

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -1723,8 +1723,8 @@ describe('TaskAgentManager', () => {
 			expect(session._enqueuedMessages.length).toBeGreaterThan(0);
 			const msgs = session._enqueuedMessages.map((m) => m.msg);
 			expect(msgs.some((m) => m.includes('resuming after a daemon restart'))).toBe(true);
-			// Workflow tasks should reference check_step_status to resume the workflow
-			expect(msgs.some((m) => m.includes('check_step_status'))).toBe(true);
+			// Workflow tasks should reference check_node_status to resume the workflow
+			expect(msgs.some((m) => m.includes('check_node_status'))).toBe(true);
 		});
 
 		test('restore returning null skips task and does not add to map', async () => {
@@ -1979,7 +1979,7 @@ describe('TaskAgentManager', () => {
 			restoreSpy.mockRestore();
 		});
 
-		test('step-agent MCP server is re-attached on rehydrated sub-sessions', async () => {
+		test('node-agent MCP server is re-attached on rehydrated sub-sessions', async () => {
 			// Seed a workflow run so sub-sessions are rebuilt
 			const wfId = 'wf-rehydrate-step-mcp';
 			const now = Date.now();
@@ -2045,10 +2045,10 @@ describe('TaskAgentManager', () => {
 
 			await ctx.manager.rehydrate();
 
-			// The rehydrated sub-session should have the step-agent MCP server attached
+			// The rehydrated sub-session should have the node-agent MCP server attached
 			const subSession = ctx.createdSessions.get(subSessionId)!;
 			expect(subSession).toBeDefined();
-			expect(Object.keys(subSession._mcpServers)).toContain('step-agent');
+			expect(Object.keys(subSession._mcpServers)).toContain('node-agent');
 
 			restoreSpy.mockRestore();
 		});

--- a/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
@@ -8,8 +8,8 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
-	SpawnStepAgentSchema,
-	CheckStepStatusSchema,
+	SpawnNodeAgentSchema,
+	CheckNodeStatusSchema,
 	ReportResultSchema,
 	RequestHumanInputSchema,
 	TaskResultStatusSchema,
@@ -18,12 +18,12 @@ import {
 } from '../../../src/lib/space/tools/task-agent-tool-schemas.ts';
 
 // ---------------------------------------------------------------------------
-// spawn_step_agent
+// spawn_node_agent
 // ---------------------------------------------------------------------------
 
-describe('SpawnStepAgentSchema', () => {
+describe('SpawnNodeAgentSchema', () => {
 	test('accepts valid input with step_id only', () => {
-		const result = SpawnStepAgentSchema.safeParse({ step_id: 'step-abc' });
+		const result = SpawnNodeAgentSchema.safeParse({ step_id: 'step-abc' });
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data.step_id).toBe('step-abc');
@@ -32,7 +32,7 @@ describe('SpawnStepAgentSchema', () => {
 	});
 
 	test('accepts valid input with step_id and instructions', () => {
-		const result = SpawnStepAgentSchema.safeParse({
+		const result = SpawnNodeAgentSchema.safeParse({
 			step_id: 'step-abc',
 			instructions: 'Focus on unit tests only',
 		});
@@ -43,33 +43,33 @@ describe('SpawnStepAgentSchema', () => {
 	});
 
 	test('rejects missing step_id', () => {
-		const result = SpawnStepAgentSchema.safeParse({ instructions: 'some instructions' });
+		const result = SpawnNodeAgentSchema.safeParse({ instructions: 'some instructions' });
 		expect(result.success).toBe(false);
 	});
 
 	test('rejects non-string step_id', () => {
-		const result = SpawnStepAgentSchema.safeParse({ step_id: 42 });
+		const result = SpawnNodeAgentSchema.safeParse({ step_id: 42 });
 		expect(result.success).toBe(false);
 	});
 
 	test('rejects non-string instructions', () => {
-		const result = SpawnStepAgentSchema.safeParse({ step_id: 'step-1', instructions: 123 });
+		const result = SpawnNodeAgentSchema.safeParse({ step_id: 'step-1', instructions: 123 });
 		expect(result.success).toBe(false);
 	});
 
 	test('rejects empty object', () => {
-		const result = SpawnStepAgentSchema.safeParse({});
+		const result = SpawnNodeAgentSchema.safeParse({});
 		expect(result.success).toBe(false);
 	});
 });
 
 // ---------------------------------------------------------------------------
-// check_step_status
+// check_node_status
 // ---------------------------------------------------------------------------
 
-describe('CheckStepStatusSchema', () => {
+describe('CheckNodeStatusSchema', () => {
 	test('accepts empty object (check current active step)', () => {
-		const result = CheckStepStatusSchema.safeParse({});
+		const result = CheckNodeStatusSchema.safeParse({});
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data.step_id).toBeUndefined();
@@ -77,7 +77,7 @@ describe('CheckStepStatusSchema', () => {
 	});
 
 	test('accepts valid input with step_id', () => {
-		const result = CheckStepStatusSchema.safeParse({ step_id: 'step-xyz' });
+		const result = CheckNodeStatusSchema.safeParse({ step_id: 'step-xyz' });
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data.step_id).toBe('step-xyz');
@@ -85,12 +85,12 @@ describe('CheckStepStatusSchema', () => {
 	});
 
 	test('rejects non-string step_id', () => {
-		const result = CheckStepStatusSchema.safeParse({ step_id: true });
+		const result = CheckNodeStatusSchema.safeParse({ step_id: true });
 		expect(result.success).toBe(false);
 	});
 
 	test('rejects null step_id', () => {
-		const result = CheckStepStatusSchema.safeParse({ step_id: null });
+		const result = CheckNodeStatusSchema.safeParse({ step_id: null });
 		expect(result.success).toBe(false);
 	});
 });
@@ -249,8 +249,8 @@ describe('RequestHumanInputSchema', () => {
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
 	test('contains all 5 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
-		expect(keys).toContain('spawn_step_agent');
-		expect(keys).toContain('check_step_status');
+		expect(keys).toContain('spawn_node_agent');
+		expect(keys).toContain('check_node_status');
 		expect(keys).toContain('report_result');
 		expect(keys).toContain('request_human_input');
 		expect(keys).toContain('list_group_members');

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -2,12 +2,12 @@
  * Unit tests for createTaskAgentToolHandlers()
  *
  * Covers Task Agent tools:
- *   spawn_step_agent    — creates sub-session, registers callback, injects message
- *   check_step_status   — polling detection of sub-session completion
+ *   spawn_node_agent    — creates sub-session, registers callback, injects message
+ *   check_node_status   — polling detection of sub-session completion
  *   report_result       — transitions main task to final status
  *   request_human_input — pauses execution, marks task needs_attention
  *   list_group_members  — lists group members with session IDs and channel info
- *   send_message        — sends message to peer step agents via channel topology
+ *   send_message        — sends message to peer node agents via channel topology
  *
  * Tests use a real SQLite database (via runMigrations) and mock SubSessionFactory
  * so no real agent sessions are created.
@@ -386,10 +386,10 @@ async function startRun(
 }
 
 // ===========================================================================
-// spawn_step_agent tests
+// spawn_node_agent tests
 // ===========================================================================
 
-describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
+describe('createTaskAgentToolHandlers — spawn_node_agent', () => {
 	let ctx: TestCtx;
 	beforeEach(() => {
 		ctx = makeCtx();
@@ -406,7 +406,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -426,7 +426,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		const before = ctx.taskRepo.getTask(mainTask.id);
 		expect(before?.status).toBe('pending');
 
-		await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 
 		const after = ctx.taskRepo.getTask(mainTask.id);
 		expect(after?.status).toBe('in_progress');
@@ -439,7 +439,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		const updatedStepTask = ctx.taskRepo.getTask(stepTask.id);
@@ -465,7 +465,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 			})
 		);
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		// Trigger sub-session completion
@@ -490,7 +490,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 			})
 		);
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(injections).toHaveLength(1);
@@ -513,7 +513,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 			})
 		);
 
-		await handlers.spawn_step_agent({
+		await handlers.spawn_node_agent({
 			step_id: wf.startNodeId,
 			instructions: 'Custom override instructions here',
 		});
@@ -530,7 +530,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: 'step-does-not-exist' });
+		const result = await handlers.spawn_node_agent({ step_id: 'step-does-not-exist' });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(false);
@@ -546,7 +546,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 
 		// The second step has no task yet because the workflow has not advanced to it
 		const step2Id = wf.nodes[1].id;
-		const result = await handlers.spawn_step_agent({ step_id: step2Id });
+		const result = await handlers.spawn_node_agent({ step_id: step2Id });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(false);
@@ -567,7 +567,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 			makeConfig(ctx, mainTask.id, 'run-does-not-exist', factory)
 		);
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(false);
@@ -586,7 +586,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(false);
@@ -602,7 +602,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -617,14 +617,14 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
 		// First spawn
-		const first = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const first = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const firstParsed = JSON.parse(first.content[0].text);
 		expect(firstParsed.success).toBe(true);
 		const firstSessionId = firstParsed.sessionId;
 
 		// Second spawn for same step — the step task already has taskAgentSessionId set
 		// Handler should detect the existing session and return it without creating a new one
-		const second = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const second = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const secondParsed = JSON.parse(second.content[0].text);
 
 		// Must not error out — should succeed or return existing session info
@@ -639,7 +639,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
@@ -656,10 +656,10 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 });
 
 // ===========================================================================
-// check_step_status tests
+// check_node_status tests
 // ===========================================================================
 
-describe('createTaskAgentToolHandlers — check_step_status', () => {
+describe('createTaskAgentToolHandlers — check_node_status', () => {
 	let ctx: TestCtx;
 	beforeEach(() => {
 		ctx = makeCtx();
@@ -676,7 +676,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.check_step_status({ step_id: wf.startNodeId });
+		const result = await handlers.check_node_status({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -690,12 +690,12 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		// Spawn the step agent first
-		const spawnResult = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		// Spawn the node agent first
+		const spawnResult = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const { sessionId } = JSON.parse(spawnResult.content[0].text);
 
 		// Factory returns isProcessing: true by default
-		const result = await handlers.check_step_status({ step_id: wf.startNodeId });
+		const result = await handlers.check_node_status({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -713,7 +713,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 		// Mark the step task as completed directly (simulating completion callback)
 		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
 
-		const result = await handlers.check_step_status({ step_id: wf.startNodeId });
+		const result = await handlers.check_node_status({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -734,7 +734,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 		// Manually set taskAgentSessionId without spawning (simulate orphaned session)
 		ctx.taskRepo.updateTask(stepTask.id, { taskAgentSessionId: 'orphaned-session-id' });
 
-		const result = await handlers.check_step_status({ step_id: wf.startNodeId });
+		const result = await handlers.check_node_status({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -749,7 +749,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
 		// Call without step_id — should use run.currentNodeId
-		const result = await handlers.check_step_status({});
+		const result = await handlers.check_node_status({});
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -765,7 +765,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 
 		// Check step 2 which has no task (step not yet started)
 		const step2Id = wf.nodes[1].id;
-		const result = await handlers.check_step_status({ step_id: step2Id });
+		const result = await handlers.check_node_status({ step_id: step2Id });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -787,7 +787,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 			makeConfig(ctx, mainTask.id, 'run-missing', factory)
 		);
 
-		const result = await handlers.check_step_status({});
+		const result = await handlers.check_node_status({});
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(false);
@@ -802,7 +802,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
 		// Spawn and then trigger complete (but don't update DB task status yet)
-		const spawnResult = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const spawnResult = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const { sessionId } = JSON.parse(spawnResult.content[0].text);
 
 		// Simulate session completing without the completion callback updating DB
@@ -811,7 +811,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 			factory as unknown as { getProcessingState: (id: string) => SubSessionState }
 		).getProcessingState = (_id: string) => ({ isProcessing: false, isComplete: true });
 
-		const result = await handlers.check_step_status({ step_id: wf.startNodeId });
+		const result = await handlers.check_node_status({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
@@ -1275,23 +1275,23 @@ describe('createTaskAgentToolHandlers — end-to-end lifecycle', () => {
 			})
 		);
 
-		// 1. Spawn step agent
-		const spawnResult = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		// 1. Spawn node agent
+		const spawnResult = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const { sessionId } = JSON.parse(spawnResult.content[0].text);
 		expect(sessionId).toBeString();
 
 		// 2. Check status — running
-		const checkRunning = await handlers.check_step_status({ step_id: wf.startNodeId });
+		const checkRunning = await handlers.check_node_status({ step_id: wf.startNodeId });
 		expect(JSON.parse(checkRunning.content[0].text).sessionStatus).toBe('running');
 
 		// 3. Trigger sub-session completion (fires onSubSessionComplete callback)
 		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(sessionId);
 
 		// 4. Check status — completed
-		const checkDone = await handlers.check_step_status({ step_id: wf.startNodeId });
+		const checkDone = await handlers.check_node_status({ step_id: wf.startNodeId });
 		expect(JSON.parse(checkDone.content[0].text).taskStatus).toBe('completed');
 
-		// 5. Report result (mainTask is already in_progress after spawn_step_agent)
+		// 5. Report result (mainTask is already in_progress after spawn_node_agent)
 		const reportResult = await handlers.report_result({
 			status: 'completed',
 			summary: 'Workflow completed successfully.',
@@ -1348,27 +1348,27 @@ describe('createTaskAgentMcpServer', () => {
 		const { server } = await makeServerCtx();
 		const registered = Object.keys(server.instance._registeredTools).sort();
 		expect(registered).toEqual([
-			'check_step_status',
+			'check_node_status',
 			'list_group_members',
 			'report_result',
 			'request_human_input',
 			'send_message',
-			'spawn_step_agent',
+			'spawn_node_agent',
 		]);
 	});
 
-	test('spawn_step_agent has correct description', async () => {
+	test('spawn_node_agent has correct description', async () => {
 		const { server } = await makeServerCtx();
-		const entry = server.instance._registeredTools['spawn_step_agent'];
+		const entry = server.instance._registeredTools['spawn_node_agent'];
 		expect(entry).toBeDefined();
-		expect(entry.description).toContain("Start a sub-session for a workflow step's assigned agent");
+		expect(entry.description).toContain("Start a sub-session for a workflow node's assigned agent");
 	});
 
-	test('check_step_status has correct description', async () => {
+	test('check_node_status has correct description', async () => {
 		const { server } = await makeServerCtx();
-		const entry = server.instance._registeredTools['check_step_status'];
+		const entry = server.instance._registeredTools['check_node_status'];
 		expect(entry).toBeDefined();
-		expect(entry.description).toContain('Poll the status of a running step agent sub-session');
+		expect(entry.description).toContain('Poll the status of a running node agent sub-session');
 	});
 
 	test('report_result has correct description', async () => {
@@ -1390,8 +1390,8 @@ describe('createTaskAgentMcpServer', () => {
 	test('each registered tool has an inputSchema', async () => {
 		const { server } = await makeServerCtx();
 		const toolNames = [
-			'spawn_step_agent',
-			'check_step_status',
+			'spawn_node_agent',
+			'check_node_status',
 			'report_result',
 			'request_human_input',
 		];
@@ -1406,10 +1406,10 @@ describe('createTaskAgentMcpServer', () => {
 	// Handler delegation — invoke via the MCP server's registered handler
 	// ---------------------------------------------------------------------------
 
-	test('check_step_status registered handler returns not_found for an unknown step', async () => {
+	test('check_node_status registered handler returns not_found for an unknown step', async () => {
 		const { server } = await makeServerCtx();
 		// Invoke through the server's registered handler to verify the wiring
-		const handler = server.instance._registeredTools['check_step_status'].handler;
+		const handler = server.instance._registeredTools['check_node_status'].handler;
 		const result = await handler({ step_id: 'step-that-does-not-exist' }, {});
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.taskStatus).toBe('not_found');
@@ -1634,10 +1634,10 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 });
 
 // ===========================================================================
-// spawn_step_agent — slot role and overrides
+// spawn_node_agent — slot role and overrides
 // ===========================================================================
 
-describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrides', () => {
+describe('createTaskAgentToolHandlers — spawn_node_agent slot role and overrides', () => {
 	let ctx: TestCtx;
 	beforeEach(() => {
 		ctx = makeCtx();
@@ -1675,7 +1675,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const result = await handlers.spawn_node_agent({ step_id: stepId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
@@ -1694,12 +1694,12 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: wf.startNodeId });
+		const result = await handlers.spawn_node_agent({ step_id: wf.startNodeId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
 		// For agentId shorthand, resolveNodeAgents synthesizes role = agentId (the UUID string).
-		// spawn_step_agent picks memberRole = agentSlot.role (always set to the synthetic UUID),
+		// spawn_node_agent picks memberRole = agentSlot.role (always set to the synthetic UUID),
 		// so no fallback to agentForMember.role ('coder') ever occurs on this path.
 		const sessionId = parsed.sessionId;
 		const capturedInfo = (
@@ -1747,7 +1747,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		});
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const result = await handlers.spawn_node_agent({ step_id: stepId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
@@ -1793,7 +1793,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		});
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
 
-		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const result = await handlers.spawn_node_agent({ step_id: stepId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
@@ -1805,7 +1805,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 	test('same agent twice in one node: last task uses its own agent name (not the first slot)', async () => {
 		// Regression test for the slot disambiguation bug:
 		// When the same agentId appears twice in a node with different agent names,
-		// spawn_step_agent must select the task's own agent name — not always the first match.
+		// spawn_node_agent must select the task's own agent name — not always the first match.
 		// The fix stores agentName on the task at creation time so the lookup is exact.
 		const agentId = ctx.agentId;
 		const stepId = `step-dual-${Math.random().toString(36).slice(2)}`;
@@ -1841,18 +1841,18 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		expect(stepTasks[0]?.agentName).toBe('strict-reviewer');
 		expect(stepTasks[1]?.agentName).toBe('quick-reviewer');
 
-		// spawn_step_agent picks stepTasks[last] = the quick-reviewer task
+		// spawn_node_agent picks stepTasks[last] = the quick-reviewer task
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const result = await handlers.spawn_node_agent({ step_id: stepId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
 		// The spawned session must use 'quick-reviewer' — NOT 'strict-reviewer' (the first slot),
 		// confirming that agentName-based lookup picks the correct slot.
 		// Note: this test only covers the last-created (quick-reviewer) task because
-		// spawn_step_agent selects stepTasks[last]. In practice the Task Agent calls
-		// spawn_step_agent once per task; the strict-reviewer task is covered by the
+		// spawn_node_agent selects stepTasks[last]. In practice the Task Agent calls
+		// spawn_node_agent once per task; the strict-reviewer task is covered by the
 		// slot-role membership test above which uses the single-agent (agents[]) path.
 		const sessionId = parsed.sessionId;
 		const capturedInfo = (
@@ -1903,7 +1903,7 @@ describe('createTaskAgentToolHandlers — spawn_step_agent slot role and overrid
 		});
 
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-		const result = await handlers.spawn_step_agent({ step_id: stepId });
+		const result = await handlers.spawn_node_agent({ step_id: stepId });
 		const parsed = JSON.parse(result.content[0].text);
 
 		// Spawn must succeed — stale agentName is not a hard error

--- a/packages/daemon/tests/unit/space/task-agent.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent.test.ts
@@ -172,14 +172,14 @@ describe('buildTaskAgentSystemPrompt — basic structure', () => {
 });
 
 describe('buildTaskAgentSystemPrompt — MCP tools', () => {
-	test('includes spawn_step_agent tool', () => {
+	test('includes spawn_node_agent tool', () => {
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
-		expect(prompt).toContain('spawn_step_agent');
+		expect(prompt).toContain('spawn_node_agent');
 	});
 
-	test('includes check_step_status tool', () => {
+	test('includes check_node_status tool', () => {
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
-		expect(prompt).toContain('check_step_status');
+		expect(prompt).toContain('check_node_status');
 	});
 
 	test('includes report_result tool', () => {
@@ -194,14 +194,14 @@ describe('buildTaskAgentSystemPrompt — MCP tools', () => {
 });
 
 describe('buildTaskAgentSystemPrompt — workflow execution instructions', () => {
-	test('mentions spawning step agents', () => {
+	test('mentions spawning node agents', () => {
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
-		expect(prompt).toContain('spawn_step_agent');
+		expect(prompt).toContain('spawn_node_agent');
 	});
 
-	test('mentions monitoring completion via check_step_status', () => {
+	test('mentions monitoring completion via check_node_status', () => {
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
-		expect(prompt).toContain('check_step_status');
+		expect(prompt).toContain('check_node_status');
 	});
 
 	test('includes instructions to call report_result on terminal step', () => {
@@ -386,7 +386,7 @@ describe('buildTaskAgentInitialMessage — workflow structure', () => {
 		expect(msg).toContain('Review');
 	});
 
-	test('includes step agent names', () => {
+	test('includes node agent names', () => {
 		const msg = buildTaskAgentInitialMessage(makeContext());
 		expect(msg).toContain('Coder');
 		expect(msg).toContain('Planner');
@@ -608,16 +608,16 @@ describe('buildTaskAgentInitialMessage — previous task results', () => {
 });
 
 describe('buildTaskAgentInitialMessage — start instruction', () => {
-	test('instructs to begin with spawn_step_agent for workflow tasks', () => {
+	test('instructs to begin with spawn_node_agent for workflow tasks', () => {
 		const msg = buildTaskAgentInitialMessage(makeContext());
-		expect(msg).toContain('spawn_step_agent');
+		expect(msg).toContain('spawn_node_agent');
 		expect(msg).toContain('step-plan');
 	});
 
 	test('instructs to spawn agent for tasks without workflow', () => {
 		const ctx = makeContext({ workflow: undefined, workflowRun: undefined });
 		const msg = buildTaskAgentInitialMessage(ctx);
-		expect(msg).toContain('spawn_step_agent');
+		expect(msg).toContain('spawn_node_agent');
 	});
 });
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -164,7 +164,7 @@ export interface SpaceTask {
 	customAgentId?: string;
 	/**
 	 * The `WorkflowNodeAgent.name` of the specific agent slot that spawned this task.
-	 * Stored at task creation time so `spawn_step_agent` can unambiguously map the task
+	 * Stored at task creation time so `spawn_node_agent` can unambiguously map the task
 	 * back to the correct slot even when the same `agentId` appears multiple times in the node.
 	 */
 	agentName?: string;

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -64,7 +64,7 @@ interface AgentsSectionProps {
 
 function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	const multi = isMultiAgentNode(step);
-	const stepAgents = step.agents ?? [];
+	const nodeAgents = step.agents ?? [];
 
 	// Track which slots have their override fields expanded (keyed by role)
 	const [expandedSlots, setExpandedSlots] = useState<Set<string>>(new Set());
@@ -89,18 +89,18 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 		const baseRole = agentInfo?.role?.trim() || agentId;
 		// Ensure the slot role is unique within this node. When the same agent is added
 		// multiple times, append a numeric suffix to distinguish the slots.
-		const usedRoles = new Set(stepAgents.map((a) => a.name));
+		const usedRoles = new Set(nodeAgents.map((a) => a.name));
 		let role = baseRole;
 		for (let i = 2; usedRoles.has(role); i++) {
 			role = `${baseRole}-${i}`;
 		}
-		const next = [...stepAgents, { agentId, name: role }];
+		const next = [...nodeAgents, { agentId, name: role }];
 		onUpdate({ ...step, agents: next, agentId: '' });
 	}
 
 	function removeAgent(role: string) {
-		const removed = stepAgents.find((a) => a.name === role);
-		const next = stepAgents.filter((a) => a.name !== role);
+		const removed = nodeAgents.find((a) => a.name === role);
+		const next = nodeAgents.filter((a) => a.name !== role);
 		if (next.length === 0) {
 			// Switch back to single-agent mode: restore agentId from the removed agent and
 			// clear channels (orphaned channels on a single-agent step are semantically invalid)
@@ -117,7 +117,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 
 	function updateAgentInstructions(role: string, instructions: string) {
 		updateAgents(
-			stepAgents.map((a) =>
+			nodeAgents.map((a) =>
 				a.name === role ? { ...a, instructions: instructions || undefined } : a
 			)
 		);
@@ -125,13 +125,13 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 
 	function updateAgentModel(role: string, model: string) {
 		updateAgents(
-			stepAgents.map((a) => (a.name === role ? { ...a, model: model || undefined } : a))
+			nodeAgents.map((a) => (a.name === role ? { ...a, model: model || undefined } : a))
 		);
 	}
 
 	function updateAgentSystemPrompt(role: string, systemPrompt: string) {
 		updateAgents(
-			stepAgents.map((a) =>
+			nodeAgents.map((a) =>
 				a.name === role ? { ...a, systemPrompt: systemPrompt || undefined } : a
 			)
 		);
@@ -190,9 +190,9 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 		<div class="space-y-2">
 			<div class="flex items-center justify-between">
 				<label class="text-xs font-medium text-gray-400">
-					Agents <span class="text-gray-600">({stepAgents.length})</span>
+					Agents <span class="text-gray-600">({nodeAgents.length})</span>
 				</label>
-				{stepAgents.length === 1 && (
+				{nodeAgents.length === 1 && (
 					<button
 						type="button"
 						data-testid="switch-to-single-button"
@@ -200,7 +200,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 							onUpdate({
 								...step,
 								agents: undefined,
-								agentId: stepAgents[0]?.agentId ?? '',
+								agentId: nodeAgents[0]?.agentId ?? '',
 								channels: undefined,
 							})
 						}
@@ -212,7 +212,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 			</div>
 
 			<div class="space-y-1.5" data-testid="agents-list">
-				{stepAgents.map((sa) => {
+				{nodeAgents.map((sa) => {
 					const agentInfo = agents.find((a) => a.id === sa.agentId);
 					const hasOverrides = !!(sa.model || sa.systemPrompt);
 					const isExpanded = expandedSlots.has(sa.name);
@@ -241,7 +241,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 											return next;
 										});
 										updateAgents(
-											stepAgents.map((a) => (a.name === oldRole ? { ...a, name: newRole } : a))
+											nodeAgents.map((a) => (a.name === oldRole ? { ...a, name: newRole } : a))
 										);
 									}}
 									placeholder="slot role"


### PR DESCRIPTION
## Summary

- Completes the step-agent → node-agent rename across 23 files (3 file renames + 20 content updates)
- Renamed source files: `step-agent-tool-schemas.ts` → `node-agent-tool-schemas.ts`, `step-agent-tools.ts` → `node-agent-tools.ts`
- Renamed test file: `step-agent-tools.test.ts` → `node-agent-tools.test.ts`
- Updated all type/function/variable names: `StepAgentToolsConfig` → `NodeAgentToolsConfig`, `createStepAgentMcpServer` → `createNodeAgentMcpServer`, `spawn_step_agent` → `spawn_node_agent`, `check_step_status` → `check_node_status`, MCP server name `'step-agent'` → `'node-agent'`
- Preserved standalone `step` references (`step_id`, `step.agentId`, `step.agents`) that refer to workflow steps, not step agents

## Test plan

- [x] All 1505 space unit tests pass
- [x] All 779 web component tests pass
- [x] Lint, format, typecheck, knip all pass