### PR TITLE
feat(space): wire SpaceWorktreeManager into TaskAgentManager (M4.3)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -450,6 +450,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// On startup: clean up orphaned worktrees (directories missing from disk) and run the TTL reaper.
 	// Both are non-blocking — errors are logged but never propagate to block server start.
+	let reaperTimer: ReturnType<typeof setInterval> | null = null;
 	if (process.env.NODE_ENV !== 'test') {
 		const worktreeStartupCleanup = async () => {
 			try {
@@ -473,7 +474,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 		// Run TTL reaper periodically (every hour) for long-running daemon processes.
 		const WORKTREE_REAPER_INTERVAL_MS = 60 * 60 * 1000;
-		const reaperTimer = setInterval(() => {
+		reaperTimer = setInterval(() => {
 			spaceWorktreeManager.reapExpiredWorktrees().catch((err) => {
 				logError('[Daemon] Periodic worktree TTL reaper failed:', err);
 			});
@@ -489,6 +490,12 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			return;
 		}
 		isCleanedUp = true;
+
+		// Stop the hourly worktree TTL reaper before shutting down other resources.
+		if (reaperTimer !== null) {
+			clearInterval(reaperTimer);
+			reaperTimer = null;
+		}
 
 		try {
 			try {

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -20,6 +20,7 @@ import { SpaceAgentManager } from './lib/space/managers/space-agent-manager';
 import { SpaceManager } from './lib/space/managers/space-manager';
 import type { SpaceRuntimeService } from './lib/space/runtime/space-runtime-service';
 import type { TaskAgentManager } from './lib/space/runtime/task-agent-manager';
+import type { SpaceWorktreeManager } from './lib/space/managers/space-worktree-manager';
 import { JobQueueRepository } from './storage/repositories/job-queue-repository';
 import { JobQueueProcessor } from './storage/job-queue-processor';
 import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
@@ -71,6 +72,8 @@ export interface DaemonAppContext {
 	spaceRuntimeService: SpaceRuntimeService;
 	/** Task Agent Manager — manages Task Agent session lifecycle for space tasks */
 	taskAgentManager: TaskAgentManager;
+	/** Space Worktree Manager — one git worktree per task, shared by all node agents */
+	spaceWorktreeManager: SpaceWorktreeManager;
 	/** Persistent job queue repository */
 	jobQueue: JobQueueRepository;
 	/** Persistent job queue processor */
@@ -288,6 +291,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		cleanup: rpcHandlerCleanup,
 		spaceRuntimeService,
 		taskAgentManager,
+		spaceWorktreeManager,
 	} = setupRPCHandlers({
 		messageHub,
 		sessionManager,
@@ -444,6 +448,40 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	jobProcessor.start();
 	logInfo('[Daemon] Job queue processor started');
 
+	// On startup: clean up orphaned worktrees (directories missing from disk) and run the TTL reaper.
+	// Both are non-blocking — errors are logged but never propagate to block server start.
+	if (process.env.NODE_ENV !== 'test') {
+		const worktreeStartupCleanup = async () => {
+			try {
+				const spaces = await spaceManager.listSpaces(false);
+				for (const space of spaces) {
+					await spaceWorktreeManager.cleanupOrphaned(space.id);
+				}
+				logInfo('[Daemon] Worktree orphan cleanup complete');
+			} catch (err) {
+				logError('[Daemon] Worktree orphan cleanup failed:', err);
+			}
+
+			try {
+				await spaceWorktreeManager.reapExpiredWorktrees();
+				logInfo('[Daemon] Worktree TTL reaper complete');
+			} catch (err) {
+				logError('[Daemon] Worktree TTL reaper failed:', err);
+			}
+		};
+		void worktreeStartupCleanup();
+
+		// Run TTL reaper periodically (every hour) for long-running daemon processes.
+		const WORKTREE_REAPER_INTERVAL_MS = 60 * 60 * 1000;
+		const reaperTimer = setInterval(() => {
+			spaceWorktreeManager.reapExpiredWorktrees().catch((err) => {
+				logError('[Daemon] Periodic worktree TTL reaper failed:', err);
+			});
+		}, WORKTREE_REAPER_INTERVAL_MS);
+		// Allow the process to exit even if this timer is still pending.
+		reaperTimer.unref();
+	}
+
 	// Cleanup function for graceful shutdown
 	let isCleanedUp = false;
 	const cleanup = async () => {
@@ -561,6 +599,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		spaceManager,
 		spaceRuntimeService,
 		taskAgentManager,
+		spaceWorktreeManager,
 		jobQueue,
 		jobProcessor,
 		appMcpManager,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -49,6 +49,7 @@ import { setupSpaceHandlers } from './space-handlers';
 import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-task-handlers';
 import { setupSpaceTaskMessageHandlers } from './space-task-message-handlers';
 import { TaskAgentManager } from '../space/runtime/task-agent-manager';
+import { SpaceWorktreeManager } from '../space/managers/space-worktree-manager';
 import { setupSpaceWorkflowHandlers } from './space-workflow-handlers';
 import type { SpaceManager } from '../space/managers/space-manager';
 import { SpaceTaskManager } from '../space/managers/space-task-manager';
@@ -127,6 +128,7 @@ export interface RPCHandlerSetupResult {
 	cleanup: RPCHandlerCleanup;
 	spaceRuntimeService: SpaceRuntimeService;
 	taskAgentManager: TaskAgentManager;
+	spaceWorktreeManager: SpaceWorktreeManager;
 }
 
 /**
@@ -368,6 +370,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		taskRepo: spaceTaskRepo,
 	});
 
+	// Space Worktree Manager — one worktree per task, shared by all node agents.
+	const spaceWorktreeManager = new SpaceWorktreeManager(deps.db.getDatabase());
+
 	// Task Agent Manager — manages Task Agent session lifecycle and message injection.
 	// Must be created after spaceRuntimeService so it can get WorkflowExecutors via
 	// spaceRuntimeService.createOrGetRuntime(spaceId).
@@ -386,6 +391,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		getApiKey: () => deps.authManager.getCurrentApiKey(),
 		defaultModel: deps.config.defaultModel,
 		appMcpManager: deps.appMcpManager,
+		worktreeManager: spaceWorktreeManager,
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn
@@ -488,5 +494,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		},
 		spaceRuntimeService,
 		taskAgentManager,
+		spaceWorktreeManager,
 	};
 }

--- a/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
@@ -191,6 +191,50 @@ export class SpaceWorktreeManager {
 	}
 
 	/**
+	 * Mark a task's worktree as completed so the TTL reaper can clean it up later.
+	 *
+	 * Called when a task finishes normally (not cancelled).  The worktree is NOT
+	 * removed immediately — the TTL reaper will delete it after `ttlMs` has elapsed.
+	 *
+	 * Idempotent: calling more than once for the same task is a no-op after the
+	 * first call sets `completed_at`.
+	 */
+	markTaskWorktreeCompleted(spaceId: string, taskId: string): void {
+		this.worktreeRepo.markCompleted(spaceId, taskId);
+	}
+
+	/**
+	 * Remove all worktrees that were completed more than `ttlMs` milliseconds ago.
+	 *
+	 * Iterates over every expired record, removes the git worktree + branch, and
+	 * deletes the SQLite row.  Errors for individual worktrees are logged and
+	 * skipped so one bad worktree cannot block the rest of the cleanup pass.
+	 *
+	 * @param ttlMs - TTL in milliseconds (default: 7 days)
+	 */
+	async reapExpiredWorktrees(ttlMs: number = 7 * 24 * 60 * 60 * 1000): Promise<void> {
+		const cutoff = Date.now() - ttlMs;
+		const expired = this.worktreeRepo.listCompletedBefore(cutoff);
+
+		for (const record of expired) {
+			try {
+				await this.removeTaskWorktree(record.spaceId, record.taskId);
+				this.logger.info(
+					`TTL reaper: removed expired worktree for task ${record.taskId} (completed_at: ${record.completedAt})`
+				);
+			} catch (err) {
+				this.logger.warn(
+					`TTL reaper: failed to remove worktree for task ${record.taskId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		}
+
+		if (expired.length > 0) {
+			this.logger.info(`TTL reaper: removed ${expired.length} expired worktree(s)`);
+		}
+	}
+
+	/**
 	 * Return the filesystem path for a task's worktree, or null if none exists.
 	 */
 	async getTaskWorktreePath(spaceId: string, taskId: string): Promise<string | null> {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -36,6 +36,7 @@
  * registered `onComplete` callbacks are fired.
  */
 
+import { existsSync } from 'node:fs';
 import { generateUUID } from '@neokai/shared';
 import type {
 	Space,
@@ -999,16 +1000,23 @@ export class TaskAgentManager {
 		}
 
 		// --- Restore worktree path from workflow run config (persisted at spawn time).
-		// If the path is still present on disk we restore it so sub-sessions spawned
-		// after restart share the same worktree; otherwise fall back gracefully.
+		// Only restores the path when the worktree directory still exists on disk —
+		// if the directory was deleted between restarts (manual cleanup, disk failure),
+		// fall back to space.workspacePath to avoid directing sub-sessions at a
+		// non-existent location.
 		const rehydrateWorkspacePath = (() => {
 			const storedPath =
 				workflowRun?.config && typeof workflowRun.config.worktreePath === 'string'
 					? workflowRun.config.worktreePath
 					: null;
-			if (storedPath) {
+			if (storedPath && existsSync(storedPath)) {
 				this.taskWorktreePaths.set(taskId, storedPath);
 				return storedPath;
+			}
+			if (storedPath) {
+				log.warn(
+					`TaskAgentManager.rehydrate: worktree path ${storedPath} no longer exists on disk for task ${taskId} — falling back to space workspace`
+				);
 			}
 			return space.workspacePath;
 		})();

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -59,6 +59,7 @@ import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceRuntimeService } from './space-runtime-service';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type {
 	SubSessionFactory,
 	SubSessionMemberInfo,
@@ -111,6 +112,12 @@ export interface TaskAgentManagerConfig {
 	 * over registry entries on name collision.
 	 */
 	appMcpManager?: AppMcpLifecycleManager;
+	/**
+	 * Space worktree manager for creating and cleaning up task worktrees.
+	 * When provided, each task gets its own isolated git worktree at run start.
+	 * All sub-sessions (node agents) share the same worktree path as their workspace.
+	 */
+	worktreeManager?: SpaceWorktreeManager;
 }
 
 // ---------------------------------------------------------------------------
@@ -156,6 +163,14 @@ export class TaskAgentManager {
 	 * Key: session ID.
 	 */
 	private sessionListeners = new Map<string, () => void>();
+
+	/**
+	 * Maps taskId → absolute worktree path for active tasks.
+	 * Populated in spawnTaskAgent() after worktree creation.
+	 * Used by createSubSessionFactory() to forward the worktree path to sub-sessions.
+	 * Also populated during rehydrateTaskAgent() from the workflow run config.
+	 */
+	private taskWorktreePaths = new Map<string, string>();
 
 	constructor(private readonly config: TaskAgentManagerConfig) {}
 
@@ -239,6 +254,38 @@ export class TaskAgentManager {
 			const baseSessionId = `space:${spaceId}:task:${taskId}`;
 			const sessionId = this.resolveSessionId(baseSessionId);
 
+			// --- Create task worktree (one per task, shared by all node agents).
+			// Falls back to space.workspacePath when worktreeManager is not configured.
+			let workspacePath = space.workspacePath;
+			if (this.config.worktreeManager) {
+				try {
+					const result = await this.config.worktreeManager.createTaskWorktree(
+						spaceId,
+						taskId,
+						task.title,
+						task.taskNumber
+					);
+					workspacePath = result.path;
+					this.taskWorktreePaths.set(taskId, result.path);
+					log.info(
+						`TaskAgentManager: created worktree for task ${taskId} at ${result.path} (slug: ${result.slug})`
+					);
+
+					// Persist worktree path in workflow run config for M6 artifacts RPC.
+					if (workflowRun) {
+						const updatedConfig = {
+							...workflowRun.config,
+							worktreePath: result.path,
+						};
+						this.config.workflowRunRepo.updateRun(workflowRun.id, { config: updatedConfig });
+					}
+				} catch (err) {
+					log.warn(
+						`TaskAgentManager: failed to create worktree for task ${taskId}, falling back to space workspace: ${err instanceof Error ? err.message : String(err)}`
+					);
+				}
+			}
+
 			// --- Create AgentSessionInit
 			const init = createTaskAgentInit({
 				task,
@@ -246,7 +293,7 @@ export class TaskAgentManager {
 				workflow,
 				workflowRun,
 				sessionId,
-				workspacePath: space.workspacePath,
+				workspacePath,
 			});
 
 			// --- Create the session in DB via AgentSession.fromInit()
@@ -281,7 +328,7 @@ export class TaskAgentManager {
 				taskId,
 				space,
 				workflowRunId,
-				workspacePath: space.workspacePath,
+				workspacePath,
 				workflowManager: this.config.spaceWorkflowManager,
 				taskRepo: this.config.taskRepo,
 				workflowRunRepo: this.config.workflowRunRepo,
@@ -474,6 +521,14 @@ export class TaskAgentManager {
 		);
 	}
 
+	/**
+	 * Returns the worktree path for a task, or undefined if no worktree was created.
+	 * Useful for test assertions and M6 artifact RPCs.
+	 */
+	getTaskWorktreePath(taskId: string): string | undefined {
+		return this.taskWorktreePaths.get(taskId);
+	}
+
 	/** Returns the Task Agent's AgentSession, or undefined if not spawned. */
 	getTaskAgent(taskId: string): AgentSession | undefined {
 		return this.taskAgentSessions.get(taskId);
@@ -565,8 +620,12 @@ export class TaskAgentManager {
 	 *
 	 * Stops the Task Agent session and all sub-sessions, removes DB records
 	 * via SessionManager.deleteSession(), and clears in-memory maps.
+	 *
+	 * @param taskId - The task to clean up.
+	 * @param reason - 'cancelled': remove the worktree immediately.
+	 *                 'completed' (default): mark the worktree as completed for TTL-based cleanup.
 	 */
-	async cleanup(taskId: string): Promise<void> {
+	async cleanup(taskId: string, reason: 'completed' | 'cancelled' = 'completed'): Promise<void> {
 		// Collect the exact session IDs that belong to this task so that
 		// the callback/listener cleanup in steps 3 & 4 uses precise matches
 		// rather than a fragile substring check.
@@ -607,7 +666,29 @@ export class TaskAgentManager {
 			}
 		}
 
-		log.info(`TaskAgentManager: cleaned up all sessions for task ${taskId}`);
+		// 5. Worktree lifecycle: remove on cancellation, mark completed otherwise.
+		if (this.config.worktreeManager) {
+			const spaceId = this.config.taskRepo.getTask(taskId)?.spaceId;
+			if (spaceId) {
+				if (reason === 'cancelled') {
+					try {
+						await this.config.worktreeManager.removeTaskWorktree(spaceId, taskId);
+						log.info(`TaskAgentManager: removed worktree for cancelled task ${taskId}`);
+					} catch (err) {
+						log.warn(
+							`TaskAgentManager: failed to remove worktree for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+						);
+					}
+				} else {
+					this.config.worktreeManager.markTaskWorktreeCompleted(spaceId, taskId);
+					log.info(`TaskAgentManager: marked worktree completed for task ${taskId}`);
+				}
+			}
+		}
+		// Always remove from in-memory path map regardless of worktreeManager presence.
+		this.taskWorktreePaths.delete(taskId);
+
+		log.info(`TaskAgentManager: cleaned up all sessions for task ${taskId} (reason: ${reason})`);
 	}
 
 	// -------------------------------------------------------------------------
@@ -636,7 +717,17 @@ export class TaskAgentManager {
 				init: AgentSessionInit,
 				_memberInfo?: SubSessionMemberInfo
 			): Promise<string> => {
-				const sessionId = await this.createSubSession(taskId, init.sessionId, init);
+				// Forward the task's worktree path to every sub-session so all node
+				// agents share the same isolated git worktree for the duration of the run.
+				const worktreePath = this.taskWorktreePaths.get(taskId);
+				const effectiveInit: AgentSessionInit = worktreePath
+					? { ...init, workspacePath: worktreePath }
+					: init;
+				const sessionId = await this.createSubSession(
+					taskId,
+					effectiveInit.sessionId,
+					effectiveInit
+				);
 				return sessionId;
 			},
 
@@ -907,6 +998,21 @@ export class TaskAgentManager {
 			return;
 		}
 
+		// --- Restore worktree path from workflow run config (persisted at spawn time).
+		// If the path is still present on disk we restore it so sub-sessions spawned
+		// after restart share the same worktree; otherwise fall back gracefully.
+		const rehydrateWorkspacePath = (() => {
+			const storedPath =
+				workflowRun?.config && typeof workflowRun.config.worktreePath === 'string'
+					? workflowRun.config.worktreePath
+					: null;
+			if (storedPath) {
+				this.taskWorktreePaths.set(taskId, storedPath);
+				return storedPath;
+			}
+			return space.workspacePath;
+		})();
+
 		// --- Build the SpaceTaskManager for this space
 		const taskManager = new SpaceTaskManager(this.config.db.getDatabase(), spaceId);
 
@@ -928,7 +1034,7 @@ export class TaskAgentManager {
 			taskId,
 			space,
 			workflowRunId: rehydrateWorkflowRunId,
-			workspacePath: space.workspacePath,
+			workspacePath: rehydrateWorkspacePath,
 			workflowManager: this.config.spaceWorkflowManager,
 			taskRepo: this.config.taskRepo,
 			workflowRunRepo: this.config.workflowRunRepo,
@@ -979,7 +1085,7 @@ export class TaskAgentManager {
 			workflow,
 			workflowRun,
 			sessionId,
-			workspacePath: space.workspacePath,
+			workspacePath: rehydrateWorkspacePath,
 		});
 		if (init.systemPrompt) {
 			agentSession.setRuntimeSystemPrompt(init.systemPrompt);

--- a/packages/daemon/src/storage/repositories/space-worktree-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-worktree-repository.ts
@@ -15,6 +15,8 @@ export interface SpaceWorktreeRecord {
 	slug: string;
 	path: string;
 	createdAt: number;
+	/** Unix epoch ms when the task completed. NULL while the task is still active. */
+	completedAt?: number;
 }
 
 export class SpaceWorktreeRepository {
@@ -73,6 +75,33 @@ export class SpaceWorktreeRepository {
 	}
 
 	/**
+	 * Set completed_at on the worktree record for a task.
+	 * Called when a task finishes normally — worktree is kept for TTL-based cleanup.
+	 * Returns true if a row was updated.
+	 */
+	markCompleted(spaceId: string, taskId: string, completedAt: number = Date.now()): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE space_worktrees SET completed_at = ? WHERE space_id = ? AND task_id = ? AND completed_at IS NULL`
+			)
+			.run(completedAt, spaceId, taskId);
+		return result.changes > 0;
+	}
+
+	/**
+	 * List all worktree records whose completed_at is older than the given cutoff.
+	 * Used by the TTL reaper to find expired worktrees across all spaces.
+	 */
+	listCompletedBefore(cutoffMs: number): SpaceWorktreeRecord[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM space_worktrees WHERE completed_at IS NOT NULL AND completed_at < ? ORDER BY completed_at ASC`
+			)
+			.all(cutoffMs) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToRecord(r));
+	}
+
+	/**
 	 * Remove the worktree record for a specific task.
 	 * Returns true if a row was deleted.
 	 */
@@ -99,6 +128,7 @@ export class SpaceWorktreeRepository {
 			slug: row.slug as string,
 			path: row.path as string,
 			createdAt: row.created_at as number,
+			completedAt: (row.completed_at as number | null) ?? undefined,
 		};
 	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -265,6 +265,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 64: Create space_worktrees table for persisting task ↔ git worktree mappings.
 	// One row per task; keyed by (space_id, task_id) with a per-space unique slug constraint.
 	runMigration64(db);
+
+	// Migration 65: Add completed_at column to space_worktrees for TTL-based reaper.
+	// Worktrees are not removed on task completion; instead they are timestamped and
+	// removed by the reaper after a configurable TTL (default: 7 days).
+	runMigration65(db);
 }
 
 /**
@@ -4243,4 +4248,20 @@ function runMigration64(db: BunDatabase): void {
 		)
 	`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_worktrees_space_id ON space_worktrees(space_id)`);
+}
+
+/**
+ * Migration 65: Add completed_at to space_worktrees.
+ *
+ * Adds a nullable `completed_at` INTEGER column so the TTL-based reaper can
+ * identify worktrees whose tasks have finished and remove them after 7 days.
+ * NULL = task still active; non-NULL = Unix epoch ms when the task completed.
+ */
+function runMigration65(db: BunDatabase): void {
+	try {
+		db.prepare(`SELECT completed_at FROM space_worktrees LIMIT 1`).all();
+	} catch {
+		// Column doesn't exist yet — add it
+		db.exec(`ALTER TABLE space_worktrees ADD COLUMN completed_at INTEGER`);
+	}
 }

--- a/packages/daemon/tests/unit/space/task-agent-manager-worktree.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager-worktree.test.ts
@@ -286,6 +286,8 @@ interface TestCtx {
 	createdSessions: Map<string, MockAgentSession>;
 	fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
 	sessionManagerDeleteCalls: string[];
+	/** Adds a fake session record to the in-memory DB mock so getSession() returns it */
+	addDbSession: (id: string, type: string) => void;
 }
 
 function makeCtx(worktreePath = '/tmp/worktrees/test-task'): TestCtx {
@@ -402,6 +404,9 @@ function makeCtx(worktreePath = '/tmp/worktrees/test-task'): TestCtx {
 		createdSessions,
 		fromInitSpy,
 		sessionManagerDeleteCalls,
+		addDbSession: (id: string, type: string) => {
+			mockDb.createSession({ id, type });
+		},
 	};
 }
 
@@ -505,43 +510,61 @@ describe('TaskAgentManager × SpaceWorktreeManager (M4.3)', () => {
 	// -------------------------------------------------------------------------
 
 	describe('worktree reuse across node agents', () => {
-		test('sub-sessions receive the same worktree path as workspacePath', async () => {
+		test('SubSessionFactory.create overrides workspacePath with worktree path', async () => {
 			const task = await makeTask(ctx.taskManager);
 			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
 
-			// Manually trigger sub-session creation via the factory
-			// (we access the internal createSubSession method through public API)
-			const subSessionId = `sub-${task.id}-node-1`;
-			const fakeInit = {
+			// Access the private factory method via type cast so we can invoke it directly.
+			// This exercises the path-override logic in createSubSessionFactory() without
+			// needing a full MCP server stack.
+			type ManagerPrivate = {
+				createSubSessionFactory(id: string): { create(init: object): Promise<string> };
+			};
+			const factory = (ctx.manager as unknown as ManagerPrivate).createSubSessionFactory(task.id);
+
+			const subSessionId = `sub-factory-test-${task.id}`;
+			const initWithOriginalPath = {
 				sessionId: subSessionId,
-				workspacePath: '/original-path', // will be overridden
+				workspacePath: '/original-path', // must be overridden to '/tmp/worktrees/test-task'
 				messages: [],
-				type: 'space_task_node_agent' as const,
+				type: 'space_task_node_agent',
 				context: {},
 			};
-			await ctx.manager.createSubSession(
-				task.id,
-				subSessionId,
-				fakeInit as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit
-			);
+			await factory.create(initWithOriginalPath);
 
+			// AgentSession.fromInit was called by createSubSession with effectiveInit that has
+			// the worktree path, not /original-path.
 			const subSession = ctx.createdSessions.get(subSessionId)!;
-			// The sub-session should have received the worktree path, not the original path
-			// Note: createSubSession directly receives the init; the path override happens in
-			// createSubSessionFactory. Here we test that the factory correctly overrides the path.
-			// We check via getSubSession which returns the sub-session.
-			expect(ctx.manager.getSubSession(subSessionId)).toBeDefined();
+			expect(subSession).toBeDefined();
+			expect(subSession._workspacePath).toBe('/tmp/worktrees/test-task');
 		});
 
-		test('SubSessionFactory overrides workspacePath with worktree path', async () => {
-			// We test the factory override by checking that when the internal factory creates
-			// a session it stores the worktree path (not the original init path).
-			// Spy on createSubSession to verify the init received has the correct path.
+		test('createSubSession without worktree path preserves original workspacePath', async () => {
+			// When no worktree exists for a task, the factory must not override the path.
 			const task = await makeTask(ctx.taskManager);
+			// Spawn without worktreeManager worktree path set (use a manager with no worktree mock)
+			// by temporarily making the mock throw so the path is never stored.
+			ctx.worktreeMock.createError = new Error('force fallback');
 			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+			ctx.worktreeMock.createError = undefined;
 
-			// After spawn, the worktree path should be in the map
-			expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp/worktrees/test-task');
+			// No path in map — factory must leave workspacePath intact.
+			type ManagerPrivate = {
+				createSubSessionFactory(id: string): { create(init: object): Promise<string> };
+			};
+			const factory = (ctx.manager as unknown as ManagerPrivate).createSubSessionFactory(task.id);
+
+			const subSessionId = `sub-nopath-${task.id}`;
+			await factory.create({
+				sessionId: subSessionId,
+				workspacePath: '/keep-this',
+				messages: [],
+				type: 'space_task_node_agent',
+				context: {},
+			});
+
+			const subSession = ctx.createdSessions.get(subSessionId)!;
+			expect(subSession._workspacePath).toBe('/keep-this');
 		});
 	});
 
@@ -796,25 +819,85 @@ describe('TaskAgentManager × SpaceWorktreeManager (M4.3)', () => {
 	// -------------------------------------------------------------------------
 
 	describe('rehydration restores worktree path from run config', () => {
-		test('getTaskWorktreePath returns path after successful rehydration', async () => {
-			// After spawnTaskAgent the path is in the map; verify it's present
+		test('rehydrate() reads worktreePath from run config and sets taskWorktreePaths', async () => {
+			// Simulate a daemon restart: seed DB with an in-progress task whose
+			// workflow run config already has a worktreePath stored by spawnTaskAgent.
+			const sessionId = `session-rehydrate-${Date.now()}`;
+
 			const task = await makeTask(ctx.taskManager);
 			const workflowRun = ctx.workflowRunRepo.createRun({
 				spaceId: ctx.spaceId,
 				workflowId: 'workflow-rehydrate',
 				title: 'Rehydrate run',
 			});
-			ctx.taskRepo.updateTask(task.id, { workflowRunId: workflowRun.id });
-			const linkedTask = ctx.taskRepo.getTask(task.id)!;
 
-			await ctx.manager.spawnTaskAgent(linkedTask, ctx.space, null, workflowRun);
+			// Store worktreePath in run config (as spawnTaskAgent would have done).
+			// Use '/tmp' — guaranteed to exist on disk so existsSync() passes.
+			ctx.workflowRunRepo.updateRun(workflowRun.id, { config: { worktreePath: '/tmp' } });
 
-			// The worktree path is now in the run config
-			const updatedRun = ctx.workflowRunRepo.getRun(workflowRun.id)!;
-			expect(updatedRun.config?.worktreePath).toBe('/tmp/worktrees/test-task');
+			// Mark task as in_progress with a session id and workflow run link.
+			ctx.taskRepo.updateTask(task.id, {
+				status: 'in_progress',
+				taskAgentSessionId: sessionId,
+				workflowRunId: workflowRun.id,
+			});
 
-			// And in the in-memory map
-			expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp/worktrees/test-task');
+			// Seed the session in the mock DB so rehydrate() identifies it as a task-agent session.
+			ctx.addDbSession(sessionId, 'space_task_agent');
+
+			// Spy on AgentSession.restore so no real DB/SDK calls are made.
+			const mockSession = makeMockSession(sessionId);
+			const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(
+				mockSession as unknown as AgentSession
+			);
+
+			try {
+				await ctx.manager.rehydrate();
+			} finally {
+				restoreSpy.mockRestore();
+			}
+
+			// The critical assertion: rehydrateTaskAgent() should have read
+			// workflowRun.config.worktreePath and called taskWorktreePaths.set(taskId, '/tmp').
+			expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp');
+		});
+
+		test('rehydrate() skips worktree path when stored path no longer exists on disk', async () => {
+			const sessionId = `session-rehydrate-gone-${Date.now()}`;
+
+			const task = await makeTask(ctx.taskManager);
+			const workflowRun = ctx.workflowRunRepo.createRun({
+				spaceId: ctx.spaceId,
+				workflowId: 'workflow-rehydrate-gone',
+				title: 'Rehydrate gone run',
+			});
+
+			// Use a path that definitely does not exist on disk.
+			ctx.workflowRunRepo.updateRun(workflowRun.id, {
+				config: { worktreePath: '/nonexistent/worktree/path/that/surely/does/not/exist' },
+			});
+
+			ctx.taskRepo.updateTask(task.id, {
+				status: 'in_progress',
+				taskAgentSessionId: sessionId,
+				workflowRunId: workflowRun.id,
+			});
+
+			ctx.addDbSession(sessionId, 'space_task_agent');
+
+			const mockSession = makeMockSession(sessionId);
+			const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(
+				mockSession as unknown as AgentSession
+			);
+
+			try {
+				await ctx.manager.rehydrate();
+			} finally {
+				restoreSpy.mockRestore();
+			}
+
+			// Path did not exist on disk → not stored in the map (falls back to space.workspacePath).
+			expect(ctx.manager.getTaskWorktreePath(task.id)).toBeUndefined();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-manager-worktree.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager-worktree.test.ts
@@ -1,0 +1,820 @@
+/**
+ * Unit tests for TaskAgentManager × SpaceWorktreeManager integration (M4.3)
+ *
+ * Covers:
+ *   - Worktree created at spawnTaskAgent() time
+ *   - Worktree path stored in workflow run config
+ *   - Sub-sessions (node agents) reuse the same worktree path
+ *   - Completion marks worktree as completed (TTL path)
+ *   - Cancellation removes worktree immediately
+ *   - Rehydration restores worktree path from run config
+ *   - cleanupOrphaned wires through SpaceWorktreeManager
+ *   - TTL reaper removes expired worktrees
+ *
+ * Strategy: SpaceWorktreeManager is replaced with a controllable mock that
+ * records calls and returns predictable paths.  Real SQLite DB is used for
+ * space/task/workflow-run repositories. AgentSession.fromInit is spied on.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager.ts';
+import { AgentSession } from '../../../src/lib/agent/agent-session.ts';
+import type { Space, SpaceWorkflow, SpaceWorkflowRun, SpaceTask } from '@neokai/shared';
+import type { AgentProcessingState } from '@neokai/shared';
+import type { SpaceWorktreeManager } from '../../../src/lib/space/managers/space-worktree-manager.ts';
+
+// ---------------------------------------------------------------------------
+// Minimal in-process DaemonHub for tests
+// ---------------------------------------------------------------------------
+
+type EventHandler = (data: Record<string, unknown>) => void;
+
+class TestDaemonHub {
+	private listeners = new Map<string, Map<string, EventHandler>>();
+	readonly emitted: Array<{ event: string; data: Record<string, unknown> }> = [];
+
+	on(event: string, handler: EventHandler, opts?: { sessionId?: string }): () => void {
+		const key = opts?.sessionId ? `${event}:${opts.sessionId}` : `${event}:*`;
+		if (!this.listeners.has(key)) {
+			this.listeners.set(key, new Map());
+		}
+		const id = Math.random().toString(36).slice(2);
+		this.listeners.get(key)!.set(id, handler);
+		return () => {
+			this.listeners.get(key)?.delete(id);
+		};
+	}
+
+	emit(event: string, data: Record<string, unknown>): Promise<void> {
+		this.emitted.push({ event, data });
+		const sessionId = (data as { sessionId?: string }).sessionId;
+		if (sessionId) {
+			const key = `${event}:${sessionId}`;
+			for (const handler of this.listeners.get(key)?.values() ?? []) {
+				handler(data);
+			}
+		}
+		for (const handler of this.listeners.get(`${event}:*`)?.values() ?? []) {
+			handler(data);
+		}
+		return Promise.resolve();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock AgentSession factory
+// ---------------------------------------------------------------------------
+
+interface MockAgentSession {
+	session: { id: string; context?: Record<string, unknown> };
+	getProcessingState: () => AgentProcessingState;
+	getSDKMessageCount: () => number;
+	getSessionData: () => { id: string; context?: Record<string, unknown> };
+	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
+	startStreamingQuery: () => Promise<void>;
+	ensureQueryStarted: () => Promise<void>;
+	handleInterrupt: () => Promise<void>;
+	cleanup: () => Promise<void>;
+	messageQueue: { enqueueWithId: (id: string, msg: string) => Promise<void> };
+	_processingState: AgentProcessingState;
+	_sdkMessageCount: number;
+	_startCalled: boolean;
+	_cleanupCalled: boolean;
+	_mcpServers: Record<string, unknown>;
+	_enqueuedMessages: Array<{ id: string; msg: string }>;
+	_workspacePath?: string;
+}
+
+function makeMockSession(
+	sessionId: string,
+	contextOverrides?: Record<string, unknown>
+): MockAgentSession {
+	const m: MockAgentSession = {
+		session: { id: sessionId, context: contextOverrides ?? {} },
+		_processingState: { status: 'idle' } as AgentProcessingState,
+		_sdkMessageCount: 0,
+		_startCalled: false,
+		_cleanupCalled: false,
+		_mcpServers: {},
+		_enqueuedMessages: [],
+
+		getProcessingState() {
+			return this._processingState;
+		},
+		getSDKMessageCount() {
+			return this._sdkMessageCount;
+		},
+		getSessionData() {
+			return this.session;
+		},
+		setRuntimeMcpServers(servers) {
+			this._mcpServers = servers;
+		},
+		setRuntimeSystemPrompt(_systemPrompt: unknown) {},
+		async startStreamingQuery() {
+			this._startCalled = true;
+		},
+		async ensureQueryStarted() {
+			this._startCalled = true;
+		},
+		async handleInterrupt() {},
+		async cleanup() {
+			this._cleanupCalled = true;
+		},
+		messageQueue: {
+			async enqueueWithId(id: string, msg: string) {
+				m._enqueuedMessages.push({ id, msg });
+			},
+		},
+	};
+	return m;
+}
+
+// ---------------------------------------------------------------------------
+// Mock SpaceWorktreeManager
+// ---------------------------------------------------------------------------
+
+interface MockWorktreeManager {
+	createCalls: Array<{ spaceId: string; taskId: string; taskTitle: string; taskNumber: number }>;
+	removeCalls: Array<{ spaceId: string; taskId: string }>;
+	completedCalls: Array<{ spaceId: string; taskId: string }>;
+	orphanedCleanupCalls: string[];
+	reapCalls: number;
+	/** Path returned by createTaskWorktree */
+	worktreePath: string;
+	/** If set, createTaskWorktree throws this error */
+	createError?: Error;
+
+	createTaskWorktree(
+		spaceId: string,
+		taskId: string,
+		taskTitle: string,
+		taskNumber: number
+	): Promise<{ path: string; slug: string }>;
+	removeTaskWorktree(spaceId: string, taskId: string): Promise<void>;
+	markTaskWorktreeCompleted(spaceId: string, taskId: string): void;
+	cleanupOrphaned(spaceId: string): Promise<void>;
+	reapExpiredWorktrees(ttlMs?: number): Promise<void>;
+	getTaskWorktreePath(spaceId: string, taskId: string): Promise<string | null>;
+	listWorktrees(spaceId: string): Promise<[]>;
+}
+
+function makeMockWorktreeManager(worktreePath = '/tmp/worktrees/test-task'): MockWorktreeManager {
+	const m: MockWorktreeManager = {
+		createCalls: [],
+		removeCalls: [],
+		completedCalls: [],
+		orphanedCleanupCalls: [],
+		reapCalls: 0,
+		worktreePath,
+
+		async createTaskWorktree(spaceId, taskId, taskTitle, taskNumber) {
+			m.createCalls.push({ spaceId, taskId, taskTitle, taskNumber });
+			if (m.createError) throw m.createError;
+			return { path: m.worktreePath, slug: 'test-slug' };
+		},
+		async removeTaskWorktree(spaceId, taskId) {
+			m.removeCalls.push({ spaceId, taskId });
+		},
+		markTaskWorktreeCompleted(spaceId, taskId) {
+			m.completedCalls.push({ spaceId, taskId });
+		},
+		async cleanupOrphaned(spaceId) {
+			m.orphanedCleanupCalls.push(spaceId);
+		},
+		async reapExpiredWorktrees(_ttlMs) {
+			m.reapCalls++;
+		},
+		async getTaskWorktreePath(_spaceId, _taskId) {
+			return m.worktreePath;
+		},
+		async listWorktrees(_spaceId) {
+			return [];
+		},
+	};
+	return m;
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-tam-worktree',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, role, description, model, tools, system_prompt,
+     config, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '', null, '[]', '', null, ?, ?)`
+	).run(agentId, spaceId, `Agent ${agentId}`, 'coder', Date.now(), Date.now());
+}
+
+function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {
+	return {
+		id: spaceId,
+		slug: `space-${spaceId}`,
+		workspacePath,
+		name: `Space ${spaceId}`,
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+async function makeTask(taskManager: SpaceTaskManager): Promise<SpaceTask> {
+	return taskManager.createTask({
+		title: 'Test task',
+		description: 'A test task',
+		taskType: 'coding',
+		status: 'pending',
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Build test context
+// ---------------------------------------------------------------------------
+
+interface TestCtx {
+	bunDb: BunDatabase;
+	dir: string;
+	spaceId: string;
+	space: Space;
+	taskRepo: SpaceTaskRepository;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	workflowRepo: SpaceWorkflowRepository;
+	taskManager: SpaceTaskManager;
+	manager: TaskAgentManager;
+	worktreeMock: MockWorktreeManager;
+	createdSessions: Map<string, MockAgentSession>;
+	fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
+	sessionManagerDeleteCalls: string[];
+}
+
+function makeCtx(worktreePath = '/tmp/worktrees/test-task'): TestCtx {
+	const { db: bunDb, dir } = makeDb();
+	const spaceId = 'space-wt-test';
+	const workspacePath = '/tmp/test-workspace';
+
+	seedSpaceRow(bunDb, spaceId, workspacePath);
+
+	const agentId = 'agent-coder-wt';
+	seedAgentRow(bunDb, agentId, spaceId);
+
+	const agentRepo = new SpaceAgentRepository(bunDb);
+	const agentManager = new SpaceAgentManager(agentRepo);
+	const workflowRepo = new SpaceWorkflowRepository(bunDb);
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+	const workflowRunRepo = new SpaceWorkflowRunRepository(bunDb);
+	const taskRepo = new SpaceTaskRepository(bunDb);
+	const spaceManager = new SpaceManager(bunDb);
+	const taskManager = new SpaceTaskManager(bunDb, spaceId);
+	const runtime = new SpaceRuntime({
+		db: bunDb,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		workflowRunRepo,
+		taskRepo,
+	});
+	const daemonHub = new TestDaemonHub();
+	const space = makeSpace(spaceId, workspacePath);
+
+	const createdSessions = new Map<string, MockAgentSession>();
+	const sessionManagerDeleteCalls: string[] = [];
+	const dbSessions = new Map<string, unknown>();
+
+	const mockDb = {
+		getSession: (id: string) => (dbSessions.has(id) ? dbSessions.get(id) : null),
+		createSession: (session: unknown) => {
+			dbSessions.set((session as { id: string }).id, session);
+		},
+		deleteSession: (id: string) => {
+			dbSessions.delete(id);
+		},
+		saveUserMessage: (_sessionId: string, _msg: unknown, _status: string) => 'msg-id',
+		updateSession: () => {},
+		getDatabase: () => bunDb,
+	};
+
+	const mockSpaceRuntimeService = {
+		createOrGetRuntime: async (_spaceId: string) => runtime,
+	};
+
+	const mockSessionManager = {
+		deleteSession: async (sessionId: string) => {
+			sessionManagerDeleteCalls.push(sessionId);
+		},
+		registerSession: (_agentSession: unknown) => {},
+	};
+
+	const fromInitSpy = spyOn(AgentSession, 'fromInit').mockImplementation(
+		(
+			init: unknown,
+			_db: unknown,
+			_hub: unknown,
+			_dHub: unknown,
+			_key: unknown,
+			_model: unknown
+		) => {
+			const initTyped = init as {
+				sessionId: string;
+				context?: Record<string, unknown>;
+				workspacePath?: string;
+			};
+			const mockSession = makeMockSession(initTyped.sessionId, initTyped.context);
+			// Store the workspacePath so tests can assert it was set correctly
+			mockSession._workspacePath = initTyped.workspacePath;
+			createdSessions.set(initTyped.sessionId, mockSession);
+			mockDb.createSession({ id: initTyped.sessionId });
+			return mockSession as unknown as AgentSession;
+		}
+	);
+
+	const worktreeMock = makeMockWorktreeManager(worktreePath);
+
+	const manager = new TaskAgentManager({
+		db: mockDb as unknown as import('../../../src/storage/database.ts').Database,
+		sessionManager:
+			mockSessionManager as unknown as import('../../../src/lib/session/session-manager.ts').SessionManager,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		spaceRuntimeService:
+			mockSpaceRuntimeService as unknown as import('../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
+		taskRepo,
+		workflowRunRepo,
+		daemonHub: daemonHub as unknown as import('../../../src/lib/daemon-hub.ts').DaemonHub,
+		messageHub: {} as unknown as import('@neokai/shared').MessageHub,
+		getApiKey: async () => 'test-key',
+		defaultModel: 'claude-sonnet-4-5-20250929',
+		worktreeManager: worktreeMock as unknown as SpaceWorktreeManager,
+	});
+
+	return {
+		bunDb,
+		dir,
+		spaceId,
+		space,
+		taskRepo,
+		workflowRunRepo,
+		workflowRepo,
+		taskManager,
+		manager,
+		worktreeMock,
+		createdSessions,
+		fromInitSpy,
+		sessionManagerDeleteCalls,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TaskAgentManager × SpaceWorktreeManager (M4.3)', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.fromInitSpy.mockRestore();
+		try {
+			rmSync(ctx.dir, { recursive: true, force: true });
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Worktree creation at run start
+	// -------------------------------------------------------------------------
+
+	describe('worktree creation', () => {
+		test('createTaskWorktree is called when spawnTaskAgent is called', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			expect(ctx.worktreeMock.createCalls).toHaveLength(1);
+			expect(ctx.worktreeMock.createCalls[0].taskId).toBe(task.id);
+			expect(ctx.worktreeMock.createCalls[0].spaceId).toBe(ctx.spaceId);
+		});
+
+		test('task agent session uses worktree path as workspacePath', async () => {
+			const task = await makeTask(ctx.taskManager);
+			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const session = ctx.createdSessions.get(sessionId)!;
+			expect(session._workspacePath).toBe('/tmp/worktrees/test-task');
+		});
+
+		test('getTaskWorktreePath returns the path after spawn', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp/worktrees/test-task');
+		});
+
+		test('worktree path stored in workflow run config', async () => {
+			const task = await makeTask(ctx.taskManager);
+
+			// Create a workflow run so we can check config
+			const workflowRun = ctx.workflowRunRepo.createRun({
+				spaceId: ctx.spaceId,
+				workflowId: 'workflow-test',
+				title: 'Test run',
+			});
+
+			// Link the task to the workflow run
+			ctx.taskRepo.updateTask(task.id, { workflowRunId: workflowRun.id });
+			const linkedTask = ctx.taskRepo.getTask(task.id)!;
+
+			await ctx.manager.spawnTaskAgent(linkedTask, ctx.space, null, workflowRun);
+
+			const updatedRun = ctx.workflowRunRepo.getRun(workflowRun.id)!;
+			expect(updatedRun.config?.worktreePath).toBe('/tmp/worktrees/test-task');
+		});
+
+		test('falls back to space workspacePath when worktreeManager creation fails', async () => {
+			ctx.worktreeMock.createError = new Error('git worktree add failed');
+			const task = await makeTask(ctx.taskManager);
+			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			// Should still succeed (fallback)
+			expect(sessionId).toBeTruthy();
+
+			// workspacePath should be the original space.workspacePath
+			const session = ctx.createdSessions.get(sessionId)!;
+			expect(session._workspacePath).toBe('/tmp/test-workspace');
+
+			// In-memory path map should be empty (no path was stored)
+			expect(ctx.manager.getTaskWorktreePath(task.id)).toBeUndefined();
+		});
+
+		test('worktree creation is idempotent — second spawn returns existing session', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			// createTaskWorktree only called once (idempotency from task-agent perspective)
+			expect(ctx.worktreeMock.createCalls).toHaveLength(1);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Worktree reuse across sub-sessions (node agents)
+	// -------------------------------------------------------------------------
+
+	describe('worktree reuse across node agents', () => {
+		test('sub-sessions receive the same worktree path as workspacePath', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			// Manually trigger sub-session creation via the factory
+			// (we access the internal createSubSession method through public API)
+			const subSessionId = `sub-${task.id}-node-1`;
+			const fakeInit = {
+				sessionId: subSessionId,
+				workspacePath: '/original-path', // will be overridden
+				messages: [],
+				type: 'space_task_node_agent' as const,
+				context: {},
+			};
+			await ctx.manager.createSubSession(
+				task.id,
+				subSessionId,
+				fakeInit as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit
+			);
+
+			const subSession = ctx.createdSessions.get(subSessionId)!;
+			// The sub-session should have received the worktree path, not the original path
+			// Note: createSubSession directly receives the init; the path override happens in
+			// createSubSessionFactory. Here we test that the factory correctly overrides the path.
+			// We check via getSubSession which returns the sub-session.
+			expect(ctx.manager.getSubSession(subSessionId)).toBeDefined();
+		});
+
+		test('SubSessionFactory overrides workspacePath with worktree path', async () => {
+			// We test the factory override by checking that when the internal factory creates
+			// a session it stores the worktree path (not the original init path).
+			// Spy on createSubSession to verify the init received has the correct path.
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			// After spawn, the worktree path should be in the map
+			expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp/worktrees/test-task');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Completion lifecycle
+	// -------------------------------------------------------------------------
+
+	describe('completion lifecycle', () => {
+		test('cleanup(completed) marks worktree as completed, does not remove it', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			await ctx.manager.cleanup(task.id, 'completed');
+
+			expect(ctx.worktreeMock.completedCalls).toHaveLength(1);
+			expect(ctx.worktreeMock.completedCalls[0].taskId).toBe(task.id);
+			expect(ctx.worktreeMock.removeCalls).toHaveLength(0);
+		});
+
+		test('cleanup(cancelled) removes worktree immediately', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			await ctx.manager.cleanup(task.id, 'cancelled');
+
+			expect(ctx.worktreeMock.removeCalls).toHaveLength(1);
+			expect(ctx.worktreeMock.removeCalls[0].taskId).toBe(task.id);
+			expect(ctx.worktreeMock.completedCalls).toHaveLength(0);
+		});
+
+		test('cleanup with no reason defaults to completed', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			await ctx.manager.cleanup(task.id);
+
+			expect(ctx.worktreeMock.completedCalls).toHaveLength(1);
+			expect(ctx.worktreeMock.removeCalls).toHaveLength(0);
+		});
+
+		test('worktree path removed from in-memory map after cleanup', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+			expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp/worktrees/test-task');
+
+			await ctx.manager.cleanup(task.id);
+
+			expect(ctx.manager.getTaskWorktreePath(task.id)).toBeUndefined();
+		});
+
+		test('cleanup without worktreeManager does not throw', async () => {
+			// Create manager without worktreeManager
+			const { db: bunDb, dir } = makeDb();
+			const spaceId2 = 'space-no-wt';
+			seedSpaceRow(bunDb, spaceId2);
+			const taskManager2 = new SpaceTaskManager(bunDb, spaceId2);
+			const task2 = await taskManager2.createTask({
+				title: 'No worktree task',
+				description: '',
+				taskType: 'coding',
+				status: 'pending',
+			});
+
+			const dbSessions2 = new Map<string, unknown>();
+			const mockDb2 = {
+				getSession: (id: string) => dbSessions2.get(id) ?? null,
+				createSession: (s: unknown) => dbSessions2.set((s as { id: string }).id, s),
+				deleteSession: (id: string) => dbSessions2.delete(id),
+				saveUserMessage: () => 'msg-id',
+				updateSession: () => {},
+				getDatabase: () => bunDb,
+			};
+
+			const agentRepo2 = new SpaceAgentRepository(bunDb);
+			const agentManager2 = new SpaceAgentManager(agentRepo2);
+			const workflowRepo2 = new SpaceWorkflowRepository(bunDb);
+			const workflowManager2 = new SpaceWorkflowManager(workflowRepo2);
+			const workflowRunRepo2 = new SpaceWorkflowRunRepository(bunDb);
+			const taskRepo2 = new SpaceTaskRepository(bunDb);
+			const spaceManager2 = new SpaceManager(bunDb);
+			const runtime2 = new SpaceRuntime({
+				db: bunDb,
+				spaceManager: spaceManager2,
+				spaceAgentManager: agentManager2,
+				spaceWorkflowManager: workflowManager2,
+				workflowRunRepo: workflowRunRepo2,
+				taskRepo: taskRepo2,
+			});
+			const daemonHub2 = new TestDaemonHub();
+			const mockSpaceRuntimeService2 = { createOrGetRuntime: async () => runtime2 };
+			const mockSessionManager2 = {
+				deleteSession: async () => {},
+				registerSession: () => {},
+			};
+
+			const manager2 = new TaskAgentManager({
+				db: mockDb2 as unknown as import('../../../src/storage/database.ts').Database,
+				sessionManager:
+					mockSessionManager2 as unknown as import('../../../src/lib/session/session-manager.ts').SessionManager,
+				spaceManager: spaceManager2,
+				spaceAgentManager: agentManager2,
+				spaceWorkflowManager: workflowManager2,
+				spaceRuntimeService:
+					mockSpaceRuntimeService2 as unknown as import('../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
+				taskRepo: taskRepo2,
+				workflowRunRepo: workflowRunRepo2,
+				daemonHub: daemonHub2 as unknown as import('../../../src/lib/daemon-hub.ts').DaemonHub,
+				messageHub: {} as unknown as import('@neokai/shared').MessageHub,
+				getApiKey: async () => 'key',
+				defaultModel: 'claude-sonnet-4-5-20250929',
+				// No worktreeManager
+			});
+
+			const space2 = makeSpace(spaceId2);
+			await manager2.spawnTaskAgent(task2, space2, null, null);
+			// Should not throw — call directly and let bun:test surface any error
+			await manager2.cleanup(task2.id);
+
+			ctx.fromInitSpy.mockRestore(); // will be restored in afterEach but this saves redundancy
+			rmSync(dir, { recursive: true, force: true });
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// TTL reaper and orphan cleanup
+	// -------------------------------------------------------------------------
+
+	describe('SpaceWorktreeRepository TTL reaper', () => {
+		test('markCompleted sets completedAt and reapExpiredWorktrees removes expired records', () => {
+			const { SpaceWorktreeRepository } =
+				require('../../../src/storage/repositories/space-worktree-repository.ts') as typeof import('../../../src/storage/repositories/space-worktree-repository.ts');
+
+			const { db: bunDb2, dir: dir2 } = makeDb();
+			const spaceId2 = 'space-ttl-test';
+			seedSpaceRow(bunDb2, spaceId2);
+
+			// Insert a task row so FK constraint is satisfied
+			bunDb2
+				.prepare(
+					`INSERT INTO space_tasks (id, space_id, title, description, task_type, status, task_number, created_at, updated_at)
+				 VALUES ('task-ttl-1', ?, 'TTL task', '', 'coding', 'completed', 1, ?, ?)`
+				)
+				.run(spaceId2, Date.now(), Date.now());
+
+			const repo = new SpaceWorktreeRepository(bunDb2);
+			repo.create({
+				spaceId: spaceId2,
+				taskId: 'task-ttl-1',
+				slug: 'ttl-slug',
+				path: '/tmp/ttl-worktree',
+			});
+
+			// Mark as completed with a timestamp 8 days in the past
+			const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+			const updated = repo.markCompleted(spaceId2, 'task-ttl-1', eightDaysAgo);
+			expect(updated).toBe(true);
+
+			const record = repo.getByTaskId(spaceId2, 'task-ttl-1');
+			expect(record?.completedAt).toBe(eightDaysAgo);
+
+			// listCompletedBefore should find this record (TTL = 7 days → cutoff = now - 7d)
+			const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+			const expired = repo.listCompletedBefore(cutoff);
+			expect(expired.length).toBe(1);
+			expect(expired[0].taskId).toBe('task-ttl-1');
+
+			// Should NOT find it if the cutoff is further in the past (i.e. TTL not yet elapsed)
+			const notExpiredCutoff = eightDaysAgo - 1; // before completedAt
+			const notExpired = repo.listCompletedBefore(notExpiredCutoff);
+			expect(notExpired.length).toBe(0);
+
+			rmSync(dir2, { recursive: true, force: true });
+		});
+
+		test('markCompleted is idempotent — second call returns false', () => {
+			const { SpaceWorktreeRepository } =
+				require('../../../src/storage/repositories/space-worktree-repository.ts') as typeof import('../../../src/storage/repositories/space-worktree-repository.ts');
+
+			const { db: bunDb2, dir: dir2 } = makeDb();
+			const spaceId2 = 'space-idem-test';
+			seedSpaceRow(bunDb2, spaceId2);
+
+			bunDb2
+				.prepare(
+					`INSERT INTO space_tasks (id, space_id, title, description, task_type, status, task_number, created_at, updated_at)
+				 VALUES ('task-idem-1', ?, 'Idem task', '', 'coding', 'completed', 1, ?, ?)`
+				)
+				.run(spaceId2, Date.now(), Date.now());
+
+			const repo = new SpaceWorktreeRepository(bunDb2);
+			repo.create({
+				spaceId: spaceId2,
+				taskId: 'task-idem-1',
+				slug: 'idem-slug',
+				path: '/tmp/idem',
+			});
+
+			const first = repo.markCompleted(spaceId2, 'task-idem-1');
+			expect(first).toBe(true);
+
+			const second = repo.markCompleted(spaceId2, 'task-idem-1');
+			expect(second).toBe(false); // already marked — WHERE completed_at IS NULL filters it out
+
+			rmSync(dir2, { recursive: true, force: true });
+		});
+
+		test('SpaceWorktreeManager.reapExpiredWorktrees delegates to removeTaskWorktree', async () => {
+			// Use real repository + mock removeTaskWorktree to verify delegation
+			const { SpaceWorktreeRepository } =
+				require('../../../src/storage/repositories/space-worktree-repository.ts') as typeof import('../../../src/storage/repositories/space-worktree-repository.ts');
+			const { SpaceWorktreeManager } =
+				require('../../../src/lib/space/managers/space-worktree-manager.ts') as typeof import('../../../src/lib/space/managers/space-worktree-manager.ts');
+
+			const { db: bunDb2, dir: dir2 } = makeDb();
+			const spaceId2 = 'space-reap-test';
+			seedSpaceRow(bunDb2, spaceId2);
+
+			bunDb2
+				.prepare(
+					`INSERT INTO space_tasks (id, space_id, title, description, task_type, status, task_number, created_at, updated_at)
+				 VALUES ('task-reap-1', ?, 'Reap task', '', 'coding', 'completed', 1, ?, ?)`
+				)
+				.run(spaceId2, Date.now(), Date.now());
+
+			const manager = new SpaceWorktreeManager(bunDb2);
+			const repo = new SpaceWorktreeRepository(bunDb2);
+
+			// Insert directly via repo to skip filesystem operations
+			repo.create({
+				spaceId: spaceId2,
+				taskId: 'task-reap-1',
+				slug: 'reap-slug',
+				path: '/tmp/reap',
+			});
+			const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+			repo.markCompleted(spaceId2, 'task-reap-1', eightDaysAgo);
+
+			// Spy on removeTaskWorktree to avoid real filesystem operations
+			const removeSpy = spyOn(manager, 'removeTaskWorktree').mockResolvedValue(undefined);
+
+			await manager.reapExpiredWorktrees();
+
+			expect(removeSpy).toHaveBeenCalledWith(spaceId2, 'task-reap-1');
+			removeSpy.mockRestore();
+
+			rmSync(dir2, { recursive: true, force: true });
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Rehydration restores worktree path
+	// -------------------------------------------------------------------------
+
+	describe('rehydration restores worktree path from run config', () => {
+		test('getTaskWorktreePath returns path after successful rehydration', async () => {
+			// After spawnTaskAgent the path is in the map; verify it's present
+			const task = await makeTask(ctx.taskManager);
+			const workflowRun = ctx.workflowRunRepo.createRun({
+				spaceId: ctx.spaceId,
+				workflowId: 'workflow-rehydrate',
+				title: 'Rehydrate run',
+			});
+			ctx.taskRepo.updateTask(task.id, { workflowRunId: workflowRun.id });
+			const linkedTask = ctx.taskRepo.getTask(task.id)!;
+
+			await ctx.manager.spawnTaskAgent(linkedTask, ctx.space, null, workflowRun);
+
+			// The worktree path is now in the run config
+			const updatedRun = ctx.workflowRunRepo.getRun(workflowRun.id)!;
+			expect(updatedRun.config?.worktreePath).toBe('/tmp/worktrees/test-task');
+
+			// And in the in-memory map
+			expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp/worktrees/test-task');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- **Migration 65**: adds `completed_at` column to `space_worktrees` for TTL-based reaper
- **SpaceWorktreeRepository**: `markCompleted()`, `listCompletedBefore()` for lifecycle tracking
- **SpaceWorktreeManager**: `markTaskWorktreeCompleted()`, `reapExpiredWorktrees()` (7-day default TTL)
- **TaskAgentManager**: creates worktree at `spawnTaskAgent()` time; all sub-sessions (node agents) share the same path via factory override; `cleanup(cancelled)` removes immediately, `cleanup(completed)` timestamps for TTL; worktree path stored in workflow run config for M6 artifacts RPC; rehydration restores path from run config
- **rpc-handlers**: `SpaceWorktreeManager` instantiated and injected into `TaskAgentManager`
- **app.ts**: orphan cleanup + TTL reaper run on startup; hourly `setInterval` reaper with `unref()`
- **17 new unit tests**: creation at run start, reuse across nodes, TTL logic, cancellation cleanup, fallback on failure, idempotent markCompleted, reaper delegation

## Test plan

- [ ] `make test-daemon` passes (8927+ tests)
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` 0 errors