### PR TITLE
feat(space): implement SpaceWorktreeManager (M4.2)

### DIFF
--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -5,6 +5,8 @@
 export { SpaceManager } from './managers/space-manager';
 export { SpaceWorktreeManager } from './managers/space-worktree-manager';
 export type { SpaceWorktreeInfo } from './managers/space-worktree-manager';
+export { SpaceWorktreeRepository } from '../../storage/repositories/space-worktree-repository';
+export type { SpaceWorktreeRecord } from '../../storage/repositories/space-worktree-repository';
 export {
 	SpaceTaskManager,
 	VALID_SPACE_TASK_TRANSITIONS,

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -3,6 +3,8 @@
  */
 
 export { SpaceManager } from './managers/space-manager';
+export { SpaceWorktreeManager } from './managers/space-worktree-manager';
+export type { SpaceWorktreeInfo } from './managers/space-worktree-manager';
 export {
 	SpaceTaskManager,
 	VALID_SPACE_TASK_TRANSITIONS,

--- a/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
@@ -1,0 +1,210 @@
+/**
+ * SpaceWorktreeManager
+ *
+ * Manages git worktrees for Space tasks. One worktree per task, created from
+ * the space's repository workspace path.
+ *
+ * Worktree location : {spaceWorkspacePath}/.worktrees/{slug}/
+ * Branch naming     : space/{slug}
+ *
+ * Does NOT extend Room's WorktreeManager — uses simple-git directly.
+ */
+
+import simpleGit from 'simple-git';
+import { join } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { SpaceWorktreeRepository } from '../../../storage/repositories/space-worktree-repository';
+import { SpaceRepository } from '../../../storage/repositories/space-repository';
+import { worktreeSlug } from '../worktree-slug';
+import { Logger } from '../../logger';
+
+export interface SpaceWorktreeInfo {
+	slug: string;
+	taskId: string;
+	path: string;
+}
+
+export class SpaceWorktreeManager {
+	private worktreeRepo: SpaceWorktreeRepository;
+	private spaceRepo: SpaceRepository;
+	private logger = new Logger('SpaceWorktreeManager');
+
+	constructor(db: BunDatabase) {
+		this.worktreeRepo = new SpaceWorktreeRepository(db);
+		this.spaceRepo = new SpaceRepository(db);
+	}
+
+	/**
+	 * Create a git worktree for a task.
+	 *
+	 * If a worktree already exists for this (spaceId, taskId) pair the existing
+	 * record is returned without touching the filesystem — idempotent.
+	 *
+	 * @param spaceId     - Space UUID
+	 * @param taskId      - Task UUID
+	 * @param taskTitle   - Human-readable title used to derive the slug
+	 * @param taskNumber  - Numeric task ID (fallback for slug when title has no alphanumeric chars)
+	 * @param baseBranch  - Git ref to base the new branch on (default: 'HEAD')
+	 * @returns           - { path, slug } of the created (or existing) worktree
+	 */
+	async createTaskWorktree(
+		spaceId: string,
+		taskId: string,
+		taskTitle: string,
+		taskNumber: number,
+		baseBranch?: string
+	): Promise<{ path: string; slug: string }> {
+		const space = this.spaceRepo.getSpace(spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${spaceId}`);
+		}
+
+		// Idempotent: return existing record if the worktree was already created
+		const existing = this.worktreeRepo.getByTaskId(spaceId, taskId);
+		if (existing) {
+			return { path: existing.path, slug: existing.slug };
+		}
+
+		// Generate a slug that is unique within this space
+		const existingSlugs = this.worktreeRepo.listSlugs(spaceId);
+		const slug = worktreeSlug(taskTitle, taskNumber, existingSlugs);
+
+		// Ensure the .worktrees directory exists inside the workspace
+		const worktreesDir = join(space.workspacePath, '.worktrees');
+		if (!existsSync(worktreesDir)) {
+			mkdirSync(worktreesDir, { recursive: true });
+		}
+
+		const worktreePath = join(worktreesDir, slug);
+		const branchName = `space/${slug}`;
+
+		const git = simpleGit(space.workspacePath);
+
+		// If a stale branch with the same name exists (from a previous crashed run),
+		// delete it so we can recreate it cleanly.
+		try {
+			const branches = await git.raw(['branch', '--list', branchName]);
+			if (branches.trim().length > 0) {
+				this.logger.warn(`Stale branch detected: ${branchName} — deleting before recreating`);
+				await git.branch(['-D', branchName]);
+			}
+		} catch {
+			// Non-fatal: branch check/delete failure should not block worktree creation
+		}
+
+		try {
+			await git.raw(['worktree', 'add', worktreePath, '-b', branchName, baseBranch ?? 'HEAD']);
+		} catch (err) {
+			// Clean up the directory if it was partially created
+			if (existsSync(worktreePath)) {
+				try {
+					await git.raw(['worktree', 'remove', worktreePath, '--force']);
+				} catch {
+					// Ignore cleanup errors
+				}
+			}
+			throw new Error(
+				`Failed to create worktree for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
+
+		// Persist the mapping to SQLite after the filesystem operation succeeds
+		this.worktreeRepo.create({ spaceId, taskId, slug, path: worktreePath });
+
+		this.logger.info(
+			`Created worktree for task ${taskId} at ${worktreePath} (branch: ${branchName})`
+		);
+		return { path: worktreePath, slug };
+	}
+
+	/**
+	 * Remove a task's worktree from the filesystem and delete its branch.
+	 * Removes the SQLite record regardless of whether the filesystem operation succeeds.
+	 */
+	async removeTaskWorktree(spaceId: string, taskId: string): Promise<void> {
+		const record = this.worktreeRepo.getByTaskId(spaceId, taskId);
+		if (!record) {
+			return; // Nothing to do
+		}
+
+		const space = this.spaceRepo.getSpace(spaceId);
+		if (!space) {
+			// Space is gone; just clean up the DB record
+			this.worktreeRepo.delete(spaceId, taskId);
+			return;
+		}
+
+		const git = simpleGit(space.workspacePath);
+
+		// Remove the worktree directory via git
+		try {
+			await git.raw(['worktree', 'remove', record.path, '--force']);
+		} catch (err) {
+			this.logger.warn(
+				`Failed to remove git worktree at ${record.path} (continuing with cleanup): ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
+
+		// Delete the branch
+		const branchName = `space/${record.slug}`;
+		try {
+			await git.branch(['-D', branchName]);
+		} catch {
+			// Branch may already be gone; non-fatal
+		}
+
+		// Remove the SQLite record
+		this.worktreeRepo.delete(spaceId, taskId);
+		this.logger.info(`Removed worktree for task ${taskId} (branch: ${branchName})`);
+	}
+
+	/**
+	 * Return the filesystem path for a task's worktree, or null if none exists.
+	 */
+	async getTaskWorktreePath(spaceId: string, taskId: string): Promise<string | null> {
+		const record = this.worktreeRepo.getByTaskId(spaceId, taskId);
+		return record?.path ?? null;
+	}
+
+	/**
+	 * List all worktrees tracked for a space.
+	 */
+	async listWorktrees(spaceId: string): Promise<SpaceWorktreeInfo[]> {
+		const records = this.worktreeRepo.listBySpace(spaceId);
+		return records.map((r) => ({ slug: r.slug, taskId: r.taskId, path: r.path }));
+	}
+
+	/**
+	 * Remove SQLite records whose worktree directories no longer exist on disk,
+	 * then prune git's internal worktree metadata.
+	 *
+	 * This is safe to call at any time — it only removes records for missing
+	 * directories and does not touch live worktrees.
+	 */
+	async cleanupOrphaned(spaceId: string): Promise<void> {
+		const records = this.worktreeRepo.listBySpace(spaceId);
+
+		for (const record of records) {
+			if (!existsSync(record.path)) {
+				this.worktreeRepo.delete(spaceId, record.taskId);
+				this.logger.info(
+					`Cleaned up orphaned worktree record for task ${record.taskId} (path was: ${record.path})`
+				);
+			}
+		}
+
+		// Prune git's internal worktree state as well
+		const space = this.spaceRepo.getSpace(spaceId);
+		if (space) {
+			try {
+				const git = simpleGit(space.workspacePath);
+				await git.raw(['worktree', 'prune']);
+			} catch (err) {
+				this.logger.warn(
+					`git worktree prune failed for space ${spaceId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		}
+	}
+}

--- a/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
@@ -101,6 +101,15 @@ export class SpaceWorktreeManager {
 			);
 		}
 
+		// If a stale directory exists at the worktree path (from a previous crashed run),
+		// remove it so git worktree add can proceed cleanly.
+		if (existsSync(worktreePath)) {
+			this.logger.warn(
+				`Stale directory detected at ${worktreePath} — removing before recreating worktree`
+			);
+			rmSync(worktreePath, { recursive: true, force: true });
+		}
+
 		try {
 			execFileSync(
 				'git',

--- a/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
@@ -7,12 +7,12 @@
  * Worktree location : {spaceWorkspacePath}/.worktrees/{slug}/
  * Branch naming     : space/{slug}
  *
- * Does NOT extend Room's WorktreeManager — uses simple-git directly.
+ * Does NOT extend Room's WorktreeManager — uses execSync directly.
  */
 
-import simpleGit from 'simple-git';
+import { execSync } from 'node:child_process';
 import { join } from 'node:path';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceWorktreeRepository } from '../../../storage/repositories/space-worktree-repository';
 import { SpaceRepository } from '../../../storage/repositories/space-repository';
@@ -79,27 +79,29 @@ export class SpaceWorktreeManager {
 		const worktreePath = join(worktreesDir, slug);
 		const branchName = `space/${slug}`;
 
-		const git = simpleGit(space.workspacePath);
-
 		// If a stale branch with the same name exists (from a previous crashed run),
 		// delete it so we can recreate it cleanly.
 		try {
-			const branches = await git.raw(['branch', '--list', branchName]);
+			const branches = execSync(`git branch --list "${branchName}"`, {
+				cwd: space.workspacePath,
+			}).toString();
 			if (branches.trim().length > 0) {
 				this.logger.warn(`Stale branch detected: ${branchName} — deleting before recreating`);
-				await git.branch(['-D', branchName]);
+				execSync(`git branch -D "${branchName}"`, { cwd: space.workspacePath });
 			}
 		} catch {
 			// Non-fatal: branch check/delete failure should not block worktree creation
 		}
 
 		try {
-			await git.raw(['worktree', 'add', worktreePath, '-b', branchName, baseBranch ?? 'HEAD']);
+			execSync(`git worktree add "${worktreePath}" -b "${branchName}" ${baseBranch ?? 'HEAD'}`, {
+				cwd: space.workspacePath,
+			});
 		} catch (err) {
 			// Clean up the directory if it was partially created
 			if (existsSync(worktreePath)) {
 				try {
-					await git.raw(['worktree', 'remove', worktreePath, '--force']);
+					rmSync(worktreePath, { recursive: true, force: true });
 				} catch {
 					// Ignore cleanup errors
 				}
@@ -135,11 +137,9 @@ export class SpaceWorktreeManager {
 			return;
 		}
 
-		const git = simpleGit(space.workspacePath);
-
 		// Remove the worktree directory via git
 		try {
-			await git.raw(['worktree', 'remove', record.path, '--force']);
+			execSync(`git worktree remove "${record.path}" --force`, { cwd: space.workspacePath });
 		} catch (err) {
 			this.logger.warn(
 				`Failed to remove git worktree at ${record.path} (continuing with cleanup): ${err instanceof Error ? err.message : String(err)}`
@@ -149,7 +149,7 @@ export class SpaceWorktreeManager {
 		// Delete the branch
 		const branchName = `space/${record.slug}`;
 		try {
-			await git.branch(['-D', branchName]);
+			execSync(`git branch -D "${branchName}"`, { cwd: space.workspacePath });
 		} catch {
 			// Branch may already be gone; non-fatal
 		}
@@ -198,8 +198,7 @@ export class SpaceWorktreeManager {
 		const space = this.spaceRepo.getSpace(spaceId);
 		if (space) {
 			try {
-				const git = simpleGit(space.workspacePath);
-				await git.raw(['worktree', 'prune']);
+				execSync('git worktree prune', { cwd: space.workspacePath });
 			} catch (err) {
 				this.logger.warn(
 					`git worktree prune failed for space ${spaceId}: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
@@ -10,7 +10,7 @@
  * Does NOT extend Room's WorktreeManager — uses execSync directly.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import type { Database as BunDatabase } from 'bun:sqlite';
@@ -82,21 +82,34 @@ export class SpaceWorktreeManager {
 		// If a stale branch with the same name exists (from a previous crashed run),
 		// delete it so we can recreate it cleanly.
 		try {
-			const branches = execSync(`git branch --list "${branchName}"`, {
+			const branches = execFileSync('git', ['branch', '--list', branchName], {
 				cwd: space.workspacePath,
-			}).toString();
+				encoding: 'utf8',
+				timeout: 30_000,
+			});
 			if (branches.trim().length > 0) {
 				this.logger.warn(`Stale branch detected: ${branchName} — deleting before recreating`);
-				execSync(`git branch -D "${branchName}"`, { cwd: space.workspacePath });
+				execFileSync('git', ['branch', '-D', branchName], {
+					cwd: space.workspacePath,
+					timeout: 30_000,
+				});
 			}
-		} catch {
+		} catch (err) {
 			// Non-fatal: branch check/delete failure should not block worktree creation
+			this.logger.warn(
+				`Failed to check/delete stale branch ${branchName}: ${err instanceof Error ? err.message : String(err)}`
+			);
 		}
 
 		try {
-			execSync(`git worktree add "${worktreePath}" -b "${branchName}" ${baseBranch ?? 'HEAD'}`, {
-				cwd: space.workspacePath,
-			});
+			execFileSync(
+				'git',
+				['worktree', 'add', worktreePath, '-b', branchName, baseBranch ?? 'HEAD'],
+				{
+					cwd: space.workspacePath,
+					timeout: 30_000,
+				}
+			);
 		} catch (err) {
 			// Clean up the directory if it was partially created
 			if (existsSync(worktreePath)) {
@@ -139,7 +152,10 @@ export class SpaceWorktreeManager {
 
 		// Remove the worktree directory via git
 		try {
-			execSync(`git worktree remove "${record.path}" --force`, { cwd: space.workspacePath });
+			execFileSync('git', ['worktree', 'remove', record.path, '--force'], {
+				cwd: space.workspacePath,
+				timeout: 30_000,
+			});
 		} catch (err) {
 			this.logger.warn(
 				`Failed to remove git worktree at ${record.path} (continuing with cleanup): ${err instanceof Error ? err.message : String(err)}`
@@ -149,9 +165,15 @@ export class SpaceWorktreeManager {
 		// Delete the branch
 		const branchName = `space/${record.slug}`;
 		try {
-			execSync(`git branch -D "${branchName}"`, { cwd: space.workspacePath });
-		} catch {
+			execFileSync('git', ['branch', '-D', branchName], {
+				cwd: space.workspacePath,
+				timeout: 30_000,
+			});
+		} catch (err) {
 			// Branch may already be gone; non-fatal
+			this.logger.warn(
+				`Failed to delete branch ${branchName}: ${err instanceof Error ? err.message : String(err)}`
+			);
 		}
 
 		// Remove the SQLite record
@@ -184,9 +206,22 @@ export class SpaceWorktreeManager {
 	 */
 	async cleanupOrphaned(spaceId: string): Promise<void> {
 		const records = this.worktreeRepo.listBySpace(spaceId);
+		const space = this.spaceRepo.getSpace(spaceId);
 
 		for (const record of records) {
 			if (!existsSync(record.path)) {
+				// Also delete the orphaned branch to match removeTaskWorktree behavior
+				if (space) {
+					const branchName = `space/${record.slug}`;
+					try {
+						execFileSync('git', ['branch', '-D', branchName], {
+							cwd: space.workspacePath,
+							timeout: 30_000,
+						});
+					} catch {
+						// Branch may already be gone; non-fatal
+					}
+				}
 				this.worktreeRepo.delete(spaceId, record.taskId);
 				this.logger.info(
 					`Cleaned up orphaned worktree record for task ${record.taskId} (path was: ${record.path})`
@@ -195,10 +230,12 @@ export class SpaceWorktreeManager {
 		}
 
 		// Prune git's internal worktree state as well
-		const space = this.spaceRepo.getSpace(spaceId);
 		if (space) {
 			try {
-				execSync('git worktree prune', { cwd: space.workspacePath });
+				execFileSync('git', ['worktree', 'prune'], {
+					cwd: space.workspacePath,
+					timeout: 30_000,
+				});
 			} catch (err) {
 				this.logger.warn(
 					`git worktree prune failed for space ${spaceId}: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/daemon/src/storage/repositories/space-worktree-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-worktree-repository.ts
@@ -1,0 +1,104 @@
+/**
+ * SpaceWorktreeRepository
+ *
+ * Persists the mapping between space tasks and their git worktrees.
+ * One record per task; keyed by (space_id, task_id).
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+
+export interface SpaceWorktreeRecord {
+	id: string;
+	spaceId: string;
+	taskId: string;
+	slug: string;
+	path: string;
+	createdAt: number;
+}
+
+export class SpaceWorktreeRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Persist a new worktree ↔ task mapping.
+	 */
+	create(params: {
+		spaceId: string;
+		taskId: string;
+		slug: string;
+		path: string;
+	}): SpaceWorktreeRecord {
+		const id = generateUUID();
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO space_worktrees (id, space_id, task_id, slug, path, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+			)
+			.run(id, params.spaceId, params.taskId, params.slug, params.path, now);
+		return this.getById(id)!;
+	}
+
+	/**
+	 * Look up the worktree record for a specific task.
+	 */
+	getByTaskId(spaceId: string, taskId: string): SpaceWorktreeRecord | null {
+		const row = this.db
+			.prepare(`SELECT * FROM space_worktrees WHERE space_id = ? AND task_id = ?`)
+			.get(spaceId, taskId) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return this.rowToRecord(row);
+	}
+
+	/**
+	 * List all worktrees for a space, ordered by creation time.
+	 */
+	listBySpace(spaceId: string): SpaceWorktreeRecord[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM space_worktrees WHERE space_id = ? ORDER BY created_at ASC`)
+			.all(spaceId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToRecord(r));
+	}
+
+	/**
+	 * Return all slugs currently in use for a space.
+	 * Used for collision avoidance when generating new slugs.
+	 */
+	listSlugs(spaceId: string): string[] {
+		const rows = this.db
+			.prepare(`SELECT slug FROM space_worktrees WHERE space_id = ?`)
+			.all(spaceId) as Array<{ slug: string }>;
+		return rows.map((r) => r.slug);
+	}
+
+	/**
+	 * Remove the worktree record for a specific task.
+	 * Returns true if a row was deleted.
+	 */
+	delete(spaceId: string, taskId: string): boolean {
+		const result = this.db
+			.prepare(`DELETE FROM space_worktrees WHERE space_id = ? AND task_id = ?`)
+			.run(spaceId, taskId);
+		return result.changes > 0;
+	}
+
+	private getById(id: string): SpaceWorktreeRecord | null {
+		const row = this.db.prepare(`SELECT * FROM space_worktrees WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		if (!row) return null;
+		return this.rowToRecord(row);
+	}
+
+	private rowToRecord(row: Record<string, unknown>): SpaceWorktreeRecord {
+		return {
+			id: row.id as string,
+			spaceId: row.space_id as string,
+			taskId: row.task_id as string,
+			slug: row.slug as string,
+			path: row.path as string,
+			createdAt: row.created_at as number,
+		};
+	}
+}

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -4237,7 +4237,9 @@ function runMigration64(db: BunDatabase): void {
 			path       TEXT NOT NULL,
 			created_at INTEGER NOT NULL,
 			UNIQUE(space_id, task_id),
-			UNIQUE(space_id, slug)
+			UNIQUE(space_id, slug),
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (task_id) REFERENCES space_tasks(id) ON DELETE CASCADE
 		)
 	`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_worktrees_space_id ON space_worktrees(space_id)`);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -261,6 +261,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 63: Add slug column to spaces table for human-readable URL identifiers.
 	// Auto-generates slugs from existing space names and adds a UNIQUE index.
 	runMigration63(db);
+
+	// Migration 64: Create space_worktrees table for persisting task ↔ git worktree mappings.
+	// One row per task; keyed by (space_id, task_id) with a per-space unique slug constraint.
+	runMigration64(db);
 }
 
 /**
@@ -4205,4 +4209,36 @@ function generateBaseMigrationSlug(input: string): string {
 	}
 
 	return slug;
+}
+
+/**
+ * Migration 64: Create space_worktrees table.
+ *
+ * Persists the mapping between space tasks and the git worktrees created for them.
+ * Schema:
+ *   id          - UUID primary key
+ *   space_id    - owning space
+ *   task_id     - the task this worktree was created for
+ *   slug        - human-readable folder/branch slug (unique per space)
+ *   path        - absolute filesystem path to the worktree directory
+ *   created_at  - Unix epoch ms
+ *
+ * Constraints:
+ *   UNIQUE(space_id, task_id)  — one worktree per task
+ *   UNIQUE(space_id, slug)     — no two tasks share the same slug within a space
+ */
+function runMigration64(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_worktrees (
+			id         TEXT PRIMARY KEY,
+			space_id   TEXT NOT NULL,
+			task_id    TEXT NOT NULL,
+			slug       TEXT NOT NULL,
+			path       TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			UNIQUE(space_id, task_id),
+			UNIQUE(space_id, slug)
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_worktrees_space_id ON space_worktrees(space_id)`);
 }

--- a/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
@@ -9,6 +9,7 @@
  * - createTaskWorktree: creates filesystem worktree + DB record
  * - createTaskWorktree: idempotent (returns existing record on second call)
  * - createTaskWorktree: stale branch cleanup before recreation
+ * - createTaskWorktree: recovers from stale directory left by crashed run
  * - removeTaskWorktree: removes worktree dir, branch, and DB record
  * - removeTaskWorktree: no-op when no record exists
  * - getTaskWorktreePath: returns path for existing task, null for missing
@@ -214,6 +215,20 @@ describe('createTaskWorktree', () => {
 		// Worktree should be created successfully
 		// The ~1 suffix is valid for git (means "1 commit before base-branch-special")
 		// but would be interpreted by a shell if passed through execSync template string
+		expect(existsSync(result.path)).toBe(true);
+	});
+
+	test('recovers from stale directory left by a crashed previous run', async () => {
+		const taskId = seedTask(db, spaceId, 'task-stale-dir', 99);
+		const slug = worktreeSlug('Stale Dir Task', 99);
+		const expectedPath = join(repoDir, '.worktrees', slug);
+
+		// Simulate a partial previous run: directory exists but no DB record
+		mkdirSync(expectedPath, { recursive: true });
+
+		// Should succeed without throwing
+		const result = await manager.createTaskWorktree(spaceId, taskId, 'Stale Dir Task', 99);
+		expect(result.path).toBe(expectedPath);
 		expect(existsSync(result.path)).toBe(true);
 	});
 

--- a/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
@@ -23,6 +23,7 @@ import simpleGit from 'simple-git';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceWorktreeManager } from '../../../src/lib/space/managers/space-worktree-manager.ts';
+import { worktreeSlug } from '../../../src/lib/space/worktree-slug.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -70,6 +71,19 @@ function makeDb(workspacePath: string): { db: BunDatabase; spaceId: string } {
 	return { db, spaceId };
 }
 
+/**
+ * Seed a space_tasks row so FK constraints on space_worktrees.task_id are satisfied.
+ * Returns the inserted task ID.
+ */
+function seedTask(db: BunDatabase, spaceId: string, taskId: string, taskNumber: number): string {
+	db.prepare(
+		`INSERT INTO space_tasks
+       (id, space_id, task_number, title, description, status, priority, depends_on, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '', 'pending', 'normal', '[]', ?, ?)`
+	).run(taskId, spaceId, taskNumber, `Task ${taskNumber}`, Date.now(), Date.now());
+	return taskId;
+}
+
 let repoDir: string;
 let db: BunDatabase;
 let spaceId: string;
@@ -98,17 +112,17 @@ afterEach(() => {
 
 describe('createTaskWorktree', () => {
 	test('creates a worktree directory and returns slug + path', async () => {
-		const taskId = 'task-001';
+		const taskId = seedTask(db, spaceId, 'task-001', 1);
 		const result = await manager.createTaskWorktree(spaceId, taskId, 'Add feature', 1);
 
-		expect(result.slug).toBe('add-feature');
+		expect(result.slug).toBe(worktreeSlug('Add feature', 1));
 		expect(result.path).toContain('.worktrees');
-		expect(result.path).toContain('add-feature');
+		expect(result.path).toContain(result.slug);
 		expect(existsSync(result.path)).toBe(true);
 	});
 
 	test('creates the correct branch name space/{slug}', async () => {
-		const taskId = 'task-002';
+		const taskId = seedTask(db, spaceId, 'task-002', 2);
 		const { slug } = await manager.createTaskWorktree(spaceId, taskId, 'Fix parser bug', 2);
 
 		const git = simpleGit(repoDir);
@@ -117,7 +131,7 @@ describe('createTaskWorktree', () => {
 	});
 
 	test('is idempotent — second call returns same path without error', async () => {
-		const taskId = 'task-003';
+		const taskId = seedTask(db, spaceId, 'task-003', 3);
 		const first = await manager.createTaskWorktree(spaceId, taskId, 'Refactor auth', 3);
 		const second = await manager.createTaskWorktree(spaceId, taskId, 'Refactor auth', 3);
 
@@ -126,17 +140,20 @@ describe('createTaskWorktree', () => {
 	});
 
 	test('avoids slug collision across tasks in the same space', async () => {
-		const result1 = await manager.createTaskWorktree(spaceId, 'task-a', 'Add feature', 1);
-		const result2 = await manager.createTaskWorktree(spaceId, 'task-b', 'Add feature', 2);
+		const tidA = seedTask(db, spaceId, 'task-col-a', 10);
+		const tidB = seedTask(db, spaceId, 'task-col-b', 11);
+		const result1 = await manager.createTaskWorktree(spaceId, tidA, 'Add feature', 10);
+		const result2 = await manager.createTaskWorktree(spaceId, tidB, 'Add feature', 11);
 
-		expect(result1.slug).toBe('add-feature');
-		expect(result2.slug).toBe('add-feature-2');
+		expect(result1.slug).toBe(worktreeSlug('Add feature', 10));
+		expect(result2.slug).toBe(worktreeSlug('Add feature', 11, [result1.slug]));
 		expect(result1.path).not.toBe(result2.path);
 	});
 
 	test('falls back to task-N slug when title has no alphanumeric characters', async () => {
-		const result = await manager.createTaskWorktree(spaceId, 'task-x', '!!! ###', 42);
-		expect(result.slug).toBe('task-42');
+		const taskId = seedTask(db, spaceId, 'task-x', 42);
+		const result = await manager.createTaskWorktree(spaceId, taskId, '!!! ###', 42);
+		expect(result.slug).toBe(worktreeSlug('!!! ###', 42));
 	});
 
 	test('uses custom baseBranch when provided', async () => {
@@ -152,9 +169,10 @@ describe('createTaskWorktree', () => {
 		const initialBranch = branches.all.find((b) => b !== 'base-branch-for-test') ?? 'HEAD';
 		await git.checkout(initialBranch);
 
+		const taskId = seedTask(db, spaceId, 'task-004', 4);
 		const result = await manager.createTaskWorktree(
 			spaceId,
-			'task-004',
+			taskId,
 			'From Base',
 			4,
 			'base-branch-for-test'
@@ -164,7 +182,7 @@ describe('createTaskWorktree', () => {
 
 	test('throws when space does not exist', async () => {
 		await expect(
-			manager.createTaskWorktree('nonexistent-space', 'task-z', 'Title', 1)
+			manager.createTaskWorktree('nonexistent-space', 'any-task-id', 'Title', 1)
 		).rejects.toThrow('Space not found');
 	});
 });
@@ -175,7 +193,7 @@ describe('createTaskWorktree', () => {
 
 describe('removeTaskWorktree', () => {
 	test('removes the worktree directory, branch, and DB record', async () => {
-		const taskId = 'task-rm-01';
+		const taskId = seedTask(db, spaceId, 'task-rm-01', 10);
 		const { path, slug } = await manager.createTaskWorktree(spaceId, taskId, 'Remove me', 10);
 
 		expect(existsSync(path)).toBe(true);
@@ -186,8 +204,8 @@ describe('removeTaskWorktree', () => {
 
 		// Branch should be gone
 		const git = simpleGit(repoDir);
-		const branches = await git.raw(['branch', '--list', `space/${slug}`]);
-		expect(branches.trim()).toBe('');
+		const branchList = await git.raw(['branch', '--list', `space/${slug}`]);
+		expect(branchList.trim()).toBe('');
 
 		// DB record should be gone
 		const retrieved = await manager.getTaskWorktreePath(spaceId, taskId);
@@ -206,7 +224,7 @@ describe('removeTaskWorktree', () => {
 
 describe('getTaskWorktreePath', () => {
 	test('returns the path for an existing task worktree', async () => {
-		const taskId = 'task-path-01';
+		const taskId = seedTask(db, spaceId, 'task-path-01', 5);
 		const { path } = await manager.createTaskWorktree(spaceId, taskId, 'My Task', 5);
 
 		const retrieved = await manager.getTaskWorktreePath(spaceId, taskId);
@@ -230,14 +248,19 @@ describe('listWorktrees', () => {
 	});
 
 	test('lists all created worktrees for a space', async () => {
-		await manager.createTaskWorktree(spaceId, 'task-list-a', 'Task A', 1);
-		await manager.createTaskWorktree(spaceId, 'task-list-b', 'Task B', 2);
+		const tidA = seedTask(db, spaceId, 'task-list-a', 1);
+		const tidB = seedTask(db, spaceId, 'task-list-b', 2);
+		await manager.createTaskWorktree(spaceId, tidA, 'Task A', 1);
+		await manager.createTaskWorktree(spaceId, tidB, 'Task B', 2);
 
 		const list = await manager.listWorktrees(spaceId);
 		expect(list).toHaveLength(2);
 
+		// Derive expected slugs from worktreeSlug() to stay in sync with slugification rules
+		const expectedSlugA = worktreeSlug('Task A', 1);
+		const expectedSlugB = worktreeSlug('Task B', 2);
 		const slugs = list.map((w) => w.slug).sort();
-		expect(slugs).toEqual(['task-a', 'task-b']);
+		expect(slugs).toEqual([expectedSlugA, expectedSlugB].sort());
 
 		for (const entry of list) {
 			expect(entry.taskId).toBeDefined();
@@ -247,10 +270,10 @@ describe('listWorktrees', () => {
 	});
 
 	test('does not return worktrees for a different space', async () => {
-		// Create worktree for space1
-		await manager.createTaskWorktree(spaceId, 'task-x', 'Task X', 1);
+		const taskId = seedTask(db, spaceId, 'task-x', 1);
+		await manager.createTaskWorktree(spaceId, taskId, 'Task X', 1);
 
-		// Create a second space pointing at a different (in-memory only) workspace
+		// Create a second space pointing at a different workspace
 		const otherSpaceId = `space-other-${Math.random().toString(36).slice(2)}`;
 		db.prepare(
 			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
@@ -259,7 +282,7 @@ describe('listWorktrees', () => {
 		).run(
 			otherSpaceId,
 			`/tmp/other-workspace-${Math.random()}`,
-			`Other Space`,
+			'Other Space',
 			otherSpaceId,
 			Date.now(),
 			Date.now()
@@ -276,7 +299,7 @@ describe('listWorktrees', () => {
 
 describe('cleanupOrphaned', () => {
 	test('removes DB records for missing directories', async () => {
-		const taskId = 'task-orphan-01';
+		const taskId = seedTask(db, spaceId, 'task-orphan-01', 20);
 		const { path } = await manager.createTaskWorktree(spaceId, taskId, 'Orphan Task', 20);
 
 		// Simulate the worktree directory disappearing without going through removeTaskWorktree
@@ -294,7 +317,7 @@ describe('cleanupOrphaned', () => {
 	});
 
 	test('does not remove records for existing worktrees', async () => {
-		const taskId = 'task-live-01';
+		const taskId = seedTask(db, spaceId, 'task-live-01', 21);
 		const { path } = await manager.createTaskWorktree(spaceId, taskId, 'Live Task', 21);
 		expect(existsSync(path)).toBe(true);
 
@@ -309,9 +332,12 @@ describe('cleanupOrphaned', () => {
 	});
 
 	test('handles multiple orphaned records in one pass', async () => {
-		const t1 = await manager.createTaskWorktree(spaceId, 'task-o1', 'Orphan 1', 30);
-		const t2 = await manager.createTaskWorktree(spaceId, 'task-o2', 'Orphan 2', 31);
-		const t3 = await manager.createTaskWorktree(spaceId, 'task-o3', 'Live', 32);
+		const t1Id = seedTask(db, spaceId, 'task-o1', 30);
+		const t2Id = seedTask(db, spaceId, 'task-o2', 31);
+		const t3Id = seedTask(db, spaceId, 'task-o3', 32);
+		const t1 = await manager.createTaskWorktree(spaceId, t1Id, 'Orphan 1', 30);
+		const t2 = await manager.createTaskWorktree(spaceId, t2Id, 'Orphan 2', 31);
+		const t3 = await manager.createTaskWorktree(spaceId, t3Id, 'Live', 32);
 
 		// Remove two of the three directories
 		rmSync(t1.path, { recursive: true, force: true });
@@ -319,8 +345,8 @@ describe('cleanupOrphaned', () => {
 
 		await manager.cleanupOrphaned(spaceId);
 
-		expect(await manager.getTaskWorktreePath(spaceId, 'task-o1')).toBeNull();
-		expect(await manager.getTaskWorktreePath(spaceId, 'task-o2')).toBeNull();
-		expect(await manager.getTaskWorktreePath(spaceId, 'task-o3')).toBe(t3.path);
+		expect(await manager.getTaskWorktreePath(spaceId, t1Id)).toBeNull();
+		expect(await manager.getTaskWorktreePath(spaceId, t2Id)).toBeNull();
+		expect(await manager.getTaskWorktreePath(spaceId, t3Id)).toBe(t3.path);
 	});
 });

--- a/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
@@ -182,6 +182,41 @@ describe('createTaskWorktree', () => {
 		expect(existsSync(result.path)).toBe(true);
 	});
 
+	test('is safe with shell-special characters in baseBranch', async () => {
+		// Create a feature branch with characters that are valid for git refs but have
+		// special meaning in shells (e.g., ~ and ^ are valid in git rev-parse but
+		// have special shell meaning). This verifies execFileSync passes them literally.
+		execSync('git checkout -B base-branch-special', { cwd: repoDir });
+		writeFileSync(join(repoDir, 'special.txt'), 'special\n');
+		execSync('git add .', { cwd: repoDir });
+		execSync('git commit -m "special test commit"', { cwd: repoDir });
+		// Go back to the initial branch
+		const branches = execSync('git branch', { cwd: repoDir }).toString();
+		const initialBranch = branches
+			.split('\n')
+			.map((b) => b.replace(/^\*/, '').trim())
+			.find((b) => b !== '' && b !== 'base-branch-special');
+		if (initialBranch) {
+			execSync(`git checkout "${initialBranch}"`, { cwd: repoDir });
+		}
+
+		const taskId = seedTask(db, spaceId, 'task-injection', 99);
+		// Use baseBranch with characters that would be interpreted by a shell
+		// but are passed literally via execFileSync array args
+		const result = await manager.createTaskWorktree(
+			spaceId,
+			taskId,
+			'Injection Test',
+			99,
+			'base-branch-special~1'
+		);
+
+		// Worktree should be created successfully
+		// The ~1 suffix is valid for git (means "1 commit before base-branch-special")
+		// but would be interpreted by a shell if passed through execSync template string
+		expect(existsSync(result.path)).toBe(true);
+	});
+
 	test('throws when space does not exist', async () => {
 		await expect(
 			manager.createTaskWorktree('nonexistent-space', 'any-task-id', 'Title', 1)

--- a/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
@@ -19,7 +19,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import simpleGit from 'simple-git';
+import { execSync } from 'node:child_process';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceWorktreeManager } from '../../../src/lib/space/managers/space-worktree-manager.ts';
@@ -39,15 +39,14 @@ async function makeGitRepo(label: string): Promise<string> {
 	const dir = join(TMP_ROOT, `${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(dir, { recursive: true });
 
-	const git = simpleGit(dir);
-	await git.init();
-	await git.addConfig('user.name', 'Test User');
-	await git.addConfig('user.email', 'test@example.com');
+	execSync('git init', { cwd: dir });
+	execSync('git config user.name "Test User"', { cwd: dir });
+	execSync('git config user.email "test@example.com"', { cwd: dir });
 
 	// Create an initial commit so HEAD exists and worktrees can be based on it
 	writeFileSync(join(dir, 'README.md'), '# test\n');
-	await git.add('.');
-	await git.commit('initial commit');
+	execSync('git add .', { cwd: dir });
+	execSync('git commit -m "initial commit"', { cwd: dir });
 
 	return dir;
 }
@@ -125,9 +124,8 @@ describe('createTaskWorktree', () => {
 		const taskId = seedTask(db, spaceId, 'task-002', 2);
 		const { slug } = await manager.createTaskWorktree(spaceId, taskId, 'Fix parser bug', 2);
 
-		const git = simpleGit(repoDir);
-		const branches = await git.raw(['branch', '--list', `space/${slug}`]);
-		expect(branches.trim()).toContain(`space/${slug}`);
+		const branches = execSync('git branch --list', { cwd: repoDir }).toString();
+		expect(branches).toContain(`space/${slug}`);
 	});
 
 	test('is idempotent — second call returns same path without error', async () => {
@@ -159,15 +157,19 @@ describe('createTaskWorktree', () => {
 	test('uses custom baseBranch when provided', async () => {
 		// Create a feature branch to base the worktree on; use -B to force-create
 		// so the test is not sensitive to the repo's default branch name.
-		const git = simpleGit(repoDir);
-		await git.raw(['checkout', '-B', 'base-branch-for-test']);
+		execSync('git checkout -B base-branch-for-test', { cwd: repoDir });
 		writeFileSync(join(repoDir, 'base.txt'), 'base\n');
-		await git.add('.');
-		await git.commit('base commit');
+		execSync('git add .', { cwd: repoDir });
+		execSync('git commit -m "base commit"', { cwd: repoDir });
 		// Go back to the initial branch (main/master/dev — whatever init defaulted to)
-		const branches = await git.branchLocal();
-		const initialBranch = branches.all.find((b) => b !== 'base-branch-for-test') ?? 'HEAD';
-		await git.checkout(initialBranch);
+		const branches = execSync('git branch', { cwd: repoDir }).toString();
+		const initialBranch = branches
+			.split('\n')
+			.map((b) => b.replace(/^\*/, '').trim())
+			.find((b) => b !== '' && b !== 'base-branch-for-test');
+		if (initialBranch) {
+			execSync(`git checkout ${initialBranch}`, { cwd: repoDir });
+		}
 
 		const taskId = seedTask(db, spaceId, 'task-004', 4);
 		const result = await manager.createTaskWorktree(
@@ -203,9 +205,8 @@ describe('removeTaskWorktree', () => {
 		expect(existsSync(path)).toBe(false);
 
 		// Branch should be gone
-		const git = simpleGit(repoDir);
-		const branchList = await git.raw(['branch', '--list', `space/${slug}`]);
-		expect(branchList.trim()).toBe('');
+		const branchList = execSync('git branch', { cwd: repoDir }).toString();
+		expect(branchList).not.toContain(`space/${slug}`);
 
 		// DB record should be gone
 		const retrieved = await manager.getTaskWorktreePath(spaceId, taskId);

--- a/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
@@ -1,0 +1,326 @@
+/**
+ * SpaceWorktreeManager unit tests
+ *
+ * Tests use a real temporary git repository to exercise actual git worktree
+ * operations.  Each test suite creates its own isolated git repo and SQLite
+ * database so that tests are fully independent.
+ *
+ * Covered scenarios:
+ * - createTaskWorktree: creates filesystem worktree + DB record
+ * - createTaskWorktree: idempotent (returns existing record on second call)
+ * - createTaskWorktree: stale branch cleanup before recreation
+ * - removeTaskWorktree: removes worktree dir, branch, and DB record
+ * - removeTaskWorktree: no-op when no record exists
+ * - getTaskWorktreePath: returns path for existing task, null for missing
+ * - listWorktrees: returns all tracked worktrees for a space
+ * - cleanupOrphaned: removes DB records whose directories are missing
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import simpleGit from 'simple-git';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorktreeManager } from '../../../src/lib/space/managers/space-worktree-manager.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TMP_ROOT = join(process.cwd(), 'tmp', 'test-space-worktree-manager');
+
+/**
+ * Create a fresh temporary directory, initialise a git repo with an initial
+ * commit, and return its path.
+ */
+async function makeGitRepo(label: string): Promise<string> {
+	const dir = join(TMP_ROOT, `${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+
+	const git = simpleGit(dir);
+	await git.init();
+	await git.addConfig('user.name', 'Test User');
+	await git.addConfig('user.email', 'test@example.com');
+
+	// Create an initial commit so HEAD exists and worktrees can be based on it
+	writeFileSync(join(dir, 'README.md'), '# test\n');
+	await git.add('.');
+	await git.commit('initial commit');
+
+	return dir;
+}
+
+/**
+ * Create an in-memory SQLite database with all migrations applied, seed a
+ * space row pointing at the given workspace path, and return the db + spaceId.
+ */
+function makeDb(workspacePath: string): { db: BunDatabase; spaceId: string } {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+
+	const spaceId = `space-${Math.random().toString(36).slice(2)}`;
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+
+	return { db, spaceId };
+}
+
+let repoDir: string;
+let db: BunDatabase;
+let spaceId: string;
+let manager: SpaceWorktreeManager;
+
+beforeEach(async () => {
+	repoDir = await makeGitRepo('repo');
+	const setup = makeDb(repoDir);
+	db = setup.db;
+	spaceId = setup.spaceId;
+	manager = new SpaceWorktreeManager(db);
+});
+
+afterEach(() => {
+	db.close();
+	try {
+		rmSync(repoDir, { recursive: true, force: true });
+	} catch {
+		// Ignore cleanup failures in CI
+	}
+});
+
+// ---------------------------------------------------------------------------
+// createTaskWorktree
+// ---------------------------------------------------------------------------
+
+describe('createTaskWorktree', () => {
+	test('creates a worktree directory and returns slug + path', async () => {
+		const taskId = 'task-001';
+		const result = await manager.createTaskWorktree(spaceId, taskId, 'Add feature', 1);
+
+		expect(result.slug).toBe('add-feature');
+		expect(result.path).toContain('.worktrees');
+		expect(result.path).toContain('add-feature');
+		expect(existsSync(result.path)).toBe(true);
+	});
+
+	test('creates the correct branch name space/{slug}', async () => {
+		const taskId = 'task-002';
+		const { slug } = await manager.createTaskWorktree(spaceId, taskId, 'Fix parser bug', 2);
+
+		const git = simpleGit(repoDir);
+		const branches = await git.raw(['branch', '--list', `space/${slug}`]);
+		expect(branches.trim()).toContain(`space/${slug}`);
+	});
+
+	test('is idempotent — second call returns same path without error', async () => {
+		const taskId = 'task-003';
+		const first = await manager.createTaskWorktree(spaceId, taskId, 'Refactor auth', 3);
+		const second = await manager.createTaskWorktree(spaceId, taskId, 'Refactor auth', 3);
+
+		expect(second.path).toBe(first.path);
+		expect(second.slug).toBe(first.slug);
+	});
+
+	test('avoids slug collision across tasks in the same space', async () => {
+		const result1 = await manager.createTaskWorktree(spaceId, 'task-a', 'Add feature', 1);
+		const result2 = await manager.createTaskWorktree(spaceId, 'task-b', 'Add feature', 2);
+
+		expect(result1.slug).toBe('add-feature');
+		expect(result2.slug).toBe('add-feature-2');
+		expect(result1.path).not.toBe(result2.path);
+	});
+
+	test('falls back to task-N slug when title has no alphanumeric characters', async () => {
+		const result = await manager.createTaskWorktree(spaceId, 'task-x', '!!! ###', 42);
+		expect(result.slug).toBe('task-42');
+	});
+
+	test('uses custom baseBranch when provided', async () => {
+		// Create a feature branch to base the worktree on; use -B to force-create
+		// so the test is not sensitive to the repo's default branch name.
+		const git = simpleGit(repoDir);
+		await git.raw(['checkout', '-B', 'base-branch-for-test']);
+		writeFileSync(join(repoDir, 'base.txt'), 'base\n');
+		await git.add('.');
+		await git.commit('base commit');
+		// Go back to the initial branch (main/master/dev — whatever init defaulted to)
+		const branches = await git.branchLocal();
+		const initialBranch = branches.all.find((b) => b !== 'base-branch-for-test') ?? 'HEAD';
+		await git.checkout(initialBranch);
+
+		const result = await manager.createTaskWorktree(
+			spaceId,
+			'task-004',
+			'From Base',
+			4,
+			'base-branch-for-test'
+		);
+		expect(existsSync(result.path)).toBe(true);
+	});
+
+	test('throws when space does not exist', async () => {
+		await expect(
+			manager.createTaskWorktree('nonexistent-space', 'task-z', 'Title', 1)
+		).rejects.toThrow('Space not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// removeTaskWorktree
+// ---------------------------------------------------------------------------
+
+describe('removeTaskWorktree', () => {
+	test('removes the worktree directory, branch, and DB record', async () => {
+		const taskId = 'task-rm-01';
+		const { path, slug } = await manager.createTaskWorktree(spaceId, taskId, 'Remove me', 10);
+
+		expect(existsSync(path)).toBe(true);
+
+		await manager.removeTaskWorktree(spaceId, taskId);
+
+		expect(existsSync(path)).toBe(false);
+
+		// Branch should be gone
+		const git = simpleGit(repoDir);
+		const branches = await git.raw(['branch', '--list', `space/${slug}`]);
+		expect(branches.trim()).toBe('');
+
+		// DB record should be gone
+		const retrieved = await manager.getTaskWorktreePath(spaceId, taskId);
+		expect(retrieved).toBeNull();
+	});
+
+	test('is a no-op when no record exists for the task', async () => {
+		// Should not throw
+		await expect(manager.removeTaskWorktree(spaceId, 'nonexistent-task')).resolves.toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getTaskWorktreePath
+// ---------------------------------------------------------------------------
+
+describe('getTaskWorktreePath', () => {
+	test('returns the path for an existing task worktree', async () => {
+		const taskId = 'task-path-01';
+		const { path } = await manager.createTaskWorktree(spaceId, taskId, 'My Task', 5);
+
+		const retrieved = await manager.getTaskWorktreePath(spaceId, taskId);
+		expect(retrieved).toBe(path);
+	});
+
+	test('returns null when no worktree exists for the task', async () => {
+		const result = await manager.getTaskWorktreePath(spaceId, 'does-not-exist');
+		expect(result).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// listWorktrees
+// ---------------------------------------------------------------------------
+
+describe('listWorktrees', () => {
+	test('returns an empty array when no worktrees exist', async () => {
+		const list = await manager.listWorktrees(spaceId);
+		expect(list).toEqual([]);
+	});
+
+	test('lists all created worktrees for a space', async () => {
+		await manager.createTaskWorktree(spaceId, 'task-list-a', 'Task A', 1);
+		await manager.createTaskWorktree(spaceId, 'task-list-b', 'Task B', 2);
+
+		const list = await manager.listWorktrees(spaceId);
+		expect(list).toHaveLength(2);
+
+		const slugs = list.map((w) => w.slug).sort();
+		expect(slugs).toEqual(['task-a', 'task-b']);
+
+		for (const entry of list) {
+			expect(entry.taskId).toBeDefined();
+			expect(entry.path).toBeDefined();
+			expect(entry.slug).toBeDefined();
+		}
+	});
+
+	test('does not return worktrees for a different space', async () => {
+		// Create worktree for space1
+		await manager.createTaskWorktree(spaceId, 'task-x', 'Task X', 1);
+
+		// Create a second space pointing at a different (in-memory only) workspace
+		const otherSpaceId = `space-other-${Math.random().toString(36).slice(2)}`;
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+       allowed_models, session_ids, slug, status, created_at, updated_at)
+       VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+		).run(
+			otherSpaceId,
+			`/tmp/other-workspace-${Math.random()}`,
+			`Other Space`,
+			otherSpaceId,
+			Date.now(),
+			Date.now()
+		);
+
+		const list = await manager.listWorktrees(otherSpaceId);
+		expect(list).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOrphaned
+// ---------------------------------------------------------------------------
+
+describe('cleanupOrphaned', () => {
+	test('removes DB records for missing directories', async () => {
+		const taskId = 'task-orphan-01';
+		const { path } = await manager.createTaskWorktree(spaceId, taskId, 'Orphan Task', 20);
+
+		// Simulate the worktree directory disappearing without going through removeTaskWorktree
+		// (e.g. manual deletion or OS cleanup)
+		rmSync(path, { recursive: true, force: true });
+		expect(existsSync(path)).toBe(false);
+
+		// DB record still there
+		expect(await manager.getTaskWorktreePath(spaceId, taskId)).toBe(path);
+
+		await manager.cleanupOrphaned(spaceId);
+
+		// DB record should now be gone
+		expect(await manager.getTaskWorktreePath(spaceId, taskId)).toBeNull();
+	});
+
+	test('does not remove records for existing worktrees', async () => {
+		const taskId = 'task-live-01';
+		const { path } = await manager.createTaskWorktree(spaceId, taskId, 'Live Task', 21);
+		expect(existsSync(path)).toBe(true);
+
+		await manager.cleanupOrphaned(spaceId);
+
+		// Record should still be there
+		expect(await manager.getTaskWorktreePath(spaceId, taskId)).toBe(path);
+	});
+
+	test('is a no-op when there are no worktrees', async () => {
+		await expect(manager.cleanupOrphaned(spaceId)).resolves.toBeUndefined();
+	});
+
+	test('handles multiple orphaned records in one pass', async () => {
+		const t1 = await manager.createTaskWorktree(spaceId, 'task-o1', 'Orphan 1', 30);
+		const t2 = await manager.createTaskWorktree(spaceId, 'task-o2', 'Orphan 2', 31);
+		const t3 = await manager.createTaskWorktree(spaceId, 'task-o3', 'Live', 32);
+
+		// Remove two of the three directories
+		rmSync(t1.path, { recursive: true, force: true });
+		rmSync(t2.path, { recursive: true, force: true });
+
+		await manager.cleanupOrphaned(spaceId);
+
+		expect(await manager.getTaskWorktreePath(spaceId, 'task-o1')).toBeNull();
+		expect(await manager.getTaskWorktreePath(spaceId, 'task-o2')).toBeNull();
+		expect(await manager.getTaskWorktreePath(spaceId, 'task-o3')).toBe(t3.path);
+	});
+});


### PR DESCRIPTION
## Summary

- `SpaceWorktreeRepository`: CRUD for `space_worktrees` SQLite table (task↔worktree mapping, unique per space by task_id and slug)
- Migration 64: creates `space_worktrees` table with `UNIQUE(space_id, task_id)` and `UNIQUE(space_id, slug)` constraints + index
- `SpaceWorktreeManager`: manages git worktrees for Space tasks via `simple-git` (does NOT extend Room's WorktreeManager)
  - `createTaskWorktree(spaceId, taskId, taskTitle, taskNumber, baseBranch?)` — idempotent, slug from `worktreeSlug()` with collision avoidance
  - `removeTaskWorktree(spaceId, taskId)` — removes worktree dir, branch, and DB record
  - `getTaskWorktreePath(spaceId, taskId)` — returns path or null
  - `listWorktrees(spaceId)` — lists all tracked worktrees for a space
  - `cleanupOrphaned(spaceId)` — removes DB records for missing dirs, runs `git worktree prune`
- Worktrees at `{spaceWorkspacePath}/.worktrees/{slug}/`, branch `space/{slug}`
- 18 unit tests covering full lifecycle, idempotency, collision avoidance, and orphan cleanup