### PR TITLE
feat(space): add test helpers and plan-to-approve flow (M7.1)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -363,6 +363,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Space Runtime Service — wraps SpaceRuntime with per-space lifecycle API.
 	// Not started yet: TaskAgentManager is created next and injected before start().
+	// gateDataRepo is injected so notifyGateDataChanged() can trigger lazy node activation
+	// after gate data is written externally (e.g. approveGate RPC, writeGateData RPC).
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		spaceManager: deps.spaceManager,
@@ -370,6 +372,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceWorkflowManager,
 		workflowRunRepo: spaceWorkflowRunRepo,
 		taskRepo: spaceTaskRepo,
+		gateDataRepo,
 	});
 
 	// Space Worktree Manager — one worktree per task, shared by all node agents.

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -108,6 +108,16 @@ export function setupSpaceWorkflowRunHandlers(
 	taskManagerFactory: SpaceWorkflowRunTaskManagerFactory,
 	daemonHub: DaemonHub
 ): void {
+	/**
+	 * Helper: notify the channel router that gate data has changed.
+	 * Triggers lazy node activation for any newly-unblocked channels.
+	 * Fire-and-forget — callers do not need to await this.
+	 */
+	function fireGateChanged(runId: string, gateId: string): void {
+		void spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch((err) => {
+			log.warn(`notifyGateDataChanged failed for gate "${gateId}" in run "${runId}":`, err);
+		});
+	}
 	// ─── spaceWorkflowRun.start ──────────────────────────────────────────────
 	messageHub.onRequest('spaceWorkflowRun.start', async (data) => {
 		const params = data as {
@@ -356,6 +366,9 @@ export function setupSpaceWorkflowRunHandlers(
 					log.warn('Failed to emit space.gateData.updated:', err);
 				});
 
+			// Trigger channel re-evaluation so downstream nodes activate if the gate is now open.
+			fireGateChanged(params.runId, params.gateId);
+
 			return { run: updatedRun, gateData };
 		} else {
 			// Rejection — idempotent: gate data already shows rejected
@@ -404,6 +417,44 @@ export function setupSpaceWorkflowRunHandlers(
 
 			return { run: updated, gateData };
 		}
+	});
+
+	// ─── spaceWorkflowRun.writeGateData ──────────────────────────────────────
+	//
+	// Writes (merges) arbitrary data into a gate's runtime record and triggers
+	// channel re-evaluation so downstream nodes activate when a gate opens.
+	//
+	// Used by test helpers to simulate agent behavior (e.g. planner writing
+	// plan_submitted to plan-pr-gate) without spinning up a real agent session.
+	// Does NOT enforce allowedWriterRoles — callers are trusted.
+	messageHub.onRequest('spaceWorkflowRun.writeGateData', async (data) => {
+		const params = data as { runId: string; gateId: string; data: Record<string, unknown> };
+
+		if (!params.runId) throw new Error('runId is required');
+		if (!params.gateId) throw new Error('gateId is required');
+		if (!params.data || typeof params.data !== 'object') throw new Error('data must be an object');
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		const gateData = gateDataRepo.merge(params.runId, params.gateId, params.data);
+
+		daemonHub
+			.emit('space.gateData.updated', {
+				sessionId: 'global',
+				spaceId: run.spaceId,
+				runId: params.runId,
+				gateId: params.gateId,
+				data: gateData.data,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.gateData.updated:', err);
+			});
+
+		// Trigger channel re-evaluation so downstream nodes activate if the gate is now open.
+		fireGateChanged(params.runId, params.gateId);
+
+		return { gateData };
 	});
 
 	// ─── spaceWorkflowRun.listGateData ───────────────────────────────────────

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -432,10 +432,16 @@ export function setupSpaceWorkflowRunHandlers(
 
 		if (!params.runId) throw new Error('runId is required');
 		if (!params.gateId) throw new Error('gateId is required');
-		if (!params.data || typeof params.data !== 'object') throw new Error('data must be an object');
+		if (!params.data || typeof params.data !== 'object' || Array.isArray(params.data)) {
+			throw new Error('data must be an object');
+		}
 
 		const run = workflowRunRepo.getRun(params.runId);
 		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		if (run.status === 'completed' || run.status === 'cancelled' || run.status === 'pending') {
+			throw new Error(`Cannot write gate data on a ${run.status} workflow run`);
+		}
 
 		const gateData = gateDataRepo.merge(params.runId, params.gateId, params.data);
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -10,14 +10,17 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
+import type { SpaceTask } from '@neokai/shared';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { NotificationSink } from './notification-sink';
 import type { TaskAgentManager } from './task-agent-manager';
 import { SpaceRuntime } from './space-runtime';
+import { ChannelRouter } from './channel-router';
 import { Logger } from '../../logger';
 
 const log = new Logger('space-runtime-service');
@@ -39,6 +42,12 @@ export interface SpaceRuntimeServiceConfig {
 	 */
 	taskAgentManager?: TaskAgentManager;
 	tickIntervalMs?: number;
+	/**
+	 * Optional gate data repository for onGateDataChanged support.
+	 * When provided, notifyGateDataChanged() can be called to trigger lazy node
+	 * activation after gate data is written externally (e.g. human approval via RPC).
+	 */
+	gateDataRepo?: GateDataRepository;
 }
 
 export class SpaceRuntimeService {
@@ -128,5 +137,30 @@ export class SpaceRuntimeService {
 	 */
 	stopRuntime(_spaceId: string): void {
 		// No-op: shared runtime handles all spaces; use stop() to stop entirely.
+	}
+
+	/**
+	 * Notify that gate data has changed for a given run/gate pair.
+	 *
+	 * Creates a temporary ChannelRouter and calls onGateDataChanged() to re-evaluate
+	 * all channels referencing the gate and lazily activate any newly-unblocked nodes.
+	 *
+	 * Used by the approveGate RPC handler and the writeGateData RPC handler to trigger
+	 * downstream node activation after gate data is written externally (i.e. without going
+	 * through the write_gate MCP tool, which has its own onGateDataChanged wiring).
+	 *
+	 * No-op when gateDataRepo was not provided at construction time.
+	 */
+	async notifyGateDataChanged(runId: string, gateId: string): Promise<SpaceTask[]> {
+		if (!this.config.gateDataRepo) return [];
+		const router = new ChannelRouter({
+			taskRepo: this.config.taskRepo,
+			workflowRunRepo: this.config.workflowRunRepo,
+			workflowManager: this.config.spaceWorkflowManager,
+			agentManager: this.config.spaceAgentManager,
+			gateDataRepo: this.config.gateDataRepo,
+			db: this.config.db,
+		});
+		return router.onGateDataChanged(runId, gateId);
 	}
 }

--- a/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
+++ b/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
@@ -1,0 +1,387 @@
+/**
+ * Shared test helpers for Space online integration tests.
+ *
+ * These helpers drive the workflow gate machinery directly via RPC without
+ * spinning up real LLM agent sessions. This lets gate-open/close and node-
+ * activation logic be exercised deterministically and quickly with dev proxy.
+ *
+ * ## Key helpers
+ *
+ * - createTestSpace        — create a Space with CODING_WORKFLOW_V2 pre-seeded
+ * - startWorkflowRun       — start a run and return its ID + initial tasks
+ * - writeGateData          — write arbitrary data to a gate (simulates agent write_gate call)
+ * - readGateData           — read current gate data for a (runId, gateId) pair
+ * - approveGate            — human-approve a gate (writes approved:true + triggers activation)
+ * - rejectGate             — human-reject a gate (writes approved:false, run → needs_attention)
+ * - waitForNodeStatus      — poll until at least one task for a node reaches a target status
+ * - waitForRunStatus       — poll until the workflow run reaches a target status
+ * - getGateArtifacts       — fetch gate artifacts (changed files + diff) for a run
+ * - mockAgentDone          — mark a task as completed directly via spaceTask.update
+ *
+ * ## Usage
+ *
+ *   NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/space/...
+ */
+
+import type { DaemonServerContext } from '../../helpers/daemon-server';
+import type { Space, SpaceAgent, SpaceWorkflow, SpaceWorkflowRun, SpaceTask } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TestSpaceFixture {
+	space: Space;
+	/** All agents seeded into the space */
+	agents: SpaceAgent[];
+	/** The CODING_WORKFLOW_V2 workflow (preferred) or the first available */
+	workflow: SpaceWorkflow;
+}
+
+export interface GateDataRecord {
+	runId: string;
+	gateId: string;
+	data: Record<string, unknown>;
+	updatedAt: number;
+}
+
+export interface GateArtifacts {
+	files: Array<{ path: string; additions: number; deletions: number }>;
+	totalAdditions: number;
+	totalDeletions: number;
+	prUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Space + workflow setup
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a Space whose name embeds a unique suffix so tests never collide.
+ * space.create auto-seeds preset agents and built-in workflows (including V2).
+ *
+ * Returns the Space, all its agents, and the CODING_WORKFLOW_V2 workflow.
+ * Falls back to the first workflow if V2 is not found (should not happen with
+ * normal seeding, but keeps tests robust).
+ */
+export async function createTestSpace(daemon: DaemonServerContext): Promise<TestSpaceFixture> {
+	const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+	const space = (await daemon.messageHub.request('space.create', {
+		name: `Test Space ${suffix}`,
+		description: 'Integration test space — plan-to-approve flow',
+		workspacePath: process.cwd(),
+		autonomyLevel: 'supervised',
+	})) as Space;
+
+	const { agents } = (await daemon.messageHub.request('spaceAgent.list', {
+		spaceId: space.id,
+	})) as { agents: SpaceAgent[] };
+
+	const { workflows } = (await daemon.messageHub.request('spaceWorkflow.list', {
+		spaceId: space.id,
+	})) as { workflows: SpaceWorkflow[] };
+
+	// Prefer the V2 workflow (tags include 'v2')
+	const workflow =
+		workflows.find((w) => Array.isArray(w.tags) && w.tags.includes('v2')) ?? workflows[0];
+
+	if (!workflow)
+		throw new Error('No workflows found after space creation — seeding may have failed');
+
+	return { space, agents, workflow };
+}
+
+// ---------------------------------------------------------------------------
+// Workflow run lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Start a workflow run and return its ID plus the initial pending tasks.
+ *
+ * spaceTask.list returns an array directly (not wrapped in { tasks }).
+ */
+export async function startWorkflowRun(
+	daemon: DaemonServerContext,
+	spaceId: string,
+	workflowId: string,
+	title: string
+): Promise<{ runId: string; tasks: SpaceTask[] }> {
+	const { run } = (await daemon.messageHub.request('spaceWorkflowRun.start', {
+		spaceId,
+		workflowId,
+		title,
+	})) as { run: SpaceWorkflowRun };
+
+	const tasks = (await daemon.messageHub.request('spaceTask.list', {
+		spaceId,
+	})) as SpaceTask[];
+
+	const runTasks = tasks.filter((t) => t.workflowRunId === run.id);
+	return { runId: run.id, tasks: runTasks };
+}
+
+// ---------------------------------------------------------------------------
+// Gate data helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Write (merge) data into a gate's runtime record and trigger channel
+ * re-evaluation via spaceWorkflowRun.writeGateData RPC.
+ *
+ * Simulates what an agent does when it calls the write_gate MCP tool —
+ * without requiring a real LLM session.
+ */
+export async function writeGateData(
+	daemon: DaemonServerContext,
+	runId: string,
+	gateId: string,
+	data: Record<string, unknown>
+): Promise<GateDataRecord> {
+	const result = (await daemon.messageHub.request('spaceWorkflowRun.writeGateData', {
+		runId,
+		gateId,
+		data,
+	})) as { gateData: GateDataRecord };
+	return result.gateData;
+}
+
+/**
+ * Read current gate data for a (runId, gateId) pair.
+ * Returns null when no data has been written to the gate yet.
+ */
+export async function readGateData(
+	daemon: DaemonServerContext,
+	runId: string,
+	gateId: string
+): Promise<GateDataRecord | null> {
+	const { gateData } = (await daemon.messageHub.request('spaceWorkflowRun.listGateData', {
+		runId,
+	})) as { gateData: GateDataRecord[] };
+	return gateData.find((g) => g.gateId === gateId) ?? null;
+}
+
+/**
+ * Human-approve a gate: writes approved:true and triggers downstream node activation.
+ * If the run was previously in needs_attention+humanRejected, it resumes to in_progress.
+ */
+export async function approveGate(
+	daemon: DaemonServerContext,
+	runId: string,
+	gateId: string,
+	reason?: string
+): Promise<{ run: SpaceWorkflowRun; gateData: GateDataRecord }> {
+	return (await daemon.messageHub.request('spaceWorkflowRun.approveGate', {
+		runId,
+		gateId,
+		approved: true,
+		reason,
+	})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
+}
+
+/**
+ * Human-reject a gate: writes approved:false and transitions run to needs_attention
+ * with failureReason: 'humanRejected'.
+ */
+export async function rejectGate(
+	daemon: DaemonServerContext,
+	runId: string,
+	gateId: string,
+	reason?: string
+): Promise<{ run: SpaceWorkflowRun; gateData: GateDataRecord }> {
+	return (await daemon.messageHub.request('spaceWorkflowRun.approveGate', {
+		runId,
+		gateId,
+		approved: false,
+		reason,
+	})) as { run: SpaceWorkflowRun; gateData: GateDataRecord };
+}
+
+// ---------------------------------------------------------------------------
+// Status polling helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Poll spaceTask.list until at least one task for the given node name has
+ * one of the expected statuses. Returns the first matching task.
+ *
+ * Matches tasks by:
+ * 1. task.title (which equals node.name, e.g. 'Planning', 'Plan Review', 'Coding')
+ * 2. task.workflowNodeId (UUID, for direct UUID matching)
+ * 3. task.agentName (agent slot name)
+ */
+export async function waitForNodeStatus(
+	daemon: DaemonServerContext,
+	spaceId: string,
+	runId: string,
+	/** Node name (e.g. 'Planning', 'Plan Review', 'Coding') or node UUID */
+	nodeNameOrId: string,
+	expectedStatuses: string[],
+	timeout: number
+): Promise<SpaceTask> {
+	const deadline = Date.now() + timeout;
+	while (Date.now() < deadline) {
+		const tasks = (await daemon.messageHub.request('spaceTask.list', {
+			spaceId,
+		})) as SpaceTask[];
+
+		const runTasks = tasks.filter((t) => t.workflowRunId === runId);
+		const match = runTasks.find(
+			(t) =>
+				(t.title === nodeNameOrId ||
+					t.workflowNodeId === nodeNameOrId ||
+					t.agentName === nodeNameOrId) &&
+				expectedStatuses.includes(t.status)
+		);
+		if (match) return match;
+
+		await new Promise((resolve) => setTimeout(resolve, 300));
+	}
+	throw new Error(
+		`Node "${nodeNameOrId}" did not reach status [${expectedStatuses.join(', ')}] within ${timeout}ms`
+	);
+}
+
+/**
+ * Poll spaceTask.list until any task for the given node name exists in the run
+ * (i.e. the node has been activated). Useful before calling waitForNodeStatus
+ * when you just want to confirm activation happened.
+ */
+export async function waitForNodeActivated(
+	daemon: DaemonServerContext,
+	spaceId: string,
+	runId: string,
+	nodeNameOrId: string,
+	timeout: number
+): Promise<SpaceTask> {
+	return waitForNodeStatus(
+		daemon,
+		spaceId,
+		runId,
+		nodeNameOrId,
+		['pending', 'in_progress', 'completed', 'review', 'needs_attention'],
+		timeout
+	);
+}
+
+/**
+ * Poll spaceWorkflowRun.get until the run reaches one of the expected statuses.
+ * Returns the final run object.
+ */
+export async function waitForRunStatus(
+	daemon: DaemonServerContext,
+	runId: string,
+	expectedStatuses: string[],
+	timeout: number
+): Promise<SpaceWorkflowRun> {
+	const deadline = Date.now() + timeout;
+	while (Date.now() < deadline) {
+		// spaceWorkflowRun.get uses 'id' not 'runId'
+		const { run } = (await daemon.messageHub.request('spaceWorkflowRun.get', {
+			id: runId,
+		})) as { run: SpaceWorkflowRun };
+
+		if (expectedStatuses.includes(run.status)) return run;
+		await new Promise((resolve) => setTimeout(resolve, 300));
+	}
+	throw new Error(
+		`Run "${runId}" did not reach status [${expectedStatuses.join(', ')}] within ${timeout}ms`
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Artifact helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch gate artifacts (changed files and diff summary) for a workflow run.
+ */
+export async function getGateArtifacts(
+	daemon: DaemonServerContext,
+	runId: string
+): Promise<GateArtifacts> {
+	return (await daemon.messageHub.request('spaceWorkflowRun.getGateArtifacts', {
+		runId,
+	})) as GateArtifacts;
+}
+
+// ---------------------------------------------------------------------------
+// Task simulation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark a task as 'completed' directly via spaceTask.update.
+ *
+ * Simulates an agent calling report_result without actually running a session.
+ * Handles intermediate transitions: if the task is still 'pending', it is first
+ * moved to 'in_progress' before completing.
+ */
+export async function mockAgentDone(
+	daemon: DaemonServerContext,
+	spaceId: string,
+	taskId: string,
+	result?: string
+): Promise<SpaceTask> {
+	// Fetch current status to determine whether we need an intermediate transition
+	const current = (await daemon.messageHub.request('spaceTask.get', {
+		spaceId,
+		taskId,
+	})) as SpaceTask;
+
+	// pending → in_progress → completed; in_progress → completed
+	if (current.status === 'pending' || current.status === 'draft') {
+		await daemon.messageHub.request('spaceTask.update', {
+			spaceId,
+			taskId,
+			status: 'in_progress',
+		});
+	}
+
+	return (await daemon.messageHub.request('spaceTask.update', {
+		spaceId,
+		taskId,
+		status: 'completed',
+		result: result ?? 'Mock agent completed',
+	})) as SpaceTask;
+}
+
+/**
+ * Find tasks for a given node name in a run.
+ * Matches by task.title (= node.name), workflowNodeId (UUID), or agentName.
+ * Returns empty array when the node has not been activated yet.
+ */
+export async function getTasksForNode(
+	daemon: DaemonServerContext,
+	spaceId: string,
+	runId: string,
+	nodeNameOrId: string
+): Promise<SpaceTask[]> {
+	const tasks = (await daemon.messageHub.request('spaceTask.list', {
+		spaceId,
+	})) as SpaceTask[];
+
+	return tasks.filter(
+		(t) =>
+			t.workflowRunId === runId &&
+			(t.title === nodeNameOrId ||
+				t.workflowNodeId === nodeNameOrId ||
+				t.agentName === nodeNameOrId)
+	);
+}
+
+/**
+ * Find tasks for a given workflow node UUID in a run.
+ * Unlike getTasksForNode, this does an exact UUID match on workflowNodeId.
+ */
+export async function getTasksForNodeId(
+	daemon: DaemonServerContext,
+	spaceId: string,
+	runId: string,
+	nodeId: string
+): Promise<SpaceTask[]> {
+	const tasks = (await daemon.messageHub.request('spaceTask.list', {
+		spaceId,
+	})) as SpaceTask[];
+
+	return tasks.filter((t) => t.workflowRunId === runId && t.workflowNodeId === nodeId);
+}

--- a/packages/daemon/tests/online/space/space-happy-path-plan-to-approve.test.ts
+++ b/packages/daemon/tests/online/space/space-happy-path-plan-to-approve.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Space Happy Path — Plan-to-Approve Flow
+ *
+ * End-to-end integration test for the Planning → Plan Review → Coding gate sequence
+ * in CODING_WORKFLOW_V2.  Instead of running real LLM agents, this test writes gate
+ * data directly via RPC to simulate agent actions and verify the gate/channel
+ * machinery activates the correct downstream nodes.
+ *
+ * ## Workflow gates under test
+ *
+ *   plan-pr-gate       (planner writes `plan_submitted`)
+ *     └─► Plan Review node activates when gate opens
+ *   plan-approval-gate (reviewer writes `approved:true`, or human calls approveGate)
+ *     └─► Coding node activates when gate opens
+ *
+ * ## Scenarios
+ *
+ * 1. Planning node is created on run start (pending task exists)
+ * 2. Writing plan-pr-gate opens the gate → Plan Review activates
+ * 3. plan-pr-gate is readable and contains the written data
+ * 4. plan-approval-gate blocks Coding when no approval exists
+ * 5. Approving plan-approval-gate → Coding node activates
+ * 6. Rejecting plan-approval-gate → run transitions to needs_attention + humanRejected
+ *
+ * ## Running
+ *
+ *   NEOKAI_USE_DEV_PROXY=1 bun test \
+ *     packages/daemon/tests/online/space/space-happy-path-plan-to-approve.test.ts
+ *
+ * MODES:
+ * - Dev Proxy (recommended): NEOKAI_USE_DEV_PROXY=1 — no real Anthropic calls needed
+ * - Real API (default): requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ *   (no LLM calls are made in this test — API key only needed for daemon startup)
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { DaemonServerContext } from '../../helpers/daemon-server';
+import { createDaemonServer } from '../../helpers/daemon-server';
+import {
+	createTestSpace,
+	startWorkflowRun,
+	writeGateData,
+	readGateData,
+	approveGate,
+	rejectGate,
+	waitForNodeActivated,
+	waitForRunStatus,
+	getTasksForNode,
+} from './helpers/space-test-helpers';
+
+// ---------------------------------------------------------------------------
+// Timing constants — shorter for mock mode since no real I/O happens
+// ---------------------------------------------------------------------------
+
+const IS_MOCK = !!process.env.NEOKAI_USE_DEV_PROXY;
+
+/** How long to wait for a node to appear after gate data is written */
+const NODE_ACTIVATION_TIMEOUT = IS_MOCK ? 3_000 : 15_000;
+/** How long to wait for run status transitions */
+const RUN_STATUS_TIMEOUT = IS_MOCK ? 3_000 : 10_000;
+/** Setup / teardown guard */
+const SETUP_TIMEOUT = IS_MOCK ? 15_000 : 30_000;
+/** Per-test timeout */
+const TEST_TIMEOUT = IS_MOCK ? 20_000 : 60_000;
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('Space Happy Path — Plan-to-Approve Flow', () => {
+	let daemon: DaemonServerContext;
+
+	beforeEach(async () => {
+		// Fresh daemon with an empty in-memory SQLite DB per test — no cross-test state.
+		// Dev Proxy is not needed for the daemon itself (no LLM calls), but NEOKAI_USE_DEV_PROXY
+		// is respected for the shared dev proxy lifecycle (start/stop once per process).
+		daemon = await createDaemonServer();
+	}, SETUP_TIMEOUT);
+
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, SETUP_TIMEOUT);
+
+	// -------------------------------------------------------------------------
+	// Test 1: Planning node activates on run start
+	// -------------------------------------------------------------------------
+	test(
+		'Planning node is created as a pending task when the workflow run starts',
+		async () => {
+			const { space, workflow } = await createTestSpace(daemon);
+			const { runId, tasks } = await startWorkflowRun(
+				daemon,
+				space.id,
+				workflow.id,
+				'Test run — Planning node'
+			);
+
+			// At least one pending task should exist for the Planning node.
+			// The start node in CODING_WORKFLOW_V2 is "Planning" (planner agent).
+			expect(tasks.length).toBeGreaterThanOrEqual(1);
+			const planningTask = tasks.find((t) => t.title === 'Planning');
+			expect(planningTask).toBeDefined();
+			expect(planningTask!.status).toBe('pending');
+			expect(planningTask!.workflowRunId).toBe(runId);
+
+			// Plan Review should NOT be activated yet — no plan has been submitted
+			const planReviewTasks = await getTasksForNode(daemon, space.id, runId, 'Plan Review');
+			expect(planReviewTasks.length).toBe(0);
+		},
+		TEST_TIMEOUT
+	);
+
+	// -------------------------------------------------------------------------
+	// Test 2: plan-pr-gate → Plan Review activates
+	// -------------------------------------------------------------------------
+	test(
+		'Writing plan_submitted to plan-pr-gate activates the Plan Review node',
+		async () => {
+			const { space, workflow } = await createTestSpace(daemon);
+			const { runId } = await startWorkflowRun(
+				daemon,
+				space.id,
+				workflow.id,
+				'Test run — plan-pr-gate'
+			);
+
+			// Simulate the Planner agent calling write_gate("plan-pr-gate", { plan_submitted: ... })
+			const gateRecord = await writeGateData(daemon, runId, 'plan-pr-gate', {
+				plan_submitted: 'https://github.com/example/repo/pull/1',
+				pr_number: 1,
+				branch: 'plan/test-branch',
+			});
+
+			expect(gateRecord.gateId).toBe('plan-pr-gate');
+			expect(gateRecord.data.plan_submitted).toBeDefined();
+
+			// After writing, the channel router should have re-evaluated plan-pr-gate
+			// and activated the Plan Review node (condition: plan_submitted exists)
+			const planReviewTask = await waitForNodeActivated(
+				daemon,
+				space.id,
+				runId,
+				'Plan Review',
+				NODE_ACTIVATION_TIMEOUT
+			);
+
+			expect(planReviewTask.title).toBe('Plan Review');
+			expect(planReviewTask.workflowRunId).toBe(runId);
+			expect(['pending', 'in_progress']).toContain(planReviewTask.status);
+		},
+		TEST_TIMEOUT
+	);
+
+	// -------------------------------------------------------------------------
+	// Test 3: readGateData returns the written data
+	// -------------------------------------------------------------------------
+	test(
+		'readGateData returns the current gate data after a write',
+		async () => {
+			const { space, workflow } = await createTestSpace(daemon);
+			const { runId } = await startWorkflowRun(
+				daemon,
+				space.id,
+				workflow.id,
+				'Test run — readGateData'
+			);
+
+			// Before any write, gate data should be null (or not present)
+			const beforeWrite = await readGateData(daemon, runId, 'plan-pr-gate');
+			expect(beforeWrite).toBeNull();
+
+			await writeGateData(daemon, runId, 'plan-pr-gate', {
+				plan_submitted: 'https://github.com/example/repo/pull/42',
+				pr_number: 42,
+				branch: 'plan/feature-x',
+			});
+
+			const afterWrite = await readGateData(daemon, runId, 'plan-pr-gate');
+			expect(afterWrite).not.toBeNull();
+			expect(afterWrite!.gateId).toBe('plan-pr-gate');
+			expect(afterWrite!.data.plan_submitted).toBe('https://github.com/example/repo/pull/42');
+			expect(afterWrite!.data.pr_number).toBe(42);
+			expect(afterWrite!.data.branch).toBe('plan/feature-x');
+		},
+		TEST_TIMEOUT
+	);
+
+	// -------------------------------------------------------------------------
+	// Test 4: plan-approval-gate blocks Coding until approved
+	// -------------------------------------------------------------------------
+	test(
+		'plan-approval-gate blocks Coding node until approval is written',
+		async () => {
+			const { space, workflow } = await createTestSpace(daemon);
+			const { runId } = await startWorkflowRun(
+				daemon,
+				space.id,
+				workflow.id,
+				'Test run — plan-approval-gate blocks'
+			);
+
+			// Open plan-pr-gate to activate Plan Review
+			await writeGateData(daemon, runId, 'plan-pr-gate', {
+				plan_submitted: 'https://github.com/example/repo/pull/2',
+			});
+
+			// Wait for Plan Review to activate (plan-pr-gate opened)
+			await waitForNodeActivated(daemon, space.id, runId, 'Plan Review', NODE_ACTIVATION_TIMEOUT);
+
+			// Coding should NOT be active — plan-approval-gate is still blocked
+			const codingTasksBefore = await getTasksForNode(daemon, space.id, runId, 'Coding');
+			expect(codingTasksBefore.length).toBe(0);
+
+			// Verify plan-approval-gate has no data yet
+			const approvalGate = await readGateData(daemon, runId, 'plan-approval-gate');
+			expect(approvalGate).toBeNull();
+		},
+		TEST_TIMEOUT
+	);
+
+	// -------------------------------------------------------------------------
+	// Test 5: Approval → Coding activates
+	// -------------------------------------------------------------------------
+	test(
+		'Approving plan-approval-gate activates the Coding node',
+		async () => {
+			const { space, workflow } = await createTestSpace(daemon);
+			const { runId } = await startWorkflowRun(
+				daemon,
+				space.id,
+				workflow.id,
+				'Test run — approve to coding'
+			);
+
+			// Step 1: Open plan-pr-gate (simulate planner done)
+			await writeGateData(daemon, runId, 'plan-pr-gate', {
+				plan_submitted: 'https://github.com/example/repo/pull/3',
+			});
+
+			// Step 2: Wait for Plan Review to activate
+			await waitForNodeActivated(daemon, space.id, runId, 'Plan Review', NODE_ACTIVATION_TIMEOUT);
+
+			// Step 3: Approve plan-approval-gate (simulate reviewer approved)
+			const { run: updatedRun, gateData } = await approveGate(daemon, runId, 'plan-approval-gate');
+
+			expect(gateData.data.approved).toBe(true);
+			expect(gateData.data.approvedAt).toBeDefined();
+			// Run should still be in_progress after approval (Coding is now active)
+			expect(updatedRun.status).toBe('in_progress');
+
+			// Step 4: Coding node should now be active
+			const codingTask = await waitForNodeActivated(
+				daemon,
+				space.id,
+				runId,
+				'Coding',
+				NODE_ACTIVATION_TIMEOUT
+			);
+
+			expect(codingTask.title).toBe('Coding');
+			expect(codingTask.workflowRunId).toBe(runId);
+			expect(['pending', 'in_progress']).toContain(codingTask.status);
+		},
+		TEST_TIMEOUT
+	);
+
+	// -------------------------------------------------------------------------
+	// Test 6: Rejection → needs_attention with humanRejected
+	// -------------------------------------------------------------------------
+	test(
+		'Rejecting plan-approval-gate transitions run to needs_attention with humanRejected',
+		async () => {
+			const { space, workflow } = await createTestSpace(daemon);
+			const { runId } = await startWorkflowRun(
+				daemon,
+				space.id,
+				workflow.id,
+				'Test run — rejection flow'
+			);
+
+			// Open plan-pr-gate so the run has something to reject
+			await writeGateData(daemon, runId, 'plan-pr-gate', {
+				plan_submitted: 'https://github.com/example/repo/pull/4',
+			});
+
+			await waitForNodeActivated(daemon, space.id, runId, 'Plan Review', NODE_ACTIVATION_TIMEOUT);
+
+			// Reject the plan-approval-gate
+			const { run: rejectedRun, gateData: rejectedGate } = await rejectGate(
+				daemon,
+				runId,
+				'plan-approval-gate',
+				'Plan needs more detail on implementation approach'
+			);
+
+			// Gate data should reflect the rejection
+			expect(rejectedGate.data.approved).toBe(false);
+			expect(rejectedGate.data.rejectedAt).toBeDefined();
+			expect(rejectedGate.data.reason).toBe('Plan needs more detail on implementation approach');
+
+			// Run must be in needs_attention with humanRejected
+			expect(rejectedRun.status).toBe('needs_attention');
+			expect(rejectedRun.failureReason).toBe('humanRejected');
+
+			// Coding must NOT have been activated
+			const codingTasks = await getTasksForNode(daemon, space.id, runId, 'Coding');
+			expect(codingTasks.length).toBe(0);
+
+			// Confirm via polling helper too
+			const finalRun = await waitForRunStatus(
+				daemon,
+				runId,
+				['needs_attention'],
+				RUN_STATUS_TIMEOUT
+			);
+			expect(finalRun.failureReason).toBe('humanRejected');
+		},
+		TEST_TIMEOUT
+	);
+
+	// -------------------------------------------------------------------------
+	// Test 7: Re-approve after rejection resumes the run
+	// -------------------------------------------------------------------------
+	test(
+		'Approving after a rejection resumes the run and activates Coding',
+		async () => {
+			const { space, workflow } = await createTestSpace(daemon);
+			const { runId } = await startWorkflowRun(
+				daemon,
+				space.id,
+				workflow.id,
+				'Test run — re-approve after rejection'
+			);
+
+			// Open plan-pr-gate
+			await writeGateData(daemon, runId, 'plan-pr-gate', {
+				plan_submitted: 'https://github.com/example/repo/pull/5',
+			});
+			await waitForNodeActivated(daemon, space.id, runId, 'Plan Review', NODE_ACTIVATION_TIMEOUT);
+
+			// Reject first
+			await rejectGate(daemon, runId, 'plan-approval-gate', 'Needs revision');
+			const afterReject = await waitForRunStatus(
+				daemon,
+				runId,
+				['needs_attention'],
+				RUN_STATUS_TIMEOUT
+			);
+			expect(afterReject.failureReason).toBe('humanRejected');
+
+			// Now approve (overrides rejection)
+			const { run: resumedRun, gateData: approvedGate } = await approveGate(
+				daemon,
+				runId,
+				'plan-approval-gate'
+			);
+
+			// Run must be back to in_progress with no failureReason
+			expect(resumedRun.status).toBe('in_progress');
+			// failureReason is cleared to null in DB; may deserialize as null or undefined
+			expect(resumedRun.failureReason ?? null).toBeNull();
+			expect(approvedGate.data.approved).toBe(true);
+
+			// Coding should now activate
+			const codingTask = await waitForNodeActivated(
+				daemon,
+				space.id,
+				runId,
+				'Coding',
+				NODE_ACTIVATION_TIMEOUT
+			);
+			expect(codingTask.title).toBe('Coding');
+		},
+		TEST_TIMEOUT
+	);
+
+	// -------------------------------------------------------------------------
+	// Test 8: Idempotent double-approve
+	// -------------------------------------------------------------------------
+	test(
+		'Approving an already-approved gate is idempotent and does not cause errors',
+		async () => {
+			const { space, workflow } = await createTestSpace(daemon);
+			const { runId } = await startWorkflowRun(
+				daemon,
+				space.id,
+				workflow.id,
+				'Test run — idempotent approve'
+			);
+
+			await writeGateData(daemon, runId, 'plan-pr-gate', {
+				plan_submitted: 'https://github.com/example/repo/pull/6',
+			});
+			await waitForNodeActivated(daemon, space.id, runId, 'Plan Review', NODE_ACTIVATION_TIMEOUT);
+
+			// Approve twice
+			const first = await approveGate(daemon, runId, 'plan-approval-gate');
+			const second = await approveGate(daemon, runId, 'plan-approval-gate');
+
+			expect(first.gateData.data.approved).toBe(true);
+			expect(second.gateData.data.approved).toBe(true);
+			// Both calls should return the same gate data (idempotent)
+			expect(first.gateData.data.approvedAt).toBe(second.gateData.data.approvedAt);
+			// Run stays in_progress
+			expect(second.run.status).toBe('in_progress');
+		},
+		TEST_TIMEOUT
+	);
+});

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -195,6 +195,7 @@ function createMockRuntimeService(): SpaceRuntimeService {
 		createOrGetRuntime: mock(async () => ({
 			startWorkflowRun: mock(async () => ({ run: mockRun, tasks: [] })),
 		})),
+		notifyGateDataChanged: mock(async (_runId: string, _gateId: string) => []),
 		start: mock(() => {}),
 		stop: mock(() => {}),
 	} as unknown as SpaceRuntimeService;

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -177,6 +177,7 @@ function createMockRunRepo(run: SpaceWorkflowRun | null = mockRun): SpaceWorkflo
 function createMockGateDataRepo(existing: GateDataRecord | null = null): GateDataRepository {
 	return {
 		get: mock(() => existing),
+		listByRun: mock(() => (existing ? [existing] : [])),
 		merge: mock((_runId: string, _gateId: string, partial: Record<string, unknown>) => ({
 			...mockGateData,
 			data: { ...(existing?.data ?? {}), ...partial },
@@ -749,6 +750,123 @@ describe('space-workflow-run gate handlers', () => {
 
 			expect(result.additions).toBe(2);
 			expect(result.deletions).toBe(1);
+		});
+	});
+
+	// ─── spaceWorkflowRun.writeGateData ───────────────────────────────────
+
+	describe('spaceWorkflowRun.writeGateData', () => {
+		it('throws if runId is missing', async () => {
+			await expect(
+				call('spaceWorkflowRun.writeGateData', { gateId: 'plan-pr-gate', data: {} })
+			).rejects.toThrow('runId is required');
+		});
+
+		it('throws if gateId is missing', async () => {
+			await expect(
+				call('spaceWorkflowRun.writeGateData', { runId: 'run-1', data: {} })
+			).rejects.toThrow('gateId is required');
+		});
+
+		it('throws if data is missing', async () => {
+			await expect(
+				call('spaceWorkflowRun.writeGateData', { runId: 'run-1', gateId: 'plan-pr-gate' })
+			).rejects.toThrow('data must be an object');
+		});
+
+		it('throws if data is an array', async () => {
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'run-1',
+					gateId: 'plan-pr-gate',
+					data: ['not', 'an', 'object'],
+				})
+			).rejects.toThrow('data must be an object');
+		});
+
+		it('throws if data is a string', async () => {
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'run-1',
+					gateId: 'plan-pr-gate',
+					data: 'plain string',
+				})
+			).rejects.toThrow('data must be an object');
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'missing',
+					gateId: 'plan-pr-gate',
+					data: { plan_submitted: 'https://github.com/example/pull/1' },
+				})
+			).rejects.toThrow('WorkflowRun not found: missing');
+		});
+
+		it('throws if run is completed (status guard)', async () => {
+			setup({ run: { ...mockRun, status: 'completed' } });
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'run-1',
+					gateId: 'plan-pr-gate',
+					data: { plan_submitted: 'https://github.com/example/pull/1' },
+				})
+			).rejects.toThrow('Cannot write gate data on a completed workflow run');
+		});
+
+		it('throws if run is cancelled (status guard)', async () => {
+			setup({ run: { ...mockRun, status: 'cancelled' } });
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'run-1',
+					gateId: 'plan-pr-gate',
+					data: { plan_submitted: 'https://github.com/example/pull/1' },
+				})
+			).rejects.toThrow('Cannot write gate data on a cancelled workflow run');
+		});
+
+		it('throws if run is pending (status guard)', async () => {
+			setup({ run: { ...mockRun, status: 'pending' } });
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'run-1',
+					gateId: 'plan-pr-gate',
+					data: { plan_submitted: 'https://github.com/example/pull/1' },
+				})
+			).rejects.toThrow('Cannot write gate data on a pending workflow run');
+		});
+
+		it('merges data into the gate and returns gateData', async () => {
+			const result = (await call('spaceWorkflowRun.writeGateData', {
+				runId: 'run-1',
+				gateId: 'plan-pr-gate',
+				data: { plan_submitted: 'https://github.com/example/pull/7', pr_number: 7 },
+			})) as { gateData: GateDataRecord };
+
+			expect(gateDataRepo.merge).toHaveBeenCalledWith('run-1', 'plan-pr-gate', {
+				plan_submitted: 'https://github.com/example/pull/7',
+				pr_number: 7,
+			});
+			expect(result.gateData).toBeDefined();
+		});
+
+		it('emits space.gateData.updated after a successful write', async () => {
+			await call('spaceWorkflowRun.writeGateData', {
+				runId: 'run-1',
+				gateId: 'plan-pr-gate',
+				data: { plan_submitted: 'https://github.com/example/pull/8' },
+			});
+
+			expect(daemonHub.emit).toHaveBeenCalledWith(
+				'space.gateData.updated',
+				expect.objectContaining({
+					spaceId: 'space-1',
+					runId: 'run-1',
+					gateId: 'plan-pr-gate',
+				})
+			);
 		});
 	});
 });


### PR DESCRIPTION
Implements M7.1: shared test helpers for Space workflow gate testing and an integration test covering the Planning → Plan Review → Coding gate sequence.

## Changes

**Backend fixes/additions:**
- `SpaceRuntimeService.notifyGateDataChanged()` — triggers lazy node activation after external gate writes (e.g. human approval via RPC)
- `approveGate` RPC — now calls `notifyGateDataChanged` so downstream nodes activate immediately after approval (was missing)
- New `spaceWorkflowRun.writeGateData` RPC — writes arbitrary gate data + triggers channel re-evaluation (for test helpers)
- `index.ts` — passes `gateDataRepo` to `SpaceRuntimeService`

**Test helpers** (`space/helpers/space-test-helpers.ts`):
`createTestSpace`, `startWorkflowRun`, `writeGateData`, `readGateData`, `approveGate`, `rejectGate`, `waitForNodeStatus`, `waitForNodeActivated`, `waitForRunStatus`, `getGateArtifacts`, `mockAgentDone`, `getTasksForNode`, `getTasksForNodeId`

**New online test** (`space-happy-path-plan-to-approve.test.ts`, 8 tests, all passing):
- Planning node activates on run start
- Writing `plan_submitted` opens `plan-pr-gate` → Plan Review activates
- `readGateData` returns written data
- `plan-approval-gate` blocks Coding until approved
- Approve → Coding activates
- Reject → `needs_attention` + `humanRejected`
- Re-approve after rejection resumes run
- Idempotent double-approve

**Unit test fix:** added `notifyGateDataChanged` mock to `SpaceRuntimeService` stub in `space-workflow-run-gate-handlers.test.ts`.

All 9181 daemon tests pass. `bun run check` clean.