### PR TITLE
feat(room): add built-in sub-agent definitions for leader and reviewers

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -761,6 +761,177 @@ export function toAgentModel(modelId: string): AgentDefinition['model'] {
 	return 'sonnet';
 }
 
+// ---------------------------------------------------------------------------
+// Built-in sub-agent definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Built-in explorer sub-agent for leader analysis.
+ * Performs read-only codebase exploration delegated by the leader.
+ * No Task tools — one level max.
+ */
+export function buildLeaderExplorerAgentDef(): AgentDefinition {
+	return {
+		description:
+			'Read-only codebase explorer for leader analysis. Explores files, searches patterns, and returns structured findings to keep the main leader context clean.',
+		tools: ['Read', 'Grep', 'Glob', 'Bash'],
+		model: 'inherit',
+		prompt: `You are a Leader Explorer Agent. Your job is to perform read-only codebase analysis tasks delegated by the main Leader Agent.
+
+## Rules
+
+1. **Read-only** — do NOT modify, create, or delete files
+2. **No sub-agents** — do not spawn further sub-agents (no Task tool)
+3. **Return structured findings** — always end with the structured block below
+
+## What You Do
+
+- Explore files, search for patterns, understand code structure
+- Identify relevant code areas, dependencies, callers, callees
+- Summarize findings concisely for the leader to use in decision-making
+
+## Required Output Format
+
+End your response with this structured block:
+
+---ANALYSIS_RESULT---
+status: success | partial | failed
+summary: <1-3 sentence description of findings>
+details: <key findings, file paths, patterns found>
+---END_ANALYSIS_RESULT---
+`,
+	};
+}
+
+/**
+ * Built-in fact-checker sub-agent for leader decisions.
+ * Uses web search to validate technical decisions and check API docs.
+ * No Task tools — one level max.
+ */
+export function buildLeaderFactCheckerAgentDef(): AgentDefinition {
+	return {
+		description:
+			'Web-based fact-checker for leader decisions. Validates technical choices against current docs and best practices using WebSearch and WebFetch.',
+		tools: ['WebSearch', 'WebFetch'],
+		model: 'inherit',
+		prompt: `You are a Leader Fact-Checker Agent. Your job is to validate technical decisions by checking current documentation, API references, and best practices.
+
+## Rules
+
+1. **Web-only** — use WebSearch and WebFetch; do NOT read local files (codebase access is the explorer's responsibility)
+2. **No sub-agents** — do not spawn further sub-agents (no Task tool)
+3. **Return structured findings** — always end with the structured block below
+
+## What You Do
+
+- Verify API usage against the latest official documentation
+- Check that libraries and patterns follow current best practices
+- Flag deprecated APIs, breaking changes, or outdated approaches
+- Validate technical assumptions made in the plan or implementation
+
+## Required Output Format
+
+End your response with this structured block:
+
+---ANALYSIS_RESULT---
+status: success | partial | failed
+summary: <1-3 sentence description of findings>
+verified: <what was confirmed as correct>
+concerns: <deprecated patterns, outdated APIs, or best practice violations found>
+---END_ANALYSIS_RESULT---
+`,
+	};
+}
+
+/**
+ * Built-in explorer sub-agent for reviewer agents.
+ * Explores the codebase around changed files to provide full context before review.
+ * No Task tools — one level max.
+ */
+export function buildReviewerExplorerAgentDef(): AgentDefinition {
+	return {
+		description:
+			'Read-only codebase explorer for code review context. Explores callers, callees, related tests, and architectural patterns around changed files.',
+		tools: ['Read', 'Grep', 'Glob', 'Bash'],
+		model: 'inherit',
+		prompt: `You are a Reviewer Explorer Agent. Your job is to explore the codebase around changed files to give the reviewer full context before they evaluate the changes.
+
+## Rules
+
+1. **Read-only** — do NOT modify, create, or delete files
+2. **No sub-agents** — do not spawn further sub-agents (no Task tool)
+3. **Return structured findings** — always end with the structured block below
+
+## What You Do
+
+Given a set of changed files or a PR number, explore:
+- **Callers**: Who calls the changed functions/methods?
+- **Callees**: What does the changed code depend on?
+- **Related tests**: What tests cover the changed areas?
+- **Architectural patterns**: How does this change fit the existing patterns?
+- **Integration points**: How do the changes interact with surrounding code?
+
+Use Read, Grep, Glob, and Bash (e.g., \`git diff\`, \`git log\`) to gather this context.
+
+## Required Output Format
+
+End your response with this structured block:
+
+---CONTEXT_FINDINGS---
+changed_files: <list of key changed files>
+callers: <who calls the changed code>
+callees: <what the changed code depends on>
+tests: <related test files and coverage gaps>
+patterns: <architectural patterns observed>
+risks: <potential integration issues or side effects>
+---END_CONTEXT_FINDINGS---
+`,
+	};
+}
+
+/**
+ * Built-in fact-checker sub-agent for reviewer agents.
+ * Validates implementation against current best practices and API documentation.
+ * No Task tools — one level max.
+ */
+export function buildReviewerFactCheckerAgentDef(): AgentDefinition {
+	return {
+		description:
+			'Web-based fact-checker for code review. Verifies implementation follows current best practices and checks API usage against the latest documentation.',
+		tools: ['WebSearch', 'WebFetch'],
+		model: 'inherit',
+		prompt: `You are a Reviewer Fact-Checker Agent. Your job is to validate the implementation by checking current best practices, API documentation, and known pitfalls.
+
+## Rules
+
+1. **Web-only** — use WebSearch and WebFetch; do NOT read local files (codebase exploration is the explorer's responsibility)
+2. **No sub-agents** — do not spawn further sub-agents (no Task tool)
+3. **Return structured findings** — always end with the structured block below
+
+## What You Do
+
+Given a description of what was implemented, validate:
+- **API correctness**: Is the API used as documented? Any deprecated methods?
+- **Best practices**: Does the implementation follow current community standards?
+- **Security**: Are there known security pitfalls for this pattern?
+- **Version compatibility**: Are the APIs compatible with the versions in use?
+- **Known bugs**: Are there reported bugs or gotchas for this library version?
+
+## Required Output Format
+
+End your response with this structured block:
+
+---FACT_CHECK_RESULT---
+status: pass | warn | fail
+summary: <1-3 sentence description of findings>
+verified: <what was confirmed as correct and up-to-date>
+warnings: <deprecated patterns, version mismatches, or best practice deviations>
+blockers: <security issues or API misuse that must be fixed>
+---END_FACT_CHECK_RESULT---
+`,
+	};
+}
+
 /** Restricted tools for reviewer sub-agents (read-only + gh CLI) */
 const REVIEWER_TOOLS: AgentDefinition['tools'] = [
 	'Read',

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'bun:test';
 import {
+	buildLeaderExplorerAgentDef,
+	buildLeaderFactCheckerAgentDef,
 	buildLeaderHelperAgents,
 	buildLeaderSystemPrompt,
 	buildLeaderTaskContext,
 	buildReviewerAgents,
+	buildReviewerExplorerAgentDef,
+	buildReviewerFactCheckerAgentDef,
 	createLeaderAgentInit,
 	createLeaderToolHandlers,
 	getLeaderHelperSubagents,
@@ -1458,6 +1462,242 @@ describe('Leader Helper Sub-Agents', () => {
 			expect(prompt).toContain('Available Specialists');
 			expect(prompt).toContain('reviewer-haiku');
 			expect(prompt).toContain('leader-helper-sonnet');
+		});
+	});
+
+	describe('buildLeaderExplorerAgentDef', () => {
+		it('should return a valid AgentDefinition', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def).toBeDefined();
+			expect(def.tools).toBeDefined();
+			expect(def.model).toBeDefined();
+			expect(def.prompt).toBeDefined();
+		});
+
+		it('should use inherit model', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def.model).toBe('inherit');
+		});
+
+		it('should have read-only exploration tools', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def.tools).toContain('Read');
+			expect(def.tools).toContain('Grep');
+			expect(def.tools).toContain('Glob');
+			expect(def.tools).toContain('Bash');
+		});
+
+		it('should NOT have Task tools', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def.tools).not.toContain('Task');
+			expect(def.tools).not.toContain('TaskOutput');
+			expect(def.tools).not.toContain('TaskStop');
+		});
+
+		it('should NOT have Write/Edit tools', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def.tools).not.toContain('Write');
+			expect(def.tools).not.toContain('Edit');
+		});
+
+		it('should NOT have web tools', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def.tools).not.toContain('WebSearch');
+			expect(def.tools).not.toContain('WebFetch');
+		});
+
+		it('should include structured ANALYSIS_RESULT output format in prompt', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def.prompt).toContain('---ANALYSIS_RESULT---');
+			expect(def.prompt).toContain('---END_ANALYSIS_RESULT---');
+		});
+
+		it('should instruct not to spawn sub-agents', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def.prompt).toContain('No sub-agents');
+		});
+
+		it('should instruct read-only behavior', () => {
+			const def = buildLeaderExplorerAgentDef();
+			expect(def.prompt).toContain('Read-only');
+		});
+	});
+
+	describe('buildLeaderFactCheckerAgentDef', () => {
+		it('should return a valid AgentDefinition', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def).toBeDefined();
+			expect(def.tools).toBeDefined();
+			expect(def.model).toBeDefined();
+			expect(def.prompt).toBeDefined();
+		});
+
+		it('should use inherit model', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.model).toBe('inherit');
+		});
+
+		it('should have web-only tools', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.tools).toContain('WebSearch');
+			expect(def.tools).toContain('WebFetch');
+		});
+
+		it('should NOT have Task tools', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Task');
+			expect(def.tools).not.toContain('TaskOutput');
+			expect(def.tools).not.toContain('TaskStop');
+		});
+
+		it('should NOT have Write/Edit tools', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Write');
+			expect(def.tools).not.toContain('Edit');
+		});
+
+		it('should NOT have file system tools', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Read');
+			expect(def.tools).not.toContain('Grep');
+			expect(def.tools).not.toContain('Glob');
+			expect(def.tools).not.toContain('Bash');
+		});
+
+		it('should include structured ANALYSIS_RESULT output format in prompt', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.prompt).toContain('---ANALYSIS_RESULT---');
+			expect(def.prompt).toContain('---END_ANALYSIS_RESULT---');
+		});
+
+		it('should instruct not to spawn sub-agents', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.prompt).toContain('No sub-agents');
+		});
+
+		it('should focus on validating technical decisions', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.prompt).toContain('validate');
+		});
+	});
+
+	describe('buildReviewerExplorerAgentDef', () => {
+		it('should return a valid AgentDefinition', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def).toBeDefined();
+			expect(def.tools).toBeDefined();
+			expect(def.model).toBeDefined();
+			expect(def.prompt).toBeDefined();
+		});
+
+		it('should use inherit model', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def.model).toBe('inherit');
+		});
+
+		it('should have read-only exploration tools', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def.tools).toContain('Read');
+			expect(def.tools).toContain('Grep');
+			expect(def.tools).toContain('Glob');
+			expect(def.tools).toContain('Bash');
+		});
+
+		it('should NOT have Task tools', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def.tools).not.toContain('Task');
+			expect(def.tools).not.toContain('TaskOutput');
+			expect(def.tools).not.toContain('TaskStop');
+		});
+
+		it('should NOT have Write/Edit tools', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def.tools).not.toContain('Write');
+			expect(def.tools).not.toContain('Edit');
+		});
+
+		it('should NOT have web tools', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def.tools).not.toContain('WebSearch');
+			expect(def.tools).not.toContain('WebFetch');
+		});
+
+		it('should include CONTEXT_FINDINGS structured output block', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def.prompt).toContain('---CONTEXT_FINDINGS---');
+			expect(def.prompt).toContain('---END_CONTEXT_FINDINGS---');
+		});
+
+		it('should instruct not to spawn sub-agents', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def.prompt).toContain('No sub-agents');
+		});
+
+		it('should focus on callers, callees, tests, and architectural patterns', () => {
+			const def = buildReviewerExplorerAgentDef();
+			expect(def.prompt).toContain('Callers');
+			expect(def.prompt).toContain('Callees');
+			expect(def.prompt).toContain('tests');
+			expect(def.prompt).toContain('patterns');
+		});
+	});
+
+	describe('buildReviewerFactCheckerAgentDef', () => {
+		it('should return a valid AgentDefinition', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def).toBeDefined();
+			expect(def.tools).toBeDefined();
+			expect(def.model).toBeDefined();
+			expect(def.prompt).toBeDefined();
+		});
+
+		it('should use inherit model', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.model).toBe('inherit');
+		});
+
+		it('should have web-only tools', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.tools).toContain('WebSearch');
+			expect(def.tools).toContain('WebFetch');
+		});
+
+		it('should NOT have Task tools', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Task');
+			expect(def.tools).not.toContain('TaskOutput');
+			expect(def.tools).not.toContain('TaskStop');
+		});
+
+		it('should NOT have Write/Edit tools', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Write');
+			expect(def.tools).not.toContain('Edit');
+		});
+
+		it('should NOT have file system tools', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.tools).not.toContain('Read');
+			expect(def.tools).not.toContain('Grep');
+			expect(def.tools).not.toContain('Glob');
+			expect(def.tools).not.toContain('Bash');
+		});
+
+		it('should include FACT_CHECK_RESULT structured output block', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.prompt).toContain('---FACT_CHECK_RESULT---');
+			expect(def.prompt).toContain('---END_FACT_CHECK_RESULT---');
+		});
+
+		it('should instruct not to spawn sub-agents', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.prompt).toContain('No sub-agents');
+		});
+
+		it('should focus on best practices and API documentation validation', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.prompt).toContain('best practices');
+			expect(def.prompt).toContain('deprecated');
 		});
 	});
 });


### PR DESCRIPTION
Add four exported builder functions to `leader-agent.ts` for built-in sub-agents:

- `buildLeaderExplorerAgentDef()` — read-only codebase exploration (Read/Grep/Glob/Bash, model: inherit)
- `buildLeaderFactCheckerAgentDef()` — web-based fact validation (WebSearch/WebFetch, model: inherit)
- `buildReviewerExplorerAgentDef()` — code context exploration for reviewer sub-agents (CONTEXT_FINDINGS output)
- `buildReviewerFactCheckerAgentDef()` — best-practice validation for reviewer sub-agents (FACT_CHECK_RESULT output)

All four return valid `AgentDefinition` objects with `model: 'inherit'` and no Task/Write/Edit tools (one level max).

Adds 36 unit tests covering tools, model, structured output format, and no-sub-agent constraints.