### PR TITLE
fix(skills): skip disabled AppMcpServer entries in getMcpServersFromSkills()

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -73,6 +73,15 @@ export class QueryOptionsBuilder {
 	}
 
 	/**
+	 * Return MCP servers contributed by enabled skills for this session.
+	 * Skips skills that are room-disabled and AppMcpServer entries that are disabled.
+	 * Useful for inspecting effective skill injection without running a full build.
+	 */
+	getSkillMcpServers(): Record<string, McpServerConfig> {
+		return this.getMcpServersFromSkills();
+	}
+
+	/**
 	 * Build complete SDK query options
 	 *
 	 * Maps all SessionConfig (which extends SDKConfig) options to SDK Options

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -850,6 +850,8 @@ CRITICAL RULES:
 			const appServer = this.ctx.appMcpServerRepo.get(skill.config.appMcpServerId);
 			// Skip silently if the referenced app_mcp_servers entry was deleted or no longer exists
 			if (!appServer) continue;
+			// Skip if the AppMcpServer itself is disabled, even if the wrapping skill is enabled
+			if (!appServer.enabled) continue;
 
 			servers[skill.name] = this.appMcpServerToSdkConfig(appServer);
 		}

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -156,6 +156,21 @@ export function setupSessionHandlers(
 		}
 	});
 
+	/**
+	 * Return MCP servers injected from enabled skills for the given session.
+	 * Reflects the AppMcpServer.enabled flag: disabled servers are excluded even
+	 * if the wrapping skill is enabled. Useful for testing and debugging injection.
+	 */
+	messageHub.onRequest('session.getSkillMcpServers', async (data) => {
+		const { sessionId: targetSessionId } = data as { sessionId: string };
+		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
+		if (!agentSession) {
+			throw new Error(`Session not found: ${targetSessionId}`);
+		}
+		const servers = agentSession.optionsBuilder.getSkillMcpServers();
+		return { servers };
+	});
+
 	messageHub.onRequest('session.update', async (data, _ctx) => {
 		const { sessionId: targetSessionId, ...updates } = data as UpdateSessionRequest & {
 			sessionId: string;

--- a/packages/daemon/tests/online/mcp/app-mcp-server-enabled-check.integration.test.ts
+++ b/packages/daemon/tests/online/mcp/app-mcp-server-enabled-check.integration.test.ts
@@ -56,12 +56,14 @@ describe('AppMcpServer.enabled check — skills-based MCP injection', () => {
 
 		// Create a skill referencing the AppMcpServer
 		const skillResult = (await daemon.messageHub.request('skill.create', {
-			name: 'test-echo-skill',
-			displayName: 'Test Echo Skill',
-			description: 'Skill backed by echo server',
-			sourceType: 'mcp_server',
-			config: { type: 'mcp_server', appMcpServerId: serverId },
-			enabled: true,
+			params: {
+				name: 'test-echo-skill',
+				displayName: 'Test Echo Skill',
+				description: 'Skill backed by echo server',
+				sourceType: 'mcp_server',
+				config: { type: 'mcp_server', appMcpServerId: serverId },
+				enabled: true,
+			},
 		})) as { skill: AppSkill };
 		expect(skillResult.skill.enabled).toBe(true);
 
@@ -96,12 +98,14 @@ describe('AppMcpServer.enabled check — skills-based MCP injection', () => {
 
 		// Create + enable skill
 		const skillResult = (await daemon.messageHub.request('skill.create', {
-			name: 'test-echo-skill-2',
-			displayName: 'Test Echo Skill 2',
-			description: 'Skill backed by echo server 2',
-			sourceType: 'mcp_server',
-			config: { type: 'mcp_server', appMcpServerId: serverId },
-			enabled: true,
+			params: {
+				name: 'test-echo-skill-2',
+				displayName: 'Test Echo Skill 2',
+				description: 'Skill backed by echo server 2',
+				sourceType: 'mcp_server',
+				config: { type: 'mcp_server', appMcpServerId: serverId },
+				enabled: true,
+			},
 		})) as { skill: AppSkill };
 		expect(skillResult.skill.enabled).toBe(true);
 
@@ -141,12 +145,14 @@ describe('AppMcpServer.enabled check — skills-based MCP injection', () => {
 
 		// Create + enable skill referencing this server
 		await daemon.messageHub.request('skill.create', {
-			name: 'test-echo-skill-3',
-			displayName: 'Test Echo Skill 3',
-			description: 'Skill backed by echo server 3',
-			sourceType: 'mcp_server',
-			config: { type: 'mcp_server', appMcpServerId: serverId },
-			enabled: true,
+			params: {
+				name: 'test-echo-skill-3',
+				displayName: 'Test Echo Skill 3',
+				description: 'Skill backed by echo server 3',
+				sourceType: 'mcp_server',
+				config: { type: 'mcp_server', appMcpServerId: serverId },
+				enabled: true,
+			},
 		});
 
 		// Create a normal session
@@ -182,12 +188,14 @@ describe('AppMcpServer.enabled check — skills-based MCP injection', () => {
 
 		// Create + enable skill referencing this server
 		await daemon.messageHub.request('skill.create', {
-			name: 'test-echo-skill-4',
-			displayName: 'Test Echo Skill 4',
-			description: 'Skill backed by disabled server',
-			sourceType: 'mcp_server',
-			config: { type: 'mcp_server', appMcpServerId: serverId },
-			enabled: true,
+			params: {
+				name: 'test-echo-skill-4',
+				displayName: 'Test Echo Skill 4',
+				description: 'Skill backed by disabled server',
+				sourceType: 'mcp_server',
+				config: { type: 'mcp_server', appMcpServerId: serverId },
+				enabled: true,
+			},
 		});
 
 		// Disable the AppMcpServer — skill stays enabled

--- a/packages/daemon/tests/online/mcp/app-mcp-server-enabled-check.integration.test.ts
+++ b/packages/daemon/tests/online/mcp/app-mcp-server-enabled-check.integration.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Integration test for AppMcpServer.enabled check in skills-based MCP injection.
+ *
+ * Verifies via the full RPC stack that:
+ * 1. An enabled AppMcpServer + enabled skill → server appears in mcp.registry.list
+ * 2. Disabling the AppMcpServer via mcp.registry.setEnabled removes it from enabled list
+ * 3. A normal session can be created with the skill state intact
+ *
+ * The core injection filtering logic (disabled AppMcpServer skipped even when skill
+ * is enabled) is covered by unit tests in
+ * packages/daemon/tests/unit/agent/query-options-builder.test.ts.
+ *
+ * REQUIREMENTS:
+ * - Requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN (for daemon startup)
+ * - Does NOT make LLM API calls; only tests RPC-level state management
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DaemonServerContext } from '../../helpers/daemon-server';
+import { createDaemonServer } from '../../helpers/daemon-server';
+import type { AppMcpServer } from '@neokai/shared';
+import type { AppSkill } from '@neokai/shared';
+
+const TMP_DIR = process.env.TMPDIR || '/tmp';
+
+describe('AppMcpServer.enabled check — skills-based MCP injection', () => {
+	let daemon: DaemonServerContext;
+	let workspacePath: string;
+
+	beforeEach(async () => {
+		daemon = await createDaemonServer();
+		workspacePath = join(TMP_DIR, `neokai-test-app-mcp-${Date.now()}`);
+		mkdirSync(workspacePath, { recursive: true });
+	}, 30_000);
+
+	afterEach(async () => {
+		if (!daemon) return;
+		daemon.kill('SIGTERM');
+		await daemon.waitForExit();
+	}, 15_000);
+
+	test('enabled AppMcpServer + enabled skill: server appears in registry list as enabled', async () => {
+		// Create an AppMcpServer with enabled=true
+		const createResult = (await daemon.messageHub.request('mcp.registry.create', {
+			name: 'test-echo-server',
+			description: 'Echo server for testing',
+			sourceType: 'stdio',
+			command: 'echo',
+			args: ['hello'],
+			enabled: true,
+		})) as { server: AppMcpServer };
+		expect(createResult.server.enabled).toBe(true);
+		const serverId = createResult.server.id;
+
+		// Create a skill referencing the AppMcpServer
+		const skillResult = (await daemon.messageHub.request('skill.create', {
+			name: 'test-echo-skill',
+			displayName: 'Test Echo Skill',
+			description: 'Skill backed by echo server',
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: serverId },
+			enabled: true,
+		})) as { skill: AppSkill };
+		expect(skillResult.skill.enabled).toBe(true);
+
+		// Verify AppMcpServer appears in registry with enabled=true
+		const listResult = (await daemon.messageHub.request('mcp.registry.list', {})) as {
+			servers: AppMcpServer[];
+		};
+		const server = listResult.servers.find((s) => s.id === serverId);
+		expect(server).toBeDefined();
+		expect(server!.enabled).toBe(true);
+
+		// Verify skill appears as enabled
+		const skillListResult = (await daemon.messageHub.request('skill.list', {})) as {
+			skills: AppSkill[];
+		};
+		const skill = skillListResult.skills.find((s) => s.id === skillResult.skill.id);
+		expect(skill).toBeDefined();
+		expect(skill!.enabled).toBe(true);
+	}, 60_000);
+
+	test('disabling AppMcpServer while skill remains enabled: registry shows server as disabled', async () => {
+		// Create an AppMcpServer with enabled=true
+		const createResult = (await daemon.messageHub.request('mcp.registry.create', {
+			name: 'test-echo-server-2',
+			description: 'Echo server for disable test',
+			sourceType: 'stdio',
+			command: 'echo',
+			args: ['hello'],
+			enabled: true,
+		})) as { server: AppMcpServer };
+		const serverId = createResult.server.id;
+
+		// Create + enable skill
+		const skillResult = (await daemon.messageHub.request('skill.create', {
+			name: 'test-echo-skill-2',
+			displayName: 'Test Echo Skill 2',
+			description: 'Skill backed by echo server 2',
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: serverId },
+			enabled: true,
+		})) as { skill: AppSkill };
+		expect(skillResult.skill.enabled).toBe(true);
+
+		// Disable only the AppMcpServer — skill stays enabled
+		const disableResult = (await daemon.messageHub.request('mcp.registry.setEnabled', {
+			id: serverId,
+			enabled: false,
+		})) as { server: AppMcpServer };
+		expect(disableResult.server.enabled).toBe(false);
+
+		// Skill is still enabled
+		const skillListResult = (await daemon.messageHub.request('skill.list', {})) as {
+			skills: AppSkill[];
+		};
+		const skill = skillListResult.skills.find((s) => s.id === skillResult.skill.id);
+		expect(skill!.enabled).toBe(true);
+
+		// AppMcpServer is now disabled
+		const listResult = (await daemon.messageHub.request('mcp.registry.list', {})) as {
+			servers: AppMcpServer[];
+		};
+		const server = listResult.servers.find((s) => s.id === serverId);
+		expect(server!.enabled).toBe(false);
+	}, 60_000);
+
+	test('normal session creation succeeds with globally-enabled skill + AppMcpServer', async () => {
+		// Create an AppMcpServer with enabled=true
+		const serverResult = (await daemon.messageHub.request('mcp.registry.create', {
+			name: 'test-echo-server-3',
+			description: 'Echo server for session test',
+			sourceType: 'stdio',
+			command: 'echo',
+			args: ['hello'],
+			enabled: true,
+		})) as { server: AppMcpServer };
+		const serverId = serverResult.server.id;
+
+		// Create + enable skill referencing this server
+		await daemon.messageHub.request('skill.create', {
+			name: 'test-echo-skill-3',
+			displayName: 'Test Echo Skill 3',
+			description: 'Skill backed by echo server 3',
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: serverId },
+			enabled: true,
+		});
+
+		// Create a normal session — QueryOptionsBuilder will inject the MCP server
+		const createResult = (await daemon.messageHub.request('session.create', {
+			workspacePath,
+			title: 'App MCP Server Test Session',
+		})) as { sessionId: string };
+		daemon.trackSession(createResult.sessionId);
+
+		// Session creation should succeed
+		expect(createResult.sessionId).toBeString();
+
+		// Verify session is accessible and the skill registry state is correct
+		const skillListResult = (await daemon.messageHub.request('skill.list', {})) as {
+			skills: AppSkill[];
+		};
+		const injectedSkill = skillListResult.skills.find((s) => s.name === 'test-echo-skill-3');
+		expect(injectedSkill).toBeDefined();
+		expect(injectedSkill!.enabled).toBe(true);
+
+		// Verify AppMcpServer is enabled (so QueryOptionsBuilder will include it)
+		const registryResult = (await daemon.messageHub.request('mcp.registry.list', {})) as {
+			servers: AppMcpServer[];
+		};
+		const registryServer = registryResult.servers.find((s) => s.id === serverId);
+		expect(registryServer).toBeDefined();
+		expect(registryServer!.enabled).toBe(true);
+	}, 60_000);
+});

--- a/packages/daemon/tests/online/mcp/app-mcp-server-enabled-check.integration.test.ts
+++ b/packages/daemon/tests/online/mcp/app-mcp-server-enabled-check.integration.test.ts
@@ -127,7 +127,7 @@ describe('AppMcpServer.enabled check — skills-based MCP injection', () => {
 		expect(server!.enabled).toBe(false);
 	}, 60_000);
 
-	test('normal session creation succeeds with globally-enabled skill + AppMcpServer', async () => {
+	test('normal session gets enabled AppMcpServer injected into its skill MCP servers', async () => {
 		// Create an AppMcpServer with enabled=true
 		const serverResult = (await daemon.messageHub.request('mcp.registry.create', {
 			name: 'test-echo-server-3',
@@ -149,30 +149,61 @@ describe('AppMcpServer.enabled check — skills-based MCP injection', () => {
 			enabled: true,
 		});
 
-		// Create a normal session — QueryOptionsBuilder will inject the MCP server
+		// Create a normal session
 		const createResult = (await daemon.messageHub.request('session.create', {
 			workspacePath,
 			title: 'App MCP Server Test Session',
 		})) as { sessionId: string };
 		daemon.trackSession(createResult.sessionId);
-
-		// Session creation should succeed
 		expect(createResult.sessionId).toBeString();
 
-		// Verify session is accessible and the skill registry state is correct
-		const skillListResult = (await daemon.messageHub.request('skill.list', {})) as {
-			skills: AppSkill[];
-		};
-		const injectedSkill = skillListResult.skills.find((s) => s.name === 'test-echo-skill-3');
-		expect(injectedSkill).toBeDefined();
-		expect(injectedSkill!.enabled).toBe(true);
+		// Directly verify that the session's QueryOptionsBuilder includes the MCP server
+		// from the enabled skill + enabled AppMcpServer
+		const skillMcpResult = (await daemon.messageHub.request('session.getSkillMcpServers', {
+			sessionId: createResult.sessionId,
+		})) as { servers: Record<string, unknown> };
+		expect(skillMcpResult.servers['test-echo-skill-3']).toBeDefined();
+		expect((skillMcpResult.servers['test-echo-skill-3'] as { command: string }).command).toBe(
+			'echo'
+		);
+	}, 60_000);
 
-		// Verify AppMcpServer is enabled (so QueryOptionsBuilder will include it)
-		const registryResult = (await daemon.messageHub.request('mcp.registry.list', {})) as {
-			servers: AppMcpServer[];
-		};
-		const registryServer = registryResult.servers.find((s) => s.id === serverId);
-		expect(registryServer).toBeDefined();
-		expect(registryServer!.enabled).toBe(true);
+	test('normal session does not inject disabled AppMcpServer even when skill is enabled', async () => {
+		// Create an AppMcpServer initially enabled, then disable it
+		const serverResult = (await daemon.messageHub.request('mcp.registry.create', {
+			name: 'test-echo-server-4',
+			description: 'Echo server to be disabled',
+			sourceType: 'stdio',
+			command: 'echo',
+			args: ['disabled'],
+			enabled: true,
+		})) as { server: AppMcpServer };
+		const serverId = serverResult.server.id;
+
+		// Create + enable skill referencing this server
+		await daemon.messageHub.request('skill.create', {
+			name: 'test-echo-skill-4',
+			displayName: 'Test Echo Skill 4',
+			description: 'Skill backed by disabled server',
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: serverId },
+			enabled: true,
+		});
+
+		// Disable the AppMcpServer — skill stays enabled
+		await daemon.messageHub.request('mcp.registry.setEnabled', { id: serverId, enabled: false });
+
+		// Create a normal session
+		const createResult = (await daemon.messageHub.request('session.create', {
+			workspacePath,
+			title: 'Disabled App MCP Server Test Session',
+		})) as { sessionId: string };
+		daemon.trackSession(createResult.sessionId);
+
+		// The disabled AppMcpServer must not appear in the session's skill MCP servers
+		const skillMcpResult = (await daemon.messageHub.request('session.getSkillMcpServers', {
+			sessionId: createResult.sessionId,
+		})) as { servers: Record<string, unknown> };
+		expect(skillMcpResult.servers['test-echo-skill-4']).toBeUndefined();
 	}, 60_000);
 });

--- a/packages/daemon/tests/unit/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/agent/query-options-builder.test.ts
@@ -932,6 +932,33 @@ describe('QueryOptionsBuilder', () => {
 			});
 		});
 
+		it('should skip disabled AppMcpServer entries even when the wrapping skill is enabled', async () => {
+			const disabledAppMcpServer = {
+				...mockAppMcpServer,
+				enabled: false,
+			};
+			const mockAppMcpServerRepo = {
+				get: mock(() => disabledAppMcpServer),
+			};
+			const mockSkillsManager = {
+				// Skill itself is enabled (getEnabledSkills returns it)
+				getEnabledSkills: mock(() => [enabledSkills[1]]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../src/lib/skills-manager').SkillsManager,
+				appMcpServerRepo:
+					mockAppMcpServerRepo as unknown as import('../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+			};
+			const builder = new QueryOptionsBuilder(context);
+			const options = await builder.build();
+
+			// Disabled AppMcpServer must not be injected even though the skill is enabled
+			expect(options.mcpServers).toBeUndefined();
+		});
+
 		it('should skip MCP server skills when referenced app_mcp_servers entry is deleted', async () => {
 			const mockAppMcpServerRepo = {
 				get: mock(() => null), // Simulates deleted entry
@@ -1138,9 +1165,12 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.mcpServers?.['web-search-mcp']).toBeUndefined();
 		});
 
-		it('injects web-search-mcp MCP server into session options when skill is enabled', async () => {
+		it('injects web-search-mcp MCP server into session options when skill and AppMcpServer are both enabled', async () => {
 			const skill = skillsManager.listSkills().find((s) => s.name === 'web-search-mcp')!;
 			skillsManager.setSkillEnabled(skill.id, true);
+			// The backing AppMcpServer is created with enabled=false (opt-in); enable it too
+			const braveServer = appMcpServerRepo.getByName('brave-search')!;
+			appMcpServerRepo.update(braveServer.id, { enabled: true });
 
 			const context: QueryOptionsBuilderContext = {
 				session: mockSession,


### PR DESCRIPTION
## Summary

- Add `appServer.enabled` check in `QueryOptionsBuilder.getMcpServersFromSkills()` — disabled `AppMcpServer` entries are no longer injected even when the wrapping `AppSkill` remains enabled
- Update the `web-search-mcp` built-in injection unit test to also enable the backing `AppMcpServer` (which is created with `enabled=false`), since the missing check was masking this requirement
- New unit test: `should skip disabled AppMcpServer entries even when the wrapping skill is enabled`
- New online integration test: verifies the full RPC flow — `mcp.registry.create` → `skill.create` → `mcp.registry.setEnabled` — and confirms a normal session can be created with an enabled skill + AppMcpServer