### PR TITLE
docs: document no_pr and artifacts in leader system prompt

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -167,6 +167,8 @@ You MUST call tools (no text-only final responses).
   - mode=\`defer\`: enqueue for next-turn processing (default, preferred for review URLs)
   - mode=\`immediate\`: inject for current-turn steering
 - \`complete_task\` — Accept the work if it meets all requirements
+  - \`no_pr\`: set to true when the task produced no PR — use for research, investigation, meta-tasks (e.g., "create more tasks"), or any work without code changes. Do NOT set for coding tasks that should produce a PR.
+  - \`artifacts\`: free-form description of what was produced or accomplished (use with \`no_pr=true\`)
 - \`fail_task\` — Mark the task as not achievable
 - \`replan_goal\` — The current approach isn't working; fail this task and trigger replanning with context about what was tried
 - \`submit_for_review\` — Work is done with a PR ready; submit for peer review and human approval

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -113,8 +113,17 @@ function makeCallbacks(): LeaderToolCallbacks & {
 			calls.push({ method: 'sendToWorker', args: [groupId, message, mode, progressSummary] });
 			return { content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }] };
 		},
-		async completeTask(groupId: string, summary: string, progressSummary?: string) {
-			calls.push({ method: 'completeTask', args: [groupId, summary, progressSummary] });
+		async completeTask(
+			groupId: string,
+			summary: string,
+			progressSummary?: string,
+			no_pr?: boolean,
+			artifacts?: string
+		) {
+			calls.push({
+				method: 'completeTask',
+				args: [groupId, summary, progressSummary, no_pr, artifacts],
+			});
 			return { content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }] };
 		},
 		async failTask(groupId: string, reason: string, progressSummary?: string) {
@@ -145,11 +154,22 @@ describe('Leader Agent', () => {
 
 		it('should document no_pr and artifacts for complete_task', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig());
-			expect(prompt).toContain('no_pr');
-			expect(prompt).toContain('artifacts');
-			expect(prompt).toContain('research');
-			expect(prompt).toContain('investigation');
-			expect(prompt).toContain('meta-tasks');
+			// Verify the documentation appears under complete_task in Review Tools
+			const completeTaskIdx = prompt.indexOf('`complete_task`');
+			const noPrIdx = prompt.indexOf('`no_pr`');
+			const artifactsIdx = prompt.indexOf('`artifacts`');
+			// no_pr and artifacts docs must appear after complete_task
+			expect(completeTaskIdx).toBeGreaterThan(-1);
+			expect(noPrIdx).toBeGreaterThan(completeTaskIdx);
+			expect(artifactsIdx).toBeGreaterThan(completeTaskIdx);
+			// Both must appear before the next tool section (Task Management Tools)
+			const taskMgmtIdx = prompt.indexOf('Task Management Tools');
+			expect(noPrIdx).toBeLessThan(taskMgmtIdx);
+			expect(artifactsIdx).toBeLessThan(taskMgmtIdx);
+			// Verify usage guidance content
+			expect(prompt).toContain('research, investigation, meta-tasks');
+			expect(prompt).toContain('Do NOT set for coding tasks');
+			expect(prompt).toContain('description of what was produced or accomplished');
 		});
 
 		it('should include task management tools in tool contract', () => {

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -143,6 +143,15 @@ describe('Leader Agent', () => {
 			expect(prompt).toContain('replan_goal');
 		});
 
+		it('should document no_pr and artifacts for complete_task', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig());
+			expect(prompt).toContain('no_pr');
+			expect(prompt).toContain('artifacts');
+			expect(prompt).toContain('research');
+			expect(prompt).toContain('investigation');
+			expect(prompt).toContain('meta-tasks');
+		});
+
 		it('should include task management tools in tool contract', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig());
 			expect(prompt).toContain('create_task');


### PR DESCRIPTION
Update `leaderToolContractSection()` in Review Tools to document `complete_task`'s `no_pr` and `artifacts` parameters:
- `no_pr`: when to use (research, investigation, meta-tasks) and when not to (coding tasks with PRs)
- `artifacts`: describes what was produced (used with `no_pr=true`)

Adds test verifying the new prompt content.