### PR TITLE
test(daemon): Task 2.2 — regression guards for auto-recovery removal from AgentSession

### DIFF
--- a/packages/daemon/tests/unit/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/agent/agent-session.test.ts
@@ -351,6 +351,20 @@ describe('AgentSession', () => {
 		it('should initialize with false cleaningUp state', () => {
 			expect(agentSession.isCleaningUp()).toBe(false);
 		});
+
+		it('should NOT have startupTimeoutAutoRecoverAttempts field (Task 2.2)', () => {
+			// Regression guard: auto-recovery wiring removed in Task 2.1/2.2
+			expect(
+				'startupTimeoutAutoRecoverAttempts' in (agentSession as unknown as Record<string, unknown>)
+			).toBe(false);
+		});
+
+		it('should NOT have onStartupTimeoutAutoRecover method (Task 2.2)', () => {
+			// Regression guard: auto-recovery wiring removed in Task 2.1/2.2
+			expect(
+				typeof (agentSession as unknown as Record<string, unknown>).onStartupTimeoutAutoRecover
+			).toBe('undefined');
+		});
 	});
 
 	describe('getter methods', () => {


### PR DESCRIPTION
Task 2.2 verified: `onStartupTimeoutAutoRecover()` and `startupTimeoutAutoRecoverAttempts` were already removed from `agent-session.ts` as part of Task 2.1 (PR #936).

This PR adds regression test guards to `agent-session.test.ts` asserting both symbols are absent from `AgentSession`, preventing accidental re-introduction.