### PR TITLE
feat(space): add buildReviewerNodeAgentPrompt for reviewer node agents (M2.3)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -224,6 +224,201 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 	return sections.join('\n');
 }
 
+/**
+ * Build the specialized behavioral system prompt for a reviewer node agent.
+ *
+ * Reviewer agents do NOT commit code or open PRs — their job is to read a PR,
+ * post a GitHub review, and write a vote to the `review-votes-gate`.
+ *
+ * Structure:
+ *   1. Role identification
+ *   2. Custom system prompt from SpaceAgent.systemPrompt (if provided)
+ *   3. Review process: find PR URL from gate → read diff → evaluate → post review
+ *   4. Severity classification (critical / major / minor)
+ *   5. Review posting via GitHub REST API
+ *   6. Structured output block (---REVIEW_POSTED---)
+ *   7. Gate interaction: read code-pr-gate, write review-votes-gate
+ *   8. Edge case: idempotency / re-spawn protection
+ *   9. Peer communication
+ *  10. Completion signalling
+ */
+export function buildReviewerNodeAgentPrompt(customAgent: SpaceAgent): string {
+	const sections: string[] = [];
+
+	sections.push(
+		`You are ${customAgent.name}, a Reviewer Agent responsible for reviewing a pull request ` +
+			`and recording your vote in the workflow gate system.`
+	);
+	sections.push(
+		`Your job is to evaluate the PR for correctness, completeness, and security, post a GitHub review, ` +
+			`and write your vote to the \`review-votes-gate\`.`
+	);
+
+	// Custom instructions from the agent definition
+	if (customAgent.systemPrompt) {
+		sections.push(`\n## Agent Instructions\n`);
+		sections.push(customAgent.systemPrompt);
+	}
+
+	// Review process
+	sections.push(`\n## Review Process\n`);
+	sections.push(`Follow these steps in order:`);
+	sections.push(
+		`1. **Find the PR URL** — call \`read_gate\` with \`gateId: "code-pr-gate"\` to retrieve the PR URL from gate data.\n` +
+			`   - Expected data shape: \`{ pr: "https://github.com/..." }\`\n` +
+			`   - If the gate is empty or \`pr\` is missing, stop and output: \`PR URL not found in code-pr-gate\``
+	);
+	sections.push(
+		`2. **Fetch PR details** — view the PR title, description, and changed files:\n` +
+			`   \`\`\`bash\n` +
+			`   # Extract owner, repo, and PR number from the URL first\n` +
+			`   GH_PAGER=cat gh pr view {pr_number} --repo {owner}/{repo} --json title,body,additions,deletions,files\n` +
+			`   \`\`\``
+	);
+	sections.push(
+		`3. **Read the diff** — examine the actual changes:\n` +
+			`   \`\`\`bash\n` +
+			`   GH_PAGER=cat gh pr diff {pr_number} --repo {owner}/{repo}\n` +
+			`   \`\`\``
+	);
+	sections.push(
+		`4. **Evaluate the changes** — assess three dimensions:\n` +
+			`   - **Correctness**: Does the code do what it claims? Are there logic errors or missed edge cases?\n` +
+			`   - **Completeness**: Are all requirements addressed? Do tests exist and cover the new behavior?\n` +
+			`   - **Security**: Are there OWASP-class vulnerabilities (injection, auth bypass, data exposure, etc.)?`
+	);
+	sections.push(`5. **Post the PR review** — see the "Posting the PR Review" section below.`);
+	sections.push(`6. **Write your vote** — see the "Gate Interaction" section below.`);
+	sections.push(`7. **Call \`report_done\`** to signal completion.`);
+
+	// Severity classification
+	sections.push(`\n## Severity Classification\n`);
+	sections.push(`Classify all findings by severity when writing your review body:`);
+	sections.push(
+		`- **Critical** — security vulnerabilities, data corruption, crash-inducing bugs. Block approval; use \`REQUEST_CHANGES\`.\n` +
+			`- **Major** — incorrect behavior, missing test coverage for changed code, logic errors. Block approval; use \`REQUEST_CHANGES\`.\n` +
+			`- **Minor** — style issues, non-critical suggestions, nitpicks. Do not block approval; still include in review body.`
+	);
+	sections.push(`Count each severity level for the structured output block.`);
+
+	// Posting the review
+	sections.push(`\n## Posting the PR Review\n`);
+	sections.push(
+		`Post your review via the GitHub API. Extract \`{owner}\`, \`{repo}\`, and \`{pr_number}\` from the PR URL ` +
+			`(e.g., \`https://github.com/owner/repo/pull/42\` → owner=\`owner\`, repo=\`repo\`, pr_number=\`42\`).`
+	);
+	sections.push(
+		`\`\`\`bash\n` +
+			`GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \\\n` +
+			`  --method POST \\\n` +
+			`  --field body="Your detailed review body with findings" \\\n` +
+			`  --field event="APPROVE"  # or "REQUEST_CHANGES"\n` +
+			`\`\`\``
+	);
+	sections.push(
+		`- Use \`"APPROVE"\` when there are zero critical and zero major issues.\n` +
+			`- Use \`"REQUEST_CHANGES"\` when there is one or more critical or major issues.`
+	);
+	sections.push(
+		`The API response JSON contains an \`html_url\` field — capture it for the structured output block.`
+	);
+
+	// Structured output
+	sections.push(`\n## Structured Output Block\n`);
+	sections.push(
+		`After posting the review, output the following block **exactly** (no extra whitespace before \`---\`):`
+	);
+	sections.push(
+		`\`\`\`\n` +
+			`---REVIEW_POSTED---\n` +
+			`{\n` +
+			`  "url": "https://github.com/{owner}/{repo}/pull/{pr_number}#pullrequestreview-{review_id}",\n` +
+			`  "recommendation": "approve",\n` +
+			`  "severityCounts": {\n` +
+			`    "critical": 0,\n` +
+			`    "major": 0,\n` +
+			`    "minor": 0\n` +
+			`  }\n` +
+			`}\n` +
+			`\`\`\``
+	);
+	sections.push(
+		`- \`recommendation\` must be \`"approve"\` or \`"reject"\` (matching your \`event\` field).\n` +
+			`- \`url\` must be the \`html_url\` from the GitHub API response.`
+	);
+
+	// Gate interaction
+	sections.push(`\n## Gate Interaction\n`);
+	sections.push(`### Step 1 — Read the PR URL from \`code-pr-gate\`\n`);
+	sections.push(
+		`Call \`read_gate\` with \`gateId: "code-pr-gate"\`. The response includes a \`nodeId\` field — ` +
+			`save this value; you will use it as your vote key.`
+	);
+	sections.push(`Expected data shape: \`{ pr: "https://github.com/..." }\``);
+
+	sections.push(`\n### Step 2 — Write your vote to \`review-votes-gate\`\n`);
+	sections.push(
+		`After posting the review, write your vote using the \`nodeId\` you received earlier:`
+	);
+	sections.push(
+		`\`\`\`json\n` +
+			`// write_gate call\n` +
+			`{\n` +
+			`  "gateId": "review-votes-gate",\n` +
+			`  "data": {\n` +
+			`    "votes": {\n` +
+			`      "[your-nodeId]": "approve"  // or "reject"\n` +
+			`    }\n` +
+			`  }\n` +
+			`}\n` +
+			`\`\`\``
+	);
+	sections.push(
+		`The gate uses a \`count\` condition (e.g., \`votes.approve >= 3\`). ` +
+			`It opens automatically once enough reviewers have approved. ` +
+			`Do not wait for the gate to open — write your vote and call \`report_done\`.`
+	);
+
+	// Idempotency
+	sections.push(`\n## Idempotency — Re-Spawn Protection\n`);
+	sections.push(
+		`Before writing your vote, verify you have not already voted (you may be re-spawned after a crash):`
+	);
+	sections.push(
+		`1. Call \`read_gate\` with \`gateId: "review-votes-gate"\`.\n` +
+			`2. Check whether \`data.votes[nodeId]\` already has a value.\n` +
+			`3. **If already voted**: skip the \`write_gate\` call — your vote is already recorded.\n` +
+			`4. **If not yet voted**: proceed with \`write_gate\` as described above.`
+	);
+
+	// Peer communication
+	sections.push(`\n## Peer Communication\n`);
+	sections.push(
+		`You are part of a multi-agent team within this workflow step. ` +
+			`You have MCP tools for communicating with peer agents in the same group.`
+	);
+	sections.push(
+		`Use \`send_message\` to send feedback or status to permitted peers (e.g., to the coder when requesting changes). ` +
+			`Use \`list_peers\` to discover other agents and their permitted outgoing channels.`
+	);
+	sections.push(
+		`- \`target: 'role'\` — point-to-point to a specific role (e.g., \`'coder'\`)\n` +
+			`- \`target: '*'\` — broadcast to all permitted targets`
+	);
+
+	// Completion signalling
+	sections.push(`\n## Signalling Completion\n`);
+	sections.push(
+		`When all steps are done (review posted + vote written), call \`report_done\` with a brief summary:`
+	);
+	sections.push(
+		`- After calling \`report_done\`, stop — do not perform further actions.\n` +
+			`- Always call \`report_done\` explicitly; do not rely on the session ending naturally.`
+	);
+
+	return sections.join('\n');
+}
+
 // ============================================================================
 // Task message builder
 // ============================================================================
@@ -367,7 +562,10 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 		slotOverrides?.systemPrompt !== undefined
 			? { ...customAgent, systemPrompt: slotOverrides.systemPrompt }
 			: customAgent;
-	const behavioralPrompt = buildCustomAgentSystemPrompt(agentForPrompt);
+	const behavioralPrompt =
+		agentForPrompt.role === 'reviewer'
+			? buildReviewerNodeAgentPrompt(agentForPrompt)
+			: buildCustomAgentSystemPrompt(agentForPrompt);
 
 	// When custom tools are configured, use the agent/agents pattern so the SDK
 	// enforces the allowlist. Otherwise, fall back to the simple preset path.

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -233,14 +233,15 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
  * Structure:
  *   1. Role identification
  *   2. Custom system prompt from SpaceAgent.systemPrompt (if provided)
- *   3. Review process: find PR URL from gate → read diff → evaluate → post review
- *   4. Severity classification (critical / major / minor)
- *   5. Review posting via GitHub REST API
- *   6. Structured output block (---REVIEW_POSTED---)
- *   7. Gate interaction: read code-pr-gate, write review-votes-gate
- *   8. Edge case: idempotency / re-spawn protection
- *   9. Peer communication
- *  10. Completion signalling
+ *   3. Idempotency check FIRST (re-spawn protection before any action)
+ *   4. Gate interaction: call list_gates to get nodeId + PR URL
+ *   5. Review process: fetch PR → read diff → evaluate
+ *   6. Severity classification (P0/P1/P2/P3)
+ *   7. Review posting via GitHub REST API
+ *   8. Structured output block (---REVIEW_POSTED--- / ---END_REVIEW_POSTED---)
+ *   9. Write vote to review-votes-gate
+ *  10. Peer communication
+ *  11. Completion signalling
  */
 export function buildReviewerNodeAgentPrompt(customAgent: SpaceAgent): string {
 	const sections: string[] = [];
@@ -260,52 +261,75 @@ export function buildReviewerNodeAgentPrompt(customAgent: SpaceAgent): string {
 		sections.push(customAgent.systemPrompt);
 	}
 
-	// Review process
-	sections.push(`\n## Review Process\n`);
-	sections.push(`Follow these steps in order:`);
+	// Idempotency check FIRST — must happen before any external action
+	sections.push(`\n## Step 1 — Idempotency Check (Do This Before Anything Else)\n`);
 	sections.push(
-		`1. **Find the PR URL** — call \`read_gate\` with \`gateId: "code-pr-gate"\` to retrieve the PR URL from gate data.\n` +
-			`   - Expected data shape: \`{ pr: "https://github.com/..." }\`\n` +
-			`   - If the gate is empty or \`pr\` is missing, stop and output: \`PR URL not found in code-pr-gate\``
+		`You may be re-spawned after a crash. Before posting a review or writing a vote, ` +
+			`check whether you have already acted in this run:`
 	);
 	sections.push(
-		`2. **Fetch PR details** — view the PR title, description, and changed files:\n` +
+		`1. Call \`list_gates\` (no arguments). The response includes a \`nodeId\` field — **save this value**; ` +
+			`it is your unique identity key for vote-counting gates.\n` +
+			`2. In the response, find the gate with \`gateId: "review-votes-gate"\`.\n` +
+			`3. Check whether \`currentData.votes[nodeId]\` already has a value.\n` +
+			`   - **If already voted**: your vote is recorded. Skip directly to calling \`report_done\`.\n` +
+			`   - **If not yet voted**: continue with the steps below.`
+	);
+
+	// Gate data: get PR URL
+	sections.push(`\n## Step 2 — Get the PR URL from \`code-pr-gate\`\n`);
+	sections.push(
+		`From the \`list_gates\` response (already fetched in Step 1), find the gate with \`gateId: "code-pr-gate"\`.\n` +
+			`Extract the \`currentData.pr\` field — this is the PR URL (e.g., \`https://github.com/owner/repo/pull/42\`).\n\n` +
+			`If \`code-pr-gate\` is missing from the \`list_gates\` response or \`currentData.pr\` is empty, stop and output:\n` +
+			`\`PR URL not found in code-pr-gate — cannot proceed with review.\``
+	);
+
+	// Review process
+	sections.push(`\n## Step 3 — Review the Pull Request\n`);
+	sections.push(
+		`Extract \`{owner}\`, \`{repo}\`, and \`{pr_number}\` from the PR URL ` +
+			`(e.g., \`https://github.com/owner/repo/pull/42\` → owner=\`owner\`, repo=\`repo\`, pr_number=\`42\`).`
+	);
+	sections.push(
+		`1. **Fetch PR details**:\n` +
 			`   \`\`\`bash\n` +
-			`   # Extract owner, repo, and PR number from the URL first\n` +
 			`   GH_PAGER=cat gh pr view {pr_number} --repo {owner}/{repo} --json title,body,additions,deletions,files\n` +
 			`   \`\`\``
 	);
 	sections.push(
-		`3. **Read the diff** — examine the actual changes:\n` +
+		`2. **Read the diff**:\n` +
 			`   \`\`\`bash\n` +
 			`   GH_PAGER=cat gh pr diff {pr_number} --repo {owner}/{repo}\n` +
 			`   \`\`\``
 	);
 	sections.push(
-		`4. **Evaluate the changes** — assess three dimensions:\n` +
+		`3. **Evaluate the changes** — assess three dimensions:\n` +
 			`   - **Correctness**: Does the code do what it claims? Are there logic errors or missed edge cases?\n` +
 			`   - **Completeness**: Are all requirements addressed? Do tests exist and cover the new behavior?\n` +
 			`   - **Security**: Are there OWASP-class vulnerabilities (injection, auth bypass, data exposure, etc.)?`
 	);
-	sections.push(`5. **Post the PR review** — see the "Posting the PR Review" section below.`);
-	sections.push(`6. **Write your vote** — see the "Gate Interaction" section below.`);
-	sections.push(`7. **Call \`report_done\`** to signal completion.`);
 
 	// Severity classification
 	sections.push(`\n## Severity Classification\n`);
 	sections.push(`Classify all findings by severity when writing your review body:`);
 	sections.push(
-		`- **Critical** — security vulnerabilities, data corruption, crash-inducing bugs. Block approval; use \`REQUEST_CHANGES\`.\n` +
-			`- **Major** — incorrect behavior, missing test coverage for changed code, logic errors. Block approval; use \`REQUEST_CHANGES\`.\n` +
-			`- **Minor** — style issues, non-critical suggestions, nitpicks. Do not block approval; still include in review body.`
+		`- **P0 (blocking)**: Bugs, security vulnerabilities, data loss risks, broken functionality. Always use \`REQUEST_CHANGES\`.\n` +
+			`- **P1 (should-fix)**: Poor patterns, missing error handling, test gaps, unclear code. Use \`REQUEST_CHANGES\`.\n` +
+			`- **P2 (important suggestion)**: Meaningful improvements to quality, readability, maintainability. Use \`REQUEST_CHANGES\`.\n` +
+			`- **P3 (nit)**: Style nits, minor cosmetic issues, optional documentation. Do not block approval.`
 	);
-	sections.push(`Count each severity level for the structured output block.`);
+	sections.push(
+		`Decision rule:\n` +
+			`- Use \`"REQUEST_CHANGES"\` when any P0, P1, or P2 issues exist.\n` +
+			`- Use \`"APPROVE"\` when only P3 issues or no issues exist.`
+	);
 
 	// Posting the review
-	sections.push(`\n## Posting the PR Review\n`);
+	sections.push(`\n## Step 4 — Post the PR Review\n`);
 	sections.push(
-		`Post your review via the GitHub API. Extract \`{owner}\`, \`{repo}\`, and \`{pr_number}\` from the PR URL ` +
-			`(e.g., \`https://github.com/owner/repo/pull/42\` → owner=\`owner\`, repo=\`repo\`, pr_number=\`42\`).`
+		`Post your review via the GitHub API. If the API call fails (network error, auth error, etc.), ` +
+			`output the \`---REVIEW_POSTED---\` block with \`recommendation: ERROR\` and include the error in \`summary\`.`
 	);
 	sections.push(
 		`\`\`\`bash\n` +
@@ -316,49 +340,35 @@ export function buildReviewerNodeAgentPrompt(customAgent: SpaceAgent): string {
 			`\`\`\``
 	);
 	sections.push(
-		`- Use \`"APPROVE"\` when there are zero critical and zero major issues.\n` +
-			`- Use \`"REQUEST_CHANGES"\` when there is one or more critical or major issues.`
-	);
-	sections.push(
 		`The API response JSON contains an \`html_url\` field — capture it for the structured output block.`
 	);
 
 	// Structured output
-	sections.push(`\n## Structured Output Block\n`);
+	sections.push(`\n## Step 5 — Output the Structured Block\n`);
 	sections.push(
-		`After posting the review, output the following block **exactly** (no extra whitespace before \`---\`):`
+		`After posting the review, output the following block **exactly** (no code fences, no extra whitespace before \`---\`):`
 	);
 	sections.push(
-		`\`\`\`\n` +
-			`---REVIEW_POSTED---\n` +
-			`{\n` +
-			`  "url": "https://github.com/{owner}/{repo}/pull/{pr_number}#pullrequestreview-{review_id}",\n` +
-			`  "recommendation": "approve",\n` +
-			`  "severityCounts": {\n` +
-			`    "critical": 0,\n` +
-			`    "major": 0,\n` +
-			`    "minor": 0\n` +
-			`  }\n` +
-			`}\n` +
-			`\`\`\``
+		`---REVIEW_POSTED---\n` +
+			`url: <the html_url returned by the gh api call>\n` +
+			`recommendation: APPROVE | REQUEST_CHANGES | ERROR\n` +
+			`p0: <count of P0 issues>\n` +
+			`p1: <count of P1 issues>\n` +
+			`p2: <count of P2 issues>\n` +
+			`p3: <count of P3 issues>\n` +
+			`summary: <1-2 sentence summary of key findings>\n` +
+			`---END_REVIEW_POSTED---`
 	);
 	sections.push(
-		`- \`recommendation\` must be \`"approve"\` or \`"reject"\` (matching your \`event\` field).\n` +
-			`- \`url\` must be the \`html_url\` from the GitHub API response.`
+		`- \`recommendation\` must be exactly \`APPROVE\`, \`REQUEST_CHANGES\`, or \`ERROR\` (matching the GitHub API event).\n` +
+			`- \`url\` must be the \`html_url\` from the API response (or empty string on \`ERROR\`).\n` +
+			`- Count only issues you actually found — use \`0\` for levels with no issues.`
 	);
 
-	// Gate interaction
-	sections.push(`\n## Gate Interaction\n`);
-	sections.push(`### Step 1 — Read the PR URL from \`code-pr-gate\`\n`);
+	// Vote
+	sections.push(`\n## Step 6 — Write Your Vote to \`review-votes-gate\`\n`);
 	sections.push(
-		`Call \`read_gate\` with \`gateId: "code-pr-gate"\`. The response includes a \`nodeId\` field — ` +
-			`save this value; you will use it as your vote key.`
-	);
-	sections.push(`Expected data shape: \`{ pr: "https://github.com/..." }\``);
-
-	sections.push(`\n### Step 2 — Write your vote to \`review-votes-gate\`\n`);
-	sections.push(
-		`After posting the review, write your vote using the \`nodeId\` you received earlier:`
+		`Write your vote using the \`nodeId\` saved in Step 1. Use \`"approve"\` if you APPROVED, \`"reject"\` otherwise:`
 	);
 	sections.push(
 		`\`\`\`json\n` +
@@ -376,19 +386,7 @@ export function buildReviewerNodeAgentPrompt(customAgent: SpaceAgent): string {
 	sections.push(
 		`The gate uses a \`count\` condition (e.g., \`votes.approve >= 3\`). ` +
 			`It opens automatically once enough reviewers have approved. ` +
-			`Do not wait for the gate to open — write your vote and call \`report_done\`.`
-	);
-
-	// Idempotency
-	sections.push(`\n## Idempotency — Re-Spawn Protection\n`);
-	sections.push(
-		`Before writing your vote, verify you have not already voted (you may be re-spawned after a crash):`
-	);
-	sections.push(
-		`1. Call \`read_gate\` with \`gateId: "review-votes-gate"\`.\n` +
-			`2. Check whether \`data.votes[nodeId]\` already has a value.\n` +
-			`3. **If already voted**: skip the \`write_gate\` call — your vote is already recorded.\n` +
-			`4. **If not yet voted**: proceed with \`write_gate\` as described above.`
+			`Do not wait for the gate to open — write your vote and proceed to \`report_done\`.`
 	);
 
 	// Peer communication
@@ -403,6 +401,7 @@ export function buildReviewerNodeAgentPrompt(customAgent: SpaceAgent): string {
 	);
 	sections.push(
 		`- \`target: 'role'\` — point-to-point to a specific role (e.g., \`'coder'\`)\n` +
+			`- \`target: ['role1', 'role2']\` — multicast to multiple roles\n` +
 			`- \`target: '*'\` — broadcast to all permitted targets`
 	);
 

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -210,51 +210,86 @@ describe('buildReviewerNodeAgentPrompt', () => {
 		expect(prompt).not.toContain('Agent Instructions');
 	});
 
+	it('uses list_gates to discover nodeId, does not mention read_gate', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		// nodeId is returned by list_gates, NOT read_gate — prompt must use list_gates
+		expect(prompt).toContain('list_gates');
+		expect(prompt).toContain('nodeId');
+		// read_gate does NOT return nodeId; remove it to avoid LLM confusion
+		expect(prompt).not.toContain('read_gate');
+	});
+
+	it('retrieves PR URL from list_gates response (code-pr-gate currentData)', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('code-pr-gate');
+		expect(prompt).toContain('currentData');
+	});
+
 	it('includes review process steps', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
-		expect(prompt).toContain('Review Process');
-		expect(prompt).toContain('read_gate');
 		expect(prompt).toContain('gh pr diff');
 		expect(prompt).toContain('Evaluate the changes');
 	});
 
-	it('includes severity classification', () => {
+	it('includes P0/P1/P2/P3 severity classification', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
 		expect(prompt).toContain('Severity Classification');
-		expect(prompt).toContain('Critical');
-		expect(prompt).toContain('Major');
-		expect(prompt).toContain('Minor');
+		expect(prompt).toContain('P0');
+		expect(prompt).toContain('P1');
+		expect(prompt).toContain('P2');
+		expect(prompt).toContain('P3');
 	});
 
 	it('includes PR review posting via GitHub REST API', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
-		expect(prompt).toContain('Posting the PR Review');
 		expect(prompt).toContain('gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews');
 		expect(prompt).toContain('--method POST');
 		expect(prompt).toContain('APPROVE');
 		expect(prompt).toContain('REQUEST_CHANGES');
 	});
 
-	it('includes ---REVIEW_POSTED--- structured output block', () => {
+	it('includes guidance for API failure handling', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('ERROR');
+	});
+
+	it('includes ---REVIEW_POSTED--- and ---END_REVIEW_POSTED--- structured output block', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
 		expect(prompt).toContain('---REVIEW_POSTED---');
-		expect(prompt).toContain('"recommendation"');
-		expect(prompt).toContain('"severityCounts"');
-		expect(prompt).toContain('"critical"');
-		expect(prompt).toContain('"major"');
-		expect(prompt).toContain('"minor"');
-		expect(prompt).toContain('"url"');
+		expect(prompt).toContain('---END_REVIEW_POSTED---');
 	});
 
-	it('includes gate interaction: read code-pr-gate for PR URL', () => {
+	it('structured output uses flat key-value format with p0/p1/p2/p3 fields', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
-		expect(prompt).toContain('code-pr-gate');
-		expect(prompt).toContain('Gate Interaction');
+		// Flat format — NOT JSON with severityCounts
+		expect(prompt).toContain('p0:');
+		expect(prompt).toContain('p1:');
+		expect(prompt).toContain('p2:');
+		expect(prompt).toContain('p3:');
+		expect(prompt).toContain('summary:');
+		expect(prompt).toContain('url:');
+		expect(prompt).toContain('recommendation:');
+		// Should NOT use old nested JSON format
+		expect(prompt).not.toContain('"severityCounts"');
+		expect(prompt).not.toContain('"critical"');
+	});
+
+	it('recommendation vocabulary is APPROVE / REQUEST_CHANGES (uppercase), not approve/reject', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		// Flat block: recommendation: APPROVE | REQUEST_CHANGES
+		expect(prompt).toContain('recommendation: APPROVE | REQUEST_CHANGES');
+		// Should NOT use lowercase "approve"/"reject" as recommendation values
+		expect(prompt).not.toContain('"recommendation": "approve"');
+		expect(prompt).not.toContain('"recommendation": "reject"');
 	});
 
 	it('includes gate interaction: write vote to review-votes-gate using nodeId', () => {
@@ -262,24 +297,40 @@ describe('buildReviewerNodeAgentPrompt', () => {
 		const prompt = buildReviewerNodeAgentPrompt(agent);
 		expect(prompt).toContain('review-votes-gate');
 		expect(prompt).toContain('write_gate');
-		expect(prompt).toContain('nodeId');
 		expect(prompt).toContain('"votes"');
+		expect(prompt).toContain('"approve"');
+		expect(prompt).toContain('"reject"');
 	});
 
-	it('includes idempotency / re-spawn protection instructions', () => {
+	it('idempotency check comes before any action (Step 1 position)', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
-		expect(prompt).toContain('Idempotency');
+		expect(prompt).toContain('Idempotency Check');
 		expect(prompt).toContain('already voted');
-		expect(prompt).toContain('skip');
+		// Idempotency section must appear before the PR review posting section
+		const idempotencyPos = prompt.indexOf('Idempotency Check');
+		const postReviewPos = prompt.indexOf('Post the PR Review');
+		expect(idempotencyPos).toBeLessThan(postReviewPos);
 	});
 
-	it('includes peer communication section', () => {
+	it('list_gates call appears in idempotency section (nodeId discovery is part of idempotency)', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		// The idempotency section tells agent to call list_gates to get nodeId
+		const idempotencyPos = prompt.indexOf('Idempotency Check');
+		const listGatesPos = prompt.indexOf('list_gates');
+		expect(idempotencyPos).toBeGreaterThanOrEqual(0);
+		expect(listGatesPos).toBeGreaterThan(idempotencyPos);
+	});
+
+	it('includes peer communication section with all target modes including multicast', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
 		expect(prompt).toContain('Peer Communication');
 		expect(prompt).toContain('send_message');
 		expect(prompt).toContain('list_peers');
+		// Must include multicast target form
+		expect(prompt).toContain("['role1', 'role2']");
 	});
 
 	it('includes completion signalling via report_done', () => {
@@ -292,19 +343,9 @@ describe('buildReviewerNodeAgentPrompt', () => {
 	it('does NOT include git commit/push workflow instructions', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
-		// Reviewer should not be committing/pushing code
 		expect(prompt).not.toContain('Git Workflow (MANDATORY)');
 		expect(prompt).not.toContain('git push -u origin HEAD');
 		expect(prompt).not.toContain('gh pr create');
-	});
-
-	it('vote data shape uses nodeId key and approve/reject values', () => {
-		const agent = makeAgent({ role: 'reviewer' });
-		const prompt = buildReviewerNodeAgentPrompt(agent);
-		// The data shape for the vote: { votes: { [nodeId]: "approve" | "reject" } }
-		expect(prompt).toContain('"votes"');
-		expect(prompt).toContain('"approve"');
-		expect(prompt).toContain('"reject"');
 	});
 });
 

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, mock } from 'bun:test';
 import {
 	buildCustomAgentSystemPrompt,
+	buildReviewerNodeAgentPrompt,
 	buildCustomAgentTaskMessage,
 	createCustomAgentInit,
 	resolveAgentInit,
@@ -181,6 +182,129 @@ describe('buildCustomAgentSystemPrompt', () => {
 		const agent = makeAgent();
 		const prompt = buildCustomAgentSystemPrompt(agent);
 		expect(prompt).toContain('Do NOT commit directly to the main/dev/master branch');
+	});
+});
+
+// ============================================================================
+// buildReviewerNodeAgentPrompt
+// ============================================================================
+
+describe('buildReviewerNodeAgentPrompt', () => {
+	it('identifies agent as a Reviewer Agent', () => {
+		const agent = makeAgent({ name: 'PRBot', role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('PRBot');
+		expect(prompt).toContain('Reviewer Agent');
+	});
+
+	it('includes custom systemPrompt when provided', () => {
+		const agent = makeAgent({ role: 'reviewer', systemPrompt: 'Focus on security.' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('Focus on security.');
+		expect(prompt).toContain('Agent Instructions');
+	});
+
+	it('omits Agent Instructions section when systemPrompt is unset', () => {
+		const agent = makeAgent({ role: 'reviewer', systemPrompt: undefined });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).not.toContain('Agent Instructions');
+	});
+
+	it('includes review process steps', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('Review Process');
+		expect(prompt).toContain('read_gate');
+		expect(prompt).toContain('gh pr diff');
+		expect(prompt).toContain('Evaluate the changes');
+	});
+
+	it('includes severity classification', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('Severity Classification');
+		expect(prompt).toContain('Critical');
+		expect(prompt).toContain('Major');
+		expect(prompt).toContain('Minor');
+	});
+
+	it('includes PR review posting via GitHub REST API', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('Posting the PR Review');
+		expect(prompt).toContain('gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews');
+		expect(prompt).toContain('--method POST');
+		expect(prompt).toContain('APPROVE');
+		expect(prompt).toContain('REQUEST_CHANGES');
+	});
+
+	it('includes ---REVIEW_POSTED--- structured output block', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('---REVIEW_POSTED---');
+		expect(prompt).toContain('"recommendation"');
+		expect(prompt).toContain('"severityCounts"');
+		expect(prompt).toContain('"critical"');
+		expect(prompt).toContain('"major"');
+		expect(prompt).toContain('"minor"');
+		expect(prompt).toContain('"url"');
+	});
+
+	it('includes gate interaction: read code-pr-gate for PR URL', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('code-pr-gate');
+		expect(prompt).toContain('Gate Interaction');
+	});
+
+	it('includes gate interaction: write vote to review-votes-gate using nodeId', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('review-votes-gate');
+		expect(prompt).toContain('write_gate');
+		expect(prompt).toContain('nodeId');
+		expect(prompt).toContain('"votes"');
+	});
+
+	it('includes idempotency / re-spawn protection instructions', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('Idempotency');
+		expect(prompt).toContain('already voted');
+		expect(prompt).toContain('skip');
+	});
+
+	it('includes peer communication section', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('Peer Communication');
+		expect(prompt).toContain('send_message');
+		expect(prompt).toContain('list_peers');
+	});
+
+	it('includes completion signalling via report_done', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		expect(prompt).toContain('Signalling Completion');
+		expect(prompt).toContain('report_done');
+	});
+
+	it('does NOT include git commit/push workflow instructions', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		// Reviewer should not be committing/pushing code
+		expect(prompt).not.toContain('Git Workflow (MANDATORY)');
+		expect(prompt).not.toContain('git push -u origin HEAD');
+		expect(prompt).not.toContain('gh pr create');
+	});
+
+	it('vote data shape uses nodeId key and approve/reject values', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildReviewerNodeAgentPrompt(agent);
+		// The data shape for the vote: { votes: { [nodeId]: "approve" | "reject" } }
+		expect(prompt).toContain('"votes"');
+		expect(prompt).toContain('"approve"');
+		expect(prompt).toContain('"reject"');
 	});
 });
 
@@ -393,7 +517,7 @@ describe('createCustomAgentInit', () => {
 		expect(init.features?.sessionInfo).toBe(false);
 	});
 
-	it('builds correct init for reviewer role (no role-specific instructions)', () => {
+	it('builds correct init for reviewer role (uses reviewer-specific prompt)', () => {
 		const config = makeConfig({
 			customAgent: makeAgent({ role: 'reviewer', name: 'CodeReviewer' }),
 		});
@@ -401,7 +525,9 @@ describe('createCustomAgentInit', () => {
 
 		expect(init.type).toBe('worker');
 		expect(init.systemPrompt?.append).toContain('Reviewer Agent');
-		expect(init.systemPrompt?.append).not.toContain('Review Responsibilities');
+		// Reviewer prompt contains gate interaction instructions, not generic git workflow
+		expect(init.systemPrompt?.append).toContain('code-pr-gate');
+		expect(init.systemPrompt?.append).toContain('review-votes-gate');
 	});
 
 	it('builds correct init for planner role (treated as worker)', () => {


### PR DESCRIPTION
## Summary
- Adds `buildReviewerNodeAgentPrompt()` to `custom-agent.ts` — a specialized system prompt builder for reviewer node agents
- Reviewer prompt covers: PR review process (read `code-pr-gate`, fetch diff, evaluate), severity classification, GitHub REST API review posting, `---REVIEW_POSTED---` structured output, gate interaction (read/write), and idempotency re-spawn protection
- `createCustomAgentInit` dispatches to the reviewer prompt when `agent.role === 'reviewer'`
- 14 new unit tests; all 8981 daemon tests pass, lint/typecheck clean