### PR TITLE
fix: add SDK mock to worker-mcp test to survive module isolation

### DIFF
--- a/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
@@ -15,6 +15,30 @@ import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import type { McpServerConfig } from '@neokai/shared';
 import type { AgentSessionInit } from '../../../src/lib/agent/agent-session';
 
+// Re-declare the SDK mock here so it survives Bun's module isolation between
+// test files.  Without this, dynamic `await import(...)` calls in this file
+// (e.g. `import('../../../src/lib/room/runtime/room-runtime-service')`) can
+// resolve the real SDK module before the preload-level mock from setup.ts is
+// re-applied, causing a SyntaxError on CI where the installed SDK version
+// (0.2.81) does not always export `createSdkMcpServer` at the ESM level.
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+	query: mock(async () => ({ interrupt: () => {} })),
+	interrupt: mock(async () => {}),
+	supportedModels: mock(async () => {
+		throw new Error('SDK unavailable');
+	}),
+	createSdkMcpServer: mock((_opts: { name: string }) => ({
+		type: 'sdk' as const,
+		name: _opts.name,
+		version: '1.0.0',
+		tools: [],
+		instance: { connect() {}, disconnect() {} },
+	})),
+	tool: mock((_name: string, _desc: string, _schema: unknown, _handler: unknown) => ({
+		name: _name,
+	})),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Bun's module isolation between test files invalidates the `mock.module()` from `setup.ts`. When `room-runtime-service-worker-mcp.test.ts` uses dynamic `await import(...)` to load source modules that transitively import `createSdkMcpServer` from `@anthropic-ai/claude-agent-sdk`, the real module gets resolved before the preload mock is re-applied, causing `SyntaxError` on CI (Ubuntu) where SDK 0.2.81 doesn't always export `createSdkMcpServer` at the ESM level.

This causes 8 test failures and 46 "Unhandled error between tests" SyntaxErrors in the unit test suite.

## Fix

Re-declare the SDK mock at the top of `room-runtime-service-worker-mcp.test.ts` so it survives Bun's module isolation between test files.

## Scope

Single file change: `packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts`