### PR TITLE
feat(space): add report_workflow_done tool to Task Agent

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -218,6 +218,12 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`Call this when the workflow reaches a terminal step or an unrecoverable error occurs.`
 	);
 	sections.push(
+		`- **report_workflow_done** — Explicitly mark the entire workflow run as completed and close the main task. ` +
+			`Pass an optional \`summary\` string describing what the workflow accomplished. ` +
+			`Call this when all node agents have finished and you are certain the workflow is done. ` +
+			`This immediately marks the run completed without waiting for the automatic detector.`
+	);
+	sections.push(
 		`- **request_human_input** — Surface a human gate and block until the human responds. ` +
 			`Pass a \`question\` describing what decision or approval is needed. ` +
 			`Returns the human's response. ` +
@@ -269,7 +275,8 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`\`condition\` and \`task_result\` gates are evaluated automatically by the system. ` +
 			`If a node agent reports that a message was blocked by a gate, surface the gate to the user.\n` +
 			`5. **Detect completion** — When \`list_group_members\` shows all members have completed, ` +
-			`call \`report_result\` to close the task.\n` +
+			`call \`report_workflow_done\` to mark the workflow run and task as completed. ` +
+			`You may also use \`report_result\` directly for finer-grained status control.\n` +
 			`6. **Handle errors** — If a node agent errors, call \`report_result\` with ` +
 			`\`status: "cancelled"\` and the error details.`
 	);

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -124,6 +124,26 @@ export const ListGroupMembersSchema = z.object({});
 export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
 
 // ---------------------------------------------------------------------------
+// report_workflow_done
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `report_workflow_done` input.
+ * Explicitly marks the entire workflow run as completed, bypassing the
+ * automatic all-agents-done detector. Use this when all node agents have
+ * finished and you are certain the run is complete.
+ */
+export const ReportWorkflowDoneSchema = z.object({
+	/** Optional summary of what the workflow accomplished overall. */
+	summary: z
+		.string()
+		.describe('Optional human-readable summary of what the workflow accomplished')
+		.optional(),
+});
+
+export type ReportWorkflowDoneInput = z.infer<typeof ReportWorkflowDoneSchema>;
+
+// ---------------------------------------------------------------------------
 // Aggregate export for MCP server factory (Milestone 3)
 // ---------------------------------------------------------------------------
 
@@ -135,6 +155,7 @@ export const TASK_AGENT_TOOL_SCHEMAS = {
 	spawn_node_agent: SpawnNodeAgentSchema,
 	check_node_status: CheckNodeStatusSchema,
 	report_result: ReportResultSchema,
+	report_workflow_done: ReportWorkflowDoneSchema,
 	request_human_input: RequestHumanInputSchema,
 	list_group_members: ListGroupMembersSchema,
 } as const;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -1,10 +1,11 @@
 /**
  * Task Agent Tools — MCP tool handlers for the Task Agent session.
  *
- * These handlers implement the business logic for the 6 Task Agent tools:
+ * These handlers implement the business logic for the 7 Task Agent tools:
  *   spawn_node_agent      — Spawn a sub-session for a workflow node's assigned agent
  *   check_node_status     — Poll the status of a running node agent sub-session
  *   report_result         — Mark the task as completed/failed and record the result
+ *   report_workflow_done  — Explicitly mark the workflow run as completed
  *   request_human_input   — Pause execution and surface a question to the human user
  *   list_group_members    — List all members of the current task's session group
  *   send_message          — Send a message to peer node agents via channel topology
@@ -40,6 +41,7 @@ import {
 	SpawnNodeAgentSchema,
 	CheckNodeStatusSchema,
 	ReportResultSchema,
+	ReportWorkflowDoneSchema,
 	RequestHumanInputSchema,
 	ListGroupMembersSchema,
 } from './task-agent-tool-schemas';
@@ -49,6 +51,7 @@ import type {
 	SpawnNodeAgentInput,
 	CheckNodeStatusInput,
 	ReportResultInput,
+	ReportWorkflowDoneInput,
 	RequestHumanInputInput,
 	ListGroupMembersInput,
 } from './task-agent-tool-schemas';
@@ -638,6 +641,89 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		},
 
 		/**
+		 * Explicitly mark the workflow run as completed.
+		 *
+		 * Use this tool when all node agents have finished and you are certain the
+		 * overall workflow is done. It:
+		 *   1. Validates the workflow run exists and is still in_progress
+		 *   2. Marks the workflow run as completed (sets completedAt)
+		 *   3. Marks the main task as completed via report_result logic
+		 *   4. Emits a space.task.completed event so listeners are notified
+		 *
+		 * The SpaceRuntime tick loop will detect the completed run status on the next
+		 * tick and emit a workflow_run_completed notification to the Space Agent.
+		 */
+		async report_workflow_done(args: ReportWorkflowDoneInput): Promise<ToolResult> {
+			const { summary } = args;
+
+			const run = workflowRunRepo.getRun(workflowRunId);
+			if (!run) {
+				return jsonResult({
+					success: false,
+					error: `Workflow run not found: ${workflowRunId}`,
+				});
+			}
+
+			if (run.status !== 'in_progress') {
+				return jsonResult({
+					success: false,
+					error:
+						`Cannot mark workflow run as completed when status is "${run.status}". ` +
+						`Workflow run must be in_progress.`,
+					currentStatus: run.status,
+				});
+			}
+
+			const mainTask = taskRepo.getTask(taskId);
+			if (!mainTask) {
+				return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+			}
+
+			try {
+				// Mark the workflow run as completed — SpaceRuntime tick will detect this
+				// and emit workflow_run_completed via the notification sink.
+				workflowRunRepo.updateStatus(workflowRunId, 'completed');
+
+				// Mark the main task as completed (mirrors report_result logic).
+				await taskManager.setTaskStatus(taskId, 'completed', {
+					result: summary,
+				});
+
+				// Emit DaemonHub event so the Space Agent is notified.
+				if (daemonHub) {
+					void daemonHub
+						.emit('space.task.completed', {
+							sessionId: 'global',
+							taskId,
+							spaceId: space.id,
+							status: 'completed',
+							summary: summary ?? '',
+							workflowRunId,
+							taskTitle: mainTask.title,
+						})
+						.catch((err) => {
+							log.warn(
+								`Failed to emit space.task.completed for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+							);
+						});
+				}
+
+				return jsonResult({
+					success: true,
+					workflowRunId,
+					taskId,
+					summary,
+					message:
+						'Workflow run has been marked as completed. ' +
+						'The main task has also been closed. Stop here — do not call any further tools.',
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
 		 * List all members of the current task's session group.
 		 *
 		 * Returns every member (including the Task Agent itself) with:
@@ -984,6 +1070,14 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 				'Call this when the workflow reaches a terminal step or an unrecoverable error occurs.',
 			ReportResultSchema.shape,
 			(args) => handlers.report_result(args)
+		),
+		tool(
+			'report_workflow_done',
+			'Explicitly mark the entire workflow run as completed and close the main task. ' +
+				'Call this when all node agents have finished and the workflow is fully done. ' +
+				'This bypasses the automatic all-agents-done detector and immediately marks the run completed.',
+			ReportWorkflowDoneSchema.shape,
+			(args) => handlers.report_workflow_done(args)
 		),
 		tool(
 			'request_human_input',

--- a/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
@@ -247,14 +247,15 @@ describe('RequestHumanInputSchema', () => {
 // ---------------------------------------------------------------------------
 
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
-	test('contains all 5 tool schemas', () => {
+	test('contains all 6 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
 		expect(keys).toContain('spawn_node_agent');
 		expect(keys).toContain('check_node_status');
 		expect(keys).toContain('report_result');
+		expect(keys).toContain('report_workflow_done');
 		expect(keys).toContain('request_human_input');
 		expect(keys).toContain('list_group_members');
-		expect(keys).toHaveLength(5);
+		expect(keys).toHaveLength(6);
 	});
 
 	test('each schema value is a valid Zod schema with safeParse', () => {

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -1344,13 +1344,14 @@ describe('createTaskAgentMcpServer', () => {
 		expect(server.name).toBe('task-agent');
 	});
 
-	test('registers all 6 expected tools', async () => {
+	test('registers all 7 expected tools', async () => {
 		const { server } = await makeServerCtx();
 		const registered = Object.keys(server.instance._registeredTools).sort();
 		expect(registered).toEqual([
 			'check_node_status',
 			'list_group_members',
 			'report_result',
+			'report_workflow_done',
 			'request_human_input',
 			'send_message',
 			'spawn_node_agent',
@@ -1455,9 +1456,9 @@ describe('createTaskAgentMcpServer', () => {
 
 		// Each call returns a distinct server instance
 		expect(server1.instance).not.toBe(server2.instance);
-		// Both register all 6 tools
-		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(6);
-		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(6);
+		// Both register all 7 tools
+		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(7);
+		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(7);
 	});
 });
 
@@ -1911,5 +1912,154 @@ describe('createTaskAgentToolHandlers — spawn_node_agent slot role and overrid
 		// The slot model override ('claude-opus-4-6') must NOT be applied because the slot
 		// was not found; base agent config is used instead (no model set → DEFAULT_CUSTOM_AGENT_MODEL)
 		expect(capturedInit?.model).not.toBe('claude-opus-4-6');
+	});
+});
+
+// ===========================================================================
+// report_workflow_done tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — report_workflow_done', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('marks workflow run as completed when run is in_progress', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		// Task agent would have called spawn_node_agent before report_workflow_done,
+		// which transitions the main task to in_progress.
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.report_workflow_done({ summary: 'All done' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.workflowRunId).toBe(run.id);
+
+		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
+		expect(updatedRun?.status).toBe('completed');
+		expect(updatedRun?.completedAt).toBeDefined();
+	});
+
+	test('marks main task as completed', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Transition main task to in_progress so report_workflow_done can close it
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		await handlers.report_workflow_done({ summary: 'Workflow complete' });
+
+		const updatedTask = ctx.taskRepo.getTask(mainTask.id);
+		expect(updatedTask?.status).toBe('completed');
+	});
+
+	test('stores summary on the main task result', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		await handlers.report_workflow_done({ summary: 'The PR was merged successfully.' });
+
+		const updatedTask = ctx.taskRepo.getTask(mainTask.id);
+		expect(updatedTask?.result).toBe('The PR was merged successfully.');
+	});
+
+	test('succeeds without a summary (summary is optional)', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.report_workflow_done({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
+		expect(updatedRun?.status).toBe('completed');
+	});
+
+	test('rejects when workflow run is not in_progress', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Manually mark the run as already completed
+		ctx.workflowRunRepo.updateStatus(run.id, 'completed');
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.report_workflow_done({ summary: 'Duplicate' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.currentStatus).toBe('completed');
+	});
+
+	test('rejects when workflow run does not exist', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, 'nonexistent-run-id', factory)
+		);
+
+		const result = await handlers.report_workflow_done({ summary: 'Should fail' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('nonexistent-run-id');
+	});
+
+	test('emits space.task.completed event via daemonHub', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		const { hub, emittedEvents } = makeMockDaemonHub();
+		const factory = makeMockSessionFactory();
+		const config = makeConfig(ctx, mainTask.id, run.id, factory);
+		const handlers = createTaskAgentToolHandlers({ ...config, daemonHub: hub });
+
+		await handlers.report_workflow_done({ summary: 'Done!' });
+
+		const completedEvent = emittedEvents.find((e) => e.name === 'space.task.completed');
+		expect(completedEvent).toBeDefined();
+		expect(completedEvent?.payload.taskId).toBe(mainTask.id);
+		expect(completedEvent?.payload.workflowRunId).toBe(run.id);
+		expect(completedEvent?.payload.status).toBe('completed');
+	});
+
+	test('does not emit event when daemonHub is not provided', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		const factory = makeMockSessionFactory();
+		// No daemonHub in config
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Should succeed without throwing
+		const result = await handlers.report_workflow_done({ summary: 'No hub' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

- Adds `report_workflow_done` MCP tool to the Task Agent with schema `{ summary?: string }`
- Handler validates the workflow run exists and is `in_progress`, marks it completed, closes the main task via `report_result` logic, and emits `space.task.completed` via DaemonHub
- The SpaceRuntime tick loop detects the completed run status and emits `workflow_run_completed` to the Space Agent on the next cycle
- Tool registered in `createTaskAgentMcpServer()` (7 tools total)
- System prompt updated to list the new tool and reference it in step 4 of the execution loop
- 7 new unit tests; existing tool-count assertions updated