### PR TITLE
fix: restore scroll position synchronously after loading older messages

### DIFF
--- a/packages/e2e/tests/features/task-message-pagination.e2e.ts
+++ b/packages/e2e/tests/features/task-message-pagination.e2e.ts
@@ -226,9 +226,7 @@ test.describe('TaskView — Message Pagination', () => {
 			// Verify newest messages are still present (they should not have disappeared)
 			await expect(page.getByText('Message number 55', { exact: true })).toBeVisible();
 
-			// Wait for the requestAnimationFrame-based scroll restoration to complete.
-			// The component restores scrollTop inside rAF, so we must let one frame pass
-			// before reading the scroll position; otherwise we capture the pre-restore value.
+			// Wait for any pending microtask/flush to settle before reading scroll state.
 			await page.evaluate(() => new Promise((r) => requestAnimationFrame(r)));
 
 			// Verify scroll position was preserved (not jumped to top).

--- a/packages/e2e/tests/features/task-message-pagination.e2e.ts
+++ b/packages/e2e/tests/features/task-message-pagination.e2e.ts
@@ -226,6 +226,11 @@ test.describe('TaskView — Message Pagination', () => {
 			// Verify newest messages are still present (they should not have disappeared)
 			await expect(page.getByText('Message number 55', { exact: true })).toBeVisible();
 
+			// Wait for the requestAnimationFrame-based scroll restoration to complete.
+			// The component restores scrollTop inside rAF, so we must let one frame pass
+			// before reading the scroll position; otherwise we capture the pre-restore value.
+			await page.evaluate(() => new Promise((r) => requestAnimationFrame(r)));
+
 			// Verify scroll position was preserved (not jumped to top).
 			// Only assert when scrollBefore > 0 — if the container was too short to
 			// overflow before clicking, scrollTop stays 0 and there is nothing to preserve.

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -8,7 +8,7 @@
  * which agent produced it. Role transitions show a small divider label.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { RefObject } from 'preact';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { SessionInfo } from '@neokai/shared';
@@ -112,9 +112,11 @@ export function TaskConversationRenderer({
 
 	// After rawMessages changes (triggered by loadEarlier), restore scroll position
 	// so older prepended messages don't cause a jarring jump to the top.
+	// Uses useLayoutEffect to restore scroll synchronously before paint, preventing
+	// useEffect-based auto-scroll (in the parent) from racing and overriding the position.
 	// IMPORTANT: onLoadingOlderChange?.(false) must be called on ALL exit paths so
 	// isLoadingOlder never gets stuck true (which would permanently disable auto-scroll).
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (!scrollRestoreRef.current) return;
 		if (!scrollContainerRef?.current) {
 			// Container unmounted between handleLoadEarlier and this effect — clear the flag.
@@ -124,16 +126,9 @@ export function TaskConversationRenderer({
 		}
 		const { scrollHeight, scrollTop } = scrollRestoreRef.current;
 		scrollRestoreRef.current = null;
-		requestAnimationFrame(() => {
-			if (!scrollContainerRef.current) {
-				// Container unmounted between rAF scheduling and rAF execution — clear the flag.
-				onLoadingOlderChange?.(false);
-				return;
-			}
-			const newScrollHeight = scrollContainerRef.current.scrollHeight;
-			scrollContainerRef.current.scrollTop = scrollTop + (newScrollHeight - scrollHeight);
-			onLoadingOlderChange?.(false);
-		});
+		const newScrollHeight = scrollContainerRef.current.scrollHeight;
+		scrollContainerRef.current.scrollTop = scrollTop + (newScrollHeight - scrollHeight);
+		onLoadingOlderChange?.(false);
 	}, [rawMessages, scrollContainerRef, onLoadingOlderChange]);
 
 	const messages = useMemo(

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -269,6 +269,37 @@ describe('useAutoScroll', () => {
 
 			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 		});
+
+		it('should not auto-scroll when loadingOlder transitions from true to false', () => {
+			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, loadingOlder }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled: true,
+						messageCount,
+						isInitialLoad: false,
+						loadingOlder,
+					}),
+				{
+					initialProps: { messageCount: 50, loadingOlder: false },
+				}
+			);
+
+			scrollIntoViewMock.mockClear();
+
+			// Start loading older — message count increases as hidden messages are revealed
+			rerender({ messageCount: 55, loadingOlder: true });
+			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+			// Finish loading older — message count stays at 55, loadingOlder flips to false.
+			// This should NOT trigger auto-scroll because the count increase came from
+			// revealing older messages, not from genuinely new messages.
+			rerender({ messageCount: 55, loadingOlder: false });
+			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('scroll position detection', () => {

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -122,6 +122,16 @@ export function useAutoScroll({
 		return setupScrollDetection(container);
 	}, [nearBottomThreshold, messageCount]);
 
+	// When loadingOlder transitions from true to false, skip the message-count delta
+	// that was introduced by revealing older messages so that auto-scroll doesn't fire.
+	const prevLoadingOlderRef = useRef(loadingOlder);
+	useEffect(() => {
+		if (prevLoadingOlderRef.current && !loadingOlder) {
+			prevMessageCountRef.current = messageCount;
+		}
+		prevLoadingOlderRef.current = loadingOlder;
+	}, [loadingOlder, messageCount]);
+
 	// Auto-scroll on new messages
 	useEffect(() => {
 		const hasNewContent = messageCount > prevMessageCountRef.current;

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -30,7 +30,7 @@ import {
 } from '@neokai/shared';
 import type { SDKMessage, SDKSystemMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useSignalEffect } from '@preact/signals';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { ArchiveConfirmDialog } from '../components/ArchiveConfirmDialog.tsx';
 import { ChatHeader } from '../components/ChatHeader.tsx';
 import { ErrorBanner } from '../components/ErrorBanner.tsx';
@@ -527,8 +527,10 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 		};
 	}, [sessionId]);
 
-	// Restore scroll position after older messages are loaded and DOM has updated
-	useEffect(() => {
+	// Restore scroll position after older messages are loaded and DOM has updated.
+	// Uses useLayoutEffect (synchronous, before paint) to restore scroll before any
+	// useEffect-based auto-scroll can race and override the position.
+	useLayoutEffect(() => {
 		if (!scrollPositionRestoreRef.current?.shouldRestore) return;
 
 		const { oldScrollHeight, oldScrollTop } = scrollPositionRestoreRef.current;
@@ -536,20 +538,13 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 
 		if (!container) return;
 
-		// Use multiple requestAnimationFrame calls to ensure DOM has fully updated
-		// This is necessary because Preact's signal updates and DOM reflows are asynchronous
-		requestAnimationFrame(() => {
-			requestAnimationFrame(() => {
-				if (container) {
-					// Calculate the new scroll position to maintain visual position
-					// The scrollHeight has increased by the height of prepended messages
-					const newScrollTop = oldScrollTop + (container.scrollHeight - oldScrollHeight);
-					container.scrollTop = newScrollTop;
-				}
-				// Clear the restore flag
-				scrollPositionRestoreRef.current = null;
-			});
-		});
+		// Calculate the new scroll position to maintain visual position.
+		// The scrollHeight has increased by the height of prepended messages.
+		const newScrollTop = oldScrollTop + (container.scrollHeight - oldScrollHeight);
+		container.scrollTop = newScrollTop;
+
+		// Clear the restore flag
+		scrollPositionRestoreRef.current = null;
 	}, [messages.length, loadingOlder]);
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix "Load earlier messages" scroll position being overridden by auto-scroll-to-bottom
- Root cause: scroll restoration used `useEffect` + `requestAnimationFrame`, allowing `useAutoScroll` (also `useEffect`) to race and scroll to bottom before restoration completed
- Fix: changed to `useLayoutEffect` (synchronous, before paint) so scroll position is locked in before any auto-scroll effect fires

## Changes
- `TaskConversationRenderer.tsx`: `useEffect` + rAF → `useLayoutEffect` (synchronous scroll restore)
- `useAutoScroll.ts`: defense-in-depth guard to skip message-count delta when `loadingOlder` transitions `true → false`
- `task-message-pagination.e2e.ts`: add rAF wait before reading scroll position for deterministic assertion
- `useAutoScroll.test.ts`: add test for `loadingOlder` transition suppressing auto-scroll