### PR TITLE
feat(daemon): apply room skill overrides to session init

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -84,6 +84,7 @@ import type {
 	SystemPromptConfig,
 	McpServerConfig,
 	Provider,
+	RoomSkillOverride,
 } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import type { DaemonHub } from '../daemon-hub';
@@ -138,6 +139,12 @@ export interface AgentSessionInit {
 
 	/** Disable automatic /context queuing after each turn (default: true) */
 	contextAutoQueue?: boolean;
+	/**
+	 * Room-level skill overrides applied on top of the global skills registry.
+	 * Skills with enabled=false in this list are excluded from injection even if
+	 * globally enabled. Populated by the room runtime when spawning sessions.
+	 */
+	roomSkillOverrides?: RoomSkillOverride[];
 }
 
 // Extracted components
@@ -242,7 +249,8 @@ export class AgentSession
 		readonly daemonHub: DaemonHub,
 		private getApiKey: () => Promise<string | null>,
 		readonly skillsManager?: import('../skills-manager').SkillsManager,
-		readonly appMcpServerRepo?: import('../../storage/repositories/app-mcp-server-repository').AppMcpServerRepository
+		readonly appMcpServerRepo?: import('../../storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+		readonly roomSkillOverrides?: RoomSkillOverride[]
 	) {
 		this.errorManager = new ErrorManager(this.messageHub, this.daemonHub);
 		this.logger = new Logger(`AgentSession ${session.id}`);
@@ -351,7 +359,9 @@ export class AgentSession
 		messageHub: MessageHub,
 		daemonHub: DaemonHub,
 		getApiKey: () => Promise<string | null>,
-		defaultModel: string
+		defaultModel: string,
+		skillsManager?: import('../skills-manager').SkillsManager,
+		appMcpServerRepo?: import('../../storage/repositories/app-mcp-server-repository').AppMcpServerRepository
 	): AgentSession {
 		// Check if session already exists in DB
 		let session = db.getSession(init.sessionId);
@@ -431,7 +441,16 @@ export class AgentSession
 			};
 		}
 
-		const agentSession = new AgentSession(session, db, messageHub, daemonHub, getApiKey);
+		const agentSession = new AgentSession(
+			session,
+			db,
+			messageHub,
+			daemonHub,
+			getApiKey,
+			skillsManager,
+			appMcpServerRepo,
+			init.roomSkillOverrides
+		);
 		if (init.contextAutoQueue === false) {
 			agentSession.contextAutoQueueEnabled = false;
 		}

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -35,6 +35,7 @@ import type { AppMcpServerSourceType } from '@neokai/shared';
 import type { SettingsManager } from '../settings-manager';
 import type { SkillsManager } from '../skills-manager';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
+import type { RoomSkillOverride } from '@neokai/shared';
 import { getProviderContextManager } from '../providers/factory.js';
 import { resolveSDKCliPath, isRunningUnderBun } from './sdk-cli-resolver.js';
 import { homedir } from 'os';
@@ -51,6 +52,11 @@ export interface QueryOptionsBuilderContext {
 	readonly skillsManager?: SkillsManager;
 	/** App MCP server repo for resolving mcp_server skill configs. Optional for backwards compatibility. */
 	readonly appMcpServerRepo?: AppMcpServerRepository;
+	/**
+	 * Room-level skill overrides. When provided, a skill with `enabled: false` in this list
+	 * is excluded from injection even if it is globally enabled in the skills registry.
+	 */
+	readonly roomSkillOverrides?: RoomSkillOverride[];
 }
 
 export class QueryOptionsBuilder {
@@ -791,16 +797,28 @@ CRITICAL RULES:
 	}
 
 	/**
+	 * Returns the set of skill IDs disabled by room-level overrides.
+	 * A skill in this set must be excluded even if globally enabled.
+	 */
+	private getRoomDisabledSkillIds(): Set<string> {
+		if (!this.ctx.roomSkillOverrides?.length) return new Set();
+		return new Set(this.ctx.roomSkillOverrides.filter((o) => !o.enabled).map((o) => o.skillId));
+	}
+
+	/**
 	 * Build plugin entries from enabled skills with sourceType === 'plugin'.
+	 * Room overrides with enabled=false exclude the skill even if globally enabled.
 	 * Returns an array of SdkPluginConfig objects for injection into options.plugins.
 	 */
 	private buildPluginsFromSkills(): Array<{ type: 'local'; path: string }> {
 		if (!this.ctx.skillsManager) return [];
 
 		const skills = this.ctx.skillsManager.getEnabledSkills();
+		const roomDisabled = this.getRoomDisabledSkillIds();
 		const plugins: Array<{ type: 'local'; path: string }> = [];
 
 		for (const skill of skills) {
+			if (roomDisabled.has(skill.id)) continue;
 			if (skill.sourceType === 'plugin' && skill.config.type === 'plugin') {
 				plugins.push({ type: 'local', path: skill.config.pluginPath });
 			}
@@ -811,6 +829,7 @@ CRITICAL RULES:
 
 	/**
 	 * Build MCP server entries from enabled skills with sourceType === 'mcp_server'.
+	 * Room overrides with enabled=false exclude the skill even if globally enabled.
 	 * Resolves each skill's appMcpServerId to an AppMcpServer entry and maps it
 	 * to an McpServerConfig keyed by skill.name.
 	 *
@@ -821,9 +840,11 @@ CRITICAL RULES:
 		if (!this.ctx.skillsManager || !this.ctx.appMcpServerRepo) return {};
 
 		const skills = this.ctx.skillsManager.getEnabledSkills();
+		const roomDisabled = this.getRoomDisabledSkillIds();
 		const servers: Record<string, McpServerConfig> = {};
 
 		for (const skill of skills) {
+			if (roomDisabled.has(skill.id)) continue;
 			if (skill.sourceType !== 'mcp_server' || skill.config.type !== 'mcp_server') continue;
 
 			const appServer = this.ctx.appMcpServerRepo.get(skill.config.appMcpServerId);

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -8,7 +8,13 @@
  * Follows the LobbyAgentService pattern.
  */
 
-import type { Room, McpServerConfig, RuntimeState, GlobalSettings } from '@neokai/shared';
+import type {
+	Room,
+	McpServerConfig,
+	RuntimeState,
+	GlobalSettings,
+	RoomSkillOverride,
+} from '@neokai/shared';
 import type { SettingsManager } from '../../settings-manager';
 import type { AppMcpLifecycleManager } from '../../mcp/app-mcp-lifecycle-manager';
 import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
@@ -38,6 +44,9 @@ import type { RoomManager } from '../managers/room-manager';
 import { WorktreeManager } from '../../worktree-manager';
 import { inferProviderForModel, getProviderRegistry } from '../../providers/registry';
 import { Logger } from '../../logger';
+import type { SkillsManager } from '../../skills-manager';
+import type { AppMcpServerRepository } from '../../../storage/repositories/app-mcp-server-repository';
+import type { RoomSkillOverrideRepository } from '../../../storage/repositories/room-skill-override-repository';
 
 const log = new Logger('room-runtime-service');
 
@@ -68,6 +77,12 @@ export interface RoomRuntimeServiceConfig {
 	 * Must be provided for the job-queue-based tick loop to function.
 	 */
 	jobProcessor?: JobQueueProcessor;
+	/** Application-level skills manager for injecting skills into session SDK options. Optional for backwards compatibility. */
+	skillsManager?: SkillsManager;
+	/** App MCP server repository for resolving mcp_server skill configs. Optional for backwards compatibility. */
+	appMcpServerRepo?: AppMcpServerRepository;
+	/** Room skill override repository for fetching per-room skill enablement overrides. Optional for backwards compatibility. */
+	roomSkillOverrideRepo?: RoomSkillOverrideRepository;
 }
 
 export class RoomRuntimeService {
@@ -266,6 +281,24 @@ export class RoomRuntimeService {
 		});
 	}
 
+	/**
+	 * Resolve the roomId from a session ID.
+	 * Handles the two ID formats used by room sessions:
+	 *   - `room:chat:{roomId}` — room chat coordinator session
+	 *   - `{role}:{roomId}:{taskId}:{uuid8}` — worker/leader sessions
+	 * Returns null if the format is not recognized.
+	 */
+	private static extractRoomId(sessionId: string): string | null {
+		const parts = sessionId.split(':');
+		if (parts.length >= 3 && parts[0] === 'room' && parts[1] === 'chat') {
+			return parts[2];
+		}
+		if (parts.length >= 4) {
+			return parts[1];
+		}
+		return null;
+	}
+
 	private createSessionFactory(): SessionFactory {
 		const ctx = this.ctx;
 		const agentSessions = this.agentSessions;
@@ -273,13 +306,26 @@ export class RoomRuntimeService {
 
 		return {
 			createAndStartSession: async (init, role) => {
+				// Resolve room-level skill overrides for this session.
+				// The override list is merged with the global skills registry in
+				// QueryOptionsBuilder so that room-disabled skills are excluded.
+				let roomSkillOverrides: RoomSkillOverride[] | undefined;
+				if (ctx.roomSkillOverrideRepo) {
+					const roomId = RoomRuntimeService.extractRoomId(init.sessionId);
+					if (roomId) {
+						roomSkillOverrides = ctx.roomSkillOverrideRepo.getOverrides(roomId);
+					}
+				}
+
 				const session = AgentSession.fromInit(
-					init,
+					{ ...init, roomSkillOverrides },
 					ctx.db,
 					ctx.messageHub,
 					ctx.daemonHub,
 					ctx.getApiKey,
-					ctx.defaultModel
+					ctx.defaultModel,
+					ctx.skillsManager,
+					ctx.appMcpServerRepo
 				);
 				agentSessions.set(init.sessionId, session);
 				ctx.sessionManager.registerSession(session);

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -207,6 +207,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		reactiveDb: deps.reactiveDb,
 		jobQueue: deps.jobQueue,
 		jobProcessor: deps.jobProcessor,
+		skillsManager: deps.skillsManager,
+		appMcpServerRepo: deps.reactiveDb.db.appMcpServers,
+		roomSkillOverrideRepo: deps.reactiveDb.db.roomSkillOverrides,
 	});
 
 	// Seed an initial room.tick job for every room after startup, and for each

--- a/packages/daemon/tests/unit/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/agent/query-options-builder.test.ts
@@ -1159,4 +1159,162 @@ describe('QueryOptionsBuilder', () => {
 			);
 		});
 	});
+
+	describe('room skill overrides', () => {
+		const pluginSkill = {
+			id: 'skill-plugin-room-1',
+			name: 'room-plugin',
+			displayName: 'Room Plugin',
+			description: 'Plugin skill used in room override tests',
+			sourceType: 'plugin' as const,
+			config: { type: 'plugin' as const, pluginPath: '/plugins/room-plugin' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'valid' as const,
+			createdAt: Date.now(),
+		};
+
+		const mcpSkill = {
+			id: 'skill-mcp-room-1',
+			name: 'room-mcp',
+			displayName: 'Room MCP',
+			description: 'MCP skill used in room override tests',
+			sourceType: 'mcp_server' as const,
+			config: { type: 'mcp_server' as const, appMcpServerId: 'mcp-room-uuid' },
+			enabled: true,
+			builtIn: false,
+			validationStatus: 'valid' as const,
+			createdAt: Date.now(),
+		};
+
+		const mockRoomMcpServer = {
+			id: 'mcp-room-uuid',
+			name: 'room-mcp-server',
+			sourceType: 'stdio' as const,
+			command: 'npx',
+			args: ['-y', 'room-mcp'],
+			enabled: true,
+		};
+
+		it('should exclude a plugin skill disabled by a room override', async () => {
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [pluginSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				roomSkillOverrides: [{ skillId: pluginSkill.id, roomId: 'room-1', enabled: false }],
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			// Room override disables the skill — must not appear in plugins
+			expect(options.plugins).toBeUndefined();
+		});
+
+		it('should exclude an MCP server skill disabled by a room override', async () => {
+			const mockAppMcpServerRepo = {
+				get: mock(() => mockRoomMcpServer),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [mcpSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				appMcpServerRepo:
+					mockAppMcpServerRepo as unknown as import('../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+				roomSkillOverrides: [{ skillId: mcpSkill.id, roomId: 'room-1', enabled: false }],
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			// Room override disables the MCP skill — must not appear in mcpServers
+			expect(options.mcpServers).toBeUndefined();
+		});
+
+		it('should still include a plugin skill when room override has enabled=true', async () => {
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [pluginSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				roomSkillOverrides: [{ skillId: pluginSkill.id, roomId: 'room-1', enabled: true }],
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.plugins).toEqual([{ type: 'local', path: '/plugins/room-plugin' }]);
+		});
+
+		it('should apply room override only to the matching skill ID', async () => {
+			const anotherPlugin = {
+				id: 'skill-plugin-other',
+				name: 'other-plugin',
+				displayName: 'Other Plugin',
+				description: 'Another plugin not targeted by the override',
+				sourceType: 'plugin' as const,
+				config: { type: 'plugin' as const, pluginPath: '/plugins/other-plugin' },
+				enabled: true,
+				builtIn: false,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [pluginSkill, anotherPlugin]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				// Disable only pluginSkill; anotherPlugin should still appear
+				roomSkillOverrides: [{ skillId: pluginSkill.id, roomId: 'room-1', enabled: false }],
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.plugins).toEqual([{ type: 'local', path: '/plugins/other-plugin' }]);
+		});
+
+		it('should include all skills when roomSkillOverrides is empty', async () => {
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [pluginSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				roomSkillOverrides: [],
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.plugins).toEqual([{ type: 'local', path: '/plugins/room-plugin' }]);
+		});
+
+		it('should include all skills when roomSkillOverrides is not provided', async () => {
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [pluginSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			expect(options.plugins).toEqual([{ type: 'local', path: '/plugins/room-plugin' }]);
+		});
+	});
 });


### PR DESCRIPTION
Applies room-level skill overrides when initializing sessions for room agents (coder, planner, general, leader, room chat).

## Changes

- **`QueryOptionsBuilderContext`**: added `roomSkillOverrides?: RoomSkillOverride[]`
- **`QueryOptionsBuilder`**: `getRoomDisabledSkillIds()` helper builds a set of skill IDs disabled by room overrides; applied in `buildPluginsFromSkills()` and `getMcpServersFromSkills()` to filter out room-disabled skills
- **`AgentSessionInit`**: added `roomSkillOverrides?` field
- **`AgentSession`**: `roomSkillOverrides` stored as constructor param (implements `QueryOptionsBuilderContext`); `fromInit()` accepts optional `skillsManager`/`appMcpServerRepo` and reads `roomSkillOverrides` from init
- **`RoomRuntimeServiceConfig`**: added `skillsManager?`, `appMcpServerRepo?`, `roomSkillOverrideRepo?`
- **`RoomRuntimeService.createSessionFactory()`**: parses `roomId` from session ID, fetches overrides via `roomSkillOverrideRepo`, merges into `AgentSessionInit`; also passes `skillsManager`/`appMcpServerRepo` to `AgentSession.fromInit()`
- **`rpc-handlers/index.ts`**: wires `skillsManager`, `appMcpServers`, and `roomSkillOverrides` into `RoomRuntimeService`
- 6 new unit tests covering: disable by override, MCP disable, enable override, partial match (only matching skill excluded), empty override list, absent override list