### PR TITLE
feat(web): migrate roomSkills to EntityStore

### DIFF
--- a/packages/daemon/tests/online/cross-provider/conversation-continuity-after-switch.test.ts
+++ b/packages/daemon/tests/online/cross-provider/conversation-continuity-after-switch.test.ts
@@ -154,7 +154,7 @@ describe('Cross-Provider Conversation Continuity After Model Switch', () => {
 		// Re-read sdkSessionId — it should be the same
 		const sdkIdAfter = getAgentSdkSessionId(daemon, sessionId);
 		expect(sdkIdAfter).toBe(sdkIdBefore);
-	}, 60000);
+	}, 90000);
 
 	test('sdkSessionId is preserved after cross-provider model switch (GLM -> MiniMax)', async () => {
 		// Create session with GLM
@@ -188,7 +188,7 @@ describe('Cross-Provider Conversation Continuity After Model Switch', () => {
 		// sdkSessionId should be preserved
 		const sdkIdAfter = getAgentSdkSessionId(daemon, sessionId);
 		expect(sdkIdAfter).toBe(sdkIdBefore);
-	}, 60000);
+	}, 90000);
 
 	test('message count does not reset after model switch', async () => {
 		// Create session with GLM
@@ -222,7 +222,7 @@ describe('Cross-Provider Conversation Continuity After Model Switch', () => {
 		// Get message count after switch — should not reset
 		const countAfter = await getMessageCount(daemon, sessionId);
 		expect(countAfter).toBeGreaterThanOrEqual(countBefore);
-	}, 60000);
+	}, 90000);
 
 	test('sdkSessionId unchanged after post-switch message completes (cross-provider)', async () => {
 		// Create session with MiniMax
@@ -349,5 +349,5 @@ describe('Cross-Provider Conversation Continuity After Model Switch', () => {
 		})) as { session: { sdkSessionId?: string } };
 
 		expect(sessionResult.session.sdkSessionId).toBe(sdkIdBefore);
-	}, 60000);
+	}, 90000);
 });

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -112,7 +112,10 @@ class RoomStore {
 	// ========================================
 
 	/** Effective per-room skills (global enabled state merged with room overrides via skills.byRoom). */
-	readonly roomSkills = signal<EffectiveRoomSkill[]>([]);
+	readonly skillStore = new EntityStore<EffectiveRoomSkill>();
+
+	/** Pass-through computed for backward-compatible access to skill array. */
+	readonly roomSkills = computed(() => this.skillStore.toArray());
 
 	/** Auto-completed task notifications (from semi-autonomous mode) */
 	readonly autoCompletedNotifications = signal<
@@ -304,7 +307,7 @@ class RoomStore {
 		this.sessions.value = [];
 		this.error.value = null;
 		this.goalStore.clear();
-		this.roomSkills.value = [];
+		this.skillStore.clear();
 		this.autoCompletedNotifications.value = [];
 		this.runtimeState.value = null;
 
@@ -540,7 +543,7 @@ class RoomStore {
 				(event) => {
 					if (event.subscriptionId !== skillsSubId) return;
 					if (!this.activeSubscriptionIds.has(skillsSubId)) return; // stale-event guard
-					this.roomSkills.value = event.rows as EffectiveRoomSkill[];
+					this.skillStore.applySnapshot(event.rows as EffectiveRoomSkill[]);
 				}
 			);
 			cleanups.push(unsubSkillSnapshot);
@@ -548,19 +551,9 @@ class RoomStore {
 			const unsubSkillDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId !== skillsSubId) return;
 				if (!this.activeSubscriptionIds.has(skillsSubId)) return; // stale-event guard
-				let current = this.roomSkills.value;
-				if (event.removed?.length) {
-					const removedIds = new Set((event.removed as EffectiveRoomSkill[]).map((r) => r.id));
-					current = current.filter((s) => !removedIds.has(s.id));
-				}
-				if (event.updated?.length) {
-					const updatedMap = new Map((event.updated as EffectiveRoomSkill[]).map((u) => [u.id, u]));
-					current = current.map((s) => updatedMap.get(s.id) ?? s);
-				}
-				if (event.added?.length) {
-					current = [...current, ...(event.added as EffectiveRoomSkill[])];
-				}
-				this.roomSkills.value = current;
+				this.skillStore.applyDelta(
+					event as { added?: EffectiveRoomSkill[]; removed?: EffectiveRoomSkill[]; updated?: EffectiveRoomSkill[] }
+				);
 			});
 			cleanups.push(unsubSkillDelta);
 

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -552,7 +552,11 @@ class RoomStore {
 				if (event.subscriptionId !== skillsSubId) return;
 				if (!this.activeSubscriptionIds.has(skillsSubId)) return; // stale-event guard
 				this.skillStore.applyDelta(
-					event as { added?: EffectiveRoomSkill[]; removed?: EffectiveRoomSkill[]; updated?: EffectiveRoomSkill[] }
+					event as {
+						added?: EffectiveRoomSkill[];
+						removed?: EffectiveRoomSkill[];
+						updated?: EffectiveRoomSkill[];
+					}
 				);
 			});
 			cleanups.push(unsubSkillDelta);


### PR DESCRIPTION
Replace roomSkills signal with skillStore = new EntityStore<EffectiveRoomSkill>()
and add a computed() pass-through so roomStore.roomSkills.value remains backward-
compatible. subscribeRoom's skills snapshot/delta handling now delegates to
skillStore.applySnapshot / skillStore.applyDelta, and doSelect calls skillStore.clear().

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
