### PR TITLE
feat(leader): add create_task tool to leader agent's tool contract

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -170,6 +170,7 @@ You MUST call tools (no text-only final responses).
 - \`submit_for_review\` — Work is done with a PR ready; submit for peer review and human approval
 
 ### Task Management Tools (for managing other tasks in the room)
+- \`create_task\` — Create a new task, optionally linked to a goal. Use to spawn fix tasks, investigation tasks, or sub-tasks discovered during execution
 - \`update_task\` — Edit title, description, priority, or dependencies of any task
 - \`cancel_task\` — Cancel a task and cascade to any pending dependents
 - \`update_task_status\` — Change a task's status (e.g., retry a failed task: needs_attention → pending)

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -1259,6 +1259,7 @@ export type LeaderContextMcpConfig = Pick<
  *
  * Included tools:
  *   - list_goals, list_tasks, get_task_detail, get_room_status: read-only context
+ *   - create_task: create new tasks under the current goal (for adaptive planning and recurring missions)
  *   - update_task: edit title, description, priority, or dependencies of any task
  *   - cancel_task: cancel a task and cascade to pending dependents
  *   - update_task_status: change task status with transition validation
@@ -1266,7 +1267,6 @@ export type LeaderContextMcpConfig = Pick<
  * Excluded tools and reasons:
  *   - approve_task / reject_task: human-only decisions
  *   - create_goal / update_goal: not the leader's role
- *   - create_task: leader delegates task creation to worker via send_to_worker
  *   - stop_session: session management is handled by the runtime
  *   - complete_task / fail_task: leader uses these from leader-agent-tools for the current task
  *   - send_message_to_task: leader uses send_to_worker from leader-agent-tools instead
@@ -1308,6 +1308,35 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 			'Get an overview of the room state including goals, tasks, active groups, and tasks needing review',
 			{},
 			() => handlers.get_room_status()
+		),
+		tool(
+			'create_task',
+			'Create a new task and optionally link it to a goal. Use to spawn fix tasks, investigation tasks, or sub-tasks discovered during execution.',
+			{
+				title: z.string().describe('Short title for the task'),
+				description: z.string().describe('Detailed task description and acceptance criteria'),
+				goal_id: z.string().optional().describe('Goal ID to link this task to'),
+				priority: z
+					.enum(['low', 'normal', 'high', 'urgent'])
+					.optional()
+					.default('normal')
+					.describe('Task priority'),
+				depends_on: z
+					.array(z.string())
+					.optional()
+					.describe('IDs of tasks this task depends on (must complete first)'),
+				task_type: z
+					.enum(['coding', 'research', 'design', 'goal_review'])
+					.optional()
+					.describe(
+						"Task type - determines agent preset (default: coding). Note: 'planning' is reserved for internal use."
+					),
+				assigned_agent: z
+					.enum(['coder', 'general', 'planner'])
+					.optional()
+					.describe('Agent type to execute this task (default: coder)'),
+			},
+			(args) => handlers.create_task(args)
 		),
 		tool(
 			'update_task',

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -558,12 +558,12 @@ describe('Leader Agent', () => {
 			expect(init.mcpServers).toBeDefined();
 			const ctxServer = init.mcpServers!['leader-context-tools'] as unknown as {
 				name: string;
-				instance: { _registeredTools: Record<string, unknown> };
+				tools: Array<{ name: string }>;
 			};
 			expect(ctxServer).toBeDefined();
 			// Verify it is the narrow leader-context server, not the full room-agent server
 			expect(ctxServer.name).toBe('leader-context');
-			const toolNames = Object.keys(ctxServer.instance._registeredTools).sort();
+			const toolNames = ctxServer.tools.map((t) => t.name).sort();
 			// Should include both read-only context tools and task management tools
 			expect(toolNames).toEqual(
 				[

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -145,6 +145,7 @@ describe('Leader Agent', () => {
 
 		it('should include task management tools in tool contract', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig());
+			expect(prompt).toContain('create_task');
 			expect(prompt).toContain('update_task');
 			expect(prompt).toContain('cancel_task');
 			expect(prompt).toContain('update_task_status');
@@ -567,6 +568,7 @@ describe('Leader Agent', () => {
 			expect(toolNames).toEqual(
 				[
 					'cancel_task',
+					'create_task',
 					'get_room_status',
 					'get_task_detail',
 					'list_goals',

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1873,11 +1873,12 @@ describe('Room Agent Tools', () => {
 			return Object.keys(server.instance._registeredTools).sort();
 		}
 
-		it('should expose the 7 leader tools (context + task management)', () => {
+		it('should expose the 8 leader tools (context + task management)', () => {
 			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
 			const names = getRegisteredToolNames(server as never);
 			expect(names).toEqual([
 				'cancel_task',
+				'create_task',
 				'get_room_status',
 				'get_task_detail',
 				'list_goals',
@@ -1905,7 +1906,6 @@ describe('Room Agent Tools', () => {
 			const excluded = [
 				'create_goal',
 				'update_goal',
-				'create_task',
 				'stop_session',
 				'send_message_to_task',
 				'approve_task',
@@ -1914,6 +1914,134 @@ describe('Room Agent Tools', () => {
 			for (const w of excluded) {
 				expect(names).not.toContain(w);
 			}
+		});
+
+		describe('create_task tool', () => {
+			it('should create a task and return its ID', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Fix failing test',
+						description: 'The auth test is flaky due to race condition',
+					})
+				);
+				expect(result.success).toBe(true);
+				expect(result.taskId).toBeDefined();
+				expect(result.task).toBeDefined();
+				const task = result.task as { title: string; status: string };
+				expect(task.title).toBe('Fix failing test');
+				expect(task.status).toBe('pending');
+			});
+
+			it('should create a task linked to a goal', async () => {
+				const goal = await goalManager.createGoal({
+					title: 'Stabilize CI',
+					description: 'Fix flaky tests',
+				});
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Fix auth test',
+						description: 'Race condition in login flow',
+						goal_id: goal.id,
+					})
+				);
+				expect(result.success).toBe(true);
+				// Verify the task is linked to the goal via list_tasks
+				const tasksResult = parseResult(await leaderHandlers.list_tasks({ goal_id: goal.id }));
+				const tasks = tasksResult.tasks as Array<{ id: string }>;
+				expect(tasks.some((t) => t.id === result.taskId)).toBe(true);
+			});
+
+			it('should create a task with dependencies', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const prereq = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Investigate root cause',
+						description: 'Find why the test fails',
+					})
+				);
+				const result = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Apply fix',
+						description: 'Fix the identified issue',
+						depends_on: [prereq.taskId as string],
+					})
+				);
+				expect(result.success).toBe(true);
+				const task = result.task as { dependsOn: string[] };
+				expect(task.dependsOn).toContain(prereq.taskId);
+			});
+
+			it('should create a task with priority', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Critical fix',
+						description: 'P0 production issue',
+						priority: 'urgent',
+					})
+				);
+				expect(result.success).toBe(true);
+				const task = result.task as { priority: string };
+				expect(task.priority).toBe('urgent');
+			});
+
+			it('should reject planning task type', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Plan something',
+						description: 'Should be rejected',
+						task_type: 'planning' as never,
+					})
+				);
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('reserved');
+			});
+
+			it('should fail gracefully when dependency does not exist', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Depends on nothing',
+						description: 'Bad dep reference',
+						depends_on: ['non-existent-task-id'],
+					})
+				);
+				expect(result.success).toBe(false);
+				expect(result.error).toBeDefined();
+			});
 		});
 
 		describe('update_task tool', () => {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1865,12 +1865,11 @@ describe('Room Agent Tools', () => {
 	describe('createLeaderContextMcpServer', () => {
 		/**
 		 * Helper: return the registered tool names from an SDK MCP server.
-		 * The SDK stores registered tools in `instance._registeredTools` keyed by tool name.
+		 * Extracts names from the `tools` array (passed at creation time) which is
+		 * available on both the real SDK and the unit-test mock.
 		 */
-		function getRegisteredToolNames(server: {
-			instance: { _registeredTools: Record<string, unknown> };
-		}): string[] {
-			return Object.keys(server.instance._registeredTools).sort();
+		function getRegisteredToolNames(server: { tools: Array<{ name: string }> }): string[] {
+			return server.tools.map((t) => t.name).sort();
 		}
 
 		it('should expose the 8 leader tools (context + task management)', () => {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -2007,6 +2007,44 @@ describe('Room Agent Tools', () => {
 				expect(task.priority).toBe('urgent');
 			});
 
+			it('should create a task with assigned_agent', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Research task',
+						description: 'Investigate options',
+						assigned_agent: 'general',
+					})
+				);
+				expect(result.success).toBe(true);
+				const task = result.task as { assignedAgent: string };
+				expect(task.assignedAgent).toBe('general');
+			});
+
+			it('should default assigned_agent to planner for goal_review tasks', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.create_task({
+						title: 'Review goal',
+						description: 'Review progress on goal',
+						task_type: 'goal_review',
+					})
+				);
+				expect(result.success).toBe(true);
+				const task = result.task as { assignedAgent: string };
+				expect(task.assignedAgent).toBe('planner');
+			});
+
 			it('should reject planning task type', async () => {
 				const leaderHandlers = createRoomAgentToolHandlers({
 					roomId,

--- a/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-worker-mcp.test.ts
@@ -15,6 +15,30 @@ import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import type { McpServerConfig } from '@neokai/shared';
 import type { AgentSessionInit } from '../../../src/lib/agent/agent-session';
 
+// Re-declare the SDK mock here so it survives Bun's module isolation between
+// test files.  Without this, dynamic `await import(...)` calls in this file
+// (e.g. `import('../../../src/lib/room/runtime/room-runtime-service')`) can
+// resolve the real SDK module before the preload-level mock from setup.ts is
+// re-applied, causing a SyntaxError on CI where the installed SDK version
+// (0.2.81) does not always export `createSdkMcpServer` at the ESM level.
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+	query: mock(async () => ({ interrupt: () => {} })),
+	interrupt: mock(async () => {}),
+	supportedModels: mock(async () => {
+		throw new Error('SDK unavailable');
+	}),
+	createSdkMcpServer: mock((_opts: { name: string }) => ({
+		type: 'sdk' as const,
+		name: _opts.name,
+		version: '1.0.0',
+		tools: [],
+		instance: { connect() {}, disconnect() {} },
+	})),
+	tool: mock((_name: string, _desc: string, _schema: unknown, _handler: unknown) => ({
+		name: _name,
+	})),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Expose `create_task` in the leader agent's `leader-context` MCP server so leaders can dynamically spawn tasks during execution.

**What changed:**
- Added `create_task` tool to `createLeaderContextMcpServer()` in `room-agent-tools.ts`
- Updated leader agent system prompt tool contract to document `create_task`
- Updated tests: expected tool list (7 → 8), exclusion list, added 6 handler-level tests

**Why:** Leader agents had `update_task`, `cancel_task`, and `update_task_status` but no `create_task`. This blocked recurring missions (e.g., Guardian discovering runtime failures) and adaptive planning where leaders discover sub-problems at execution time.

**Note:** The `create_task` handler already existed in the room-agent layer — this change simply exposes it through the leader's context MCP server with the same schema.