### PR TITLE
feat(space): task creation from conversation and V2 workflow activation (M5.3)

### DIFF
--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -163,6 +163,22 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
 	);
 	sections.push('');
 	sections.push(
+		`**Ask for clarification** before creating any work when:\n` +
+			`  - The request is too vague to determine what needs to be built (e.g. "improve the app", "make it better", "help me")\n` +
+			`  - The scope or success criteria are unclear\n` +
+			`  - Multiple interpretations are possible and choosing the wrong one would waste significant effort\n` +
+			`  Never start work — create tasks or workflow runs — until the request is specific enough to act on.`
+	);
+	sections.push('');
+	sections.push(
+		`**Clear requests** (ready to act on without clarification):\n` +
+			`  - "Implement user authentication with JWT tokens"\n` +
+			`  - "Fix the bug in the payment service where charges fail for international cards"\n` +
+			`  - "Add pagination to the user list endpoint"\n` +
+			`  For clear multi-step coding work, prefer \`start_workflow_run\` with a V2 workflow over \`create_standalone_task\`.`
+	);
+	sections.push('');
+	sections.push(
 		`**IMPORTANT**: Never create tasks immediately when a goal or plan is mentioned. ` +
 			`If the request involves a workflow, start the workflow run and let the workflow ` +
 			`orchestrate task creation. Only use \`create_standalone_task\` for explicitly standalone work.`

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -1449,3 +1449,129 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		expect(parsed.error).toContain('Session queue is full');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// M5.3 — Task creation and workflow activation
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — task creation and planning node activation (M5.3)', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('create_standalone_task creates task with pending status (clear request)', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Fix the login bug where international users cannot authenticate',
+			description: 'Fix authentication failure for international card payments',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('pending');
+		expect(parsed.task.workflowRunId ?? null).toBeNull();
+	});
+
+	test('create_standalone_task task persists to DB and is retrievable', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Add JWT auth',
+			description: 'Implement user authentication with JWT tokens',
+		});
+		const taskId = JSON.parse(result.content[0].text).task.id;
+		const stored = ctx.taskRepo.getTask(taskId);
+		expect(stored).not.toBeNull();
+		expect(stored?.title).toBe('Add JWT auth');
+		expect(stored?.status).toBe('pending');
+	});
+
+	test('start_workflow_run with planning start node creates task with planning taskType', async () => {
+		// Seed a planner agent so resolveTaskTypeForAgent returns 'planning'
+		seedAgentRow(ctx.db, 'agent-planner-1', ctx.spaceId, 'Planner', 'planner');
+
+		const stepId = 'planning-step-1';
+		const wf = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Plan-first Workflow',
+			description: 'Workflow with planning start node',
+			nodes: [{ id: stepId, name: 'Planning', agentId: 'agent-planner-1' }],
+			transitions: [],
+			startNodeId: stepId,
+			rules: [],
+			tags: ['coding', 'v2'],
+		});
+
+		const result = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'Implement payment system',
+			description: 'Build a secure payment processing module',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.tasks).toHaveLength(1);
+		// Planning node activation: taskType must be 'planning'
+		expect(parsed.tasks[0].taskType).toBe('planning');
+		expect(parsed.tasks[0].workflowNodeId).toBe(stepId);
+		expect(parsed.tasks[0].status).toBe('pending');
+	});
+
+	test('start_workflow_run with V2 planning workflow stores run in DB', async () => {
+		seedAgentRow(ctx.db, 'agent-planner-2', ctx.spaceId, 'Planner', 'planner');
+
+		const stepId = 'v2-planning-step';
+		const wf = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Coding Workflow V2',
+			description: 'Full-cycle coding workflow with plan review',
+			nodes: [{ id: stepId, name: 'Planning', agentId: 'agent-planner-2' }],
+			transitions: [],
+			startNodeId: stepId,
+			rules: [],
+			tags: ['coding', 'v2', 'default'],
+		});
+
+		await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'Implement authentication system',
+		});
+
+		const runs = ctx.workflowRunRepo.listBySpace(ctx.spaceId);
+		expect(runs).toHaveLength(1);
+		expect(runs[0].status).toBe('in_progress');
+
+		const tasks = ctx.taskRepo.listByWorkflowRun(runs[0].id);
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0].taskType).toBe('planning');
+	});
+
+	test('suggest_workflow ranks V2 workflow first for clear coding request', async () => {
+		buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Coding Workflow',
+			['coding', 'default'],
+			'For writing code'
+		);
+		buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Coding Workflow V2',
+			['coding', 'v2', 'default'],
+			'Full-cycle coding with plan review and parallel reviewers'
+		);
+
+		const result = await makeHandlers(ctx).suggest_workflow({
+			description: 'implement authentication system with JWT tokens',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		// V2 must rank first — it has the 'v2' tiebreaker tag
+		expect(parsed.workflows[0].name).toBe('Coding Workflow V2');
+	});
+});

--- a/packages/daemon/tests/unit/space/space-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/space/space-chat-agent.test.ts
@@ -405,6 +405,58 @@ describe('buildSpaceChatSystemPrompt — escalation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Clarification guidance (M5.3)
+// ---------------------------------------------------------------------------
+
+describe('buildSpaceChatSystemPrompt — clarification guidance', () => {
+	test('includes instruction to ask for clarification on ambiguous requests', () => {
+		const prompt = buildSpaceChatSystemPrompt();
+		expect(prompt).toContain('Ask for clarification');
+	});
+
+	test('includes examples of vague requests that require clarification', () => {
+		const prompt = buildSpaceChatSystemPrompt();
+		expect(prompt).toContain('improve the app');
+		expect(prompt).toContain('make it better');
+		expect(prompt).toContain('help me');
+	});
+
+	test('instructs not to start work until the request is specific enough', () => {
+		const prompt = buildSpaceChatSystemPrompt();
+		expect(prompt).toContain('specific enough to act on');
+	});
+
+	test('mentions unclear scope or success criteria as a reason to ask', () => {
+		const prompt = buildSpaceChatSystemPrompt();
+		expect(prompt).toContain('success criteria');
+	});
+
+	test('mentions multiple interpretations as a reason to ask', () => {
+		const prompt = buildSpaceChatSystemPrompt();
+		expect(prompt).toContain('Multiple interpretations');
+	});
+
+	test('includes examples of clear requests ready to act on', () => {
+		const prompt = buildSpaceChatSystemPrompt();
+		expect(prompt).toContain('Clear requests');
+	});
+
+	test('guides to prefer workflow run with V2 for clear coding work', () => {
+		const prompt = buildSpaceChatSystemPrompt();
+		expect(prompt).toContain('V2 workflow');
+	});
+
+	test('clarification guidance present regardless of autonomy level', () => {
+		const supervised = buildSpaceChatSystemPrompt({ autonomyLevel: 'supervised' });
+		const semi = buildSpaceChatSystemPrompt({ autonomyLevel: 'semi_autonomous' });
+		for (const prompt of [supervised, semi]) {
+			expect(prompt).toContain('Ask for clarification');
+			expect(prompt).toContain('specific enough to act on');
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Coordination tools section
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Added explicit clarification guidance to `buildSpaceChatSystemPrompt`: agent now asks for clarification when a request is vague (e.g. "improve the app", "make it better") before creating any tasks or workflow runs
- Added "Clear requests" examples and instruction to prefer `start_workflow_run` with V2 workflow for clear multi-step coding work
- 8 new tests in `space-chat-agent.test.ts` verifying clarification section content
- 5 new tests in `space-agent-tools.test.ts` covering M5.3 acceptance criteria: `create_standalone_task` persists with `pending` status, `start_workflow_run` with planning node creates `planning` taskType task and activates correctly, V2 workflow ranked first by `suggest_workflow` for coding requests

## Acceptance criteria met

- Clear coding request → `start_workflow_run` with V2 workflow (planning node activates as first task)
- Ambiguous request → clarification guidance in prompt prevents premature task creation
- Planning node activates: task created with `taskType: 'planning'` and correct `workflowNodeId`
- All unit tests pass (9154 total, 0 failures)