### PR TITLE
fix(room): improve create_goal tool description to surface mission_type

### DIFF
--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -954,7 +954,7 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 	const tools = [
 		tool(
 			'create_goal',
-			'Create a new goal for the room',
+			'Create a new goal (mission) for the room. Use mission_type to specify one_shot (default), measurable (KPI tracking), or recurring (cron-scheduled).',
 			{
 				title: z.string().describe('Short title for the goal'),
 				description: z.string().optional().describe('Detailed description'),

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -2453,6 +2453,48 @@ describe('Room Agent Tools', () => {
 			expect(metrics[0].direction).toBe('decrease');
 			expect(metrics[0].baseline).toBe(500);
 		});
+
+		it('should persist mission_type and allow set_schedule on recurring goal', async () => {
+			// Create a recurring goal via create_goal with mission_type
+			const created = parseResult(
+				await handlers.create_goal({
+					title: 'Nightly rebuild',
+					mission_type: 'recurring',
+					autonomy_level: 'semi_autonomous',
+				})
+			);
+			expect(created.success).toBe(true);
+			const goalId = created.goalId as string;
+
+			// Verify missionType persists via list_goals
+			const listed = parseResult(await handlers.list_goals());
+			const goals = listed.goals as Array<Record<string, unknown>>;
+			const recurringGoal = goals.find((g) => g.id === goalId);
+			expect(recurringGoal).toBeDefined();
+			expect(recurringGoal!.missionType).toBe('recurring');
+			expect(recurringGoal!.autonomyLevel).toBe('semi_autonomous');
+
+			// Verify set_schedule works on the recurring goal created via create_goal
+			const scheduleResult = parseResult(
+				await handlers.set_schedule({ goal_id: goalId, cron_expression: '0 2 * * *' })
+			);
+			expect(scheduleResult.success).toBe(true);
+			const scheduledGoal = scheduleResult.goal as Record<string, unknown>;
+			expect(scheduledGoal.missionType).toBe('recurring');
+			expect((scheduledGoal.schedule as Record<string, unknown>).expression).toBe('0 2 * * *');
+			expect(scheduleResult.nextRunAt).toBeDefined();
+		});
+
+		it('should default to one_shot when mission_type is omitted', async () => {
+			const result = parseResult(
+				await handlers.create_goal({
+					title: 'Default goal',
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.missionType).toBe('one_shot');
+		});
 	});
 
 	describe('update_goal V2 fields', () => {


### PR DESCRIPTION
The `create_goal` MCP tool had `mission_type` in its Zod input schema, but the tool description was just "Create a new goal for the room" — it didn't mention mission types at all. This made it easy for the LLM to overlook the parameter when a user asked for a recurring or measurable mission.

**Change:** Updated the tool description to explicitly enumerate the three mission types (one_shot, measurable, recurring) and their purposes.

**Tests:** Added two new tests:
- Full `create_goal` → `set_schedule` flow verifying recurring missions work end-to-end
- Explicit test confirming `one_shot` default when `mission_type` is omitted

All 8674 daemon unit tests pass.