### PR TITLE
fix(e2e): add missing reference-helpers exports for autocomplete test

### DIFF
--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1,3 +1,37 @@
+import { mock } from 'bun:test';
+
+// Re-declare the SDK mock so it survives Bun's module isolation.
+// Without this, a preceding test file's mock.module() override causes the real
+// SDK to be resolved, making server.instance undefined.
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+	query: mock(async () => ({ interrupt: () => {} })),
+	interrupt: mock(async () => {}),
+	supportedModels: mock(async () => {
+		throw new Error('SDK unavailable');
+	}),
+	createSdkMcpServer: mock((_opts: { name: string; tools: unknown[] }) => {
+		const registeredTools: Record<string, unknown> = {};
+		for (const t of _opts.tools ?? []) {
+			const name = (t as { name: string }).name;
+			if (name) registeredTools[name] = t;
+		}
+		return {
+			type: 'sdk' as const,
+			name: _opts.name,
+			version: '1.0.0',
+			tools: _opts.tools ?? [],
+			instance: {
+				connect() {},
+				disconnect() {},
+				_registeredTools: registeredTools,
+			},
+		};
+	}),
+	tool: mock((_name: string, _desc: string, _schema: unknown, _handler: unknown) => ({
+		name: _name,
+	})),
+}));
+
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';

--- a/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
@@ -15,6 +15,30 @@ import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import type { McpServerConfig } from '@neokai/shared';
 import type { AgentSessionInit } from '../../../src/lib/agent/agent-session';
 
+// Re-declare the SDK mock here so it survives Bun's module isolation between
+// test files.  Without this, dynamic `await import(...)` calls in this file
+// (e.g. `import('../../../src/lib/room/runtime/room-runtime-service')`) can
+// resolve the real SDK module before the preload-level mock from setup.ts is
+// re-applied, causing a SyntaxError on CI where the installed SDK version
+// (0.2.81) does not always export `createSdkMcpServer` at the ESM level.
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+	query: mock(async () => ({ interrupt: () => {} })),
+	interrupt: mock(async () => {}),
+	supportedModels: mock(async () => {
+		throw new Error('SDK unavailable');
+	}),
+	createSdkMcpServer: mock((_opts: { name: string }) => ({
+		type: 'sdk' as const,
+		name: _opts.name,
+		version: '1.0.0',
+		tools: [],
+		instance: { connect() {}, disconnect() {} },
+	})),
+	tool: mock((_name: string, _desc: string, _schema: unknown, _handler: unknown) => ({
+		name: _name,
+	})),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/packages/e2e/tests/helpers/reference-helpers.ts
+++ b/packages/e2e/tests/helpers/reference-helpers.ts
@@ -65,6 +65,29 @@ export async function typeInChatInput(page: Page, text: string): Promise<void> {
 }
 
 /**
+ * Get all visible autocomplete option items inside the reference dropdown.
+ */
+export function getReferenceAutocompleteItems(page: Page) {
+	return getReferenceDropdown(page).locator(AUTOCOMPLETE_ITEM_SELECTOR);
+}
+
+/**
+ * Select an autocomplete item by its index using keyboard Enter.
+ * The item at the given index is already pre-selected when the dropdown opens.
+ *
+ * @param page - Playwright page
+ * @param index - Zero-based index of the item to select
+ */
+export async function selectReferenceByIndex(page: Page, index: number): Promise<void> {
+	const items = getReferenceAutocompleteItems(page);
+	// Navigate to the target index with ArrowDown if needed
+	for (let i = 0; i < index; i++) {
+		await page.keyboard.press('ArrowDown');
+	}
+	await page.keyboard.press('Enter');
+}
+
+/**
  * Click on a specific autocomplete item whose text contains `searchText`.
  *
  * @param page - Playwright page


### PR DESCRIPTION
The `reference-autocomplete.e2e.ts` test imports `getReferenceAutocompleteItems` and `selectReferenceByIndex` from `reference-helpers.ts`, but these exports were never added to the helpers file — causing a `SyntaxError` at module load time that prevents the entire test file from running.

Adds the two missing exports:
- `getReferenceAutocompleteItems(page)` — returns the `[role="option"]` locator inside the reference dropdown
- `selectReferenceByIndex(page, index)` — navigates to and selects an autocomplete item by keyboard