### PR TITLE
fix(planner): remove broken Explore sub-agent instruction from plan-writer

### DIFF
--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -4,8 +4,8 @@
  * Creates AgentSessionInit for Planner sessions that break goals into tasks.
  *
  * The Planner agent orchestrates two phases:
- * 1. Plan phase: Spawns the plan-writer sub-agent to explore the codebase and produce
- *    plan document(s) on a feature branch/PR.
+ * 1. Plan phase: Spawns the plan-writer sub-agent to explore the codebase, assess scope,
+ *    and produce plan document(s) on a feature branch/PR.
  * 2. Task creation phase: After human approval, merges the PR and creates tasks.
  *
  * The plan-writer sub-agent handles scope assessment and file structure:
@@ -122,9 +122,9 @@ export function toPlanSlug(goalTitle: string): string {
 /**
  * Build the system prompt for the Plan Writer sub-agent.
  *
- * The plan-writer receives pre-gathered explorer findings and fact-checker results
- * as context in its task prompt (passed by the Planner). It uses Read/Grep/Glob/Bash
- * for its own verification during writing, but does NOT spawn sub-agents.
+ * The plan-writer explores the codebase using its own tools (Read/Grep/Glob/Bash),
+ * assesses scope, and produces plan documents. It does NOT spawn further sub-agents
+ * (it is itself a sub-agent and cannot nest further).
  *
  * For large-scope goals it uses an iterative two-pass approach:
  * - Pass 1: Create 00-overview.md with milestones list
@@ -138,15 +138,11 @@ export function toPlanSlug(goalTitle: string): string {
 export function buildPlanWriterPrompt(): string {
 	return `You are a Plan Writer Agent spawned by the Planner to produce a structured plan for a goal.
 
-## Context
-
-The Planner has already run an Explorer sub-agent and a Fact-Checker sub-agent before spawning you. Their findings are provided in your task prompt as pre-gathered context. Use this context as your foundation — do NOT attempt to spawn further sub-agents (you cannot; you are already a sub-agent).
-
-During writing, use your own tools (Read, Grep, Glob, Bash) to verify findings, read specific files, and fill in gaps. Use WebSearch/WebFetch for targeted lookups when external, up-to-date information would improve plan accuracy.
+Your task prompt contains the goal title, description, and any room context provided by the Planner. Use your own tools (Read, Grep, Glob, Bash) to explore the codebase directly — do NOT attempt to spawn further sub-agents (you cannot; you are already a sub-agent).
 
 ## Pre-Work: Git Sync (MANDATORY)
 
-Before writing, sync with the default branch — run all three lines as a **single bash invocation**:
+Before exploring, sync with the default branch — run all three lines as a **single bash invocation**:
 \`\`\`bash
 DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
 [ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
@@ -154,9 +150,9 @@ git fetch origin && git rebase origin/$DEFAULT_BRANCH
 \`\`\`
 **If the rebase fails with conflicts, stop immediately and report the error** — do NOT plan against a stale codebase.
 
-## Step 1: Verify Explorer Findings
+## Step 1: Codebase Exploration
 
-Review the explorer and fact-checker context provided in your task prompt. Use Read/Grep/Glob/Bash to verify key claims, read referenced files, and confirm file paths exist. Fill in any gaps the Explorer missed. Use WebSearch/WebFetch only for targeted external lookups (API versions, breaking changes, community best practices) — not for general patterns you already know.
+Explore the codebase using Read, Grep, Glob, and Bash to understand existing patterns, affected areas, and dependencies. Focus on areas relevant to the goal. Use WebSearch/WebFetch for targeted external lookups (API versions, breaking changes, community best practices) when external, up-to-date information would improve plan accuracy — not for general patterns you already know.
 
 ## Step 2: Scope Assessment
 
@@ -230,9 +226,8 @@ export function buildPlanWriterAgentDef(planSlug: string): AgentDefinition {
 
 	return {
 		description:
-			'Plan writer that receives pre-gathered explorer and fact-checker context, verifies findings, ' +
-			'and produces structured plan documents. Supports single-file plans for small goals and ' +
-			'multi-file iterative plans for large-scope goals.',
+			'Plan writer that explores the codebase using its own tools and produces structured plan documents. ' +
+			'Supports single-file plans for small goals and multi-file iterative plans for large-scope goals.',
 		tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'],
 		model: 'inherit',
 		prompt,

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -122,8 +122,9 @@ export function toPlanSlug(goalTitle: string): string {
 /**
  * Build the system prompt for the Plan Writer sub-agent.
  *
- * The plan-writer handles all Phase 1 work: codebase exploration, scope assessment,
- * plan document creation (single file or multi-file), branch/commit/PR.
+ * The plan-writer receives pre-gathered explorer findings and fact-checker results
+ * as context in its task prompt (passed by the Planner). It uses Read/Grep/Glob/Bash
+ * for its own verification during writing, but does NOT spawn sub-agents.
  *
  * For large-scope goals it uses an iterative two-pass approach:
  * - Pass 1: Create 00-overview.md with milestones list
@@ -137,9 +138,15 @@ export function toPlanSlug(goalTitle: string): string {
 export function buildPlanWriterPrompt(): string {
 	return `You are a Plan Writer Agent spawned by the Planner to produce a structured plan for a goal.
 
+## Context
+
+The Planner has already run an Explorer sub-agent and a Fact-Checker sub-agent before spawning you. Their findings are provided in your task prompt as pre-gathered context. Use this context as your foundation — do NOT attempt to spawn further sub-agents (you cannot; you are already a sub-agent).
+
+During writing, use your own tools (Read, Grep, Glob, Bash) to verify findings, read specific files, and fill in gaps. Use WebSearch/WebFetch for targeted lookups when external, up-to-date information would improve plan accuracy.
+
 ## Pre-Work: Git Sync (MANDATORY)
 
-Before exploring, sync with the default branch — run all three lines as a **single bash invocation**:
+Before writing, sync with the default branch — run all three lines as a **single bash invocation**:
 \`\`\`bash
 DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
 [ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
@@ -147,21 +154,9 @@ git fetch origin && git rebase origin/$DEFAULT_BRANCH
 \`\`\`
 **If the rebase fails with conflicts, stop immediately and report the error** — do NOT plan against a stale codebase.
 
-## Step 1: Codebase Exploration
+## Step 1: Verify Explorer Findings
 
-Explore the codebase using Explore sub-agents (each has its own context window):
-\`\`\`
-Task(subagent_type: "Explore", prompt: "Explore [area]. I need: [questions]. Return key findings, file paths, patterns.")
-\`\`\`
-Spawn multiple Explore agents **in parallel** to cover different areas. Gather enough context to understand existing patterns, affected areas, dependencies, and overall complexity.
-
-## Optional: Web Research
-
-When the goal involves integrating external technologies, APIs, or libraries that may have recent changes (e.g., after your knowledge cutoff), use \`WebSearch\` to look up current documentation or changelog entries before planning.
-
-- Use \`WebSearch\` for: finding latest API patterns, library versions, breaking changes, or community best practices.
-- Use \`WebFetch\` for: fetching a specific documentation page or GitHub release notes by URL.
-- Do NOT search for general coding patterns you already know — only search when external, up-to-date information would improve plan accuracy.
+Review the explorer and fact-checker context provided in your task prompt. Use Read/Grep/Glob/Bash to verify key claims, read referenced files, and confirm file paths exist. Fill in any gaps the Explorer missed. Use WebSearch/WebFetch only for targeted external lookups (API versions, breaking changes, community best practices) — not for general patterns you already know.
 
 ## Step 2: Scope Assessment
 
@@ -235,21 +230,10 @@ export function buildPlanWriterAgentDef(planSlug: string): AgentDefinition {
 
 	return {
 		description:
-			'Plan writer that explores the codebase and produces structured plan documents. ' +
-			'Supports single-file plans for small goals and multi-file iterative plans for large-scope goals.',
-		tools: [
-			'Task',
-			'TaskOutput',
-			'TaskStop',
-			'Read',
-			'Write',
-			'Edit',
-			'Bash',
-			'Grep',
-			'Glob',
-			'WebFetch',
-			'WebSearch',
-		],
+			'Plan writer that receives pre-gathered explorer and fact-checker context, verifies findings, ' +
+			'and produces structured plan documents. Supports single-file plans for small goals and ' +
+			'multi-file iterative plans for large-scope goals.',
+		tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'],
 		model: 'inherit',
 		prompt,
 	};

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -195,17 +195,17 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('rebase fails with conflicts, stop immediately');
 		});
 
-		it('should explain that explorer/fact-checker context is provided as input', () => {
+		it('should instruct to explore using own tools, not spawn sub-agents', () => {
 			const prompt = buildPlanWriterPrompt();
-			expect(prompt).toContain('Explorer sub-agent');
-			expect(prompt).toContain('Fact-Checker sub-agent');
 			expect(prompt).toContain('do NOT attempt to spawn further sub-agents');
+			expect(prompt).not.toContain('Task(subagent_type:');
+			expect(prompt).not.toContain('subagent_type: "Explore"');
 		});
 
-		it('should instruct to verify findings using own tools', () => {
+		it('should describe codebase exploration using Read/Grep/Glob/Bash', () => {
 			const prompt = buildPlanWriterPrompt();
-			expect(prompt).toContain('Read/Grep/Glob/Bash');
-			expect(prompt).toContain('verify');
+			expect(prompt).toContain('Read, Grep, Glob, and Bash');
+			expect(prompt).toContain('Step 1: Codebase Exploration');
 		});
 
 		it('should define small vs large scope thresholds', () => {
@@ -267,13 +267,13 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('WebFetch');
 		});
 
-		it('should position verification step before scope assessment', () => {
+		it('should position codebase exploration step before scope assessment', () => {
 			const prompt = buildPlanWriterPrompt();
-			const verifyIdx = prompt.indexOf('Step 1: Verify Explorer Findings');
+			const exploreIdx = prompt.indexOf('Step 1: Codebase Exploration');
 			const scopeIdx = prompt.indexOf('Step 2: Scope Assessment');
-			expect(verifyIdx).toBeGreaterThanOrEqual(0);
+			expect(exploreIdx).toBeGreaterThanOrEqual(0);
 			expect(scopeIdx).toBeGreaterThanOrEqual(0);
-			expect(verifyIdx).toBeLessThan(scopeIdx);
+			expect(exploreIdx).toBeLessThan(scopeIdx);
 		});
 
 		it('should clarify when NOT to use web search for general patterns', () => {

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -195,15 +195,17 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('rebase fails with conflicts, stop immediately');
 		});
 
-		it('should include Explore sub-agent guidance for codebase exploration', () => {
+		it('should explain that explorer/fact-checker context is provided as input', () => {
 			const prompt = buildPlanWriterPrompt();
-			expect(prompt).toContain('Explore');
-			expect(prompt).toContain('subagent_type');
+			expect(prompt).toContain('Explorer sub-agent');
+			expect(prompt).toContain('Fact-Checker sub-agent');
+			expect(prompt).toContain('do NOT attempt to spawn further sub-agents');
 		});
 
-		it('should recommend spawning multiple Explore agents in parallel', () => {
+		it('should instruct to verify findings using own tools', () => {
 			const prompt = buildPlanWriterPrompt();
-			expect(prompt).toContain('parallel');
+			expect(prompt).toContain('Read/Grep/Glob/Bash');
+			expect(prompt).toContain('verify');
 		});
 
 		it('should define small vs large scope thresholds', () => {
@@ -259,28 +261,24 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('git checkout -b plan/<plan_slug>');
 		});
 
-		it('should include optional web research section', () => {
+		it('should include web research guidance (WebSearch/WebFetch) for verification', () => {
 			const prompt = buildPlanWriterPrompt();
-			expect(prompt).toContain('Optional: Web Research');
 			expect(prompt).toContain('WebSearch');
 			expect(prompt).toContain('WebFetch');
 		});
 
-		it('should position web research section after codebase exploration and before scope assessment', () => {
+		it('should position verification step before scope assessment', () => {
 			const prompt = buildPlanWriterPrompt();
-			const explorationIdx = prompt.indexOf('Step 1: Codebase Exploration');
-			const webResearchIdx = prompt.indexOf('Optional: Web Research');
+			const verifyIdx = prompt.indexOf('Step 1: Verify Explorer Findings');
 			const scopeIdx = prompt.indexOf('Step 2: Scope Assessment');
-			expect(explorationIdx).toBeGreaterThanOrEqual(0);
-			expect(webResearchIdx).toBeGreaterThanOrEqual(0);
+			expect(verifyIdx).toBeGreaterThanOrEqual(0);
 			expect(scopeIdx).toBeGreaterThanOrEqual(0);
-			expect(explorationIdx).toBeLessThan(webResearchIdx);
-			expect(webResearchIdx).toBeLessThan(scopeIdx);
+			expect(verifyIdx).toBeLessThan(scopeIdx);
 		});
 
-		it('should clarify when NOT to use web search', () => {
+		it('should clarify when NOT to use web search for general patterns', () => {
 			const prompt = buildPlanWriterPrompt();
-			expect(prompt).toContain('Do NOT search');
+			expect(prompt).toContain('not for general patterns you already know');
 		});
 	});
 
@@ -299,11 +297,11 @@ describe('planner-agent', () => {
 			expect(def.prompt).not.toContain('<plan_slug>');
 		});
 
-		it('has Task tool for spawning Explore sub-agents', () => {
+		it('does NOT have Task/TaskOutput/TaskStop tools (cannot spawn sub-agents)', () => {
 			const def = buildPlanWriterAgentDef('my-goal');
-			expect(def.tools).toContain('Task');
-			expect(def.tools).toContain('TaskOutput');
-			expect(def.tools).toContain('TaskStop');
+			expect(def.tools).not.toContain('Task');
+			expect(def.tools).not.toContain('TaskOutput');
+			expect(def.tools).not.toContain('TaskStop');
 		});
 
 		it('has standard codebase tools', () => {
@@ -511,10 +509,12 @@ describe('planner-agent', () => {
 			expect(init.agents).toHaveProperty('plan-writer');
 		});
 
-		it('plan-writer agent has Task tool for spawning Explore sub-agents', () => {
+		it('plan-writer agent does NOT have Task tool (cannot spawn sub-agents)', () => {
 			const init = createPlannerAgentInit(sharedBaseConfig);
 			const planWriter = init.agents?.['plan-writer'];
-			expect(planWriter?.tools).toContain('Task');
+			expect(planWriter?.tools).not.toContain('Task');
+			expect(planWriter?.tools).not.toContain('TaskOutput');
+			expect(planWriter?.tools).not.toContain('TaskStop');
 		});
 
 		it('plan-writer agent uses inherit model', () => {


### PR DESCRIPTION
Remove broken `Task(subagent_type: "Explore", ...)` instruction from the plan-writer prompt and `Task`/`TaskOutput`/`TaskStop` from its tools list. The plan-writer is a sub-agent and cannot spawn further sub-agents.

- Replaces the "Step 1: Codebase Exploration" section with a "Context" section explaining that explorer and fact-checker findings are passed in as input
- Adds a "Step 1: Verify Explorer Findings" section instructing the plan-writer to use Read/Grep/Glob/Bash to verify the provided context
- Keeps WebSearch/WebFetch for targeted external lookups
- Updates tests to assert Task/TaskOutput/TaskStop are NOT present (opposite of the broken assertion)