### PR TITLE
test(e2e): global Skills Registry lifecycle (Task 5.3)

### DIFF
--- a/packages/e2e/tests/features/global-skills.e2e.ts
+++ b/packages/e2e/tests/features/global-skills.e2e.ts
@@ -1,0 +1,219 @@
+/**
+ * Global Skills Registry E2E Tests
+ *
+ * Tests the full lifecycle of a skill in the Global Settings > Skills panel:
+ * - Navigate to Settings > Skills
+ * - Add a new MCP server skill
+ * - Verify the skill appears with correct name and type badge
+ * - Toggle the skill off and verify disabled state
+ * - Edit the description and verify it updates
+ * - Delete the skill and verify it is removed
+ *
+ * Setup: no room needed; tests the global Settings panel directly.
+ * Cleanup: delete is the final step in the test itself.
+ */
+
+import { test, expect, type Page } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+// fetch-mcp is a pre-seeded Application MCP Server always present in the registry
+const TEST_MCP_SERVER_NAME = 'fetch-mcp';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Open the Global Settings panel via the NavRail Settings button.
+ */
+async function openGlobalSettings(page: Page): Promise<void> {
+	const settingsButton = page.getByRole('button', { name: 'Settings', exact: true });
+	await settingsButton.waitFor({ state: 'visible', timeout: 5000 });
+	await settingsButton.click();
+	await expect(page.getByText('Global Settings')).toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * Navigate to the Skills section inside the Global Settings panel.
+ * Assumes Global Settings is already open.
+ */
+async function navigateToSkillsSection(page: Page): Promise<void> {
+	// The Skills nav button in the settings sidebar
+	const skillsNavButton = page.locator('nav button:has-text("Skills")').first();
+	await skillsNavButton.waitFor({ state: 'visible', timeout: 5000 });
+	await skillsNavButton.click();
+
+	// Wait for the Skills content area to appear
+	await page
+		.locator('text=Application-level skills are available to any room or session')
+		.first()
+		.waitFor({ state: 'visible', timeout: 5000 });
+}
+
+/**
+ * Add a new MCP server skill through the Add Skill dialog.
+ * After submission, reloads the page so all Preact state (including any stale
+ * Portal modal overlays) is fully cleared before the test continues.
+ * The skill persists in the database, so it is still visible after reload.
+ */
+async function addMcpSkill(page: Page, displayName: string): Promise<void> {
+	// Click the "Add Skill" button
+	const addSkillButton = page
+		.locator('button')
+		.filter({ hasText: /^Add Skill$/ })
+		.first();
+	await addSkillButton.waitFor({ state: 'visible', timeout: 5000 });
+	await addSkillButton.click();
+
+	// Wait for the dialog to open
+	await page
+		.locator('[role="dialog"] h2')
+		.filter({ hasText: 'Add Skill' })
+		.first()
+		.waitFor({ state: 'visible', timeout: 5000 });
+
+	// Fill in Display Name
+	const displayNameInput = page.locator('[role="dialog"] input[placeholder="e.g., Web Search"]');
+	await displayNameInput.waitFor({ state: 'visible', timeout: 5000 });
+	await displayNameInput.fill(displayName);
+
+	// Select "MCP Server" source type radio
+	const mcpServerRadio = page.locator('[role="dialog"] input[type="radio"][value="mcp_server"]');
+	await mcpServerRadio.click();
+
+	// Wait for the MCP server select dropdown to appear
+	const mcpSelect = page.locator('[role="dialog"] select');
+	await mcpSelect.waitFor({ state: 'visible', timeout: 5000 });
+
+	// Select the fetch-mcp option
+	await mcpSelect.selectOption({ label: TEST_MCP_SERVER_NAME });
+
+	// Click the submit button inside the dialog
+	const submitButton = page
+		.locator('[role="dialog"] button[type="submit"]')
+		.filter({ hasText: 'Add Skill' });
+	await submitButton.click();
+
+	// Wait for the skill to appear in the list (LiveQuery fires before RPC returns)
+	await page.locator(`text="${displayName}"`).first().waitFor({ state: 'visible', timeout: 15000 });
+
+	// Reload the page to clear all Preact state. The Add Skill dialog creates a Portal
+	// modal overlay that can persist as a stale backdrop (due to a Preact VNode cleanup
+	// race when signals update during an open dialog). A page reload fully resets all
+	// component state while the skill remains persisted in the database.
+	await page.reload();
+	await waitForWebSocketConnected(page);
+	await openGlobalSettings(page);
+	await navigateToSkillsSection(page);
+
+	// Verify the skill is still in the list after reload
+	await page.locator(`text="${displayName}"`).first().waitFor({ state: 'visible', timeout: 10000 });
+}
+
+/**
+ * Find the skill row by navigating from the display name text up to its nearest
+ * ancestor div that contains a Delete button. The ancestor:: axis in XPath starts
+ * from the nearest ancestor, so [1] picks the skill row div itself (not a parent container).
+ * Uses .first() to guard against brief double-render of the SkillsRegistry.
+ */
+function getSkillRow(page: Page, displayName: string) {
+	// Walk up from the display name element to find the nearest ancestor div
+	// that contains a Delete button (i.e., the skill row itself).
+	return page
+		.locator(
+			`xpath=//*[normalize-space(text())="${displayName}"]/ancestor::div[.//button[@title="Delete"]][1]`
+		)
+		.first();
+}
+
+/**
+ * Delete the skill with the given display name via the UI delete button + confirm modal.
+ */
+async function deleteSkillByName(page: Page, displayName: string): Promise<void> {
+	const row = getSkillRow(page, displayName);
+	const deleteButton = row.locator('button[title="Delete"]');
+	await deleteButton.waitFor({ state: 'visible', timeout: 5000 });
+	await deleteButton.click();
+
+	// Wait for confirm modal and click the confirm "Delete" button
+	// Use the modal's button specifically to avoid matching the list's delete buttons
+	const confirmModal = page.locator('[role="dialog"]').filter({ hasText: 'Delete Skill' });
+	await confirmModal.waitFor({ state: 'visible', timeout: 5000 });
+	const confirmButton = confirmModal.locator('button').filter({ hasText: 'Delete' }).last();
+	await confirmButton.click();
+
+	// Wait for the skill to disappear from the list
+	await page.locator(`text="${displayName}"`).first().waitFor({ state: 'hidden', timeout: 10000 });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe('Global Skills Registry', () => {
+	// Unique display name to avoid conflicts across test runs
+	const displayName = `E2E Skill ${Date.now()}`;
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		await openGlobalSettings(page);
+		await navigateToSkillsSection(page);
+	});
+
+	test('full lifecycle: add, toggle, edit, delete a skill', async ({ page }) => {
+		// ── 1. Add the skill ──────────────────────────────────────────────────
+
+		await addMcpSkill(page, displayName);
+
+		// Skill row should now be visible
+		const skillRow = getSkillRow(page, displayName);
+		await expect(skillRow).toBeVisible({ timeout: 10000 });
+
+		// MCP type badge shows "mcp" — the badge span shows source type label
+		await expect(skillRow.getByText('mcp', { exact: true }).first()).toBeVisible({ timeout: 5000 });
+
+		// ── 2. Toggle the skill off ───────────────────────────────────────────
+
+		const toggle = skillRow.locator('[role="switch"]').first();
+		// After adding, the skill is enabled by default
+		await expect(toggle).toHaveAttribute('aria-checked', 'true', { timeout: 5000 });
+
+		// Click toggle to disable
+		await toggle.click();
+
+		// Verify toggle shows disabled state
+		await expect(toggle).toHaveAttribute('aria-checked', 'false', { timeout: 5000 });
+
+		// ── 3. Edit the skill's description ──────────────────────────────────
+
+		const editButton = skillRow.locator('button[title="Edit"]');
+		await editButton.click();
+
+		// Wait for edit dialog
+		const editDialog = page.locator('[role="dialog"]').filter({ hasText: 'Edit Skill' }).first();
+		await editDialog.waitFor({ state: 'visible', timeout: 5000 });
+
+		// Update the description field
+		const updatedDescription = 'Updated E2E description';
+		const descriptionInput = editDialog.locator('input[placeholder="Optional description"]');
+		await descriptionInput.fill(updatedDescription);
+
+		// Save changes
+		const saveButton = editDialog
+			.locator('button[type="submit"]')
+			.filter({ hasText: 'Save Changes' });
+		await saveButton.click();
+
+		// Wait for the edit dialog to close
+		await editDialog.waitFor({ state: 'hidden', timeout: 5000 });
+
+		// Verify updated description appears in the skill row
+		await expect(skillRow.locator(`text="${updatedDescription}"`)).toBeVisible({ timeout: 5000 });
+
+		// ── 4. Delete the skill ───────────────────────────────────────────────
+
+		await deleteSkillByName(page, displayName);
+
+		// Verify the skill no longer appears in the list
+		await expect(page.locator(`text="${displayName}"`).first()).not.toBeVisible({ timeout: 5000 });
+	});
+});

--- a/packages/e2e/tests/features/global-skills.e2e.ts
+++ b/packages/e2e/tests/features/global-skills.e2e.ts
@@ -52,9 +52,7 @@ async function navigateToSkillsSection(page: Page): Promise<void> {
 
 /**
  * Add a new MCP server skill through the Add Skill dialog.
- * After submission, reloads the page so all Preact state (including any stale
- * Portal modal overlays) is fully cleared before the test continues.
- * The skill persists in the database, so it is still visible after reload.
+ * Waits for the skill to appear in the list and the dialog to close.
  */
 async function addMcpSkill(page: Page, displayName: string): Promise<void> {
 	// Click the "Add Skill" button
@@ -97,17 +95,13 @@ async function addMcpSkill(page: Page, displayName: string): Promise<void> {
 	// Wait for the skill to appear in the list (LiveQuery fires before RPC returns)
 	await page.locator(`text="${displayName}"`).first().waitFor({ state: 'visible', timeout: 15000 });
 
-	// Reload the page to clear all Preact state. The Add Skill dialog creates a Portal
-	// modal overlay that can persist as a stale backdrop (due to a Preact VNode cleanup
-	// race when signals update during an open dialog). A page reload fully resets all
-	// component state while the skill remains persisted in the database.
-	await page.reload();
-	await waitForWebSocketConnected(page);
-	await openGlobalSettings(page);
-	await navigateToSkillsSection(page);
-
-	// Verify the skill is still in the list after reload
-	await page.locator(`text="${displayName}"`).first().waitFor({ state: 'visible', timeout: 10000 });
+	// Wait for the dialog to close after the RPC completes and handleClose() fires.
+	// The Add Skill dialog title h2 was used to open the dialog; wait for it to disappear.
+	await page
+		.locator('[role="dialog"] h2')
+		.filter({ hasText: 'Add Skill' })
+		.first()
+		.waitFor({ state: 'hidden', timeout: 10000 });
 }
 
 /**

--- a/packages/web/src/components/settings/SkillsRegistry.tsx
+++ b/packages/web/src/components/settings/SkillsRegistry.tsx
@@ -30,7 +30,11 @@ const SOURCE_TYPE_LABELS: Record<string, string> = {
 };
 
 export function SkillsRegistry() {
-	const { skills, isLoading, error } = useSkills();
+	// useSkills() bridges signal changes into plain useState values so that this
+	// component never reads signal.value directly. This prevents the
+	// @preact/preset-vite transform from creating extra signal subscriptions
+	// that cause double-render artifacts when the LiveQuery snapshot fires.
+	const { skills: skillsList, isLoading: isLoadingVal, error: errorVal } = useSkills();
 
 	const [showAddDialog, setShowAddDialog] = useState(false);
 	const [editingSkill, setEditingSkill] = useState<AppSkill | null>(null);
@@ -68,7 +72,7 @@ export function SkillsRegistry() {
 		}
 	};
 
-	if (isLoading.value && skills.value.length === 0) {
+	if (isLoadingVal && skillsList.length === 0) {
 		return (
 			<SettingsSection title="Skills">
 				<div class="text-sm text-gray-500 py-2">Loading skills...</div>
@@ -76,10 +80,10 @@ export function SkillsRegistry() {
 		);
 	}
 
-	if (error.value) {
+	if (errorVal) {
 		return (
 			<SettingsSection title="Skills">
-				<div class="text-sm text-red-400 py-2">Error: {error.value}</div>
+				<div class="text-sm text-red-400 py-2">Error: {errorVal}</div>
 			</SettingsSection>
 		);
 	}
@@ -97,11 +101,11 @@ export function SkillsRegistry() {
 					</Button>
 				</div>
 
-				{skills.value.length === 0 ? (
+				{skillsList.length === 0 ? (
 					<div class="text-sm text-gray-500 py-4">No skills added yet. Add your first skill.</div>
 				) : (
 					<div class="space-y-2">
-						{skills.value.map((skill) => (
+						{skillsList.map((skill) => (
 							<div
 								key={skill.id}
 								class={cn(

--- a/packages/web/src/components/settings/__tests__/SkillsRegistry.test.tsx
+++ b/packages/web/src/components/settings/__tests__/SkillsRegistry.test.tsx
@@ -53,12 +53,12 @@ vi.mock('../../../lib/skills-store.ts', () => ({
 	},
 }));
 
-// Mock useSkills hook
+// Mock useSkills hook — returns plain values matching the new UseSkillsResult interface
 vi.mock('../../../hooks/useSkills.ts', () => ({
 	useSkills: () => ({
-		skills: mockSkillsSignal,
-		isLoading: mockIsLoadingSignal,
-		error: mockErrorSignal,
+		skills: mockSkillsSignal.value,
+		isLoading: mockIsLoadingSignal.value,
+		error: mockErrorSignal.value,
 	}),
 }));
 

--- a/packages/web/src/components/ui/Portal.tsx
+++ b/packages/web/src/components/ui/Portal.tsx
@@ -1,6 +1,6 @@
 import { ComponentChildren } from 'preact';
-import { useEffect, useRef, useState } from 'preact/hooks';
-import { render } from 'preact';
+import { useMemo, useEffect } from 'preact/hooks';
+import { createPortal } from 'preact/compat';
 
 interface PortalProps {
 	children: ComponentChildren;
@@ -10,8 +10,10 @@ interface PortalProps {
 /**
  * Portal component for Preact 10+
  *
- * Renders children into a DOM node outside the parent component's DOM hierarchy.
- * Compatible with Preact 10.x (unlike preact-portal which uses deprecated APIs).
+ * Renders children into a DOM node outside the parent component's DOM hierarchy
+ * using Preact's built-in createPortal. Because createPortal keeps children inside
+ * the main Preact VNode tree, cleanup is guaranteed when the parent unmounts —
+ * no stale portal overlays can persist after navigation.
  *
  * @example
  * <Portal into="body">
@@ -19,41 +21,23 @@ interface PortalProps {
  * </Portal>
  */
 export function Portal({ children, into = 'body' }: PortalProps) {
-	const containerRef = useRef<HTMLDivElement | null>(null);
-	const [mounted, setMounted] = useState(false);
+	const container = useMemo(() => {
+		const el = document.createElement('div');
+		el.setAttribute('data-portal', 'true');
+		return el;
+	}, []);
 
 	useEffect(() => {
-		// Create a container element
-		const container = document.createElement('div');
-		container.setAttribute('data-portal', 'true');
-		containerRef.current = container;
-
-		// Find target element
 		const target = typeof into === 'string' ? document.querySelector(into) : into;
-
 		if (target) {
 			target.appendChild(container);
-			setMounted(true);
 		}
-
-		// Cleanup on unmount
 		return () => {
-			if (containerRef.current?.parentNode) {
-				// Unmount any rendered content first
-				render(null, containerRef.current);
-				containerRef.current.parentNode.removeChild(containerRef.current);
+			if (container.parentNode) {
+				container.parentNode.removeChild(container);
 			}
-			containerRef.current = null;
 		};
-	}, [into]);
+	}, [into, container]);
 
-	// Render children into the container
-	useEffect(() => {
-		if (mounted && containerRef.current) {
-			render(<>{children}</>, containerRef.current);
-		}
-	}, [mounted, children]);
-
-	// Portal renders nothing in its original location
-	return null;
+	return createPortal(children, container);
 }

--- a/packages/web/src/hooks/useSkills.ts
+++ b/packages/web/src/hooks/useSkills.ts
@@ -4,55 +4,59 @@
  * Lifecycle adapter that manages the global Skills registry LiveQuery subscription.
  *
  * Responsibilities:
- * - On mount: call skillsStore.subscribe()
- * - On unmount: call skillsStore.unsubscribe()
+ * - On mount: subscribe to skillsStore signals via callback, then start the LiveQuery
+ * - On unmount: unsubscribe from signals and tear down the LiveQuery
  *
- * The store owns the subscription handles and cleanup logic.
- * This hook is purely a lifecycle adapter between the Preact component
- * tree and the skills store's LiveQuery methods.
- *
- * @returns The store signals for use in components.
- *
- * @example
- * ```tsx
- * export default function SkillsRegistry() {
- *   const { skills, isLoading, error } = useSkills();
- *   if (isLoading.value) return <div>Loading...</div>;
- *   return <ul>{skills.value.map(s => <li key={s.id}>{s.displayName}</li>)}</ul>;
- * }
- * ```
+ * Signal bridging: uses signal.subscribe() to push plain values into useState so that
+ * SkillsRegistry never reads signal.value directly in its component body or JSX. This
+ * avoids the @preact/preset-vite transform from creating conflicting fine-grained
+ * subscriptions that produce double-rendered VNode trees.
  */
 
-import { useEffect } from 'preact/hooks';
-import type { Signal } from '@preact/signals';
+import { useState, useEffect } from 'preact/hooks';
 import type { AppSkill } from '@neokai/shared';
 import { skillsStore } from '../lib/skills-store';
 
 interface UseSkillsResult {
-	skills: Signal<AppSkill[]>;
-	isLoading: Signal<boolean>;
-	error: Signal<string | null>;
+	skills: AppSkill[];
+	isLoading: boolean;
+	error: string | null;
 }
 
 /**
- * Subscribe to the global Skills registry and return reactive signals.
+ * Subscribe to the global Skills registry and return plain reactive values.
+ *
+ * Uses signal.subscribe() callbacks to bridge signals into useState, so that
+ * the consuming component only sees plain JS values (not Signal objects).
+ * This prevents the @preact/preset-vite signals transform from creating
+ * extra component-level subscriptions that cause double-render artifacts.
  *
  * Manages the LiveQuery subscription lifecycle:
  * subscribe on mount, unsubscribe on unmount.
  */
 export function useSkills(): UseSkillsResult {
+	const [skills, setSkills] = useState<AppSkill[]>(skillsStore.skills.value);
+	const [isLoading, setIsLoading] = useState<boolean>(skillsStore.isLoading.value);
+	const [error, setError] = useState<string | null>(skillsStore.error.value);
+
 	useEffect(() => {
+		// Bridge signal changes into useState. signal.subscribe() calls the
+		// callback immediately with the current value, then on every future change.
+		const unsubSkills = skillsStore.skills.subscribe(setSkills);
+		const unsubLoading = skillsStore.isLoading.subscribe(setIsLoading);
+		const unsubError = skillsStore.error.subscribe(setError);
+
 		skillsStore.subscribe().catch(() => {
-			// Error is surfaced via skillsStore.error signal
+			// Error is surfaced via skillsStore.error signal → setError callback above
 		});
+
 		return () => {
+			unsubSkills();
+			unsubLoading();
+			unsubError();
 			skillsStore.unsubscribe();
 		};
 	}, []);
 
-	return {
-		skills: skillsStore.skills,
-		isLoading: skillsStore.isLoading,
-		error: skillsStore.error,
-	};
+	return { skills, isLoading, error };
 }


### PR DESCRIPTION
## Summary

- Adds E2E test covering the full skill lifecycle: add via MCP server dialog, verify badge, toggle off, edit description, delete
- Fixes `Portal` to use `preact/compat` `createPortal` instead of a separate `render()` tree — stale backdrop overlays can no longer persist after parent unmount
- Bridges `skillsStore` signals into `useState` in `useSkills()` so `SkillsRegistry` never reads `signal.value` directly, preventing `@preact/preset-vite` double-render artifacts