### PR TITLE
fix(web): use onInput for all Preact select elements

### DIFF
--- a/packages/web/src/components/room/GoalsEditor.test.tsx
+++ b/packages/web/src/components/room/GoalsEditor.test.tsx
@@ -596,7 +596,7 @@ describe('GoalsEditor', () => {
 			fireEvent.click(recurringBtn!);
 
 			const presetSelect = document.body.querySelector('[data-testid="schedule-preset"]');
-			fireEvent.change(presetSelect!, { target: { value: 'custom' } });
+			fireEvent.input(presetSelect!, { target: { value: 'custom' } });
 
 			expect(document.body.querySelector('[data-testid="custom-cron"]')).toBeTruthy();
 		});
@@ -610,7 +610,7 @@ describe('GoalsEditor', () => {
 			fireEvent.click(recurringBtn!);
 
 			const presetSelect = document.body.querySelector('[data-testid="schedule-preset"]');
-			fireEvent.change(presetSelect!, { target: { value: 'custom' } });
+			fireEvent.input(presetSelect!, { target: { value: 'custom' } });
 
 			// The "Create" button (not "Skip & Create") should be disabled
 			const createBtn = Array.from(document.body.querySelectorAll('button')).find(
@@ -628,7 +628,7 @@ describe('GoalsEditor', () => {
 			fireEvent.click(recurringBtn!);
 
 			const presetSelect = document.body.querySelector('[data-testid="schedule-preset"]');
-			fireEvent.change(presetSelect!, { target: { value: 'custom' } });
+			fireEvent.input(presetSelect!, { target: { value: 'custom' } });
 
 			// "Skip & Create" should NOT be disabled (it uses defaults, not current step 2 values)
 			const skipBtn = Array.from(document.body.querySelectorAll('button')).find(

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -576,8 +576,7 @@ function GoalForm({
 						<div class="flex gap-2">
 							<select
 								value={schedulePreset}
-								onChange={(e) => setSchedulePreset((e.target as HTMLSelectElement).value)}
-								onInput={(e) => setSchedulePreset((e.target as HTMLSelectElement).value)}
+								onInput={(e) => setSchedulePreset((e.currentTarget as HTMLSelectElement).value)}
 								class="flex-1 px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
 								data-testid="schedule-preset"
 							>
@@ -956,8 +955,7 @@ function CreateGoalWizard({ onSubmit, onCancel, isLoading }: CreateGoalWizardPro
 						<div class="flex gap-2">
 							<select
 								value={schedulePreset}
-								onChange={(e) => setSchedulePreset((e.target as HTMLSelectElement).value)}
-								onInput={(e) => setSchedulePreset((e.target as HTMLSelectElement).value)}
+								onInput={(e) => setSchedulePreset((e.currentTarget as HTMLSelectElement).value)}
 								class="flex-1 px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
 								data-testid="schedule-preset"
 							>

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -588,7 +588,7 @@ function GoalForm({
 							</select>
 							<select
 								value={timezone}
-								onChange={(e) => setTimezone((e.target as HTMLSelectElement).value)}
+								onInput={(e) => setTimezone((e.currentTarget as HTMLSelectElement).value)}
 								class="flex-1 px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
 								data-testid="timezone-select"
 							>
@@ -627,7 +627,7 @@ function GoalForm({
 				<select
 					id="goal-priority"
 					value={priority}
-					onChange={(e) => setPriority((e.target as HTMLSelectElement).value as GoalPriority)}
+					onInput={(e) => setPriority((e.currentTarget as HTMLSelectElement).value as GoalPriority)}
 					class="w-full px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
 				>
 					<option value="low">Low</option>
@@ -967,7 +967,7 @@ function CreateGoalWizard({ onSubmit, onCancel, isLoading }: CreateGoalWizardPro
 							</select>
 							<select
 								value={timezone}
-								onChange={(e) => setTimezone((e.target as HTMLSelectElement).value)}
+								onInput={(e) => setTimezone((e.currentTarget as HTMLSelectElement).value)}
 								class="flex-1 px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
 								data-testid="timezone-select"
 							>

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -577,6 +577,7 @@ function GoalForm({
 							<select
 								value={schedulePreset}
 								onChange={(e) => setSchedulePreset((e.target as HTMLSelectElement).value)}
+								onInput={(e) => setSchedulePreset((e.target as HTMLSelectElement).value)}
 								class="flex-1 px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
 								data-testid="schedule-preset"
 							>
@@ -956,6 +957,7 @@ function CreateGoalWizard({ onSubmit, onCancel, isLoading }: CreateGoalWizardPro
 							<select
 								value={schedulePreset}
 								onChange={(e) => setSchedulePreset((e.target as HTMLSelectElement).value)}
+								onInput={(e) => setSchedulePreset((e.target as HTMLSelectElement).value)}
 								class="flex-1 px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
 								data-testid="schedule-preset"
 							>

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2567,7 +2567,7 @@ describe('TaskView — SetStatusModal', () => {
 		// Select 'pending' from the dropdown (portal renders in document.body)
 		const select = document.querySelector('select') as HTMLSelectElement;
 		await act(async () => {
-			fireEvent.change(select, { target: { value: 'pending' } });
+			fireEvent.input(select, { target: { value: 'pending' } });
 		});
 
 		// Confirm
@@ -2642,7 +2642,7 @@ describe('TaskView — SetStatusModal', () => {
 		// Select 'pending' to trigger destructive warning
 		const select = document.querySelector('select') as HTMLSelectElement;
 		await act(async () => {
-			fireEvent.change(select, { target: { value: 'pending' } });
+			fireEvent.input(select, { target: { value: 'pending' } });
 		});
 
 		// Warning text should appear in the modal

--- a/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
+++ b/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
@@ -399,6 +399,11 @@ export function SetStatusModal({ task, isOpen, onClose, onConfirm }: SetStatusMo
 							setSelectedStatus((val as TaskStatus) || null);
 							setError(null);
 						}}
+						onInput={(e) => {
+							const val = (e.target as HTMLSelectElement).value;
+							setSelectedStatus((val as TaskStatus) || null);
+							setError(null);
+						}}
 					>
 						<option value="">Select a status…</option>
 						{availableStatuses.map((s) => (

--- a/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
+++ b/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
@@ -394,13 +394,8 @@ export function SetStatusModal({ task, isOpen, onClose, onConfirm }: SetStatusMo
 					<select
 						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-600"
 						value={selectedStatus ?? ''}
-						onChange={(e) => {
-							const val = (e.target as HTMLSelectElement).value;
-							setSelectedStatus((val as TaskStatus) || null);
-							setError(null);
-						}}
 						onInput={(e) => {
-							const val = (e.target as HTMLSelectElement).value;
+							const val = (e.currentTarget as HTMLSelectElement).value;
 							setSelectedStatus((val as TaskStatus) || null);
 							setError(null);
 						}}

--- a/packages/web/src/components/room/task-shared/__tests__/TaskActionDialogs.test.tsx
+++ b/packages/web/src/components/room/task-shared/__tests__/TaskActionDialogs.test.tsx
@@ -215,7 +215,7 @@ describe('SetStatusModal', () => {
 		);
 
 		const select = getByTestId('modal').querySelector('select') as HTMLSelectElement;
-		fireEvent.change(select, { target: { value: 'completed' } });
+		fireEvent.input(select, { target: { value: 'completed' } });
 
 		fireEvent.click(getByTestId('set-status-confirm'));
 

--- a/packages/web/src/components/space/ImportPreviewDialog.tsx
+++ b/packages/web/src/components/space/ImportPreviewDialog.tsx
@@ -60,10 +60,9 @@ function ConflictSelector({
 		<select
 			aria-label={`Conflict resolution for ${name}`}
 			value={value}
-			onChange={(e) =>
-				onChange((e.target as HTMLSelectElement).value as ConflictResolutionStrategy)
+			onInput={(e) =>
+				onChange((e.currentTarget as HTMLSelectElement).value as ConflictResolutionStrategy)
 			}
-			onInput={(e) => onChange((e.target as HTMLSelectElement).value as ConflictResolutionStrategy)}
 			class="text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1 text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
 		>
 			{(Object.keys(STRATEGY_LABELS) as ConflictResolutionStrategy[]).map((s) => (

--- a/packages/web/src/components/space/ImportPreviewDialog.tsx
+++ b/packages/web/src/components/space/ImportPreviewDialog.tsx
@@ -61,8 +61,9 @@ function ConflictSelector({
 			aria-label={`Conflict resolution for ${name}`}
 			value={value}
 			onChange={(e) =>
-				onChange((e.currentTarget as HTMLSelectElement).value as ConflictResolutionStrategy)
+				onChange((e.target as HTMLSelectElement).value as ConflictResolutionStrategy)
 			}
+			onInput={(e) => onChange((e.target as HTMLSelectElement).value as ConflictResolutionStrategy)}
 			class="text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1 text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
 		>
 			{(Object.keys(STRATEGY_LABELS) as ConflictResolutionStrategy[]).map((s) => (

--- a/packages/web/src/components/space/__tests__/ImportPreviewDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/ImportPreviewDialog.test.tsx
@@ -124,7 +124,7 @@ describe('ImportPreviewDialog', () => {
 			/>
 		);
 		const select = screen.getByLabelText(/Conflict resolution for Agent Two/i) as HTMLSelectElement;
-		fireEvent.change(select, { target: { value: 'rename' } });
+		fireEvent.input(select, { target: { value: 'rename' } });
 
 		const importBtn = screen.getByRole('button', { name: /^Import$/ }) as HTMLButtonElement;
 		expect(importBtn.disabled).toBe(false);
@@ -146,7 +146,7 @@ describe('ImportPreviewDialog', () => {
 			/>
 		);
 		const select = screen.getByLabelText(/Conflict resolution for Agent Two/i) as HTMLSelectElement;
-		fireEvent.change(select, { target: { value: 'replace' } });
+		fireEvent.input(select, { target: { value: 'replace' } });
 
 		const importBtn = screen.getByRole('button', { name: /^Import$/ });
 		fireEvent.click(importBtn);


### PR DESCRIPTION
Migrate all native `<select>` elements from `onChange` to `onInput` to align with Preact's signal-based reactivity model, and update tests to fire `input` events.

**Changed select elements:**
- `GoalsEditor.tsx` — schedule preset (2 locations), timezone (2), priority (1)
- `SetStatusModal` (in `TaskActionDialogs.tsx`) — status dropdown
- `ImportPreviewDialog.tsx` — conflict resolution strategy