### PR TITLE
fix: detect stale messageQueue state and retry worker-to-leader routing

### DIFF
--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -313,6 +313,11 @@ export class QueryLifecycleManager {
 	 *
 	 * Waits for any pending interrupt, validates SDK session file,
 	 * and starts the streaming query if not already running.
+	 *
+	 * Detects stale running state: if messageQueue.isRunning() is true but
+	 * queryPromise is null, the queue was not properly stopped after the previous
+	 * query ended (race between SDK query completion and finally block cleanup).
+	 * In this case, force-stop the queue and restart.
 	 */
 	async ensureQueryStarted(): Promise<void> {
 		const { session, db, messageQueue, interruptHandler } = this.ctx;
@@ -328,7 +333,25 @@ export class QueryLifecycleManager {
 		}
 
 		if (messageQueue.isRunning()) {
-			return;
+			// Stale running state detection: if the queue thinks it's running but
+			// there's no active query promise, the previous query's finally block
+			// hasn't called stop() yet (or it was lost). Force-stop and restart
+			// so the enqueued message is not orphaned.
+			if (!this.ctx.queryPromise) {
+				this.logger.warn(
+					`Stale running state detected for session ${session.id}: ` +
+						`messageQueue.isRunning()=true but queryPromise=null. Force-stopping and restarting.`
+				);
+				messageQueue.stop();
+				// Fall through to start a fresh query below
+			} else {
+				this.logger.debug(
+					`ensureQueryStarted: session ${session.id} already running, skipping start`
+				);
+				return;
+			}
+		} else {
+			this.logger.debug(`ensureQueryStarted: session ${session.id} not running, starting query`);
 		}
 
 		// Validate SDK session file

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -333,16 +333,22 @@ export class QueryLifecycleManager {
 		}
 
 		if (messageQueue.isRunning()) {
-			// Stale running state detection: if the queue thinks it's running but
-			// there's no active query promise, the previous query's finally block
-			// hasn't called stop() yet (or it was lost). Force-stop and restart
-			// so the enqueued message is not orphaned.
+			// Defensive stale state detection: if the queue thinks it's running but
+			// there's no active query promise, the session is in an inconsistent state
+			// (e.g., restored session with stale queue flag, or cleanup was interrupted).
+			// The primary race (between for-await loop ending and finally block cleanup)
+			// is handled by the early messageQueue.stop() in QueryRunner.runQuery().
+			// This check catches residual edge cases where queryPromise has already
+			// been nulled but the queue wasn't stopped.
 			if (!this.ctx.queryPromise) {
 				this.logger.warn(
 					`Stale running state detected for session ${session.id}: ` +
 						`messageQueue.isRunning()=true but queryPromise=null. Force-stopping and restarting.`
 				);
 				messageQueue.stop();
+				// Clear stale query reference to prevent concurrent callers from
+				// seeing a dead query object during the restart window.
+				this.ctx.queryObject = null;
 				// Fall through to start a fresh query below
 			} else {
 				this.logger.debug(

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -316,6 +316,15 @@ export class QueryRunner {
 				}
 			}
 
+			// Stop the queue immediately after the query ends to close the race window
+			// between the for-await loop ending and the finally block calling stop().
+			// Without this, ensureQueryStarted() can see isRunning()=true while no
+			// generator is consuming messages, causing enqueued messages to be orphaned.
+			// Guard: only stop if this is still the current query (not stale from a restart).
+			if (this.ctx.getQueryGeneration() === queryGeneration) {
+				messageQueue.stop();
+			}
+
 			// If startup timed out before first message, surface as timeout error
 			// (after abort-driven iterator shutdown) so error state is visible.
 			if (startupTimeoutReached && messageCount === 0) {

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -98,12 +98,21 @@ export class QueryRunner {
 	 * Start the streaming query (called from AgentSession.startStreamingQuery)
 	 */
 	async start(): Promise<void> {
-		const { messageQueue } = this.ctx;
+		const { messageQueue, logger } = this.ctx;
 
 		if (messageQueue.isRunning()) {
+			logger.warn(
+				`QueryRunner.start(): messageQueue already running for session ${this.ctx.session.id}, ` +
+					`skipping start (generation=${messageQueue.getGeneration()}, ` +
+					`queryPromise=${this.ctx.queryPromise ? 'active' : 'null'})`
+			);
 			return;
 		}
 
+		logger.debug(
+			`QueryRunner.start(): starting query for session ${this.ctx.session.id} ` +
+				`(generation=${messageQueue.getGeneration()})`
+		);
 		messageQueue.start();
 
 		// Increment query generation for this new query

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -434,7 +434,7 @@ export class RoomRuntimeService {
 				ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
 				log.debug(
 					`[injectMessage] Session ${sessionId}: saved user message ${messageId}, ` +
-						`enqueuing into messageQueue (isRunning=${session.messageQueue.isRunning()})`
+						`enqueuing into messageQueue (isRunning=${session.messageQueue.isRunning?.() ?? 'unknown'})`
 				);
 				await session.messageQueue.enqueueWithId(messageId, message);
 				log.debug(

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -389,12 +389,19 @@ export class RoomRuntimeService {
 			injectMessage: async (sessionId, message, opts) => {
 				const session = agentSessions.get(sessionId);
 				if (!session) {
+					log.error(`[injectMessage] Session ${sessionId}: not found in service cache`);
 					throw new Error(`Session not in service cache: ${sessionId}`);
 				}
 
 				const deliveryMode = opts?.deliveryMode ?? 'immediate';
 				const state = session.getProcessingState();
 				const isBusy = state.status === 'processing' || state.status === 'queued';
+
+				log.debug(
+					`[injectMessage] Session ${sessionId}: deliveryMode=${deliveryMode}, ` +
+						`status=${state.status}, isBusy=${isBusy}, ` +
+						`messageLength=${message.length}`
+				);
 
 				const messageId = generateUUID();
 				const sdkUserMessage: SDKUserMessage = {
@@ -412,6 +419,7 @@ export class RoomRuntimeService {
 				// - defer + busy => persist as 'deferred' (replayed after current turn)
 				// - otherwise => enqueue now ('enqueued') so worker can start ASAP when idle
 				if (deliveryMode === 'defer' && isBusy) {
+					log.debug(`[injectMessage] Session ${sessionId}: deferring message ${messageId} (busy)`);
 					ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred');
 					return;
 				}
@@ -419,9 +427,19 @@ export class RoomRuntimeService {
 				// Ensure the SDK query is running before enqueuing. After daemon
 				// restart, restored sessions are in cache but haven't started
 				// their query yet (lazy start to avoid startup timeout).
+				log.debug(
+					`[injectMessage] Session ${sessionId}: calling ensureQueryStarted before enqueue`
+				);
 				await session.ensureQueryStarted();
 				ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+				log.debug(
+					`[injectMessage] Session ${sessionId}: saved user message ${messageId}, ` +
+						`enqueuing into messageQueue (isRunning=${session.messageQueue.isRunning()})`
+				);
 				await session.messageQueue.enqueueWithId(messageId, message);
+				log.debug(
+					`[injectMessage] Session ${sessionId}: message ${messageId} enqueued successfully`
+				);
 			},
 			hasSession: (sessionId) => {
 				return agentSessions.has(sessionId);

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -470,14 +470,49 @@ export class TaskGroupManager {
 			? `${deferredLeader.leaderTaskContext}\n\n---\n\n${workerOutput}`
 			: workerOutput;
 
-		// Inject worker output into Leader session
+		// Inject worker output into Leader session with retry.
+		// The injectMessage call can fail due to race conditions (e.g., stale queue state,
+		// timeout during SDK startup). Retry with backoff to ensure delivery.
 		log.debug(
 			`[routeWorkerToLeader] Group ${groupId}: injecting worker output into leader session`
 		);
 		// Mark leader as having work before injecting so onLeaderTerminalState won't drop
 		// the resulting idle event even if the leader completes synchronously.
 		this.groupRepo.setLeaderHasWork(groupId);
-		await this.sessionFactory.injectMessage(group.leaderSessionId, leaderMessage);
+
+		const MAX_INJECT_RETRIES = 2;
+		const RETRY_DELAY_MS = 1000;
+		let lastError: Error | null = null;
+		for (let attempt = 0; attempt <= MAX_INJECT_RETRIES; attempt++) {
+			try {
+				if (attempt > 0) {
+					log.warn(
+						`[routeWorkerToLeader] Group ${groupId}: retry attempt ${attempt}/${MAX_INJECT_RETRIES} ` +
+							`after ${RETRY_DELAY_MS * attempt}ms delay`
+					);
+					await new Promise((r) => setTimeout(r, RETRY_DELAY_MS * attempt));
+				}
+				await this.sessionFactory.injectMessage(group.leaderSessionId, leaderMessage);
+				lastError = null;
+				break;
+			} catch (error) {
+				lastError = error instanceof Error ? error : new Error(String(error));
+				log.error(
+					`[routeWorkerToLeader] Group ${groupId}: injectMessage failed ` +
+						`(attempt ${attempt + 1}/${MAX_INJECT_RETRIES + 1}): ${lastError.message}`
+				);
+			}
+		}
+
+		if (lastError) {
+			log.error(
+				`[routeWorkerToLeader] Group ${groupId}: all ${MAX_INJECT_RETRIES + 1} inject attempts failed, ` +
+					`failing task: ${lastError.message}`
+			);
+			await this.fail(groupId, `Failed to deliver worker output to leader: ${lastError.message}`);
+			return null;
+		}
+
 		log.info(
 			`[routeWorkerToLeader] Group ${groupId}: worker output injected into leader session successfully`
 		);

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -480,36 +480,14 @@ export class TaskGroupManager {
 		// the resulting idle event even if the leader completes synchronously.
 		this.groupRepo.setLeaderHasWork(groupId);
 
-		const MAX_INJECT_RETRIES = 2;
-		const RETRY_DELAY_MS = 1000;
-		let lastError: Error | null = null;
-		for (let attempt = 0; attempt <= MAX_INJECT_RETRIES; attempt++) {
-			try {
-				if (attempt > 0) {
-					log.warn(
-						`[routeWorkerToLeader] Group ${groupId}: retry attempt ${attempt}/${MAX_INJECT_RETRIES} ` +
-							`after ${RETRY_DELAY_MS * attempt}ms delay`
-					);
-					await new Promise((r) => setTimeout(r, RETRY_DELAY_MS * attempt));
-				}
-				await this.sessionFactory.injectMessage(group.leaderSessionId, leaderMessage);
-				lastError = null;
-				break;
-			} catch (error) {
-				lastError = error instanceof Error ? error : new Error(String(error));
-				log.error(
-					`[routeWorkerToLeader] Group ${groupId}: injectMessage failed ` +
-						`(attempt ${attempt + 1}/${MAX_INJECT_RETRIES + 1}): ${lastError.message}`
-				);
-			}
-		}
+		const injectError = await this.injectMessageWithRetry(
+			group.leaderSessionId,
+			leaderMessage,
+			`routeWorkerToLeader:${groupId}`
+		);
 
-		if (lastError) {
-			log.error(
-				`[routeWorkerToLeader] Group ${groupId}: all ${MAX_INJECT_RETRIES + 1} inject attempts failed, ` +
-					`failing task: ${lastError.message}`
-			);
-			await this.fail(groupId, `Failed to deliver worker output to leader: ${lastError.message}`);
+		if (injectError) {
+			await this.fail(groupId, `Failed to deliver worker output to leader: ${injectError.message}`);
 			return null;
 		}
 
@@ -576,12 +554,22 @@ export class TaskGroupManager {
 		}
 
 		// If worker is waiting for input (AskUserQuestion), answer the question.
-		// Otherwise inject feedback as a regular message.
+		// Otherwise inject feedback as a regular message with retry.
 		const answered = await this.sessionFactory.answerQuestion(group.workerSessionId, message);
 		if (!answered) {
-			await this.sessionFactory.injectMessage(group.workerSessionId, message, {
-				deliveryMode: opts?.deliveryMode,
-			});
+			const injectError = await this.injectMessageWithRetry(
+				group.workerSessionId,
+				message,
+				`routeLeaderToWorker:${groupId}`,
+				{ deliveryMode: opts?.deliveryMode }
+			);
+			if (injectError) {
+				await this.fail(
+					groupId,
+					`Failed to deliver leader feedback to worker: ${injectError.message}`
+				);
+				return null;
+			}
 		}
 
 		return this.groupRepo.getGroup(groupId);
@@ -827,6 +815,49 @@ export class TaskGroupManager {
 		await this.cleanupWorktree(group);
 
 		return group;
+	}
+
+	/**
+	 * Inject a message into a session with retry and backoff.
+	 *
+	 * Retries transient failures (e.g., stale queue state, SDK startup timeout)
+	 * but bails immediately on permanent errors (e.g., session not in cache).
+	 *
+	 * @returns null on success, or the last Error if all attempts failed
+	 */
+	private async injectMessageWithRetry(
+		sessionId: string,
+		message: string,
+		context: string,
+		opts?: { deliveryMode?: MessageDeliveryMode }
+	): Promise<Error | null> {
+		const MAX_ATTEMPTS = 3;
+		const BASE_DELAY_MS = 500;
+		const NON_RETRYABLE_PATTERNS = ['not in service cache', 'not found in service cache'];
+
+		let lastError: Error | null = null;
+		for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+			try {
+				if (attempt > 0) {
+					const delayMs = BASE_DELAY_MS * 2 ** (attempt - 1);
+					log.warn(`[${context}] retry ${attempt}/${MAX_ATTEMPTS - 1} after ${delayMs}ms`);
+					await new Promise((r) => setTimeout(r, delayMs));
+				}
+				await this.sessionFactory.injectMessage(sessionId, message, opts);
+				return null; // success
+			} catch (error) {
+				lastError = error instanceof Error ? error : new Error(String(error));
+				log.error(
+					`[${context}] injectMessage failed (attempt ${attempt + 1}/${MAX_ATTEMPTS}): ${lastError.message}`
+				);
+				// Bail immediately on non-retryable errors (e.g., session doesn't exist)
+				if (NON_RETRYABLE_PATTERNS.some((p) => lastError!.message.includes(p))) {
+					log.error(`[${context}] non-retryable error, skipping remaining retries`);
+					break;
+				}
+			}
+		}
+		return lastError;
 	}
 
 	/**

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -573,21 +573,26 @@ describe('QueryLifecycleManager', () => {
 
 		test('detects stale running state and restarts when isRunning=true but queryPromise=null', async () => {
 			// Simulate stale state: messageQueue thinks it's running but queryPromise is null
-			// This happens when the SDK query finishes but the finally block hasn't called stop() yet
+			// This is a defensive check for edge cases (e.g., restored sessions with stale flags).
+			// The primary race (between for-await loop ending and finally block) is handled by
+			// the early messageQueue.stop() in QueryRunner.runQuery().
 			messageQueue.start(async function* () {
 				yield 'test';
 			});
 			mockContext = createMockContext();
 			// queryPromise is null (default) — this is the stale state
 			mockContext.queryPromise = null;
+			// Set a stale queryObject to verify it gets cleared
+			mockContext.queryObject = { close: () => {} } as unknown as typeof mockContext.queryObject;
 			manager = new QueryLifecycleManager(mockContext);
 
 			const stopSpy = spyOn(messageQueue, 'stop');
 
 			await manager.ensureQueryStarted();
 
-			// Should have force-stopped the stale queue and started a new query
+			// Should have force-stopped the stale queue, cleared queryObject, and started a new query
 			expect(stopSpy).toHaveBeenCalled();
+			expect(mockContext.queryObject).toBeNull();
 			expect(startStreamingCalled).toBe(true);
 		});
 

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -557,16 +557,38 @@ describe('QueryLifecycleManager', () => {
 	});
 
 	describe('ensureQueryStarted', () => {
-		test('returns early if message queue is already running', async () => {
+		test('returns early if message queue is already running and queryPromise is active', async () => {
 			messageQueue.start(async function* () {
 				yield 'test';
 			});
 			mockContext = createMockContext();
+			// Set queryPromise to indicate an active query
+			mockContext.queryPromise = Promise.resolve();
 			manager = new QueryLifecycleManager(mockContext);
 
 			await manager.ensureQueryStarted();
 
 			expect(startStreamingCalled).toBe(false);
+		});
+
+		test('detects stale running state and restarts when isRunning=true but queryPromise=null', async () => {
+			// Simulate stale state: messageQueue thinks it's running but queryPromise is null
+			// This happens when the SDK query finishes but the finally block hasn't called stop() yet
+			messageQueue.start(async function* () {
+				yield 'test';
+			});
+			mockContext = createMockContext();
+			// queryPromise is null (default) — this is the stale state
+			mockContext.queryPromise = null;
+			manager = new QueryLifecycleManager(mockContext);
+
+			const stopSpy = spyOn(messageQueue, 'stop');
+
+			await manager.ensureQueryStarted();
+
+			// Should have force-stopped the stale queue and started a new query
+			expect(stopSpy).toHaveBeenCalled();
+			expect(startStreamingCalled).toBe(true);
 		});
 
 		test('starts streaming query when queue is not running', async () => {

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -119,6 +119,7 @@ describe('QueryRunner', () => {
 			clear: clearSpy,
 			stop: stopSpy,
 			size: sizeSpy,
+			getGeneration: mock(() => 0),
 			messageGenerator: mock(async function* () {
 				// Empty generator for tests
 			}),

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -872,6 +872,59 @@ describe('TaskGroupManager', () => {
 			expect(failedTask!.status).toBe('needs_attention');
 			expect(failedTask!.error).toContain('Failed to deliver worker output to leader');
 		});
+
+		it('should skip retries on non-retryable errors (session not in cache)', async () => {
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+
+			let injectAttempts = 0;
+			const failFactory = createMockSessionFactory();
+			const origInject = failFactory.injectMessage.bind(failFactory);
+			failFactory.injectMessage = async (
+				sessionId: string,
+				message: string,
+				opts?: { deliveryMode?: 'immediate' | 'defer' }
+			) => {
+				if (sessionId.startsWith('leader:')) {
+					injectAttempts++;
+					throw new Error('Session not in service cache: ' + sessionId);
+				}
+				return origInject(sessionId, message, opts);
+			};
+
+			const failManager = new TaskGroupManager({
+				groupRepo,
+				sessionObserver: observer,
+				taskManager,
+				goalManager,
+				sessionFactory: failFactory,
+				workspacePath: '/workspace',
+				getRoom: (roomId) => (roomId === 'room-1' ? room : null),
+				getTask: (taskId) => taskManager.getTask(taskId),
+				getGoal: (goalId) => goalManager.getGoal(goalId),
+			});
+
+			const group = await failManager.spawn(
+				room,
+				task,
+				goal,
+				() => {},
+				() => {},
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			const result = await failManager.routeWorkerToLeader(
+				group.id,
+				'Worker output',
+				(_groupId) => callbacks
+			);
+
+			// Should fail immediately without retrying
+			expect(result).toBeNull();
+			expect(injectAttempts).toBe(1); // only one attempt, no retries
+		});
 	});
 
 	describe('routeLeaderToWorker', () => {
@@ -1037,6 +1090,57 @@ describe('TaskGroupManager', () => {
 			const failedTask = await taskManager.getTask(task.id);
 			expect(failedTask!.status).toBe('needs_attention');
 			expect(failedTask!.error).toContain('Worker session lost during restart');
+		});
+
+		it('should retry injectMessage on transient failure when routing to worker', async () => {
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+
+			let workerInjectAttempts = 0;
+			const retryFactory = createMockSessionFactory();
+			const origInject = retryFactory.injectMessage.bind(retryFactory);
+			retryFactory.injectMessage = async (
+				sessionId: string,
+				message: string,
+				opts?: { deliveryMode?: 'immediate' | 'defer' }
+			) => {
+				if (sessionId.startsWith('coder:') && message === 'Fix the tests') {
+					workerInjectAttempts++;
+					if (workerInjectAttempts === 1) {
+						throw new Error('Transient failure');
+					}
+				}
+				return origInject(sessionId, message, opts);
+			};
+
+			const retryManager = new TaskGroupManager({
+				groupRepo,
+				sessionObserver: observer,
+				taskManager,
+				goalManager,
+				sessionFactory: retryFactory,
+				workspacePath: '/workspace',
+				getRoom: (roomId) => (roomId === 'room-1' ? room : null),
+				getTask: (taskId) => taskManager.getTask(taskId),
+				getGoal: (goalId) => goalManager.getGoal(goalId),
+			});
+
+			const group = await retryManager.spawn(
+				room,
+				task,
+				goal,
+				() => {},
+				() => {},
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			await retryManager.routeWorkerToLeader(group.id, 'Worker output', (_groupId) => callbacks);
+			const result = await retryManager.routeLeaderToWorker(group.id, 'Fix the tests');
+
+			expect(result).not.toBeNull();
+			expect(workerInjectAttempts).toBe(2); // first failed, second succeeded
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -757,6 +757,121 @@ describe('TaskGroupManager', () => {
 			expect(failedTask!.status).toBe('needs_attention');
 			expect(failedTask!.error).toContain('Leader session lost during restart');
 		});
+
+		it('should retry injectMessage on transient failure and succeed', async () => {
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+
+			// Create a factory that fails injectMessage on the first call to the leader
+			// but succeeds on the second
+			let injectAttempts = 0;
+			const retryFactory = createMockSessionFactory();
+			const origInject = retryFactory.injectMessage.bind(retryFactory);
+			retryFactory.injectMessage = async (
+				sessionId: string,
+				message: string,
+				opts?: { deliveryMode?: 'immediate' | 'defer' }
+			) => {
+				// Only fail inject to leader session on the first attempt
+				if (sessionId.startsWith('leader:')) {
+					injectAttempts++;
+					if (injectAttempts === 1) {
+						throw new Error('Transient inject failure');
+					}
+				}
+				return origInject(sessionId, message, opts);
+			};
+
+			const retryManager = new TaskGroupManager({
+				groupRepo,
+				sessionObserver: observer,
+				taskManager,
+				goalManager,
+				sessionFactory: retryFactory,
+				workspacePath: '/workspace',
+				getRoom: (roomId) => (roomId === 'room-1' ? room : null),
+				getTask: (taskId) => taskManager.getTask(taskId),
+				getGoal: (goalId) => goalManager.getGoal(goalId),
+			});
+
+			const group = await retryManager.spawn(
+				room,
+				task,
+				goal,
+				() => {},
+				() => {},
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			const result = await retryManager.routeWorkerToLeader(
+				group.id,
+				'Worker output',
+				(_groupId) => callbacks
+			);
+
+			// Should succeed after retry
+			expect(result).not.toBeNull();
+			expect(injectAttempts).toBe(2); // first failed, second succeeded
+			expect(result!.feedbackIteration).toBe(1);
+		});
+
+		it('should fail task after all inject retries are exhausted', async () => {
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+
+			// Create a factory that always fails injectMessage for the leader
+			const failFactory = createMockSessionFactory();
+			const origInject = failFactory.injectMessage.bind(failFactory);
+			failFactory.injectMessage = async (
+				sessionId: string,
+				message: string,
+				opts?: { deliveryMode?: 'immediate' | 'defer' }
+			) => {
+				if (sessionId.startsWith('leader:')) {
+					throw new Error('Persistent inject failure');
+				}
+				return origInject(sessionId, message, opts);
+			};
+
+			const failManager = new TaskGroupManager({
+				groupRepo,
+				sessionObserver: observer,
+				taskManager,
+				goalManager,
+				sessionFactory: failFactory,
+				workspacePath: '/workspace',
+				getRoom: (roomId) => (roomId === 'room-1' ? room : null),
+				getTask: (taskId) => taskManager.getTask(taskId),
+				getGoal: (goalId) => goalManager.getGoal(goalId),
+			});
+
+			const group = await failManager.spawn(
+				room,
+				task,
+				goal,
+				() => {},
+				() => {},
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			const result = await failManager.routeWorkerToLeader(
+				group.id,
+				'Worker output',
+				(_groupId) => callbacks
+			);
+
+			// Should return null (failed)
+			expect(result).toBeNull();
+
+			// Task should be marked as failed
+			const failedTask = await taskManager.getTask(task.id);
+			expect(failedTask!.status).toBe('needs_attention');
+			expect(failedTask!.error).toContain('Failed to deliver worker output to leader');
+		});
 	});
 
 	describe('routeLeaderToWorker', () => {


### PR DESCRIPTION
## Summary

Fixes a race condition where `routeWorkerToLeader()` fails to deliver worker output to the leader session. When a leader's SDK query finishes, there's a window between the for-await loop ending and the `finally` block calling `messageQueue.stop()` where `isRunning()` returns true but no generator is consuming messages, causing `injectMessage` to silently orphan the message.

- `ensureQueryStarted()` now detects stale running state (`isRunning=true` but `queryPromise=null`) and force-stops the queue before restarting
- `routeWorkerToLeader()` retries `injectMessage` up to 3 times with backoff, failing the task only after all retries are exhausted
- Added diagnostic logging to `QueryRunner.start()`, `ensureQueryStarted()`, and `injectMessage` for message delivery tracing

## Test plan

- Unit test: `ensureQueryStarted` detects stale running state and restarts query
- Unit test: `routeWorkerToLeader` retries on transient inject failure and succeeds
- Unit test: `routeWorkerToLeader` fails task after all retries exhausted
- All 225 existing tests across affected files pass