### PR TITLE
feat: add numeric task IDs scoped per space

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -244,7 +244,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 	const sections: string[] = [];
 
 	// Task context
-	sections.push(`## Task\n`);
+	sections.push(`## Task #${task.taskNumber}\n`);
 	sections.push(`**Title:** ${task.title}`);
 	sections.push(`**Description:** ${task.description}`);
 	if (task.priority) {

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -331,7 +331,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 
 	// ---- Task context -------------------------------------------------------
-	sections.push(`\n## Task Details\n`);
+	sections.push(`\n## Task #${context.task.taskNumber} Details\n`);
 	sections.push(`**Title:** ${context.task.title}`);
 	sections.push(`**Priority:** ${context.task.priority}`);
 	sections.push(`**Status:** ${context.task.status}`);
@@ -363,7 +363,7 @@ export function buildTaskAgentInitialMessage(context: TaskAgentContext): string 
 
 	// ---- Task assignment -----------------------------------------------------
 	parts.push(
-		`## Task Assignment\n` +
+		`## Task #${context.task.taskNumber} Assignment\n` +
 			`\n` +
 			`You have been assigned the following task:\n` +
 			`\n` +

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -79,6 +79,13 @@ export class SpaceTaskManager {
 	}
 
 	/**
+	 * Get a task by its space-scoped numeric ID (e.g. task #5)
+	 */
+	async getTaskByNumber(taskNumber: number): Promise<SpaceTask | null> {
+		return this.taskRepo.getTaskByNumber(this.spaceId, taskNumber);
+	}
+
+	/**
 	 * List tasks in this space
 	 */
 	async listTasks(includeArchived = false): Promise<SpaceTask[]> {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -331,12 +331,23 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		},
 
 		/**
-		 * Get the full detail of a task by ID.
+		 * Get the full detail of a task by UUID or by numeric task number (e.g. #5).
 		 */
-		async get_task_detail(args: { task_id: string }): Promise<ToolResult> {
-			const task = await taskManager.getTask(args.task_id);
+		async get_task_detail(args: { task_id?: string; task_number?: number }): Promise<ToolResult> {
+			let task = null;
+			if (args.task_number !== undefined) {
+				task = await taskManager.getTaskByNumber(args.task_number);
+			} else if (args.task_id) {
+				task = await taskManager.getTask(args.task_id);
+			} else {
+				return jsonResult({
+					success: false,
+					error: 'Either task_id or task_number is required',
+				});
+			}
 			if (!task) {
-				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+				const ref = args.task_number !== undefined ? `#${args.task_number}` : args.task_id;
+				return jsonResult({ success: false, error: `Task not found: ${ref}` });
 			}
 			return jsonResult({ success: true, task });
 		},
@@ -588,9 +599,13 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'get_task_detail',
-			'Get the full detail of a task by ID, including error, result, PR URL, PR number, progress, and current step.',
+			'Get the full detail of a task by its numeric ID (e.g. task #5) or UUID. Includes error, result, PR URL, PR number, progress, and current step.',
 			{
-				task_id: z.string().describe('ID of the task to retrieve'),
+				task_id: z.string().optional().describe('UUID of the task to retrieve'),
+				task_number: z
+					.number()
+					.optional()
+					.describe('Numeric task ID (e.g. 5 for task #5) — preferred over task_id'),
 			},
 			(args) => handlers.get_task_detail(args)
 		),

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -24,43 +24,49 @@ export class SpaceTaskRepository {
 		const id = generateUUID();
 		const now = Date.now();
 
-		// Auto-assign task_number: MAX+1 scoped to this space, inside the same write.
-		// SQLite serialises writes, so MAX+1 is safe without an explicit transaction here.
-		const nextNumber = (
+		// Wrap SELECT MAX + INSERT in an explicit transaction to prevent concurrent
+		// requests from computing the same task_number. SQLite serialises write
+		// transactions, so the UNIQUE index is the safety net, but the transaction
+		// ensures correctness without relying on constraint errors.
+		const insertTx = this.db.transaction(() => {
+			const nextNumber = (
+				this.db
+					.prepare(
+						`SELECT COALESCE(MAX(task_number), 0) + 1 AS next FROM space_tasks WHERE space_id = ?`
+					)
+					.get(params.spaceId) as { next: number }
+			).next;
+
 			this.db
 				.prepare(
-					`SELECT COALESCE(MAX(task_number), 0) + 1 AS next FROM space_tasks WHERE space_id = ?`
-				)
-				.get(params.spaceId) as { next: number }
-		).next;
-
-		const stmt = this.db.prepare(
-			`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, task_type, assigned_agent, custom_agent_id, agent_name, completion_summary, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
+					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, task_type, assigned_agent, custom_agent_id, agent_name, completion_summary, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-		);
+				)
+				.run(
+					id,
+					params.spaceId,
+					nextNumber,
+					params.title,
+					params.description,
+					params.status ?? 'pending',
+					params.priority ?? 'normal',
+					params.taskType ?? null,
+					params.assignedAgent ?? 'coder',
+					params.customAgentId ?? null,
+					params.agentName ?? null,
+					null,
+					params.workflowRunId ?? null,
+					params.workflowNodeId ?? null,
+					params.createdByTaskId ?? null,
+					params.goalId ?? null,
+					JSON.stringify(params.dependsOn ?? []),
+					params.taskAgentSessionId ?? null,
+					now,
+					now
+				);
+		});
 
-		stmt.run(
-			id,
-			params.spaceId,
-			nextNumber,
-			params.title,
-			params.description,
-			params.status ?? 'pending',
-			params.priority ?? 'normal',
-			params.taskType ?? null,
-			params.assignedAgent ?? 'coder',
-			params.customAgentId ?? null,
-			params.agentName ?? null,
-			null,
-			params.workflowRunId ?? null,
-			params.workflowNodeId ?? null,
-			params.createdByTaskId ?? null,
-			params.goalId ?? null,
-			JSON.stringify(params.dependsOn ?? []),
-			params.taskAgentSessionId ?? null,
-			now,
-			now
-		);
+		insertTx();
 
 		return this.getTask(id)!;
 	}
@@ -374,7 +380,7 @@ export class SpaceTaskRepository {
 		return {
 			id: row.id as string,
 			spaceId: row.space_id as string,
-			taskNumber: row.task_number as number,
+			taskNumber: (row.task_number as number | null) ?? 0,
 			title: row.title as string,
 			description: (row.description as string) ?? '',
 			status: row.status as SpaceTask['status'],

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -24,14 +24,25 @@ export class SpaceTaskRepository {
 		const id = generateUUID();
 		const now = Date.now();
 
+		// Auto-assign task_number: MAX+1 scoped to this space, inside the same write.
+		// SQLite serialises writes, so MAX+1 is safe without an explicit transaction here.
+		const nextNumber = (
+			this.db
+				.prepare(
+					`SELECT COALESCE(MAX(task_number), 0) + 1 AS next FROM space_tasks WHERE space_id = ?`
+				)
+				.get(params.spaceId) as { next: number }
+		).next;
+
 		const stmt = this.db.prepare(
-			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, agent_name, completion_summary, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, task_type, assigned_agent, custom_agent_id, agent_name, completion_summary, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
 			id,
 			params.spaceId,
+			nextNumber,
 			params.title,
 			params.description,
 			params.status ?? 'pending',
@@ -334,6 +345,17 @@ export class SpaceTaskRepository {
 	}
 
 	/**
+	 * Get a task by its space-scoped numeric ID
+	 */
+	getTaskByNumber(spaceId: string, taskNumber: number): SpaceTask | null {
+		const row = this.db
+			.prepare(`SELECT * FROM space_tasks WHERE space_id = ? AND task_number = ?`)
+			.get(spaceId, taskNumber) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return this.rowToSpaceTask(row);
+	}
+
+	/**
 	 * Get draft tasks created by a specific planning task
 	 */
 	getDraftTasksByCreator(createdByTaskId: string): SpaceTask[] {
@@ -352,6 +374,7 @@ export class SpaceTaskRepository {
 		return {
 			id: row.id as string,
 			spaceId: row.space_id as string,
+			taskNumber: row.task_number as number,
 			title: row.title as string,
 			description: (row.description as string) ?? '',
 			status: row.status as SpaceTask['status'],

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -3801,28 +3801,117 @@ export function runMigration62(db: BunDatabase): void {
 	const cols = db.prepare('PRAGMA table_info(space_tasks)').all() as Array<{ name: string }>;
 	if (cols.some((c) => c.name === 'task_number')) return;
 
-	// Add the column (nullable initially so existing rows don't violate NOT NULL)
-	db.exec(`ALTER TABLE space_tasks ADD COLUMN task_number INTEGER`);
+	// SQLite cannot ALTER a column to NOT NULL, so we:
+	// 1. Add nullable column and backfill existing rows
+	// 2. Rebuild table with NOT NULL constraint via rename pattern
+	db.exec(`PRAGMA foreign_keys = OFF`);
+	db.exec(`BEGIN`);
+	try {
+		// Step 1: Add nullable column and backfill
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN task_number INTEGER`);
 
-	// Backfill existing rows: assign sequential numbers per space ordered by created_at
-	const spaces = db.prepare(`SELECT DISTINCT space_id FROM space_tasks`).all() as Array<{
-		space_id: string;
-	}>;
-	for (const { space_id } of spaces) {
-		const tasks = db
-			.prepare(`SELECT id FROM space_tasks WHERE space_id = ? ORDER BY created_at ASC`)
-			.all(space_id) as Array<{ id: string }>;
-		const updateStmt = db.prepare(`UPDATE space_tasks SET task_number = ? WHERE id = ?`);
-		let num = 1;
-		for (const { id } of tasks) {
-			updateStmt.run(num++, id);
+		const spaces = db.prepare(`SELECT DISTINCT space_id FROM space_tasks`).all() as Array<{
+			space_id: string;
+		}>;
+		for (const { space_id } of spaces) {
+			const tasks = db
+				.prepare(`SELECT id FROM space_tasks WHERE space_id = ? ORDER BY created_at ASC`)
+				.all(space_id) as Array<{ id: string }>;
+			const updateStmt = db.prepare(`UPDATE space_tasks SET task_number = ? WHERE id = ?`);
+			let num = 1;
+			for (const { id } of tasks) {
+				updateStmt.run(num++, id);
+			}
 		}
-	}
 
-	// Create unique index (enforces per-space uniqueness)
-	db.exec(
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
-	);
+		// Step 2: Rebuild table with NOT NULL on task_number
+		db.exec(`DROP TABLE IF EXISTS space_tasks_m61_new`);
+		db.exec(`
+			CREATE TABLE space_tasks_m61_new (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				task_number INTEGER NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed',
+						'needs_attention', 'cancelled', 'archived', 'rate_limited', 'usage_limited')),
+				priority TEXT NOT NULL DEFAULT 'normal'
+					CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				task_type TEXT
+					CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+				assigned_agent TEXT
+					CHECK(assigned_agent IN ('coder', 'general', 'planner')),
+				custom_agent_id TEXT,
+				agent_name TEXT,
+				completion_summary TEXT,
+				workflow_run_id TEXT,
+				workflow_node_id TEXT,
+				created_by_task_id TEXT,
+				goal_id TEXT,
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				input_draft TEXT,
+				active_session TEXT
+					CHECK(active_session IN ('worker', 'leader')),
+				task_agent_session_id TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				archived_at INTEGER,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+				FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
+			)
+		`);
+
+		db.exec(`
+			INSERT INTO space_tasks_m61_new
+			SELECT id, space_id, task_number, title, description, status, priority, task_type,
+				assigned_agent, custom_agent_id, agent_name, completion_summary,
+				workflow_run_id, workflow_node_id, created_by_task_id, goal_id,
+				progress, current_step, result, error, depends_on, input_draft,
+				active_session, task_agent_session_id, pr_url, pr_number, pr_created_at,
+				archived_at, created_at, started_at, completed_at, updated_at
+			FROM space_tasks
+		`);
+
+		db.exec(`DROP TABLE space_tasks`);
+		db.exec(`ALTER TABLE space_tasks_m61_new RENAME TO space_tasks`);
+
+		// Recreate all indexes (dropped with the old table)
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
+		);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
+		);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`
+		);
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_one_per_agent_slot ON space_tasks (workflow_run_id, workflow_node_id, agent_name) WHERE workflow_run_id IS NOT NULL AND workflow_node_id IS NOT NULL AND agent_name IS NOT NULL`
+		);
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
+		);
+
+		db.exec(`COMMIT`);
+	} catch (err) {
+		db.exec(`ROLLBACK`);
+		throw err;
+	} finally {
+		db.exec(`PRAGMA foreign_keys = ON`);
+	}
 }
 
 export function runMigration60(db: BunDatabase): void {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -3898,9 +3898,18 @@ export function runMigration62(db: BunDatabase): void {
 		db.exec(
 			`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`
 		);
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
 		db.exec(
-			`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_one_per_agent_slot ON space_tasks (workflow_run_id, workflow_node_id, agent_name) WHERE workflow_run_id IS NOT NULL AND workflow_node_id IS NOT NULL AND agent_name IS NOT NULL`
+			`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
 		);
+		db.exec(`
+			CREATE UNIQUE INDEX IF NOT EXISTS uq_space_tasks_run_node_agent
+			ON space_tasks (workflow_run_id, workflow_node_id, agent_name)
+			WHERE workflow_run_id IS NOT NULL
+				AND workflow_node_id IS NOT NULL
+				AND agent_name IS NOT NULL
+				AND status IN ('pending', 'in_progress', 'review', 'rate_limited', 'usage_limited')
+		`);
 		db.exec(
 			`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
 		);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -253,6 +253,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// and failure_reason column to space_workflow_runs.
 	// Part of M1.1 — separated Channel + Gate types.
 	runMigration61(db);
+
+	// Migration 62: Add task_number column to space_tasks for human-friendly numeric IDs.
+	// Scoped per space via UNIQUE(space_id, task_number). Backfills existing rows.
+	runMigration62(db);
 }
 
 /**
@@ -3790,6 +3794,37 @@ export function runMigration59(db: BunDatabase): void {
  *
  * currentNodeId is replaced by the agent-centric model where tasks track state.
  */
+export function runMigration62(db: BunDatabase): void {
+	if (!tableExists(db, 'space_tasks')) return;
+
+	// Check if column already exists (idempotent guard)
+	const cols = db.prepare('PRAGMA table_info(space_tasks)').all() as Array<{ name: string }>;
+	if (cols.some((c) => c.name === 'task_number')) return;
+
+	// Add the column (nullable initially so existing rows don't violate NOT NULL)
+	db.exec(`ALTER TABLE space_tasks ADD COLUMN task_number INTEGER`);
+
+	// Backfill existing rows: assign sequential numbers per space ordered by created_at
+	const spaces = db.prepare(`SELECT DISTINCT space_id FROM space_tasks`).all() as Array<{
+		space_id: string;
+	}>;
+	for (const { space_id } of spaces) {
+		const tasks = db
+			.prepare(`SELECT id FROM space_tasks WHERE space_id = ? ORDER BY created_at ASC`)
+			.all(space_id) as Array<{ id: string }>;
+		const updateStmt = db.prepare(`UPDATE space_tasks SET task_number = ? WHERE id = ?`);
+		let num = 1;
+		for (const { id } of tasks) {
+			updateStmt.run(num++, id);
+		}
+	}
+
+	// Create unique index (enforces per-space uniqueness)
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
+	);
+}
+
 export function runMigration60(db: BunDatabase): void {
 	// Disable FK enforcement before any DDL so that:
 	// - DROP TABLE space_workflow_runs does NOT fire ON DELETE SET NULL on space_tasks.workflow_run_id

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -146,7 +146,7 @@ export function createSpaceTables(db: BunDatabase): void {
 		CREATE TABLE IF NOT EXISTS space_tasks (
 			id TEXT PRIMARY KEY,
 			space_id TEXT NOT NULL,
-			task_number INTEGER,
+			task_number INTEGER NOT NULL,
 			title TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
 			status TEXT NOT NULL DEFAULT 'pending'

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -146,6 +146,7 @@ export function createSpaceTables(db: BunDatabase): void {
 		CREATE TABLE IF NOT EXISTS space_tasks (
 			id TEXT PRIMARY KEY,
 			space_id TEXT NOT NULL,
+			task_number INTEGER,
 			title TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
 			status TEXT NOT NULL DEFAULT 'pending'
@@ -185,4 +186,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
 		)
 	`);
+
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
+	);
 }

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -751,5 +751,22 @@ describe('SpaceTaskManager', () => {
 			const otherManager = new SpaceTaskManager(db as any, otherSpace.id);
 			expect(await otherManager.getTaskByNumber(1)).toBeNull();
 		});
+
+		it('concurrent createTask assigns unique taskNumbers', async () => {
+			// Fire 20 async createTask calls concurrently via Promise.all.
+			// The db.transaction() in the repository serialises the SELECT MAX + INSERT,
+			// so each task should get a unique, monotonically increasing taskNumber.
+			const results = await Promise.all(
+				Array.from({ length: 20 }, (_, i) =>
+					manager.createTask({ title: `Concurrent ${i}`, description: '' })
+				)
+			);
+
+			const numbers = results.map((t) => t.taskNumber);
+			const uniqueNumbers = new Set(numbers);
+			expect(uniqueNumbers.size).toBe(20);
+			expect(Math.min(...numbers)).toBe(1);
+			expect(Math.max(...numbers)).toBe(20);
+		});
 	});
 });

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -717,4 +717,39 @@ describe('SpaceTaskManager', () => {
 			await expect(manager.retryTask(task.id)).rejects.toThrow("Cannot retry task in 'archived'");
 		});
 	});
+
+	describe('taskNumber (numeric task IDs)', () => {
+		it('createTask assigns auto-incrementing taskNumber', async () => {
+			const t1 = await manager.createTask({ title: 'A', description: '' });
+			const t2 = await manager.createTask({ title: 'B', description: '' });
+			expect(t1.taskNumber).toBe(1);
+			expect(t2.taskNumber).toBe(2);
+		});
+
+		it('getTaskByNumber retrieves the correct task', async () => {
+			const t1 = await manager.createTask({ title: 'A', description: '' });
+			await manager.createTask({ title: 'B', description: '' });
+
+			const found = await manager.getTaskByNumber(1);
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(t1.id);
+			expect(found!.taskNumber).toBe(1);
+		});
+
+		it('getTaskByNumber returns null for non-existent number', async () => {
+			await manager.createTask({ title: 'A', description: '' });
+			expect(await manager.getTaskByNumber(999)).toBeNull();
+		});
+
+		it('getTaskByNumber is scoped to this space', async () => {
+			await manager.createTask({ title: 'A', description: '' });
+
+			const otherSpace = spaceRepo.createSpace({
+				workspacePath: '/workspace/other',
+				name: 'Other',
+			});
+			const otherManager = new SpaceTaskManager(db as any, otherSpace.id);
+			expect(await otherManager.getTaskByNumber(1)).toBeNull();
+		});
+	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -46,6 +46,7 @@ const mockSpace: Space = {
 const mockTask: SpaceTask = {
 	id: 'task-1',
 	spaceId: 'space-1',
+	taskNumber: 1,
 	title: 'Test Task',
 	description: 'desc',
 	status: 'pending',

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
@@ -42,6 +42,7 @@ const mockSpace: Space = {
 const mockTask: SpaceTask = {
 	id: 'task-1',
 	spaceId: 'space-1',
+	taskNumber: 1,
 	title: 'Test Task',
 	description: 'A task description',
 	status: 'pending',

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
@@ -30,6 +30,7 @@ const NOW = Date.now();
 const mockTaskWithSession: SpaceTask = {
 	id: 'task-1',
 	spaceId: 'space-1',
+	taskNumber: 1,
 	title: 'Test Task',
 	description: 'A task description',
 	status: 'in_progress',
@@ -43,6 +44,7 @@ const mockTaskWithSession: SpaceTask = {
 const mockTaskWithoutSession: SpaceTask = {
 	id: 'task-2',
 	spaceId: 'space-1',
+	taskNumber: 2,
 	title: 'Pending Task',
 	description: 'Not yet spawned',
 	status: 'pending',

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -72,6 +72,7 @@ const mockRun: SpaceWorkflowRun = {
 const mockTask: SpaceTask = {
 	id: 'task-1',
 	spaceId: 'space-1',
+	taskNumber: 1,
 	title: 'Step One',
 	description: '',
 	status: 'pending',

--- a/packages/daemon/tests/unit/space/agent-completion.test.ts
+++ b/packages/daemon/tests/unit/space/agent-completion.test.ts
@@ -76,11 +76,12 @@ function seedSpaceTask(
 	db.exec('PRAGMA foreign_keys = OFF');
 	db.prepare(
 		`INSERT INTO space_tasks
-         (id, space_id, title, description, status, priority, agent_name, completion_summary,
+         (id, space_id, task_number, title, description, status, priority, agent_name, completion_summary,
           workflow_run_id, workflow_node_id, depends_on, created_at, updated_at)
-         VALUES (?, ?, ?, '', ?, 'normal', ?, ?, ?, ?, '[]', ?, ?)`
+         VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, '', ?, 'normal', ?, ?, ?, ?, '[]', ?, ?)`
 	).run(
 		id,
+		spaceId,
 		spaceId,
 		`Task for ${agentName}`,
 		status,

--- a/packages/daemon/tests/unit/space/agent-liveness.test.ts
+++ b/packages/daemon/tests/unit/space/agent-liveness.test.ts
@@ -68,12 +68,13 @@ function seedTask(
 	const now = Date.now();
 	db.prepare(
 		`INSERT INTO space_tasks
-       (id, space_id, title, description, status, priority, depends_on,
+       (id, space_id, task_number, title, description, status, priority, depends_on,
         task_agent_session_id, started_at, workflow_run_id, workflow_node_id,
         created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, 'normal', '[]', ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, ?, ?, 'normal', '[]', ?, ?, ?, ?, ?, ?)`
 	).run(
 		id,
+		spaceId,
 		spaceId,
 		`Task ${id}`,
 		'',

--- a/packages/daemon/tests/unit/space/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/space/agent-message-router.test.ts
@@ -128,11 +128,12 @@ function seedPeerTask(
 	const id = `task-${Math.random().toString(36).slice(2)}`;
 	db.prepare(
 		`INSERT INTO space_tasks
-       (id, space_id, title, description, status, priority, agent_name,
+       (id, space_id, task_number, title, description, status, priority, agent_name,
         workflow_run_id, workflow_node_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, '', 'in_progress', 'normal', ?, ?, ?, '[]', ?, ?, ?)`
+       VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, '', 'in_progress', 'normal', ?, ?, ?, '[]', ?, ?, ?)`
 	).run(
 		id,
+		spaceId,
 		spaceId,
 		`Task for ${agentName}`,
 		agentName,

--- a/packages/daemon/tests/unit/space/completion-detector.test.ts
+++ b/packages/daemon/tests/unit/space/completion-detector.test.ts
@@ -98,11 +98,12 @@ function seedTask(
 	const now = Date.now();
 	db.prepare(
 		`INSERT INTO space_tasks
-       (id, space_id, title, description, status, priority, depends_on,
+       (id, space_id, task_number, title, description, status, priority, depends_on,
         workflow_run_id, workflow_node_id, created_at, updated_at)
-       VALUES (?, ?, ?, '', ?, 'normal', '[]', ?, ?, ?, ?)`
+       VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, '', ?, 'normal', '[]', ?, ?, ?, ?)`
 	).run(
 		id,
+		spaceId,
 		spaceId,
 		`Task ${id}`,
 		overrides.status ?? 'in_progress',

--- a/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -107,11 +107,12 @@ function seedTask(
 	const id = `task-int-${Math.random().toString(36).slice(2)}`;
 	db.prepare(
 		`INSERT INTO space_tasks
-       (id, space_id, title, description, status, priority, agent_name,
+       (id, space_id, task_number, title, description, status, priority, agent_name,
         workflow_run_id, workflow_node_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, '', ?, 'normal', ?, ?, ?, '[]', ?, ?, ?)`
+       VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, '', ?, 'normal', ?, ?, ?, '[]', ?, ?, ?)`
 	).run(
 		id,
+		spaceId,
 		spaceId,
 		`Task for ${agentName}`,
 		status,

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -105,10 +105,20 @@ function seedRunTask(
 	const id = `task-cam-${Math.random().toString(36).slice(2)}`;
 	db.prepare(
 		`INSERT INTO space_tasks
-       (id, space_id, title, description, status, priority, agent_name,
+       (id, space_id, task_number, title, description, status, priority, agent_name,
         workflow_run_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, '', 'in_progress', 'normal', ?, ?, '[]', ?, ?, ?)`
-	).run(id, spaceId, `Task for ${agentName}`, agentName, workflowRunId, sessionId, now, now);
+       VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, '', 'in_progress', 'normal', ?, ?, '[]', ?, ?, ?)`
+	).run(
+		id,
+		spaceId,
+		spaceId,
+		`Task for ${agentName}`,
+		agentName,
+		workflowRunId,
+		sessionId,
+		now,
+		now
+	);
 	db.exec('PRAGMA foreign_keys = ON');
 }
 
@@ -157,11 +167,12 @@ function seedStepTask(
 	const id = `task-cam-${Math.random().toString(36).slice(2)}`;
 	db.prepare(
 		`INSERT INTO space_tasks
-       (id, space_id, title, description, status, priority, agent_name,
+       (id, space_id, task_number, title, description, status, priority, agent_name,
         workflow_run_id, workflow_node_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, '', ?, 'normal', ?, ?, ?, '[]', ?, ?, ?)`
+       VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, '', ?, 'normal', ?, ?, ?, '[]', ?, ?, ?)`
 	).run(
 		id,
+		spaceId,
 		spaceId,
 		`Task for ${agentName}`,
 		status,

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -53,6 +53,7 @@ function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
 	return {
 		id: 'task-1',
 		spaceId: 'space-1',
+		taskNumber: 1,
 		title: 'Implement feature X',
 		description: 'Add feature X to the codebase',
 		status: 'pending',

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -66,11 +66,12 @@ function seedSpaceTask(
 	db.exec('PRAGMA foreign_keys = OFF');
 	db.prepare(
 		`INSERT INTO space_tasks
-         (id, space_id, title, description, status, priority, agent_name, completion_summary,
+         (id, space_id, task_number, title, description, status, priority, agent_name, completion_summary,
           workflow_run_id, workflow_node_id, depends_on, created_at, updated_at)
-         VALUES (?, ?, ?, '', ?, 'normal', ?, ?, ?, ?, '[]', ?, ?)`
+         VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, '', ?, 'normal', ?, ?, ?, ?, '[]', ?, ?)`
 	).run(
 		id,
+		spaceId,
 		spaceId,
 		`Task for ${agentName}`,
 		status,

--- a/packages/daemon/tests/unit/space/send-message-unified.test.ts
+++ b/packages/daemon/tests/unit/space/send-message-unified.test.ts
@@ -129,14 +129,22 @@ function seedPeerTask(
 	db.exec('PRAGMA foreign_keys = OFF');
 	const now = Date.now();
 	const id = `task-${Math.random().toString(36).slice(2)}`;
+	const nextNumber = (
+		db
+			.prepare(
+				`SELECT COALESCE(MAX(task_number), 0) + 1 AS next FROM space_tasks WHERE space_id = ?`
+			)
+			.get(spaceId) as { next: number }
+	).next;
 	db.prepare(
 		`INSERT INTO space_tasks
-       (id, space_id, title, description, status, priority, agent_name,
+       (id, space_id, task_number, title, description, status, priority, agent_name,
         workflow_run_id, workflow_node_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, '', 'in_progress', 'normal', ?, ?, ?, '[]', ?, ?, ?)`
+       VALUES (?, ?, ?, ?, '', 'in_progress', 'normal', ?, ?, ?, '[]', ?, ?, ?)`
 	).run(
 		id,
 		spaceId,
+		nextNumber,
 		`Task for ${agentName}`,
 		agentName,
 		workflowRunId,

--- a/packages/daemon/tests/unit/space/space-agent-autonomy.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-autonomy.test.ts
@@ -392,11 +392,12 @@ describe('retry_task tool — autonomy level does not affect tool behavior', () 
 		ctx.db
 			.prepare(
 				`INSERT INTO space_tasks
-         (id, space_id, title, description, status, priority, task_type, created_at, updated_at)
-         VALUES (?, ?, ?, ?, 'needs_attention', 'normal', 'coding', ?, ?)`
+         (id, space_id, task_number, title, description, status, priority, task_type, created_at, updated_at)
+         VALUES (?, ?, (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?), ?, ?, 'needs_attention', 'normal', 'coding', ?, ?)`
 			)
 			.run(
 				taskId,
+				ctx.spaceId,
 				ctx.spaceId,
 				'Failing task',
 				'Task that needs attention',

--- a/packages/daemon/tests/unit/space/task-agent-init.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-init.test.ts
@@ -41,6 +41,7 @@ function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
 	return {
 		id: 'task-1',
 		spaceId: 'space-1',
+		taskNumber: 1,
 		title: 'Implement feature X',
 		description: 'Add the X feature to the codebase with tests.',
 		status: 'in_progress',

--- a/packages/daemon/tests/unit/space/task-agent.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent.test.ts
@@ -47,6 +47,7 @@ function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
 	return {
 		id: 'task-1',
 		spaceId: 'space-1',
+		taskNumber: 1,
 		title: 'Implement feature X',
 		description: 'Add the X feature to the codebase with tests.',
 		status: 'in_progress',

--- a/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
@@ -278,8 +278,8 @@ describe('Migration 29: Space system tables', () => {
 
 		// Insert a task
 		db.exec(
-			`INSERT INTO space_tasks (id, space_id, title, created_at, updated_at)
-			 VALUES ('task-1', 'sp-1', 'Task 1', ${now}, ${now})`
+			`INSERT INTO space_tasks (id, space_id, task_number, title, created_at, updated_at)
+			 VALUES ('task-1', 'sp-1', 1, 'Task 1', ${now}, ${now})`
 		);
 
 		// Note: space_session_groups and space_session_group_members were dropped by migration 60.
@@ -323,8 +323,8 @@ describe('Migration 29: Space system tables', () => {
 			 VALUES ('wr-2', 'sp-2', 'wf-2', 'Run 2', ${now}, ${now})`
 		);
 		db.exec(
-			`INSERT INTO space_tasks (id, space_id, title, workflow_run_id, created_at, updated_at)
-			 VALUES ('task-2', 'sp-2', 'Task 2', 'wr-2', ${now}, ${now})`
+			`INSERT INTO space_tasks (id, space_id, task_number, title, workflow_run_id, created_at, updated_at)
+			 VALUES ('task-2', 'sp-2', 1, 'Task 2', 'wr-2', ${now}, ${now})`
 		);
 
 		// Delete the workflow run
@@ -353,6 +353,7 @@ describe('Migration 29: Space system tables', () => {
 		);
 
 		// Valid status values
+		let taskNum = 0;
 		for (const status of [
 			'draft',
 			'pending',
@@ -362,10 +363,11 @@ describe('Migration 29: Space system tables', () => {
 			'needs_attention',
 			'cancelled',
 		]) {
+			taskNum++;
 			expect(() => {
 				db.exec(
-					`INSERT INTO space_tasks (id, space_id, title, status, created_at, updated_at)
-					 VALUES ('t-${status}', 'sp-3', 'Task', '${status}', ${now}, ${now})`
+					`INSERT INTO space_tasks (id, space_id, task_number, title, status, created_at, updated_at)
+					 VALUES ('t-${status}', 'sp-3', ${taskNum}, 'Task', '${status}', ${now}, ${now})`
 				);
 			}).not.toThrow();
 		}
@@ -373,8 +375,8 @@ describe('Migration 29: Space system tables', () => {
 		// Invalid status
 		expect(() => {
 			db.exec(
-				`INSERT INTO space_tasks (id, space_id, title, status, created_at, updated_at)
-				 VALUES ('t-bad', 'sp-3', 'Task', 'invalid', ${now}, ${now})`
+				`INSERT INTO space_tasks (id, space_id, task_number, title, status, created_at, updated_at)
+				 VALUES ('t-bad', 'sp-3', ${taskNum + 1}, 'Task', 'invalid', ${now}, ${now})`
 			);
 		}).toThrow();
 	});
@@ -390,15 +392,15 @@ describe('Migration 29: Space system tables', () => {
 
 		expect(() => {
 			db.exec(
-				`INSERT INTO space_tasks (id, space_id, title, priority, created_at, updated_at)
-				 VALUES ('t-urgent', 'sp-4', 'Task', 'urgent', ${now}, ${now})`
+				`INSERT INTO space_tasks (id, space_id, task_number, title, priority, created_at, updated_at)
+				 VALUES ('t-urgent', 'sp-4', 1, 'Task', 'urgent', ${now}, ${now})`
 			);
 		}).not.toThrow();
 
 		expect(() => {
 			db.exec(
-				`INSERT INTO space_tasks (id, space_id, title, priority, created_at, updated_at)
-				 VALUES ('t-bad-pri', 'sp-4', 'Task', 'extreme', ${now}, ${now})`
+				`INSERT INTO space_tasks (id, space_id, task_number, title, priority, created_at, updated_at)
+				 VALUES ('t-bad-pri', 'sp-4', 2, 'Task', 'extreme', ${now}, ${now})`
 			);
 		}).toThrow();
 	});
@@ -449,8 +451,8 @@ describe('Migration 29: Space system tables', () => {
 			 VALUES ('step-s1', 'wf-step', 'Step 1', 0, ${now}, ${now})`
 		);
 		db.exec(
-			`INSERT INTO space_tasks (id, space_id, title, workflow_node_id, created_at, updated_at)
-			 VALUES ('task-step', 'sp-step', 'Task Step', 'step-s1', ${now}, ${now})`
+			`INSERT INTO space_tasks (id, space_id, task_number, title, workflow_node_id, created_at, updated_at)
+			 VALUES ('task-step', 'sp-step', 1, 'Task Step', 'step-s1', ${now}, ${now})`
 		);
 
 		// Delete the workflow node

--- a/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
@@ -126,9 +126,9 @@ describe('Migration 34: Add archived to status CHECK constraints', () => {
 
 		expect(() => {
 			db.prepare(
-				`INSERT INTO space_tasks (id, space_id, title, description, status, created_at, updated_at)
-				 VALUES (?, ?, ?, ?, ?, ?, ?)`
-			).run('st-1', 'space-1', 'Test Task', 'desc', 'archived', now, now);
+				`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+			).run('st-1', 'space-1', 1, 'Test Task', 'desc', 'archived', now, now);
 		}).not.toThrow();
 
 		const row = db.prepare(`SELECT status FROM space_tasks WHERE id = 'st-1'`).get() as {

--- a/packages/daemon/tests/unit/storage/migrations/migration-54_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-54_test.ts
@@ -68,13 +68,22 @@ function insertTask(
 	// without needing to create all referenced parent rows.
 	db.exec('PRAGMA foreign_keys = OFF');
 	try {
+		const spaceId = opts.spaceId ?? 'sp-1';
+		const nextNumber = (
+			db
+				.prepare(
+					`SELECT COALESCE(MAX(task_number), 0) + 1 AS next FROM space_tasks WHERE space_id = ?`
+				)
+				.get(spaceId) as { next: number }
+		).next;
 		db.prepare(
 			`INSERT INTO space_tasks
-		 (id, space_id, title, description, status, priority, depends_on, workflow_run_id, workflow_node_id, agent_name, created_at, updated_at)
-		 VALUES (?, ?, 'Task', '', ?, 'normal', '[]', ?, ?, ?, ?, ?)`
+		 (id, space_id, task_number, title, description, status, priority, depends_on, workflow_run_id, workflow_node_id, agent_name, created_at, updated_at)
+		 VALUES (?, ?, ?, 'Task', '', ?, 'normal', '[]', ?, ?, ?, ?, ?)`
 		).run(
 			opts.id,
-			opts.spaceId ?? 'sp-1',
+			spaceId,
+			nextNumber,
 			opts.status ?? 'pending',
 			opts.runId ?? null,
 			opts.nodeId ?? null,

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -570,4 +570,23 @@ describe('SpaceTaskRepository', () => {
 			expect(repo.getTaskByNumber(space2.id, 1)).toBeNull();
 		});
 	});
+
+	describe('concurrent task creation', () => {
+		it('assigns unique taskNumbers when creating tasks rapidly', () => {
+			// Simulate concurrent creation by creating many tasks in tight succession.
+			// The transaction in createTask prevents duplicate task_numbers.
+			const tasks = Array.from({ length: 20 }, (_, i) =>
+				repo.createTask({ spaceId, title: `Task ${i}`, description: '' })
+			);
+
+			const numbers = tasks.map((t) => t.taskNumber);
+			const uniqueNumbers = new Set(numbers);
+			expect(uniqueNumbers.size).toBe(20);
+
+			// Verify monotonically increasing
+			for (let i = 1; i < numbers.length; i++) {
+				expect(numbers[i]).toBeGreaterThan(numbers[i - 1]);
+			}
+		});
+	});
 });

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -465,4 +465,109 @@ describe('SpaceTaskRepository', () => {
 			expect(tasks.map((t) => t.title)).toEqual(['First', 'Second', 'Third']);
 		});
 	});
+
+	describe('taskNumber (numeric task IDs)', () => {
+		it('auto-assigns taskNumber starting at 1', () => {
+			const task = repo.createTask({ spaceId, title: 'First', description: '' });
+			expect(task.taskNumber).toBe(1);
+		});
+
+		it('auto-increments taskNumber within a space', () => {
+			const t1 = repo.createTask({ spaceId, title: 'A', description: '' });
+			const t2 = repo.createTask({ spaceId, title: 'B', description: '' });
+			const t3 = repo.createTask({ spaceId, title: 'C', description: '' });
+			expect(t1.taskNumber).toBe(1);
+			expect(t2.taskNumber).toBe(2);
+			expect(t3.taskNumber).toBe(3);
+		});
+
+		it('scopes taskNumber per space (two spaces get independent sequences)', () => {
+			const space2 = spaceRepo.createSpace({
+				workspacePath: '/workspace/test2',
+				name: 'Space 2',
+			});
+
+			const s1t1 = repo.createTask({ spaceId, title: 'S1-A', description: '' });
+			const s1t2 = repo.createTask({ spaceId, title: 'S1-B', description: '' });
+			const s2t1 = repo.createTask({ spaceId: space2.id, title: 'S2-A', description: '' });
+			const s2t2 = repo.createTask({ spaceId: space2.id, title: 'S2-B', description: '' });
+
+			expect(s1t1.taskNumber).toBe(1);
+			expect(s1t2.taskNumber).toBe(2);
+			expect(s2t1.taskNumber).toBe(1);
+			expect(s2t2.taskNumber).toBe(2);
+		});
+
+		it('leaves gaps when non-highest task is deleted', () => {
+			repo.createTask({ spaceId, title: 'A', description: '' });
+			const t2 = repo.createTask({ spaceId, title: 'B', description: '' });
+			repo.createTask({ spaceId, title: 'C', description: '' });
+			repo.deleteTask(t2.id);
+
+			// After deleting #2, next task gets MAX(1,3)+1 = 4, leaving a gap at #2
+			const t4 = repo.createTask({ spaceId, title: 'D', description: '' });
+			expect(t4.taskNumber).toBe(4);
+		});
+
+		it('is monotonically increasing (MAX+1 strategy)', () => {
+			const t1 = repo.createTask({ spaceId, title: 'A', description: '' });
+			const t2 = repo.createTask({ spaceId, title: 'B', description: '' });
+			expect(t1.taskNumber).toBeLessThan(t2.taskNumber);
+		});
+
+		it('enforces UNIQUE(space_id, task_number) constraint', () => {
+			repo.createTask({ spaceId, title: 'A', description: '' });
+			// Manually inserting a duplicate task_number should throw
+			expect(() => {
+				(db as any)
+					.prepare(
+						`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, depends_on, created_at, updated_at)
+						VALUES ('dup-id', ?, 1, 'Dup', '', 'pending', 'normal', '[]', ?, ?)`
+					)
+					.run(spaceId, Date.now(), Date.now());
+			}).toThrow();
+		});
+
+		it('taskNumber is returned by getTask', () => {
+			const created = repo.createTask({ spaceId, title: 'T', description: '' });
+			const fetched = repo.getTask(created.id);
+			expect(fetched!.taskNumber).toBe(1);
+		});
+
+		it('taskNumber is returned in list queries', () => {
+			repo.createTask({ spaceId, title: 'A', description: '' });
+			repo.createTask({ spaceId, title: 'B', description: '' });
+
+			const tasks = repo.listBySpace(spaceId);
+			const numbers = tasks.map((t) => t.taskNumber).sort();
+			expect(numbers).toEqual([1, 2]);
+		});
+	});
+
+	describe('getTaskByNumber', () => {
+		it('returns the correct task by (spaceId, taskNumber)', () => {
+			const t1 = repo.createTask({ spaceId, title: 'A', description: '' });
+			repo.createTask({ spaceId, title: 'B', description: '' });
+
+			const found = repo.getTaskByNumber(spaceId, 1);
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(t1.id);
+			expect(found!.taskNumber).toBe(1);
+		});
+
+		it('returns null for a non-existent taskNumber', () => {
+			repo.createTask({ spaceId, title: 'A', description: '' });
+			expect(repo.getTaskByNumber(spaceId, 999)).toBeNull();
+		});
+
+		it('returns null when taskNumber exists in a different space', () => {
+			repo.createTask({ spaceId, title: 'A', description: '' });
+
+			const space2 = spaceRepo.createSpace({
+				workspacePath: '/workspace/test3',
+				name: 'Space 3',
+			});
+			expect(repo.getTaskByNumber(space2.id, 1)).toBeNull();
+		});
+	});
 });

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -571,10 +571,11 @@ describe('SpaceTaskRepository', () => {
 		});
 	});
 
-	describe('concurrent task creation', () => {
-		it('assigns unique taskNumbers when creating tasks rapidly', () => {
-			// Simulate concurrent creation by creating many tasks in tight succession.
-			// The transaction in createTask prevents duplicate task_numbers.
+	describe('bulk task creation', () => {
+		it('assigns unique monotonically increasing taskNumbers for many tasks', () => {
+			// Repo-level createTask is synchronous (bun:sqlite), so this tests
+			// sequential bulk creation. Concurrent (Promise.all) tests live in
+			// space-task-manager.test.ts where createTask is async.
 			const tasks = Array.from({ length: 20 }, (_, i) =>
 				repo.createTask({ spaceId, title: `Task ${i}`, description: '' })
 			);
@@ -582,11 +583,8 @@ describe('SpaceTaskRepository', () => {
 			const numbers = tasks.map((t) => t.taskNumber);
 			const uniqueNumbers = new Set(numbers);
 			expect(uniqueNumbers.size).toBe(20);
-
-			// Verify monotonically increasing
-			for (let i = 1; i < numbers.length; i++) {
-				expect(numbers[i]).toBeGreaterThan(numbers[i - 1]);
-			}
+			expect(Math.min(...numbers)).toBe(1);
+			expect(Math.max(...numbers)).toBe(20);
 		});
 	});
 });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -148,6 +148,8 @@ export interface SpaceTask {
 	id: string;
 	/** Space this task belongs to */
 	spaceId: string;
+	/** Human-friendly numeric ID, unique per space (auto-incremented, like GitHub issue numbers) */
+	taskNumber: number;
 	/** Task title */
 	title: string;
 	/** Detailed description */

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -43,10 +43,12 @@ function makeSpace(id = 'space-1'): Space {
 	};
 }
 
+let _taskCounter = 0;
 function makeTask(id: string, status = 'pending', workflowRunId?: string): SpaceTask {
 	return {
 		id,
 		spaceId: 'space-1',
+		taskNumber: ++_taskCounter,
 		title: `Task ${id}`,
 		description: '',
 		status: status as SpaceTask['status'],


### PR DESCRIPTION
## Summary

- Adds `task_number` column (INTEGER, UNIQUE per space) to `space_tasks` with migration 61, backfilling existing rows
- Auto-assigns via MAX+1 on creation; UUID `id` stays as internal PK for FK references
- Adds `getTaskByNumber(spaceId, taskNumber)` lookup at repository and manager layers
- Agent prompts and `get_task_detail` tool now reference tasks by number ("Task #5")
- Unit tests cover auto-increment, space-scoped uniqueness, gap behavior, and lookup by number

## Test plan

- [x] All 8218 daemon unit tests pass (0 failures)
- [x] TypeScript typecheck clean
- [x] Lint + format clean
- [x] Knip (dead code detection) clean