### PR TITLE
chore(deps): pin all dependency versions to exact

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,16 @@
+# Dependency Version Pin Audit
+
+Verified all dependency versions across every package.json in the monorepo are exact (no ~ or ^ prefixes).
+
+## Result
+
+No violations found. All versions are already pinned to exact versions.
+
+## Files Checked
+
+- package.json
+- packages/cli/package.json
+- packages/daemon/package.json
+- packages/shared/package.json
+- packages/web/package.json
+- packages/e2e/package.json


### PR DESCRIPTION
## Summary
- Audited all `package.json` files for `~` or `^` version prefixes
- All dependency versions across the monorepo are already pinned to exact versions — no violations found

## Files checked
- `package.json` (root)
- `packages/cli/package.json`
- `packages/daemon/package.json`
- `packages/shared/package.json`
- `packages/web/package.json`
- `packages/e2e/package.json`

## Result
No changes needed — all versions are exact.