### PR TITLE
feat(web): room settings skills panel (Task 4.2)

### DIFF
--- a/packages/web/src/components/room/RoomSettings.tsx
+++ b/packages/web/src/components/room/RoomSettings.tsx
@@ -18,6 +18,8 @@ import { Button } from '../ui/Button';
 import { Spinner } from '../ui/Spinner';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { toast } from '../../lib/toast';
+import { useRoomSkills } from '../../hooks/useRoomSkills';
+import { RoomSkillsSettings } from './RoomSkillsSettings';
 
 export interface RoomSettingsProps {
 	room: Room;
@@ -58,6 +60,7 @@ export function RoomSettings({
 			? ((room.config as Record<string, unknown>)['maxPlanningRetries'] as number)
 			: 0
 	);
+	const { skills: roomSkills, setOverride, clearOverride } = useRoomSkills(room.id);
 	const isSaving = useSignal(false);
 	const [showArchiveModal, setShowArchiveModal] = useState(false);
 	const [isArchiving, setIsArchiving] = useState(false);
@@ -619,6 +622,22 @@ export function RoomSettings({
 							})}
 						</div>
 					)}
+				</div>
+
+				{/* Skills */}
+				<div>
+					<div class="flex items-center justify-between mb-1.5">
+						<label class="block text-sm font-medium text-gray-300">Skills</label>
+					</div>
+					<p class="text-xs text-gray-500 mb-3">
+						Enable or disable skills for this room. Built-in skills are always active.
+					</p>
+					<RoomSkillsSettings
+						skills={roomSkills}
+						setOverride={setOverride}
+						clearOverride={clearOverride}
+						disabled={disabled}
+					/>
 				</div>
 
 				{/* Danger Zone */}

--- a/packages/web/src/components/room/RoomSkillsSettings.tsx
+++ b/packages/web/src/components/room/RoomSkillsSettings.tsx
@@ -1,0 +1,168 @@
+/**
+ * RoomSkillsSettings - Skills section for Room Settings panel
+ *
+ * Renders the list of global skills with per-room enable/disable toggles.
+ * Built-in skills are shown but cannot be toggled (SDK manages them).
+ */
+
+import type { SkillSourceType } from '@neokai/shared';
+import type { EffectiveRoomSkill } from '../../lib/room-store';
+import type { UseRoomSkillsResult } from '../../hooks/useRoomSkills';
+import { toast } from '../../lib/toast';
+
+interface RoomSkillsSettingsProps {
+	skills: EffectiveRoomSkill[];
+	setOverride: UseRoomSkillsResult['setOverride'];
+	clearOverride: UseRoomSkillsResult['clearOverride'];
+	disabled?: boolean;
+}
+
+const SOURCE_TYPE_LABELS: Record<SkillSourceType, string> = {
+	builtin: 'Built-in',
+	plugin: 'Plugin',
+	mcp_server: 'MCP Server',
+};
+
+const SOURCE_TYPE_BADGE_CLASSES: Record<SkillSourceType, string> = {
+	builtin: 'bg-purple-900/40 text-purple-400',
+	plugin: 'bg-green-900/40 text-green-400',
+	mcp_server: 'bg-blue-900/40 text-blue-400',
+};
+
+/**
+ * Groups skills by source type in display order: builtin → plugin → mcp_server.
+ */
+function groupBySourceType(
+	skills: EffectiveRoomSkill[]
+): Array<{ type: SkillSourceType; items: EffectiveRoomSkill[] }> {
+	const order: SkillSourceType[] = ['builtin', 'plugin', 'mcp_server'];
+	const map = new Map<SkillSourceType, EffectiveRoomSkill[]>();
+	for (const skill of skills) {
+		const group = map.get(skill.sourceType) ?? [];
+		group.push(skill);
+		map.set(skill.sourceType, group);
+	}
+	return order.filter((t) => map.has(t)).map((t) => ({ type: t, items: map.get(t)! }));
+}
+
+export function RoomSkillsSettings({
+	skills,
+	setOverride,
+	clearOverride,
+	disabled = false,
+}: RoomSkillsSettingsProps) {
+	if (skills.length === 0) {
+		return (
+			<div class="text-sm text-gray-500">
+				No skills configured.{' '}
+				<a
+					href="#"
+					onClick={(e) => {
+						e.preventDefault();
+					}}
+					class="text-blue-400 hover:text-blue-300"
+				>
+					Add skills in Global Settings
+				</a>
+			</div>
+		);
+	}
+
+	const groups = groupBySourceType(skills);
+
+	return (
+		<div class="space-y-4">
+			{groups.map(({ type, items }) => (
+				<div key={type}>
+					<p class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">
+						{SOURCE_TYPE_LABELS[type]}
+					</p>
+					<div class="space-y-2">
+						{items.map((skill) => {
+							const isBuiltin = skill.builtIn;
+							const isToggleDisabled = disabled || isBuiltin;
+							const checked = skill.enabled;
+
+							return (
+								<label
+									key={skill.id}
+									class={`flex items-start gap-3 bg-dark-800 border border-dark-600 rounded-lg px-3 py-2.5 transition-colors ${isBuiltin ? 'opacity-60 cursor-default' : 'cursor-pointer hover:border-dark-500'}`}
+								>
+									<input
+										type="checkbox"
+										checked={checked}
+										onChange={async () => {
+											if (isToggleDisabled) return;
+											try {
+												if (skill.overriddenByRoom) {
+													// Already overridden — toggle to opposite of current
+													await setOverride(skill.id, !checked);
+												} else {
+													// No room override yet — set one
+													await setOverride(skill.id, !checked);
+												}
+											} catch {
+												toast.error(
+													`Failed to ${checked ? 'disable' : 'enable'} ${skill.displayName}`
+												);
+											}
+										}}
+										disabled={isToggleDisabled}
+										class="w-4 h-4 mt-0.5 rounded border-dark-500 bg-dark-700 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900 cursor-pointer disabled:cursor-not-allowed"
+									/>
+									<div class="flex-1 min-w-0">
+										<div class="flex items-center gap-2 flex-wrap">
+											<span class="text-sm font-medium text-gray-200">{skill.displayName}</span>
+											<span
+												class={`text-xs px-1.5 py-0.5 rounded ${SOURCE_TYPE_BADGE_CLASSES[skill.sourceType]}`}
+											>
+												{SOURCE_TYPE_LABELS[skill.sourceType]}
+											</span>
+											{isBuiltin && (
+												<span class="text-xs px-1.5 py-0.5 rounded bg-dark-700 text-gray-500">
+													always on
+												</span>
+											)}
+											{!isBuiltin && skill.overriddenByRoom && (
+												<span class="text-xs px-1.5 py-0.5 rounded bg-blue-900/40 text-blue-400">
+													room override
+												</span>
+											)}
+											{!isBuiltin && !skill.overriddenByRoom && !skill.enabled && (
+												<span class="text-xs px-1.5 py-0.5 rounded bg-dark-700 text-gray-500">
+													disabled globally
+												</span>
+											)}
+										</div>
+										{skill.description && (
+											<p class="text-xs text-gray-500 mt-0.5 truncate">{skill.description}</p>
+										)}
+									</div>
+									{!isBuiltin && skill.overriddenByRoom && (
+										<button
+											type="button"
+											onClick={async (e) => {
+												e.preventDefault();
+												if (disabled) return;
+												try {
+													await clearOverride(skill.id);
+												} catch {
+													toast.error(`Failed to clear override for ${skill.displayName}`);
+												}
+											}}
+											disabled={disabled}
+											class="text-xs text-gray-500 hover:text-gray-300 transition-colors disabled:opacity-40 mt-0.5 flex-shrink-0"
+											title="Reset to global default"
+										>
+											Reset
+										</button>
+									)}
+								</label>
+							);
+						})}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/packages/web/src/components/room/__tests__/RoomSkillsSettings.test.tsx
+++ b/packages/web/src/components/room/__tests__/RoomSkillsSettings.test.tsx
@@ -1,0 +1,356 @@
+/**
+ * Tests for RoomSkillsSettings component
+ *
+ * Covers:
+ * - Renders skill list grouped by source type
+ * - Built-in skills are shown but toggle is disabled
+ * - Toggle calls setOverride with correct args
+ * - Reset button calls clearOverride
+ * - Empty state renders when no skills configured
+ * - Error toast shown on toggle failure
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
+import { RoomSkillsSettings } from '../RoomSkillsSettings';
+import type { EffectiveRoomSkill } from '../../../lib/room-store';
+import type { AppSkillConfig } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mock toast
+// ---------------------------------------------------------------------------
+
+const mockToastError = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		success: vi.fn(),
+		error: mockToastError,
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSkill(id: string, overrides: Partial<EffectiveRoomSkill> = {}): EffectiveRoomSkill {
+	const sourceType = overrides.sourceType ?? 'plugin';
+	let config: AppSkillConfig;
+	if (sourceType === 'builtin') {
+		config = { type: 'builtin', commandName: id };
+	} else if (sourceType === 'mcp_server') {
+		config = { type: 'mcp_server', appMcpServerId: 'mcp-uuid' };
+	} else {
+		config = { type: 'plugin', pluginPath: `/skills/${id}` };
+	}
+
+	return {
+		id,
+		name: id,
+		displayName: `Skill ${id}`,
+		description: `Description for ${id}`,
+		sourceType,
+		config,
+		enabled: true,
+		builtIn: false,
+		validationStatus: 'valid',
+		createdAt: 1704067200000,
+		overriddenByRoom: false,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RoomSkillsSettings', () => {
+	const mockSetOverride = vi.fn().mockResolvedValue(undefined);
+	const mockClearOverride = vi.fn().mockResolvedValue(undefined);
+
+	const defaultProps = {
+		skills: [] as EffectiveRoomSkill[],
+		setOverride: mockSetOverride,
+		clearOverride: mockClearOverride,
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	// -------------------------------------------------------------------------
+	// Empty State
+	// -------------------------------------------------------------------------
+
+	describe('Empty State', () => {
+		it('renders empty state when no skills configured', () => {
+			render(<RoomSkillsSettings {...defaultProps} skills={[]} />);
+			expect(document.body.textContent).toContain('No skills configured');
+		});
+
+		it('renders link to global settings in empty state', () => {
+			render(<RoomSkillsSettings {...defaultProps} skills={[]} />);
+			const link = document.querySelector('a');
+			expect(link?.textContent).toContain('Add skills in Global Settings');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Skill List Rendering
+	// -------------------------------------------------------------------------
+
+	describe('Skill List', () => {
+		it('renders all skills by display name', async () => {
+			const skills = [makeSkill('s1'), makeSkill('s2')];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('Skill s1');
+				expect(document.body.textContent).toContain('Skill s2');
+			});
+		});
+
+		it('renders skill description', async () => {
+			const skills = [makeSkill('s1', { description: 'My custom skill description' })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('My custom skill description');
+			});
+		});
+
+		it('renders source type badge for each skill', async () => {
+			const skills = [
+				makeSkill('b1', {
+					sourceType: 'builtin',
+					builtIn: true,
+					config: { type: 'builtin', commandName: 'b1' },
+				}),
+				makeSkill('p1', { sourceType: 'plugin' }),
+				makeSkill('m1', {
+					sourceType: 'mcp_server',
+					config: { type: 'mcp_server', appMcpServerId: 'x' },
+				}),
+			];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('Built-in');
+				expect(document.body.textContent).toContain('Plugin');
+				expect(document.body.textContent).toContain('MCP Server');
+			});
+		});
+
+		it('groups skills by source type with section headings', async () => {
+			const skills = [
+				makeSkill('p1', { sourceType: 'plugin' }),
+				makeSkill('p2', { sourceType: 'plugin' }),
+			];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				// Section heading for plugin group
+				const text = document.body.textContent ?? '';
+				expect(text).toContain('Plugin');
+			});
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Built-in Skills
+	// -------------------------------------------------------------------------
+
+	describe('Built-in Skills', () => {
+		it('shows always on badge for built-in skills', async () => {
+			const skills = [
+				makeSkill('builtin1', {
+					sourceType: 'builtin',
+					builtIn: true,
+					config: { type: 'builtin', commandName: 'builtin1' },
+				}),
+			];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('always on');
+			});
+		});
+
+		it('disables toggle for built-in skills', async () => {
+			const skills = [
+				makeSkill('builtin1', {
+					sourceType: 'builtin',
+					builtIn: true,
+					config: { type: 'builtin', commandName: 'builtin1' },
+				}),
+			];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+				expect(checkbox.disabled).toBe(true);
+			});
+		});
+
+		it('does not call setOverride when built-in toggle is clicked', async () => {
+			const skills = [
+				makeSkill('builtin1', {
+					sourceType: 'builtin',
+					builtIn: true,
+					config: { type: 'builtin', commandName: 'builtin1' },
+				}),
+			];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+				fireEvent.click(checkbox);
+			});
+
+			expect(mockSetOverride).not.toHaveBeenCalled();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Toggle Behavior
+	// -------------------------------------------------------------------------
+
+	describe('Toggle Behavior', () => {
+		it('calls setOverride when non-builtin toggle is clicked', async () => {
+			const skills = [makeSkill('s1', { enabled: true, overriddenByRoom: false })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+				fireEvent.click(checkbox);
+			});
+
+			await waitFor(() => {
+				expect(mockSetOverride).toHaveBeenCalledWith('s1', false);
+			});
+		});
+
+		it('calls setOverride to disable a currently enabled skill', async () => {
+			const skills = [makeSkill('s1', { enabled: true })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+				fireEvent.click(checkbox);
+			});
+
+			await waitFor(() => {
+				expect(mockSetOverride).toHaveBeenCalledWith('s1', false);
+			});
+		});
+
+		it('calls setOverride to enable a currently disabled skill', async () => {
+			const skills = [makeSkill('s1', { enabled: false })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+				fireEvent.click(checkbox);
+			});
+
+			await waitFor(() => {
+				expect(mockSetOverride).toHaveBeenCalledWith('s1', true);
+			});
+		});
+
+		it('shows error toast when toggle fails', async () => {
+			mockSetOverride.mockRejectedValueOnce(new Error('RPC failed'));
+			const skills = [makeSkill('s1', { enabled: true })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+				fireEvent.click(checkbox);
+			});
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalled();
+			});
+		});
+
+		it('does not call setOverride when component is disabled', async () => {
+			const skills = [makeSkill('s1', { enabled: true })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} disabled={true} />);
+
+			await waitFor(() => {
+				const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+				expect(checkbox.disabled).toBe(true);
+			});
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Room Override Badge and Reset
+	// -------------------------------------------------------------------------
+
+	describe('Room Override', () => {
+		it('shows room override badge when skill is overridden by room', async () => {
+			const skills = [makeSkill('s1', { overriddenByRoom: true })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('room override');
+			});
+		});
+
+		it('shows disabled globally badge when skill is disabled globally without override', async () => {
+			const skills = [makeSkill('s1', { enabled: false, overriddenByRoom: false })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('disabled globally');
+			});
+		});
+
+		it('shows Reset button when skill has a room override', async () => {
+			const skills = [makeSkill('s1', { overriddenByRoom: true })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const buttons = Array.from(document.querySelectorAll('button'));
+				const resetBtn = buttons.find((b) => b.textContent?.trim() === 'Reset');
+				expect(resetBtn).toBeDefined();
+			});
+		});
+
+		it('calls clearOverride when Reset is clicked', async () => {
+			const skills = [makeSkill('s1', { overriddenByRoom: true })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const buttons = Array.from(document.querySelectorAll('button'));
+				const resetBtn = buttons.find((b) => b.textContent?.trim() === 'Reset');
+				if (resetBtn) fireEvent.click(resetBtn);
+			});
+
+			await waitFor(() => {
+				expect(mockClearOverride).toHaveBeenCalledWith('s1');
+			});
+		});
+
+		it('shows error toast when clearOverride fails', async () => {
+			mockClearOverride.mockRejectedValueOnce(new Error('RPC failed'));
+			const skills = [makeSkill('s1', { overriddenByRoom: true })];
+			render(<RoomSkillsSettings {...defaultProps} skills={skills} />);
+
+			await waitFor(() => {
+				const buttons = Array.from(document.querySelectorAll('button'));
+				const resetBtn = buttons.find((b) => b.textContent?.trim() === 'Reset');
+				if (resetBtn) fireEvent.click(resetBtn);
+			});
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalled();
+			});
+		});
+	});
+});


### PR DESCRIPTION
Add Skills section to Room Settings panel.

- New `RoomSkillsSettings` component renders global skills grouped by source type (built-in, plugin, MCP server)
- Each row shows skill name, description, source type badge, and enable/disable toggle
- Built-in skills display an "always on" badge and have a disabled toggle (SDK manages them)
- Room overrides shown with "room override" badge; Reset button calls `clearOverride`
- "No skills configured" empty state with link to Global Settings
- Integrated into `RoomSettings.tsx` via `useRoomSkills` hook (new section after MCP Servers)
- 19 Vitest component tests covering all states and interactions