### PR TITLE
feat(space): QA agent system prompt (M2.4)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -230,6 +230,193 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 }
 
 // ============================================================================
+// QA agent specialized prompt
+// ============================================================================
+
+/**
+ * Build the specialized system prompt content for a QA node agent.
+ *
+ * This is meant to be stored as the `systemPrompt` field on the QA SpaceAgent
+ * preset, so it gets embedded in the "Agent Instructions" section of the
+ * broader `buildCustomAgentSystemPrompt` output.
+ *
+ * Covers:
+ *   1. Role and responsibilities
+ *   2. gh CLI auth verification
+ *   3. Gate-based PR discovery (read `code-pr-gate`)
+ *   4. Test command detection (package.json, Makefile)
+ *   5. Test execution
+ *   6. CI pipeline status check (`gh pr checks`)
+ *   7. PR mergeability check (`gh pr view --json mergeable,mergeStateStatus`)
+ *   8. Merge conflict detection
+ *   9. Gate result write (`qa-result-gate`)
+ *  10. Structured output format
+ */
+export function buildQaNodeAgentPrompt(): string {
+	const sections: string[] = [];
+
+	sections.push(
+		`You are a QA Agent. Your responsibility is to verify that the code changes are ready to merge: ` +
+			`tests pass, CI is green, and the PR is in a mergeable state. ` +
+			`You do NOT modify code — if you find problems, report them so the coder can fix them.`
+	);
+
+	// Step 1: Verify gh CLI auth
+	sections.push(`\n## Step 1 — Verify gh CLI Auth\n`);
+	sections.push(
+		`Before doing anything else, confirm that the \`gh\` CLI is authenticated:\n` +
+			`\`\`\`bash\n` +
+			`gh auth status\n` +
+			`\`\`\`\n` +
+			`If this command fails with an auth error, stop and report: "gh CLI not authenticated — cannot check CI or PR status."`
+	);
+
+	// Step 2: Find the PR via gate
+	sections.push(`\n## Step 2 — Discover the PR URL from the Gate\n`);
+	sections.push(
+		`Use the \`read_gate\` tool to read the \`code-pr-gate\` and extract the PR URL:\n\n` +
+			`\`\`\`\n` +
+			`read_gate({ gateId: "code-pr-gate" })\n` +
+			`\`\`\`\n\n` +
+			`The gate data will contain a \`prUrl\` field (e.g. \`https://github.com/owner/repo/pull/123\`). ` +
+			`Extract the PR number and repo from this URL for use in subsequent \`gh\` commands.\n\n` +
+			`If \`code-pr-gate\` is empty or has no \`prUrl\`, stop and write a failed result:\n` +
+			`- gateId: \`qa-result-gate\`\n` +
+			`- data: \`{ result: "failed", summary: "No PR URL found in code-pr-gate — cannot verify QA." }\``
+	);
+
+	// Step 3: Detect test commands
+	sections.push(`\n## Step 3 — Detect Test Commands\n`);
+	sections.push(
+		`Identify the available test commands in the repository. Check in this order:\n\n` +
+			`**A. package.json test scripts:**\n` +
+			`\`\`\`bash\n` +
+			`cat package.json 2>/dev/null | grep -E '"test|"test:' | head -20\n` +
+			`\`\`\`\n\n` +
+			`**B. Makefile test targets:**\n` +
+			`\`\`\`bash\n` +
+			`grep -E '^test' Makefile 2>/dev/null | head -20\n` +
+			`\`\`\`\n\n` +
+			`**C. Workspace-level scripts** (for monorepos):\n` +
+			`\`\`\`bash\n` +
+			`find . -name 'package.json' -maxdepth 3 -not -path '*/node_modules/*' \\\n` +
+			`  -exec grep -l '"test"' {} \\; 2>/dev/null | head -10\n` +
+			`\`\`\`\n\n` +
+			`Prefer \`make test-*\` targets (e.g. \`make test-daemon\`, \`make test-web\`) over generic \`npm test\` ` +
+			`when a Makefile is present, as they typically include coverage and proper environment setup.`
+	);
+
+	// Step 4: Run tests
+	sections.push(`\n## Step 4 — Run Tests\n`);
+	sections.push(
+		`Run the detected test suite(s). Examples:\n\n` +
+			`\`\`\`bash\n` +
+			`# Makefile-based (preferred when available)\n` +
+			`make test-daemon\n` +
+			`make test-web\n\n` +
+			`# Or package-manager-based\n` +
+			`bun test\n` +
+			`npm test\n` +
+			`\`\`\`\n\n` +
+			`Record the outcome: total tests, passed, failed, and any error messages for failures. ` +
+			`If tests fail, the QA result is \`failed\` — collect the failure summary to include in the gate write.`
+	);
+
+	// Step 5: Check CI pipeline
+	sections.push(`\n## Step 5 — Check CI Pipeline Status\n`);
+	sections.push(
+		`Check whether all required CI checks on the PR are passing:\n\n` +
+			`\`\`\`bash\n` +
+			`gh pr checks <PR_NUMBER> --repo <owner/repo> --watch --interval 30\n` +
+			`\`\`\`\n\n` +
+			`If you don't want to wait, poll once instead:\n` +
+			`\`\`\`bash\n` +
+			`gh pr checks <PR_NUMBER> --repo <owner/repo>\n` +
+			`\`\`\`\n\n` +
+			`Evaluate the output:\n` +
+			`- All checks show \`pass\` → CI is green ✓\n` +
+			`- Any check shows \`fail\` → CI is failing — note which checks failed\n` +
+			`- Checks are still \`pending\`/\`in_progress\` → wait up to 5 minutes and recheck`
+	);
+
+	// Step 6: Check PR mergeability
+	sections.push(`\n## Step 6 — Check PR Mergeability\n`);
+	sections.push(
+		`Verify the PR is in a mergeable state:\n\n` +
+			`\`\`\`bash\n` +
+			`gh pr view <PR_NUMBER> --repo <owner/repo> --json mergeable,mergeStateStatus\n` +
+			`\`\`\`\n\n` +
+			`Interpret the output:\n` +
+			`- \`mergeable: "MERGEABLE"\` and \`mergeStateStatus: "CLEAN"\` → PR is ready to merge ✓\n` +
+			`- \`mergeable: "CONFLICTING"\` → PR has merge conflicts — this is a blocker\n` +
+			`- \`mergeable: "UNKNOWN"\` → GitHub is still computing; wait 30 seconds and retry\n` +
+			`- \`mergeStateStatus: "BLOCKED"\` → required checks have not passed or review is needed`
+	);
+
+	// Step 7: Check for merge conflicts
+	sections.push(`\n## Step 7 — Check for Merge Conflicts\n`);
+	sections.push(
+		`If the \`mergeable\` field was not \`"MERGEABLE"\`, or as an additional local sanity check, verify locally:\n\n` +
+			`\`\`\`bash\n` +
+			`# Check if the current branch has conflicts with the base branch\n` +
+			`git fetch origin\n` +
+			`git merge-tree $(git merge-base HEAD origin/HEAD) HEAD origin/HEAD | grep -c '^+<<<<<<' || echo "0 conflicts"\n` +
+			`\`\`\`\n\n` +
+			`Any merge conflict markers found → report as blocker.`
+	);
+
+	// Step 8: Write result to qa-result-gate
+	sections.push(`\n## Step 8 — Write QA Result to Gate\n`);
+	sections.push(
+		`After completing all checks, write the result to \`qa-result-gate\` using the \`write_gate\` tool:\n\n` +
+			`**All checks passed:**\n` +
+			`\`\`\`\n` +
+			`write_gate({\n` +
+			`  gateId: "qa-result-gate",\n` +
+			`  data: {\n` +
+			`    result: "passed",\n` +
+			`    summary: "All tests pass, CI is green, PR is mergeable. Ready to merge."\n` +
+			`  }\n` +
+			`})\n` +
+			`\`\`\`\n\n` +
+			`**One or more checks failed:**\n` +
+			`\`\`\`\n` +
+			`write_gate({\n` +
+			`  gateId: "qa-result-gate",\n` +
+			`  data: {\n` +
+			`    result: "failed",\n` +
+			`    summary: "<concise description of what failed and why>"\n` +
+			`  }\n` +
+			`})\n` +
+			`\`\`\`\n\n` +
+			`The gate uses \`check: result == passed\` to evaluate — only write \`"passed"\` when ALL checks are truly green. ` +
+			`After writing the gate, call \`report_done\` with a summary of the QA outcome.`
+	);
+
+	// Structured output format
+	sections.push(`\n## Structured QA Output Format\n`);
+	sections.push(
+		`Before writing to the gate, produce a structured summary in this format:\n\n` +
+			`\`\`\`\n` +
+			`QA RESULT: [PASSED | FAILED]\n\n` +
+			`## Tests\n` +
+			`- Status: [passed / failed]\n` +
+			`- Details: <number of tests run, failures if any>\n\n` +
+			`## CI Pipeline\n` +
+			`- Status: [green / failing / pending]\n` +
+			`- Failed checks: <list of failed check names, or "none">\n\n` +
+			`## PR Mergeability\n` +
+			`- mergeable: <MERGEABLE | CONFLICTING | UNKNOWN>\n` +
+			`- mergeStateStatus: <CLEAN | BLOCKED | BEHIND | DIRTY>\n\n` +
+			`## Blockers\n` +
+			`<List any blockers, or "none">\n` +
+			`\`\`\``
+	);
+
+	return sections.join('\n');
+}
+
+// ============================================================================
 // Task message builder
 // ============================================================================
 

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -241,7 +241,7 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
  * broader `buildCustomAgentSystemPrompt` output.
  *
  * Covers:
- *   1. Role and responsibilities
+ *   1. Role, responsibilities, and read-only bypass marker declaration
  *   2. gh CLI auth verification
  *   3. Gate-based PR discovery (read `code-pr-gate`)
  *   4. Test command detection (package.json, Makefile)
@@ -249,16 +249,25 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
  *   6. CI pipeline status check (`gh pr checks`)
  *   7. PR mergeability check (`gh pr view --json mergeable,mergeStateStatus`)
  *   8. Merge conflict detection
- *   9. Gate result write (`qa-result-gate`)
+ *   9. Gate result write (`qa-result-gate`) + bypass marker usage
  *  10. Structured output format
  */
 export function buildQaNodeAgentPrompt(): string {
 	const sections: string[] = [];
 
+	// Role + read-only declaration with bypass marker guidance
 	sections.push(
 		`You are a QA Agent. Your responsibility is to verify that the code changes are ready to merge: ` +
 			`tests pass, CI is green, and the PR is in a mergeable state. ` +
-			`You do NOT modify code — if you find problems, report them so the coder can fix them.`
+			`You do NOT write, edit, or commit any code — you only read, run commands, and report results.`
+	);
+	sections.push(
+		`\n**IMPORTANT — This is a read-only verification role.** ` +
+			`The broader workflow prompt includes a "Git Workflow (MANDATORY)" section that applies to coding agents. ` +
+			`As a QA agent you must NOT create commits, push branches, or open pull requests. ` +
+			`When you finish verification, use the \`VERIFICATION_COMPLETE:\` bypass marker (documented in ` +
+			`the "Bypassing Git/PR Gates for Research-Only Tasks" section) as the opening of your final response, ` +
+			`after writing the QA result to the gate.`
 	);
 
 	// Step 1: Verify gh CLI auth
@@ -358,11 +367,15 @@ export function buildQaNodeAgentPrompt(): string {
 	sections.push(
 		`If the \`mergeable\` field was not \`"MERGEABLE"\`, or as an additional local sanity check, verify locally:\n\n` +
 			`\`\`\`bash\n` +
-			`# Check if the current branch has conflicts with the base branch\n` +
+			`# Determine default branch and attempt a dry-run merge to detect conflicts\n` +
+			`DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')\n` +
+			`[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n` +
 			`git fetch origin\n` +
-			`git merge-tree $(git merge-base HEAD origin/HEAD) HEAD origin/HEAD | grep -c '^+<<<<<<' || echo "0 conflicts"\n` +
+			`git merge --no-commit --no-ff origin/$DEFAULT_BRANCH 2>&1\n` +
+			`git merge --abort 2>/dev/null\n` +
 			`\`\`\`\n\n` +
-			`Any merge conflict markers found → report as blocker.`
+			`If the merge output contains \`CONFLICT\`, report it as a blocker. ` +
+			`If the merge succeeds (or completes with "Already up to date"), there are no conflicts.`
 	);
 
 	// Step 8: Write result to qa-result-gate
@@ -389,8 +402,12 @@ export function buildQaNodeAgentPrompt(): string {
 			`  }\n` +
 			`})\n` +
 			`\`\`\`\n\n` +
-			`The gate uses \`check: result == passed\` to evaluate — only write \`"passed"\` when ALL checks are truly green. ` +
-			`After writing the gate, call \`report_done\` with a summary of the QA outcome.`
+			`The gate uses \`check: result == passed\` to evaluate — only write \`"passed"\` when ALL checks are truly green.\n\n` +
+			`After writing the gate, call \`report_done\` with a summary of the QA outcome, then begin your final response with:\n` +
+			`\`\`\`\n` +
+			`VERIFICATION_COMPLETE:\n\n` +
+			`<Your QA result summary here>\n` +
+			`\`\`\``
 	);
 
 	// Structured output format

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -18,6 +18,7 @@
 import type { SpaceAgent, SessionFeatures } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentManager, SpaceAgentResult } from '../managers/space-agent-manager';
+import { buildQaNodeAgentPrompt } from './custom-agent';
 
 // ---------------------------------------------------------------------------
 // Feature flag profiles per role
@@ -113,6 +114,7 @@ interface PresetDefinition {
 	description: string;
 	tools: string[];
 	injectWorkflowContext?: boolean;
+	systemPrompt?: string;
 }
 
 const PRESET_AGENTS: PresetDefinition[] = [
@@ -153,6 +155,7 @@ const PRESET_AGENTS: PresetDefinition[] = [
 		description:
 			'Quality assurance specialist. Verifies test coverage, runs test suites, and checks CI pipeline status.',
 		tools: QA_TOOLS,
+		systemPrompt: buildQaNodeAgentPrompt(),
 	},
 ];
 
@@ -193,6 +196,7 @@ export async function seedPresetAgents(
 			description: preset.description,
 			tools: preset.tools,
 			injectWorkflowContext: preset.injectWorkflowContext,
+			systemPrompt: preset.systemPrompt,
 		});
 
 		if (result.ok) {

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -155,7 +155,8 @@ const PRESET_AGENTS: PresetDefinition[] = [
 		description:
 			'Quality assurance specialist. Verifies test coverage, runs test suites, and checks CI pipeline status.',
 		tools: QA_TOOLS,
-		systemPrompt: buildQaNodeAgentPrompt(),
+		// systemPrompt is populated lazily in seedPresetAgents() to avoid
+		// calling buildQaNodeAgentPrompt() at module-init time.
 	},
 ];
 
@@ -189,6 +190,9 @@ export async function seedPresetAgents(
 	const errors: Array<{ name: string; error: string }> = [];
 
 	for (const preset of PRESET_AGENTS) {
+		// Resolve role-specific system prompts lazily (at seed time, not module-init).
+		const systemPrompt = preset.role === 'qa' ? buildQaNodeAgentPrompt() : preset.systemPrompt;
+
 		const result: SpaceAgentResult<SpaceAgent> = await agentManager.create({
 			spaceId,
 			name: preset.name,
@@ -196,7 +200,7 @@ export async function seedPresetAgents(
 			description: preset.description,
 			tools: preset.tools,
 			injectWorkflowContext: preset.injectWorkflowContext,
-			systemPrompt: preset.systemPrompt,
+			systemPrompt,
 		});
 
 		if (result.ok) {

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -10,6 +10,7 @@ import {
 	buildCustomAgentSystemPrompt,
 	buildCustomAgentTaskMessage,
 	buildPlannerNodeAgentPrompt,
+	buildQaNodeAgentPrompt,
 	createCustomAgentInit,
 	resolveAgentInit,
 	type CustomAgentConfig,
@@ -1227,5 +1228,139 @@ describe('buildCustomAgentSystemPrompt planner integration', () => {
 		const plannerIdx = prompt.indexOf('Planner Responsibilities');
 		const completionIdx = prompt.indexOf('Signalling Completion');
 		expect(plannerIdx).toBeLessThan(completionIdx);
+	});
+});
+
+// ============================================================================
+// buildQaNodeAgentPrompt
+// ============================================================================
+
+describe('buildQaNodeAgentPrompt', () => {
+	it('returns a non-empty string', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(typeof prompt).toBe('string');
+		expect(prompt.length).toBeGreaterThan(0);
+	});
+
+	it('includes role and responsibility description', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('QA Agent');
+		expect(prompt).toContain('verify');
+	});
+
+	it('includes gh CLI auth verification step', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('gh auth status');
+		expect(prompt).toContain('not authenticated');
+	});
+
+	it('includes read_gate instruction for code-pr-gate', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('read_gate');
+		expect(prompt).toContain('code-pr-gate');
+		expect(prompt).toContain('prUrl');
+	});
+
+	it('includes test command detection for package.json', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('package.json');
+	});
+
+	it('includes test command detection for Makefile', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('Makefile');
+	});
+
+	it('includes CI pipeline check via gh pr checks', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('gh pr checks');
+	});
+
+	it('includes PR mergeability check via gh pr view', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('gh pr view');
+		expect(prompt).toContain('mergeable');
+		expect(prompt).toContain('mergeStateStatus');
+	});
+
+	it('includes merge conflict detection using git merge dry-run (not deprecated git merge-tree)', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('git merge --no-commit --no-ff');
+		expect(prompt).toContain('git merge --abort');
+		expect(prompt).toContain('CONFLICT');
+		// Must NOT use the deprecated 3-argument git merge-tree form
+		expect(prompt).not.toContain('git merge-tree $(git merge-base');
+	});
+
+	it('includes write_gate instruction for qa-result-gate', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('write_gate');
+		expect(prompt).toContain('qa-result-gate');
+	});
+
+	it('specifies result field with passed and failed values', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('"passed"');
+		expect(prompt).toContain('"failed"');
+		expect(prompt).toContain('result');
+	});
+
+	it('specifies summary field in gate write', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('summary');
+	});
+
+	it('mentions gate check condition', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('check: result == passed');
+	});
+
+	it('includes VERIFICATION_COMPLETE bypass marker instruction', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('VERIFICATION_COMPLETE:');
+	});
+
+	it('explicitly warns not to create commits, push, or open PRs', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('NOT create commits');
+		expect(prompt).toContain('push branches');
+		expect(prompt).toContain('open pull requests');
+	});
+
+	it('references the Git Workflow MANDATORY section to explain bypass', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('Git Workflow (MANDATORY)');
+	});
+
+	it('includes structured QA output format', () => {
+		const prompt = buildQaNodeAgentPrompt();
+		expect(prompt).toContain('QA RESULT');
+		expect(prompt).toContain('CI Pipeline');
+		expect(prompt).toContain('PR Mergeability');
+		expect(prompt).toContain('Blockers');
+	});
+
+	it('embeds into custom agent system prompt as Agent Instructions when set as systemPrompt', () => {
+		const agent = makeAgent({ role: 'qa', systemPrompt: buildQaNodeAgentPrompt() });
+		const fullPrompt = buildCustomAgentSystemPrompt(agent);
+		expect(fullPrompt).toContain('Agent Instructions');
+		expect(fullPrompt).toContain('QA Agent');
+		expect(fullPrompt).toContain('code-pr-gate');
+		expect(fullPrompt).toContain('qa-result-gate');
+		// The assembled prompt must include the bypass marker so the agent knows to use it
+		expect(fullPrompt).toContain('VERIFICATION_COMPLETE:');
+	});
+
+	it('assembled prompt does not instruct QA agent to commit code', () => {
+		const agent = makeAgent({ role: 'qa', systemPrompt: buildQaNodeAgentPrompt() });
+		const fullPrompt = buildCustomAgentSystemPrompt(agent);
+		// The QA prompt must explicitly counter the git workflow section's commit instruction
+		expect(fullPrompt).toContain('NOT create commits');
+	});
+
+	it('is deterministic — returns the same string on multiple calls', () => {
+		const prompt1 = buildQaNodeAgentPrompt();
+		const prompt2 = buildQaNodeAgentPrompt();
+		expect(prompt1).toBe(prompt2);
 	});
 });


### PR DESCRIPTION
Implements M2.4: QA Agent System Prompt.

- `buildQaNodeAgentPrompt()` in `custom-agent.ts` — comprehensive QA instructions covering gh auth, gate-based PR discovery via `read_gate("code-pr-gate")`, test command detection (package.json/Makefile), test execution, CI check (`gh pr checks`), PR mergeability check (`gh pr view --json mergeable,mergeStateStatus`), merge conflict detection, structured output format, and result write to `qa-result-gate` via `write_gate`
- QA seed agent in `seed-agents.ts` now uses this prompt as its `systemPrompt`
- 14 new unit tests; all 104 tests in `custom-agent.test.ts` pass