### PR TITLE
feat(space): add default tag to CODING_WORKFLOW_V2 and expand seeding tests (M3.2)

### DIFF
--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -323,7 +323,7 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 	],
 	startNodeId: V2_PLANNING_STEP,
 	rules: [],
-	tags: ['coding', 'v2', 'parallel-review'],
+	tags: ['coding', 'v2', 'parallel-review', 'default'],
 	createdAt: 0,
 	updatedAt: 0,
 	// Gates — independent entities referenced by channels via gateId

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -483,6 +483,14 @@ describe('CODING_WORKFLOW_V2 template', () => {
 	test('maxIterations is set to 5', () => {
 		expect(CODING_WORKFLOW_V2.maxIterations).toBe(5);
 	});
+
+	test('has the default tag so workflow selector ranks it first for coding requests', () => {
+		expect(CODING_WORKFLOW_V2.tags).toContain('default');
+	});
+
+	test('has the coding tag', () => {
+		expect(CODING_WORKFLOW_V2.tags).toContain('coding');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -777,6 +785,19 @@ describe('seedBuiltInWorkflows()', () => {
 			expect(nodeNames.has(ch.from as string)).toBe(true);
 			expect(nodeNames.has(ch.to as string)).toBe(true);
 		}
+	});
+
+	test('CODING_WORKFLOW_V2 seeded with default tag for workflow selector ranking', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW_V2.name)!;
+		expect(wf.tags).toContain('default');
+	});
+
+	test('CODING_WORKFLOW_V2 seeded alongside CODING_WORKFLOW_V1 — both present', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const names = manager.listWorkflows(SPACE_ID).map((w) => w.name);
+		expect(names).toContain(CODING_WORKFLOW.name);
+		expect(names).toContain(CODING_WORKFLOW_V2.name);
 	});
 
 	test('all seeded workflows have the real spaceId assigned', async () => {

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -171,4 +171,13 @@ describe('seedPresetAgents', () => {
 		expect(qa?.tools).toContain('Grep');
 		expect(qa?.tools).toContain('Glob');
 	});
+
+	it('QA agent has a system prompt set', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const qa = seeded.find((a) => a.role === 'qa');
+
+		expect(qa).toBeDefined();
+		expect(typeof qa?.systemPrompt).toBe('string');
+		expect((qa?.systemPrompt?.length ?? 0) > 0).toBe(true);
+	});
 });


### PR DESCRIPTION
Add `'default'` tag to `CODING_WORKFLOW_V2` so the workflow selector ranks it first for coding-type requests. V1 kept unchanged for backward compatibility.

All seeding behavior (V2 alongside V1, QA agent, idempotent re-seeding) was already implemented in M3.1/M4.4. This PR adds the missing tag and expands test coverage:
- V2 has `'default'` tag
- V2 seeded alongside V1
- QA agent system prompt set on seed