### PR TITLE
feat(space): define CODING_WORKFLOW_V2 template (M3.1)

### DIFF
--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -278,7 +278,10 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 			agentId: 'reviewer',
 			instructions:
 				'Review the pull request for correctness, style, and test coverage. ' +
-				'Write your vote to review-votes-gate and review-reject-gate (field: votes, key: your name, value: "approved" or "rejected").',
+				'To record your vote: (1) use read_gate to fetch the current votes map from review-votes-gate, ' +
+				'(2) add your entry (key: "Reviewer 1", value: "approved" or "rejected") to the map, ' +
+				'(3) write the complete updated map back via write_gate on both review-votes-gate and review-reject-gate ' +
+				'(field: votes). Never write only your own entry — always include all existing votes to avoid overwriting peers.',
 		},
 		{
 			id: V2_REVIEWER2_STEP,
@@ -286,7 +289,10 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 			agentId: 'reviewer',
 			instructions:
 				'Review the pull request for correctness, style, and test coverage. ' +
-				'Write your vote to review-votes-gate and review-reject-gate (field: votes, key: your name, value: "approved" or "rejected").',
+				'To record your vote: (1) use read_gate to fetch the current votes map from review-votes-gate, ' +
+				'(2) add your entry (key: "Reviewer 2", value: "approved" or "rejected") to the map, ' +
+				'(3) write the complete updated map back via write_gate on both review-votes-gate and review-reject-gate ' +
+				'(field: votes). Never write only your own entry — always include all existing votes to avoid overwriting peers.',
 		},
 		{
 			id: V2_REVIEWER3_STEP,
@@ -294,7 +300,10 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 			agentId: 'reviewer',
 			instructions:
 				'Review the pull request for correctness, style, and test coverage. ' +
-				'Write your vote to review-votes-gate and review-reject-gate (field: votes, key: your name, value: "approved" or "rejected").',
+				'To record your vote: (1) use read_gate to fetch the current votes map from review-votes-gate, ' +
+				'(2) add your entry (key: "Reviewer 3", value: "approved" or "rejected") to the map, ' +
+				'(3) write the complete updated map back via write_gate on both review-votes-gate and review-reject-gate ' +
+				'(field: votes). Never write only your own entry — always include all existing votes to avoid overwriting peers.',
 		},
 		{
 			id: V2_QA_STEP,
@@ -302,7 +311,9 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 			agentId: 'qa',
 			instructions:
 				'Verify test coverage, run the CI pipeline, and confirm the PR is mergeable. ' +
-				'Write to qa-result-gate: "result: passed" if everything is green, or "result: failed" with details if issues are found.',
+				'Always write an explicit result to qa-result-gate on every QA pass — do not assume the gate was reset. ' +
+				'Write "result: passed" if everything is green, or "result: failed" with details if issues are found. ' +
+				'Writing is required on every pass because qa-result-gate retains its previous value across cycles.',
 		},
 		{
 			id: V2_DONE_STEP,
@@ -343,7 +354,11 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 		},
 		{
 			id: 'review-votes-gate',
-			description: 'All three reviewers have approved the code changes',
+			description:
+				'All three reviewers have approved the code changes. ' +
+				'Agents must read the current votes map first, add their entry, then write the full map back ' +
+				'(read-merge-write) — write_gate performs a shallow merge so writing only your own entry ' +
+				"would overwrite all other reviewers' votes.",
 			condition: { type: 'count', field: 'votes', matchValue: 'approved', min: 3 },
 			data: {},
 			allowedWriterRoles: ['reviewer'],
@@ -351,7 +366,11 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 		},
 		{
 			id: 'review-reject-gate',
-			description: 'At least one reviewer has rejected the code changes',
+			description:
+				'At least one reviewer has rejected the code changes. ' +
+				'Agents must read the current votes map first, add their entry, then write the full map back ' +
+				'(read-merge-write) — write_gate performs a shallow merge so writing only your own entry ' +
+				"would overwrite all other reviewers' votes.",
 			condition: { type: 'count', field: 'votes', matchValue: 'rejected', min: 1 },
 			data: {},
 			allowedWriterRoles: ['reviewer'],
@@ -359,7 +378,10 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 		},
 		{
 			id: 'qa-result-gate',
-			description: 'QA verification has passed — tests, CI, and PR are green',
+			description:
+				'QA verification has passed — tests, CI, and PR are green. ' +
+				'resetOnCycle is intentionally false: this gate is only referenced by the non-cyclic QA→Done ' +
+				'channel, so it never auto-resets. QA must write an explicit "result" on every pass.',
 			condition: { type: 'check', field: 'result', op: '==', value: 'passed' },
 			data: {},
 			allowedWriterRoles: ['qa'],
@@ -510,7 +532,7 @@ export function getBuiltInWorkflows(): SpaceWorkflow[] {
 }
 
 /**
- * Seeds all three built-in workflow templates into the given space.
+ * Seeds all four built-in workflow templates into the given space.
  *
  * Each template step's `agentId` placeholder (e.g., `'planner'`, `'coder'`,
  * `'general'`) is resolved to a real SpaceAgent UUID via `resolveAgentId`.

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -33,6 +33,16 @@ const CODING_CODER_STEP = 'tpl-coding-coder';
 const CODING_VERIFY_STEP = 'tpl-coding-verify';
 const CODING_DONE_STEP = 'tpl-coding-done';
 
+// V2 node IDs
+const V2_PLANNING_STEP = 'tpl-v2-planning';
+const V2_PLAN_REVIEW_STEP = 'tpl-v2-plan-review';
+const V2_CODING_STEP = 'tpl-v2-coding';
+const V2_REVIEWER1_STEP = 'tpl-v2-reviewer1';
+const V2_REVIEWER2_STEP = 'tpl-v2-reviewer2';
+const V2_REVIEWER3_STEP = 'tpl-v2-reviewer3';
+const V2_QA_STEP = 'tpl-v2-qa';
+const V2_DONE_STEP = 'tpl-v2-done';
+
 const RESEARCH_PLANNER_STEP = 'tpl-research-planner';
 const RESEARCH_GENERAL_STEP = 'tpl-research-general';
 
@@ -209,6 +219,280 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 	updatedAt: 0,
 };
 
+/**
+ * Coding Workflow V2
+ *
+ * Eight-node graph with parallel reviewers and QA verification.
+ *
+ * Main progression:
+ *   Planning → Plan Review (plan-pr-gate: planner submits plan)
+ *   Plan Review → Coding (plan-approval-gate: reviewer approves)
+ *   Coding → Reviewer 1/2/3 in parallel (code-pr-gate: PR opened)
+ *   Reviewer 1/2/3 → QA (review-votes-gate: all 3 approve)
+ *   QA → Done (qa-result-gate: QA passes)
+ *
+ * Cyclic paths:
+ *   Reviewer 1/2/3 → Coding (review-reject-gate: any reviewer rejects)
+ *   QA → Coding (qa-fail-gate: QA finds issues)
+ *
+ * Ungated feedback channels:
+ *   Plan Review → Planning (reviewer requests plan changes)
+ *   Coding → Planning (coder asks planner for clarification)
+ */
+export const CODING_WORKFLOW_V2: SpaceWorkflow = {
+	id: '',
+	spaceId: '',
+	name: 'Coding Workflow V2',
+	description:
+		'Full-cycle coding workflow with plan review, parallel code reviewers, and QA gate. ' +
+		'Supports rejection cycles at both review and QA stages.',
+	maxIterations: 5,
+	nodes: [
+		{
+			id: V2_PLANNING_STEP,
+			name: 'Planning',
+			agentId: 'planner',
+			instructions:
+				'Break down the task into an actionable implementation plan. ' +
+				'When the plan is ready, write it to the plan-pr-gate (field: plan_submitted) to notify reviewers.',
+		},
+		{
+			id: V2_PLAN_REVIEW_STEP,
+			name: 'Plan Review',
+			agentId: 'reviewer',
+			instructions:
+				'Review the implementation plan for feasibility and completeness. ' +
+				'Write to plan-approval-gate with field "approved: true" to approve, or send feedback to Planning.',
+		},
+		{
+			id: V2_CODING_STEP,
+			name: 'Coding',
+			agentId: 'coder',
+			instructions:
+				'Implement the approved plan. Open a pull request when done. ' +
+				'Write the PR URL to code-pr-gate (field: pr_url) to notify reviewers.',
+		},
+		{
+			id: V2_REVIEWER1_STEP,
+			name: 'Reviewer 1',
+			agentId: 'reviewer',
+			instructions:
+				'Review the pull request for correctness, style, and test coverage. ' +
+				'Write your vote to review-votes-gate and review-reject-gate (field: votes, key: your name, value: "approved" or "rejected").',
+		},
+		{
+			id: V2_REVIEWER2_STEP,
+			name: 'Reviewer 2',
+			agentId: 'reviewer',
+			instructions:
+				'Review the pull request for correctness, style, and test coverage. ' +
+				'Write your vote to review-votes-gate and review-reject-gate (field: votes, key: your name, value: "approved" or "rejected").',
+		},
+		{
+			id: V2_REVIEWER3_STEP,
+			name: 'Reviewer 3',
+			agentId: 'reviewer',
+			instructions:
+				'Review the pull request for correctness, style, and test coverage. ' +
+				'Write your vote to review-votes-gate and review-reject-gate (field: votes, key: your name, value: "approved" or "rejected").',
+		},
+		{
+			id: V2_QA_STEP,
+			name: 'QA',
+			agentId: 'qa',
+			instructions:
+				'Verify test coverage, run the CI pipeline, and confirm the PR is mergeable. ' +
+				'Write to qa-result-gate: "result: passed" if everything is green, or "result: failed" with details if issues are found.',
+		},
+		{
+			id: V2_DONE_STEP,
+			name: 'Done',
+			agentId: 'general',
+		},
+	],
+	startNodeId: V2_PLANNING_STEP,
+	rules: [],
+	tags: ['coding', 'v2', 'parallel-review'],
+	createdAt: 0,
+	updatedAt: 0,
+	// Gates — independent entities referenced by channels via gateId
+	gates: [
+		{
+			id: 'plan-pr-gate',
+			description: 'Planning agent has submitted a plan for review',
+			condition: { type: 'check', field: 'plan_submitted', op: 'exists' },
+			data: {},
+			allowedWriterRoles: ['planner'],
+			resetOnCycle: false,
+		},
+		{
+			id: 'plan-approval-gate',
+			description: 'Plan has been reviewed and approved by the plan reviewer',
+			condition: { type: 'check', field: 'approved', op: '==', value: true },
+			data: {},
+			allowedWriterRoles: ['reviewer'],
+			resetOnCycle: true,
+		},
+		{
+			id: 'code-pr-gate',
+			description: 'Code has been implemented and a pull request has been opened',
+			condition: { type: 'check', field: 'pr_url', op: 'exists' },
+			data: {},
+			allowedWriterRoles: ['coder'],
+			resetOnCycle: true,
+		},
+		{
+			id: 'review-votes-gate',
+			description: 'All three reviewers have approved the code changes',
+			condition: { type: 'count', field: 'votes', matchValue: 'approved', min: 3 },
+			data: {},
+			allowedWriterRoles: ['reviewer'],
+			resetOnCycle: true,
+		},
+		{
+			id: 'review-reject-gate',
+			description: 'At least one reviewer has rejected the code changes',
+			condition: { type: 'count', field: 'votes', matchValue: 'rejected', min: 1 },
+			data: {},
+			allowedWriterRoles: ['reviewer'],
+			resetOnCycle: true,
+		},
+		{
+			id: 'qa-result-gate',
+			description: 'QA verification has passed — tests, CI, and PR are green',
+			condition: { type: 'check', field: 'result', op: '==', value: 'passed' },
+			data: {},
+			allowedWriterRoles: ['qa'],
+			resetOnCycle: false,
+		},
+		{
+			id: 'qa-fail-gate',
+			description: 'QA found issues — needs another coding and review cycle',
+			condition: { type: 'check', field: 'result', op: '==', value: 'failed' },
+			data: {},
+			allowedWriterRoles: ['qa'],
+			resetOnCycle: true,
+		},
+	],
+	// Channels — simple unidirectional pipes, gated via gateId references
+	channels: [
+		// Main progression: Planning → Plan Review → Coding
+		{
+			from: 'Planning',
+			to: 'Plan Review',
+			direction: 'one-way',
+			gateId: 'plan-pr-gate',
+			label: 'Planning → Plan Review',
+		},
+		{
+			from: 'Plan Review',
+			to: 'Coding',
+			direction: 'one-way',
+			gateId: 'plan-approval-gate',
+			label: 'Plan Review → Coding',
+		},
+		// Coding → Reviewers (fan-out, shared code-pr-gate)
+		{
+			from: 'Coding',
+			to: 'Reviewer 1',
+			direction: 'one-way',
+			gateId: 'code-pr-gate',
+			label: 'Coding → Reviewer 1',
+		},
+		{
+			from: 'Coding',
+			to: 'Reviewer 2',
+			direction: 'one-way',
+			gateId: 'code-pr-gate',
+			label: 'Coding → Reviewer 2',
+		},
+		{
+			from: 'Coding',
+			to: 'Reviewer 3',
+			direction: 'one-way',
+			gateId: 'code-pr-gate',
+			label: 'Coding → Reviewer 3',
+		},
+		// Reviewers → QA (fan-in, shared review-votes-gate: all 3 must approve)
+		{
+			from: 'Reviewer 1',
+			to: 'QA',
+			direction: 'one-way',
+			gateId: 'review-votes-gate',
+			label: 'Reviewer 1 → QA',
+		},
+		{
+			from: 'Reviewer 2',
+			to: 'QA',
+			direction: 'one-way',
+			gateId: 'review-votes-gate',
+			label: 'Reviewer 2 → QA',
+		},
+		{
+			from: 'Reviewer 3',
+			to: 'QA',
+			direction: 'one-way',
+			gateId: 'review-votes-gate',
+			label: 'Reviewer 3 → QA',
+		},
+		// QA → Done (success path)
+		{
+			from: 'QA',
+			to: 'Done',
+			direction: 'one-way',
+			gateId: 'qa-result-gate',
+			label: 'QA → Done',
+		},
+		// Cyclic: QA → Coding (QA found issues)
+		{
+			from: 'QA',
+			to: 'Coding',
+			direction: 'one-way',
+			gateId: 'qa-fail-gate',
+			isCyclic: true,
+			label: 'QA → Coding (on fail)',
+		},
+		// Cyclic: Reviewer 1/2/3 → Coding (reviewer rejected changes)
+		{
+			from: 'Reviewer 1',
+			to: 'Coding',
+			direction: 'one-way',
+			gateId: 'review-reject-gate',
+			isCyclic: true,
+			label: 'Reviewer 1 → Coding (on reject)',
+		},
+		{
+			from: 'Reviewer 2',
+			to: 'Coding',
+			direction: 'one-way',
+			gateId: 'review-reject-gate',
+			isCyclic: true,
+			label: 'Reviewer 2 → Coding (on reject)',
+		},
+		{
+			from: 'Reviewer 3',
+			to: 'Coding',
+			direction: 'one-way',
+			gateId: 'review-reject-gate',
+			isCyclic: true,
+			label: 'Reviewer 3 → Coding (on reject)',
+		},
+		// Ungated feedback: Plan Review ↔ Planning, Coding → Planning
+		{
+			from: 'Plan Review',
+			to: 'Planning',
+			direction: 'one-way',
+			label: 'Plan Review → Planning (feedback)',
+		},
+		{
+			from: 'Coding',
+			to: 'Planning',
+			direction: 'one-way',
+			label: 'Coding → Planning (feedback)',
+		},
+	],
+};
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -222,7 +506,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
  * to persist them with real SpaceAgent IDs for a given space.
  */
 export function getBuiltInWorkflows(): SpaceWorkflow[] {
-	return [CODING_WORKFLOW, RESEARCH_WORKFLOW, REVIEW_ONLY_WORKFLOW];
+	return [CODING_WORKFLOW, CODING_WORKFLOW_V2, RESEARCH_WORKFLOW, REVIEW_ONLY_WORKFLOW];
 }
 
 /**
@@ -304,6 +588,7 @@ export function seedBuiltInWorkflows(
 			tags: [...template.tags],
 			maxIterations: template.maxIterations,
 			channels: template.channels ? [...template.channels] : undefined,
+			gates: template.gates ? [...template.gates] : undefined,
 		});
 	}
 }

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -19,6 +19,7 @@ import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import {
 	CODING_WORKFLOW,
+	CODING_WORKFLOW_V2,
 	RESEARCH_WORKFLOW,
 	REVIEW_ONLY_WORKFLOW,
 	getBuiltInWorkflows,
@@ -68,7 +69,7 @@ function seedAgent(
 }
 
 /** Valid builtin roles — 'leader' must NOT appear in any template step. */
-const VALID_BUILTIN_ROLES = new Set<string>(['planner', 'coder', 'general', 'reviewer']);
+const VALID_BUILTIN_ROLES = new Set<string>(['planner', 'coder', 'general', 'reviewer', 'qa']);
 
 /**
  * Returns true if any step in the workflow has 'leader' as its agentId placeholder.
@@ -249,18 +250,231 @@ describe('REVIEW_ONLY_WORKFLOW template', () => {
 	});
 });
 
+describe('CODING_WORKFLOW_V2 template', () => {
+	test('has eight nodes', () => {
+		expect(CODING_WORKFLOW_V2.nodes).toHaveLength(8);
+	});
+
+	test('node names are correct', () => {
+		expect(CODING_WORKFLOW_V2.nodes.map((n) => n.name)).toEqual([
+			'Planning',
+			'Plan Review',
+			'Coding',
+			'Reviewer 1',
+			'Reviewer 2',
+			'Reviewer 3',
+			'QA',
+			'Done',
+		]);
+	});
+
+	test('node agentId placeholders are correct', () => {
+		const nodes = CODING_WORKFLOW_V2.nodes;
+		expect(nodes[0].agentId).toBe('planner'); // Planning
+		expect(nodes[1].agentId).toBe('reviewer'); // Plan Review
+		expect(nodes[2].agentId).toBe('coder'); // Coding
+		expect(nodes[3].agentId).toBe('reviewer'); // Reviewer 1
+		expect(nodes[4].agentId).toBe('reviewer'); // Reviewer 2
+		expect(nodes[5].agentId).toBe('reviewer'); // Reviewer 3
+		expect(nodes[6].agentId).toBe('qa'); // QA
+		expect(nodes[7].agentId).toBe('general'); // Done
+	});
+
+	test('startNodeId points to the Planning (planner) node', () => {
+		const planningNode = CODING_WORKFLOW_V2.nodes.find((n) => n.name === 'Planning');
+		expect(CODING_WORKFLOW_V2.startNodeId).toBe(planningNode?.id);
+	});
+
+	test('has seven gates', () => {
+		expect(CODING_WORKFLOW_V2.gates).toHaveLength(7);
+	});
+
+	test('gate IDs are correct', () => {
+		const ids = CODING_WORKFLOW_V2.gates!.map((g) => g.id);
+		expect(ids).toContain('plan-pr-gate');
+		expect(ids).toContain('plan-approval-gate');
+		expect(ids).toContain('code-pr-gate');
+		expect(ids).toContain('review-votes-gate');
+		expect(ids).toContain('review-reject-gate');
+		expect(ids).toContain('qa-result-gate');
+		expect(ids).toContain('qa-fail-gate');
+	});
+
+	test('plan-pr-gate has check condition and planner writer role', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'plan-pr-gate')!;
+		expect(gate.condition.type).toBe('check');
+		expect((gate.condition as { field: string }).field).toBe('plan_submitted');
+		expect(gate.allowedWriterRoles).toContain('planner');
+		expect(gate.resetOnCycle).toBe(false);
+	});
+
+	test('plan-approval-gate has check==true condition and reviewer writer role', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'plan-approval-gate')!;
+		expect(gate.condition.type).toBe('check');
+		expect((gate.condition as { field: string; value: unknown }).value).toBe(true);
+		expect(gate.allowedWriterRoles).toContain('reviewer');
+		expect(gate.resetOnCycle).toBe(true);
+	});
+
+	test('code-pr-gate has check-exists condition and coder writer role', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'code-pr-gate')!;
+		expect(gate.condition.type).toBe('check');
+		expect((gate.condition as { op: string }).op).toBe('exists');
+		expect(gate.allowedWriterRoles).toContain('coder');
+		expect(gate.resetOnCycle).toBe(true);
+	});
+
+	test('review-votes-gate has count condition requiring min 3 approved', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'review-votes-gate')!;
+		expect(gate.condition.type).toBe('count');
+		const cond = gate.condition as { matchValue: unknown; min: number };
+		expect(cond.matchValue).toBe('approved');
+		expect(cond.min).toBe(3);
+		expect(gate.allowedWriterRoles).toContain('reviewer');
+		expect(gate.resetOnCycle).toBe(true);
+	});
+
+	test('review-reject-gate has count condition requiring min 1 rejected', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'review-reject-gate')!;
+		expect(gate.condition.type).toBe('count');
+		const cond = gate.condition as { matchValue: unknown; min: number };
+		expect(cond.matchValue).toBe('rejected');
+		expect(cond.min).toBe(1);
+		expect(gate.allowedWriterRoles).toContain('reviewer');
+		expect(gate.resetOnCycle).toBe(true);
+	});
+
+	test('qa-result-gate has check==passed condition and qa writer role', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'qa-result-gate')!;
+		expect(gate.condition.type).toBe('check');
+		expect((gate.condition as { value: unknown }).value).toBe('passed');
+		expect(gate.allowedWriterRoles).toContain('qa');
+		expect(gate.resetOnCycle).toBe(false);
+	});
+
+	test('qa-fail-gate has check==failed condition and qa writer role', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'qa-fail-gate')!;
+		expect(gate.condition.type).toBe('check');
+		expect((gate.condition as { value: unknown }).value).toBe('failed');
+		expect(gate.allowedWriterRoles).toContain('qa');
+		expect(gate.resetOnCycle).toBe(true);
+	});
+
+	test('has 15 channels', () => {
+		expect(CODING_WORKFLOW_V2.channels).toHaveLength(15);
+	});
+
+	test('main progression channels have correct gateIds', () => {
+		const ch = CODING_WORKFLOW_V2.channels!;
+
+		const planToReview = ch.find((c) => c.from === 'Planning' && c.to === 'Plan Review');
+		expect(planToReview?.gateId).toBe('plan-pr-gate');
+
+		const reviewToCoding = ch.find((c) => c.from === 'Plan Review' && c.to === 'Coding');
+		expect(reviewToCoding?.gateId).toBe('plan-approval-gate');
+
+		const codingToRev1 = ch.find((c) => c.from === 'Coding' && c.to === 'Reviewer 1');
+		expect(codingToRev1?.gateId).toBe('code-pr-gate');
+
+		const codingToRev2 = ch.find((c) => c.from === 'Coding' && c.to === 'Reviewer 2');
+		expect(codingToRev2?.gateId).toBe('code-pr-gate');
+
+		const codingToRev3 = ch.find((c) => c.from === 'Coding' && c.to === 'Reviewer 3');
+		expect(codingToRev3?.gateId).toBe('code-pr-gate');
+	});
+
+	test('reviewer-to-QA channels share review-votes-gate', () => {
+		const ch = CODING_WORKFLOW_V2.channels!;
+		const rev1ToQA = ch.find((c) => c.from === 'Reviewer 1' && c.to === 'QA');
+		const rev2ToQA = ch.find((c) => c.from === 'Reviewer 2' && c.to === 'QA');
+		const rev3ToQA = ch.find((c) => c.from === 'Reviewer 3' && c.to === 'QA');
+		expect(rev1ToQA?.gateId).toBe('review-votes-gate');
+		expect(rev2ToQA?.gateId).toBe('review-votes-gate');
+		expect(rev3ToQA?.gateId).toBe('review-votes-gate');
+	});
+
+	test('QA-to-Done uses qa-result-gate', () => {
+		const ch = CODING_WORKFLOW_V2.channels!.find((c) => c.from === 'QA' && c.to === 'Done');
+		expect(ch?.gateId).toBe('qa-result-gate');
+		expect(ch?.isCyclic).toBeUndefined();
+	});
+
+	test('cyclic channels are marked isCyclic', () => {
+		const ch = CODING_WORKFLOW_V2.channels!;
+
+		const qaToCoding = ch.find((c) => c.from === 'QA' && c.to === 'Coding');
+		expect(qaToCoding?.gateId).toBe('qa-fail-gate');
+		expect(qaToCoding?.isCyclic).toBe(true);
+
+		const rev1ToCoding = ch.find((c) => c.from === 'Reviewer 1' && c.to === 'Coding');
+		expect(rev1ToCoding?.gateId).toBe('review-reject-gate');
+		expect(rev1ToCoding?.isCyclic).toBe(true);
+
+		const rev2ToCoding = ch.find((c) => c.from === 'Reviewer 2' && c.to === 'Coding');
+		expect(rev2ToCoding?.gateId).toBe('review-reject-gate');
+		expect(rev2ToCoding?.isCyclic).toBe(true);
+
+		const rev3ToCoding = ch.find((c) => c.from === 'Reviewer 3' && c.to === 'Coding');
+		expect(rev3ToCoding?.gateId).toBe('review-reject-gate');
+		expect(rev3ToCoding?.isCyclic).toBe(true);
+	});
+
+	test('ungated feedback channels have no gateId', () => {
+		const ch = CODING_WORKFLOW_V2.channels!;
+		const reviewToPlanning = ch.find((c) => c.from === 'Plan Review' && c.to === 'Planning');
+		expect(reviewToPlanning).toBeDefined();
+		expect(reviewToPlanning?.gateId).toBeUndefined();
+
+		const codingToPlanning = ch.find((c) => c.from === 'Coding' && c.to === 'Planning');
+		expect(codingToPlanning).toBeDefined();
+		expect(codingToPlanning?.gateId).toBeUndefined();
+	});
+
+	test('all channels have direction one-way', () => {
+		for (const ch of CODING_WORKFLOW_V2.channels!) {
+			expect(ch.direction).toBe('one-way');
+		}
+	});
+
+	test('all channel from/to fields reference valid node names', () => {
+		const nodeNames = new Set(CODING_WORKFLOW_V2.nodes.map((n) => n.name));
+		for (const ch of CODING_WORKFLOW_V2.channels!) {
+			expect(nodeNames.has(ch.from as string)).toBe(true);
+			expect(nodeNames.has(ch.to as string)).toBe(true);
+		}
+	});
+
+	test('does not reference leader', () => {
+		expect(hasLeaderAgentId(CODING_WORKFLOW_V2)).toBe(false);
+	});
+
+	test('template id and spaceId are empty (not space-specific)', () => {
+		expect(CODING_WORKFLOW_V2.id).toBe('');
+		expect(CODING_WORKFLOW_V2.spaceId).toBe('');
+	});
+
+	test('maxIterations is set to 5', () => {
+		expect(CODING_WORKFLOW_V2.maxIterations).toBe(5);
+	});
+});
+
 // ---------------------------------------------------------------------------
 // getBuiltInWorkflows()
 // ---------------------------------------------------------------------------
 
 describe('getBuiltInWorkflows()', () => {
-	test('returns exactly three templates', () => {
-		expect(getBuiltInWorkflows()).toHaveLength(3);
+	test('returns exactly four templates', () => {
+		expect(getBuiltInWorkflows()).toHaveLength(4);
 	});
 
 	test('includes CODING_WORKFLOW', () => {
 		const names = getBuiltInWorkflows().map((w) => w.name);
 		expect(names).toContain(CODING_WORKFLOW.name);
+	});
+
+	test('includes CODING_WORKFLOW_V2', () => {
+		const names = getBuiltInWorkflows().map((w) => w.name);
+		expect(names).toContain(CODING_WORKFLOW_V2.name);
 	});
 
 	test('includes RESEARCH_WORKFLOW', () => {
@@ -306,11 +520,13 @@ describe('seedBuiltInWorkflows()', () => {
 	const GENERAL_ID = 'agent-general-uuid';
 
 	// Role resolver — mirrors what the real call site does
+	const QA_ID = 'agent-qa-uuid';
 	const roleMap: Record<string, string> = {
 		planner: PLANNER_ID,
 		coder: CODER_ID,
 		general: GENERAL_ID,
 		reviewer: 'agent-reviewer-uuid',
+		qa: QA_ID,
 	};
 	const resolveAgentId = (role: string): string | undefined => roleMap[role];
 
@@ -321,6 +537,7 @@ describe('seedBuiltInWorkflows()', () => {
 		seedAgent(db, PLANNER_ID, SPACE_ID, 'Planner', 'planner');
 		seedAgent(db, CODER_ID, SPACE_ID, 'Coder', 'coder');
 		seedAgent(db, GENERAL_ID, SPACE_ID, 'General', 'general');
+		seedAgent(db, QA_ID, SPACE_ID, 'QA', 'qa');
 
 		const repo = new SpaceWorkflowRepository(db);
 		// No agentLookup — seeder bypasses lookup by passing real IDs directly
@@ -340,16 +557,17 @@ describe('seedBuiltInWorkflows()', () => {
 		}
 	});
 
-	test('seeds all three built-in templates for an empty space', async () => {
+	test('seeds all four built-in templates for an empty space', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const workflows = manager.listWorkflows(SPACE_ID);
-		expect(workflows).toHaveLength(3);
+		expect(workflows).toHaveLength(4);
 	});
 
-	test('seeded workflow names match all three templates', async () => {
+	test('seeded workflow names match all four templates', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const names = manager.listWorkflows(SPACE_ID).map((w) => w.name);
 		expect(names).toContain(CODING_WORKFLOW.name);
+		expect(names).toContain(CODING_WORKFLOW_V2.name);
 		expect(names).toContain(RESEARCH_WORKFLOW.name);
 		expect(names).toContain(REVIEW_ONLY_WORKFLOW.name);
 	});
@@ -473,6 +691,67 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(wf!.nodes[0].agentId).toBe(CODER_ID);
 	});
 
+	test('CODING_WORKFLOW_V2 seeded correctly — eight nodes with real agent IDs', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW_V2.name);
+		expect(wf).toBeDefined();
+		expect(wf!.nodes).toHaveLength(8);
+		expect(wf!.nodes[0].agentId).toBe(PLANNER_ID); // Planning
+		expect(wf!.nodes[1].agentId).toBe(roleMap.reviewer); // Plan Review
+		expect(wf!.nodes[2].agentId).toBe(CODER_ID); // Coding
+		expect(wf!.nodes[3].agentId).toBe(roleMap.reviewer); // Reviewer 1
+		expect(wf!.nodes[4].agentId).toBe(roleMap.reviewer); // Reviewer 2
+		expect(wf!.nodes[5].agentId).toBe(roleMap.reviewer); // Reviewer 3
+		expect(wf!.nodes[6].agentId).toBe(QA_ID); // QA
+		expect(wf!.nodes[7].agentId).toBe(GENERAL_ID); // Done
+	});
+
+	test('CODING_WORKFLOW_V2 seeded with 15 channels', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW_V2.name)!;
+		expect(wf.channels).toHaveLength(15);
+	});
+
+	test('CODING_WORKFLOW_V2 seeded with 7 gates', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW_V2.name)!;
+		expect(wf.gates).toHaveLength(7);
+		const gateIds = wf.gates!.map((g) => g.id);
+		expect(gateIds).toContain('plan-pr-gate');
+		expect(gateIds).toContain('plan-approval-gate');
+		expect(gateIds).toContain('code-pr-gate');
+		expect(gateIds).toContain('review-votes-gate');
+		expect(gateIds).toContain('review-reject-gate');
+		expect(gateIds).toContain('qa-result-gate');
+		expect(gateIds).toContain('qa-fail-gate');
+	});
+
+	test('CODING_WORKFLOW_V2 seeded channels use gateId (not legacy gate)', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW_V2.name)!;
+		const gatedChannels = wf.channels!.filter((c) => c.gateId !== undefined);
+		// 13 channels have gateIds (15 total minus 2 ungated feedback channels)
+		expect(gatedChannels).toHaveLength(13);
+	});
+
+	test('CODING_WORKFLOW_V2 seeded cyclic channels are marked isCyclic', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW_V2.name)!;
+		const cyclicChannels = wf.channels!.filter((c) => c.isCyclic === true);
+		// 4 cyclic: QA→Coding, Reviewer1→Coding, Reviewer2→Coding, Reviewer3→Coding
+		expect(cyclicChannels).toHaveLength(4);
+	});
+
+	test('CODING_WORKFLOW_V2 seeded channels from/to fields are node names (not UUIDs)', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW_V2.name)!;
+		const nodeNames = new Set(wf.nodes.map((n) => n.name));
+		for (const ch of wf.channels!) {
+			expect(nodeNames.has(ch.from as string)).toBe(true);
+			expect(nodeNames.has(ch.to as string)).toBe(true);
+		}
+	});
+
 	test('all seeded workflows have the real spaceId assigned', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		for (const wf of manager.listWorkflows(SPACE_ID)) {
@@ -491,7 +770,7 @@ describe('seedBuiltInWorkflows()', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const workflows = manager.listWorkflows(SPACE_ID);
-		expect(workflows).toHaveLength(3);
+		expect(workflows).toHaveLength(4);
 	});
 
 	test('is idempotent — leaves user-created workflows untouched', async () => {
@@ -562,12 +841,14 @@ describe('Coding Workflow export/import round-trip', () => {
 	const PLANNER_ID = 'agent-planner-uuid';
 	const CODER_ID = 'agent-coder-uuid';
 	const GENERAL_ID = 'agent-general-uuid';
+	const QA_ID = 'agent-qa-uuid';
 
 	const roleMap: Record<string, string> = {
 		planner: PLANNER_ID,
 		coder: CODER_ID,
 		general: GENERAL_ID,
 		reviewer: 'agent-reviewer-uuid',
+		qa: QA_ID,
 	};
 	const resolveAgentId = (role: string): string | undefined => roleMap[role];
 
@@ -620,6 +901,7 @@ describe('Coding Workflow export/import round-trip', () => {
 		seedAgent(db, PLANNER_ID, SPACE_ID, 'Planner', 'planner');
 		seedAgent(db, CODER_ID, SPACE_ID, 'Coder', 'coder');
 		seedAgent(db, GENERAL_ID, SPACE_ID, 'General', 'general');
+		seedAgent(db, QA_ID, SPACE_ID, 'QA', 'qa');
 
 		const repo = new SpaceWorkflowRepository(db);
 		manager = new SpaceWorkflowManager(repo);

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -444,6 +444,33 @@ describe('CODING_WORKFLOW_V2 template', () => {
 		}
 	});
 
+	test('reviewer nodes instruct read-merge-write for votes (not bare write)', () => {
+		for (const name of ['Reviewer 1', 'Reviewer 2', 'Reviewer 3']) {
+			const node = CODING_WORKFLOW_V2.nodes.find((n) => n.name === name)!;
+			expect(node.instructions).toContain('read_gate');
+			expect(node.instructions).toContain('write_gate');
+			// Must warn against writing only own entry to prevent overwriting peers
+			expect(node.instructions).toContain('overwriting');
+		}
+	});
+
+	test('QA node instructions require explicit result write on every pass', () => {
+		const qa = CODING_WORKFLOW_V2.nodes.find((n) => n.name === 'QA')!;
+		expect(qa.instructions).toContain('every pass');
+		expect(qa.instructions).toMatch(/do not assume/i);
+	});
+
+	test('review-votes-gate description mentions read-merge-write requirement', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'review-votes-gate')!;
+		expect(gate.description).toContain('read-merge-write');
+	});
+
+	test('qa-result-gate description explains why resetOnCycle is false', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'qa-result-gate')!;
+		expect(gate.description).toContain('resetOnCycle');
+		expect(gate.description).toMatch(/intentionally false/i);
+	});
+
 	test('does not reference leader', () => {
 		expect(hasLeaderAgentId(CODING_WORKFLOW_V2)).toBe(false);
 	});

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -1094,9 +1094,9 @@ describe('SpaceRuntime', () => {
 				)
 			).not.toThrow();
 
-			// Three built-in workflows should exist
+			// Four built-in workflows should exist
 			const workflows = workflowManager.listWorkflows(newSpaceId);
-			expect(workflows).toHaveLength(3);
+			expect(workflows).toHaveLength(4);
 		});
 
 		test('seedBuiltInWorkflows is idempotent (calling twice is a no-op)', async () => {
@@ -1117,7 +1117,7 @@ describe('SpaceRuntime', () => {
 			seedBuiltInWorkflows(newSpaceId, workflowManager, resolver); // second call is no-op
 
 			const workflows = workflowManager.listWorkflows(newSpaceId);
-			expect(workflows).toHaveLength(3); // still 3, not 6
+			expect(workflows).toHaveLength(4); // still 4, not 8
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Adds `CODING_WORKFLOW_V2` to `built-in-workflows.ts` with 8 nodes: Planning, Plan Review, Coding, Reviewer 1/2/3, QA, Done
- 7 independent `Gate` entities with composable conditions (`check`, `count`) and `allowedWriterRoles`
- 15 `WorkflowChannel` entries using `gateId` references (M1.1 separated channel/gate model)
- Cyclic rejection paths: QA→Coding (qa-fail-gate), each Reviewer→Coding (review-reject-gate)
- 2 ungated feedback channels: Plan Review→Planning and Coding→Planning
- `seedBuiltInWorkflows` now passes `template.gates` to `createWorkflow`
- `VALID_BUILTIN_ROLES` expanded to include `'qa'`
- All 1859 daemon unit tests pass