### PR TITLE
feat(space): channel and gate MCP tools for node agents (M1.3)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -57,6 +57,7 @@ import { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceAgentLookup } from '../space/managers/space-workflow-manager';
 import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import { GateDataRepository } from '../../storage/repositories/gate-data-repository';
 import { setupSpaceAgentHandlers } from './space-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
@@ -315,6 +316,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());
 	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(deps.db.getDatabase());
+	const gateDataRepo = new GateDataRepository(deps.db.getDatabase());
 
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
@@ -386,6 +388,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceRuntimeService,
 		taskRepo: spaceTaskRepo,
 		workflowRunRepo: spaceWorkflowRunRepo,
+		gateDataRepo,
 		daemonHub: deps.daemonHub,
 		messageHub: deps.messageHub,
 		getApiKey: () => deps.authManager.getCurrentApiKey(),

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -56,6 +56,7 @@ import type {
 	WorkflowCondition,
 	WorkflowRule,
 	SessionFeatures,
+	Gate,
 } from '@neokai/shared';
 import { resolveNodeAgents } from '@neokai/shared';
 import type { AgentSessionInit } from '../../agent/agent-session';
@@ -133,6 +134,19 @@ function formatChannel(ch: WorkflowChannel): string {
 	const gateLabel = ch.gate ? formatGateCondition(ch.gate) : '';
 	const label = ch.label ? ` (${ch.label})` : '';
 	return `- \`${ch.from}\` ${dir} \`${to}\`${label}${gateLabel}`;
+}
+
+function formatGate(gate: Gate): string {
+	const desc = gate.description ? ` — ${gate.description}` : '';
+	const writers =
+		gate.allowedWriterRoles.length > 0 ? gate.allowedWriterRoles.join(', ') : '(none)';
+	const condType = gate.condition.type;
+	return (
+		`- **Gate \`${gate.id}\`**${desc}\n` +
+		`  - Condition type: \`${condType}\`\n` +
+		`  - Allowed writer roles: ${writers}\n` +
+		`  - Reset on cycle: ${gate.resetOnCycle}`
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -446,6 +460,22 @@ export function buildTaskAgentInitialMessage(context: TaskAgentContext): string 
 				`No channels are declared for this workflow. ` +
 					`Agents are fully isolated — \`send_message\` is unavailable unless channels are added.`
 			);
+		}
+
+		// ---- Gates (M1.1 separated Gate entities) ----------------------------
+		const gates = context.workflow.gates;
+		if (gates && gates.length > 0) {
+			parts.push(`\n## Workflow Gates\n`);
+			parts.push(
+				`Gates guard channels — a message on a gated channel is held until the gate's condition passes. ` +
+					`Node agents use \`list_gates\`, \`read_gate\`, and \`write_gate\` tools to inspect and update gate state.\n` +
+					`\n` +
+					`**Vote counting:** for \`count\` condition gates, node agents use their \`nodeId\` ` +
+					`(workflow node ID) as the map key — each node votes exactly once.\n`
+			);
+			for (const gate of gates) {
+				parts.push(formatGate(gate));
+			}
 		}
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1311,7 +1311,7 @@ export class TaskAgentManager {
 		stepTaskId: string,
 		taskManager: SpaceTaskManager
 	) {
-		const workflowNodeId = this.config.taskRepo.getTask(taskId)?.workflowNodeId ?? '';
+		const workflowNodeId = this.config.taskRepo.getTask(stepTaskId)?.workflowNodeId ?? '';
 		// Build the ChannelResolver from the workflow run's stored config at spawn time.
 		// Channels are written once at step-start by SpaceRuntime.storeResolvedChannels(),
 		// so reading them here gives the correct topology for this sub-session's lifetime.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -60,6 +60,7 @@ import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceRuntimeService } from './space-runtime-service';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type {
 	SubSessionFactory,
@@ -98,6 +99,8 @@ export interface TaskAgentManagerConfig {
 	taskRepo: SpaceTaskRepository;
 	/** Workflow run repository — reading and updating runs */
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Gate data repository — for reading and writing gate runtime data in node agent tools */
+	gateDataRepo: GateDataRepository;
 	/** DaemonHub — event bus for session state change subscriptions */
 	daemonHub: DaemonHub;
 	/** MessageHub — used to write SDK messages */
@@ -1317,6 +1320,11 @@ export class TaskAgentManager {
 			run?.config as Record<string, unknown> | undefined
 		);
 
+		// Load the workflow definition so node agents can access channel/gate metadata.
+		const workflow = run?.workflowId
+			? (this.config.spaceWorkflowManager.getWorkflow(run.workflowId) ?? null)
+			: null;
+
 		return createNodeAgentMcpServer({
 			mySessionId: subSessionId,
 			myRole: role,
@@ -1331,6 +1339,8 @@ export class TaskAgentManager {
 				this.injectSubSessionMessage(targetSessionId, message),
 			taskManager,
 			daemonHub: this.config.daemonHub,
+			workflow,
+			gateDataRepo: this.config.gateDataRepo,
 		});
 	}
 }

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -111,6 +111,78 @@ export const ListReachableAgentsSchema = z.object({});
 export type ListReachableAgentsInput = z.infer<typeof ListReachableAgentsSchema>;
 
 // ---------------------------------------------------------------------------
+// list_channels
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `list_channels` input.
+ * Lists all channels declared in the current workflow.
+ * No arguments — channels are derived from the workflow run context.
+ */
+export const ListChannelsSchema = z.object({});
+
+export type ListChannelsInput = z.infer<typeof ListChannelsSchema>;
+
+// ---------------------------------------------------------------------------
+// list_gates
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `list_gates` input.
+ * Lists all gates declared in the current workflow with their current data.
+ * No arguments — gates are derived from the workflow run context.
+ */
+export const ListGatesSchema = z.object({});
+
+export type ListGatesInput = z.infer<typeof ListGatesSchema>;
+
+// ---------------------------------------------------------------------------
+// read_gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `read_gate` input.
+ * Reads the current runtime data for a specific gate from the gate_data table.
+ */
+export const ReadGateSchema = z.object({
+	/** The ID of the gate to read data for. */
+	gateId: z.string().min(1).describe('The gate ID to read current data for'),
+});
+
+export type ReadGateInput = z.infer<typeof ReadGateSchema>;
+
+// ---------------------------------------------------------------------------
+// write_gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `write_gate` input.
+ *
+ * Merges key-value data into a gate's runtime data store. The caller's role must
+ * be listed in the gate's `allowedWriterRoles` (or the list contains `'*'`).
+ *
+ * For vote-counting gates (count conditions): use your `nodeId` (returned in the
+ * tool response) as the key in the vote map so each node's vote counts only once
+ * even if multiple agents in the node send votes.
+ */
+export const WriteGateSchema = z.object({
+	/** The ID of the gate to write data to. */
+	gateId: z.string().min(1).describe('The gate ID to write data to'),
+	/**
+	 * Key-value data to merge (shallow) into the gate's data store.
+	 * For vote-counting (count conditions), use your nodeId (provided in the response)
+	 * as the map key: e.g. { votes: { [nodeId]: "approved" } }
+	 */
+	data: z
+		.record(z.string(), z.unknown())
+		.describe(
+			'Key-value data to merge into the gate data store. Shallow merge: top-level keys overwrite existing entries.'
+		),
+});
+
+export type WriteGateInput = z.infer<typeof WriteGateSchema>;
+
+// ---------------------------------------------------------------------------
 // Aggregate export
 // ---------------------------------------------------------------------------
 
@@ -122,6 +194,10 @@ export const NODE_AGENT_TOOL_SCHEMAS = {
 	send_message: SendMessageSchema,
 	report_done: ReportDoneSchema,
 	list_reachable_agents: ListReachableAgentsSchema,
+	list_channels: ListChannelsSchema,
+	list_gates: ListGatesSchema,
+	read_gate: ReadGateSchema,
+	write_gate: WriteGateSchema,
 } as const;
 
 export type NodeAgentToolName = keyof typeof NODE_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -504,6 +504,10 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		 * channels define which agents can communicate and whether a gate
 		 * guards the channel. Use this to understand the full channel map
 		 * before calling list_reachable_agents or send_message.
+		 *
+		 * Note: `gateId` is always null — `WorkflowChannel` uses an inline
+		 * `gate?: WorkflowCondition` rather than a `gateId` reference.
+		 * Separated gate entities require a future type migration to `Channel`.
 		 */
 		async list_channels(_args: ListChannelsInput): Promise<ToolResult> {
 			const channels = workflow?.channels ?? [];
@@ -609,7 +613,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		 * Nested objects are replaced wholesale (not deep-merged).
 		 *
 		 * For vote-counting gates (count conditions), use your nodeId as the
-		 * map key so each node counts only once. Your nodeId is "${workflowNodeId}".
+		 * map key so each node counts only once. Your nodeId is returned in the JSON response.
 		 *
 		 * Writing triggers gate re-evaluation — the response includes whether
 		 * the gate is now open so you know if the gated channel is unblocked.
@@ -746,7 +750,9 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 			'list_channels',
 			'List all channels declared in this workflow. ' +
 				'Channels define the messaging topology — which agents can communicate and whether a gate ' +
-				'guards the channel. Use this to understand the full channel map for this workflow run.',
+				'guards the channel. Use this to understand the full channel map for this workflow run. ' +
+				'Note: `gateId` is not yet available — `WorkflowChannel` uses inline `gate?: WorkflowCondition` ' +
+				'instead of a separated `Gate` reference; correlation via `gateId` requires a type migration.',
 			ListChannelsSchema.shape,
 			(args) => handlers.list_channels(args)
 		),
@@ -771,7 +777,8 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 			"Write (merge) data into a gate's runtime data store. " +
 				"Your role must be in the gate's allowedWriterRoles. " +
 				'For vote-counting (count condition) gates, use your nodeId as the map key so each node votes once. ' +
-				'After writing, gate re-evaluation is triggered — the response tells you if the gate is now open.',
+				'After writing, gate re-evaluation is triggered locally — the response tells you if the gate is now open. ' +
+				'Note: the workflow runtime polls gate state at channel-routing time; this tool does not directly push channel unblock events.',
 			WriteGateSchema.shape,
 			(args) => handlers.write_gate(args)
 		),

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -31,7 +31,10 @@ import { Logger } from '../../logger';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import { ChannelResolver } from '../runtime/channel-resolver';
+import { evaluateGate } from '../runtime/gate-evaluator';
 import type { AgentMessageRouter } from '../runtime/agent-message-router';
+import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
+import type { SpaceWorkflow } from '@neokai/shared';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
@@ -39,12 +42,20 @@ import {
 	SendMessageSchema,
 	ReportDoneSchema,
 	ListReachableAgentsSchema,
+	ListChannelsSchema,
+	ListGatesSchema,
+	ReadGateSchema,
+	WriteGateSchema,
 } from './node-agent-tool-schemas';
 import type {
 	ListPeersInput,
 	SendMessageInput,
 	ReportDoneInput,
 	ListReachableAgentsInput,
+	ListChannelsInput,
+	ListGatesInput,
+	ReadGateInput,
+	WriteGateInput,
 } from './node-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
@@ -102,6 +113,17 @@ export interface NodeAgentToolsConfig {
 	 * TODO: Remove legacy path once TaskAgentManager injects AgentMessageRouter for all sub-sessions.
 	 */
 	agentMessageRouter?: AgentMessageRouter;
+	/**
+	 * Workflow definition for this task.
+	 * Used by list_channels, list_gates, read_gate, write_gate to access channel and
+	 * gate definitions. Null when the task has no workflow assigned.
+	 */
+	workflow: SpaceWorkflow | null;
+	/**
+	 * Gate data repository for reading and writing gate runtime data.
+	 * Used by list_gates, read_gate, write_gate.
+	 */
+	gateDataRepo: GateDataRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -127,6 +149,8 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		taskManager,
 		daemonHub,
 		agentMessageRouter,
+		workflow,
+		gateDataRepo,
 	} = config;
 
 	return {
@@ -474,6 +498,170 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		},
 
 		/**
+		 * List all channels declared in this workflow.
+		 *
+		 * Returns the messaging topology for the current workflow run —
+		 * channels define which agents can communicate and whether a gate
+		 * guards the channel. Use this to understand the full channel map
+		 * before calling list_reachable_agents or send_message.
+		 */
+		async list_channels(_args: ListChannelsInput): Promise<ToolResult> {
+			const channels = workflow?.channels ?? [];
+			const result = channels.map((ch) => ({
+				channelId: ch.id ?? null,
+				from: ch.from,
+				to: ch.to,
+				direction: ch.direction,
+				isCyclic: ch.isCyclic ?? false,
+				label: ch.label ?? null,
+				// Legacy inline gate — summarize presence without exposing full condition
+				hasGate: ch.gate !== undefined,
+			}));
+			return jsonResult({
+				success: true,
+				channels: result,
+				total: result.length,
+				message: `Found ${result.length} channel(s) in workflow "${workflow?.name ?? 'unknown'}".`,
+			});
+		},
+
+		/**
+		 * List all gates declared in this workflow with their current runtime data.
+		 *
+		 * Gates guard channels — a message on a gated channel is held until the
+		 * gate condition passes. Use this to understand what conditions are
+		 * currently evaluated and what data has been written to each gate.
+		 *
+		 * Your nodeId is included in the response — use it as the map key when
+		 * writing to count-condition gates (vote gates) so each node's vote
+		 * counts exactly once.
+		 */
+		async list_gates(_args: ListGatesInput): Promise<ToolResult> {
+			const gates = workflow?.gates ?? [];
+			const gateResults = gates.map((gate) => {
+				const record = gateDataRepo.get(workflowRunId, gate.id);
+				return {
+					gateId: gate.id,
+					condition: gate.condition,
+					description: gate.description ?? null,
+					allowedWriterRoles: gate.allowedWriterRoles,
+					currentData: record?.data ?? gate.data,
+				};
+			});
+			return jsonResult({
+				success: true,
+				gates: gateResults,
+				total: gateResults.length,
+				nodeId: workflowNodeId,
+				message:
+					`Found ${gateResults.length} gate(s). ` +
+					`Your nodeId is "${workflowNodeId}" — use it as the map key for vote-counting (count condition) gates.`,
+			});
+		},
+
+		/**
+		 * Read the current runtime data for a specific gate.
+		 *
+		 * Returns the live data from the gate_data table for this workflow run.
+		 * Use this to inspect the current state of a gate before deciding
+		 * whether to write to it.
+		 */
+		async read_gate(args: ReadGateInput): Promise<ToolResult> {
+			const { gateId } = args;
+
+			// Verify gate exists in this workflow
+			const gates = workflow?.gates ?? [];
+			const gateDef = gates.find((g) => g.id === gateId);
+			if (!gateDef) {
+				return jsonResult({
+					success: false,
+					error: `Gate "${gateId}" not found in this workflow.`,
+					availableGateIds: gates.map((g) => g.id),
+				});
+			}
+
+			const record = gateDataRepo.get(workflowRunId, gateId);
+			const currentData = record?.data ?? gateDef.data;
+
+			// Evaluate current gate status
+			const evalResult = evaluateGate({ ...gateDef, data: currentData });
+
+			return jsonResult({
+				success: true,
+				gateId,
+				data: currentData,
+				gateOpen: evalResult.open,
+				reason: evalResult.reason ?? null,
+				updatedAt: record?.updatedAt ?? null,
+				message: evalResult.open
+					? `Gate "${gateId}" is currently OPEN.`
+					: `Gate "${gateId}" is currently CLOSED: ${evalResult.reason ?? 'condition not met'}.`,
+			});
+		},
+
+		/**
+		 * Write data to a gate's runtime data store (merge semantics).
+		 *
+		 * Authorization: your role must be in the gate's allowedWriterRoles,
+		 * or the list must contain '*' (allow all).
+		 *
+		 * Merge semantics: top-level keys in `data` overwrite existing entries.
+		 * Nested objects are replaced wholesale (not deep-merged).
+		 *
+		 * For vote-counting gates (count conditions), use your nodeId as the
+		 * map key so each node counts only once. Your nodeId is "${workflowNodeId}".
+		 *
+		 * Writing triggers gate re-evaluation — the response includes whether
+		 * the gate is now open so you know if the gated channel is unblocked.
+		 */
+		async write_gate(args: WriteGateInput): Promise<ToolResult> {
+			const { gateId, data } = args;
+
+			// Verify gate exists in this workflow
+			const gates = workflow?.gates ?? [];
+			const gateDef = gates.find((g) => g.id === gateId);
+			if (!gateDef) {
+				return jsonResult({
+					success: false,
+					error: `Gate "${gateId}" not found in this workflow.`,
+					availableGateIds: gates.map((g) => g.id),
+				});
+			}
+
+			// Authorization check
+			const allowed = gateDef.allowedWriterRoles;
+			const isAuthorized = allowed.includes('*') || allowed.includes(myRole);
+			if (!isAuthorized) {
+				return jsonResult({
+					success: false,
+					error:
+						`Role "${myRole}" is not authorized to write to gate "${gateId}". ` +
+						`Allowed writer roles: ${allowed.length > 0 ? allowed.join(', ') : '(none)'}.`,
+					allowedWriterRoles: allowed,
+					myRole,
+				});
+			}
+
+			// Merge data into gate_data table
+			const updated = gateDataRepo.merge(workflowRunId, gateId, data);
+
+			// Re-evaluate gate with updated data
+			const evalResult = evaluateGate({ ...gateDef, data: updated.data });
+
+			return jsonResult({
+				success: true,
+				gateId,
+				updatedData: updated.data,
+				gateOpen: evalResult.open,
+				reason: evalResult.reason ?? null,
+				nodeId: workflowNodeId,
+				message: evalResult.open
+					? `Gate "${gateId}" is now OPEN — gated channel(s) may unblock.`
+					: `Gate "${gateId}" is still CLOSED after write: ${evalResult.reason ?? 'condition not met'}.`,
+			});
+		},
+
+		/**
 		 * Signal that this node agent has completed its work.
 		 *
 		 * Marks the step's SpaceTask as 'completed', persists the optional summary
@@ -555,10 +743,44 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 			(args) => handlers.list_reachable_agents(args)
 		),
 		tool(
+			'list_channels',
+			'List all channels declared in this workflow. ' +
+				'Channels define the messaging topology — which agents can communicate and whether a gate ' +
+				'guards the channel. Use this to understand the full channel map for this workflow run.',
+			ListChannelsSchema.shape,
+			(args) => handlers.list_channels(args)
+		),
+		tool(
+			'list_gates',
+			'List all gates declared in this workflow with their current runtime data and condition. ' +
+				'Gates guard channels — a message on a gated channel is held until the gate condition passes. ' +
+				'Use this to see what data each gate currently holds and whether any gate is open. ' +
+				'Your nodeId is included — use it as the map key when writing to count-condition (vote) gates.',
+			ListGatesSchema.shape,
+			(args) => handlers.list_gates(args)
+		),
+		tool(
+			'read_gate',
+			'Read the current runtime data for a specific gate. ' +
+				'Returns the live data from the gate_data table and whether the gate is currently open.',
+			ReadGateSchema.shape,
+			(args) => handlers.read_gate(args)
+		),
+		tool(
+			'write_gate',
+			"Write (merge) data into a gate's runtime data store. " +
+				"Your role must be in the gate's allowedWriterRoles. " +
+				'For vote-counting (count condition) gates, use your nodeId as the map key so each node votes once. ' +
+				'After writing, gate re-evaluation is triggered — the response tells you if the gate is now open.',
+			WriteGateSchema.shape,
+			(args) => handlers.write_gate(args)
+		),
+		tool(
 			'send_message',
 			'Send a message to a peer agent by name (DM), a node by name (fan-out), or broadcast to all permitted targets. ' +
 				"Use agent role name for DM (e.g. 'coder'), node name for fan-out, or '*' for broadcast. " +
-				'Validates against declared channel topology — returns an error with available targets if not permitted.',
+				'Validates against declared channel topology — returns an error with available targets if not permitted. ' +
+				'Include structured data in the optional `data` field for gate writes or machine-readable payloads.',
 			SendMessageSchema.shape,
 			(args) => handlers.send_message(args)
 		),

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -179,13 +179,13 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			// Build peers from all node tasks, excluding self and task-agent.
 			// Includes completed tasks (taskAgentSessionId may be null) so callers
 			// can see completion state even after the peer session has ended.
-			// Pending tasks with no session are excluded — they cannot receive messages.
+			// Tasks with no session are excluded unless they are completed (post-session completion).
 			const peers = nodeTasks
 				.filter(
 					(t) =>
 						t.agentName !== 'task-agent' &&
 						t.taskAgentSessionId !== mySessionId &&
-						(t.taskAgentSessionId !== null || t.status === 'completed')
+						(t.taskAgentSessionId != null || t.status === 'completed')
 				)
 				.map((t) => {
 					const taskStatus = t.status;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -179,8 +179,14 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			// Build peers from all node tasks, excluding self and task-agent.
 			// Includes completed tasks (taskAgentSessionId may be null) so callers
 			// can see completion state even after the peer session has ended.
+			// Pending tasks with no session are excluded — they cannot receive messages.
 			const peers = nodeTasks
-				.filter((t) => t.agentName !== 'task-agent' && t.taskAgentSessionId !== mySessionId)
+				.filter(
+					(t) =>
+						t.agentName !== 'task-agent' &&
+						t.taskAgentSessionId !== mySessionId &&
+						(t.taskAgentSessionId !== null || t.status === 'completed')
+				)
 				.map((t) => {
 					const taskStatus = t.status;
 					const memberStatus =
@@ -190,7 +196,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 								? ('failed' as const)
 								: ('active' as const);
 					return {
-						sessionId: t.taskAgentSessionId!,
+						sessionId: t.taskAgentSessionId ?? null,
 						role: t.agentName ?? 'agent',
 						agentId: t.customAgentId ?? null,
 						status: memberStatus,

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -52,6 +52,20 @@ function seedSpaceRow(db: BunDatabase, spaceId: string): void {
 	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 }
 
+function seedSpaceWorkflowRunRow(
+	db: BunDatabase,
+	runId: string,
+	spaceId: string,
+	workflowId: string
+): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO space_workflow_runs
+     (id, space_id, workflow_id, title, description, status, config, iteration_count, max_iterations, goal_id, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', 'pending', NULL, 0, 5, NULL, ?, ?)`
+	).run(runId, spaceId, workflowId, now, now);
+}
+
 function seedSpaceTask(
 	db: BunDatabase,
 	spaceId: string,
@@ -150,6 +164,9 @@ function makeCtx(): TestCtx {
 	// Workflow run/node IDs for peer task seeding
 	const workflowRunId = 'run-node-tools-default';
 	const nodeId = 'node-node-tools-default';
+
+	// Seed workflow run so gate_data FK constraint is satisfied for write_gate tests
+	seedSpaceWorkflowRunRow(db, workflowRunId, spaceId, 'wf-seed');
 
 	// Seed peer tasks: coder and reviewer on the default node
 	seedSpaceTask(db, spaceId, workflowRunId, nodeId, 'coder', 'in_progress', null);
@@ -859,8 +876,579 @@ describe('node-agent-tools: report_done', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: list_reachable_agents
+// Tests: list_channels
 // ---------------------------------------------------------------------------
+
+describe('node-agent-tools: list_channels', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns empty channels when workflow is null', async () => {
+		const config = makeConfig(ctx, { workflow: null });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_channels({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.channels).toHaveLength(0);
+		expect(data.total).toBe(0);
+	});
+
+	test('returns empty channels when workflow has no channels', async () => {
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_channels({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.channels).toHaveLength(0);
+	});
+
+	test('returns channel with hasGate false when no inline gate', async () => {
+		const channel: WorkflowChannel = {
+			id: 'ch-1',
+			from: 'coder',
+			to: 'reviewer',
+			direction: 'one-way',
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [channel],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_channels({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.channels).toHaveLength(1);
+		expect(data.channels[0].channelId).toBe('ch-1');
+		expect(data.channels[0].from).toBe('coder');
+		expect(data.channels[0].to).toBe('reviewer');
+		expect(data.channels[0].hasGate).toBe(false);
+	});
+
+	test('returns channel with hasGate true when inline gate present', async () => {
+		const channel: WorkflowChannel = {
+			id: 'ch-2',
+			from: 'coder',
+			to: 'reviewer',
+			direction: 'one-way',
+			gate: { type: 'human', description: 'Needs approval' },
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [channel],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_channels({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.channels).toHaveLength(1);
+		expect(data.channels[0].hasGate).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: list_gates
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: list_gates', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns empty gates when workflow is null', async () => {
+		const config = makeConfig(ctx, { workflow: null });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_gates({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gates).toHaveLength(0);
+		expect(data.nodeId).toBe(ctx.nodeId);
+	});
+
+	test('returns empty gates when workflow has no gates', async () => {
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_gates({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gates).toHaveLength(0);
+	});
+
+	test('returns gate with default data when no runtime data exists', async () => {
+		const gate: Gate = {
+			id: 'gate-approval',
+			condition: { type: 'check', field: 'approved', op: '==', value: true },
+			data: { approved: undefined },
+			allowedWriterRoles: ['reviewer'],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_gates({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gates).toHaveLength(1);
+		expect(data.gates[0].gateId).toBe('gate-approval');
+		expect(data.gates[0].currentData).toEqual({ approved: undefined });
+		expect(data.gates[0].allowedWriterRoles).toEqual(['reviewer']);
+		expect(data.nodeId).toBe(ctx.nodeId);
+	});
+
+	test('returns gate with runtime data overriding defaults', async () => {
+		const gate: Gate = {
+			id: 'gate-vote',
+			condition: {
+				type: 'count',
+				field: 'votes',
+				matchValue: 'approved',
+				min: 2,
+			},
+			data: { votes: {} },
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		// Pre-write some runtime data
+		const gateDataRepo = new GateDataRepository(ctx.db);
+		gateDataRepo.merge(ctx.workflowRunId, 'gate-vote', {
+			votes: { 'node-a': 'approved', 'node-b': 'approved' },
+		});
+
+		const config = makeConfig(ctx, { workflow, gateDataRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_gates({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gates).toHaveLength(1);
+		expect(data.gates[0].currentData).toEqual({
+			votes: { 'node-a': 'approved', 'node-b': 'approved' },
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: read_gate
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: read_gate', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns error for non-existent gateId', async () => {
+		const gate: Gate = {
+			id: 'gate-real',
+			condition: { type: 'check', field: 'x', op: '==', value: 1 },
+			data: {},
+			allowedWriterRoles: [],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.read_gate({ gateId: 'gate-does-not-exist' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('not found');
+		expect(data.availableGateIds).toEqual(['gate-real']);
+	});
+
+	test('returns gate data and open status for existing gate (closed)', async () => {
+		const gate: Gate = {
+			id: 'gate-check',
+			condition: { type: 'check', field: 'ready', op: '==', value: true },
+			data: { ready: false },
+			allowedWriterRoles: ['coder'],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.read_gate({ gateId: 'gate-check' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateId).toBe('gate-check');
+		expect(data.data).toEqual({ ready: false });
+		expect(data.gateOpen).toBe(false);
+	});
+
+	test('returns gate data and open status for existing gate (open)', async () => {
+		const gate: Gate = {
+			id: 'gate-open',
+			condition: { type: 'check', field: 'status', op: '==', value: 'go' },
+			data: { status: 'go' },
+			allowedWriterRoles: [],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.read_gate({ gateId: 'gate-open' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: write_gate
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: write_gate', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns error for non-existent gateId', async () => {
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gateghost', data: { x: 1 } });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('not found');
+	});
+
+	test('returns error when role is not in allowedWriterRoles', async () => {
+		const gate: Gate = {
+			id: 'gate-restricted',
+			condition: { type: 'check', field: 'x', op: 'exists' },
+			data: {},
+			allowedWriterRoles: ['reviewer'], // only reviewer can write
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		// makeConfig uses myRole: 'coder' by default
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-restricted', data: { x: 1 } });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('not authorized');
+		expect(data.allowedWriterRoles).toEqual(['reviewer']);
+		expect(data.myRole).toBe('coder');
+	});
+
+	test('succeeds when role is in allowedWriterRoles and merges data', async () => {
+		const gate: Gate = {
+			id: 'gate-writable',
+			condition: { type: 'check', field: 'x', op: 'exists' },
+			data: { x: undefined, y: 'original' },
+			allowedWriterRoles: ['coder'],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		// First write: creates the record with { x: 42 }
+		const result = await handlers.write_gate({ gateId: 'gate-writable', data: { x: 42 } });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		// Shallow merge: x=42 overwrites existing x, y is not in the partial so it's absent.
+		// Gate defaults are NOT merged in by write_gate — merge is only against stored data.
+		expect(data.updatedData).toEqual({ x: 42 });
+		expect(data.gateOpen).toBe(true); // x now exists
+		expect(data.nodeId).toBe(ctx.nodeId);
+
+		// Second write: merge adds 'y' alongside existing 'x'
+		const result2 = await handlers.write_gate({ gateId: 'gate-writable', data: { y: 'original' } });
+		const data2 = JSON.parse(result2.content[0].text);
+		expect(data2.success).toBe(true);
+		expect(data2.updatedData).toEqual({ x: 42, y: 'original' });
+	});
+
+	test('shallow merge: nested object is replaced wholesale', async () => {
+		const gate: Gate = {
+			id: 'gate-nested',
+			condition: { type: 'check', field: 'config', op: 'exists' },
+			data: { config: { a: 1, b: 2 } },
+			allowedWriterRoles: ['coder'],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// Write with new nested object
+		const result = await handlers.write_gate({
+			gateId: 'gate-nested',
+			data: { config: { c: 3 } },
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		// Nested object replaced (not deep-merged)
+		expect(data.updatedData).toEqual({ config: { c: 3 } });
+	});
+
+	test('authorized role with wildcard (*) allows any role to write', async () => {
+		const gate: Gate = {
+			id: 'gate-open',
+			condition: { type: 'check', field: 'voted', op: 'exists' },
+			data: {},
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		// myRole is 'coder' but '*' should authorize any role
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-open', data: { voted: true } });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(true);
+	});
+
+	test('count condition gate opens after sufficient votes', async () => {
+		const gate: Gate = {
+			id: 'gate-vote',
+			condition: {
+				type: 'count',
+				field: 'votes',
+				matchValue: 'approved',
+				min: 2,
+			},
+			data: { votes: {} },
+			allowedWriterRoles: ['*'],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+
+		// First vote (node-a): write only node-a's vote, gate is still closed
+		const configA = makeConfig(ctx, {
+			workflow,
+			workflowNodeId: 'node-a',
+		});
+		const handlersA = createNodeAgentToolHandlers(configA);
+		const resultA = await handlersA.write_gate({
+			gateId: 'gate-vote',
+			data: { votes: { 'node-a': 'approved' } },
+		});
+		const dataA = JSON.parse(resultA.content[0].text);
+		expect(dataA.success).toBe(true);
+		expect(dataA.gateOpen).toBe(false); // only 1 vote, need 2
+
+		// Second vote (node-b): shallow merge replaces the entire votes map,
+		// so node-b must write the accumulated map. In practice, an agent would
+		// read the current state first and then write the updated map.
+		const configB = makeConfig(ctx, {
+			workflow,
+			workflowNodeId: 'node-b',
+		});
+		const handlersB = createNodeAgentToolHandlers(configB);
+		const resultB = await handlersB.write_gate({
+			gateId: 'gate-vote',
+			data: { votes: { 'node-a': 'approved', 'node-b': 'approved' } },
+		});
+		const dataB = JSON.parse(resultB.content[0].text);
+		expect(dataB.success).toBe(true);
+		expect(dataB.gateOpen).toBe(true); // 2 votes, min=2
+	});
+});
 
 describe('node-agent-tools: list_reachable_agents', () => {
 	let ctx: TestCtx;

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -329,6 +329,78 @@ describe('node-agent-tools: list_peers', () => {
 		expect(data.success).toBe(true);
 		expect(data.peers).toHaveLength(0);
 	});
+
+	test('excludes pending task with no session from peers list', async () => {
+		// Seed a pending task with no session — should not appear in peers
+		const isolatedNodeId = 'node-no-session';
+		seedSpaceTask(
+			ctx.db,
+			ctx.spaceId,
+			ctx.workflowRunId,
+			isolatedNodeId,
+			'tester',
+			'pending',
+			null
+		);
+		// Do NOT set task_agent_session_id — simulates not-yet-spawned task
+
+		const config = makeConfig(ctx, { workflowNodeId: isolatedNodeId });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_peers({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.peers).toHaveLength(0);
+	});
+
+	test('excludes failed task with no session from peers list', async () => {
+		// A needs_attention task that never got a session should also be excluded
+		const isolatedNodeId = 'node-failed-no-sess';
+		seedSpaceTask(
+			ctx.db,
+			ctx.spaceId,
+			ctx.workflowRunId,
+			isolatedNodeId,
+			'tester',
+			'needs_attention',
+			'Failed before session'
+		);
+
+		const config = makeConfig(ctx, { workflowNodeId: isolatedNodeId });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_peers({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.peers).toHaveLength(0);
+	});
+
+	test('includes completed task with no session in peers list', async () => {
+		// A completed task whose session was cleared should still appear for visibility
+		const isolatedNodeId = 'node-completed-no-sess';
+		seedSpaceTask(
+			ctx.db,
+			ctx.spaceId,
+			ctx.workflowRunId,
+			isolatedNodeId,
+			'tester',
+			'completed',
+			'Done'
+		);
+		// Do NOT set task_agent_session_id — simulates post-session cleanup
+
+		const config = makeConfig(ctx, { workflowNodeId: isolatedNodeId });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_peers({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.peers).toHaveLength(1);
+		expect(data.peers[0].role).toBe('tester');
+		expect(data.peers[0].sessionId).toBeNull();
+		expect(data.peers[0].status).toBe('completed');
+		expect(data.peers[0].completionState.completionSummary).toBe('Done');
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -17,13 +17,14 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
+import { GateDataRepository } from '../../../src/storage/repositories/gate-data-repository.ts';
 import {
 	createNodeAgentToolHandlers,
 	createNodeAgentMcpServer,
 	type NodeAgentToolsConfig,
 } from '../../../src/lib/space/tools/node-agent-tools.ts';
 import { ChannelResolver } from '../../../src/lib/space/runtime/channel-resolver.ts';
-import type { ResolvedChannel } from '@neokai/shared';
+import type { ResolvedChannel, SpaceWorkflow, Gate, WorkflowChannel } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // DB helpers
@@ -217,6 +218,9 @@ function makeConfig(
 			injectedMessages.push({ sessionId, message });
 		},
 		taskManager: ctx.taskManager,
+		// New M1.3 fields — default to null/no-op so existing tests are unaffected
+		workflow: null,
+		gateDataRepo: new GateDataRepository(ctx.db),
 		...overrides,
 	};
 }

--- a/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager-mcp.test.ts
@@ -23,6 +23,7 @@ import { runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { GateDataRepository } from '../../../src/storage/repositories/gate-data-repository.ts';
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -172,6 +173,7 @@ function buildManager(opts: {
 	const workflowManager = new SpaceWorkflowManager(workflowRepo);
 	const workflowRunRepo = new SpaceWorkflowRunRepository(bunDb);
 	const taskRepo = new SpaceTaskRepository(bunDb);
+	const gateDataRepo = new GateDataRepository(bunDb);
 	const spaceManager = new SpaceManager(bunDb);
 	const taskManager = new SpaceTaskManager(bunDb, spaceId);
 	const runtime = new SpaceRuntime({
@@ -234,6 +236,7 @@ function buildManager(opts: {
 		} as unknown as import('../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
 		taskRepo,
 		workflowRunRepo,
+		gateDataRepo,
 		daemonHub: daemonHub as unknown as import('../../../src/lib/daemon-hub.ts').DaemonHub,
 		messageHub: {} as unknown as import('@neokai/shared').MessageHub,
 		getApiKey: async () => 'test-key',
@@ -530,7 +533,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 	});
 
 	test('buildNodeAgentMcpServerForSession injects ChannelResolver with declared channels', () => {
-		const { manager, fromInitSpy, bunDb, dir, space } = buildManager({});
+		const { manager, fromInitSpy, bunDb, dir, space, taskManager } = buildManager({});
 		spies.push(fromInitSpy);
 		dirs.push(dir);
 
@@ -559,7 +562,9 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 				subSessionId: string,
 				role: string,
 				spaceId: string,
-				workflowRunId: string
+				workflowRunId: string,
+				stepTaskId: string,
+				taskManager: SpaceTaskManager
 			): unknown;
 		};
 		mgr.buildNodeAgentMcpServerForSession(
@@ -567,7 +572,9 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 			'sub-session-1',
 			'coder',
 			space.id,
-			workflowRunId
+			workflowRunId,
+			'step-task-1',
+			taskManager
 		);
 
 		expect(capturedConfig).not.toBeNull();
@@ -581,7 +588,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 	});
 
 	test('buildNodeAgentMcpServerForSession injects empty ChannelResolver when run has no channels', () => {
-		const { manager, fromInitSpy, bunDb, dir, space } = buildManager({});
+		const { manager, fromInitSpy, bunDb, dir, space, taskManager } = buildManager({});
 		spies.push(fromInitSpy);
 		dirs.push(dir);
 
@@ -605,7 +612,9 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 				subSessionId: string,
 				role: string,
 				spaceId: string,
-				workflowRunId: string
+				workflowRunId: string,
+				stepTaskId: string,
+				taskManager: SpaceTaskManager
 			): unknown;
 		};
 		mgr.buildNodeAgentMcpServerForSession(
@@ -613,7 +622,9 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 			'sub-session-1',
 			'coder',
 			space.id,
-			workflowRunId
+			workflowRunId,
+			'step-task-1',
+			taskManager
 		);
 
 		expect(capturedConfig).not.toBeNull();
@@ -624,7 +635,7 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 	});
 
 	test('buildNodeAgentMcpServerForSession injects empty ChannelResolver when workflowRunId is empty', () => {
-		const { manager, fromInitSpy, dir, space } = buildManager({});
+		const { manager, fromInitSpy, dir, space, taskManager } = buildManager({});
 		spies.push(fromInitSpy);
 		dirs.push(dir);
 
@@ -645,11 +656,21 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 				subSessionId: string,
 				role: string,
 				spaceId: string,
-				workflowRunId: string
+				workflowRunId: string,
+				stepTaskId: string,
+				taskManager: SpaceTaskManager
 			): unknown;
 		};
 		// Empty workflowRunId — no run will be found
-		mgr.buildNodeAgentMcpServerForSession('task-1', 'sub-session-1', 'coder', space.id, '');
+		mgr.buildNodeAgentMcpServerForSession(
+			'task-1',
+			'sub-session-1',
+			'coder',
+			space.id,
+			'',
+			'step-task-1',
+			taskManager
+		);
 
 		expect(capturedConfig).not.toBeNull();
 		const resolver = (capturedConfig as { channelResolver: { isEmpty: () => boolean } })
@@ -659,9 +680,22 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 	});
 
 	test('buildNodeAgentMcpServerForSession passes correct mySessionId, myRole, and taskId', () => {
-		const { manager, fromInitSpy, dir, space } = buildManager({});
+		const { manager, fromInitSpy, bunDb, dir, space, taskManager, taskRepo } = buildManager({});
 		spies.push(fromInitSpy);
 		dirs.push(dir);
+
+		// Seed a step task with a known workflowNodeId so the P0 fix is regression-tested
+		const stepTask = taskRepo.createTask({
+			spaceId: space.id,
+			title: 'Step Task',
+			description: '',
+			status: 'in_progress',
+		});
+		bunDb.exec('PRAGMA foreign_keys = OFF');
+		bunDb
+			.prepare('UPDATE space_tasks SET workflow_node_id = ? WHERE id = ?')
+			.run('node-p0-regression', stepTask.id);
+		bunDb.exec('PRAGMA foreign_keys = ON');
 
 		let capturedConfig: Record<string, unknown> | null = null;
 		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
@@ -680,7 +714,9 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 				subSessionId: string,
 				role: string,
 				spaceId: string,
-				workflowRunId: string
+				workflowRunId: string,
+				stepTaskId: string,
+				taskManager: SpaceTaskManager
 			): unknown;
 		};
 		mgr.buildNodeAgentMcpServerForSession(
@@ -688,12 +724,16 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 			'my-sub-session-id',
 			'reviewer',
 			space.id,
-			''
+			'',
+			stepTask.id,
+			taskManager
 		);
 
 		expect(capturedConfig).not.toBeNull();
 		expect(capturedConfig!['mySessionId']).toBe('my-sub-session-id');
 		expect(capturedConfig!['myRole']).toBe('reviewer');
 		expect(capturedConfig!['taskId']).toBe('my-task-id');
+		// Regression test for P0: workflowNodeId must come from the step task, not the parent task
+		expect(capturedConfig!['workflowNodeId']).toBe('node-p0-regression');
 	});
 });


### PR DESCRIPTION
## Summary

- Adds four new MCP tools for node agents: `list_channels`, `list_gates`, `read_gate`, `write_gate`
- Gates guard channels — node agents use these tools to inspect and update gate state for vote-counting and coordination
- Role-based authorization enforced on `write_gate` via `allowedWriterRoles`
- `write_gate` re-evaluates gate condition after each write

## Changes since initial review

- **P0 fix**: `workflowNodeId` now resolved from `stepTaskId` (sub-session task) instead of `taskId` (parent orchestration task) — was always empty before
- **P2**: `write_gate` description notes runtime polling model (tool updates data, runtime polls at channel-routing time)
- **P2**: `list_channels` description notes `gateId` type limitation (`WorkflowChannel` uses inline `gate?: WorkflowCondition`; separated `Gate` entities require a future type migration)
- **P3**: Removed misleading literal `${workflowNodeId}` from JSDoc
- **P1**: Added comprehensive unit tests for all four tools (590+ lines added)

## Test plan

- [x] Unit tests pass (`bun test packages/daemon/tests/unit/space/node-agent-tools.test.ts`) — 63 tests