### PR TITLE
fix(e2e): update multi-agent editor and settings modal tests for current UI

### DIFF
--- a/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
+++ b/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
@@ -178,25 +178,24 @@ test.describe('Multi-Agent Step Editor', () => {
 		// Set up two agents (required for channels section to appear)
 		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
 
-		// Channels section should now be visible (multi-agent mode)
-		const channelsSection = panel.getByTestId('channels-section');
+		// Channels section should now be visible (multi-agent mode) — it lives in the
+		// editor sidebar, not inside the node-config-panel
+		const channelsSection = editor.getByTestId('channels-section');
 		await expect(channelsSection).toBeVisible({ timeout: 3000 });
 
-		const addChannelForm = panel.getByTestId('add-channel-form');
-		const channelsList = panel.getByTestId('channels-list');
+		const addChannelForm = channelsSection.getByTestId('add-channel-form');
+		const channelsList = channelsSection.getByTestId('channels-list');
 
 		// ── Add one-way channel: coder → reviewer ────────────────────────────
 
-		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
+		await addChannelForm.getByTestId('new-channel-from-select').selectOption({ value: ROLE_A });
 		// Direction defaults to 'one-way' — no change needed
-		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
-		await addChannelForm.getByTestId('add-channel-button').click();
+		await addChannelForm.getByTestId('new-channel-to-select').selectOption({ value: ROLE_B });
+		await addChannelForm.getByTestId('add-channel-submit-button').click();
 
 		// Channel entry should appear: "coder → reviewer"
-		// setupMultiAgentStep creates 1 default channel (task-agent → first agent),
-		// so 2 total channels exist after this add (1 default + 1 user-added)
-		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(2, { timeout: 3000 });
-		// The user-added channel is the last one
+		// setupMultiAgentStep does not create default channels — only the user-added channel
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(1, { timeout: 3000 });
 		const lastEntry = channelsList.getByTestId('channel-entry').last();
 		await expect(lastEntry).toContainText(ROLE_A);
 		await expect(lastEntry).toContainText('→');
@@ -204,16 +203,16 @@ test.describe('Multi-Agent Step Editor', () => {
 
 		// ── Add bidirectional channel: reviewer ↔ coder ──────────────────────
 
-		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_B });
+		await addChannelForm.getByTestId('new-channel-from-select').selectOption({ value: ROLE_B });
 		await addChannelForm
-			.getByTestId('channel-direction-select')
+			.getByTestId('new-channel-direction-select')
 			.selectOption({ value: 'bidirectional' });
-		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_A);
-		await addChannelForm.getByTestId('add-channel-button').click();
+		await addChannelForm.getByTestId('new-channel-to-select').selectOption({ value: ROLE_A });
+		await addChannelForm.getByTestId('add-channel-submit-button').click();
 
-		// Three channel entries should now be present (1 default + 2 user-added)
-		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(3, { timeout: 3000 });
-		const secondEntry = channelsList.getByTestId('channel-entry').nth(2);
+		// Two channel entries should now be present (1 one-way + 1 bidirectional)
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(2, { timeout: 3000 });
+		const secondEntry = channelsList.getByTestId('channel-entry').nth(1);
 		await expect(secondEntry).toContainText(ROLE_B);
 		await expect(secondEntry).toContainText('↔');
 		await expect(secondEntry).toContainText(ROLE_A);
@@ -259,12 +258,15 @@ test.describe('Multi-Agent Step Editor', () => {
 		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
 
 		// Add channel coder → reviewer
-		const addChannelForm = panel.getByTestId('add-channel-form');
-		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
-		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
-		await addChannelForm.getByTestId('add-channel-button').click();
-		// setupMultiAgentStep creates 1 default channel, plus 1 user-added = 2 total
-		await expect(panel.getByTestId('channels-list').getByTestId('channel-entry')).toHaveCount(2, {
+		const channelsSection = editor.getByTestId('channels-section');
+		await expect(channelsSection).toBeVisible({ timeout: 3000 });
+		const addChannelForm = channelsSection.getByTestId('add-channel-form');
+		const channelsList = channelsSection.getByTestId('channels-list');
+		await addChannelForm.getByTestId('new-channel-from-select').selectOption({ value: ROLE_A });
+		await addChannelForm.getByTestId('new-channel-to-select').selectOption({ value: ROLE_B });
+		await addChannelForm.getByTestId('add-channel-submit-button').click();
+		// 1 user-added channel
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(1, {
 			timeout: 3000,
 		});
 
@@ -286,14 +288,11 @@ test.describe('Multi-Agent Step Editor', () => {
 		const switchToSingleBtn = panel.getByTestId('switch-to-single-button');
 		await expect(switchToSingleBtn).toBeVisible({ timeout: 3000 });
 
-		// Click "Switch to single" — reverts to single-agent mode and clears channels
+		// Click "Switch to single" — reverts to single-agent mode
 		await switchToSingleBtn.click();
 
-		// Channels section is still visible but shows empty state message (channels cleared)
-		await expect(panel.getByTestId('channels-section')).toBeVisible({ timeout: 3000 });
-		await expect(panel.locator('text=No channels — agents are isolated.')).toBeVisible({
-			timeout: 2000,
-		});
+		// Channels section is still visible (channels are workflow-level, not node-level)
+		await expect(editor.getByTestId('channels-section')).toBeVisible({ timeout: 3000 });
 
 		// Single-agent select dropdown and add-agent button should be visible
 		await expect(panel.getByTestId('agent-select')).toBeVisible({ timeout: 3000 });

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -329,11 +329,12 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				step: node.step,
 				position: node.position,
 				agents,
+				workflowChannels: channels,
 				isStartNode: nodeIsStart(node),
 				nodeTaskStates: nodeTaskStates.length > 0 ? nodeTaskStates : undefined,
 			};
 		});
-	}, [nodes, agents, nodeIsStart, tasksByNodeId, relevantRunId]);
+	}, [nodes, agents, channels, nodeIsStart, tasksByNodeId, relevantRunId]);
 
 	// ------------------------------------------------------------------
 	// Derived: selected node / edge

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -163,7 +163,7 @@ export function computeChannelEdges(nodes: WorkflowNodeData[]): ResolvedWorkflow
 	}
 
 	for (const node of nodes) {
-		const channels = node.step.channels;
+		const channels = node.workflowChannels;
 		if (!channels) continue;
 
 		for (const channel of channels) {

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -132,10 +132,10 @@ export function WorkflowNode({
 	const nodeAgentNames: string[] = isTaskAgent
 		? ['task-agent']
 		: multi
-		  ? step.agents!.map((a) => a.name)
-		  : step.agentId
-		    ? [step.agentId]
-		    : [];
+			? step.agents!.map((a) => a.name)
+			: step.agentId
+				? [step.agentId]
+				: [];
 
 	// Build a lookup: agentName → AgentTaskState
 	const taskStateByAgent = new Map<string | null, AgentTaskState>(
@@ -339,7 +339,10 @@ export function WorkflowNode({
 						{step.name || 'Task Agent'}
 					</p>
 					{/* Channel topology */}
-					<ChannelTopologyBadge workflowChannels={workflowChannels} nodeAgentNames={nodeAgentNames} />
+					<ChannelTopologyBadge
+						workflowChannels={workflowChannels}
+						nodeAgentNames={nodeAgentNames}
+					/>
 				</div>
 			</div>
 		);

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useCallback, useRef } from 'preact/hooks';
-import type { SpaceAgent } from '@neokai/shared';
+import type { SpaceAgent, WorkflowChannel } from '@neokai/shared';
 import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 import type { NodeDraft, AgentTaskState } from '../WorkflowNodeCard';
 import { isMultiAgentNode, isNodeFullyCompleted, AgentStatusIcon } from '../WorkflowNodeCard';
@@ -26,9 +26,18 @@ import type { Point } from './types';
 // ============================================================================
 
 /** Renders a compact text representation of channel topology. */
-function ChannelTopologyBadge({ step }: { step: NodeDraft }) {
-	const channels = step.channels;
-	if (!channels || channels.length === 0) return null;
+function ChannelTopologyBadge({
+	workflowChannels,
+	nodeAgentNames,
+}: {
+	workflowChannels?: WorkflowChannel[];
+	nodeAgentNames: string[];
+}) {
+	if (!workflowChannels || workflowChannels.length === 0) return null;
+
+	// Show only channels where the source agent is in this node's agent list
+	const visibleChannels = (workflowChannels ?? []).filter((ch) => nodeAgentNames.includes(ch.from));
+	if (visibleChannels.length === 0) return null;
 
 	/** Truncate a role string for compact display. Channels already use role strings as identifiers. */
 	const roleLabel = (role: string) => (role.length > 8 ? role.slice(0, 8) + '…' : role);
@@ -40,7 +49,7 @@ function ChannelTopologyBadge({ step }: { step: NodeDraft }) {
 
 	return (
 		<div class="mt-1.5 space-y-0.5" data-testid="channel-topology-badge">
-			{channels.map((ch, i) => (
+			{visibleChannels.map((ch, i) => (
 				<div key={i} class="flex items-center gap-0.5 text-xs text-gray-500">
 					<span class="font-mono">{roleLabel(ch.from)}</span>
 					<span class="text-gray-600">{ch.direction === 'bidirectional' ? '↔' : '→'}</span>
@@ -66,6 +75,8 @@ export interface WorkflowNodeProps {
 	position: Point;
 	/** Full agents list — used to resolve the agent name from step.agentId */
 	agents: SpaceAgent[];
+	/** Workflow-level channels — shown filtered by this node's agent roles */
+	workflowChannels?: WorkflowChannel[];
 	isSelected?: boolean;
 	/** First step in the workflow — hides input port, adds green border + START badge */
 	isStartNode?: boolean;
@@ -99,6 +110,7 @@ export function WorkflowNode({
 	step,
 	position,
 	agents,
+	workflowChannels = [],
 	isSelected = false,
 	isStartNode = false,
 	isDropTarget = false,
@@ -115,6 +127,15 @@ export function WorkflowNode({
 
 	const multi = isMultiAgentNode(step);
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
+
+	// Derive agent slot names for this node (used to filter workflow-level channels)
+	const nodeAgentNames: string[] = isTaskAgent
+		? ['task-agent']
+		: multi
+		  ? step.agents!.map((a) => a.name)
+		  : step.agentId
+		    ? [step.agentId]
+		    : [];
 
 	// Build a lookup: agentName → AgentTaskState
 	const taskStateByAgent = new Map<string | null, AgentTaskState>(
@@ -318,7 +339,7 @@ export function WorkflowNode({
 						{step.name || 'Task Agent'}
 					</p>
 					{/* Channel topology */}
-					<ChannelTopologyBadge step={step} />
+					<ChannelTopologyBadge workflowChannels={workflowChannels} nodeAgentNames={nodeAgentNames} />
 				</div>
 			</div>
 		);
@@ -430,7 +451,7 @@ export function WorkflowNode({
 				)}
 
 				{/* Channel topology */}
-				<ChannelTopologyBadge step={step} />
+				<ChannelTopologyBadge workflowChannels={workflowChannels} nodeAgentNames={nodeAgentNames} />
 			</div>
 
 			{/* Bottom port */}

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -52,6 +52,7 @@ const NODES: WorkflowNodeData[] = [
 		stepIndex: 1,
 		position: { x: 10, y: 10 },
 		agents: AGENTS,
+		workflowChannels: [],
 		isStartNode: false,
 	},
 	{
@@ -59,6 +60,7 @@ const NODES: WorkflowNodeData[] = [
 		stepIndex: 2,
 		position: { x: 200, y: 10 },
 		agents: AGENTS,
+		workflowChannels: [],
 		isStartNode: false,
 	},
 ];
@@ -485,12 +487,12 @@ describe('computeChannelEdges', () => {
 				name,
 				agentId: agents[0]?.id ?? '',
 				agents: agents.map((a) => ({ agentId: a.id })),
-				channels,
 				instructions: '',
 			},
 			stepIndex: 0,
 			position: { x: 0, y: 0 },
 			agents,
+			workflowChannels: channels ?? [],
 			isStartNode: false,
 		};
 	}
@@ -636,18 +638,18 @@ describe('WorkflowCanvas — channel edge rendering', () => {
 	});
 
 	it('renders channel edges when nodes have task-agent channels', () => {
-		// Create nodes with task-agent channels
+		// Create nodes with task-agent channels (now passed via workflowChannels prop)
 		const agents = [makeAgent('agent-1', 'Coder')];
 		const nodesWithChannels: WorkflowNodeData[] = [
 			{
 				step: {
 					...makeStep('step-1', 'Step One'),
 					agentId: 'agent-1',
-					channels: [{ from: 'task-agent', to: 'coder', direction: 'bidirectional' }],
 				},
 				stepIndex: 1,
 				position: { x: 10, y: 10 },
 				agents,
+				workflowChannels: [{ from: 'task-agent', to: 'coder', direction: 'bidirectional' }],
 				isStartNode: false,
 			},
 		];
@@ -710,7 +712,7 @@ describe('WorkflowCanvas — explicit channels prop', () => {
 	});
 
 	it('deduplicates explicit channels with computed node channels', () => {
-		// Node has a channel from step-1 to step-2
+		// Node has a channel from step-1 to step-2 (via workflowChannels prop)
 		const agentWithRole = makeAgent('agent-1', 'Coder');
 		agentWithRole.role = 'coder';
 		const nodesWithChannels: WorkflowNodeData[] = [
@@ -718,11 +720,11 @@ describe('WorkflowCanvas — explicit channels prop', () => {
 				step: {
 					...makeStep('step-1', 'Step One'),
 					agentId: 'agent-1',
-					channels: [{ from: 'task-agent', to: 'coder', direction: 'bidirectional' }],
 				},
 				stepIndex: 1,
 				position: { x: 10, y: 10 },
 				agents: [agentWithRole],
+				workflowChannels: [{ from: 'task-agent', to: 'coder', direction: 'bidirectional' }],
 				isStartNode: false,
 			},
 			{
@@ -730,6 +732,7 @@ describe('WorkflowCanvas — explicit channels prop', () => {
 				stepIndex: 2,
 				position: { x: 200, y: 10 },
 				agents: [makeAgent('agent-2', 'Reviewer')],
+				workflowChannels: [],
 				isStartNode: false,
 			},
 		];

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -80,6 +80,7 @@ function makeProps(overrides: Partial<WorkflowNodeProps> = {}): WorkflowNodeProp
 		step: STEP_DRAFT,
 		position: DEFAULT_POSITION,
 		agents: [AGENT_A, AGENT_B],
+		workflowChannels: [],
 		isSelected: false,
 		isStartNode: false,
 		scale: 1,

--- a/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
@@ -64,6 +64,7 @@ function makeNode(
 		stepIndex: 0,
 		position: { x: 0, y: 0 },
 		agents: AGENTS,
+		workflowChannels: [],
 		isStartNode: false,
 		...opts,
 	};


### PR DESCRIPTION
## Summary

Fix `space-multi-agent-editor.e2e.ts` (3 tests) broken by PR #884's channel refactor:

- `channels-section` moved from `NodeConfigPanel` to `VisualWorkflowEditor` sidebar → fixed locator scope
- Channel form elements renamed: `channel-from/to-select` → `new-channel-from/to-select`, `add-channel-button` → `add-channel-submit-button`
- Channel form uses `select` elements (not `input`) for to/from fields
- No default channel created by `setupMultiAgentStep` → updated channel count expectations
- `step.channels` never populated post-#884 refactor → updated `ChannelTopologyBadge` to read from `workflowChannels` prop
- Channels are workflow-level (not node-level) → removed stale empty-state assertion

**Product code changes** (`WorkflowNode`, `WorkflowCanvas`, `VisualWorkflowEditor`):
- `ChannelTopologyBadge` now accepts `workflowChannels` prop filtered by the node's agent roles
- `computeChannelEdges` reads from `node.workflowChannels`

## Test plan
- [x] `tests/features/space-multi-agent-editor.e2e.ts` — 3 tests pass (test 4 skipped due to product bug #815)
- [x] Unit tests pass (WorkflowNode, WorkflowCanvas, useConnectionDrag)