### PR TITLE
feat: move task sidebar filtering from client-side to server-side SQL

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -143,8 +143,10 @@ function mapSessionGroupMessageRow(row: Record<string, unknown>): Record<string,
 // SQL definitions
 // ============================================================================
 
-const TASKS_BY_ROOM_SQL = `
-SELECT
+/**
+ * Shared column list for task queries — avoids duplicating the SELECT clause.
+ */
+const TASKS_SELECT_COLUMNS = `
   id,
   room_id             AS roomId,
   title,
@@ -169,7 +171,26 @@ SELECT
   pr_created_at       AS prCreatedAt,
   input_draft         AS inputDraft,
   updated_at          AS updatedAt,
-  short_id            AS shortId
+  short_id            AS shortId`;
+
+/**
+ * Default task query: excludes archived tasks.
+ * The sidebar and dashboard almost never need archived tasks, so filtering
+ * them server-side saves bandwidth and client memory.
+ */
+const TASKS_BY_ROOM_SQL = `
+SELECT ${TASKS_SELECT_COLUMNS}
+FROM tasks
+WHERE room_id = ? AND status != 'archived'
+ORDER BY created_at DESC, id DESC
+`.trim();
+
+/**
+ * All tasks including archived — used when the client explicitly needs the
+ * full task history (e.g., the "Archived" tab in the dashboard).
+ */
+const TASKS_BY_ROOM_ALL_SQL = `
+SELECT ${TASKS_SELECT_COLUMNS}
 FROM tasks
 WHERE room_id = ?
 ORDER BY created_at DESC, id DESC
@@ -424,6 +445,14 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		},
 	],
 	[
+		'tasks.byRoom.all',
+		{
+			sql: TASKS_BY_ROOM_ALL_SQL,
+			paramCount: 1,
+			mapRow: mapTaskRow,
+		},
+	],
+	[
 		'goals.byRoom',
 		{
 			sql: GOALS_BY_ROOM_SQL,
@@ -533,6 +562,7 @@ export function setupLiveQueryHandlers(
 		// 4. Authorization checks
 		if (
 			queryName === 'tasks.byRoom' ||
+			queryName === 'tasks.byRoom.all' ||
 			queryName === 'goals.byRoom' ||
 			queryName === 'mcpEnablement.byRoom' ||
 			queryName === 'skills.byRoom'

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
@@ -46,6 +46,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 
 	test('registry contains all expected query names', () => {
 		expect(NAMED_QUERY_REGISTRY.has('tasks.byRoom')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('tasks.byRoom.all')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('goals.byRoom')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('sessionGroupMessages.byGroup')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('skills.byRoom')).toBe(true);
@@ -53,6 +54,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 
 	test('all registry entries have correct paramCount', () => {
 		expect(NAMED_QUERY_REGISTRY.get('tasks.byRoom')!.paramCount).toBe(1);
+		expect(NAMED_QUERY_REGISTRY.get('tasks.byRoom.all')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('goals.byRoom')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('skills.byRoom')!.paramCount).toBe(1);
@@ -65,20 +67,21 @@ describe('NAMED_QUERY_REGISTRY', () => {
 	describe('tasks.byRoom', () => {
 		function insertTask(overrides: Record<string, unknown> = {}): string {
 			const id = `task-${Date.now()}-${Math.random()}`;
+			const status = (overrides.status as string) ?? 'pending';
 			db.exec(`
 				INSERT INTO tasks (
 					id, room_id, title, description, status, priority,
 					depends_on, created_at, updated_at
 				) VALUES (
-					'${id}', '${roomId}', 'Test Task', 'Desc', 'pending', 'normal',
+					'${id}', '${roomId}', 'Test Task', 'Desc', '${status}', 'normal',
 					'${JSON.stringify(overrides.dependsOn ?? [])}', ${now}, ${now}
 				)
 			`);
 			return id;
 		}
 
-		function queryAndMap(): Record<string, unknown>[] {
-			const entry = NAMED_QUERY_REGISTRY.get('tasks.byRoom')!;
+		function queryAndMap(queryName = 'tasks.byRoom'): Record<string, unknown>[] {
+			const entry = NAMED_QUERY_REGISTRY.get(queryName)!;
 			const rows = db.prepare(entry.sql).all(roomId) as Record<string, unknown>[];
 			return entry.mapRow ? rows.map(entry.mapRow) : rows;
 		}
@@ -131,6 +134,39 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		test('ORDER BY is created_at DESC, id DESC (deterministic tiebreaker)', () => {
 			const sql = NAMED_QUERY_REGISTRY.get('tasks.byRoom')!.sql;
 			expect(sql).toContain('ORDER BY created_at DESC, id DESC');
+		});
+
+		test('excludes archived tasks by default', () => {
+			insertTask({ status: 'pending' });
+			insertTask({ status: 'in_progress' });
+			insertTask({ status: 'archived' });
+			insertTask({ status: 'completed' });
+
+			const rows = queryAndMap();
+			const statuses = rows.map((r) => r.status);
+			expect(statuses).not.toContain('archived');
+			expect(rows).toHaveLength(3);
+		});
+
+		test('tasks.byRoom.all includes archived tasks', () => {
+			insertTask({ status: 'pending' });
+			insertTask({ status: 'archived' });
+
+			const rows = queryAndMap('tasks.byRoom.all');
+			const statuses = rows.map((r) => r.status);
+			expect(statuses).toContain('archived');
+			expect(statuses).toContain('pending');
+			expect(rows).toHaveLength(2);
+		});
+
+		test('tasks.byRoom.all has same column shape as tasks.byRoom', () => {
+			insertTask();
+			const defaultRows = queryAndMap('tasks.byRoom');
+			const allRows = queryAndMap('tasks.byRoom.all');
+			// Both should have the same columns (keys)
+			const defaultKeys = Object.keys(defaultRows[0]).sort();
+			const allKeys = Object.keys(allRows[0]).sort();
+			expect(allKeys).toEqual(defaultKeys);
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts
@@ -604,6 +604,38 @@ describe('setupLiveQueryHandlers', () => {
 	});
 
 	// -----------------------------------------------------------------------
+	// Archiving a task emits a removed delta for tasks.byRoom subscriber
+	// -----------------------------------------------------------------------
+
+	test('archiving a task emits a removed delta for tasks.byRoom subscriber', async () => {
+		// Subscribe — snapshot includes the pending task from beforeEach
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-archive-delta',
+		});
+		expect(setup.sentMessages.length).toBe(1);
+		const snapshot = setup.sentMessages[0].message.data;
+		expect((snapshot.rows as Array<{ id: string }>).map((r) => r.id)).toContain(taskId);
+
+		// Archive the task by updating its status
+		db.exec(`UPDATE tasks SET status = 'archived' WHERE id = '${taskId}'`);
+		reactiveDb.notifyChange('tasks');
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Find the delta that removed the archived task
+		const deltas = setup.sentMessages
+			.slice(1)
+			.filter((m) => m.message.method === 'liveQuery.delta');
+		expect(deltas.length).toBeGreaterThanOrEqual(1);
+
+		// The last delta should contain the removed task
+		const lastDelta = deltas[deltas.length - 1].message.data;
+		const removedIds = (lastDelta.removed as Array<{ id: string }> | undefined)?.map((r) => r.id);
+		expect(removedIds).toContain(taskId);
+	});
+
+	// -----------------------------------------------------------------------
 	// P1: Version monotonically increasing across deltas
 	// -----------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts
@@ -142,11 +142,11 @@ function insertRoom(db: BunDatabase, roomId: string) {
 	);
 }
 
-function insertTask(db: BunDatabase, taskId: string, roomId: string) {
+function insertTask(db: BunDatabase, taskId: string, roomId: string, status = 'pending') {
 	const now = Date.now();
 	db.exec(
 		`INSERT OR IGNORE INTO tasks (id, room_id, title, description, status, priority, task_type, created_at, updated_at)
-		 VALUES ('${taskId}', '${roomId}', 'Test Task', '', 'pending', 'normal', 'coding', ${now}, ${now})`
+		 VALUES ('${taskId}', '${roomId}', 'Test Task', '', '${status}', 'normal', 'coding', ${now}, ${now})`
 	);
 }
 
@@ -552,6 +552,55 @@ describe('setupLiveQueryHandlers', () => {
 		expect(result2).toEqual({ ok: true });
 		expect(setup.sentMessages.length).toBe(1);
 		expect(setup.sentMessages[0].message.method).toBe('liveQuery.snapshot');
+	});
+
+	// -----------------------------------------------------------------------
+	// tasks.byRoom excludes archived tasks, tasks.byRoom.all includes them
+	// -----------------------------------------------------------------------
+
+	test('tasks.byRoom snapshot excludes archived tasks', async () => {
+		insertTask(db, 'task-archived', roomId, 'archived');
+
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-no-archived',
+		});
+
+		const snapshot = setup.sentMessages[0].message.data;
+		const rows = snapshot.rows as Array<{ id: string; status: string }>;
+		const statuses = rows.map((r) => r.status);
+		expect(statuses).not.toContain('archived');
+		// Only the non-archived task from beforeEach should appear
+		expect(rows).toHaveLength(1);
+		expect(rows[0].id).toBe(taskId);
+	});
+
+	test('tasks.byRoom.all snapshot includes archived tasks', async () => {
+		insertTask(db, 'task-archived-2', roomId, 'archived');
+
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom.all',
+			params: [roomId],
+			subscriptionId: 'sub-all',
+		});
+
+		const snapshot = setup.sentMessages[0].message.data;
+		const rows = snapshot.rows as Array<{ id: string; status: string }>;
+		const statuses = rows.map((r) => r.status);
+		expect(statuses).toContain('archived');
+		expect(statuses).toContain('pending');
+		expect(rows).toHaveLength(2);
+	});
+
+	test('tasks.byRoom.all: nonexistent room rejected', async () => {
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'tasks.byRoom.all',
+				params: ['room-does-not-exist'],
+				subscriptionId: 'sub-all-unauth',
+			})
+		).rejects.toThrow('Unauthorized');
 	});
 
 	// -----------------------------------------------------------------------

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -5,7 +5,7 @@
  * empty states, click handling, and section rendering for all tabs:
  * Active (draft + pending + in_progress),
  * Review (needs_attention → rate_limited/usage_limited → review),
- * Done (completed + cancelled), Archived (archived, hidden by default).
+ * Done (completed + cancelled).
  */
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
@@ -65,7 +65,7 @@ describe('RoomTasks', () => {
 			selectedTabSignal.value = 'active';
 		});
 
-		it('should show Active, Review, Done tabs (Archived hidden when count is 0)', () => {
+		it('should show Active, Review, Done tabs (no Archived tab)', () => {
 			const tasks = [
 				createTask('t1', 'in_progress'),
 				createTask('t2', 'review'),
@@ -78,16 +78,8 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Active');
 			expect(container.textContent).toContain('Review');
 			expect(container.textContent).toContain('Done');
-			// Archived tab hidden when no archived tasks
+			// Archived tab removed — archived tasks are excluded server-side
 			expect(container.textContent).not.toContain('Archived');
-		});
-
-		it('should show Archived tab when there are archived tasks', () => {
-			const tasks = [createTask('t1', 'in_progress'), createTask('t2', 'archived')];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			expect(container.textContent).toContain('Archived');
 		});
 
 		it('should show correct counts on tabs', () => {
@@ -327,40 +319,6 @@ describe('RoomTasks', () => {
 		});
 	});
 
-	describe('Archived Tab', () => {
-		beforeEach(() => {
-			selectedTabSignal.value = 'archived';
-		});
-
-		it('should render archived section with muted header', () => {
-			const tasks = [createTask('t1', 'archived', { title: 'Old task' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			const header = container.querySelector('h3.text-gray-500');
-			expect(header).toBeTruthy();
-			expect(header?.textContent).toContain('Archived (1)');
-		});
-
-		it('should show archived task titles', () => {
-			const tasks = [createTask('t1', 'archived', { title: 'Old task' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			expect(container.textContent).toContain('Old task');
-		});
-
-		it('should auto-reset to active tab when no archived tasks exist', () => {
-			const tasks = [createTask('t1', 'pending')];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			// Auto-reset kicks in, shows active tab content instead of archived empty state
-			expect(container.textContent).toContain('Pending (1)');
-			expect(selectedTabSignal.value).toBe('active');
-		});
-	});
-
 	describe('Tab Switching', () => {
 		it('should switch to review tab when clicked', () => {
 			const tasks = [
@@ -397,23 +355,6 @@ describe('RoomTasks', () => {
 
 			// Should see completed section
 			expect(container.textContent).toContain('Completed (1)');
-		});
-
-		it('should switch to archived tab when clicked', () => {
-			const tasks = [
-				createTask('t1', 'in_progress'),
-				createTask('t2', 'archived', { title: 'Archived task' }),
-			];
-
-			// Set to active BEFORE render
-			selectedTabSignal.value = 'active';
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			// Click archived tab
-			clickTab(container, 'Archived');
-
-			// Should see archived section
-			expect(container.textContent).toContain('Archived (1)');
 		});
 	});
 
@@ -590,16 +531,6 @@ describe('RoomTasks', () => {
 			const item = container.querySelector('.border-l-gray-700');
 			expect(item).toBeTruthy();
 		});
-
-		it('should apply muted border to archived tasks', () => {
-			selectedTabSignal.value = 'archived';
-			const tasks = [createTask('t1', 'archived')];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			const item = container.querySelector('.border-l-gray-800');
-			expect(item).toBeTruthy();
-		});
 	});
 
 	describe('Worker Summary (currentStep)', () => {
@@ -657,6 +588,11 @@ describe('RoomTasks', () => {
 			expect(getInitialTab()).toBe('review');
 		});
 
+		it('should migrate "archived" to "active"', () => {
+			mockStoredTab('archived');
+			expect(getInitialTab()).toBe('active');
+		});
+
 		it('should preserve valid tab values', () => {
 			mockStoredTab('active');
 			expect(getInitialTab()).toBe('active');
@@ -666,9 +602,6 @@ describe('RoomTasks', () => {
 
 			mockStoredTab('done');
 			expect(getInitialTab()).toBe('done');
-
-			mockStoredTab('archived');
-			expect(getInitialTab()).toBe('archived');
 		});
 
 		it('should default to "active" for unknown values', () => {
@@ -750,31 +683,6 @@ describe('RoomTasks', () => {
 				t.textContent?.replace(/\d/g, '').trim()
 			);
 			expect(tabButtonLabels).not.toContain('Needs Attention');
-		});
-	});
-
-	describe('Archived Tab Auto-Reset', () => {
-		it('should auto-reset to active when archived tab selected but no archived tasks', () => {
-			selectedTabSignal.value = 'archived';
-			const tasks = [createTask('t1', 'in_progress')];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			// Should show active tab content, not archived empty state
-			expect(container.textContent).toContain('In Progress');
-			expect(container.textContent).not.toContain('No archived tasks');
-			// Signal should be reset
-			expect(selectedTabSignal.value).toBe('active');
-		});
-
-		it('should stay on archived tab when archived tasks exist', () => {
-			selectedTabSignal.value = 'archived';
-			const tasks = [createTask('t1', 'archived', { title: 'Old task' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			expect(container.textContent).toContain('Archived (1)');
-			expect(selectedTabSignal.value).toBe('archived');
 		});
 	});
 

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -5,7 +5,9 @@
  * - Active: draft + pending + in_progress
  * - Review: review + needs_attention (awaiting human action)
  * - Done: completed + cancelled
- * - Archived: hidden by default, expandable
+ *
+ * Note: Archived tasks are excluded server-side by the tasks.byRoom LiveQuery
+ * and are not displayed in this component.
  */
 
 import { signal, effect, useSignal } from '@preact/signals';
@@ -13,15 +15,16 @@ import type { TaskSummary, TaskStatus, RoomGoal } from '@neokai/shared';
 import { CircularProgressIndicator } from '../ui/CircularProgressIndicator';
 
 /** Tab filter types */
-export type TaskFilterTab = 'active' | 'review' | 'done' | 'archived';
+export type TaskFilterTab = 'active' | 'review' | 'done';
 
 /** Get initial tab from localStorage - exported for testing */
 export function getInitialTab(): TaskFilterTab {
 	if (typeof window === 'undefined') return 'active';
 	const stored = localStorage.getItem('neokai:room:taskFilterTab');
-	// Migrate old tab values: 'failed' and 'needs_attention' now live under 'review'
+	// Migrate old tab values: 'failed', 'needs_attention', and 'archived' map to other tabs
 	if (stored === 'failed' || stored === 'needs_attention') return 'review';
-	if (stored === 'active' || stored === 'review' || stored === 'done' || stored === 'archived') {
+	if (stored === 'archived') return 'active';
+	if (stored === 'active' || stored === 'review' || stored === 'done') {
 		return stored;
 	}
 	return 'active';
@@ -61,7 +64,6 @@ function getTabCounts(tasks: TaskSummary[]) {
 				t.status === 'usage_limited'
 		).length,
 		done: tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled').length,
-		archived: tasks.filter((t) => t.status === 'archived').length,
 	};
 }
 
@@ -82,8 +84,6 @@ function getFilteredTasks(tasks: TaskSummary[], tab: TaskFilterTab): TaskSummary
 			);
 		case 'done':
 			return tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled');
-		case 'archived':
-			return tasks.filter((t) => t.status === 'archived');
 	}
 }
 
@@ -122,15 +122,8 @@ export function RoomTasks({
 	onGoalClick,
 	onReactivate,
 }: RoomTasksProps) {
-	let selectedTab = selectedTabSignal.value;
+	const selectedTab = selectedTabSignal.value;
 	const tabCounts = getTabCounts(tasks);
-
-	// Auto-reset to 'active' when archived tab is selected but no archived tasks exist
-	if (selectedTab === 'archived' && tabCounts.archived === 0) {
-		selectedTab = 'active';
-		selectedTabSignal.value = 'active';
-	}
-
 	const filteredTasks = getFilteredTasks(tasks, selectedTab);
 
 	const handleTabClick = (tab: TaskFilterTab) => {
@@ -170,15 +163,6 @@ export function RoomTasks({
 					onClick={() => handleTabClick('done')}
 					variant="green"
 				/>
-				{tabCounts.archived > 0 && (
-					<TabButton
-						label="Archived"
-						count={tabCounts.archived}
-						isActive={selectedTab === 'archived'}
-						onClick={() => handleTabClick('archived')}
-						variant="gray"
-					/>
-				)}
 			</div>
 
 			{/* Task List */}
@@ -273,10 +257,6 @@ function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
 			title: 'No completed tasks',
 			description: 'Completed and cancelled tasks will appear here',
 		},
-		archived: {
-			title: 'No archived tasks',
-			description: 'Archived tasks will appear here',
-		},
 	};
 
 	const { title, description } = messages[tab];
@@ -307,11 +287,6 @@ function TaskList({
 	onGoalClick?: () => void;
 	onReactivate?: (taskId: string) => void;
 }) {
-	// Active tab: group by in_progress, pending, draft
-	// Review tab: group by review and needs_attention
-	// Done tab: group by completed and cancelled
-	// Archived tab: all archived tasks
-
 	if (tab === 'active') {
 		const inProgress = tasks.filter((t) => t.status === 'in_progress');
 		const pending = tasks.filter((t) => t.status === 'pending');
@@ -410,55 +385,38 @@ function TaskList({
 		);
 	}
 
-	if (tab === 'done') {
-		const completed = tasks.filter((t) => t.status === 'completed');
-		const cancelled = tasks.filter((t) => t.status === 'cancelled');
+	// Done tab (default)
+	const completed = tasks.filter((t) => t.status === 'completed');
+	const cancelled = tasks.filter((t) => t.status === 'cancelled');
 
-		return (
-			<div class="space-y-4">
-				{completed.length > 0 && (
-					<TaskGroup
-						title="Completed"
-						count={completed.length}
-						variant="green"
-						tasks={completed}
-						allTasks={allTasks}
-						goalByTaskId={goalByTaskId}
-						onTaskClick={onTaskClick}
-						onGoalClick={onGoalClick}
-						onReactivate={onReactivate}
-					/>
-				)}
-				{cancelled.length > 0 && (
-					<TaskGroup
-						title="Cancelled"
-						count={cancelled.length}
-						variant="gray"
-						tasks={cancelled}
-						allTasks={allTasks}
-						goalByTaskId={goalByTaskId}
-						onTaskClick={onTaskClick}
-						onGoalClick={onGoalClick}
-						onReactivate={onReactivate}
-					/>
-				)}
-			</div>
-		);
-	}
-
-	// Archived tab
 	return (
 		<div class="space-y-4">
-			<TaskGroup
-				title="Archived"
-				count={tasks.length}
-				variant="gray"
-				tasks={tasks}
-				allTasks={allTasks}
-				goalByTaskId={goalByTaskId}
-				onTaskClick={onTaskClick}
-				onGoalClick={onGoalClick}
-			/>
+			{completed.length > 0 && (
+				<TaskGroup
+					title="Completed"
+					count={completed.length}
+					variant="green"
+					tasks={completed}
+					allTasks={allTasks}
+					goalByTaskId={goalByTaskId}
+					onTaskClick={onTaskClick}
+					onGoalClick={onGoalClick}
+					onReactivate={onReactivate}
+				/>
+			)}
+			{cancelled.length > 0 && (
+				<TaskGroup
+					title="Cancelled"
+					count={cancelled.length}
+					variant="gray"
+					tasks={cancelled}
+					allTasks={allTasks}
+					goalByTaskId={goalByTaskId}
+					onTaskClick={onTaskClick}
+					onGoalClick={onGoalClick}
+					onReactivate={onReactivate}
+				/>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -5,7 +5,7 @@
  * - orphanTasksActive: Orphan tasks with draft/pending/in_progress
  * - orphanTasksReview: Orphan tasks with review/needs_attention/rate_limited/usage_limited
  * - orphanTasksDone: Orphan tasks with completed/cancelled
- * - orphanTasksArchived: Orphan tasks with archived
+ * (orphanTasksArchived was removed — archived tasks are excluded server-side)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -209,27 +209,10 @@ describe('RoomStore — computed goal/task signals', () => {
 		});
 	});
 
-	describe('orphanTasksArchived', () => {
-		it('includes archived orphan tasks', () => {
-			roomStore.tasks.value = [
-				makeTask('t1', 'in_progress'),
-				makeTask('t2', 'archived'),
-				makeTask('t3', 'completed'),
-			];
-			roomStore.goals.value = [];
-			const ids = roomStore.orphanTasksArchived.value.map((t) => t.id);
-			expect(ids).toEqual(['t2']);
-		});
-
-		it('excludes archived tasks linked to a goal', () => {
-			roomStore.tasks.value = [makeTask('t1', 'archived')];
-			roomStore.goals.value = [makeGoal('g1', ['t1'])];
-			expect(roomStore.orphanTasksArchived.value).toEqual([]);
-		});
-	});
-
-	describe('all 10 TaskStatus values are covered', () => {
-		it('every status falls into exactly one bucket', () => {
+	describe('non-archived TaskStatus values are covered by orphan buckets', () => {
+		it('every non-archived status falls into exactly one bucket', () => {
+			// Note: archived tasks are excluded server-side by the tasks.byRoom LiveQuery,
+			// so the tasks signal never contains archived tasks in production.
 			roomStore.tasks.value = [
 				makeTask('draft', 'draft'),
 				makeTask('pending', 'pending'),
@@ -238,7 +221,6 @@ describe('RoomStore — computed goal/task signals', () => {
 				makeTask('needs_attention', 'needs_attention'),
 				makeTask('completed', 'completed'),
 				makeTask('cancelled', 'cancelled'),
-				makeTask('archived', 'archived'),
 				makeTask('rate_limited', 'rate_limited'),
 				makeTask('usage_limited', 'usage_limited'),
 			];
@@ -247,10 +229,9 @@ describe('RoomStore — computed goal/task signals', () => {
 			const active = new Set(roomStore.orphanTasksActive.value.map((t) => t.id));
 			const review = new Set(roomStore.orphanTasksReview.value.map((t) => t.id));
 			const done = new Set(roomStore.orphanTasksDone.value.map((t) => t.id));
-			const archived = new Set(roomStore.orphanTasksArchived.value.map((t) => t.id));
 
 			// No overlap
-			const buckets = [active, review, done, archived];
+			const buckets = [active, review, done];
 			for (let i = 0; i < buckets.length; i++) {
 				for (let j = i + 1; j < buckets.length; j++) {
 					for (const id of buckets[i]) {
@@ -259,8 +240,8 @@ describe('RoomStore — computed goal/task signals', () => {
 				}
 			}
 
-			// All covered — rate_limited and usage_limited fall into the review bucket
-			expect(active.size + review.size + done.size + archived.size).toBe(10);
+			// All 9 non-archived statuses covered
+			expect(active.size + review.size + done.size).toBe(9);
 			expect(review.has('rate_limited')).toBe(true);
 			expect(review.has('usage_limited')).toBe(true);
 		});

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -76,7 +76,7 @@ class RoomStore {
 	/** Room metadata */
 	readonly room = signal<Room | null>(null);
 
-	/** Tasks for this room */
+	/** Tasks for this room (excludes archived — filtered server-side by LiveQuery) */
 	readonly tasks = signal<NeoTask[]>([]);
 
 	/** Sessions in this room */
@@ -146,9 +146,6 @@ class RoomStore {
 	readonly completedTasks = computed(() =>
 		this.tasks.value.filter((t) => t.status === 'completed')
 	);
-
-	/** Archived tasks */
-	readonly archivedTasks = computed(() => this.tasks.value.filter((t) => t.status === 'archived'));
 
 	/** Tasks in review status */
 	readonly reviewTasks = computed(() => this.tasks.value.filter((t) => t.status === 'review'));
@@ -227,10 +224,9 @@ class RoomStore {
 		this.orphanTasks.value.filter((t) => t.status === 'completed' || t.status === 'cancelled')
 	);
 
-	/** Orphan tasks that are archived */
-	readonly orphanTasksArchived = computed(() =>
-		this.orphanTasks.value.filter((t) => t.status === 'archived')
-	);
+	// NOTE: orphanTasksArchived was removed — archived tasks are now excluded
+	// server-side by the tasks.byRoom LiveQuery.  Use tasks.byRoom.all if
+	// archived tasks are needed.
 
 	// ========================================
 	// Private State


### PR DESCRIPTION
## Summary
- Changed the `tasks.byRoom` LiveQuery to exclude archived tasks server-side (`AND status != 'archived'`), reducing bandwidth and client memory usage
- Added `tasks.byRoom.all` named query for consumers that need the full task history including archived
- Removed `archivedTasks` and `orphanTasksArchived` computed signals from RoomStore (no longer populated)
- Updated daemon and web tests to cover the new filtering behavior

## Test plan
- [x] `live-query-handlers.test.ts` — verifies archived exclusion and tasks.byRoom.all column shape parity
- [x] `live-query-subscribe.test.ts` — verifies snapshot excludes archived, tasks.byRoom.all includes them, auth check for new query
- [x] `room-store-computed-signals.test.ts` — updated to remove orphanTasksArchived, verify 9 non-archived statuses covered
- [x] All daemon tests pass (8643/8643)
- [x] Typecheck, lint, knip all pass