### PR TITLE
feat(coder): add built-in explorer sub-agent definition

### DIFF
--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -175,7 +175,7 @@ Your job is to gather accurate, focused information about the codebase and retur
 
 ## Rules
 
-1. **Read-only** — you MUST NOT create, edit, or delete any files. No Write, Edit, or file-mutating Bash commands (no \`rm\`, \`mv\`, \`cp\` to new paths, \`git commit\`, etc.)
+1. **Read-only** — you MUST NOT create, edit, or delete any files. No Write, Edit, or file-mutating Bash commands (no rm, mv, cp to new paths, git commit, etc.)
 2. **No sub-agents** — you MUST NOT spawn further sub-agents. Do not use the Task tool.
 3. **Focused exploration** — explore only what is relevant to the question asked; do not wander
 4. **Concise summary** — return findings in the structured format below; omit irrelevant detail
@@ -362,6 +362,22 @@ export function buildCoderSystemPrompt(helperAgentNames?: string[]): string {
 			`The tester commits test files to the current branch and returns a \`---TEST_RESULT---\` block.`
 		);
 
+		// Explorer is always available in agent mode
+		sections.push(`\n### Built-in: \`explorer\``);
+		sections.push(
+			`Read-only codebase exploration. Use before implementing complex or unfamiliar changes.`
+		);
+		sections.push(`**Spawn before implementation** when you need to understand the codebase:`);
+		sections.push(
+			`\`\`\`\nTask(subagent_type: "explorer", prompt: "Explore <area/pattern/file> to understand <what you need to know>.")\n\`\`\``
+		);
+		sections.push(
+			`The explorer returns an \`---EXPLORE_RESULT---\` block with relevant files, patterns, dependencies, and findings.`
+		);
+		sections.push(
+			`**Do not spawn explorer for simple single-file tasks** — only for unfamiliar areas.`
+		);
+
 		// Custom helpers (if configured)
 		const helperList = helperAgentNames!.join(', ');
 		sections.push(`\n### Custom helpers: ${helperList}`);
@@ -505,6 +521,7 @@ export function createCoderAgentInit(config: CoderAgentConfig): AgentSessionInit
 			agents: {
 				Coder: coderAgentDef,
 				tester: buildTesterAgentDef(),
+				explorer: buildCoderExplorerAgentDef(),
 				...helperAgents,
 			},
 			contextAutoQueue: false,

--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -154,6 +154,49 @@ summary: <1-3 sentence description of what was tested and the outcome>
 }
 
 /**
+ * Build the AgentDefinition for the built-in Explorer sub-agent.
+ *
+ * The Explorer is a read-only codebase exploration agent automatically included
+ * whenever the Coder is in agent/agents mode. It uses Grep/Glob/Read/Bash to
+ * explore the codebase and returns structured findings about file paths, patterns,
+ * dependencies, and architecture.
+ *
+ * The Explorer MUST NOT modify files and MUST NOT spawn further sub-agents.
+ */
+export function buildCoderExplorerAgentDef(): AgentDefinition {
+	return {
+		description:
+			'Read-only codebase explorer. Spawned by the Coder to gather structured findings about file paths, patterns, dependencies, and architecture before implementation.',
+		tools: ['Read', 'Grep', 'Glob', 'Bash'],
+		model: 'inherit',
+		prompt: `You are an Explorer Agent spawned by the main Coder Agent to explore the codebase and return structured findings.
+
+Your job is to gather accurate, focused information about the codebase and return it in a structured format.
+
+## Rules
+
+1. **Read-only** — you MUST NOT create, edit, or delete any files. No Write, Edit, or file-mutating Bash commands (no \`rm\`, \`mv\`, \`cp\` to new paths, \`git commit\`, etc.)
+2. **No sub-agents** — you MUST NOT spawn further sub-agents. Do not use the Task tool.
+3. **Focused exploration** — explore only what is relevant to the question asked; do not wander
+4. **Concise summary** — return findings in the structured format below; omit irrelevant detail
+5. **Bash for read-only operations only** — e.g., \`git log\`, \`git grep\`, \`wc -l\`, listing directory contents
+
+## Output Format
+
+End your response with a structured result block:
+
+---EXPLORE_RESULT---
+relevant_files: <comma-separated list of file paths most relevant to the task>
+patterns: <key patterns, conventions, or idioms observed (e.g., "uses Hono router", "signals for state")>
+dependencies: <relevant imports, external packages, or internal modules involved>
+architecture_notes: <brief description of how the relevant area is structured>
+findings: <1-5 sentences summarizing what you found and what the Coder should know before implementing>
+---END_EXPLORE_RESULT---
+`,
+	};
+}
+
+/**
  * Build the AgentDefinition map for worker helper sub-agents.
  * Returns a map of helper name to AgentDefinition.
  */

--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -370,6 +370,35 @@ describe('Coder Agent', () => {
 				expect(prompt).toContain('---TEST_RESULT---');
 			});
 
+			it('includes built-in explorer agent in agents map', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				expect(init.agents).toHaveProperty('explorer');
+			});
+
+			it('explorer agent has only Read, Grep, Glob, Bash tools', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				const explorer = init.agents?.['explorer'];
+				expect(explorer?.tools).toContain('Read');
+				expect(explorer?.tools).toContain('Grep');
+				expect(explorer?.tools).toContain('Glob');
+				expect(explorer?.tools).toContain('Bash');
+				expect(explorer?.tools).not.toContain('Write');
+				expect(explorer?.tools).not.toContain('Edit');
+				expect(explorer?.tools).not.toContain('Task');
+			});
+
+			it('explorer agent uses inherit model', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				expect(init.agents?.['explorer']?.model).toBe('inherit');
+			});
+
+			it('Coder system prompt includes explorer sub-agent instructions', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				const prompt = init.agents?.['Coder']?.prompt ?? '';
+				expect(prompt).toContain('explorer');
+				expect(prompt).toContain('---EXPLORE_RESULT---');
+			});
+
 			it('uses simple preset path when no worker sub-agents configured', () => {
 				const init = createCoderAgentInit(makeConfig());
 				expect(init.agent).toBeUndefined();
@@ -381,8 +410,10 @@ describe('Coder Agent', () => {
 				const init = createCoderAgentInit(
 					makeConfigWithWorkers([{ model: 'haiku' }, { model: 'haiku' }])
 				);
-				// Filter out built-in Coder and tester; count only the helper sub-agents
-				const keys = Object.keys(init.agents ?? {}).filter((k) => k !== 'Coder' && k !== 'tester');
+				// Filter out built-ins (Coder, tester, explorer); count only the helper sub-agents
+				const keys = Object.keys(init.agents ?? {}).filter(
+					(k) => k !== 'Coder' && k !== 'tester' && k !== 'explorer'
+				);
 				// Two haiku configs should produce unique names
 				expect(keys.length).toBe(2);
 				expect(new Set(keys).size).toBe(2);
@@ -529,6 +560,12 @@ describe('Coder Agent', () => {
 		it('does NOT have Task tool (no sub-agent spawning)', () => {
 			const def = buildCoderExplorerAgentDef();
 			expect(def.tools).not.toContain('Task');
+		});
+
+		it('does NOT have WebFetch or WebSearch tools (local exploration only)', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.tools).not.toContain('WebFetch');
+			expect(def.tools).not.toContain('WebSearch');
 		});
 
 		it('uses inherit model', () => {

--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import {
+	buildCoderExplorerAgentDef,
 	buildCoderHelperAgentPrompt,
 	buildCoderSystemPrompt,
 	buildCoderTaskMessage,
@@ -506,6 +507,66 @@ describe('Coder Agent', () => {
 			const def = buildTesterAgentDef();
 			expect(def.prompt).toContain('current branch');
 			expect(def.prompt).toContain('do NOT create new PRs');
+		});
+	});
+
+	describe('buildCoderExplorerAgentDef', () => {
+		it('has Read, Grep, Glob, and Bash tools only', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.tools).toContain('Read');
+			expect(def.tools).toContain('Grep');
+			expect(def.tools).toContain('Glob');
+			expect(def.tools).toContain('Bash');
+			expect(def.tools).toHaveLength(4);
+		});
+
+		it('does NOT have Write or Edit tools (read-only)', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.tools).not.toContain('Write');
+			expect(def.tools).not.toContain('Edit');
+		});
+
+		it('does NOT have Task tool (no sub-agent spawning)', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.tools).not.toContain('Task');
+		});
+
+		it('uses inherit model', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.model).toBe('inherit');
+		});
+
+		it('has a non-empty description', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.description).toBeTruthy();
+			expect(def.description.length).toBeGreaterThan(10);
+		});
+
+		it('prompt requires ---EXPLORE_RESULT--- structured output block', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.prompt).toContain('---EXPLORE_RESULT---');
+			expect(def.prompt).toContain('---END_EXPLORE_RESULT---');
+		});
+
+		it('prompt includes relevant_files, patterns, dependencies, architecture_notes, findings fields', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.prompt).toContain('relevant_files');
+			expect(def.prompt).toContain('patterns');
+			expect(def.prompt).toContain('dependencies');
+			expect(def.prompt).toContain('architecture_notes');
+			expect(def.prompt).toContain('findings');
+		});
+
+		it('prompt explicitly forbids file modifications', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.prompt).toContain('Read-only');
+			expect(def.prompt).toContain('MUST NOT');
+		});
+
+		it('prompt explicitly forbids spawning sub-agents', () => {
+			const def = buildCoderExplorerAgentDef();
+			expect(def.prompt).toContain('No sub-agents');
+			expect(def.prompt).toContain('MUST NOT spawn');
 		});
 	});
 


### PR DESCRIPTION
Add `buildCoderExplorerAgentDef()` to `coder-agent.ts` — a read-only codebase exploration sub-agent that the Coder can spawn to gather structured findings before implementing complex changes.

- Tools: `Read`, `Grep`, `Glob`, `Bash` (no Write/Edit/Task)
- Model: `inherit` (uses parent coder's model)
- Prompt enforces read-only access, forbids sub-agent spawning, returns structured `---EXPLORE_RESULT---` block
- Unit tests cover all acceptance criteria (tools, model, prompt constraints, output format)