### PR TITLE
feat(space): replace built-in workflow transitions with gated channels

### DIFF
--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -9,9 +9,9 @@
  * - Templates use placeholder `id` / `spaceId` (empty strings) and role names
  *   as `agentId` placeholders ('planner', 'coder', 'general'). These are
  *   replaced with real SpaceAgent UUIDs by `seedBuiltInWorkflows`.
- * - Workflows are directed graphs: nodes are nodes, transitions are edges.
- *   A node with no outgoing transitions is a terminal node — the run
- *   completes when that node is reached and advance() is called.
+ * - Workflows use gated channels for inter-agent communication (agent-centric
+ *   model). Transitions are empty for agent-centric workflows; completion is
+ *   detected when all agents report done.
  * - At Space creation time, preset SpaceAgent records are seeded for each
  *   BuiltinAgentRole. `seedBuiltInWorkflows` must be called after those agents
  *   exist so that the `agentId` values resolve correctly.
@@ -25,7 +25,7 @@ import type { SpaceWorkflow } from '@neokai/shared';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 
 // ---------------------------------------------------------------------------
-// Template step ID constants (used to wire up transitions)
+// Template node ID constants (used as stable IDs for nodes and startNodeId)
 // ---------------------------------------------------------------------------
 
 const CODING_PLANNER_STEP = 'tpl-coding-planner';
@@ -46,10 +46,11 @@ const REVIEW_CODER_STEP = 'tpl-review-coder';
  * Coding Workflow
  *
  * Four-node graph: Plan → Code → Verify → Done (with cycle).
- * - Plan → Code: `human` condition — a human must approve the plan.
- * - Code → Verify: `always` condition — automatically verify after coding.
- * - Verify → Plan: `task_result` condition on 'failed' — loops back (cyclic).
- * - Verify → Done: `task_result` condition on 'passed' — completes the workflow.
+ * Routing is channel-based (agent-centric model); transitions are empty.
+ * - Plan → Code: `human` gate — a human must approve the plan.
+ * - Code → Verify: `always` gate — automatically verify after coding.
+ * - Verify → Plan: `task_result` gate on 'failed' — loops back (cyclic).
+ * - Verify → Done: `task_result` gate on 'passed' — completes the workflow.
  * - `maxIterations: 3` caps the number of Plan→Code→Verify cycles.
  */
 export const CODING_WORKFLOW: SpaceWorkflow = {
@@ -84,51 +85,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 			agentId: 'general',
 		},
 	],
-	transitions: [
-		{
-			id: 'tpl-coding-plan-to-code',
-			from: CODING_PLANNER_STEP,
-			to: CODING_CODER_STEP,
-			condition: {
-				type: 'human',
-				description: 'Review and approve the plan before coding begins',
-			},
-			order: 0,
-		},
-		{
-			id: 'tpl-coding-code-to-verify',
-			from: CODING_CODER_STEP,
-			to: CODING_VERIFY_STEP,
-			condition: {
-				type: 'always',
-				description: 'Automatically verify after coding is complete',
-			},
-			order: 0,
-		},
-		{
-			id: 'tpl-coding-verify-to-plan',
-			from: CODING_VERIFY_STEP,
-			to: CODING_PLANNER_STEP,
-			condition: {
-				type: 'task_result',
-				expression: 'failed',
-				description: 'Loop back to planning when verification fails',
-			},
-			order: 0,
-			isCyclic: true,
-		},
-		{
-			id: 'tpl-coding-verify-to-done',
-			from: CODING_VERIFY_STEP,
-			to: CODING_DONE_STEP,
-			condition: {
-				type: 'task_result',
-				expression: 'passed',
-				description: 'Complete workflow when verification passes',
-			},
-			order: 1,
-		},
-	],
+	transitions: [],
 	startNodeId: CODING_PLANNER_STEP,
 	rules: [],
 	tags: ['coding', 'default'],
@@ -185,8 +142,8 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
  * Research Workflow
  *
  * Two-node graph: Planner → General.
- * Both transitions use `always` conditions — the workflow advances without
- * human intervention, suited for fully autonomous research and summarisation tasks.
+ * Routing is channel-based (agent-centric model); transitions are empty.
+ * - Plan Research → Research: `always` gate — advances without human intervention.
  */
 export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 	id: '',
@@ -206,18 +163,7 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 			agentId: 'general',
 		},
 	],
-	transitions: [
-		{
-			id: 'tpl-research-plan-to-research',
-			from: RESEARCH_PLANNER_STEP,
-			to: RESEARCH_GENERAL_STEP,
-			condition: {
-				type: 'always',
-				description: 'Automatically advance after planning is complete',
-			},
-			order: 0,
-		},
-	],
+	transitions: [],
 	startNodeId: RESEARCH_PLANNER_STEP,
 	rules: [],
 	tags: ['research'],

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -15,6 +15,9 @@
  * - At Space creation time, preset SpaceAgent records are seeded for each
  *   BuiltinAgentRole. `seedBuiltInWorkflows` must be called after those agents
  *   exist so that the `agentId` values resolve correctly.
+ * - Channels use node names (e.g. 'Plan', 'Code') in `from`/`to` so they
+ *   resolve correctly at runtime without UUID translation in the seeder.
+ *   `resolveChannels()` matches node names via the `nodeNameToAgents` lookup.
  */
 
 import { generateUUID } from '@neokai/shared';
@@ -131,6 +134,51 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 	tags: ['coding', 'default'],
 	createdAt: 0,
 	updatedAt: 0,
+	channels: [
+		{
+			from: 'Plan',
+			to: 'Code',
+			direction: 'one-way',
+			gate: {
+				type: 'human',
+				description: 'Review and approve the plan before coding begins',
+			},
+			label: 'Plan → Code',
+		},
+		{
+			from: 'Code',
+			to: 'Verify & Test',
+			direction: 'one-way',
+			gate: {
+				type: 'always',
+				description: 'Automatically verify after coding is complete',
+			},
+			label: 'Code → Verify',
+		},
+		{
+			from: 'Verify & Test',
+			to: 'Plan',
+			direction: 'one-way',
+			isCyclic: true,
+			gate: {
+				type: 'task_result',
+				expression: 'failed',
+				description: 'Loop back to planning when verification fails',
+			},
+			label: 'Verify → Plan (on fail)',
+		},
+		{
+			from: 'Verify & Test',
+			to: 'Done',
+			direction: 'one-way',
+			gate: {
+				type: 'task_result',
+				expression: 'passed',
+				description: 'Complete workflow when verification passes',
+			},
+			label: 'Verify → Done (on pass)',
+		},
+	],
 };
 
 /**
@@ -175,6 +223,18 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 	tags: ['research'],
 	createdAt: 0,
 	updatedAt: 0,
+	channels: [
+		{
+			from: 'Plan Research',
+			to: 'Research',
+			direction: 'one-way',
+			gate: {
+				type: 'always',
+				description: 'Automatically advance after planning is complete',
+			},
+			label: 'Plan → Research',
+		},
+	],
 };
 
 /**
@@ -309,6 +369,7 @@ export function seedBuiltInWorkflows(
 			rules: [],
 			tags: [...template.tags],
 			maxIterations: template.maxIterations,
+			channels: template.channels ? [...template.channels] : undefined,
 		});
 	}
 }

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -106,6 +106,34 @@ describe('CODING_WORKFLOW template', () => {
 		expect(verifyStep?.instructions).toContain('failed');
 	});
 
+	test('has four channels with correct gate conditions', () => {
+		expect(CODING_WORKFLOW.channels).toHaveLength(4);
+
+		const planToCode = CODING_WORKFLOW.channels!.find((c) => c.from === 'Plan' && c.to === 'Code');
+		expect(planToCode?.gate?.type).toBe('human');
+		expect(planToCode?.direction).toBe('one-way');
+
+		const codeToVerify = CODING_WORKFLOW.channels!.find(
+			(c) => c.from === 'Code' && c.to === 'Verify & Test'
+		);
+		expect(codeToVerify?.gate?.type).toBe('always');
+		expect(codeToVerify?.direction).toBe('one-way');
+
+		const verifyToPlan = CODING_WORKFLOW.channels!.find(
+			(c) => c.from === 'Verify & Test' && c.to === 'Plan'
+		);
+		expect(verifyToPlan?.gate?.type).toBe('task_result');
+		expect((verifyToPlan?.gate as { expression?: string })?.expression).toBe('failed');
+		expect(verifyToPlan?.isCyclic).toBe(true);
+
+		const verifyToDone = CODING_WORKFLOW.channels!.find(
+			(c) => c.from === 'Verify & Test' && c.to === 'Done'
+		);
+		expect(verifyToDone?.gate?.type).toBe('task_result');
+		expect((verifyToDone?.gate as { expression?: string })?.expression).toBe('passed');
+		expect(verifyToDone?.isCyclic).toBeUndefined();
+	});
+
 	test('has four transitions forming Plan→Code→Verify→Plan/Done graph', () => {
 		expect(CODING_WORKFLOW.transitions).toHaveLength(4);
 
@@ -179,6 +207,15 @@ describe('RESEARCH_WORKFLOW template', () => {
 		expect(RESEARCH_WORKFLOW.transitions[0].condition?.type).toBe('always');
 	});
 
+	test('has one channel (Plan Research → Research) with always gate', () => {
+		expect(RESEARCH_WORKFLOW.channels).toHaveLength(1);
+		const ch = RESEARCH_WORKFLOW.channels![0];
+		expect(ch.from).toBe('Plan Research');
+		expect(ch.to).toBe('Research');
+		expect(ch.direction).toBe('one-way');
+		expect(ch.gate?.type).toBe('always');
+	});
+
 	test('startNodeId points to the planner step', () => {
 		const plannerStep = RESEARCH_WORKFLOW.nodes.find((s) => s.agentId === 'planner');
 		expect(RESEARCH_WORKFLOW.startNodeId).toBe(plannerStep?.id);
@@ -205,6 +242,10 @@ describe('REVIEW_ONLY_WORKFLOW template', () => {
 
 	test('has no transitions (terminal step — run completes immediately on advance)', () => {
 		expect(REVIEW_ONLY_WORKFLOW.transitions).toHaveLength(0);
+	});
+
+	test('has no channels (single-node workflow needs no inter-agent channels)', () => {
+		expect(REVIEW_ONLY_WORKFLOW.channels ?? []).toHaveLength(0);
 	});
 
 	test('startNodeId points to the coder step', () => {
@@ -375,6 +416,38 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(passedTransition!.isCyclic).toBeUndefined();
 	});
 
+	test('CODING_WORKFLOW seeded with four channels and correct gate types', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		expect(wf.channels).toHaveLength(4);
+
+		const humanChannel = wf.channels!.find((c) => c.gate?.type === 'human');
+		expect(humanChannel).toBeDefined();
+		expect(humanChannel!.from).toBe('Plan');
+		expect(humanChannel!.to).toBe('Code');
+
+		const alwaysChannel = wf.channels!.find((c) => c.gate?.type === 'always');
+		expect(alwaysChannel).toBeDefined();
+		expect(alwaysChannel!.from).toBe('Code');
+		expect(alwaysChannel!.to).toBe('Verify & Test');
+
+		const failedChannel = wf.channels!.find(
+			(c) =>
+				c.gate?.type === 'task_result' &&
+				(c.gate as { expression?: string }).expression === 'failed'
+		);
+		expect(failedChannel).toBeDefined();
+		expect(failedChannel!.isCyclic).toBe(true);
+
+		const passedChannel = wf.channels!.find(
+			(c) =>
+				c.gate?.type === 'task_result' &&
+				(c.gate as { expression?: string }).expression === 'passed'
+		);
+		expect(passedChannel).toBeDefined();
+		expect(passedChannel!.isCyclic).toBeUndefined();
+	});
+
 	test('CODING_WORKFLOW seeded with maxIterations', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name);
@@ -389,6 +462,16 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(verifyStep!.instructions).toContain('Run tests');
 	});
 
+	test('RESEARCH_WORKFLOW seeded with one channel (Plan Research → Research, always gate)', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === RESEARCH_WORKFLOW.name)!;
+		expect(wf.channels).toHaveLength(1);
+		const ch = wf.channels![0];
+		expect(ch.from).toBe('Plan Research');
+		expect(ch.to).toBe('Research');
+		expect(ch.gate?.type).toBe('always');
+	});
+
 	test('RESEARCH_WORKFLOW seeded correctly — planner + general with always transition', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === RESEARCH_WORKFLOW.name);
@@ -398,6 +481,12 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(wf!.nodes[1].agentId).toBe(GENERAL_ID);
 		expect(wf!.transitions).toHaveLength(1);
 		expect(wf!.transitions[0].condition?.type).toBe('always');
+	});
+
+	test('REVIEW_ONLY_WORKFLOW seeded with no channels', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === REVIEW_ONLY_WORKFLOW.name)!;
+		expect(wf.channels ?? []).toHaveLength(0);
 	});
 
 	test('REVIEW_ONLY_WORKFLOW seeded correctly — single coder step, no transitions', async () => {

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -134,40 +134,8 @@ describe('CODING_WORKFLOW template', () => {
 		expect(verifyToDone?.isCyclic).toBeUndefined();
 	});
 
-	test('has four transitions forming Plan→Code→Verify→Plan/Done graph', () => {
-		expect(CODING_WORKFLOW.transitions).toHaveLength(4);
-
-		const planToCode = CODING_WORKFLOW.transitions.find((t) => t.id === 'tpl-coding-plan-to-code');
-		expect(planToCode?.condition?.type).toBe('human');
-
-		const codeToVerify = CODING_WORKFLOW.transitions.find(
-			(t) => t.id === 'tpl-coding-code-to-verify'
-		);
-		expect(codeToVerify?.condition?.type).toBe('always');
-
-		const verifyToPlan = CODING_WORKFLOW.transitions.find(
-			(t) => t.id === 'tpl-coding-verify-to-plan'
-		);
-		expect(verifyToPlan?.condition?.type).toBe('task_result');
-		expect(verifyToPlan?.condition?.expression).toBe('failed');
-		expect(verifyToPlan?.isCyclic).toBe(true);
-
-		const verifyToDone = CODING_WORKFLOW.transitions.find(
-			(t) => t.id === 'tpl-coding-verify-to-done'
-		);
-		expect(verifyToDone?.condition?.type).toBe('task_result');
-		expect(verifyToDone?.condition?.expression).toBe('passed');
-		expect(verifyToDone?.isCyclic).toBeUndefined();
-	});
-
-	test('Verify→Plan transition has lower order than Verify→Done', () => {
-		const verifyToPlan = CODING_WORKFLOW.transitions.find(
-			(t) => t.id === 'tpl-coding-verify-to-plan'
-		);
-		const verifyToDone = CODING_WORKFLOW.transitions.find(
-			(t) => t.id === 'tpl-coding-verify-to-done'
-		);
-		expect(verifyToPlan!.order).toBeLessThan(verifyToDone!.order);
+	test('has no transitions (routing is channel-based)', () => {
+		expect(CODING_WORKFLOW.transitions).toHaveLength(0);
 	});
 
 	test('maxIterations is set to 3', () => {
@@ -202,9 +170,8 @@ describe('RESEARCH_WORKFLOW template', () => {
 		expect(RESEARCH_WORKFLOW.nodes[1].agentId).toBe('general');
 	});
 
-	test('has one transition (planner → general) with always condition', () => {
-		expect(RESEARCH_WORKFLOW.transitions).toHaveLength(1);
-		expect(RESEARCH_WORKFLOW.transitions[0].condition?.type).toBe('always');
+	test('has no transitions (routing is channel-based)', () => {
+		expect(RESEARCH_WORKFLOW.transitions).toHaveLength(0);
 	});
 
 	test('has one channel (Plan Research → Research) with always gate', () => {
@@ -378,42 +345,10 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(wf!.nodes[3].agentId).toBe(GENERAL_ID);
 	});
 
-	test('CODING_WORKFLOW seeded with four transitions and correct conditions', async () => {
+	test('CODING_WORKFLOW seeded with no transitions (routing is channel-based)', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name);
-		expect(wf!.transitions).toHaveLength(4);
-
-		// Find transitions by condition type and expression
-		const humanTransition = wf!.transitions.find((t) => t.condition?.type === 'human');
-		expect(humanTransition).toBeDefined();
-
-		const alwaysTransition = wf!.transitions.find((t) => t.condition?.type === 'always');
-		expect(alwaysTransition).toBeDefined();
-
-		const failedTransition = wf!.transitions.find(
-			(t) => t.condition?.type === 'task_result' && t.condition?.expression === 'failed'
-		);
-		expect(failedTransition).toBeDefined();
-
-		const passedTransition = wf!.transitions.find(
-			(t) => t.condition?.type === 'task_result' && t.condition?.expression === 'passed'
-		);
-		expect(passedTransition).toBeDefined();
-	});
-
-	test('CODING_WORKFLOW seeded with isCyclic on Verify→Plan transition', async () => {
-		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
-		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name);
-		const failedTransition = wf!.transitions.find(
-			(t) => t.condition?.type === 'task_result' && t.condition?.expression === 'failed'
-		);
-		expect(failedTransition!.isCyclic).toBe(true);
-
-		// Verify→Done should NOT be cyclic
-		const passedTransition = wf!.transitions.find(
-			(t) => t.condition?.type === 'task_result' && t.condition?.expression === 'passed'
-		);
-		expect(passedTransition!.isCyclic).toBeUndefined();
+		expect(wf!.transitions).toHaveLength(0);
 	});
 
 	test('CODING_WORKFLOW seeded with four channels and correct gate types', async () => {
@@ -472,15 +407,14 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(ch.gate?.type).toBe('always');
 	});
 
-	test('RESEARCH_WORKFLOW seeded correctly — planner + general with always transition', async () => {
+	test('RESEARCH_WORKFLOW seeded correctly — planner + general, no transitions', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === RESEARCH_WORKFLOW.name);
 		expect(wf).toBeDefined();
 		expect(wf!.nodes).toHaveLength(2);
 		expect(wf!.nodes[0].agentId).toBe(PLANNER_ID);
 		expect(wf!.nodes[1].agentId).toBe(GENERAL_ID);
-		expect(wf!.transitions).toHaveLength(1);
-		expect(wf!.transitions[0].condition?.type).toBe('always');
+		expect(wf!.transitions).toHaveLength(0);
 	});
 
 	test('REVIEW_ONLY_WORKFLOW seeded with no channels', async () => {
@@ -673,49 +607,57 @@ describe('Coding Workflow export/import round-trip', () => {
 		expect(result.ok).toBe(true);
 	});
 
-	test('exported Coding Workflow preserves isCyclic on Verify→Plan transition', () => {
+	test('exported Coding Workflow has no transitions (routing is channel-based)', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
 
 		const exported = exportWorkflow(wf, mockAgents);
+		expect(exported.transitions).toHaveLength(0);
+	});
 
-		const verifyToPlan = exported.transitions.find(
-			(t) => t.fromNode === 'Verify & Test' && t.toNode === 'Plan'
+	test('exported Coding Workflow preserves isCyclic on Verify→Plan channel', () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+
+		const exported = exportWorkflow(wf, mockAgents);
+		expect(exported.channels).toBeDefined();
+
+		const verifyToPlan = exported.channels!.find(
+			(c) => c.from === 'Verify & Test' && c.to === 'Plan'
 		);
 		expect(verifyToPlan).toBeDefined();
 		expect(verifyToPlan!.isCyclic).toBe(true);
 
-		// Non-cyclic transitions should not have isCyclic
-		const verifyToDone = exported.transitions.find(
-			(t) => t.fromNode === 'Verify & Test' && t.toNode === 'Done'
+		const verifyToDone = exported.channels!.find(
+			(c) => c.from === 'Verify & Test' && c.to === 'Done'
 		);
 		expect(verifyToDone).toBeDefined();
 		expect(verifyToDone!.isCyclic).toBeUndefined();
 	});
 
-	test('exported Coding Workflow preserves task_result conditions', () => {
+	test('exported Coding Workflow preserves task_result gate conditions on channels', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
 
 		const exported = exportWorkflow(wf, mockAgents);
 
-		const taskResultTransitions = exported.transitions.filter(
-			(t) => t.condition?.type === 'task_result'
+		const taskResultChannels = (exported.channels ?? []).filter(
+			(c) => c.gate?.type === 'task_result'
 		);
-		expect(taskResultTransitions).toHaveLength(2);
+		expect(taskResultChannels).toHaveLength(2);
 
-		const failedTransition = taskResultTransitions.find(
-			(t) => t.condition?.expression === 'failed'
+		const failedChannel = taskResultChannels.find(
+			(c) => (c.gate as { expression?: string }).expression === 'failed'
 		);
-		expect(failedTransition).toBeDefined();
+		expect(failedChannel).toBeDefined();
 
-		const passedTransition = taskResultTransitions.find(
-			(t) => t.condition?.expression === 'passed'
+		const passedChannel = taskResultChannels.find(
+			(c) => (c.gate as { expression?: string }).expression === 'passed'
 		);
-		expect(passedTransition).toBeDefined();
+		expect(passedChannel).toBeDefined();
 	});
 
-	test('re-imported Coding Workflow preserves isCyclic and task_result conditions', () => {
+	test('re-imported Coding Workflow preserves channels with isCyclic and task_result gates', () => {
 		// Seed → export → re-import → verify round-trip fidelity
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
@@ -727,12 +669,6 @@ describe('Coding Workflow export/import round-trip', () => {
 		}
 		expect(manager.listWorkflows(SPACE_ID)).toHaveLength(0);
 
-		// Re-import using the same mechanism as seedBuiltInWorkflows but from the exported format
-		const stepNameToId = new Map<string, string>();
-		for (const step of exported.nodes) {
-			stepNameToId.set(step.name, `reimport-${step.name}`);
-		}
-
 		// Build agent name → ID map for resolving agentRef
 		const agentNameToId = new Map<string, string>(mockAgents.map((a) => [a.name, a.id]));
 
@@ -741,21 +677,15 @@ describe('Coding Workflow export/import round-trip', () => {
 			name: exported.name,
 			description: exported.description,
 			nodes: exported.nodes.map((s) => ({
-				id: stepNameToId.get(s.name)!,
 				name: s.name,
 				agentId: agentNameToId.get(s.agentRef) ?? s.agentRef,
 				instructions: s.instructions,
 			})),
-			transitions: exported.transitions.map((t) => ({
-				from: stepNameToId.get(t.fromNode)!,
-				to: stepNameToId.get(t.toNode)!,
-				condition: t.condition,
-				order: t.order,
-				isCyclic: t.isCyclic,
-			})),
-			startNodeId: stepNameToId.get(exported.startNode),
+			transitions: [],
+			startNodeId: undefined,
 			rules: [],
 			tags: exported.tags,
+			channels: exported.channels,
 		});
 
 		// Verify the re-imported workflow
@@ -764,27 +694,26 @@ describe('Coding Workflow export/import round-trip', () => {
 			.find((w) => w.name === CODING_WORKFLOW.name)!;
 		expect(reimported).toBeDefined();
 		expect(reimported.nodes).toHaveLength(4);
-		expect(reimported.transitions).toHaveLength(4);
+		expect(reimported.transitions).toHaveLength(0);
+		expect(reimported.channels).toHaveLength(4);
 
-		// isCyclic preserved on Verify→Plan
-		const verifyToPlan = reimported.transitions.find(
-			(t) => t.condition?.type === 'task_result' && t.condition?.expression === 'failed'
+		// isCyclic preserved on Verify→Plan channel
+		const verifyToPlan = reimported.channels!.find(
+			(c) =>
+				c.gate?.type === 'task_result' &&
+				(c.gate as { expression?: string }).expression === 'failed'
 		);
 		expect(verifyToPlan).toBeDefined();
 		expect(verifyToPlan!.isCyclic).toBe(true);
 
-		// Non-cyclic transition should not have isCyclic
-		const verifyToDone = reimported.transitions.find(
-			(t) => t.condition?.type === 'task_result' && t.condition?.expression === 'passed'
+		// Non-cyclic channel should not have isCyclic
+		const verifyToDone = reimported.channels!.find(
+			(c) =>
+				c.gate?.type === 'task_result' &&
+				(c.gate as { expression?: string }).expression === 'passed'
 		);
 		expect(verifyToDone).toBeDefined();
 		expect(verifyToDone!.isCyclic).toBeUndefined();
-
-		// task_result conditions preserved
-		expect(verifyToPlan!.condition?.type).toBe('task_result');
-		expect(verifyToPlan!.condition?.expression).toBe('failed');
-		expect(verifyToDone!.condition?.type).toBe('task_result');
-		expect(verifyToDone!.condition?.expression).toBe('passed');
 	});
 
 	test('Zod schema accepts task_result condition type with expression', () => {


### PR DESCRIPTION
Replace transition-based flow in built-in workflow templates with gated `WorkflowChannel` entries.

**Coding Workflow** gains 4 channels:
- `Plan → Code`: `human` gate (approval before coding)
- `Code → Verify & Test`: `always` gate (auto-advance after coding)
- `Verify & Test → Plan`: `task_result` gate on `failed`, `isCyclic: true`
- `Verify & Test → Done`: `task_result` gate on `passed`

**Research Workflow** gains 1 channel:
- `Plan Research → Research`: `always` gate

**Review-Only** unchanged (single node, no channels needed).

Channels reference node names in `from`/`to` — `resolveChannels()` resolves these via `nodeNameToAgents` at runtime, so no UUID translation is required in `seedBuiltInWorkflows()`. The seeder now passes `channels: template.channels` to `createWorkflow()`.

9 new tests added covering channel structure on templates and seeder persistence.