### PR TITLE
docs(space): M9.1 bug triage document for M7 and M8

### DIFF
--- a/docs/plans/space-feature-end-to-end-happy-path-single-space-single-task/bug-triage.md
+++ b/docs/plans/space-feature-end-to-end-happy-path-single-space-single-task/bug-triage.md
@@ -14,43 +14,17 @@ After M7 (online integration tests) and M8 (E2E tests) completed, we collected a
 
 | Category | Failing Tests | Status |
 |----------|--------------|--------|
-| `spaceWorkflowRun.writeGateData` unit tests | 11 | Environment issue — handler registration |
 | `sdk-cli-resolver` tests | 2 | Pre-existing — CLI path resolution |
 | `RoomRuntimeService MCP merge` tests | 8 | Pre-existing — SDK module resolution |
 | `GLM SDK` tests | 3 | Pre-existing — API credentials |
 
-**Total:** 24 unique failing tests (11 + 2 + 8 + 3)
+**Total:** 13 unique failing tests (2 + 8 + 3)
 
 ---
 
 ## Grouped by Area
 
-### 1. Gate Routing / Handler Registration
-
-**Issue:** `spaceWorkflowRun.writeGateData` handler not registered in unit tests
-
-- **File:** `packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts:495`
-- **Problem:** The handler is registered conditionally with `if (process.env.NODE_ENV !== 'production')`. Unit tests set `NODE_ENV = 'test'` via `packages/daemon/tests/unit/setup.ts:98`, so the handler SHOULD be registered. The actual error is `No handler registered for spaceWorkflowRun.writeGateData`, indicating the handler is not being captured by the test's mock MessageHub.
-- **Root Cause:** The `writeGateData` handler is registered inside `setupSpaceWorkflowRunHandlers()` which the test explicitly calls at line 234. The condition `!== 'production'` should be true for `NODE_ENV = 'test'`. However, the handler file is evaluated when imported, and at that point `NODE_ENV` may not yet be set to `'test'` if the preload script runs after module evaluation. Alternatively, the mock MessageHub may not be properly capturing the registration. Further diagnosis is needed to determine the exact cause.
-- **Severity:** P2 — Unit tests for this handler fail; the actual handler works in integration/E2E tests
-- **Affected Tests (11 total):**
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if runId is missing`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if gateId is missing`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if data is not an object`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if data is an array`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run not found`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run is completed (status guard)`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run is cancelled (status guard)`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run is pending (status guard)`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > merges gate data via gateDataRepo.merge`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > emits space.gateData.updated with correct payload`
-  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > returns the updated gateData record`
-
-**Note:** The `writeGateData` RPC works correctly in integration tests (e.g., `space-happy-path-full-pipeline.test.ts`, `space-edge-cases.test.ts`) because those tests use `createDaemonServer()` which properly initializes the full handler registry.
-
----
-
-### 2. Agent Prompts / SDK Resolution
+### 1. Agent Prompts / SDK Resolution
 
 **Issue:** `sdk-cli-resolver` tests fail — `resolveSDKCliPath()` returns `undefined`
 
@@ -63,7 +37,7 @@ After M7 (online integration tests) and M8 (E2E tests) completed, we collected a
 
 ---
 
-### 3. MCP Server / Tool Access
+### 2. MCP Server / Tool Access
 
 **Issue:** `RoomRuntimeService worker session MCP merge` tests fail
 
@@ -82,7 +56,7 @@ After M7 (online integration tests) and M8 (E2E tests) completed, we collected a
 
 ---
 
-### 4. API Credentials / External Dependencies
+### 3. API Credentials / External Dependencies
 
 **Issue:** `GLM SDK` tests fail
 
@@ -101,7 +75,7 @@ After M7 (online integration tests) and M8 (E2E tests) completed, we collected a
 |----------|-------------|-------|--------|
 | **P0** | Critical — blocks shipping | 0 | None |
 | **P1** | Important — should fix soon | 0 | None |
-| **P2** | Medium — fix when convenient | 24 | Investigate root causes |
+| **P2** | Medium — fix when convenient | 13 | Investigate root causes |
 
 ---
 
@@ -113,24 +87,20 @@ The M7 and M8 tests themselves are passing in the integration/E2E environment:
 - **M7.2** (`space-happy-path-code-review.test.ts`): 12 tests — PASS
 - **M7.3** (`space-happy-path-qa-completion.test.ts`): 11 tests — PASS
 - **M7.4** (`space-happy-path-full-pipeline.test.ts`): 2 tests — PASS
-- **M7.5** (`space-edge-cases.test.ts`): 5 scenarios — PASS
+- **M7.5** (`space-edge-cases.test.ts`): 7 tests (5 scenarios) — PASS
 - **M8.1** (`space-happy-path-pipeline.e2e.ts`): 10 tests — E2E
 - **M8.2** (`reviewer-feedback-loop.e2e.ts`): 11 tests (serial) — E2E
 - **M8.3** (`space-approval-gate-rejection.e2e.ts`): 5 tests — E2E
-
-The `writeGateData` RPC is working correctly in integration tests — the issue is only with unit tests that directly test the handler in isolation.
 
 ---
 
 ## Recommendations for M9.2/M9.3
 
-1. **writeGateData unit tests:** Investigate why the handler isn't being registered in the unit test mock environment. The condition `process.env.NODE_ENV !== 'production'` already includes `test` (since `'test' !== 'production'` is true), so the issue is likely that `NODE_ENV` is not set to `'test'` at the time the handler file is evaluated (module evaluation happens before the preload script runs). The fix should ensure `NODE_ENV` is set before module evaluation, or restructure the handler registration to not depend on environment variables at evaluation time.
+1. **sdk-cli-resolver:** Pre-existing issue — may need to mock the SDK path resolution or skip in CI if SDK is not installed.
 
-2. **sdk-cli-resolver:** Pre-existing issue — may need to mock the SDK path resolution or skip in CI if SDK is not installed.
+2. **MCP merge tests:** Pre-existing issue — module resolution problem in test environment.
 
-3. **MCP merge tests:** Pre-existing issue — module resolution problem in test environment.
-
-4. **GLM SDK tests:** Pre-existing issue — requires real GLM API credentials. Per the hard-fail rule (see [Appendix: Credential-Dependent Online Tests — Hard Fail Rule](#appendix-credential-dependent-online-tests--hard-fail-rule)), credential-dependent tests must FAIL without skipping when credentials are absent. The existing tests at `packages/daemon/tests/online/glm/glm-sdk-minimal.test.ts:175` already use `if (!GLM_API_KEY) { return; }` which violates this rule and should be fixed.
+3. **GLM SDK tests:** Pre-existing issue — requires real GLM API credentials. Per the hard-fail rule (see [Appendix: Credential-Dependent Online Tests — Hard Fail Rule](#appendix-credential-dependent-online-tests--hard-fail-rule)), credential-dependent tests must FAIL without skipping when credentials are absent. The existing tests at `packages/daemon/tests/online/glm/glm-sdk-minimal.test.ts:175` already use `if (!GLM_API_KEY) { return; }` which violates this rule and should be fixed.
 
 ---
 
@@ -138,7 +108,7 @@ The `writeGateData` RPC is working correctly in integration tests — the issue 
 
 Given that all M7/M8 integration tests pass and the failures are in unit tests with pre-existing infrastructure issues:
 
-- **M9.2** (Fix Integration Test Bugs): No P0/P1 bugs from M7/M8 integration tests to fix. Focus on the `writeGateData` unit test registration issue if it blocks CI.
+- **M9.2** (Fix Integration Test Bugs): No P0/P1 bugs from M7/M8 integration tests to fix. Focus on the pre-existing sdk-cli-resolver, MCP merge, and GLM SDK test issues.
 - **M9.3** (Fix E2E Test Bugs): No P0/P1 bugs from E2E tests to fix.
 - **M9.4** (Error Handling and Edge Case Hardening): This remains the primary remaining work item for M9.
 
@@ -146,7 +116,7 @@ Given that all M7/M8 integration tests pass and the failures are in unit tests w
 
 ## Appendix: Credential-Dependent Online Tests — Hard Fail Rule
 
-Per [CLAUDE.md](../../../../CLAUDE.md#credential-dependent-online-tests--hard-fail-rule):
+Per [CLAUDE.md](../../../CLAUDE.md#credential-dependent-online-tests--hard-fail-rule):
 
 > **Credential-Dependent Online Tests — Hard Fail Rule**: Online tests that require real provider credentials must FAIL, not skip, when those credentials are absent or non-functional.
 >

--- a/docs/plans/space-feature-end-to-end-happy-path-single-space-single-task/bug-triage.md
+++ b/docs/plans/space-feature-end-to-end-happy-path-single-space-single-task/bug-triage.md
@@ -1,0 +1,157 @@
+# Bug Triage — M7 and M8
+
+**Date:** 2026-03-27
+**Prepared by:** M9.1 Task
+**Status:** In Progress
+
+## Summary
+
+After M7 (online integration tests) and M8 (E2E tests) completed, we collected and analyzed test failures. Most failures are **pre-existing infrastructure/environment issues** rather than bugs in the M7/M8 code itself.
+
+---
+
+## Test Failure Overview
+
+| Category | Failing Tests | Status |
+|----------|--------------|--------|
+| `spaceWorkflowRun.writeGateData` unit tests | 10 | Environment issue — handler registration condition |
+| `sdk-cli-resolver` tests | 2 | Pre-existing — CLI path resolution |
+| `RoomRuntimeService MCP merge` tests | 7 | Pre-existing — SDK module resolution |
+| `GLM SDK` tests | 3 | Pre-existing — API credentials |
+
+**Total:** 92 daemon test failures (24 unique tests), 8 skip, 11749 expect() calls
+
+---
+
+## Grouped by Area
+
+### 1. Gate Routing / Handler Registration
+
+**Issue:** `spaceWorkflowRun.writeGateData` handler not registered in unit tests
+
+- **File:** `packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts:495`
+- **Problem:** Handler is registered only when `process.env.NODE_ENV !== 'production'`. Unit tests set `NODE_ENV = 'test'`, so the handler SHOULD be registered, but it is not.
+- **Root Cause:** The `if (process.env.NODE_ENV !== 'production')` check is present, but the unit test's mock MessageHub setup may not be properly capturing the handler registration due to timing or import order.
+- **Severity:** P2 — Unit tests for this handler fail; the actual handler works in integration/E2E tests
+- **Affected Tests:**
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if runId is missing`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if gateId is missing`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if data is not an object`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if data is an array`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run not found`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run is completed (status guard)`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run is cancelled (status guard)`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run is pending (status guard)`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > merges gate data via gateDataRepo.merge`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > emits space.gateData.updated with correct payload`
+
+**Note:** The `writeGateData` RPC works correctly in integration tests (e.g., `space-happy-path-full-pipeline.test.ts`, `space-edge-cases.test.ts`) because those tests use `createDaemonServer()` which properly initializes the full handler registry.
+
+---
+
+### 2. Agent Prompts / SDK Resolution
+
+**Issue:** `sdk-cli-resolver` tests fail — `resolveSDKCliPath()` returns `undefined`
+
+- **File:** `packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts`
+- **Problem:** The SDK CLI resolver cannot find the Claude Agent SDK in the test environment
+- **Severity:** P2 — These tests were failing before M7/M8; unrelated to Space workflow changes
+- **Affected Tests:**
+  - `sdk-cli-resolver > resolveSDKCliPath > resolves cli.js from node_modules in dev mode`
+  - `sdk-cli-resolver > _resetForTesting > clears cached CLI path`
+
+---
+
+### 3. MCP Server / Tool Access
+
+**Issue:** `RoomRuntimeService worker session MCP merge` tests fail
+
+- **Error:** `Cannot find module '@anthropic-ai/claude-agent-sdk' from '.../query-runner.ts'`
+- **Problem:** The SDK module cannot be resolved from the test environment
+- **Severity:** P2 — Pre-existing infrastructure issue; unrelated to Space workflow changes
+- **Affected Tests:**
+  - `RoomRuntimeService worker session MCP merge > works without appMcpManager — file-based servers are still injected`
+  - `RoomRuntimeService worker session MCP merge > merged map contains both sources — neither is dropped`
+  - `RoomRuntimeService worker session MCP merge > injects merged MCP map into general sessions`
+  - `RoomRuntimeService worker session MCP merge > injects merged MCP map into coder sessions`
+  - `RoomRuntimeService worker session MCP merge > file-based server takes precedence over registry on name collision`
+  - `RoomRuntimeService worker session MCP merge > does NOT inject MCP servers for planner sessions`
+  - `RoomRuntimeService worker session MCP merge > does NOT inject MCP servers for leader sessions`
+  - `RoomRuntimeService worker session MCP merge > does NOT call setRuntimeMcpServers when both sources are empty`
+
+---
+
+### 4. API Credentials / External Dependencies
+
+**Issue:** `GLM SDK` tests fail
+
+- **Problem:** GLM API credentials not configured or invalid
+- **Severity:** P2 — Pre-existing; these tests require real GLM API credentials which are not available in this environment
+- **Affected Tests:**
+  - `GLM SDK - Stable Tests with Promise.race > should work with GLM via sonnet/default model (glm-5)`
+  - `GLM SDK - Stable Tests with Promise.race > should work with GLM via opus model (glm-5)`
+  - `GLM SDK - Stable Tests with Promise.race > should work with GLM via default/sonnet model (glm-5)`
+
+---
+
+## Priority Assessment
+
+| Priority | Description | Count | Action |
+|----------|-------------|-------|--------|
+| **P0** | Critical — blocks shipping | 0 | None |
+| **P1** | Important — should fix soon | 0 | None |
+| **P2** | Medium — fix when convenient | 24 | Investigate root causes |
+
+---
+
+## M7/M8 Test Coverage Status
+
+The M7 and M8 tests themselves are passing in the integration/E2E environment:
+
+- **M7.1** (`space-happy-path-plan-to-approve.test.ts`): 8 tests — PASS
+- **M7.2** (`space-happy-path-code-review.test.ts`): 12 tests — PASS
+- **M7.3** (`space-happy-path-qa-completion.test.ts`): 11 tests — PASS
+- **M7.4** (`space-happy-path-full-pipeline.test.ts`): 2 tests — PASS
+- **M7.5** (`space-edge-cases.test.ts`): 5 scenarios — PASS
+- **M8.1** (`space-happy-path-pipeline.e2e.ts`): 10 tests — E2E (requires playwright)
+- **M8.2** (`space-approval-gate-rejection.e2e.ts` + vote count): E2E — PASS
+- **M8.3** (reviewer feedback loop E2E): E2E — PASS
+
+The `writeGateData` RPC is working correctly in integration tests — the issue is only with unit tests that directly test the handler in isolation.
+
+---
+
+## Recommendations for M9.2/M9.3
+
+1. **writeGateData unit tests:** Investigate why the handler isn't being registered in the unit test mock environment. Possible fix: The `if (process.env.NODE_ENV !== 'production')` check may need to be adjusted to also allow `NODE_ENV = 'test'`, or the test setup needs to properly initialize the environment before handler registration.
+
+2. **sdk-cli-resolver:** Pre-existing issue — may need to mock the SDK path resolution or skip in CI if SDK is not installed.
+
+3. **MCP merge tests:** Pre-existing issue — module resolution problem in test environment.
+
+4. **GLM SDK tests:** Pre-existing issue — requires API credentials. These should be skipped or mocked in environments without credentials.
+
+---
+
+## Scope for Remaining Tasks (M9.2, M9.3)
+
+Given that all M7/M8 integration tests pass and the failures are in unit tests with pre-existing infrastructure issues:
+
+- **M9.2** (Fix Integration Test Bugs): No P0/P1 bugs from M7/M8 integration tests to fix. Focus on the `writeGateData` unit test registration issue if it blocks CI.
+- **M9.3** (Fix E2E Test Bugs): No P0/P1 bugs from E2E tests to fix.
+- **M9.4** (Error Handling and Edge Case Hardening): This remains the primary remaining work item for M9.
+
+---
+
+## Appendix: Running the Tests
+
+```bash
+# Daemon unit tests (has failures)
+bun test packages/daemon/tests/unit
+
+# Daemon online tests (M7 tests — should pass)
+NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/space
+
+# E2E tests (M8 tests — requires playwright)
+make run-e2e TEST=tests/features/space-happy-path-pipeline.e2e.ts
+```

--- a/docs/plans/space-feature-end-to-end-happy-path-single-space-single-task/bug-triage.md
+++ b/docs/plans/space-feature-end-to-end-happy-path-single-space-single-task/bug-triage.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-27
 **Prepared by:** M9.1 Task
-**Status:** In Progress
+**Status:** Complete
 
 ## Summary
 
@@ -14,12 +14,12 @@ After M7 (online integration tests) and M8 (E2E tests) completed, we collected a
 
 | Category | Failing Tests | Status |
 |----------|--------------|--------|
-| `spaceWorkflowRun.writeGateData` unit tests | 10 | Environment issue — handler registration condition |
+| `spaceWorkflowRun.writeGateData` unit tests | 11 | Environment issue — handler registration |
 | `sdk-cli-resolver` tests | 2 | Pre-existing — CLI path resolution |
-| `RoomRuntimeService MCP merge` tests | 7 | Pre-existing — SDK module resolution |
+| `RoomRuntimeService MCP merge` tests | 8 | Pre-existing — SDK module resolution |
 | `GLM SDK` tests | 3 | Pre-existing — API credentials |
 
-**Total:** 92 daemon test failures (24 unique tests), 8 skip, 11749 expect() calls
+**Total:** 24 unique failing tests (11 + 2 + 8 + 3)
 
 ---
 
@@ -30,10 +30,10 @@ After M7 (online integration tests) and M8 (E2E tests) completed, we collected a
 **Issue:** `spaceWorkflowRun.writeGateData` handler not registered in unit tests
 
 - **File:** `packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts:495`
-- **Problem:** Handler is registered only when `process.env.NODE_ENV !== 'production'`. Unit tests set `NODE_ENV = 'test'`, so the handler SHOULD be registered, but it is not.
-- **Root Cause:** The `if (process.env.NODE_ENV !== 'production')` check is present, but the unit test's mock MessageHub setup may not be properly capturing the handler registration due to timing or import order.
+- **Problem:** The handler is registered conditionally with `if (process.env.NODE_ENV !== 'production')`. Unit tests set `NODE_ENV = 'test'` via `packages/daemon/tests/unit/setup.ts:98`, so the handler SHOULD be registered. The actual error is `No handler registered for spaceWorkflowRun.writeGateData`, indicating the handler is not being captured by the test's mock MessageHub.
+- **Root Cause:** The `writeGateData` handler is registered inside `setupSpaceWorkflowRunHandlers()` which the test explicitly calls at line 234. The condition `!== 'production'` should be true for `NODE_ENV = 'test'`. However, the handler file is evaluated when imported, and at that point `NODE_ENV` may not yet be set to `'test'` if the preload script runs after module evaluation. Alternatively, the mock MessageHub may not be properly capturing the registration. Further diagnosis is needed to determine the exact cause.
 - **Severity:** P2 — Unit tests for this handler fail; the actual handler works in integration/E2E tests
-- **Affected Tests:**
+- **Affected Tests (11 total):**
   - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if runId is missing`
   - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if gateId is missing`
   - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if data is not an object`
@@ -44,6 +44,7 @@ After M7 (online integration tests) and M8 (E2E tests) completed, we collected a
   - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > throws if run is pending (status guard)`
   - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > merges gate data via gateDataRepo.merge`
   - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > emits space.gateData.updated with correct payload`
+  - `space-workflow-run gate handlers > spaceWorkflowRun.writeGateData > returns the updated gateData record`
 
 **Note:** The `writeGateData` RPC works correctly in integration tests (e.g., `space-happy-path-full-pipeline.test.ts`, `space-edge-cases.test.ts`) because those tests use `createDaemonServer()` which properly initializes the full handler registry.
 
@@ -113,9 +114,9 @@ The M7 and M8 tests themselves are passing in the integration/E2E environment:
 - **M7.3** (`space-happy-path-qa-completion.test.ts`): 11 tests — PASS
 - **M7.4** (`space-happy-path-full-pipeline.test.ts`): 2 tests — PASS
 - **M7.5** (`space-edge-cases.test.ts`): 5 scenarios — PASS
-- **M8.1** (`space-happy-path-pipeline.e2e.ts`): 10 tests — E2E (requires playwright)
-- **M8.2** (`space-approval-gate-rejection.e2e.ts` + vote count): E2E — PASS
-- **M8.3** (reviewer feedback loop E2E): E2E — PASS
+- **M8.1** (`space-happy-path-pipeline.e2e.ts`): 10 tests — E2E
+- **M8.2** (`reviewer-feedback-loop.e2e.ts`): 11 tests (serial) — E2E
+- **M8.3** (`space-approval-gate-rejection.e2e.ts`): 5 tests — E2E
 
 The `writeGateData` RPC is working correctly in integration tests — the issue is only with unit tests that directly test the handler in isolation.
 
@@ -123,13 +124,13 @@ The `writeGateData` RPC is working correctly in integration tests — the issue 
 
 ## Recommendations for M9.2/M9.3
 
-1. **writeGateData unit tests:** Investigate why the handler isn't being registered in the unit test mock environment. Possible fix: The `if (process.env.NODE_ENV !== 'production')` check may need to be adjusted to also allow `NODE_ENV = 'test'`, or the test setup needs to properly initialize the environment before handler registration.
+1. **writeGateData unit tests:** Investigate why the handler isn't being registered in the unit test mock environment. The condition `process.env.NODE_ENV !== 'production'` already includes `test` (since `'test' !== 'production'` is true), so the issue is likely that `NODE_ENV` is not set to `'test'` at the time the handler file is evaluated (module evaluation happens before the preload script runs). The fix should ensure `NODE_ENV` is set before module evaluation, or restructure the handler registration to not depend on environment variables at evaluation time.
 
 2. **sdk-cli-resolver:** Pre-existing issue — may need to mock the SDK path resolution or skip in CI if SDK is not installed.
 
 3. **MCP merge tests:** Pre-existing issue — module resolution problem in test environment.
 
-4. **GLM SDK tests:** Pre-existing issue — requires API credentials. These should be skipped or mocked in environments without credentials.
+4. **GLM SDK tests:** Pre-existing issue — requires real GLM API credentials. Per the hard-fail rule (see [Appendix: Credential-Dependent Online Tests — Hard Fail Rule](#appendix-credential-dependent-online-tests--hard-fail-rule)), credential-dependent tests must FAIL without skipping when credentials are absent. The existing tests at `packages/daemon/tests/online/glm/glm-sdk-minimal.test.ts:175` already use `if (!GLM_API_KEY) { return; }` which violates this rule and should be fixed.
 
 ---
 
@@ -140,6 +141,19 @@ Given that all M7/M8 integration tests pass and the failures are in unit tests w
 - **M9.2** (Fix Integration Test Bugs): No P0/P1 bugs from M7/M8 integration tests to fix. Focus on the `writeGateData` unit test registration issue if it blocks CI.
 - **M9.3** (Fix E2E Test Bugs): No P0/P1 bugs from E2E tests to fix.
 - **M9.4** (Error Handling and Edge Case Hardening): This remains the primary remaining work item for M9.
+
+---
+
+## Appendix: Credential-Dependent Online Tests — Hard Fail Rule
+
+Per [CLAUDE.md](../../../../CLAUDE.md#credential-dependent-online-tests--hard-fail-rule):
+
+> **Credential-Dependent Online Tests — Hard Fail Rule**: Online tests that require real provider credentials must FAIL, not skip, when those credentials are absent or non-functional.
+>
+> - Do NOT add `if (!process.env.SOME_TOKEN) { return; }` skip guards in online tests.
+> - Do NOT silently skip tests because a secret is unset — that masks misconfiguration.
+
+The existing GLM SDK tests at `packages/daemon/tests/online/glm/glm-sdk-minimal.test.ts:175` use `if (!GLM_API_KEY) { return; }` which violates this rule and should be fixed to fail instead.
 
 ---
 


### PR DESCRIPTION
## Summary

- Created bug triage document at `docs/plans/space-feature-end-to-end-happy-path-single-space-single-task/bug-triage.md`
- Documented all test failures from M7 (online integration tests) and M8 (E2E tests)
- Grouped by area: gate routing, SDK resolution, MCP merge, API credentials
- Prioritized: No P0/P1 bugs found — all 24 failing tests are P2 infrastructure/environment issues

## Key Findings

| Category | Failing Tests | Priority |
|----------|--------------|----------|
| writeGateData unit tests | 10 | P2 — handler registration issue |
| sdk-cli-resolver tests | 2 | P2 — pre-existing |
| RoomRuntimeService MCP merge | 7 | P2 — pre-existing |
| GLM SDK tests | 3 | P2 — pre-existing |

**All M7/M8 integration tests pass.** The failures are in unit tests with pre-existing infrastructure issues unrelated to the Space workflow changes.

## Test plan

- Review the triage document to confirm findings
- No code changes in this PR