### PR TITLE
fix(web): align inbox-store RPC method names with server handlers

### DIFF
--- a/packages/web/src/lib/inbox-store.test.ts
+++ b/packages/web/src/lib/inbox-store.test.ts
@@ -203,7 +203,7 @@ describe('InboxStore', () => {
 	});
 
 	describe('approveTask()', () => {
-		it('should call room.task.approve, refresh, and return true on success', async () => {
+		it('should call task.approve, refresh, and return true on success', async () => {
 			const room = makeRoom('r', 'R');
 			mockRoomsSignal.value = [room];
 
@@ -218,7 +218,7 @@ describe('InboxStore', () => {
 			const result = await inboxStore.approveTask('task-1', 'r');
 
 			expect(result).toBe(true);
-			expect(mockHub.request).toHaveBeenCalledWith('room.task.approve', {
+			expect(mockHub.request).toHaveBeenCalledWith('task.approve', {
 				roomId: 'r',
 				taskId: 'task-1',
 			});
@@ -238,7 +238,7 @@ describe('InboxStore', () => {
 	});
 
 	describe('rejectTask()', () => {
-		it('should call room.task.reject with feedback, refresh, and return true on success', async () => {
+		it('should call task.reject with feedback, refresh, and return true on success', async () => {
 			const room = makeRoom('r', 'R');
 			mockRoomsSignal.value = [room];
 
@@ -253,7 +253,7 @@ describe('InboxStore', () => {
 			const result = await inboxStore.rejectTask('task-1', 'r', 'needs more work');
 
 			expect(result).toBe(true);
-			expect(mockHub.request).toHaveBeenCalledWith('room.task.reject', {
+			expect(mockHub.request).toHaveBeenCalledWith('task.reject', {
 				roomId: 'r',
 				taskId: 'task-1',
 				feedback: 'needs more work',

--- a/packages/web/src/lib/inbox-store.ts
+++ b/packages/web/src/lib/inbox-store.ts
@@ -79,7 +79,7 @@ async function refresh(): Promise<void> {
 async function approveTask(taskId: string, roomId: string): Promise<boolean> {
 	try {
 		const hub = await connectionManager.getHub();
-		await hub.request('room.task.approve', { roomId, taskId });
+		await hub.request('task.approve', { roomId, taskId });
 		await refresh();
 		return true;
 	} catch (err) {
@@ -91,7 +91,7 @@ async function approveTask(taskId: string, roomId: string): Promise<boolean> {
 async function rejectTask(taskId: string, roomId: string, feedback: string): Promise<boolean> {
 	try {
 		const hub = await connectionManager.getHub();
-		await hub.request('room.task.reject', { roomId, taskId, feedback });
+		await hub.request('task.reject', { roomId, taskId, feedback });
 		await refresh();
 		return true;
 	} catch (err) {


### PR DESCRIPTION
Client was sending `room.task.approve` / `room.task.reject` but server
registers `task.approve` / `task.reject`, causing "No handler for method"
errors when clicking Approve/Reject in the Inbox.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
