### PR TITLE
test(e2e): reviewer feedback loop E2E test and vote count display (M8.2)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -10,6 +10,7 @@
  * - spaceWorkflowRun.listGateData   - Returns all gate data records for a run
  * - spaceWorkflowRun.getGateArtifacts - Returns changed files and diff summary for a run's worktree
  * - spaceWorkflowRun.getFileDiff    - Returns unified diff for a specific file in the worktree
+ * - spaceWorkflowRun.writeGateData  - Writes arbitrary gate data (E2E test infrastructure only)
  */
 
 import { execFile } from 'node:child_process';
@@ -556,5 +557,39 @@ export function setupSpaceWorkflowRunHandlers(
 		}
 
 		return { diff, additions, deletions, filePath: params.filePath };
+	});
+
+	// ─── spaceWorkflowRun.writeGateData ──────────────────────────────────────
+	//
+	// Writes arbitrary gate data for E2E test infrastructure.
+	// Bypasses allowedWriterRoles — intended for use in test beforeEach/setup only.
+	// Does NOT trigger onGateDataChanged (no automatic node activation or cycle reset).
+	messageHub.onRequest('spaceWorkflowRun.writeGateData', async (data) => {
+		const params = data as { runId: string; gateId: string; data: Record<string, unknown> };
+
+		if (!params.runId) throw new Error('runId is required');
+		if (!params.gateId) throw new Error('gateId is required');
+		if (!params.data || typeof params.data !== 'object' || Array.isArray(params.data)) {
+			throw new Error('data must be a plain object');
+		}
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		const gateData = gateDataRepo.merge(params.runId, params.gateId, params.data);
+
+		daemonHub
+			.emit('space.gateData.updated', {
+				sessionId: 'global',
+				spaceId: run.spaceId,
+				runId: params.runId,
+				gateId: params.gateId,
+				data: gateData.data,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.gateData.updated:', err);
+			});
+
+		return { gateData };
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -428,41 +428,44 @@ export function setupSpaceWorkflowRunHandlers(
 	// Used by test helpers to simulate agent behavior (e.g. planner writing
 	// plan_submitted to plan-pr-gate) without spinning up a real agent session.
 	// Does NOT enforce allowedWriterRoles — callers are trusted.
-	messageHub.onRequest('spaceWorkflowRun.writeGateData', async (data) => {
-		const params = data as { runId: string; gateId: string; data: Record<string, unknown> };
+	//
+	// Disabled in production to prevent unauthorized gate manipulation.
+	if (process.env.NODE_ENV !== 'production')
+		messageHub.onRequest('spaceWorkflowRun.writeGateData', async (data) => {
+			const params = data as { runId: string; gateId: string; data: Record<string, unknown> };
 
-		if (!params.runId) throw new Error('runId is required');
-		if (!params.gateId) throw new Error('gateId is required');
-		if (!params.data || typeof params.data !== 'object' || Array.isArray(params.data)) {
-			throw new Error('data must be an object');
-		}
+			if (!params.runId) throw new Error('runId is required');
+			if (!params.gateId) throw new Error('gateId is required');
+			if (!params.data || typeof params.data !== 'object' || Array.isArray(params.data)) {
+				throw new Error('data must be an object');
+			}
 
-		const run = workflowRunRepo.getRun(params.runId);
-		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+			const run = workflowRunRepo.getRun(params.runId);
+			if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
 
-		if (run.status === 'completed' || run.status === 'cancelled' || run.status === 'pending') {
-			throw new Error(`Cannot write gate data on a ${run.status} workflow run`);
-		}
+			if (run.status === 'completed' || run.status === 'cancelled' || run.status === 'pending') {
+				throw new Error(`Cannot write gate data on a ${run.status} workflow run`);
+			}
 
-		const gateData = gateDataRepo.merge(params.runId, params.gateId, params.data);
+			const gateData = gateDataRepo.merge(params.runId, params.gateId, params.data);
 
-		daemonHub
-			.emit('space.gateData.updated', {
-				sessionId: 'global',
-				spaceId: run.spaceId,
-				runId: params.runId,
-				gateId: params.gateId,
-				data: gateData.data,
-			})
-			.catch((err) => {
-				log.warn('Failed to emit space.gateData.updated:', err);
-			});
+			daemonHub
+				.emit('space.gateData.updated', {
+					sessionId: 'global',
+					spaceId: run.spaceId,
+					runId: params.runId,
+					gateId: params.gateId,
+					data: gateData.data,
+				})
+				.catch((err) => {
+					log.warn('Failed to emit space.gateData.updated:', err);
+				});
 
-		// Trigger channel re-evaluation so downstream nodes activate if the gate is now open.
-		fireGateChanged(params.runId, params.gateId);
+			// Trigger channel re-evaluation so downstream nodes activate if the gate is now open.
+			fireGateChanged(params.runId, params.gateId);
 
-		return { gateData };
-	});
+			return { gateData };
+		});
 
 	// ─── spaceWorkflowRun.listGateData ───────────────────────────────────────
 	//
@@ -557,39 +560,5 @@ export function setupSpaceWorkflowRunHandlers(
 		}
 
 		return { diff, additions, deletions, filePath: params.filePath };
-	});
-
-	// ─── spaceWorkflowRun.writeGateData ──────────────────────────────────────
-	//
-	// Writes arbitrary gate data for E2E test infrastructure.
-	// Bypasses allowedWriterRoles — intended for use in test beforeEach/setup only.
-	// Does NOT trigger onGateDataChanged (no automatic node activation or cycle reset).
-	messageHub.onRequest('spaceWorkflowRun.writeGateData', async (data) => {
-		const params = data as { runId: string; gateId: string; data: Record<string, unknown> };
-
-		if (!params.runId) throw new Error('runId is required');
-		if (!params.gateId) throw new Error('gateId is required');
-		if (!params.data || typeof params.data !== 'object' || Array.isArray(params.data)) {
-			throw new Error('data must be a plain object');
-		}
-
-		const run = workflowRunRepo.getRun(params.runId);
-		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
-
-		const gateData = gateDataRepo.merge(params.runId, params.gateId, params.data);
-
-		daemonHub
-			.emit('space.gateData.updated', {
-				sessionId: 'global',
-				spaceId: run.spaceId,
-				runId: params.runId,
-				gateId: params.gateId,
-				data: gateData.data,
-			})
-			.catch((err) => {
-				log.warn('Failed to emit space.gateData.updated:', err);
-			});
-
-		return { gateData };
 	});
 }

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -786,6 +786,39 @@ describe('space-workflow-run gate handlers', () => {
 			).rejects.toThrow('WorkflowRun not found: run-1');
 		});
 
+		it('throws if run is completed (status guard)', async () => {
+			setup({ run: { ...mockRun, status: 'completed' } });
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'run-1',
+					gateId: 'review-votes-gate',
+					data: { votes: { 'Reviewer 1': 'approved' } },
+				})
+			).rejects.toThrow('Cannot write gate data on a completed workflow run');
+		});
+
+		it('throws if run is cancelled (status guard)', async () => {
+			setup({ run: { ...mockRun, status: 'cancelled' } });
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'run-1',
+					gateId: 'review-votes-gate',
+					data: { votes: { 'Reviewer 1': 'approved' } },
+				})
+			).rejects.toThrow('Cannot write gate data on a cancelled workflow run');
+		});
+
+		it('throws if run is pending (status guard)', async () => {
+			setup({ run: { ...mockRun, status: 'pending' } });
+			await expect(
+				call('spaceWorkflowRun.writeGateData', {
+					runId: 'run-1',
+					gateId: 'review-votes-gate',
+					data: { votes: { 'Reviewer 1': 'approved' } },
+				})
+			).rejects.toThrow('Cannot write gate data on a pending workflow run');
+		});
+
 		it('merges gate data via gateDataRepo.merge', async () => {
 			await call('spaceWorkflowRun.writeGateData', {
 				runId: 'run-1',

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -177,7 +177,6 @@ function createMockRunRepo(run: SpaceWorkflowRun | null = mockRun): SpaceWorkflo
 function createMockGateDataRepo(existing: GateDataRecord | null = null): GateDataRepository {
 	return {
 		get: mock(() => existing),
-		listByRun: mock(() => (existing ? [existing] : [])),
 		merge: mock((_runId: string, _gateId: string, partial: Record<string, unknown>) => ({
 			...mockGateData,
 			data: { ...(existing?.data ?? {}), ...partial },
@@ -196,7 +195,6 @@ function createMockRuntimeService(): SpaceRuntimeService {
 		createOrGetRuntime: mock(async () => ({
 			startWorkflowRun: mock(async () => ({ run: mockRun, tasks: [] })),
 		})),
-		notifyGateDataChanged: mock(async (_runId: string, _gateId: string) => []),
 		start: mock(() => {}),
 		stop: mock(() => {}),
 	} as unknown as SpaceRuntimeService;
@@ -753,12 +751,12 @@ describe('space-workflow-run gate handlers', () => {
 		});
 	});
 
-	// ─── spaceWorkflowRun.writeGateData ───────────────────────────────────
+	// ─── spaceWorkflowRun.writeGateData ───────────────────────────────────────
 
 	describe('spaceWorkflowRun.writeGateData', () => {
 		it('throws if runId is missing', async () => {
 			await expect(
-				call('spaceWorkflowRun.writeGateData', { gateId: 'plan-pr-gate', data: {} })
+				call('spaceWorkflowRun.writeGateData', { gateId: 'g1', data: {} })
 			).rejects.toThrow('runId is required');
 		});
 
@@ -768,105 +766,63 @@ describe('space-workflow-run gate handlers', () => {
 			).rejects.toThrow('gateId is required');
 		});
 
-		it('throws if data is missing', async () => {
+		it('throws if data is not a plain object', async () => {
 			await expect(
-				call('spaceWorkflowRun.writeGateData', { runId: 'run-1', gateId: 'plan-pr-gate' })
-			).rejects.toThrow('data must be an object');
+				call('spaceWorkflowRun.writeGateData', { runId: 'run-1', gateId: 'g1', data: 'bad' })
+			).rejects.toThrow('data must be a plain object');
 		});
 
 		it('throws if data is an array', async () => {
 			await expect(
-				call('spaceWorkflowRun.writeGateData', {
-					runId: 'run-1',
-					gateId: 'plan-pr-gate',
-					data: ['not', 'an', 'object'],
-				})
-			).rejects.toThrow('data must be an object');
-		});
-
-		it('throws if data is a string', async () => {
-			await expect(
-				call('spaceWorkflowRun.writeGateData', {
-					runId: 'run-1',
-					gateId: 'plan-pr-gate',
-					data: 'plain string',
-				})
-			).rejects.toThrow('data must be an object');
+				call('spaceWorkflowRun.writeGateData', { runId: 'run-1', gateId: 'g1', data: [] })
+			).rejects.toThrow('data must be a plain object');
 		});
 
 		it('throws if run not found', async () => {
 			setup({ run: null });
 			await expect(
-				call('spaceWorkflowRun.writeGateData', {
-					runId: 'missing',
-					gateId: 'plan-pr-gate',
-					data: { plan_submitted: 'https://github.com/example/pull/1' },
-				})
-			).rejects.toThrow('WorkflowRun not found: missing');
+				call('spaceWorkflowRun.writeGateData', { runId: 'run-1', gateId: 'g1', data: {} })
+			).rejects.toThrow('WorkflowRun not found: run-1');
 		});
 
-		it('throws if run is completed (status guard)', async () => {
-			setup({ run: { ...mockRun, status: 'completed' } });
-			await expect(
-				call('spaceWorkflowRun.writeGateData', {
-					runId: 'run-1',
-					gateId: 'plan-pr-gate',
-					data: { plan_submitted: 'https://github.com/example/pull/1' },
-				})
-			).rejects.toThrow('Cannot write gate data on a completed workflow run');
-		});
-
-		it('throws if run is cancelled (status guard)', async () => {
-			setup({ run: { ...mockRun, status: 'cancelled' } });
-			await expect(
-				call('spaceWorkflowRun.writeGateData', {
-					runId: 'run-1',
-					gateId: 'plan-pr-gate',
-					data: { plan_submitted: 'https://github.com/example/pull/1' },
-				})
-			).rejects.toThrow('Cannot write gate data on a cancelled workflow run');
-		});
-
-		it('throws if run is pending (status guard)', async () => {
-			setup({ run: { ...mockRun, status: 'pending' } });
-			await expect(
-				call('spaceWorkflowRun.writeGateData', {
-					runId: 'run-1',
-					gateId: 'plan-pr-gate',
-					data: { plan_submitted: 'https://github.com/example/pull/1' },
-				})
-			).rejects.toThrow('Cannot write gate data on a pending workflow run');
-		});
-
-		it('merges data into the gate and returns gateData', async () => {
-			const result = (await call('spaceWorkflowRun.writeGateData', {
-				runId: 'run-1',
-				gateId: 'plan-pr-gate',
-				data: { plan_submitted: 'https://github.com/example/pull/7', pr_number: 7 },
-			})) as { gateData: GateDataRecord };
-
-			expect(gateDataRepo.merge).toHaveBeenCalledWith('run-1', 'plan-pr-gate', {
-				plan_submitted: 'https://github.com/example/pull/7',
-				pr_number: 7,
-			});
-			expect(result.gateData).toBeDefined();
-		});
-
-		it('emits space.gateData.updated after a successful write', async () => {
+		it('merges gate data via gateDataRepo.merge', async () => {
 			await call('spaceWorkflowRun.writeGateData', {
 				runId: 'run-1',
-				gateId: 'plan-pr-gate',
-				data: { plan_submitted: 'https://github.com/example/pull/8' },
+				gateId: 'review-votes-gate',
+				data: { votes: { 'Reviewer 1': 'approved' } },
+			});
+			expect(gateDataRepo.merge).toHaveBeenCalledWith('run-1', 'review-votes-gate', {
+				votes: { 'Reviewer 1': 'approved' },
+			});
+		});
+
+		it('emits space.gateData.updated with correct payload', async () => {
+			await call('spaceWorkflowRun.writeGateData', {
+				runId: 'run-1',
+				gateId: 'review-votes-gate',
+				data: { votes: { 'Reviewer 2': 'rejected' } },
 			});
 
 			expect(daemonHub.emit).toHaveBeenCalledWith(
 				'space.gateData.updated',
 				expect.objectContaining({
-					spaceId: 'space-1',
+					sessionId: 'global',
+					spaceId: mockRun.spaceId,
 					runId: 'run-1',
-					gateId: 'plan-pr-gate',
+					gateId: 'review-votes-gate',
 				})
 			);
+		});
+
+		it('returns the updated gateData record', async () => {
+			const result = (await call('spaceWorkflowRun.writeGateData', {
+				runId: 'run-1',
+				gateId: 'code-pr-gate',
+				data: { pr_url: 'https://github.com/test/repo/pull/1' },
+			})) as { gateData: { runId: string; gateId: string } };
+
+			expect(result.gateData).toBeDefined();
+			expect(result.gateData.gateId).toBe('gate-approval'); // mockGateData default id
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -195,6 +195,7 @@ function createMockRuntimeService(): SpaceRuntimeService {
 		createOrGetRuntime: mock(async () => ({
 			startWorkflowRun: mock(async () => ({ run: mockRun, tasks: [] })),
 		})),
+		notifyGateDataChanged: mock(async () => {}),
 		start: mock(() => {}),
 		stop: mock(() => {}),
 	} as unknown as SpaceRuntimeService;
@@ -766,16 +767,16 @@ describe('space-workflow-run gate handlers', () => {
 			).rejects.toThrow('gateId is required');
 		});
 
-		it('throws if data is not a plain object', async () => {
+		it('throws if data is not an object', async () => {
 			await expect(
 				call('spaceWorkflowRun.writeGateData', { runId: 'run-1', gateId: 'g1', data: 'bad' })
-			).rejects.toThrow('data must be a plain object');
+			).rejects.toThrow('data must be an object');
 		});
 
 		it('throws if data is an array', async () => {
 			await expect(
 				call('spaceWorkflowRun.writeGateData', { runId: 'run-1', gateId: 'g1', data: [] })
-			).rejects.toThrow('data must be a plain object');
+			).rejects.toThrow('data must be an object');
 		});
 
 		it('throws if run not found', async () => {

--- a/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
+++ b/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
@@ -1,0 +1,493 @@
+/**
+ * Reviewer Feedback Loop E2E Tests (M8.2)
+ *
+ * Tests that verify the canvas correctly visualizes:
+ * 1. Reviewer rejection — review-reject-gate shows open (green) when a reviewer rejects
+ * 2. Coder re-activation — Coding node shows active (blue pulsing) after re-activation
+ * 3. review-votes-gate vote display — "N/M" badge shows correct partial/full vote counts
+ * 4. All 3 reviewers approve — review-votes-gate opens (green) when min is met
+ * 5. QA and Done pipeline — qa-result-gate opens after QA passes
+ *
+ * Setup strategy (per describe block):
+ *   - Space + run created via RPC in beforeEach (infrastructure)
+ *   - Gate data injected via `spaceWorkflowRun.writeGateData` RPC (infrastructure)
+ *   - For "Coding active" test: task created + set to in_progress via RPC (infrastructure)
+ *   - All assertions verify visible DOM state only
+ *
+ * Cleanup:
+ *   - Run cancelled + space deleted in afterEach (infrastructure)
+ *
+ * E2E Rules:
+ *   - All test actions go through the UI (navigation, assertions on visible DOM)
+ *   - RPC is used only in beforeEach / afterEach for infrastructure setup / teardown
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+
+// ─── Infrastructure types ─────────────────────────────────────────────────────
+
+interface SpaceRunIds {
+	spaceId: string;
+	runId: string;
+}
+
+// ─── Infrastructure helpers (RPC — beforeEach / afterEach only) ────────────────
+
+async function createSpaceWithRun(
+	page: Parameters<typeof waitForWebSocketConnected>[0]
+): Promise<SpaceRunIds> {
+	await waitForWebSocketConnected(page);
+	const workspaceRoot = await getWorkspaceRoot(page);
+
+	return page.evaluate(
+		async ({ wsPath }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			// Clean up any leftover space at this workspace path.
+			const norm = (p: string) => p.replace(/^\/private/, '');
+			try {
+				const list = (await hub.request('space.list', {})) as Array<{
+					id: string;
+					workspacePath: string;
+				}>;
+				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
+				if (existing) await hub.request('space.delete', { id: existing.id });
+			} catch {
+				// Ignore cleanup errors
+			}
+
+			const spaceRes = (await hub.request('space.create', {
+				name: `E2E Reviewer Loop ${Date.now()}`,
+				workspacePath: wsPath,
+			})) as { id: string };
+			const spaceId = spaceRes.id;
+
+			const runRes = (await hub.request('spaceWorkflowRun.start', {
+				spaceId,
+				title: 'E2E: Reviewer feedback loop test',
+				description: 'Test task for reviewer feedback loop E2E test.',
+			})) as { run: { id: string } };
+			const runId = runRes.run.id;
+
+			return { spaceId, runId };
+		},
+		{ wsPath: workspaceRoot }
+	);
+}
+
+async function writeGateData(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	runId: string,
+	gateId: string,
+	data: Record<string, unknown>
+): Promise<void> {
+	await page.evaluate(
+		async ({ rid, gid, d }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			await hub.request('spaceWorkflowRun.writeGateData', { runId: rid, gateId: gid, data: d });
+		},
+		{ rid: runId, gid: gateId, d: data }
+	);
+}
+
+async function cancelRun(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	runId: string
+): Promise<void> {
+	try {
+		await page.evaluate(async (rid) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('spaceWorkflowRun.cancel', { id: rid });
+		}, runId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+async function deleteSpace(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	spaceId: string
+): Promise<void> {
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('space.delete', { id });
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+// ─── Get the Coding workflow node UUID ────────────────────────────────────────
+
+async function getCodingNodeId(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	spaceId: string,
+	runId: string
+): Promise<string> {
+	return page.evaluate(
+		async ({ sid, rid }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			const run = (await hub.request('spaceWorkflowRun.get', { id: rid })) as {
+				run: { workflowId: string };
+			};
+			const workflow = (await hub.request('spaceWorkflow.get', {
+				spaceId: sid,
+				id: run.run.workflowId,
+			})) as { workflow: { nodes: Array<{ id: string; name: string }> } };
+
+			const codingNode = workflow.workflow.nodes.find((n) => n.name === 'Coding');
+			if (!codingNode) throw new Error('Coding node not found in workflow');
+			return codingNode.id;
+		},
+		{ sid: spaceId, rid: runId }
+	);
+}
+
+// ─── Create + start a task for a specific workflow node ───────────────────────
+
+async function createActiveTaskForNode(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	spaceId: string,
+	runId: string,
+	nodeId: string
+): Promise<string> {
+	return page.evaluate(
+		async ({ sid, rid, nid }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			const task = (await hub.request('spaceTask.create', {
+				spaceId: sid,
+				title: 'E2E: Coding task (re-activated)',
+				description: 'Test task simulating coder re-activation after rejection.',
+				workflowRunId: rid,
+				workflowNodeId: nid,
+			})) as { id: string };
+
+			await hub.request('spaceTask.update', {
+				spaceId: sid,
+				taskId: task.id,
+				status: 'in_progress',
+			});
+
+			return task.id;
+		},
+		{ sid: spaceId, rid: runId, nid: nodeId }
+	);
+}
+
+// ─── Test suites ──────────────────────────────────────────────────────────────
+
+test.describe('Space Reviewer Feedback Loop', () => {
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	// ── 1. Reviewer rejection visible on canvas ──────────────────────────────
+	test.describe('reviewer rejection state', () => {
+		let spaceId = '';
+		let runId = '';
+
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/');
+			const ids = await createSpaceWithRun(page);
+			spaceId = ids.spaceId;
+			runId = ids.runId;
+
+			// Write code-pr-gate to unblock reviewers, then write a rejection vote
+			await writeGateData(page, runId, 'code-pr-gate', {
+				pr_url: 'https://github.com/test/repo/pull/1',
+			});
+			await writeGateData(page, runId, 'review-reject-gate', {
+				votes: { 'Reviewer 1': 'rejected' },
+			});
+		});
+
+		test.afterEach(async ({ page }) => {
+			if (runId) await cancelRun(page, runId);
+			if (spaceId) await deleteSpace(page, spaceId);
+			spaceId = '';
+			runId = '';
+		});
+
+		test('review-reject-gate shows open (green) when one reviewer rejects', async ({ page }) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			// Canvas must be visible in runtime mode
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// review-reject-gate condition is: count 'rejected' votes >= 1
+			// With 1 rejection written, the gate evaluates to open → green checkmark
+			await expect(page.getByTestId('gate-icon-open').first()).toBeVisible({ timeout: 10000 });
+		});
+
+		test('review-reject-gate vote count badge shows 1/1 when one reviewer rejects', async ({
+			page,
+		}) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// The review-reject-gate (min: 1) should show "1/1" vote count badge
+			const badge = page.locator('[data-testid="gate-vote-count"]:has-text("1/1")');
+			await expect(badge.first()).toBeVisible({ timeout: 10000 });
+		});
+	});
+
+	// ── 2. Coder re-activation visible ────────────────────────────────────────
+	test.describe('coder re-activation state', () => {
+		let spaceId = '';
+		let runId = '';
+		let codingNodeId = '';
+
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/');
+			const ids = await createSpaceWithRun(page);
+			spaceId = ids.spaceId;
+			runId = ids.runId;
+
+			// Get the Coding node UUID so we can create a task for it
+			codingNodeId = await getCodingNodeId(page, spaceId, runId);
+
+			// Create a task for the Coding node and set it to in_progress
+			await createActiveTaskForNode(page, spaceId, runId, codingNodeId);
+		});
+
+		test.afterEach(async ({ page }) => {
+			if (runId) await cancelRun(page, runId);
+			if (spaceId) await deleteSpace(page, spaceId);
+			spaceId = '';
+			runId = '';
+			codingNodeId = '';
+		});
+
+		test('Coding node shows active (blue pulsing) after re-activation', async ({ page }) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// The Coding node with in_progress task renders the g element with animate-pulse class
+			const codingNodeEl = page.getByTestId(`node-${codingNodeId}`);
+			await expect(codingNodeEl).toBeVisible({ timeout: 10000 });
+
+			// Active nodes have animate-pulse CSS class
+			await expect(codingNodeEl).toHaveClass(/animate-pulse/, { timeout: 5000 });
+		});
+	});
+
+	// ── 3. review-votes-gate partial vote count ───────────────────────────────
+	test.describe('partial review votes (2 of 3 approved)', () => {
+		let spaceId = '';
+		let runId = '';
+
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/');
+			const ids = await createSpaceWithRun(page);
+			spaceId = ids.spaceId;
+			runId = ids.runId;
+
+			await writeGateData(page, runId, 'code-pr-gate', {
+				pr_url: 'https://github.com/test/repo/pull/1',
+			});
+			// 2 out of 3 reviewers approved
+			await writeGateData(page, runId, 'review-votes-gate', {
+				votes: { 'Reviewer 1': 'approved', 'Reviewer 2': 'approved' },
+			});
+		});
+
+		test.afterEach(async ({ page }) => {
+			if (runId) await cancelRun(page, runId);
+			if (spaceId) await deleteSpace(page, spaceId);
+			spaceId = '';
+			runId = '';
+		});
+
+		test('review-votes-gate remains blocked (2/3 not enough to open)', async ({ page }) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// 2 approvals < 3 required → gate stays blocked (gray lock)
+			// We expect at least one blocked gate icon
+			await expect(page.getByTestId('gate-icon-blocked').first()).toBeVisible({
+				timeout: 10000,
+			});
+		});
+
+		test('review-votes-gate vote count badge shows 2/3', async ({ page }) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// review-votes-gate has 3 channels sharing it (Reviewer 1/2/3 → QA)
+			// Each shows the same "2/3" badge — expect at least one
+			const badge = page.locator('[data-testid="gate-vote-count"]:has-text("2/3")');
+			await expect(badge.first()).toBeVisible({ timeout: 10000 });
+		});
+	});
+
+	// ── 4. All 3 reviewers approve ────────────────────────────────────────────
+	test.describe('all reviewers approved (3 of 3)', () => {
+		let spaceId = '';
+		let runId = '';
+
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/');
+			const ids = await createSpaceWithRun(page);
+			spaceId = ids.spaceId;
+			runId = ids.runId;
+
+			await writeGateData(page, runId, 'code-pr-gate', {
+				pr_url: 'https://github.com/test/repo/pull/1',
+			});
+			await writeGateData(page, runId, 'review-votes-gate', {
+				votes: {
+					'Reviewer 1': 'approved',
+					'Reviewer 2': 'approved',
+					'Reviewer 3': 'approved',
+				},
+			});
+		});
+
+		test.afterEach(async ({ page }) => {
+			if (runId) await cancelRun(page, runId);
+			if (spaceId) await deleteSpace(page, spaceId);
+			spaceId = '';
+			runId = '';
+		});
+
+		test('review-votes-gate shows open (green) when all 3 reviewers approve', async ({ page }) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// 3 approvals >= 3 required → review-votes-gate opens
+			// At least one gate-icon-open must be visible on the Reviewer→QA channels
+			await expect(page.getByTestId('gate-icon-open').first()).toBeVisible({ timeout: 10000 });
+		});
+
+		test('review-votes-gate vote count badge shows 3/3', async ({ page }) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			const badge = page.locator('[data-testid="gate-vote-count"]:has-text("3/3")');
+			await expect(badge.first()).toBeVisible({ timeout: 10000 });
+		});
+	});
+
+	// ── 5. QA to Done channel (final completion) ──────────────────────────────
+	test.describe('QA passes → completion state', () => {
+		let spaceId = '';
+		let runId = '';
+
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/');
+			const ids = await createSpaceWithRun(page);
+			spaceId = ids.spaceId;
+			runId = ids.runId;
+
+			// Write all gates to simulate a fully approved + QA-passed state
+			await writeGateData(page, runId, 'code-pr-gate', {
+				pr_url: 'https://github.com/test/repo/pull/1',
+			});
+			await writeGateData(page, runId, 'review-votes-gate', {
+				votes: {
+					'Reviewer 1': 'approved',
+					'Reviewer 2': 'approved',
+					'Reviewer 3': 'approved',
+				},
+			});
+			await writeGateData(page, runId, 'qa-result-gate', { result: 'passed' });
+		});
+
+		test.afterEach(async ({ page }) => {
+			if (runId) await cancelRun(page, runId);
+			if (spaceId) await deleteSpace(page, spaceId);
+			spaceId = '';
+			runId = '';
+		});
+
+		test('QA-to-Done channel gate opens after QA passes (qa-result-gate open)', async ({
+			page,
+		}) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// qa-result-gate condition: { type: 'check', field: 'result', op: '==', value: 'passed' }
+			// With result: 'passed' written, the gate opens → green checkmark on QA→Done channel
+			await expect(page.getByTestId('gate-icon-open').first()).toBeVisible({ timeout: 10000 });
+		});
+
+		test('canvas shows all three Reviewer nodes and QA + Done (pipeline tail)', async ({
+			page,
+		}) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// All key nodes in the reviewer→QA→Done pipeline must be visible
+			await expect(page.locator('text=Reviewer 1')).toBeVisible({ timeout: 5000 });
+			await expect(page.locator('text=Reviewer 2')).toBeVisible({ timeout: 5000 });
+			await expect(page.locator('text=Reviewer 3')).toBeVisible({ timeout: 5000 });
+			await expect(page.locator('text=QA')).toBeVisible({ timeout: 5000 });
+			await expect(page.locator('text=Done')).toBeVisible({ timeout: 5000 });
+		});
+	});
+
+	// ── 6. vote reset after cycle (votes cleared) ─────────────────────────────
+	test.describe('review-votes-gate reset after rejection cycle', () => {
+		let spaceId = '';
+		let runId = '';
+
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/');
+			const ids = await createSpaceWithRun(page);
+			spaceId = ids.spaceId;
+			runId = ids.runId;
+
+			// Simulate state AFTER a rejection cycle: code-pr-gate persists (resetOnCycle: false),
+			// review-votes-gate has been cleared (resetOnCycle: true) — no votes written.
+			await writeGateData(page, runId, 'code-pr-gate', {
+				pr_url: 'https://github.com/test/repo/pull/1',
+			});
+			// review-votes-gate is intentionally empty (reset state) — we don't write it
+		});
+
+		test.afterEach(async ({ page }) => {
+			if (runId) await cancelRun(page, runId);
+			if (spaceId) await deleteSpace(page, spaceId);
+			spaceId = '';
+			runId = '';
+		});
+
+		test('review-votes-gate shows 0/3 after votes are reset (empty)', async ({ page }) => {
+			await page.goto(`/space/${spaceId}`);
+			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+			// With no votes written, the review-votes-gate shows 0/3
+			const badge = page.locator('[data-testid="gate-vote-count"]:has-text("0/3")');
+			await expect(badge.first()).toBeVisible({ timeout: 10000 });
+		});
+	});
+});

--- a/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
+++ b/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
@@ -201,9 +201,15 @@ function gateIcon(
 	return page.locator(`[data-testid="gate-icon-${status}"][data-gate-id="${gateId}"]`);
 }
 
-/** Returns a locator for the vote-count badge for a specific gate. */
-function voteBadge(page: Parameters<typeof waitForWebSocketConnected>[0], text: string) {
-	return page.locator(`[data-testid="gate-vote-count"]:has-text("${text}")`).first();
+/** Returns a locator for the vote-count badge scoped to a specific gate. */
+function voteBadge(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	gateId: string,
+	text: string
+) {
+	return page
+		.locator(`[data-gate-id="${gateId}"] [data-testid="gate-vote-count"]:has-text("${text}")`)
+		.first();
 }
 
 // ─── Test suites ──────────────────────────────────────────────────────────────
@@ -262,7 +268,7 @@ test.describe
 				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
 
 				// The review-reject-gate (min: 1) should show "1/1" vote count badge
-				await expect(voteBadge(page, '1/1')).toBeVisible({ timeout: 10000 });
+				await expect(voteBadge(page, 'review-reject-gate', '1/1')).toBeVisible({ timeout: 10000 });
 			});
 		});
 
@@ -355,7 +361,7 @@ test.describe
 
 				// review-votes-gate has 3 channels sharing it (Reviewer 1/2/3 → QA)
 				// Each shows the same "2/3" badge — expect at least one
-				await expect(voteBadge(page, '2/3')).toBeVisible({ timeout: 10000 });
+				await expect(voteBadge(page, 'review-votes-gate', '2/3')).toBeVisible({ timeout: 10000 });
 			});
 		});
 
@@ -407,7 +413,7 @@ test.describe
 
 				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
 
-				await expect(voteBadge(page, '3/3')).toBeVisible({ timeout: 10000 });
+				await expect(voteBadge(page, 'review-votes-gate', '3/3')).toBeVisible({ timeout: 10000 });
 			});
 		});
 
@@ -506,7 +512,7 @@ test.describe
 				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
 
 				// With no votes written, the review-votes-gate shows 0/3
-				await expect(voteBadge(page, '0/3')).toBeVisible({ timeout: 10000 });
+				await expect(voteBadge(page, 'review-votes-gate', '0/3')).toBeVisible({ timeout: 10000 });
 			});
 		});
 
@@ -548,7 +554,7 @@ test.describe
 
 				// Step 2: After cycle reset — votes cleared, badge shows 0/3
 				await writeGateData(page, runId, 'review-votes-gate', { votes: {} });
-				await expect(voteBadge(page, '0/3')).toBeVisible({ timeout: 10000 });
+				await expect(voteBadge(page, 'review-votes-gate', '0/3')).toBeVisible({ timeout: 10000 });
 
 				// Step 3: All 3 reviewers approve the revised code
 				await writeGateData(page, runId, 'review-votes-gate', {
@@ -561,7 +567,7 @@ test.describe
 				await expect(gateIcon(page, 'review-votes-gate', 'open')).toBeVisible({
 					timeout: 10000,
 				});
-				await expect(voteBadge(page, '3/3')).toBeVisible({ timeout: 10000 });
+				await expect(voteBadge(page, 'review-votes-gate', '3/3')).toBeVisible({ timeout: 10000 });
 			});
 		});
 	});

--- a/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
+++ b/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
@@ -7,8 +7,9 @@
  * 3. review-votes-gate vote display — "N/M" badge shows correct partial/full vote counts
  * 4. All 3 reviewers approve — review-votes-gate opens (green) when min is met
  * 5. QA and Done pipeline — qa-result-gate opens after QA passes
+ * 6. State transition: inject rejection then approval votes in sequence
  *
- * Setup strategy (per describe block):
+ * Setup strategy (per test):
  *   - Space + run created via RPC in beforeEach (infrastructure)
  *   - Gate data injected via `spaceWorkflowRun.writeGateData` RPC (infrastructure)
  *   - For "Coding active" test: task created + set to in_progress via RPC (infrastructure)
@@ -20,6 +21,9 @@
  * E2E Rules:
  *   - All test actions go through the UI (navigation, assertions on visible DOM)
  *   - RPC is used only in beforeEach / afterEach for infrastructure setup / teardown
+ *
+ * Isolation:
+ *   - test.describe.serial forces sequential execution to avoid workspace path conflicts
  */
 
 import { test, expect } from '../../fixtures';
@@ -186,308 +190,378 @@ async function createActiveTaskForNode(
 	);
 }
 
+// ─── Selector helpers ─────────────────────────────────────────────────────────
+
+/** Returns a locator for a gate icon with a specific gate ID and status. */
+function gateIcon(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	gateId: string,
+	status: 'open' | 'blocked' | 'waiting_human'
+) {
+	return page.locator(`[data-testid="gate-icon-${status}"][data-gate-id="${gateId}"]`);
+}
+
+/** Returns a locator for the vote-count badge for a specific gate. */
+function voteBadge(page: Parameters<typeof waitForWebSocketConnected>[0], text: string) {
+	return page.locator(`[data-testid="gate-vote-count"]:has-text("${text}")`).first();
+}
+
 // ─── Test suites ──────────────────────────────────────────────────────────────
 
-test.describe('Space Reviewer Feedback Loop', () => {
-	test.use({ viewport: DESKTOP_VIEWPORT });
+// serial: prevent parallel workers from racing on the shared workspace path
+test.describe
+	.serial('Space Reviewer Feedback Loop', () => {
+		test.use({ viewport: DESKTOP_VIEWPORT });
 
-	// ── 1. Reviewer rejection visible on canvas ──────────────────────────────
-	test.describe('reviewer rejection state', () => {
-		let spaceId = '';
-		let runId = '';
+		// ── 1. Reviewer rejection visible on canvas ──────────────────────────────
+		test.describe('reviewer rejection state', () => {
+			let spaceId = '';
+			let runId = '';
 
-		test.beforeEach(async ({ page }) => {
-			await page.goto('/');
-			const ids = await createSpaceWithRun(page);
-			spaceId = ids.spaceId;
-			runId = ids.runId;
+			test.beforeEach(async ({ page }) => {
+				await page.goto('/');
+				const ids = await createSpaceWithRun(page);
+				spaceId = ids.spaceId;
+				runId = ids.runId;
 
-			// Write code-pr-gate to unblock reviewers, then write a rejection vote
-			await writeGateData(page, runId, 'code-pr-gate', {
-				pr_url: 'https://github.com/test/repo/pull/1',
+				// Write code-pr-gate to unblock reviewers, then write a rejection vote
+				await writeGateData(page, runId, 'code-pr-gate', {
+					pr_url: 'https://github.com/test/repo/pull/1',
+				});
+				await writeGateData(page, runId, 'review-reject-gate', {
+					votes: { 'Reviewer 1': 'rejected' },
+				});
 			});
-			await writeGateData(page, runId, 'review-reject-gate', {
-				votes: { 'Reviewer 1': 'rejected' },
+
+			test.afterEach(async ({ page }) => {
+				if (runId) await cancelRun(page, runId);
+				if (spaceId) await deleteSpace(page, spaceId);
+				spaceId = '';
+				runId = '';
+			});
+
+			test('review-reject-gate shows open (green) when one reviewer rejects', async ({ page }) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// review-reject-gate condition: count 'rejected' votes >= 1
+				// With 1 rejection written, gate evaluates to open → green checkmark
+				await expect(gateIcon(page, 'review-reject-gate', 'open')).toBeVisible({
+					timeout: 10000,
+				});
+			});
+
+			test('review-reject-gate vote count badge shows 1/1 when one reviewer rejects', async ({
+				page,
+			}) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// The review-reject-gate (min: 1) should show "1/1" vote count badge
+				await expect(voteBadge(page, '1/1')).toBeVisible({ timeout: 10000 });
 			});
 		});
 
-		test.afterEach(async ({ page }) => {
-			if (runId) await cancelRun(page, runId);
-			if (spaceId) await deleteSpace(page, spaceId);
-			spaceId = '';
-			runId = '';
+		// ── 2. Coder re-activation visible ────────────────────────────────────────
+		test.describe('coder re-activation state', () => {
+			let spaceId = '';
+			let runId = '';
+			let codingNodeId = '';
+
+			test.beforeEach(async ({ page }) => {
+				await page.goto('/');
+				const ids = await createSpaceWithRun(page);
+				spaceId = ids.spaceId;
+				runId = ids.runId;
+
+				// Get the Coding node UUID so we can create a task for it
+				codingNodeId = await getCodingNodeId(page, spaceId, runId);
+
+				// Create a task for the Coding node and set it to in_progress
+				await createActiveTaskForNode(page, spaceId, runId, codingNodeId);
+			});
+
+			test.afterEach(async ({ page }) => {
+				if (runId) await cancelRun(page, runId);
+				if (spaceId) await deleteSpace(page, spaceId);
+				spaceId = '';
+				runId = '';
+				codingNodeId = '';
+			});
+
+			test('Coding node shows active (blue pulsing) after re-activation', async ({ page }) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// The Coding node with in_progress task renders the g element with animate-pulse class
+				const codingNodeEl = page.getByTestId(`node-${codingNodeId}`);
+				await expect(codingNodeEl).toBeVisible({ timeout: 10000 });
+
+				// Active nodes have animate-pulse CSS class
+				await expect(codingNodeEl).toHaveClass(/animate-pulse/, { timeout: 5000 });
+			});
 		});
 
-		test('review-reject-gate shows open (green) when one reviewer rejects', async ({ page }) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+		// ── 3. review-votes-gate partial vote count ───────────────────────────────
+		test.describe('partial review votes (2 of 3 approved)', () => {
+			let spaceId = '';
+			let runId = '';
 
-			// Canvas must be visible in runtime mode
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+			test.beforeEach(async ({ page }) => {
+				await page.goto('/');
+				const ids = await createSpaceWithRun(page);
+				spaceId = ids.spaceId;
+				runId = ids.runId;
 
-			// review-reject-gate condition is: count 'rejected' votes >= 1
-			// With 1 rejection written, the gate evaluates to open → green checkmark
-			await expect(page.getByTestId('gate-icon-open').first()).toBeVisible({ timeout: 10000 });
+				await writeGateData(page, runId, 'code-pr-gate', {
+					pr_url: 'https://github.com/test/repo/pull/1',
+				});
+				// 2 out of 3 reviewers approved
+				await writeGateData(page, runId, 'review-votes-gate', {
+					votes: { 'Reviewer 1': 'approved', 'Reviewer 2': 'approved' },
+				});
+			});
+
+			test.afterEach(async ({ page }) => {
+				if (runId) await cancelRun(page, runId);
+				if (spaceId) await deleteSpace(page, spaceId);
+				spaceId = '';
+				runId = '';
+			});
+
+			test('review-votes-gate remains blocked (2/3 not enough to open)', async ({ page }) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// 2 approvals < 3 required → review-votes-gate stays blocked (gray lock)
+				await expect(gateIcon(page, 'review-votes-gate', 'blocked')).toBeVisible({
+					timeout: 10000,
+				});
+			});
+
+			test('review-votes-gate vote count badge shows 2/3', async ({ page }) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// review-votes-gate has 3 channels sharing it (Reviewer 1/2/3 → QA)
+				// Each shows the same "2/3" badge — expect at least one
+				await expect(voteBadge(page, '2/3')).toBeVisible({ timeout: 10000 });
+			});
 		});
 
-		test('review-reject-gate vote count badge shows 1/1 when one reviewer rejects', async ({
-			page,
-		}) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+		// ── 4. All 3 reviewers approve ────────────────────────────────────────────
+		test.describe('all reviewers approved (3 of 3)', () => {
+			let spaceId = '';
+			let runId = '';
 
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+			test.beforeEach(async ({ page }) => {
+				await page.goto('/');
+				const ids = await createSpaceWithRun(page);
+				spaceId = ids.spaceId;
+				runId = ids.runId;
 
-			// The review-reject-gate (min: 1) should show "1/1" vote count badge
-			const badge = page.locator('[data-testid="gate-vote-count"]:has-text("1/1")');
-			await expect(badge.first()).toBeVisible({ timeout: 10000 });
+				await writeGateData(page, runId, 'code-pr-gate', {
+					pr_url: 'https://github.com/test/repo/pull/1',
+				});
+				await writeGateData(page, runId, 'review-votes-gate', {
+					votes: {
+						'Reviewer 1': 'approved',
+						'Reviewer 2': 'approved',
+						'Reviewer 3': 'approved',
+					},
+				});
+			});
+
+			test.afterEach(async ({ page }) => {
+				if (runId) await cancelRun(page, runId);
+				if (spaceId) await deleteSpace(page, spaceId);
+				spaceId = '';
+				runId = '';
+			});
+
+			test('review-votes-gate shows open (green) when all 3 reviewers approve', async ({
+				page,
+			}) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// 3 approvals >= 3 required → review-votes-gate opens
+				await expect(gateIcon(page, 'review-votes-gate', 'open')).toBeVisible({ timeout: 10000 });
+			});
+
+			test('review-votes-gate vote count badge shows 3/3', async ({ page }) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				await expect(voteBadge(page, '3/3')).toBeVisible({ timeout: 10000 });
+			});
+		});
+
+		// ── 5. QA to Done channel (final completion) ──────────────────────────────
+		test.describe('QA passes → completion state', () => {
+			let spaceId = '';
+			let runId = '';
+
+			test.beforeEach(async ({ page }) => {
+				await page.goto('/');
+				const ids = await createSpaceWithRun(page);
+				spaceId = ids.spaceId;
+				runId = ids.runId;
+
+				// Write all gates to simulate a fully approved + QA-passed state
+				await writeGateData(page, runId, 'code-pr-gate', {
+					pr_url: 'https://github.com/test/repo/pull/1',
+				});
+				await writeGateData(page, runId, 'review-votes-gate', {
+					votes: {
+						'Reviewer 1': 'approved',
+						'Reviewer 2': 'approved',
+						'Reviewer 3': 'approved',
+					},
+				});
+				await writeGateData(page, runId, 'qa-result-gate', { result: 'passed' });
+			});
+
+			test.afterEach(async ({ page }) => {
+				if (runId) await cancelRun(page, runId);
+				if (spaceId) await deleteSpace(page, spaceId);
+				spaceId = '';
+				runId = '';
+			});
+
+			test('QA-to-Done channel gate opens after QA passes (qa-result-gate open)', async ({
+				page,
+			}) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// qa-result-gate condition: { type: 'check', field: 'result', op: '==', value: 'passed' }
+				// With result: 'passed' written, the gate opens → green checkmark on QA→Done channel
+				await expect(gateIcon(page, 'qa-result-gate', 'open')).toBeVisible({ timeout: 10000 });
+			});
+
+			test('canvas shows all three Reviewer nodes and QA + Done (pipeline tail)', async ({
+				page,
+			}) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// All key nodes in the reviewer→QA→Done pipeline must be visible
+				await expect(page.locator('text=Reviewer 1')).toBeVisible({ timeout: 5000 });
+				await expect(page.locator('text=Reviewer 2')).toBeVisible({ timeout: 5000 });
+				await expect(page.locator('text=Reviewer 3')).toBeVisible({ timeout: 5000 });
+				await expect(page.locator('text=QA')).toBeVisible({ timeout: 5000 });
+				await expect(page.locator('text=Done')).toBeVisible({ timeout: 5000 });
+			});
+		});
+
+		// ── 6. vote reset after cycle (votes cleared) ─────────────────────────────
+		test.describe('review-votes-gate reset after rejection cycle', () => {
+			let spaceId = '';
+			let runId = '';
+
+			test.beforeEach(async ({ page }) => {
+				await page.goto('/');
+				const ids = await createSpaceWithRun(page);
+				spaceId = ids.spaceId;
+				runId = ids.runId;
+
+				// Simulate state AFTER a rejection cycle: code-pr-gate persists (resetOnCycle: false),
+				// review-votes-gate has been cleared (resetOnCycle: true) — no votes written.
+				await writeGateData(page, runId, 'code-pr-gate', {
+					pr_url: 'https://github.com/test/repo/pull/1',
+				});
+				// review-votes-gate is intentionally empty (reset state) — we don't write it
+			});
+
+			test.afterEach(async ({ page }) => {
+				if (runId) await cancelRun(page, runId);
+				if (spaceId) await deleteSpace(page, spaceId);
+				spaceId = '';
+				runId = '';
+			});
+
+			test('review-votes-gate shows 0/3 after votes are reset (empty)', async ({ page }) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// With no votes written, the review-votes-gate shows 0/3
+				await expect(voteBadge(page, '0/3')).toBeVisible({ timeout: 10000 });
+			});
+		});
+
+		// ── 7. State transition: rejection → re-approval (feedback loop cycle) ────
+		test.describe('rejection-to-approval state transition', () => {
+			let spaceId = '';
+			let runId = '';
+
+			test.beforeEach(async ({ page }) => {
+				await page.goto('/');
+				const ids = await createSpaceWithRun(page);
+				spaceId = ids.spaceId;
+				runId = ids.runId;
+
+				await writeGateData(page, runId, 'code-pr-gate', {
+					pr_url: 'https://github.com/test/repo/pull/1',
+				});
+			});
+
+			test.afterEach(async ({ page }) => {
+				if (runId) await cancelRun(page, runId);
+				if (spaceId) await deleteSpace(page, spaceId);
+				spaceId = '';
+				runId = '';
+			});
+
+			test('canvas updates from rejection to full approval in sequence', async ({ page }) => {
+				await page.goto(`/space/${spaceId}`);
+				await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+				await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
+
+				// Step 1: Reviewer 1 rejects — review-reject-gate opens
+				await writeGateData(page, runId, 'review-reject-gate', {
+					votes: { 'Reviewer 1': 'rejected' },
+				});
+				await expect(gateIcon(page, 'review-reject-gate', 'open')).toBeVisible({
+					timeout: 10000,
+				});
+
+				// Step 2: After cycle reset — votes cleared, badge shows 0/3
+				await writeGateData(page, runId, 'review-votes-gate', { votes: {} });
+				await expect(voteBadge(page, '0/3')).toBeVisible({ timeout: 10000 });
+
+				// Step 3: All 3 reviewers approve the revised code
+				await writeGateData(page, runId, 'review-votes-gate', {
+					votes: {
+						'Reviewer 1': 'approved',
+						'Reviewer 2': 'approved',
+						'Reviewer 3': 'approved',
+					},
+				});
+				await expect(gateIcon(page, 'review-votes-gate', 'open')).toBeVisible({
+					timeout: 10000,
+				});
+				await expect(voteBadge(page, '3/3')).toBeVisible({ timeout: 10000 });
+			});
 		});
 	});
-
-	// ── 2. Coder re-activation visible ────────────────────────────────────────
-	test.describe('coder re-activation state', () => {
-		let spaceId = '';
-		let runId = '';
-		let codingNodeId = '';
-
-		test.beforeEach(async ({ page }) => {
-			await page.goto('/');
-			const ids = await createSpaceWithRun(page);
-			spaceId = ids.spaceId;
-			runId = ids.runId;
-
-			// Get the Coding node UUID so we can create a task for it
-			codingNodeId = await getCodingNodeId(page, spaceId, runId);
-
-			// Create a task for the Coding node and set it to in_progress
-			await createActiveTaskForNode(page, spaceId, runId, codingNodeId);
-		});
-
-		test.afterEach(async ({ page }) => {
-			if (runId) await cancelRun(page, runId);
-			if (spaceId) await deleteSpace(page, spaceId);
-			spaceId = '';
-			runId = '';
-			codingNodeId = '';
-		});
-
-		test('Coding node shows active (blue pulsing) after re-activation', async ({ page }) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
-
-			// The Coding node with in_progress task renders the g element with animate-pulse class
-			const codingNodeEl = page.getByTestId(`node-${codingNodeId}`);
-			await expect(codingNodeEl).toBeVisible({ timeout: 10000 });
-
-			// Active nodes have animate-pulse CSS class
-			await expect(codingNodeEl).toHaveClass(/animate-pulse/, { timeout: 5000 });
-		});
-	});
-
-	// ── 3. review-votes-gate partial vote count ───────────────────────────────
-	test.describe('partial review votes (2 of 3 approved)', () => {
-		let spaceId = '';
-		let runId = '';
-
-		test.beforeEach(async ({ page }) => {
-			await page.goto('/');
-			const ids = await createSpaceWithRun(page);
-			spaceId = ids.spaceId;
-			runId = ids.runId;
-
-			await writeGateData(page, runId, 'code-pr-gate', {
-				pr_url: 'https://github.com/test/repo/pull/1',
-			});
-			// 2 out of 3 reviewers approved
-			await writeGateData(page, runId, 'review-votes-gate', {
-				votes: { 'Reviewer 1': 'approved', 'Reviewer 2': 'approved' },
-			});
-		});
-
-		test.afterEach(async ({ page }) => {
-			if (runId) await cancelRun(page, runId);
-			if (spaceId) await deleteSpace(page, spaceId);
-			spaceId = '';
-			runId = '';
-		});
-
-		test('review-votes-gate remains blocked (2/3 not enough to open)', async ({ page }) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
-
-			// 2 approvals < 3 required → gate stays blocked (gray lock)
-			// We expect at least one blocked gate icon
-			await expect(page.getByTestId('gate-icon-blocked').first()).toBeVisible({
-				timeout: 10000,
-			});
-		});
-
-		test('review-votes-gate vote count badge shows 2/3', async ({ page }) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
-
-			// review-votes-gate has 3 channels sharing it (Reviewer 1/2/3 → QA)
-			// Each shows the same "2/3" badge — expect at least one
-			const badge = page.locator('[data-testid="gate-vote-count"]:has-text("2/3")');
-			await expect(badge.first()).toBeVisible({ timeout: 10000 });
-		});
-	});
-
-	// ── 4. All 3 reviewers approve ────────────────────────────────────────────
-	test.describe('all reviewers approved (3 of 3)', () => {
-		let spaceId = '';
-		let runId = '';
-
-		test.beforeEach(async ({ page }) => {
-			await page.goto('/');
-			const ids = await createSpaceWithRun(page);
-			spaceId = ids.spaceId;
-			runId = ids.runId;
-
-			await writeGateData(page, runId, 'code-pr-gate', {
-				pr_url: 'https://github.com/test/repo/pull/1',
-			});
-			await writeGateData(page, runId, 'review-votes-gate', {
-				votes: {
-					'Reviewer 1': 'approved',
-					'Reviewer 2': 'approved',
-					'Reviewer 3': 'approved',
-				},
-			});
-		});
-
-		test.afterEach(async ({ page }) => {
-			if (runId) await cancelRun(page, runId);
-			if (spaceId) await deleteSpace(page, spaceId);
-			spaceId = '';
-			runId = '';
-		});
-
-		test('review-votes-gate shows open (green) when all 3 reviewers approve', async ({ page }) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
-
-			// 3 approvals >= 3 required → review-votes-gate opens
-			// At least one gate-icon-open must be visible on the Reviewer→QA channels
-			await expect(page.getByTestId('gate-icon-open').first()).toBeVisible({ timeout: 10000 });
-		});
-
-		test('review-votes-gate vote count badge shows 3/3', async ({ page }) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
-
-			const badge = page.locator('[data-testid="gate-vote-count"]:has-text("3/3")');
-			await expect(badge.first()).toBeVisible({ timeout: 10000 });
-		});
-	});
-
-	// ── 5. QA to Done channel (final completion) ──────────────────────────────
-	test.describe('QA passes → completion state', () => {
-		let spaceId = '';
-		let runId = '';
-
-		test.beforeEach(async ({ page }) => {
-			await page.goto('/');
-			const ids = await createSpaceWithRun(page);
-			spaceId = ids.spaceId;
-			runId = ids.runId;
-
-			// Write all gates to simulate a fully approved + QA-passed state
-			await writeGateData(page, runId, 'code-pr-gate', {
-				pr_url: 'https://github.com/test/repo/pull/1',
-			});
-			await writeGateData(page, runId, 'review-votes-gate', {
-				votes: {
-					'Reviewer 1': 'approved',
-					'Reviewer 2': 'approved',
-					'Reviewer 3': 'approved',
-				},
-			});
-			await writeGateData(page, runId, 'qa-result-gate', { result: 'passed' });
-		});
-
-		test.afterEach(async ({ page }) => {
-			if (runId) await cancelRun(page, runId);
-			if (spaceId) await deleteSpace(page, spaceId);
-			spaceId = '';
-			runId = '';
-		});
-
-		test('QA-to-Done channel gate opens after QA passes (qa-result-gate open)', async ({
-			page,
-		}) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
-
-			// qa-result-gate condition: { type: 'check', field: 'result', op: '==', value: 'passed' }
-			// With result: 'passed' written, the gate opens → green checkmark on QA→Done channel
-			await expect(page.getByTestId('gate-icon-open').first()).toBeVisible({ timeout: 10000 });
-		});
-
-		test('canvas shows all three Reviewer nodes and QA + Done (pipeline tail)', async ({
-			page,
-		}) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
-
-			// All key nodes in the reviewer→QA→Done pipeline must be visible
-			await expect(page.locator('text=Reviewer 1')).toBeVisible({ timeout: 5000 });
-			await expect(page.locator('text=Reviewer 2')).toBeVisible({ timeout: 5000 });
-			await expect(page.locator('text=Reviewer 3')).toBeVisible({ timeout: 5000 });
-			await expect(page.locator('text=QA')).toBeVisible({ timeout: 5000 });
-			await expect(page.locator('text=Done')).toBeVisible({ timeout: 5000 });
-		});
-	});
-
-	// ── 6. vote reset after cycle (votes cleared) ─────────────────────────────
-	test.describe('review-votes-gate reset after rejection cycle', () => {
-		let spaceId = '';
-		let runId = '';
-
-		test.beforeEach(async ({ page }) => {
-			await page.goto('/');
-			const ids = await createSpaceWithRun(page);
-			spaceId = ids.spaceId;
-			runId = ids.runId;
-
-			// Simulate state AFTER a rejection cycle: code-pr-gate persists (resetOnCycle: false),
-			// review-votes-gate has been cleared (resetOnCycle: true) — no votes written.
-			await writeGateData(page, runId, 'code-pr-gate', {
-				pr_url: 'https://github.com/test/repo/pull/1',
-			});
-			// review-votes-gate is intentionally empty (reset state) — we don't write it
-		});
-
-		test.afterEach(async ({ page }) => {
-			if (runId) await cancelRun(page, runId);
-			if (spaceId) await deleteSpace(page, spaceId);
-			spaceId = '';
-			runId = '';
-		});
-
-		test('review-votes-gate shows 0/3 after votes are reset (empty)', async ({ page }) => {
-			await page.goto(`/space/${spaceId}`);
-			await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-			await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 10000 });
-
-			// With no votes written, the review-votes-gate shows 0/3
-			const badge = page.locator('[data-testid="gate-vote-count"]:has-text("0/3")');
-			await expect(badge.first()).toBeVisible({ timeout: 10000 });
-		});
-	});
-});

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -315,6 +315,7 @@ interface GateIconProps {
 	y: number;
 	status: GateStatus;
 	isRuntimeMode: boolean;
+	gateId?: string;
 	onApprove?: () => void;
 	onReject?: () => void;
 	onViewArtifacts?: () => void;
@@ -328,6 +329,7 @@ function GateIcon({
 	y,
 	status,
 	isRuntimeMode,
+	gateId,
 	onApprove,
 	onReject,
 	onViewArtifacts,
@@ -423,6 +425,7 @@ function GateIcon({
 	return (
 		<g
 			data-testid={`gate-icon-${status}`}
+			data-gate-id={gateId}
 			style={{ cursor: isRuntimeMode && status === 'waiting_human' ? 'pointer' : 'default' }}
 			onClick={handleClick}
 		>
@@ -1212,6 +1215,7 @@ export function WorkflowCanvas({
 									y={pts.my}
 									status={gateStatus}
 									isRuntimeMode={isRuntimeMode}
+									gateId={ch.gateId}
 									voteCount={voteCount}
 									onApprove={
 										isHumanGate ? () => void handleApproveGate(ch.gateId!, true) : undefined

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -95,6 +95,26 @@ function isHumanApprovalGate(condition: GateCondition): boolean {
 }
 
 /**
+ * Compute the current matching vote count for a count-type gate condition.
+ * Returns `{ current, min }` so the UI can render "N/M" progress.
+ * Returns `undefined` for non-count conditions.
+ */
+function computeVoteCount(
+	condition: GateCondition,
+	data: Record<string, unknown>
+): { current: number; min: number } | undefined {
+	if (condition.type !== 'count') return undefined;
+	const map = data[condition.field];
+	if (!map || typeof map !== 'object' || Array.isArray(map)) {
+		return { current: 0, min: condition.min };
+	}
+	const current = Object.values(map as Record<string, unknown>).filter(
+		(v) => v === condition.matchValue
+	).length;
+	return { current, min: condition.min };
+}
+
+/**
  * Evaluate gate status from current gate data.
  *
  * Simplified frontend evaluation (no recursion needed for most gates):
@@ -298,6 +318,7 @@ interface GateIconProps {
 	onApprove?: () => void;
 	onReject?: () => void;
 	onViewArtifacts?: () => void;
+	voteCount?: { current: number; min: number };
 }
 
 const GATE_ICON_R = 11; // radius
@@ -310,6 +331,7 @@ function GateIcon({
 	onApprove,
 	onReject,
 	onViewArtifacts,
+	voteCount,
 }: GateIconProps): JSX.Element {
 	const [showActions, setShowActions] = useState(false);
 
@@ -414,6 +436,19 @@ function GateIcon({
 				class={pulseClass}
 			/>
 			<g transform={`translate(${x}, ${y})`}>{icon}</g>
+
+			{voteCount !== undefined && isRuntimeMode && (
+				<text
+					x={x}
+					y={y + GATE_ICON_R + 11}
+					textAnchor="middle"
+					dominantBaseline="middle"
+					style={{ fontSize: '9px', fill: '#a8a29e', fontFamily: 'monospace' }}
+					data-testid="gate-vote-count"
+				>
+					{voteCount.current}/{voteCount.min}
+				</text>
+			)}
 
 			{showActions && isRuntimeMode && (
 				<foreignObject x={x - 65} y={y + 14} width={130} height={onViewArtifacts ? 84 : 56}>
@@ -1146,6 +1181,8 @@ export function WorkflowCanvas({
 
 					// Channels without gates are always available (plain arrows)
 					const isHumanGate = gate ? isHumanApprovalGate(gate.condition) : false;
+					const voteCount =
+						gate && isRuntimeMode ? computeVoteCount(gate.condition, gateData) : undefined;
 
 					return (
 						<g key={`ch-${ch.id}-${ch.toId}`} data-testid={`channel-${ch.id}`}>
@@ -1175,6 +1212,7 @@ export function WorkflowCanvas({
 									y={pts.my}
 									status={gateStatus}
 									isRuntimeMode={isRuntimeMode}
+									voteCount={voteCount}
 									onApprove={
 										isHumanGate ? () => void handleApproveGate(ch.gateId!, true) : undefined
 									}

--- a/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
@@ -545,6 +545,129 @@ describe('WorkflowCanvas', () => {
 		await waitFor(() => expect(queryByTestId('artifacts-panel-overlay')).toBeNull());
 	});
 
+	// ---- Vote count badge (count-type gates) ----
+
+	it('shows vote count badge "N/M" for a count gate with partial votes in runtime mode', async () => {
+		const gate = makeGate({
+			id: 'vote-gate',
+			condition: { type: 'count', field: 'votes', matchValue: 'approved', min: 3 },
+		});
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'vote-gate' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockResolvedValue({
+			gateData: [
+				{
+					runId: 'run-1',
+					gateId: 'vote-gate',
+					data: { votes: { 'Reviewer 1': 'approved', 'Reviewer 2': 'approved' } },
+					updatedAt: 2000,
+				},
+			],
+		});
+
+		const { findByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		const badge = await findByTestId('gate-vote-count');
+		expect(badge.textContent).toBe('2/3');
+	});
+
+	it('shows vote count badge "0/3" when no votes written yet', async () => {
+		const gate = makeGate({
+			id: 'vote-gate',
+			condition: { type: 'count', field: 'votes', matchValue: 'approved', min: 3 },
+		});
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'vote-gate' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { findByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		const badge = await findByTestId('gate-vote-count');
+		expect(badge.textContent).toBe('0/3');
+	});
+
+	it('shows vote count badge "3/3" when all votes approve (gate open)', async () => {
+		const gate = makeGate({
+			id: 'vote-gate',
+			condition: { type: 'count', field: 'votes', matchValue: 'approved', min: 3 },
+		});
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'vote-gate' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockResolvedValue({
+			gateData: [
+				{
+					runId: 'run-1',
+					gateId: 'vote-gate',
+					data: {
+						votes: {
+							'Reviewer 1': 'approved',
+							'Reviewer 2': 'approved',
+							'Reviewer 3': 'approved',
+						},
+					},
+					updatedAt: 2000,
+				},
+			],
+		});
+
+		const { findByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		await findByTestId('gate-icon-open');
+		const badge = await findByTestId('gate-vote-count');
+		expect(badge.textContent).toBe('3/3');
+	});
+
+	it('does NOT show vote count badge in template mode', () => {
+		const gate = makeGate({
+			id: 'vote-gate',
+			condition: { type: 'count', field: 'votes', matchValue: 'approved', min: 3 },
+		});
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'vote-gate' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		// No runId → template mode
+
+		const { queryByTestId } = render(<WorkflowCanvas workflowId="wf-1" spaceId="sp-1" />);
+		expect(queryByTestId('gate-vote-count')).toBeNull();
+	});
+
+	it('does NOT show vote count badge for non-count gate types', async () => {
+		const gate = makeGate({
+			id: 'check-gate',
+			condition: { type: 'check', field: 'approved', op: '==', value: true },
+		});
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch-1', from: 'n1', to: 'n2', direction: 'one-way', gateId: 'check-gate' }],
+			gates: [gate],
+		});
+		mockWorkflows.value = [wf];
+		mockWorkflowRuns.value = [makeRun()];
+		mockHub.request.mockResolvedValue({ gateData: [] });
+
+		const { queryByTestId } = render(
+			<WorkflowCanvas workflowId="wf-1" runId="run-1" spaceId="sp-1" />
+		);
+		await waitFor(() => expect(mockHub.request).toHaveBeenCalled());
+		expect(queryByTestId('gate-vote-count')).toBeNull();
+	});
+
 	// ---- Gate approval action ----
 
 	it('clicking Approve on waiting_human gate calls approveGate RPC', async () => {


### PR DESCRIPTION
Add E2E tests for the Space reviewer feedback loop (M8.2).

- `spaceWorkflowRun.writeGateData` debug RPC to inject gate data in tests (bypasses allowedWriterRoles)
- N/M vote count badge on `review-votes-gate` icons in WorkflowCanvas (count-type gates only, runtime mode)
- E2E test file covering: reviewer rejection visibility, coder re-activation pulse, partial/full approval badges, QA completion, vote reset state
- Unit tests for the new RPC handler and vote count badge rendering