### PR TITLE
feat(space): implement GateArtifactsView and FileDiffView (M6.3)

### DIFF
--- a/packages/web/src/components/space/FileDiffView.tsx
+++ b/packages/web/src/components/space/FileDiffView.tsx
@@ -64,7 +64,12 @@ export function parseDiff(diff: string): ParsedLine[] {
 			raw.startsWith('new file') ||
 			raw.startsWith('deleted file') ||
 			raw.startsWith('old mode') ||
-			raw.startsWith('new mode')
+			raw.startsWith('new mode') ||
+			raw.startsWith('similarity index') ||
+			raw.startsWith('rename from') ||
+			raw.startsWith('rename to') ||
+			raw.startsWith('copy from') ||
+			raw.startsWith('copy to')
 		) {
 			result.push({ type: 'index', content: raw, oldLineNum: null, newLineNum: null });
 		} else if (raw.startsWith('--- ') || raw.startsWith('+++ ')) {
@@ -87,6 +92,9 @@ export function parseDiff(diff: string): ParsedLine[] {
 				oldLineNum: oldLine,
 				newLineNum: null,
 			});
+		} else if (raw.startsWith('\\')) {
+			// "\ No newline at end of file" — informational; no line number increment
+			result.push({ type: 'index', content: raw, oldLineNum: null, newLineNum: null });
 		} else {
 			// context line (starts with space) or empty
 			oldLine++;

--- a/packages/web/src/components/space/FileDiffView.tsx
+++ b/packages/web/src/components/space/FileDiffView.tsx
@@ -1,0 +1,276 @@
+/**
+ * FileDiffView — syntax-highlighted unified diff viewer
+ *
+ * Fetches the diff for a single file from the worktree via
+ * `spaceWorkflowRun.getFileDiff` and renders it line-by-line with:
+ *   - Green rows for additions (+)
+ *   - Red rows for removals (-)
+ *   - Blue rows for hunk headers (@@)
+ *   - Dual line-number columns (old / new)
+ */
+
+import { useState, useEffect } from 'preact/hooks';
+import { connectionManager } from '../../lib/connection-manager';
+import { cn } from '../../lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface FileDiffViewProps {
+	runId: string;
+	filePath: string;
+	onBack: () => void;
+	class?: string;
+}
+
+type DiffLineType = 'header' | 'index' | 'file-header' | 'hunk' | 'added' | 'removed' | 'context';
+
+interface ParsedLine {
+	type: DiffLineType;
+	content: string;
+	oldLineNum: number | null;
+	newLineNum: number | null;
+}
+
+// ============================================================================
+// Diff parser
+// ============================================================================
+
+/**
+ * Parse a unified diff string into typed, line-numbered rows.
+ *
+ * Handles:
+ *   diff --git  → header
+ *   index ...   → index
+ *   --- / +++   → file-header
+ *   @@ ...      → hunk (resets line counters)
+ *   -           → removed (increments old counter)
+ *   +           → added   (increments new counter)
+ *   (space)     → context (increments both)
+ */
+export function parseDiff(diff: string): ParsedLine[] {
+	if (!diff) return [];
+
+	const result: ParsedLine[] = [];
+	let oldLine = 0;
+	let newLine = 0;
+
+	for (const raw of diff.split('\n')) {
+		if (raw.startsWith('diff --git')) {
+			result.push({ type: 'header', content: raw, oldLineNum: null, newLineNum: null });
+		} else if (
+			raw.startsWith('index ') ||
+			raw.startsWith('new file') ||
+			raw.startsWith('deleted file') ||
+			raw.startsWith('old mode') ||
+			raw.startsWith('new mode')
+		) {
+			result.push({ type: 'index', content: raw, oldLineNum: null, newLineNum: null });
+		} else if (raw.startsWith('--- ') || raw.startsWith('+++ ')) {
+			result.push({ type: 'file-header', content: raw, oldLineNum: null, newLineNum: null });
+		} else if (raw.startsWith('@@ ')) {
+			const m = raw.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+			if (m) {
+				oldLine = parseInt(m[1], 10) - 1;
+				newLine = parseInt(m[2], 10) - 1;
+			}
+			result.push({ type: 'hunk', content: raw, oldLineNum: null, newLineNum: null });
+		} else if (raw.startsWith('+')) {
+			newLine++;
+			result.push({ type: 'added', content: raw.slice(1), oldLineNum: null, newLineNum: newLine });
+		} else if (raw.startsWith('-')) {
+			oldLine++;
+			result.push({
+				type: 'removed',
+				content: raw.slice(1),
+				oldLineNum: oldLine,
+				newLineNum: null,
+			});
+		} else {
+			// context line (starts with space) or empty
+			oldLine++;
+			newLine++;
+			result.push({
+				type: 'context',
+				content: raw.startsWith(' ') ? raw.slice(1) : raw,
+				oldLineNum: oldLine,
+				newLineNum: newLine,
+			});
+		}
+	}
+
+	return result;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function FileDiffView({ runId, filePath, onBack, class: className }: FileDiffViewProps) {
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [diffText, setDiffText] = useState<string | null>(null);
+	const [additions, setAdditions] = useState(0);
+	const [deletions, setDeletions] = useState(0);
+
+	useEffect(() => {
+		setLoading(true);
+		setError(null);
+		setDiffText(null);
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setError('Not connected');
+			setLoading(false);
+			return;
+		}
+
+		hub
+			.request<{ diff: string; additions: number; deletions: number; filePath: string }>(
+				'spaceWorkflowRun.getFileDiff',
+				{ runId, filePath }
+			)
+			.then((result) => {
+				setDiffText(result.diff);
+				setAdditions(result.additions);
+				setDeletions(result.deletions);
+			})
+			.catch((err: unknown) => {
+				setError(err instanceof Error ? err.message : 'Failed to load diff');
+			})
+			.finally(() => setLoading(false));
+	}, [runId, filePath]);
+
+	const parsedLines = diffText ? parseDiff(diffText) : [];
+
+	return (
+		<div class={cn('flex flex-col h-full overflow-hidden', className)} data-testid="file-diff-view">
+			{/* Header bar */}
+			<div class="flex items-center gap-3 px-4 py-3 border-b border-dark-700 flex-shrink-0 bg-dark-850">
+				<button
+					onClick={onBack}
+					class="text-gray-400 hover:text-gray-100 transition-colors flex-shrink-0"
+					aria-label="Back to file list"
+					data-testid="file-diff-back"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M15 19l-7-7 7-7"
+						/>
+					</svg>
+				</button>
+				<p class="flex-1 text-xs font-mono text-gray-200 truncate min-w-0" title={filePath}>
+					{filePath}
+				</p>
+				{!loading && !error && (
+					<div class="flex items-center gap-2 text-xs font-mono flex-shrink-0">
+						<span class="text-green-400" data-testid="diff-additions">
+							+{additions}
+						</span>
+						<span class="text-red-400" data-testid="diff-deletions">
+							-{deletions}
+						</span>
+					</div>
+				)}
+			</div>
+
+			{/* Content area */}
+			<div class="flex-1 overflow-auto">
+				{loading && (
+					<div class="flex items-center justify-center h-32" data-testid="diff-loading">
+						<div class="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+					</div>
+				)}
+
+				{error && (
+					<div class="px-4 py-4" data-testid="diff-error">
+						<p class="text-sm text-red-400">{error}</p>
+					</div>
+				)}
+
+				{!loading && !error && diffText !== null && parsedLines.length === 0 && (
+					<div class="px-4 py-6 text-center" data-testid="diff-empty">
+						<p class="text-sm text-gray-500">No changes in this file</p>
+					</div>
+				)}
+
+				{!loading && !error && parsedLines.length > 0 && (
+					<table
+						class="w-full text-xs font-mono border-collapse"
+						style={{ tableLayout: 'fixed' }}
+						data-testid="diff-table"
+					>
+						<colgroup>
+							<col style={{ width: '3.5rem' }} />
+							<col style={{ width: '3.5rem' }} />
+							<col />
+						</colgroup>
+						<tbody>
+							{parsedLines.map((line, idx) => {
+								let rowClass = '';
+								let contentClass = 'text-gray-300';
+								let sigil: string | null = null;
+
+								switch (line.type) {
+									case 'added':
+										rowClass = 'bg-green-950/40';
+										contentClass = 'text-green-300';
+										sigil = '+';
+										break;
+									case 'removed':
+										rowClass = 'bg-red-950/40';
+										contentClass = 'text-red-300';
+										sigil = '-';
+										break;
+									case 'hunk':
+										rowClass = 'bg-blue-950/30';
+										contentClass = 'text-blue-400';
+										break;
+									case 'header':
+										rowClass = 'bg-dark-800';
+										contentClass = 'text-gray-400';
+										break;
+									case 'file-header':
+									case 'index':
+										rowClass = 'bg-dark-850';
+										contentClass = 'text-gray-500';
+										break;
+									default:
+										break;
+								}
+
+								return (
+									<tr key={idx} class={rowClass}>
+										<td class="px-2 py-0.5 text-gray-600 text-right select-none border-r border-dark-700 w-14">
+											{line.oldLineNum ?? ''}
+										</td>
+										<td class="px-2 py-0.5 text-gray-600 text-right select-none border-r border-dark-700 w-14">
+											{line.newLineNum ?? ''}
+										</td>
+										<td class={cn('px-3 py-0.5 whitespace-pre overflow-hidden', contentClass)}>
+											{sigil !== null && (
+												<span
+													class={cn(
+														'mr-1 select-none',
+														sigil === '+' ? 'text-green-600' : 'text-red-600'
+													)}
+												>
+													{sigil}
+												</span>
+											)}
+											{line.content}
+										</td>
+									</tr>
+								);
+							})}
+						</tbody>
+					</table>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/FileDiffView.tsx
+++ b/packages/web/src/components/space/FileDiffView.tsx
@@ -95,8 +95,10 @@ export function parseDiff(diff: string): ParsedLine[] {
 		} else if (raw.startsWith('\\')) {
 			// "\ No newline at end of file" — informational; no line number increment
 			result.push({ type: 'index', content: raw, oldLineNum: null, newLineNum: null });
+		} else if (!raw) {
+			// trailing newline produces an empty string — skip it
 		} else {
-			// context line (starts with space) or empty
+			// context line (starts with space)
 			oldLine++;
 			newLine++;
 			result.push({
@@ -207,14 +209,10 @@ export function FileDiffView({ runId, filePath, onBack, class: className }: File
 				)}
 
 				{!loading && !error && parsedLines.length > 0 && (
-					<table
-						class="w-full text-xs font-mono border-collapse"
-						style={{ tableLayout: 'fixed' }}
-						data-testid="diff-table"
-					>
+					<table class="min-w-full text-xs font-mono border-collapse" data-testid="diff-table">
 						<colgroup>
-							<col style={{ width: '3.5rem' }} />
-							<col style={{ width: '3.5rem' }} />
+							<col style={{ width: '3.5rem', flexShrink: 0 }} />
+							<col style={{ width: '3.5rem', flexShrink: 0 }} />
 							<col />
 						</colgroup>
 						<tbody>
@@ -259,7 +257,7 @@ export function FileDiffView({ runId, filePath, onBack, class: className }: File
 										<td class="px-2 py-0.5 text-gray-600 text-right select-none border-r border-dark-700 w-14">
 											{line.newLineNum ?? ''}
 										</td>
-										<td class={cn('px-3 py-0.5 whitespace-pre overflow-hidden', contentClass)}>
+										<td class={cn('px-3 py-0.5 whitespace-pre', contentClass)}>
 											{sigil !== null && (
 												<span
 													class={cn(

--- a/packages/web/src/components/space/GateArtifactsView.tsx
+++ b/packages/web/src/components/space/GateArtifactsView.tsx
@@ -1,0 +1,376 @@
+/**
+ * GateArtifactsView — shows changed files and diff summary for a workflow run gate.
+ *
+ * Fetches `spaceWorkflowRun.getGateArtifacts` and renders:
+ *   - PR link (if available in gate data)
+ *   - Diff summary: N files, +additions, -deletions
+ *   - Clickable file tree → opens FileDiffView for the selected file
+ *   - Approve / Reject primary action buttons
+ *   - Chat-command input as secondary approval mechanism
+ *     (accepts "approve" / "yes" / "lgtm" → approve, "reject" / "no" → reject)
+ */
+
+import { useState, useEffect, useCallback } from 'preact/hooks';
+import { connectionManager } from '../../lib/connection-manager';
+import { cn } from '../../lib/utils';
+import { FileDiffView } from './FileDiffView';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface GateArtifactsViewProps {
+	/** Workflow run ID */
+	runId: string;
+	/** Gate ID to approve/reject */
+	gateId: string;
+	/** Space ID (for future event filtering if needed) */
+	spaceId: string;
+	/** Current gate data — used to extract PR link */
+	gateData?: Record<string, unknown>;
+	/** Called when the panel should close */
+	onClose?: () => void;
+	/** Called after a successful approve or reject */
+	onDecision?: () => void;
+	class?: string;
+}
+
+interface FileDiffStat {
+	path: string;
+	additions: number;
+	deletions: number;
+}
+
+interface GateArtifactsResult {
+	files: FileDiffStat[];
+	totalAdditions: number;
+	totalDeletions: number;
+	worktreePath?: string;
+	baseRef?: string;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function GateArtifactsView({
+	runId,
+	gateId,
+	spaceId: _spaceId,
+	gateData,
+	onClose,
+	onDecision,
+	class: className,
+}: GateArtifactsViewProps) {
+	// ---- Artifacts fetch ----
+	const [loading, setLoading] = useState(true);
+	const [fetchError, setFetchError] = useState<string | null>(null);
+	const [artifacts, setArtifacts] = useState<GateArtifactsResult | null>(null);
+
+	// ---- Selected file for diff view ----
+	const [selectedFile, setSelectedFile] = useState<string | null>(null);
+
+	// ---- Approval state ----
+	const [approving, setApproving] = useState(false);
+	const [approveError, setApproveError] = useState<string | null>(null);
+
+	// ---- Chat command input ----
+	const [chatInput, setChatInput] = useState('');
+
+	// ---- Extract PR info from gate data ----
+	const prUrl = typeof gateData?.pr_url === 'string' ? gateData.pr_url : null;
+	const prNumber = typeof gateData?.pr_number === 'number' ? gateData.pr_number : null;
+
+	// ---- Fetch artifacts ----
+	useEffect(() => {
+		setLoading(true);
+		setFetchError(null);
+		setArtifacts(null);
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setFetchError('Not connected');
+			setLoading(false);
+			return;
+		}
+
+		hub
+			.request<GateArtifactsResult>('spaceWorkflowRun.getGateArtifacts', { runId })
+			.then((result) => setArtifacts(result))
+			.catch((err: unknown) => {
+				setFetchError(err instanceof Error ? err.message : 'Failed to load artifacts');
+			})
+			.finally(() => setLoading(false));
+	}, [runId]);
+
+	// ---- Approve / Reject handler ----
+	const handleDecision = useCallback(
+		async (approved: boolean) => {
+			setApproving(true);
+			setApproveError(null);
+			try {
+				const hub = connectionManager.getHubIfConnected();
+				if (!hub) throw new Error('Not connected');
+				await hub.request('spaceWorkflowRun.approveGate', { runId, gateId, approved });
+				onDecision?.();
+				onClose?.();
+			} catch (err: unknown) {
+				setApproveError(err instanceof Error ? err.message : 'Failed to submit decision');
+			} finally {
+				setApproving(false);
+			}
+		},
+		[runId, gateId, onDecision, onClose]
+	);
+
+	// ---- Chat command handler ----
+	const handleChatSubmit = (e: Event) => {
+		e.preventDefault();
+		const cmd = chatInput.trim().toLowerCase();
+		if (cmd === 'approve' || cmd === 'yes' || cmd === 'lgtm') {
+			setChatInput('');
+			void handleDecision(true);
+		} else if (cmd === 'reject' || cmd === 'no') {
+			setChatInput('');
+			void handleDecision(false);
+		} else {
+			setApproveError('Type "approve" or "reject" to submit your decision');
+		}
+	};
+
+	// ---- If a file is selected, show FileDiffView ----
+	if (selectedFile) {
+		return (
+			<FileDiffView
+				runId={runId}
+				filePath={selectedFile}
+				onBack={() => setSelectedFile(null)}
+				class={className}
+			/>
+		);
+	}
+
+	// ---- Main view ----
+	return (
+		<div
+			class={cn('flex flex-col h-full overflow-hidden', className)}
+			data-testid="gate-artifacts-view"
+		>
+			{/* Header */}
+			<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700 flex-shrink-0 bg-dark-850">
+				<div>
+					<h2 class="text-sm font-semibold text-gray-100">Review Changes</h2>
+					<p class="text-xs text-gray-500 mt-0.5">Approve or reject the proposed changes</p>
+				</div>
+				{onClose && (
+					<button
+						onClick={onClose}
+						class="text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0 ml-3"
+						aria-label="Close"
+						data-testid="artifacts-close"
+					>
+						<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				)}
+			</div>
+
+			{/* Scrollable body */}
+			<div class="flex-1 overflow-y-auto min-h-0">
+				{/* Loading */}
+				{loading && (
+					<div class="flex items-center justify-center h-32" data-testid="artifacts-loading">
+						<div class="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+					</div>
+				)}
+
+				{/* Fetch error */}
+				{fetchError && !loading && (
+					<div class="px-4 py-4" data-testid="artifacts-error">
+						<p class="text-sm text-red-400">{fetchError}</p>
+					</div>
+				)}
+
+				{/* Artifacts content */}
+				{!loading && !fetchError && artifacts && (
+					<div class="p-4 space-y-4">
+						{/* PR link */}
+						{prUrl && (
+							<div class="flex items-center gap-2 p-3 bg-blue-950/30 border border-blue-800/40 rounded-lg">
+								<svg
+									class="w-4 h-4 text-blue-400 flex-shrink-0"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+									/>
+								</svg>
+								<a
+									href={prUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+									data-testid="pr-link"
+								>
+									{prNumber != null ? `PR #${prNumber}` : 'Pull Request'}
+								</a>
+							</div>
+						)}
+
+						{/* Diff summary */}
+						<div class="flex items-center gap-4 text-xs" data-testid="diff-summary">
+							<span class="text-gray-400">
+								{artifacts.files.length} {artifacts.files.length === 1 ? 'file' : 'files'} changed
+							</span>
+							<span class="text-green-400 font-mono">+{artifacts.totalAdditions}</span>
+							<span class="text-red-400 font-mono">-{artifacts.totalDeletions}</span>
+						</div>
+
+						{/* File tree */}
+						{artifacts.files.length === 0 ? (
+							<p class="text-sm text-gray-500" data-testid="no-files">
+								No changed files found
+							</p>
+						) : (
+							<div class="space-y-0.5" data-testid="file-list">
+								{artifacts.files.map((file) => (
+									<button
+										key={file.path}
+										onClick={() => setSelectedFile(file.path)}
+										class={cn(
+											'w-full flex items-center gap-3 px-3 py-2 rounded text-left',
+											'hover:bg-dark-700 transition-colors group'
+										)}
+										data-testid={`file-row-${file.path}`}
+									>
+										{/* File icon */}
+										<svg
+											class="w-3.5 h-3.5 text-gray-500 flex-shrink-0"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+											/>
+										</svg>
+										{/* Path */}
+										<span
+											class="flex-1 text-xs font-mono text-gray-300 truncate min-w-0 group-hover:text-gray-100"
+											title={file.path}
+										>
+											{file.path}
+										</span>
+										{/* Stats */}
+										<span class="flex-shrink-0 flex items-center gap-1.5 text-xs font-mono">
+											<span class="text-green-400">+{file.additions}</span>
+											<span class="text-red-400">-{file.deletions}</span>
+										</span>
+										{/* Chevron */}
+										<svg
+											class="w-3 h-3 text-gray-600 flex-shrink-0 group-hover:text-gray-400"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M9 5l7 7-7 7"
+											/>
+										</svg>
+									</button>
+								))}
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+
+			{/* Footer: primary approve/reject + chat command */}
+			<div class="flex-shrink-0 border-t border-dark-700 p-4 space-y-3 bg-dark-850">
+				{approveError && (
+					<p class="text-xs text-red-400" data-testid="approve-error">
+						{approveError}
+					</p>
+				)}
+
+				{/* Primary buttons */}
+				<div class="flex gap-3">
+					<button
+						onClick={() => void handleDecision(true)}
+						disabled={approving}
+						data-testid="approve-button"
+						class={cn(
+							'flex-1 py-2 text-sm font-medium rounded-lg transition-colors',
+							'bg-green-900/40 text-green-300 border border-green-700/50',
+							'hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed'
+						)}
+					>
+						{approving ? 'Submitting…' : 'Approve'}
+					</button>
+					<button
+						onClick={() => void handleDecision(false)}
+						disabled={approving}
+						data-testid="reject-button"
+						class={cn(
+							'flex-1 py-2 text-sm font-medium rounded-lg transition-colors',
+							'bg-red-900/40 text-red-300 border border-red-700/50',
+							'hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed'
+						)}
+					>
+						{approving ? 'Submitting…' : 'Reject'}
+					</button>
+				</div>
+
+				{/* Chat-based secondary mechanism */}
+				<form
+					onSubmit={handleChatSubmit}
+					class="flex items-center gap-2"
+					data-testid="chat-approval-form"
+				>
+					<input
+						type="text"
+						value={chatInput}
+						onInput={(e) => setChatInput((e.target as HTMLInputElement).value)}
+						placeholder='Type "approve" or "reject"'
+						disabled={approving}
+						data-testid="chat-input"
+						class={cn(
+							'flex-1 bg-dark-800 border border-dark-600 rounded-md px-3 py-1.5 text-xs text-gray-100',
+							'placeholder-gray-600 focus:outline-none focus:border-gray-500',
+							'disabled:opacity-50'
+						)}
+					/>
+					<button
+						type="submit"
+						disabled={!chatInput.trim() || approving}
+						data-testid="chat-submit"
+						class={cn(
+							'px-3 py-1.5 text-xs font-medium rounded-md transition-colors flex-shrink-0',
+							'bg-dark-700 text-gray-300 border border-dark-600',
+							'hover:bg-dark-600 disabled:opacity-50 disabled:cursor-not-allowed'
+						)}
+					>
+						Send
+					</button>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -313,6 +313,14 @@ function GateIcon({
 }: GateIconProps): JSX.Element {
 	const [showActions, setShowActions] = useState(false);
 
+	// Dismiss the popup when the user clicks anywhere outside the gate icon
+	useEffect(() => {
+		if (!showActions) return;
+		const dismiss = () => setShowActions(false);
+		document.addEventListener('click', dismiss, { once: true });
+		return () => document.removeEventListener('click', dismiss);
+	}, [showActions]);
+
 	let fill: string;
 	let strokeColor: string;
 	let icon: JSX.Element;

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -33,6 +33,7 @@ import type {
 import { spaceStore } from '../../lib/space-store';
 import { connectionManager } from '../../lib/connection-manager';
 import { cn } from '../../lib/utils';
+import { GateArtifactsView } from './GateArtifactsView';
 
 // ============================================================================
 // Constants
@@ -296,6 +297,7 @@ interface GateIconProps {
 	isRuntimeMode: boolean;
 	onApprove?: () => void;
 	onReject?: () => void;
+	onViewArtifacts?: () => void;
 }
 
 const GATE_ICON_R = 11; // radius
@@ -307,6 +309,7 @@ function GateIcon({
 	isRuntimeMode,
 	onApprove,
 	onReject,
+	onViewArtifacts,
 }: GateIconProps): JSX.Element {
 	const [showActions, setShowActions] = useState(false);
 
@@ -405,7 +408,7 @@ function GateIcon({
 			<g transform={`translate(${x}, ${y})`}>{icon}</g>
 
 			{showActions && isRuntimeMode && (
-				<foreignObject x={x - 60} y={y + 14} width={120} height={56}>
+				<foreignObject x={x - 65} y={y + 14} width={130} height={onViewArtifacts ? 84 : 56}>
 					<div
 						style={{
 							background: '#1c1917',
@@ -413,37 +416,57 @@ function GateIcon({
 							borderRadius: 6,
 							padding: '6px',
 							display: 'flex',
+							flexDirection: 'column',
 							gap: '4px',
 						}}
 					>
-						<button
-							class={cn(
-								'flex-1 text-xs py-1 rounded font-medium',
-								'bg-green-900/60 text-green-300 border border-green-700/50',
-								'hover:bg-green-800/60'
-							)}
-							onClick={(e) => {
-								e.stopPropagation();
-								setShowActions(false);
-								onApprove?.();
-							}}
-						>
-							Approve
-						</button>
-						<button
-							class={cn(
-								'flex-1 text-xs py-1 rounded font-medium',
-								'bg-red-900/60 text-red-300 border border-red-700/50',
-								'hover:bg-red-800/60'
-							)}
-							onClick={(e) => {
-								e.stopPropagation();
-								setShowActions(false);
-								onReject?.();
-							}}
-						>
-							Reject
-						</button>
+						<div style={{ display: 'flex', gap: '4px' }}>
+							<button
+								class={cn(
+									'flex-1 text-xs py-1 rounded font-medium',
+									'bg-green-900/60 text-green-300 border border-green-700/50',
+									'hover:bg-green-800/60'
+								)}
+								onClick={(e) => {
+									e.stopPropagation();
+									setShowActions(false);
+									onApprove?.();
+								}}
+							>
+								Approve
+							</button>
+							<button
+								class={cn(
+									'flex-1 text-xs py-1 rounded font-medium',
+									'bg-red-900/60 text-red-300 border border-red-700/50',
+									'hover:bg-red-800/60'
+								)}
+								onClick={(e) => {
+									e.stopPropagation();
+									setShowActions(false);
+									onReject?.();
+								}}
+							>
+								Reject
+							</button>
+						</div>
+						{onViewArtifacts && (
+							<button
+								class={cn(
+									'w-full text-xs py-1 rounded font-medium',
+									'bg-stone-800/80 text-stone-300 border border-stone-700/50',
+									'hover:bg-stone-700/80'
+								)}
+								onClick={(e) => {
+									e.stopPropagation();
+									setShowActions(false);
+									onViewArtifacts();
+								}}
+								data-testid="view-artifacts-btn"
+							>
+								View Artifacts
+							</button>
+						)}
 					</div>
 				</foreignObject>
 			)}
@@ -843,6 +866,9 @@ export function WorkflowCanvas({
 	const [gateDataMap, setGateDataMap] = useState<Map<string, Record<string, unknown>>>(new Map());
 	const [gateDataLoading, setGateDataLoading] = useState(false);
 
+	// ---- Artifacts panel state (gateId of the panel open, null = closed) ----
+	const [artifactsPanelGateId, setArtifactsPanelGateId] = useState<string | null>(null);
+
 	// ---- Template-mode: local gate assignments (channelId → gateId) ----
 	const [localGateAssignments, setLocalGateAssignments] = useState<Map<string, string>>(new Map());
 
@@ -1147,6 +1173,11 @@ export function WorkflowCanvas({
 									onReject={
 										isHumanGate ? () => void handleApproveGate(ch.gateId!, false) : undefined
 									}
+									onViewArtifacts={
+										isHumanGate && gateStatus === 'waiting_human'
+											? () => setArtifactsPanelGateId(ch.gateId!)
+											: undefined
+									}
 								/>
 							)}
 
@@ -1226,6 +1257,27 @@ export function WorkflowCanvas({
 					);
 				})}
 			</svg>
+
+			{/* Artifacts panel overlay (shown when a human gate requests it) */}
+			{artifactsPanelGateId && runId && (
+				<div
+					class="absolute inset-0 bg-stone-950/95 z-20 flex flex-col"
+					data-testid="artifacts-panel-overlay"
+				>
+					<GateArtifactsView
+						runId={runId}
+						gateId={artifactsPanelGateId}
+						spaceId={spaceId}
+						gateData={gateDataMap.get(artifactsPanelGateId)}
+						onClose={() => setArtifactsPanelGateId(null)}
+						onDecision={() => {
+							setArtifactsPanelGateId(null);
+							void fetchGateData();
+						}}
+						class="h-full"
+					/>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/components/space/__tests__/FileDiffView.test.tsx
+++ b/packages/web/src/components/space/__tests__/FileDiffView.test.tsx
@@ -1,0 +1,213 @@
+// @ts-nocheck
+/**
+ * Unit tests for FileDiffView
+ *
+ * Tests:
+ * - parseDiff: addition lines
+ * - parseDiff: removal lines
+ * - parseDiff: hunk header resets line counters
+ * - parseDiff: context lines track both old/new numbers
+ * - parseDiff: file-header (--- / +++) lines
+ * - parseDiff: diff --git header
+ * - parseDiff: index lines
+ * - parseDiff: empty diff string returns empty array
+ * - Component shows loading spinner while fetching
+ * - Component shows error when not connected
+ * - Component shows error on RPC failure
+ * - Component shows diff table when RPC succeeds
+ * - Component shows additions/deletions counts in header
+ * - Back button calls onBack
+ * - Empty diff shows "no changes" message
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { render, cleanup, waitFor, fireEvent } from '@testing-library/preact';
+import { parseDiff } from '../FileDiffView';
+
+// ---- Mock connection-manager ----
+const mockRequest: Mock = vi.fn();
+const mockHub = { request: mockRequest };
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: vi.fn(() => mockHub),
+	},
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+import { FileDiffView } from '../FileDiffView';
+
+// ============================================================================
+// parseDiff unit tests
+// ============================================================================
+
+describe('parseDiff', () => {
+	it('returns empty array for empty string', () => {
+		expect(parseDiff('')).toEqual([]);
+	});
+
+	it('parses diff --git header', () => {
+		const lines = parseDiff('diff --git a/foo.ts b/foo.ts');
+		expect(lines).toHaveLength(1);
+		expect(lines[0].type).toBe('header');
+		expect(lines[0].oldLineNum).toBeNull();
+		expect(lines[0].newLineNum).toBeNull();
+	});
+
+	it('parses index line', () => {
+		const lines = parseDiff('index abc123..def456 100644');
+		expect(lines).toHaveLength(1);
+		expect(lines[0].type).toBe('index');
+	});
+
+	it('parses file-header lines (--- and +++)', () => {
+		const diff = '--- a/foo.ts\n+++ b/foo.ts';
+		const lines = parseDiff(diff);
+		expect(lines).toHaveLength(2);
+		expect(lines[0].type).toBe('file-header');
+		expect(lines[1].type).toBe('file-header');
+	});
+
+	it('resets line counters on hunk header', () => {
+		const diff = '@@ -5,3 +10,3 @@ function foo() {\n -old\n +new\n  ctx';
+		const lines = parseDiff(diff);
+		const hunk = lines.find((l) => l.type === 'hunk');
+		expect(hunk).toBeDefined();
+		expect(hunk!.oldLineNum).toBeNull();
+		expect(hunk!.newLineNum).toBeNull();
+	});
+
+	it('increments new line number for additions', () => {
+		const diff = '@@ -1,1 +1,2 @@\n+added line\n+another';
+		const lines = parseDiff(diff).filter((l) => l.type === 'added');
+		expect(lines[0].newLineNum).toBe(1);
+		expect(lines[1].newLineNum).toBe(2);
+		expect(lines[0].oldLineNum).toBeNull();
+	});
+
+	it('increments old line number for removals', () => {
+		const diff = '@@ -3,2 +3,1 @@\n-removed1\n-removed2';
+		const lines = parseDiff(diff).filter((l) => l.type === 'removed');
+		expect(lines[0].oldLineNum).toBe(3);
+		expect(lines[1].oldLineNum).toBe(4);
+		expect(lines[0].newLineNum).toBeNull();
+	});
+
+	it('increments both counters for context lines', () => {
+		const diff = '@@ -2,1 +2,1 @@\n context';
+		const lines = parseDiff(diff).filter((l) => l.type === 'context');
+		expect(lines[0].oldLineNum).toBe(2);
+		expect(lines[0].newLineNum).toBe(2);
+	});
+
+	it('strips leading sigil from addition content', () => {
+		const diff = '@@ -1,1 +1,1 @@\n+const x = 1;';
+		const lines = parseDiff(diff).filter((l) => l.type === 'added');
+		expect(lines[0].content).toBe('const x = 1;');
+	});
+
+	it('strips leading sigil from removal content', () => {
+		const diff = '@@ -1,1 +1,1 @@\n-const x = 0;';
+		const lines = parseDiff(diff).filter((l) => l.type === 'removed');
+		expect(lines[0].content).toBe('const x = 0;');
+	});
+});
+
+// ============================================================================
+// FileDiffView component tests
+// ============================================================================
+
+describe('FileDiffView', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows loading spinner while fetching', async () => {
+		// Never resolves
+		mockRequest.mockReturnValue(new Promise(() => {}));
+		const { getByTestId } = render(
+			<FileDiffView runId="run-1" filePath="src/foo.ts" onBack={vi.fn()} />
+		);
+		expect(getByTestId('diff-loading')).toBeDefined();
+	});
+
+	it('shows error when hub not connected', async () => {
+		const { connectionManager } = await import('../../../lib/connection-manager');
+		(connectionManager.getHubIfConnected as Mock).mockReturnValueOnce(null);
+
+		const { getByTestId } = render(
+			<FileDiffView runId="run-1" filePath="src/foo.ts" onBack={vi.fn()} />
+		);
+		await waitFor(() => expect(getByTestId('diff-error')).toBeDefined());
+	});
+
+	it('shows error when RPC fails', async () => {
+		mockRequest.mockRejectedValue(new Error('git error'));
+		const { getByTestId } = render(
+			<FileDiffView runId="run-1" filePath="src/foo.ts" onBack={vi.fn()} />
+		);
+		await waitFor(() => {
+			const el = getByTestId('diff-error');
+			expect(el.textContent).toContain('git error');
+		});
+	});
+
+	it('renders diff table when RPC succeeds', async () => {
+		const sampleDiff =
+			'diff --git a/f.ts b/f.ts\n--- a/f.ts\n+++ b/f.ts\n@@ -1,1 +1,1 @@\n-old\n+new';
+		mockRequest.mockResolvedValue({
+			diff: sampleDiff,
+			additions: 1,
+			deletions: 1,
+			filePath: 'f.ts',
+		});
+		const { getByTestId } = render(<FileDiffView runId="run-1" filePath="f.ts" onBack={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('diff-table')).toBeDefined());
+	});
+
+	it('shows additions and deletions counts', async () => {
+		mockRequest.mockResolvedValue({
+			diff: '@@ -1,1 +1,1 @@\n-old\n+new',
+			additions: 5,
+			deletions: 3,
+			filePath: 'f.ts',
+		});
+		const { getByTestId } = render(<FileDiffView runId="run-1" filePath="f.ts" onBack={vi.fn()} />);
+		await waitFor(() => {
+			expect(getByTestId('diff-additions').textContent).toBe('+5');
+			expect(getByTestId('diff-deletions').textContent).toBe('-3');
+		});
+	});
+
+	it('calls onBack when back button is clicked', async () => {
+		mockRequest.mockResolvedValue({ diff: '', additions: 0, deletions: 0, filePath: 'f.ts' });
+		const onBack = vi.fn();
+		const { getByTestId } = render(<FileDiffView runId="run-1" filePath="f.ts" onBack={onBack} />);
+		await waitFor(() => expect(getByTestId('diff-empty')).toBeDefined());
+		fireEvent.click(getByTestId('file-diff-back'));
+		expect(onBack).toHaveBeenCalledOnce();
+	});
+
+	it('shows no-changes message for empty diff', async () => {
+		mockRequest.mockResolvedValue({ diff: '', additions: 0, deletions: 0, filePath: 'f.ts' });
+		const { getByTestId } = render(<FileDiffView runId="run-1" filePath="f.ts" onBack={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('diff-empty')).toBeDefined());
+	});
+
+	it('sends correct RPC params', async () => {
+		mockRequest.mockResolvedValue({ diff: '', additions: 0, deletions: 0, filePath: 'src/bar.ts' });
+		render(<FileDiffView runId="run-42" filePath="src/bar.ts" onBack={vi.fn()} />);
+		await waitFor(() => expect(mockRequest).toHaveBeenCalledOnce());
+		expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.getFileDiff', {
+			runId: 'run-42',
+			filePath: 'src/bar.ts',
+		});
+	});
+});

--- a/packages/web/src/components/space/__tests__/FileDiffView.test.tsx
+++ b/packages/web/src/components/space/__tests__/FileDiffView.test.tsx
@@ -103,6 +103,15 @@ describe('parseDiff', () => {
 		expect(lines[0].newLineNum).toBe(2);
 	});
 
+	it('trailing newline does not produce a phantom context line', () => {
+		// git diff output always ends with \n — the trailing empty string must be skipped
+		const diff = '@@ -1,1 +1,1 @@\n-old\n+new\n';
+		const lines = parseDiff(diff);
+		// Only 3 lines: hunk header, removed, added — no phantom context
+		expect(lines.length).toBe(3);
+		expect(lines.map((l) => l.type)).toEqual(['hunk', 'removed', 'added']);
+	});
+
 	it('does not increment counters for "no newline at end of file" line', () => {
 		// "\ No newline at end of file" must NOT increment old or new line counters
 		const diff =

--- a/packages/web/src/components/space/__tests__/FileDiffView.test.tsx
+++ b/packages/web/src/components/space/__tests__/FileDiffView.test.tsx
@@ -103,6 +103,40 @@ describe('parseDiff', () => {
 		expect(lines[0].newLineNum).toBe(2);
 	});
 
+	it('does not increment counters for "no newline at end of file" line', () => {
+		// "\ No newline at end of file" must NOT increment old or new line counters
+		const diff =
+			'@@ -1,1 +1,1 @@\n-old\n\\ No newline at end of file\n+new\n\\ No newline at end of file';
+		const lines = parseDiff(diff);
+		const noNewline = lines.filter((l) => l.content.startsWith('\\ No newline'));
+		expect(noNewline.length).toBe(2);
+		noNewline.forEach((l) => {
+			expect(l.oldLineNum).toBeNull();
+			expect(l.newLineNum).toBeNull();
+		});
+		// Line numbers must still be correct for removed/added lines
+		const removed = lines.find((l) => l.type === 'removed');
+		const added = lines.find((l) => l.type === 'added');
+		expect(removed!.oldLineNum).toBe(1);
+		expect(added!.newLineNum).toBe(1);
+	});
+
+	it('treats rename/similarity lines as index (no counter increment)', () => {
+		const diff =
+			'diff --git a/a.ts b/b.ts\nsimilarity index 95%\nrename from a.ts\nrename to b.ts\n--- a/a.ts\n+++ b/b.ts\n@@ -1,1 +1,1 @@\n-old\n+new';
+		const lines = parseDiff(diff);
+		const renameLines = lines.filter(
+			(l) => l.content.startsWith('similarity') || l.content.startsWith('rename')
+		);
+		expect(renameLines.length).toBe(3);
+		renameLines.forEach((l) => expect(l.type).toBe('index'));
+		// Line numbers should still be 1 for removed/added after rename header
+		const removed = lines.find((l) => l.type === 'removed');
+		const added = lines.find((l) => l.type === 'added');
+		expect(removed!.oldLineNum).toBe(1);
+		expect(added!.newLineNum).toBe(1);
+	});
+
 	it('strips leading sigil from addition content', () => {
 		const diff = '@@ -1,1 +1,1 @@\n+const x = 1;';
 		const lines = parseDiff(diff).filter((l) => l.type === 'added');

--- a/packages/web/src/components/space/__tests__/GateArtifactsView.test.tsx
+++ b/packages/web/src/components/space/__tests__/GateArtifactsView.test.tsx
@@ -1,0 +1,309 @@
+// @ts-nocheck
+/**
+ * Unit tests for GateArtifactsView
+ *
+ * Tests:
+ * - Shows loading spinner while fetching artifacts
+ * - Shows error when hub not connected
+ * - Shows error on RPC failure
+ * - Renders diff summary (files changed, +additions, -deletions)
+ * - Renders file list with per-file stats
+ * - Clicking a file row opens FileDiffView
+ * - Back button in FileDiffView returns to artifact list
+ * - Approve button calls approveGate with approved=true
+ * - Reject button calls approveGate with approved=false
+ * - onDecision and onClose called after successful decision
+ * - Chat command "approve" triggers approval
+ * - Chat command "yes" triggers approval
+ * - Chat command "lgtm" triggers approval
+ * - Chat command "reject" triggers rejection
+ * - Chat command "no" triggers rejection
+ * - Unknown chat command shows error
+ * - PR link rendered when gate data has pr_url
+ * - PR link shows number when pr_number present
+ * - No files shows "no changed files" message
+ * - Close button calls onClose
+ * - Approve/Reject buttons disabled while approving
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { render, cleanup, waitFor, fireEvent, act } from '@testing-library/preact';
+
+// ---- Mock hub ----
+const mockRequest: Mock = vi.fn();
+const mockHub = { request: mockRequest };
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: vi.fn(() => mockHub),
+	},
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+import { GateArtifactsView } from '../GateArtifactsView';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeArtifacts(overrides = {}) {
+	return {
+		files: [
+			{ path: 'src/foo.ts', additions: 10, deletions: 3 },
+			{ path: 'src/bar.ts', additions: 2, deletions: 0 },
+		],
+		totalAdditions: 12,
+		totalDeletions: 3,
+		worktreePath: '/tmp/wt',
+		baseRef: 'abc123',
+		...overrides,
+	};
+}
+
+function defaultProps(overrides = {}) {
+	return {
+		runId: 'run-1',
+		gateId: 'gate-1',
+		spaceId: 'space-1',
+		onClose: vi.fn(),
+		onDecision: vi.fn(),
+		...overrides,
+	};
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('GateArtifactsView', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows loading spinner while fetching', () => {
+		mockRequest.mockReturnValue(new Promise(() => {}));
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		expect(getByTestId('artifacts-loading')).toBeDefined();
+	});
+
+	it('shows error when hub not connected', async () => {
+		const { connectionManager } = await import('../../../lib/connection-manager');
+		(connectionManager.getHubIfConnected as Mock).mockReturnValueOnce(null);
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => expect(getByTestId('artifacts-error')).toBeDefined());
+	});
+
+	it('shows error on RPC failure', async () => {
+		mockRequest.mockRejectedValue(new Error('no worktree'));
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => {
+			const el = getByTestId('artifacts-error');
+			expect(el.textContent).toContain('no worktree');
+		});
+	});
+
+	it('renders diff summary', async () => {
+		mockRequest.mockResolvedValue(makeArtifacts());
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => {
+			const summary = getByTestId('diff-summary');
+			expect(summary.textContent).toContain('2 files changed');
+			expect(summary.textContent).toContain('+12');
+			expect(summary.textContent).toContain('-3');
+		});
+	});
+
+	it('renders file list', async () => {
+		mockRequest.mockResolvedValue(makeArtifacts());
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => {
+			expect(getByTestId('file-list')).toBeDefined();
+			expect(getByTestId('file-row-src/foo.ts')).toBeDefined();
+			expect(getByTestId('file-row-src/bar.ts')).toBeDefined();
+		});
+	});
+
+	it('clicking a file row opens FileDiffView', async () => {
+		// Artifacts fetch succeeds; diff fetch never resolves (we just check mount)
+		mockRequest.mockResolvedValueOnce(makeArtifacts()).mockReturnValue(new Promise(() => {})); // getFileDiff pending
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => expect(getByTestId('file-list')).toBeDefined());
+		fireEvent.click(getByTestId('file-row-src/foo.ts'));
+		await waitFor(() => expect(getByTestId('file-diff-view')).toBeDefined());
+	});
+
+	it('back button in FileDiffView returns to artifact list', async () => {
+		mockRequest
+			.mockResolvedValueOnce(makeArtifacts())
+			.mockResolvedValueOnce({ diff: '', additions: 0, deletions: 0, filePath: 'src/foo.ts' });
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => expect(getByTestId('file-list')).toBeDefined());
+		fireEvent.click(getByTestId('file-row-src/foo.ts'));
+		await waitFor(() => expect(getByTestId('file-diff-view')).toBeDefined());
+		fireEvent.click(getByTestId('file-diff-back'));
+		await waitFor(() => expect(getByTestId('gate-artifacts-view')).toBeDefined());
+	});
+
+	it('approve button calls approveGate with approved=true', async () => {
+		mockRequest
+			.mockResolvedValueOnce(makeArtifacts())
+			.mockResolvedValueOnce({ run: {}, gateData: {} }); // approveGate
+		const props = defaultProps();
+		const { getByTestId } = render(<GateArtifactsView {...props} />);
+		await waitFor(() => expect(getByTestId('approve-button')).toBeDefined());
+		await act(async () => {
+			fireEvent.click(getByTestId('approve-button'));
+		});
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-1',
+				approved: true,
+			});
+		});
+	});
+
+	it('reject button calls approveGate with approved=false', async () => {
+		mockRequest
+			.mockResolvedValueOnce(makeArtifacts())
+			.mockResolvedValueOnce({ run: {}, gateData: {} });
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => expect(getByTestId('reject-button')).toBeDefined());
+		await act(async () => {
+			fireEvent.click(getByTestId('reject-button'));
+		});
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-1',
+				approved: false,
+			});
+		});
+	});
+
+	it('calls onDecision and onClose after successful approval', async () => {
+		mockRequest
+			.mockResolvedValueOnce(makeArtifacts())
+			.mockResolvedValueOnce({ run: {}, gateData: {} });
+		const props = defaultProps();
+		const { getByTestId } = render(<GateArtifactsView {...props} />);
+		await waitFor(() => expect(getByTestId('approve-button')).toBeDefined());
+		await act(async () => {
+			fireEvent.click(getByTestId('approve-button'));
+		});
+		await waitFor(() => {
+			expect(props.onDecision).toHaveBeenCalledOnce();
+			expect(props.onClose).toHaveBeenCalledOnce();
+		});
+	});
+
+	it('shows approval error when approveGate fails', async () => {
+		mockRequest
+			.mockResolvedValueOnce(makeArtifacts())
+			.mockRejectedValueOnce(new Error('permission denied'));
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => expect(getByTestId('approve-button')).toBeDefined());
+		await act(async () => {
+			fireEvent.click(getByTestId('approve-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('approve-error').textContent).toContain('permission denied');
+		});
+	});
+
+	it.each([
+		['approve', true],
+		['yes', true],
+		['lgtm', true],
+		['reject', false],
+		['no', false],
+	])('chat command "%s" triggers decision=%s', async (cmd, expected) => {
+		mockRequest
+			.mockResolvedValueOnce(makeArtifacts())
+			.mockResolvedValueOnce({ run: {}, gateData: {} });
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => expect(getByTestId('chat-input')).toBeDefined());
+		fireEvent.input(getByTestId('chat-input'), { target: { value: cmd } });
+		await act(async () => {
+			fireEvent.submit(getByTestId('chat-approval-form'));
+		});
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.approveGate', {
+				runId: 'run-1',
+				gateId: 'gate-1',
+				approved: expected,
+			});
+		});
+	});
+
+	it('unknown chat command shows error', async () => {
+		mockRequest.mockResolvedValueOnce(makeArtifacts());
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => expect(getByTestId('chat-input')).toBeDefined());
+		fireEvent.input(getByTestId('chat-input'), { target: { value: 'maybe' } });
+		fireEvent.submit(getByTestId('chat-approval-form'));
+		await waitFor(() => {
+			expect(getByTestId('approve-error').textContent).toContain('approve');
+		});
+	});
+
+	it('renders PR link when gate data has pr_url', async () => {
+		mockRequest.mockResolvedValue(makeArtifacts());
+		const { getByTestId } = render(
+			<GateArtifactsView
+				{...defaultProps()}
+				gateData={{ pr_url: 'https://github.com/owner/repo/pull/42', pr_number: 42 }}
+			/>
+		);
+		await waitFor(() => {
+			const link = getByTestId('pr-link');
+			expect(link.textContent).toBe('PR #42');
+			expect(link.getAttribute('href')).toBe('https://github.com/owner/repo/pull/42');
+		});
+	});
+
+	it('renders PR link without number when pr_number absent', async () => {
+		mockRequest.mockResolvedValue(makeArtifacts());
+		const { getByTestId } = render(
+			<GateArtifactsView
+				{...defaultProps()}
+				gateData={{ pr_url: 'https://github.com/owner/repo/pull/1' }}
+			/>
+		);
+		await waitFor(() => {
+			expect(getByTestId('pr-link').textContent).toBe('Pull Request');
+		});
+	});
+
+	it('shows no-files message when file list is empty', async () => {
+		mockRequest.mockResolvedValue(
+			makeArtifacts({ files: [], totalAdditions: 0, totalDeletions: 0 })
+		);
+		const { getByTestId } = render(<GateArtifactsView {...defaultProps()} />);
+		await waitFor(() => expect(getByTestId('no-files')).toBeDefined());
+	});
+
+	it('close button calls onClose', async () => {
+		mockRequest.mockResolvedValue(makeArtifacts());
+		const props = defaultProps();
+		const { getByTestId } = render(<GateArtifactsView {...props} />);
+		await waitFor(() => expect(getByTestId('gate-artifacts-view')).toBeDefined());
+		fireEvent.click(getByTestId('artifacts-close'));
+		expect(props.onClose).toHaveBeenCalledOnce();
+	});
+
+	it('does not render PR link when no pr_url in gate data', async () => {
+		mockRequest.mockResolvedValue(makeArtifacts());
+		const { queryByTestId } = render(
+			<GateArtifactsView {...defaultProps()} gateData={{ someOtherKey: 'value' }} />
+		);
+		await waitFor(() => expect(queryByTestId('pr-link')).toBeNull());
+	});
+});

--- a/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
@@ -16,6 +16,8 @@
  * - Completed node shows checkmark indicator
  * - Active run banner shows when run is needs_attention
  * - Gate data event subscription updates gate status
+ * - "View Artifacts" button opens artifacts panel overlay for waiting_human gate
+ * - Closing the artifacts panel overlay hides it
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
@@ -483,6 +485,64 @@ describe('WorkflowCanvas', () => {
 			'spaceWorkflowRun.listGateData',
 			expect.anything()
 		);
+	});
+
+	// ---- View Artifacts overlay ----
+
+	it('"View Artifacts" button opens artifacts panel overlay for waiting_human gate', async () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		// listGateData returns empty so gate stays waiting_human;
+		// getGateArtifacts is called by GateArtifactsView — keep it pending so we only test the overlay mount
+		mockHub.request.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.listGateData') return Promise.resolve({ gateData: [] });
+			return new Promise(() => {});
+		});
+
+		const { findByText, getByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+
+		// Open the gate icon action popup
+		fireEvent.click(getByTestId('gate-icon-waiting_human'));
+		// Click "View Artifacts"
+		const viewBtn = await findByText('View Artifacts');
+		fireEvent.click(viewBtn);
+
+		// Overlay must be visible
+		await waitFor(() => expect(getByTestId('artifacts-panel-overlay')).toBeTruthy());
+	});
+
+	it('closing the artifacts panel overlay hides it', async () => {
+		const gate = makeGate();
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'gate-1' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.listGateData') return Promise.resolve({ gateData: [] });
+			return new Promise(() => {});
+		});
+
+		const { findByText, getByTestId, queryByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+
+		// Open overlay
+		fireEvent.click(getByTestId('gate-icon-waiting_human'));
+		fireEvent.click(await findByText('View Artifacts'));
+		await waitFor(() => expect(getByTestId('artifacts-panel-overlay')).toBeTruthy());
+
+		// Close via the × button inside GateArtifactsView
+		fireEvent.click(getByTestId('artifacts-close'));
+		await waitFor(() => expect(queryByTestId('artifacts-panel-overlay')).toBeNull());
 	});
 
 	// ---- Gate approval action ----

--- a/packages/web/src/components/space/index.ts
+++ b/packages/web/src/components/space/index.ts
@@ -14,6 +14,10 @@ export { WorkflowEditor, filterAgents, initFromWorkflow } from './WorkflowEditor
 export { WorkflowList } from './WorkflowList';
 export { WorkflowCanvas } from './WorkflowCanvas';
 export type { WorkflowCanvasProps } from './WorkflowCanvas';
+export { GateArtifactsView } from './GateArtifactsView';
+export type { GateArtifactsViewProps } from './GateArtifactsView';
+export { FileDiffView, parseDiff } from './FileDiffView';
+export type { FileDiffViewProps } from './FileDiffView';
 export { WorkflowRulesEditor, makeEmptyRule, rulesToDrafts } from './WorkflowRulesEditor';
 export { WorkflowNodeCard } from './WorkflowNodeCard';
 export { ImportPreviewDialog } from './ImportPreviewDialog';


### PR DESCRIPTION
Implements M6.3: Artifacts View and Diff Rendering.

## Changes

**New components:**
- `FileDiffView.tsx` — syntax-highlighted unified diff with dual line numbers (old/new), green/red/blue row coloring, loading and error states. Exports `parseDiff()` utility.
- `GateArtifactsView.tsx` — file tree with per-file +/- stats, total diff summary, PR link from gate data, Approve/Reject buttons (calls `spaceWorkflowRun.approveGate`), and chat-command input as secondary approval mechanism (`approve`/`yes`/`lgtm` → approve, `reject`/`no` → reject).

**WorkflowCanvas updated:**
- `GateIcon` gains `onViewArtifacts` prop; a "View Artifacts" button appears in the `waiting_human` gate popup.
- New `artifactsPanelGateId` state drives a full-screen overlay rendering `GateArtifactsView`.
- Clicking a file in the artifacts view opens `FileDiffView`; back button returns to the file list.

**Tests:** 40 new unit tests covering `parseDiff`, `FileDiffView`, and `GateArtifactsView`.