### PR TITLE
test(room): add getCurrentModel to local SessionFactory mocks

### DIFF
--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -368,6 +368,12 @@ describe('RoomRuntimeService restart recovery', () => {
 			async removeWorktree() {
 				return false;
 			},
+			async switchModel(_sessionId: string, model: string, _provider: string) {
+				return { success: true, model };
+			},
+			async getCurrentModel(_sessionId: string) {
+				return { currentModel: 'sonnet', provider: 'anthropic' };
+			},
 		} satisfies SessionFactory;
 	}
 

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -58,6 +58,18 @@ function createMockSessionFactory() {
 			calls.push({ method: 'startSession', args: [sessionId] });
 			return true;
 		},
+		setSessionMcpServers(_sessionId: string, _mcpServers: Record<string, unknown>) {
+			return true;
+		},
+		async removeWorktree(_workspacePath: string) {
+			return true;
+		},
+		async switchModel(_sessionId: string, model: string, _provider: string) {
+			return { success: true, model };
+		},
+		async getCurrentModel(_sessionId: string) {
+			return { currentModel: 'sonnet', provider: 'anthropic' };
+		},
 	} satisfies SessionFactory & { calls: Array<{ method: string; args: unknown[] }> };
 }
 

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -102,6 +102,12 @@ function createMockSessionFactory(
 		setSessionMcpServers(_sessionId: string, _mcpServers: Record<string, unknown>) {
 			return true;
 		},
+		async switchModel(_sessionId: string, model: string, _provider: string) {
+			return { success: true, model };
+		},
+		async getCurrentModel(_sessionId: string) {
+			return { currentModel: 'sonnet', provider: 'anthropic' };
+		},
 	} satisfies SessionFactory & {
 		calls: Array<{ method: string; args: unknown[] }>;
 		liveSessions: Set<string>;


### PR DESCRIPTION
Add `getCurrentModel` (and `switchModel`, `setSessionMcpServers`, `removeWorktree` where absent) to local `SessionFactory` mock factories in three test files, completing the mock updates needed after Task 1.1 added `getCurrentModel` to the interface.

Files updated:
- `tests/unit/room/task-group-manager.test.ts`
- `tests/unit/room/runtime-recovery.test.ts`
- `tests/unit/room/room-runtime-service.test.ts`

All 372 room-runtime unit tests pass.