### PR TITLE
test(space): verify Task Agent MCP server tool list is clean and agent-centric

### DIFF
--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -1,11 +1,13 @@
 /**
- * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 5
- * tools available to the Task Agent session.
+ * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 6
+ * tools available to the Task Agent session (send_message schema is shared
+ * from node-agent-tool-schemas.ts, making 7 tools total in the MCP server).
  *
- * Tools:
+ * Tools (defined in this file):
  *   spawn_node_agent      — spawn a sub-session for a specific workflow node
  *   check_node_status     — check the status of the current or a specific node's sub-session
  *   report_result         — report the final task result (terminal tool)
+ *   report_workflow_done  — explicitly mark the entire workflow run as completed
  *   request_human_input   — pause execution and surface a question to the human user
  *   list_group_members    — list all members of the current task's session group
  *

--- a/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
@@ -11,6 +11,7 @@ import {
 	SpawnNodeAgentSchema,
 	CheckNodeStatusSchema,
 	ReportResultSchema,
+	ReportWorkflowDoneSchema,
 	RequestHumanInputSchema,
 	TaskResultStatusSchema,
 	TASK_AGENT_TOOL_SCHEMAS,
@@ -243,6 +244,40 @@ describe('RequestHumanInputSchema', () => {
 });
 
 // ---------------------------------------------------------------------------
+// report_workflow_done
+// ---------------------------------------------------------------------------
+
+describe('ReportWorkflowDoneSchema', () => {
+	test('accepts empty object (summary is optional)', () => {
+		const result = ReportWorkflowDoneSchema.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.summary).toBeUndefined();
+		}
+	});
+
+	test('accepts valid input with summary', () => {
+		const result = ReportWorkflowDoneSchema.safeParse({
+			summary: 'All agents completed successfully. PR #42 merged.',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.summary).toBe('All agents completed successfully. PR #42 merged.');
+		}
+	});
+
+	test('rejects non-string summary', () => {
+		const result = ReportWorkflowDoneSchema.safeParse({ summary: 123 });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects null summary', () => {
+		const result = ReportWorkflowDoneSchema.safeParse({ summary: null });
+		expect(result.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // TASK_AGENT_TOOL_SCHEMAS aggregate
 // ---------------------------------------------------------------------------
 
@@ -262,6 +297,13 @@ describe('TASK_AGENT_TOOL_SCHEMAS', () => {
 		for (const schema of Object.values(TASK_AGENT_TOOL_SCHEMAS)) {
 			expect(typeof schema.safeParse).toBe('function');
 		}
+	});
+
+	test('does not contain advance_workflow or any old step-advancement tool', () => {
+		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
+		expect(keys).not.toContain('advance_workflow');
+		expect(keys).not.toContain('spawn_step_agent');
+		expect(keys).not.toContain('check_step_status');
 	});
 });
 


### PR DESCRIPTION
Fixes a stale comment and adds missing test coverage for the Task Agent MCP server configuration (Task 5.4).

- Fix `task-agent-tool-schemas.ts` header: update "5 tools" → "6 tools" and add `report_workflow_done` to the tools list
- Add `ReportWorkflowDoneSchema` unit tests (4 cases: empty object, with summary, non-string summary, null summary)
- Add explicit assertion that `advance_workflow`, `spawn_step_agent`, and `check_step_status` are absent from `TASK_AGENT_TOOL_SCHEMAS`

The existing `createTaskAgentMcpServer` test already verifies the exact 7-tool list; these additions make the schema file self-consistent with what the MCP server registers.