### PR TITLE
fix(e2e): fix P1 bugs in space E2E tests (M9.3)

### DIFF
--- a/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
+++ b/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
@@ -300,6 +300,6 @@ test.describe('Approval Gate Rejection', () => {
 		// pre-coding phase (plan-approval-gate). If the workflow adds more human gates
 		// in the future, this assertion would need revisiting — but for the current
 		// template it confirms the gate correctly transitioned away from waiting_human.
-		await expect(page.getByTestId('gate-icon-waiting_human')).toBeHidden({ timeout: 5000 });
+		await expect(page.getByTestId('gate-icon-waiting_human')).toBeHidden({ timeout: 10000 });
 	});
 });

--- a/packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts
+++ b/packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts
@@ -281,19 +281,13 @@ test.describe('Space Happy Path Pipeline', () => {
 		const diffSummaryEl = page.getByTestId('diff-summary');
 		const noFilesEl = page.getByTestId('no-files');
 
-		const state = await Promise.race([
-			errorEl
-				.waitFor({ state: 'visible', timeout: 5000 })
-				.then(() => 'error' as const)
-				.catch(() => {}),
-			diffSummaryEl
-				.waitFor({ state: 'visible', timeout: 5000 })
-				.then(() => 'diff' as const)
-				.catch(() => {}),
-			noFilesEl
-				.waitFor({ state: 'visible', timeout: 5000 })
-				.then(() => 'no-files' as const)
-				.catch(() => {}),
+		// Promise.any resolves with the first fulfilled value; if all three time out it
+		// rejects with an AggregateError, giving a clear failure instead of the silent
+		// `undefined` that Promise.race with swallowed .catch() would return.
+		const state = await Promise.any([
+			errorEl.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'error' as const),
+			diffSummaryEl.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'diff' as const),
+			noFilesEl.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'no-files' as const),
 		]);
 
 		// Any terminal state is acceptable for an E2E test without a real worktree.


### PR DESCRIPTION
## What

Two P1 bugs fixed in the space E2E test suite.

**Bug 1 — Promise.race() with swallowed errors** (`space-happy-path-pipeline.e2e.ts`):
The original `Promise.race()` used `.catch(() => {})` handlers that silently returned `undefined`. When none of the three elements became visible within 5 s, `Promise.race()` resolved with `undefined`, causing a confusing `expected ['error', 'diff', 'no-files'] to contain undefined` failure. Replaced with `Promise.any()`, which rejects with an `AggregateError` when all promises fail — giving a clear, actionable error message.

**Bug 2 — Short timeout for server-dependent assertion** (`space-approval-gate-rejection.e2e.ts`):
`gate-icon-waiting_human` `toBeHidden` was using a 5000ms timeout, but the state change requires a server round-trip (RPC call → gate update → WebSocket event → UI re-render). Every other server-dependent assertion in the suite uses 10000ms. Increased to match.