### PR TITLE
fix: add --no-delete-branch to gh pr merge to prevent worktree branch hijack

### DIFF
--- a/docs/plans/dev-branch-e2e-tests-health-check.md
+++ b/docs/plans/dev-branch-e2e-tests-health-check.md
@@ -189,7 +189,7 @@ After applying fixes, verify they pass CI. Always use PRs for review and safety 
 5. If CI fails on the fix, investigate and iterate (return to Task 2/3).
 6. Once CI passes, merge the PR:
    ```bash
-   gh pr merge --squash --delete-branch
+   gh pr merge --squash --no-delete-branch
    ```
 7. Trigger a fresh CI run on dev to confirm all e2e tests pass:
    ```bash

--- a/docs/plans/dev-branch-e2e-tests-health-check.md
+++ b/docs/plans/dev-branch-e2e-tests-health-check.md
@@ -189,7 +189,7 @@ After applying fixes, verify they pass CI. Always use PRs for review and safety 
 5. If CI fails on the fix, investigate and iterate (return to Task 2/3).
 6. Once CI passes, merge the PR:
    ```bash
-   gh pr merge --squash --no-delete-branch
+   gh pr merge --squash
    ```
 7. Trigger a fresh CI run on dev to confirm all e2e tests pass:
    ```bash

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -210,7 +210,7 @@ For planning tasks the planner must run a second phase to create tasks.
 
 1. **Send the planner back** — Call \`send_to_worker\` (mode: "defer") with:
    "The plan is approved. Please:
-   1. Merge the plan PR: \`gh pr merge <PR_NUMBER>\`
+   1. Merge the plan PR: \`gh pr merge <PR_NUMBER> --no-delete-branch\`
    2. Read the plan file under docs/plans/
    3. Create all tasks 1:1 from the plan using the \`create_task\` tool
    4. Finish your response after all tasks are created"
@@ -230,7 +230,7 @@ When the human message indicates approval (e.g., "approved", "merge it", "looks 
 
 1. **Merge the PR** — Use \`gh pr merge\` to merge the approved PR:
    \`\`\`bash
-   gh pr merge <PR_NUMBER>
+   gh pr merge <PR_NUMBER> --no-delete-branch
    \`\`\`
 2. **Sync the root repo** — Pull the merged changes into the root workspace:
    \`\`\`bash

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -210,7 +210,7 @@ For planning tasks the planner must run a second phase to create tasks.
 
 1. **Send the planner back** — Call \`send_to_worker\` (mode: "defer") with:
    "The plan is approved. Please:
-   1. Merge the plan PR: \`gh pr merge <PR_NUMBER> --no-delete-branch\`
+   1. Merge the plan PR: \`gh pr merge <PR_NUMBER>\` (do NOT use --delete-branch)
    2. Read the plan file under docs/plans/
    3. Create all tasks 1:1 from the plan using the \`create_task\` tool
    4. Finish your response after all tasks are created"
@@ -228,9 +228,9 @@ For planning tasks the planner must run a second phase to create tasks.
 
 When the human message indicates approval (e.g., "approved", "merge it", "looks good"), you must complete the task by:
 
-1. **Merge the PR** — Use \`gh pr merge\` to merge the approved PR:
+1. **Merge the PR** — Use \`gh pr merge\` to merge the approved PR (do NOT use --delete-branch, branch cleanup is handled separately):
    \`\`\`bash
-   gh pr merge <PR_NUMBER> --no-delete-branch
+   gh pr merge <PR_NUMBER>
    \`\`\`
 2. **Sync the root repo** — Pull the merged changes into the root workspace:
    \`\`\`bash

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -322,7 +322,7 @@ Finish your response after the plan-writer completes — the Leader will dispatc
 When the Leader sends you an approval message, you are in Phase 2.
 **IMPORTANT**: Do NOT skip straight to \`create_task\` — you MUST merge the plan PR first.
 
-1. Merge the plan PR: run \`gh pr merge <PR_NUMBER> --no-delete-branch\` (use the pr_number from the Phase 1 plan-writer result)
+1. Merge the plan PR: run \`gh pr merge <PR_NUMBER>\` (use the pr_number from the Phase 1 plan-writer result; do NOT use --delete-branch)
 2. Read the plan files (use the \`plan_files\` list from Phase 1, or find them under \`${planDir}/\` or at \`${planPath}\`)
 3. Create tasks 1:1 from the plan sections using the \`create_task\` tool
 4. Each task title and description should match the plan exactly

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -322,7 +322,7 @@ Finish your response after the plan-writer completes — the Leader will dispatc
 When the Leader sends you an approval message, you are in Phase 2.
 **IMPORTANT**: Do NOT skip straight to \`create_task\` — you MUST merge the plan PR first.
 
-1. Merge the plan PR: run \`gh pr merge <PR_NUMBER>\` (use the pr_number from the Phase 1 plan-writer result)
+1. Merge the plan PR: run \`gh pr merge <PR_NUMBER> --no-delete-branch\` (use the pr_number from the Phase 1 plan-writer result)
 2. Read the plan files (use the \`plan_files\` list from Phase 1, or find them under \`${planDir}/\` or at \`${planPath}\`)
 3. Create tasks 1:1 from the plan sections using the \`create_task\` tool
 4. Each task title and description should match the plan exactly

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -310,7 +310,7 @@ export async function checkWorkerPrMerged(
 				`The PR for branch "${branch}" is CLOSED — it was closed without merging.\n\n` +
 				`A closed PR cannot be merged directly. To fix this:\n` +
 				`1. Reopen the PR: \`gh pr reopen ${branch}\`\n` +
-				`2. Then merge: \`gh pr merge ${branch}\`\n` +
+				`2. Then merge: \`gh pr merge ${branch} --no-delete-branch\`\n` +
 				`3. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
 				`4. Then finish your response.`,
 		};
@@ -322,7 +322,7 @@ export async function checkWorkerPrMerged(
 		bounceMessage:
 			`The PR for branch "${branch}" is not merged yet (state: ${prState}).\n\n` +
 			`You were asked to merge the PR. Please complete this step:\n` +
-			`1. Run: \`gh pr merge ${branch}\`\n` +
+			`1. Run: \`gh pr merge ${branch} --no-delete-branch\`\n` +
 			`2. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
 			`3. Then finish your response.`,
 	};
@@ -389,7 +389,7 @@ export async function checkLeaderPrMerged(
 				`The PR for this task is CLOSED — it was closed without merging.\n\n` +
 				'A closed PR cannot be merged directly. To fix this:\n' +
 				'1. Use `send_to_worker` with: "The PR was closed without merging. ' +
-				`Reopen it with \`gh pr reopen ${branch}\`, then merge with \`gh pr merge ${branch}\`, ` +
+				`Reopen it with \`gh pr reopen ${branch}\`, then merge with \`gh pr merge ${branch} --no-delete-branch\`, ` +
 				`and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
 				'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
 		};
@@ -402,7 +402,7 @@ export async function checkLeaderPrMerged(
 			`The PR for this task is not merged (state: ${prState}). You cannot mark the task complete until the PR is actually merged.\n\n` +
 			'To fix this:\n' +
 			'1. Use `send_to_worker` to ask the worker: "The PR merge did not complete. ' +
-			`Please run \`gh pr merge ${branch}\` and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
+			`Please run \`gh pr merge ${branch} --no-delete-branch\` and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
 			'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
 	};
 }
@@ -610,7 +610,7 @@ export async function checkLeaderDraftsExist(
 			'No draft tasks were created by the planner yet. The planner must run Phase 2 to create tasks.\n\n' +
 			'To fix this:\n' +
 			'1. Call `send_to_worker` (mode: "defer") with: "The plan is approved. Please:\n' +
-			'   1. Merge the plan PR: `gh pr merge <PR_NUMBER>`\n' +
+			'   1. Merge the plan PR: `gh pr merge <PR_NUMBER> --no-delete-branch`\n' +
 			'   2. Read the plan file under docs/plans/\n' +
 			'   3. Create all tasks 1:1 from the plan using the `create_task` tool\n' +
 			'   4. Finish your response after all tasks are created"\n' +

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -310,7 +310,7 @@ export async function checkWorkerPrMerged(
 				`The PR for branch "${branch}" is CLOSED — it was closed without merging.\n\n` +
 				`A closed PR cannot be merged directly. To fix this:\n` +
 				`1. Reopen the PR: \`gh pr reopen ${branch}\`\n` +
-				`2. Then merge: \`gh pr merge ${branch} --no-delete-branch\`\n` +
+				`2. Then merge: \`gh pr merge ${branch}\` (do NOT use --delete-branch)\n` +
 				`3. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
 				`4. Then finish your response.`,
 		};
@@ -322,7 +322,7 @@ export async function checkWorkerPrMerged(
 		bounceMessage:
 			`The PR for branch "${branch}" is not merged yet (state: ${prState}).\n\n` +
 			`You were asked to merge the PR. Please complete this step:\n` +
-			`1. Run: \`gh pr merge ${branch} --no-delete-branch\`\n` +
+			`1. Run: \`gh pr merge ${branch}\` (do NOT use --delete-branch)\n` +
 			`2. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
 			`3. Then finish your response.`,
 	};
@@ -389,7 +389,7 @@ export async function checkLeaderPrMerged(
 				`The PR for this task is CLOSED — it was closed without merging.\n\n` +
 				'A closed PR cannot be merged directly. To fix this:\n' +
 				'1. Use `send_to_worker` with: "The PR was closed without merging. ' +
-				`Reopen it with \`gh pr reopen ${branch}\`, then merge with \`gh pr merge ${branch} --no-delete-branch\`, ` +
+				`Reopen it with \`gh pr reopen ${branch}\`, then merge with \`gh pr merge ${branch}\` (do NOT use --delete-branch), ` +
 				`and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
 				'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
 		};
@@ -402,7 +402,7 @@ export async function checkLeaderPrMerged(
 			`The PR for this task is not merged (state: ${prState}). You cannot mark the task complete until the PR is actually merged.\n\n` +
 			'To fix this:\n' +
 			'1. Use `send_to_worker` to ask the worker: "The PR merge did not complete. ' +
-			`Please run \`gh pr merge ${branch} --no-delete-branch\` and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
+			`Please run \`gh pr merge ${branch}\` (do NOT use --delete-branch) and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
 			'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
 	};
 }
@@ -610,7 +610,7 @@ export async function checkLeaderDraftsExist(
 			'No draft tasks were created by the planner yet. The planner must run Phase 2 to create tasks.\n\n' +
 			'To fix this:\n' +
 			'1. Call `send_to_worker` (mode: "defer") with: "The plan is approved. Please:\n' +
-			'   1. Merge the plan PR: `gh pr merge <PR_NUMBER> --no-delete-branch`\n' +
+			'   1. Merge the plan PR: `gh pr merge <PR_NUMBER>` (do NOT use --delete-branch)\n' +
 			'   2. Read the plan file under docs/plans/\n' +
 			'   3. Create all tasks 1:1 from the plan using the `create_task` tool\n' +
 			'   4. Finish your response after all tasks are created"\n' +

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -543,10 +543,10 @@ export function setupGoalHandlers(
 		const message =
 			task.taskType === 'planning'
 				? 'Your plan has been approved by AI reviewers and the human reviewer. ' +
-					'Now merge the plan PR (run `gh pr merge` or merge the branch manually), ' +
+					'Now merge the plan PR (run `gh pr merge --no-delete-branch` or merge the branch manually), ' +
 					'then read the plan file under `docs/plans/` and create tasks 1:1 from the approved plan using `create_task`. ' +
 					'Each task title and description should match the plan exactly.'
-				: 'Human has approved the PR. Merge it now by running `gh pr merge`. ' +
+				: 'Human has approved the PR. Merge it now by running `gh pr merge --no-delete-branch`. ' +
 					'After the merge completes, your work is done.';
 
 		const resumed = await runtime.resumeWorkerFromHuman(taskId, message, {

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -543,10 +543,10 @@ export function setupGoalHandlers(
 		const message =
 			task.taskType === 'planning'
 				? 'Your plan has been approved by AI reviewers and the human reviewer. ' +
-					'Now merge the plan PR (run `gh pr merge --no-delete-branch` or merge the branch manually), ' +
+					'Now merge the plan PR (run `gh pr merge` — do NOT use --delete-branch), ' +
 					'then read the plan file under `docs/plans/` and create tasks 1:1 from the approved plan using `create_task`. ' +
 					'Each task title and description should match the plan exactly.'
-				: 'Human has approved the PR. Merge it now by running `gh pr merge --no-delete-branch`. ' +
+				: 'Human has approved the PR. Merge it now by running `gh pr merge` (do NOT use --delete-branch). ' +
 					'After the merge completes, your work is done.';
 
 		const resumed = await runtime.resumeWorkerFromHuman(taskId, message, {

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -276,13 +276,16 @@ describe('Leader Agent', () => {
 			expect(prompt).toContain('create_task');
 			// The "merge PR yourself" instructions should NOT be present for plan_review
 			expect(prompt).not.toContain('Do NOT send the worker back to do the merge');
+			// Plan merge instruction must also use --no-delete-branch to prevent worktree branch hijack
+			expect(prompt).toContain('gh pr merge <PR_NUMBER> --no-delete-branch');
 		});
 
 		it('should use direct merge post-approval workflow for code review', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig());
 			// Leader merges the PR directly for coder/general tasks (no hardcoded merge method)
-			expect(prompt).toContain('gh pr merge <PR_NUMBER>');
-			expect(prompt).not.toContain('gh pr merge <PR_NUMBER> --');
+			expect(prompt).toContain('gh pr merge <PR_NUMBER> --no-delete-branch');
+			// Must not include bare --delete-branch (without the "no-" prefix)
+			expect(prompt).not.toMatch(/(?<!no-)--delete-branch/);
 			expect(prompt).toContain('Do NOT send the worker back to do the merge');
 		});
 

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -276,16 +276,16 @@ describe('Leader Agent', () => {
 			expect(prompt).toContain('create_task');
 			// The "merge PR yourself" instructions should NOT be present for plan_review
 			expect(prompt).not.toContain('Do NOT send the worker back to do the merge');
-			// Plan merge instruction must also use --no-delete-branch to prevent worktree branch hijack
-			expect(prompt).toContain('gh pr merge <PR_NUMBER> --no-delete-branch');
+			// Plan merge instruction must warn against --delete-branch to prevent worktree branch hijack
+			expect(prompt).toContain('do NOT use --delete-branch');
 		});
 
 		it('should use direct merge post-approval workflow for code review', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig());
 			// Leader merges the PR directly for coder/general tasks (no hardcoded merge method)
-			expect(prompt).toContain('gh pr merge <PR_NUMBER> --no-delete-branch');
-			// Must not include bare --delete-branch (without the "no-" prefix)
-			expect(prompt).not.toMatch(/(?<!no-)--delete-branch/);
+			expect(prompt).toContain('gh pr merge <PR_NUMBER>');
+			// Must warn against --delete-branch which causes worktree branch hijack
+			expect(prompt).toContain('do NOT use --delete-branch');
 			expect(prompt).toContain('Do NOT send the worker back to do the merge');
 		});
 

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -511,6 +511,7 @@ describe('checkWorkerPrMerged', () => {
 		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
 		expect(result.pass).toBe(false);
 		expect(result.bounceMessage).toContain('gh pr merge');
+		expect(result.bounceMessage).toContain('--no-delete-branch');
 		expect(result.bounceMessage).toContain('OPEN');
 		expect(result.bounceMessage).toContain('feat/add-alerts');
 	});

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -511,7 +511,7 @@ describe('checkWorkerPrMerged', () => {
 		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
 		expect(result.pass).toBe(false);
 		expect(result.bounceMessage).toContain('gh pr merge');
-		expect(result.bounceMessage).toContain('--no-delete-branch');
+		expect(result.bounceMessage).toContain('do NOT use --delete-branch');
 		expect(result.bounceMessage).toContain('OPEN');
 		expect(result.bounceMessage).toContain('feat/add-alerts');
 	});

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -172,6 +172,7 @@ describe('planner-agent', () => {
 		it('should instruct to merge PR before creating tasks in Phase 2', () => {
 			const prompt = buildPlannerSystemPrompt('Test');
 			expect(prompt).toContain('gh pr merge');
+			expect(prompt).toContain('--no-delete-branch');
 			expect(prompt).toContain('pr_number');
 		});
 

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -172,7 +172,7 @@ describe('planner-agent', () => {
 		it('should instruct to merge PR before creating tasks in Phase 2', () => {
 			const prompt = buildPlannerSystemPrompt('Test');
 			expect(prompt).toContain('gh pr merge');
-			expect(prompt).toContain('--no-delete-branch');
+			expect(prompt).toContain('do NOT use --delete-branch');
 			expect(prompt).toContain('pr_number');
 		});
 


### PR DESCRIPTION
## Summary
- Add `--no-delete-branch` to all `gh pr merge` commands in leader-agent, planner-agent, lifecycle-hooks, and goal-handlers
- Replace `--delete-branch` with `--no-delete-branch` in docs/plans
- Prevents GitHub from deleting the branch mid-merge inside a worktree, which causes git to auto-switch to the default branch and orphan the worktree

## Test plan
- Updated leader-agent test to assert `--no-delete-branch` is present and bare `--delete-branch` is absent
- Updated planner-agent test to assert `--no-delete-branch` in merge instructions
- Updated lifecycle-hooks test to assert `--no-delete-branch` in bounce messages