### PR TITLE
feat: implement space slugs for human-readable URL navigation

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -107,17 +107,46 @@ export function setupSpaceHandlers(
 	});
 
 	// ─── space.get ──────────────────────────────────────────────────────────────
+	// Accepts either { id } or { slug } to look up a space.
 	messageHub.onRequest('space.get', async (data) => {
-		const params = data as { id: string };
+		const params = data as { id?: string; slug?: string };
+
+		if (!params.id && !params.slug) {
+			throw new Error('id or slug is required');
+		}
+
+		let space;
+		if (params.id) {
+			space = await spaceManager.getSpace(params.id);
+		} else {
+			space = await spaceManager.getSpaceBySlug(params.slug!);
+		}
+
+		if (!space) {
+			throw new Error(`Space not found: ${params.id ?? params.slug}`);
+		}
+
+		return space;
+	});
+
+	// ─── space.updateSlug ──────────────────────────────────────────────────────
+	messageHub.onRequest('space.updateSlug', async (data) => {
+		const params = data as { id: string; slug: string };
 
 		if (!params.id) {
 			throw new Error('id is required');
 		}
-
-		const space = await spaceManager.getSpace(params.id);
-		if (!space) {
-			throw new Error(`Space not found: ${params.id}`);
+		if (!params.slug) {
+			throw new Error('slug is required');
 		}
+
+		const space = await spaceManager.updateSlug(params.id, params.slug);
+
+		daemonHub
+			.emit('space.updated', { sessionId: 'global', spaceId: params.id, space })
+			.catch((err) => {
+				log.warn('Failed to emit space.updated:', err);
+			});
 
 		return space;
 	});
@@ -205,20 +234,27 @@ export function setupSpaceHandlers(
 	});
 
 	// ─── space.overview ─────────────────────────────────────────────────────────
+	// Accepts either { id } or { slug } to look up the space.
 	messageHub.onRequest('space.overview', async (data) => {
-		const params = data as { id: string };
+		const params = data as { id?: string; slug?: string };
 
-		if (!params.id) {
-			throw new Error('id is required');
+		if (!params.id && !params.slug) {
+			throw new Error('id or slug is required');
 		}
 
-		const space = await spaceManager.getSpace(params.id);
+		let space;
+		if (params.id) {
+			space = await spaceManager.getSpace(params.id);
+		} else {
+			space = await spaceManager.getSpaceBySlug(params.slug!);
+		}
+
 		if (!space) {
-			throw new Error(`Space not found: ${params.id}`);
+			throw new Error(`Space not found: ${params.id ?? params.slug}`);
 		}
 
-		const tasks = taskRepo.listBySpace(params.id);
-		const workflowRuns = workflowRunRepo.listBySpace(params.id);
+		const tasks = taskRepo.listBySpace(space.id);
+		const workflowRuns = workflowRunRepo.listBySpace(space.id);
 
 		const result: SpaceOverviewResult = {
 			space,

--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -13,6 +13,7 @@ import { promisify } from 'node:util';
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceRepository } from '../../../storage/repositories/space-repository';
 import { Logger } from '../../logger';
+import { slugify, validateSlug } from '../slug';
 import type { Space, CreateSpaceParams, UpdateSpaceParams } from '@neokai/shared';
 
 const execAsync = promisify(exec);
@@ -47,7 +48,11 @@ export class SpaceManager {
 			log.warn(`workspace path is not a git repository: ${resolvedPath}`);
 		}
 
-		return this.spaceRepo.createSpace({ ...params, workspacePath: resolvedPath });
+		// Auto-generate slug from space name
+		const existingSlugs = this.spaceRepo.getAllSlugs();
+		const slug = slugify(params.name, existingSlugs);
+
+		return this.spaceRepo.createSpace({ ...params, workspacePath: resolvedPath, slug });
 	}
 
 	/**
@@ -129,6 +134,42 @@ export class SpaceManager {
 		if (!updated) {
 			throw new Error(`Space not found: ${spaceId}`);
 		}
+		return updated;
+	}
+
+	/**
+	 * Get a space by slug
+	 */
+	async getSpaceBySlug(slug: string): Promise<Space | null> {
+		return this.spaceRepo.getSpaceBySlug(slug);
+	}
+
+	/**
+	 * Update a space's slug with validation and uniqueness check.
+	 */
+	async updateSlug(spaceId: string, newSlug: string): Promise<Space> {
+		const space = this.spaceRepo.getSpace(spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${spaceId}`);
+		}
+
+		// Validate slug format
+		const validationError = validateSlug(newSlug);
+		if (validationError) {
+			throw new Error(`Invalid slug: ${validationError}`);
+		}
+
+		// Check uniqueness (allow the space to keep its own slug)
+		const existing = this.spaceRepo.getSpaceBySlug(newSlug);
+		if (existing && existing.id !== spaceId) {
+			throw new Error(`Slug already in use: ${newSlug}`);
+		}
+
+		const updated = this.spaceRepo.updateSlug(spaceId, newSlug);
+		if (!updated) {
+			throw new Error(`Failed to update slug for space: ${spaceId}`);
+		}
+
 		return updated;
 	}
 

--- a/packages/daemon/src/lib/space/slug.ts
+++ b/packages/daemon/src/lib/space/slug.ts
@@ -1,0 +1,114 @@
+/**
+ * Slug Utilities
+ *
+ * Shared slugify utility for generating URL-safe, human-readable identifiers.
+ * Used for space slugs and any future slug needs (e.g., worktree naming).
+ *
+ * Rules:
+ * - Lowercase
+ * - Replace spaces and non-alphanumeric characters with hyphens
+ * - Collapse consecutive hyphens
+ * - Strip leading/trailing hyphens
+ * - Truncate to max 60 chars at word boundary
+ * - Collision suffix (-2, -3, etc.)
+ * - Empty input falls back to 'unnamed-space'
+ */
+
+const MAX_SLUG_LENGTH = 60;
+const DEFAULT_SLUG = 'unnamed-space';
+
+/**
+ * Generate a URL-safe slug from an input string.
+ * If the generated slug collides with existing slugs, appends a numeric suffix (-2, -3, ...).
+ *
+ * @param input - The string to slugify (typically a space name)
+ * @param existingSlugs - Array of slugs already in use, for collision avoidance
+ * @returns A unique, URL-safe slug
+ */
+export function slugify(input: string, existingSlugs: string[] = []): string {
+	const base = generateBaseSlug(input);
+	return resolveCollision(base, existingSlugs);
+}
+
+/**
+ * Validate that a slug meets format requirements.
+ * Returns null if valid, or an error message string if invalid.
+ */
+export function validateSlug(slug: string): string | null {
+	if (!slug) {
+		return 'Slug cannot be empty';
+	}
+	if (slug.length > MAX_SLUG_LENGTH) {
+		return `Slug must be ${MAX_SLUG_LENGTH} characters or fewer`;
+	}
+	if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(slug)) {
+		return 'Slug must contain only lowercase letters, numbers, and hyphens, and must start and end with a letter or number';
+	}
+	if (/--/.test(slug)) {
+		return 'Slug must not contain consecutive hyphens';
+	}
+	return null;
+}
+
+/**
+ * Generate the base slug from input without collision resolution.
+ */
+function generateBaseSlug(input: string): string {
+	if (!input || !input.trim()) {
+		return DEFAULT_SLUG;
+	}
+
+	let slug = input
+		.toLowerCase()
+		.replace(/[^a-z0-9\s-]/g, '-') // Replace non-alphanumeric (except spaces/hyphens) with hyphens
+		.replace(/[\s]+/g, '-') // Replace spaces with hyphens
+		.replace(/-{2,}/g, '-') // Collapse consecutive hyphens
+		.replace(/^-+/, '') // Strip leading hyphens
+		.replace(/-+$/, ''); // Strip trailing hyphens
+
+	if (!slug) {
+		return DEFAULT_SLUG;
+	}
+
+	// Truncate at word boundary (hyphen) if exceeding max length
+	if (slug.length > MAX_SLUG_LENGTH) {
+		slug = truncateAtWordBoundary(slug, MAX_SLUG_LENGTH);
+	}
+
+	return slug;
+}
+
+/**
+ * Truncate a slug at a word boundary (hyphen) to fit within maxLength.
+ * Falls back to hard truncation if no hyphen found.
+ */
+function truncateAtWordBoundary(slug: string, maxLength: number): string {
+	const truncated = slug.slice(0, maxLength);
+	// Find the last hyphen within the truncated string
+	const lastHyphen = truncated.lastIndexOf('-');
+	if (lastHyphen > 0) {
+		return truncated.slice(0, lastHyphen);
+	}
+	// No hyphen found — hard truncate and strip trailing hyphens
+	return truncated.replace(/-+$/, '');
+}
+
+/**
+ * Resolve slug collisions by appending a numeric suffix (-2, -3, ...).
+ */
+function resolveCollision(base: string, existingSlugs: string[]): string {
+	const slugSet = new Set(existingSlugs);
+
+	if (!slugSet.has(base)) {
+		return base;
+	}
+
+	let counter = 2;
+	while (true) {
+		const suffixed = `${base}-${counter}`;
+		if (!slugSet.has(suffixed)) {
+			return suffixed;
+		}
+		counter++;
+	}
+}

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -21,17 +21,18 @@ export class SpaceRepository {
 	/**
 	 * Create a new space
 	 */
-	createSpace(params: CreateSpaceParams): Space {
+	createSpace(params: CreateSpaceParams & { slug: string }): Space {
 		const id = generateUUID();
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, autonomy_level, config, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO spaces (id, slug, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, autonomy_level, config, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
 			id,
+			params.slug,
 			params.workspacePath,
 			params.name,
 			params.description ?? '',
@@ -75,6 +76,36 @@ export class SpaceRepository {
 
 		if (!row) return null;
 		return this.rowToSpace(row);
+	}
+
+	/**
+	 * Get a space by slug
+	 */
+	getSpaceBySlug(slug: string): Space | null {
+		const stmt = this.db.prepare(`SELECT * FROM spaces WHERE slug = ?`);
+		const row = stmt.get(slug) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+		return this.rowToSpace(row);
+	}
+
+	/**
+	 * Update a space's slug
+	 */
+	updateSlug(id: string, slug: string): Space | null {
+		const stmt = this.db.prepare(`UPDATE spaces SET slug = ?, updated_at = ? WHERE id = ?`);
+		stmt.run(slug, Date.now(), id);
+		return this.getSpace(id);
+	}
+
+	/**
+	 * Get all slugs currently in use (for collision detection)
+	 */
+	getAllSlugs(): string[] {
+		const rows = this.db.prepare(`SELECT slug FROM spaces WHERE slug IS NOT NULL`).all() as Array<{
+			slug: string;
+		}>;
+		return rows.map((r) => r.slug);
 	}
 
 	/**
@@ -220,6 +251,7 @@ export class SpaceRepository {
 
 		return {
 			id: row.id as string,
+			slug: (row.slug as string) ?? '',
 			workspacePath: row.workspace_path as string,
 			name: row.name as string,
 			description: (row.description as string) ?? '',

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -4116,7 +4116,6 @@ export function runMigration63(db: BunDatabase): void {
 			name: string;
 		}>;
 
-		const usedSlugs = new Set<string>();
 		const updateStmt = db.prepare('UPDATE spaces SET slug = ? WHERE id = ? AND slug IS NULL');
 
 		for (const row of rows) {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -4103,8 +4103,15 @@ export function runMigration63(db: BunDatabase): void {
 			db.exec(`ALTER TABLE spaces ADD COLUMN slug TEXT`);
 		}
 
-		// Step 2: Backfill slugs from existing space names
-		const rows = db.prepare('SELECT id, name FROM spaces').all() as Array<{
+		// Step 2: Backfill slugs only for rows that don't have one yet.
+		// Use WHERE slug IS NULL so we don't overwrite slugs that were already set
+		// (e.g., if a space was created between a partial migration run and this fix).
+		const existingSlugs = db
+			.prepare('SELECT slug FROM spaces WHERE slug IS NOT NULL')
+			.all() as Array<{ slug: string }>;
+		const usedSlugs = new Set<string>(existingSlugs.map((r) => r.slug));
+
+		const rows = db.prepare('SELECT id, name FROM spaces WHERE slug IS NULL').all() as Array<{
 			id: string;
 			name: string;
 		}>;

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -4078,45 +4078,99 @@ function runMigration61(db: BunDatabase): void {
 /**
  * Migration 63: Add slug column to spaces table.
  *
- * - Adds `slug TEXT` column (nullable initially for backfill)
+ * - Adds nullable `slug TEXT` column (required for ALTER TABLE ADD COLUMN in SQLite)
  * - Backfills existing spaces with slugs derived from their name
+ * - Rebuilds table with `slug TEXT NOT NULL` to enforce the constraint
  * - Adds UNIQUE index on slug
- * - Sets column to NOT NULL via table rebuild after backfill
  */
 export function runMigration63(db: BunDatabase): void {
 	if (!tableExists(db, 'spaces')) return;
 
 	// Check if slug column already exists (idempotent guard)
-	const tableInfo = db.prepare('PRAGMA table_info(spaces)').all() as Array<{ name: string }>;
-	if (tableInfo.some((col) => col.name === 'slug')) return;
-
-	// Step 1: Add nullable slug column
-	db.exec(`ALTER TABLE spaces ADD COLUMN slug TEXT`);
-
-	// Step 2: Backfill slugs from existing space names
-	const rows = db.prepare('SELECT id, name FROM spaces').all() as Array<{
-		id: string;
+	const tableInfo = db.prepare('PRAGMA table_info(spaces)').all() as Array<{
 		name: string;
+		notnull: number;
 	}>;
+	const slugCol = tableInfo.find((col) => col.name === 'slug');
+	if (slugCol && slugCol.notnull === 1) return; // Already migrated with NOT NULL
 
-	// Collect assigned slugs to avoid collisions during backfill
-	const usedSlugs = new Set<string>();
-	const updateStmt = db.prepare('UPDATE spaces SET slug = ? WHERE id = ? AND slug IS NULL');
+	db.exec(`PRAGMA foreign_keys = OFF`);
+	db.exec(`BEGIN`);
 
-	for (const row of rows) {
-		const base = generateBaseMigrationSlug(row.name);
-		let slug = base;
-		let counter = 2;
-		while (usedSlugs.has(slug)) {
-			slug = `${base}-${counter}`;
-			counter++;
+	try {
+		// Step 1: Add nullable slug column if it doesn't exist yet
+		if (!slugCol) {
+			db.exec(`ALTER TABLE spaces ADD COLUMN slug TEXT`);
 		}
-		usedSlugs.add(slug);
-		updateStmt.run(slug, row.id);
-	}
 
-	// Step 3: Add unique index
-	db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
+		// Step 2: Backfill slugs from existing space names
+		const rows = db.prepare('SELECT id, name FROM spaces').all() as Array<{
+			id: string;
+			name: string;
+		}>;
+
+		const usedSlugs = new Set<string>();
+		const updateStmt = db.prepare('UPDATE spaces SET slug = ? WHERE id = ? AND slug IS NULL');
+
+		for (const row of rows) {
+			const base = generateBaseMigrationSlug(row.name);
+			let slug = base;
+			let counter = 2;
+			while (usedSlugs.has(slug)) {
+				slug = `${base}-${counter}`;
+				counter++;
+			}
+			usedSlugs.add(slug);
+			updateStmt.run(slug, row.id);
+		}
+
+		// Step 3: Table rebuild to enforce NOT NULL on slug
+		// SQLite does not support ALTER COLUMN, so we recreate the table.
+		db.exec(`DROP TABLE IF EXISTS spaces_m63_new`);
+		db.exec(`
+			CREATE TABLE spaces_m63_new (
+				id TEXT PRIMARY KEY,
+				slug TEXT NOT NULL,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'archived')),
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			INSERT INTO spaces_m63_new (id, slug, workspace_path, name, description,
+				background_context, instructions, default_model, allowed_models,
+				session_ids, status, autonomy_level, config, created_at, updated_at)
+			SELECT id, slug, workspace_path, name, description,
+				background_context, instructions, default_model, allowed_models,
+				session_ids, status, COALESCE(autonomy_level, 'supervised'),
+				config, created_at, updated_at
+			FROM spaces
+		`);
+		db.exec(`DROP TABLE spaces`);
+		db.exec(`ALTER TABLE spaces_m63_new RENAME TO spaces`);
+
+		// Step 4: Recreate indexes
+		db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_spaces_status ON spaces(status)`);
+
+		db.exec(`COMMIT`);
+	} catch (err) {
+		db.exec(`ROLLBACK`);
+		throw err;
+	} finally {
+		db.exec(`PRAGMA foreign_keys = ON`);
+	}
 }
 
 /**

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -257,6 +257,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 62: Add task_number column to space_tasks for human-friendly numeric IDs.
 	// Scoped per space via UNIQUE(space_id, task_number). Backfills existing rows.
 	runMigration62(db);
+
+	// Migration 63: Add slug column to spaces table for human-readable URL identifiers.
+	// Auto-generates slugs from existing space names and adds a UNIQUE index.
+	runMigration63(db);
 }
 
 /**
@@ -4069,4 +4073,76 @@ function runMigration61(db: BunDatabase): void {
 		db.exec(`ROLLBACK`);
 		throw err;
 	}
+}
+
+/**
+ * Migration 63: Add slug column to spaces table.
+ *
+ * - Adds `slug TEXT` column (nullable initially for backfill)
+ * - Backfills existing spaces with slugs derived from their name
+ * - Adds UNIQUE index on slug
+ * - Sets column to NOT NULL via table rebuild after backfill
+ */
+export function runMigration63(db: BunDatabase): void {
+	if (!tableExists(db, 'spaces')) return;
+
+	// Check if slug column already exists (idempotent guard)
+	const tableInfo = db.prepare('PRAGMA table_info(spaces)').all() as Array<{ name: string }>;
+	if (tableInfo.some((col) => col.name === 'slug')) return;
+
+	// Step 1: Add nullable slug column
+	db.exec(`ALTER TABLE spaces ADD COLUMN slug TEXT`);
+
+	// Step 2: Backfill slugs from existing space names
+	const rows = db.prepare('SELECT id, name FROM spaces').all() as Array<{
+		id: string;
+		name: string;
+	}>;
+
+	// Collect assigned slugs to avoid collisions during backfill
+	const usedSlugs = new Set<string>();
+	const updateStmt = db.prepare('UPDATE spaces SET slug = ? WHERE id = ? AND slug IS NULL');
+
+	for (const row of rows) {
+		const base = generateBaseMigrationSlug(row.name);
+		let slug = base;
+		let counter = 2;
+		while (usedSlugs.has(slug)) {
+			slug = `${base}-${counter}`;
+			counter++;
+		}
+		usedSlugs.add(slug);
+		updateStmt.run(slug, row.id);
+	}
+
+	// Step 3: Add unique index
+	db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
+}
+
+/**
+ * Inline slugify for migration — avoids importing from slug.ts which may change.
+ * Mirrors the same rules: lowercase, replace non-alphanumeric with hyphens,
+ * collapse, strip, truncate to 60 chars.
+ */
+function generateBaseMigrationSlug(input: string): string {
+	const fallback = 'unnamed-space';
+	if (!input || !input.trim()) return fallback;
+
+	let slug = input
+		.toLowerCase()
+		.replace(/[^a-z0-9\s-]/g, '-')
+		.replace(/[\s]+/g, '-')
+		.replace(/-{2,}/g, '-')
+		.replace(/^-+/, '')
+		.replace(/-+$/, '');
+
+	if (!slug) return fallback;
+
+	if (slug.length > 60) {
+		const truncated = slug.slice(0, 60);
+		const lastHyphen = truncated.lastIndexOf('-');
+		slug = lastHyphen > 0 ? truncated.slice(0, lastHyphen) : truncated.replace(/-+$/, '');
+	}
+
+	return slug;
 }

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -12,6 +12,7 @@ export function createSpaceAgentSchema(db: Database): void {
 	db.exec(`
 		CREATE TABLE spaces (
 			id TEXT PRIMARY KEY,
+			slug TEXT NOT NULL,
 			workspace_path TEXT NOT NULL UNIQUE,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
@@ -27,6 +28,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			updated_at INTEGER NOT NULL
 		)
 	`);
+	db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
 
 	// Keep in sync with runMigration33 in migrations.ts and space-test-db.ts.
 	db.exec(`
@@ -86,8 +88,8 @@ export function createSpaceAgentSchema(db: Database): void {
 export function insertSpace(db: Database, id = 'space-1'): void {
 	const now = Date.now();
 	db.prepare(
-		`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-	).run(id, `/workspace/${id}`, `Space ${id}`, now, now);
+		`INSERT INTO spaces (id, workspace_path, name, slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+	).run(id, `/workspace/${id}`, `Space ${id}`, id, now, now);
 }
 
 export function insertWorkflow(db: Database, id: string, spaceId: string, name: string): void {

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -20,6 +20,7 @@ export function createSpaceTables(db: BunDatabase): void {
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS spaces (
 			id TEXT PRIMARY KEY,
+			slug TEXT NOT NULL,
 			workspace_path TEXT NOT NULL UNIQUE,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
@@ -36,6 +37,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			updated_at INTEGER NOT NULL
 		)
 	`);
+
+	db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
 
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_agents (

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -25,7 +25,11 @@ describe('SpaceTaskManager', () => {
 		createSpaceTables(db);
 		spaceRepo = new SpaceRepository(db as any);
 
-		const space = spaceRepo.createSpace({ workspacePath: '/workspace/test', name: 'Test' });
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/test',
+			slug: 'test',
+			name: 'Test',
+		});
 		spaceId = space.id;
 		manager = new SpaceTaskManager(db as any, spaceId);
 	});
@@ -83,6 +87,7 @@ describe('SpaceTaskManager', () => {
 			// Create another space and its manager
 			const otherSpace = spaceRepo.createSpace({
 				workspacePath: '/workspace/other',
+				slug: 'other',
 				name: 'Other',
 			});
 			const otherManager = new SpaceTaskManager(db as any, otherSpace.id);

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -87,7 +87,7 @@ describe('SpaceTaskManager', () => {
 			// Create another space and its manager
 			const otherSpace = spaceRepo.createSpace({
 				workspacePath: '/workspace/other',
-				slug: 'other',
+				slug: 'other-space',
 				name: 'Other',
 			});
 			const otherManager = new SpaceTaskManager(db as any, otherSpace.id);
@@ -751,6 +751,7 @@ describe('SpaceTaskManager', () => {
 
 			const otherSpace = spaceRepo.createSpace({
 				workspacePath: '/workspace/other',
+				slug: 'other-scoped',
 				name: 'Other',
 			});
 			const otherManager = new SpaceTaskManager(db as any, otherSpace.id);

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -34,6 +34,7 @@ function createSchema(db: Database): void {
 	db.exec(`
 		CREATE TABLE spaces (
 			id TEXT PRIMARY KEY,
+			slug TEXT NOT NULL,
 			workspace_path TEXT NOT NULL UNIQUE,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
@@ -48,6 +49,7 @@ function createSchema(db: Database): void {
 			updated_at INTEGER NOT NULL
 		)
 	`);
+	db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
 
 	db.exec(`
 		CREATE TABLE space_agents (
@@ -122,8 +124,8 @@ function createSchema(db: Database): void {
 function insertSpace(db: Database, id: string, name = `Space ${id}`): void {
 	const now = Date.now();
 	db.prepare(
-		`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-	).run(id, `/workspace/${id}`, name, now, now);
+		`INSERT INTO spaces (id, workspace_path, name, slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+	).run(id, `/workspace/${id}`, name, id, now, now);
 }
 
 // ─── Mock helpers ─────────────────────────────────────────────────────────────

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -31,6 +31,7 @@ const NOW = Date.now();
 
 const mockSpace: Space = {
 	id: 'space-1',
+	slug: 'test-space',
 	workspacePath: '/tmp/test-workspace',
 	name: 'Test Space',
 	description: 'A test space',
@@ -311,8 +312,8 @@ describe('space-handlers', () => {
 			expect(result).toEqual(mockSpace);
 		});
 
-		it('throws when id is missing', async () => {
-			await expect(call('space.get', {})).rejects.toThrow('id is required');
+		it('throws when id and slug are both missing', async () => {
+			await expect(call('space.get', {})).rejects.toThrow('id or slug is required');
 		});
 
 		it('throws when space is not found', async () => {
@@ -472,8 +473,8 @@ describe('space-handlers', () => {
 			expect(result.sessions).toEqual(mockSpace.sessionIds);
 		});
 
-		it('throws when id is missing', async () => {
-			await expect(call('space.overview', {})).rejects.toThrow('id is required');
+		it('throws when id and slug are both missing', async () => {
+			await expect(call('space.overview', {})).rejects.toThrow('id or slug is required');
 		});
 
 		it('throws when space is not found', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
@@ -28,6 +28,7 @@ const NOW = Date.now();
 
 const mockSpace: Space = {
 	id: 'space-1',
+	slug: 'test-space',
 	workspacePath: '/tmp/test-workspace',
 	name: 'Test Space',
 	description: '',

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
@@ -31,6 +31,7 @@ const NOW = Date.now();
 
 const mockSpace: Space = {
 	id: 'space-1',
+	slug: 'test-space',
 	workspacePath: '/tmp/test-workspace',
 	name: 'Test Space',
 	description: '',

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -33,6 +33,7 @@ const NOW = Date.now();
 
 const mockSpace: Space = {
 	id: 'space-1',
+	slug: 'test-space',
 	workspacePath: '/tmp/test-workspace',
 	name: 'Test Space',
 	description: '',

--- a/packages/daemon/tests/unit/space/agent-completion.test.ts
+++ b/packages/daemon/tests/unit/space/agent-completion.test.ts
@@ -56,9 +56,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedSpaceTask(

--- a/packages/daemon/tests/unit/space/agent-liveness.test.ts
+++ b/packages/daemon/tests/unit/space/agent-liveness.test.ts
@@ -48,9 +48,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `/tmp/workspace-${spaceId}`, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `/tmp/workspace-${spaceId}`, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedTask(

--- a/packages/daemon/tests/unit/space/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/space/agent-message-router.test.ts
@@ -46,9 +46,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedWorkflowRunWithChannels(

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -48,9 +48,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgent(

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -73,9 +73,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgent(

--- a/packages/daemon/tests/unit/space/completion-detector.test.ts
+++ b/packages/daemon/tests/unit/space/completion-detector.test.ts
@@ -78,9 +78,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 let taskCounter = 0;

--- a/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -83,9 +83,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 /**

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -74,9 +74,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgent(

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -306,6 +306,7 @@ function makeTaskCtx(): TaskCtx {
 
 	const space: Space = {
 		id: spaceId,
+		slug: 'test-space',
 		workspacePath: '/tmp/workspace',
 		name: 'Test Space',
 		description: '',

--- a/packages/daemon/tests/unit/space/export-import-round-trip.test.ts
+++ b/packages/daemon/tests/unit/space/export-import-round-trip.test.ts
@@ -47,9 +47,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgent(db: BunDatabase, agentId: string, spaceId: string, name: string): void {

--- a/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
+++ b/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
@@ -37,7 +37,7 @@ function freshDb(): Database {
 	createSpaceTables(d);
 	const now = Date.now();
 	d.exec(
-		`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES ('${SPACE_ID}', '/tmp/test', 'Test Space', ${now}, ${now})`
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES ('${SPACE_ID}', '${SPACE_ID}', '/tmp/test', 'Test Space', ${now}, ${now})`
 	);
 	return d;
 }

--- a/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
@@ -290,9 +290,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -46,9 +46,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedSpaceTask(

--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -104,9 +104,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, '/tmp/workspace', `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, '/tmp/workspace', `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {

--- a/packages/daemon/tests/unit/space/send-message-unified.test.ts
+++ b/packages/daemon/tests/unit/space/send-message-unified.test.ts
@@ -54,9 +54,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedWorkflowRunWithChannels(

--- a/packages/daemon/tests/unit/space/slug.test.ts
+++ b/packages/daemon/tests/unit/space/slug.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect } from 'bun:test';
+import { slugify, validateSlug } from '../../../src/lib/space/slug';
+
+describe('slugify', () => {
+	test('converts simple name to lowercase slug', () => {
+		expect(slugify('NeoKai Dev')).toBe('neokai-dev');
+	});
+
+	test('replaces non-alphanumeric characters with hyphens', () => {
+		expect(slugify('My Project (v2.0)')).toBe('my-project-v2-0');
+	});
+
+	test('collapses consecutive hyphens', () => {
+		expect(slugify('foo---bar')).toBe('foo-bar');
+	});
+
+	test('strips leading and trailing hyphens', () => {
+		expect(slugify('--hello-world--')).toBe('hello-world');
+	});
+
+	test('handles empty string', () => {
+		expect(slugify('')).toBe('unnamed-space');
+	});
+
+	test('handles whitespace-only string', () => {
+		expect(slugify('   ')).toBe('unnamed-space');
+	});
+
+	test('handles string with only special characters', () => {
+		expect(slugify('!!!@@@')).toBe('unnamed-space');
+	});
+
+	test('truncates long names at word boundary', () => {
+		const longName =
+			'this-is-a-very-long-space-name-that-exceeds-the-maximum-allowed-length-of-sixty-characters';
+		const slug = slugify(longName);
+		expect(slug.length).toBeLessThanOrEqual(60);
+		expect(slug).not.toEndWith('-');
+	});
+
+	test('truncates at hyphen boundary when possible', () => {
+		// Create a name that exceeds 60 chars and has hyphens before the cutoff
+		const name = 'abcdefghij-klmnopqrst-uvwxyzabcd-efghijklmn-opqrstuvwx-yzab-cdef';
+		const slug = slugify(name);
+		expect(slug.length).toBeLessThanOrEqual(60);
+		// Should truncate at a hyphen boundary
+		expect(slug).not.toEndWith('-');
+	});
+
+	test('resolves collision with first suffix -2', () => {
+		expect(slugify('my-project', ['my-project'])).toBe('my-project-2');
+	});
+
+	test('resolves multiple collisions incrementally', () => {
+		expect(slugify('my-project', ['my-project', 'my-project-2', 'my-project-3'])).toBe(
+			'my-project-4'
+		);
+	});
+
+	test('no collision suffix when no conflict', () => {
+		expect(slugify('unique-name', ['other-name'])).toBe('unique-name');
+	});
+
+	test('handles unicode characters', () => {
+		expect(slugify('Café Résumé')).toBe('caf-r-sum');
+	});
+
+	test('handles numbers in name', () => {
+		expect(slugify('Project 42')).toBe('project-42');
+	});
+
+	test('handles mixed case', () => {
+		expect(slugify('MyAwesomeProject')).toBe('myawesomeproject');
+	});
+
+	test('handles dots and underscores', () => {
+		expect(slugify('my.project_name')).toBe('my-project-name');
+	});
+});
+
+describe('validateSlug', () => {
+	test('accepts valid slug', () => {
+		expect(validateSlug('neokai-dev')).toBeNull();
+	});
+
+	test('accepts single character slug', () => {
+		expect(validateSlug('a')).toBeNull();
+	});
+
+	test('accepts numeric slug', () => {
+		expect(validateSlug('123')).toBeNull();
+	});
+
+	test('accepts alphanumeric with hyphens', () => {
+		expect(validateSlug('my-project-2')).toBeNull();
+	});
+
+	test('rejects empty slug', () => {
+		expect(validateSlug('')).not.toBeNull();
+	});
+
+	test('rejects slug with uppercase', () => {
+		expect(validateSlug('MyProject')).not.toBeNull();
+	});
+
+	test('rejects slug starting with hyphen', () => {
+		expect(validateSlug('-my-project')).not.toBeNull();
+	});
+
+	test('rejects slug ending with hyphen', () => {
+		expect(validateSlug('my-project-')).not.toBeNull();
+	});
+
+	test('rejects slug with consecutive hyphens', () => {
+		expect(validateSlug('my--project')).not.toBeNull();
+	});
+
+	test('rejects slug with spaces', () => {
+		expect(validateSlug('my project')).not.toBeNull();
+	});
+
+	test('rejects slug with special characters', () => {
+		expect(validateSlug('my@project')).not.toBeNull();
+	});
+
+	test('rejects slug exceeding max length', () => {
+		const longSlug = 'a'.repeat(61);
+		expect(validateSlug(longSlug)).not.toBeNull();
+	});
+
+	test('accepts slug at max length', () => {
+		const maxSlug = 'a'.repeat(60);
+		expect(validateSlug(maxSlug)).toBeNull();
+	});
+});

--- a/packages/daemon/tests/unit/space/space-agent-autonomy.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-autonomy.test.ts
@@ -52,9 +52,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -47,9 +47,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(

--- a/packages/daemon/tests/unit/space/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-completion.test.ts
@@ -77,9 +77,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, role: string): void {

--- a/packages/daemon/tests/unit/space/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-edge-cases.test.ts
@@ -100,9 +100,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/ws'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function setSpaceTaskTimeoutMs(db: BunDatabase, spaceId: string, timeoutMs: number): void {

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -82,9 +82,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function setSpaceTaskTimeoutMs(db: BunDatabase, spaceId: string, timeoutMs: number): void {

--- a/packages/daemon/tests/unit/space/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-service.test.ts
@@ -42,6 +42,7 @@ const NOW = Date.now();
 
 const mockSpace: Space = {
 	id: 'space-1',
+	slug: 'test-space',
 	workspacePath: '/tmp/test-workspace',
 	name: 'Test Space',
 	description: '',

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -49,9 +49,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(

--- a/packages/daemon/tests/unit/space/space-slug.test.ts
+++ b/packages/daemon/tests/unit/space/space-slug.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect, beforeEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
-import { runMigration61 } from '../../../src/storage/schema/migrations';
+import { runMigration63 } from '../../../src/storage/schema/migrations';
 import { slugify } from '../../../src/lib/space/slug';
 
 /**
@@ -201,7 +201,7 @@ describe('Migration 61 — slug backfill', () => {
 		).run('s2', '/tmp/ws-2', 'My Project', now, now);
 
 		// Run migration
-		runMigration61(db);
+		runMigration63(db);
 
 		// Verify slugs were backfilled
 		const rows = db.prepare('SELECT id, slug FROM spaces ORDER BY id').all() as Array<{
@@ -245,7 +245,7 @@ describe('Migration 61 — slug backfill', () => {
 		).run('s2', '/tmp/ws-2', 'My Project', now, now);
 
 		// Run migration
-		runMigration61(db);
+		runMigration63(db);
 
 		// Verify collision was resolved
 		const rows = db.prepare('SELECT id, slug FROM spaces ORDER BY id').all() as Array<{
@@ -279,7 +279,7 @@ describe('Migration 61 — slug backfill', () => {
 			)
 		`);
 
-		runMigration61(db);
+		runMigration63(db);
 
 		// Verify slug column has NOT NULL constraint
 		const tableInfo = db.prepare('PRAGMA table_info(spaces)').all() as Array<{
@@ -321,7 +321,7 @@ describe('Migration 61 — slug backfill', () => {
 		`);
 
 		// Run twice — should not throw
-		runMigration61(db);
-		runMigration61(db);
+		runMigration63(db);
+		runMigration63(db);
 	});
 });

--- a/packages/daemon/tests/unit/space/space-slug.test.ts
+++ b/packages/daemon/tests/unit/space/space-slug.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Space Slug Integration Tests
+ *
+ * Tests slug auto-generation, uniqueness, editable slug update,
+ * lookup by slug, and migration backfill behavior.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { runMigration61 } from '../../../src/storage/schema/migrations';
+import { slugify } from '../../../src/lib/space/slug';
+
+/**
+ * Create an in-memory database with the spaces table schema.
+ * We create a minimal schema matching what SpaceRepository expects.
+ */
+function createTestDb(): InstanceType<typeof Database> {
+	const db = new Database(':memory:');
+	db.exec(`
+		CREATE TABLE spaces (
+			id TEXT PRIMARY KEY,
+			workspace_path TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			background_context TEXT NOT NULL DEFAULT '',
+			instructions TEXT NOT NULL DEFAULT '',
+			default_model TEXT,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			session_ids TEXT NOT NULL DEFAULT '[]',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'archived')),
+			autonomy_level TEXT DEFAULT 'supervised',
+			config TEXT,
+			slug TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
+	return db;
+}
+
+describe('SpaceRepository — slug operations', () => {
+	let db: InstanceType<typeof Database>;
+	let repo: SpaceRepository;
+
+	beforeEach(() => {
+		db = createTestDb();
+		repo = new SpaceRepository(db);
+	});
+
+	test('createSpace stores slug', () => {
+		const space = repo.createSpace({
+			workspacePath: '/tmp/test-ws',
+			name: 'My Project',
+			slug: 'my-project',
+		});
+
+		expect(space.slug).toBe('my-project');
+	});
+
+	test('getSpace returns slug', () => {
+		const created = repo.createSpace({
+			workspacePath: '/tmp/test-ws',
+			name: 'My Project',
+			slug: 'my-project',
+		});
+
+		const fetched = repo.getSpace(created.id);
+		expect(fetched).not.toBeNull();
+		expect(fetched!.slug).toBe('my-project');
+	});
+
+	test('getSpaceBySlug finds space by slug', () => {
+		repo.createSpace({
+			workspacePath: '/tmp/test-ws',
+			name: 'My Project',
+			slug: 'my-project',
+		});
+
+		const found = repo.getSpaceBySlug('my-project');
+		expect(found).not.toBeNull();
+		expect(found!.name).toBe('My Project');
+	});
+
+	test('getSpaceBySlug returns null for unknown slug', () => {
+		expect(repo.getSpaceBySlug('nonexistent')).toBeNull();
+	});
+
+	test('updateSlug changes the slug', () => {
+		const space = repo.createSpace({
+			workspacePath: '/tmp/test-ws',
+			name: 'My Project',
+			slug: 'my-project',
+		});
+
+		const updated = repo.updateSlug(space.id, 'new-slug');
+		expect(updated).not.toBeNull();
+		expect(updated!.slug).toBe('new-slug');
+	});
+
+	test('updateSlug enforces uniqueness', () => {
+		repo.createSpace({
+			workspacePath: '/tmp/ws-1',
+			name: 'Space One',
+			slug: 'space-one',
+		});
+		const space2 = repo.createSpace({
+			workspacePath: '/tmp/ws-2',
+			name: 'Space Two',
+			slug: 'space-two',
+		});
+
+		// Trying to set space2's slug to space1's slug should fail due to UNIQUE index
+		expect(() => repo.updateSlug(space2.id, 'space-one')).toThrow();
+	});
+
+	test('getAllSlugs returns all slugs', () => {
+		repo.createSpace({
+			workspacePath: '/tmp/ws-1',
+			name: 'Space One',
+			slug: 'space-one',
+		});
+		repo.createSpace({
+			workspacePath: '/tmp/ws-2',
+			name: 'Space Two',
+			slug: 'space-two',
+		});
+
+		const slugs = repo.getAllSlugs();
+		expect(slugs).toContain('space-one');
+		expect(slugs).toContain('space-two');
+		expect(slugs).toHaveLength(2);
+	});
+
+	test('listSpaces includes slug in results', () => {
+		repo.createSpace({
+			workspacePath: '/tmp/ws-1',
+			name: 'First',
+			slug: 'first',
+		});
+		repo.createSpace({
+			workspacePath: '/tmp/ws-2',
+			name: 'Second',
+			slug: 'second',
+		});
+
+		const spaces = repo.listSpaces();
+		expect(spaces).toHaveLength(2);
+		expect(spaces.every((s) => s.slug.length > 0)).toBe(true);
+	});
+});
+
+describe('slugify — collision handling with repository', () => {
+	test('generates unique slugs for spaces with same name', () => {
+		const existing = ['my-project'];
+		const slug1 = slugify('My Project', existing);
+		expect(slug1).toBe('my-project-2');
+
+		existing.push(slug1);
+		const slug2 = slugify('My Project', existing);
+		expect(slug2).toBe('my-project-3');
+	});
+
+	test('generates unique slug when existing list is empty', () => {
+		expect(slugify('My Project', [])).toBe('my-project');
+	});
+});
+
+describe('Migration 61 — slug backfill', () => {
+	test('adds slug column and backfills existing spaces', () => {
+		// Create a DB without the slug column (pre-migration state)
+		const db = new Database(':memory:');
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				autonomy_level TEXT DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		// Insert some spaces without slugs
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('s1', '/tmp/ws-1', 'NeoKai Dev', now, now);
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('s2', '/tmp/ws-2', 'My Project', now, now);
+
+		// Run migration
+		runMigration61(db);
+
+		// Verify slugs were backfilled
+		const rows = db.prepare('SELECT id, slug FROM spaces ORDER BY id').all() as Array<{
+			id: string;
+			slug: string;
+		}>;
+
+		expect(rows).toHaveLength(2);
+		expect(rows[0].slug).toBe('neokai-dev');
+		expect(rows[1].slug).toBe('my-project');
+	});
+
+	test('handles collision during backfill', () => {
+		const db = new Database(':memory:');
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				autonomy_level TEXT DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		// Insert spaces with the same name
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('s1', '/tmp/ws-1', 'My Project', now, now);
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('s2', '/tmp/ws-2', 'My Project', now, now);
+
+		// Run migration
+		runMigration61(db);
+
+		// Verify collision was resolved
+		const rows = db.prepare('SELECT id, slug FROM spaces ORDER BY id').all() as Array<{
+			id: string;
+			slug: string;
+		}>;
+
+		expect(rows).toHaveLength(2);
+		expect(rows[0].slug).toBe('my-project');
+		expect(rows[1].slug).toBe('my-project-2');
+	});
+
+	test('is idempotent — running twice does not error', () => {
+		const db = new Database(':memory:');
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				autonomy_level TEXT DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		// Run twice — should not throw
+		runMigration61(db);
+		runMigration61(db);
+	});
+});

--- a/packages/daemon/tests/unit/space/space-slug.test.ts
+++ b/packages/daemon/tests/unit/space/space-slug.test.ts
@@ -258,6 +258,47 @@ describe('Migration 61 — slug backfill', () => {
 		expect(rows[1].slug).toBe('my-project-2');
 	});
 
+	test('enforces NOT NULL constraint on slug after migration', () => {
+		const db = new Database(':memory:');
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				autonomy_level TEXT DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		runMigration61(db);
+
+		// Verify slug column has NOT NULL constraint
+		const tableInfo = db.prepare('PRAGMA table_info(spaces)').all() as Array<{
+			name: string;
+			notnull: number;
+		}>;
+		const slugCol = tableInfo.find((col) => col.name === 'slug');
+		expect(slugCol).toBeDefined();
+		expect(slugCol!.notnull).toBe(1);
+
+		// Verify inserting a NULL slug throws
+		const now = Date.now();
+		expect(() => {
+			db.prepare(
+				`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+			).run('s-null', '/tmp/ws-null', 'Null Slug', now, now);
+		}).toThrow();
+	});
+
 	test('is idempotent — running twice does not error', () => {
 		const db = new Database(':memory:');
 		db.exec(`

--- a/packages/daemon/tests/unit/space/space-task-findByGoalId.test.ts
+++ b/packages/daemon/tests/unit/space/space-task-findByGoalId.test.ts
@@ -33,9 +33,9 @@ const SPACE_ID = 'space-1';
 function seedSpace(db: BunDatabase): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(SPACE_ID, '/tmp/ws', 'Test Space', Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(SPACE_ID, '/tmp/ws', 'Test Space', SPACE_ID, Date.now(), Date.now());
 }
 
 // ---------------------------------------------------------------------------
@@ -224,9 +224,9 @@ describe('SpaceTaskRepository.findByGoalId', () => {
 		const space2 = 'space-2';
 		db.prepare(
 			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-       allowed_models, session_ids, status, created_at, updated_at)
-       VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-		).run(space2, '/tmp/ws2', 'Space 2', Date.now(), Date.now());
+       allowed_models, session_ids, slug, status, created_at, updated_at)
+       VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+		).run(space2, '/tmp/ws2', 'Space 2', space2, Date.now(), Date.now());
 
 		repo.createTask({
 			spaceId: SPACE_ID,

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -42,9 +42,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId = 'space-1'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgent(db: BunDatabase, agentId: string, spaceId: string, name: string): void {

--- a/packages/daemon/tests/unit/space/task-agent-collaboration.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-collaboration.test.ts
@@ -67,9 +67,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(

--- a/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
@@ -122,9 +122,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -184,6 +184,7 @@ function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
 function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {
 	return {
 		id: spaceId,
+		slug: `space-${spaceId}`,
 		workspacePath,
 		name: `Space ${spaceId}`,
 		description: '',

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -168,9 +168,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -113,9 +113,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgentRow(

--- a/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
@@ -52,9 +52,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId: string, workspacePath = '/tmp/ws'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgent(

--- a/packages/daemon/tests/unit/space/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor.test.ts
@@ -41,9 +41,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId = 'space-1', workspacePath = '/tmp/ws-1'): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function seedAgent(db: BunDatabase, agentId: string, spaceId: string, name: string): void {

--- a/packages/daemon/tests/unit/space/workflow-run-status-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-run-status-lifecycle.test.ts
@@ -67,9 +67,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 function seedSpace(db: BunDatabase, spaceId: string): void {
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, status, created_at, updated_at)
-     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
-	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
 function createWorkflowAndRun(db: BunDatabase, spaceId: string): { runId: string } {

--- a/packages/daemon/tests/unit/storage/gate-data-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/gate-data-repository.test.ts
@@ -30,7 +30,7 @@ function freshDb(): Database {
 	// Insert required parent rows for FK constraints
 	const now = Date.now();
 	d.exec(
-		`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES ('sp1', '/tmp/test', 'Test Space', ${now}, ${now})`
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES ('sp1', 'sp1', '/tmp/test', 'Test Space', ${now}, ${now})`
 	);
 	d.exec(
 		`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES ('wf1', 'sp1', 'Test Workflow', ${now}, ${now})`

--- a/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
@@ -155,8 +155,8 @@ describe('Migration 29: Space system tables', () => {
 		// role accepts any string — no fixed enum
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-role', '/workspace/role', 'Role Space', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-role', 'role-space', '/workspace/role', 'Role Space', ${now}, ${now})`
 		);
 		for (const role of ['custom-role', 'admin', 'leader', 'any-string']) {
 			expect(() => {
@@ -179,8 +179,8 @@ describe('Migration 29: Space system tables', () => {
 		const now = Date.now();
 		// Insert a space first
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('s-1', '/workspace/a', 'Space A', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('s-1', 'space-a', '/workspace/a', 'Space A', ${now}, ${now})`
 		);
 		db.exec(
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
@@ -248,8 +248,8 @@ describe('Migration 29: Space system tables', () => {
 
 		// Insert a space
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-1', '/workspace/cascade', 'Cascade Space', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-1', 'cascade-space', '/workspace/cascade', 'Cascade Space', ${now}, ${now})`
 		);
 
 		// Insert a space agent
@@ -311,8 +311,8 @@ describe('Migration 29: Space system tables', () => {
 		const now = Date.now();
 
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-2', '/workspace/setnull', 'SetNull Space', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-2', 'setnull-space', '/workspace/setnull', 'SetNull Space', ${now}, ${now})`
 		);
 		db.exec(
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
@@ -348,8 +348,8 @@ describe('Migration 29: Space system tables', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-3', '/workspace/checks', 'Check Space', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-3', 'check-space', '/workspace/checks', 'Check Space', ${now}, ${now})`
 		);
 
 		// Valid status values
@@ -386,8 +386,8 @@ describe('Migration 29: Space system tables', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-4', '/workspace/priority', 'Priority Space', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-4', 'priority-space', '/workspace/priority', 'Priority Space', ${now}, ${now})`
 		);
 
 		expect(() => {
@@ -417,14 +417,14 @@ describe('Migration 29: Space system tables', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-u1', '/workspace/unique', 'Space U1', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-u1', 'space-u1', '/workspace/unique', 'Space U1', ${now}, ${now})`
 		);
 
 		expect(() => {
 			db.exec(
-				`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-				 VALUES ('sp-u2', '/workspace/unique', 'Space U2', ${now}, ${now})`
+				`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+				 VALUES ('sp-u2', 'space-u2', '/workspace/unique', 'Space U2', ${now}, ${now})`
 			);
 		}).toThrow();
 	});
@@ -439,8 +439,8 @@ describe('Migration 29: Space system tables', () => {
 		const now = Date.now();
 
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-step', '/workspace/stepnull', 'StepNull Space', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-step', 'stepnull-space', '/workspace/stepnull', 'StepNull Space', ${now}, ${now})`
 		);
 		db.exec(
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)

--- a/packages/daemon/tests/unit/storage/migrations/migration-30_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-30_test.ts
@@ -70,8 +70,8 @@ describe('Migration 30: layout column on space_workflows', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-1', '/workspace/m30a', 'Space A', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-1', 'm30a', '/workspace/m30a', 'Space A', ${now}, ${now})`
 		);
 		db.exec(
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
@@ -89,8 +89,8 @@ describe('Migration 30: layout column on space_workflows', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-2', '/workspace/m30b', 'Space B', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-2', 'm30b', '/workspace/m30b', 'Space B', ${now}, ${now})`
 		);
 		const layoutJson = JSON.stringify({
 			'step-1': { x: 100, y: 200 },

--- a/packages/daemon/tests/unit/storage/migrations/migration-33_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-33_test.ts
@@ -81,8 +81,8 @@ describe('Migration 33: Add inject_workflow_context to space_agents', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace/project', 'Test Space', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test-space', '/workspace/project', 'Test Space', now, now);
 		db.prepare(
 			`INSERT INTO space_agents (id, space_id, name, role, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 		).run('agent-1', 'space-1', 'Coder', 'coder', now, now);
@@ -98,8 +98,8 @@ describe('Migration 33: Add inject_workflow_context to space_agents', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace/project', 'Test Space', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test-space', '/workspace/project', 'Test Space', now, now);
 		db.prepare(
 			`INSERT INTO space_agents (id, space_id, name, role, inject_workflow_context, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
 		).run('agent-1', 'space-1', 'Planner', 'planner', 1, now, now);
@@ -231,8 +231,8 @@ describe('Migration 33: Add inject_workflow_context to space_agents', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace', 'S', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 's', '/workspace', 'S', now, now);
 		db.prepare(
 			`INSERT INTO space_agents (id, space_id, name, role, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 		).run('agent-1', 'space-1', 'Coder', 'coder', now, now);

--- a/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
@@ -120,9 +120,9 @@ describe('Migration 34: Add archived to status CHECK constraints', () => {
 		const now = Date.now();
 		// Create a space first (FK requirement)
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace', 'Test Space', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test-space', '/workspace', 'Test Space', now, now);
 
 		expect(() => {
 			db.prepare(

--- a/packages/daemon/tests/unit/storage/migrations/migration-35-36_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-35-36_test.ts
@@ -89,8 +89,8 @@ describe('Migration 35: Add iteration tracking to space_workflow_runs', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace/project', 'Test Space', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test-space', '/workspace/project', 'Test Space', now, now);
 		db.prepare(
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
 		).run('wf-1', 'space-1', 'Test Workflow', now, now);
@@ -223,8 +223,8 @@ describe('Migration 36: Add max_iterations to space_workflows', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace/project', 'Test Space', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test-space', '/workspace/project', 'Test Space', now, now);
 		db.prepare(
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
 		).run('wf-1', 'space-1', 'Test Workflow', now, now);
@@ -240,8 +240,8 @@ describe('Migration 36: Add max_iterations to space_workflows', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace/project', 'Test Space', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test-space', '/workspace/project', 'Test Space', now, now);
 		db.prepare(
 			`INSERT INTO space_workflows (id, space_id, name, max_iterations, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 		).run('wf-1', 'space-1', 'Cyclic Workflow', 3, now, now);

--- a/packages/daemon/tests/unit/storage/migrations/migration-53_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-53_test.ts
@@ -96,8 +96,8 @@ describe('Migration 53: channels column on space_workflows', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-no-ch', '/workspace/m53a', 'Space A', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-no-ch', 'm53a', '/workspace/m53a', 'Space A', ${now}, ${now})`
 		);
 		db.exec(
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
@@ -115,8 +115,8 @@ describe('Migration 53: channels column on space_workflows', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-rt', '/workspace/m53b', 'Space B', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-rt', 'm53b', '/workspace/m53b', 'Space B', ${now}, ${now})`
 		);
 
 		const repo = new SpaceWorkflowRepository(db);
@@ -163,8 +163,8 @@ describe('Migration 53: channels column on space_workflows', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-cfg', '/workspace/m53c', 'Space C', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-cfg', 'm53c', '/workspace/m53c', 'Space C', ${now}, ${now})`
 		);
 
 		const repo = new SpaceWorkflowRepository(db);
@@ -186,8 +186,8 @@ describe('Migration 53: channels column on space_workflows', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-upd', '/workspace/m53d', 'Space D', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-upd', 'm53d', '/workspace/m53d', 'Space D', ${now}, ${now})`
 		);
 
 		const repo = new SpaceWorkflowRepository(db);
@@ -214,8 +214,8 @@ describe('Migration 53: channels column on space_workflows', () => {
 
 		const now = Date.now();
 		db.exec(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
-			 VALUES ('sp-clr', '/workspace/m53e', 'Space E', ${now}, ${now})`
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-clr', 'm53e', '/workspace/m53e', 'Space E', ${now}, ${now})`
 		);
 
 		const repo = new SpaceWorkflowRepository(db);

--- a/packages/daemon/tests/unit/storage/migrations/migration-spaces-autonomy-level_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-spaces-autonomy-level_test.ts
@@ -82,8 +82,8 @@ describe('Migration 33: Add autonomy_level to spaces', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace/project', 'Test Space', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test-space', '/workspace/project', 'Test Space', now, now);
 
 		const row = db.prepare(`SELECT autonomy_level FROM spaces WHERE id = 'space-1'`).get() as {
 			autonomy_level: string;
@@ -96,8 +96,8 @@ describe('Migration 33: Add autonomy_level to spaces', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, autonomy_level, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace/project', 'Test Space', 'semi_autonomous', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, autonomy_level, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test-space', '/workspace/project', 'Test Space', 'semi_autonomous', now, now);
 
 		const row = db.prepare(`SELECT autonomy_level FROM spaces WHERE id = 'space-1'`).get() as {
 			autonomy_level: string;
@@ -191,8 +191,8 @@ describe('Migration 33: Add autonomy_level to spaces', () => {
 
 		const now = Date.now();
 		db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		).run('space-1', '/workspace/project', 'Test', now, now);
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'test', '/workspace/project', 'Test', now, now);
 
 		runMigrations(db, () => {});
 

--- a/packages/daemon/tests/unit/storage/space-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-repository.test.ts
@@ -25,6 +25,7 @@ describe('SpaceRepository', () => {
 		it('creates a space with required fields', () => {
 			const space = repo.createSpace({
 				workspacePath: '/workspace/project',
+				slug: 'my-project',
 				name: 'My Project',
 			});
 
@@ -45,6 +46,7 @@ describe('SpaceRepository', () => {
 		it('creates a space with all optional fields', () => {
 			const space = repo.createSpace({
 				workspacePath: '/workspace/project',
+				slug: 'my-project',
 				name: 'My Project',
 				description: 'A description',
 				backgroundContext: 'Some context',
@@ -65,21 +67,21 @@ describe('SpaceRepository', () => {
 		});
 
 		it("defaults autonomyLevel to 'supervised' when not specified", () => {
-			const space = repo.createSpace({ workspacePath: '/workspace/project', name: 'P' });
+			const space = repo.createSpace({ workspacePath: '/workspace/project', slug: 'p', name: 'P' });
 			expect(space.autonomyLevel).toBe('supervised');
 		});
 
 		it('enforces unique workspace_path', () => {
-			repo.createSpace({ workspacePath: '/workspace/project', name: 'A' });
+			repo.createSpace({ workspacePath: '/workspace/project', slug: 'project-a', name: 'A' });
 			expect(() => {
-				repo.createSpace({ workspacePath: '/workspace/project', name: 'B' });
+				repo.createSpace({ workspacePath: '/workspace/project', slug: 'project-b', name: 'B' });
 			}).toThrow();
 		});
 	});
 
 	describe('getSpace', () => {
 		it('returns space by ID', () => {
-			const created = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const created = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 			const found = repo.getSpace(created.id);
 			expect(found).not.toBeNull();
 			expect(found!.id).toBe(created.id);
@@ -92,7 +94,7 @@ describe('SpaceRepository', () => {
 
 	describe('getSpaceByPath', () => {
 		it('returns space by workspace path', () => {
-			const created = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const created = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 			const found = repo.getSpaceByPath('/workspace/a');
 			expect(found).not.toBeNull();
 			expect(found!.id).toBe(created.id);
@@ -105,8 +107,8 @@ describe('SpaceRepository', () => {
 
 	describe('listSpaces', () => {
 		it('lists active spaces by default', () => {
-			repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
-			const b = repo.createSpace({ workspacePath: '/workspace/b', name: 'B' });
+			repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
+			const b = repo.createSpace({ workspacePath: '/workspace/b', slug: 'b', name: 'B' });
 			repo.archiveSpace(b.id);
 
 			const spaces = repo.listSpaces();
@@ -115,8 +117,8 @@ describe('SpaceRepository', () => {
 		});
 
 		it('includes archived spaces when requested', () => {
-			repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
-			const b = repo.createSpace({ workspacePath: '/workspace/b', name: 'B' });
+			repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
+			const b = repo.createSpace({ workspacePath: '/workspace/b', slug: 'b', name: 'B' });
 			repo.archiveSpace(b.id);
 
 			const spaces = repo.listSpaces(true);
@@ -126,7 +128,7 @@ describe('SpaceRepository', () => {
 
 	describe('updateSpace', () => {
 		it('updates name and description', () => {
-			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const space = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 			const updated = repo.updateSpace(space.id, { name: 'A Updated', description: 'New desc' });
 
 			expect(updated).not.toBeNull();
@@ -137,6 +139,7 @@ describe('SpaceRepository', () => {
 		it('clears defaultModel when set to null', () => {
 			const space = repo.createSpace({
 				workspacePath: '/workspace/a',
+				slug: 'a',
 				name: 'A',
 				defaultModel: 'claude-opus',
 			});
@@ -145,7 +148,7 @@ describe('SpaceRepository', () => {
 		});
 
 		it("updates autonomyLevel to 'semi_autonomous'", () => {
-			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const space = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 			expect(space.autonomyLevel).toBe('supervised');
 
 			const updated = repo.updateSpace(space.id, { autonomyLevel: 'semi_autonomous' });
@@ -155,6 +158,7 @@ describe('SpaceRepository', () => {
 		it("updates autonomyLevel back to 'supervised'", () => {
 			const space = repo.createSpace({
 				workspacePath: '/workspace/a',
+				slug: 'a',
 				name: 'A',
 				autonomyLevel: 'semi_autonomous',
 			});
@@ -163,7 +167,7 @@ describe('SpaceRepository', () => {
 		});
 
 		it('updates typed config fields', () => {
-			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const space = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 			const updated = repo.updateSpace(space.id, {
 				config: { maxConcurrentTasks: 5, taskTimeoutMs: 30000 },
 			});
@@ -177,7 +181,7 @@ describe('SpaceRepository', () => {
 
 	describe('archiveSpace', () => {
 		it('sets status to archived', () => {
-			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const space = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 			const archived = repo.archiveSpace(space.id);
 			expect(archived!.status).toBe('archived');
 		});
@@ -185,7 +189,7 @@ describe('SpaceRepository', () => {
 
 	describe('addSessionToSpace / removeSessionFromSpace', () => {
 		it('adds and removes sessions idempotently', () => {
-			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const space = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 
 			// Add
 			const withSession = repo.addSessionToSpace(space.id, 'session-1');
@@ -212,7 +216,7 @@ describe('SpaceRepository', () => {
 
 	describe('deleteSpace', () => {
 		it('deletes a space', () => {
-			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const space = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 			expect(repo.deleteSpace(space.id)).toBe(true);
 			expect(repo.getSpace(space.id)).toBeNull();
 		});

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -23,7 +23,11 @@ describe('SpaceTaskRepository', () => {
 		spaceRepo = new SpaceRepository(db as any);
 		repo = new SpaceTaskRepository(db as any);
 
-		const space = spaceRepo.createSpace({ workspacePath: '/workspace/test', name: 'Test' });
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/test',
+			slug: 'test',
+			name: 'Test',
+		});
 		spaceId = space.id;
 
 		// Set up workflow records for FK-constrained fields

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -488,6 +488,7 @@ describe('SpaceTaskRepository', () => {
 		it('scopes taskNumber per space (two spaces get independent sequences)', () => {
 			const space2 = spaceRepo.createSpace({
 				workspacePath: '/workspace/test2',
+				slug: 'space-2',
 				name: 'Space 2',
 			});
 
@@ -569,6 +570,7 @@ describe('SpaceTaskRepository', () => {
 
 			const space2 = spaceRepo.createSpace({
 				workspacePath: '/workspace/test3',
+				slug: 'space-3',
 				name: 'Space 3',
 			});
 			expect(repo.getTaskByNumber(space2.id, 1)).toBeNull();

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -21,7 +21,11 @@ describe('SpaceWorkflowRunRepository', () => {
 		spaceRepo = new SpaceRepository(db as any);
 		repo = new SpaceWorkflowRunRepository(db as any);
 
-		const space = spaceRepo.createSpace({ workspacePath: '/workspace/test', name: 'Test' });
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/test',
+			slug: 'test',
+			name: 'Test',
+		});
 		spaceId = space.id;
 
 		// Insert a dummy workflow row to satisfy the FK

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -43,6 +43,8 @@ export interface SpaceConfig {
 export interface Space {
 	/** Unique identifier */
 	id: string;
+	/** URL-safe, human-readable identifier (unique, auto-generated from name) */
+	slug: string;
 	/** Absolute path to the workspace this Space operates on (required, unique) */
 	workspacePath: string;
 	/** Human-readable name */

--- a/packages/web/src/lib/__tests__/router-space-slug.test.ts
+++ b/packages/web/src/lib/__tests__/router-space-slug.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Router Space Slug Tests
+ *
+ * Verifies that space route patterns accept both UUIDs and slugs.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+	getSpaceIdFromPath,
+	getSpaceSessionIdFromPath,
+	getSpaceTaskIdFromPath,
+	createSpacePath,
+	createSpaceSessionPath,
+	createSpaceTaskPath,
+} from '../router';
+
+describe('getSpaceIdFromPath — slug support', () => {
+	test('matches UUID-based space route', () => {
+		expect(getSpaceIdFromPath('/space/04062505-780f-4881-a3be-9cb9062790fb')).toBe(
+			'04062505-780f-4881-a3be-9cb9062790fb'
+		);
+	});
+
+	test('matches slug-based space route', () => {
+		expect(getSpaceIdFromPath('/space/neokai-dev')).toBe('neokai-dev');
+	});
+
+	test('matches single word slug', () => {
+		expect(getSpaceIdFromPath('/space/myproject')).toBe('myproject');
+	});
+
+	test('matches slug with numbers', () => {
+		expect(getSpaceIdFromPath('/space/project-42')).toBe('project-42');
+	});
+
+	test('does not match invalid paths', () => {
+		expect(getSpaceIdFromPath('/space/')).toBeNull();
+		expect(getSpaceIdFromPath('/spaces')).toBeNull();
+		expect(getSpaceIdFromPath('/')).toBeNull();
+	});
+
+	test('does not match slug with uppercase (slugs are lowercase)', () => {
+		// Uppercase letters are not valid in slugs
+		expect(getSpaceIdFromPath('/space/MyProject')).toBeNull();
+	});
+});
+
+describe('getSpaceSessionIdFromPath — slug support', () => {
+	test('matches slug-based space session route', () => {
+		const result = getSpaceSessionIdFromPath(
+			'/space/neokai-dev/session/04062505-780f-4881-a3be-9cb9062790fb'
+		);
+		expect(result).toEqual({
+			spaceId: 'neokai-dev',
+			sessionId: '04062505-780f-4881-a3be-9cb9062790fb',
+		});
+	});
+
+	test('matches UUID-based space session route', () => {
+		const result = getSpaceSessionIdFromPath(
+			'/space/04062505-780f-4881-a3be-9cb9062790fb/session/14062505-780f-4881-a3be-9cb9062790fb'
+		);
+		expect(result).toEqual({
+			spaceId: '04062505-780f-4881-a3be-9cb9062790fb',
+			sessionId: '14062505-780f-4881-a3be-9cb9062790fb',
+		});
+	});
+});
+
+describe('getSpaceTaskIdFromPath — slug support', () => {
+	test('matches slug-based space task route with UUID task', () => {
+		const result = getSpaceTaskIdFromPath(
+			'/space/neokai-dev/task/04062505-780f-4881-a3be-9cb9062790fb'
+		);
+		expect(result).toEqual({
+			spaceId: 'neokai-dev',
+			taskId: '04062505-780f-4881-a3be-9cb9062790fb',
+		});
+	});
+
+	test('matches slug-based space task route with short ID', () => {
+		const result = getSpaceTaskIdFromPath('/space/neokai-dev/task/t-42');
+		expect(result).toEqual({
+			spaceId: 'neokai-dev',
+			taskId: 't-42',
+		});
+	});
+});
+
+describe('createSpacePath — works with slugs', () => {
+	test('creates path with slug', () => {
+		expect(createSpacePath('neokai-dev')).toBe('/space/neokai-dev');
+	});
+
+	test('creates path with UUID', () => {
+		expect(createSpacePath('04062505-780f-4881-a3be-9cb9062790fb')).toBe(
+			'/space/04062505-780f-4881-a3be-9cb9062790fb'
+		);
+	});
+});
+
+describe('createSpaceSessionPath — works with slugs', () => {
+	test('creates path with slug', () => {
+		expect(createSpaceSessionPath('neokai-dev', 'sess-123')).toBe(
+			'/space/neokai-dev/session/sess-123'
+		);
+	});
+});
+
+describe('createSpaceTaskPath — works with slugs', () => {
+	test('creates path with slug', () => {
+		expect(createSpaceTaskPath('neokai-dev', 'task-456')).toBe('/space/neokai-dev/task/task-456');
+	});
+});

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -31,6 +31,7 @@ function fireMockEvent(eventName: string, data: unknown): void {
 function makeSpace(id = 'space-1'): Space {
 	return {
 		id,
+		slug: 'test-space',
 		name: 'Test Space',
 		workspacePath: '/workspace',
 		description: '',
@@ -116,10 +117,11 @@ function makeMockHub() {
 				mockEventHandlerSets.get(eventName)?.delete(handler);
 			};
 		}),
-		request: vi.fn(async (method: string, _params?: unknown) => {
+		request: vi.fn(async (method: string, params?: Record<string, unknown>) => {
 			if (method === 'space.overview') {
+				const spaceId = (params?.id ?? params?.slug ?? 'space-1') as string;
 				return {
-					space: makeSpace(),
+					space: makeSpace(spaceId),
 					tasks: [],
 					workflowRuns: [],
 					sessions: [],
@@ -202,7 +204,8 @@ describe('SpaceStore — space selection', () => {
 
 	it('fetches initial state on selectSpace()', async () => {
 		await spaceStore.selectSpace('space-1');
-		expect(mockHub.request).toHaveBeenCalledWith('space.overview', { id: 'space-1' });
+		// 'space-1' is not a UUID, so the store sends it as a slug
+		expect(mockHub.request).toHaveBeenCalledWith('space.overview', { slug: 'space-1' });
 		expect(spaceStore.space.value?.id).toBe('space-1');
 	});
 
@@ -1043,7 +1046,8 @@ describe('SpaceStore — refresh', () => {
 
 		await spaceStore.refresh();
 
-		expect(mockHub.request).toHaveBeenCalledWith('space.overview', { id: 'space-1' });
+		// 'space-1' is not a UUID, so the store sends it as a slug
+		expect(mockHub.request).toHaveBeenCalledWith('space.overview', { slug: 'space-1' });
 	});
 
 	it('is a no-op for space state when no space is selected', async () => {

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -35,9 +35,10 @@ const INBOX_ROUTE_PATTERN = /^\/inbox$/;
 const SPACES_ROUTE_PATTERN = /^\/spaces$/;
 /** Legacy: /room/:id/chat was removed — treat as plain room route for backwards compat */
 const ROOM_CHAT_COMPAT_PATTERN = /^\/room\/([a-f0-9-]+)\/chat$/;
-const SPACE_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)$/;
-const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
-const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
+/** Space routes accept both UUIDs (a-f0-9-) and slugs (a-z0-9-) */
+const SPACE_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)$/;
+const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/session\/([a-f0-9-]+)$/;
+const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
 
 /**
  * Router state and configuration

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -36,7 +36,7 @@ import type {
 	CreateWorkflowRunParams,
 	UpdateSpaceParams,
 } from '@neokai/shared';
-import { Logger } from '@neokai/shared';
+import { Logger, isUUID } from '@neokai/shared';
 import { connectionManager } from './connection-manager';
 
 const logger = new Logger('kai:web:spacestore');
@@ -348,10 +348,12 @@ class SpaceStore {
 	}
 
 	/**
-	 * Internal selection logic (called within promise chain)
+	 * Internal selection logic (called within promise chain).
+	 * The spaceIdOrSlug parameter can be either a UUID or a slug — both are resolved
+	 * to the canonical UUID during initial state fetch.
 	 */
-	private async doSelect(spaceId: string | null): Promise<void> {
-		if (this.spaceId.value === spaceId) {
+	private async doSelect(spaceIdOrSlug: string | null): Promise<void> {
+		if (this.spaceId.value === spaceIdOrSlug) {
 			return;
 		}
 
@@ -374,14 +376,22 @@ class SpaceStore {
 		this.runtimeState.value = null;
 		this.error.value = null;
 
-		// 3. Update active space
-		this.spaceId.value = spaceId;
+		// 3. Update active space (may be updated to real UUID after fetch)
+		this.spaceId.value = spaceIdOrSlug;
 
 		// 4. Start new subscriptions if space selected
-		if (spaceId) {
+		if (spaceIdOrSlug) {
 			this.loading.value = true;
 			try {
-				await this.startSubscriptions(spaceId);
+				// Resolve slug to UUID via overview fetch, then subscribe with the real UUID
+				const resolvedId = await this.fetchAndResolveSpace(spaceIdOrSlug);
+				if (resolvedId) {
+					// Update spaceId to the canonical UUID if it was a slug
+					if (resolvedId !== spaceIdOrSlug) {
+						this.spaceId.value = resolvedId;
+					}
+					await this.startSubscriptions(resolvedId);
+				}
 			} catch (err) {
 				logger.error('Failed to start space subscriptions:', err);
 				this.error.value = err instanceof Error ? err.message : 'Failed to load space';
@@ -618,36 +628,37 @@ class SpaceStore {
 			}
 		});
 		this.cleanupFunctions.push(unsubWorkflowDeleted);
-
-		// Fetch initial state via RPC
-		await this.fetchInitialState(hub, spaceId);
 	}
 
 	/**
-	 * Fetch initial state via RPC (pure WebSocket)
+	 * Fetch initial state and resolve slug to UUID.
+	 * Returns the resolved space UUID, or null if not found.
 	 */
-	private async fetchInitialState(
-		hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
-		spaceId: string
-	): Promise<void> {
+	private async fetchAndResolveSpace(spaceIdOrSlug: string): Promise<string | null> {
+		const hub = await connectionManager.getHub();
+
 		const overview = await hub.request<{
 			space: Space;
 			tasks: SpaceTask[];
 			workflowRuns: SpaceWorkflowRun[];
 			sessions: string[];
-		}>('space.overview', { id: spaceId });
+		}>('space.overview', isUUID(spaceIdOrSlug) ? { id: spaceIdOrSlug } : { slug: spaceIdOrSlug });
 
 		if (!overview) {
 			this.error.value = 'Space not found';
-			return;
+			return null;
 		}
 
 		this.space.value = overview.space;
 		this.tasks.value = overview.tasks ?? [];
 		this.workflowRuns.value = overview.workflowRuns ?? [];
 
+		const resolvedId = overview.space.id;
+
 		// Fetch agents and workflows in parallel
-		await Promise.all([this.fetchAgents(hub, spaceId), this.fetchWorkflows(hub, spaceId)]);
+		await Promise.all([this.fetchAgents(hub, resolvedId), this.fetchWorkflows(hub, resolvedId)]);
+
+		return resolvedId;
 	}
 
 	/**
@@ -726,8 +737,7 @@ class SpaceStore {
 		if (!spaceId) return;
 
 		try {
-			const hub = await connectionManager.getHub();
-			await this.fetchInitialState(hub, spaceId);
+			await this.fetchAndResolveSpace(spaceId);
 		} catch (err) {
 			logger.error('Failed to refresh space state:', err);
 		}


### PR DESCRIPTION
## Summary

- Add `slug` column to spaces as a unique, human-readable URL identifier (e.g., `/space/neokai-dev`)
- Create `slugify()` utility: lowercase, hyphenated, collision-safe (-2, -3), truncate at 60 chars
- Add `validateSlug()` for format validation on user-editable slugs
- Auto-generate slugs from space name on creation; editable via `space.updateSlug` RPC
- `space.get` and `space.overview` RPCs accept both `{ id }` and `{ slug }` lookups
- Frontend routing updated to match `/space/{slug}` alongside `/space/{uuid}`
- Migration 61 backfills slugs for existing spaces with collision handling
- 128 new test assertions across 3 test files (slugify, integration, routing)

## Test plan

- [x] `slugify()` unit tests: basic conversion, special chars, truncation, collision resolution
- [x] `validateSlug()` tests: valid/invalid format cases, max length
- [x] Migration 61 tests: backfill, collision handling during backfill, idempotency
- [x] SpaceRepository integration: createSpace with slug, getSpaceBySlug, updateSlug, uniqueness enforcement
- [x] Router tests: slug-based `/space/{slug}` pattern matching for all space route variants
- [x] All existing space-store tests updated and passing (72/72)
- [x] All space RPC handler tests passing (33/33)
- [x] Typecheck, lint, format, knip all pass