### PR TITLE
feat(space): prefer CODING_WORKFLOW_V2 in suggest_workflow tiebreaker (M3.4)

### DIFF
--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -266,8 +266,15 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				});
 			}
 
-			// Stable sort descending by hits; 0-hit workflows appear at the end
-			scored.sort((a, b) => b.hits - a.hits);
+			// Stable sort descending by hits; tiebreak: prefer 'v2'-tagged workflows (e.g.
+			// CODING_WORKFLOW_V2 over CODING_WORKFLOW) so V2 is always recommended first
+			// when both match equally. Falls back to V1 naturally if V2 is not seeded.
+			scored.sort((a, b) => {
+				if (b.hits !== a.hits) return b.hits - a.hits;
+				const aIsV2 = (a.workflow.tags ?? []).includes('v2') ? 1 : 0;
+				const bIsV2 = (b.workflow.tags ?? []).includes('v2') ? 1 : 0;
+				return bIsV2 - aIsV2;
+			});
 			return jsonResult({ success: true, workflows: scored.map((s) => s.workflow) });
 		},
 

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -689,6 +689,85 @@ describe('createSpaceAgentToolHandlers — suggest_workflow', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.workflows).toHaveLength(1);
 	});
+
+	test('V2 workflow preferred over V1 when both match equally (coding task)', async () => {
+		buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Coding Workflow',
+			['coding', 'default'],
+			'For writing code'
+		);
+		buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Coding Workflow V2',
+			['coding', 'v2', 'parallel-review', 'default'],
+			'For writing code with parallel review'
+		);
+
+		const result = await makeHandlers(ctx).suggest_workflow({
+			description: 'implement a new coding feature',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.workflows).toHaveLength(2);
+		// V2 must be ranked first (tiebreaker: 'v2' tag)
+		expect(parsed.workflows[0].name).toBe('Coding Workflow V2');
+		expect(parsed.workflows[1].name).toBe('Coding Workflow');
+	});
+
+	test('V1 fallback when V2 is not seeded (backward compatibility)', async () => {
+		buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Coding Workflow',
+			['coding', 'default'],
+			'For writing code'
+		);
+
+		const result = await makeHandlers(ctx).suggest_workflow({
+			description: 'implement a new coding feature',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.workflows).toHaveLength(1);
+		expect(parsed.workflows[0].name).toBe('Coding Workflow');
+	});
+
+	test('non-coding workflows unaffected by v2 tiebreaker', async () => {
+		buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Research Workflow',
+			['research'],
+			'For research tasks'
+		);
+		buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Deploy Workflow',
+			['deploy', 'v2'],
+			'For deployment tasks'
+		);
+
+		// A research query — deploy v2 workflow should NOT hijack top spot
+		const result = await makeHandlers(ctx).suggest_workflow({
+			description: 'research competitors',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		// Research Workflow has more hits; Deploy Workflow should not outrank it
+		expect(parsed.workflows[0].name).toBe('Research Workflow');
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
When two workflows match equally on keyword hits, workflows tagged `v2` are ranked first. This ensures `CODING_WORKFLOW_V2` is suggested over V1 for coding tasks while V1 remains as a natural fallback when V2 is not seeded (backward compatibility for older spaces). Non-coding workflows are unaffected.

- Modified `suggest_workflow` sort in `space-agent-tools.ts` to apply `v2`-tag tiebreaker
- 3 new unit tests: V2 preferred, V1 fallback when V2 not seeded, non-coding workflows unaffected