### PR TITLE
feat(space): wire QA into V2 workflow with feedback loop (M5.1)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -501,6 +501,15 @@ export class ChannelRouter {
 		const gateResult = this.evaluateGateById(runId, gateId, workflow);
 		if (!gateResult.open) return [];
 
+		// Determine if any of these channels are cyclic — if so, enforce the iteration cap
+		// before activating any node (mirrors the guard in deliverMessage).
+		const hasCyclicChannel = channels.some((ch) => ch.isCyclic);
+		if (hasCyclicChannel && run.iterationCount >= run.maxIterations) {
+			throw new ActivationError(
+				`Cyclic channel via gate "${gateId}" has reached the maximum iteration count (${run.iterationCount}/${run.maxIterations}). Increase maxIterations to allow more cycles.`
+			);
+		}
+
 		// Gate is open → collect all unique node IDs that need activation.
 		// Multiple channels may point to the same target (e.g. fan-out via node name),
 		// so deduplicate before spawning to avoid redundant activateNode() calls.
@@ -539,6 +548,14 @@ export class ChannelRouter {
 			}
 			// Rejected: run may have transitioned to terminal state between the
 			// nodeIdsToActivate check above and the activation attempt — silently skip.
+		}
+
+		// For cyclic channels: atomically increment the iteration counter and reset
+		// gates with `resetOnCycle: true`. This mirrors the logic in deliverMessage and
+		// ensures the QA→Coding feedback path (triggered via write_gate MCP tool →
+		// onGateDataChanged) correctly resets reviewer votes and advances the cycle counter.
+		if (hasCyclicChannel && activatedTasks.length > 0) {
+			this.incrementAndResetCyclicGates(runId, workflow);
 		}
 
 		return activatedTasks;

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -311,9 +311,9 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 			agentId: 'qa',
 			instructions:
 				'Verify test coverage, run the CI pipeline, and confirm the PR is mergeable. ' +
-				'Always write an explicit result to qa-result-gate on every QA pass — do not assume the gate was reset. ' +
-				'Write "result: passed" if everything is green, or "result: failed" with details if issues are found. ' +
-				'Writing is required on every pass because qa-result-gate retains its previous value across cycles.',
+				'Write "result: passed" to qa-result-gate if everything is green, or ' +
+				'"result: failed" with a summary to qa-fail-gate if issues are found. ' +
+				'If QA fails, the coder will fix the issues and all reviewers must re-vote before QA runs again.',
 		},
 		{
 			id: V2_DONE_STEP,
@@ -346,11 +346,14 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 		},
 		{
 			id: 'code-pr-gate',
-			description: 'Code has been implemented and a pull request has been opened',
+			description:
+				'Code has been implemented and a pull request has been opened. ' +
+				'resetOnCycle is false: the same PR is updated across fix cycles — coder pushes ' +
+				'new commits to the existing branch rather than opening a new PR each time.',
 			condition: { type: 'check', field: 'pr_url', op: 'exists' },
 			data: {},
 			allowedWriterRoles: ['coder'],
-			resetOnCycle: true,
+			resetOnCycle: false,
 		},
 		{
 			id: 'review-votes-gate',
@@ -380,12 +383,11 @@ export const CODING_WORKFLOW_V2: SpaceWorkflow = {
 			id: 'qa-result-gate',
 			description:
 				'QA verification has passed — tests, CI, and PR are green. ' +
-				'resetOnCycle is intentionally false: this gate is only referenced by the non-cyclic QA→Done ' +
-				'channel, so it never auto-resets. QA must write an explicit "result" on every pass.',
+				'Resets on each QA→Coding cycle so QA always starts from a clean state.',
 			condition: { type: 'check', field: 'result', op: '==', value: 'passed' },
 			data: {},
 			allowedWriterRoles: ['qa'],
-			resetOnCycle: false,
+			resetOnCycle: true,
 		},
 		{
 			id: 'qa-fail-gate',

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -321,7 +321,8 @@ describe('CODING_WORKFLOW_V2 template', () => {
 		expect(gate.condition.type).toBe('check');
 		expect((gate.condition as { op: string }).op).toBe('exists');
 		expect(gate.allowedWriterRoles).toContain('coder');
-		expect(gate.resetOnCycle).toBe(true);
+		// Preserved across fix cycles — coder updates the existing PR rather than opening a new one
+		expect(gate.resetOnCycle).toBe(false);
 	});
 
 	test('review-votes-gate has count condition requiring min 3 approved', () => {
@@ -349,7 +350,8 @@ describe('CODING_WORKFLOW_V2 template', () => {
 		expect(gate.condition.type).toBe('check');
 		expect((gate.condition as { value: unknown }).value).toBe('passed');
 		expect(gate.allowedWriterRoles).toContain('qa');
-		expect(gate.resetOnCycle).toBe(false);
+		// Resets on QA→Coding cycle so QA starts clean each time
+		expect(gate.resetOnCycle).toBe(true);
 	});
 
 	test('qa-fail-gate has check==failed condition and qa writer role', () => {
@@ -454,10 +456,10 @@ describe('CODING_WORKFLOW_V2 template', () => {
 		}
 	});
 
-	test('QA node instructions require explicit result write on every pass', () => {
+	test('QA node instructions describe both pass and fail write targets', () => {
 		const qa = CODING_WORKFLOW_V2.nodes.find((n) => n.name === 'QA')!;
-		expect(qa.instructions).toContain('every pass');
-		expect(qa.instructions).toMatch(/do not assume/i);
+		expect(qa.instructions).toContain('qa-result-gate');
+		expect(qa.instructions).toContain('qa-fail-gate');
 	});
 
 	test('review-votes-gate description mentions read-merge-write requirement', () => {
@@ -465,10 +467,15 @@ describe('CODING_WORKFLOW_V2 template', () => {
 		expect(gate.description).toContain('read-merge-write');
 	});
 
-	test('qa-result-gate description explains why resetOnCycle is false', () => {
+	test('qa-result-gate description explains it resets on cycle', () => {
 		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'qa-result-gate')!;
+		expect(gate.description).toContain('clean state');
+	});
+
+	test('code-pr-gate description explains it is preserved across fix cycles', () => {
+		const gate = CODING_WORKFLOW_V2.gates!.find((g) => g.id === 'code-pr-gate')!;
 		expect(gate.description).toContain('resetOnCycle');
-		expect(gate.description).toMatch(/intentionally false/i);
+		expect(gate.description).toMatch(/fix cycles/i);
 	});
 
 	test('does not reference leader', () => {

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -2806,7 +2806,7 @@ describe('ChannelRouter', () => {
 				seedAgent(db, AGENT_DONE, SPACE_ID, 'general');
 			});
 
-			test('QA failure activates Coding via cyclic qa-fail-gate channel', async () => {
+			test('QA failure via onGateDataChanged activates Coding, increments counter, resets cycle gates', async () => {
 				const workflow = buildQaWorkflow();
 				const run = workflowRunRepo.createRun({
 					spaceId: SPACE_ID,
@@ -2817,17 +2817,38 @@ describe('ChannelRouter', () => {
 				workflowRunRepo.transitionStatus(run.id, 'in_progress');
 				gateDataRepo.initializeForRun(run.id, allGates);
 
-				// QA writes failed result with summary to qa-fail-gate
+				// Simulate pre-existing state from a completed review cycle
+				gateDataRepo.set(run.id, 'code-pr-gate', { pr_url: 'https://github.com/org/repo/pull/42' });
+				gateDataRepo.set(run.id, 'review-votes-gate', {
+					votes: { 'reviewer-1': 'approved', 'reviewer-2': 'approved', 'reviewer-3': 'approved' },
+				});
+				gateDataRepo.set(run.id, 'review-reject-gate', { votes: { 'reviewer-1': 'approved' } });
+				gateDataRepo.set(run.id, 'qa-result-gate', { result: 'passed' });
+
+				// QA writes failed result with summary to qa-fail-gate (as the write_gate MCP tool would)
 				gateDataRepo.set(run.id, 'qa-fail-gate', {
 					result: 'failed',
 					summary: 'CI pipeline red: 3 tests failing',
 				});
 				const activated = await router.onGateDataChanged(run.id, 'qa-fail-gate');
 
-				// Coding node should be activated via the cyclic QA→Coding channel
-				expect(activated.length).toBeGreaterThanOrEqual(1);
-				const codingTask = activated.find((t) => t.workflowNodeId === NODE_CODING);
-				expect(codingTask).toBeDefined();
+				// Exactly one task: the Coding node activated via the cyclic QA→Coding channel
+				expect(activated).toHaveLength(1);
+				expect(activated[0].workflowNodeId).toBe(NODE_CODING);
+
+				// Iteration counter must increment
+				expect(workflowRunRepo.getRun(run.id)!.iterationCount).toBe(1);
+
+				// Cyclic-reset gates must be wiped
+				expect(gateDataRepo.get(run.id, 'review-votes-gate')!.data).toEqual({ votes: {} });
+				expect(gateDataRepo.get(run.id, 'review-reject-gate')!.data).toEqual({});
+				expect(gateDataRepo.get(run.id, 'qa-result-gate')!.data).toEqual({});
+				expect(gateDataRepo.get(run.id, 'qa-fail-gate')!.data).toEqual({});
+
+				// code-pr-gate must be preserved (resetOnCycle: false)
+				expect(gateDataRepo.get(run.id, 'code-pr-gate')!.data).toEqual({
+					pr_url: 'https://github.com/org/repo/pull/42',
+				});
 			});
 
 			test('QA failure resets review-votes-gate, qa-result-gate, qa-fail-gate; preserves code-pr-gate', async () => {
@@ -2947,6 +2968,29 @@ describe('ChannelRouter', () => {
 				await expect(
 					router.deliverMessage(run.id, 'QA', 'Coding', 'QA cycle 3 — should fail')
 				).rejects.toBeInstanceOf(ActivationError);
+			});
+
+			test('onGateDataChanged throws ActivationError when cyclic channel at max iterations', async () => {
+				const workflow = buildQaWorkflow();
+				const run = workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'Max Iterations via onGateDataChanged',
+					maxIterations: 1,
+				});
+				workflowRunRepo.transitionStatus(run.id, 'in_progress');
+				gateDataRepo.initializeForRun(run.id, allGates);
+
+				// Use up the 1 iteration via onGateDataChanged
+				gateDataRepo.set(run.id, 'qa-fail-gate', { result: 'failed' });
+				await router.onGateDataChanged(run.id, 'qa-fail-gate');
+				expect(workflowRunRepo.getRun(run.id)!.iterationCount).toBe(1);
+
+				// Second attempt must throw before any activation
+				gateDataRepo.set(run.id, 'qa-fail-gate', { result: 'failed' });
+				await expect(router.onGateDataChanged(run.id, 'qa-fail-gate')).rejects.toBeInstanceOf(
+					ActivationError
+				);
 			});
 
 			test('QA passes → QA→Done channel opens when qa-result-gate satisfied', async () => {

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -2678,6 +2678,297 @@ describe('ChannelRouter', () => {
 		// gateId takes precedence over legacy inline gate
 		// -----------------------------------------------------------------------
 
+		// -----------------------------------------------------------------------
+		// QA feedback loop — M5.1
+		// -----------------------------------------------------------------------
+
+		describe('QA feedback loop', () => {
+			const AGENT_REVIEWER = 'agent-reviewer-qa';
+			const AGENT_QA = 'agent-qa-loop';
+			const AGENT_DONE = 'agent-done-loop';
+
+			const NODE_CODING = 'node-coding-qa';
+			const NODE_REV1 = 'node-rev1-qa';
+			const NODE_REV2 = 'node-rev2-qa';
+			const NODE_REV3 = 'node-rev3-qa';
+			const NODE_QA = 'node-qa-loop';
+			const NODE_DONE = 'node-done-qa';
+
+			// Gates matching CODING_WORKFLOW_V2 design
+			const gateCodePr: Gate = {
+				id: 'code-pr-gate',
+				condition: { type: 'check', field: 'pr_url', op: 'exists' },
+				data: {},
+				allowedWriterRoles: ['coder'],
+				resetOnCycle: false, // preserved across fix cycles
+			};
+			const gateReviewVotes: Gate = {
+				id: 'review-votes-gate',
+				condition: { type: 'count', field: 'votes', matchValue: 'approved', min: 3 },
+				data: { votes: {} },
+				allowedWriterRoles: ['reviewer'],
+				resetOnCycle: true,
+			};
+			const gateReviewReject: Gate = {
+				id: 'review-reject-gate',
+				condition: { type: 'count', field: 'votes', matchValue: 'rejected', min: 1 },
+				data: {},
+				allowedWriterRoles: ['reviewer'],
+				resetOnCycle: true,
+			};
+			const gateQaResult: Gate = {
+				id: 'qa-result-gate',
+				condition: { type: 'check', field: 'result', op: '==', value: 'passed' },
+				data: {},
+				allowedWriterRoles: ['qa'],
+				resetOnCycle: true, // resets on each QA→Coding cycle
+			};
+			const gateQaFail: Gate = {
+				id: 'qa-fail-gate',
+				condition: { type: 'check', field: 'result', op: '==', value: 'failed' },
+				data: {},
+				allowedWriterRoles: ['qa'],
+				resetOnCycle: true,
+			};
+			const allGates = [gateCodePr, gateReviewVotes, gateReviewReject, gateQaResult, gateQaFail];
+
+			function buildQaWorkflow() {
+				const channels: WorkflowChannel[] = [
+					// Coding → Reviewers
+					{ from: 'Coding', to: 'Reviewer 1', direction: 'one-way', gateId: 'code-pr-gate' },
+					{ from: 'Coding', to: 'Reviewer 2', direction: 'one-way', gateId: 'code-pr-gate' },
+					{ from: 'Coding', to: 'Reviewer 3', direction: 'one-way', gateId: 'code-pr-gate' },
+					// Reviewers → QA
+					{
+						from: 'Reviewer 1',
+						to: 'QA',
+						direction: 'one-way',
+						gateId: 'review-votes-gate',
+					},
+					{
+						from: 'Reviewer 2',
+						to: 'QA',
+						direction: 'one-way',
+						gateId: 'review-votes-gate',
+					},
+					{
+						from: 'Reviewer 3',
+						to: 'QA',
+						direction: 'one-way',
+						gateId: 'review-votes-gate',
+					},
+					// QA → Done (success)
+					{ from: 'QA', to: 'Done', direction: 'one-way', gateId: 'qa-result-gate' },
+					// QA → Coding (cyclic, fail)
+					{
+						from: 'QA',
+						to: 'Coding',
+						direction: 'one-way',
+						gateId: 'qa-fail-gate',
+						isCyclic: true,
+					},
+				];
+				return buildWorkflowWithGates(
+					SPACE_ID,
+					workflowManager,
+					[
+						{ id: NODE_CODING, name: 'Coding', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+						{
+							id: NODE_REV1,
+							name: 'Reviewer 1',
+							agents: [{ agentId: AGENT_REVIEWER, name: 'reviewer-1' }],
+						},
+						{
+							id: NODE_REV2,
+							name: 'Reviewer 2',
+							agents: [{ agentId: AGENT_REVIEWER, name: 'reviewer-2' }],
+						},
+						{
+							id: NODE_REV3,
+							name: 'Reviewer 3',
+							agents: [{ agentId: AGENT_REVIEWER, name: 'reviewer-3' }],
+						},
+						{ id: NODE_QA, name: 'QA', agents: [{ agentId: AGENT_QA, name: 'qa' }] },
+						{
+							id: NODE_DONE,
+							name: 'Done',
+							agents: [{ agentId: AGENT_DONE, name: 'done' }],
+						},
+					],
+					channels,
+					allGates
+				);
+			}
+
+			beforeEach(() => {
+				seedAgent(db, AGENT_REVIEWER, SPACE_ID, 'reviewer');
+				seedAgent(db, AGENT_QA, SPACE_ID, 'qa');
+				seedAgent(db, AGENT_DONE, SPACE_ID, 'general');
+			});
+
+			test('QA failure activates Coding via cyclic qa-fail-gate channel', async () => {
+				const workflow = buildQaWorkflow();
+				const run = workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'QA Fail Loop Run',
+					maxIterations: 5,
+				});
+				workflowRunRepo.transitionStatus(run.id, 'in_progress');
+				gateDataRepo.initializeForRun(run.id, allGates);
+
+				// QA writes failed result with summary to qa-fail-gate
+				gateDataRepo.set(run.id, 'qa-fail-gate', {
+					result: 'failed',
+					summary: 'CI pipeline red: 3 tests failing',
+				});
+				const activated = await router.onGateDataChanged(run.id, 'qa-fail-gate');
+
+				// Coding node should be activated via the cyclic QA→Coding channel
+				expect(activated.length).toBeGreaterThanOrEqual(1);
+				const codingTask = activated.find((t) => t.workflowNodeId === NODE_CODING);
+				expect(codingTask).toBeDefined();
+			});
+
+			test('QA failure resets review-votes-gate, qa-result-gate, qa-fail-gate; preserves code-pr-gate', async () => {
+				const workflow = buildQaWorkflow();
+				const run = workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'Gate Reset On QA Fail',
+					maxIterations: 5,
+				});
+				workflowRunRepo.transitionStatus(run.id, 'in_progress');
+				gateDataRepo.initializeForRun(run.id, allGates);
+
+				// Simulate pre-existing gate state from a completed review cycle;
+				// qa-fail-gate must be set to satisfy the gated channel before delivery
+				gateDataRepo.set(run.id, 'code-pr-gate', { pr_url: 'https://github.com/org/repo/pull/42' });
+				gateDataRepo.set(run.id, 'review-votes-gate', {
+					votes: { 'reviewer-1': 'approved', 'reviewer-2': 'approved', 'reviewer-3': 'approved' },
+				});
+				gateDataRepo.set(run.id, 'review-reject-gate', {
+					votes: { 'reviewer-1': 'approved' },
+				});
+				gateDataRepo.set(run.id, 'qa-result-gate', { result: 'passed' });
+				gateDataRepo.set(run.id, 'qa-fail-gate', { result: 'failed' });
+
+				// QA delivers to Coding via cyclic channel (gate already satisfied above)
+				await router.deliverMessage(run.id, 'QA', 'Coding', 'QA found issues');
+
+				// code-pr-gate must be preserved (not reset) so Coding can update the existing PR
+				const codePr = gateDataRepo.get(run.id, 'code-pr-gate');
+				expect(codePr!.data).toEqual({
+					pr_url: 'https://github.com/org/repo/pull/42',
+				});
+
+				// review-votes-gate, review-reject-gate, qa-result-gate, qa-fail-gate must reset
+				const reviewVotes = gateDataRepo.get(run.id, 'review-votes-gate');
+				expect(reviewVotes!.data).toEqual({ votes: {} });
+
+				const reviewReject = gateDataRepo.get(run.id, 'review-reject-gate');
+				expect(reviewReject!.data).toEqual({});
+
+				const qaResult = gateDataRepo.get(run.id, 'qa-result-gate');
+				expect(qaResult!.data).toEqual({});
+
+				const qaFail = gateDataRepo.get(run.id, 'qa-fail-gate');
+				expect(qaFail!.data).toEqual({});
+			});
+
+			test('QA→Coding cycle increments iteration counter', async () => {
+				const workflow = buildQaWorkflow();
+				const run = workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'Iteration Counter Run',
+					maxIterations: 5,
+				});
+				workflowRunRepo.transitionStatus(run.id, 'in_progress');
+				gateDataRepo.initializeForRun(run.id, allGates);
+
+				expect(workflowRunRepo.getRun(run.id)!.iterationCount).toBe(0);
+
+				// Must satisfy qa-fail-gate before delivering on cyclic QA→Coding channel
+				gateDataRepo.set(run.id, 'qa-fail-gate', { result: 'failed' });
+				await router.deliverMessage(run.id, 'QA', 'Coding', 'QA cycle 1');
+
+				expect(workflowRunRepo.getRun(run.id)!.iterationCount).toBe(1);
+			});
+
+			test('after QA fail cycle, reviewers must re-vote from scratch (votes reset to empty)', async () => {
+				const workflow = buildQaWorkflow();
+				const run = workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'Re-vote From Scratch',
+					maxIterations: 5,
+				});
+				workflowRunRepo.transitionStatus(run.id, 'in_progress');
+				gateDataRepo.initializeForRun(run.id, allGates);
+
+				// Populate existing votes and satisfy qa-fail-gate
+				gateDataRepo.set(run.id, 'review-votes-gate', {
+					votes: { 'reviewer-1': 'approved', 'reviewer-2': 'approved', 'reviewer-3': 'approved' },
+				});
+				gateDataRepo.set(run.id, 'qa-fail-gate', { result: 'failed' });
+
+				// QA→Coding cycle
+				await router.deliverMessage(run.id, 'QA', 'Coding', 'issues found');
+
+				// All votes wiped — reviewers must re-vote
+				const votes = gateDataRepo.get(run.id, 'review-votes-gate');
+				expect(votes!.data).toEqual({ votes: {} });
+
+				// QA channel now blocked (only 0/3 approved)
+				const canDeliver = await router.canDeliver(run.id, 'Reviewer 1', 'QA');
+				expect(canDeliver.allowed).toBe(false);
+			});
+
+			test('QA→Coding cycle throws ActivationError when max iterations reached', async () => {
+				const workflow = buildQaWorkflow();
+				const run = workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'Max Iterations QA',
+					maxIterations: 2,
+				});
+				workflowRunRepo.transitionStatus(run.id, 'in_progress');
+				gateDataRepo.initializeForRun(run.id, allGates);
+
+				// Use up 2 iterations (must satisfy qa-fail-gate before each delivery; gate resets on each cycle)
+				gateDataRepo.set(run.id, 'qa-fail-gate', { result: 'failed' });
+				await router.deliverMessage(run.id, 'QA', 'Coding', 'QA cycle 1');
+				gateDataRepo.set(run.id, 'qa-fail-gate', { result: 'failed' });
+				await router.deliverMessage(run.id, 'QA', 'Coding', 'QA cycle 2');
+
+				// Third attempt should throw
+				gateDataRepo.set(run.id, 'qa-fail-gate', { result: 'failed' });
+				await expect(
+					router.deliverMessage(run.id, 'QA', 'Coding', 'QA cycle 3 — should fail')
+				).rejects.toBeInstanceOf(ActivationError);
+			});
+
+			test('QA passes → QA→Done channel opens when qa-result-gate satisfied', async () => {
+				const workflow = buildQaWorkflow();
+				const run = workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'QA Pass Run',
+					maxIterations: 5,
+				});
+				workflowRunRepo.transitionStatus(run.id, 'in_progress');
+				gateDataRepo.initializeForRun(run.id, allGates);
+
+				// QA writes passed result
+				gateDataRepo.set(run.id, 'qa-result-gate', { result: 'passed' });
+				const activated = await router.onGateDataChanged(run.id, 'qa-result-gate');
+
+				const doneTask = activated.find((t) => t.workflowNodeId === NODE_DONE);
+				expect(doneTask).toBeDefined();
+			});
+		});
+
 		test('gateId takes precedence over legacy inline gate when both are set', async () => {
 			const gate: Gate = {
 				id: 'new-gate',


### PR DESCRIPTION
Wire QA into CODING_WORKFLOW_V2 and verify the QA→Coding feedback loop works correctly.

**Gate design corrections:**
- `code-pr-gate`: `resetOnCycle: false` — PR is preserved across fix cycles (coder pushes to existing PR)
- `qa-result-gate`: `resetOnCycle: true` — QA starts from a clean state each cycle

**New unit tests (7) in channel-router covering:**
- QA failure activates Coding via cyclic qa-fail-gate channel
- Gate resets on cycle: review-votes-gate, qa-result-gate, review-reject-gate, qa-fail-gate → `{}`; code-pr-gate preserved
- Iteration counter increments on QA→Coding cycle
- Reviewers must re-vote from scratch after QA fail (votes reset to empty)
- ActivationError thrown when max iterations reached on QA→Coding
- QA pass opens QA→Done via qa-result-gate