### PR TITLE
feat(space): add buildPlannerNodeAgentPrompt for planner node agent (M2.2)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -189,6 +189,11 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 			`- All communication is scoped to this group — you cannot message agents in other tasks`
 	);
 
+	// Planner-specific instructions (injected before completion signalling)
+	if (customAgent.role === 'planner') {
+		sections.push(buildPlannerNodeAgentPrompt());
+	}
+
 	// Completion signalling
 	sections.push(`\n## Signalling Completion\n`);
 	sections.push(`\n### \`report_done\` (signal task completion)\n`);
@@ -498,6 +503,123 @@ export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionIn
 		previousTaskSummaries,
 		slotOverrides,
 	});
+}
+
+// ============================================================================
+// Planner-specific prompt builder
+// ============================================================================
+
+/**
+ * Build the planner-specific section of the system prompt.
+ *
+ * Injected into the full system prompt when the agent's role is 'planner'.
+ * Covers:
+ *   1. Plan document creation (explore codebase → write plan → create PR)
+ *   2. Gate interaction: write plan PR data to `plan-pr-gate` after opening the PR
+ *   3. Communicating with plan reviewers via `send_message`
+ *
+ * This function is intentionally exported so that it can be unit-tested
+ * independently of the full `buildCustomAgentSystemPrompt` output.
+ */
+export function buildPlannerNodeAgentPrompt(): string {
+	const sections: string[] = [];
+
+	sections.push(`\n## Planner Responsibilities\n`);
+	sections.push(
+		`As a Planner Agent you are responsible for producing a written plan document, ` +
+			`opening a plan pull request, and unblocking the downstream review channel ` +
+			`by writing the PR data to the \`plan-pr-gate\` gate.`
+	);
+
+	// Step 1 — explore + write plan
+	sections.push(`\n### Step 1 — Explore the codebase and write the plan\n`);
+	sections.push(
+		`Before writing anything, explore the codebase thoroughly to understand the ` +
+			`current state of the relevant code. Use \`Read\`, \`Grep\`, \`Glob\`, and \`Bash\` ` +
+			`to build an accurate picture of what exists before making decisions.`
+	);
+	sections.push(
+		`Create a plan document on a feature branch. Suggested location: \`docs/plans/<task-slug>.md\`.`
+	);
+	sections.push(
+		`The plan document should include:\n` +
+			`- **Objective** — what is being built and why\n` +
+			`- **Current state** — what already exists in the codebase\n` +
+			`- **Approach** — the implementation strategy, key decisions, trade-offs\n` +
+			`- **Milestones / subtasks** — ordered list of concrete steps\n` +
+			`- **Test strategy** — how the changes will be tested\n` +
+			`- **Out of scope** — what is explicitly excluded`
+	);
+
+	// Step 2 — commit + push + PR
+	sections.push(`\n### Step 2 — Commit, push, and open a plan PR\n`);
+	sections.push(
+		`After writing the plan document, commit it and open a pull request following the ` +
+			`mandatory Git workflow above. The PR title should be descriptive, e.g. ` +
+			`\`plan: <task title>\`. Do NOT use \`--delete-branch\` when merging.`
+	);
+	sections.push(
+		`Record the PR URL and PR number from the \`gh pr create\` output — ` +
+			`you will need them in the next step.`
+	);
+
+	// Step 3 — write gate
+	sections.push(`\n### Step 3 — Write PR data to \`plan-pr-gate\`\n`);
+	sections.push(
+		`After the plan PR is open, call \`write_gate\` to unblock the plan-review channel ` +
+			`for the downstream reviewer agents. This is **mandatory** — reviewers cannot ` +
+			`start until the gate is open.`
+	);
+	sections.push(
+		`\`\`\`json\n` +
+			`write_gate({\n` +
+			`  "gateId": "plan-pr-gate",\n` +
+			`  "data": {\n` +
+			`    "prUrl": "<PR URL from gh pr create>",\n` +
+			`    "prNumber": <PR number as integer>,\n` +
+			`    "branch": "<feature branch name>"\n` +
+			`  }\n` +
+			`})\n` +
+			`\`\`\``
+	);
+	sections.push(
+		`The gate condition is \`check: prUrl exists\`. Once \`prUrl\` is present in the ` +
+			`gate data, the condition passes and the plan-review channel opens automatically.`
+	);
+
+	// Step 4 — notify reviewers
+	sections.push(`\n### Step 4 — Notify plan reviewers via \`send_message\`\n`);
+	sections.push(
+		`After writing the gate, send a message to plan reviewers so they know the plan is ` +
+			`ready for review. Use \`send_message\` with the reviewer role as the target:`
+	);
+	sections.push(
+		`\`\`\`json\n` +
+			`send_message({\n` +
+			`  "target": "reviewer",\n` +
+			`  "text": "Plan PR is ready for review.",\n` +
+			`  "data": {\n` +
+			`    "prUrl": "<PR URL>",\n` +
+			`    "prNumber": <PR number>\n` +
+			`  }\n` +
+			`})\n` +
+			`\`\`\``
+	);
+	sections.push(
+		`Use \`list_peers\` first if you are unsure which roles are available as review targets.`
+	);
+
+	// Step 5 — workflow context awareness
+	sections.push(`\n### Using workflow context (\`injectWorkflowContext\`)\n`);
+	sections.push(
+		`When a \`## Workflow Structure\` section appears in your task message, use it to ` +
+			`align your plan with the declared workflow steps. Each step in the workflow ` +
+			`corresponds to a node that will execute after your plan is approved. Your plan ` +
+			`should describe the work for each relevant node so downstream agents have clear ` +
+			`instructions to follow.`
+	);
+
+	return sections.join('\n');
 }
 
 // ============================================================================

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -597,7 +597,7 @@ export function buildPlannerNodeAgentPrompt(): string {
 		`\`\`\`json\n` +
 			`send_message({\n` +
 			`  "target": "reviewer",\n` +
-			`  "text": "Plan PR is ready for review.",\n` +
+			`  "message": "Plan PR is ready for review.",\n` +
 			`  "data": {\n` +
 			`    "prUrl": "<PR URL>",\n` +
 			`    "prNumber": <PR number>\n` +
@@ -610,7 +610,7 @@ export function buildPlannerNodeAgentPrompt(): string {
 	);
 
 	// Step 5 — workflow context awareness
-	sections.push(`\n### Using workflow context (\`injectWorkflowContext\`)\n`);
+	sections.push(`\n### Step 5 — Aligning the plan with workflow steps\n`);
 	sections.push(
 		`When a \`## Workflow Structure\` section appears in your task message, use it to ` +
 			`align your plan with the declared workflow steps. Each step in the workflow ` +

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -1153,10 +1153,16 @@ describe('buildPlannerNodeAgentPrompt', () => {
 		expect(prompt).toContain('reviewer');
 	});
 
-	it('mentions injectWorkflowContext usage', () => {
+	it('send_message example uses "message" field (not "text")', () => {
 		const prompt = buildPlannerNodeAgentPrompt();
-		expect(prompt).toContain('injectWorkflowContext');
+		expect(prompt).toContain('"message"');
+		expect(prompt).not.toContain('"text"');
+	});
+
+	it('mentions workflow structure alignment (step 5)', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
 		expect(prompt).toContain('Workflow Structure');
+		expect(prompt).toContain('Step 5');
 	});
 });
 

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, mock } from 'bun:test';
 import {
 	buildCustomAgentSystemPrompt,
 	buildCustomAgentTaskMessage,
+	buildPlannerNodeAgentPrompt,
 	createCustomAgentInit,
 	resolveAgentInit,
 	type CustomAgentConfig,
@@ -1089,5 +1090,136 @@ describe('buildCustomAgentTaskMessage — workflow context injection', () => {
 		const msg = buildCustomAgentTaskMessage(config);
 
 		expect(msg).toContain('Workflow Structure');
+	});
+});
+
+// ============================================================================
+// buildPlannerNodeAgentPrompt
+// ============================================================================
+
+describe('buildPlannerNodeAgentPrompt', () => {
+	it('returns a non-empty string', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(typeof prompt).toBe('string');
+		expect(prompt.length).toBeGreaterThan(0);
+	});
+
+	it('includes plan document creation instructions', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('Planner Responsibilities');
+		expect(prompt).toContain('plan document');
+		expect(prompt).toContain('docs/plans/');
+	});
+
+	it('includes codebase exploration instructions', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('explore the codebase');
+	});
+
+	it('includes plan document structure guidance', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('Objective');
+		expect(prompt).toContain('Approach');
+		expect(prompt).toContain('Test strategy');
+	});
+
+	it('instructs to commit, push, and open a plan PR', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('plan PR');
+		expect(prompt).toContain('plan:');
+	});
+
+	it('instructs to call write_gate with plan-pr-gate', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('write_gate');
+		expect(prompt).toContain('plan-pr-gate');
+	});
+
+	it('specifies the required gate data fields: prUrl, prNumber, branch', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('prUrl');
+		expect(prompt).toContain('prNumber');
+		expect(prompt).toContain('branch');
+	});
+
+	it('explains the gate condition (prUrl exists)', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('prUrl exists');
+	});
+
+	it('instructs to notify reviewers via send_message', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('send_message');
+		expect(prompt).toContain('reviewer');
+	});
+
+	it('mentions injectWorkflowContext usage', () => {
+		const prompt = buildPlannerNodeAgentPrompt();
+		expect(prompt).toContain('injectWorkflowContext');
+		expect(prompt).toContain('Workflow Structure');
+	});
+});
+
+// ============================================================================
+// buildCustomAgentSystemPrompt — planner role integration
+// ============================================================================
+
+describe('buildCustomAgentSystemPrompt planner integration', () => {
+	it('includes planner-specific sections for planner role', () => {
+		const agent = makeAgent({ role: 'planner', name: 'Planner' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Planner Responsibilities');
+		expect(prompt).toContain('plan-pr-gate');
+		expect(prompt).toContain('write_gate');
+	});
+
+	it('does NOT include planner sections for coder role', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).not.toContain('Planner Responsibilities');
+		expect(prompt).not.toContain('plan-pr-gate');
+	});
+
+	it('does NOT include planner sections for reviewer role', () => {
+		const agent = makeAgent({ role: 'reviewer', name: 'Reviewer' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).not.toContain('Planner Responsibilities');
+		expect(prompt).not.toContain('plan-pr-gate');
+	});
+
+	it('does NOT include planner sections for qa role', () => {
+		const agent = makeAgent({ role: 'qa', name: 'QA' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).not.toContain('Planner Responsibilities');
+		expect(prompt).not.toContain('plan-pr-gate');
+	});
+
+	it('planner prompt still includes mandatory git workflow', () => {
+		const agent = makeAgent({ role: 'planner', name: 'Planner' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Git Workflow (MANDATORY)');
+		expect(prompt).toContain('git push -u origin HEAD');
+	});
+
+	it('planner prompt still includes completion signalling', () => {
+		const agent = makeAgent({ role: 'planner', name: 'Planner' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Signalling Completion');
+		expect(prompt).toContain('report_done');
+	});
+
+	it('planner prompt still includes peer communication', () => {
+		const agent = makeAgent({ role: 'planner', name: 'Planner' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Peer Communication');
+		expect(prompt).toContain('list_peers');
+	});
+
+	it('planner-specific sections appear before completion signalling', () => {
+		const agent = makeAgent({ role: 'planner', name: 'Planner' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		const plannerIdx = prompt.indexOf('Planner Responsibilities');
+		const completionIdx = prompt.indexOf('Signalling Completion');
+		expect(plannerIdx).toBeLessThan(completionIdx);
 	});
 });


### PR DESCRIPTION
Implements M2.2: specialized planner system prompt for the Space workflow.

## Changes

- `buildPlannerNodeAgentPrompt()` — new exported function in `custom-agent.ts` that returns planner-specific prompt sections covering:
  1. Plan document creation: explore codebase → write `docs/plans/<task-slug>.md` → commit + PR
  2. Gate interaction: `write_gate("plan-pr-gate", { prUrl, prNumber, branch })` after PR is created, unblocking the plan-review channel
  3. Reviewer notification: `send_message` to `"reviewer"` role after writing the gate
  4. Workflow context guidance: instructs planner to align plan with declared workflow nodes when `injectWorkflowContext` is active

- Wired into `buildCustomAgentSystemPrompt` for `role === 'planner'`; all other roles are unaffected

## Tests

20 new unit tests: 11 for `buildPlannerNodeAgentPrompt` directly and 9 for planner integration in `buildCustomAgentSystemPrompt`. All 106 tests in `custom-agent.test.ts` pass.