### PR TITLE
feat: implement separated Channel + Gate types and gate_data store (M1.1)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/agent-message-router.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-message-router.ts
@@ -50,6 +50,13 @@ export interface AgentMessageParams {
 	target: string | string[];
 	/** Message content to deliver. */
 	message: string;
+	/**
+	 * Optional structured data payload attached to the message.
+	 * Included in the delivered message as a JSON appendix when present,
+	 * making it available to the receiving agent for programmatic use
+	 * (e.g. gate writes, task results, structured feedback).
+	 */
+	data?: Record<string, unknown>;
 }
 
 export interface AgentMessageResult {
@@ -91,7 +98,7 @@ export class AgentMessageRouter {
 	 * Returns a structured result — never throws.
 	 */
 	async deliverMessage(params: AgentMessageParams): Promise<AgentMessageResult> {
-		const { fromRole, fromSessionId, target, message } = params;
+		const { fromRole, fromSessionId, target, message, data } = params;
 		const {
 			spaceTaskRepo,
 			workflowNodeId,
@@ -201,7 +208,12 @@ export class AgentMessageRouter {
 				continue;
 			}
 			for (const member of roleSessions) {
-				const prefixedMessage = `[Message from ${fromRole}]: ${message}`;
+				// Include structured data as a JSON appendix when present
+				const dataAppendix =
+					data && Object.keys(data).length > 0
+						? `\n\n<structured-data>\n${JSON.stringify(data, null, 2)}\n</structured-data>`
+						: '';
+				const prefixedMessage = `[Message from ${fromRole}]: ${message}${dataAppendix}`;
 				try {
 					await messageInjector(member.sessionId, prefixedMessage);
 					delivered.push({ role, sessionId: member.sessionId });

--- a/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
@@ -1,0 +1,121 @@
+/**
+ * GateEvaluator — evaluates GateCondition trees against gate data.
+ *
+ * This evaluator works with the new separated Gate/Channel system (M1.1).
+ * It reads gate data from the data store and evaluates the gate's condition
+ * tree to determine whether the gate is open or closed.
+ *
+ * Condition types:
+ *   check — field equality: data[field] === value
+ *   count — numeric threshold: data[field] >= threshold
+ *   all   — composite AND: all sub-conditions must pass (short-circuits on failure)
+ *   any   — composite OR: at least one sub-condition must pass (short-circuits on success)
+ */
+
+import type { Gate, GateCondition } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Result of evaluating a gate condition. */
+export interface GateEvalResult {
+	/** Whether the gate is open (condition passed). */
+	open: boolean;
+	/** Human-readable explanation when the gate is closed. */
+	reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// GateEvaluator
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluates a Gate's condition tree against the current gate data.
+ *
+ * Stateless — all data is passed in. No I/O or side effects.
+ */
+export function evaluateGate(gate: Gate, data: Record<string, unknown>): GateEvalResult {
+	return evaluateCondition(gate.condition, data);
+}
+
+/**
+ * Evaluates a single GateCondition node against the provided data.
+ * Recursive for composite conditions (`all`, `any`).
+ */
+export function evaluateCondition(
+	condition: GateCondition,
+	data: Record<string, unknown>
+): GateEvalResult {
+	switch (condition.type) {
+		case 'check':
+			return evaluateCheck(condition.field, condition.value, data);
+
+		case 'count':
+			return evaluateCount(condition.field, condition.threshold, data);
+
+		case 'all': {
+			for (const sub of condition.conditions) {
+				const result = evaluateCondition(sub, data);
+				if (!result.open) return result;
+			}
+			return { open: true };
+		}
+
+		case 'any': {
+			const reasons: string[] = [];
+			for (const sub of condition.conditions) {
+				const result = evaluateCondition(sub, data);
+				if (result.open) return { open: true };
+				if (result.reason) reasons.push(result.reason);
+			}
+			return {
+				open: false,
+				reason: `None of the conditions passed: [${reasons.join('; ')}]`,
+			};
+		}
+
+		default: {
+			const _exhaustive: never = condition;
+			return {
+				open: false,
+				reason: `Unknown condition type: ${(_exhaustive as GateCondition).type}`,
+			};
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primitive evaluators
+// ---------------------------------------------------------------------------
+
+function evaluateCheck(
+	field: string,
+	expected: unknown,
+	data: Record<string, unknown>
+): GateEvalResult {
+	const actual = data[field];
+	if (actual === expected) {
+		return { open: true };
+	}
+	return {
+		open: false,
+		reason: `Gate check failed: data["${field}"] is ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`,
+	};
+}
+
+function evaluateCount(
+	field: string,
+	threshold: number,
+	data: Record<string, unknown>
+): GateEvalResult {
+	const raw = data[field];
+	const value = typeof raw === 'number' ? raw : 0;
+	if (value >= threshold) {
+		return { open: true };
+	}
+	return {
+		open: false,
+		reason: `Gate count failed: data["${field}"] is ${value}, need >= ${threshold}`,
+	};
+}

--- a/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
@@ -5,6 +5,10 @@
  * It reads gate data from the data store and evaluates the gate's condition
  * tree to determine whether the gate is open or closed.
  *
+ * Since conditions are deserialized from JSON at runtime, the evaluator
+ * includes runtime validation via `validateGateCondition` to catch malformed
+ * objects before they reach the evaluation logic.
+ *
  * Condition types:
  *   check — field equality: data[field] === value
  *   count — numeric threshold: data[field] >= threshold
@@ -27,6 +31,68 @@ export interface GateEvalResult {
 }
 
 // ---------------------------------------------------------------------------
+// Runtime validation
+// ---------------------------------------------------------------------------
+
+const VALID_CONDITION_TYPES = new Set(['check', 'count', 'all', 'any']);
+
+/**
+ * Validates a GateCondition object at runtime.
+ *
+ * Since conditions are deserialized from JSON (SQLite, RPC), they may be
+ * malformed. This function checks structural validity before evaluation.
+ *
+ * @returns Array of human-readable error strings. Empty array = valid.
+ */
+export function validateGateCondition(condition: unknown, path = 'condition'): string[] {
+	const errors: string[] = [];
+
+	if (!condition || typeof condition !== 'object') {
+		errors.push(`${path}: expected an object, got ${typeof condition}`);
+		return errors;
+	}
+
+	const cond = condition as Record<string, unknown>;
+	if (typeof cond.type !== 'string' || !VALID_CONDITION_TYPES.has(cond.type)) {
+		errors.push(
+			`${path}.type: expected one of [check, count, all, any], got ${JSON.stringify(cond.type)}`
+		);
+		return errors;
+	}
+
+	switch (cond.type) {
+		case 'check':
+			if (typeof cond.field !== 'string' || cond.field.length === 0) {
+				errors.push(`${path}.field: expected non-empty string`);
+			}
+			// value can be anything — no validation needed
+			break;
+
+		case 'count':
+			if (typeof cond.field !== 'string' || cond.field.length === 0) {
+				errors.push(`${path}.field: expected non-empty string`);
+			}
+			if (typeof cond.threshold !== 'number') {
+				errors.push(`${path}.threshold: expected number, got ${typeof cond.threshold}`);
+			}
+			break;
+
+		case 'all':
+		case 'any':
+			if (!Array.isArray(cond.conditions)) {
+				errors.push(`${path}.conditions: expected array, got ${typeof cond.conditions}`);
+			} else {
+				for (let i = 0; i < cond.conditions.length; i++) {
+					errors.push(...validateGateCondition(cond.conditions[i], `${path}.conditions[${i}]`));
+				}
+			}
+			break;
+	}
+
+	return errors;
+}
+
+// ---------------------------------------------------------------------------
 // GateEvaluator
 // ---------------------------------------------------------------------------
 
@@ -34,6 +100,8 @@ export interface GateEvalResult {
  * Evaluates a Gate's condition tree against the current gate data.
  *
  * Stateless — all data is passed in. No I/O or side effects.
+ * Callers should validate condition structure with `validateGateCondition`
+ * before calling this function with data from untrusted JSON sources.
  */
 export function evaluateGate(gate: Gate, data: Record<string, unknown>): GateEvalResult {
 	return evaluateCondition(gate.condition, data);
@@ -42,6 +110,9 @@ export function evaluateGate(gate: Gate, data: Record<string, unknown>): GateEva
 /**
  * Evaluates a single GateCondition node against the provided data.
  * Recursive for composite conditions (`all`, `any`).
+ *
+ * If the condition has an unrecognized `type`, returns `{ open: false }`
+ * with a descriptive reason. This handles malformed JSON gracefully at runtime.
  */
 export function evaluateCondition(
 	condition: GateCondition,
@@ -71,15 +142,20 @@ export function evaluateCondition(
 			}
 			return {
 				open: false,
-				reason: `None of the conditions passed: [${reasons.join('; ')}]`,
+				reason:
+					reasons.length > 0
+						? `None of the conditions passed: [${reasons.join('; ')}]`
+						: 'Gate blocked: "any" condition has no sub-conditions to evaluate',
 			};
 		}
 
 		default: {
-			const _exhaustive: never = condition;
+			// Runtime fallback for malformed JSON — condition.type is not in the union.
+			// The `never` assertion is compile-time only; at runtime unknown types land here.
+			const unknownType = (condition as { type: string }).type;
 			return {
 				open: false,
-				reason: `Unknown condition type: ${(_exhaustive as GateCondition).type}`,
+				reason: `Gate blocked: unknown condition type "${unknownType}"`,
 			};
 		}
 	}

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -59,6 +59,17 @@ export const SendMessageSchema = z.object({
 		),
 	/** The message to send to the target(s). */
 	message: z.string().min(1).describe('The message content to send to the target peer(s)'),
+	/**
+	 * Optional structured data payload attached to the message.
+	 * Used for machine-readable data (gate writes, task results, structured feedback)
+	 * alongside the human-readable `message` text.
+	 */
+	data: z
+		.record(z.string(), z.unknown())
+		.describe(
+			'Optional structured data payload (key-value pairs) attached to the message. Used for gate writes, task results, and structured feedback.'
+		)
+		.optional(),
 });
 
 export type SendMessageInput = z.infer<typeof SendMessageSchema>;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -215,7 +215,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		 * available targets if not permitted.
 		 */
 		async send_message(args: SendMessageInput): Promise<ToolResult> {
-			const { target, message } = args;
+			const { target, message, data } = args;
 
 			// --- New path: delegate to AgentMessageRouter when available ---
 			if (agentMessageRouter) {
@@ -224,6 +224,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					fromSessionId: mySessionId,
 					target,
 					message,
+					data,
 				});
 
 				if (!result.success) {
@@ -327,7 +328,12 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					continue;
 				}
 				for (const targetMember of targetSessions) {
-					const prefixedMessage = `[Message from ${myRole}]: ${message}`;
+					// Include structured data as a JSON appendix when present
+					const dataAppendix =
+						data && Object.keys(data).length > 0
+							? `\n\n<structured-data>\n${JSON.stringify(data, null, 2)}\n</structured-data>`
+							: '';
+					const prefixedMessage = `[Message from ${myRole}]: ${message}${dataAppendix}`;
 					try {
 						await messageInjector(targetMember.sessionId, prefixedMessage);
 						delivered.push({ role: targetRole, sessionId: targetMember.sessionId });

--- a/packages/daemon/src/storage/repositories/gate-data-repository.ts
+++ b/packages/daemon/src/storage/repositories/gate-data-repository.ts
@@ -1,0 +1,125 @@
+/**
+ * Gate Data Repository
+ *
+ * Persistence layer for gate runtime data, keyed by `(run_id, gate_id)`.
+ * Gate data is a JSON key-value store that gate conditions evaluate against.
+ * Agents write to gate data via MCP tools; the runtime reads it to decide
+ * whether a gated channel is open.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+/** A single gate data record as returned by the repository. */
+export interface GateDataRecord {
+	runId: string;
+	gateId: string;
+	data: Record<string, unknown>;
+	updatedAt: number;
+}
+
+export class GateDataRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Get gate data for a specific `(run_id, gate_id)` pair.
+	 * Returns null when no data has been written for this gate in this run.
+	 */
+	get(runId: string, gateId: string): GateDataRecord | null {
+		const row = this.db
+			.prepare('SELECT * FROM gate_data WHERE run_id = ? AND gate_id = ?')
+			.get(runId, gateId) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return this.rowToRecord(row);
+	}
+
+	/**
+	 * Get all gate data records for a workflow run.
+	 */
+	listByRun(runId: string): GateDataRecord[] {
+		const rows = this.db
+			.prepare('SELECT * FROM gate_data WHERE run_id = ? ORDER BY gate_id')
+			.all(runId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToRecord(r));
+	}
+
+	/**
+	 * Upsert gate data for a `(run_id, gate_id)` pair.
+	 * Replaces the entire data object — callers must merge before calling.
+	 */
+	set(runId: string, gateId: string, data: Record<string, unknown>): GateDataRecord {
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO gate_data (run_id, gate_id, data, updated_at)
+				 VALUES (?, ?, ?, ?)
+				 ON CONFLICT(run_id, gate_id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at`
+			)
+			.run(runId, gateId, JSON.stringify(data), now);
+
+		return { runId, gateId, data, updatedAt: now };
+	}
+
+	/**
+	 * Merge partial data into an existing gate data record.
+	 * Creates the record with the provided partial data if it does not exist.
+	 */
+	merge(runId: string, gateId: string, partial: Record<string, unknown>): GateDataRecord {
+		const existing = this.get(runId, gateId);
+		const merged = existing ? { ...existing.data, ...partial } : { ...partial };
+		return this.set(runId, gateId, merged);
+	}
+
+	/**
+	 * Delete gate data for a specific `(run_id, gate_id)` pair.
+	 * Returns true if a record was deleted.
+	 */
+	delete(runId: string, gateId: string): boolean {
+		const result = this.db
+			.prepare('DELETE FROM gate_data WHERE run_id = ? AND gate_id = ?')
+			.run(runId, gateId);
+		return result.changes > 0;
+	}
+
+	/**
+	 * Delete all gate data for a workflow run.
+	 * Returns the number of records deleted.
+	 */
+	deleteByRun(runId: string): number {
+		const result = this.db.prepare('DELETE FROM gate_data WHERE run_id = ?').run(runId);
+		return result.changes;
+	}
+
+	/**
+	 * Initialize gate data for all gates in a workflow run.
+	 * Populates each gate's default data. Skips gates that already have data.
+	 */
+	initializeForRun(
+		runId: string,
+		gates: Array<{ id: string; data: Record<string, unknown> }>
+	): void {
+		const stmt = this.db.prepare(
+			`INSERT OR IGNORE INTO gate_data (run_id, gate_id, data, updated_at) VALUES (?, ?, ?, ?)`
+		);
+		const now = Date.now();
+		for (const gate of gates) {
+			stmt.run(runId, gate.id, JSON.stringify(gate.data), now);
+		}
+	}
+
+	/**
+	 * Reset a gate's data to its defaults.
+	 * Used when a cyclic workflow loops back through a gate with `resetOnCycle: true`.
+	 */
+	reset(runId: string, gateId: string, defaultData: Record<string, unknown>): GateDataRecord {
+		return this.set(runId, gateId, defaultData);
+	}
+
+	private rowToRecord(row: Record<string, unknown>): GateDataRecord {
+		return {
+			runId: row.run_id as string,
+			gateId: row.gate_id as string,
+			data: JSON.parse(row.data as string) as Record<string, unknown>,
+			updatedAt: row.updated_at as number,
+		};
+	}
+}

--- a/packages/daemon/src/storage/repositories/gate-data-repository.ts
+++ b/packages/daemon/src/storage/repositories/gate-data-repository.ts
@@ -62,6 +62,11 @@ export class GateDataRepository {
 	/**
 	 * Merge partial data into an existing gate data record.
 	 * Creates the record with the provided partial data if it does not exist.
+	 *
+	 * **Shallow merge only**: top-level keys in `partial` overwrite existing keys.
+	 * Nested objects are replaced wholesale, not merged recursively.
+	 * Example: merging `{ nested: { b: 2 } }` into `{ nested: { a: 1 } }`
+	 * yields `{ nested: { b: 2 } }` — `a` is lost.
 	 */
 	merge(runId: string, gateId: string, partial: Record<string, unknown>): GateDataRecord {
 		const existing = this.get(runId, gateId);

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -22,6 +22,7 @@ import type {
 	WorkflowRuleInput,
 	WorkflowNodeAgent,
 	WorkflowChannel,
+	Gate,
 	CreateSpaceWorkflowParams,
 	UpdateSpaceWorkflowParams,
 } from '@neokai/shared';
@@ -38,6 +39,7 @@ interface WorkflowRow {
 	start_node_id: string | null;
 	config: string | null;
 	channels: string | null;
+	gates: string | null;
 	layout: string | null;
 	max_iterations: number | null;
 	created_at: number;
@@ -113,6 +115,8 @@ function rowToWorkflow(row: WorkflowRow, nodes: WorkflowNode[]): SpaceWorkflow {
 	const layout = parseJson<Record<string, { x: number; y: number }> | null>(row.layout, null);
 	// Read channels from the dedicated column (Migration 53+).
 	const channels = parseJson<WorkflowChannel[] | null>(row.channels, null);
+	// Read gates from the dedicated column (Migration 61+).
+	const gates = parseJson<Gate[] | null>(row.gates, null);
 	return {
 		id: row.id,
 		spaceId: row.space_id,
@@ -123,6 +127,7 @@ function rowToWorkflow(row: WorkflowRow, nodes: WorkflowNode[]): SpaceWorkflow {
 		rules: cfg.rules ?? [],
 		tags: cfg.tags ?? [],
 		channels: channels && channels.length > 0 ? channels : undefined,
+		gates: gates && gates.length > 0 ? gates : undefined,
 		config: cfg.extra,
 		maxIterations: row.max_iterations ?? undefined,
 		layout: layout ?? undefined,
@@ -166,12 +171,13 @@ export class SpaceWorkflowRepository {
 
 		const channelsJson =
 			params.channels && params.channels.length > 0 ? JSON.stringify(params.channels) : null;
+		const gatesJson = params.gates && params.gates.length > 0 ? JSON.stringify(params.gates) : null;
 		const layoutJson = params.layout ? JSON.stringify(params.layout) : null;
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, channels, layout, max_iterations, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, channels, gates, layout, max_iterations, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				workflowId,
@@ -181,6 +187,7 @@ export class SpaceWorkflowRepository {
 				startNodeId,
 				JSON.stringify(cfg),
 				channelsJson,
+				gatesJson,
 				layoutJson,
 				params.maxIterations ?? null,
 				now,
@@ -271,6 +278,11 @@ export class SpaceWorkflowRepository {
 			values.push(
 				params.channels && params.channels.length > 0 ? JSON.stringify(params.channels) : null
 			);
+		}
+
+		if (params.gates !== undefined) {
+			fields.push('gates = ?');
+			values.push(params.gates && params.gates.length > 0 ? JSON.stringify(params.gates) : null);
 		}
 
 		if (params.maxIterations !== undefined) {

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -22,6 +22,7 @@ export interface UpdateWorkflowRunParams {
 	config?: Record<string, unknown>;
 	iterationCount?: number;
 	maxIterations?: number;
+	failureReason?: WorkflowRunFailureReason | null;
 }
 
 export class SpaceWorkflowRunRepository {
@@ -149,6 +150,10 @@ export class SpaceWorkflowRunRepository {
 		if (params.maxIterations !== undefined) {
 			fields.push('max_iterations = ?');
 			values.push(params.maxIterations);
+		}
+		if (params.failureReason !== undefined) {
+			fields.push('failure_reason = ?');
+			values.push(params.failureReason);
 		}
 
 		if (fields.length > 0) {

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -6,7 +6,12 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
-import type { SpaceWorkflowRun, WorkflowRunStatus, CreateWorkflowRunParams } from '@neokai/shared';
+import type {
+	SpaceWorkflowRun,
+	WorkflowRunStatus,
+	CreateWorkflowRunParams,
+	WorkflowRunFailureReason,
+} from '@neokai/shared';
 import type { SQLiteValue } from '../types';
 import { assertValidTransition } from '../../lib/space/runtime/workflow-run-status-machine';
 
@@ -234,6 +239,7 @@ export class SpaceWorkflowRunRepository {
 			iterationCount: (row.iteration_count as number | undefined) ?? 0,
 			maxIterations: (row.max_iterations as number | undefined) ?? 5,
 			goalId: (row.goal_id as string | null) ?? undefined,
+			failureReason: (row.failure_reason as WorkflowRunFailureReason | null) ?? undefined,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
 			completedAt: (row.completed_at as number | null) ?? undefined,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -3875,12 +3875,33 @@ export function runMigration60(db: BunDatabase): void {
  * - `failure_reason` column on `space_workflow_runs`: Enum-like TEXT for run failure reasons.
  */
 function runMigration61(db: BunDatabase): void {
-	const migrated = db
+	// Check all 3 schema additions for idempotency
+	const hasGatesCol = db
 		.prepare(
 			"SELECT COUNT(*) as count FROM pragma_table_info('space_workflows') WHERE name = 'gates'"
 		)
 		.get() as { count: number } | null;
-	if (migrated && migrated.count > 0) return;
+	const hasFailureReasonCol = db
+		.prepare(
+			"SELECT COUNT(*) as count FROM pragma_table_info('space_workflow_runs') WHERE name = 'failure_reason'"
+		)
+		.get() as { count: number } | null;
+	const hasGateDataTable = db
+		.prepare(
+			"SELECT COUNT(*) as count FROM sqlite_master WHERE type = 'table' AND name = 'gate_data'"
+		)
+		.get() as { count: number } | null;
+
+	if (
+		hasGatesCol &&
+		hasGatesCol.count > 0 &&
+		hasFailureReasonCol &&
+		hasFailureReasonCol.count > 0 &&
+		hasGateDataTable &&
+		hasGateDataTable.count > 0
+	) {
+		return;
+	}
 
 	db.exec(`BEGIN TRANSACTION`);
 	try {
@@ -3897,11 +3918,18 @@ function runMigration61(db: BunDatabase): void {
 		`);
 		db.exec(`CREATE INDEX IF NOT EXISTS idx_gate_data_run ON gate_data(run_id)`);
 
-		// 2. Add gates column to space_workflows
-		db.exec(`ALTER TABLE space_workflows ADD COLUMN gates TEXT`);
+		// 2. Add gates column to space_workflows (if not already present)
+		if (!hasGatesCol || hasGatesCol.count === 0) {
+			db.exec(`ALTER TABLE space_workflows ADD COLUMN gates TEXT`);
+		}
 
-		// 3. Add failure_reason column to space_workflow_runs
-		db.exec(`ALTER TABLE space_workflow_runs ADD COLUMN failure_reason TEXT`);
+		// 3. Add failure_reason column to space_workflow_runs (if not already present)
+		// CHECK constraint restricts values to the WorkflowRunFailureReason union.
+		if (!hasFailureReasonCol || hasFailureReasonCol.count === 0) {
+			db.exec(
+				`ALTER TABLE space_workflow_runs ADD COLUMN failure_reason TEXT CHECK(failure_reason IN ('humanRejected', 'maxIterationsReached', 'nodeTimeout', 'agentCrash'))`
+			);
+		}
 
 		db.exec(`COMMIT`);
 	} catch (err) {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -248,6 +248,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Session groups are replaced by direct space_tasks queries.
 	// currentNodeId is replaced by the agent-centric model where tasks track state.
 	runMigration60(db);
+
+	// Migration 61: Add gate_data table, gates column to space_workflows,
+	// and failure_reason column to space_workflow_runs.
+	// Part of M1.1 — separated Channel + Gate types.
+	runMigration61(db);
 }
 
 /**
@@ -3855,5 +3860,52 @@ export function runMigration60(db: BunDatabase): void {
 		throw err;
 	} finally {
 		db.exec(`PRAGMA foreign_keys = ON`);
+	}
+}
+
+/**
+ * Migration 61: Add gate_data table, gates column to space_workflows,
+ * and failure_reason column to space_workflow_runs.
+ *
+ * Part of M1.1 — separated Channel + Gate types.
+ *
+ * - `gate_data`: Persistent data store for gates, keyed by `(run_id, gate_id)`.
+ *   Stores JSON data that gate conditions evaluate against at runtime.
+ * - `gates` column on `space_workflows`: JSON array of Gate definitions.
+ * - `failure_reason` column on `space_workflow_runs`: Enum-like TEXT for run failure reasons.
+ */
+function runMigration61(db: BunDatabase): void {
+	const migrated = db
+		.prepare(
+			"SELECT COUNT(*) as count FROM pragma_table_info('space_workflows') WHERE name = 'gates'"
+		)
+		.get() as { count: number } | null;
+	if (migrated && migrated.count > 0) return;
+
+	db.exec(`BEGIN TRANSACTION`);
+	try {
+		// 1. Create gate_data table
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS gate_data (
+				run_id TEXT NOT NULL,
+				gate_id TEXT NOT NULL,
+				data TEXT NOT NULL DEFAULT '{}',
+				updated_at INTEGER NOT NULL,
+				PRIMARY KEY (run_id, gate_id),
+				FOREIGN KEY (run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_gate_data_run ON gate_data(run_id)`);
+
+		// 2. Add gates column to space_workflows
+		db.exec(`ALTER TABLE space_workflows ADD COLUMN gates TEXT`);
+
+		// 3. Add failure_reason column to space_workflow_runs
+		db.exec(`ALTER TABLE space_workflow_runs ADD COLUMN failure_reason TEXT`);
+
+		db.exec(`COMMIT`);
+	} catch (err) {
+		db.exec(`ROLLBACK`);
+		throw err;
 	}
 }

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -58,6 +58,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			start_node_id TEXT,
 			config TEXT,
 			channels TEXT,
+			gates TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -120,7 +120,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			iteration_count INTEGER NOT NULL DEFAULT 0,
 			max_iterations INTEGER NOT NULL DEFAULT 5,
 			goal_id TEXT,
-			failure_reason TEXT,
+			failure_reason TEXT
+				CHECK(failure_reason IN ('humanRejected', 'maxIterationsReached', 'nodeTimeout', 'agentCrash')),
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			completed_at INTEGER,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -65,6 +65,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			start_node_id TEXT,
 			config TEXT,
 			channels TEXT,
+			gates TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,
@@ -119,6 +120,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			iteration_count INTEGER NOT NULL DEFAULT 0,
 			max_iterations INTEGER NOT NULL DEFAULT 5,
 			goal_id TEXT,
+			failure_reason TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			completed_at INTEGER,
@@ -126,6 +128,18 @@ export function createSpaceTables(db: BunDatabase): void {
 			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
 		)
 	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS gate_data (
+			run_id TEXT NOT NULL,
+			gate_id TEXT NOT NULL,
+			data TEXT NOT NULL DEFAULT '{}',
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY (run_id, gate_id),
+			FOREIGN KEY (run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_gate_data_run ON gate_data(run_id)`);
 
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_tasks (

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -77,6 +77,7 @@ function createSchema(db: Database): void {
 			start_node_id TEXT,
 			config TEXT,
 			channels TEXT,
+			gates TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,

--- a/packages/daemon/tests/unit/space/gate-evaluator.test.ts
+++ b/packages/daemon/tests/unit/space/gate-evaluator.test.ts
@@ -13,7 +13,11 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { evaluateGate, evaluateCondition } from '../../../src/lib/space/runtime/gate-evaluator.ts';
+import {
+	evaluateGate,
+	evaluateCondition,
+	validateGateCondition,
+} from '../../../src/lib/space/runtime/gate-evaluator.ts';
 import type { Gate, GateCondition } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
@@ -205,10 +209,11 @@ describe('GateEvaluator — any condition (OR)', () => {
 		expect(result.reason).toContain('None of the conditions passed');
 	});
 
-	test('blocks with empty conditions list', () => {
+	test('blocks with empty conditions list and provides reason', () => {
 		const condition: GateCondition = { type: 'any', conditions: [] };
 		const result = evaluateCondition(condition, {});
 		expect(result.open).toBe(false);
+		expect(result.reason).toContain('no sub-conditions');
 	});
 });
 
@@ -292,5 +297,96 @@ describe('evaluateGate', () => {
 		};
 		const result = evaluateGate(gate, { approvals: 1 });
 		expect(result.open).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Runtime validation — validateGateCondition
+// ---------------------------------------------------------------------------
+
+describe('validateGateCondition', () => {
+	test('valid check condition passes', () => {
+		const errors = validateGateCondition({ type: 'check', field: 'approved', value: true });
+		expect(errors).toEqual([]);
+	});
+
+	test('valid count condition passes', () => {
+		const errors = validateGateCondition({ type: 'count', field: 'approvals', threshold: 2 });
+		expect(errors).toEqual([]);
+	});
+
+	test('valid all condition passes', () => {
+		const errors = validateGateCondition({
+			type: 'all',
+			conditions: [{ type: 'check', field: 'ok', value: true }],
+		});
+		expect(errors).toEqual([]);
+	});
+
+	test('valid any condition passes', () => {
+		const errors = validateGateCondition({
+			type: 'any',
+			conditions: [{ type: 'count', field: 'x', threshold: 1 }],
+		});
+		expect(errors).toEqual([]);
+	});
+
+	test('rejects null', () => {
+		const errors = validateGateCondition(null);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('expected an object');
+	});
+
+	test('rejects non-object', () => {
+		const errors = validateGateCondition('not an object');
+		expect(errors.length).toBeGreaterThan(0);
+	});
+
+	test('rejects unknown type', () => {
+		const errors = validateGateCondition({ type: 'unknown_type' });
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('expected one of');
+	});
+
+	test('rejects check with missing field', () => {
+		const errors = validateGateCondition({ type: 'check', value: true });
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('field');
+	});
+
+	test('rejects count with non-numeric threshold', () => {
+		const errors = validateGateCondition({ type: 'count', field: 'x', threshold: 'not a number' });
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('threshold');
+	});
+
+	test('rejects all with non-array conditions', () => {
+		const errors = validateGateCondition({ type: 'all', conditions: 'not an array' });
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('expected array');
+	});
+
+	test('validates nested conditions recursively', () => {
+		const errors = validateGateCondition({
+			type: 'all',
+			conditions: [{ type: 'check', value: true }], // missing field
+		});
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('conditions[0].field');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Malformed JSON — runtime fallback for unknown condition type
+// ---------------------------------------------------------------------------
+
+describe('evaluateCondition — malformed input', () => {
+	test('unknown condition type returns closed with descriptive reason', () => {
+		// Simulate malformed JSON deserialized from the database
+		const malformed = { type: 'nonexistent' } as unknown as GateCondition;
+		const result = evaluateCondition(malformed, {});
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('unknown condition type');
+		expect(result.reason).toContain('nonexistent');
 	});
 });

--- a/packages/daemon/tests/unit/space/gate-evaluator.test.ts
+++ b/packages/daemon/tests/unit/space/gate-evaluator.test.ts
@@ -1,0 +1,296 @@
+/**
+ * GateEvaluator Unit Tests
+ *
+ * Covers all 4 GateCondition types:
+ *   check — field equality: data[field] === value
+ *   count — numeric threshold: data[field] >= threshold
+ *   all   — composite AND (recursive, short-circuits on failure)
+ *   any   — composite OR (recursive, short-circuits on success)
+ *
+ * Also covers:
+ *   - evaluateGate: gate-level evaluation with data store
+ *   - Edge cases: missing fields, zero values, nested composites
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { evaluateGate, evaluateCondition } from '../../../src/lib/space/runtime/gate-evaluator.ts';
+import type { Gate, GateCondition } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// check condition
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — check condition', () => {
+	test('opens when field matches expected value', () => {
+		const condition: GateCondition = { type: 'check', field: 'approved', value: true };
+		const result = evaluateCondition(condition, { approved: true });
+		expect(result.open).toBe(true);
+		expect(result.reason).toBeUndefined();
+	});
+
+	test('blocks when field does not match', () => {
+		const condition: GateCondition = { type: 'check', field: 'approved', value: true };
+		const result = evaluateCondition(condition, { approved: false });
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('approved');
+		expect(result.reason).toContain('false');
+	});
+
+	test('blocks when field is missing from data', () => {
+		const condition: GateCondition = { type: 'check', field: 'approved', value: true };
+		const result = evaluateCondition(condition, {});
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('undefined');
+	});
+
+	test('matches string values', () => {
+		const condition: GateCondition = { type: 'check', field: 'result', value: 'passed' };
+		const result = evaluateCondition(condition, { result: 'passed' });
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks on string mismatch', () => {
+		const condition: GateCondition = { type: 'check', field: 'result', value: 'passed' };
+		const result = evaluateCondition(condition, { result: 'failed' });
+		expect(result.open).toBe(false);
+	});
+
+	test('matches null value', () => {
+		const condition: GateCondition = { type: 'check', field: 'error', value: null };
+		const result = evaluateCondition(condition, { error: null });
+		expect(result.open).toBe(true);
+	});
+
+	test('matches numeric value', () => {
+		const condition: GateCondition = { type: 'check', field: 'count', value: 42 };
+		const result = evaluateCondition(condition, { count: 42 });
+		expect(result.open).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// count condition
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — count condition', () => {
+	test('opens when field >= threshold', () => {
+		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 2 };
+		const result = evaluateCondition(condition, { approvals: 3 });
+		expect(result.open).toBe(true);
+	});
+
+	test('opens when field equals threshold exactly', () => {
+		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 2 };
+		const result = evaluateCondition(condition, { approvals: 2 });
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks when field < threshold', () => {
+		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 2 };
+		const result = evaluateCondition(condition, { approvals: 1 });
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('1');
+		expect(result.reason).toContain('>= 2');
+	});
+
+	test('treats missing field as 0', () => {
+		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 1 };
+		const result = evaluateCondition(condition, {});
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('0');
+	});
+
+	test('treats non-numeric field as 0', () => {
+		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 1 };
+		const result = evaluateCondition(condition, { approvals: 'not a number' });
+		expect(result.open).toBe(false);
+	});
+
+	test('opens with threshold of 0 when field is missing', () => {
+		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 0 };
+		const result = evaluateCondition(condition, {});
+		expect(result.open).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// all condition (AND)
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — all condition (AND)', () => {
+	test('opens when all sub-conditions pass', () => {
+		const condition: GateCondition = {
+			type: 'all',
+			conditions: [
+				{ type: 'check', field: 'approved', value: true },
+				{ type: 'count', field: 'reviews', threshold: 2 },
+			],
+		};
+		const result = evaluateCondition(condition, { approved: true, reviews: 3 });
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks when first sub-condition fails (short-circuit)', () => {
+		const condition: GateCondition = {
+			type: 'all',
+			conditions: [
+				{ type: 'check', field: 'approved', value: true },
+				{ type: 'count', field: 'reviews', threshold: 2 },
+			],
+		};
+		const result = evaluateCondition(condition, { approved: false, reviews: 3 });
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('approved');
+	});
+
+	test('blocks when second sub-condition fails', () => {
+		const condition: GateCondition = {
+			type: 'all',
+			conditions: [
+				{ type: 'check', field: 'approved', value: true },
+				{ type: 'count', field: 'reviews', threshold: 2 },
+			],
+		};
+		const result = evaluateCondition(condition, { approved: true, reviews: 1 });
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('reviews');
+	});
+
+	test('opens with empty conditions list', () => {
+		const condition: GateCondition = { type: 'all', conditions: [] };
+		const result = evaluateCondition(condition, {});
+		expect(result.open).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// any condition (OR)
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — any condition (OR)', () => {
+	test('opens when first sub-condition passes (short-circuit)', () => {
+		const condition: GateCondition = {
+			type: 'any',
+			conditions: [
+				{ type: 'check', field: 'approved', value: true },
+				{ type: 'count', field: 'reviews', threshold: 2 },
+			],
+		};
+		const result = evaluateCondition(condition, { approved: true, reviews: 0 });
+		expect(result.open).toBe(true);
+	});
+
+	test('opens when second sub-condition passes', () => {
+		const condition: GateCondition = {
+			type: 'any',
+			conditions: [
+				{ type: 'check', field: 'approved', value: true },
+				{ type: 'count', field: 'reviews', threshold: 2 },
+			],
+		};
+		const result = evaluateCondition(condition, { approved: false, reviews: 3 });
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks when all sub-conditions fail', () => {
+		const condition: GateCondition = {
+			type: 'any',
+			conditions: [
+				{ type: 'check', field: 'approved', value: true },
+				{ type: 'count', field: 'reviews', threshold: 2 },
+			],
+		};
+		const result = evaluateCondition(condition, { approved: false, reviews: 1 });
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('None of the conditions passed');
+	});
+
+	test('blocks with empty conditions list', () => {
+		const condition: GateCondition = { type: 'any', conditions: [] };
+		const result = evaluateCondition(condition, {});
+		expect(result.open).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Nested composite conditions
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — nested composites', () => {
+	test('all containing any: passes when inner any passes', () => {
+		const condition: GateCondition = {
+			type: 'all',
+			conditions: [
+				{
+					type: 'any',
+					conditions: [
+						{ type: 'check', field: 'fast_track', value: true },
+						{ type: 'count', field: 'approvals', threshold: 2 },
+					],
+				},
+				{ type: 'check', field: 'tests_passed', value: true },
+			],
+		};
+		// fast_track is true (any passes), tests_passed is true (all passes)
+		const result = evaluateCondition(condition, {
+			fast_track: true,
+			approvals: 0,
+			tests_passed: true,
+		});
+		expect(result.open).toBe(true);
+	});
+
+	test('any containing all: passes when inner all passes', () => {
+		const condition: GateCondition = {
+			type: 'any',
+			conditions: [
+				{ type: 'check', field: 'override', value: true },
+				{
+					type: 'all',
+					conditions: [
+						{ type: 'check', field: 'reviewed', value: true },
+						{ type: 'check', field: 'tested', value: true },
+					],
+				},
+			],
+		};
+		// override is false, but reviewed+tested both true
+		const result = evaluateCondition(condition, {
+			override: false,
+			reviewed: true,
+			tested: true,
+		});
+		expect(result.open).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// evaluateGate (top-level)
+// ---------------------------------------------------------------------------
+
+describe('evaluateGate', () => {
+	test('evaluates gate condition against provided data', () => {
+		const gate: Gate = {
+			id: 'gate-1',
+			condition: { type: 'check', field: 'approved', value: true },
+			data: { approved: false },
+			allowedWriterRoles: ['reviewer'],
+			resetOnCycle: false,
+		};
+		// Gate data says approved is true → gate opens
+		const result = evaluateGate(gate, { approved: true });
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks when gate data does not satisfy condition', () => {
+		const gate: Gate = {
+			id: 'gate-1',
+			condition: { type: 'count', field: 'approvals', threshold: 2 },
+			data: {},
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		const result = evaluateGate(gate, { approvals: 1 });
+		expect(result.open).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/space/gate-migration.test.ts
+++ b/packages/daemon/tests/unit/space/gate-migration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Gate Migration Utility Tests
+ *
+ * Covers migration of legacy WorkflowCondition types to the separated Gate format:
+ *   always      → no gate (channel always open)
+ *   human       → check approved === true
+ *   condition   → check result === true (expression preserved in description)
+ *   task_result → check result === expression value
+ *   undefined   → no gate
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { migrateLegacyCondition } from '@neokai/shared';
+import type { WorkflowCondition } from '@neokai/shared';
+
+describe('migrateLegacyCondition', () => {
+	test('undefined condition → no gate', () => {
+		const result = migrateLegacyCondition(undefined, 'gate-1');
+		expect(result.gate).toBeNull();
+		expect(result.gateId).toBeUndefined();
+	});
+
+	test('always → no gate (channel is gateless)', () => {
+		const condition: WorkflowCondition = { type: 'always' };
+		const result = migrateLegacyCondition(condition, 'gate-1');
+		expect(result.gate).toBeNull();
+		expect(result.gateId).toBeUndefined();
+	});
+
+	test('human → check gate with approved field', () => {
+		const condition: WorkflowCondition = {
+			type: 'human',
+			description: 'Requires human approval',
+		};
+		const result = migrateLegacyCondition(condition, 'gate-human-1');
+
+		expect(result.gate).not.toBeNull();
+		expect(result.gateId).toBe('gate-human-1');
+
+		const gate = result.gate!;
+		expect(gate.id).toBe('gate-human-1');
+		expect(gate.condition.type).toBe('check');
+		if (gate.condition.type === 'check') {
+			expect(gate.condition.field).toBe('approved');
+			expect(gate.condition.value).toBe(true);
+		}
+		expect(gate.data).toEqual({ approved: false });
+		expect(gate.allowedWriterRoles).toEqual(['*']);
+		expect(gate.resetOnCycle).toBe(false);
+		expect(gate.description).toBe('Requires human approval');
+	});
+
+	test('human without description gets default description', () => {
+		const condition: WorkflowCondition = { type: 'human' };
+		const result = migrateLegacyCondition(condition, 'gate-1');
+
+		expect(result.gate!.description).toContain('migrated from legacy');
+	});
+
+	test('condition → check gate with result field', () => {
+		const condition: WorkflowCondition = {
+			type: 'condition',
+			expression: 'test -f /tmp/ready',
+			description: 'File exists check',
+		};
+		const result = migrateLegacyCondition(condition, 'gate-cond-1');
+
+		expect(result.gate).not.toBeNull();
+		expect(result.gateId).toBe('gate-cond-1');
+
+		const gate = result.gate!;
+		expect(gate.condition.type).toBe('check');
+		if (gate.condition.type === 'check') {
+			expect(gate.condition.field).toBe('result');
+			expect(gate.condition.value).toBe(true);
+		}
+		expect(gate.data).toEqual({ result: false });
+		expect(gate.description).toBe('File exists check');
+	});
+
+	test('condition without description preserves original expression in description', () => {
+		const condition: WorkflowCondition = {
+			type: 'condition',
+			expression: 'echo hello',
+		};
+		const result = migrateLegacyCondition(condition, 'gate-1');
+
+		expect(result.gate!.description).toContain('echo hello');
+	});
+
+	test('task_result → check gate with result field matching expression', () => {
+		const condition: WorkflowCondition = {
+			type: 'task_result',
+			expression: 'passed',
+			description: 'Task must pass',
+		};
+		const result = migrateLegacyCondition(condition, 'gate-task-1');
+
+		expect(result.gate).not.toBeNull();
+		expect(result.gateId).toBe('gate-task-1');
+
+		const gate = result.gate!;
+		expect(gate.condition.type).toBe('check');
+		if (gate.condition.type === 'check') {
+			expect(gate.condition.field).toBe('result');
+			expect(gate.condition.value).toBe('passed');
+		}
+		expect(gate.data).toEqual({});
+		expect(gate.description).toBe('Task must pass');
+	});
+
+	test('task_result without expression defaults to "passed"', () => {
+		const condition: WorkflowCondition = { type: 'task_result' };
+		const result = migrateLegacyCondition(condition, 'gate-1');
+
+		const gate = result.gate!;
+		if (gate.condition.type === 'check') {
+			expect(gate.condition.value).toBe('passed');
+		}
+	});
+});

--- a/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
+++ b/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Gate Types and Schema Integration Tests
+ *
+ * Validates that:
+ *   - Channel and Gate types are structurally correct
+ *   - Gate definitions persist to and load from SQLite (workflow repository)
+ *   - gate_data table supports CRUD via the repository
+ *   - send_message schema accepts the optional `data` field
+ *   - SpaceWorkflowRun supports failureReason
+ *   - Gateless channels route without obstruction
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createSpaceTables } from '../helpers/space-test-db.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { GateDataRepository } from '../../../src/storage/repositories/gate-data-repository.ts';
+import { SendMessageSchema } from '../../../src/lib/space/tools/node-agent-tool-schemas.ts';
+import type {
+	Gate,
+	Channel,
+	GateCondition,
+	WorkflowRunFailureReason,
+	SpaceWorkflowRun,
+} from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB setup
+// ---------------------------------------------------------------------------
+
+let db: Database;
+const SPACE_ID = 'space-test-1';
+
+function freshDb(): Database {
+	const d = new Database(':memory:');
+	createSpaceTables(d);
+	const now = Date.now();
+	d.exec(
+		`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES ('${SPACE_ID}', '/tmp/test', 'Test Space', ${now}, ${now})`
+	);
+	return d;
+}
+
+beforeEach(() => {
+	db = freshDb();
+});
+
+// ---------------------------------------------------------------------------
+// Type validation — compile-time checks expressed as runtime assertions
+// ---------------------------------------------------------------------------
+
+describe('Gate and Channel type validation', () => {
+	test('Channel without gateId is always open (type-level)', () => {
+		const channel: Channel = {
+			id: 'ch-1',
+			from: 'planner',
+			to: 'coder',
+		};
+		expect(channel.gateId).toBeUndefined();
+	});
+
+	test('Channel with gateId references a gate', () => {
+		const channel: Channel = {
+			id: 'ch-2',
+			from: 'coder',
+			to: 'reviewer',
+			gateId: 'gate-approval',
+			isCyclic: false,
+			label: 'Code Review Gate',
+		};
+		expect(channel.gateId).toBe('gate-approval');
+	});
+
+	test('Gate with check condition', () => {
+		const gate: Gate = {
+			id: 'gate-1',
+			condition: { type: 'check', field: 'approved', value: true },
+			data: { approved: false },
+			allowedWriterRoles: ['reviewer'],
+			resetOnCycle: false,
+			description: 'Approval gate',
+		};
+		expect(gate.condition.type).toBe('check');
+	});
+
+	test('Gate with count condition', () => {
+		const gate: Gate = {
+			id: 'gate-2',
+			condition: { type: 'count', field: 'approvals', threshold: 2 },
+			data: { approvals: 0 },
+			allowedWriterRoles: ['reviewer-1', 'reviewer-2'],
+			resetOnCycle: true,
+		};
+		expect(gate.condition.type).toBe('count');
+	});
+
+	test('Gate with composite all condition', () => {
+		const condition: GateCondition = {
+			type: 'all',
+			conditions: [
+				{ type: 'check', field: 'approved', value: true },
+				{ type: 'count', field: 'reviews', threshold: 2 },
+			],
+		};
+		const gate: Gate = {
+			id: 'gate-3',
+			condition,
+			data: { approved: false, reviews: 0 },
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		expect(gate.condition.type).toBe('all');
+		if (gate.condition.type === 'all') {
+			expect(gate.condition.conditions).toHaveLength(2);
+		}
+	});
+
+	test('Gate with composite any condition', () => {
+		const condition: GateCondition = {
+			type: 'any',
+			conditions: [
+				{ type: 'check', field: 'fast_track', value: true },
+				{ type: 'count', field: 'approvals', threshold: 3 },
+			],
+		};
+		const gate: Gate = {
+			id: 'gate-4',
+			condition,
+			data: {},
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		expect(gate.condition.type).toBe('any');
+	});
+
+	test('WorkflowRunFailureReason type accepts all valid values', () => {
+		const reasons: WorkflowRunFailureReason[] = [
+			'humanRejected',
+			'maxIterationsReached',
+			'nodeTimeout',
+			'agentCrash',
+		];
+		expect(reasons).toHaveLength(4);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Workflow repository — gates persistence
+// ---------------------------------------------------------------------------
+
+describe('SpaceWorkflowRepository — gates round-trip', () => {
+	test('creates workflow with gates and retrieves them', () => {
+		const workflowRepo = new SpaceWorkflowRepository(db);
+
+		const gates: Gate[] = [
+			{
+				id: 'gate-approval',
+				condition: { type: 'check', field: 'approved', value: true },
+				data: { approved: false },
+				allowedWriterRoles: ['reviewer'],
+				resetOnCycle: false,
+				description: 'Plan approval gate',
+			},
+			{
+				id: 'gate-review-count',
+				condition: { type: 'count', field: 'approvals', threshold: 2 },
+				data: { approvals: 0 },
+				allowedWriterRoles: ['reviewer-1', 'reviewer-2'],
+				resetOnCycle: true,
+			},
+		];
+
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'Test Workflow',
+			gates,
+		});
+
+		expect(workflow.gates).toBeDefined();
+		expect(workflow.gates).toHaveLength(2);
+		expect(workflow.gates![0].id).toBe('gate-approval');
+		expect(workflow.gates![0].condition.type).toBe('check');
+		expect(workflow.gates![1].id).toBe('gate-review-count');
+		expect(workflow.gates![1].condition.type).toBe('count');
+		expect(workflow.gates![1].resetOnCycle).toBe(true);
+	});
+
+	test('workflow without gates returns undefined gates', () => {
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'No Gates Workflow',
+		});
+		expect(workflow.gates).toBeUndefined();
+	});
+
+	test('updateWorkflow can set and clear gates', () => {
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'Update Gates Test',
+		});
+
+		// Set gates
+		const updated = workflowRepo.updateWorkflow(workflow.id, {
+			gates: [
+				{
+					id: 'gate-1',
+					condition: { type: 'check', field: 'ready', value: true },
+					data: { ready: false },
+					allowedWriterRoles: ['*'],
+					resetOnCycle: false,
+				},
+			],
+		});
+		expect(updated!.gates).toHaveLength(1);
+
+		// Clear gates
+		const cleared = workflowRepo.updateWorkflow(workflow.id, { gates: null });
+		expect(cleared!.gates).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Workflow run — failureReason persistence
+// ---------------------------------------------------------------------------
+
+describe('SpaceWorkflowRunRepository — failureReason', () => {
+	test('failureReason is undefined for normal runs', () => {
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'FR Test Workflow',
+		});
+
+		const runRepo = new SpaceWorkflowRunRepository(db);
+		const run = runRepo.createRun({
+			spaceId: SPACE_ID,
+			workflowId: workflow.id,
+			title: 'Test Run',
+		});
+		expect(run.failureReason).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Gate data — schema creation and CRUD
+// ---------------------------------------------------------------------------
+
+describe('gate_data table — schema and CRUD', () => {
+	test('gate_data table exists and supports insert/select', () => {
+		const repo = new GateDataRepository(db);
+
+		// First create a workflow and run for FK
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'GD Test Workflow',
+		});
+		const runRepo = new SpaceWorkflowRunRepository(db);
+		const run = runRepo.createRun({
+			spaceId: SPACE_ID,
+			workflowId: workflow.id,
+			title: 'GD Test Run',
+		});
+
+		// CRUD
+		repo.set(run.id, 'gate-1', { approved: false });
+		const record = repo.get(run.id, 'gate-1');
+		expect(record).not.toBeNull();
+		expect(record!.data).toEqual({ approved: false });
+
+		// Merge
+		repo.merge(run.id, 'gate-1', { approved: true });
+		expect(repo.get(run.id, 'gate-1')!.data).toEqual({ approved: true });
+
+		// Delete
+		repo.delete(run.id, 'gate-1');
+		expect(repo.get(run.id, 'gate-1')).toBeNull();
+	});
+
+	test('gate_data cascade deletes with workflow run', () => {
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'Cascade Test',
+		});
+		const runRepo = new SpaceWorkflowRunRepository(db);
+		const run = runRepo.createRun({
+			spaceId: SPACE_ID,
+			workflowId: workflow.id,
+			title: 'Cascade Run',
+		});
+
+		const gateRepo = new GateDataRepository(db);
+		gateRepo.set(run.id, 'gate-a', { value: 1 });
+		gateRepo.set(run.id, 'gate-b', { value: 2 });
+
+		// Delete the run
+		runRepo.deleteRun(run.id);
+
+		// Gate data should be gone (CASCADE)
+		expect(gateRepo.listByRun(run.id)).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// send_message schema — data field
+// ---------------------------------------------------------------------------
+
+describe('SendMessageSchema — data field', () => {
+	test('accepts message without data', () => {
+		const result = SendMessageSchema.safeParse({
+			target: 'reviewer',
+			message: 'Hello',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts message with data', () => {
+		const result = SendMessageSchema.safeParse({
+			target: 'reviewer',
+			message: 'Approve please',
+			data: { approved: true, score: 95 },
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.data).toEqual({ approved: true, score: 95 });
+		}
+	});
+
+	test('accepts message with empty data object', () => {
+		const result = SendMessageSchema.safeParse({
+			target: 'reviewer',
+			message: 'No data',
+			data: {},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects message with non-object data', () => {
+		const result = SendMessageSchema.safeParse({
+			target: 'reviewer',
+			message: 'Bad data',
+			data: 'not an object',
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
+++ b/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
@@ -242,6 +242,80 @@ describe('SpaceWorkflowRunRepository — failureReason', () => {
 		});
 		expect(run.failureReason).toBeUndefined();
 	});
+
+	test('failureReason persists through updateRun and round-trips correctly', () => {
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'FR Persist Test',
+		});
+
+		const runRepo = new SpaceWorkflowRunRepository(db);
+		const run = runRepo.createRun({
+			spaceId: SPACE_ID,
+			workflowId: workflow.id,
+			title: 'Failure Test Run',
+		});
+
+		// Set failureReason
+		const updated = runRepo.updateRun(run.id, {
+			status: 'needs_attention',
+			failureReason: 'maxIterationsReached',
+		});
+		expect(updated).not.toBeNull();
+		expect(updated!.failureReason).toBe('maxIterationsReached');
+
+		// Verify round-trip through getRun
+		const fetched = runRepo.getRun(run.id);
+		expect(fetched!.failureReason).toBe('maxIterationsReached');
+	});
+
+	test('failureReason can be cleared by setting to null', () => {
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'FR Clear Test',
+		});
+
+		const runRepo = new SpaceWorkflowRunRepository(db);
+		const run = runRepo.createRun({
+			spaceId: SPACE_ID,
+			workflowId: workflow.id,
+			title: 'Clear Test Run',
+		});
+
+		// Set then clear
+		runRepo.updateRun(run.id, { failureReason: 'humanRejected' });
+		const cleared = runRepo.updateRun(run.id, { failureReason: null });
+		expect(cleared!.failureReason).toBeUndefined();
+	});
+
+	test('all four failureReason values persist correctly', () => {
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'FR All Values',
+		});
+		const runRepo = new SpaceWorkflowRunRepository(db);
+
+		const reasons: WorkflowRunFailureReason[] = [
+			'humanRejected',
+			'maxIterationsReached',
+			'nodeTimeout',
+			'agentCrash',
+		];
+
+		for (const reason of reasons) {
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: `Run for ${reason}`,
+			});
+			runRepo.updateRun(run.id, { failureReason: reason });
+			const fetched = runRepo.getRun(run.id);
+			expect(fetched!.failureReason).toBe(reason);
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/storage/gate-data-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/gate-data-repository.test.ts
@@ -1,0 +1,211 @@
+/**
+ * GateDataRepository Unit Tests
+ *
+ * Covers:
+ *   - CRUD operations: get, set, merge, delete
+ *   - Batch operations: listByRun, deleteByRun, initializeForRun
+ *   - Persistence round-trip: data survives close/reopen
+ *   - Reset: resetOnCycle behavior
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { GateDataRepository } from '../../../src/storage/repositories/gate-data-repository.ts';
+import { createSpaceTables } from '../helpers/space-test-db.ts';
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let db: Database;
+let repo: GateDataRepository;
+
+const RUN_ID = 'run-001';
+const GATE_ID_A = 'gate-a';
+const GATE_ID_B = 'gate-b';
+
+function freshDb(): Database {
+	const d = new Database(':memory:');
+	createSpaceTables(d);
+	// Insert required parent rows for FK constraints
+	const now = Date.now();
+	d.exec(
+		`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES ('sp1', '/tmp/test', 'Test Space', ${now}, ${now})`
+	);
+	d.exec(
+		`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES ('wf1', 'sp1', 'Test Workflow', ${now}, ${now})`
+	);
+	d.exec(
+		`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, iteration_count, max_iterations, created_at, updated_at) VALUES ('${RUN_ID}', 'sp1', 'wf1', 'Test Run', 'in_progress', 0, 5, ${now}, ${now})`
+	);
+	return d;
+}
+
+beforeEach(() => {
+	db = freshDb();
+	repo = new GateDataRepository(db);
+});
+
+// ---------------------------------------------------------------------------
+// get / set
+// ---------------------------------------------------------------------------
+
+describe('GateDataRepository — get/set', () => {
+	test('returns null for non-existent gate data', () => {
+		const result = repo.get(RUN_ID, GATE_ID_A);
+		expect(result).toBeNull();
+	});
+
+	test('set creates new record and get retrieves it', () => {
+		const data = { approved: true, count: 3 };
+		repo.set(RUN_ID, GATE_ID_A, data);
+
+		const record = repo.get(RUN_ID, GATE_ID_A);
+		expect(record).not.toBeNull();
+		expect(record!.runId).toBe(RUN_ID);
+		expect(record!.gateId).toBe(GATE_ID_A);
+		expect(record!.data).toEqual(data);
+		expect(typeof record!.updatedAt).toBe('number');
+	});
+
+	test('set upserts existing record', () => {
+		repo.set(RUN_ID, GATE_ID_A, { count: 1 });
+		repo.set(RUN_ID, GATE_ID_A, { count: 5, extra: true });
+
+		const record = repo.get(RUN_ID, GATE_ID_A);
+		expect(record!.data).toEqual({ count: 5, extra: true });
+	});
+
+	test('different gate IDs are independent', () => {
+		repo.set(RUN_ID, GATE_ID_A, { a: 1 });
+		repo.set(RUN_ID, GATE_ID_B, { b: 2 });
+
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({ a: 1 });
+		expect(repo.get(RUN_ID, GATE_ID_B)!.data).toEqual({ b: 2 });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// merge
+// ---------------------------------------------------------------------------
+
+describe('GateDataRepository — merge', () => {
+	test('creates record if none exists', () => {
+		const result = repo.merge(RUN_ID, GATE_ID_A, { approved: true });
+		expect(result.data).toEqual({ approved: true });
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({ approved: true });
+	});
+
+	test('merges partial data into existing record', () => {
+		repo.set(RUN_ID, GATE_ID_A, { count: 1, name: 'test' });
+		repo.merge(RUN_ID, GATE_ID_A, { count: 2, extra: true });
+
+		const record = repo.get(RUN_ID, GATE_ID_A);
+		expect(record!.data).toEqual({ count: 2, name: 'test', extra: true });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+describe('GateDataRepository — delete', () => {
+	test('delete removes a specific gate data record', () => {
+		repo.set(RUN_ID, GATE_ID_A, { a: 1 });
+		repo.set(RUN_ID, GATE_ID_B, { b: 2 });
+
+		const deleted = repo.delete(RUN_ID, GATE_ID_A);
+		expect(deleted).toBe(true);
+		expect(repo.get(RUN_ID, GATE_ID_A)).toBeNull();
+		expect(repo.get(RUN_ID, GATE_ID_B)).not.toBeNull();
+	});
+
+	test('delete returns false for non-existent record', () => {
+		const deleted = repo.delete(RUN_ID, 'no-such-gate');
+		expect(deleted).toBe(false);
+	});
+
+	test('deleteByRun removes all gate data for a run', () => {
+		repo.set(RUN_ID, GATE_ID_A, { a: 1 });
+		repo.set(RUN_ID, GATE_ID_B, { b: 2 });
+
+		const count = repo.deleteByRun(RUN_ID);
+		expect(count).toBe(2);
+		expect(repo.listByRun(RUN_ID)).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// listByRun
+// ---------------------------------------------------------------------------
+
+describe('GateDataRepository — listByRun', () => {
+	test('returns empty array when no data exists', () => {
+		expect(repo.listByRun(RUN_ID)).toEqual([]);
+	});
+
+	test('lists all gate data for a run, ordered by gate_id', () => {
+		repo.set(RUN_ID, 'gate-z', { z: 1 });
+		repo.set(RUN_ID, 'gate-a', { a: 2 });
+
+		const records = repo.listByRun(RUN_ID);
+		expect(records).toHaveLength(2);
+		expect(records[0].gateId).toBe('gate-a');
+		expect(records[1].gateId).toBe('gate-z');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// initializeForRun
+// ---------------------------------------------------------------------------
+
+describe('GateDataRepository — initializeForRun', () => {
+	test('initializes gate data with defaults', () => {
+		repo.initializeForRun(RUN_ID, [
+			{ id: GATE_ID_A, data: { approved: false } },
+			{ id: GATE_ID_B, data: { count: 0 } },
+		]);
+
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({ approved: false });
+		expect(repo.get(RUN_ID, GATE_ID_B)!.data).toEqual({ count: 0 });
+	});
+
+	test('does not overwrite existing data (INSERT OR IGNORE)', () => {
+		repo.set(RUN_ID, GATE_ID_A, { approved: true });
+
+		repo.initializeForRun(RUN_ID, [{ id: GATE_ID_A, data: { approved: false } }]);
+
+		// Should keep the existing data, not overwrite with default
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({ approved: true });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reset
+// ---------------------------------------------------------------------------
+
+describe('GateDataRepository — reset', () => {
+	test('resets gate data to defaults', () => {
+		repo.set(RUN_ID, GATE_ID_A, { approved: true, extra: 'value' });
+
+		const result = repo.reset(RUN_ID, GATE_ID_A, { approved: false });
+		expect(result.data).toEqual({ approved: false });
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({ approved: false });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Persistence round-trip
+// ---------------------------------------------------------------------------
+
+describe('GateDataRepository — persistence', () => {
+	test('data persists across repository instances (same db)', () => {
+		repo.set(RUN_ID, GATE_ID_A, { persistent: true, value: 42 });
+
+		// Create a new repository instance pointing to the same DB
+		const repo2 = new GateDataRepository(db);
+		const record = repo2.get(RUN_ID, GATE_ID_A);
+		expect(record).not.toBeNull();
+		expect(record!.data).toEqual({ persistent: true, value: 42 });
+	});
+});

--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -18,6 +18,7 @@ export * from './types/neo.ts';
 export * from './types/github.ts';
 export * from './types/space.ts';
 export * from './types/space-utils.ts';
+export * from './types/gate-migration.ts';
 export * from './types/tools.ts';
 export * from './types/app-mcp-server.ts';
 export * from './types/skills.ts';

--- a/packages/shared/src/types/gate-migration.ts
+++ b/packages/shared/src/types/gate-migration.ts
@@ -99,7 +99,8 @@ export function migrateLegacyCondition(
 		}
 
 		default: {
-			// Unknown type — create a conservative check gate
+			// Unknown type — fail open (no gate). Forward migration is lossy for
+			// unrecognized types; callers should handle this case explicitly.
 			return { gate: null, gateId: undefined };
 		}
 	}

--- a/packages/shared/src/types/gate-migration.ts
+++ b/packages/shared/src/types/gate-migration.ts
@@ -1,0 +1,106 @@
+/**
+ * Gate Migration Utilities
+ *
+ * Converts legacy `WorkflowCondition` gate definitions (inline on channels)
+ * to the separated `Gate` + `Channel` format (M1.1).
+ *
+ * Migration rules:
+ *   always      → remove gate (channel without gateId is always open)
+ *   human       → Gate with check condition: { field: 'approved', value: true }
+ *   condition   → Gate with check condition: { field: 'result', value: true }
+ *                  (shell expression stored in gate description for reference)
+ *   task_result → Gate with check condition: { field: 'result', value: expression }
+ */
+
+import type { WorkflowCondition } from './space.ts';
+import type { Gate, GateCondition } from './space.ts';
+
+/** Result of migrating a legacy channel's inline gate to the separated format. */
+export interface GateMigrationResult {
+	/** The migrated gate, or null if the channel had no gate or was 'always'. */
+	gate: Gate | null;
+	/** The gate ID to set on the channel, or undefined if the channel is gateless. */
+	gateId: string | undefined;
+}
+
+/**
+ * Converts a legacy `WorkflowCondition` to a separated `Gate`.
+ *
+ * @param legacyCondition - The old inline condition from `WorkflowChannel.gate`.
+ * @param gateId - The ID to assign to the new Gate entity.
+ * @returns Migration result with the new Gate (or null for `always`/absent conditions).
+ */
+export function migrateLegacyCondition(
+	legacyCondition: WorkflowCondition | undefined,
+	gateId: string
+): GateMigrationResult {
+	if (!legacyCondition) {
+		return { gate: null, gateId: undefined };
+	}
+
+	switch (legacyCondition.type) {
+		case 'always':
+			// always → no gate needed; channel is always open
+			return { gate: null, gateId: undefined };
+
+		case 'human': {
+			const condition: GateCondition = { type: 'check', field: 'approved', value: true };
+			return {
+				gate: {
+					id: gateId,
+					condition,
+					data: { approved: false },
+					allowedWriterRoles: ['*'],
+					description: legacyCondition.description ?? 'Human approval gate (migrated from legacy)',
+					resetOnCycle: false,
+				},
+				gateId,
+			};
+		}
+
+		case 'condition': {
+			// Shell expression conditions become a check on 'result' field.
+			// The actual shell expression is stored in description for reference.
+			const condition: GateCondition = { type: 'check', field: 'result', value: true };
+			return {
+				gate: {
+					id: gateId,
+					condition,
+					data: { result: false },
+					allowedWriterRoles: ['*'],
+					description:
+						legacyCondition.description ??
+						`Shell condition gate (migrated). Original expression: ${legacyCondition.expression ?? '(empty)'}`,
+					resetOnCycle: false,
+				},
+				gateId,
+			};
+		}
+
+		case 'task_result': {
+			const condition: GateCondition = {
+				type: 'check',
+				field: 'result',
+				value: legacyCondition.expression ?? 'passed',
+			};
+			return {
+				gate: {
+					id: gateId,
+					condition,
+					data: {},
+					allowedWriterRoles: ['*'],
+					description:
+						legacyCondition.description ??
+						`Task result gate: awaiting result="${legacyCondition.expression ?? 'passed'}" (migrated)`,
+					resetOnCycle: false,
+				},
+				gateId,
+			};
+		}
+
+		default: {
+			// Unknown type — create a conservative check gate
+			return { gate: null, gateId: undefined };
+		}
+	}
+}

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -334,6 +334,11 @@ export interface SpaceWorkflowRun {
 	maxIterations: number;
 	/** Optional goal/mission ID this run is associated with */
 	goalId?: string;
+	/**
+	 * Reason for workflow run failure. Only set when the run reaches a terminal
+	 * failure state (e.g. `needs_attention` or `cancelled`).
+	 */
+	failureReason?: WorkflowRunFailureReason;
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Last update timestamp (milliseconds since epoch) */
@@ -446,20 +451,18 @@ export interface UpdateSpaceAgentParams {
 // Workflow Types (M3)
 // ============================================================================
 
+// ---- Legacy condition types (kept for backward compatibility) ----
+
 /**
- * Primitive condition type for workflow channel gates.
+ * @deprecated Use `GateCondition` instead. Will be removed in a future milestone.
  *
- * - `always`: The gate opens unconditionally.
- * - `human`: Blocks until a human explicitly approves (via a signal / run config update).
- * - `condition`: A user-supplied shell expression; the gate opens when it exits with code 0.
- *   NeoKai is a framework — no allowlist is applied. Users are responsible for what they run.
- * - `task_result`: Matches against the `result` field of the most recently completed task on the
- *   current node. The gate opens when the task result starts with or equals the condition's
- *   `expression` value (e.g., `'passed'`, `'failed'`).
+ * Primitive condition type for workflow channel gates.
  */
 export type WorkflowConditionType = 'always' | 'human' | 'condition' | 'task_result';
 
 /**
+ * @deprecated Use `GateCondition` instead. Will be removed in a future milestone.
+ *
  * A condition that guards a workflow channel gate.
  * Conditions determine whether a channel may deliver a message.
  */
@@ -468,12 +471,6 @@ export interface WorkflowCondition {
 	type: WorkflowConditionType;
 	/**
 	 * Expression to evaluate for the `condition` and `task_result` types.
-	 *
-	 * - For `condition`: a shell expression; the gate opens when it exits with code 0.
-	 *   No allowlist is applied — users are responsible for the expression content.
-	 * - For `task_result`: the match value to compare against the completed task's `result`
-	 *   field (e.g., `'passed'`, `'failed'`). The gate opens when the task result
-	 *   starts with or equals this value.
 	 */
 	expression?: string;
 	/** Human-readable description of what this condition checks */
@@ -486,6 +483,164 @@ export interface WorkflowCondition {
 	/** Timeout for condition evaluation in milliseconds (0 = use default) */
 	timeoutMs?: number;
 }
+
+// ============================================================================
+// Gate System (M1.1) — separated from channels
+// ============================================================================
+
+/**
+ * A `check` condition evaluates a named key in the gate's data store.
+ *
+ * The gate opens when `data[field]` equals `value`.
+ *
+ * Examples:
+ *   - Human approval: `{ type: 'check', field: 'approved', value: true }`
+ *   - Task result:    `{ type: 'check', field: 'result', value: 'passed' }`
+ */
+export interface GateConditionCheck {
+	type: 'check';
+	/** Key in the gate's data store to evaluate. */
+	field: string;
+	/** Expected value. Gate opens when `data[field] === value`. */
+	value: unknown;
+}
+
+/**
+ * A `count` condition checks the numeric value of a field against a threshold.
+ *
+ * The gate opens when `data[field] >= threshold`.
+ *
+ * Examples:
+ *   - Require 2 approvals: `{ type: 'count', field: 'approvals', threshold: 2 }`
+ */
+export interface GateConditionCount {
+	type: 'count';
+	/** Key in the gate's data store whose numeric value to compare. */
+	field: string;
+	/** Gate opens when the field value ≥ threshold. */
+	threshold: number;
+}
+
+/**
+ * Composite `all` condition — logical AND. Gate opens when ALL nested conditions pass.
+ *
+ * Conditions are evaluated in order; short-circuits on first failure.
+ */
+export interface GateConditionAll {
+	type: 'all';
+	/** Nested conditions that must all pass. */
+	conditions: GateCondition[];
+}
+
+/**
+ * Composite `any` condition — logical OR. Gate opens when ANY nested condition passes.
+ *
+ * Conditions are evaluated in order; short-circuits on first success.
+ */
+export interface GateConditionAny {
+	type: 'any';
+	/** Nested conditions — at least one must pass. */
+	conditions: GateCondition[];
+}
+
+/**
+ * Discriminated union of gate condition types.
+ *
+ * Four types cover all gate behaviors:
+ * - `check`  — field equality check against gate data
+ * - `count`  — numeric threshold check against gate data
+ * - `all`    — composite AND (recursive)
+ * - `any`    — composite OR (recursive)
+ *
+ * No `always` type — a channel without a `gateId` is always open.
+ */
+export type GateCondition =
+	| GateConditionCheck
+	| GateConditionCount
+	| GateConditionAll
+	| GateConditionAny;
+
+/**
+ * A Gate — an independent entity that controls passage through channels.
+ *
+ * Gates are referenced by channels via `gateId`. A gate has no back-reference
+ * to any channel — the same gate can guard multiple channels.
+ *
+ * Gate data is a key-value store persisted per `(run_id, gate_id)` in the
+ * `gate_data` SQLite table. Agents write to gate data via `write_gate`;
+ * the runtime evaluates the condition against current data to decide passage.
+ */
+export interface Gate {
+	/** Unique identifier */
+	id: string;
+	/** Condition that must be satisfied for the gate to open. */
+	condition: GateCondition;
+	/**
+	 * Default data values for the gate. Populated into `gate_data` when a
+	 * workflow run starts. Keys not present here default to `undefined`.
+	 */
+	data: Record<string, unknown>;
+	/**
+	 * Roles allowed to write to this gate's data store.
+	 * An empty array means no role can write (effectively read-only).
+	 * Use `['*']` to allow all roles.
+	 */
+	allowedWriterRoles: string[];
+	/** Human-readable description of what this gate checks. */
+	description?: string;
+	/**
+	 * When true, gate data is reset to `data` (defaults) each time the workflow
+	 * cycles through a channel referencing this gate. Used for cyclic workflows.
+	 */
+	resetOnCycle: boolean;
+}
+
+/**
+ * A Channel — a simple unidirectional pipe between agents in a workflow.
+ *
+ * Channels define messaging topology. A channel without a `gateId` is always open.
+ * When `gateId` is set, the channel is gated — messages are held until the
+ * referenced Gate's condition passes.
+ *
+ * This is the separated Channel type (M1.1). The legacy `WorkflowChannel` type
+ * with its inline `gate?: WorkflowCondition` is preserved for backward compatibility
+ * but new code should use `Channel` + `Gate`.
+ */
+export interface Channel {
+	/** Unique identifier */
+	id: string;
+	/**
+	 * Source agent name string (`WorkflowNodeAgent.name`), node name,
+	 * or `'*'` for all agents. Cross-node format: `"nodeId/agentName"`.
+	 */
+	from: string;
+	/**
+	 * Target agent name string, array of name strings, or `'*'` for all agents.
+	 * An array enables fan-out or hub-spoke topologies.
+	 */
+	to: string | string[];
+	/**
+	 * Optional reference to a Gate entity. When absent, the channel is always open.
+	 * When present, message delivery is blocked until the gate's condition passes.
+	 */
+	gateId?: string;
+	/**
+	 * When true, each delivery on this channel increments the run's iteration counter.
+	 * Used for cyclic workflows.
+	 */
+	isCyclic?: boolean;
+	/** Optional human-readable label for display in the visual editor. */
+	label?: string;
+}
+
+/**
+ * Failure reason for a workflow run that entered a terminal failure state.
+ */
+export type WorkflowRunFailureReason =
+	| 'humanRejected'
+	| 'maxIterationsReached'
+	| 'nodeTimeout'
+	| 'agentCrash';
 
 /**
  * A single agent entry within a multi-agent workflow node.
@@ -701,6 +856,12 @@ export interface SpaceWorkflow {
 	 */
 	channels?: WorkflowChannel[];
 	/**
+	 * Gate definitions for this workflow.
+	 * Gates are independent entities referenced by channels via `gateId`.
+	 * Persisted as JSON in the `gates` column of `space_workflows`.
+	 */
+	gates?: Gate[];
+	/**
 	 * @deprecated isDefault is no longer used for workflow selection.
 	 * Workflow selection uses only two modes: explicit workflowId or AI auto-select.
 	 * This field is retained for backward compatibility but has no runtime effect.
@@ -745,6 +906,8 @@ export interface CreateSpaceWorkflowParams {
 	 * Workflow-level messaging channels. `id` is optional — backend generates one when omitted.
 	 */
 	channels?: WorkflowChannel[];
+	/** Gate definitions for this workflow. */
+	gates?: Gate[];
 	/**
 	 * @deprecated isDefault has no runtime effect. Workflow selection uses only explicit workflowId or AI auto-select.
 	 */
@@ -786,6 +949,10 @@ export interface UpdateSpaceWorkflowParams {
 	 * Replaces the channel list. Pass `[]` or `null` to clear all channels.
 	 */
 	channels?: WorkflowChannel[] | null;
+	/**
+	 * Replaces the gate list. Pass `[]` or `null` to clear all gates.
+	 */
+	gates?: Gate[] | null;
 	/**
 	 * @deprecated isDefault has no runtime effect. Workflow selection uses only explicit workflowId or AI auto-select.
 	 */


### PR DESCRIPTION
## Summary

- Define separated `Channel` and `Gate` interfaces replacing the coupled gate/channel system
- `Channel`: simple unidirectional pipe — no gate = always open
- `Gate`: independent entity with composable `GateCondition` (check, count, all, any)
- `gate_data` SQLite table for persistent gate data stores keyed by (run_id, gate_id)
- `GateDataRepository` with CRUD, merge, initialize, and reset operations
- `GateEvaluator` for the new condition types
- `send_message` MCP tool now accepts optional structured `data` field
- `failureReason` field added to `SpaceWorkflowRun`
- Migration utility for legacy condition types (always→remove, human→check, condition→check, task_result→check)
- 65 new unit tests, 0 regressions in existing 8266 tests

## Test plan

- [x] Gate evaluator: check, count, all, any conditions with edge cases
- [x] Gate data repository: CRUD, merge, cascade delete, persistence round-trip
- [x] Gate migration: all 4 legacy types convert correctly
- [x] Type validation: Channel/Gate structure, failureReason enum
- [x] Schema: gate_data table creation, workflow gates column, send_message data field
- [x] Full daemon test suite: 0 failures, 0 regressions