### PR TITLE
test(daemon): regression guards for Task 2.3 auto-recovery test cleanup

### DIFF
--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -832,6 +832,24 @@ describe('QueryRunner', () => {
 			expect(metadata.startupMaxRetries).toBeUndefined();
 		});
 	});
+
+	describe('auto-recovery removal regression guards (Task 2.3)', () => {
+		// Regression guards: verify that auto-recovery fields removed in Task 2.1 are absent
+		// from QueryRunnerContext.  If any are reintroduced, TypeScript will catch callers
+		// that omit the field; these runtime checks provide belt-and-suspenders coverage.
+
+		it('should not have onStartupTimeoutAutoRecover in QueryRunnerContext', () => {
+			// createContext() returns a full QueryRunnerContext built from all known fields.
+			// A reintroduced onStartupTimeoutAutoRecover would appear as a defined property.
+			const ctx = createContext();
+			expect((ctx as Record<string, unknown>).onStartupTimeoutAutoRecover).toBeUndefined();
+		});
+
+		it('should not have startupTimeoutAutoRecoverAttempts in QueryRunnerContext', () => {
+			const ctx = createContext();
+			expect((ctx as Record<string, unknown>).startupTimeoutAutoRecoverAttempts).toBeUndefined();
+		});
+	});
 });
 
 describe('QueryRunner error categorization', () => {


### PR DESCRIPTION
Task 2.1 (PR #936) already removed all auto-recovery logic and tests from `query-runner.ts`. This PR adds explicit regression guard tests documenting the removal, following the Task 2.2 pattern from PR #954.

## Changes

- Added `describe('auto-recovery removal regression guards (Task 2.3)')` inside the `QueryRunner` test suite
- Two tests assert that `onStartupTimeoutAutoRecover` and `startupTimeoutAutoRecoverAttempts` are absent from `QueryRunnerContext` — if either is reintroduced, the test fails
- All 76 query-runner unit tests pass