### PR TITLE
feat: configure feature flags and tool access per role (M4.4)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -13,21 +13,13 @@ import type {
 	SpaceWorkflow,
 	SpaceWorkflowRun,
 	Space,
-	SessionFeatures,
 	AgentDefinition,
 } from '@neokai/shared';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import { inferProviderForModel } from '../../providers/registry';
+import { getFeaturesForRole } from './seed-agents';
 
 const DEFAULT_CUSTOM_AGENT_MODEL = 'claude-sonnet-4-5-20250929';
-
-const CUSTOM_AGENT_FEATURES: SessionFeatures = {
-	rewind: false,
-	worktree: false,
-	coordinator: false,
-	archive: false,
-	sessionInfo: false,
-};
 
 // ============================================================================
 // Config
@@ -397,7 +389,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 				type: 'preset',
 				preset: 'claude_code',
 			},
-			features: CUSTOM_AGENT_FEATURES,
+			features: getFeaturesForRole(customAgent.role),
 			context: { spaceId: space.id },
 			type: 'worker',
 			model,
@@ -417,7 +409,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 			preset: 'claude_code',
 			append: behavioralPrompt,
 		},
-		features: CUSTOM_AGENT_FEATURES,
+		features: getFeaturesForRole(customAgent.role),
 		context: { spaceId: space.id },
 		type: 'worker',
 		model,

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -1,7 +1,7 @@
 /**
  * Space Preset Agent Seeding
  *
- * Seeds the four default SpaceAgent records when a new Space is created.
+ * Seeds the five default SpaceAgent records when a new Space is created.
  * Preset agents are regular SpaceAgent rows — fully editable by users — that
  * happen to have a well-known role label and sensible defaults for system
  * prompt, tools, and model. SpaceRuntime resolves all agents by ID at
@@ -12,11 +12,63 @@
  *   - General  (role: 'general')  — general-purpose worker
  *   - Planner  (role: 'planner')  — planning/orchestration worker
  *   - Reviewer (role: 'reviewer') — code review specialist
+ *   - QA       (role: 'qa')       — quality assurance specialist
  */
 
-import type { SpaceAgent } from '@neokai/shared';
+import type { SpaceAgent, SessionFeatures } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentManager, SpaceAgentResult } from '../managers/space-agent-manager';
+
+// ---------------------------------------------------------------------------
+// Feature flag profiles per role
+// ---------------------------------------------------------------------------
+
+/**
+ * All sub-session roles disable UI features — sub-sessions are internal
+ * and should not expose rewind, worktree, coordinator, archive, or sessionInfo.
+ */
+export const ROLE_FEATURES: Record<string, SessionFeatures> = {
+	coder: { rewind: false, worktree: false, coordinator: false, archive: false, sessionInfo: false },
+	general: {
+		rewind: false,
+		worktree: false,
+		coordinator: false,
+		archive: false,
+		sessionInfo: false,
+	},
+	planner: {
+		rewind: false,
+		worktree: false,
+		coordinator: false,
+		archive: false,
+		sessionInfo: false,
+	},
+	reviewer: {
+		rewind: false,
+		worktree: false,
+		coordinator: false,
+		archive: false,
+		sessionInfo: false,
+	},
+	qa: { rewind: false, worktree: false, coordinator: false, archive: false, sessionInfo: false },
+};
+
+/** Default features for roles not explicitly listed in ROLE_FEATURES */
+export const DEFAULT_ROLE_FEATURES: SessionFeatures = {
+	rewind: false,
+	worktree: false,
+	coordinator: false,
+	archive: false,
+	sessionInfo: false,
+};
+
+/**
+ * Look up feature flags for a given role.
+ * Falls back to DEFAULT_ROLE_FEATURES for unknown roles.
+ */
+export function getFeaturesForRole(role: string): SessionFeatures {
+	return ROLE_FEATURES[role] ?? DEFAULT_ROLE_FEATURES;
+}
 
 // ---------------------------------------------------------------------------
 // Tool defaults per role
@@ -33,8 +85,23 @@ const GENERAL_TOOLS = CODER_TOOLS;
 /** Planner uses the same toolset as coder (orchestration patterns reserved for future) */
 const PLANNER_TOOLS = CODER_TOOLS;
 
-/** Reviewers read and run tests — no file write/edit by default */
+/** Reviewers read-only — no Write or Edit */
 const REVIEWER_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+
+/** QA: read-only + bash for running tests — no Write or Edit */
+const QA_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+
+/**
+ * Tool profiles per role. Exported for testing and external consumption.
+ * Keys match the SpaceAgent.role value.
+ */
+export const ROLE_TOOLS: Record<string, string[]> = {
+	coder: CODER_TOOLS,
+	general: GENERAL_TOOLS,
+	planner: PLANNER_TOOLS,
+	reviewer: REVIEWER_TOOLS,
+	qa: QA_TOOLS,
+};
 
 // ---------------------------------------------------------------------------
 // Preset definitions
@@ -79,6 +146,13 @@ const PRESET_AGENTS: PresetDefinition[] = [
 		description:
 			'Code review specialist. Reviews pull requests for correctness, style, and test coverage.',
 		tools: REVIEWER_TOOLS,
+	},
+	{
+		name: 'QA',
+		role: 'qa',
+		description:
+			'Quality assurance specialist. Verifies test coverage, runs test suites, and checks CI pipeline status.',
+		tools: QA_TOOLS,
 	},
 ];
 

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -168,7 +168,7 @@ export interface SeedPresetAgentsResult {
 }
 
 /**
- * Seed the four preset SpaceAgents for a newly-created Space.
+ * Seed the five preset SpaceAgents for a newly-created Space.
  *
  * Idempotent by design: if a preset name is already taken in this Space
  * (e.g. because this was called twice), the error is recorded but does not

--- a/packages/daemon/tests/unit/space/role-config.test.ts
+++ b/packages/daemon/tests/unit/space/role-config.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Role Configuration Unit Tests
+ *
+ * Verifies feature flag profiles and tool access per role.
+ * Ensures reviewers and QA cannot use Write/Edit, while coders and planners
+ * have full tool access.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+	ROLE_FEATURES,
+	ROLE_TOOLS,
+	DEFAULT_ROLE_FEATURES,
+	getFeaturesForRole,
+} from '../../../src/lib/space/agents/seed-agents';
+import {
+	createCustomAgentInit,
+	type CustomAgentConfig,
+} from '../../../src/lib/space/agents/custom-agent';
+import type { SpaceAgent, Space, SpaceTask, SessionFeatures } from '@neokai/shared';
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+function makeAgent(overrides?: Partial<SpaceAgent>): SpaceAgent {
+	return {
+		id: 'agent-1',
+		spaceId: 'space-1',
+		name: 'TestAgent',
+		role: 'coder',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeSpace(overrides?: Partial<Space>): Space {
+	return {
+		id: 'space-1',
+		workspacePath: '/workspace/project',
+		name: 'Test Space',
+		description: 'A test space',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		title: 'Test task',
+		description: 'A test task',
+		status: 'pending',
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeConfig(role: string, tools?: string[]): CustomAgentConfig {
+	return {
+		customAgent: makeAgent({ role, tools, name: `Test${role}` }),
+		task: makeTask(),
+		workflowRun: null,
+		space: makeSpace(),
+		sessionId: 'session-test',
+		workspacePath: '/workspace/project',
+	};
+}
+
+const ALL_FEATURES_FALSE: SessionFeatures = {
+	rewind: false,
+	worktree: false,
+	coordinator: false,
+	archive: false,
+	sessionInfo: false,
+};
+
+// ============================================================================
+// Feature flag profiles per role
+// ============================================================================
+
+describe('ROLE_FEATURES', () => {
+	it('defines feature profiles for all known roles', () => {
+		const knownRoles = ['coder', 'general', 'planner', 'reviewer', 'qa'];
+		for (const role of knownRoles) {
+			expect(ROLE_FEATURES[role]).toBeDefined();
+		}
+	});
+
+	it('disables all features for coder role', () => {
+		expect(ROLE_FEATURES.coder).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('disables all features for reviewer role', () => {
+		expect(ROLE_FEATURES.reviewer).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('disables all features for planner role', () => {
+		expect(ROLE_FEATURES.planner).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('disables all features for qa role', () => {
+		expect(ROLE_FEATURES.qa).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('disables all features for general role', () => {
+		expect(ROLE_FEATURES.general).toEqual(ALL_FEATURES_FALSE);
+	});
+});
+
+describe('getFeaturesForRole', () => {
+	it('returns correct features for known roles', () => {
+		expect(getFeaturesForRole('coder')).toEqual(ALL_FEATURES_FALSE);
+		expect(getFeaturesForRole('reviewer')).toEqual(ALL_FEATURES_FALSE);
+		expect(getFeaturesForRole('qa')).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('falls back to DEFAULT_ROLE_FEATURES for unknown roles', () => {
+		expect(getFeaturesForRole('unknown-role')).toEqual(DEFAULT_ROLE_FEATURES);
+		expect(getFeaturesForRole('')).toEqual(DEFAULT_ROLE_FEATURES);
+	});
+});
+
+// ============================================================================
+// Tool access per role
+// ============================================================================
+
+describe('ROLE_TOOLS', () => {
+	it('coder has full tool access (Read, Write, Edit, Bash, Grep, Glob)', () => {
+		const tools = ROLE_TOOLS.coder;
+		expect(tools).toContain('Read');
+		expect(tools).toContain('Write');
+		expect(tools).toContain('Edit');
+		expect(tools).toContain('Bash');
+		expect(tools).toContain('Grep');
+		expect(tools).toContain('Glob');
+	});
+
+	it('coder does not have Task/TaskOutput/TaskStop', () => {
+		const tools = ROLE_TOOLS.coder;
+		expect(tools).not.toContain('Task');
+		expect(tools).not.toContain('TaskOutput');
+		expect(tools).not.toContain('TaskStop');
+	});
+
+	it('planner has full tool access', () => {
+		const tools = ROLE_TOOLS.planner;
+		expect(tools).toContain('Read');
+		expect(tools).toContain('Write');
+		expect(tools).toContain('Edit');
+		expect(tools).toContain('Bash');
+		expect(tools).toContain('Grep');
+		expect(tools).toContain('Glob');
+	});
+
+	it('reviewer cannot Write or Edit', () => {
+		const tools = ROLE_TOOLS.reviewer;
+		expect(tools).not.toContain('Write');
+		expect(tools).not.toContain('Edit');
+	});
+
+	it('reviewer has read-only tools', () => {
+		const tools = ROLE_TOOLS.reviewer;
+		expect(tools).toContain('Read');
+		expect(tools).toContain('Bash');
+		expect(tools).toContain('Grep');
+		expect(tools).toContain('Glob');
+	});
+
+	it('qa cannot Write or Edit', () => {
+		const tools = ROLE_TOOLS.qa;
+		expect(tools).not.toContain('Write');
+		expect(tools).not.toContain('Edit');
+	});
+
+	it('qa has read-only + bash tools for running tests', () => {
+		const tools = ROLE_TOOLS.qa;
+		expect(tools).toContain('Read');
+		expect(tools).toContain('Bash');
+		expect(tools).toContain('Grep');
+		expect(tools).toContain('Glob');
+	});
+
+	it('general has the same tools as coder', () => {
+		expect(ROLE_TOOLS.general).toEqual(ROLE_TOOLS.coder);
+	});
+});
+
+// ============================================================================
+// createCustomAgentInit applies role-based configuration
+// ============================================================================
+
+describe('createCustomAgentInit — role-based configuration', () => {
+	it('applies correct features for coder role', () => {
+		const init = createCustomAgentInit(makeConfig('coder', ROLE_TOOLS.coder));
+		expect(init.features).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('applies correct features for reviewer role', () => {
+		const init = createCustomAgentInit(makeConfig('reviewer', ROLE_TOOLS.reviewer));
+		expect(init.features).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('applies correct features for planner role', () => {
+		const init = createCustomAgentInit(makeConfig('planner', ROLE_TOOLS.planner));
+		expect(init.features).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('applies correct features for qa role', () => {
+		const init = createCustomAgentInit(makeConfig('qa', ROLE_TOOLS.qa));
+		expect(init.features).toEqual(ALL_FEATURES_FALSE);
+	});
+
+	it('applies correct features for unknown role', () => {
+		const init = createCustomAgentInit(makeConfig('custom-role', ['Read', 'Bash']));
+		expect(init.features).toEqual(DEFAULT_ROLE_FEATURES);
+	});
+
+	it('reviewer init uses agents pattern with restricted tools', () => {
+		const config = makeConfig('reviewer', ROLE_TOOLS.reviewer);
+		const init = createCustomAgentInit(config);
+
+		// When tools are specified, the agents pattern is used
+		expect(init.agent).toBeDefined();
+		expect(init.agents).toBeDefined();
+
+		// The agent definition should use the reviewer's restricted tools
+		const agentKey = init.agent as string;
+		const agentDef = init.agents![agentKey];
+		expect(agentDef.tools).toEqual(ROLE_TOOLS.reviewer);
+		expect(agentDef.tools).not.toContain('Write');
+		expect(agentDef.tools).not.toContain('Edit');
+	});
+
+	it('qa init uses agents pattern with restricted tools', () => {
+		const config = makeConfig('qa', ROLE_TOOLS.qa);
+		const init = createCustomAgentInit(config);
+
+		expect(init.agent).toBeDefined();
+		expect(init.agents).toBeDefined();
+
+		const agentKey = init.agent as string;
+		const agentDef = init.agents![agentKey];
+		expect(agentDef.tools).toEqual(ROLE_TOOLS.qa);
+		expect(agentDef.tools).not.toContain('Write');
+		expect(agentDef.tools).not.toContain('Edit');
+	});
+
+	it('coder init uses agents pattern with full tools', () => {
+		const config = makeConfig('coder', ROLE_TOOLS.coder);
+		const init = createCustomAgentInit(config);
+
+		expect(init.agent).toBeDefined();
+		expect(init.agents).toBeDefined();
+
+		const agentKey = init.agent as string;
+		const agentDef = init.agents![agentKey];
+		expect(agentDef.tools).toContain('Write');
+		expect(agentDef.tools).toContain('Edit');
+	});
+
+	it('agent without tools uses simple preset path (no agent key)', () => {
+		const config = makeConfig('coder');
+		const init = createCustomAgentInit(config);
+
+		expect(init.agent).toBeUndefined();
+		expect(init.agents).toBeUndefined();
+	});
+});

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -1,7 +1,7 @@
 /**
  * seedPresetAgents Unit Tests
  *
- * Verifies that the four preset SpaceAgent records are created with correct
+ * Verifies that the five preset SpaceAgent records are created with correct
  * defaults (role, tools, description) and that seeding is idempotent (errors
  * on name collision are captured but do not abort remaining seeds).
  */
@@ -32,10 +32,10 @@ describe('seedPresetAgents', () => {
 		setModelsCache(new Map());
 	});
 
-	it('creates exactly four preset agents', async () => {
+	it('creates exactly five preset agents', async () => {
 		const result = await seedPresetAgents('space-1', manager);
 
-		expect(result.seeded).toHaveLength(4);
+		expect(result.seeded).toHaveLength(5);
 		expect(result.errors).toHaveLength(0);
 	});
 
@@ -43,14 +43,14 @@ describe('seedPresetAgents', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 
 		const roles = seeded.map((a) => a.role).sort();
-		expect(roles).toEqual(['coder', 'general', 'planner', 'reviewer']);
+		expect(roles).toEqual(['coder', 'general', 'planner', 'qa', 'reviewer']);
 	});
 
 	it('creates agents with correct names', async () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 
 		const names = seeded.map((a) => a.name).sort();
-		expect(names).toEqual(['Coder', 'General', 'Planner', 'Reviewer']);
+		expect(names).toEqual(['Coder', 'General', 'Planner', 'QA', 'Reviewer']);
 	});
 
 	it('sets tools on each preset agent', async () => {
@@ -108,7 +108,7 @@ describe('seedPresetAgents', () => {
 		const second = await seedPresetAgents('space-1', manager);
 
 		expect(second.seeded).toHaveLength(0);
-		expect(second.errors).toHaveLength(4);
+		expect(second.errors).toHaveLength(5);
 		for (const err of second.errors) {
 			expect(err.error).toMatch(/already exists/i);
 		}
@@ -120,8 +120,8 @@ describe('seedPresetAgents', () => {
 		const r1 = await seedPresetAgents('space-1', manager);
 		const r2 = await seedPresetAgents('space-2', manager);
 
-		expect(r1.seeded).toHaveLength(4);
-		expect(r2.seeded).toHaveLength(4);
+		expect(r1.seeded).toHaveLength(5);
+		expect(r2.seeded).toHaveLength(5);
 		expect(r1.errors).toHaveLength(0);
 		expect(r2.errors).toHaveLength(0);
 
@@ -137,7 +137,7 @@ describe('seedPresetAgents', () => {
 		const result = await seedPresetAgents('space-1', manager);
 
 		// Coder fails, others succeed
-		expect(result.seeded).toHaveLength(3);
+		expect(result.seeded).toHaveLength(4);
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0].name).toBe('Coder');
 	});
@@ -157,5 +157,18 @@ describe('seedPresetAgents', () => {
 		for (const agent of nonPlanners) {
 			expect(agent.injectWorkflowContext).toBeUndefined();
 		}
+	});
+
+	it('QA agent has restricted tools (no Write or Edit)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const qa = seeded.find((a) => a.role === 'qa');
+
+		expect(qa).toBeDefined();
+		expect(qa?.tools).not.toContain('Write');
+		expect(qa?.tools).not.toContain('Edit');
+		expect(qa?.tools).toContain('Read');
+		expect(qa?.tools).toContain('Bash');
+		expect(qa?.tools).toContain('Grep');
+		expect(qa?.tools).toContain('Glob');
 	});
 });


### PR DESCRIPTION
Add role-based feature flag profiles and tool access configuration for Space agents.

## Changes
- Export `ROLE_FEATURES`, `ROLE_TOOLS`, `DEFAULT_ROLE_FEATURES`, and `getFeaturesForRole()` from `seed-agents.ts`
- Add QA preset agent (role: `qa`) with read-only + bash tools (no Write/Edit)
- Wire `createCustomAgentInit()` to use `getFeaturesForRole()` instead of hardcoded features
- Reviewers and QA restricted to Read, Bash, Grep, Glob, WebFetch, WebSearch
- Coders, planners, and general agents retain full tool access

## Tests
- New `role-config.test.ts` with tests for feature flag profiles, tool access per role, and `createCustomAgentInit` role-based configuration
- Updated `seed-agents.test.ts` for 5 preset agents (added QA) with QA-specific tool restriction tests