### PR TITLE
fix(room): replace messageHub RPC with sessionFactory.getCurrentModel in trySwitchToFallbackModel

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -106,12 +106,6 @@ export interface WorkerMessage {
 	toolCallNames: string[];
 }
 
-/** Response from session.model.get RPC */
-interface SessionModelGetResult {
-	currentModel: string;
-	modelInfo?: { provider?: string };
-}
-
 export interface RoomRuntimeConfig {
 	room: Room;
 	groupRepo: SessionGroupRepository;
@@ -353,19 +347,17 @@ export class RoomRuntime {
 	): Promise<boolean> {
 		const settings = this.getGlobalSettings();
 
-		// Get current model info from the session
+		// Get current model info from the session (DB-first, no RPC over WebSocket)
 		let currentModel: string;
 		let currentProvider: string;
 		try {
-			const modelInfo = (await this.messageHub?.request('session.model.get', { sessionId })) as
-				| SessionModelGetResult
-				| undefined;
+			const modelInfo = await this.sessionFactory.getCurrentModel(sessionId);
 			if (!modelInfo || !modelInfo.currentModel) {
 				log.warn(`Could not get current model for session ${sessionId}`);
 				return false;
 			}
 			currentModel = modelInfo.currentModel;
-			currentProvider = modelInfo.modelInfo?.provider ?? 'anthropic';
+			currentProvider = modelInfo.provider ?? 'anthropic';
 		} catch (err) {
 			log.warn(`Error getting current model for session ${sessionId}:`, err);
 			return false;

--- a/packages/daemon/tests/unit/room/room-runtime-leader-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-terminal-errors.test.ts
@@ -26,16 +26,12 @@ describe('RoomRuntime - leader terminal error detection', () => {
 		return { id: 'msg-1', text, toolCallNames: [] };
 	}
 
-	/** Shared mock messageHub that returns current model info for session.model.get requests. */
-	function createMockMessageHub() {
-		return {
-			request: async (method: string) => {
-				if (method === 'session.model.get') {
-					return { currentModel: 'claude-opus-4-5', modelInfo: { provider: 'anthropic' } };
-				}
-				return undefined;
-			},
-		};
+	/** Shared getCurrentModel impl that returns current model info for trySwitchToFallbackModel. */
+	function makeGetCurrentModel() {
+		return async (_sessionId: string) => ({
+			currentModel: 'claude-opus-4-5',
+			provider: 'anthropic',
+		});
 	}
 
 	/**
@@ -268,7 +264,7 @@ describe('RoomRuntime - leader terminal error detection', () => {
 					({
 						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
 					}) as never,
-				messageHub: createMockMessageHub(),
+				getCurrentModelImpl: makeGetCurrentModel(),
 			});
 
 			const { task } = await createGoalAndTask(ctx);
@@ -339,7 +335,7 @@ describe('RoomRuntime - leader terminal error detection', () => {
 					({
 						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
 					}) as never,
-				messageHub: createMockMessageHub(),
+				getCurrentModelImpl: makeGetCurrentModel(),
 			});
 
 			const { task } = await createGoalAndTask(ctx);
@@ -407,7 +403,7 @@ describe('RoomRuntime - leader terminal error detection', () => {
 					({
 						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
 					}) as never,
-				messageHub: createMockMessageHub(),
+				getCurrentModelImpl: makeGetCurrentModel(),
 			});
 
 			const { task } = await createGoalAndTask(ctx);

--- a/packages/daemon/tests/unit/room/room-runtime-mirroring-usage-limit.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-mirroring-usage-limit.test.ts
@@ -15,29 +15,16 @@ import {
 	createGoalAndTask,
 	type RuntimeTestContext,
 } from './room-runtime-test-helpers';
-import type { MessageHub } from '@neokai/shared';
 import type { GlobalSettings } from '@neokai/shared';
 
 const USAGE_LIMIT_MSG = "You've hit your limit · resets 11pm (America/New_York)";
 
-/** Build a minimal MessageHub mock that responds to session.model.get */
-function makeMessageHubMock(opts: {
-	model?: string;
-	provider?: string;
-	failModelGet?: boolean;
-}): MessageHub {
-	return {
-		request: async (method: string, _params: unknown) => {
-			if (method === 'session.model.get') {
-				if (opts.failModelGet) throw new Error('model get failed');
-				return {
-					currentModel: opts.model ?? 'claude-3-5-sonnet-20241022',
-					modelInfo: { provider: opts.provider ?? 'anthropic' },
-				};
-			}
-			return undefined;
-		},
-	} as unknown as MessageHub;
+/** Default getCurrentModel impl: returns sonnet/anthropic for any session */
+function defaultGetCurrentModel() {
+	return async (_sessionId: string) => ({
+		currentModel: 'claude-3-5-sonnet-20241022',
+		provider: 'anthropic',
+	});
 }
 
 /** Global settings with one fallback model configured */
@@ -136,7 +123,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		it('calls trySwitchToFallbackModel when usage_limit detected', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
-				messageHub: makeMessageHubMock({}),
+				getCurrentModelImpl: defaultGetCurrentModel(),
 			});
 
 			const { group } = await spawnGroup();
@@ -155,7 +142,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		it('appends model_fallback event on successful switch', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
-				messageHub: makeMessageHubMock({}),
+				getCurrentModelImpl: defaultGetCurrentModel(),
 			});
 
 			const { group } = await spawnGroup();
@@ -179,7 +166,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		it('does NOT set group.rateLimit on successful switch', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
-				messageHub: makeMessageHubMock({}),
+				getCurrentModelImpl: defaultGetCurrentModel(),
 			});
 
 			const { group } = await spawnGroup();
@@ -197,7 +184,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		it('clears task restriction when task was usage_limited before successful switch', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
-				messageHub: makeMessageHubMock({}),
+				getCurrentModelImpl: defaultGetCurrentModel(),
 			});
 
 			const { group, task } = await spawnGroup();
@@ -228,7 +215,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		it('does not attempt fallback twice for the same session+message', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
-				messageHub: makeMessageHubMock({}),
+				getCurrentModelImpl: defaultGetCurrentModel(),
 			});
 
 			const { group } = await spawnGroup();
@@ -253,7 +240,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		it('does not attempt fallback twice for different UUIDs (race condition: both fired before .then() resolves)', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
-				messageHub: makeMessageHubMock({}),
+				getCurrentModelImpl: defaultGetCurrentModel(),
 			});
 
 			const { group } = await spawnGroup();
@@ -418,7 +405,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		it('does not trigger fallback switch for user message with usage_limit text', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
-				messageHub: makeMessageHubMock({}),
+				getCurrentModelImpl: defaultGetCurrentModel(),
 			});
 
 			const { group } = await spawnGroup();
@@ -577,7 +564,7 @@ describe('setupMirroring - usage_limit real-time detection', () => {
 		it('resetting mirroring clears fallbackAttempted so a new setup can attempt fallback again', async () => {
 			ctx = createRuntimeTestContext({
 				getGlobalSettings: withFallbackModel(),
-				messageHub: makeMessageHubMock({}),
+				getCurrentModelImpl: defaultGetCurrentModel(),
 			});
 
 			const { group } = await spawnGroup();

--- a/packages/daemon/tests/unit/room/room-runtime-model-fallback-map.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-model-fallback-map.test.ts
@@ -34,18 +34,8 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 		return [{ id: 'msg-1', text, toolCallNames: [] }];
 	}
 
-	function makeMessageHub(currentModel: string, provider: string = 'anthropic') {
-		return {
-			async request(method: string, _args: unknown): Promise<unknown> {
-				if (method === 'session.model.get') {
-					return {
-						currentModel,
-						modelInfo: { provider },
-					};
-				}
-				return undefined;
-			},
-		};
+	function makeGetCurrentModel(currentModel: string, provider: string = 'anthropic') {
+		return async (_sessionId: string) => ({ currentModel, provider });
 	}
 
 	function makeGlobalSettings(overrides: Partial<GlobalSettings>): () => GlobalSettings {
@@ -81,7 +71,7 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 						],
 					},
 				}),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 			});
 
 			const { group } = await spawnGroup();
@@ -110,7 +100,7 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 						'anthropic/opus': [{ model: 'glm-4', provider: 'glm' }],
 					},
 				}),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 			});
 
 			const { group } = await spawnGroup();
@@ -141,7 +131,7 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 						],
 					},
 				}),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 			});
 
 			const { group } = await spawnGroup();
@@ -170,7 +160,7 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 						],
 					},
 				}),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 			});
 
 			const { group } = await spawnGroup();
@@ -198,7 +188,7 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 						],
 					},
 				}),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 				isProviderAvailable: async (provider, model) => {
 					if (provider === 'minimax' && model === 'minimax-turbo') return false;
 					return true;
@@ -231,7 +221,7 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 						],
 					},
 				}),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 				isProviderAvailable: async () => false,
 			});
 
@@ -258,7 +248,7 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 					fallbackModels: [{ model: 'haiku', provider: 'anthropic' }],
 					modelFallbackMap: {}, // empty map, no matching key
 				}),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 			});
 
 			const { group } = await spawnGroup();
@@ -279,7 +269,7 @@ describe('RoomRuntime - modelFallbackMap in trySwitchToFallbackModel', () => {
 			ctx = createRuntimeTestContext({
 				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
 				getGlobalSettings: makeGlobalSettings({}),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 			});
 
 			const { group, task } = await spawnGroup();

--- a/packages/daemon/tests/unit/room/room-runtime-provider-availability.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-provider-availability.test.ts
@@ -32,22 +32,9 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 		return [{ id: 'msg-1', text, toolCallNames: [] }];
 	}
 
-	/**
-	 * Create a messageHub mock that responds to 'session.model.get' with the
-	 * given current model / provider.
-	 */
-	function makeMessageHub(currentModel: string, provider: string = 'anthropic') {
-		return {
-			async request(method: string, _args: unknown): Promise<unknown> {
-				if (method === 'session.model.get') {
-					return {
-						currentModel,
-						modelInfo: { provider },
-					};
-				}
-				return undefined;
-			},
-		};
+	/** Create a getCurrentModel impl that returns the given current model / provider. */
+	function makeGetCurrentModel(currentModel: string, provider: string = 'anthropic') {
+		return async (_sessionId: string) => ({ currentModel, provider });
 	}
 
 	function makeGlobalSettings(
@@ -78,7 +65,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'haiku', provider: 'anthropic' },
 					{ model: 'glm-4', provider: 'glm' },
 				]),
-				messageHub: makeMessageHub('not-in-chain', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('not-in-chain', 'anthropic'),
 				// isProviderAvailable intentionally omitted
 			});
 
@@ -106,7 +93,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'haiku', provider: 'anthropic' },
 					{ model: 'glm-4', provider: 'glm' },
 				]),
-				messageHub: makeMessageHub('not-in-chain', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('not-in-chain', 'anthropic'),
 				isProviderAvailable: async (provider, model) => {
 					availabilityChecks.push({ provider, model });
 					return true;
@@ -138,7 +125,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'glm-4', provider: 'glm' },
 					{ model: 'sonnet', provider: 'anthropic' },
 				]),
-				messageHub: makeMessageHub('not-in-chain', 'other'),
+				getCurrentModelImpl: makeGetCurrentModel('not-in-chain', 'other'),
 				isProviderAvailable: async (provider, model) => {
 					// anthropic/haiku is down, glm/glm-4 is down, anthropic/sonnet is up
 					if (provider === 'anthropic' && model === 'haiku') return false;
@@ -167,7 +154,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'haiku', provider: 'anthropic' },
 					{ model: 'glm-4', provider: 'glm' },
 				]),
-				messageHub: makeMessageHub('not-in-chain', 'other'),
+				getCurrentModelImpl: makeGetCurrentModel('not-in-chain', 'other'),
 				isProviderAvailable: async () => false, // all providers down
 			});
 
@@ -199,7 +186,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'glm-4', provider: 'glm' },
 					{ model: 'sonnet', provider: 'anthropic' },
 				]),
-				messageHub: makeMessageHub('haiku', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('haiku', 'anthropic'),
 				isProviderAvailable: async (provider, model) => {
 					if (provider === 'glm' && model === 'glm-4') return false;
 					return true;
@@ -226,7 +213,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'haiku', provider: 'anthropic' },
 					{ model: 'sonnet', provider: 'anthropic' },
 				]),
-				messageHub: makeMessageHub('sonnet', 'anthropic'),
+				getCurrentModelImpl: makeGetCurrentModel('sonnet', 'anthropic'),
 				isProviderAvailable: async () => true,
 			});
 
@@ -254,7 +241,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'haiku', provider: 'anthropic' },
 					{ model: 'glm-4', provider: 'glm' },
 				]),
-				messageHub: makeMessageHub('not-in-chain', 'other'),
+				getCurrentModelImpl: makeGetCurrentModel('not-in-chain', 'other'),
 				isProviderAvailable: async (_provider, model) => {
 					if (model === 'haiku') throw new Error('network timeout');
 					return true;
@@ -280,7 +267,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'haiku', provider: 'anthropic' },
 					{ model: 'glm-4', provider: 'glm' },
 				]),
-				messageHub: makeMessageHub('not-in-chain', 'other'),
+				getCurrentModelImpl: makeGetCurrentModel('not-in-chain', 'other'),
 				isProviderAvailable: async () => {
 					throw new Error('check service down');
 				},
@@ -306,7 +293,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 			ctx = createRuntimeTestContext({
 				getWorkerMessages: () => makeWorkerMessages(USAGE_LIMIT_MSG),
 				getGlobalSettings: makeGlobalSettings([{ model: 'haiku', provider: 'anthropic' }]),
-				messageHub: makeMessageHub('not-in-chain', 'other'),
+				getCurrentModelImpl: makeGetCurrentModel('not-in-chain', 'other'),
 				isProviderAvailable: async () => true, // provider is available
 			});
 
@@ -343,7 +330,7 @@ describe('RoomRuntime - isProviderAvailable in trySwitchToFallbackModel', () => 
 					{ model: 'haiku', provider: 'anthropic' },
 					{ model: 'glm-4', provider: 'glm' },
 				]),
-				messageHub: makeMessageHub('haiku', 'anthropic'), // same as chain[0]
+				getCurrentModelImpl: makeGetCurrentModel('haiku', 'anthropic'), // same as chain[0]
 				isProviderAvailable: async () => true,
 			});
 

--- a/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-rate-limit-persistence.test.ts
@@ -651,7 +651,7 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 		/**
 		 * Creates a context where trySwitchToFallbackModel succeeds:
 		 * - getGlobalSettings returns a fallback model chain
-		 * - messageHub.request('session.model.get') returns a current model not in the chain
+		 * - sessionFactory.getCurrentModel returns a current model not in the chain
 		 *   (so the first fallback is selected)
 		 * - sessionFactory.switchModel returns success
 		 */
@@ -667,17 +667,10 @@ describe('RoomRuntime - rate limit restriction persistence', () => {
 					({
 						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
 					}) as never,
-				messageHub: {
-					async request(method: string, _params: unknown) {
-						if (method === 'session.model.get') {
-							return {
-								currentModel: 'claude-sonnet-4-6',
-								modelInfo: { provider: 'anthropic' },
-							};
-						}
-						return undefined;
-					},
-				},
+				getCurrentModelImpl: async () => ({
+					currentModel: 'claude-sonnet-4-6',
+					provider: 'anthropic',
+				}),
 			});
 		}
 

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -386,15 +386,7 @@ describe('RoomRuntime - terminal error detection', () => {
 		});
 
 		it('returns early without routing to leader after successful fallback switch', async () => {
-			// Configure a fallback model and a mock messageHub that provides the current model
-			const mockMessageHub = {
-				request: async (method: string) => {
-					if (method === 'session.model.get') {
-						return { currentModel: 'claude-opus-4-5', modelInfo: { provider: 'anthropic' } };
-					}
-					return undefined;
-				},
-			};
+			// Configure a fallback model and getCurrentModel to provide the current model info
 			ctx = createRuntimeTestContext({
 				getWorkerMessages: () => [
 					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
@@ -403,7 +395,10 @@ describe('RoomRuntime - terminal error detection', () => {
 					({
 						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
 					}) as never,
-				messageHub: mockMessageHub,
+				getCurrentModelImpl: async () => ({
+					currentModel: 'claude-opus-4-5',
+					provider: 'anthropic',
+				}),
 			});
 
 			const { group, task } = await spawnAndSimulateWorkerOutput('');
@@ -445,14 +440,10 @@ describe('RoomRuntime - terminal error detection', () => {
 					({
 						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
 					}) as never,
-				messageHub: {
-					request: async (method: string) => {
-						if (method === 'session.model.get') {
-							return { currentModel: 'claude-opus-4-5', modelInfo: { provider: 'anthropic' } };
-						}
-						return undefined;
-					},
-				},
+				getCurrentModelImpl: async () => ({
+					currentModel: 'claude-opus-4-5',
+					provider: 'anthropic',
+				}),
 			});
 
 			const { task } = await createGoalAndTask(ctx);
@@ -510,14 +501,6 @@ describe('RoomRuntime - terminal error detection', () => {
 			//   5. trySwitchToFallbackModel succeeds
 			//   6. clearTaskRestriction must clear the stale restriction from step 1
 
-			const mockMessageHub = {
-				request: async (method: string) => {
-					if (method === 'session.model.get') {
-						return { currentModel: 'claude-opus-4-5', modelInfo: { provider: 'anthropic' } };
-					}
-					return undefined;
-				},
-			};
 			ctx = createRuntimeTestContext({
 				getWorkerMessages: () => [
 					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
@@ -526,7 +509,10 @@ describe('RoomRuntime - terminal error detection', () => {
 					({
 						fallbackModels: [{ model: 'claude-haiku-4-5', provider: 'anthropic' }],
 					}) as never,
-				messageHub: mockMessageHub,
+				getCurrentModelImpl: async () => ({
+					currentModel: 'claude-opus-4-5',
+					provider: 'anthropic',
+				}),
 			});
 
 			const { task } = await createGoalAndTask(ctx);

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -83,6 +83,10 @@ export function createMockSessionFactory() {
 		model,
 		_provider
 	) => ({ success: true, model });
+	/** Override for getCurrentModel — tests can replace this to control model info */
+	let getCurrentModelImpl: (
+		sessionId: string
+	) => Promise<{ currentModel: string; provider: string } | null> = async (_sessionId) => null;
 	return {
 		calls,
 		processingStates,
@@ -99,6 +103,12 @@ export function createMockSessionFactory() {
 			provider: string
 		) => Promise<{ success: boolean; model: string; error?: string }>) {
 			switchModelImpl = fn;
+		},
+		/** Override to control getCurrentModel responses in tests */
+		set getCurrentModelImpl(fn: (
+			sessionId: string
+		) => Promise<{ currentModel: string; provider: string } | null>) {
+			getCurrentModelImpl = fn;
 		},
 		async createAndStartSession(init: unknown, role: string) {
 			calls.push({ method: 'createAndStartSession', args: [init, role] });
@@ -148,6 +158,9 @@ export function createMockSessionFactory() {
 		async switchModel(sessionId: string, model: string, provider: string) {
 			calls.push({ method: 'switchModel', args: [sessionId, model, provider] });
 			return switchModelImpl(sessionId, model, provider);
+		},
+		async getCurrentModel(sessionId: string) {
+			return getCurrentModelImpl(sessionId);
 		},
 	} satisfies SessionFactory & {
 		calls: Array<{ method: string; args: unknown[] }>;
@@ -300,7 +313,11 @@ export interface RuntimeTestContextOptions {
 	getGlobalSettings?: () => GlobalSettings;
 	/** Optional provider availability check for testing fallback chain skipping */
 	isProviderAvailable?: (provider: string, model: string) => Promise<boolean>;
-	/** Optional MessageHub mock for testing trySwitchToFallbackModel (session.model.get RPC) */
+	/** Override getCurrentModel on the mock SessionFactory for testing trySwitchToFallbackModel */
+	getCurrentModelImpl?: (
+		sessionId: string
+	) => Promise<{ currentModel: string; provider: string } | null>;
+	/** Optional MessageHub mock (kept for backward compat; no longer used by trySwitchToFallbackModel) */
 	messageHub?: MessageHub;
 }
 
@@ -318,6 +335,9 @@ export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): Runt
 	const taskManager = new TaskManager(db as never, 'room-1', noOpReactiveDb);
 	const goalManager = new GoalManager(db as never, 'room-1', noOpReactiveDb);
 	const sessionFactory = createMockSessionFactory();
+	if (opts?.getCurrentModelImpl) {
+		sessionFactory.getCurrentModelImpl = opts.getCurrentModelImpl;
+	}
 	const room = makeRoom(opts?.room);
 
 	const runtime = new RoomRuntime({


### PR DESCRIPTION
Fixes the RPC routing bug where `trySwitchToFallbackModel` was sending `session.model.get` requests over WebSocket to browser clients instead of reading model info server-side.

## Changes

- **`room-runtime.ts`**: Replace `messageHub?.request('session.model.get', ...)` with `sessionFactory.getCurrentModel(sessionId)` (DB-first, no RPC). Update destructuring to use `modelInfo.provider` instead of `modelInfo.modelInfo?.provider`. Remove the now-unused `SessionModelGetResult` interface.
- **`room-runtime-test-helpers.ts`**: Add `getCurrentModel` method and `getCurrentModelImpl` setter to the mock session factory; add `getCurrentModelImpl` option to `RuntimeTestContextOptions`.
- **6 test files**: Replace `messageHub` mock stubs for `session.model.get` with `getCurrentModelImpl` configuration on the session factory.