### PR TITLE
docs: e2e health check run #23660910158 (2026-03-27)

### DIFF
--- a/docs/e2e-health-check-log.md
+++ b/docs/e2e-health-check-log.md
@@ -161,6 +161,8 @@ at createTestSpaceWithTask (/home/runner/work/neokai/neokai/packages/e2e/tests/f
 
 ### E2E Test Failures at #23660910158
 
+**Note on job naming**: The E2E job names in this report (e.g., `E2E No-LLM (features-space-agent-centric-workflow)`) are derived from the discovered test suite identifiers used as artifact names, not from the GitHub API top-level job list. The E2E matrix uses dynamic job expansion via `needs.discover.outputs`, and the API may not surface all matrix child jobs at the top level. Artifact names (e.g., `e2e-no-llm-results-features-space-agent-centric-workflow`) confirm the suites ran and failed.
+
 **4 failing tests** across 3 suites. All failures were on a pre-PR#1044 baseline.
 
 #### 1. `features-space-agent-centric-workflow` — `clickedNode is not defined`
@@ -183,9 +185,9 @@ at createTestSpaceWithTask (/home/runner/work/neokai/neokai/packages/e2e/tests/f
 **Test**: `creates space and shows tabbed dashboard layout`
 **Error**: `locator('text=Quick Actions').toBeVisible()` timeout after 5s
 
-**Root cause**: Timing/race condition — the dashboard tabbed layout loaded but "Quick Actions" text wasn't visible in time. The next CI run at commit `3885cb5` (`#23659893244`) had the same suite **pass** (5/5), confirming this is a flaky/timing issue, not a code bug.
+**Root cause**: Timing/race condition — the dashboard tabbed layout loaded but "Quick Actions" text wasn't visible in time. No subsequent non-cancelled CI run exists to verify (all runs after #23660910158 were cancelled), so this is currently classified as **suspected flaky** pending the next successful run.
 
-**Status**: Flaky — no action needed; monitoring.
+**Status**: Suspected flaky — requires verification in the next non-cancelled CI run.
 
 ---
 

--- a/docs/e2e-health-check-log.md
+++ b/docs/e2e-health-check-log.md
@@ -143,3 +143,102 @@ at createTestSpaceWithTask (/home/runner/work/neokai/neokai/packages/e2e/tests/f
 
 - **worktree-isolation session deletion**: Race condition in session deletion navigation (still failing)
 - **space-session-groups workspace path**: Likely env/race condition issue (1 failure in this run)
+
+---
+
+## 2026-03-27 — Check Run #23660910158
+
+### CI Run Overview
+- **Run ID**: 23660910158
+- **Branch**: dev (commit 8fe82aaf — `feat(space): implement completion flow with Done node summary (M5.2) (#1050)`)
+- **Event**: push
+- **Status**: Completed with e2e failures
+
+### Build/Discover Jobs
+- `Discover Tests`: **PASSED**
+- `Build Binary (linux-x64)`: **PASSED**
+- All unit test jobs: **SKIPPED** (gated by build prerequisites)
+
+### E2E Test Failures at #23660910158
+
+**4 failing tests** across 3 suites. All failures were on a pre-PR#1044 baseline.
+
+#### 1. `features-space-agent-centric-workflow` — `clickedNode is not defined`
+**Test**: `Multi-agent node renders agent badges and completion state structure`
+**Error**: `ReferenceError: clickedNode is not defined` at line 243
+
+```
+241 | // addStep double-invocation issue, nodes.first() picks the old/duplicate node
+242 | // rather than the one that was just configured in the panel.
+243 > const node = clickedNode;
+```
+
+**Root cause**: Test code bug — `clickedNode` variable was never defined. Left over from PR #1011 `hasNot`→`:not()` selector refactor which removed the variable declaration but left the reference.
+
+**Fix**: Already fixed in PR #1044 (`d7145d27f`) — replaced `clickedNode` with `nodes.first()`.
+
+---
+
+#### 2. `features-space-creation` — `text=Quick Actions` not visible (flaky)
+**Test**: `creates space and shows tabbed dashboard layout`
+**Error**: `locator('text=Quick Actions').toBeVisible()` timeout after 5s
+
+**Root cause**: Timing/race condition — the dashboard tabbed layout loaded but "Quick Actions" text wasn't visible in time. The next CI run at commit `3885cb5` (`#23659893244`) had the same suite **pass** (5/5), confirming this is a flaky/timing issue, not a code bug.
+
+**Status**: Flaky — no action needed; monitoring.
+
+---
+
+#### 3. `features-reference-autocomplete` — Worktree creation fails (no git repo)
+**Tests**: `clicking a task result inserts @ref{task:…}`, `clicking a goal result inserts @ref{goal:…}`, `keyboard navigation`, `task and goal both appear`, and `does not show autocomplete for plain text input` (12+ failures with retries)
+
+**Error** (repeating for every test):
+```
+[kai:daemon:worktreemanager] No .git found traversing from: /tmp/tmp.zRQ3QaHVJs
+[kai:daemon:worktreemanager] createWorktree: no git root found for repoPath=/tmp/tmp.zRQ3QaHVJs
+[kai:daemon:room-runtime] Failed to spawn planning group for goal <id>: Error: Worktree creation failed — task requires isolation
+[kai:daemon:room-runtime] Goal <id> (Insert Goal) exceeded max planning attempts (1), marking needs_human
+```
+
+**Root cause**: The E2E test workspace path (`/tmp/tmp.*`) is not a git repository. `WorktreeManager.findGitRoot()` returns `null`, causing `createWorktree` to fail. This cascades: tasks can't be created → autocomplete results are empty → tests time out waiting for dropdown items.
+
+**Impact**: All reference-autocomplete tests that navigate to room agent chat fail. Also triggers cascade failures in task-lifecycle (see below).
+
+**Status**: Unresolved — this issue was already noted in the 2026-03-22 health check log. The root cause has not been addressed. Also see Root Cause 2 below.
+
+**PR#1044 context**: PR #1044 moved `reference-autocomplete` from discover-only (No-LLM) to `LLM_TESTS` in the workflow matrix. This means it now runs in E2E LLM jobs alongside LLM-required tests. However, the underlying worktree/git-repo issue persists — the test still fails in both LLM and No-LLM matrices because task creation (via the room agent) requires isolated git worktrees.
+
+---
+
+#### 4. `features-task-lifecycle` — Cascade from worktree failure
+**Tests**: `archives completed task and it disappears from Done tab`, `archived task appears in Archived tab, not Done tab`
+
+**Error**:
+```
+TimeoutError: locator.click: Timeout 60000ms exceeded.
+Call log: waiting for getByRole('button', { name: /Done/ })
+```
+
+**Root cause**: Cascade failure — the preceding test (or test setup) creates tasks via the room agent, which requires isolated git worktrees. Since the E2E workspace has no `.git`, tasks are never created → the Done tab never shows a completed task → archive assertions fail.
+
+**Fix**: Resolves automatically when the `features-reference-autocomplete` worktree issue is fixed.
+
+---
+
+### Previous Failures (from #23412078420, now fixed)
+
+| Test | Root Cause | Fix |
+|---|---|---|
+| `features-space-agent-centric-workflow` | `clickedNode` undefined | PR #1044 — `d7145d27f` |
+| `features-task-lifecycle` (archive tests) | Archived tab removed in #1016, LiveQuery filtering | PR #1044 — `d7145d27f` |
+
+### Unresolved Issue: Worktree/GitRepo in E2E CI
+
+The `features-reference-autocomplete` suite and its cascade failures (`features-task-lifecycle` archive tests) both stem from the same root cause: **E2E temp workspaces lack a `.git` directory**, preventing `WorktreeManager` from creating isolated worktrees for task planning.
+
+This was first documented in the 2026-03-22 health check log and remains unresolved.
+
+**Options to resolve**:
+1. **Test fix**: Initialize the E2E temp workspace as a git repo before running tests (e.g., `git init` in the test setup)
+2. **Backend fix**: Allow task creation without git worktree isolation for non-git workspaces
+3. **Skip**: Mark tests requiring task isolation as LLM-only and ensure the No-LLM matrix excludes them


### PR DESCRIPTION
## Summary
- Investigated CI run #23660910158 (commit 8fe82aaf4) which had 4 failing E2E test suites
- `features-space-agent-centric-workflow`: `clickedNode is not defined` — already fixed in PR #1044 (`d7145d27f`)
- `features-space-creation`: `text=Quick Actions` not visible — **suspected flaky** (all subsequent CI runs were cancelled; requires verification in the next non-cancelled run)
- `features-reference-autocomplete`: worktree creation fails because E2E temp workspace has no `.git` — **unresolved** (carried forward from 2026-03-22 log)
- `features-task-lifecycle`: cascade from reference-autocomplete worktree failure — resolves automatically when that is fixed

## Test plan
- [x] Report written to `docs/e2e-health-check-log.md`