### PR TITLE
fix: E2E test failures — draft tasks, selectors, reference search

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -206,15 +206,22 @@ export function setupReferenceHandlers(messageHub: MessageHub, deps: ReferenceHa
 		if (typeof params.query !== 'string') throw new Error('query must be a string');
 
 		const query = params.query.trim();
-		// Empty/whitespace-only query would match everything — return nothing instead
-		if (!query) return { results: [] };
 
 		const requestedTypes: ReferenceType[] =
 			params.types && params.types.length > 0 ? params.types : ['task', 'goal', 'file', 'folder'];
 
-		// Resolve room context from session
+		// Resolve room context from session.
+		// The room agent route uses a synthetic session ID "room:chat:<roomId>"
+		// which has no DB entry — extract the roomId from it directly.
 		const session = sessionManager.getSessionFromDB(params.sessionId);
-		const roomId = session?.context?.roomId;
+		let roomId = session?.context?.roomId;
+		if (!roomId && params.sessionId.startsWith('room:chat:')) {
+			roomId = params.sessionId.slice('room:chat:'.length);
+		}
+
+		// Empty query with no room context: nothing to search.
+		// Empty query WITH room context: return all tasks/goals for the room.
+		if (!query && !roomId) return { results: [] };
 
 		const allResults: ReferenceSearchResult[] = [];
 
@@ -317,6 +324,11 @@ async function resolveSessionContext(
 ): Promise<{ workspacePath: string; roomId: string | null }> {
 	const agentSession = await deps.sessionManager.getSessionAsync(sessionId);
 	if (!agentSession) {
+		// The room agent route uses a synthetic session ID "room:chat:<roomId>"
+		// which has no DB entry — extract the roomId from it.
+		if (sessionId.startsWith('room:chat:')) {
+			return { workspacePath: deps.workspaceRoot, roomId: sessionId.slice('room:chat:'.length) };
+		}
 		return { workspacePath: deps.workspaceRoot, roomId: null };
 	}
 

--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -273,6 +273,9 @@ export function setupReferenceHandlers(messageHub: MessageHub, deps: ReferenceHa
 		if (requestedTypes.includes('folder')) fileTypes.push('folder');
 
 		if (fileTypes.length > 0 && query.length > 0) {
+			// Note: file/folder search requires a non-empty query — returning all files
+			// on empty query would be too slow and noisy. Task/goal results above are
+			// returned for empty queries since they are bounded to the room scope.
 			// Path traversal check — reject queries with .. or absolute paths
 			if (query.includes('..') || query.startsWith('/')) {
 				// Return what we have so far without file results

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -104,6 +104,7 @@ export function setupTaskHandlers(
 			description: string;
 			priority?: TaskPriority;
 			dependsOn?: string[];
+			status?: TaskStatus;
 		};
 
 		if (!params.roomId) {
@@ -119,6 +120,7 @@ export function setupTaskHandlers(
 			description: params.description ?? '',
 			priority: params.priority,
 			dependsOn: params.dependsOn,
+			status: params.status,
 		});
 
 		// Emit room.overview for new task creation (significant change)

--- a/packages/daemon/tests/unit/providers/anthropic-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-provider.test.ts
@@ -123,13 +123,45 @@ describe('AnthropicProvider', () => {
 			// Set credentials so SDK load is attempted
 			process.env.ANTHROPIC_API_KEY = 'test-key';
 
-			// Mock the SDK module with a query that fails when supportedModels is called
+			// Mock the SDK module with a query that fails when supportedModels is called.
+			// IMPORTANT: we must still provide createSdkMcpServer and tool so that other
+			// tests (e.g. provision-global-agent, task-agent-tools) don't break when
+			// this mock replaces setup.ts's default SDK mock.
+			class MockMcpServer {
+				readonly _registeredTools: Record<string, object> = {};
+				connect(): void {}
+				disconnect(): void {}
+			}
+			let _toolBatch: Array<{ name: string; def: object }> = [];
 			mock.module('@anthropic-ai/claude-agent-sdk', () => ({
 				query: async () => ({
 					interrupt: () => {},
 					supportedModels: async () => {
 						throw new Error('SDK unavailable');
 					},
+				}),
+				interrupt: mock(async () => {}),
+				supportedModels: mock(async () => {
+					throw new Error('SDK unavailable');
+				}),
+				createSdkMcpServer: mock((_options: { name: string; tools?: unknown[] }) => {
+					const server = new MockMcpServer();
+					for (const { name, def } of _toolBatch) {
+						server._registeredTools[name] = def;
+					}
+					_toolBatch = [];
+					return {
+						type: 'sdk' as const,
+						name: _options.name,
+						version: _options.version ?? '1.0.0',
+						tools: _options.tools ?? [],
+						instance: server,
+					};
+				}),
+				tool: mock((name: string, description: string, inputSchema: unknown, handler: unknown) => {
+					const def = { name, description, inputSchema, handler };
+					_toolBatch.push({ name, def });
+					return def;
 				}),
 			}));
 

--- a/packages/daemon/tests/unit/reference-handlers.test.ts
+++ b/packages/daemon/tests/unit/reference-handlers.test.ts
@@ -755,10 +755,11 @@ describe('reference.search handler', () => {
 			);
 		});
 
-		it('returns empty results for whitespace-only query', async () => {
+		it('returns empty results for whitespace-only query without room context', async () => {
 			insertTask(db, roomId, 'task-1', 'Some task', 't-1');
 
-			const sessions = new Map([['sess-1', { roomId }]]);
+			// No room context — empty query should return nothing
+			const sessions = new Map();
 			const { hub, call } = buildMessageHub();
 			setupReferenceHandlers(hub, {
 				db: db as never,
@@ -774,6 +775,53 @@ describe('reference.search handler', () => {
 			})) as { results: unknown[] };
 
 			expect(result.results).toHaveLength(0);
+		});
+
+		it('returns all tasks for empty query when room context exists', async () => {
+			insertTask(db, roomId, 'task-1', 'Some task', 't-1');
+
+			const sessions = new Map([['sess-1', { roomId }]]);
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: 'sess-1',
+				query: '   ',
+			})) as { results: Array<{ type: string }> };
+
+			// Empty query with room context returns all tasks
+			expect(result.results).toHaveLength(1);
+			expect(result.results[0].type).toBe('task');
+		});
+
+		it('extracts roomId from synthetic room:chat: session ID', async () => {
+			insertTask(db, roomId, 'task-1', 'Room Agent Task', 't-1');
+
+			// No real session in DB — the synthetic ID "room:chat:<roomId>" should be parsed
+			const sessions = new Map();
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: `room:chat:${roomId}`,
+				query: '',
+			})) as { results: Array<{ type: string; displayText: string }> };
+
+			expect(result.results).toHaveLength(1);
+			expect(result.results[0].type).toBe('task');
+			expect(result.results[0].displayText).toBe('Room Agent Task');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/reference-handlers.test.ts
+++ b/packages/daemon/tests/unit/reference-handlers.test.ts
@@ -823,6 +823,29 @@ describe('reference.search handler', () => {
 			expect(result.results[0].type).toBe('task');
 			expect(result.results[0].displayText).toBe('Room Agent Task');
 		});
+
+		it('returns all tasks for whitespace-only query with synthetic session ID', async () => {
+			insertTask(db, roomId, 'task-1', 'Synthetic WS Task', 't-1');
+
+			// Whitespace-only query trims to "" — with room context, should return all tasks
+			const sessions = new Map();
+			const { hub, call } = buildMessageHub();
+			setupReferenceHandlers(hub, {
+				db: db as never,
+				reactiveDb: buildReactiveDb(),
+				shortIdAllocator: buildShortIdAllocator(),
+				sessionManager: buildSessionManager(sessions) as never,
+				fileIndex: buildFileIndex(),
+			});
+
+			const result = (await call('reference.search', {
+				sessionId: `room:chat:${roomId}`,
+				query: '   ',
+			})) as { results: Array<{ type: string }> };
+
+			expect(result.results).toHaveLength(1);
+			expect(result.results[0].type).toBe('task');
+		});
 	});
 });
 

--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -910,17 +910,18 @@ describe('GoalManager.patchGoal — schedule nextRunAt auto-computation', () => 
 		expect(goal.nextRunAt).toBeDefined();
 		const originalNextRunAt = goal.nextRunAt!;
 
-		// Patch the schedule to a new expression
+		// Patch the schedule to @weekly — guaranteed different nextRunAt than @daily
+		// (they can coincide at midnight for @hourly or @daily).
 		const before = Math.floor(Date.now() / 1000);
 		const patched = await goalManager.patchGoal(goal.id, {
-			schedule: { expression: '@hourly', timezone: 'UTC' },
+			schedule: { expression: '@weekly', timezone: 'UTC' },
 		});
-		const after = Math.floor(Date.now() / 1000) + 3700; // up to 1 hour + buffer
+		const after = Math.floor(Date.now() / 1000) + 7 * 24 * 3600 + 100; // @weekly = up to 7 days
 
-		expect(patched.schedule?.expression).toBe('@hourly');
+		expect(patched.schedule?.expression).toBe('@weekly');
 		expect(patched.nextRunAt).toBeDefined();
 		expect(patched.nextRunAt!).toBeGreaterThan(before);
-		// @hourly fires within the next hour
+		// @weekly fires within the next week
 		expect(patched.nextRunAt!).toBeLessThanOrEqual(after);
 		// nextRunAt should change when the cron expression changes
 		expect(patched.nextRunAt!).not.toBe(originalNextRunAt);

--- a/packages/daemon/tests/unit/session/session-lifecycle-sdk-title.test.ts
+++ b/packages/daemon/tests/unit/session/session-lifecycle-sdk-title.test.ts
@@ -50,6 +50,12 @@ function makeQueryMock(messages: unknown[]) {
 // Mocking internal relative-import modules here would permanently replace
 // them for ALL test files in the same bun test run, breaking tests that
 // import those modules directly (e.g. provider-service.test.ts).
+class MockMcpServerForSdk {
+	readonly _registeredTools: Record<string, object> = {};
+	connect(): void {}
+	disconnect(): void {}
+}
+let _toolBatch: Array<{ name: string; def: object }> = [];
 mock.module('@anthropic-ai/claude-agent-sdk', () => ({
 	query: (params: { prompt: string; options?: Record<string, unknown> }) => {
 		const opts = params.options ?? {};
@@ -60,6 +66,29 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
 			lastTitleQueryOptions = opts;
 		}
 		return makeQueryMock(mockSdkMessages);
+	},
+	interrupt: mock(async () => {}),
+	supportedModels: mock(async () => {
+		throw new Error('SDK unavailable in unit test');
+	}),
+	createSdkMcpServer: mock((_options: { name: string; tools?: unknown[] }) => {
+		const server = new MockMcpServerForSdk();
+		for (const { name, def } of _toolBatch) {
+			server._registeredTools[name] = def;
+		}
+		_toolBatch = [];
+		return {
+			type: 'sdk' as const,
+			name: _options.name,
+			version: _options.version ?? '1.0.0',
+			tools: _options.tools ?? [],
+			instance: server,
+		};
+	}),
+	tool: (name: string, description: string, inputSchema: unknown, handler: unknown) => {
+		const def = { name, description, inputSchema, handler };
+		_toolBatch.push({ name, def });
+		return def;
 	},
 }));
 

--- a/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
+++ b/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
@@ -47,6 +47,9 @@ async function createTask(
 				roomId: rId,
 				title: t,
 				description: 'LiveQuery E2E test task',
+				// Use 'draft' to prevent the scheduler from spawning a worktree
+				// (the E2E workspace is not a git repo, so worktree creation fails).
+				status: 'draft',
 			});
 			return (res as { task: { id: string } }).task.id;
 		},

--- a/packages/e2e/tests/features/short-id-display.e2e.ts
+++ b/packages/e2e/tests/features/short-id-display.e2e.ts
@@ -49,6 +49,9 @@ async function createTask(
 			roomId: rId,
 			title: 'Short ID E2E Test Task',
 			description: 'Task used to verify short ID display and copy behavior',
+			// Use 'draft' to prevent the scheduler from spawning a worktree
+			// (the E2E workspace is not a git repo, so worktree creation fails).
+			status: 'draft',
 		});
 		const task = (res as { task: { id: string; shortId?: string } }).task;
 		if (!task.shortId)

--- a/packages/e2e/tests/features/space-agent-centric-workflow.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-centric-workflow.e2e.ts
@@ -122,19 +122,12 @@ test.describe('Agent-Centric Workflow', () => {
 		// Add a node and configure two agents so agentRoles is populated,
 		// which gives the ChannelEditor select dropdowns instead of text inputs.
 		await editor.getByTestId('add-step-button').click();
-		// Wait for exactly 1 non-Task-Agent node. If 2 appear (product bug: addStep
-		// double-invokes in dev), wait briefly then use .last() (the newly added node).
-		const nodes = editor.locator('[data-testid^="workflow-node-"]').filter({
-			hasNot: page.locator('[data-task-agent="true"]'),
-		});
-		try {
-			await expect(nodes).toHaveCount(1, { timeout: 2000 });
-		} catch {
-			// 2 nodes appeared (known product issue). Use the last one (most recent).
-			await page.waitForTimeout(200);
-		}
-		const clickedNode = (await nodes.count()) > 1 ? nodes.last() : nodes.first();
-		await clickedNode.click();
+		// :not([data-task-agent]) excludes the Task Agent virtual node by its own attribute.
+		// Note: Playwright's filter({hasNot}) only matches descendants, not the element itself.
+		const nodes = editor.locator('[data-testid^="workflow-node-"]:not([data-task-agent])');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
 		await panel.getByTestId('step-name-input').fill('Parallel Step');
@@ -183,16 +176,10 @@ test.describe('Agent-Centric Workflow', () => {
 
 		// Add a node with two agents so agentRoles is populated
 		await editor.getByTestId('add-step-button').click();
-		const nodes = editor.locator('[data-testid^="workflow-node-"]').filter({
-			hasNot: page.locator('[data-task-agent="true"]'),
-		});
-		try {
-			await expect(nodes).toHaveCount(1, { timeout: 2000 });
-		} catch {
-			await page.waitForTimeout(200);
-		}
-		const clickedNode = (await nodes.count()) > 1 ? nodes.last() : nodes.first();
-		await clickedNode.click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]:not([data-task-agent])');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
 		await panel.getByTestId('step-name-input').fill('Gate Step');
@@ -238,16 +225,10 @@ test.describe('Agent-Centric Workflow', () => {
 
 		// Add a step with two agents
 		await editor.getByTestId('add-step-button').click();
-		const nodes = editor.locator('[data-testid^="workflow-node-"]').filter({
-			hasNot: page.locator('[data-task-agent="true"]'),
-		});
-		try {
-			await expect(nodes).toHaveCount(1, { timeout: 2000 });
-		} catch {
-			await page.waitForTimeout(200);
-		}
-		const clickedNode = (await nodes.count()) > 1 ? nodes.last() : nodes.first();
-		await clickedNode.click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]:not([data-task-agent])');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
 		await panel.getByTestId('step-name-input').fill('Parallel Agents');
@@ -282,18 +263,11 @@ test.describe('Agent-Centric Workflow', () => {
 		await switchToVisualMode(page);
 
 		const editorReopen = page.getByTestId('visual-workflow-editor');
-		const reopenedNodes = editorReopen.locator('[data-testid^="workflow-node-"]').filter({
-			hasNot: page.locator('[data-task-agent="true"]'),
-		});
-		// The saved workflow may have been serialized with a double-invocation node artifact.
-		// Apply the same try/catch workaround used during creation.
-		try {
-			await expect(reopenedNodes).toHaveCount(1, { timeout: 3000 });
-		} catch {
-			await page.waitForTimeout(200);
-		}
-		const reopenedNode =
-			(await reopenedNodes.count()) > 1 ? reopenedNodes.last() : reopenedNodes.first();
+		const reopenedNodes = editorReopen.locator(
+			'[data-testid^="workflow-node-"]:not([data-task-agent])'
+		);
+		await expect(reopenedNodes).toHaveCount(1, { timeout: 5000 });
+		const reopenedNode = reopenedNodes.first();
 
 		// Agent badges should be visible after reload
 		const reopenedBadges = reopenedNode.getByTestId('agent-badges');
@@ -320,16 +294,10 @@ test.describe('Agent-Centric Workflow', () => {
 
 		// Add step with two agents
 		await editor.getByTestId('add-step-button').click();
-		const nodes = editor.locator('[data-testid^="workflow-node-"]').filter({
-			hasNot: page.locator('[data-task-agent="true"]'),
-		});
-		try {
-			await expect(nodes).toHaveCount(1, { timeout: 2000 });
-		} catch {
-			await page.waitForTimeout(200);
-		}
-		const clickedNode = (await nodes.count()) > 1 ? nodes.last() : nodes.first();
-		await clickedNode.click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]:not([data-task-agent])');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
 		await panel.getByTestId('step-name-input').fill('Collab Step');

--- a/packages/e2e/tests/features/task-goal-indicator.e2e.ts
+++ b/packages/e2e/tests/features/task-goal-indicator.e2e.ts
@@ -39,6 +39,9 @@ async function createRoomWithLinkedGoalAndTask(
 			roomId,
 			title: 'Goal-Linked Task',
 			description: 'A task linked to a mission',
+			// Use 'draft' to prevent the scheduler from spawning a worktree
+			// (the E2E workspace is not a git repo, so worktree creation fails).
+			status: 'draft',
 		});
 		const taskId = (taskRes as { task: { id: string } }).task.id;
 
@@ -76,6 +79,9 @@ async function createRoomWithUnlinkedTask(
 			roomId,
 			title: 'Unlinked Task',
 			description: 'A task with no mission',
+			// Use 'draft' to prevent the scheduler from spawning a worktree
+			// (the E2E workspace is not a git repo, so worktree creation fails).
+			status: 'draft',
 		});
 		const taskId = (taskRes as { task: { id: string } }).task.id;
 

--- a/packages/e2e/tests/helpers/mobile-helpers.ts
+++ b/packages/e2e/tests/helpers/mobile-helpers.ts
@@ -56,7 +56,8 @@ export async function closeMobilePanel(page: Page): Promise<void> {
 
 	// Use force: true because the BottomTabBar (z-50) overlaps the panel (z-40)
 	// on mobile, causing Playwright's actionability check to report click interception.
-	await closePanelButton(page).click({ force: true });
+	// Use .first() for robustness in case multiple elements match the selector.
+	await closePanelButton(page).first().click({ force: true, timeout: 5000 });
 
 	// Wait for close button to leave the viewport — confirms panel finished closing
 	const closeBtn = closePanelButton(page);

--- a/packages/e2e/tests/helpers/mobile-helpers.ts
+++ b/packages/e2e/tests/helpers/mobile-helpers.ts
@@ -14,22 +14,35 @@ const openMenuButton = (page: Page) => page.locator('button[aria-label="Open nav
 const closePanelButton = (page: Page) => page.locator('button[title="Close panel"]');
 
 /**
+ * Check whether the mobile context panel is currently open.
+ *
+ * Uses boundingBox() instead of isVisible() because the panel uses CSS
+ * translate-x for show/hide — translated-off elements are still "visible"
+ * per Playwright but are outside the viewport.
+ */
+async function isPanelOpen(page: Page): Promise<boolean> {
+	const box = await closePanelButton(page)
+		.boundingBox()
+		.catch(() => null);
+	if (!box) return false;
+	// When the panel is open, the close button is within the viewport (x >= 0).
+	// When closed via -translate-x-full, the button is off-screen (x < -200).
+	return box.x >= 0;
+}
+
+/**
  * Open the mobile context panel (sidebar/drawer) and wait for it to be ready.
  * If already open, this is a no-op.
  */
 export async function openMobilePanel(page: Page): Promise<void> {
-	const menuBtn = openMenuButton(page);
-	const closeBtn = closePanelButton(page);
-
-	// Panel is open if close button is visible
-	if (await closeBtn.isVisible().catch(() => false)) {
+	if (await isPanelOpen(page)) {
 		return;
 	}
 
-	await menuBtn.click();
+	await openMenuButton(page).click();
 
-	// Wait for close button to appear — confirms panel finished its open animation
-	await expect(closeBtn).toBeVisible({ timeout: 5000 });
+	// Wait for close button to be in viewport — confirms panel finished its open animation
+	await expect(closePanelButton(page)).toBeInViewport({ timeout: 5000 });
 }
 
 /**
@@ -37,14 +50,15 @@ export async function openMobilePanel(page: Page): Promise<void> {
  * If already closed, this is a no-op.
  */
 export async function closeMobilePanel(page: Page): Promise<void> {
-	const closeBtn = closePanelButton(page);
-
-	if (!(await closeBtn.isVisible().catch(() => false))) {
+	if (!(await isPanelOpen(page))) {
 		return;
 	}
 
-	await closeBtn.click();
+	// Use force: true because the BottomTabBar (z-50) overlaps the panel (z-40)
+	// on mobile, causing Playwright's actionability check to report click interception.
+	await closePanelButton(page).click({ force: true });
 
-	// Wait for close button to disappear — confirms panel finished closing
-	await expect(closeBtn).toBeHidden({ timeout: 5000 });
+	// Wait for close button to leave the viewport — confirms panel finished closing
+	const closeBtn = closePanelButton(page);
+	await expect(closeBtn).not.toBeInViewport({ timeout: 5000 });
 }

--- a/packages/e2e/tests/helpers/room-helpers.ts
+++ b/packages/e2e/tests/helpers/room-helpers.ts
@@ -73,7 +73,14 @@ export async function createTask(
 		async ({ rId, t, d }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
-			const res = await hub.request('task.create', { roomId: rId, title: t, description: d });
+			const res = await hub.request('task.create', {
+				roomId: rId,
+				title: t,
+				description: d,
+				// Use 'draft' to prevent the scheduler from spawning a worktree
+				// (the E2E workspace is not a git repo, so worktree creation fails).
+				status: 'draft',
+			});
 			return (res as { task: { id: string } }).task.id;
 		},
 		{ rId: roomId, t: title, d: description }

--- a/packages/e2e/tests/responsive/mobile.e2e.ts
+++ b/packages/e2e/tests/responsive/mobile.e2e.ts
@@ -333,7 +333,7 @@ test.describe('Mobile Room Agent Navigation', () => {
 		const bottomTabBar = page.getByRole('tablist', { name: 'Main navigation' });
 		await expect(bottomTabBar.getByRole('tab', { name: 'Agent' })).toBeVisible();
 
-		// Click the "/" (Home) tab to navigate away from the room
+		// Click the "/" (Home) tab — present in room context, navigates to global home
 		await bottomTabBar.getByRole('tab', { name: '/' }).click();
 
 		// URL should change to home

--- a/packages/e2e/tests/responsive/mobile.e2e.ts
+++ b/packages/e2e/tests/responsive/mobile.e2e.ts
@@ -333,11 +333,11 @@ test.describe('Mobile Room Agent Navigation', () => {
 		const bottomTabBar = page.getByRole('tablist', { name: 'Main navigation' });
 		await expect(bottomTabBar.getByRole('tab', { name: 'Agent' })).toBeVisible();
 
-		// Click Inbox tab (present in both room and global contexts)
-		await bottomTabBar.getByRole('tab', { name: 'Inbox' }).click();
+		// Click the "/" (Home) tab to navigate away from the room
+		await bottomTabBar.getByRole('tab', { name: '/' }).click();
 
-		// URL should change to inbox
-		await expect(page).toHaveURL(/\/inbox$/, { timeout: 5000 });
+		// URL should change to home
+		await expect(page).toHaveURL(/\/$/, { timeout: 5000 });
 
 		// Now global tabs should be shown (Rooms tab visible)
 		await expect(bottomTabBar.getByRole('tab', { name: 'Rooms' })).toBeVisible({ timeout: 5000 });

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -395,6 +395,11 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				(n) => n.step.id !== TASK_AGENT_NODE_ID && n.step.localId !== TASK_AGENT_NODE_ID
 			).length;
 			const position: Point = { x: 120, y: 80 + regularCount * 100 };
+
+			// Auto-set start step for the first regular node (pure — reads from prev).
+			const isFirstRegular = regularCount === 0;
+			if (isFirstRegular) setStartStepId(newLocalId);
+
 			return [...prev, { step: newStep, position }];
 		});
 	}


### PR DESCRIPTION
## Summary
- Fix E2E tests that fail because tasks auto-execute in a non-git workspace by adding `status: 'draft'` to task creation calls
- Replace broken Playwright `filter({ hasNot })` with CSS `:not()` selector for Task Agent node exclusion
- Fix mobile panel detection using `boundingBox()` instead of `isVisible()` for CSS translate-x hidden elements
- Handle synthetic `room:chat:<roomId>` session ID in `reference.search` so autocomplete works on the room agent route
- Move `setStartStepId` inside `setNodes` updater to fix React StrictMode violation

## Test plan
- [ ] Unit tests pass: `bun test packages/daemon/tests/unit/reference-handlers.test.ts`
- [ ] E2E tests: short-id-display, task-goal-indicator, livequery-task-goal-updates, space-agent-centric-workflow (tests 1-2), mobile room agent navigation
- [ ] `bun run check` passes (lint, typecheck, knip)