### PR TITLE
feat(reviewer): add explorer/fact-checker sub-agents to reviewer agents

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -1307,7 +1307,9 @@ export function buildReviewerAgents(
 		'reviewer-explorer': buildReviewerExplorerAgentDef(),
 		'reviewer-fact-checker': buildReviewerFactCheckerAgentDef(),
 	};
-	const usedNames = new Set<string>();
+	// Pre-populate usedNames with reserved sub-agent names so toReviewerName()
+	// never generates a name that overwrites the built-in definitions.
+	const usedNames = new Set<string>(['reviewer-explorer', 'reviewer-fact-checker']);
 	const runtimeModelLabel = leaderModel ?? 'sonnet';
 
 	for (const reviewer of reviewers) {

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -932,7 +932,7 @@ blockers: <security issues or API misuse that must be fixed>
 	};
 }
 
-/** Restricted tools for reviewer sub-agents (read-only + gh CLI) */
+/** Restricted tools for reviewer sub-agents (read-only + gh CLI + sub-agent spawning) */
 const REVIEWER_TOOLS: AgentDefinition['tools'] = [
 	'Read',
 	'Grep',
@@ -940,6 +940,9 @@ const REVIEWER_TOOLS: AgentDefinition['tools'] = [
 	'Bash',
 	'WebFetch',
 	'WebSearch',
+	'Task',
+	'TaskOutput',
+	'TaskStop',
 ];
 
 const REVIEWER_OUTPUT_FORMAT = `
@@ -982,16 +985,38 @@ function buildSdkReviewerPrompt(model: string, provider?: string): string {
 - **Provider:** ${displayProvider}
 You MUST include this identity block at the top of every PR comment you post.
 
+## Sub-Agent Support
+
+You have two specialist sub-agents available via the Task tool. Use them when reviewing non-trivial changes — skip them for straightforward, isolated edits.
+
+- **reviewer-explorer**: Explores callers, callees, related tests, and architectural patterns around changed files. Use it to build full context before evaluating the implementation. Invoke with the list of changed files and the PR description.
+- **reviewer-fact-checker**: Validates implementation against current API documentation, best practices, and known pitfalls. Use it when you are unsure whether an API is used correctly, whether a pattern follows current community standards, or whether there are version-compatibility issues.
+
+**When to use sub-agents:**
+- Non-trivial changes touching multiple files or architectural boundaries → use \`reviewer-explorer\` first
+- Implementation uses external APIs, third-party libraries, or patterns you want to verify → use \`reviewer-fact-checker\`
+- Simple, self-contained changes (single function, obvious correctness) → skip sub-agents
+
+**How to invoke:**
+\`\`\`
+Task: Use reviewer-explorer to explore the context around <changed files>
+Task: Use reviewer-fact-checker to validate that <implementation description> follows current best practices
+\`\`\`
+
+Wait for each sub-agent to complete and incorporate its findings into your review.
+
 ## Review Process
 
 1. Read the task prompt carefully — it describes what was requested and what was implemented
 2. Understand the original ask: what was the goal? What should the final result look like?
-3. Explore the codebase thoroughly (use Read, Grep, Glob to understand the full picture):
+3. For non-trivial changes, spawn \`reviewer-explorer\` to understand the full context (callers, callees, tests, integration points) before reading files yourself
+4. Explore the codebase thoroughly (use Read, Grep, Glob to understand the full picture):
    - Read the changed/new files completely, not just diffs
    - Read surrounding code to understand integration points
    - Check imports, exports, and cross-file dependencies
    - Look at test files to verify coverage
-4. Evaluate the implementation holistically:
+5. If unsure about API correctness or best practices, spawn \`reviewer-fact-checker\` to validate against current documentation
+6. Evaluate the implementation holistically:
    - **Correctness**: Does the code actually achieve the original ask?
    - **Completeness**: Are all aspects of the request addressed? Any missing pieces?
    - **Bugs & edge cases**: Logic errors, off-by-one, null handling, race conditions
@@ -1002,7 +1027,7 @@ You MUST include this identity block at the top of every PR comment you post.
    - **Over-engineering**: Is there unnecessary complexity, dead code, or premature abstraction?
 
    The most critical bugs are often **omissions** — missing error handling, uncovered edge cases, absent validation at system boundaries. Prioritize what's NOT there over what is.
-5. Post your review via the REST API, which returns the review URL directly:
+7. Post your review via the REST API, which returns the review URL directly:
    \`\`\`bash
    # For APPROVE:
    GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/{pr}/reviews \\
@@ -1032,7 +1057,7 @@ You MUST include this identity block at the top of every PR comment you post.
 
    > **Model:** ${model} | **Client:** NeoKai | **Provider:** ${displayProvider}
    \`\`\`
-6. The \`--jq '.html_url'\` output is the review URL — use it in the structured output block below
+8. The \`--jq '.html_url'\` output is the review URL — use it in the structured output block below
 
 ## Guidelines
 
@@ -1156,6 +1181,10 @@ You MUST include this identity block at the top of every PR comment you post.
 5. **ALWAYS run the CLI tool synchronously** — set \`timeout: 600000\` (10 minutes) on the Bash call. Do NOT use \`run_in_background\`. The output will be returned when the command completes. Do NOT poll, sleep, or check for output in separate steps.
 6. If the CLI tool times out or errors, do NOT retry. Do NOT post a GitHub review. Instead, output the structured block with \`recommendation: TIMEOUT\` (or \`ERROR\`), \`url: none\`, and a summary describing what happened. The leader will decide how to proceed.
 
+## Sub-Agent Support
+
+Two specialist sub-agents are available in the agent namespace: \`reviewer-explorer\` (codebase context) and \`reviewer-fact-checker\` (API/best-practice validation). As a relay, you should NOT use these to supplement the CLI tool's findings — the CLI tool does ALL reviewing. Do not spawn sub-agents.
+
 ## Review Process
 
 1. Read the task prompt carefully — extract the PR number and task description
@@ -1274,7 +1303,10 @@ export function buildReviewerAgents(
 	reviewers: SubagentConfig[],
 	leaderModel?: string
 ): Record<string, AgentDefinition> {
-	const agents: Record<string, AgentDefinition> = {};
+	const agents: Record<string, AgentDefinition> = {
+		'reviewer-explorer': buildReviewerExplorerAgentDef(),
+		'reviewer-fact-checker': buildReviewerFactCheckerAgentDef(),
+	};
 	const usedNames = new Set<string>();
 	const runtimeModelLabel = leaderModel ?? 'sonnet';
 

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -933,6 +933,16 @@ describe('Leader Agent', () => {
 			expect(agent.prompt).toContain('Do not spawn sub-agents');
 		});
 
+		it('should not overwrite built-in sub-agents if reviewer model maps to same short name', () => {
+			// A model named 'explorer' would normally produce 'reviewer-explorer' via toShortModelName,
+			// which would collide with the built-in definition. usedNames must prevent this.
+			const agents = buildReviewerAgents([{ model: 'explorer' }]);
+			// Built-in reviewer-explorer must be the real sub-agent definition (has CONTEXT_FINDINGS format)
+			expect(agents['reviewer-explorer'].prompt).toContain('---CONTEXT_FINDINGS---');
+			// The colliding reviewer must be renamed with a counter suffix
+			expect(agents['reviewer-explorer-2']).toBeDefined();
+		});
+
 		it('should detect GLM provider label for SDK reviewers', () => {
 			const agents = buildReviewerAgents([{ model: 'glm-5' }]);
 			const agent = agents['reviewer-glm-5'];

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -747,10 +747,12 @@ describe('Leader Agent', () => {
 			);
 			expect(init.agent).toBe('Leader');
 			expect(init.agents).toBeDefined();
-			expect(Object.keys(init.agents!)).toHaveLength(3); // Leader + 2 reviewers
+			expect(Object.keys(init.agents!)).toHaveLength(5); // Leader + 2 reviewers + reviewer-explorer + reviewer-fact-checker
 			expect(Object.keys(init.agents!)).toContain('Leader');
 			expect(Object.keys(init.agents!)).toContain('reviewer-opus');
 			expect(Object.keys(init.agents!)).toContain('reviewer-sonnet');
+			expect(Object.keys(init.agents!)).toContain('reviewer-explorer');
+			expect(Object.keys(init.agents!)).toContain('reviewer-fact-checker');
 		});
 
 		it('should include Task tools in Leader agent definition', () => {
@@ -856,15 +858,79 @@ describe('Leader Agent', () => {
 			expect(agent.prompt).toContain('EVENT="COMMENT"');
 		});
 
-		it('should include read-only tools for reviewers', () => {
+		it('should include read-only tools and Task tools for reviewers', () => {
 			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6' }]);
 			const agent = agents['reviewer-opus'];
 			expect(agent.tools).toContain('Read');
 			expect(agent.tools).toContain('Grep');
 			expect(agent.tools).toContain('Glob');
 			expect(agent.tools).toContain('Bash');
+			expect(agent.tools).toContain('Task');
+			expect(agent.tools).toContain('TaskOutput');
+			expect(agent.tools).toContain('TaskStop');
 			expect(agent.tools).not.toContain('Edit');
 			expect(agent.tools).not.toContain('Write');
+		});
+
+		it('should always include reviewer-explorer and reviewer-fact-checker in agents map', () => {
+			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6' }]);
+			expect(agents['reviewer-explorer']).toBeDefined();
+			expect(agents['reviewer-fact-checker']).toBeDefined();
+		});
+
+		it('should include reviewer-explorer and reviewer-fact-checker even with no reviewers', () => {
+			const agents = buildReviewerAgents([]);
+			expect(agents['reviewer-explorer']).toBeDefined();
+			expect(agents['reviewer-fact-checker']).toBeDefined();
+		});
+
+		it('should include reviewer-explorer and reviewer-fact-checker with multiple reviewers', () => {
+			const agents = buildReviewerAgents([
+				{ model: 'claude-opus-4-6' },
+				{ model: 'custom-cli', type: 'cli' },
+			]);
+			expect(agents['reviewer-explorer']).toBeDefined();
+			expect(agents['reviewer-fact-checker']).toBeDefined();
+			expect(agents['reviewer-opus']).toBeDefined();
+			expect(agents['reviewer-custom-cli']).toBeDefined();
+		});
+
+		it('reviewer-explorer should NOT have Task tools (one level max)', () => {
+			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6' }]);
+			const explorer = agents['reviewer-explorer'];
+			expect(explorer.tools).not.toContain('Task');
+			expect(explorer.tools).not.toContain('TaskOutput');
+			expect(explorer.tools).not.toContain('TaskStop');
+		});
+
+		it('reviewer-fact-checker should NOT have Task tools (one level max)', () => {
+			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6' }]);
+			const factChecker = agents['reviewer-fact-checker'];
+			expect(factChecker.tools).not.toContain('Task');
+			expect(factChecker.tools).not.toContain('TaskOutput');
+			expect(factChecker.tools).not.toContain('TaskStop');
+		});
+
+		it('SDK reviewer prompt should describe reviewer-explorer sub-agent usage', () => {
+			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6' }]);
+			const agent = agents['reviewer-opus'];
+			expect(agent.prompt).toContain('reviewer-explorer');
+			expect(agent.prompt).toContain('reviewer-fact-checker');
+		});
+
+		it('SDK reviewer prompt should instruct when to use sub-agents vs skip them', () => {
+			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6' }]);
+			const agent = agents['reviewer-opus'];
+			expect(agent.prompt).toContain('Non-trivial');
+			expect(agent.prompt).toContain('trivial');
+		});
+
+		it('CLI reviewer prompt should mention sub-agents are available but not to use them', () => {
+			const agents = buildReviewerAgents([{ model: 'custom-cli', type: 'cli' }]);
+			const agent = agents['reviewer-custom-cli'];
+			expect(agent.prompt).toContain('reviewer-explorer');
+			expect(agent.prompt).toContain('reviewer-fact-checker');
+			expect(agent.prompt).toContain('Do not spawn sub-agents');
 		});
 
 		it('should detect GLM provider label for SDK reviewers', () => {


### PR DESCRIPTION
Always include `reviewer-explorer` and `reviewer-fact-checker` in the agents map returned by `buildReviewerAgents()`, add Task/TaskOutput/TaskStop to reviewer tools, and update prompts to guide sub-agent usage.

- `buildReviewerAgents()` now always seeds `reviewer-explorer` and `reviewer-fact-checker` into the returned agents map alongside the configured reviewer agents
- `REVIEWER_TOOLS` gains `Task`, `TaskOutput`, `TaskStop` so reviewer agents can spawn sub-agents
- `buildSdkReviewerPrompt()` updated with a Sub-Agent Support section describing when to use explorer (non-trivial multi-file changes) and fact-checker (API/best-practice validation), and when to skip them
- `buildCliReviewerPrompt()` notes that sub-agents are available but the CLI relay should not spawn them
- Sub-agents (`reviewer-explorer`, `reviewer-fact-checker`) retain no Task tools — one level max
- 9 new tests; 176 pass (1 pre-existing failure unrelated to this PR)