### PR TITLE
feat(web): migrate RoomStore tasks and goals to EntityStore

### DIFF
--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -164,7 +164,7 @@ vi.mock('../InputTextarea.tsx', () => ({
 // -------------------------------------------------------
 // File-level setup: reset roomStore.tasks after each test
 afterEach(() => {
-	roomStore.tasks.value = [];
+	roomStore.taskStore.applySnapshot([]);
 });
 
 // -------------------------------------------------------
@@ -222,7 +222,7 @@ describe('TaskView — awaiting_human badge', () => {
 	});
 
 	it('shows pulsing "Awaiting your review" badge when group.state === awaiting_human', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -240,7 +240,7 @@ describe('TaskView — awaiting_human badge', () => {
 	});
 
 	it('does NOT show pulsing badge when group.state is not awaiting_human', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -256,7 +256,7 @@ describe('TaskView — awaiting_human badge', () => {
 	});
 
 	it('does NOT show pulsing badge when group is null', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'pending') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'pending') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -272,7 +272,7 @@ describe('TaskView — awaiting_human badge', () => {
 	});
 
 	it('does not show review bar when group is not submitted for review', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
 			return {};
@@ -306,7 +306,7 @@ describe('TaskView — autoscroll / ScrollToBottomButton', () => {
 	it('does NOT render scroll-to-bottom button when showScrollButton is false', async () => {
 		mockShowScrollButton.value = false;
 		mockMessageCount.value = 0;
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -321,7 +321,7 @@ describe('TaskView — autoscroll / ScrollToBottomButton', () => {
 
 	it('renders scroll-to-bottom button when showScrollButton is true', async () => {
 		mockShowScrollButton.value = true;
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -336,7 +336,7 @@ describe('TaskView — autoscroll / ScrollToBottomButton', () => {
 
 	it('calls scrollToBottom when scroll-to-bottom button is clicked', async () => {
 		mockShowScrollButton.value = true;
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -375,7 +375,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('renders InputTextarea in awaiting_human state', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -389,7 +389,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('renders InputTextarea in awaiting_leader state', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
 			return {};
@@ -403,7 +403,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('renders InputTextarea in awaiting_worker state', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -420,7 +420,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('sends feedback via task.sendHumanMessage in awaiting_human state (default target: leader)', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -449,7 +449,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('approves task via task.approve in awaiting_human state', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			if (method === 'task.approve') return {};
@@ -480,7 +480,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('shows feedback textarea in bottom area (not in header) when awaiting_human', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -501,7 +501,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('sends message to leader via task.sendHumanMessage in awaiting_leader state', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -535,7 +535,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('sends message to worker in awaiting_worker state when worker is explicitly selected', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -568,7 +568,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('shows target dropdown with both options always available', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -588,7 +588,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('default target is leader', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -606,7 +606,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('shows pending queue overlay for the selected target session', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method, payload) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'session.messages.byStatus') {
@@ -662,7 +662,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('refreshes pending queue overlay when target switches to worker', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method, payload) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'session.messages.byStatus') {
@@ -731,7 +731,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 			resolveLeaderEnqueued = resolve;
 		});
 
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method, payload) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'session.messages.byStatus') {
@@ -797,7 +797,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('sends message when Enter is pressed (desktop)', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -827,7 +827,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('does NOT send when Shift+Enter is pressed', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -855,7 +855,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('sends message when Cmd+Enter is pressed', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -885,7 +885,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('sends message when Ctrl+Enter is pressed', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -915,7 +915,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('placeholder text reflects Enter-to-send UX', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -950,7 +950,7 @@ describe('TaskView — useAutoScroll call args', () => {
 	});
 
 	it('calls useAutoScroll with enabled:true and isInitialLoad:true on initial render', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -985,7 +985,7 @@ describe('TaskView — InputTextarea maxChars forwarding', () => {
 	});
 
 	it('passes maxChars=50000 to InputTextarea in awaiting_human state', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -1002,7 +1002,7 @@ describe('TaskView — InputTextarea maxChars forwarding', () => {
 	});
 
 	it('passes maxChars=50000 to InputTextarea in awaiting_leader state', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
 			return {};
@@ -1038,7 +1038,7 @@ describe('TaskView — isFirstLoad state transitions', () => {
 	it('flips isFirstLoad to false after first messages arrive via onMessageCountChange', async () => {
 		// Simulate TaskConversationRenderer reporting 3 messages on mount
 		mockMessageCount.value = 3;
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1056,7 +1056,7 @@ describe('TaskView — isFirstLoad state transitions', () => {
 
 	it('starts with isInitialLoad:true when no messages have arrived yet', async () => {
 		// mockMessageCount.value = 0 (default) — mock never calls onMessageCountChange with > 0
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1090,7 +1090,7 @@ describe('TaskView — ScrollToBottomButton bottomClass', () => {
 	});
 
 	it('passes bottomClass="bottom-0" to ScrollToBottomButton', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1125,7 +1125,7 @@ describe('TaskView — cancelled flag prevents post-unmount state updates', () =
 	it('does not call task.getGroup after unmount mid-fetch', async () => {
 		// Task is available from store; defer task.getGroup so we can unmount before it resolves
 		let resolveTaskGetGroup!: (value: { group: null }) => void;
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation((method: unknown) =>
 			method === 'task.getGroup'
 				? new Promise<{ group: null }>((resolve) => {
@@ -1162,7 +1162,7 @@ describe('TaskView — cancelled flag prevents post-unmount state updates', () =
 			if (eventName === 'session.updated') sessionUpdateHandler = handler;
 			return () => {};
 		});
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method: unknown) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'session.get') return { session: null };
@@ -1213,7 +1213,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('shows cancel button for pending tasks (cancel only)', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'pending') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'pending') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1238,7 +1238,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('shows cancel button and dropdown with complete action for in_progress tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1263,7 +1263,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('shows cancel button for review tasks (no complete button — review status)', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -1288,7 +1288,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('does NOT show action buttons for completed tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1312,7 +1312,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('does NOT show cancel button for needs_attention tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'needs_attention') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'needs_attention') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1335,7 +1335,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('does NOT show action buttons for cancelled tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'cancelled') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'cancelled') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1358,7 +1358,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('shows both cancel and complete buttons for in_progress task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1375,7 +1375,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('shows only cancel button (no complete) for pending task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'pending') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'pending') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1392,7 +1392,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('opens cancel dialog when cancel button is clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1423,7 +1423,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('opens complete dialog when complete button is clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1456,7 +1456,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('calls task.cancel RPC and navigates away on cancel confirmation', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.cancel') return {};
@@ -1502,7 +1502,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('calls task.setStatus RPC and navigates away on complete confirmation', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.setStatus') return { task: makeTask('task-1', 'completed') };
@@ -1552,7 +1552,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('closes info panel when Complete action is clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1580,7 +1580,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('closes info panel when Cancel action is clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1608,7 +1608,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('closes info panel when Archive action is clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1636,7 +1636,7 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('closes info panel when Escape key is pressed', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1680,7 +1680,7 @@ describe('TaskView — Interrupt button', () => {
 	});
 
 	it('shows interrupt button for in_progress tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1699,7 +1699,7 @@ describe('TaskView — Interrupt button', () => {
 	});
 
 	it('shows interrupt button for review tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -1718,7 +1718,7 @@ describe('TaskView — Interrupt button', () => {
 	});
 
 	it('does NOT show interrupt button for pending tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'pending') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'pending') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1737,7 +1737,7 @@ describe('TaskView — Interrupt button', () => {
 	});
 
 	it('does NOT show interrupt button for failed tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'failed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'failed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1756,7 +1756,7 @@ describe('TaskView — Interrupt button', () => {
 	});
 
 	it('does NOT show interrupt button for cancelled tasks', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'cancelled') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'cancelled') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -1794,7 +1794,7 @@ describe('TaskView — Reject button in HeaderReviewBar', () => {
 	});
 
 	it('shows reject button when group.state === awaiting_human', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -1811,7 +1811,7 @@ describe('TaskView — Reject button in HeaderReviewBar', () => {
 	});
 
 	it('does NOT show reject button when group.state is not awaiting_human', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -1829,7 +1829,7 @@ describe('TaskView — Reject button in HeaderReviewBar', () => {
 	});
 
 	it('calls task.reject RPC when reject button is clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			if (method === 'task.reject') return { success: true };
@@ -1898,7 +1898,7 @@ describe('TaskView — draft-restored banner', () => {
 	});
 
 	it('shows draft-restored banner when draftRestored is true', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -1923,7 +1923,7 @@ describe('TaskView — draft-restored banner', () => {
 	});
 
 	it('hides draft-restored banner when draftRestored is false', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -1949,7 +1949,7 @@ describe('TaskView — draft-restored banner', () => {
 	});
 
 	it('calls clearDraft when "Discard draft" button is clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -1988,13 +1988,13 @@ describe('TaskView — PR link in header', () => {
 	});
 
 	it('shows PR link in header for in_progress task with prUrl', async () => {
-		roomStore.tasks.value = [
+		roomStore.taskStore.applySnapshot([
 			{
 				...makeTask('task-1', 'in_progress'),
 				prUrl: 'https://github.com/org/repo/pull/42',
 				prNumber: 42,
 			} as unknown as NeoTask,
-		];
+		]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -2011,7 +2011,7 @@ describe('TaskView — PR link in header', () => {
 	});
 
 	it('does not show PR link in header for in_progress task without prUrl', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -2027,13 +2027,13 @@ describe('TaskView — PR link in header', () => {
 	});
 
 	it('shows PR link in header AND in review bar for review task (both render)', async () => {
-		roomStore.tasks.value = [
+		roomStore.taskStore.applySnapshot([
 			{
 				...makeTask('task-1', 'review'),
 				prUrl: 'https://github.com/org/repo/pull/99',
 				prNumber: 99,
 			} as unknown as NeoTask,
-		];
+		]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -2051,13 +2051,13 @@ describe('TaskView — PR link in header', () => {
 	});
 
 	it('shows PR link in header for needs_attention task with prUrl', async () => {
-		roomStore.tasks.value = [
+		roomStore.taskStore.applySnapshot([
 			{
 				...makeTask('task-1', 'needs_attention'),
 				prUrl: 'https://github.com/org/repo/pull/7',
 				prNumber: 7,
 			} as unknown as NeoTask,
-		];
+		]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2074,13 +2074,13 @@ describe('TaskView — PR link in header', () => {
 	});
 
 	it('shows PR link in header for review task even without submittedForReview (no review bar)', async () => {
-		roomStore.tasks.value = [
+		roomStore.taskStore.applySnapshot([
 			{
 				...makeTask('task-1', 'review'),
 				prUrl: 'https://github.com/org/repo/pull/55',
 				prNumber: 55,
 			} as unknown as NeoTask,
-		];
+		]);
 		mockRequest.mockImplementation(async (method) => {
 			// group not awaiting_human, so submittedForReview is false → review bar hidden
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
@@ -2099,13 +2099,13 @@ describe('TaskView — PR link in header', () => {
 	});
 
 	it('shows PR link in header for completed task with prUrl', async () => {
-		roomStore.tasks.value = [
+		roomStore.taskStore.applySnapshot([
 			{
 				...makeTask('task-1', 'completed'),
 				prUrl: 'https://github.com/org/repo/pull/101',
 				prNumber: 101,
 			} as unknown as NeoTask,
-		];
+		]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2145,7 +2145,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('shows Reactivate button for completed task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2161,7 +2161,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('shows Archive action in dropdown for completed task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2183,7 +2183,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('shows Reactivate button for cancelled task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'cancelled') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'cancelled') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2199,7 +2199,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('shows "Sending a message will reactivate this task" hint for completed task without group', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2215,7 +2215,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('input is disabled for archived task (no group)', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'archived') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'archived') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2234,7 +2234,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('calls task.setStatus with in_progress when Reactivate button is clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			if (method === 'task.setStatus') return { task: makeTask('task-1', 'in_progress') };
@@ -2267,7 +2267,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('shows Archive action in dropdown for needs_attention task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'needs_attention') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'needs_attention') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2289,7 +2289,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('calls task.setStatus with archived when Archive dialog is confirmed', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			if (method === 'task.setStatus') return {};
@@ -2338,7 +2338,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('does NOT show reactivation hint when completed task has an active group', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -2354,7 +2354,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('shows Archive action in dropdown for cancelled task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'cancelled') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'cancelled') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2376,7 +2376,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('does NOT show Reactivate button for in_progress task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -2392,7 +2392,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('does NOT show Reactivate button for archived task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'archived') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'archived') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2408,7 +2408,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('does NOT show Archive action in dropdown for in_progress task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -2430,7 +2430,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('does NOT show Archive action in dropdown for archived task', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'archived') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'archived') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2452,7 +2452,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('archived status badge has text-gray-600 class', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'archived') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'archived') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2471,7 +2471,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('input is enabled for completed task (no group)', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2490,7 +2490,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('input is enabled for cancelled task (no group)', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'cancelled') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'cancelled') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2513,7 +2513,7 @@ describe('TaskView — SetStatusModal', () => {
 	beforeEach(() => {
 		mockRequest.mockReset();
 		mockOnEvent.mockReset();
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			if (method === 'task.setStatus') return { task: makeTask('task-1', 'pending') };
@@ -2594,7 +2594,7 @@ describe('TaskView — SetStatusModal', () => {
 	});
 
 	it('shows destructive warning when transitioning from archived', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'archived') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'archived') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			if (method === 'task.setStatus') return { task: makeTask('task-1', 'pending') };
@@ -2620,7 +2620,7 @@ describe('TaskView — SetStatusModal', () => {
 	});
 
 	it('shows destructive warning for completed→pending transition', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'completed') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'completed') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			if (method === 'task.setStatus') return { task: makeTask('task-1', 'pending') };
@@ -2673,24 +2673,24 @@ describe('TaskView — goal badge', () => {
 		mockMessageCount.value = 0;
 		vi.mocked(useAutoScroll).mockClear();
 		// Clear goals between tests
-		roomStore.goals.value = [];
+		roomStore.goalStore.applySnapshot([]);
 		currentRoomTabSignal.value = null;
 	});
 
 	afterEach(() => {
 		cleanup();
-		roomStore.goals.value = [];
+		roomStore.goalStore.applySnapshot([]);
 		currentRoomTabSignal.value = null;
 	});
 
 	it('shows goal badge when task is linked to a goal', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
 		});
 
-		roomStore.goals.value = [
+		roomStore.goalStore.applySnapshot([
 			{
 				id: 'goal-1',
 				roomId: 'room-1',
@@ -2703,7 +2703,7 @@ describe('TaskView — goal badge', () => {
 				createdAt: Date.now(),
 				updatedAt: Date.now(),
 			},
-		];
+		]);
 
 		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
 
@@ -2717,7 +2717,7 @@ describe('TaskView — goal badge', () => {
 	});
 
 	it('does NOT show goal badge when task has no linked goal', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2735,13 +2735,13 @@ describe('TaskView — goal badge', () => {
 	});
 
 	it('sets currentRoomTabSignal to "goals" and navigates to room when goal badge clicked', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
 		});
 
-		roomStore.goals.value = [
+		roomStore.goalStore.applySnapshot([
 			{
 				id: 'goal-1',
 				roomId: 'room-1',
@@ -2754,7 +2754,7 @@ describe('TaskView — goal badge', () => {
 				createdAt: Date.now(),
 				updatedAt: Date.now(),
 			},
-		];
+		]);
 
 		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
 
@@ -2772,13 +2772,13 @@ describe('TaskView — goal badge', () => {
 	});
 
 	it('shows goal title as tooltip on badge', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
 		});
 
-		roomStore.goals.value = [
+		roomStore.goalStore.applySnapshot([
 			{
 				id: 'goal-1',
 				roomId: 'room-1',
@@ -2791,7 +2791,7 @@ describe('TaskView — goal badge', () => {
 				createdAt: Date.now(),
 				updatedAt: Date.now(),
 			},
-		];
+		]);
 
 		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
 
@@ -2828,7 +2828,7 @@ describe('TaskView — task.getGroup retry on failure', () => {
 
 	it('retries task.getGroup once after 1s if first attempt throws', async () => {
 		let getGroupCallCount = 0;
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') {
 				getGroupCallCount++;
@@ -2866,7 +2866,7 @@ describe('TaskView — task.getGroup retry on failure', () => {
 
 	it('shows "Loading conversation history" for review task while group is null', async () => {
 		// task.getGroup always returns null (daemon just restarted, group not yet returned).
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2914,7 +2914,7 @@ describe('TaskView — no reload on message send (bug regression)', () => {
 	});
 
 	it('TaskConversationRenderer DOM node is NOT replaced after a successful message send', async () => {
-		roomStore.tasks.value = [makeTask('task-1', 'in_progress') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -2949,7 +2949,7 @@ describe('TaskView — no reload on message send (bug regression)', () => {
 	it('conversationKey bumps only for approve (not for normal message send)', async () => {
 		// This test verifies that approve still causes a remount (intentional),
 		// while a normal message send does not.
-		roomStore.tasks.value = [makeTask('task-1', 'review') as unknown as NeoTask];
+		roomStore.taskStore.applySnapshot([makeTask('task-1', 'review') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			if (method === 'task.approve') return {};

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1312,7 +1312,9 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 
 	it('does NOT show cancel button for needs_attention tasks', async () => {
-		roomStore.taskStore.applySnapshot([makeTask('task-1', 'needs_attention') as unknown as NeoTask]);
+		roomStore.taskStore.applySnapshot([
+			makeTask('task-1', 'needs_attention') as unknown as NeoTask,
+		]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -2267,7 +2269,9 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 
 	it('shows Archive action in dropdown for needs_attention task', async () => {
-		roomStore.taskStore.applySnapshot([makeTask('task-1', 'needs_attention') as unknown as NeoTask]);
+		roomStore.taskStore.applySnapshot([
+			makeTask('task-1', 'needs_attention') as unknown as NeoTask,
+		]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
 			return {};

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -102,35 +102,35 @@ describe('RoomStore — computed goal/task signals', () => {
 
 	describe('tasksByGoalId', () => {
 		it('returns empty map when no goals', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending')];
-			roomStore.goals.value = [];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending')]);
+			roomStore.goalStore.applySnapshot([]);
 			const map = roomStore.tasksByGoalId.value;
 			expect(map.size).toBe(0);
 		});
 
 		it('maps goals to their linked tasks', () => {
-			roomStore.tasks.value = [
+			roomStore.taskStore.applySnapshot([
 				makeTask('t1', 'pending'),
 				makeTask('t2', 'in_progress'),
 				makeTask('t3', 'completed'),
-			];
-			roomStore.goals.value = [makeGoal('g1', ['t1', 't2']), makeGoal('g2', ['t3'])];
+			]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1', 't2']), makeGoal('g2', ['t3'])]);
 			const map = roomStore.tasksByGoalId.value;
 			expect(map.get('g1')?.map((t) => t.id)).toEqual(['t1', 't2']);
 			expect(map.get('g2')?.map((t) => t.id)).toEqual(['t3']);
 		});
 
 		it('skips linked task IDs that do not exist in tasks signal', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending')];
-			roomStore.goals.value = [makeGoal('g1', ['t1', 'nonexistent'])];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending')]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1', 'nonexistent'])]);
 			const map = roomStore.tasksByGoalId.value;
 			expect(map.has('g1')).toBe(true);
 			expect(map.get('g1')?.map((t) => t.id)).toEqual(['t1']);
 		});
 
 		it('includes goal with empty linkedTaskIds as a key with empty array', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending')];
-			roomStore.goals.value = [makeGoal('g1', []), makeGoal('g2', ['t1'])];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending')]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', []), makeGoal('g2', ['t1'])]);
 			const map = roomStore.tasksByGoalId.value;
 			expect(map.has('g1')).toBe(true);
 			expect(map.get('g1')).toEqual([]);
@@ -141,31 +141,31 @@ describe('RoomStore — computed goal/task signals', () => {
 
 	describe('orphanTasks', () => {
 		it('returns all tasks when no goals exist', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending'), makeTask('t2', 'draft')];
-			roomStore.goals.value = [];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending'), makeTask('t2', 'draft')]);
+			roomStore.goalStore.applySnapshot([]);
 			expect(roomStore.orphanTasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
 		});
 
 		it('excludes tasks linked to any goal', () => {
-			roomStore.tasks.value = [
+			roomStore.taskStore.applySnapshot([
 				makeTask('t1', 'pending'),
 				makeTask('t2', 'in_progress'),
 				makeTask('t3', 'completed'),
-			];
-			roomStore.goals.value = [makeGoal('g1', ['t1', 't3'])];
+			]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1', 't3'])]);
 			expect(roomStore.orphanTasks.value.map((t) => t.id)).toEqual(['t2']);
 		});
 
 		it('returns empty when all tasks are linked', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending')];
-			roomStore.goals.value = [makeGoal('g1', ['t1'])];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending')]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1'])]);
 			expect(roomStore.orphanTasks.value).toEqual([]);
 		});
 	});
 
 	describe('orphanTasksActive', () => {
 		it('includes draft, pending, and in_progress orphan tasks', () => {
-			roomStore.tasks.value = [
+			roomStore.taskStore.applySnapshot([
 				makeTask('t1', 'draft'),
 				makeTask('t2', 'pending'),
 				makeTask('t3', 'in_progress'),
@@ -173,8 +173,8 @@ describe('RoomStore — computed goal/task signals', () => {
 				makeTask('t5', 'completed'),
 				makeTask('t6', 'needs_attention'),
 				makeTask('t7', 'cancelled'),
-			];
-			roomStore.goals.value = [];
+			]);
+			roomStore.goalStore.applySnapshot([]);
 			const ids = roomStore.orphanTasksActive.value.map((t) => t.id);
 			expect(ids).toEqual(['t1', 't2', 't3']);
 		});
@@ -182,15 +182,15 @@ describe('RoomStore — computed goal/task signals', () => {
 
 	describe('orphanTasksReview', () => {
 		it('includes review, needs_attention, rate_limited, and usage_limited orphan tasks', () => {
-			roomStore.tasks.value = [
+			roomStore.taskStore.applySnapshot([
 				makeTask('t1', 'draft'),
 				makeTask('t2', 'review'),
 				makeTask('t3', 'needs_attention'),
 				makeTask('t4', 'completed'),
 				makeTask('t5', 'rate_limited'),
 				makeTask('t6', 'usage_limited'),
-			];
-			roomStore.goals.value = [];
+			]);
+			roomStore.goalStore.applySnapshot([]);
 			const ids = roomStore.orphanTasksReview.value.map((t) => t.id);
 			expect(ids).toEqual(['t2', 't3', 't5', 't6']);
 		});
@@ -198,12 +198,12 @@ describe('RoomStore — computed goal/task signals', () => {
 
 	describe('orphanTasksDone', () => {
 		it('includes completed and cancelled orphan tasks', () => {
-			roomStore.tasks.value = [
+			roomStore.taskStore.applySnapshot([
 				makeTask('t1', 'in_progress'),
 				makeTask('t2', 'completed'),
 				makeTask('t3', 'cancelled'),
-			];
-			roomStore.goals.value = [];
+			]);
+			roomStore.goalStore.applySnapshot([]);
 			const ids = roomStore.orphanTasksDone.value.map((t) => t.id);
 			expect(ids).toEqual(['t2', 't3']);
 		});
@@ -213,7 +213,7 @@ describe('RoomStore — computed goal/task signals', () => {
 		it('every non-archived status falls into exactly one bucket', () => {
 			// Note: archived tasks are excluded server-side by the tasks.byRoom LiveQuery,
 			// so the tasks signal never contains archived tasks in production.
-			roomStore.tasks.value = [
+			roomStore.taskStore.applySnapshot([
 				makeTask('draft', 'draft'),
 				makeTask('pending', 'pending'),
 				makeTask('in_progress', 'in_progress'),
@@ -223,8 +223,8 @@ describe('RoomStore — computed goal/task signals', () => {
 				makeTask('cancelled', 'cancelled'),
 				makeTask('rate_limited', 'rate_limited'),
 				makeTask('usage_limited', 'usage_limited'),
-			];
-			roomStore.goals.value = [];
+			]);
+			roomStore.goalStore.applySnapshot([]);
 
 			const active = new Set(roomStore.orphanTasksActive.value.map((t) => t.id));
 			const review = new Set(roomStore.orphanTasksReview.value.map((t) => t.id));
@@ -247,14 +247,15 @@ describe('RoomStore — computed goal/task signals', () => {
 		});
 	});
 
+
 	describe('filtered orphan tasks exclude linked tasks', () => {
 		it('does not include linked tasks in any orphan bucket', () => {
-			roomStore.tasks.value = [
+			roomStore.taskStore.applySnapshot([
 				makeTask('t1', 'draft'),
 				makeTask('t2', 'review'),
 				makeTask('t3', 'completed'),
-			];
-			roomStore.goals.value = [makeGoal('g1', ['t1', 't2', 't3'])];
+			]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1', 't2', 't3'])]);
 
 			expect(roomStore.orphanTasksActive.value).toEqual([]);
 			expect(roomStore.orphanTasksReview.value).toEqual([]);
@@ -264,8 +265,8 @@ describe('RoomStore — computed goal/task signals', () => {
 
 	describe('edge cases', () => {
 		it('returns empty arrays when tasks and goals are both empty', () => {
-			roomStore.tasks.value = [];
-			roomStore.goals.value = [];
+			roomStore.taskStore.applySnapshot([]);
+			roomStore.goalStore.applySnapshot([]);
 			expect(roomStore.tasksByGoalId.value.size).toBe(0);
 			expect(roomStore.orphanTasks.value).toEqual([]);
 			expect(roomStore.orphanTasksActive.value).toEqual([]);
@@ -274,8 +275,8 @@ describe('RoomStore — computed goal/task signals', () => {
 		});
 
 		it('handles a goal linking to the same task as another goal', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending')];
-			roomStore.goals.value = [makeGoal('g1', ['t1']), makeGoal('g2', ['t1'])];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending')]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1']), makeGoal('g2', ['t1'])]);
 			// t1 appears under both goals
 			expect(roomStore.tasksByGoalId.value.get('g1')?.map((t) => t.id)).toEqual(['t1']);
 			expect(roomStore.tasksByGoalId.value.get('g2')?.map((t) => t.id)).toEqual(['t1']);
@@ -284,8 +285,8 @@ describe('RoomStore — computed goal/task signals', () => {
 		});
 
 		it('handles no tasks linked (all are orphans)', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending'), makeTask('t2', 'review')];
-			roomStore.goals.value = [makeGoal('g1', [])];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending'), makeTask('t2', 'review')]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', [])]);
 			expect(roomStore.orphanTasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
 			expect(roomStore.tasksByGoalId.value.get('g1')).toEqual([]);
 		});
@@ -293,55 +294,55 @@ describe('RoomStore — computed goal/task signals', () => {
 
 	describe('reactivity', () => {
 		it('updates tasksByGoalId when tasks signal changes', () => {
-			roomStore.goals.value = [makeGoal('g1', ['t1', 't2'])];
-			roomStore.tasks.value = [makeTask('t1', 'pending')];
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1', 't2'])]);
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending')]);
 			expect(roomStore.tasksByGoalId.value.get('g1')?.map((t) => t.id)).toEqual(['t1']);
 
 			// Add t2
-			roomStore.tasks.value = [makeTask('t1', 'pending'), makeTask('t2', 'in_progress')];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending'), makeTask('t2', 'in_progress')]);
 			expect(roomStore.tasksByGoalId.value.get('g1')?.map((t) => t.id)).toEqual(['t1', 't2']);
 		});
 
 		it('updates tasksByGoalId when goals signal changes', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending'), makeTask('t2', 'review')];
-			roomStore.goals.value = [makeGoal('g1', ['t1'])];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending'), makeTask('t2', 'review')]);
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1'])]);
 			expect(roomStore.tasksByGoalId.value.get('g1')?.map((t) => t.id)).toEqual(['t1']);
 
 			// Change goals to link t2 instead
-			roomStore.goals.value = [makeGoal('g1', ['t2'])];
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t2'])]);
 			expect(roomStore.tasksByGoalId.value.get('g1')?.map((t) => t.id)).toEqual(['t2']);
 		});
 
 		it('updates orphanTasks when a task becomes linked to a goal', () => {
-			roomStore.tasks.value = [makeTask('t1', 'draft'), makeTask('t2', 'pending')];
-			roomStore.goals.value = [];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'draft'), makeTask('t2', 'pending')]);
+			roomStore.goalStore.applySnapshot([]);
 			expect(roomStore.orphanTasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
 
 			// Link t1 to a goal
-			roomStore.goals.value = [makeGoal('g1', ['t1'])];
+			roomStore.goalStore.applySnapshot([makeGoal('g1', ['t1'])]);
 			expect(roomStore.orphanTasks.value.map((t) => t.id)).toEqual(['t2']);
 		});
 
 		it('updates orphan buckets when task status changes', () => {
-			roomStore.tasks.value = [makeTask('t1', 'pending')];
-			roomStore.goals.value = [];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'pending')]);
+			roomStore.goalStore.applySnapshot([]);
 			expect(roomStore.orphanTasksActive.value.map((t) => t.id)).toEqual(['t1']);
 			expect(roomStore.orphanTasksReview.value).toEqual([]);
 
 			// Change t1 status to review
-			roomStore.tasks.value = [makeTask('t1', 'review')];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'review')]);
 			expect(roomStore.orphanTasksActive.value).toEqual([]);
 			expect(roomStore.orphanTasksReview.value.map((t) => t.id)).toEqual(['t1']);
 		});
 
 		it('updates orphanTasksDone when task transitions to completed', () => {
-			roomStore.tasks.value = [makeTask('t1', 'in_progress')];
-			roomStore.goals.value = [];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'in_progress')]);
+			roomStore.goalStore.applySnapshot([]);
 			expect(roomStore.orphanTasksActive.value.map((t) => t.id)).toEqual(['t1']);
 			expect(roomStore.orphanTasksDone.value).toEqual([]);
 
 			// Complete the task
-			roomStore.tasks.value = [makeTask('t1', 'completed')];
+			roomStore.taskStore.applySnapshot([makeTask('t1', 'completed')]);
 			expect(roomStore.orphanTasksActive.value).toEqual([]);
 			expect(roomStore.orphanTasksDone.value.map((t) => t.id)).toEqual(['t1']);
 		});

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -247,7 +247,6 @@ describe('RoomStore — computed goal/task signals', () => {
 		});
 	});
 
-
 	describe('filtered orphan tasks exclude linked tasks', () => {
 		it('does not include linked tasks in any orphan bucket', () => {
 			roomStore.taskStore.applySnapshot([

--- a/packages/web/src/lib/__tests__/room-store-review.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-review.test.ts
@@ -106,7 +106,7 @@ describe('RoomStore — review toast notification (via liveQuery.delta)', () => 
 		// populates tasks — the task is not yet in local state.
 		await roomStore.select(ROOM_ID);
 		await roomStore.subscribeRoom(ROOM_ID);
-		roomStore.tasks.value = [];
+		roomStore.taskStore.applySnapshot([]);
 
 		// Delta with an 'updated' task that is not in current state
 		fireEvent('liveQuery.delta', {
@@ -255,7 +255,7 @@ describe('RoomStore — reviewTaskCount computed signal', () => {
 	it('returns 0 when no tasks are in review', async () => {
 		await roomStore.select(ROOM_ID);
 
-		roomStore.tasks.value = [makeTask('t1', 'pending'), makeTask('t2', 'in_progress')];
+		roomStore.taskStore.applySnapshot([makeTask('t1', 'pending'), makeTask('t2', 'in_progress')]);
 
 		expect(roomStore.reviewTaskCount.value).toBe(0);
 	});
@@ -263,11 +263,11 @@ describe('RoomStore — reviewTaskCount computed signal', () => {
 	it('counts tasks in review status', async () => {
 		await roomStore.select(ROOM_ID);
 
-		roomStore.tasks.value = [
+		roomStore.taskStore.applySnapshot([
 			makeTask('t1', 'review'),
 			makeTask('t2', 'in_progress'),
 			makeTask('t3', 'review'),
-		];
+		]);
 
 		expect(roomStore.reviewTaskCount.value).toBe(2);
 	});
@@ -275,10 +275,10 @@ describe('RoomStore — reviewTaskCount computed signal', () => {
 	it('updates reactively when tasks change', async () => {
 		await roomStore.select(ROOM_ID);
 
-		roomStore.tasks.value = [makeTask('t1', 'pending')];
+		roomStore.taskStore.applySnapshot([makeTask('t1', 'pending')]);
 		expect(roomStore.reviewTaskCount.value).toBe(0);
 
-		roomStore.tasks.value = [makeTask('t1', 'review')];
+		roomStore.taskStore.applySnapshot([makeTask('t1', 'review')]);
 		expect(roomStore.reviewTaskCount.value).toBe(1);
 	});
 });

--- a/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { TaskSummary } from '@neokai/shared';
+import type { NeoTask } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -91,7 +91,7 @@ import { roomStore } from '../room-store.js';
 const ROOM_ID = 'room-tasks-test';
 const TASKS_SUB_ID = `tasks-byRoom-${ROOM_ID}`;
 
-function makeTask(id: string, overrides: Partial<TaskSummary> = {}): TaskSummary {
+function makeTask(id: string, overrides: Partial<NeoTask> = {}): NeoTask {
 	return {
 		id,
 		roomId: ROOM_ID,
@@ -100,10 +100,11 @@ function makeTask(id: string, overrides: Partial<TaskSummary> = {}): TaskSummary
 		status: 'pending',
 		priority: 'normal',
 		progress: 0,
+		dependsOn: [],
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		...overrides,
-	} as TaskSummary;
+	} as NeoTask;
 }
 
 function setupHubRequests(hub: MockHub): void {

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -16,6 +16,7 @@
  */
 
 import { signal, computed } from '@preact/signals';
+import { EntityStore } from './entity-store';
 import type {
 	Room,
 	NeoTask,
@@ -76,8 +77,11 @@ class RoomStore {
 	/** Room metadata */
 	readonly room = signal<Room | null>(null);
 
-	/** Tasks for this room (excludes archived — filtered server-side by LiveQuery) */
-	readonly tasks = signal<NeoTask[]>([]);
+	/** Entity store for tasks — Map-backed for O(1) lookups and delta application */
+	readonly taskStore = new EntityStore<NeoTask>();
+
+	/** Tasks for this room — computed pass-through from taskStore (excludes archived — filtered server-side by LiveQuery) */
+	readonly tasks = computed(() => this.taskStore.toArray());
 
 	/** Sessions in this room */
 	readonly sessions = signal<SessionSummary[]>([]);
@@ -92,11 +96,16 @@ class RoomStore {
 	// Goals Signals
 	// ========================================
 
-	/** Goals for this room */
-	readonly goals = signal<RoomGoal[]>([]);
+	/** Entity store for goals — Map-backed for O(1) lookups and delta application */
+	readonly goalStore = new EntityStore<RoomGoal>();
 
-	/** Goals loading state */
-	readonly goalsLoading = signal<boolean>(false);
+	/** Goals for this room — computed pass-through from goalStore */
+	readonly goals = computed(() => this.goalStore.toArray());
+
+	/** Goals loading state — delegates to goalStore.loading */
+	get goalsLoading() {
+		return this.goalStore.loading;
+	}
 
 	// ========================================
 	// Room Skills Signals
@@ -291,11 +300,10 @@ class RoomStore {
 
 		// 2. Clear state
 		this.room.value = null;
-		this.tasks.value = [];
+		this.taskStore.clear();
 		this.sessions.value = [];
 		this.error.value = null;
-		this.goals.value = [];
-		this.goalsLoading.value = false;
+		this.goalStore.clear();
 		this.roomSkills.value = [];
 		this.autoCompletedNotifications.value = [];
 		this.runtimeState.value = null;
@@ -363,7 +371,7 @@ class RoomStore {
 				(event) => {
 					if (event.subscriptionId !== tasksSubId) return;
 					if (!this.activeSubscriptionIds.has(tasksSubId)) return; // stale-event guard
-					this.tasks.value = event.rows as NeoTask[];
+					this.taskStore.applySnapshot(event.rows as NeoTask[]);
 				}
 			);
 			cleanups.push(unsubTaskSnapshot);
@@ -371,17 +379,12 @@ class RoomStore {
 			const unsubTaskDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId !== tasksSubId) return;
 				if (!this.activeSubscriptionIds.has(tasksSubId)) return; // stale-event guard
-				let current = this.tasks.value;
-				if (event.removed?.length) {
-					const removedIds = new Set((event.removed as NeoTask[]).map((r) => r.id));
-					current = current.filter((t) => !removedIds.has(t.id));
-				}
+				// Show toast when a known task transitions into review/rate-limited/usage-limited status.
+				// Must read prevTask from the store BEFORE applyDelta overwrites it.
+				// Skip when prevTask is absent to avoid spurious toasts during hydration.
 				if (event.updated?.length) {
-					const updatedTasks = event.updated as NeoTask[];
-					// Show toast when a known task transitions into review/rate-limited/usage-limited status.
-					// Skip when prevTask is absent to avoid spurious toasts during hydration.
-					for (const updatedTask of updatedTasks) {
-						const prevTask = current.find((t) => t.id === updatedTask.id);
+					for (const updatedTask of event.updated as NeoTask[]) {
+						const prevTask = this.taskStore.getById(updatedTask.id);
 						if (prevTask) {
 							if (updatedTask.status === 'review' && prevTask.status !== 'review') {
 								toast.info(`Task ready for review: ${updatedTask.title}`);
@@ -394,13 +397,8 @@ class RoomStore {
 							}
 						}
 					}
-					const updatedMap = new Map(updatedTasks.map((u) => [u.id, u]));
-					current = current.map((t) => updatedMap.get(t.id) ?? t);
 				}
-				if (event.added?.length) {
-					current = [...current, ...(event.added as NeoTask[])];
-				}
-				this.tasks.value = current;
+				this.taskStore.applyDelta(event as { added?: NeoTask[]; removed?: NeoTask[]; updated?: NeoTask[] });
 			});
 			cleanups.push(unsubTaskDelta);
 
@@ -460,8 +458,7 @@ class RoomStore {
 				(event) => {
 					if (event.subscriptionId !== goalsSubId) return;
 					if (!this.activeSubscriptionIds.has(goalsSubId)) return; // stale-event guard
-					this.goals.value = event.rows as RoomGoal[];
-					this.goalsLoading.value = false;
+					this.goalStore.applySnapshot(event.rows as RoomGoal[]);
 				}
 			);
 			cleanups.push(unsubGoalSnapshot);
@@ -469,25 +466,13 @@ class RoomStore {
 			const unsubGoalDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId !== goalsSubId) return;
 				if (!this.activeSubscriptionIds.has(goalsSubId)) return; // stale-event guard
-				let current = this.goals.value;
-				if (event.removed?.length) {
-					const removedIds = new Set((event.removed as RoomGoal[]).map((r) => r.id));
-					current = current.filter((g) => !removedIds.has(g.id));
-				}
-				if (event.updated?.length) {
-					const updatedMap = new Map((event.updated as RoomGoal[]).map((u) => [u.id, u]));
-					current = current.map((g) => updatedMap.get(g.id) ?? g);
-				}
-				if (event.added?.length) {
-					current = [...current, ...(event.added as RoomGoal[])];
-				}
-				this.goals.value = current;
+				this.goalStore.applyDelta(event as { added?: RoomGoal[]; removed?: RoomGoal[]; updated?: RoomGoal[] });
 			});
 			cleanups.push(unsubGoalDelta);
 
 			// Subscribe to the goals.byRoom named query.
 			// Mark loading before subscribing; the snapshot handler clears it.
-			this.goalsLoading.value = true;
+			this.goalStore.loading.value = true;
 			await hub.request('liveQuery.subscribe', {
 				queryName: 'goals.byRoom',
 				params: [roomId],
@@ -506,7 +491,7 @@ class RoomStore {
 				this.liveQueryCleanups.delete(roomId);
 				// Reset goalsLoading: it was set to true above but the snapshot
 				// handler (which normally clears it) will never fire.
-				this.goalsLoading.value = false;
+				this.goalStore.loading.value = false;
 				return;
 			}
 
@@ -516,7 +501,7 @@ class RoomStore {
 			// snapshot handler above.
 			const unsubGoalReconnect = hub.onConnection((state) => {
 				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
-				this.goalsLoading.value = true;
+				this.goalStore.loading.value = true;
 				hub
 					.request('liveQuery.subscribe', {
 						queryName: 'goals.byRoom',
@@ -525,7 +510,7 @@ class RoomStore {
 					})
 					.catch((err) => {
 						logger.warn('Goals LiveQuery re-subscribe failed:', err);
-						this.goalsLoading.value = false;
+						this.goalStore.loading.value = false;
 					});
 			});
 			cleanups.push(unsubGoalReconnect);
@@ -633,7 +618,7 @@ class RoomStore {
 			}
 			this.liveQueryCleanups.delete(roomId);
 			// Reset goalsLoading in case the error occurred after it was set to true.
-			this.goalsLoading.value = false;
+			this.goalStore.loading.value = false;
 			logger.error('Failed to subscribe room LiveQuery:', err);
 		}
 	}

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -398,7 +398,9 @@ class RoomStore {
 						}
 					}
 				}
-				this.taskStore.applyDelta(event as { added?: NeoTask[]; removed?: NeoTask[]; updated?: NeoTask[] });
+				this.taskStore.applyDelta(
+					event as { added?: NeoTask[]; removed?: NeoTask[]; updated?: NeoTask[] }
+				);
 			});
 			cleanups.push(unsubTaskDelta);
 
@@ -466,7 +468,9 @@ class RoomStore {
 			const unsubGoalDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId !== goalsSubId) return;
 				if (!this.activeSubscriptionIds.has(goalsSubId)) return; // stale-event guard
-				this.goalStore.applyDelta(event as { added?: RoomGoal[]; removed?: RoomGoal[]; updated?: RoomGoal[] });
+				this.goalStore.applyDelta(
+					event as { added?: RoomGoal[]; removed?: RoomGoal[]; updated?: RoomGoal[] }
+				);
 			});
 			cleanups.push(unsubGoalDelta);
 


### PR DESCRIPTION
Replace raw tasks/goals signals with EntityStore<NeoTask> /
EntityStore<RoomGoal> instances. Computed pass-through getters
(`tasks`, `goals`) preserve the existing consumer API unchanged.

Changes:
- Add `taskStore = new EntityStore<NeoTask>()` and
  `goalStore = new EntityStore<RoomGoal>()`
- `tasks` and `goals` are now `computed(() => store.toArray())`
- `goalsLoading` is a getter delegating to `goalStore.loading`
- `subscribeRoom` snapshot/delta handlers use `applySnapshot` /
  `applyDelta`; toast side-effect reads `getById` before applying delta
- `doSelect` clears stores via `taskStore.clear()` / `goalStore.clear()`
- Update all tests that directly assigned `.value` to use
  `taskStore.applySnapshot()` / `goalStore.applySnapshot()`
- `room-store-tasks-live-query.test.ts`: TaskSummary → NeoTask

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
