### PR TITLE
feat(space): implement unified gate evaluator (M1.2)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
@@ -69,6 +69,10 @@ export function validateGateCondition(condition: unknown, path = 'condition'): s
 			if (cond.op !== undefined && (typeof cond.op !== 'string' || !VALID_CHECK_OPS.has(cond.op))) {
 				errors.push(`${path}.op: expected one of [exists, ==, !=], got ${JSON.stringify(cond.op)}`);
 			}
+			// Warn when value is set but op is 'exists' (value is ignored by exists)
+			if (cond.op === 'exists' && cond.value !== undefined) {
+				errors.push(`${path}: "value" is set but ignored when op is "exists"`);
+			}
 			break;
 
 		case 'count':
@@ -78,7 +82,9 @@ export function validateGateCondition(condition: unknown, path = 'condition'): s
 			if (typeof cond.min !== 'number') {
 				errors.push(`${path}.min: expected number, got ${typeof cond.min}`);
 			}
-			// matchValue can be anything — no validation needed
+			if (cond.matchValue === undefined) {
+				errors.push(`${path}.matchValue: required but missing`);
+			}
 			break;
 
 		case 'all':

--- a/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
@@ -1,22 +1,22 @@
 /**
- * GateEvaluator — evaluates GateCondition trees against gate data.
+ * Unified Gate Evaluator (M1.2)
  *
- * This evaluator works with the new separated Gate/Channel system (M1.1).
- * It reads gate data from the data store and evaluates the gate's condition
- * tree to determine whether the gate is open or closed.
+ * Single `evaluateGate(gate)` function that handles all four condition types
+ * (check, count, all, any) including recursive all/any.
  *
- * Since conditions are deserialized from JSON at runtime, the evaluator
- * includes runtime validation via `validateGateCondition` to catch malformed
- * objects before they reach the evaluation logic.
+ * The evaluator reads from the gate's own `data` store — callers populate
+ * `gate.data` with runtime data from the `gate_data` table before evaluation.
  *
  * Condition types:
- *   check — field equality: data[field] === value
- *   count — numeric threshold: data[field] >= threshold
+ *   check — field check with operator: exists / == / !=
+ *   count — map-counting: count entries matching matchValue, check >= min
  *   all   — composite AND: all sub-conditions must pass (short-circuits on failure)
  *   any   — composite OR: at least one sub-condition must pass (short-circuits on success)
+ *
+ * Channels without a gate are always open — use `isChannelOpen()` as the entry point.
  */
 
-import type { Gate, GateCondition } from '@neokai/shared';
+import type { Gate, Channel, GateCondition } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -35,6 +35,7 @@ export interface GateEvalResult {
 // ---------------------------------------------------------------------------
 
 const VALID_CONDITION_TYPES = new Set(['check', 'count', 'all', 'any']);
+const VALID_CHECK_OPS = new Set(['exists', '==', '!=']);
 
 /**
  * Validates a GateCondition object at runtime.
@@ -65,16 +66,19 @@ export function validateGateCondition(condition: unknown, path = 'condition'): s
 			if (typeof cond.field !== 'string' || cond.field.length === 0) {
 				errors.push(`${path}.field: expected non-empty string`);
 			}
-			// value can be anything — no validation needed
+			if (cond.op !== undefined && (typeof cond.op !== 'string' || !VALID_CHECK_OPS.has(cond.op))) {
+				errors.push(`${path}.op: expected one of [exists, ==, !=], got ${JSON.stringify(cond.op)}`);
+			}
 			break;
 
 		case 'count':
 			if (typeof cond.field !== 'string' || cond.field.length === 0) {
 				errors.push(`${path}.field: expected non-empty string`);
 			}
-			if (typeof cond.threshold !== 'number') {
-				errors.push(`${path}.threshold: expected number, got ${typeof cond.threshold}`);
+			if (typeof cond.min !== 'number') {
+				errors.push(`${path}.min: expected number, got ${typeof cond.min}`);
 			}
+			// matchValue can be anything — no validation needed
 			break;
 
 		case 'all':
@@ -93,18 +97,55 @@ export function validateGateCondition(condition: unknown, path = 'condition'): s
 }
 
 // ---------------------------------------------------------------------------
-// GateEvaluator
+// Channel helper
 // ---------------------------------------------------------------------------
 
 /**
- * Evaluates a Gate's condition tree against the current gate data.
+ * Checks whether a channel is open for message delivery.
  *
- * Stateless — all data is passed in. No I/O or side effects.
- * Callers should validate condition structure with `validateGateCondition`
- * before calling this function with data from untrusted JSON sources.
+ * - Channels without a `gateId` are always open (no evaluation needed).
+ * - Channels with a `gateId` look up the gate in `gates` and evaluate it.
+ * - If the gate is not found in the map, the channel is treated as closed
+ *   (missing gate = misconfiguration, fail closed).
+ *
+ * @param channel  The channel to check.
+ * @param gates    Map of gate ID → Gate (with runtime data already populated).
  */
-export function evaluateGate(gate: Gate, data: Record<string, unknown>): GateEvalResult {
-	return evaluateCondition(gate.condition, data);
+export function isChannelOpen(
+	channel: Channel,
+	gates: ReadonlyMap<string, Gate> | Record<string, Gate>
+): GateEvalResult {
+	if (!channel.gateId) {
+		return { open: true };
+	}
+
+	const gate =
+		gates instanceof Map
+			? gates.get(channel.gateId)
+			: (gates as Record<string, Gate>)[channel.gateId];
+	if (!gate) {
+		return {
+			open: false,
+			reason: `Gate "${channel.gateId}" not found — channel "${channel.id}" is closed (misconfiguration)`,
+		};
+	}
+
+	return evaluateGate(gate);
+}
+
+// ---------------------------------------------------------------------------
+// Gate evaluator
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluates a Gate's condition tree against the gate's own data store.
+ *
+ * Stateless — reads from `gate.data`. No I/O or side effects.
+ * Callers should populate `gate.data` with runtime data from the `gate_data`
+ * table before calling this function.
+ */
+export function evaluateGate(gate: Gate): GateEvalResult {
+	return evaluateCondition(gate.condition, gate.data);
 }
 
 /**
@@ -120,10 +161,10 @@ export function evaluateCondition(
 ): GateEvalResult {
 	switch (condition.type) {
 		case 'check':
-			return evaluateCheck(condition.field, condition.value, data);
+			return evaluateCheck(condition.field, condition.op ?? '==', condition.value, data);
 
 		case 'count':
-			return evaluateCount(condition.field, condition.threshold, data);
+			return evaluateCount(condition.field, condition.matchValue, condition.min, data);
 
 		case 'all': {
 			for (const sub of condition.conditions) {
@@ -150,8 +191,6 @@ export function evaluateCondition(
 		}
 
 		default: {
-			// Runtime fallback for malformed JSON — condition.type is not in the union.
-			// The `never` assertion is compile-time only; at runtime unknown types land here.
 			const unknownType = (condition as { type: string }).type;
 			return {
 				open: false,
@@ -167,31 +206,74 @@ export function evaluateCondition(
 
 function evaluateCheck(
 	field: string,
+	op: 'exists' | '==' | '!=',
 	expected: unknown,
 	data: Record<string, unknown>
 ): GateEvalResult {
-	const actual = data[field];
-	if (actual === expected) {
-		return { open: true };
+	switch (op) {
+		case 'exists': {
+			if (data[field] !== undefined) {
+				return { open: true };
+			}
+			return {
+				open: false,
+				reason: `Gate check failed: data["${field}"] does not exist`,
+			};
+		}
+
+		case '==': {
+			const actual = data[field];
+			if (actual === expected) {
+				return { open: true };
+			}
+			return {
+				open: false,
+				reason: `Gate check failed: data["${field}"] is ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`,
+			};
+		}
+
+		case '!=': {
+			const actual = data[field];
+			if (actual !== expected) {
+				return { open: true };
+			}
+			return {
+				open: false,
+				reason: `Gate check failed: data["${field}"] is ${JSON.stringify(actual)}, expected != ${JSON.stringify(expected)}`,
+			};
+		}
+
+		default: {
+			return {
+				open: false,
+				reason: `Gate check failed: unknown op "${op as string}"`,
+			};
+		}
 	}
-	return {
-		open: false,
-		reason: `Gate check failed: data["${field}"] is ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`,
-	};
 }
 
 function evaluateCount(
 	field: string,
-	threshold: number,
+	matchValue: unknown,
+	min: number,
 	data: Record<string, unknown>
 ): GateEvalResult {
 	const raw = data[field];
-	const value = typeof raw === 'number' ? raw : 0;
-	if (value >= threshold) {
+
+	// Field must be a non-null object (Record/map). Missing or non-object → count 0.
+	let count = 0;
+	if (raw !== null && raw !== undefined && typeof raw === 'object' && !Array.isArray(raw)) {
+		const map = raw as Record<string, unknown>;
+		for (const val of Object.values(map)) {
+			if (val === matchValue) count++;
+		}
+	}
+
+	if (count >= min) {
 		return { open: true };
 	}
 	return {
 		open: false,
-		reason: `Gate count failed: data["${field}"] is ${value}, need >= ${threshold}`,
+		reason: `Gate count failed: data["${field}"] has ${count} entries matching ${JSON.stringify(matchValue)}, need >= ${min}`,
 	};
 }

--- a/packages/daemon/tests/unit/space/gate-evaluator.test.ts
+++ b/packages/daemon/tests/unit/space/gate-evaluator.test.ts
@@ -778,6 +778,37 @@ describe('validateGateCondition', () => {
 		expect(errors[0]).toContain('min');
 	});
 
+	test('rejects count with missing matchValue', () => {
+		const errors = validateGateCondition({
+			type: 'count',
+			field: 'reviews',
+			min: 2,
+		});
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('matchValue');
+	});
+
+	test('warns when check has value with exists op', () => {
+		const errors = validateGateCondition({
+			type: 'check',
+			field: 'plan',
+			op: 'exists',
+			value: 'something',
+		});
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('ignored');
+		expect(errors[0]).toContain('exists');
+	});
+
+	test('no warning when check has exists op without value', () => {
+		const errors = validateGateCondition({
+			type: 'check',
+			field: 'plan',
+			op: 'exists',
+		});
+		expect(errors).toEqual([]);
+	});
+
 	test('rejects all with non-array conditions', () => {
 		const errors = validateGateCondition({ type: 'all', conditions: 'not an array' });
 		expect(errors.length).toBeGreaterThan(0);

--- a/packages/daemon/tests/unit/space/gate-evaluator.test.ts
+++ b/packages/daemon/tests/unit/space/gate-evaluator.test.ts
@@ -1,30 +1,33 @@
 /**
- * GateEvaluator Unit Tests
+ * Unified Gate Evaluator Unit Tests (M1.2)
  *
  * Covers all 4 GateCondition types:
- *   check — field equality: data[field] === value
- *   count — numeric threshold: data[field] >= threshold
+ *   check — field check with operators: exists / == / !=
+ *   count — map-counting: count entries matching matchValue, check >= min
  *   all   — composite AND (recursive, short-circuits on failure)
  *   any   — composite OR (recursive, short-circuits on success)
  *
  * Also covers:
- *   - evaluateGate: gate-level evaluation with data store
+ *   - evaluateGate: reads from gate.data directly
+ *   - isChannelOpen: gateless channels always open, gated channels delegate
  *   - Edge cases: missing fields, zero values, nested composites
+ *   - Validation: validateGateCondition for all types and ops
  */
 
 import { describe, test, expect } from 'bun:test';
 import {
 	evaluateGate,
 	evaluateCondition,
+	isChannelOpen,
 	validateGateCondition,
 } from '../../../src/lib/space/runtime/gate-evaluator.ts';
-import type { Gate, GateCondition } from '@neokai/shared';
+import type { Gate, Channel, GateCondition } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
-// check condition
+// check condition — op: '==' (default)
 // ---------------------------------------------------------------------------
 
-describe('GateEvaluator — check condition', () => {
+describe('GateEvaluator — check condition (== op, default)', () => {
 	test('opens when field matches expected value', () => {
 		const condition: GateCondition = { type: 'check', field: 'approved', value: true };
 		const result = evaluateCondition(condition, { approved: true });
@@ -70,50 +73,260 @@ describe('GateEvaluator — check condition', () => {
 		const result = evaluateCondition(condition, { count: 42 });
 		expect(result.open).toBe(true);
 	});
+
+	test('explicit op: "==" behaves same as default', () => {
+		const condition: GateCondition = { type: 'check', field: 'x', op: '==', value: 10 };
+		expect(evaluateCondition(condition, { x: 10 }).open).toBe(true);
+		expect(evaluateCondition(condition, { x: 20 }).open).toBe(false);
+	});
 });
 
 // ---------------------------------------------------------------------------
-// count condition
+// check condition — op: 'exists'
 // ---------------------------------------------------------------------------
 
-describe('GateEvaluator — count condition', () => {
-	test('opens when field >= threshold', () => {
-		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 2 };
-		const result = evaluateCondition(condition, { approvals: 3 });
+describe('GateEvaluator — check condition (exists op)', () => {
+	test('opens when field is present', () => {
+		const condition: GateCondition = { type: 'check', field: 'plan', op: 'exists' };
+		const result = evaluateCondition(condition, { plan: 'some plan text' });
 		expect(result.open).toBe(true);
 	});
 
-	test('opens when field equals threshold exactly', () => {
-		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 2 };
-		const result = evaluateCondition(condition, { approvals: 2 });
+	test('opens when field is present with null value', () => {
+		const condition: GateCondition = { type: 'check', field: 'plan', op: 'exists' };
+		const result = evaluateCondition(condition, { plan: null });
 		expect(result.open).toBe(true);
 	});
 
-	test('blocks when field < threshold', () => {
-		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 2 };
-		const result = evaluateCondition(condition, { approvals: 1 });
+	test('opens when field is present with false value', () => {
+		const condition: GateCondition = { type: 'check', field: 'plan', op: 'exists' };
+		const result = evaluateCondition(condition, { plan: false });
+		expect(result.open).toBe(true);
+	});
+
+	test('opens when field is present with empty string', () => {
+		const condition: GateCondition = { type: 'check', field: 'plan', op: 'exists' };
+		const result = evaluateCondition(condition, { plan: '' });
+		expect(result.open).toBe(true);
+	});
+
+	test('opens when field is present with zero', () => {
+		const condition: GateCondition = { type: 'check', field: 'count', op: 'exists' };
+		const result = evaluateCondition(condition, { count: 0 });
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks when field is missing', () => {
+		const condition: GateCondition = { type: 'check', field: 'plan', op: 'exists' };
+		const result = evaluateCondition(condition, {});
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('does not exist');
+	});
+
+	test('blocks when field is explicitly undefined', () => {
+		const condition: GateCondition = { type: 'check', field: 'plan', op: 'exists' };
+		const result = evaluateCondition(condition, { plan: undefined });
+		expect(result.open).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// check condition — op: '!='
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — check condition (!= op)', () => {
+	test('opens when field does not equal value', () => {
+		const condition: GateCondition = {
+			type: 'check',
+			field: 'status',
+			op: '!=',
+			value: 'rejected',
+		};
+		const result = evaluateCondition(condition, { status: 'approved' });
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks when field equals value', () => {
+		const condition: GateCondition = {
+			type: 'check',
+			field: 'status',
+			op: '!=',
+			value: 'rejected',
+		};
+		const result = evaluateCondition(condition, { status: 'rejected' });
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('!=');
+	});
+
+	test('opens when field is missing (undefined != value)', () => {
+		const condition: GateCondition = {
+			type: 'check',
+			field: 'status',
+			op: '!=',
+			value: 'rejected',
+		};
+		const result = evaluateCondition(condition, {});
+		expect(result.open).toBe(true);
+	});
+
+	test('opens when comparing different types', () => {
+		const condition: GateCondition = { type: 'check', field: 'x', op: '!=', value: 42 };
+		const result = evaluateCondition(condition, { x: '42' });
+		expect(result.open).toBe(true); // strict inequality: '42' !== 42
+	});
+});
+
+// ---------------------------------------------------------------------------
+// count condition (map-counting)
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — count condition (map-counting)', () => {
+	test('opens when matching entries >= min', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 2,
+		};
+		const result = evaluateCondition(condition, {
+			reviews: { alice: 'approved', bob: 'approved', carol: 'pending' },
+		});
+		expect(result.open).toBe(true);
+	});
+
+	test('opens when matching entries equal min exactly', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 2,
+		};
+		const result = evaluateCondition(condition, {
+			reviews: { alice: 'approved', bob: 'approved' },
+		});
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks when matching entries < min', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 2,
+		};
+		const result = evaluateCondition(condition, {
+			reviews: { alice: 'approved', bob: 'pending' },
+		});
 		expect(result.open).toBe(false);
 		expect(result.reason).toContain('1');
 		expect(result.reason).toContain('>= 2');
 	});
 
-	test('treats missing field as 0', () => {
-		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 1 };
+	test('treats missing field as 0 matching entries', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 1,
+		};
 		const result = evaluateCondition(condition, {});
 		expect(result.open).toBe(false);
 		expect(result.reason).toContain('0');
 	});
 
-	test('treats non-numeric field as 0', () => {
-		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 1 };
-		const result = evaluateCondition(condition, { approvals: 'not a number' });
+	test('treats non-object field as 0 matching entries', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 1,
+		};
+		const result = evaluateCondition(condition, { reviews: 'not an object' });
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('0');
+	});
+
+	test('treats null field as 0 matching entries', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 1,
+		};
+		const result = evaluateCondition(condition, { reviews: null });
 		expect(result.open).toBe(false);
 	});
 
-	test('opens with threshold of 0 when field is missing', () => {
-		const condition: GateCondition = { type: 'count', field: 'approvals', threshold: 0 };
+	test('treats array field as 0 matching entries (not a record)', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 1,
+		};
+		const result = evaluateCondition(condition, { reviews: ['approved'] });
+		expect(result.open).toBe(false);
+	});
+
+	test('opens with min of 0 when field is empty map', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 0,
+		};
+		const result = evaluateCondition(condition, { reviews: {} });
+		expect(result.open).toBe(true);
+	});
+
+	test('opens with min of 0 when field is missing', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 0,
+		};
 		const result = evaluateCondition(condition, {});
 		expect(result.open).toBe(true);
+	});
+
+	test('counts boolean matchValue correctly', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'votes',
+			matchValue: true,
+			min: 2,
+		};
+		const result = evaluateCondition(condition, {
+			votes: { alice: true, bob: true, carol: false },
+		});
+		expect(result.open).toBe(true);
+	});
+
+	test('counts numeric matchValue correctly', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'scores',
+			matchValue: 100,
+			min: 2,
+		};
+		const result = evaluateCondition(condition, {
+			scores: { alice: 100, bob: 95, carol: 100 },
+		});
+		expect(result.open).toBe(true);
+	});
+
+	test('does not count entries that do not strictly equal matchValue', () => {
+		const condition: GateCondition = {
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 1,
+		};
+		const result = evaluateCondition(condition, {
+			reviews: { alice: 'Approved', bob: 'APPROVED' }, // case-sensitive
+		});
+		expect(result.open).toBe(false);
 	});
 });
 
@@ -127,10 +340,13 @@ describe('GateEvaluator — all condition (AND)', () => {
 			type: 'all',
 			conditions: [
 				{ type: 'check', field: 'approved', value: true },
-				{ type: 'count', field: 'reviews', threshold: 2 },
+				{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
 			],
 		};
-		const result = evaluateCondition(condition, { approved: true, reviews: 3 });
+		const result = evaluateCondition(condition, {
+			approved: true,
+			reviews: { a: 'approved', b: 'approved' },
+		});
 		expect(result.open).toBe(true);
 	});
 
@@ -139,10 +355,13 @@ describe('GateEvaluator — all condition (AND)', () => {
 			type: 'all',
 			conditions: [
 				{ type: 'check', field: 'approved', value: true },
-				{ type: 'count', field: 'reviews', threshold: 2 },
+				{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
 			],
 		};
-		const result = evaluateCondition(condition, { approved: false, reviews: 3 });
+		const result = evaluateCondition(condition, {
+			approved: false,
+			reviews: { a: 'approved', b: 'approved' },
+		});
 		expect(result.open).toBe(false);
 		expect(result.reason).toContain('approved');
 	});
@@ -152,10 +371,13 @@ describe('GateEvaluator — all condition (AND)', () => {
 			type: 'all',
 			conditions: [
 				{ type: 'check', field: 'approved', value: true },
-				{ type: 'count', field: 'reviews', threshold: 2 },
+				{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
 			],
 		};
-		const result = evaluateCondition(condition, { approved: true, reviews: 1 });
+		const result = evaluateCondition(condition, {
+			approved: true,
+			reviews: { a: 'approved' },
+		});
 		expect(result.open).toBe(false);
 		expect(result.reason).toContain('reviews');
 	});
@@ -177,10 +399,10 @@ describe('GateEvaluator — any condition (OR)', () => {
 			type: 'any',
 			conditions: [
 				{ type: 'check', field: 'approved', value: true },
-				{ type: 'count', field: 'reviews', threshold: 2 },
+				{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
 			],
 		};
-		const result = evaluateCondition(condition, { approved: true, reviews: 0 });
+		const result = evaluateCondition(condition, { approved: true, reviews: {} });
 		expect(result.open).toBe(true);
 	});
 
@@ -189,10 +411,13 @@ describe('GateEvaluator — any condition (OR)', () => {
 			type: 'any',
 			conditions: [
 				{ type: 'check', field: 'approved', value: true },
-				{ type: 'count', field: 'reviews', threshold: 2 },
+				{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
 			],
 		};
-		const result = evaluateCondition(condition, { approved: false, reviews: 3 });
+		const result = evaluateCondition(condition, {
+			approved: false,
+			reviews: { a: 'approved', b: 'approved', c: 'approved' },
+		});
 		expect(result.open).toBe(true);
 	});
 
@@ -201,10 +426,13 @@ describe('GateEvaluator — any condition (OR)', () => {
 			type: 'any',
 			conditions: [
 				{ type: 'check', field: 'approved', value: true },
-				{ type: 'count', field: 'reviews', threshold: 2 },
+				{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
 			],
 		};
-		const result = evaluateCondition(condition, { approved: false, reviews: 1 });
+		const result = evaluateCondition(condition, {
+			approved: false,
+			reviews: { a: 'pending' },
+		});
 		expect(result.open).toBe(false);
 		expect(result.reason).toContain('None of the conditions passed');
 	});
@@ -230,16 +458,15 @@ describe('GateEvaluator — nested composites', () => {
 					type: 'any',
 					conditions: [
 						{ type: 'check', field: 'fast_track', value: true },
-						{ type: 'count', field: 'approvals', threshold: 2 },
+						{ type: 'count', field: 'approvals', matchValue: 'yes', min: 2 },
 					],
 				},
 				{ type: 'check', field: 'tests_passed', value: true },
 			],
 		};
-		// fast_track is true (any passes), tests_passed is true (all passes)
 		const result = evaluateCondition(condition, {
 			fast_track: true,
-			approvals: 0,
+			approvals: {},
 			tests_passed: true,
 		});
 		expect(result.open).toBe(true);
@@ -259,7 +486,6 @@ describe('GateEvaluator — nested composites', () => {
 				},
 			],
 		};
-		// override is false, but reviewed+tested both true
 		const result = evaluateCondition(condition, {
 			override: false,
 			reviewed: true,
@@ -267,36 +493,182 @@ describe('GateEvaluator — nested composites', () => {
 		});
 		expect(result.open).toBe(true);
 	});
+
+	test('deeply nested: all > any > all', () => {
+		const condition: GateCondition = {
+			type: 'all',
+			conditions: [
+				{
+					type: 'any',
+					conditions: [
+						{
+							type: 'all',
+							conditions: [
+								{ type: 'check', field: 'a', value: true },
+								{ type: 'check', field: 'b', value: true },
+							],
+						},
+						{ type: 'check', field: 'shortcut', value: true },
+					],
+				},
+				{ type: 'check', field: 'final', value: true },
+			],
+		};
+		// a=true, b=true satisfies inner all → any passes; final=true → outer all passes
+		expect(
+			evaluateCondition(condition, { a: true, b: true, shortcut: false, final: true }).open
+		).toBe(true);
+		// a=false → inner all fails; shortcut=false → any fails → outer all fails
+		expect(
+			evaluateCondition(condition, { a: false, b: true, shortcut: false, final: true }).open
+		).toBe(false);
+	});
+
+	test('mixed ops in composite: exists + count + !=', () => {
+		const condition: GateCondition = {
+			type: 'all',
+			conditions: [
+				{ type: 'check', field: 'plan', op: 'exists' },
+				{ type: 'check', field: 'status', op: '!=', value: 'rejected' },
+				{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
+			],
+		};
+		const result = evaluateCondition(condition, {
+			plan: 'my plan',
+			status: 'in_review',
+			reviews: { alice: 'approved', bob: 'approved' },
+		});
+		expect(result.open).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
-// evaluateGate (top-level)
+// evaluateGate (reads from gate.data)
 // ---------------------------------------------------------------------------
 
 describe('evaluateGate', () => {
-	test('evaluates gate condition against provided data', () => {
+	test('evaluates gate condition against gate.data', () => {
+		const gate: Gate = {
+			id: 'gate-1',
+			condition: { type: 'check', field: 'approved', value: true },
+			data: { approved: true },
+			allowedWriterRoles: ['reviewer'],
+			resetOnCycle: false,
+		};
+		const result = evaluateGate(gate);
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks when gate.data does not satisfy condition', () => {
+		const gate: Gate = {
+			id: 'gate-1',
+			condition: { type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
+			data: { reviews: { alice: 'approved' } },
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		const result = evaluateGate(gate);
+		expect(result.open).toBe(false);
+	});
+
+	test('opens with exists op when field present in gate.data', () => {
+		const gate: Gate = {
+			id: 'gate-plan',
+			condition: { type: 'check', field: 'plan', op: 'exists' },
+			data: { plan: 'implement feature X' },
+			allowedWriterRoles: ['planner'],
+			resetOnCycle: false,
+		};
+		const result = evaluateGate(gate);
+		expect(result.open).toBe(true);
+	});
+
+	test('blocks with exists op when field missing from gate.data', () => {
+		const gate: Gate = {
+			id: 'gate-plan',
+			condition: { type: 'check', field: 'plan', op: 'exists' },
+			data: {},
+			allowedWriterRoles: ['planner'],
+			resetOnCycle: false,
+		};
+		const result = evaluateGate(gate);
+		expect(result.open).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isChannelOpen
+// ---------------------------------------------------------------------------
+
+describe('isChannelOpen', () => {
+	test('channel without gateId is always open', () => {
+		const channel: Channel = { id: 'ch-1', from: 'planner', to: 'coder' };
+		const result = isChannelOpen(channel, new Map());
+		expect(result.open).toBe(true);
+	});
+
+	test('channel with gateId opens when gate passes', () => {
+		const gate: Gate = {
+			id: 'gate-1',
+			condition: { type: 'check', field: 'approved', value: true },
+			data: { approved: true },
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		const channel: Channel = { id: 'ch-1', from: 'coder', to: 'reviewer', gateId: 'gate-1' };
+		const result = isChannelOpen(channel, new Map([['gate-1', gate]]));
+		expect(result.open).toBe(true);
+	});
+
+	test('channel with gateId blocks when gate fails', () => {
 		const gate: Gate = {
 			id: 'gate-1',
 			condition: { type: 'check', field: 'approved', value: true },
 			data: { approved: false },
-			allowedWriterRoles: ['reviewer'],
-			resetOnCycle: false,
-		};
-		// Gate data says approved is true → gate opens
-		const result = evaluateGate(gate, { approved: true });
-		expect(result.open).toBe(true);
-	});
-
-	test('blocks when gate data does not satisfy condition', () => {
-		const gate: Gate = {
-			id: 'gate-1',
-			condition: { type: 'count', field: 'approvals', threshold: 2 },
-			data: {},
 			allowedWriterRoles: ['*'],
 			resetOnCycle: false,
 		};
-		const result = evaluateGate(gate, { approvals: 1 });
+		const channel: Channel = { id: 'ch-1', from: 'coder', to: 'reviewer', gateId: 'gate-1' };
+		const result = isChannelOpen(channel, new Map([['gate-1', gate]]));
 		expect(result.open).toBe(false);
+	});
+
+	test('channel blocks when referenced gate is not found (misconfiguration)', () => {
+		const channel: Channel = {
+			id: 'ch-1',
+			from: 'coder',
+			to: 'reviewer',
+			gateId: 'missing-gate',
+		};
+		const result = isChannelOpen(channel, new Map());
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('not found');
+		expect(result.reason).toContain('missing-gate');
+	});
+
+	test('works with Record<string, Gate> instead of Map', () => {
+		const gate: Gate = {
+			id: 'gate-1',
+			condition: { type: 'check', field: 'ready', value: true },
+			data: { ready: true },
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		const channel: Channel = { id: 'ch-1', from: 'a', to: 'b', gateId: 'gate-1' };
+		const result = isChannelOpen(channel, { 'gate-1': gate });
+		expect(result.open).toBe(true);
+	});
+
+	test('works with Record<string, Gate> when gate missing', () => {
+		const channel: Channel = { id: 'ch-1', from: 'a', to: 'b', gateId: 'nope' };
+		const result = isChannelOpen(channel, {});
+		expect(result.open).toBe(false);
+	});
+
+	test('gateless channel with isCyclic flag is still open', () => {
+		const channel: Channel = { id: 'ch-1', from: 'a', to: 'b', isCyclic: true };
+		const result = isChannelOpen(channel, new Map());
+		expect(result.open).toBe(true);
 	});
 });
 
@@ -305,13 +677,54 @@ describe('evaluateGate', () => {
 // ---------------------------------------------------------------------------
 
 describe('validateGateCondition', () => {
-	test('valid check condition passes', () => {
+	test('valid check condition (no op) passes', () => {
 		const errors = validateGateCondition({ type: 'check', field: 'approved', value: true });
 		expect(errors).toEqual([]);
 	});
 
+	test('valid check condition with op passes', () => {
+		const errors = validateGateCondition({ type: 'check', field: 'plan', op: 'exists' });
+		expect(errors).toEqual([]);
+	});
+
+	test('valid check condition with == op passes', () => {
+		const errors = validateGateCondition({
+			type: 'check',
+			field: 'x',
+			op: '==',
+			value: 'hello',
+		});
+		expect(errors).toEqual([]);
+	});
+
+	test('valid check condition with != op passes', () => {
+		const errors = validateGateCondition({
+			type: 'check',
+			field: 'x',
+			op: '!=',
+			value: 'bad',
+		});
+		expect(errors).toEqual([]);
+	});
+
+	test('rejects check with invalid op', () => {
+		const errors = validateGateCondition({
+			type: 'check',
+			field: 'x',
+			op: 'gt',
+		});
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain('op');
+		expect(errors[0]).toContain('exists');
+	});
+
 	test('valid count condition passes', () => {
-		const errors = validateGateCondition({ type: 'count', field: 'approvals', threshold: 2 });
+		const errors = validateGateCondition({
+			type: 'count',
+			field: 'reviews',
+			matchValue: 'approved',
+			min: 2,
+		});
 		expect(errors).toEqual([]);
 	});
 
@@ -326,7 +739,7 @@ describe('validateGateCondition', () => {
 	test('valid any condition passes', () => {
 		const errors = validateGateCondition({
 			type: 'any',
-			conditions: [{ type: 'count', field: 'x', threshold: 1 }],
+			conditions: [{ type: 'count', field: 'x', matchValue: true, min: 1 }],
 		});
 		expect(errors).toEqual([]);
 	});
@@ -354,10 +767,15 @@ describe('validateGateCondition', () => {
 		expect(errors[0]).toContain('field');
 	});
 
-	test('rejects count with non-numeric threshold', () => {
-		const errors = validateGateCondition({ type: 'count', field: 'x', threshold: 'not a number' });
+	test('rejects count with non-numeric min', () => {
+		const errors = validateGateCondition({
+			type: 'count',
+			field: 'x',
+			matchValue: 'a',
+			min: 'not a number',
+		});
 		expect(errors.length).toBeGreaterThan(0);
-		expect(errors[0]).toContain('threshold');
+		expect(errors[0]).toContain('min');
 	});
 
 	test('rejects all with non-array conditions', () => {
@@ -382,7 +800,6 @@ describe('validateGateCondition', () => {
 
 describe('evaluateCondition — malformed input', () => {
 	test('unknown condition type returns closed with descriptive reason', () => {
-		// Simulate malformed JSON deserialized from the database
 		const malformed = { type: 'nonexistent' } as unknown as GateCondition;
 		const result = evaluateCondition(malformed, {});
 		expect(result.open).toBe(false);

--- a/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
+++ b/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
@@ -87,8 +87,8 @@ describe('Gate and Channel type validation', () => {
 	test('Gate with count condition', () => {
 		const gate: Gate = {
 			id: 'gate-2',
-			condition: { type: 'count', field: 'approvals', threshold: 2 },
-			data: { approvals: 0 },
+			condition: { type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
+			data: { reviews: {} },
 			allowedWriterRoles: ['reviewer-1', 'reviewer-2'],
 			resetOnCycle: true,
 		};
@@ -100,7 +100,7 @@ describe('Gate and Channel type validation', () => {
 			type: 'all',
 			conditions: [
 				{ type: 'check', field: 'approved', value: true },
-				{ type: 'count', field: 'reviews', threshold: 2 },
+				{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 },
 			],
 		};
 		const gate: Gate = {
@@ -121,7 +121,7 @@ describe('Gate and Channel type validation', () => {
 			type: 'any',
 			conditions: [
 				{ type: 'check', field: 'fast_track', value: true },
-				{ type: 'count', field: 'approvals', threshold: 3 },
+				{ type: 'count', field: 'approvals', matchValue: 'approved', min: 3 },
 			],
 		};
 		const gate: Gate = {
@@ -164,8 +164,8 @@ describe('SpaceWorkflowRepository — gates round-trip', () => {
 			},
 			{
 				id: 'gate-review-count',
-				condition: { type: 'count', field: 'approvals', threshold: 2 },
-				data: { approvals: 0 },
+				condition: { type: 'count', field: 'approvals', matchValue: 'approved', min: 2 },
+				data: { approvals: {} },
 				allowedWriterRoles: ['reviewer-1', 'reviewer-2'],
 				resetOnCycle: true,
 			},

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -491,34 +491,58 @@ export interface WorkflowCondition {
 /**
  * A `check` condition evaluates a named key in the gate's data store.
  *
- * The gate opens when `data[field]` equals `value`.
+ * The `op` field determines the comparison:
+ *   - `'exists'` — gate opens when the field is present (not `undefined`)
+ *   - `'=='`     — gate opens when `data[field] === value` (default)
+ *   - `'!='`     — gate opens when `data[field] !== value`
  *
  * Examples:
- *   - Human approval: `{ type: 'check', field: 'approved', value: true }`
- *   - Task result:    `{ type: 'check', field: 'result', value: 'passed' }`
+ *   - Human approval: `{ type: 'check', field: 'approved', op: '==', value: true }`
+ *   - Field exists:   `{ type: 'check', field: 'plan', op: 'exists' }`
+ *   - Not rejected:   `{ type: 'check', field: 'status', op: '!=', value: 'rejected' }`
+ *   - Legacy compat:  `{ type: 'check', field: 'approved', value: true }` (op defaults to '==')
  */
 export interface GateConditionCheck {
 	type: 'check';
 	/** Key in the gate's data store to evaluate. */
 	field: string;
-	/** Expected value. Gate opens when `data[field] === value`. */
-	value: unknown;
+	/**
+	 * Comparison operator. Defaults to `'=='` when omitted (backward compatible).
+	 *   - `'exists'` — passes when the field is present in data (not `undefined`)
+	 *   - `'=='`     — passes when `data[field] === value`
+	 *   - `'!='`     — passes when `data[field] !== value`
+	 */
+	op?: 'exists' | '==' | '!=';
+	/** Expected value. Used by `==` and `!=` ops. Ignored by `exists`. */
+	value?: unknown;
 }
 
 /**
- * A `count` condition checks the numeric value of a field against a threshold.
+ * A `count` condition reads a map (Record) from the gate's data store, counts
+ * entries whose value matches `matchValue`, and checks `>= min`.
  *
- * The gate opens when `data[field] >= threshold`.
+ * This is designed for multi-reviewer approval gates: each reviewer writes their
+ * decision into a map keyed by their name, and the gate counts how many have
+ * the expected value.
  *
  * Examples:
- *   - Require 2 approvals: `{ type: 'count', field: 'approvals', threshold: 2 }`
+ *   - Require 2 "approved" reviews:
+ *     `{ type: 'count', field: 'reviews', matchValue: 'approved', min: 2 }`
+ *     with data: `{ reviews: { alice: 'approved', bob: 'approved', carol: 'pending' } }`
+ *     → count = 2 (alice + bob), 2 >= 2 → open
+ *
+ * Edge cases:
+ *   - Missing field → count = 0
+ *   - Field is not an object → count = 0
  */
 export interface GateConditionCount {
 	type: 'count';
-	/** Key in the gate's data store whose numeric value to compare. */
+	/** Key in the gate's data store — expected to hold a Record/map. */
 	field: string;
-	/** Gate opens when the field value ≥ threshold. */
-	threshold: number;
+	/** Value to match against map entries. Count of entries where `value === matchValue`. */
+	matchValue: unknown;
+	/** Minimum number of matching entries required for the gate to open. */
+	min: number;
 }
 
 /**
@@ -547,8 +571,8 @@ export interface GateConditionAny {
  * Discriminated union of gate condition types.
  *
  * Four types cover all gate behaviors:
- * - `check`  — field equality check against gate data
- * - `count`  — numeric threshold check against gate data
+ * - `check`  — field check against gate data (exists / == / !=)
+ * - `count`  — map-counting: count matching entries >= min
  * - `all`    — composite AND (recursive)
  * - `any`    — composite OR (recursive)
  *


### PR DESCRIPTION
## Summary

- Enhanced `GateConditionCheck` with `op` field supporting `exists`, `==`, `!=` operators (defaults to `==` for backward compatibility)
- Replaced `GateConditionCount` threshold semantics with map-counting: reads `data[field]` as a Record, counts entries matching `matchValue`, checks `>= min` — designed for multi-reviewer approval gates
- Unified `evaluateGate(gate)` to read from `gate.data` directly instead of taking a separate data parameter
- Added `isChannelOpen(channel, gates)` helper: gateless channels always open, gated channels delegate to `evaluateGate()`
- Updated runtime validation (`validateGateCondition`) for new fields
- 70 unit tests covering all condition types, ops, composites, edge cases, and gateless channels