### PR TITLE
feat(space): implement WorkflowCanvas component (M6.2)

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -485,6 +485,14 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		runId: string;
 		run?: Partial<import('@neokai/shared').SpaceWorkflowRun>;
 	};
+	/** Emitted when gate data changes (agent write_gate, or human approveGate). */
+	'space.gateData.updated': {
+		sessionId: string;
+		spaceId: string;
+		runId: string;
+		gateId: string;
+		data: Record<string, unknown>;
+	};
 
 	// Space Agent events (channel: 'space:${spaceId}')
 	'spaceAgent.created': {

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -7,6 +7,7 @@
  * - spaceWorkflowRun.get            - Gets a run by ID
  * - spaceWorkflowRun.cancel         - Cancels a run and all pending tasks
  * - spaceWorkflowRun.approveGate    - Approves or rejects a human approval gate
+ * - spaceWorkflowRun.listGateData   - Returns all gate data records for a run
  * - spaceWorkflowRun.getGateArtifacts - Returns changed files and diff summary for a run's worktree
  * - spaceWorkflowRun.getFileDiff    - Returns unified diff for a specific file in the worktree
  */
@@ -343,6 +344,18 @@ export function setupSpaceWorkflowRunHandlers(
 					log.warn('Failed to emit space.workflowRun.updated:', err);
 				});
 
+			daemonHub
+				.emit('space.gateData.updated', {
+					sessionId: 'global',
+					spaceId: run.spaceId,
+					runId: params.runId,
+					gateId: params.gateId,
+					data: gateData.data,
+				})
+				.catch((err) => {
+					log.warn('Failed to emit space.gateData.updated:', err);
+				});
+
 			return { run: updatedRun, gateData };
 		} else {
 			// Rejection — idempotent: gate data already shows rejected
@@ -377,8 +390,37 @@ export function setupSpaceWorkflowRunHandlers(
 					log.warn('Failed to emit space.workflowRun.updated:', err);
 				});
 
+			daemonHub
+				.emit('space.gateData.updated', {
+					sessionId: 'global',
+					spaceId: run.spaceId,
+					runId: params.runId,
+					gateId: params.gateId,
+					data: gateData.data,
+				})
+				.catch((err) => {
+					log.warn('Failed to emit space.gateData.updated:', err);
+				});
+
 			return { run: updated, gateData };
 		}
+	});
+
+	// ─── spaceWorkflowRun.listGateData ───────────────────────────────────────
+	//
+	// Returns all gate data records for a workflow run.
+	// Used by the WorkflowCanvas component to show gate status on channel lines.
+	messageHub.onRequest('spaceWorkflowRun.listGateData', async (data) => {
+		const params = data as { runId: string };
+
+		if (!params.runId) throw new Error('runId is required');
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		const gateDataRecords = gateDataRepo.listByRun(params.runId);
+
+		return { gateData: gateDataRecords };
 	});
 
 	// ─── spaceWorkflowRun.getGateArtifacts ───────────────────────────────────

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -685,6 +685,21 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				});
 			}
 
+			// Notify UI about gate data change for real-time canvas updates.
+			if (daemonHub) {
+				void daemonHub
+					.emit('space.gateData.updated', {
+						sessionId: 'global',
+						spaceId,
+						runId: workflowRunId,
+						gateId,
+						data: updated.data,
+					})
+					.catch((err) => {
+						log.warn(`Failed to emit space.gateData.updated for gate "${gateId}":`, err);
+					});
+			}
+
 			return jsonResult({
 				success: true,
 				gateId,

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -451,6 +451,41 @@ describe('space-workflow-run gate handlers', () => {
 			});
 			expect(gateDataRepo.merge).toHaveBeenCalledTimes(1);
 		});
+
+		it('approveGate emits space.gateData.updated with gate data on approval', async () => {
+			await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: true,
+			});
+			expect(daemonHub.emit).toHaveBeenCalledWith(
+				'space.gateData.updated',
+				expect.objectContaining({
+					spaceId: 'space-1',
+					runId: 'run-1',
+					gateId: 'gate-approval',
+					data: expect.objectContaining({ approved: true }),
+				})
+			);
+		});
+
+		it('approveGate emits space.gateData.updated with gate data on rejection', async () => {
+			await call('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-approval',
+				approved: false,
+				reason: 'Not ready',
+			});
+			expect(daemonHub.emit).toHaveBeenCalledWith(
+				'space.gateData.updated',
+				expect.objectContaining({
+					spaceId: 'space-1',
+					runId: 'run-1',
+					gateId: 'gate-approval',
+					data: expect.objectContaining({ approved: false }),
+				})
+			);
+		});
 	});
 
 	// ─── spaceWorkflowRun.getGateArtifacts ────────────────────────────────

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -603,4 +603,68 @@ describe('space-workflow-run-handlers', () => {
 			expect(runRepo.transitionStatus).toHaveBeenCalledWith('run-1', 'cancelled');
 		});
 	});
+
+	describe('spaceWorkflowRun.listGateData', () => {
+		it('throws if runId is missing', async () => {
+			setup();
+			await expect(call('spaceWorkflowRun.listGateData', {})).rejects.toThrow('runId is required');
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(call('spaceWorkflowRun.listGateData', { runId: 'nonexistent' })).rejects.toThrow(
+				'WorkflowRun not found: nonexistent'
+			);
+		});
+
+		it('returns empty gateData when no records exist', async () => {
+			setup();
+			const result = await call('spaceWorkflowRun.listGateData', { runId: 'run-1' });
+			expect(result).toEqual({ gateData: [] });
+		});
+
+		it('returns all gate data records for the run via listByRun', async () => {
+			const gateRecords = [
+				{ runId: 'run-1', gateId: 'gate-1', data: { approved: true }, updatedAt: NOW },
+				{
+					runId: 'run-1',
+					gateId: 'gate-2',
+					data: { reviews: { alice: 'approved' } },
+					updatedAt: NOW,
+				},
+			];
+
+			// Set up with a custom gateDataRepo that has the test records
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			daemonHub = createMockDaemonHub();
+			spaceManager = createMockSpaceManager(mockSpace);
+			workflowManager = createMockWorkflowManager([mockWorkflow], mockWorkflow);
+			runRepo = createMockRunRepo(mockRun, [mockRun]);
+			runtime = createMockRuntime(mockRun);
+			runtimeService = createMockRuntimeService(mockSpace, runtime);
+			taskManagerFactory = mock(() => createMockTaskManager([]));
+
+			const customGateRepo = {
+				...createMockGateDataRepo(),
+				listByRun: mock(() => gateRecords),
+			} as unknown as GateDataRepository;
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				spaceManager,
+				workflowManager,
+				runRepo,
+				customGateRepo,
+				runtimeService,
+				taskManagerFactory,
+				daemonHub
+			);
+
+			const result = await call('spaceWorkflowRun.listGateData', { runId: 'run-1' });
+			expect(result).toEqual({ gateData: gateRecords });
+			expect(customGateRepo.listByRun).toHaveBeenCalledWith('run-1');
+		});
+	});
 });

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -1,0 +1,1223 @@
+/**
+ * WorkflowCanvas
+ *
+ * SVG-based canvas that renders a workflow as nodes + channels + gates.
+ *
+ * Two modes (auto-detected by context):
+ *   - Runtime mode (`runId` provided): read-only, shows live node/gate status
+ *     with real-time updates from space.task.updated and space.gateData.updated events.
+ *   - Template mode (no `runId`): editable, allows adding/removing gates on channels.
+ *
+ * Gate visual states (ON the channel line, like a valve on a pipe):
+ *   - open:         green checkmark — condition satisfied
+ *   - blocked:      red/gray lock — condition not met or rejected
+ *   - waiting_human: amber pulsing — human approval gate waiting for input
+ *
+ * Node status (from tasks in the space store):
+ *   - pending:    gray box, no tasks yet
+ *   - active:     blue box, pulsing — has in_progress tasks
+ *   - completed:  green box, checkmark + elapsed time
+ *   - failed:     red box — task errored or run failed
+ */
+
+import { useState, useEffect, useCallback, useRef, useMemo } from 'preact/hooks';
+import type { JSX } from 'preact';
+import type {
+	SpaceWorkflow,
+	SpaceWorkflowRun,
+	SpaceTask,
+	Gate,
+	GateCondition,
+	WorkflowNode,
+} from '@neokai/shared';
+import { spaceStore } from '../../lib/space-store';
+import { connectionManager } from '../../lib/connection-manager';
+import { cn } from '../../lib/utils';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const NODE_WIDTH = 160;
+const NODE_HEIGHT = 72;
+const H_GAP = 220;
+const V_GAP = 130;
+const START_Y = 40;
+const CANVAS_PADDING = 40;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type NodeStatus = 'pending' | 'active' | 'completed' | 'failed';
+
+type GateStatus = 'open' | 'blocked' | 'waiting_human';
+
+interface GateDataRecord {
+	runId: string;
+	gateId: string;
+	data: Record<string, unknown>;
+	updatedAt: number;
+}
+
+interface NodeLayout {
+	id: string;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+interface RenderedChannel {
+	id: string;
+	fromId: string;
+	toId: string;
+	gateId?: string;
+}
+
+// ============================================================================
+// Gate status evaluation
+// ============================================================================
+
+/**
+ * Determine whether a human approval gate is involved — checks for a
+ * `check` condition on the `approved` field anywhere in the condition tree.
+ */
+function isHumanApprovalGate(condition: GateCondition): boolean {
+	if (condition.type === 'check') {
+		return condition.field === 'approved';
+	}
+	if (condition.type === 'all' || condition.type === 'any') {
+		return condition.conditions.some(isHumanApprovalGate);
+	}
+	return false;
+}
+
+/**
+ * Evaluate gate status from current gate data.
+ *
+ * Simplified frontend evaluation (no recursion needed for most gates):
+ *   - Human approval gate (check on 'approved'):
+ *       data.approved === true  → open
+ *       data.approved === false → blocked
+ *       otherwise               → waiting_human
+ *   - Count gate:
+ *       count matching entries ≥ min → open, else blocked
+ *   - check / all / any (non-approval):
+ *       if any data present → open optimistically, else blocked
+ */
+function evaluateGateStatus(gate: Gate, data: Record<string, unknown>): GateStatus {
+	return evalConditionStatus(gate.condition, data);
+}
+
+function evalConditionStatus(condition: GateCondition, data: Record<string, unknown>): GateStatus {
+	switch (condition.type) {
+		case 'check': {
+			const val = data[condition.field];
+			if (condition.field === 'approved') {
+				if (val === true) return 'open';
+				if (val === false) return 'blocked';
+				return 'waiting_human';
+			}
+			const op = condition.op ?? '==';
+			if (op === 'exists') return val !== undefined ? 'open' : 'blocked';
+			if (op === '==') return val === condition.value ? 'open' : 'blocked';
+			if (op === '!=') return val !== condition.value ? 'open' : 'blocked';
+			return 'blocked';
+		}
+		case 'count': {
+			const map = data[condition.field];
+			if (!map || typeof map !== 'object' || Array.isArray(map)) return 'blocked';
+			const count = Object.values(map as Record<string, unknown>).filter(
+				(v) => v === condition.matchValue
+			).length;
+			return count >= condition.min ? 'open' : 'blocked';
+		}
+		case 'all': {
+			// All must be open
+			const allStatuses = condition.conditions.map((c) => evalConditionStatus(c, data));
+			if (allStatuses.every((s) => s === 'open')) return 'open';
+			if (allStatuses.some((s) => s === 'waiting_human')) return 'waiting_human';
+			return 'blocked';
+		}
+		case 'any': {
+			// Any must be open
+			const anyStatuses = condition.conditions.map((c) => evalConditionStatus(c, data));
+			if (anyStatuses.some((s) => s === 'open')) return 'open';
+			if (anyStatuses.some((s) => s === 'waiting_human')) return 'waiting_human';
+			return 'blocked';
+		}
+	}
+}
+
+// ============================================================================
+// Layout
+// ============================================================================
+
+/**
+ * Compute node positions using a layered DAG layout.
+ * Returns a map from node ID → {x, y, width, height}.
+ */
+function computeLayout(workflow: SpaceWorkflow): Map<string, NodeLayout> {
+	const nodes = workflow.nodes;
+	const startId = workflow.startNodeId;
+	const channels = workflow.channels ?? [];
+
+	if (nodes.length === 0) return new Map();
+
+	// Build successor map from channels
+	const successors = new Map<string, Set<string>>();
+	for (const node of nodes) {
+		successors.set(node.id, new Set());
+	}
+	for (const ch of channels) {
+		const targets = Array.isArray(ch.to) ? ch.to : [ch.to];
+		for (const t of targets) {
+			if (successors.has(ch.from) && successors.has(t)) {
+				successors.get(ch.from)!.add(t);
+			}
+		}
+	}
+
+	// BFS layer assignment from start node
+	const layers = new Map<string, number>();
+	const queue: string[] = [startId];
+	layers.set(startId, 0);
+
+	while (queue.length > 0) {
+		const current = queue.shift()!;
+		const currentLayer = layers.get(current) ?? 0;
+		for (const next of successors.get(current) ?? []) {
+			const existing = layers.get(next);
+			if (existing === undefined || existing < currentLayer + 1) {
+				layers.set(next, currentLayer + 1);
+				queue.push(next);
+			}
+		}
+	}
+
+	// Assign orphaned nodes to a final layer
+	const maxLayer = Math.max(0, ...layers.values());
+	for (const node of nodes) {
+		if (!layers.has(node.id)) {
+			layers.set(node.id, maxLayer + 1);
+		}
+	}
+
+	// Group nodes by layer
+	const byLayer = new Map<number, string[]>();
+	for (const [nodeId, layer] of layers) {
+		if (!byLayer.has(layer)) byLayer.set(layer, []);
+		byLayer.get(layer)!.push(nodeId);
+	}
+
+	// Calculate canvas dimensions for centering
+	const maxPerLayer = Math.max(...Array.from(byLayer.values()).map((n) => n.length));
+	const totalWidth = maxPerLayer * (NODE_WIDTH + H_GAP) - H_GAP + CANVAS_PADDING * 2;
+
+	const result = new Map<string, NodeLayout>();
+
+	for (const [layer, nodeIds] of byLayer) {
+		const y = START_Y + layer * (NODE_HEIGHT + V_GAP);
+		const rowWidth = nodeIds.length * (NODE_WIDTH + H_GAP) - H_GAP;
+		const rowStartX = (totalWidth - rowWidth) / 2;
+
+		nodeIds.forEach((nodeId, i) => {
+			result.set(nodeId, {
+				id: nodeId,
+				x: rowStartX + i * (NODE_WIDTH + H_GAP),
+				y,
+				width: NODE_WIDTH,
+				height: NODE_HEIGHT,
+			});
+		});
+	}
+
+	return result;
+}
+
+// ============================================================================
+// Bezier path helpers
+// ============================================================================
+
+interface BezierPoints {
+	sx: number;
+	sy: number;
+	cp1x: number;
+	cp1y: number;
+	cp2x: number;
+	cp2y: number;
+	tx: number;
+	ty: number;
+	mx: number; // midpoint x for gate icon
+	my: number; // midpoint y for gate icon
+}
+
+function computeChannelPath(fromLayout: NodeLayout, toLayout: NodeLayout): BezierPoints {
+	// Source: bottom-center of from-node
+	const sx = fromLayout.x + fromLayout.width / 2;
+	const sy = fromLayout.y + fromLayout.height;
+
+	// Target: top-center of to-node
+	const tx = toLayout.x + toLayout.width / 2;
+	const ty = toLayout.y;
+
+	const dy = ty - sy;
+	const cpOffset = Math.max(50, Math.abs(dy) * 0.5);
+	const cp1x = sx;
+	const cp1y = sy + cpOffset;
+	const cp2x = tx;
+	const cp2y = ty - cpOffset;
+
+	// Approximate bezier midpoint (t=0.5)
+	const t = 0.5;
+	const mx =
+		(1 - t) ** 3 * sx + 3 * (1 - t) ** 2 * t * cp1x + 3 * (1 - t) * t ** 2 * cp2x + t ** 3 * tx;
+	const my =
+		(1 - t) ** 3 * sy + 3 * (1 - t) ** 2 * t * cp1y + 3 * (1 - t) * t ** 2 * cp2y + t ** 3 * ty;
+
+	return { sx, sy, cp1x, cp1y, cp2x, cp2y, tx, ty, mx, my };
+}
+
+function buildBezierD(pts: BezierPoints): string {
+	return `M ${pts.sx} ${pts.sy} C ${pts.cp1x} ${pts.cp1y}, ${pts.cp2x} ${pts.cp2y}, ${pts.tx} ${pts.ty}`;
+}
+
+// ============================================================================
+// Gate icon rendered at midpoint of a channel line
+// ============================================================================
+
+interface GateIconProps {
+	x: number;
+	y: number;
+	status: GateStatus;
+	isRuntimeMode: boolean;
+	onApprove?: () => void;
+	onReject?: () => void;
+}
+
+const GATE_ICON_R = 11; // radius
+
+function GateIcon({
+	x,
+	y,
+	status,
+	isRuntimeMode,
+	onApprove,
+	onReject,
+}: GateIconProps): JSX.Element {
+	const [showActions, setShowActions] = useState(false);
+
+	let fill: string;
+	let strokeColor: string;
+	let icon: JSX.Element;
+	let pulseClass = '';
+
+	switch (status) {
+		case 'open':
+			fill = '#052e16';
+			strokeColor = '#16a34a';
+			icon = (
+				// checkmark
+				<path
+					d="M -5 0 L -1.5 4 L 6 -4"
+					stroke="#16a34a"
+					strokeWidth={2}
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					fill="none"
+				/>
+			);
+			break;
+		case 'waiting_human':
+			fill = '#431407';
+			strokeColor = '#f59e0b';
+			pulseClass = 'animate-pulse';
+			icon = (
+				// clock / hourglass
+				<>
+					<line
+						x1={0}
+						y1={-5}
+						x2={0}
+						y2={-1}
+						stroke="#f59e0b"
+						strokeWidth={1.5}
+						strokeLinecap="round"
+					/>
+					<circle cx={0} cy={2} r={1.5} fill="#f59e0b" />
+				</>
+			);
+			break;
+		case 'blocked':
+		default:
+			fill = '#1c1917';
+			strokeColor = '#6b7280';
+			icon = (
+				// lock body + shackle
+				<>
+					<rect
+						x={-4}
+						y={-1}
+						width={8}
+						height={6}
+						rx={1}
+						stroke="#6b7280"
+						strokeWidth={1.5}
+						fill="none"
+					/>
+					<path
+						d="M -3 -1 L -3 -3.5 Q 0 -6.5 3 -3.5 L 3 -1"
+						stroke="#6b7280"
+						strokeWidth={1.5}
+						fill="none"
+						strokeLinecap="round"
+					/>
+				</>
+			);
+			break;
+	}
+
+	const handleClick = (e: MouseEvent) => {
+		e.stopPropagation();
+		if (isRuntimeMode && status === 'waiting_human') {
+			setShowActions((v) => !v);
+		}
+	};
+
+	return (
+		<g
+			data-testid={`gate-icon-${status}`}
+			style={{ cursor: isRuntimeMode && status === 'waiting_human' ? 'pointer' : 'default' }}
+			onClick={handleClick}
+		>
+			<circle
+				cx={x}
+				cy={y}
+				r={GATE_ICON_R}
+				fill={fill}
+				stroke={strokeColor}
+				strokeWidth={1.5}
+				class={pulseClass}
+			/>
+			<g transform={`translate(${x}, ${y})`}>{icon}</g>
+
+			{showActions && isRuntimeMode && (
+				<foreignObject x={x - 60} y={y + 14} width={120} height={56}>
+					<div
+						style={{
+							background: '#1c1917',
+							border: '1px solid #44403c',
+							borderRadius: 6,
+							padding: '6px',
+							display: 'flex',
+							gap: '4px',
+						}}
+					>
+						<button
+							class={cn(
+								'flex-1 text-xs py-1 rounded font-medium',
+								'bg-green-900/60 text-green-300 border border-green-700/50',
+								'hover:bg-green-800/60'
+							)}
+							onClick={(e) => {
+								e.stopPropagation();
+								setShowActions(false);
+								onApprove?.();
+							}}
+						>
+							Approve
+						</button>
+						<button
+							class={cn(
+								'flex-1 text-xs py-1 rounded font-medium',
+								'bg-red-900/60 text-red-300 border border-red-700/50',
+								'hover:bg-red-800/60'
+							)}
+							onClick={(e) => {
+								e.stopPropagation();
+								setShowActions(false);
+								onReject?.();
+							}}
+						>
+							Reject
+						</button>
+					</div>
+				</foreignObject>
+			)}
+		</g>
+	);
+}
+
+// ============================================================================
+// Single workflow node box
+// ============================================================================
+
+interface NodeBoxProps {
+	node: WorkflowNode;
+	layout: NodeLayout;
+	status: NodeStatus;
+	tasks: SpaceTask[];
+	isRuntimeMode: boolean;
+}
+
+function NodeBox({ node, layout, status, tasks, isRuntimeMode }: NodeBoxProps): JSX.Element {
+	const { x, y, width, height } = layout;
+
+	let borderColor: string;
+	let bgColor: string;
+	let labelColor: string;
+	let pulseClass = '';
+	let statusIndicator: JSX.Element | null = null;
+
+	switch (status) {
+		case 'active':
+			borderColor = '#3b82f6';
+			bgColor = '#1e3a5f';
+			labelColor = '#93c5fd';
+			pulseClass = 'animate-pulse';
+			statusIndicator = (
+				<circle
+					cx={x + width - 10}
+					cy={y + 10}
+					r={4}
+					fill="#3b82f6"
+					class="animate-ping"
+					opacity={0.75}
+				/>
+			);
+			break;
+		case 'completed': {
+			borderColor = '#16a34a';
+			bgColor = '#052e16';
+			labelColor = '#86efac';
+			// Find most recent completed task for elapsed time
+			const completedTasks = tasks.filter((t) => t.status === 'completed' && t.updatedAt);
+			const elapsed =
+				completedTasks.length > 0
+					? formatElapsed(
+							completedTasks[completedTasks.length - 1].updatedAt,
+							completedTasks[completedTasks.length - 1].createdAt
+						)
+					: null;
+			statusIndicator = (
+				<>
+					<path
+						d={`M ${x + width - 18} ${y + 8} L ${x + width - 13} ${y + 13} L ${x + width - 7} ${y + 6}`}
+						stroke="#16a34a"
+						strokeWidth={2}
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						fill="none"
+					/>
+					{elapsed && (
+						<text
+							x={x + width / 2}
+							y={y + height - 6}
+							textAnchor="middle"
+							style={{ fontSize: '9px', fill: '#4ade80', fontFamily: 'monospace' }}
+						>
+							{elapsed}
+						</text>
+					)}
+				</>
+			);
+			break;
+		}
+		case 'failed':
+			borderColor = '#dc2626';
+			bgColor = '#450a0a';
+			labelColor = '#fca5a5';
+			statusIndicator = (
+				<>
+					<line
+						x1={x + width - 16}
+						y1={y + 7}
+						x2={x + width - 8}
+						y2={y + 15}
+						stroke="#dc2626"
+						strokeWidth={2}
+						strokeLinecap="round"
+					/>
+					<line
+						x1={x + width - 8}
+						y1={y + 7}
+						x2={x + width - 16}
+						y2={y + 15}
+						stroke="#dc2626"
+						strokeWidth={2}
+						strokeLinecap="round"
+					/>
+				</>
+			);
+			break;
+		case 'pending':
+		default:
+			borderColor = '#44403c';
+			bgColor = '#1c1917';
+			labelColor = '#a8a29e';
+			break;
+	}
+
+	// Agent count badge
+	const agentCount = node.agents?.length ?? (node.agentId ? 1 : 0);
+	const agentLabel = agentCount > 1 ? `×${agentCount}` : null;
+
+	// Active task progress
+	const activeTasks = isRuntimeMode ? tasks.filter((t) => t.status === 'in_progress') : [];
+	const progressTask = activeTasks.find((t) => t.progress != null);
+
+	return (
+		<g data-testid={`node-${node.id}`} class={status === 'active' ? pulseClass : undefined}>
+			{/* Shadow */}
+			<rect x={x + 2} y={y + 2} width={width} height={height} rx={6} fill="rgba(0,0,0,0.4)" />
+			{/* Main box */}
+			<rect
+				x={x}
+				y={y}
+				width={width}
+				height={height}
+				rx={6}
+				fill={bgColor}
+				stroke={borderColor}
+				strokeWidth={status === 'active' ? 2 : 1.5}
+			/>
+
+			{/* Node name */}
+			<text
+				x={x + width / 2}
+				y={y + height / 2 - (agentLabel ? 6 : 0)}
+				textAnchor="middle"
+				dominantBaseline="middle"
+				style={{
+					fontSize: '12px',
+					fontWeight: '600',
+					fill: labelColor,
+					fontFamily: 'system-ui, sans-serif',
+				}}
+			>
+				{truncate(node.name, 18)}
+			</text>
+
+			{agentLabel && (
+				<text
+					x={x + width / 2}
+					y={y + height / 2 + 10}
+					textAnchor="middle"
+					style={{ fontSize: '10px', fill: '#78716c', fontFamily: 'system-ui' }}
+				>
+					{agentLabel} agents
+				</text>
+			)}
+
+			{/* Progress bar for active task */}
+			{progressTask?.progress != null && (
+				<>
+					<rect
+						x={x + 8}
+						y={y + height - 10}
+						width={width - 16}
+						height={3}
+						rx={1.5}
+						fill="#292524"
+					/>
+					<rect
+						x={x + 8}
+						y={y + height - 10}
+						width={(width - 16) * (progressTask.progress / 100)}
+						height={3}
+						rx={1.5}
+						fill="#3b82f6"
+					/>
+				</>
+			)}
+
+			{/* Status indicator (top-right corner) */}
+			{statusIndicator}
+
+			{/* Input port (top-center) */}
+			<circle cx={x + width / 2} cy={y} r={3} fill={borderColor} stroke={bgColor} strokeWidth={1} />
+
+			{/* Output port (bottom-center) */}
+			<circle
+				cx={x + width / 2}
+				cy={y + height}
+				r={3}
+				fill={borderColor}
+				stroke={bgColor}
+				strokeWidth={1}
+			/>
+		</g>
+	);
+}
+
+// ============================================================================
+// Helper utilities
+// ============================================================================
+
+function truncate(text: string, maxLen: number): string {
+	if (text.length <= maxLen) return text;
+	return text.slice(0, maxLen - 1) + '…';
+}
+
+function formatElapsed(endMs: number, startMs: number): string {
+	const ms = endMs - startMs;
+	if (ms < 1000) return `${ms}ms`;
+	const s = Math.floor(ms / 1000);
+	if (s < 60) return `${s}s`;
+	const m = Math.floor(s / 60);
+	const rem = s % 60;
+	return rem > 0 ? `${m}m${rem}s` : `${m}m`;
+}
+
+// ============================================================================
+// Determine node status from tasks
+// ============================================================================
+
+function getNodeStatus(
+	nodeId: string,
+	tasks: SpaceTask[],
+	run: SpaceWorkflowRun | null
+): NodeStatus {
+	const nodeTasks = tasks.filter((t) => t.workflowNodeId === nodeId);
+
+	if (nodeTasks.length === 0) {
+		return 'pending';
+	}
+
+	if (nodeTasks.some((t) => t.status === 'in_progress')) return 'active';
+
+	if (
+		nodeTasks.every(
+			(t) => t.status === 'completed' || t.status === 'cancelled' || t.status === 'archived'
+		)
+	) {
+		// All terminal — check if they succeeded
+		if (nodeTasks.some((t) => t.status === 'completed')) return 'completed';
+	}
+
+	if (run?.status === 'needs_attention' || run?.status === 'cancelled') {
+		if (nodeTasks.some((t) => t.status === 'needs_attention' || t.status === 'cancelled')) {
+			return 'failed';
+		}
+	}
+
+	return 'pending';
+}
+
+// ============================================================================
+// Template-mode gate editor controls (add/remove gate on channel)
+// ============================================================================
+
+interface GateAddButtonProps {
+	x: number;
+	y: number;
+	channelId: string;
+	availableGates: Gate[];
+	onAddGate: (channelId: string, gateId: string) => void;
+}
+
+function GateAddButton({
+	x,
+	y,
+	channelId,
+	availableGates,
+	onAddGate,
+}: GateAddButtonProps): JSX.Element {
+	const [open, setOpen] = useState(false);
+
+	if (availableGates.length === 0) return <g />;
+
+	return (
+		<g>
+			<circle
+				cx={x}
+				cy={y}
+				r={9}
+				fill="#292524"
+				stroke="#57534e"
+				strokeWidth={1.5}
+				style={{ cursor: 'pointer' }}
+				onClick={(e) => {
+					e.stopPropagation();
+					setOpen((v) => !v);
+				}}
+				data-testid={`gate-add-btn-${channelId}`}
+			/>
+			<text
+				x={x}
+				y={y + 1}
+				textAnchor="middle"
+				dominantBaseline="middle"
+				style={{ fontSize: '14px', fill: '#a8a29e', pointerEvents: 'none' }}
+			>
+				+
+			</text>
+
+			{open && (
+				<foreignObject x={x - 70} y={y + 14} width={140} height={availableGates.length * 28 + 8}>
+					<div
+						style={{
+							background: '#1c1917',
+							border: '1px solid #44403c',
+							borderRadius: 6,
+							overflow: 'hidden',
+						}}
+					>
+						{availableGates.map((gate) => (
+							<div
+								key={gate.id}
+								style={{
+									padding: '5px 10px',
+									fontSize: '11px',
+									color: '#d6d3d1',
+									cursor: 'pointer',
+									borderBottom: '1px solid #292524',
+								}}
+								onClick={(e) => {
+									e.stopPropagation();
+									setOpen(false);
+									onAddGate(channelId, gate.id);
+								}}
+							>
+								{gate.description ?? gate.id}
+							</div>
+						))}
+					</div>
+				</foreignObject>
+			)}
+		</g>
+	);
+}
+
+// ============================================================================
+// Main WorkflowCanvas
+// ============================================================================
+
+export interface WorkflowCanvasProps {
+	/** ID of the workflow to render */
+	workflowId: string;
+	/**
+	 * ID of the active workflow run.
+	 * When provided → runtime mode (read-only, live status).
+	 * When absent   → template mode (editable gates).
+	 */
+	runId?: string | null;
+	/** Space ID for emitting gate approval events */
+	spaceId: string;
+	/** Optional additional class name */
+	class?: string;
+}
+
+export function WorkflowCanvas({
+	workflowId,
+	runId,
+	spaceId,
+	class: className,
+}: WorkflowCanvasProps): JSX.Element {
+	const isRuntimeMode = !!runId;
+
+	// ---- Data from store ----
+	const workflow = useMemo(
+		() => spaceStore.workflows.value.find((w) => w.id === workflowId) ?? null,
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[workflowId, spaceStore.workflows.value]
+	);
+
+	const run = useMemo(
+		() => (runId ? (spaceStore.workflowRuns.value.find((r) => r.id === runId) ?? null) : null),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[runId, spaceStore.workflowRuns.value]
+	);
+
+	// All tasks for this run (via workflowRunId)
+	const runTasks = useMemo(
+		() => (runId ? (spaceStore.tasksByRun.value.get(runId) ?? []) : []),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[runId, spaceStore.tasksByRun.value]
+	);
+
+	// ---- Gate data state ----
+	const [gateDataMap, setGateDataMap] = useState<Map<string, Record<string, unknown>>>(new Map());
+	const [gateDataLoading, setGateDataLoading] = useState(false);
+
+	// ---- Template-mode: local gate assignments (channelId → gateId) ----
+	const [localGateAssignments, setLocalGateAssignments] = useState<Map<string, string>>(new Map());
+
+	// Initialize local gate assignments from workflow definition
+	useEffect(() => {
+		if (!workflow) return;
+		const map = new Map<string, string>();
+		for (const ch of workflow.channels ?? []) {
+			if (ch.id && ch.gateId) {
+				map.set(ch.id, ch.gateId);
+			}
+		}
+		setLocalGateAssignments(map);
+	}, [workflow]);
+
+	// ---- Fetch gate data for runtime mode ----
+	const fetchGateData = useCallback(async () => {
+		if (!runId) return;
+		setGateDataLoading(true);
+		try {
+			const hub = connectionManager.getHubIfConnected();
+			if (!hub) return;
+			const result = await hub.request<{ gateData: GateDataRecord[] }>(
+				'spaceWorkflowRun.listGateData',
+				{ runId }
+			);
+			const map = new Map<string, Record<string, unknown>>();
+			for (const record of result.gateData) {
+				map.set(record.gateId, record.data);
+			}
+			setGateDataMap(map);
+		} catch {
+			// non-fatal — gate data is optional display info
+		} finally {
+			setGateDataLoading(false);
+		}
+	}, [runId]);
+
+	useEffect(() => {
+		if (isRuntimeMode) {
+			void fetchGateData();
+		}
+	}, [isRuntimeMode, fetchGateData]);
+
+	// ---- Subscribe to gate data events ----
+	useEffect(() => {
+		if (!runId) return;
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) return;
+
+		const unsub = hub.onEvent<{
+			spaceId: string;
+			runId: string;
+			gateId: string;
+			data: Record<string, unknown>;
+		}>('space.gateData.updated', (event) => {
+			if (event.spaceId === spaceId && event.runId === runId) {
+				setGateDataMap((prev) => {
+					const next = new Map(prev);
+					next.set(event.gateId, event.data);
+					return next;
+				});
+			}
+		});
+
+		return unsub;
+	}, [runId, spaceId]);
+
+	// Re-fetch gate data when run status changes (catches approveGate responses)
+	const prevRunStatus = useRef<string | null>(null);
+	useEffect(() => {
+		const newStatus = run?.status ?? null;
+		if (newStatus !== prevRunStatus.current) {
+			prevRunStatus.current = newStatus;
+			if (isRuntimeMode) {
+				void fetchGateData();
+			}
+		}
+	}, [run?.status, isRuntimeMode, fetchGateData]);
+
+	// ---- Gate approval handler ----
+	const handleApproveGate = useCallback(
+		async (gateId: string, approved: boolean) => {
+			if (!runId) return;
+			try {
+				const hub = connectionManager.getHubIfConnected();
+				if (!hub) return;
+				await hub.request('spaceWorkflowRun.approveGate', { runId, gateId, approved });
+				void fetchGateData();
+			} catch {
+				// error handled by caller
+			}
+		},
+		[runId, fetchGateData]
+	);
+
+	// ---- Template mode: add/remove gate on channel ----
+	const handleAddGate = useCallback((channelId: string, gateId: string) => {
+		setLocalGateAssignments((prev) => {
+			const next = new Map(prev);
+			next.set(channelId, gateId);
+			return next;
+		});
+	}, []);
+
+	// ---- Layout computation ----
+	const layout = useMemo(
+		() => (workflow ? computeLayout(workflow) : new Map<string, NodeLayout>()),
+		[workflow]
+	);
+
+	// Canvas dimensions
+	const { canvasWidth, canvasHeight } = useMemo(() => {
+		if (layout.size === 0) return { canvasWidth: 400, canvasHeight: 300 };
+		let maxX = 0;
+		let maxY = 0;
+		for (const l of layout.values()) {
+			maxX = Math.max(maxX, l.x + l.width);
+			maxY = Math.max(maxY, l.y + l.height);
+		}
+		return {
+			canvasWidth: maxX + CANVAS_PADDING,
+			canvasHeight: maxY + CANVAS_PADDING,
+		};
+	}, [layout]);
+
+	// ---- Rendered channels ----
+	const renderedChannels = useMemo((): RenderedChannel[] => {
+		if (!workflow) return [];
+		return (workflow.channels ?? [])
+			.filter((ch) => ch.id)
+			.flatMap((ch) => {
+				const targets = Array.isArray(ch.to) ? ch.to : [ch.to];
+				return targets.map((to) => ({
+					id: ch.id!,
+					fromId: ch.from,
+					toId: to,
+					gateId: isRuntimeMode ? ch.gateId : (localGateAssignments.get(ch.id!) ?? ch.gateId),
+				}));
+			});
+	}, [workflow, isRuntimeMode, localGateAssignments]);
+
+	// ---- Gates by ID ----
+	const gatesById = useMemo(() => {
+		const map = new Map<string, Gate>();
+		for (const gate of workflow?.gates ?? []) {
+			map.set(gate.id, gate);
+		}
+		return map;
+	}, [workflow]);
+
+	// ---- Unassigned gates (for template mode add button) ----
+	const unassignedGates = useMemo(() => {
+		if (!workflow) return [];
+		const usedGateIds = new Set(localGateAssignments.values());
+		return (workflow.gates ?? []).filter((g) => !usedGateIds.has(g.id));
+	}, [workflow, localGateAssignments]);
+
+	// ---- Loading/empty states ----
+	if (!workflow) {
+		return (
+			<div class={cn('flex items-center justify-center h-full text-stone-500 text-sm', className)}>
+				Workflow not found
+			</div>
+		);
+	}
+
+	if (workflow.nodes.length === 0) {
+		return (
+			<div class={cn('flex items-center justify-center h-full text-stone-500 text-sm', className)}>
+				No nodes in workflow
+			</div>
+		);
+	}
+
+	// ============================================================================
+	// Render
+	// ============================================================================
+
+	const arrowMarkerId = `wc-arrow-${workflowId.slice(0, 8)}`;
+	const arrowMarkerGatedId = `${arrowMarkerId}-gated`;
+
+	return (
+		<div
+			class={cn('relative overflow-auto bg-stone-950', className)}
+			data-testid="workflow-canvas"
+			data-mode={isRuntimeMode ? 'runtime' : 'template'}
+			data-workflow-id={workflowId}
+		>
+			{gateDataLoading && (
+				<div class="absolute top-2 right-2 text-stone-500 text-xs">Loading gate data…</div>
+			)}
+			{run && run.status === 'needs_attention' && (
+				<div class="absolute top-0 left-0 right-0 bg-amber-900/40 border-b border-amber-700/50 px-3 py-1.5 text-xs text-amber-300 text-center z-10">
+					{run.failureReason === 'humanRejected'
+						? 'Workflow paused — awaiting approval'
+						: 'Workflow needs attention'}
+				</div>
+			)}
+
+			<svg
+				viewBox={`0 0 ${canvasWidth} ${canvasHeight}`}
+				width={canvasWidth}
+				height={canvasHeight}
+				style={{ display: 'block', minWidth: canvasWidth, minHeight: canvasHeight }}
+				data-testid="workflow-canvas-svg"
+			>
+				<defs>
+					<marker
+						id={arrowMarkerId}
+						viewBox="0 0 10 10"
+						refX="10"
+						refY="5"
+						markerWidth="6"
+						markerHeight="6"
+						orient="auto-start-reverse"
+					>
+						<path d="M 0 0 L 10 5 L 0 10 z" fill="#44403c" />
+					</marker>
+					<marker
+						id={arrowMarkerGatedId}
+						viewBox="0 0 10 10"
+						refX="10"
+						refY="5"
+						markerWidth="6"
+						markerHeight="6"
+						orient="auto-start-reverse"
+					>
+						<path d="M 0 0 L 10 5 L 0 10 z" fill="#78716c" />
+					</marker>
+				</defs>
+
+				{/* Channel lines */}
+				{renderedChannels.map((ch) => {
+					const fromLayout = layout.get(ch.fromId);
+					const toLayout = layout.get(ch.toId);
+					if (!fromLayout || !toLayout) return null;
+
+					const pts = computeChannelPath(fromLayout, toLayout);
+					const d = buildBezierD(pts);
+					const hasGate = !!ch.gateId;
+
+					const gate = ch.gateId ? gatesById.get(ch.gateId) : undefined;
+					const gateData = ch.gateId ? (gateDataMap.get(ch.gateId) ?? gate?.data ?? {}) : {};
+					const gateStatus: GateStatus = gate ? evaluateGateStatus(gate, gateData) : 'open';
+
+					// Channel color based on gate status in runtime mode
+					let strokeColor = '#44403c';
+					let strokeDash: string | undefined;
+					if (hasGate) {
+						strokeColor = '#78716c';
+					} else {
+						strokeDash = '6 4';
+					}
+					if (isRuntimeMode && hasGate) {
+						if (gateStatus === 'open') strokeColor = '#166534';
+						else if (gateStatus === 'waiting_human') strokeColor = '#92400e';
+						else strokeColor = '#44403c';
+					}
+
+					// Channels without gates are always available (plain arrows)
+					const isHumanGate = gate ? isHumanApprovalGate(gate.condition) : false;
+
+					return (
+						<g key={`ch-${ch.id}-${ch.toId}`} data-testid={`channel-${ch.id}`}>
+							{/* Invisible wider hitbox */}
+							<path
+								d={d}
+								stroke="transparent"
+								strokeWidth={12}
+								fill="none"
+								style={{ pointerEvents: 'stroke' }}
+							/>
+							{/* Visible path */}
+							<path
+								d={d}
+								stroke={strokeColor}
+								strokeWidth={1.5}
+								strokeDasharray={strokeDash}
+								strokeOpacity={0.85}
+								fill="none"
+								markerEnd={`url(#${hasGate ? arrowMarkerGatedId : arrowMarkerId})`}
+							/>
+
+							{/* Gate icon ON the channel line (at midpoint) */}
+							{hasGate && gate && (
+								<GateIcon
+									x={pts.mx}
+									y={pts.my}
+									status={gateStatus}
+									isRuntimeMode={isRuntimeMode}
+									onApprove={
+										isHumanGate ? () => void handleApproveGate(ch.gateId!, true) : undefined
+									}
+									onReject={
+										isHumanGate ? () => void handleApproveGate(ch.gateId!, false) : undefined
+									}
+								/>
+							)}
+
+							{/* Template mode: "+" add gate button */}
+							{!isRuntimeMode && !hasGate && (
+								<GateAddButton
+									x={pts.mx}
+									y={pts.my}
+									channelId={ch.id}
+									availableGates={unassignedGates}
+									onAddGate={handleAddGate}
+								/>
+							)}
+
+							{/* Template mode: remove gate button */}
+							{!isRuntimeMode && hasGate && (
+								<g
+									data-testid={`gate-remove-${ch.id}`}
+									style={{ cursor: 'pointer' }}
+									onClick={() => {
+										setLocalGateAssignments((prev) => {
+											const next = new Map(prev);
+											next.delete(ch.id);
+											return next;
+										});
+									}}
+								>
+									<circle
+										cx={pts.mx + 14}
+										cy={pts.my - 14}
+										r={7}
+										fill="#292524"
+										stroke="#57534e"
+										strokeWidth={1}
+									/>
+									<line
+										x1={pts.mx + 10}
+										y1={pts.my - 18}
+										x2={pts.mx + 18}
+										y2={pts.my - 10}
+										stroke="#a8a29e"
+										strokeWidth={1.5}
+										strokeLinecap="round"
+									/>
+									<line
+										x1={pts.mx + 18}
+										y1={pts.my - 18}
+										x2={pts.mx + 10}
+										y2={pts.my - 10}
+										stroke="#a8a29e"
+										strokeWidth={1.5}
+										strokeLinecap="round"
+									/>
+								</g>
+							)}
+						</g>
+					);
+				})}
+
+				{/* Nodes */}
+				{workflow.nodes.map((node) => {
+					const nodeLayout = layout.get(node.id);
+					if (!nodeLayout) return null;
+
+					const nodeTasks = runTasks.filter((t) => t.workflowNodeId === node.id);
+					const status = isRuntimeMode ? getNodeStatus(node.id, runTasks, run) : 'pending';
+
+					return (
+						<NodeBox
+							key={node.id}
+							node={node}
+							layout={nodeLayout}
+							status={status}
+							tasks={nodeTasks}
+							isRuntimeMode={isRuntimeMode}
+						/>
+					);
+				})}
+			</svg>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -148,6 +148,8 @@ function evalConditionStatus(condition: GateCondition, data: Record<string, unkn
 			return 'blocked';
 		}
 	}
+	// Exhaustive fallback — guards against new GateCondition types added in the future.
+	return 'blocked';
 }
 
 // ============================================================================
@@ -859,6 +861,8 @@ export function WorkflowCanvas({
 	// ---- Fetch gate data for runtime mode ----
 	const fetchGateData = useCallback(async () => {
 		if (!runId) return;
+		// Clear stale data immediately so old run's gate states don't flash on the new run's channels.
+		setGateDataMap(new Map());
 		setGateDataLoading(true);
 		try {
 			const hub = connectionManager.getHubIfConnected();
@@ -939,6 +943,10 @@ export function WorkflowCanvas({
 	);
 
 	// ---- Template mode: add/remove gate on channel ----
+	// TODO(M6.3): Persist template-mode gate assignments to the backend by calling
+	// spaceWorkflow.update (or a dedicated channel-gate RPC) when add/remove fires.
+	// Currently these changes are local-only and lost on unmount. Gate editing in
+	// WorkflowEditor.tsx remains the canonical way to persist gate assignments.
 	const handleAddGate = useCallback((channelId: string, gateId: string) => {
 		setLocalGateAssignments((prev) => {
 			const next = new Map(prev);

--- a/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
@@ -1,0 +1,521 @@
+/**
+ * Unit tests for WorkflowCanvas
+ *
+ * Tests:
+ * - Renders "Workflow not found" when workflow missing
+ * - Renders "No nodes in workflow" when workflow has no nodes
+ * - Renders node boxes for each workflow node
+ * - Renders channel paths between nodes
+ * - Gate icon rendered ON channel line (not as separate node)
+ * - Gate status: open (green), blocked (gray lock), waiting_human (amber)
+ * - Human approval gate shows waiting_human when no data
+ * - Runtime mode shows live node status (active, completed)
+ * - Template mode shows "+ add gate" buttons on channels without gates
+ * - Template mode shows remove-gate button on gated channels
+ * - Node active status shows pulsing class
+ * - Completed node shows checkmark indicator
+ * - Active run banner shows when run is needs_attention
+ * - Gate data event subscription updates gate status
+ */
+
+// @ts-nocheck
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor, fireEvent } from '@testing-library/preact';
+import { signal, type Signal } from '@preact/signals';
+import type { SpaceWorkflow, SpaceWorkflowRun, SpaceTask, Gate } from '@neokai/shared';
+
+// ---- Signals for mocking ----
+let mockWorkflows: Signal<SpaceWorkflow[]>;
+let mockWorkflowRuns: Signal<SpaceWorkflowRun[]>;
+let mockTasks: Signal<SpaceTask[]>;
+let mockTasksByRun: Signal<Map<string, SpaceTask[]>>;
+
+const mockEventListeners = new Map<string, Array<(data: unknown) => void>>();
+const mockHub = {
+	request: vi.fn(),
+	onEvent: vi.fn((event: string, handler: (data: unknown) => void) => {
+		if (!mockEventListeners.has(event)) mockEventListeners.set(event, []);
+		mockEventListeners.get(event)!.push(handler);
+		return () => {
+			const handlers = mockEventListeners.get(event) ?? [];
+			const idx = handlers.indexOf(handler);
+			if (idx >= 0) handlers.splice(idx, 1);
+		};
+	}),
+};
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			workflows: mockWorkflows,
+			workflowRuns: mockWorkflowRuns,
+			tasks: mockTasks,
+			tasksByRun: mockTasksByRun,
+		};
+	},
+}));
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: vi.fn(() => mockHub),
+	},
+}));
+
+// Initialize signals before component import
+mockWorkflows = signal<SpaceWorkflow[]>([]);
+mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
+mockTasks = signal<SpaceTask[]>([]);
+mockTasksByRun = signal<Map<string, SpaceTask[]>>(new Map());
+
+import { WorkflowCanvas } from '../WorkflowCanvas';
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeGate(overrides: Partial<Gate> = {}): Gate {
+	return {
+		id: 'gate-1',
+		condition: { type: 'check', field: 'approved', op: '==', value: true },
+		data: {},
+		allowedWriterRoles: ['*'],
+		description: 'Human approval',
+		resetOnCycle: false,
+		...overrides,
+	};
+}
+
+function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		spaceId: 'sp-1',
+		name: 'Test Workflow',
+		description: '',
+		nodes: [
+			{ id: 'n1', name: 'Planner' },
+			{ id: 'n2', name: 'Coder' },
+		],
+		startNodeId: 'n1',
+		rules: [],
+		channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way' }],
+		gates: [],
+		tags: [],
+		createdAt: 1000,
+		updatedAt: 1000,
+		...overrides,
+	};
+}
+
+function makeRun(overrides: Partial<SpaceWorkflowRun> = {}): SpaceWorkflowRun {
+	return {
+		id: 'run-1',
+		spaceId: 'sp-1',
+		workflowId: 'wf-1',
+		title: 'Run 1',
+		status: 'in_progress',
+		iterationCount: 0,
+		maxIterations: 10,
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'sp-1',
+		taskNumber: 1,
+		title: 'Task 1',
+		description: '',
+		status: 'pending',
+		priority: 'normal',
+		dependsOn: [],
+		workflowRunId: 'run-1',
+		workflowNodeId: 'n1',
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('WorkflowCanvas', () => {
+	beforeEach(() => {
+		mockWorkflows.value = [];
+		mockWorkflowRuns.value = [];
+		mockTasks.value = [];
+		mockTasksByRun.value = new Map();
+		mockEventListeners.clear();
+		mockHub.request.mockReset();
+		mockHub.request.mockResolvedValue({ gateData: [] });
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	// ---- Empty/error states ----
+
+	it('renders "Workflow not found" when workflow is missing', () => {
+		const { getByText } = render(<WorkflowCanvas workflowId="missing" spaceId="sp-1" />);
+		expect(getByText('Workflow not found')).toBeTruthy();
+	});
+
+	it('renders "No nodes in workflow" when workflow has no nodes', () => {
+		mockWorkflows.value = [makeWorkflow({ nodes: [] })];
+		const { getByText } = render(<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />);
+		expect(getByText('No nodes in workflow')).toBeTruthy();
+	});
+
+	// ---- Basic rendering ----
+
+	it('renders canvas SVG with correct mode attribute', () => {
+		mockWorkflows.value = [makeWorkflow()];
+		const { getByTestId } = render(<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />);
+		const canvas = getByTestId('workflow-canvas');
+		expect(canvas.getAttribute('data-mode')).toBe('template');
+	});
+
+	it('sets data-mode to runtime when runId is provided', () => {
+		mockWorkflows.value = [makeWorkflow()];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+		const { getByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		expect(getByTestId('workflow-canvas').getAttribute('data-mode')).toBe('runtime');
+	});
+
+	it('renders a node box for each workflow node', () => {
+		mockWorkflows.value = [makeWorkflow()];
+		const { getByTestId } = render(<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />);
+		expect(getByTestId('node-n1')).toBeTruthy();
+		expect(getByTestId('node-n2')).toBeTruthy();
+	});
+
+	it('renders channel path between nodes', () => {
+		mockWorkflows.value = [makeWorkflow()];
+		const { getByTestId } = render(<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />);
+		expect(getByTestId('channel-ch-1')).toBeTruthy();
+	});
+
+	// ---- Gate rendering on channel lines ----
+
+	it('renders gate icon ON the channel line (not as separate node)', () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		const { getAllByTestId, queryAllByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />
+		);
+		// Gate icon should exist
+		const gateIcons = getAllByTestId(/^gate-icon-/);
+		expect(gateIcons.length).toBeGreaterThan(0);
+		// Should only be 2 nodes, not 3 (gate is not a separate node)
+		expect(queryAllByTestId(/^node-/).length).toBe(2);
+	});
+
+	it('shows waiting_human gate status for human approval gate with no data', () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+		const { getByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		// Initial state (no gate data loaded yet) - gate status should be waiting_human
+		expect(getByTestId('gate-icon-waiting_human')).toBeTruthy();
+	});
+
+	it('shows open gate status when approved=true in gate data', async () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockHub.request.mockResolvedValue({
+			gateData: [{ runId: 'run-1', gateId: 'gate-1', data: { approved: true }, updatedAt: 2000 }],
+		});
+		const { findByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		await findByTestId('gate-icon-open');
+	});
+
+	it('shows blocked gate status when approved=false', async () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockHub.request.mockResolvedValue({
+			gateData: [{ runId: 'run-1', gateId: 'gate-1', data: { approved: false }, updatedAt: 2000 }],
+		});
+		const { findByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		await findByTestId('gate-icon-blocked');
+	});
+
+	it('updates gate status on space.gateData.updated event', async () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { findByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+
+		// Initially waiting_human (no data)
+		await findByTestId('gate-icon-waiting_human');
+
+		// Fire gate data update event
+		const handlers = mockEventListeners.get('space.gateData.updated') ?? [];
+		for (const h of handlers) {
+			h({ spaceId: 'sp-1', runId: 'run-1', gateId: 'gate-1', data: { approved: true } });
+		}
+
+		// Should now show open
+		await findByTestId('gate-icon-open');
+	});
+
+	// ---- Node status ----
+
+	it('renders active node with animate-pulse class when task is in_progress', () => {
+		const wf = makeWorkflow();
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockTasksByRun.value = new Map([
+			['run-1', [makeTask({ workflowNodeId: 'n1', status: 'in_progress' })]],
+		]);
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { getByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		const node = getByTestId('node-n1');
+		expect(node.getAttribute('class')).toContain('animate-pulse');
+	});
+
+	it('completed node does not have animate-pulse', () => {
+		const wf = makeWorkflow();
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockTasksByRun.value = new Map([
+			['run-1', [makeTask({ workflowNodeId: 'n2', status: 'completed' })]],
+		]);
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { getByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		const node = getByTestId('node-n2');
+		expect(node.getAttribute('class') ?? '').not.toContain('animate-pulse');
+	});
+
+	// ---- Run status banner ----
+
+	it('shows needs_attention banner for needs_attention run', () => {
+		const wf = makeWorkflow();
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [
+			makeRun({ status: 'needs_attention', failureReason: 'humanRejected' }),
+		];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { getByText } = render(<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />);
+		expect(getByText('Workflow paused — awaiting approval')).toBeTruthy();
+	});
+
+	it('does not show banner for in_progress run', () => {
+		const wf = makeWorkflow();
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun({ status: 'in_progress' })];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { queryByText } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		expect(queryByText('Workflow paused — awaiting approval')).toBeNull();
+	});
+
+	// ---- Template mode ----
+
+	it('shows gate-add-btn on channels without gates in template mode', () => {
+		const wf = makeWorkflow({
+			gates: [makeGate()], // available gates exist
+		});
+		mockWorkflows.value = [wf];
+
+		const { getByTestId } = render(<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />);
+		expect(getByTestId('gate-add-btn-ch-1')).toBeTruthy();
+	});
+
+	it('shows remove-gate button on gated channels in template mode', () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+
+		const { getByTestId } = render(<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />);
+		expect(getByTestId('gate-remove-ch-1')).toBeTruthy();
+	});
+
+	it('does not show gate-add-btn in runtime mode', () => {
+		const wf = makeWorkflow({ gates: [makeGate()] });
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { queryByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		expect(queryByTestId('gate-add-btn-ch-1')).toBeNull();
+	});
+
+	// ---- Gate status evaluation ----
+
+	it('evaluates count gate as open when min is met', async () => {
+		const gate = makeGate({
+			id: 'vote-gate',
+			condition: {
+				type: 'count',
+				field: 'reviews',
+				matchValue: 'approved',
+				min: 2,
+			},
+		});
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'vote-gate' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockHub.request.mockResolvedValue({
+			gateData: [
+				{
+					runId: 'run-1',
+					gateId: 'vote-gate',
+					data: { reviews: { alice: 'approved', bob: 'approved' } },
+					updatedAt: 2000,
+				},
+			],
+		});
+
+		const { findByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		await findByTestId('gate-icon-open');
+	});
+
+	it('evaluates count gate as blocked when min not met', async () => {
+		const gate = makeGate({
+			id: 'vote-gate',
+			condition: {
+				type: 'count',
+				field: 'reviews',
+				matchValue: 'approved',
+				min: 2,
+			},
+		});
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'vote-gate' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockHub.request.mockResolvedValue({
+			gateData: [
+				{
+					runId: 'run-1',
+					gateId: 'vote-gate',
+					data: { reviews: { alice: 'approved' } },
+					updatedAt: 2000,
+				},
+			],
+		});
+
+		const { findByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		await findByTestId('gate-icon-blocked');
+	});
+
+	// ---- listGateData RPC called on mount ----
+
+	it('calls spaceWorkflowRun.listGateData on mount in runtime mode', async () => {
+		const wf = makeWorkflow();
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		render(<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />);
+
+		await waitFor(() => {
+			expect(mockHub.request).toHaveBeenCalledWith('spaceWorkflowRun.listGateData', {
+				runId: 'run-1',
+			});
+		});
+	});
+
+	it('does NOT call spaceWorkflowRun.listGateData in template mode', () => {
+		const wf = makeWorkflow();
+		mockWorkflows.value = [wf];
+
+		render(<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />);
+
+		expect(mockHub.request).not.toHaveBeenCalledWith(
+			'spaceWorkflowRun.listGateData',
+			expect.anything()
+		);
+	});
+
+	// ---- Gate approval action ----
+
+	it('clicking Approve on waiting_human gate calls approveGate RPC', async () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { findByText, getByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+
+		// Click the gate icon to show approve/reject buttons
+		const gateIcon = getByTestId('gate-icon-waiting_human');
+		fireEvent.click(gateIcon);
+
+		const approveBtn = await findByText('Approve');
+		fireEvent.click(approveBtn);
+
+		await waitFor(() => {
+			expect(mockHub.request).toHaveBeenCalledWith('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-1',
+				approved: true,
+			});
+		});
+	});
+});

--- a/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
@@ -18,9 +18,7 @@
  * - Gate data event subscription updates gate status
  */
 
-// @ts-nocheck
-
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { render, cleanup, waitFor, fireEvent } from '@testing-library/preact';
 import { signal, type Signal } from '@preact/signals';
 import type { SpaceWorkflow, SpaceWorkflowRun, SpaceTask, Gate } from '@neokai/shared';
@@ -32,7 +30,7 @@ let mockTasks: Signal<SpaceTask[]>;
 let mockTasksByRun: Signal<Map<string, SpaceTask[]>>;
 
 const mockEventListeners = new Map<string, Array<(data: unknown) => void>>();
-const mockHub = {
+const mockHub: { request: Mock; onEvent: Mock } = {
 	request: vi.fn(),
 	onEvent: vi.fn((event: string, handler: (data: unknown) => void) => {
 		if (!mockEventListeners.has(event)) mockEventListeners.set(event, []);

--- a/packages/web/src/components/space/index.ts
+++ b/packages/web/src/components/space/index.ts
@@ -12,6 +12,8 @@ export { SpaceSettings } from './SpaceSettings';
 export { SpaceTaskPane } from './SpaceTaskPane';
 export { WorkflowEditor, filterAgents, initFromWorkflow } from './WorkflowEditor';
 export { WorkflowList } from './WorkflowList';
+export { WorkflowCanvas } from './WorkflowCanvas';
+export type { WorkflowCanvasProps } from './WorkflowCanvas';
 export { WorkflowRulesEditor, makeEmptyRule, rulesToDrafts } from './WorkflowRulesEditor';
 export { WorkflowNodeCard } from './WorkflowNodeCard';
 export { ImportPreviewDialog } from './ImportPreviewDialog';


### PR DESCRIPTION
## Summary

- Creates `WorkflowCanvas.tsx` — SVG canvas rendering workflow nodes, channels, and gates
- Gates render **ON channel lines** (like valves on pipes), not as separate nodes
- Two modes auto-detected: runtime (read-only live status) when `runId` provided, template (editable gates) otherwise
- Real-time updates via new `space.gateData.updated` WebSocket event and `spaceWorkflowRun.listGateData` RPC

## Visual states

**Nodes:** pending (gray), active (blue pulsing), completed (green + checkmark + elapsed time), failed (red)

**Gates on channel lines:** open (green check), waiting_human (amber pulsing — click to approve/reject), blocked (gray lock)

**Channels:** dashed arrows when ungated, solid when gated

## Backend additions

- `spaceWorkflowRun.listGateData` RPC — returns all `gate_data` records for a run
- `space.gateData.updated` event — emitted from `approveGate` RPC and `write_gate` MCP tool
- `DaemonEventMap` updated with the new event type

## Tests

- 23 web unit tests covering all visual states, runtime/template mode, RPC calls, event subscription
- 4 new daemon tests for `listGateData` RPC
- 2 new daemon tests verifying `space.gateData.updated` emission on approve/reject