### PR TITLE
refactor(daemon): remove emitTaskUpdate and redundant emitRoomOverview calls

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -18,7 +18,7 @@
  * - task.group.addMessage - (non-production) Insert a synthetic canonical timeline row
  */
 
-import type { MessageHub, NeoTask, TaskPriority, TaskStatus } from '@neokai/shared';
+import type { MessageHub, TaskPriority, TaskStatus } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { ReactiveDatabase } from '../../storage/reactive-database';
@@ -60,21 +60,6 @@ export function setupTaskHandlers(
 ): void {
 	const makeGroupRepo = () => new SessionGroupRepository(db.getDatabase(), reactiveDb);
 	const makeTaskRepo = () => new TaskRepository(db.getDatabase(), reactiveDb);
-
-	/**
-	 * Emit room.task.update event to notify UI clients
-	 */
-	const emitTaskUpdate = (roomId: string, task: NeoTask) => {
-		daemonHub
-			.emit('room.task.update', {
-				sessionId: `room:${roomId}`,
-				roomId,
-				task,
-			})
-			.catch((error) => {
-				log.warn(`Failed to emit room.task.update for room ${roomId}:`, error);
-			});
-	};
 
 	/**
 	 * Emit room.overview event to notify UI clients of full room state
@@ -122,9 +107,6 @@ export function setupTaskHandlers(
 			dependsOn: params.dependsOn,
 			status: params.status,
 		});
-
-		// Emit room.overview for new task creation (significant change)
-		emitRoomOverview(params.roomId);
 
 		return { task };
 	});
@@ -224,8 +206,6 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.failTask(taskId, params.error ?? '');
 
-		emitRoomOverview(params.roomId);
-
 		return { task };
 	});
 
@@ -264,7 +244,7 @@ export function setupTaskHandlers(
 				}
 				const updatedTask = await taskManager.getTask(taskId);
 				if (updatedTask) {
-					emitTaskUpdate(params.roomId, updatedTask);
+					// TODO: remove once session LiveQuery covers list
 					emitRoomOverview(params.roomId);
 					return { task: updatedTask };
 				}
@@ -273,8 +253,6 @@ export function setupTaskHandlers(
 
 		// No active group - just mark the task as cancelled
 		const cancelledTask = await taskManager.cancelTask(taskId);
-		emitTaskUpdate(params.roomId, cancelledTask);
-		emitRoomOverview(params.roomId);
 
 		return { task: cancelledTask };
 	});
@@ -361,10 +339,6 @@ export function setupTaskHandlers(
 		}
 
 		const archivedTask = await taskManager.getTask(taskId);
-		if (archivedTask) {
-			emitTaskUpdate(params.roomId, archivedTask);
-			emitRoomOverview(params.roomId);
-		}
 
 		log.info(`Task ${taskId} archived in room ${params.roomId}`);
 		return { task: archivedTask };
@@ -424,10 +398,6 @@ export function setupTaskHandlers(
 			}
 
 			const archivedTask = await taskManager.getTask(taskId);
-			if (archivedTask) {
-				emitTaskUpdate(params.roomId, archivedTask);
-				emitRoomOverview(params.roomId);
-			}
 			return { task: archivedTask };
 		}
 
@@ -451,7 +421,7 @@ export function setupTaskHandlers(
 						if (!cancelledTask) {
 							throw new Error(`Task not found: ${taskId}`);
 						}
-						emitTaskUpdate(params.roomId, cancelledTask);
+						// TODO: remove once session LiveQuery covers list
 						emitRoomOverview(params.roomId);
 						return { task: cancelledTask };
 					}
@@ -508,9 +478,6 @@ export function setupTaskHandlers(
 			error: params.error,
 			mode: params.mode,
 		});
-
-		emitTaskUpdate(params.roomId, updatedTask);
-		emitRoomOverview(params.roomId);
 
 		return { task: updatedTask };
 	});
@@ -1117,12 +1084,6 @@ export function setupTaskHandlers(
 			throw new Error(result.error ?? 'Failed to send human message');
 		}
 
-		// Emit task update after successful message routing (may have changed status)
-		const updatedTask = await taskManager.getTask(taskId);
-		if (updatedTask) {
-			emitTaskUpdate(params.roomId, updatedTask);
-		}
-
 		return { success: true };
 	});
 
@@ -1154,6 +1115,7 @@ export function setupTaskHandlers(
 			throw new Error(result.error ?? `Failed to stop session group ${params.groupId}`);
 		}
 
+		// TODO: remove once session LiveQuery covers list
 		emitRoomOverview(params.roomId);
 		return { success: true };
 	});

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -1364,7 +1364,7 @@ describe('task.setStatus RPC Handler', () => {
 			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith(TASK_UUID, undefined);
 		});
 
-		it('emits task update and room overview after archiving via runtime', async () => {
+		it('does not emit room.task.update after archiving (LiveQuery handles task data)', async () => {
 			const completedTask = { ...mockTask, status: 'completed' as const };
 			const { service } = makeRuntimeService();
 
@@ -1383,10 +1383,10 @@ describe('task.setStatus RPC Handler', () => {
 			const handler = mh.handlers.get('task.setStatus')!;
 			await handler({ roomId: 'room-1', taskId: TASK_UUID, status: 'archived' }, {});
 
-			expect(daemonHub.emit).toHaveBeenCalledWith(
-				'room.task.update',
-				expect.objectContaining({ roomId: 'room-1' })
+			const taskUpdateCalls = (daemonHub.emit as ReturnType<typeof mock>).mock.calls.filter(
+				(args: unknown[]) => args[0] === 'room.task.update'
 			);
+			expect(taskUpdateCalls).toHaveLength(0);
 		});
 
 		it('calls taskManager.archiveTask when no runtime is available', async () => {

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -309,14 +309,16 @@ describe('Task RPC Handlers', () => {
 			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Task title is required');
 		});
 
-		it('emits room overview event on creation', async () => {
+		it('returns created task without emitting room.overview (LiveQuery handles task data)', async () => {
 			const handler = messageHubData.handlers.get('task.create');
 			expect(handler).toBeDefined();
 
-			await handler!({ roomId: 'room-123', title: 'Test Task' }, {});
+			const result = (await handler!({ roomId: 'room-123', title: 'Test Task' }, {})) as {
+				task: NeoTask;
+			};
 
-			expect(roomManagerData.getRoomOverview).toHaveBeenCalledWith('room-123');
-			expect(daemonHubData.emit).toHaveBeenCalled();
+			expect(result.task).toBeDefined();
+			expect(roomManagerData.getRoomOverview).not.toHaveBeenCalled();
 		});
 	});
 
@@ -448,20 +450,18 @@ describe('Task RPC Handlers', () => {
 			);
 		});
 
-		it('emits room.overview but NOT room.task.update (redundant after LiveQuery)', async () => {
+		it('does not emit room.task.update or room.overview (LiveQuery handles task data)', async () => {
 			const handler = messageHubData.handlers.get('task.fail');
 			expect(handler).toBeDefined();
 
 			await handler!({ roomId: 'room-123', taskId: TASK_UUID, error: 'Failed' }, {});
 
-			// room.overview must still fire so clients get updated session/task metadata
-			expect(roomManagerData.getRoomOverview).toHaveBeenCalledWith('room-123');
-
-			// room.task.update must NOT be emitted — LiveQuery deltas replace this channel
+			// Neither room.task.update nor room.overview should be emitted — LiveQuery covers it
 			const taskUpdateCalls = (daemonHubData.emit as ReturnType<typeof mock>).mock.calls.filter(
 				(args: unknown[]) => args[0] === 'room.task.update'
 			);
 			expect(taskUpdateCalls).toHaveLength(0);
+			expect(roomManagerData.getRoomOverview).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
Now that useTaskViewData reads from roomStore.tasks (LiveQuery-driven),
the room.task.update channel is redundant. Remove emitTaskUpdate entirely
from task-handlers.ts and drop emitRoomOverview call sites that only
existed to propagate task data (task.create, task.fail, task.cancel
no-runtime, task.archive, task.setStatus archive/apply paths).

Three call sites that affect session list state are retained with TODO
comments: task.cancel with runtime, task.setStatus cancel with runtime,
and session_group.stop.

Update daemon unit tests to reflect the new behavior.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
