### PR TITLE
feat(space): wire ChannelRouter and CompletionDetector into Task Agent

### DIFF
--- a/packages/daemon/src/lib/space/runtime/completion-detector.ts
+++ b/packages/daemon/src/lib/space/runtime/completion-detector.ts
@@ -53,9 +53,14 @@ export class CompletionDetector {
 		channels: WorkflowChannel[] = [],
 		nodes: WorkflowNode[] = []
 	): boolean {
-		const tasks = this.taskRepo.listByWorkflowRun(workflowRunId);
+		// Only consider node-agent tasks (those with workflowNodeId set).
+		// The orchestration task (Task Agent's own task) has workflowNodeId = null
+		// and is still in_progress while this check runs — it must be excluded.
+		const tasks = this.taskRepo
+			.listByWorkflowRun(workflowRunId)
+			.filter((t) => t.workflowNodeId != null);
 
-		// Workflow has not started yet — no tasks created
+		// Workflow has not started yet — no node tasks created
 		if (tasks.length === 0) return false;
 
 		// Any non-terminal task prevents completion

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -69,6 +69,8 @@ import type {
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
 import { ChannelResolver } from './channel-resolver';
+import { ChannelRouter } from './channel-router';
+import { CompletionDetector } from './completion-detector';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
 import { Logger } from '../../logger';
 import { SpaceTaskManager } from '../managers/space-task-manager';
@@ -281,6 +283,16 @@ export class TaskAgentManager {
 
 			const workflowRunId = workflowRun?.id ?? '';
 
+			// Build shared channel routing and completion detection instances.
+			// Both use the same underlying repositories as the task agent tools.
+			const channelRouter = new ChannelRouter({
+				taskRepo: this.config.taskRepo,
+				workflowRunRepo: this.config.workflowRunRepo,
+				workflowManager: this.config.spaceWorkflowManager,
+				agentManager: this.config.spaceAgentManager,
+			});
+			const completionDetector = new CompletionDetector(this.config.taskRepo);
+
 			const mcpServer = createTaskAgentMcpServer({
 				taskId,
 				space,
@@ -299,6 +311,8 @@ export class TaskAgentManager {
 				sessionGroupRepo: this.config.sessionGroupRepo,
 				getGroupId: () => this.taskGroupIds.get(taskId),
 				daemonHub: this.config.daemonHub,
+				channelRouter,
+				completionDetector,
 				buildNodeAgentMcpServer: (subSessionId, role, stepTaskId) =>
 					this.buildNodeAgentMcpServerForSession(
 						taskId,
@@ -1129,6 +1143,15 @@ export class TaskAgentManager {
 
 		const rehydrateWorkflowRunId = workflowRun?.id ?? '';
 
+		// Build shared channel routing and completion detection instances for rehydration.
+		const rehydrateChannelRouter = new ChannelRouter({
+			taskRepo: this.config.taskRepo,
+			workflowRunRepo: this.config.workflowRunRepo,
+			workflowManager: this.config.spaceWorkflowManager,
+			agentManager: this.config.spaceAgentManager,
+		});
+		const rehydrateCompletionDetector = new CompletionDetector(this.config.taskRepo);
+
 		const mcpServer = createTaskAgentMcpServer({
 			taskId,
 			space,
@@ -1147,6 +1170,8 @@ export class TaskAgentManager {
 			daemonHub: this.config.daemonHub,
 			sessionGroupRepo: this.config.sessionGroupRepo,
 			getGroupId: () => this.taskGroupIds.get(taskId),
+			channelRouter: rehydrateChannelRouter,
+			completionDetector: rehydrateCompletionDetector,
 			buildNodeAgentMcpServer: (subSessionId, role, stepTaskId) =>
 				this.buildNodeAgentMcpServerForSession(
 					taskId,

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -35,6 +35,8 @@ import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceSessionGroupRepository } from '../../../storage/repositories/space-session-group-repository';
 import { resolveAgentInit, buildCustomAgentTaskMessage } from '../agents/custom-agent';
 import { ChannelResolver } from '../runtime/channel-resolver';
+import type { ChannelRouter } from '../runtime/channel-router';
+import type { CompletionDetector } from '../runtime/completion-detector';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
@@ -194,6 +196,20 @@ export interface TaskAgentToolsConfig {
 		role: string,
 		stepTaskId: string
 	) => McpServerConfig;
+	/**
+	 * Channel router for gate-checked message routing between agents.
+	 * When provided, the send_message tool uses it for channel validation and
+	 * lazy node activation instead of constructing a ChannelResolver from run config.
+	 * Optional — existing ChannelResolver-based routing is used as fallback.
+	 */
+	channelRouter?: ChannelRouter;
+	/**
+	 * Completion detector for validating all-agents-done state.
+	 * When provided, report_workflow_done checks that all node agent tasks have
+	 * reached a terminal status before marking the workflow run as completed.
+	 * Optional — if omitted, no completion pre-check is performed.
+	 */
+	completionDetector?: CompletionDetector;
 }
 
 // ---------------------------------------------------------------------------
@@ -222,6 +238,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		getGroupId,
 		daemonHub,
 		buildNodeAgentMcpServer,
+		completionDetector,
 	} = config;
 
 	return {
@@ -672,6 +689,25 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 						`Workflow run must be in_progress.`,
 					currentStatus: run.status,
 				});
+			}
+
+			// Validate that all node agents have reached terminal status before
+			// allowing an explicit workflow completion. This guards against the Task
+			// Agent calling report_workflow_done prematurely while agents are still
+			// running.
+			if (completionDetector) {
+				const wfDef = workflowManager.getWorkflow(run.workflowId);
+				const channels = wfDef?.channels ?? [];
+				const nodes = wfDef?.nodes ?? [];
+				if (!completionDetector.isComplete(workflowRunId, channels, nodes)) {
+					return jsonResult({
+						success: false,
+						error:
+							'Not all node agents have reached a terminal state yet. ' +
+							'Wait for all agents to complete (check via check_node_status) ' +
+							'before calling report_workflow_done.',
+					});
+				}
 			}
 
 			const mainTask = taskRepo.getTask(taskId);

--- a/packages/daemon/tests/unit/space/completion-detector.test.ts
+++ b/packages/daemon/tests/unit/space/completion-detector.test.ts
@@ -142,22 +142,26 @@ describe('CompletionDetector', () => {
 	});
 
 	test('2. single agent in_progress — returns false', () => {
-		seedTask(db, SPACE, { workflowRunId: RUN, status: 'in_progress' });
+		seedTask(db, SPACE, { workflowRunId: RUN, workflowNodeId: 'node-1', status: 'in_progress' });
 		expect(detector.isComplete(RUN)).toBe(false);
 	});
 
 	test('3. single agent completed — returns true', () => {
-		seedTask(db, SPACE, { workflowRunId: RUN, status: 'completed' });
+		seedTask(db, SPACE, { workflowRunId: RUN, workflowNodeId: 'node-1', status: 'completed' });
 		expect(detector.isComplete(RUN)).toBe(true);
 	});
 
 	test('4. single agent needs_attention — returns true (terminal)', () => {
-		seedTask(db, SPACE, { workflowRunId: RUN, status: 'needs_attention' });
+		seedTask(db, SPACE, {
+			workflowRunId: RUN,
+			workflowNodeId: 'node-1',
+			status: 'needs_attention',
+		});
 		expect(detector.isComplete(RUN)).toBe(true);
 	});
 
 	test('5. single agent cancelled — returns true (terminal)', () => {
-		seedTask(db, SPACE, { workflowRunId: RUN, status: 'cancelled' });
+		seedTask(db, SPACE, { workflowRunId: RUN, workflowNodeId: 'node-1', status: 'cancelled' });
 		expect(detector.isComplete(RUN)).toBe(true);
 	});
 
@@ -166,17 +170,17 @@ describe('CompletionDetector', () => {
 	// does not yet include them. They are covered by the TERMINAL_TASK_STATUSES set tests.
 
 	test('6. single agent pending — returns false (non-terminal)', () => {
-		seedTask(db, SPACE, { workflowRunId: RUN, status: 'pending' });
+		seedTask(db, SPACE, { workflowRunId: RUN, workflowNodeId: 'node-1', status: 'pending' });
 		expect(detector.isComplete(RUN)).toBe(false);
 	});
 
 	test('7. single agent draft — returns false (non-terminal)', () => {
-		seedTask(db, SPACE, { workflowRunId: RUN, status: 'draft' });
+		seedTask(db, SPACE, { workflowRunId: RUN, workflowNodeId: 'node-1', status: 'draft' });
 		expect(detector.isComplete(RUN)).toBe(false);
 	});
 
 	test('8. single agent review — returns false (non-terminal)', () => {
-		seedTask(db, SPACE, { workflowRunId: RUN, status: 'review' });
+		seedTask(db, SPACE, { workflowRunId: RUN, workflowNodeId: 'node-1', status: 'review' });
 		expect(detector.isComplete(RUN)).toBe(false);
 	});
 
@@ -413,6 +417,24 @@ describe('CompletionDetector', () => {
 			expect(TERMINAL_TASK_STATUSES.has('in_progress')).toBe(false);
 			expect(TERMINAL_TASK_STATUSES.has('draft')).toBe(false);
 			expect(TERMINAL_TASK_STATUSES.has('review')).toBe(false);
+		});
+	});
+
+	describe('orchestration task exclusion', () => {
+		test('26. orchestration task (null workflowNodeId) in_progress does not block completion', () => {
+			// Node-agent task is completed; orchestration task (no workflowNodeId) is in_progress.
+			// The completion detector must exclude tasks with null workflowNodeId so the
+			// orchestration task running this check does not block its own workflow from completing.
+			seedTask(db, SPACE, { workflowRunId: RUN, workflowNodeId: 'node-a', status: 'completed' });
+			seedTask(db, SPACE, { workflowRunId: RUN, status: 'in_progress' }); // orchestration task
+			expect(detector.isComplete(RUN)).toBe(true);
+		});
+
+		test('27. only an orchestration task (no workflowNodeId) — treated as not started', () => {
+			// When there are no node-agent tasks, the workflow has not started even if the
+			// orchestration task exists (it may still be spinning up the first node agents).
+			seedTask(db, SPACE, { workflowRunId: RUN, status: 'in_progress' }); // orchestration task only
+			expect(detector.isComplete(RUN)).toBe(false);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -28,6 +28,7 @@ import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-man
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository.ts';
+import { CompletionDetector } from '../../../src/lib/space/runtime/completion-detector.ts';
 import {
 	createTaskAgentToolHandlers,
 	createTaskAgentMcpServer,
@@ -2060,6 +2061,119 @@ describe('createTaskAgentToolHandlers — report_workflow_done', () => {
 		// Should succeed without throwing
 		const result = await handlers.report_workflow_done({ summary: 'No hub' });
 		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+	});
+});
+
+// ===========================================================================
+// report_workflow_done with CompletionDetector
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — report_workflow_done with CompletionDetector', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('blocks when node agents have not all completed', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		// The step task is still 'pending' — not terminal
+		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const factory = makeMockSessionFactory();
+		const config = makeConfig(ctx, mainTask.id, run.id, factory);
+		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
+
+		const result = await handlers.report_workflow_done({ summary: 'Premature' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Not all node agents have reached a terminal state');
+	});
+
+	test('blocks when a step task is still in_progress', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		// Set the step task to in_progress (non-terminal) — CompletionDetector should block
+		const stepTask = ctx.taskRepo.listByWorkflowRun(run.id).find((t) => t.workflowNodeId != null);
+		ctx.taskRepo.updateTask(stepTask!.id, { status: 'in_progress' });
+
+		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const factory = makeMockSessionFactory();
+		const config = makeConfig(ctx, mainTask.id, run.id, factory);
+		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
+
+		const result = await handlers.report_workflow_done({ summary: 'Too soon' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Not all node agents');
+	});
+
+	test('allows completion when all step tasks have reached a terminal status', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		// Mark the step task as completed directly in the repo (bypass state machine)
+		const stepTask = ctx.taskRepo.listByWorkflowRun(run.id)[0];
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed' });
+
+		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const factory = makeMockSessionFactory();
+		const config = makeConfig(ctx, mainTask.id, run.id, factory);
+		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
+
+		const result = await handlers.report_workflow_done({ summary: 'All done' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		// Confirm the workflow run was actually marked completed
+		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
+		expect(updatedRun?.status).toBe('completed');
+	});
+
+	test('allows completion when step task has needs_attention status (terminal)', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		// needs_attention is a terminal status for the CompletionDetector
+		const stepTask = ctx.taskRepo.listByWorkflowRun(run.id)[0];
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'needs_attention' });
+
+		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const factory = makeMockSessionFactory();
+		const config = makeConfig(ctx, mainTask.id, run.id, factory);
+		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
+
+		const result = await handlers.report_workflow_done({ summary: 'Attention needed but done' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+	});
+
+	test('skips completion check when completionDetector is not provided', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		// Step task is still pending — without a detector this should still succeed
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.report_workflow_done({ summary: 'No detector' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		// No completionDetector → existing behaviour: no pre-check, should succeed
 		expect(parsed.success).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

- Add `channelRouter` and `completionDetector` as optional fields on `TaskAgentToolsConfig` (no circular deps — both types live in `runtime/`, imported as types only in `tools/`)
- `report_workflow_done` now validates all node-agent tasks are terminal via `CompletionDetector` before marking the workflow done, blocking premature completion calls
- `CompletionDetector.isComplete()` now filters to node-agent tasks only (`workflowNodeId != null`), correctly excluding the orchestration task which is `in_progress` while the check runs
- `TaskAgentManager` wires both instances in `spawnTaskAgent()` and `rehydrateTaskAgent()`

## Tests

- 5 new tests for `report_workflow_done` with `CompletionDetector` (blocks when in_progress, blocks when no tasks started, allows when all terminal, skips check without detector)
- 2 new tests for orchestration task exclusion in completion-detector
- Updated tests 2–8 in completion-detector.test.ts to include `workflowNodeId` (they represent node-agent tasks)