### PR TITLE
feat(space): worktreeSlug() utility wrapping shared slugify()

### DIFF
--- a/packages/daemon/src/lib/space/slug.ts
+++ b/packages/daemon/src/lib/space/slug.ts
@@ -96,7 +96,7 @@ function truncateAtWordBoundary(slug: string, maxLength: number): string {
 /**
  * Resolve slug collisions by appending a numeric suffix (-2, -3, ...).
  */
-function resolveCollision(base: string, existingSlugs: string[]): string {
+export function resolveCollision(base: string, existingSlugs: string[]): string {
 	const slugSet = new Set(existingSlugs);
 
 	if (!slugSet.has(base)) {

--- a/packages/daemon/src/lib/space/worktree-slug.ts
+++ b/packages/daemon/src/lib/space/worktree-slug.ts
@@ -1,0 +1,58 @@
+import { slugify } from './slug';
+
+/**
+ * Generate a slug for a worktree folder name and git branch.
+ *
+ * Delegates to `slugify()` for core slugification rules.
+ * If the task title is empty/whitespace-only or produces an empty slug,
+ * falls back to `task-{taskNumber}`.
+ *
+ * The returned slug is used as:
+ * - The worktree folder name (as-is)
+ * - The git branch name (prefixed with `space/`)
+ *
+ * @param taskTitle - The task title to slugify
+ * @param taskNumber - The numeric task ID for fallback naming
+ * @param existingSlugs - Slugs already in use, for collision avoidance
+ * @returns A unique, URL-safe slug
+ */
+export function worktreeSlug(
+	taskTitle: string,
+	taskNumber: number,
+	existingSlugs: string[] = []
+): string {
+	const trimmed = taskTitle.trim();
+
+	if (!trimmed) {
+		return resolveWorktreeCollision(`task-${taskNumber}`, existingSlugs);
+	}
+
+	const slug = slugify(trimmed, existingSlugs);
+
+	// slugify() falls back to 'unnamed-space' for empty input; treat that as a
+	// signal that the title produced no usable characters.
+	if (!slug || slug === 'unnamed-space') {
+		return resolveWorktreeCollision(`task-${taskNumber}`, existingSlugs);
+	}
+
+	return slug;
+}
+
+/**
+ * Resolve collisions for the fallback `task-{taskNumber}` slug.
+ * Appends a numeric suffix (-2, -3, …) if the base is already taken.
+ */
+function resolveWorktreeCollision(base: string, existingSlugs: string[]): string {
+	const slugSet = new Set(existingSlugs);
+	if (!slugSet.has(base)) {
+		return base;
+	}
+	let counter = 2;
+	while (true) {
+		const suffixed = `${base}-${counter}`;
+		if (!slugSet.has(suffixed)) {
+			return suffixed;
+		}
+		counter++;
+	}
+}

--- a/packages/daemon/src/lib/space/worktree-slug.ts
+++ b/packages/daemon/src/lib/space/worktree-slug.ts
@@ -1,11 +1,11 @@
-import { slugify } from './slug';
+import { slugify, resolveCollision } from './slug';
 
 /**
  * Generate a slug for a worktree folder name and git branch.
  *
  * Delegates to `slugify()` for core slugification rules.
- * If the task title is empty/whitespace-only or produces an empty slug,
- * falls back to `task-{taskNumber}`.
+ * If the task title contains no alphanumeric characters (empty, whitespace-only,
+ * or all-special-chars), falls back to `task-{taskNumber}`.
  *
  * The returned slug is used as:
  * - The worktree folder name (as-is)
@@ -21,38 +21,12 @@ export function worktreeSlug(
 	taskNumber: number,
 	existingSlugs: string[] = []
 ): string {
-	const trimmed = taskTitle.trim();
-
-	if (!trimmed) {
-		return resolveWorktreeCollision(`task-${taskNumber}`, existingSlugs);
+	// Detect whether the title contains any usable (alphanumeric) characters
+	// before delegating. This avoids coupling to slug.ts' internal sentinel value
+	// ('unnamed-space') and prevents false positives for titles like "Unnamed Space".
+	if (!/[a-z0-9]/i.test(taskTitle)) {
+		return resolveCollision(`task-${taskNumber}`, existingSlugs);
 	}
 
-	const slug = slugify(trimmed, existingSlugs);
-
-	// slugify() falls back to 'unnamed-space' for empty input; treat that as a
-	// signal that the title produced no usable characters.
-	if (!slug || slug === 'unnamed-space') {
-		return resolveWorktreeCollision(`task-${taskNumber}`, existingSlugs);
-	}
-
-	return slug;
-}
-
-/**
- * Resolve collisions for the fallback `task-{taskNumber}` slug.
- * Appends a numeric suffix (-2, -3, …) if the base is already taken.
- */
-function resolveWorktreeCollision(base: string, existingSlugs: string[]): string {
-	const slugSet = new Set(existingSlugs);
-	if (!slugSet.has(base)) {
-		return base;
-	}
-	let counter = 2;
-	while (true) {
-		const suffixed = `${base}-${counter}`;
-		if (!slugSet.has(suffixed)) {
-			return suffixed;
-		}
-		counter++;
-	}
+	return slugify(taskTitle, existingSlugs);
 }

--- a/packages/daemon/tests/unit/space/worktree-slug.test.ts
+++ b/packages/daemon/tests/unit/space/worktree-slug.test.ts
@@ -16,7 +16,6 @@ describe('worktreeSlug', () => {
 		});
 
 		test('title with only special characters falls back to task-{taskNumber}', () => {
-			// slugify('!!!') → 'unnamed-space', which triggers the fallback
 			expect(worktreeSlug('!!!@@@', 7)).toBe('task-7');
 		});
 	});
@@ -43,6 +42,17 @@ describe('worktreeSlug', () => {
 			expect(slug).not.toContain('99');
 			expect(slug).toBe('refactor-database-layer');
 		});
+
+		// Regression: titles that happen to produce 'unnamed-space' when slugified
+		// must NOT fall back to task-{taskNumber} — the sentinel-value check was
+		// removed in favour of testing the raw input for alphanumeric content.
+		test('title "unnamed-space" is NOT treated as a fallback trigger', () => {
+			expect(worktreeSlug('unnamed-space', 5)).toBe('unnamed-space');
+		});
+
+		test('title "Unnamed Space" is NOT treated as a fallback trigger', () => {
+			expect(worktreeSlug('Unnamed Space', 5)).toBe('unnamed-space');
+		});
 	});
 
 	describe('collision handling', () => {
@@ -62,6 +72,12 @@ describe('worktreeSlug', () => {
 
 		test('fallback collision increments correctly', () => {
 			expect(worktreeSlug('', 2, ['task-2', 'task-2-2'])).toBe('task-2-3');
+		});
+
+		// Regression: all-special-chars title with 'unnamed-space' already taken must
+		// fall back to task-N, not 'unnamed-space-2'.
+		test('all-special-chars title with unnamed-space taken still uses task-N fallback', () => {
+			expect(worktreeSlug('!!!', 7, ['unnamed-space'])).toBe('task-7');
 		});
 
 		test('no collision when existingSlugs is empty', () => {

--- a/packages/daemon/tests/unit/space/worktree-slug.test.ts
+++ b/packages/daemon/tests/unit/space/worktree-slug.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect } from 'bun:test';
+import { worktreeSlug } from '../../../src/lib/space/worktree-slug';
+
+describe('worktreeSlug', () => {
+	describe('empty / whitespace-only titles — fallback to task-{taskNumber}', () => {
+		test('empty string falls back to task-{taskNumber}', () => {
+			expect(worktreeSlug('', 1)).toBe('task-1');
+		});
+
+		test('whitespace-only falls back to task-{taskNumber}', () => {
+			expect(worktreeSlug('   ', 5)).toBe('task-5');
+		});
+
+		test('tab-only falls back to task-{taskNumber}', () => {
+			expect(worktreeSlug('\t\n', 3)).toBe('task-3');
+		});
+
+		test('title with only special characters falls back to task-{taskNumber}', () => {
+			// slugify('!!!') → 'unnamed-space', which triggers the fallback
+			expect(worktreeSlug('!!!@@@', 7)).toBe('task-7');
+		});
+	});
+
+	describe('normal titles — delegate to slugify()', () => {
+		test('simple title is slugified correctly', () => {
+			expect(worktreeSlug('Add authentication', 1)).toBe('add-authentication');
+		});
+
+		test('title with mixed case is lowercased', () => {
+			expect(worktreeSlug('Fix Bug In Parser', 2)).toBe('fix-bug-in-parser');
+		});
+
+		test('title with special characters is cleaned up', () => {
+			expect(worktreeSlug('Implement OAuth2.0 (v2)', 3)).toBe('implement-oauth2-0-v2');
+		});
+
+		test('title with consecutive spaces/hyphens is normalised', () => {
+			expect(worktreeSlug('foo---bar  baz', 4)).toBe('foo-bar-baz');
+		});
+
+		test('task number does not appear in slug when title is non-empty', () => {
+			const slug = worktreeSlug('Refactor database layer', 99);
+			expect(slug).not.toContain('99');
+			expect(slug).toBe('refactor-database-layer');
+		});
+	});
+
+	describe('collision handling', () => {
+		test('appends -2 suffix when slug already exists', () => {
+			expect(worktreeSlug('Add feature', 1, ['add-feature'])).toBe('add-feature-2');
+		});
+
+		test('increments suffix until unique', () => {
+			expect(worktreeSlug('Add feature', 1, ['add-feature', 'add-feature-2'])).toBe(
+				'add-feature-3'
+			);
+		});
+
+		test('fallback slug gets collision suffix when task-N exists', () => {
+			expect(worktreeSlug('', 2, ['task-2'])).toBe('task-2-2');
+		});
+
+		test('fallback collision increments correctly', () => {
+			expect(worktreeSlug('', 2, ['task-2', 'task-2-2'])).toBe('task-2-3');
+		});
+
+		test('no collision when existingSlugs is empty', () => {
+			expect(worktreeSlug('my task', 1, [])).toBe('my-task');
+		});
+
+		test('no collision when slug is not in existingSlugs', () => {
+			expect(worktreeSlug('my task', 1, ['other-slug'])).toBe('my-task');
+		});
+	});
+
+	describe('task number variants', () => {
+		test('uses the correct task number in fallback', () => {
+			expect(worktreeSlug('', 42)).toBe('task-42');
+		});
+
+		test('task number 0 is valid', () => {
+			expect(worktreeSlug('', 0)).toBe('task-0');
+		});
+
+		test('large task number works', () => {
+			expect(worktreeSlug('', 9999)).toBe('task-9999');
+		});
+	});
+});


### PR DESCRIPTION
Implements `worktreeSlug(taskTitle, taskNumber, existingSlugs)` in `packages/daemon/src/lib/space/worktree-slug.ts`.

- Delegates to `slugify()` from `./slug.ts` (M1.6) for core slug generation
- Falls back to `task-{taskNumber}` when title is empty, whitespace-only, or produces no usable characters
- Collision suffix (`-2`, `-3`, …) applied to both normal slugs (via `slugify()`) and fallback slugs
- 18 unit tests covering all specified behaviors