### PR TITLE
feat(web): global Skills Registry UI component

### DIFF
--- a/packages/web/src/components/settings/AddSkillDialog.tsx
+++ b/packages/web/src/components/settings/AddSkillDialog.tsx
@@ -1,0 +1,349 @@
+/**
+ * AddSkillDialog Component
+ *
+ * Modal dialog for adding a new skill to the application-level registry.
+ * Supports three source types with distinct configuration fields.
+ */
+
+import { useState, useEffect } from 'preact/hooks';
+import type { SkillSourceType, AppSkillConfig } from '@neokai/shared';
+import type { AppMcpServer } from '@neokai/shared';
+import { skillsStore } from '../../lib/skills-store';
+import { toast } from '../../lib/toast';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { cn } from '../../lib/utils';
+import { connectionManager } from '../../lib/connection-manager';
+
+/** Convert a display name to a slug-style identifier */
+function toSlug(s: string): string {
+	return s
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+}
+
+interface FormState {
+	displayName: string;
+	name: string;
+	nameTouched: boolean;
+	description: string;
+	sourceType: SkillSourceType;
+	// builtin
+	commandName: string;
+	// plugin
+	pluginPath: string;
+	// mcp_server
+	appMcpServerId: string;
+}
+
+interface FormErrors {
+	displayName?: string;
+	name?: string;
+	commandName?: string;
+	pluginPath?: string;
+	appMcpServerId?: string;
+}
+
+const EMPTY_FORM: FormState = {
+	displayName: '',
+	name: '',
+	nameTouched: false,
+	description: '',
+	sourceType: 'builtin',
+	commandName: '',
+	pluginPath: '',
+	appMcpServerId: '',
+};
+
+interface AddSkillDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export function AddSkillDialog({ isOpen, onClose }: AddSkillDialogProps) {
+	const [form, setForm] = useState<FormState>(EMPTY_FORM);
+	const [errors, setErrors] = useState<FormErrors>({});
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [mcpServers, setMcpServers] = useState<AppMcpServer[]>([]);
+
+	// Fetch MCP servers when the dialog is open and source type is mcp_server
+	useEffect(() => {
+		if (!isOpen || form.sourceType !== 'mcp_server') return;
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) return;
+		hub
+			.request<{ servers: AppMcpServer[] }>('mcp.registry.list', {})
+			.then((res) => setMcpServers(res.servers ?? []))
+			.catch(() => setMcpServers([]));
+	}, [isOpen, form.sourceType]);
+
+	const handleDisplayNameChange = (value: string) => {
+		setForm((f) => ({
+			...f,
+			displayName: value,
+			name: f.nameTouched ? f.name : toSlug(value),
+		}));
+	};
+
+	const validate = (): boolean => {
+		const errs: FormErrors = {};
+		if (!form.displayName.trim()) {
+			errs.displayName = 'Display Name is required';
+		}
+		if (!form.name.trim()) {
+			errs.name = 'Name is required';
+		} else if (!/^[a-z0-9-]+$/.test(form.name.trim())) {
+			errs.name = 'Name must contain only lowercase letters, numbers, and hyphens';
+		}
+		if (form.sourceType === 'builtin' && !form.commandName.trim()) {
+			errs.commandName = 'Command name is required for built-in skills';
+		}
+		if (form.sourceType === 'plugin' && !form.pluginPath.trim()) {
+			errs.pluginPath = 'Plugin directory path is required';
+		}
+		if (form.sourceType === 'mcp_server' && !form.appMcpServerId) {
+			errs.appMcpServerId = 'Please select an MCP server';
+		}
+		setErrors(errs);
+		return Object.keys(errs).length === 0;
+	};
+
+	const buildConfig = (): AppSkillConfig => {
+		switch (form.sourceType) {
+			case 'builtin':
+				return { type: 'builtin', commandName: form.commandName.trim() };
+			case 'plugin':
+				return { type: 'plugin', pluginPath: form.pluginPath.trim() };
+			case 'mcp_server':
+				return { type: 'mcp_server', appMcpServerId: form.appMcpServerId };
+		}
+	};
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+		if (!validate()) return;
+		setIsSubmitting(true);
+		try {
+			await skillsStore.addSkill({
+				name: form.name.trim(),
+				displayName: form.displayName.trim(),
+				description: form.description.trim(),
+				sourceType: form.sourceType,
+				config: buildConfig(),
+				enabled: true,
+				validationStatus: 'pending',
+			});
+			toast.success(`Added "${form.displayName.trim()}"`);
+			handleClose();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to add skill');
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleClose = () => {
+		setForm(EMPTY_FORM);
+		setErrors({});
+		onClose();
+	};
+
+	return (
+		<Modal isOpen={isOpen} onClose={handleClose} title="Add Skill" size="md">
+			<form onSubmit={handleSubmit} class="space-y-4">
+				{/* Display Name */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1">
+						Display Name <span class="text-red-400">*</span>
+					</label>
+					<input
+						type="text"
+						value={form.displayName}
+						onChange={(e) => handleDisplayNameChange((e.target as HTMLInputElement).value)}
+						class={cn(
+							'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200',
+							'focus:outline-none focus:ring-1 focus:ring-blue-500',
+							errors.displayName ? 'border-red-500' : 'border-dark-700'
+						)}
+						placeholder="e.g., Web Search"
+						autoFocus
+					/>
+					{errors.displayName && <p class="text-xs text-red-400 mt-1">{errors.displayName}</p>}
+				</div>
+
+				{/* Name (slug) */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1">
+						Name <span class="text-red-400">*</span>
+					</label>
+					<input
+						type="text"
+						value={form.name}
+						onChange={(e) =>
+							setForm((f) => ({
+								...f,
+								name: (e.target as HTMLInputElement).value,
+								nameTouched: true,
+							}))
+						}
+						class={cn(
+							'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+							'focus:outline-none focus:ring-1 focus:ring-blue-500',
+							errors.name ? 'border-red-500' : 'border-dark-700'
+						)}
+						placeholder="e.g., web-search"
+					/>
+					{errors.name && <p class="text-xs text-red-400 mt-1">{errors.name}</p>}
+					<p class="text-xs text-gray-500 mt-1">
+						Unique slug identifier (auto-derived from display name)
+					</p>
+				</div>
+
+				{/* Description */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1">Description</label>
+					<input
+						type="text"
+						value={form.description}
+						onChange={(e) =>
+							setForm((f) => ({
+								...f,
+								description: (e.target as HTMLInputElement).value,
+							}))
+						}
+						class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						placeholder="Optional description of what this skill does"
+					/>
+				</div>
+
+				{/* Source Type */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-2">
+						Source Type <span class="text-red-400">*</span>
+					</label>
+					<div class="flex gap-6">
+						{(['builtin', 'plugin', 'mcp_server'] as SkillSourceType[]).map((type) => (
+							<label key={type} class="flex items-center gap-2 cursor-pointer">
+								<input
+									type="radio"
+									name="sourceType"
+									value={type}
+									checked={form.sourceType === type}
+									onChange={() => setForm((f) => ({ ...f, sourceType: type }))}
+									class="accent-blue-500"
+								/>
+								<span class="text-sm text-gray-300">
+									{type === 'builtin' ? 'Built-in' : type === 'plugin' ? 'Plugin' : 'MCP Server'}
+								</span>
+							</label>
+						))}
+					</div>
+				</div>
+
+				{/* Conditional config fields */}
+				{form.sourceType === 'builtin' && (
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							Command Name <span class="text-red-400">*</span>
+						</label>
+						<input
+							type="text"
+							value={form.commandName}
+							onChange={(e) =>
+								setForm((f) => ({
+									...f,
+									commandName: (e.target as HTMLInputElement).value,
+								}))
+							}
+							class={cn(
+								'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+								'focus:outline-none focus:ring-1 focus:ring-blue-500',
+								errors.commandName ? 'border-red-500' : 'border-dark-700'
+							)}
+							placeholder="e.g., update-config"
+						/>
+						{errors.commandName && <p class="text-xs text-red-400 mt-1">{errors.commandName}</p>}
+						<p class="text-xs text-gray-500 mt-1">
+							The slash-command name in <code class="font-mono">.claude/commands/</code>
+						</p>
+					</div>
+				)}
+
+				{form.sourceType === 'plugin' && (
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							Plugin Directory Path <span class="text-red-400">*</span>
+						</label>
+						<input
+							type="text"
+							value={form.pluginPath}
+							onChange={(e) =>
+								setForm((f) => ({
+									...f,
+									pluginPath: (e.target as HTMLInputElement).value,
+								}))
+							}
+							class={cn(
+								'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+								'focus:outline-none focus:ring-1 focus:ring-blue-500',
+								errors.pluginPath ? 'border-red-500' : 'border-dark-700'
+							)}
+							placeholder="/path/to/plugin-directory"
+						/>
+						{errors.pluginPath && <p class="text-xs text-red-400 mt-1">{errors.pluginPath}</p>}
+						<p class="text-xs text-gray-500 mt-1">Absolute path to the plugin directory on disk</p>
+					</div>
+				)}
+
+				{form.sourceType === 'mcp_server' && (
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							MCP Server <span class="text-red-400">*</span>
+						</label>
+						{mcpServers.length === 0 ? (
+							<p class="text-xs text-gray-500 py-2">
+								No application MCP servers configured. Add one in the{' '}
+								<span class="text-gray-400">Application MCP Servers</span> settings panel first.
+							</p>
+						) : (
+							<select
+								value={form.appMcpServerId}
+								onChange={(e) =>
+									setForm((f) => ({
+										...f,
+										appMcpServerId: (e.target as HTMLSelectElement).value,
+									}))
+								}
+								class={cn(
+									'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200',
+									'focus:outline-none focus:ring-1 focus:ring-blue-500',
+									errors.appMcpServerId ? 'border-red-500' : 'border-dark-700'
+								)}
+							>
+								<option value="">Select an MCP server…</option>
+								{mcpServers.map((s) => (
+									<option key={s.id} value={s.id}>
+										{s.name}
+									</option>
+								))}
+							</select>
+						)}
+						{errors.appMcpServerId && (
+							<p class="text-xs text-red-400 mt-1">{errors.appMcpServerId}</p>
+						)}
+					</div>
+				)}
+
+				<div class="flex items-center justify-end gap-3 pt-2">
+					<Button type="button" variant="secondary" size="sm" onClick={handleClose}>
+						Cancel
+					</Button>
+					<Button type="submit" variant="primary" size="sm" loading={isSubmitting}>
+						Add Skill
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/settings/EditSkillDialog.tsx
+++ b/packages/web/src/components/settings/EditSkillDialog.tsx
@@ -1,0 +1,323 @@
+/**
+ * EditSkillDialog Component
+ *
+ * Modal dialog for editing an existing skill in the application-level registry.
+ * Pre-populates all fields from the existing skill and shows read-only ID / Created.
+ */
+
+import { useState, useEffect } from 'preact/hooks';
+import type { AppSkill, AppSkillConfig } from '@neokai/shared';
+import type { AppMcpServer } from '@neokai/shared';
+import { skillsStore } from '../../lib/skills-store';
+import { toast } from '../../lib/toast';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { cn } from '../../lib/utils';
+import { connectionManager } from '../../lib/connection-manager';
+
+interface FormState {
+	displayName: string;
+	description: string;
+	// builtin
+	commandName: string;
+	// plugin
+	pluginPath: string;
+	// mcp_server
+	appMcpServerId: string;
+}
+
+interface FormErrors {
+	displayName?: string;
+	commandName?: string;
+	pluginPath?: string;
+	appMcpServerId?: string;
+}
+
+function formFromSkill(skill: AppSkill): FormState {
+	const state: FormState = {
+		displayName: skill.displayName,
+		description: skill.description,
+		commandName: '',
+		pluginPath: '',
+		appMcpServerId: '',
+	};
+	switch (skill.config.type) {
+		case 'builtin':
+			state.commandName = skill.config.commandName;
+			break;
+		case 'plugin':
+			state.pluginPath = skill.config.pluginPath;
+			break;
+		case 'mcp_server':
+			state.appMcpServerId = skill.config.appMcpServerId;
+			break;
+	}
+	return state;
+}
+
+interface EditSkillDialogProps {
+	skill: AppSkill;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export function EditSkillDialog({ skill, isOpen, onClose }: EditSkillDialogProps) {
+	const [form, setForm] = useState<FormState>(() => formFromSkill(skill));
+	const [errors, setErrors] = useState<FormErrors>({});
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [mcpServers, setMcpServers] = useState<AppMcpServer[]>([]);
+
+	// Re-sync form when the skill prop changes (e.g., live update)
+	useEffect(() => {
+		setForm(formFromSkill(skill));
+		setErrors({});
+	}, [skill.id]);
+
+	// Fetch MCP servers when dialog is open and skill is mcp_server type
+	useEffect(() => {
+		if (!isOpen || skill.sourceType !== 'mcp_server') return;
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) return;
+		hub
+			.request<{ servers: AppMcpServer[] }>('mcp.registry.list', {})
+			.then((res) => setMcpServers(res.servers ?? []))
+			.catch(() => setMcpServers([]));
+	}, [isOpen, skill.sourceType]);
+
+	const validate = (): boolean => {
+		const errs: FormErrors = {};
+		if (!form.displayName.trim()) {
+			errs.displayName = 'Display Name is required';
+		}
+		if (skill.sourceType === 'builtin' && !form.commandName.trim()) {
+			errs.commandName = 'Command name is required for built-in skills';
+		}
+		if (skill.sourceType === 'plugin' && !form.pluginPath.trim()) {
+			errs.pluginPath = 'Plugin directory path is required';
+		}
+		if (skill.sourceType === 'mcp_server' && !form.appMcpServerId) {
+			errs.appMcpServerId = 'Please select an MCP server';
+		}
+		setErrors(errs);
+		return Object.keys(errs).length === 0;
+	};
+
+	const buildConfig = (): AppSkillConfig => {
+		switch (skill.sourceType) {
+			case 'builtin':
+				return { type: 'builtin', commandName: form.commandName.trim() };
+			case 'plugin':
+				return { type: 'plugin', pluginPath: form.pluginPath.trim() };
+			case 'mcp_server':
+				return { type: 'mcp_server', appMcpServerId: form.appMcpServerId };
+		}
+	};
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+		if (!validate()) return;
+		setIsSubmitting(true);
+		try {
+			await skillsStore.updateSkill(skill.id, {
+				displayName: form.displayName.trim(),
+				description: form.description.trim(),
+				config: buildConfig(),
+			});
+			toast.success(`Updated "${form.displayName.trim()}"`);
+			onClose();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to update skill');
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const createdDate = new Date(skill.createdAt).toLocaleString();
+
+	return (
+		<Modal isOpen={isOpen} onClose={onClose} title="Edit Skill" size="md">
+			<form onSubmit={handleSubmit} class="space-y-4">
+				{/* Read-only meta fields */}
+				<div class="grid grid-cols-2 gap-3">
+					<div>
+						<label class="block text-xs font-medium text-gray-500 mb-1">ID</label>
+						<div class="text-xs text-gray-400 font-mono bg-dark-900 border border-dark-700 rounded px-2 py-1.5 truncate">
+							{skill.id}
+						</div>
+					</div>
+					<div>
+						<label class="block text-xs font-medium text-gray-500 mb-1">Created</label>
+						<div class="text-xs text-gray-400 bg-dark-900 border border-dark-700 rounded px-2 py-1.5 truncate">
+							{createdDate}
+						</div>
+					</div>
+				</div>
+
+				{/* Display Name */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1">
+						Display Name <span class="text-red-400">*</span>
+					</label>
+					<input
+						type="text"
+						value={form.displayName}
+						onChange={(e) =>
+							setForm((f) => ({
+								...f,
+								displayName: (e.target as HTMLInputElement).value,
+							}))
+						}
+						class={cn(
+							'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200',
+							'focus:outline-none focus:ring-1 focus:ring-blue-500',
+							errors.displayName ? 'border-red-500' : 'border-dark-700'
+						)}
+						autoFocus
+					/>
+					{errors.displayName && <p class="text-xs text-red-400 mt-1">{errors.displayName}</p>}
+				</div>
+
+				{/* Name — read-only after creation */}
+				<div>
+					<label class="block text-sm font-medium text-gray-500 mb-1">Name</label>
+					<div class="text-sm text-gray-500 font-mono bg-dark-900 border border-dark-700 rounded-lg px-3 py-2">
+						{skill.name}
+					</div>
+					<p class="text-xs text-gray-600 mt-1">Name cannot be changed after creation</p>
+				</div>
+
+				{/* Description */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1">Description</label>
+					<input
+						type="text"
+						value={form.description}
+						onChange={(e) =>
+							setForm((f) => ({
+								...f,
+								description: (e.target as HTMLInputElement).value,
+							}))
+						}
+						class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						placeholder="Optional description"
+					/>
+				</div>
+
+				{/* Source Type — read-only */}
+				<div>
+					<label class="block text-sm font-medium text-gray-500 mb-1">Source Type</label>
+					<div class="text-sm text-gray-500 bg-dark-900 border border-dark-700 rounded-lg px-3 py-2 capitalize">
+						{skill.sourceType === 'mcp_server'
+							? 'MCP Server'
+							: skill.sourceType === 'builtin'
+								? 'Built-in'
+								: 'Plugin'}
+					</div>
+				</div>
+
+				{/* Conditional config fields */}
+				{skill.sourceType === 'builtin' && (
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							Command Name <span class="text-red-400">*</span>
+						</label>
+						<input
+							type="text"
+							value={form.commandName}
+							onChange={(e) =>
+								setForm((f) => ({
+									...f,
+									commandName: (e.target as HTMLInputElement).value,
+								}))
+							}
+							class={cn(
+								'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+								'focus:outline-none focus:ring-1 focus:ring-blue-500',
+								errors.commandName ? 'border-red-500' : 'border-dark-700'
+							)}
+							placeholder="e.g., update-config"
+						/>
+						{errors.commandName && <p class="text-xs text-red-400 mt-1">{errors.commandName}</p>}
+						<p class="text-xs text-gray-500 mt-1">
+							The slash-command name in <code class="font-mono">.claude/commands/</code>
+						</p>
+					</div>
+				)}
+
+				{skill.sourceType === 'plugin' && (
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							Plugin Directory Path <span class="text-red-400">*</span>
+						</label>
+						<input
+							type="text"
+							value={form.pluginPath}
+							onChange={(e) =>
+								setForm((f) => ({
+									...f,
+									pluginPath: (e.target as HTMLInputElement).value,
+								}))
+							}
+							class={cn(
+								'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200 font-mono',
+								'focus:outline-none focus:ring-1 focus:ring-blue-500',
+								errors.pluginPath ? 'border-red-500' : 'border-dark-700'
+							)}
+							placeholder="/path/to/plugin-directory"
+						/>
+						{errors.pluginPath && <p class="text-xs text-red-400 mt-1">{errors.pluginPath}</p>}
+						<p class="text-xs text-gray-500 mt-1">Absolute path to the plugin directory on disk</p>
+					</div>
+				)}
+
+				{skill.sourceType === 'mcp_server' && (
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1">
+							MCP Server <span class="text-red-400">*</span>
+						</label>
+						{mcpServers.length === 0 ? (
+							<p class="text-xs text-gray-500 py-2">
+								No application MCP servers configured. Add one in the{' '}
+								<span class="text-gray-400">Application MCP Servers</span> settings panel first.
+							</p>
+						) : (
+							<select
+								value={form.appMcpServerId}
+								onChange={(e) =>
+									setForm((f) => ({
+										...f,
+										appMcpServerId: (e.target as HTMLSelectElement).value,
+									}))
+								}
+								class={cn(
+									'w-full bg-dark-800 border rounded-lg px-3 py-2 text-sm text-gray-200',
+									'focus:outline-none focus:ring-1 focus:ring-blue-500',
+									errors.appMcpServerId ? 'border-red-500' : 'border-dark-700'
+								)}
+							>
+								<option value="">Select an MCP server…</option>
+								{mcpServers.map((s) => (
+									<option key={s.id} value={s.id}>
+										{s.name}
+									</option>
+								))}
+							</select>
+						)}
+						{errors.appMcpServerId && (
+							<p class="text-xs text-red-400 mt-1">{errors.appMcpServerId}</p>
+						)}
+					</div>
+				)}
+
+				<div class="flex items-center justify-end gap-3 pt-2">
+					<Button type="button" variant="secondary" size="sm" onClick={onClose}>
+						Cancel
+					</Button>
+					<Button type="submit" variant="primary" size="sm" loading={isSubmitting}>
+						Save Changes
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/settings/SkillsRegistry.tsx
+++ b/packages/web/src/components/settings/SkillsRegistry.tsx
@@ -1,0 +1,205 @@
+/**
+ * SkillsRegistry Component
+ *
+ * Settings panel for managing the application-level Skills registry.
+ * Allows users to view, add, edit, enable/disable, and remove skills.
+ */
+
+import { useState } from 'preact/hooks';
+import type { AppSkill } from '@neokai/shared';
+import { useSkills } from '../../hooks/useSkills';
+import { skillsStore } from '../../lib/skills-store';
+import { toast } from '../../lib/toast';
+import { SettingsSection, SettingsToggle } from './SettingsSection';
+import { ConfirmModal } from '../ui/ConfirmModal';
+import { Button } from '../ui/Button';
+import { cn } from '../../lib/utils';
+import { AddSkillDialog } from './AddSkillDialog';
+import { EditSkillDialog } from './EditSkillDialog';
+
+const SOURCE_TYPE_STYLES: Record<string, string> = {
+	builtin: 'bg-green-500/20 text-green-400',
+	plugin: 'bg-blue-500/20 text-blue-400',
+	mcp_server: 'bg-purple-500/20 text-purple-400',
+};
+
+const SOURCE_TYPE_LABELS: Record<string, string> = {
+	builtin: 'built-in',
+	plugin: 'plugin',
+	mcp_server: 'mcp',
+};
+
+export function SkillsRegistry() {
+	const { skills, isLoading, error } = useSkills();
+
+	const [showAddDialog, setShowAddDialog] = useState(false);
+	const [editingSkill, setEditingSkill] = useState<AppSkill | null>(null);
+	const [deletingSkill, setDeletingSkill] = useState<AppSkill | null>(null);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
+	const [togglingId, setTogglingId] = useState<string | null>(null);
+
+	const handleDelete = async () => {
+		if (!deletingSkill) return;
+		setIsDeleting(true);
+		try {
+			await skillsStore.removeSkill(deletingSkill.id);
+			toast.success(`Deleted "${deletingSkill.displayName}"`);
+			setShowDeleteConfirm(false);
+			setDeletingSkill(null);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to delete skill');
+		} finally {
+			setIsDeleting(false);
+		}
+	};
+
+	const handleToggle = async (skill: AppSkill, enabled: boolean) => {
+		setTogglingId(skill.id);
+		try {
+			await skillsStore.setEnabled(skill.id, enabled);
+			toast.success(`${enabled ? 'Enabled' : 'Disabled'} "${skill.displayName}"`);
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : `Failed to ${enabled ? 'enable' : 'disable'} skill`
+			);
+		} finally {
+			setTogglingId(null);
+		}
+	};
+
+	if (isLoading.value && skills.value.length === 0) {
+		return (
+			<SettingsSection title="Skills">
+				<div class="text-sm text-gray-500 py-2">Loading skills...</div>
+			</SettingsSection>
+		);
+	}
+
+	if (error.value) {
+		return (
+			<SettingsSection title="Skills">
+				<div class="text-sm text-red-400 py-2">Error: {error.value}</div>
+			</SettingsSection>
+		);
+	}
+
+	return (
+		<>
+			<SettingsSection title="Skills">
+				<div class="mb-4">
+					<p class="text-xs text-gray-500 mb-3">
+						Application-level skills are available to any room or session. Built-in skills ship with
+						NeoKai; plugin and MCP server skills can be added from external sources.
+					</p>
+					<Button variant="primary" size="sm" onClick={() => setShowAddDialog(true)}>
+						Add Skill
+					</Button>
+				</div>
+
+				{skills.value.length === 0 ? (
+					<div class="text-sm text-gray-500 py-4">No skills added yet. Add your first skill.</div>
+				) : (
+					<div class="space-y-2">
+						{skills.value.map((skill) => (
+							<div
+								key={skill.id}
+								class={cn(
+									'flex items-center justify-between gap-3 py-3 px-3',
+									'bg-dark-800/50 rounded-lg border border-dark-700'
+								)}
+							>
+								<div class="flex-1 min-w-0">
+									<div class="flex items-center gap-2 flex-wrap">
+										<div class="text-sm text-gray-200 font-medium truncate">
+											{skill.displayName}
+										</div>
+										<span
+											class={cn(
+												'px-1.5 py-0.5 rounded text-[10px] uppercase font-medium',
+												SOURCE_TYPE_STYLES[skill.sourceType] ?? 'bg-gray-500/20 text-gray-400'
+											)}
+										>
+											{SOURCE_TYPE_LABELS[skill.sourceType] ?? skill.sourceType}
+										</span>
+										{skill.builtIn && (
+											<span class="px-1.5 py-0.5 rounded text-[10px] bg-yellow-500/20 text-yellow-400 uppercase font-medium">
+												system
+											</span>
+										)}
+									</div>
+									{skill.description && (
+										<div class="text-xs text-gray-500 mt-1 truncate">{skill.description}</div>
+									)}
+								</div>
+
+								<div class="flex items-center gap-2 flex-shrink-0">
+									{!skill.builtIn && (
+										<button
+											onClick={() => setEditingSkill(skill)}
+											class="p-1.5 text-gray-400 hover:text-gray-200 hover:bg-dark-700 rounded transition-colors"
+											title="Edit"
+										>
+											<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													stroke-width={2}
+													d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+												/>
+											</svg>
+										</button>
+									)}
+									{!skill.builtIn && (
+										<button
+											onClick={() => {
+												setDeletingSkill(skill);
+												setShowDeleteConfirm(true);
+											}}
+											class="p-1.5 text-gray-400 hover:text-red-400 hover:bg-dark-700 rounded transition-colors"
+											title="Delete"
+										>
+											<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													stroke-width={2}
+													d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+												/>
+											</svg>
+										</button>
+									)}
+									<SettingsToggle
+										checked={skill.enabled}
+										onChange={(enabled) => handleToggle(skill, enabled)}
+										disabled={togglingId === skill.id}
+									/>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</SettingsSection>
+
+			<AddSkillDialog isOpen={showAddDialog} onClose={() => setShowAddDialog(false)} />
+
+			{editingSkill && (
+				<EditSkillDialog skill={editingSkill} isOpen onClose={() => setEditingSkill(null)} />
+			)}
+
+			<ConfirmModal
+				isOpen={showDeleteConfirm}
+				onClose={() => {
+					setShowDeleteConfirm(false);
+					setDeletingSkill(null);
+				}}
+				onConfirm={handleDelete}
+				title="Delete Skill"
+				message={`Are you sure you want to delete "${deletingSkill?.displayName}"? This action cannot be undone.`}
+				confirmText="Delete"
+				confirmButtonVariant="danger"
+				isLoading={isDeleting}
+			/>
+		</>
+	);
+}

--- a/packages/web/src/components/settings/__tests__/SkillsRegistry.test.tsx
+++ b/packages/web/src/components/settings/__tests__/SkillsRegistry.test.tsx
@@ -1,0 +1,844 @@
+/**
+ * Tests for SkillsRegistry, AddSkillDialog, and EditSkillDialog components.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/preact';
+import type { AppSkill } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mocks — must use vi.hoisted for proper hoisting
+// ---------------------------------------------------------------------------
+
+const {
+	mockAddSkill,
+	mockUpdateSkill,
+	mockRemoveSkill,
+	mockSetEnabled,
+	mockToastError,
+	mockToastSuccess,
+	mockSubscribe,
+	mockUnsubscribe,
+	mockSkillsSignal,
+	mockIsLoadingSignal,
+	mockErrorSignal,
+	mockGetHubIfConnected,
+} = vi.hoisted(() => {
+	const mockSkillsSignal = { value: [] as AppSkill[] };
+	const mockIsLoadingSignal = { value: false };
+	const mockErrorSignal = { value: null as string | null };
+	return {
+		mockAddSkill: vi.fn(),
+		mockUpdateSkill: vi.fn(),
+		mockRemoveSkill: vi.fn(),
+		mockSetEnabled: vi.fn(),
+		mockToastError: vi.fn(),
+		mockToastSuccess: vi.fn(),
+		mockSubscribe: vi.fn().mockResolvedValue(undefined),
+		mockUnsubscribe: vi.fn(),
+		mockSkillsSignal,
+		mockIsLoadingSignal,
+		mockErrorSignal,
+		mockGetHubIfConnected: vi.fn(),
+	};
+});
+
+// Mock skillsStore
+vi.mock('../../../lib/skills-store.ts', () => ({
+	skillsStore: {
+		addSkill: (...args: unknown[]) => mockAddSkill(...args),
+		updateSkill: (...args: unknown[]) => mockUpdateSkill(...args),
+		removeSkill: (...args: unknown[]) => mockRemoveSkill(...args),
+		setEnabled: (...args: unknown[]) => mockSetEnabled(...args),
+	},
+}));
+
+// Mock useSkills hook
+vi.mock('../../../hooks/useSkills.ts', () => ({
+	useSkills: () => ({
+		skills: mockSkillsSignal,
+		isLoading: mockIsLoadingSignal,
+		error: mockErrorSignal,
+	}),
+}));
+
+// Mock toast
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		error: (msg: string) => mockToastError(msg),
+		success: (msg: string) => mockToastSuccess(msg),
+		info: vi.fn(),
+		warning: vi.fn(),
+	},
+}));
+
+// Mock connectionManager
+vi.mock('../../../lib/connection-manager.ts', () => ({
+	connectionManager: {
+		getHubIfConnected: () => mockGetHubIfConnected(),
+	},
+}));
+
+// Mock Modal
+vi.mock('../../ui/Modal.tsx', () => ({
+	Modal: ({
+		isOpen,
+		onClose,
+		title,
+		children,
+	}: {
+		isOpen: boolean;
+		onClose: () => void;
+		title: string;
+		children: import('preact').ComponentChildren;
+	}) =>
+		isOpen ? (
+			<div data-testid="modal">
+				<h2 data-testid="modal-title">{title}</h2>
+				<div data-testid="modal-content">{children}</div>
+				<button data-testid="modal-close" onClick={onClose}>
+					Close
+				</button>
+			</div>
+		) : null,
+}));
+
+// Mock ConfirmModal
+vi.mock('../../ui/ConfirmModal.tsx', () => ({
+	ConfirmModal: ({
+		isOpen,
+		onClose,
+		onConfirm,
+		title,
+		message,
+		confirmText,
+		isLoading,
+	}: {
+		isOpen: boolean;
+		onClose: () => void;
+		onConfirm: () => void;
+		title: string;
+		message: string;
+		confirmText?: string;
+		isLoading?: boolean;
+	}) =>
+		isOpen ? (
+			<div data-testid="confirm-modal">
+				<span data-testid="confirm-title">{title}</span>
+				<span data-testid="confirm-message">{message}</span>
+				<button data-testid="confirm-cancel" onClick={onClose}>
+					Cancel
+				</button>
+				<button data-testid="confirm-ok" onClick={onConfirm} disabled={isLoading}>
+					{confirmText ?? 'Confirm'}
+				</button>
+			</div>
+		) : null,
+}));
+
+// Mock SettingsSection
+vi.mock('../SettingsSection.tsx', () => ({
+	SettingsSection: ({
+		title,
+		children,
+	}: {
+		title: string;
+		children: import('preact').ComponentChildren;
+	}) => (
+		<div data-testid="settings-section">
+			<h3>{title}</h3>
+			<div>{children}</div>
+		</div>
+	),
+	SettingsToggle: ({
+		checked,
+		onChange,
+		disabled,
+	}: {
+		checked: boolean;
+		onChange: (v: boolean) => void;
+		disabled?: boolean;
+	}) => (
+		<button
+			data-testid="settings-toggle"
+			data-checked={String(checked)}
+			disabled={disabled}
+			onClick={() => onChange(!checked)}
+		>
+			Toggle
+		</button>
+	),
+}));
+
+// Mock Button
+vi.mock('../../ui/Button.tsx', () => ({
+	Button: ({
+		children,
+		variant,
+		size,
+		type,
+		onClick,
+		disabled,
+		loading,
+	}: {
+		children: import('preact').ComponentChildren;
+		variant?: string;
+		size?: string;
+		type?: 'button' | 'submit';
+		onClick?: () => void;
+		disabled?: boolean;
+		loading?: boolean;
+	}) => (
+		<button
+			data-testid={`button-${variant ?? 'primary'}`}
+			data-size={size}
+			type={type ?? 'button'}
+			disabled={disabled ?? loading}
+			onClick={onClick}
+		>
+			{loading && <span data-testid="button-loading">Loading...</span>}
+			{children}
+		</button>
+	),
+}));
+
+// Import components after mocks
+import { SkillsRegistry } from '../SkillsRegistry.tsx';
+import { AddSkillDialog } from '../AddSkillDialog.tsx';
+import { EditSkillDialog } from '../EditSkillDialog.tsx';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSkill(id: string, overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id,
+		name: `skill-${id}`,
+		displayName: `Skill ${id}`,
+		description: `Description for skill ${id}`,
+		sourceType: 'builtin',
+		config: { type: 'builtin', commandName: `cmd-${id}` },
+		enabled: true,
+		builtIn: false,
+		validationStatus: 'valid',
+		createdAt: 1000000,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// SkillsRegistry tests
+// ---------------------------------------------------------------------------
+
+describe('SkillsRegistry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		cleanup();
+		mockSkillsSignal.value = [];
+		mockIsLoadingSignal.value = false;
+		mockErrorSignal.value = null;
+
+		mockAddSkill.mockResolvedValue(makeSkill('new'));
+		mockUpdateSkill.mockResolvedValue(makeSkill('1'));
+		mockRemoveSkill.mockResolvedValue(true);
+		mockSetEnabled.mockResolvedValue(makeSkill('1'));
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	describe('Skill List Display', () => {
+		it('should show empty state when no skills', () => {
+			render(<SkillsRegistry />);
+			expect(screen.getByText(/No skills added yet/)).toBeTruthy();
+		});
+
+		it('should show loading state', () => {
+			mockIsLoadingSignal.value = true;
+			mockSkillsSignal.value = [];
+			render(<SkillsRegistry />);
+			expect(screen.getByText('Loading skills...')).toBeTruthy();
+		});
+
+		it('should show error state', () => {
+			mockErrorSignal.value = 'Connection failed';
+			render(<SkillsRegistry />);
+			expect(screen.getByText(/Connection failed/)).toBeTruthy();
+		});
+
+		it('should display skill displayName and sourceType badge', () => {
+			mockSkillsSignal.value = [
+				makeSkill('1', { displayName: 'Web Search', sourceType: 'builtin' }),
+				makeSkill('2', { displayName: 'My Plugin', sourceType: 'plugin' }),
+			];
+			render(<SkillsRegistry />);
+			expect(screen.getByText('Web Search')).toBeTruthy();
+			expect(screen.getByText('My Plugin')).toBeTruthy();
+			expect(screen.getByText('built-in')).toBeTruthy();
+			expect(screen.getByText('plugin')).toBeTruthy();
+		});
+
+		it('should display description when present', () => {
+			mockSkillsSignal.value = [makeSkill('1', { description: 'A useful skill' })];
+			render(<SkillsRegistry />);
+			expect(screen.getByText('A useful skill')).toBeTruthy();
+		});
+
+		it('should show edit and delete buttons for non-built-in skills', () => {
+			mockSkillsSignal.value = [makeSkill('1', { builtIn: false })];
+			render(<SkillsRegistry />);
+			expect(screen.getByTitle('Edit')).toBeTruthy();
+			expect(screen.getByTitle('Delete')).toBeTruthy();
+		});
+
+		it('should not show edit/delete buttons for built-in skills', () => {
+			mockSkillsSignal.value = [makeSkill('1', { builtIn: true })];
+			render(<SkillsRegistry />);
+			expect(screen.queryByTitle('Edit')).toBeNull();
+			expect(screen.queryByTitle('Delete')).toBeNull();
+		});
+
+		it('should show toggle for each skill', () => {
+			mockSkillsSignal.value = [makeSkill('1')];
+			render(<SkillsRegistry />);
+			expect(screen.getByTestId('settings-toggle')).toBeTruthy();
+		});
+
+		it('should show Add Skill button', () => {
+			render(<SkillsRegistry />);
+			expect(screen.getByText('Add Skill')).toBeTruthy();
+		});
+	});
+
+	describe('Toggle', () => {
+		it('should call setEnabled when toggle is clicked', async () => {
+			mockSkillsSignal.value = [makeSkill('1', { enabled: true })];
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTestId('settings-toggle'));
+
+			await waitFor(() => {
+				expect(mockSetEnabled).toHaveBeenCalledWith('1', false);
+			});
+		});
+
+		it('should show success toast after toggling', async () => {
+			mockSkillsSignal.value = [makeSkill('1', { displayName: 'Web Search', enabled: true })];
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTestId('settings-toggle'));
+
+			await waitFor(() => {
+				expect(mockToastSuccess).toHaveBeenCalledWith('Disabled "Web Search"');
+			});
+		});
+
+		it('should show error toast when toggle fails', async () => {
+			mockSkillsSignal.value = [makeSkill('1', { enabled: true })];
+			mockSetEnabled.mockRejectedValueOnce(new Error('Toggle failed'));
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTestId('settings-toggle'));
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith('Toggle failed');
+			});
+		});
+	});
+
+	describe('Delete', () => {
+		it('should show delete confirmation when Delete button is clicked', () => {
+			mockSkillsSignal.value = [makeSkill('1', { displayName: 'My Skill', builtIn: false })];
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+
+			expect(screen.getByTestId('confirm-modal')).toBeTruthy();
+			expect(screen.getByTestId('confirm-title').textContent).toBe('Delete Skill');
+			expect(screen.getByTestId('confirm-message').textContent).toContain('My Skill');
+		});
+
+		it('should call removeSkill when confirmed', async () => {
+			mockSkillsSignal.value = [makeSkill('1', { builtIn: false })];
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			fireEvent.click(screen.getByTestId('confirm-ok'));
+
+			await waitFor(() => {
+				expect(mockRemoveSkill).toHaveBeenCalledWith('1');
+			});
+		});
+
+		it('should show success toast after delete', async () => {
+			mockSkillsSignal.value = [makeSkill('1', { displayName: 'My Skill', builtIn: false })];
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			fireEvent.click(screen.getByTestId('confirm-ok'));
+
+			await waitFor(() => {
+				expect(mockToastSuccess).toHaveBeenCalledWith('Deleted "My Skill"');
+			});
+		});
+
+		it('should close confirmation after successful delete', async () => {
+			mockSkillsSignal.value = [makeSkill('1', { builtIn: false })];
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			expect(screen.getByTestId('confirm-modal')).toBeTruthy();
+
+			fireEvent.click(screen.getByTestId('confirm-ok'));
+
+			await waitFor(() => {
+				expect(screen.queryByTestId('confirm-modal')).toBeNull();
+			});
+		});
+
+		it('should show error toast when delete fails', async () => {
+			mockSkillsSignal.value = [makeSkill('1', { builtIn: false })];
+			mockRemoveSkill.mockRejectedValueOnce(new Error('Delete failed'));
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			fireEvent.click(screen.getByTestId('confirm-ok'));
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith('Delete failed');
+			});
+		});
+
+		it('should close confirmation when Cancel is clicked', () => {
+			mockSkillsSignal.value = [makeSkill('1', { builtIn: false })];
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTitle('Delete'));
+			expect(screen.getByTestId('confirm-modal')).toBeTruthy();
+
+			fireEvent.click(screen.getByTestId('confirm-cancel'));
+			expect(screen.queryByTestId('confirm-modal')).toBeNull();
+		});
+	});
+
+	describe('Open Add Dialog', () => {
+		it('should open AddSkillDialog when Add Skill button is clicked', () => {
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByText('Add Skill'));
+
+			expect(screen.getByTestId('modal')).toBeTruthy();
+			expect(screen.getByTestId('modal-title').textContent).toBe('Add Skill');
+		});
+	});
+
+	describe('Open Edit Dialog', () => {
+		it('should open EditSkillDialog when Edit button is clicked', () => {
+			mockSkillsSignal.value = [makeSkill('1', { builtIn: false })];
+			render(<SkillsRegistry />);
+
+			fireEvent.click(screen.getByTitle('Edit'));
+
+			expect(screen.getByTestId('modal')).toBeTruthy();
+			expect(screen.getByTestId('modal-title').textContent).toBe('Edit Skill');
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AddSkillDialog tests
+// ---------------------------------------------------------------------------
+
+describe('AddSkillDialog', () => {
+	const onClose = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		cleanup();
+		mockAddSkill.mockResolvedValue(makeSkill('new'));
+		mockGetHubIfConnected.mockReturnValue(null);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('should render form when open', () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+		expect(screen.getByTestId('modal')).toBeTruthy();
+		expect(screen.getByTestId('modal-title').textContent).toBe('Add Skill');
+	});
+
+	it('should not render when closed', () => {
+		render(<AddSkillDialog isOpen={false} onClose={onClose} />);
+		expect(screen.queryByTestId('modal')).toBeNull();
+	});
+
+	it('should auto-derive slug from display name', () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const displayNameInput = screen.getByPlaceholderText('e.g., Web Search');
+		fireEvent.change(displayNameInput, { target: { value: 'My Cool Skill' } });
+
+		const nameInput = screen.getByPlaceholderText('e.g., web-search');
+		expect((nameInput as HTMLInputElement).value).toBe('my-cool-skill');
+	});
+
+	it('should not override slug when name was manually edited', () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const nameInput = screen.getByPlaceholderText('e.g., web-search');
+		fireEvent.change(nameInput, { target: { value: 'custom-slug' } });
+
+		const displayNameInput = screen.getByPlaceholderText('e.g., Web Search');
+		fireEvent.change(displayNameInput, { target: { value: 'Something Else' } });
+
+		expect((nameInput as HTMLInputElement).value).toBe('custom-slug');
+	});
+
+	it('should show validation error when display name is empty', async () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		// Click the primary submit button (not the modal title)
+		fireEvent.click(screen.getByTestId('button-primary'));
+
+		await waitFor(() => {
+			expect(screen.getByText('Display Name is required')).toBeTruthy();
+		});
+		expect(mockAddSkill).not.toHaveBeenCalled();
+	});
+
+	it('should show validation error when name has invalid chars', async () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const displayNameInput = screen.getByPlaceholderText('e.g., Web Search');
+		fireEvent.change(displayNameInput, { target: { value: 'Test' } });
+
+		const nameInput = screen.getByPlaceholderText('e.g., web-search');
+		fireEvent.change(nameInput, { target: { value: 'Invalid Name!' } });
+
+		fireEvent.click(screen.getByTestId('button-primary'));
+
+		await waitFor(() => {
+			expect(screen.getByText(/lowercase letters, numbers, and hyphens/)).toBeTruthy();
+		});
+	});
+
+	it('should show command name field for built-in source type', () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+		expect(screen.getByPlaceholderText('e.g., update-config')).toBeTruthy();
+	});
+
+	it('should show plugin path field when plugin source type is selected', () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const pluginRadio = screen.getByDisplayValue('plugin');
+		fireEvent.click(pluginRadio);
+
+		expect(screen.getByPlaceholderText('/path/to/plugin-directory')).toBeTruthy();
+	});
+
+	it('should require command name for built-in type', async () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const displayNameInput = screen.getByPlaceholderText('e.g., Web Search');
+		fireEvent.change(displayNameInput, { target: { value: 'My Skill' } });
+
+		fireEvent.click(screen.getByTestId('button-primary'));
+
+		await waitFor(() => {
+			expect(screen.getByText('Command name is required for built-in skills')).toBeTruthy();
+		});
+		expect(mockAddSkill).not.toHaveBeenCalled();
+	});
+
+	it('should require plugin path for plugin type', async () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const pluginRadio = screen.getByDisplayValue('plugin');
+		fireEvent.click(pluginRadio);
+
+		const displayNameInput = screen.getByPlaceholderText('e.g., Web Search');
+		fireEvent.change(displayNameInput, { target: { value: 'My Skill' } });
+
+		fireEvent.click(screen.getByTestId('button-primary'));
+
+		await waitFor(() => {
+			expect(screen.getByText('Plugin directory path is required')).toBeTruthy();
+		});
+		expect(mockAddSkill).not.toHaveBeenCalled();
+	});
+
+	it('should call addSkill with correct params on valid submit', async () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		fireEvent.change(screen.getByPlaceholderText('e.g., Web Search'), {
+			target: { value: 'Web Search' },
+		});
+		fireEvent.change(screen.getByPlaceholderText('e.g., update-config'), {
+			target: { value: 'web-search-cmd' },
+		});
+
+		fireEvent.click(screen.getByTestId('button-primary'));
+
+		await waitFor(() => {
+			expect(mockAddSkill).toHaveBeenCalledWith(
+				expect.objectContaining({
+					displayName: 'Web Search',
+					name: 'web-search',
+					sourceType: 'builtin',
+					config: { type: 'builtin', commandName: 'web-search-cmd' },
+					enabled: true,
+				})
+			);
+		});
+	});
+
+	it('should show success toast and close after successful add', async () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		fireEvent.change(screen.getByPlaceholderText('e.g., Web Search'), {
+			target: { value: 'My Skill' },
+		});
+		fireEvent.change(screen.getByPlaceholderText('e.g., update-config'), {
+			target: { value: 'my-cmd' },
+		});
+
+		fireEvent.click(screen.getByTestId('button-primary'));
+
+		await waitFor(() => {
+			expect(mockToastSuccess).toHaveBeenCalledWith('Added "My Skill"');
+		});
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('should show error toast when add fails', async () => {
+		mockAddSkill.mockRejectedValueOnce(new Error('Server error'));
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		fireEvent.change(screen.getByPlaceholderText('e.g., Web Search'), {
+			target: { value: 'My Skill' },
+		});
+		fireEvent.change(screen.getByPlaceholderText('e.g., update-config'), {
+			target: { value: 'my-cmd' },
+		});
+
+		fireEvent.click(screen.getByTestId('button-primary'));
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalledWith('Server error');
+		});
+	});
+
+	it('should close when Cancel is clicked', () => {
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+		fireEvent.click(screen.getByText('Cancel'));
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('should show "no MCP servers" message when mcp_server type selected and no hub', () => {
+		mockGetHubIfConnected.mockReturnValue(null);
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const mcpRadio = screen.getByDisplayValue('mcp_server');
+		fireEvent.click(mcpRadio);
+
+		expect(screen.getByText(/No application MCP servers configured/)).toBeTruthy();
+	});
+
+	it('should populate MCP server dropdown when hub returns servers', async () => {
+		const mockHub = {
+			request: vi.fn().mockResolvedValue({
+				servers: [{ id: 'srv-1', name: 'Brave Search', sourceType: 'stdio', enabled: true }],
+			}),
+		};
+		mockGetHubIfConnected.mockReturnValue(mockHub);
+
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const mcpRadio = screen.getByDisplayValue('mcp_server');
+		fireEvent.click(mcpRadio);
+
+		await waitFor(() => {
+			expect(screen.getByText('Brave Search')).toBeTruthy();
+		});
+	});
+
+	it('should require MCP server selection for mcp_server type', async () => {
+		const mockHub = {
+			request: vi.fn().mockResolvedValue({
+				servers: [{ id: 'srv-1', name: 'Brave Search', sourceType: 'stdio', enabled: true }],
+			}),
+		};
+		mockGetHubIfConnected.mockReturnValue(mockHub);
+
+		render(<AddSkillDialog isOpen onClose={onClose} />);
+
+		const mcpRadio = screen.getByDisplayValue('mcp_server');
+		fireEvent.click(mcpRadio);
+
+		await waitFor(() => {
+			expect(screen.getByText('Brave Search')).toBeTruthy();
+		});
+
+		fireEvent.change(screen.getByPlaceholderText('e.g., Web Search'), {
+			target: { value: 'My MCP Skill' },
+		});
+
+		fireEvent.click(screen.getByTestId('button-primary'));
+
+		await waitFor(() => {
+			expect(screen.getByText('Please select an MCP server')).toBeTruthy();
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// EditSkillDialog tests
+// ---------------------------------------------------------------------------
+
+describe('EditSkillDialog', () => {
+	const onClose = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		cleanup();
+		mockUpdateSkill.mockResolvedValue(makeSkill('1'));
+		mockGetHubIfConnected.mockReturnValue(null);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('should render form pre-populated with skill data', () => {
+		const skill = makeSkill('1', {
+			displayName: 'Test Skill',
+			description: 'A test description',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'test-cmd' },
+		});
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		expect(screen.getByTestId('modal-title').textContent).toBe('Edit Skill');
+		expect((screen.getByDisplayValue('Test Skill') as HTMLInputElement).value).toBe('Test Skill');
+		expect((screen.getByDisplayValue('test-cmd') as HTMLInputElement).value).toBe('test-cmd');
+	});
+
+	it('should show read-only ID and Created fields', () => {
+		const skill = makeSkill('1', {
+			id: 'test-uuid-123',
+			createdAt: new Date('2024-01-01').getTime(),
+		});
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		expect(screen.getByText('test-uuid-123')).toBeTruthy();
+	});
+
+	it('should show read-only name field', () => {
+		const skill = makeSkill('1', { name: 'my-skill' });
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		// Name should appear as static text
+		expect(screen.getByText('my-skill')).toBeTruthy();
+		// And the "Name cannot be changed" note
+		expect(screen.getByText('Name cannot be changed after creation')).toBeTruthy();
+	});
+
+	it('should require display name', async () => {
+		const skill = makeSkill('1', { displayName: 'Original' });
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		const displayNameInput = screen.getByDisplayValue('Original');
+		fireEvent.change(displayNameInput, { target: { value: '' } });
+
+		fireEvent.click(screen.getByText('Save Changes'));
+
+		await waitFor(() => {
+			expect(screen.getByText('Display Name is required')).toBeTruthy();
+		});
+		expect(mockUpdateSkill).not.toHaveBeenCalled();
+	});
+
+	it('should call updateSkill with correct params', async () => {
+		const skill = makeSkill('1', {
+			displayName: 'Old Name',
+			sourceType: 'builtin',
+			config: { type: 'builtin', commandName: 'old-cmd' },
+		});
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		const displayNameInput = screen.getByDisplayValue('Old Name');
+		fireEvent.change(displayNameInput, { target: { value: 'New Name' } });
+
+		const cmdInput = screen.getByDisplayValue('old-cmd');
+		fireEvent.change(cmdInput, { target: { value: 'new-cmd' } });
+
+		fireEvent.click(screen.getByText('Save Changes'));
+
+		await waitFor(() => {
+			expect(mockUpdateSkill).toHaveBeenCalledWith(
+				'1',
+				expect.objectContaining({
+					displayName: 'New Name',
+					config: { type: 'builtin', commandName: 'new-cmd' },
+				})
+			);
+		});
+	});
+
+	it('should show success toast and close after save', async () => {
+		const skill = makeSkill('1', { displayName: 'My Skill' });
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		fireEvent.click(screen.getByText('Save Changes'));
+
+		await waitFor(() => {
+			expect(mockToastSuccess).toHaveBeenCalledWith('Updated "My Skill"');
+		});
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('should show error toast when update fails', async () => {
+		mockUpdateSkill.mockRejectedValueOnce(new Error('Update failed'));
+		const skill = makeSkill('1', { displayName: 'My Skill' });
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		fireEvent.click(screen.getByText('Save Changes'));
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalledWith('Update failed');
+		});
+	});
+
+	it('should close when Cancel is clicked', () => {
+		const skill = makeSkill('1');
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		fireEvent.click(screen.getByText('Cancel'));
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('should pre-populate plugin path for plugin skills', () => {
+		const skill = makeSkill('1', {
+			sourceType: 'plugin',
+			config: { type: 'plugin', pluginPath: '/my/plugin/path' },
+		});
+		render(<EditSkillDialog skill={skill} isOpen onClose={onClose} />);
+
+		expect((screen.getByDisplayValue('/my/plugin/path') as HTMLInputElement).value).toBe(
+			'/my/plugin/path'
+		);
+	});
+
+	it('should not render when closed', () => {
+		const skill = makeSkill('1');
+		render(<EditSkillDialog skill={skill} isOpen={false} onClose={onClose} />);
+		expect(screen.queryByTestId('modal')).toBeNull();
+	});
+});

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -45,6 +45,7 @@ const SETTINGS_SECTIONS: Array<{
 	{ id: 'providers', label: 'Providers', icon: 'cloud' },
 	{ id: 'mcp-servers', label: 'MCP Servers', icon: 'server' },
 	{ id: 'app-mcp-servers', label: 'Application MCP Servers', icon: 'app-server' },
+	{ id: 'skills', label: 'Skills', icon: 'skills' },
 	{ id: 'fallback-models', label: 'Fallback Models', icon: 'swap' },
 	{ id: 'usage', label: 'Usage', icon: 'chart' },
 	{ id: 'about', label: 'About', icon: 'info' },
@@ -136,6 +137,17 @@ function SectionIcon({ type }: { type: string }) {
 					/>
 					<circle cx="8" cy="8" r="1" fill="currentColor" />
 					<circle cx="12" cy="8" r="1" fill="currentColor" />
+				</svg>
+			);
+		case 'skills':
+			return (
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width={2}
+						d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18"
+					/>
 				</svg>
 			);
 		default:

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -18,6 +18,7 @@ import { GeneralSettings } from '../components/settings/GeneralSettings.tsx';
 import { ProvidersSettings } from '../components/settings/ProvidersSettings.tsx';
 import { McpServersSettings } from '../components/settings/McpServersSettings.tsx';
 import { AppMcpServersSettings } from '../components/settings/AppMcpServersSettings.tsx';
+import { SkillsRegistry } from '../components/settings/SkillsRegistry.tsx';
 import { FallbackModelsSettings } from '../components/settings/FallbackModelsSettings.tsx';
 import { UsageAnalytics } from '../components/settings/UsageAnalytics.tsx';
 import { AboutSection } from '../components/settings/AboutSection.tsx';
@@ -108,6 +109,7 @@ export default function MainContent() {
 						{settingsSection === 'providers' && <ProvidersSettings />}
 						{settingsSection === 'mcp-servers' && <McpServersSettings />}
 						{settingsSection === 'app-mcp-servers' && <AppMcpServersSettings />}
+						{settingsSection === 'skills' && <SkillsRegistry />}
 						{settingsSection === 'fallback-models' && <FallbackModelsSettings />}
 						{settingsSection === 'usage' && <UsageAnalytics />}
 						{settingsSection === 'about' && <AboutSection />}

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -60,6 +60,7 @@ export type SettingsSection =
 	| 'providers'
 	| 'mcp-servers'
 	| 'app-mcp-servers'
+	| 'skills'
 	| 'fallback-models'
 	| 'usage'
 	| 'about';


### PR DESCRIPTION
Add UI for managing the application-level Skills registry in global settings.

## Changes

- **SkillsRegistry**: list skills with displayName, sourceType badge, enabled toggle, edit/delete buttons; built-in skills are read-only; loading/error states
- **AddSkillDialog**: modal with Display Name, auto-derived slug Name, Description, Source Type radio (Built-in / Plugin / MCP Server), conditional config fields, and MCP Server dropdown populated from `mcp.registry.list` RPC
- **EditSkillDialog**: pre-populated edit form with read-only ID, Created, and Name fields
- Wired into global settings: `'skills'` added to `SettingsSection` union, nav item in `ContextPanel`, render in `MainContent`
- 47 Vitest tests covering all components