### PR TITLE
feat(web): room skills LiveQuery store and hook (Task 4.1)

### DIFF
--- a/packages/web/src/hooks/__tests__/index.test.ts
+++ b/packages/web/src/hooks/__tests__/index.test.ts
@@ -16,6 +16,7 @@ import {
 	useFileAttachments,
 	useGroupMessages,
 	useRoomLiveQuery,
+	useRoomSkills,
 	useReferenceAutocomplete,
 	extractActiveAtQuery,
 } from '../index.ts';
@@ -70,6 +71,11 @@ describe('Hooks Index', () => {
 		it('should export useRoomLiveQuery', () => {
 			expect(useRoomLiveQuery).toBeDefined();
 			expect(typeof useRoomLiveQuery).toBe('function');
+		});
+
+		it('should export useRoomSkills', () => {
+			expect(useRoomSkills).toBeDefined();
+			expect(typeof useRoomSkills).toBe('function');
 		});
 
 		it('should export useReferenceAutocomplete', () => {

--- a/packages/web/src/hooks/__tests__/useRoomSkills.test.ts
+++ b/packages/web/src/hooks/__tests__/useRoomSkills.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for useRoomSkills hook and the skills.byRoom LiveQuery subscription
+ * wired into RoomStore.
+ *
+ * Tests are structured in two groups:
+ * 1. RoomStore skills.byRoom LiveQuery subscription — verifies signal population,
+ *    delta handling, stale-event guard, reconnect, and unsubscribe.
+ * 2. useRoomSkills hook — verifies skill signal exposure and RPC calls for
+ *    setOverride / clearOverride.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AppSkill } from '@neokai/shared';
+import type { EffectiveRoomSkill } from '../../lib/room-store';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+type EventHandler<T = unknown> = (data: T) => void;
+
+interface MockHub {
+	_handlers: Map<string, EventHandler[]>;
+	_connectionHandlers: EventHandler[];
+	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	onConnection: (handler: EventHandler<string>) => () => void;
+	request: ReturnType<typeof vi.fn>;
+	joinChannel: ReturnType<typeof vi.fn>;
+	leaveChannel: ReturnType<typeof vi.fn>;
+	fire: <T>(method: string, data: T) => void;
+	fireConnection: (state: string) => void;
+}
+
+function createMockHub(): MockHub {
+	const _handlers = new Map<string, EventHandler[]>();
+	const _connectionHandlers: EventHandler[] = [];
+	return {
+		_handlers,
+		_connectionHandlers,
+		onEvent: <T>(method: string, handler: EventHandler<T>) => {
+			if (!_handlers.has(method)) _handlers.set(method, []);
+			_handlers.get(method)!.push(handler as EventHandler);
+			return () => {
+				const list = _handlers.get(method);
+				if (list) {
+					const i = list.indexOf(handler as EventHandler);
+					if (i >= 0) list.splice(i, 1);
+				}
+			};
+		},
+		onConnection: (handler: EventHandler<string>) => {
+			_connectionHandlers.push(handler as EventHandler);
+			return () => {
+				const i = _connectionHandlers.indexOf(handler as EventHandler);
+				if (i >= 0) _connectionHandlers.splice(i, 1);
+			};
+		},
+		request: vi.fn(),
+		joinChannel: vi.fn(),
+		leaveChannel: vi.fn(),
+		fire: <T>(method: string, data: T) => {
+			for (const h of _handlers.get(method) ?? []) h(data);
+		},
+		fireConnection: (state: string) => {
+			for (const h of _connectionHandlers) h(state);
+		},
+	};
+}
+
+vi.mock('../../lib/connection-manager.ts', () => ({
+	connectionManager: {
+		getHub: vi.fn(),
+		getHubIfConnected: vi.fn(),
+	},
+}));
+vi.mock('../../lib/toast', () => ({ toast: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+vi.mock('../../lib/router', () => ({ navigateToRoom: vi.fn() }));
+vi.mock('../../lib/signals', () => ({
+	currentRoomSessionIdSignal: { value: null },
+	currentRoomIdSignal: { value: null },
+	currentRoomTaskIdSignal: { value: null },
+	currentSessionIdSignal: { value: null },
+	currentSpaceIdSignal: { value: null },
+	currentSpaceSessionIdSignal: { value: null },
+	currentSpaceTaskIdSignal: { value: null },
+	navSectionSignal: { value: 'lobby' },
+}));
+
+import { connectionManager } from '../../lib/connection-manager.js';
+import { roomStore } from '../../lib/room-store.js';
+import { useRoomSkills } from '../useRoomSkills.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROOM_ID = 'room-skills-test';
+const SKILLS_SUB_ID = `skills-byRoom-${ROOM_ID}`;
+
+function makeSkill(id: string, overrides: Partial<EffectiveRoomSkill> = {}): EffectiveRoomSkill {
+	return {
+		id,
+		name: `skill-${id}`,
+		displayName: `Skill ${id}`,
+		description: '',
+		sourceType: 'builtin' as AppSkill['sourceType'],
+		config: { type: 'builtin', commandName: `skill-${id}` },
+		enabled: true,
+		builtIn: false,
+		validationStatus: 'valid' as AppSkill['validationStatus'],
+		createdAt: Date.now(),
+		overriddenByRoom: false,
+		...overrides,
+	};
+}
+
+function setupHubRequests(hub: MockHub): void {
+	hub.request.mockImplementation((method: string) => {
+		if (method === 'room.get')
+			return Promise.resolve({ room: { id: ROOM_ID }, sessions: [], allTasks: [] });
+		if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
+		return Promise.resolve({ ok: true });
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Group 1: RoomStore skills.byRoom LiveQuery subscription
+// ---------------------------------------------------------------------------
+
+describe('RoomStore — skills.byRoom LiveQuery subscription', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('subscribes to skills.byRoom with a stable subscriptionId', () => {
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const subCall = calls.find(
+			([method, params]) =>
+				method === 'liveQuery.subscribe' &&
+				(params as { queryName: string }).queryName === 'skills.byRoom'
+		);
+		expect(subCall).toBeDefined();
+		expect(subCall![1]).toMatchObject({
+			queryName: 'skills.byRoom',
+			params: [ROOM_ID],
+			subscriptionId: SKILLS_SUB_ID,
+		});
+	});
+
+	it('populates roomSkills.value from liveQuery.snapshot', () => {
+		const skills = [makeSkill('s1'), makeSkill('s2')];
+		hub.fire('liveQuery.snapshot', { subscriptionId: SKILLS_SUB_ID, rows: skills, version: 1 });
+		expect(roomStore.roomSkills.value).toEqual(skills);
+	});
+
+	it('ignores liveQuery.snapshot for a different subscriptionId', () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: 'other-sub',
+			rows: [makeSkill('irrelevant')],
+			version: 1,
+		});
+		expect(roomStore.roomSkills.value).toEqual([]);
+	});
+
+	it('appends skills from liveQuery.delta added', () => {
+		const s1 = makeSkill('s1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: SKILLS_SUB_ID, rows: [s1], version: 1 });
+		const s2 = makeSkill('s2');
+		hub.fire('liveQuery.delta', { subscriptionId: SKILLS_SUB_ID, added: [s2], version: 2 });
+		expect(roomStore.roomSkills.value.map((s) => s.id)).toEqual(['s1', 's2']);
+	});
+
+	it('removes skills from liveQuery.delta removed', () => {
+		const s1 = makeSkill('s1');
+		const s2 = makeSkill('s2');
+		hub.fire('liveQuery.snapshot', { subscriptionId: SKILLS_SUB_ID, rows: [s1, s2], version: 1 });
+		hub.fire('liveQuery.delta', { subscriptionId: SKILLS_SUB_ID, removed: [s1], version: 2 });
+		expect(roomStore.roomSkills.value.map((s) => s.id)).toEqual(['s2']);
+	});
+
+	it('updates skills from liveQuery.delta updated', () => {
+		const s1 = makeSkill('s1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: SKILLS_SUB_ID, rows: [s1], version: 1 });
+		const s1Updated = makeSkill('s1', { enabled: false, overriddenByRoom: true });
+		hub.fire('liveQuery.delta', {
+			subscriptionId: SKILLS_SUB_ID,
+			updated: [s1Updated],
+			version: 2,
+		});
+		expect(roomStore.roomSkills.value[0].enabled).toBe(false);
+		expect(roomStore.roomSkills.value[0].overriddenByRoom).toBe(true);
+	});
+
+	it('ignores liveQuery.delta for a different subscriptionId', () => {
+		const s1 = makeSkill('s1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: SKILLS_SUB_ID, rows: [s1], version: 1 });
+		hub.fire('liveQuery.delta', {
+			subscriptionId: 'other-sub',
+			removed: [s1],
+			version: 2,
+		});
+		expect(roomStore.roomSkills.value.map((s) => s.id)).toEqual(['s1']);
+	});
+
+	it('discards stale events after unsubscribeRoom (stale-event guard)', () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: SKILLS_SUB_ID,
+			rows: [makeSkill('s1')],
+			version: 1,
+		});
+		expect(roomStore.roomSkills.value).toHaveLength(1);
+
+		// Simulate unsubscribe — activeSubscriptionIds is cleared immediately
+		roomStore.unsubscribeRoom(ROOM_ID);
+
+		// Events fired after unsubscribe must be discarded
+		hub.fire('liveQuery.delta', {
+			subscriptionId: SKILLS_SUB_ID,
+			removed: [makeSkill('s1')],
+			version: 2,
+		});
+		// The list should still contain s1 because the event was stale
+		expect(roomStore.roomSkills.value).toHaveLength(1);
+	});
+
+	it('unsubscribes from skills.byRoom when unsubscribeRoom is called', () => {
+		hub.request.mockClear();
+		roomStore.unsubscribeRoom(ROOM_ID);
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const unsubCall = calls.find(
+			([method, params]) =>
+				method === 'liveQuery.unsubscribe' &&
+				(params as { subscriptionId: string }).subscriptionId === SKILLS_SUB_ID
+		);
+		expect(unsubCall).toBeDefined();
+	});
+
+	it('re-subscribes to skills.byRoom on reconnect', () => {
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const resubCall = calls.find(
+			([method, params]) =>
+				method === 'liveQuery.subscribe' &&
+				(params as { queryName: string }).queryName === 'skills.byRoom'
+		);
+		expect(resubCall).toBeDefined();
+		expect(resubCall![1]).toMatchObject({
+			queryName: 'skills.byRoom',
+			params: [ROOM_ID],
+			subscriptionId: SKILLS_SUB_ID,
+		});
+	});
+
+	it('does NOT re-subscribe on reconnect after unsubscribeRoom', () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const resubCall = calls.find(
+			([method, params]) =>
+				method === 'liveQuery.subscribe' &&
+				(params as { queryName: string }).queryName === 'skills.byRoom'
+		);
+		expect(resubCall).toBeUndefined();
+	});
+
+	it('clears roomSkills on room deselect', async () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: SKILLS_SUB_ID,
+			rows: [makeSkill('s1')],
+			version: 1,
+		});
+		expect(roomStore.roomSkills.value).toHaveLength(1);
+		await roomStore.select(null);
+		expect(roomStore.roomSkills.value).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group 2: useRoomSkills hook
+// ---------------------------------------------------------------------------
+
+describe('useRoomSkills hook', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('returns skills from roomStore.roomSkills signal', () => {
+		const s1 = makeSkill('s1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: SKILLS_SUB_ID, rows: [s1], version: 1 });
+
+		// Call hook directly (outside Preact rendering context — signal.value is synchronous)
+		const { skills } = useRoomSkills(ROOM_ID);
+		expect(skills).toEqual([s1]);
+	});
+
+	it('reflects delta updates in subsequent hook calls', () => {
+		const s1 = makeSkill('s1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: SKILLS_SUB_ID, rows: [s1], version: 1 });
+
+		const s2 = makeSkill('s2');
+		hub.fire('liveQuery.delta', { subscriptionId: SKILLS_SUB_ID, added: [s2], version: 2 });
+
+		const { skills } = useRoomSkills(ROOM_ID);
+		expect(skills.map((s) => s.id)).toEqual(['s1', 's2']);
+	});
+
+	it('setOverride calls room.setSkillOverride RPC with correct params', async () => {
+		const { setOverride } = useRoomSkills(ROOM_ID);
+		await setOverride('skill-abc', false);
+		expect(hub.request).toHaveBeenCalledWith('room.setSkillOverride', {
+			roomId: ROOM_ID,
+			skillId: 'skill-abc',
+			enabled: false,
+		});
+	});
+
+	it('clearOverride calls room.clearSkillOverride RPC with correct params', async () => {
+		const { clearOverride } = useRoomSkills(ROOM_ID);
+		await clearOverride('skill-abc');
+		expect(hub.request).toHaveBeenCalledWith('room.clearSkillOverride', {
+			roomId: ROOM_ID,
+			skillId: 'skill-abc',
+		});
+	});
+});

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -54,6 +54,7 @@ export {
 	type UseGroupMessagesResult,
 } from './useGroupMessages';
 export { useRoomLiveQuery } from './useRoomLiveQuery';
+export { useRoomSkills, type UseRoomSkillsResult } from './useRoomSkills';
 export {
 	useTurnBlocks,
 	type TurnBlock,

--- a/packages/web/src/hooks/useRoomSkills.ts
+++ b/packages/web/src/hooks/useRoomSkills.ts
@@ -1,0 +1,53 @@
+/**
+ * useRoomSkills Hook
+ *
+ * Thin hook over roomStore.roomSkills signal.
+ * Returns the effective per-room skill list (global enabled merged with room
+ * overrides by the skills.byRoom LiveQuery JOIN) plus RPC helpers to set/clear
+ * per-room overrides.
+ *
+ * Mutations are fire-and-forget at the call site: the LiveQuery delta will
+ * deliver the update automatically so there is no need to refresh manually.
+ */
+
+import type { EffectiveRoomSkill } from '../lib/room-store';
+import { roomStore } from '../lib/room-store';
+import { connectionManager } from '../lib/connection-manager';
+
+export interface UseRoomSkillsResult {
+	skills: EffectiveRoomSkill[];
+	setOverride: (skillId: string, enabled: boolean) => Promise<void>;
+	clearOverride: (skillId: string) => Promise<void>;
+}
+
+/**
+ * Returns the effective skills list for the current room plus mutation helpers.
+ *
+ * Reading `skills` inside a Preact component body (or render function) causes
+ * Preact Signals to subscribe the component to `roomStore.roomSkills` — no
+ * manual subscription wiring needed.
+ *
+ * @param roomId - The room whose skills to manage.
+ *
+ * @example
+ * ```tsx
+ * const { skills, setOverride, clearOverride } = useRoomSkills(roomId);
+ * ```
+ */
+export function useRoomSkills(roomId: string): UseRoomSkillsResult {
+	// Reactive read: Preact tracks this .value access and re-renders the
+	// component whenever roomStore.roomSkills changes.
+	const skills = roomStore.roomSkills.value;
+
+	const setOverride = async (skillId: string, enabled: boolean): Promise<void> => {
+		const hub = await connectionManager.getHub();
+		await hub.request('room.setSkillOverride', { roomId, skillId, enabled });
+	};
+
+	const clearOverride = async (skillId: string): Promise<void> => {
+		const hub = await connectionManager.getHub();
+		await hub.request('room.clearSkillOverride', { roomId, skillId });
+	};
+
+	return { skills, setOverride, clearOverride };
+}

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -34,7 +34,13 @@ import type {
 	MissionExecution,
 	LiveQuerySnapshotEvent,
 	LiveQueryDeltaEvent,
+	AppSkill,
 } from '@neokai/shared';
+
+/** AppSkill extended with the per-room effective enabled state from skills.byRoom LiveQuery. */
+export interface EffectiveRoomSkill extends AppSkill {
+	overriddenByRoom: boolean;
+}
 
 /**
  * Parameters for creating a new goal
@@ -92,6 +98,13 @@ class RoomStore {
 
 	/** Goals loading state */
 	readonly goalsLoading = signal<boolean>(false);
+
+	// ========================================
+	// Room Skills Signals
+	// ========================================
+
+	/** Effective per-room skills (global enabled state merged with room overrides via skills.byRoom). */
+	readonly roomSkills = signal<EffectiveRoomSkill[]>([]);
 
 	/** Auto-completed task notifications (from semi-autonomous mode) */
 	readonly autoCompletedNotifications = signal<
@@ -288,6 +301,7 @@ class RoomStore {
 		this.error.value = null;
 		this.goals.value = [];
 		this.goalsLoading.value = false;
+		this.roomSkills.value = [];
 		this.autoCompletedNotifications.value = [];
 		this.runtimeState.value = null;
 
@@ -528,6 +542,85 @@ class RoomStore {
 					h.request('liveQuery.unsubscribe', { subscriptionId: goalsSubId }).catch(() => {});
 				}
 			});
+
+			// --- Room Skills via LiveQuery (skills.byRoom) ---
+			// The server JOINs skills with room_skill_overrides and returns the effective
+			// enabled state + overriddenByRoom flag — no client-side merging needed.
+			const skillsSubId = `skills-byRoom-${roomId}`;
+
+			this.activeSubscriptionIds.add(skillsSubId);
+			cleanups.push(() => this.activeSubscriptionIds.delete(skillsSubId));
+
+			const unsubSkillSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
+				'liveQuery.snapshot',
+				(event) => {
+					if (event.subscriptionId !== skillsSubId) return;
+					if (!this.activeSubscriptionIds.has(skillsSubId)) return; // stale-event guard
+					this.roomSkills.value = event.rows as EffectiveRoomSkill[];
+				}
+			);
+			cleanups.push(unsubSkillSnapshot);
+
+			const unsubSkillDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+				if (event.subscriptionId !== skillsSubId) return;
+				if (!this.activeSubscriptionIds.has(skillsSubId)) return; // stale-event guard
+				let current = this.roomSkills.value;
+				if (event.removed?.length) {
+					const removedIds = new Set((event.removed as EffectiveRoomSkill[]).map((r) => r.id));
+					current = current.filter((s) => !removedIds.has(s.id));
+				}
+				if (event.updated?.length) {
+					const updatedMap = new Map((event.updated as EffectiveRoomSkill[]).map((u) => [u.id, u]));
+					current = current.map((s) => updatedMap.get(s.id) ?? s);
+				}
+				if (event.added?.length) {
+					current = [...current, ...(event.added as EffectiveRoomSkill[])];
+				}
+				this.roomSkills.value = current;
+			});
+			cleanups.push(unsubSkillDelta);
+
+			await hub.request('liveQuery.subscribe', {
+				queryName: 'skills.byRoom',
+				params: [roomId],
+				subscriptionId: skillsSubId,
+			});
+
+			// Guard: abort if unsubscribed while awaiting the subscribe request
+			if (!this.liveQueryActive.has(roomId)) {
+				for (const fn of cleanups) {
+					try {
+						fn();
+					} catch {
+						/* ignore */
+					}
+				}
+				this.liveQueryCleanups.delete(roomId);
+				return;
+			}
+
+			// Re-subscribe on reconnect: the server-side subscription is per-connection.
+			const unsubSkillReconnect = hub.onConnection((state) => {
+				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
+				hub
+					.request('liveQuery.subscribe', {
+						queryName: 'skills.byRoom',
+						params: [roomId],
+						subscriptionId: skillsSubId,
+					})
+					.catch((err) => {
+						logger.warn('Skills LiveQuery re-subscribe failed:', err);
+					});
+			});
+			cleanups.push(unsubSkillReconnect);
+
+			// Cleanup: tell the server to dispose the subscription when leaving the room.
+			cleanups.push(() => {
+				const h = connectionManager.getHubIfConnected();
+				if (h) {
+					h.request('liveQuery.unsubscribe', { subscriptionId: skillsSubId }).catch(() => {});
+				}
+			});
 		} catch (err) {
 			this.liveQueryActive.delete(roomId);
 			// Run any cleanups that were registered before the error, so that
@@ -562,6 +655,7 @@ class RoomStore {
 		// queued in the JS event loop are discarded before the handlers are removed.
 		this.activeSubscriptionIds.delete(`tasks-byRoom-${roomId}`);
 		this.activeSubscriptionIds.delete(`goals-byRoom-${roomId}`);
+		this.activeSubscriptionIds.delete(`skills-byRoom-${roomId}`);
 		const cleanups = this.liveQueryCleanups.get(roomId);
 		if (cleanups) {
 			for (const fn of cleanups) {


### PR DESCRIPTION
Implements Task 4.1 — Room Skills LiveQuery store and hook.

## Changes

- **`EffectiveRoomSkill` type** — `AppSkill & { overriddenByRoom: boolean }`, exported from `room-store.ts`
- **`roomSkills` signal** — added to `RoomStore`; cleared on room deselect
- **`subscribeRoom` extension** — wires `skills.byRoom` LiveQuery with snapshot/delta handlers, stale-event guard, reconnect re-subscribe, and cleanup on unsubscribe
- **`unsubscribeRoom`** — clears `skills-byRoom-${roomId}` from `activeSubscriptionIds`
- **`useRoomSkills` hook** — thin wrapper returning `{ skills, setOverride, clearOverride }`; mutations call `room.setSkillOverride` / `room.clearSkillOverride` RPC; LiveQuery delta delivers the update automatically
- **`hooks/index.ts`** — exports `useRoomSkills`

## Tests

16 unit tests in `useRoomSkills.test.ts`:
- snapshot populates signal; ignores wrong subscriptionId
- delta add/remove/update; ignores wrong subscriptionId
- stale-event guard discards events after unsubscribe
- unsubscribe calls `liveQuery.unsubscribe`
- reconnect re-subscribes; no re-subscribe after unsubscribeRoom
- room deselect clears signal
- hook returns correct skills and calls correct RPCs