### PR TITLE
chore: pin claude-agent-sdk to 0.2.84

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "@neokai/daemon",
       "version": "0.8.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.81",
+        "@anthropic-ai/claude-agent-sdk": "0.2.84",
         "@github/copilot-sdk": "0.2.0",
         "@neokai/shared": "workspace:*",
         "croner": "10.0.1",
@@ -106,7 +106,7 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.81", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-CBeebgibBEN/DWOQGZN67vhuTG55RbI1hlsFSSoZ4uA/Io3lw04eHTE2ISCmdbqyJaefYTt6GKZei1nP0TQMNw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.84", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-rvp3kZJM4IgDBE1zwj30H3N0bI3pYRF28tDJoyAVuWTLiWls7diNVCyFz7GeXZEAYYD87lCBE3vnQplLLluNHg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -19,7 +19,7 @@
 		"test:online": "bun test --coverage --coverage-reporter=text ./tests/online"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.81",
+		"@anthropic-ai/claude-agent-sdk": "0.2.84",
 		"@github/copilot-sdk": "0.2.0",
 		"@neokai/shared": "workspace:*",
 		"croner": "10.0.1",

--- a/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
@@ -19,7 +19,8 @@ import type { AgentSessionInit } from '../../../src/lib/agent/agent-session';
 // test files.  Without this, dynamic `await import(...)` calls in this file
 // (e.g. `import('../../../src/lib/room/runtime/room-runtime-service')`) can
 // resolve the real SDK module before the preload-level mock from setup.ts is
-// re-applied.  See setup.ts for why the SDK must be mocked in unit tests.
+// re-applied.  See the module-level comment in setup.ts for why the SDK must
+// be mocked in unit tests.
 mock.module('@anthropic-ai/claude-agent-sdk', () => ({
 	query: mock(async () => ({ interrupt: () => {} })),
 	interrupt: mock(async () => {}),

--- a/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
@@ -19,8 +19,7 @@ import type { AgentSessionInit } from '../../../src/lib/agent/agent-session';
 // test files.  Without this, dynamic `await import(...)` calls in this file
 // (e.g. `import('../../../src/lib/room/runtime/room-runtime-service')`) can
 // resolve the real SDK module before the preload-level mock from setup.ts is
-// re-applied, causing a SyntaxError on CI where the installed SDK version
-// (0.2.81) does not always export `createSdkMcpServer` at the ESM level.
+// re-applied.  See setup.ts for why the SDK must be mocked in unit tests.
 mock.module('@anthropic-ai/claude-agent-sdk', () => ({
 	query: mock(async () => ({ interrupt: () => {} })),
 	interrupt: mock(async () => {}),

--- a/packages/daemon/tests/unit/setup.ts
+++ b/packages/daemon/tests/unit/setup.ts
@@ -8,10 +8,20 @@
 
 import { mock } from 'bun:test';
 
-// Mock the Claude Agent SDK — the installed version in CI may not export
-// createSdkMcpServer at runtime (it is declared in @neokai/shared's sdk.d.ts as a
-// type-only stub).  All test files that need real SDK behaviour call mock.module()
-// at the top of their own file and will override this default stub.
+// Mock the Claude Agent SDK.  The real SDK must be mocked in unit tests for two reasons:
+//
+// 1. Unit tests must not make real API calls — query/interrupt are stubbed out.
+//
+// 2. The real createSdkMcpServer returns an McpServer whose _registeredTools is
+//    PRIVATE (no public listTools() API, no way to inspect or invoke handlers
+//    outside the MCP protocol).  Several test suites (task-agent-tools, leader-agent,
+//    room-agent-tools, provision-global-agent) rely on inspecting
+//    server.instance._registeredTools to verify tool names, descriptions, schemas,
+//    and to invoke handlers directly.  The mock provides a testable surface area
+//    that the real McpServer class does not expose.
+//
+// Individual test files that need different mock behaviour call mock.module() at the
+// top of their own file to override this default.
 mock.module('@anthropic-ai/claude-agent-sdk', () => {
 	// ---------------------------------------------------------------------------
 	// MockMcpServer — replicates the MCP server surface area needed by tests.


### PR DESCRIPTION
Upgrade `@anthropic-ai/claude-agent-sdk` from 0.2.81 to 0.2.84.

- Verified `createSdkMcpServer` and `tool` are importable at runtime
- No new test regressions (15 pre-existing failures in full-suite MCP mock tests pass in isolation)