### PR TITLE
feat(space): implement approval gate backend RPCs (M6.1)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -427,6 +427,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.spaceManager,
 		spaceWorkflowManager,
 		spaceWorkflowRunRepo,
+		gateDataRepo,
 		spaceRuntimeService,
 		spaceWorkflowRunTaskManagerFactory,
 		deps.daemonHub

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -2,23 +2,87 @@
  * Space Workflow Run RPC Handlers
  *
  * RPC handlers for SpaceWorkflowRun lifecycle:
- * - spaceWorkflowRun.start   - Creates a run and triggers first step task creation
- * - spaceWorkflowRun.list    - Lists runs for a space (optional status filter)
- * - spaceWorkflowRun.get     - Gets a run by ID
- * - spaceWorkflowRun.cancel  - Cancels a run and all pending tasks
+ * - spaceWorkflowRun.start          - Creates a run and triggers first step task creation
+ * - spaceWorkflowRun.list           - Lists runs for a space (optional status filter)
+ * - spaceWorkflowRun.get            - Gets a run by ID
+ * - spaceWorkflowRun.cancel         - Cancels a run and all pending tasks
+ * - spaceWorkflowRun.approveGate    - Approves or rejects a human approval gate
+ * - spaceWorkflowRun.getGateArtifacts - Returns changed files and diff summary for a run's worktree
+ * - spaceWorkflowRun.getFileDiff    - Returns unified diff for a specific file in the worktree
  */
 
+import { execFileSync } from 'node:child_process';
 import type { MessageHub } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import type { GateDataRepository } from '../../storage/repositories/gate-data-repository';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
 import type { WorkflowRunStatus } from '@neokai/shared';
 import { Logger } from '../logger';
 
 const log = new Logger('space-workflow-run-handlers');
+
+// ─── Git diff utilities ───────────────────────────────────────────────────────
+
+interface FileDiffStat {
+	path: string;
+	additions: number;
+	deletions: number;
+}
+
+interface DiffSummary {
+	files: FileDiffStat[];
+	totalAdditions: number;
+	totalDeletions: number;
+}
+
+/**
+ * Parse `git diff --numstat` output into structured file stats.
+ * Each line is: `<additions>\t<deletions>\t<path>`
+ * Binary files show `-\t-\t<path>` — those get 0/0 stats.
+ */
+function parseNumstat(output: string): DiffSummary {
+	const files: FileDiffStat[] = [];
+	let totalAdditions = 0;
+	let totalDeletions = 0;
+
+	for (const line of output.split('\n')) {
+		if (!line.trim()) continue;
+		const parts = line.split('\t');
+		if (parts.length < 3) continue;
+		const additions = parseInt(parts[0], 10) || 0;
+		const deletions = parseInt(parts[1], 10) || 0;
+		const path = parts.slice(2).join('\t');
+		files.push({ path, additions, deletions });
+		totalAdditions += additions;
+		totalDeletions += deletions;
+	}
+
+	return { files, totalAdditions, totalDeletions };
+}
+
+/**
+ * Get the diff base ref for a worktree.
+ * Tries `origin/dev` merge-base first; falls back to `HEAD` (uncommitted only).
+ */
+function getDiffBaseRef(worktreePath: string): string {
+	for (const candidate of ['origin/dev', 'origin/main', 'origin/master']) {
+		try {
+			const base = execFileSync('git', ['merge-base', 'HEAD', candidate], {
+				cwd: worktreePath,
+				encoding: 'utf8',
+				timeout: 5000,
+			}).trim();
+			if (base) return base;
+		} catch {
+			// candidate not available
+		}
+	}
+	return '';
+}
 
 /** Factory that creates a SpaceTaskManager bound to a specific spaceId. */
 export type SpaceWorkflowRunTaskManagerFactory = (spaceId: string) => SpaceTaskManager;
@@ -28,6 +92,7 @@ export function setupSpaceWorkflowRunHandlers(
 	spaceManager: SpaceManager,
 	spaceWorkflowManager: SpaceWorkflowManager,
 	workflowRunRepo: SpaceWorkflowRunRepository,
+	gateDataRepo: GateDataRepository,
 	spaceRuntimeService: SpaceRuntimeService,
 	taskManagerFactory: SpaceWorkflowRunTaskManagerFactory,
 	daemonHub: DaemonHub
@@ -204,5 +269,172 @@ export function setupSpaceWorkflowRunHandlers(
 			});
 
 		return { success: true };
+	});
+
+	// ─── spaceWorkflowRun.approveGate ────────────────────────────────────────
+	//
+	// Writes approval or rejection decision to gate data. Idempotent: calling
+	// approve on an already-approved gate returns the existing data unchanged.
+	// Rejection transitions the run to `needs_attention` with `humanRejected`.
+	messageHub.onRequest('spaceWorkflowRun.approveGate', async (data) => {
+		const params = data as {
+			runId: string;
+			gateId: string;
+			approved: boolean;
+			reason?: string;
+		};
+
+		if (!params.runId) throw new Error('runId is required');
+		if (!params.gateId) throw new Error('gateId is required');
+		if (params.approved === undefined || params.approved === null) {
+			throw new Error('approved is required');
+		}
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		if (run.status === 'completed' || run.status === 'cancelled') {
+			throw new Error(`Cannot modify gate on a ${run.status} workflow run`);
+		}
+
+		const existing = gateDataRepo.get(params.runId, params.gateId);
+
+		if (params.approved) {
+			// Idempotent: already approved — return existing state
+			if (existing?.data?.approved === true) {
+				return { run, gateData: existing };
+			}
+
+			const gateData = gateDataRepo.merge(params.runId, params.gateId, {
+				approved: true,
+				approvedAt: Date.now(),
+			});
+
+			daemonHub
+				.emit('space.workflowRun.updated', {
+					sessionId: 'global',
+					spaceId: run.spaceId,
+					runId: run.id,
+					run,
+				})
+				.catch((err) => {
+					log.warn('Failed to emit space.workflowRun.updated:', err);
+				});
+
+			return { run, gateData };
+		} else {
+			// Rejection — idempotent: already rejected with humanRejected
+			if (existing?.data?.approved === false && run.failureReason === 'humanRejected') {
+				return { run, gateData: existing };
+			}
+
+			const gateData = gateDataRepo.merge(params.runId, params.gateId, {
+				approved: false,
+				rejectedAt: Date.now(),
+				reason: params.reason ?? null,
+			});
+
+			const updated =
+				workflowRunRepo.updateRun(params.runId, {
+					status: 'needs_attention',
+					failureReason: 'humanRejected',
+				}) ?? run;
+
+			daemonHub
+				.emit('space.workflowRun.updated', {
+					sessionId: 'global',
+					spaceId: run.spaceId,
+					runId: run.id,
+					run: updated,
+				})
+				.catch((err) => {
+					log.warn('Failed to emit space.workflowRun.updated:', err);
+				});
+
+			return { run: updated, gateData };
+		}
+	});
+
+	// ─── spaceWorkflowRun.getGateArtifacts ───────────────────────────────────
+	//
+	// Returns the list of changed files and diff summary (additions, deletions)
+	// for the worktree associated with a workflow run. The worktree path is
+	// stored in `run.config.worktreePath` by TaskAgentManager at run start.
+	messageHub.onRequest('spaceWorkflowRun.getGateArtifacts', async (data) => {
+		const params = data as { runId: string };
+
+		if (!params.runId) throw new Error('runId is required');
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		const worktreePath = run.config?.worktreePath as string | undefined;
+		if (!worktreePath) {
+			throw new Error(`No worktree path found for run: ${params.runId}`);
+		}
+
+		const baseRef = getDiffBaseRef(worktreePath);
+		const diffArgs = baseRef
+			? ['diff', '--numstat', `${baseRef}..HEAD`]
+			: ['diff', '--numstat', 'HEAD'];
+
+		let numstatOutput = '';
+		try {
+			numstatOutput = execFileSync('git', diffArgs, {
+				cwd: worktreePath,
+				encoding: 'utf8',
+				timeout: 10000,
+			});
+		} catch (err) {
+			log.warn('git diff --numstat failed:', err);
+		}
+
+		const summary = parseNumstat(numstatOutput);
+		return { ...summary, worktreePath, baseRef: baseRef || null };
+	});
+
+	// ─── spaceWorkflowRun.getFileDiff ────────────────────────────────────────
+	//
+	// Returns the unified diff for a specific file in the run's worktree.
+	// Uses the same base ref logic as getGateArtifacts.
+	messageHub.onRequest('spaceWorkflowRun.getFileDiff', async (data) => {
+		const params = data as { runId: string; filePath: string };
+
+		if (!params.runId) throw new Error('runId is required');
+		if (!params.filePath || params.filePath.trim() === '') {
+			throw new Error('filePath is required');
+		}
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		const worktreePath = run.config?.worktreePath as string | undefined;
+		if (!worktreePath) {
+			throw new Error(`No worktree path found for run: ${params.runId}`);
+		}
+
+		const baseRef = getDiffBaseRef(worktreePath);
+		const diffRangeArgs = baseRef ? [`${baseRef}..HEAD`] : ['HEAD'];
+
+		let diff = '';
+		try {
+			diff = execFileSync('git', ['diff', ...diffRangeArgs, '--', params.filePath], {
+				cwd: worktreePath,
+				encoding: 'utf8',
+				timeout: 10000,
+			});
+		} catch (err) {
+			log.warn('git diff for file failed:', err);
+		}
+
+		// Parse per-file stats from the diff itself
+		let additions = 0;
+		let deletions = 0;
+		for (const line of diff.split('\n')) {
+			if (line.startsWith('+') && !line.startsWith('+++')) additions++;
+			else if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+		}
+
+		return { diff, additions, deletions, filePath: params.filePath };
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -324,10 +324,12 @@ export function setupSpaceWorkflowRunHandlers(
 
 			// If the run was previously rejected (needs_attention + humanRejected),
 			// approval overrides that — transition back to in_progress so the
-			// workflow executor picks it up again on the next tick.
+			// workflow executor picks it up again on the next tick, and clear
+			// the stale failureReason so the run appears clean to the UI.
 			let updatedRun = run;
 			if (run.status === 'needs_attention' && run.failureReason === 'humanRejected') {
-				updatedRun = workflowRunRepo.transitionStatus(params.runId, 'in_progress');
+				workflowRunRepo.transitionStatus(params.runId, 'in_progress');
+				updatedRun = workflowRunRepo.updateRun(params.runId, { failureReason: null }) ?? run;
 			}
 
 			daemonHub
@@ -354,14 +356,15 @@ export function setupSpaceWorkflowRunHandlers(
 				reason: params.reason ?? null,
 			});
 
-			// At this point run.status is either 'in_progress' or 'needs_attention'
-			// (completed, cancelled, and pending are all guarded above).
-			// Both transitions to 'needs_attention' are valid — write atomically.
+			// Enforce the state machine: only call transitionStatus when the run is
+			// not already in needs_attention (e.g. blocked by a different mechanism).
+			// In either case, write failureReason via a separate updateRun so it
+			// is always persisted regardless of whether the status changed.
+			if (run.status !== 'needs_attention') {
+				workflowRunRepo.transitionStatus(params.runId, 'needs_attention');
+			}
 			const updated =
-				workflowRunRepo.updateRun(params.runId, {
-					status: 'needs_attention',
-					failureReason: 'humanRejected',
-				}) ?? run;
+				workflowRunRepo.updateRun(params.runId, { failureReason: 'humanRejected' }) ?? run;
 
 			daemonHub
 				.emit('space.workflowRun.updated', {

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -11,7 +11,8 @@
  * - spaceWorkflowRun.getFileDiff    - Returns unified diff for a specific file in the worktree
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { isAbsolute } from 'node:path';
 import type { MessageHub } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
@@ -65,18 +66,27 @@ function parseNumstat(output: string): DiffSummary {
 }
 
 /**
- * Get the diff base ref for a worktree.
- * Tries `origin/dev` merge-base first; falls back to `HEAD` (uncommitted only).
+ * Async wrapper around `execFile('git', ...)`.
+ * Non-blocking — does not stall the event loop during git I/O.
  */
-function getDiffBaseRef(worktreePath: string): string {
+function execGit(args: string[], cwd: string, timeout = 10000): Promise<string> {
+	return new Promise((resolve, reject) => {
+		execFile('git', args, { cwd, encoding: 'utf8', timeout }, (err, stdout) => {
+			if (err) reject(err);
+			else resolve(stdout as string);
+		});
+	});
+}
+
+/**
+ * Get the diff base ref for a worktree.
+ * Tries `origin/dev` merge-base first; falls back to empty string (uncommitted only).
+ */
+async function getDiffBaseRef(worktreePath: string): Promise<string> {
 	for (const candidate of ['origin/dev', 'origin/main', 'origin/master']) {
 		try {
-			const base = execFileSync('git', ['merge-base', 'HEAD', candidate], {
-				cwd: worktreePath,
-				encoding: 'utf8',
-				timeout: 5000,
-			}).trim();
-			if (base) return base;
+			const base = await execGit(['merge-base', 'HEAD', candidate], worktreePath, 5000);
+			if (base.trim()) return base.trim();
 		} catch {
 			// candidate not available
 		}
@@ -275,7 +285,9 @@ export function setupSpaceWorkflowRunHandlers(
 	//
 	// Writes approval or rejection decision to gate data. Idempotent: calling
 	// approve on an already-approved gate returns the existing data unchanged.
-	// Rejection transitions the run to `needs_attention` with `humanRejected`.
+	// Rejection transitions the run to `needs_attention` with `humanRejected`
+	// via the status machine. Approval after a prior rejection also transitions
+	// the run back to `in_progress` so the workflow resumes.
 	messageHub.onRequest('spaceWorkflowRun.approveGate', async (data) => {
 		const params = data as {
 			runId: string;
@@ -293,7 +305,7 @@ export function setupSpaceWorkflowRunHandlers(
 		const run = workflowRunRepo.getRun(params.runId);
 		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
 
-		if (run.status === 'completed' || run.status === 'cancelled') {
+		if (run.status === 'completed' || run.status === 'cancelled' || run.status === 'pending') {
 			throw new Error(`Cannot modify gate on a ${run.status} workflow run`);
 		}
 
@@ -310,21 +322,29 @@ export function setupSpaceWorkflowRunHandlers(
 				approvedAt: Date.now(),
 			});
 
+			// If the run was previously rejected (needs_attention + humanRejected),
+			// approval overrides that — transition back to in_progress so the
+			// workflow executor picks it up again on the next tick.
+			let updatedRun = run;
+			if (run.status === 'needs_attention' && run.failureReason === 'humanRejected') {
+				updatedRun = workflowRunRepo.transitionStatus(params.runId, 'in_progress');
+			}
+
 			daemonHub
 				.emit('space.workflowRun.updated', {
 					sessionId: 'global',
 					spaceId: run.spaceId,
 					runId: run.id,
-					run,
+					run: updatedRun,
 				})
 				.catch((err) => {
 					log.warn('Failed to emit space.workflowRun.updated:', err);
 				});
 
-			return { run, gateData };
+			return { run: updatedRun, gateData };
 		} else {
-			// Rejection — idempotent: already rejected with humanRejected
-			if (existing?.data?.approved === false && run.failureReason === 'humanRejected') {
+			// Rejection — idempotent: gate data already shows rejected
+			if (existing?.data?.approved === false) {
 				return { run, gateData: existing };
 			}
 
@@ -334,6 +354,9 @@ export function setupSpaceWorkflowRunHandlers(
 				reason: params.reason ?? null,
 			});
 
+			// At this point run.status is either 'in_progress' or 'needs_attention'
+			// (completed, cancelled, and pending are all guarded above).
+			// Both transitions to 'needs_attention' are valid — write atomically.
 			const updated =
 				workflowRunRepo.updateRun(params.runId, {
 					status: 'needs_attention',
@@ -373,18 +396,14 @@ export function setupSpaceWorkflowRunHandlers(
 			throw new Error(`No worktree path found for run: ${params.runId}`);
 		}
 
-		const baseRef = getDiffBaseRef(worktreePath);
+		const baseRef = await getDiffBaseRef(worktreePath);
 		const diffArgs = baseRef
 			? ['diff', '--numstat', `${baseRef}..HEAD`]
 			: ['diff', '--numstat', 'HEAD'];
 
 		let numstatOutput = '';
 		try {
-			numstatOutput = execFileSync('git', diffArgs, {
-				cwd: worktreePath,
-				encoding: 'utf8',
-				timeout: 10000,
-			});
+			numstatOutput = await execGit(diffArgs, worktreePath);
 		} catch (err) {
 			log.warn('git diff --numstat failed:', err);
 		}
@@ -404,6 +423,9 @@ export function setupSpaceWorkflowRunHandlers(
 		if (!params.filePath || params.filePath.trim() === '') {
 			throw new Error('filePath is required');
 		}
+		if (params.filePath.includes('..') || isAbsolute(params.filePath)) {
+			throw new Error('filePath must be a relative path within the worktree');
+		}
 
 		const run = workflowRunRepo.getRun(params.runId);
 		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
@@ -413,16 +435,12 @@ export function setupSpaceWorkflowRunHandlers(
 			throw new Error(`No worktree path found for run: ${params.runId}`);
 		}
 
-		const baseRef = getDiffBaseRef(worktreePath);
+		const baseRef = await getDiffBaseRef(worktreePath);
 		const diffRangeArgs = baseRef ? [`${baseRef}..HEAD`] : ['HEAD'];
 
 		let diff = '';
 		try {
-			diff = execFileSync('git', ['diff', ...diffRangeArgs, '--', params.filePath], {
-				cwd: worktreePath,
-				encoding: 'utf8',
-				timeout: 10000,
-			});
+			diff = await execGit(['diff', ...diffRangeArgs, '--', params.filePath], worktreePath);
 		} catch (err) {
 			log.warn('git diff for file failed:', err);
 		}

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -28,11 +28,26 @@ import type {
 import type { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
 
-// ─── Mock module for execFileSync ─────────────────────────────────────────────
+// ─── Mock module for execFile (async) ─────────────────────────────────────────
+//
+// Production code uses execFile (callback-based) wrapped in a Promise.
+// We mock node:child_process so git calls never touch the filesystem.
+// mockExecResult is set per-test; by default returns empty string.
 
-// We mock child_process so git calls don't touch the filesystem
-const mockExecFileSync = mock((_cmd: string, _args: string[], _opts: unknown): string => '');
-mock.module('node:child_process', () => ({ execFileSync: mockExecFileSync }));
+type ExecFileCallback = (err: Error | null, stdout: string, stderr: string) => void;
+let mockExecResult: (args: string[]) => string = () => '';
+
+const mockExecFile = mock(
+	(_cmd: string, args: string[], _opts: unknown, callback: ExecFileCallback) => {
+		try {
+			callback(null, mockExecResult(args), '');
+		} catch (err) {
+			callback(err as Error, '', '');
+		}
+	}
+);
+
+mock.module('node:child_process', () => ({ execFile: mockExecFile }));
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
 
@@ -195,7 +210,8 @@ describe('space-workflow-run gate handlers', () => {
 	function setup(
 		opts: { run?: SpaceWorkflowRun | null; existingGateData?: GateDataRecord | null } = {}
 	) {
-		mockExecFileSync.mockReset();
+		mockExecResult = () => '';
+		mockExecFile.mockClear();
 
 		const mh = createMockMessageHub();
 		hub = mh.hub;
@@ -273,6 +289,13 @@ describe('space-workflow-run gate handlers', () => {
 			).rejects.toThrow('Cannot modify gate on a cancelled workflow run');
 		});
 
+		it('throws if run is pending (invalid transition)', async () => {
+			setup({ run: { ...mockRun, status: 'pending' } });
+			await expect(
+				call('spaceWorkflowRun.approveGate', { runId: 'run-1', gateId: 'g', approved: false })
+			).rejects.toThrow('Cannot modify gate on a pending workflow run');
+		});
+
 		it('approves gate: merges { approved: true } and emits event', async () => {
 			const result = (await call('spaceWorkflowRun.approveGate', {
 				runId: 'run-1',
@@ -304,7 +327,7 @@ describe('space-workflow-run gate handlers', () => {
 			expect(result.gateData.data.approved).toBe(true);
 		});
 
-		it('rejection: merges { approved: false } and transitions run to needs_attention', async () => {
+		it('rejection: merges { approved: false } and sets run to needs_attention + humanRejected', async () => {
 			const result = (await call('spaceWorkflowRun.approveGate', {
 				runId: 'run-1',
 				gateId: 'gate-approval',
@@ -317,6 +340,8 @@ describe('space-workflow-run gate handlers', () => {
 				rejectedAt: expect.any(Number),
 				reason: 'Not ready',
 			});
+			// Status and failureReason set atomically via updateRun
+			// (pending is guarded above, so transition is always valid)
 			expect(runRepo.updateRun).toHaveBeenCalledWith('run-1', {
 				status: 'needs_attention',
 				failureReason: 'humanRejected',
@@ -339,7 +364,7 @@ describe('space-workflow-run gate handlers', () => {
 			});
 		});
 
-		it('rejection is idempotent: returns existing state if already rejected + needs_attention', async () => {
+		it('rejection is idempotent: returns existing state if gate data already shows rejected', async () => {
 			const alreadyRejectedRun: SpaceWorkflowRun = {
 				...mockRun,
 				status: 'needs_attention',
@@ -356,9 +381,34 @@ describe('space-workflow-run gate handlers', () => {
 				approved: false,
 			})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
 
+			// Idempotent: no writes at all
 			expect(gateDataRepo.merge).not.toHaveBeenCalled();
 			expect(runRepo.updateRun).not.toHaveBeenCalled();
 			expect(result.gateData.data.approved).toBe(false);
+		});
+
+		it('approve after prior rejection: transitions run back to in_progress', async () => {
+			const rejectedRun: SpaceWorkflowRun = {
+				...mockRun,
+				status: 'needs_attention',
+				failureReason: 'humanRejected',
+			};
+			setup({ run: rejectedRun });
+
+			const result = (await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: true,
+			})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
+
+			expect(gateDataRepo.merge).toHaveBeenCalledWith('run-1', 'gate-approval', {
+				approved: true,
+				approvedAt: expect.any(Number),
+			});
+			// Must transition run back to in_progress
+			expect(runRepo.transitionStatus).toHaveBeenCalledWith('run-1', 'in_progress');
+			expect(result.run.status).toBe('in_progress');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflowRun.updated', expect.any(Object));
 		});
 
 		it('gate approval persists to gateDataRepo (survives restart)', async () => {
@@ -404,13 +454,11 @@ describe('space-workflow-run gate handlers', () => {
 
 		it('returns file stats from git diff --numstat', async () => {
 			// merge-base call returns a base SHA, numstat returns file changes
-			mockExecFileSync.mockImplementation(
-				(_cmd: string, args: string[], _opts: unknown): string => {
-					if (args.includes('merge-base')) return 'abc123\n';
-					if (args.includes('--numstat')) return '5\t3\tsrc/foo.ts\n2\t0\tsrc/bar.ts\n';
-					return '';
-				}
-			);
+			mockExecResult = (args) => {
+				if (args.includes('merge-base')) return 'abc123\n';
+				if (args.includes('--numstat')) return '5\t3\tsrc/foo.ts\n2\t0\tsrc/bar.ts\n';
+				return '';
+			};
 
 			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
 				runId: 'run-1',
@@ -432,13 +480,11 @@ describe('space-workflow-run gate handlers', () => {
 		});
 
 		it('falls back to uncommitted diff when merge-base fails', async () => {
-			mockExecFileSync.mockImplementation(
-				(_cmd: string, args: string[], _opts: unknown): string => {
-					if (args.includes('merge-base')) throw new Error('not found');
-					if (args.includes('--numstat')) return '10\t2\tsrc/main.ts\n';
-					return '';
-				}
-			);
+			mockExecResult = (args) => {
+				if (args.includes('merge-base')) throw new Error('not found');
+				if (args.includes('--numstat')) return '10\t2\tsrc/main.ts\n';
+				return '';
+			};
 
 			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
 				runId: 'run-1',
@@ -450,8 +496,7 @@ describe('space-workflow-run gate handlers', () => {
 		});
 
 		it('returns empty file list when no changes', async () => {
-			mockExecFileSync.mockImplementation(() => '');
-
+			// mockExecResult already returns '' by default after setup()
 			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
 				runId: 'run-1',
 			})) as { files: Array<unknown>; totalAdditions: number; totalDeletions: number };
@@ -462,13 +507,11 @@ describe('space-workflow-run gate handlers', () => {
 		});
 
 		it('handles binary files (- entries in numstat)', async () => {
-			mockExecFileSync.mockImplementation(
-				(_cmd: string, args: string[], _opts: unknown): string => {
-					if (args.includes('merge-base')) return 'abc123\n';
-					if (args.includes('--numstat')) return '-\t-\tassets/image.png\n3\t1\tsrc/foo.ts\n';
-					return '';
-				}
-			);
+			mockExecResult = (args) => {
+				if (args.includes('merge-base')) return 'abc123\n';
+				if (args.includes('--numstat')) return '-\t-\tassets/image.png\n3\t1\tsrc/foo.ts\n';
+				return '';
+			};
 
 			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
 				runId: 'run-1',
@@ -505,6 +548,24 @@ describe('space-workflow-run gate handlers', () => {
 			).rejects.toThrow('filePath is required');
 		});
 
+		it('throws if filePath contains path traversal (..)', async () => {
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', {
+					runId: 'run-1',
+					filePath: '../../etc/passwd',
+				})
+			).rejects.toThrow('filePath must be a relative path within the worktree');
+		});
+
+		it('throws if filePath is absolute', async () => {
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', {
+					runId: 'run-1',
+					filePath: '/etc/passwd',
+				})
+			).rejects.toThrow('filePath must be a relative path within the worktree');
+		});
+
 		it('throws if run not found', async () => {
 			setup({ run: null });
 			await expect(
@@ -531,12 +592,10 @@ describe('space-workflow-run gate handlers', () => {
 				'-// old comment',
 			].join('\n');
 
-			mockExecFileSync.mockImplementation(
-				(_cmd: string, args: string[], _opts: unknown): string => {
-					if (args.includes('merge-base')) return 'abc123\n';
-					return unifiedDiff;
-				}
-			);
+			mockExecResult = (args) => {
+				if (args.includes('merge-base')) return 'abc123\n';
+				return unifiedDiff;
+			};
 
 			const result = (await call('spaceWorkflowRun.getFileDiff', {
 				runId: 'run-1',
@@ -550,8 +609,7 @@ describe('space-workflow-run gate handlers', () => {
 		});
 
 		it('returns empty diff when file has no changes', async () => {
-			mockExecFileSync.mockImplementation(() => '');
-
+			// mockExecResult already returns '' by default
 			const result = (await call('spaceWorkflowRun.getFileDiff', {
 				runId: 'run-1',
 				filePath: 'src/unchanged.ts',
@@ -563,22 +621,20 @@ describe('space-workflow-run gate handlers', () => {
 		});
 
 		it('passes correct git args with baseRef', async () => {
-			mockExecFileSync.mockImplementation(
-				(_cmd: string, args: string[], _opts: unknown): string => {
-					if (args.includes('merge-base')) return 'deadbeef\n';
-					return '+added line\n-removed line\n';
-				}
-			);
+			mockExecResult = (args) => {
+				if (args.includes('merge-base')) return 'deadbeef\n';
+				return '+added line\n-removed line\n';
+			};
 
 			await call('spaceWorkflowRun.getFileDiff', {
 				runId: 'run-1',
 				filePath: 'src/foo.ts',
 			});
 
-			// Second call should be the diff call with baseRef..HEAD
-			const calls = (mockExecFileSync as ReturnType<typeof mock>).mock.calls;
+			// Find the diff call (has 'diff' and '--' separator in args)
+			const calls = mockExecFile.mock.calls;
 			const diffCall = calls.find(
-				(c: string[][]) => c[1]?.includes('diff') && c[1]?.includes('--')
+				(c: unknown[]) => Array.isArray(c[1]) && c[1].includes('diff') && c[1].includes('--')
 			);
 			expect(diffCall).toBeDefined();
 			expect(diffCall![1]).toContain('deadbeef..HEAD');
@@ -586,26 +642,25 @@ describe('space-workflow-run gate handlers', () => {
 		});
 
 		it('falls back to uncommitted diff range when merge-base fails', async () => {
-			mockExecFileSync.mockImplementation(
-				(_cmd: string, args: string[], _opts: unknown): string => {
-					if (args.includes('merge-base')) throw new Error('no remote');
-					return '+new line\n';
-				}
-			);
+			mockExecResult = (args) => {
+				if (args.includes('merge-base')) throw new Error('no remote');
+				return '+new line\n';
+			};
 
 			await call('spaceWorkflowRun.getFileDiff', {
 				runId: 'run-1',
 				filePath: 'src/foo.ts',
 			});
 
-			const calls = (mockExecFileSync as ReturnType<typeof mock>).mock.calls;
+			const calls = mockExecFile.mock.calls;
 			const diffCall = calls.find(
-				(c: string[][]) => c[1]?.includes('diff') && c[1]?.includes('--')
+				(c: unknown[]) => Array.isArray(c[1]) && c[1].includes('diff') && c[1].includes('--')
 			);
 			expect(diffCall).toBeDefined();
 			// Should use HEAD (not baseRef..HEAD) when merge-base unavailable
-			expect(diffCall![1]).toContain('HEAD');
-			expect(diffCall![1]).not.toContain('..');
+			const diffArgs = diffCall![1] as string[];
+			expect(diffArgs).toContain('HEAD');
+			expect(diffArgs.some((a) => a.includes('..'))).toBe(false);
 		});
 
 		it('correctly counts additions and deletions, ignoring diff header lines', async () => {
@@ -618,7 +673,7 @@ describe('space-workflow-run gate handlers', () => {
 				' unchanged line',
 			].join('\n');
 
-			mockExecFileSync.mockImplementation(() => unifiedDiff);
+			mockExecResult = () => unifiedDiff;
 
 			const result = (await call('spaceWorkflowRun.getFileDiff', {
 				runId: 'run-1',

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -1,0 +1,632 @@
+/**
+ * Tests for Space Workflow Run Gate RPC Handlers
+ *
+ * Covers:
+ * - spaceWorkflowRun.approveGate: approve (idempotent), reject (sets needs_attention + humanRejected),
+ *   terminal state guard, missing params, event emission
+ * - spaceWorkflowRun.getGateArtifacts: missing params, missing run, missing worktree path,
+ *   successful artifacts retrieval with mocked git
+ * - spaceWorkflowRun.getFileDiff: missing params, missing run, missing worktree path,
+ *   successful diff retrieval with mocked git
+ * - Persistence: gate data written to gateDataRepo (survives daemon restart via SQLite)
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { Space, SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
+import {
+	setupSpaceWorkflowRunHandlers,
+	type SpaceWorkflowRunTaskManagerFactory,
+} from '../../../src/lib/rpc-handlers/space-workflow-run-handlers.ts';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import type {
+	GateDataRepository,
+	GateDataRecord,
+} from '../../../src/storage/repositories/gate-data-repository.ts';
+import type { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
+import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
+
+// ─── Mock module for execFileSync ─────────────────────────────────────────────
+
+// We mock child_process so git calls don't touch the filesystem
+const mockExecFileSync = mock((_cmd: string, _args: string[], _opts: unknown): string => '');
+mock.module('node:child_process', () => ({ execFileSync: mockExecFileSync }));
+
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockSpace: Space = {
+	id: 'space-1',
+	slug: 'test-space',
+	workspacePath: '/tmp/test-workspace',
+	name: 'Test Space',
+	description: '',
+	backgroundContext: '',
+	instructions: '',
+	sessionIds: [],
+	status: 'active',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockWorkflow: SpaceWorkflow = {
+	id: 'workflow-1',
+	spaceId: 'space-1',
+	name: 'Test Workflow',
+	nodes: [{ id: 'step-1', name: 'Step One', agentId: 'agent-1' }],
+	transitions: [],
+	startNodeId: 'step-1',
+	rules: [],
+	tags: [],
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockRun: SpaceWorkflowRun = {
+	id: 'run-1',
+	spaceId: 'space-1',
+	workflowId: 'workflow-1',
+	title: 'Test Run',
+	status: 'in_progress',
+	config: { worktreePath: '/tmp/worktrees/task-1' },
+	iterationCount: 0,
+	maxIterations: 5,
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockGateData: GateDataRecord = {
+	runId: 'run-1',
+	gateId: 'gate-approval',
+	data: {},
+	updatedAt: NOW,
+};
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {
+		emit: mock(async () => {}),
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+}
+
+function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
+	return {
+		getSpace: mock(async () => space),
+	} as unknown as SpaceManager;
+}
+
+function createMockWorkflowManager(): SpaceWorkflowManager {
+	return {
+		listWorkflows: mock(() => [mockWorkflow]),
+		getWorkflow: mock(() => mockWorkflow),
+	} as unknown as SpaceWorkflowManager;
+}
+
+function createMockRunRepo(
+	run: SpaceWorkflowRun | null = mockRun,
+	updatedRun?: SpaceWorkflowRun
+): SpaceWorkflowRunRepository {
+	return {
+		getRun: mock(() => run),
+		listBySpace: mock(() => (run ? [run] : [])),
+		transitionStatus: mock((id: string, status: string) =>
+			run ? { ...run, id, status: status as SpaceWorkflowRun['status'] } : null
+		),
+		updateRun: mock((id: string, params: Partial<SpaceWorkflowRun>) =>
+			run ? { ...run, id, ...params } : null
+		),
+		...(updatedRun ? { getRun: mock(() => updatedRun) } : {}),
+	} as unknown as SpaceWorkflowRunRepository;
+}
+
+function createMockGateDataRepo(existing: GateDataRecord | null = null): GateDataRepository {
+	return {
+		get: mock(() => existing),
+		merge: mock((_runId: string, _gateId: string, partial: Record<string, unknown>) => ({
+			...mockGateData,
+			data: { ...(existing?.data ?? {}), ...partial },
+			updatedAt: Date.now(),
+		})),
+		set: mock((_runId: string, _gateId: string, data: Record<string, unknown>) => ({
+			...mockGateData,
+			data,
+			updatedAt: Date.now(),
+		})),
+	} as unknown as GateDataRepository;
+}
+
+function createMockRuntimeService(): SpaceRuntimeService {
+	return {
+		createOrGetRuntime: mock(async () => ({
+			startWorkflowRun: mock(async () => ({ run: mockRun, tasks: [] })),
+		})),
+		start: mock(() => {}),
+		stop: mock(() => {}),
+	} as unknown as SpaceRuntimeService;
+}
+
+// ─── Test Setup ───────────────────────────────────────────────────────────────
+
+describe('space-workflow-run gate handlers', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+	let runRepo: SpaceWorkflowRunRepository;
+	let gateDataRepo: GateDataRepository;
+	let taskManagerFactory: SpaceWorkflowRunTaskManagerFactory;
+
+	function setup(
+		opts: { run?: SpaceWorkflowRun | null; existingGateData?: GateDataRecord | null } = {}
+	) {
+		mockExecFileSync.mockReset();
+
+		const mh = createMockMessageHub();
+		hub = mh.hub;
+		handlers = mh.handlers;
+		daemonHub = createMockDaemonHub();
+		const resolvedRun = 'run' in opts ? opts.run : mockRun;
+		runRepo = createMockRunRepo(resolvedRun ?? null);
+		gateDataRepo = createMockGateDataRepo(
+			'existingGateData' in opts ? opts.existingGateData : null
+		);
+		taskManagerFactory = mock(() => ({
+			listTasksByWorkflowRun: mock(async () => []),
+			cancelTask: mock(async () => {}),
+		})) as unknown as SpaceWorkflowRunTaskManagerFactory;
+
+		setupSpaceWorkflowRunHandlers(
+			hub,
+			createMockSpaceManager(),
+			createMockWorkflowManager(),
+			runRepo,
+			gateDataRepo,
+			createMockRuntimeService(),
+			taskManagerFactory,
+			daemonHub
+		);
+	}
+
+	const call = (method: string, data: unknown) => {
+		const handler = handlers.get(method);
+		if (!handler) throw new Error(`No handler registered for ${method}`);
+		return handler(data);
+	};
+
+	beforeEach(() => setup());
+
+	// ─── spaceWorkflowRun.approveGate ─────────────────────────────────────
+
+	describe('spaceWorkflowRun.approveGate', () => {
+		it('throws if runId is missing', async () => {
+			await expect(
+				call('spaceWorkflowRun.approveGate', { gateId: 'gate-1', approved: true })
+			).rejects.toThrow('runId is required');
+		});
+
+		it('throws if gateId is missing', async () => {
+			await expect(
+				call('spaceWorkflowRun.approveGate', { runId: 'run-1', approved: true })
+			).rejects.toThrow('gateId is required');
+		});
+
+		it('throws if approved is missing', async () => {
+			await expect(
+				call('spaceWorkflowRun.approveGate', { runId: 'run-1', gateId: 'gate-1' })
+			).rejects.toThrow('approved is required');
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(
+				call('spaceWorkflowRun.approveGate', { runId: 'missing', gateId: 'g', approved: true })
+			).rejects.toThrow('WorkflowRun not found: missing');
+		});
+
+		it('throws if run is completed', async () => {
+			setup({ run: { ...mockRun, status: 'completed' } });
+			await expect(
+				call('spaceWorkflowRun.approveGate', { runId: 'run-1', gateId: 'g', approved: true })
+			).rejects.toThrow('Cannot modify gate on a completed workflow run');
+		});
+
+		it('throws if run is cancelled', async () => {
+			setup({ run: { ...mockRun, status: 'cancelled' } });
+			await expect(
+				call('spaceWorkflowRun.approveGate', { runId: 'run-1', gateId: 'g', approved: true })
+			).rejects.toThrow('Cannot modify gate on a cancelled workflow run');
+		});
+
+		it('approves gate: merges { approved: true } and emits event', async () => {
+			const result = (await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: true,
+			})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
+
+			expect(gateDataRepo.merge).toHaveBeenCalledWith('run-1', 'gate-approval', {
+				approved: true,
+				approvedAt: expect.any(Number),
+			});
+			expect(result.gateData.data.approved).toBe(true);
+			expect(daemonHub.emit).toHaveBeenCalledWith(
+				'space.workflowRun.updated',
+				expect.objectContaining({ runId: 'run-1', spaceId: 'space-1' })
+			);
+		});
+
+		it('approve is idempotent: returns existing data if already approved', async () => {
+			setup({ existingGateData: { ...mockGateData, data: { approved: true, approvedAt: NOW } } });
+			const result = (await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: true,
+			})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
+
+			// Should NOT call merge again for idempotent approval
+			expect(gateDataRepo.merge).not.toHaveBeenCalled();
+			expect(result.gateData.data.approved).toBe(true);
+		});
+
+		it('rejection: merges { approved: false } and transitions run to needs_attention', async () => {
+			const result = (await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: false,
+				reason: 'Not ready',
+			})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
+
+			expect(gateDataRepo.merge).toHaveBeenCalledWith('run-1', 'gate-approval', {
+				approved: false,
+				rejectedAt: expect.any(Number),
+				reason: 'Not ready',
+			});
+			expect(runRepo.updateRun).toHaveBeenCalledWith('run-1', {
+				status: 'needs_attention',
+				failureReason: 'humanRejected',
+			});
+			expect(result.run.status).toBe('needs_attention');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflowRun.updated', expect.any(Object));
+		});
+
+		it('rejection with no reason stores null reason', async () => {
+			await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: false,
+			});
+
+			expect(gateDataRepo.merge).toHaveBeenCalledWith('run-1', 'gate-approval', {
+				approved: false,
+				rejectedAt: expect.any(Number),
+				reason: null,
+			});
+		});
+
+		it('rejection is idempotent: returns existing state if already rejected + needs_attention', async () => {
+			const alreadyRejectedRun: SpaceWorkflowRun = {
+				...mockRun,
+				status: 'needs_attention',
+				failureReason: 'humanRejected',
+			};
+			setup({
+				run: alreadyRejectedRun,
+				existingGateData: { ...mockGateData, data: { approved: false, rejectedAt: NOW } },
+			});
+
+			const result = (await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: false,
+			})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
+
+			expect(gateDataRepo.merge).not.toHaveBeenCalled();
+			expect(runRepo.updateRun).not.toHaveBeenCalled();
+			expect(result.gateData.data.approved).toBe(false);
+		});
+
+		it('gate approval persists to gateDataRepo (survives restart)', async () => {
+			// Verify merge is called — data is stored in SQLite gate_data table
+			await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: true,
+			});
+			expect(gateDataRepo.merge).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// ─── spaceWorkflowRun.getGateArtifacts ────────────────────────────────
+
+	describe('spaceWorkflowRun.getGateArtifacts', () => {
+		it('throws if runId is missing', async () => {
+			await expect(call('spaceWorkflowRun.getGateArtifacts', {})).rejects.toThrow(
+				'runId is required'
+			);
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(call('spaceWorkflowRun.getGateArtifacts', { runId: 'missing' })).rejects.toThrow(
+				'WorkflowRun not found: missing'
+			);
+		});
+
+		it('throws if run has no worktree path in config', async () => {
+			setup({ run: { ...mockRun, config: {} } });
+			await expect(call('spaceWorkflowRun.getGateArtifacts', { runId: 'run-1' })).rejects.toThrow(
+				'No worktree path found for run: run-1'
+			);
+		});
+
+		it('throws if run has no config at all', async () => {
+			setup({ run: { ...mockRun, config: undefined } });
+			await expect(call('spaceWorkflowRun.getGateArtifacts', { runId: 'run-1' })).rejects.toThrow(
+				'No worktree path found for run: run-1'
+			);
+		});
+
+		it('returns file stats from git diff --numstat', async () => {
+			// merge-base call returns a base SHA, numstat returns file changes
+			mockExecFileSync.mockImplementation(
+				(_cmd: string, args: string[], _opts: unknown): string => {
+					if (args.includes('merge-base')) return 'abc123\n';
+					if (args.includes('--numstat')) return '5\t3\tsrc/foo.ts\n2\t0\tsrc/bar.ts\n';
+					return '';
+				}
+			);
+
+			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
+				runId: 'run-1',
+			})) as {
+				files: Array<{ path: string; additions: number; deletions: number }>;
+				totalAdditions: number;
+				totalDeletions: number;
+				worktreePath: string;
+				baseRef: string | null;
+			};
+
+			expect(result.files).toHaveLength(2);
+			expect(result.files[0]).toEqual({ path: 'src/foo.ts', additions: 5, deletions: 3 });
+			expect(result.files[1]).toEqual({ path: 'src/bar.ts', additions: 2, deletions: 0 });
+			expect(result.totalAdditions).toBe(7);
+			expect(result.totalDeletions).toBe(3);
+			expect(result.worktreePath).toBe('/tmp/worktrees/task-1');
+			expect(result.baseRef).toBe('abc123');
+		});
+
+		it('falls back to uncommitted diff when merge-base fails', async () => {
+			mockExecFileSync.mockImplementation(
+				(_cmd: string, args: string[], _opts: unknown): string => {
+					if (args.includes('merge-base')) throw new Error('not found');
+					if (args.includes('--numstat')) return '10\t2\tsrc/main.ts\n';
+					return '';
+				}
+			);
+
+			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
+				runId: 'run-1',
+			})) as { files: Array<{ path: string }>; baseRef: string | null };
+
+			expect(result.files).toHaveLength(1);
+			expect(result.files[0].path).toBe('src/main.ts');
+			expect(result.baseRef).toBeNull();
+		});
+
+		it('returns empty file list when no changes', async () => {
+			mockExecFileSync.mockImplementation(() => '');
+
+			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
+				runId: 'run-1',
+			})) as { files: Array<unknown>; totalAdditions: number; totalDeletions: number };
+
+			expect(result.files).toHaveLength(0);
+			expect(result.totalAdditions).toBe(0);
+			expect(result.totalDeletions).toBe(0);
+		});
+
+		it('handles binary files (- entries in numstat)', async () => {
+			mockExecFileSync.mockImplementation(
+				(_cmd: string, args: string[], _opts: unknown): string => {
+					if (args.includes('merge-base')) return 'abc123\n';
+					if (args.includes('--numstat')) return '-\t-\tassets/image.png\n3\t1\tsrc/foo.ts\n';
+					return '';
+				}
+			);
+
+			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
+				runId: 'run-1',
+			})) as {
+				files: Array<{ path: string; additions: number; deletions: number }>;
+				totalAdditions: number;
+			};
+
+			expect(result.files).toHaveLength(2);
+			// Binary file gets 0/0
+			expect(result.files[0]).toEqual({ path: 'assets/image.png', additions: 0, deletions: 0 });
+			expect(result.totalAdditions).toBe(3);
+		});
+	});
+
+	// ─── spaceWorkflowRun.getFileDiff ─────────────────────────────────────
+
+	describe('spaceWorkflowRun.getFileDiff', () => {
+		it('throws if runId is missing', async () => {
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { filePath: 'src/foo.ts' })
+			).rejects.toThrow('runId is required');
+		});
+
+		it('throws if filePath is missing', async () => {
+			await expect(call('spaceWorkflowRun.getFileDiff', { runId: 'run-1' })).rejects.toThrow(
+				'filePath is required'
+			);
+		});
+
+		it('throws if filePath is whitespace only', async () => {
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { runId: 'run-1', filePath: '   ' })
+			).rejects.toThrow('filePath is required');
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { runId: 'missing', filePath: 'src/foo.ts' })
+			).rejects.toThrow('WorkflowRun not found: missing');
+		});
+
+		it('throws if run has no worktree path', async () => {
+			setup({ run: { ...mockRun, config: undefined } });
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { runId: 'run-1', filePath: 'src/foo.ts' })
+			).rejects.toThrow('No worktree path found for run: run-1');
+		});
+
+		it('returns unified diff for a file', async () => {
+			const unifiedDiff = [
+				'diff --git a/src/foo.ts b/src/foo.ts',
+				'--- a/src/foo.ts',
+				'+++ b/src/foo.ts',
+				'@@ -1,3 +1,4 @@',
+				' const x = 1;',
+				'+const y = 2;',
+				' export { x };',
+				'-// old comment',
+			].join('\n');
+
+			mockExecFileSync.mockImplementation(
+				(_cmd: string, args: string[], _opts: unknown): string => {
+					if (args.includes('merge-base')) return 'abc123\n';
+					return unifiedDiff;
+				}
+			);
+
+			const result = (await call('spaceWorkflowRun.getFileDiff', {
+				runId: 'run-1',
+				filePath: 'src/foo.ts',
+			})) as { diff: string; additions: number; deletions: number; filePath: string };
+
+			expect(result.diff).toBe(unifiedDiff);
+			expect(result.additions).toBe(1); // +const y = 2;
+			expect(result.deletions).toBe(1); // -// old comment
+			expect(result.filePath).toBe('src/foo.ts');
+		});
+
+		it('returns empty diff when file has no changes', async () => {
+			mockExecFileSync.mockImplementation(() => '');
+
+			const result = (await call('spaceWorkflowRun.getFileDiff', {
+				runId: 'run-1',
+				filePath: 'src/unchanged.ts',
+			})) as { diff: string; additions: number; deletions: number };
+
+			expect(result.diff).toBe('');
+			expect(result.additions).toBe(0);
+			expect(result.deletions).toBe(0);
+		});
+
+		it('passes correct git args with baseRef', async () => {
+			mockExecFileSync.mockImplementation(
+				(_cmd: string, args: string[], _opts: unknown): string => {
+					if (args.includes('merge-base')) return 'deadbeef\n';
+					return '+added line\n-removed line\n';
+				}
+			);
+
+			await call('spaceWorkflowRun.getFileDiff', {
+				runId: 'run-1',
+				filePath: 'src/foo.ts',
+			});
+
+			// Second call should be the diff call with baseRef..HEAD
+			const calls = (mockExecFileSync as ReturnType<typeof mock>).mock.calls;
+			const diffCall = calls.find(
+				(c: string[][]) => c[1]?.includes('diff') && c[1]?.includes('--')
+			);
+			expect(diffCall).toBeDefined();
+			expect(diffCall![1]).toContain('deadbeef..HEAD');
+			expect(diffCall![1]).toContain('src/foo.ts');
+		});
+
+		it('falls back to uncommitted diff range when merge-base fails', async () => {
+			mockExecFileSync.mockImplementation(
+				(_cmd: string, args: string[], _opts: unknown): string => {
+					if (args.includes('merge-base')) throw new Error('no remote');
+					return '+new line\n';
+				}
+			);
+
+			await call('spaceWorkflowRun.getFileDiff', {
+				runId: 'run-1',
+				filePath: 'src/foo.ts',
+			});
+
+			const calls = (mockExecFileSync as ReturnType<typeof mock>).mock.calls;
+			const diffCall = calls.find(
+				(c: string[][]) => c[1]?.includes('diff') && c[1]?.includes('--')
+			);
+			expect(diffCall).toBeDefined();
+			// Should use HEAD (not baseRef..HEAD) when merge-base unavailable
+			expect(diffCall![1]).toContain('HEAD');
+			expect(diffCall![1]).not.toContain('..');
+		});
+
+		it('correctly counts additions and deletions, ignoring diff header lines', async () => {
+			const unifiedDiff = [
+				'--- a/src/foo.ts',
+				'+++ b/src/foo.ts',
+				'+added line 1',
+				'+added line 2',
+				'-removed line 1',
+				' unchanged line',
+			].join('\n');
+
+			mockExecFileSync.mockImplementation(() => unifiedDiff);
+
+			const result = (await call('spaceWorkflowRun.getFileDiff', {
+				runId: 'run-1',
+				filePath: 'src/foo.ts',
+			})) as { additions: number; deletions: number };
+
+			expect(result.additions).toBe(2);
+			expect(result.deletions).toBe(1);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -154,20 +154,23 @@ function createMockWorkflowManager(): SpaceWorkflowManager {
 	} as unknown as SpaceWorkflowManager;
 }
 
-function createMockRunRepo(
-	run: SpaceWorkflowRun | null = mockRun,
-	updatedRun?: SpaceWorkflowRun
-): SpaceWorkflowRunRepository {
+function createMockRunRepo(run: SpaceWorkflowRun | null = mockRun): SpaceWorkflowRunRepository {
+	// Stateful mock: transitionStatus and updateRun mutate currentRun so that
+	// chained calls (e.g. transitionStatus then updateRun) see the updated state.
+	let currentRun = run;
 	return {
-		getRun: mock(() => run),
-		listBySpace: mock(() => (run ? [run] : [])),
-		transitionStatus: mock((id: string, status: string) =>
-			run ? { ...run, id, status: status as SpaceWorkflowRun['status'] } : null
-		),
-		updateRun: mock((id: string, params: Partial<SpaceWorkflowRun>) =>
-			run ? { ...run, id, ...params } : null
-		),
-		...(updatedRun ? { getRun: mock(() => updatedRun) } : {}),
+		getRun: mock(() => currentRun),
+		listBySpace: mock(() => (currentRun ? [currentRun] : [])),
+		transitionStatus: mock((id: string, status: string) => {
+			if (!currentRun) return null;
+			currentRun = { ...currentRun, id, status: status as SpaceWorkflowRun['status'] };
+			return currentRun;
+		}),
+		updateRun: mock((id: string, params: Partial<SpaceWorkflowRun>) => {
+			if (!currentRun) return null;
+			currentRun = { ...currentRun, id, ...params };
+			return currentRun;
+		}),
 	} as unknown as SpaceWorkflowRunRepository;
 }
 
@@ -340,13 +343,12 @@ describe('space-workflow-run gate handlers', () => {
 				rejectedAt: expect.any(Number),
 				reason: 'Not ready',
 			});
-			// Status and failureReason set atomically via updateRun
-			// (pending is guarded above, so transition is always valid)
-			expect(runRepo.updateRun).toHaveBeenCalledWith('run-1', {
-				status: 'needs_attention',
-				failureReason: 'humanRejected',
-			});
+			// State machine transition to needs_attention (in_progress→needs_attention is valid)
+			expect(runRepo.transitionStatus).toHaveBeenCalledWith('run-1', 'needs_attention');
+			// failureReason written separately so it persists independently
+			expect(runRepo.updateRun).toHaveBeenCalledWith('run-1', { failureReason: 'humanRejected' });
 			expect(result.run.status).toBe('needs_attention');
+			expect(result.run.failureReason).toBe('humanRejected');
 			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflowRun.updated', expect.any(Object));
 		});
 
@@ -387,7 +389,7 @@ describe('space-workflow-run gate handlers', () => {
 			expect(result.gateData.data.approved).toBe(false);
 		});
 
-		it('approve after prior rejection: transitions run back to in_progress', async () => {
+		it('approve after prior rejection: transitions run back to in_progress and clears failureReason', async () => {
 			const rejectedRun: SpaceWorkflowRun = {
 				...mockRun,
 				status: 'needs_attention',
@@ -405,10 +407,39 @@ describe('space-workflow-run gate handlers', () => {
 				approved: true,
 				approvedAt: expect.any(Number),
 			});
-			// Must transition run back to in_progress
+			// State machine transition back to in_progress
 			expect(runRepo.transitionStatus).toHaveBeenCalledWith('run-1', 'in_progress');
+			// failureReason cleared separately so the run appears clean to the UI
+			expect(runRepo.updateRun).toHaveBeenCalledWith('run-1', { failureReason: null });
 			expect(result.run.status).toBe('in_progress');
+			// null from updateRun({ failureReason: null }) — effectively cleared
+			expect(result.run.failureReason).toBeFalsy();
 			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflowRun.updated', expect.any(Object));
+		});
+
+		it('rejection when run is already needs_attention (non-humanRejected): skips transitionStatus, sets failureReason', async () => {
+			// e.g. run is needs_attention due to maxIterationsReached; human gate rejection
+			// should override the failureReason without calling transitionStatus (which would
+			// reject needs_attention→needs_attention as a no-op or invalid transition).
+			const stuckRun: SpaceWorkflowRun = {
+				...mockRun,
+				status: 'needs_attention',
+				failureReason: 'maxIterationsReached',
+			};
+			setup({ run: stuckRun });
+
+			const result = (await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: false,
+			})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
+
+			// transitionStatus must NOT be called since status is already needs_attention
+			expect(runRepo.transitionStatus).not.toHaveBeenCalled();
+			// Only failureReason is written
+			expect(runRepo.updateRun).toHaveBeenCalledWith('run-1', { failureReason: 'humanRejected' });
+			expect(result.run.status).toBe('needs_attention');
+			expect(result.run.failureReason).toBe('humanRejected');
 		});
 
 		it('gate approval persists to gateDataRepo (survives restart)', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -20,6 +20,7 @@ import {
 import type { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import type { GateDataRepository } from '../../../src/storage/repositories/gate-data-repository.ts';
 import type { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import type { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
@@ -156,6 +157,24 @@ function createMockRunRepo(
 	} as unknown as SpaceWorkflowRunRepository;
 }
 
+function createMockGateDataRepo(): GateDataRepository {
+	return {
+		get: mock(() => null),
+		merge: mock((_runId: string, _gateId: string, partial: Record<string, unknown>) => ({
+			runId: _runId,
+			gateId: _gateId,
+			data: partial,
+			updatedAt: Date.now(),
+		})),
+		set: mock(() => null),
+		listByRun: mock(() => []),
+		delete: mock(() => false),
+		deleteByRun: mock(() => 0),
+		initializeForRun: mock(() => {}),
+		reset: mock(() => null),
+	} as unknown as GateDataRepository;
+}
+
 function createMockRuntime(run: SpaceWorkflowRun = mockRun): SpaceRuntime {
 	return {
 		startWorkflowRun: mock(async () => ({ run, tasks: [mockTask] })),
@@ -238,6 +257,7 @@ describe('space-workflow-run-handlers', () => {
 			spaceManager,
 			workflowManager,
 			runRepo,
+			createMockGateDataRepo(),
 			runtimeService,
 			taskManagerFactory,
 			daemonHub
@@ -567,6 +587,7 @@ describe('space-workflow-run-handlers', () => {
 				spaceManager,
 				workflowManager,
 				runRepo,
+				createMockGateDataRepo(),
 				createMockRuntimeService(),
 				taskManagerFactory,
 				daemonHub


### PR DESCRIPTION
## Summary

- `spaceWorkflowRun.approveGate`: writes `{ approved: true/false }` to the `gate_data` table. Idempotent — repeated calls with the same decision return existing state. Rejection transitions the run to `needs_attention` with `failureReason: 'humanRejected'`.
- `spaceWorkflowRun.getGateArtifacts`: resolves `run.config.worktreePath`, runs `git diff --numstat` vs merge-base (`origin/dev` with fallback to uncommitted), returns per-file change stats.
- `spaceWorkflowRun.getFileDiff`: returns unified diff for a specific file using the same base-ref resolution. Counts additions/deletions from the diff text.

Approval state is persisted in the existing `gate_data` SQLite table (survives daemon restart). `gateDataRepo` added as a new parameter to `setupSpaceWorkflowRunHandlers`; `index.ts` wired accordingly.

## Tests

30 new unit tests in `space-workflow-run-gate-handlers.test.ts` covering:
- Parameter validation for all three RPCs
- Idempotent approval and rejection
- Rejection transitions run status + failureReason
- Terminal state guard (completed/cancelled runs)
- Artifacts parsing with merge-base, binary files, fallback
- File diff counting, header line exclusion, fallback when merge-base unavailable
- Persistence: gate data written to gateDataRepo on each approval/rejection