### PR TITLE
feat(skills): built-in web-search-mcp skill via Brave Search MCP

### DIFF
--- a/docs/architecture/web-search-mcp.md
+++ b/docs/architecture/web-search-mcp.md
@@ -25,12 +25,17 @@ The skill is registered in `SkillsManager.initializeBuiltins()` as an `mcp_serve
 
 ### app_mcp_servers entry
 
+The skill reuses the `brave-search` entry already seeded by `seedDefaultMcpEntries()` (which
+runs first in `app.ts`). If the entry is somehow absent, `initializeBuiltins()` creates it as a
+fallback using identical parameters:
+
 ```
-name:        web-search-brave
+name:        brave-search
 sourceType:  stdio
 command:     npx
 args:        ["-y", "@modelcontextprotocol/server-brave-search"]
-enabled:     true
+env:         {}
+enabled:     false
 ```
 
 ### Skill entry
@@ -39,7 +44,7 @@ enabled:     true
 name:         web-search-mcp
 displayName:  Web Search (MCP)
 sourceType:   mcp_server
-config:       { type: "mcp_server", appMcpServerId: <id of web-search-brave entry> }
+config:       { type: "mcp_server", appMcpServerId: <id of brave-search entry> }
 enabled:      false   (opt-in)
 builtIn:      true
 ```
@@ -47,7 +52,10 @@ builtIn:      true
 ## Usage
 
 1. Obtain a Brave Search API key from https://brave.com/search/api/
-2. Set `BRAVE_API_KEY` in the daemon environment (`.env` or shell)
+2. Set `BRAVE_API_KEY` in the daemon process environment (e.g. via `.env` at the worktree root or
+   as a shell environment variable before starting the daemon). The MCP server subprocess inherits
+   the full daemon process environment, so no additional wiring is needed — the key just needs to
+   be present in the daemon's `process.env` at startup.
 3. Enable the skill in the Skills settings UI
 4. The MCP server is automatically injected into new session `mcpServers`
 

--- a/docs/architecture/web-search-mcp.md
+++ b/docs/architecture/web-search-mcp.md
@@ -1,0 +1,64 @@
+# Web Search MCP Skill
+
+## Overview
+
+The Web Search MCP skill provides agents with web search capability via a Brave Search MCP server.
+It is registered as a built-in opt-in skill at daemon startup (disabled by default).
+
+## Chosen Server: Brave Search MCP
+
+**Package:** `@modelcontextprotocol/server-brave-search`
+
+**Why Brave Search:**
+- Official MCP package maintained by the MCP project
+- Fast, privacy-focused search API
+- Simple API key authentication via `BRAVE_API_KEY` env var
+- No complex OAuth flows
+
+**Alternatives considered:**
+- **Tavily MCP** (`tavily-mcp`) — good quality results but requires paid plan sooner
+- **DuckDuckGo MCP** — no API key required but unofficial, limited results
+
+## Configuration
+
+The skill is registered in `SkillsManager.initializeBuiltins()` as an `mcp_server` type skill.
+
+### app_mcp_servers entry
+
+```
+name:        web-search-brave
+sourceType:  stdio
+command:     npx
+args:        ["-y", "@modelcontextprotocol/server-brave-search"]
+enabled:     true
+```
+
+### Skill entry
+
+```
+name:         web-search-mcp
+displayName:  Web Search (MCP)
+sourceType:   mcp_server
+config:       { type: "mcp_server", appMcpServerId: <id of web-search-brave entry> }
+enabled:      false   (opt-in)
+builtIn:      true
+```
+
+## Usage
+
+1. Obtain a Brave Search API key from https://brave.com/search/api/
+2. Set `BRAVE_API_KEY` in the daemon environment (`.env` or shell)
+3. Enable the skill in the Skills settings UI
+4. The MCP server is automatically injected into new session `mcpServers`
+
+## Session Injection
+
+When the skill is enabled, `QueryOptionsBuilder` includes the backing `app_mcp_servers` entry
+in the `mcpServers` array passed to the SDK. The SDK then spawns the `npx` process and exposes
+the `brave_web_search` tool to the agent.
+
+## Security
+
+- The MCP server runs as a local stdio subprocess — no inbound network exposure
+- `BRAVE_API_KEY` is read from the server environment, not stored in the database
+- The skill is `builtIn: true` so users cannot delete it, only enable/disable it

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -130,9 +130,45 @@ export class SkillsManager {
 	 * For mcp_server type built-ins, ensures backing app_mcp_servers entries exist.
 	 */
 	initializeBuiltins(): void {
-		// No default built-in skills defined yet — reserved for future use.
-		// Implementors: call this.repo.findAll() to check for existing entries,
-		// then this.repo.insert() for any that are missing.
+		this.initWebSearchBraveMcp();
+	}
+
+	/**
+	 * Ensure the Brave Search MCP built-in skill is registered.
+	 * Step 1: upsert the backing app_mcp_servers entry.
+	 * Step 2: upsert the skill referencing that entry.
+	 * Both are idempotent — safe to call on every startup.
+	 */
+	private initWebSearchBraveMcp(): void {
+		// Step 1: ensure app MCP server entry exists (upsert by name)
+		const appMcpEntry =
+			this.appMcpServerRepo.getByName('web-search-brave') ??
+			this.appMcpServerRepo.create({
+				name: 'web-search-brave',
+				description: 'Brave Search MCP server for web search capability',
+				sourceType: 'stdio',
+				command: 'npx',
+				args: ['-y', '@modelcontextprotocol/server-brave-search'],
+				enabled: true,
+			});
+
+		// Step 2: upsert the skill referencing the app MCP entry
+		const existing = this.repo.getByName('web-search-mcp');
+		if (!existing) {
+			const skill: AppSkill = {
+				id: generateUUID(),
+				name: 'web-search-mcp',
+				displayName: 'Web Search (MCP)',
+				description: 'Web search capability via Brave Search MCP. Requires BRAVE_API_KEY env var.',
+				sourceType: 'mcp_server',
+				config: { type: 'mcp_server', appMcpServerId: appMcpEntry.id },
+				enabled: false, // opt-in, not default
+				builtIn: true,
+				validationStatus: 'valid',
+				createdAt: Date.now(),
+			};
+			this.repo.insert(skill);
+		}
 	}
 
 	// ---------------------------------------------------------------------------

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -135,21 +135,23 @@ export class SkillsManager {
 
 	/**
 	 * Ensure the Brave Search MCP built-in skill is registered.
-	 * Step 1: upsert the backing app_mcp_servers entry.
-	 * Step 2: upsert the skill referencing that entry.
-	 * Both are idempotent — safe to call on every startup.
+	 *
+	 * Reuses the existing `brave-search` app_mcp_servers entry seeded by
+	 * seedDefaultMcpEntries() (which always runs before initializeBuiltins()).
+	 * If that entry is somehow absent, creates it as a fallback.
 	 */
 	private initWebSearchBraveMcp(): void {
-		// Step 1: ensure app MCP server entry exists (upsert by name)
+		// Step 1: resolve the backing app_mcp_servers entry (seeded by seed-defaults.ts)
 		const appMcpEntry =
-			this.appMcpServerRepo.getByName('web-search-brave') ??
+			this.appMcpServerRepo.getByName('brave-search') ??
 			this.appMcpServerRepo.create({
-				name: 'web-search-brave',
-				description: 'Brave Search MCP server for web search capability',
+				name: 'brave-search',
+				description: 'Web search via Brave Search API (requires BRAVE_API_KEY env var)',
 				sourceType: 'stdio',
 				command: 'npx',
 				args: ['-y', '@modelcontextprotocol/server-brave-search'],
-				enabled: true,
+				env: {},
+				enabled: false,
 			});
 
 		// Step 2: upsert the skill referencing the app MCP entry

--- a/packages/daemon/tests/unit/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/agent/query-options-builder.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
 import {
 	QueryOptionsBuilder,
 	type QueryOptionsBuilderContext,
@@ -13,6 +14,11 @@ import type { Session } from '@neokai/shared';
 import type { SettingsManager } from '../../../src/lib/settings-manager';
 import { generateUUID } from '@neokai/shared';
 import { homedir } from 'os';
+import { createTables } from '../../../src/storage/schema';
+import { SkillRepository } from '../../../src/storage/repositories/skill-repository';
+import { AppMcpServerRepository } from '../../../src/storage/repositories/app-mcp-server-repository';
+import { SkillsManager } from '../../../src/lib/skills-manager';
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 
 describe('QueryOptionsBuilder', () => {
 	let builder: QueryOptionsBuilder;
@@ -1099,6 +1105,58 @@ describe('QueryOptionsBuilder', () => {
 				type: 'http',
 				url: 'http://localhost:3002/mcp',
 			});
+		});
+	});
+
+	describe('web-search-mcp built-in skill injection', () => {
+		let db: BunDatabase;
+		let skillsManager: SkillsManager;
+		let appMcpServerRepo: AppMcpServerRepository;
+
+		beforeEach(() => {
+			db = new BunDatabase(':memory:');
+			createTables(db);
+			appMcpServerRepo = new AppMcpServerRepository(db, noOpReactiveDb);
+			const skillRepo = new SkillRepository(db, noOpReactiveDb);
+			skillsManager = new SkillsManager(skillRepo, appMcpServerRepo);
+			skillsManager.initializeBuiltins();
+		});
+
+		afterEach(() => {
+			db.close();
+		});
+
+		it('does not inject web-search-mcp when skill is disabled (default)', async () => {
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager,
+				appMcpServerRepo,
+			};
+			const options = await new QueryOptionsBuilder(context).build();
+
+			expect(options.mcpServers?.['web-search-mcp']).toBeUndefined();
+		});
+
+		it('injects web-search-mcp MCP server into session options when skill is enabled', async () => {
+			const skill = skillsManager.listSkills().find((s) => s.name === 'web-search-mcp')!;
+			skillsManager.setSkillEnabled(skill.id, true);
+
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager,
+				appMcpServerRepo,
+			};
+			const options = await new QueryOptionsBuilder(context).build();
+
+			expect(options.mcpServers).toBeDefined();
+			const injected = options.mcpServers!['web-search-mcp'];
+			expect(injected).toBeDefined();
+			expect((injected as { command: string }).command).toBe('npx');
+			expect((injected as { args: string[] }).args).toContain(
+				'@modelcontextprotocol/server-brave-search'
+			);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/skills-manager.test.ts
+++ b/packages/daemon/tests/unit/skills-manager.test.ts
@@ -689,10 +689,10 @@ describe('SkillsManager', () => {
 		expect(skill!.validationStatus).toBe('valid');
 	});
 
-	test('initializeBuiltins creates backing app_mcp_servers entry web-search-brave', () => {
+	test('initializeBuiltins creates backing app_mcp_servers entry brave-search if absent', () => {
 		mgr.initializeBuiltins();
 
-		const server = mcpRepo.getByName('web-search-brave');
+		const server = mcpRepo.getByName('brave-search');
 		expect(server).not.toBeNull();
 		expect(server!.command).toBe('npx');
 		expect(server!.sourceType).toBe('stdio');
@@ -703,7 +703,7 @@ describe('SkillsManager', () => {
 		mgr.initializeBuiltins();
 
 		const skill = mgr.listSkills().find((s) => s.name === 'web-search-mcp');
-		const server = mcpRepo.getByName('web-search-brave');
+		const server = mcpRepo.getByName('brave-search');
 		expect(skill).toBeDefined();
 		expect(server).not.toBeNull();
 		expect(skill!.config.type).toBe('mcp_server');
@@ -719,7 +719,7 @@ describe('SkillsManager', () => {
 		const skills = mgr.listSkills().filter((s) => s.name === 'web-search-mcp');
 		expect(skills).toHaveLength(1);
 
-		const servers = mcpRepo.list().filter((s) => s.name === 'web-search-brave');
+		const servers = mcpRepo.list().filter((s) => s.name === 'brave-search');
 		expect(servers).toHaveLength(1);
 	});
 
@@ -751,5 +751,31 @@ describe('SkillsManager', () => {
 
 		const enabledSkills = mgr.getEnabledSkills();
 		expect(enabledSkills.some((s) => s.name === 'web-search-mcp')).toBe(false);
+	});
+
+	test('initializeBuiltins reuses pre-existing brave-search app_mcp_servers entry', () => {
+		// Simulate seed-defaults.ts having already created the brave-search entry
+		const seeded = mcpRepo.create({
+			name: 'brave-search',
+			description: 'Seeded by seed-defaults',
+			sourceType: 'stdio',
+			command: 'npx',
+			args: ['-y', '@modelcontextprotocol/server-brave-search'],
+			env: {},
+			enabled: false,
+		});
+
+		mgr.initializeBuiltins();
+
+		// Should not create a second brave-search entry
+		const servers = mcpRepo.list().filter((s) => s.name === 'brave-search');
+		expect(servers).toHaveLength(1);
+
+		// Skill must reference the pre-existing seeded entry
+		const skill = mgr.listSkills().find((s) => s.name === 'web-search-mcp')!;
+		expect(skill.config.type).toBe('mcp_server');
+		if (skill.config.type === 'mcp_server') {
+			expect(skill.config.appMcpServerId).toBe(seeded.id);
+		}
 	});
 });

--- a/packages/daemon/tests/unit/skills-manager.test.ts
+++ b/packages/daemon/tests/unit/skills-manager.test.ts
@@ -674,4 +674,82 @@ describe('SkillsManager', () => {
 			mgr.updateSkill(skill.id, { config: { type: 'plugin', pluginPath: 'bad/relative' } })
 		).toThrow('absolute path');
 	});
+
+	// --- initializeBuiltins ---
+
+	test('initializeBuiltins registers web-search-mcp skill', () => {
+		mgr.initializeBuiltins();
+
+		const skill = mgr.listSkills().find((s) => s.name === 'web-search-mcp');
+		expect(skill).toBeDefined();
+		expect(skill!.displayName).toBe('Web Search (MCP)');
+		expect(skill!.sourceType).toBe('mcp_server');
+		expect(skill!.builtIn).toBe(true);
+		expect(skill!.enabled).toBe(false);
+		expect(skill!.validationStatus).toBe('valid');
+	});
+
+	test('initializeBuiltins creates backing app_mcp_servers entry web-search-brave', () => {
+		mgr.initializeBuiltins();
+
+		const server = mcpRepo.getByName('web-search-brave');
+		expect(server).not.toBeNull();
+		expect(server!.command).toBe('npx');
+		expect(server!.sourceType).toBe('stdio');
+		expect(server!.args).toContain('@modelcontextprotocol/server-brave-search');
+	});
+
+	test('initializeBuiltins skill config references the app_mcp_servers entry', () => {
+		mgr.initializeBuiltins();
+
+		const skill = mgr.listSkills().find((s) => s.name === 'web-search-mcp');
+		const server = mcpRepo.getByName('web-search-brave');
+		expect(skill).toBeDefined();
+		expect(server).not.toBeNull();
+		expect(skill!.config.type).toBe('mcp_server');
+		if (skill!.config.type === 'mcp_server') {
+			expect(skill!.config.appMcpServerId).toBe(server!.id);
+		}
+	});
+
+	test('initializeBuiltins is idempotent — does not create duplicates on second call', () => {
+		mgr.initializeBuiltins();
+		mgr.initializeBuiltins();
+
+		const skills = mgr.listSkills().filter((s) => s.name === 'web-search-mcp');
+		expect(skills).toHaveLength(1);
+
+		const servers = mcpRepo.list().filter((s) => s.name === 'web-search-brave');
+		expect(servers).toHaveLength(1);
+	});
+
+	test('initializeBuiltins web-search-mcp cannot be deleted (builtIn guard)', () => {
+		mgr.initializeBuiltins();
+
+		const skill = mgr.listSkills().find((s) => s.name === 'web-search-mcp');
+		expect(skill).toBeDefined();
+		expect(mgr.removeSkill(skill!.id)).toBe(false);
+		expect(mgr.getSkill(skill!.id)).not.toBeNull();
+	});
+
+	test('initializeBuiltins web-search-mcp can be enabled via setSkillEnabled', () => {
+		mgr.initializeBuiltins();
+
+		const skill = mgr.listSkills().find((s) => s.name === 'web-search-mcp')!;
+		expect(skill.enabled).toBe(false);
+
+		const enabled = mgr.setSkillEnabled(skill.id, true);
+		expect(enabled.enabled).toBe(true);
+
+		// Verify getEnabledSkills now includes it
+		const enabledSkills = mgr.getEnabledSkills();
+		expect(enabledSkills.some((s) => s.name === 'web-search-mcp')).toBe(true);
+	});
+
+	test('initializeBuiltins web-search-mcp absent from getEnabledSkills when disabled', () => {
+		mgr.initializeBuiltins();
+
+		const enabledSkills = mgr.getEnabledSkills();
+		expect(enabledSkills.some((s) => s.name === 'web-search-mcp')).toBe(false);
+	});
 });


### PR DESCRIPTION
Implements Task 6.4: registers a built-in opt-in skill for web search via the Brave Search MCP server.

- `SkillsManager.initializeBuiltins()` now upserts a `web-search-brave` app MCP server entry and a `web-search-mcp` skill referencing it (`builtIn: true`, `enabled: false`)
- `docs/architecture/web-search-mcp.md` documents the chosen server, configuration, and rationale
- 7 new unit tests: registration, backing server creation, config reference, idempotency, deletion guard, enable toggle, disabled-by-default

**Usage:** set `BRAVE_API_KEY` env var, then enable the skill in Settings → Skills.