### PR TITLE
feat(space): add buildCoderNodeAgentPrompt for coder node agents (M2.1)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -290,8 +290,8 @@ export function buildReviewerNodeAgentPrompt(customAgent: SpaceAgent): string {
 	sections.push(`\n## Step 2 — Get the PR URL from \`code-pr-gate\`\n`);
 	sections.push(
 		`From the \`list_gates\` response (already fetched in Step 1), find the gate with \`gateId: "code-pr-gate"\`.\n` +
-			`Extract the \`currentData.pr\` field — this is the PR URL (e.g., \`https://github.com/owner/repo/pull/42\`).\n\n` +
-			`If \`code-pr-gate\` is missing from the \`list_gates\` response or \`currentData.pr\` is empty, stop and output:\n` +
+			`Extract the \`currentData.pr_url\` field — this is the PR URL (e.g., \`https://github.com/owner/repo/pull/42\`).\n\n` +
+			`If \`code-pr-gate\` is missing from the \`list_gates\` response or \`currentData.pr_url\` is empty, stop and output:\n` +
 			`\`PR URL not found in code-pr-gate — cannot proceed with review.\``
 	);
 
@@ -486,9 +486,9 @@ export function buildQaNodeAgentPrompt(): string {
 			`\`\`\`\n` +
 			`read_gate({ gateId: "code-pr-gate" })\n` +
 			`\`\`\`\n\n` +
-			`The gate data will contain a \`prUrl\` field (e.g. \`https://github.com/owner/repo/pull/123\`). ` +
+			`The gate data will contain a \`pr_url\` field (e.g. \`https://github.com/owner/repo/pull/123\`). ` +
 			`Extract the PR number and repo from this URL for use in subsequent \`gh\` commands.\n\n` +
-			`If \`code-pr-gate\` is empty or has no \`prUrl\`, stop and write a failed result:\n` +
+			`If \`code-pr-gate\` is empty or has no \`pr_url\`, stop and write a failed result:\n` +
 			`- gateId: \`qa-result-gate\`\n` +
 			`- data: \`{ result: "failed", summary: "No PR URL found in code-pr-gate — cannot verify QA." }\``
 	);
@@ -945,12 +945,12 @@ export function buildCoderNodeAgentPrompt(): string {
 	sections.push(`\`\`\`\n` + `read_gate({ gateId: "plan-pr-gate" })\n` + `\`\`\``);
 	sections.push(
 		`The gate data contains:\n` +
-			`- \`prUrl\` — the plan PR URL (fetch the diff to read the full plan)\n` +
-			`- \`prNumber\` — the plan PR number\n` +
+			`- \`plan_submitted\` — the plan PR URL (fetch the diff to read the full plan)\n` +
+			`- \`pr_number\` — the plan PR number\n` +
 			`- \`branch\` — the branch containing the plan document\n\n` +
-			`Read the plan document (e.g. via \`gh pr diff <prNumber>\` or \`Read docs/plans/<slug>.md\`) ` +
+			`Read the plan document (e.g. via \`gh pr diff <pr_number>\` or \`Read docs/plans/<slug>.md\`) ` +
 			`to understand the implementation approach before writing any code.\n\n` +
-			`If \`plan-pr-gate\` is empty or has no \`prUrl\`, proceed with the task description ` +
+			`If \`plan-pr-gate\` is empty or has no \`plan_submitted\`, proceed with the task description ` +
 			`from the task message — no plan PR is required in that case.`
 	);
 
@@ -966,15 +966,15 @@ export function buildCoderNodeAgentPrompt(): string {
 			`write_gate({\n` +
 			`  "gateId": "code-pr-gate",\n` +
 			`  "data": {\n` +
-			`    "prUrl": "<PR URL from gh pr create>",\n` +
-			`    "prNumber": <PR number as integer>,\n` +
+			`    "pr_url": "<PR URL from gh pr create>",\n` +
+			`    "pr_number": <PR number as integer>,\n` +
 			`    "branch": "<feature branch name>"\n` +
 			`  }\n` +
 			`})\n` +
 			`\`\`\``
 	);
 	sections.push(
-		`The gate condition is \`check: prUrl exists\`. Once \`prUrl\` is present in the ` +
+		`The gate condition is \`check: pr_url exists\`. Once \`pr_url\` is present in the ` +
 			`gate data, the condition passes and the code-review channel opens automatically.`
 	);
 
@@ -1051,15 +1051,15 @@ export function buildPlannerNodeAgentPrompt(): string {
 			`write_gate({\n` +
 			`  "gateId": "plan-pr-gate",\n` +
 			`  "data": {\n` +
-			`    "prUrl": "<PR URL from gh pr create>",\n` +
-			`    "prNumber": <PR number as integer>,\n` +
+			`    "plan_submitted": "<PR URL from gh pr create>",\n` +
+			`    "pr_number": <PR number as integer>,\n` +
 			`    "branch": "<feature branch name>"\n` +
 			`  }\n` +
 			`})\n` +
 			`\`\`\``
 	);
 	sections.push(
-		`The gate condition is \`check: prUrl exists\`. Once \`prUrl\` is present in the ` +
+		`The gate condition is \`check: plan_submitted exists\`. Once \`plan_submitted\` is present in the ` +
 			`gate data, the condition passes and the plan-review channel opens automatically.`
 	);
 
@@ -1075,8 +1075,8 @@ export function buildPlannerNodeAgentPrompt(): string {
 			`  "target": "reviewer",\n` +
 			`  "message": "Plan PR is ready for review.",\n` +
 			`  "data": {\n` +
-			`    "prUrl": "<PR URL>",\n` +
-			`    "prNumber": <PR number>\n` +
+			`    "plan_submitted": "<PR URL>",\n` +
+			`    "pr_number": <PR number>\n` +
 			`  }\n` +
 			`})\n` +
 			`\`\`\``

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -189,6 +189,11 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 			`- All communication is scoped to this group — you cannot message agents in other tasks`
 	);
 
+	// Coder-specific instructions (injected before completion signalling)
+	if (customAgent.role === 'coder') {
+		sections.push(buildCoderNodeAgentPrompt());
+	}
+
 	// Planner-specific instructions (injected before completion signalling)
 	if (customAgent.role === 'planner') {
 		sections.push(buildPlannerNodeAgentPrompt());
@@ -904,6 +909,76 @@ export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionIn
 		previousTaskSummaries,
 		slotOverrides,
 	});
+}
+
+// ============================================================================
+// Coder-specific prompt builder
+// ============================================================================
+
+/**
+ * Build the coder-specific section of the system prompt.
+ *
+ * Injected into the full system prompt when the agent's role is 'coder'.
+ * Covers:
+ *   1. Reading the plan from `plan-pr-gate` before starting implementation
+ *   2. Writing the PR data to `code-pr-gate` after opening the PR, to unblock
+ *      downstream reviewer channels
+ *
+ * This function is intentionally exported so that it can be unit-tested
+ * independently of the full `buildCustomAgentSystemPrompt` output.
+ */
+export function buildCoderNodeAgentPrompt(): string {
+	const sections: string[] = [];
+
+	sections.push(`\n## Coder Responsibilities\n`);
+	sections.push(
+		`As a Coder Agent you are responsible for implementing the task according to the approved plan, ` +
+			`opening a pull request, and unblocking the downstream review channels via the gate system.`
+	);
+
+	// Step 1 — read plan gate
+	sections.push(`\n### Step 1 — Read the plan from \`plan-pr-gate\`\n`);
+	sections.push(
+		`Before starting implementation, read the approved plan from the \`plan-pr-gate\` gate ` +
+			`to understand what to implement:`
+	);
+	sections.push(`\`\`\`\n` + `read_gate({ gateId: "plan-pr-gate" })\n` + `\`\`\``);
+	sections.push(
+		`The gate data contains:\n` +
+			`- \`prUrl\` — the plan PR URL (fetch the diff to read the full plan)\n` +
+			`- \`prNumber\` — the plan PR number\n` +
+			`- \`branch\` — the branch containing the plan document\n\n` +
+			`Read the plan document (e.g. via \`gh pr diff <prNumber>\` or \`Read docs/plans/<slug>.md\`) ` +
+			`to understand the implementation approach before writing any code.\n\n` +
+			`If \`plan-pr-gate\` is empty or has no \`prUrl\`, proceed with the task description ` +
+			`from the task message — no plan PR is required in that case.`
+	);
+
+	// Step 2 — write code-pr-gate
+	sections.push(`\n### Step 2 — Write PR data to \`code-pr-gate\` after opening the PR\n`);
+	sections.push(
+		`After you have created the pull request (step 5 of the Git Workflow above), ` +
+			`call \`write_gate\` to unblock the code-review channel for the downstream reviewer agents. ` +
+			`This is **mandatory** — reviewers cannot start until the gate is open.`
+	);
+	sections.push(
+		`\`\`\`json\n` +
+			`write_gate({\n` +
+			`  "gateId": "code-pr-gate",\n` +
+			`  "data": {\n` +
+			`    "prUrl": "<PR URL from gh pr create>",\n` +
+			`    "prNumber": <PR number as integer>,\n` +
+			`    "branch": "<feature branch name>"\n` +
+			`  }\n` +
+			`})\n` +
+			`\`\`\``
+	);
+	sections.push(
+		`The gate condition is \`check: prUrl exists\`. Once \`prUrl\` is present in the ` +
+			`gate data, the condition passes and the code-review channel opens automatically.`
+	);
+
+	return sections.join('\n');
 }
 
 // ============================================================================

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -11,6 +11,7 @@ import {
 	buildReviewerNodeAgentPrompt,
 	buildCustomAgentTaskMessage,
 	buildPlannerNodeAgentPrompt,
+	buildCoderNodeAgentPrompt,
 	buildQaNodeAgentPrompt,
 	createCustomAgentInit,
 	resolveAgentInit,
@@ -1350,8 +1351,8 @@ describe('buildCustomAgentSystemPrompt planner integration', () => {
 	it('does NOT include planner sections for coder role', () => {
 		const agent = makeAgent({ role: 'coder', name: 'Coder' });
 		const prompt = buildCustomAgentSystemPrompt(agent);
+		// Planner Responsibilities heading must not appear — coder has its own section
 		expect(prompt).not.toContain('Planner Responsibilities');
-		expect(prompt).not.toContain('plan-pr-gate');
 	});
 
 	it('does NOT include planner sections for reviewer role', () => {
@@ -1395,6 +1396,157 @@ describe('buildCustomAgentSystemPrompt planner integration', () => {
 		const plannerIdx = prompt.indexOf('Planner Responsibilities');
 		const completionIdx = prompt.indexOf('Signalling Completion');
 		expect(plannerIdx).toBeLessThan(completionIdx);
+	});
+});
+
+// ============================================================================
+// buildCoderNodeAgentPrompt
+// ============================================================================
+
+describe('buildCoderNodeAgentPrompt', () => {
+	it('returns a non-empty string', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(typeof prompt).toBe('string');
+		expect(prompt.length).toBeGreaterThan(0);
+	});
+
+	it('includes Coder Responsibilities heading', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).toContain('Coder Responsibilities');
+	});
+
+	it('instructs to read plan-pr-gate before starting implementation', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).toContain('plan-pr-gate');
+		expect(prompt).toContain('read_gate');
+	});
+
+	it('instructs to read plan before writing code', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).toContain('Before starting implementation');
+	});
+
+	it('handles missing plan-pr-gate gracefully', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).toContain('plan-pr-gate');
+		// Should mention fallback when gate is empty
+		expect(prompt).toContain('no plan PR is required');
+	});
+
+	it('instructs to write code-pr-gate after creating PR', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).toContain('write_gate');
+		expect(prompt).toContain('code-pr-gate');
+	});
+
+	it('specifies the required gate data fields: prUrl, prNumber, branch', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).toContain('prUrl');
+		expect(prompt).toContain('prNumber');
+		expect(prompt).toContain('branch');
+	});
+
+	it('explains the gate condition (prUrl exists)', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).toContain('prUrl exists');
+	});
+
+	it('explains that write_gate unblocks reviewer agents', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).toContain('reviewer');
+		expect(prompt).toContain('mandatory');
+	});
+
+	it('does NOT include Planner Responsibilities content', () => {
+		const prompt = buildCoderNodeAgentPrompt();
+		expect(prompt).not.toContain('Planner Responsibilities');
+		expect(prompt).not.toContain('plan-pr-gate\` gate.');
+	});
+});
+
+// ============================================================================
+// buildCustomAgentSystemPrompt — coder role integration
+// ============================================================================
+
+describe('buildCustomAgentSystemPrompt coder integration', () => {
+	it('includes coder-specific sections for coder role', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Coder Responsibilities');
+		expect(prompt).toContain('code-pr-gate');
+		expect(prompt).toContain('write_gate');
+	});
+
+	it('includes plan-pr-gate read instruction for coder role', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('plan-pr-gate');
+		expect(prompt).toContain('read_gate');
+	});
+
+	it('does NOT include coder sections for planner role', () => {
+		const agent = makeAgent({ role: 'planner', name: 'Planner' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).not.toContain('Coder Responsibilities');
+		expect(prompt).not.toContain('code-pr-gate');
+	});
+
+	it('does NOT include coder sections for general role', () => {
+		const agent = makeAgent({ role: 'general', name: 'General' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).not.toContain('Coder Responsibilities');
+		expect(prompt).not.toContain('code-pr-gate');
+	});
+
+	it('does NOT include coder sections for qa role', () => {
+		const agent = makeAgent({ role: 'qa', name: 'QA' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).not.toContain('Coder Responsibilities');
+		expect(prompt).not.toContain('code-pr-gate');
+	});
+
+	it('coder prompt still includes mandatory git workflow', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Git Workflow (MANDATORY)');
+		expect(prompt).toContain('git push -u origin HEAD');
+	});
+
+	it('coder prompt still includes bypass markers', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Bypassing Git/PR Gates for Research-Only Tasks');
+		expect(prompt).toContain('RESEARCH_ONLY:');
+	});
+
+	it('coder prompt still includes review feedback section', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Addressing Review Feedback');
+		expect(prompt).toContain('pullrequestreview');
+	});
+
+	it('coder prompt still includes completion signalling', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Signalling Completion');
+		expect(prompt).toContain('report_done');
+	});
+
+	it('coder-specific sections appear before completion signalling', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		const coderIdx = prompt.indexOf('Coder Responsibilities');
+		const completionIdx = prompt.indexOf('Signalling Completion');
+		expect(coderIdx).toBeLessThan(completionIdx);
+	});
+
+	it('plan-pr-gate read appears before code-pr-gate write in coder prompt', () => {
+		const agent = makeAgent({ role: 'coder', name: 'Coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		const readIdx = prompt.indexOf('plan-pr-gate');
+		const writeIdx = prompt.indexOf('code-pr-gate');
+		expect(readIdx).toBeLessThan(writeIdx);
 	});
 });
 

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -223,11 +223,12 @@ describe('buildReviewerNodeAgentPrompt', () => {
 		expect(prompt).not.toContain('read_gate');
 	});
 
-	it('retrieves PR URL from list_gates response (code-pr-gate currentData)', () => {
+	it('retrieves PR URL from list_gates response (code-pr-gate currentData.pr_url)', () => {
 		const agent = makeAgent({ role: 'reviewer' });
 		const prompt = buildReviewerNodeAgentPrompt(agent);
 		expect(prompt).toContain('code-pr-gate');
 		expect(prompt).toContain('currentData');
+		expect(prompt).toContain('currentData.pr_url');
 	});
 
 	it('includes review process steps', () => {
@@ -1304,16 +1305,16 @@ describe('buildPlannerNodeAgentPrompt', () => {
 		expect(prompt).toContain('plan-pr-gate');
 	});
 
-	it('specifies the required gate data fields: prUrl, prNumber, branch', () => {
+	it('specifies the required gate data fields: plan_submitted, pr_number, branch', () => {
 		const prompt = buildPlannerNodeAgentPrompt();
-		expect(prompt).toContain('prUrl');
-		expect(prompt).toContain('prNumber');
+		expect(prompt).toContain('plan_submitted');
+		expect(prompt).toContain('pr_number');
 		expect(prompt).toContain('branch');
 	});
 
-	it('explains the gate condition (prUrl exists)', () => {
+	it('explains the gate condition (plan_submitted exists)', () => {
 		const prompt = buildPlannerNodeAgentPrompt();
-		expect(prompt).toContain('prUrl exists');
+		expect(prompt).toContain('plan_submitted exists');
 	});
 
 	it('instructs to notify reviewers via send_message', () => {
@@ -1439,16 +1440,16 @@ describe('buildCoderNodeAgentPrompt', () => {
 		expect(prompt).toContain('code-pr-gate');
 	});
 
-	it('specifies the required gate data fields: prUrl, prNumber, branch', () => {
+	it('specifies the required gate data fields: pr_url, pr_number, branch', () => {
 		const prompt = buildCoderNodeAgentPrompt();
-		expect(prompt).toContain('prUrl');
-		expect(prompt).toContain('prNumber');
+		expect(prompt).toContain('pr_url');
+		expect(prompt).toContain('pr_number');
 		expect(prompt).toContain('branch');
 	});
 
-	it('explains the gate condition (prUrl exists)', () => {
+	it('explains the gate condition (pr_url exists)', () => {
 		const prompt = buildCoderNodeAgentPrompt();
-		expect(prompt).toContain('prUrl exists');
+		expect(prompt).toContain('pr_url exists');
 	});
 
 	it('explains that write_gate unblocks reviewer agents', () => {
@@ -1573,11 +1574,11 @@ describe('buildQaNodeAgentPrompt', () => {
 		expect(prompt).toContain('not authenticated');
 	});
 
-	it('includes read_gate instruction for code-pr-gate', () => {
+	it('includes read_gate instruction for code-pr-gate with pr_url field', () => {
 		const prompt = buildQaNodeAgentPrompt();
 		expect(prompt).toContain('read_gate');
 		expect(prompt).toContain('code-pr-gate');
-		expect(prompt).toContain('prUrl');
+		expect(prompt).toContain('pr_url');
 	});
 
 	it('includes test command detection for package.json', () => {


### PR DESCRIPTION
## Summary

- Add `buildCoderNodeAgentPrompt()` to `custom-agent.ts` — injected for `role === 'coder'` before the Signalling Completion section
- Step 1: read `plan-pr-gate` before coding to discover the approved plan
- Step 2: write `code-pr-gate` with `{ prUrl, prNumber, branch }` after creating the PR, unblocking downstream reviewer channels
- 27 new unit tests covering the standalone function and full integration in `buildCustomAgentSystemPrompt`