### PR TITLE
feat(planner): add planner-explorer and planner-fact-checker sub-agent definitions

### DIFF
--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -120,6 +120,102 @@ export function toPlanSlug(goalTitle: string): string {
 }
 
 /**
+ * Build the AgentDefinition for the planner-explorer sub-agent.
+ *
+ * Read-only codebase exploration agent — explores the codebase areas relevant to the goal
+ * and returns structured findings. No write tools, no web tools, no sub-agent spawning.
+ */
+export function buildPlannerExplorerAgentDef(): AgentDefinition {
+	return {
+		description:
+			'Read-only codebase exploration agent. Explores relevant files, patterns, and dependencies, ' +
+			'then returns structured findings for the plan-writer to use.',
+		tools: ['Read', 'Grep', 'Glob', 'Bash'],
+		model: 'inherit',
+		prompt: `You are a Codebase Explorer sub-agent. Your sole job is to explore the codebase areas relevant to the given goal and return structured findings.
+
+## Instructions
+
+1. Use Read, Grep, Glob, and Bash (read-only commands only) to explore relevant parts of the codebase.
+2. Focus on: file paths, code patterns, existing implementations, dependencies, architecture, and complexity.
+3. Do NOT write, edit, or delete any files.
+4. Do NOT spawn further sub-agents.
+5. Do NOT implement anything — only explore and report.
+
+## Required Output Format
+
+End your response with an \`---EXPLORER_FINDINGS---\` block exactly as shown:
+
+\`\`\`
+---EXPLORER_FINDINGS---
+## Relevant Files
+<list of file paths with brief description of each>
+
+## Patterns Found
+<existing code patterns, conventions, and architectural patterns observed>
+
+## Dependencies
+<external packages, internal modules, and cross-package dependencies relevant to the goal>
+
+## Estimated Complexity
+<assessment: low / medium / high, with brief justification>
+
+## Key Concerns
+<potential blockers, gotchas, breaking changes, or areas that need careful attention>
+---END_EXPLORER_FINDINGS---
+\`\`\``,
+	};
+}
+
+/**
+ * Build the AgentDefinition for the planner-fact-checker sub-agent.
+ *
+ * Web-based validation agent — receives explorer findings and validates assumptions
+ * about external technologies, API versions, library patterns, and flags stale information.
+ * Has only WebSearch/WebFetch — no codebase tools, no sub-agent spawning.
+ */
+export function buildPlannerFactCheckerAgentDef(): AgentDefinition {
+	return {
+		description:
+			'Web research and validation agent. Receives explorer findings and validates assumptions ' +
+			'about external technologies, API versions, and library patterns against current documentation.',
+		tools: ['WebSearch', 'WebFetch'],
+		model: 'inherit',
+		prompt: `You are a Fact-Checker sub-agent. You receive codebase explorer findings and validate assumptions about external technologies, APIs, and libraries using web search and documentation.
+
+## Instructions
+
+1. Review the explorer findings provided in the prompt.
+2. Use WebSearch to look up current documentation, changelogs, and best practices for any external technologies mentioned.
+3. Use WebFetch to retrieve specific documentation pages or release notes when a URL is known.
+4. Focus on: API version compatibility, deprecated patterns, breaking changes since the codebase was last updated, and recommended current patterns.
+5. Do NOT read any local files — that is the explorer's responsibility.
+6. Do NOT spawn further sub-agents.
+7. Only search for things that require up-to-date external knowledge — skip general patterns you already know.
+
+## Required Output Format
+
+End your response with a \`---FACT_CHECK_RESULT---\` block exactly as shown:
+
+\`\`\`
+---FACT_CHECK_RESULT---
+## Validated Assumptions
+<list of assumptions from explorer findings that are confirmed correct>
+
+## Flagged Issues
+<list of issues found: stale API patterns, deprecated methods, version mismatches, breaking changes>
+
+## Recommended Versions/Patterns
+<current recommended versions or patterns for libraries/APIs mentioned in the findings>
+
+## Corrections to Explorer Findings
+<any specific corrections or updates to the explorer's findings based on current docs>
+---END_FACT_CHECK_RESULT---
+\`\`\``,
+	};
+}
+
+/**
  * Build the system prompt for the Plan Writer sub-agent.
  *
  * The plan-writer handles all Phase 1 work: codebase exploration, scope assessment,

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
+	buildPlannerExplorerAgentDef,
+	buildPlannerFactCheckerAgentDef,
 	buildPlannerSystemPrompt,
 	buildPlannerTaskMessage,
 	buildPlanWriterAgentDef,
@@ -495,6 +497,145 @@ describe('planner-agent', () => {
 			};
 			const msg = buildPlannerTaskMessage({ ...baseConfig, replanContext: rc });
 			expect(msg).toContain('Attempt 3');
+		});
+	});
+
+	describe('buildPlannerExplorerAgentDef', () => {
+		it('returns a valid AgentDefinition', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def).toBeDefined();
+			expect(def.tools).toBeDefined();
+			expect(def.model).toBeDefined();
+			expect(def.prompt).toBeDefined();
+		});
+
+		it('has only read-only codebase tools', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.tools).toContain('Read');
+			expect(def.tools).toContain('Grep');
+			expect(def.tools).toContain('Glob');
+			expect(def.tools).toContain('Bash');
+		});
+
+		it('does NOT have write or edit tools', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.tools).not.toContain('Write');
+			expect(def.tools).not.toContain('Edit');
+		});
+
+		it('does NOT have sub-agent spawning tools', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.tools).not.toContain('Task');
+			expect(def.tools).not.toContain('TaskOutput');
+			expect(def.tools).not.toContain('TaskStop');
+		});
+
+		it('does NOT have web tools', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.tools).not.toContain('WebSearch');
+			expect(def.tools).not.toContain('WebFetch');
+		});
+
+		it('uses inherit model', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.model).toBe('inherit');
+		});
+
+		it('prompt instructs to return ---EXPLORER_FINDINGS--- block', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.prompt).toContain('---EXPLORER_FINDINGS---');
+			expect(def.prompt).toContain('---END_EXPLORER_FINDINGS---');
+		});
+
+		it('prompt includes all required sections in findings block', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.prompt).toContain('Relevant Files');
+			expect(def.prompt).toContain('Patterns Found');
+			expect(def.prompt).toContain('Dependencies');
+			expect(def.prompt).toContain('Estimated Complexity');
+			expect(def.prompt).toContain('Key Concerns');
+		});
+
+		it('prompt instructs not to write or edit files', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.prompt).toContain('Do NOT write');
+		});
+
+		it('prompt instructs not to spawn sub-agents', () => {
+			const def = buildPlannerExplorerAgentDef();
+			expect(def.prompt).toContain('Do NOT spawn');
+		});
+	});
+
+	describe('buildPlannerFactCheckerAgentDef', () => {
+		it('returns a valid AgentDefinition', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def).toBeDefined();
+			expect(def.tools).toBeDefined();
+			expect(def.model).toBeDefined();
+			expect(def.prompt).toBeDefined();
+		});
+
+		it('has only web tools', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.tools).toContain('WebSearch');
+			expect(def.tools).toContain('WebFetch');
+			expect(def.tools).toHaveLength(2);
+		});
+
+		it('does NOT have codebase tools', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Read');
+			expect(def.tools).not.toContain('Grep');
+			expect(def.tools).not.toContain('Glob');
+			expect(def.tools).not.toContain('Bash');
+		});
+
+		it('does NOT have write or edit tools', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Write');
+			expect(def.tools).not.toContain('Edit');
+		});
+
+		it('does NOT have sub-agent spawning tools', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Task');
+			expect(def.tools).not.toContain('TaskOutput');
+			expect(def.tools).not.toContain('TaskStop');
+		});
+
+		it('uses inherit model', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.model).toBe('inherit');
+		});
+
+		it('prompt instructs to return ---FACT_CHECK_RESULT--- block', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.prompt).toContain('---FACT_CHECK_RESULT---');
+			expect(def.prompt).toContain('---END_FACT_CHECK_RESULT---');
+		});
+
+		it('prompt includes all required sections in fact-check block', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.prompt).toContain('Validated Assumptions');
+			expect(def.prompt).toContain('Flagged Issues');
+			expect(def.prompt).toContain('Recommended Versions/Patterns');
+			expect(def.prompt).toContain('Corrections to Explorer Findings');
+		});
+
+		it('prompt instructs not to read local files', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.prompt).toContain('Do NOT read any local files');
+		});
+
+		it('prompt instructs not to spawn sub-agents', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.prompt).toContain('Do NOT spawn');
+		});
+
+		it('prompt instructs to use explorer findings as input', () => {
+			const def = buildPlannerFactCheckerAgentDef();
+			expect(def.prompt).toContain('explorer findings');
 		});
 	});
 


### PR DESCRIPTION
Add two new `AgentDefinition` builder functions to `planner-agent.ts` as part of the 3-phase planner pipeline:

- `buildPlannerExplorerAgentDef()` — read-only codebase exploration with `Read/Grep/Glob/Bash`, returns structured `---EXPLORER_FINDINGS---` block covering relevant files, patterns, dependencies, complexity, and key concerns
- `buildPlannerFactCheckerAgentDef()` — web-only validation with `WebSearch/WebFetch`, receives explorer findings and returns `---FACT_CHECK_RESULT---` block with validated assumptions, flagged issues, and recommended patterns

Neither has `Task/Write/Edit` tools. The fact-checker has no codebase tools; the explorer has no web tools. Both use `inherit` model. Both are exported for test access.

82 unit tests pass covering all acceptance criteria.