### PR TITLE
feat(space): implement completion flow with Done node summary (M5.2)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -633,6 +633,138 @@ export function buildQaNodeAgentPrompt(): string {
 }
 
 // ============================================================================
+// Done node agent specialized prompt
+// ============================================================================
+
+/**
+ * Build the specialized system prompt content for a Done node agent.
+ *
+ * The Done node is the terminal node in the V2 workflow. Its job is to read
+ * gate data from completed workflow stages and produce a comprehensive,
+ * human-readable summary of what was accomplished. It does NOT write code or
+ * modify files — it only reads gates and composes a summary.
+ *
+ * This is stored as the `systemPrompt` field on the General SpaceAgent preset,
+ * so it gets embedded in the "Agent Instructions" section of the broader
+ * `buildCustomAgentSystemPrompt` output.
+ *
+ * Covers:
+ *   1. Role declaration (read-only summarizer, bypass marker required)
+ *   2. Read code-pr-gate for PR URL and branch
+ *   3. Read review-votes-gate for reviewer verdicts
+ *   4. Read qa-result-gate for QA outcome
+ *   5. Compose a Markdown summary with all findings
+ *   6. Call report_done with the summary
+ *   7. Output summary with ANALYSIS_COMPLETE: bypass marker
+ */
+export function buildDoneNodeAgentPrompt(): string {
+	const sections: string[] = [];
+
+	// Role + read-only declaration
+	sections.push(
+		`You are the Done Node Agent — the final step in the workflow. ` +
+			`Your responsibility is to read the gate data written by previous workflow stages ` +
+			`and compose a comprehensive, human-readable summary of what was accomplished. ` +
+			`You do NOT write, edit, or commit any code — you only read gate data and produce a summary.`
+	);
+	sections.push(
+		`\n**IMPORTANT — This is a read-only summarization role.** ` +
+			`The broader workflow prompt includes a "Git Workflow (MANDATORY)" section that applies to coding agents. ` +
+			`As the Done node agent you must NOT create commits, push branches, or open pull requests. ` +
+			`When you finish producing the summary, use the \`ANALYSIS_COMPLETE:\` bypass marker ` +
+			`(documented in the "Bypassing Git/PR Gates for Research-Only Tasks" section) as the opening of your final response, ` +
+			`after calling \`report_done\` with the summary.`
+	);
+
+	// Step 1: Read code-pr-gate
+	sections.push(`\n## Step 1 — Read the PR Gate\n`);
+	sections.push(
+		`Read the \`code-pr-gate\` to discover the pull request that was implemented:\n\n` +
+			`\`\`\`\n` +
+			`read_gate({ gateId: "code-pr-gate" })\n` +
+			`\`\`\`\n\n` +
+			`Extract these fields from the gate data:\n` +
+			`- \`pr_url\` — the full GitHub PR URL (e.g. \`https://github.com/owner/repo/pull/42\`)\n` +
+			`- \`pr_number\` — the PR number (if present)\n` +
+			`- \`branch\` — the feature branch name (if present)\n\n` +
+			`If \`code-pr-gate\` is empty, note "No PR data available" and continue.`
+	);
+
+	// Step 2: Read review-votes-gate
+	sections.push(`\n## Step 2 — Read the Review Votes\n`);
+	sections.push(
+		`Read the \`review-votes-gate\` to see how reviewers voted on the implementation:\n\n` +
+			`\`\`\`\n` +
+			`read_gate({ gateId: "review-votes-gate" })\n` +
+			`\`\`\`\n\n` +
+			`Extract the \`votes\` map, e.g.:\n` +
+			`\`\`\`json\n` +
+			`{ "Reviewer 1": "approve", "Reviewer 2": "approve", "Reviewer 3": "approve" }\n` +
+			`\`\`\`\n\n` +
+			`Count approvals and rejections from the votes map. ` +
+			`If no votes are present, note "No review data available".`
+	);
+
+	// Step 3: Read qa-result-gate
+	sections.push(`\n## Step 3 — Read the QA Result\n`);
+	sections.push(
+		`Read the \`qa-result-gate\` to get the QA verification outcome:\n\n` +
+			`\`\`\`\n` +
+			`read_gate({ gateId: "qa-result-gate" })\n` +
+			`\`\`\`\n\n` +
+			`Extract:\n` +
+			`- \`result\` — \`"passed"\` or \`"failed"\`\n` +
+			`- \`summary\` — the QA agent's verification summary (if present)\n\n` +
+			`If \`qa-result-gate\` is empty, note "No QA data available".`
+	);
+
+	// Step 4: Compose the summary
+	sections.push(`\n## Step 4 — Compose the Workflow Summary\n`);
+	sections.push(
+		`Using the gate data collected above, compose a comprehensive Markdown summary ` +
+			`following this exact structure:\n\n` +
+			`\`\`\`markdown\n` +
+			`## Workflow Complete\n\n` +
+			`### What Was Implemented\n` +
+			`<1-3 sentences describing what was built, based on the task title and description>\n\n` +
+			`### Pull Request\n` +
+			`- **PR URL:** <pr_url from code-pr-gate, or "Not available">\n` +
+			`- **Branch:** <branch name, or "Not available">\n` +
+			`- **Status:** Ready to merge\n\n` +
+			`### Code Review\n` +
+			`- **Approvals:** <count> reviewer(s) approved\n` +
+			`- **Rejections:** <count> (should be 0 at this stage)\n` +
+			`- **Reviewers:** <list of reviewer names and their vote>\n\n` +
+			`### QA Verification\n` +
+			`- **Result:** <PASSED / FAILED>\n` +
+			`- **Details:** <QA summary from qa-result-gate.summary>\n\n` +
+			`### Suggested Next Steps\n` +
+			`1. Review the PR at <pr_url>\n` +
+			`2. Merge the pull request when ready\n` +
+			`3. <any additional context-specific suggestions>\n` +
+			`\`\`\``
+	);
+
+	// Step 5: Call report_done and output summary
+	sections.push(`\n## Step 5 — Report Done and Output Summary\n`);
+	sections.push(
+		`After composing the summary:\n\n` +
+			`1. Call \`report_done\` with the full Markdown summary as the \`summary\` argument:\n` +
+			`   \`\`\`\n` +
+			`   report_done({ summary: "<your full Markdown summary>" })\n` +
+			`   \`\`\`\n\n` +
+			`2. Then output the summary with the bypass marker as the opening of your final response:\n` +
+			`   \`\`\`\n` +
+			`   ANALYSIS_COMPLETE:\n\n` +
+			`   <Your full Markdown summary here>\n` +
+			`   \`\`\`\n\n` +
+			`Always call \`report_done\` BEFORE outputting the final response.`
+	);
+
+	return sections.join('\n');
+}
+
+// ============================================================================
 // Task message builder
 // ============================================================================
 

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -80,8 +80,8 @@ const CODER_TOOLS = KNOWN_TOOLS.filter(
 	(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
 ) as string[];
 
-/** Same as coder — general agents have the same toolset */
-const GENERAL_TOOLS = CODER_TOOLS;
+/** Done node agent: read-only summarization — no Write or Edit */
+const DONE_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
 
 /** Planner uses the same toolset as coder (orchestration patterns reserved for future) */
 const PLANNER_TOOLS = CODER_TOOLS;
@@ -98,7 +98,7 @@ const QA_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSear
  */
 export const ROLE_TOOLS: Record<string, string[]> = {
 	coder: CODER_TOOLS,
-	general: GENERAL_TOOLS,
+	general: DONE_TOOLS,
 	planner: PLANNER_TOOLS,
 	reviewer: REVIEWER_TOOLS,
 	qa: QA_TOOLS,
@@ -131,7 +131,7 @@ const PRESET_AGENTS: PresetDefinition[] = [
 		description:
 			'Done node agent. Reads gate data from completed workflow stages and produces a ' +
 			'comprehensive human-readable summary of what was accomplished.',
-		tools: GENERAL_TOOLS,
+		tools: DONE_TOOLS,
 		// systemPrompt is populated lazily in seedPresetAgents() to avoid
 		// calling buildDoneNodeAgentPrompt() at module-init time.
 	},

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -18,7 +18,7 @@
 import type { SpaceAgent, SessionFeatures } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentManager, SpaceAgentResult } from '../managers/space-agent-manager';
-import { buildQaNodeAgentPrompt } from './custom-agent';
+import { buildQaNodeAgentPrompt, buildDoneNodeAgentPrompt } from './custom-agent';
 
 // ---------------------------------------------------------------------------
 // Feature flag profiles per role
@@ -128,8 +128,12 @@ const PRESET_AGENTS: PresetDefinition[] = [
 	{
 		name: 'General',
 		role: 'general',
-		description: 'General-purpose worker. Handles broad tasks that do not fit a specialized role.',
+		description:
+			'Done node agent. Reads gate data from completed workflow stages and produces a ' +
+			'comprehensive human-readable summary of what was accomplished.',
 		tools: GENERAL_TOOLS,
+		// systemPrompt is populated lazily in seedPresetAgents() to avoid
+		// calling buildDoneNodeAgentPrompt() at module-init time.
 	},
 	{
 		name: 'Planner',
@@ -191,7 +195,12 @@ export async function seedPresetAgents(
 
 	for (const preset of PRESET_AGENTS) {
 		// Resolve role-specific system prompts lazily (at seed time, not module-init).
-		const systemPrompt = preset.role === 'qa' ? buildQaNodeAgentPrompt() : preset.systemPrompt;
+		const systemPrompt =
+			preset.role === 'qa'
+				? buildQaNodeAgentPrompt()
+				: preset.role === 'general'
+					? buildDoneNodeAgentPrompt()
+					: preset.systemPrompt;
 
 		const result: SpaceAgentResult<SpaceAgent> = await agentManager.create({
 			spaceId,

--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -204,8 +204,10 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
 	sections.push('');
 	sections.push(
 		`- **\`workflow_run_completed\`** — A workflow run has finished (success or failure summary).\n` +
-			`  Payload fields: \`runId\`, \`reason\`, \`autonomyLevel\`\n` +
-			`  Action: Summarize the outcome to the user and suggest next steps if relevant.`
+			`  Payload fields: \`runId\`, \`summary\` (full Markdown summary from Done node), \`autonomyLevel\`\n` +
+			`  Action: Present the \`summary\` field verbatim to the user (it contains PR link, review outcome, ` +
+			`QA status, and next steps). If \`summary\` is empty, retrieve the run details via \`get_task_detail\` ` +
+			`and compose a brief status update.`
 	);
 
 	// Autonomy level section

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -214,7 +214,8 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push(
 		`- **report_workflow_done** — Explicitly mark the entire workflow run as completed and close the main task. ` +
-			`Pass an optional \`summary\` string describing what the workflow accomplished. ` +
+			`Pass a \`summary\` string describing what the workflow accomplished — use the Done node agent's ` +
+			`result summary (collected via \`check_node_status\`) as the summary when available. ` +
 			`Call this when all node agents have finished and you are certain the workflow is done. ` +
 			`This immediately marks the run completed without waiting for the automatic detector.`
 	);
@@ -270,7 +271,9 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`\`condition\` and \`task_result\` gates are evaluated automatically by the system. ` +
 			`If a node agent reports that a message was blocked by a gate, surface the gate to the user.\n` +
 			`5. **Detect completion** — When \`list_group_members\` shows all members have completed, ` +
-			`call \`report_workflow_done\` to mark the workflow run and task as completed. ` +
+			`collect the Done node agent's result summary via \`check_node_status\` (use the session ID ` +
+			`returned when you spawned the Done node agent). Then call \`report_workflow_done\` with that ` +
+			`summary to mark the workflow run and task as completed. ` +
 			`You may also use \`report_result\` directly for finer-grained status control.\n` +
 			`6. **Handle errors** — If a node agent errors, call \`report_result\` with ` +
 			`\`status: "cancelled"\` and the error details.`

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -798,6 +798,10 @@ export class SpaceRuntime {
 	 * 2. Look up completed tasks for those node IDs.
 	 * 3. Return the first non-empty result string found.
 	 *
+	 * Channel `from`/`to` values are agent slot names or node names (NOT node UUIDs).
+	 * Cross-node format `"nodeId/agentName"` encodes the node UUID before the slash.
+	 * We resolve all references to node UUIDs before comparing against `node.id`.
+	 *
 	 * Falls back to `undefined` when no terminal task result is available
 	 * (e.g. the Done node hasn't run yet, or the result field was not set).
 	 */
@@ -805,15 +809,41 @@ export class SpaceRuntime {
 		const channels = workflow.channels ?? [];
 		const nodes = workflow.nodes;
 
+		// Build name → nodeId map: node names and per-node agent slot names both resolve
+		// to the containing node's UUID.
+		const nameToNodeId = new Map<string, string>();
+		for (const node of nodes) {
+			nameToNodeId.set(node.name, node.id);
+			if (node.agents) {
+				for (const agent of node.agents) {
+					nameToNodeId.set(agent.name, node.id);
+				}
+			}
+		}
+
+		// Resolve a channel endpoint reference to a node UUID.
+		// Handles: plain names (node/agent-slot), cross-node "nodeId/agentName", '*' wildcard.
+		const resolveRef = (ref: string): string | undefined => {
+			if (ref === '*') return undefined;
+			const slashIdx = ref.indexOf('/');
+			if (slashIdx !== -1) {
+				// Cross-node format — the part before the slash is the node UUID
+				return ref.slice(0, slashIdx);
+			}
+			return nameToNodeId.get(ref);
+		};
+
 		// Collect node IDs that appear as channel sources (have outbound channels).
 		// Bidirectional channels flow both ways, so both endpoints are non-terminal.
 		const nodesWithOutbound = new Set<string>();
 		for (const ch of channels) {
-			nodesWithOutbound.add(ch.from);
+			const fromId = resolveRef(ch.from);
+			if (fromId) nodesWithOutbound.add(fromId);
 			if (ch.direction === 'bidirectional') {
 				const targets = Array.isArray(ch.to) ? ch.to : [ch.to];
 				for (const target of targets) {
-					nodesWithOutbound.add(target);
+					const toId = resolveRef(target);
+					if (toId) nodesWithOutbound.add(toId);
 				}
 			}
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -805,10 +805,17 @@ export class SpaceRuntime {
 		const channels = workflow.channels ?? [];
 		const nodes = workflow.nodes;
 
-		// Collect node IDs that appear as channel sources (have outbound channels)
+		// Collect node IDs that appear as channel sources (have outbound channels).
+		// Bidirectional channels flow both ways, so both endpoints are non-terminal.
 		const nodesWithOutbound = new Set<string>();
 		for (const ch of channels) {
 			nodesWithOutbound.add(ch.from);
+			if (ch.direction === 'bidirectional') {
+				const targets = Array.isArray(ch.to) ? ch.to : [ch.to];
+				for (const target of targets) {
+					nodesWithOutbound.add(target);
+				}
+			}
 		}
 
 		// Terminal nodes are those with no outbound channels

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -788,6 +788,51 @@ export class SpaceRuntime {
 	}
 
 	/**
+	 * Finds the result summary from the terminal (Done) node agent task for a
+	 * completed workflow run. Used to populate the `workflow_run_completed`
+	 * notification summary so the Space Chat Agent can surface it to the human.
+	 *
+	 * Strategy:
+	 * 1. Find terminal node IDs — workflow nodes that do not appear as the
+	 *    `from` source in any channel (no outbound channels).
+	 * 2. Look up completed tasks for those node IDs.
+	 * 3. Return the first non-empty result string found.
+	 *
+	 * Falls back to `undefined` when no terminal task result is available
+	 * (e.g. the Done node hasn't run yet, or the result field was not set).
+	 */
+	private resolveCompletionSummary(runId: string, workflow: SpaceWorkflow): string | undefined {
+		const channels = workflow.channels ?? [];
+		const nodes = workflow.nodes;
+
+		// Collect node IDs that appear as channel sources (have outbound channels)
+		const nodesWithOutbound = new Set<string>();
+		for (const ch of channels) {
+			nodesWithOutbound.add(ch.from);
+		}
+
+		// Terminal nodes are those with no outbound channels
+		const terminalNodeIds = new Set<string>();
+		for (const node of nodes) {
+			if (!nodesWithOutbound.has(node.id)) {
+				terminalNodeIds.add(node.id);
+			}
+		}
+
+		if (terminalNodeIds.size === 0) return undefined;
+
+		// Look up completed tasks for terminal nodes and return the first result
+		const runTasks = this.config.taskRepo.listByWorkflowRun(runId);
+		for (const task of runTasks) {
+			if (task.workflowNodeId != null && terminalNodeIds.has(task.workflowNodeId) && task.result) {
+				return task.result;
+			}
+		}
+
+		return undefined;
+	}
+
+	/**
 	 * Removes from the executors map any executor whose run has reached a
 	 * terminal state (completed or cancelled).
 	 *
@@ -797,6 +842,8 @@ export class SpaceRuntime {
 	 *
 	 * Emits a `workflow_run_completed` notification for runs that reached the
 	 * `completed` state (set by the CompletionDetector or external cancellation).
+	 * Includes the Done node agent's result summary (if available) so the
+	 * Space Chat Agent can surface it to the human.
 	 */
 	private async cleanupTerminalExecutors(): Promise<void> {
 		for (const [runId] of this.executors) {
@@ -805,11 +852,13 @@ export class SpaceRuntime {
 				if (run?.status === 'completed') {
 					const meta = this.executorMeta.get(runId);
 					if (meta) {
+						const summary = this.resolveCompletionSummary(runId, meta.workflow);
 						await this.safeNotify({
 							kind: 'workflow_run_completed',
 							spaceId: meta.spaceId,
 							runId,
 							status: 'completed',
+							summary,
 							timestamp: new Date().toISOString(),
 						});
 					}

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -13,6 +13,7 @@ import {
 	buildPlannerNodeAgentPrompt,
 	buildCoderNodeAgentPrompt,
 	buildQaNodeAgentPrompt,
+	buildDoneNodeAgentPrompt,
 	createCustomAgentInit,
 	resolveAgentInit,
 	type CustomAgentConfig,
@@ -1681,6 +1682,113 @@ describe('buildQaNodeAgentPrompt', () => {
 	it('is deterministic — returns the same string on multiple calls', () => {
 		const prompt1 = buildQaNodeAgentPrompt();
 		const prompt2 = buildQaNodeAgentPrompt();
+		expect(prompt1).toBe(prompt2);
+	});
+});
+
+// ============================================================================
+// buildDoneNodeAgentPrompt
+// ============================================================================
+
+describe('buildDoneNodeAgentPrompt', () => {
+	it('returns a non-empty string', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(typeof prompt).toBe('string');
+		expect(prompt.length).toBeGreaterThan(0);
+	});
+
+	it('identifies role as Done Node Agent', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('Done Node Agent');
+	});
+
+	it('declares read-only summarization role', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('read-only summarization role');
+	});
+
+	it('explicitly warns not to create commits, push, or open PRs', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('NOT create commits');
+		expect(prompt).toContain('push branches');
+		expect(prompt).toContain('open pull requests');
+	});
+
+	it('references the Git Workflow MANDATORY section to explain bypass', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('Git Workflow (MANDATORY)');
+	});
+
+	it('includes ANALYSIS_COMPLETE bypass marker instruction', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('ANALYSIS_COMPLETE:');
+	});
+
+	it('includes read_gate instruction for code-pr-gate with pr_url field', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('read_gate');
+		expect(prompt).toContain('code-pr-gate');
+		expect(prompt).toContain('pr_url');
+	});
+
+	it('includes read_gate instruction for review-votes-gate with votes field', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('review-votes-gate');
+		expect(prompt).toContain('votes');
+	});
+
+	it('includes read_gate instruction for qa-result-gate with result field', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('qa-result-gate');
+		expect(prompt).toContain('result');
+	});
+
+	it('includes summary Markdown structure with required sections', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('## Workflow Complete');
+		expect(prompt).toContain('### What Was Implemented');
+		expect(prompt).toContain('### Pull Request');
+		expect(prompt).toContain('### Code Review');
+		expect(prompt).toContain('### QA Verification');
+		expect(prompt).toContain('### Suggested Next Steps');
+	});
+
+	it('instructs agent to call report_done with summary', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		expect(prompt).toContain('report_done');
+		expect(prompt).toContain('summary');
+	});
+
+	it('instructs to call report_done BEFORE outputting final response', () => {
+		const prompt = buildDoneNodeAgentPrompt();
+		// Step 5 must explicitly require calling report_done before the final output
+		expect(prompt).toContain('report_done');
+		expect(prompt.toLowerCase()).toContain('before');
+		// The step that mentions calling report_done should precede the bypass marker usage instruction
+		const step5Text = prompt.slice(prompt.indexOf('## Step 5'));
+		expect(step5Text).toContain('report_done');
+		expect(step5Text).toContain('ANALYSIS_COMPLETE:');
+	});
+
+	it('embeds into custom agent system prompt as Agent Instructions when set as systemPrompt', () => {
+		const agent = makeAgent({ role: 'general', systemPrompt: buildDoneNodeAgentPrompt() });
+		const fullPrompt = buildCustomAgentSystemPrompt(agent);
+		expect(fullPrompt).toContain('Agent Instructions');
+		expect(fullPrompt).toContain('Done Node Agent');
+		expect(fullPrompt).toContain('code-pr-gate');
+		expect(fullPrompt).toContain('qa-result-gate');
+		expect(fullPrompt).toContain('ANALYSIS_COMPLETE:');
+	});
+
+	it('assembled prompt explicitly warns against committing code', () => {
+		const agent = makeAgent({ role: 'general', systemPrompt: buildDoneNodeAgentPrompt() });
+		const fullPrompt = buildCustomAgentSystemPrompt(agent);
+		expect(fullPrompt).toContain('NOT create commits');
+	});
+
+	it('is deterministic — returns the same string on multiple calls', () => {
+		const prompt1 = buildDoneNodeAgentPrompt();
+		const prompt2 = buildDoneNodeAgentPrompt();
 		expect(prompt1).toBe(prompt2);
 	});
 });

--- a/packages/daemon/tests/unit/space/role-config.test.ts
+++ b/packages/daemon/tests/unit/space/role-config.test.ts
@@ -191,8 +191,14 @@ describe('ROLE_TOOLS', () => {
 		expect(tools).toContain('Glob');
 	});
 
-	it('general has the same tools as coder', () => {
-		expect(ROLE_TOOLS.general).toEqual(ROLE_TOOLS.coder);
+	it('general (Done node) has read-only tools — no Write or Edit', () => {
+		const tools = ROLE_TOOLS.general;
+		expect(tools).not.toContain('Write');
+		expect(tools).not.toContain('Edit');
+		expect(tools).toContain('Read');
+		expect(tools).toContain('Bash');
+		expect(tools).toContain('Grep');
+		expect(tools).toContain('Glob');
 	});
 });
 

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -159,6 +159,19 @@ describe('seedPresetAgents', () => {
 		}
 	});
 
+	it('General agent has restricted tools (no Write or Edit) — read-only Done node', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const general = seeded.find((a) => a.role === 'general');
+
+		expect(general).toBeDefined();
+		expect(general?.tools).not.toContain('Write');
+		expect(general?.tools).not.toContain('Edit');
+		expect(general?.tools).toContain('Read');
+		expect(general?.tools).toContain('Bash');
+		expect(general?.tools).toContain('Grep');
+		expect(general?.tools).toContain('Glob');
+	});
+
 	it('QA agent has restricted tools (no Write or Edit)', async () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const qa = seeded.find((a) => a.role === 'qa');

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -180,4 +180,23 @@ describe('seedPresetAgents', () => {
 		expect(typeof qa?.systemPrompt).toBe('string');
 		expect((qa?.systemPrompt?.length ?? 0) > 0).toBe(true);
 	});
+
+	it('General agent has a system prompt set (Done node summarizer)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const general = seeded.find((a) => a.role === 'general');
+
+		expect(general).toBeDefined();
+		expect(typeof general?.systemPrompt).toBe('string');
+		expect((general?.systemPrompt?.length ?? 0) > 0).toBe(true);
+	});
+
+	it('General agent system prompt references done node summarization behavior', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const general = seeded.find((a) => a.role === 'general');
+
+		expect(general?.systemPrompt).toContain('Done Node Agent');
+		expect(general?.systemPrompt).toContain('code-pr-gate');
+		expect(general?.systemPrompt).toContain('qa-result-gate');
+		expect(general?.systemPrompt).toContain('ANALYSIS_COMPLETE:');
+	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -1403,6 +1403,7 @@ describe('SpaceRuntime — notification events', () => {
 		test('workflow_run_completed notification includes summary from terminal (Done) node task result', async () => {
 			const rt = makeRuntimeWithTam();
 			// 2-node workflow with an explicit channel: Coder → Done
+			// Channel from/to use node names (realistic production format, not node IDs)
 			// The Done node is terminal (no outbound channels from it)
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
@@ -1414,8 +1415,8 @@ describe('SpaceRuntime — notification events', () => {
 				channels: [
 					{
 						id: 'ch-sum',
-						from: 'step-coder-sum',
-						to: 'step-done-sum',
+						from: 'Coder',
+						to: 'Done',
 						direction: 'one-way' as const,
 					},
 				],
@@ -1487,18 +1488,19 @@ describe('SpaceRuntime — notification events', () => {
 
 		test('summary comes from Done terminal node, not from upstream Coder node', async () => {
 			const rt = makeRuntimeWithTam();
+			// Channel uses node names (realistic production format)
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Terminal Node Priority ${Date.now()}`,
 				nodes: [
-					{ id: 'step-upstream-prio', name: 'Coder', agentId: AGENT_CODER },
+					{ id: 'step-upstream-prio', name: 'Coding', agentId: AGENT_CODER },
 					{ id: 'step-terminal-prio', name: 'Done', agentId: AGENT_CODER },
 				],
 				channels: [
 					{
 						id: 'ch-priority',
-						from: 'step-upstream-prio',
-						to: 'step-terminal-prio',
+						from: 'Coding',
+						to: 'Done',
 						direction: 'one-way' as const,
 					},
 				],
@@ -1542,34 +1544,26 @@ describe('SpaceRuntime — notification events', () => {
 
 		test('no terminal nodes — all nodes have outbound channels, summary is undefined', async () => {
 			const rt = makeRuntimeWithTam();
-			// A → B → A is a cycle; both nodes have outbound edges so neither is terminal.
-			// We simulate this by using transitions (not channels) and patching the workflow after
-			// creation. More practically: two nodes each with channels pointing at the other.
-			// Use a simpler approach: workflow with one node whose only outbound channel loops
-			// back to itself (or just create a workflow where we manually verify summary=undefined).
-			// Easiest: build a workflow, then manually invoke resolveCompletionSummary via
-			// the notification payload.
-			//
-			// Actually, SpaceWorkflow.channels has `from` and `to`. Let's create two nodes both
-			// having outbound channels so neither qualifies as terminal.
+			// A ↔ B cycle: both nodes have outbound edges so neither is terminal.
+			// Channel from/to use node names (realistic production format).
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `No Terminal ${Date.now()}`,
 				nodes: [
-					{ id: 'step-nt-a', name: 'A', agentId: AGENT_CODER },
-					{ id: 'step-nt-b', name: 'B', agentId: AGENT_CODER },
+					{ id: 'step-nt-a', name: 'NodeA', agentId: AGENT_CODER },
+					{ id: 'step-nt-b', name: 'NodeB', agentId: AGENT_CODER },
 				],
 				channels: [
 					{
 						id: 'ch-nt-ab',
-						from: 'step-nt-a',
-						to: 'step-nt-b',
+						from: 'NodeA',
+						to: 'NodeB',
 						direction: 'one-way' as const,
 					},
 					{
 						id: 'ch-nt-ba',
-						from: 'step-nt-b',
-						to: 'step-nt-a',
+						from: 'NodeB',
+						to: 'NodeA',
 						direction: 'one-way' as const,
 					},
 				],
@@ -1607,6 +1601,7 @@ describe('SpaceRuntime — notification events', () => {
 		test('multiple terminal nodes — returns first non-empty result', async () => {
 			const rt = makeRuntimeWithTam();
 			// Fan-out: one start node, two terminal nodes each with a result.
+			// Channel from/to use node names (realistic production format).
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Multi Terminal ${Date.now()}`,
@@ -1618,14 +1613,14 @@ describe('SpaceRuntime — notification events', () => {
 				channels: [
 					{
 						id: 'ch-mt-1',
-						from: 'step-mt-start',
-						to: 'step-mt-done1',
+						from: 'Start',
+						to: 'Done1',
 						direction: 'one-way' as const,
 					},
 					{
 						id: 'ch-mt-2',
-						from: 'step-mt-start',
-						to: 'step-mt-done2',
+						from: 'Start',
+						to: 'Done2',
 						direction: 'one-way' as const,
 					},
 				],
@@ -1671,6 +1666,7 @@ describe('SpaceRuntime — notification events', () => {
 
 		test('multiple terminal nodes with no results — summary is undefined', async () => {
 			const rt = makeRuntimeWithTam();
+			// Channel from/to use node names (realistic production format).
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Multi Terminal No Result ${Date.now()}`,
@@ -1682,14 +1678,14 @@ describe('SpaceRuntime — notification events', () => {
 				channels: [
 					{
 						id: 'ch-mtnr-1',
-						from: 'step-mtnr-start',
-						to: 'step-mtnr-done1',
+						from: 'Start',
+						to: 'Done1',
 						direction: 'one-way' as const,
 					},
 					{
 						id: 'ch-mtnr-2',
-						from: 'step-mtnr-start',
-						to: 'step-mtnr-done2',
+						from: 'Start',
+						to: 'Done2',
 						direction: 'one-way' as const,
 					},
 				],
@@ -1760,18 +1756,19 @@ describe('SpaceRuntime — notification events', () => {
 		test('bidirectional channel — neither endpoint is treated as terminal', async () => {
 			const rt = makeRuntimeWithTam();
 			// A ↔ B — both nodes have outbound edges (bidirectional), so neither is terminal.
+			// Channel from/to use node names (realistic production format).
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Bidirectional ${Date.now()}`,
 				nodes: [
-					{ id: 'step-bidi-a', name: 'A', agentId: AGENT_CODER },
-					{ id: 'step-bidi-b', name: 'B', agentId: AGENT_CODER },
+					{ id: 'step-bidi-a', name: 'Alpha', agentId: AGENT_CODER },
+					{ id: 'step-bidi-b', name: 'Beta', agentId: AGENT_CODER },
 				],
 				channels: [
 					{
 						id: 'ch-bidi',
-						from: 'step-bidi-a',
-						to: 'step-bidi-b',
+						from: 'Alpha',
+						to: 'Beta',
 						direction: 'bidirectional' as const,
 					},
 				],
@@ -1802,6 +1799,69 @@ describe('SpaceRuntime — notification events', () => {
 			if (completedEvents[0].kind === 'workflow_run_completed') {
 				// Both nodes are bidirectional — neither is terminal, summary should be undefined
 				expect(completedEvents[0].summary).toBeUndefined();
+			}
+		});
+
+		test('channel from/to agent slot names resolve to correct node', async () => {
+			// Regression guard: channels use WorkflowNodeAgent.name (slot names), not node IDs.
+			// Multi-agent node "Parallel" has slots "coder-slot" and "reviewer-slot".
+			// Channel uses slot name "reviewer-slot" as from — that node should be non-terminal.
+			const rt = makeRuntimeWithTam();
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Slot Name Resolution ${Date.now()}`,
+				nodes: [
+					{
+						id: 'step-slot-parallel',
+						name: 'Parallel',
+						agents: [
+							{ agentId: AGENT_CODER, name: 'coder-slot' },
+							{ agentId: AGENT_PLANNER2, name: 'reviewer-slot' },
+						],
+					},
+					{ id: 'step-slot-done', name: 'Done', agentId: AGENT_CODER },
+				],
+				channels: [
+					{
+						id: 'ch-slot',
+						// Agent slot name used as from — this is the production format
+						from: 'reviewer-slot',
+						to: 'Done',
+						direction: 'one-way' as const,
+					},
+				],
+				startNodeId: 'step-slot-parallel',
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(2); // two agents in Parallel node
+
+			const doneTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Done',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-slot-done',
+				taskType: 'coding',
+				status: 'pending',
+			});
+
+			const doneSummary = '## Workflow Complete\n\nAll steps passed.';
+			for (const t of tasks) {
+				taskRepo.updateTask(t.id, { status: 'completed', result: 'Slot result' });
+			}
+			taskRepo.updateTask(doneTask.id, { status: 'completed', result: doneSummary });
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				// The Parallel node has an outbound channel (via slot name) → not terminal
+				// Only Done is terminal → its summary is returned
+				expect(completedEvents[0].summary).toBe(doneSummary);
 			}
 		});
 	});

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -1539,5 +1539,270 @@ describe('SpaceRuntime — notification events', () => {
 				expect(completedEvents[0].summary).not.toBe('Upstream result');
 			}
 		});
+
+		test('no terminal nodes — all nodes have outbound channels, summary is undefined', async () => {
+			const rt = makeRuntimeWithTam();
+			// A → B → A is a cycle; both nodes have outbound edges so neither is terminal.
+			// We simulate this by using transitions (not channels) and patching the workflow after
+			// creation. More practically: two nodes each with channels pointing at the other.
+			// Use a simpler approach: workflow with one node whose only outbound channel loops
+			// back to itself (or just create a workflow where we manually verify summary=undefined).
+			// Easiest: build a workflow, then manually invoke resolveCompletionSummary via
+			// the notification payload.
+			//
+			// Actually, SpaceWorkflow.channels has `from` and `to`. Let's create two nodes both
+			// having outbound channels so neither qualifies as terminal.
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `No Terminal ${Date.now()}`,
+				nodes: [
+					{ id: 'step-nt-a', name: 'A', agentId: AGENT_CODER },
+					{ id: 'step-nt-b', name: 'B', agentId: AGENT_CODER },
+				],
+				channels: [
+					{
+						id: 'ch-nt-ab',
+						from: 'step-nt-a',
+						to: 'step-nt-b',
+						direction: 'one-way' as const,
+					},
+					{
+						id: 'ch-nt-ba',
+						from: 'step-nt-b',
+						to: 'step-nt-a',
+						direction: 'one-way' as const,
+					},
+				],
+				startNodeId: 'step-nt-a',
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Create a task for node B as well
+			const taskB = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'B',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-nt-b',
+				taskType: 'coding',
+				status: 'pending',
+			});
+
+			taskRepo.updateTask(tasks[0].id, { status: 'completed', result: 'Result A' });
+			taskRepo.updateTask(taskB.id, { status: 'completed', result: 'Result B' });
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				// No terminal nodes → summary should be undefined
+				expect(completedEvents[0].summary).toBeUndefined();
+			}
+		});
+
+		test('multiple terminal nodes — returns first non-empty result', async () => {
+			const rt = makeRuntimeWithTam();
+			// Fan-out: one start node, two terminal nodes each with a result.
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Multi Terminal ${Date.now()}`,
+				nodes: [
+					{ id: 'step-mt-start', name: 'Start', agentId: AGENT_CODER },
+					{ id: 'step-mt-done1', name: 'Done1', agentId: AGENT_CODER },
+					{ id: 'step-mt-done2', name: 'Done2', agentId: AGENT_CODER },
+				],
+				channels: [
+					{
+						id: 'ch-mt-1',
+						from: 'step-mt-start',
+						to: 'step-mt-done1',
+						direction: 'one-way' as const,
+					},
+					{
+						id: 'ch-mt-2',
+						from: 'step-mt-start',
+						to: 'step-mt-done2',
+						direction: 'one-way' as const,
+					},
+				],
+				startNodeId: 'step-mt-start',
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			const taskDone1 = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Done1',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-mt-done1',
+				taskType: 'coding',
+				status: 'pending',
+			});
+			const taskDone2 = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Done2',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-mt-done2',
+				taskType: 'coding',
+				status: 'pending',
+			});
+
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			taskRepo.updateTask(taskDone1.id, { status: 'completed', result: 'Summary from Done1' });
+			taskRepo.updateTask(taskDone2.id, { status: 'completed', result: 'Summary from Done2' });
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				// Returns the first non-empty result found — either Done1 or Done2
+				expect(completedEvents[0].summary).toMatch(/Summary from Done[12]/);
+			}
+		});
+
+		test('multiple terminal nodes with no results — summary is undefined', async () => {
+			const rt = makeRuntimeWithTam();
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Multi Terminal No Result ${Date.now()}`,
+				nodes: [
+					{ id: 'step-mtnr-start', name: 'Start', agentId: AGENT_CODER },
+					{ id: 'step-mtnr-done1', name: 'Done1', agentId: AGENT_CODER },
+					{ id: 'step-mtnr-done2', name: 'Done2', agentId: AGENT_CODER },
+				],
+				channels: [
+					{
+						id: 'ch-mtnr-1',
+						from: 'step-mtnr-start',
+						to: 'step-mtnr-done1',
+						direction: 'one-way' as const,
+					},
+					{
+						id: 'ch-mtnr-2',
+						from: 'step-mtnr-start',
+						to: 'step-mtnr-done2',
+						direction: 'one-way' as const,
+					},
+				],
+				startNodeId: 'step-mtnr-start',
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			const taskDone1 = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Done1',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-mtnr-done1',
+				taskType: 'coding',
+				status: 'pending',
+			});
+			const taskDone2 = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Done2',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-mtnr-done2',
+				taskType: 'coding',
+				status: 'pending',
+			});
+
+			// Complete all tasks but set NO result on any terminal node
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			taskRepo.updateTask(taskDone1.id, { status: 'completed' });
+			taskRepo.updateTask(taskDone2.id, { status: 'completed' });
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				expect(completedEvents[0].summary).toBeUndefined();
+			}
+		});
+
+		test('empty result string on terminal node is not returned as summary', async () => {
+			const rt = makeRuntimeWithTam();
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Empty Result ${Date.now()}`,
+				nodes: [{ id: 'step-empty-res', name: 'Done', agentId: AGENT_CODER }],
+				startNodeId: 'step-empty-res',
+				rules: [],
+				tags: [],
+			});
+
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			// Set result to empty string — should not be treated as a valid summary
+			taskRepo.updateTask(tasks[0].id, { status: 'completed', result: '' });
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				expect(completedEvents[0].summary).toBeUndefined();
+			}
+		});
+
+		test('bidirectional channel — neither endpoint is treated as terminal', async () => {
+			const rt = makeRuntimeWithTam();
+			// A ↔ B — both nodes have outbound edges (bidirectional), so neither is terminal.
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Bidirectional ${Date.now()}`,
+				nodes: [
+					{ id: 'step-bidi-a', name: 'A', agentId: AGENT_CODER },
+					{ id: 'step-bidi-b', name: 'B', agentId: AGENT_CODER },
+				],
+				channels: [
+					{
+						id: 'ch-bidi',
+						from: 'step-bidi-a',
+						to: 'step-bidi-b',
+						direction: 'bidirectional' as const,
+					},
+				],
+				startNodeId: 'step-bidi-a',
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			const taskB = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'B',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-bidi-b',
+				taskType: 'coding',
+				status: 'pending',
+			});
+
+			taskRepo.updateTask(tasks[0].id, { status: 'completed', result: 'Result A' });
+			taskRepo.updateTask(taskB.id, { status: 'completed', result: 'Result B' });
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				// Both nodes are bidirectional — neither is terminal, summary should be undefined
+				expect(completedEvents[0].summary).toBeUndefined();
+			}
+		});
 	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -1395,5 +1395,149 @@ describe('SpaceRuntime — notification events', () => {
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
 			expect(completedEvents).toHaveLength(1);
 		});
+
+		// -----------------------------------------------------------------------
+		// Completion summary — resolveCompletionSummary
+		// -----------------------------------------------------------------------
+
+		test('workflow_run_completed notification includes summary from terminal (Done) node task result', async () => {
+			const rt = makeRuntimeWithTam();
+			// 2-node workflow with an explicit channel: Coder → Done
+			// The Done node is terminal (no outbound channels from it)
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Summary Test ${Date.now()}`,
+				nodes: [
+					{ id: 'step-coder-sum', name: 'Coder', agentId: AGENT_CODER },
+					{ id: 'step-done-sum', name: 'Done', agentId: AGENT_CODER },
+				],
+				channels: [
+					{
+						id: 'ch-sum',
+						from: 'step-coder-sum',
+						to: 'step-done-sum',
+						direction: 'one-way' as const,
+					},
+				],
+				startNodeId: 'step-coder-sum',
+				rules: [],
+				tags: [],
+			});
+
+			// startWorkflowRun creates the task for the start (Coder) node
+			const {
+				run,
+				tasks: [coderTask],
+			} = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Manually create the Done task (downstream node, not auto-created by startWorkflowRun)
+			const doneTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Done',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-done-sum',
+				taskType: 'coding',
+				status: 'pending',
+			});
+
+			// Mark both as completed; Done task has a rich result summary
+			const doneSummary =
+				'## Workflow Complete\n\n### Pull Request\n- **PR URL:** https://github.com/owner/repo/pull/42';
+			taskRepo.updateTask(coderTask.id, { status: 'completed', result: 'Code implemented' });
+			taskRepo.updateTask(doneTask.id, { status: 'completed', result: doneSummary });
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				// Summary should come from the Done (terminal) node, not the Coder node
+				expect(completedEvents[0].summary).toBe(doneSummary);
+			}
+		});
+
+		test('workflow_run_completed notification has no summary when terminal task has no result', async () => {
+			const rt = makeRuntimeWithTam();
+			// Single-node workflow — the one node is terminal (no channels)
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `No Summary Test ${Date.now()}`,
+				nodes: [{ id: 'step-nosummary', name: 'Done', agentId: AGENT_CODER }],
+				startNodeId: 'step-nosummary',
+				rules: [],
+				tags: [],
+			});
+
+			// startWorkflowRun creates the task for the start node
+			const {
+				tasks: [doneTask],
+			} = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			// Complete without a result
+			taskRepo.updateTask(doneTask.id, { status: 'completed' });
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				expect(completedEvents[0].summary).toBeUndefined();
+			}
+		});
+
+		test('summary comes from Done terminal node, not from upstream Coder node', async () => {
+			const rt = makeRuntimeWithTam();
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Terminal Node Priority ${Date.now()}`,
+				nodes: [
+					{ id: 'step-upstream-prio', name: 'Coder', agentId: AGENT_CODER },
+					{ id: 'step-terminal-prio', name: 'Done', agentId: AGENT_CODER },
+				],
+				channels: [
+					{
+						id: 'ch-priority',
+						from: 'step-upstream-prio',
+						to: 'step-terminal-prio',
+						direction: 'one-way' as const,
+					},
+				],
+				startNodeId: 'step-upstream-prio',
+				rules: [],
+				tags: [],
+			});
+
+			// startWorkflowRun creates the task for the start (Coder/upstream) node
+			const {
+				run,
+				tasks: [upstreamTask],
+			} = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Manually create the terminal (Done) task
+			const terminalTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Done',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'step-terminal-prio',
+				taskType: 'coding',
+				status: 'pending',
+			});
+
+			taskRepo.updateTask(upstreamTask.id, { status: 'completed', result: 'Upstream result' });
+			taskRepo.updateTask(terminalTask.id, {
+				status: 'completed',
+				result: 'Terminal Done summary',
+			});
+
+			await rt.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				expect(completedEvents[0].summary).toBe('Terminal Done summary');
+				expect(completedEvents[0].summary).not.toBe('Upstream result');
+			}
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- **Done node agent prompt** (`buildDoneNodeAgentPrompt`): reads `code-pr-gate`, `review-votes-gate`, `qa-result-gate` and composes a Markdown summary (PR link, reviewer votes, QA status, suggested next steps), then calls `report_done` with it
- **General agent seeded with Done prompt**: Done node in V2 workflow uses the General agent; it now gets the summary-producing instructions automatically
- **SpaceRuntime completion summary**: `resolveCompletionSummary()` identifies terminal nodes (no outbound channels) and includes their task result in the `workflow_run_completed` notification `summary` field
- **Task Agent prompt updated**: instructs the Task Agent to collect the Done node's result via `check_node_status` and pass it to `report_workflow_done`
- **Space Chat Agent updated**: instructs it to surface the `summary` field verbatim when receiving `workflow_run_completed`

## Test plan

- [x] 15 new tests for `buildDoneNodeAgentPrompt` in `custom-agent.test.ts`
- [x] 2 new tests for General agent seeding in `seed-agents.test.ts`
- [x] 3 new tests for completion summary in `space-runtime-notifications.test.ts`
- [x] All 9161 daemon tests pass