### PR TITLE
ci: add run_e2e_only input for selective E2E on PR branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
     name: Lint, Knip, Format & Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev') && !github.event.inputs.run_e2e_only
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev') && github.event.inputs.run_e2e_only != 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -120,7 +120,7 @@ jobs:
   test-daemon-online:
     name: Daemon Online (${{ matrix.module }})
     runs-on: ubuntu-latest
-    if: github.ref_type != 'tag' && (github.event_name != 'push' || github.ref != 'refs/heads/dev') && !github.event.inputs.run_e2e_only
+    if: github.ref_type != 'tag' && (github.event_name != 'push' || github.ref != 'refs/heads/dev') && github.event.inputs.run_e2e_only != 'true'
     timeout-minutes: ${{ matrix.timeout || 5 }}
 
     strategy:
@@ -377,7 +377,7 @@ jobs:
     name: Daemon + Shared Unit Tests (Coverage)
     runs-on: ubuntu-latest
     timeout-minutes: 6
-    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev') && !github.event.inputs.run_e2e_only
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev') && github.event.inputs.run_e2e_only != 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -430,7 +430,7 @@ jobs:
     name: Web Tests
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && !github.event.inputs.run_e2e_only
+    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && github.event.inputs.run_e2e_only != 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -484,7 +484,7 @@ jobs:
     name: CLI Tests
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && !github.event.inputs.run_e2e_only
+    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && github.event.inputs.run_e2e_only != 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -523,7 +523,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-daemon-shared-unit, test-web, test-daemon-online]
     timeout-minutes: 1
-    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev' || github.event_name == 'workflow_dispatch') && !github.event.inputs.run_e2e_only
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev' || github.event_name == 'workflow_dispatch') && github.event.inputs.run_e2e_only != 'true'
 
     steps:
       - name: Finalize Coveralls parallel build
@@ -544,7 +544,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [coveralls-finalize]
     timeout-minutes: 3
-    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev' || github.event_name == 'workflow_dispatch') && !github.event.inputs.run_e2e_only
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev' || github.event_name == 'workflow_dispatch') && github.event.inputs.run_e2e_only != 'true'
 
     steps:
       - name: Check coverage thresholds via Coveralls API
@@ -635,12 +635,12 @@ jobs:
       (github.event_name == 'pull_request' && github.base_ref == 'main' ||
        github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') ||
        github.event_name == 'workflow_dispatch') &&
-      (github.event.inputs.run_e2e_only ||
-       needs.discover.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.check.result) &&
-       contains(fromJSON('["success", "skipped"]'), needs.test-daemon-online.result) &&
-       contains(fromJSON('["success", "skipped"]'), needs.test-daemon-shared-unit.result) &&
-       contains(fromJSON('["success", "skipped"]'), needs.test-web.result) &&
-       contains(fromJSON('["success", "skipped"]'), needs.test-cli.result))
+      (github.event.inputs.run_e2e_only == 'true' ||
+       (needs.discover.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.check.result) &&
+        contains(fromJSON('["success", "skipped"]'), needs.test-daemon-online.result) &&
+        contains(fromJSON('["success", "skipped"]'), needs.test-daemon-shared-unit.result) &&
+        contains(fromJSON('["success", "skipped"]'), needs.test-web.result) &&
+        contains(fromJSON('["success", "skipped"]'), needs.test-cli.result)))
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,13 @@
 #
 # Test execution is flattened based on trigger:
 #
-# | Trigger               | Tests Run                                      | Rationale                      |
-# |-----------------------|-----------------------------------------------|--------------------------------|
-# | PR to dev             | check + unit + online                         | Fast feedback for PRs          |
-# | Push to dev           | e2e only                                      | Already passed unit/online    |
-# | PR to main            | all tests (check + unit + online + e2e + web + CLI) | Full gate              |
-# | Push to main          | all tests                                     | Full gate for main branch     |
+# | Trigger                              | Tests Run                                      | Rationale                      |
+# |--------------------------------------|-----------------------------------------------|--------------------------------|
+# | PR to dev                            | check + unit + online                         | Fast feedback for PRs          |
+# | Push to dev                          | e2e only                                      | Already passed unit/online    |
+# | PR to main                           | all tests (check + unit + online + e2e + web + CLI) | Full gate              |
+# | Push to main                         | all tests                                     | Full gate for main branch     |
+# | workflow_dispatch (run_e2e_only=true) | discover + build + e2e only                   | Selective E2E on PR branches  |
 #
 # Release is handled separately in release.yml (triggered by version tags).
 # Test coverage (unit, online, web) is uploaded to Coveralls.
@@ -20,6 +21,12 @@ on:
   pull_request:
     branches: [main, dev]
   workflow_dispatch:
+    inputs:
+      run_e2e_only:
+        description: 'Skip all prerequisite jobs and run only E2E tests (for PR branches)'
+        required: false
+        default: 'false'
+        type: boolean
 
 # Cancel in-progress runs when a new run is triggered on the same branch
 concurrency:
@@ -54,7 +61,7 @@ jobs:
     name: Lint, Knip, Format & Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: github.event_name != 'push' || github.ref != 'refs/heads/dev'
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev') && !github.event.inputs.run_e2e_only
 
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +120,7 @@ jobs:
   test-daemon-online:
     name: Daemon Online (${{ matrix.module }})
     runs-on: ubuntu-latest
-    if: github.ref_type != 'tag' && (github.event_name != 'push' || github.ref != 'refs/heads/dev')
+    if: github.ref_type != 'tag' && (github.event_name != 'push' || github.ref != 'refs/heads/dev') && !github.event.inputs.run_e2e_only
     timeout-minutes: ${{ matrix.timeout || 5 }}
 
     strategy:
@@ -370,7 +377,7 @@ jobs:
     name: Daemon + Shared Unit Tests (Coverage)
     runs-on: ubuntu-latest
     timeout-minutes: 6
-    if: github.event_name != 'push' || github.ref != 'refs/heads/dev'
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev') && !github.event.inputs.run_e2e_only
 
     steps:
       - uses: actions/checkout@v4
@@ -423,7 +430,7 @@ jobs:
     name: Web Tests
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && !github.event.inputs.run_e2e_only
 
     steps:
       - uses: actions/checkout@v4
@@ -477,7 +484,7 @@ jobs:
     name: CLI Tests
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    if: github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && !github.event.inputs.run_e2e_only
 
     steps:
       - uses: actions/checkout@v4
@@ -516,7 +523,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-daemon-shared-unit, test-web, test-daemon-online]
     timeout-minutes: 1
-    if: github.event_name != 'push' || github.ref != 'refs/heads/dev' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev' || github.event_name == 'workflow_dispatch') && !github.event.inputs.run_e2e_only
 
     steps:
       - name: Finalize Coveralls parallel build
@@ -537,7 +544,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [coveralls-finalize]
     timeout-minutes: 3
-    if: github.event_name != 'push' || github.ref != 'refs/heads/dev' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/dev' || github.event_name == 'workflow_dispatch') && !github.event.inputs.run_e2e_only
 
     steps:
       - name: Check coverage thresholds via Coveralls API
@@ -622,17 +629,18 @@ jobs:
   build:
     name: Build Binary (linux-x64)
     runs-on: ubuntu-latest
-    needs: [check, test-daemon-online, test-daemon-shared-unit, test-web, test-cli]
+    needs: [check, test-daemon-online, test-daemon-shared-unit, test-web, test-cli, discover]
     if: >-
       always() &&
       (github.event_name == 'pull_request' && github.base_ref == 'main' ||
        github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') ||
        github.event_name == 'workflow_dispatch') &&
-      contains(fromJSON('["success", "skipped"]'), needs.check.result) &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-daemon-online.result) &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-daemon-shared-unit.result) &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-web.result) &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-cli.result)
+      (github.event.inputs.run_e2e_only ||
+       needs.discover.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.check.result) &&
+       contains(fromJSON('["success", "skipped"]'), needs.test-daemon-online.result) &&
+       contains(fromJSON('["success", "skipped"]'), needs.test-daemon-shared-unit.result) &&
+       contains(fromJSON('["success", "skipped"]'), needs.test-web.result) &&
+       contains(fromJSON('["success", "skipped"]'), needs.test-cli.result))
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary

- Add `run_e2e_only` boolean input to `workflow_dispatch` trigger in `main.yml`
- When set to `true`, skips check/unit/online/web/CLI jobs and runs only `discover + build + e2e`
- Previously, `workflow_dispatch` triggered all CI jobs. If any failed, the `build` job was blocked and E2E never ran (confirmed empirically)

## Usage

```bash
gh workflow run main.yml --repo lsm/neokai --ref <pr-branch> -f run_e2e_only=true
```

## Changes

- **Input definition**: Add `run_e2e_only` boolean input (default `false`)
- **Prerequisite jobs** (7 jobs): Skip when `run_e2e_only == 'true'` — uses explicit string comparison because GitHub Actions boolean inputs arrive as strings
- **Build job**: Bypass prerequisite gate when `run_e2e_only == 'true'`; added `discover` to `needs` array so it's always tracked
- **Coverage jobs** (`coveralls-finalize`, `coverage-gate`): Skip when `run_e2e_only == 'true'`

## Test plan

1. Triggered workflow_dispatch on a PR branch with `run_e2e_only=true` — verified `discover + build + e2e` all executed
2. Addressed review feedback: fixed string comparison for boolean input coercion bug