### PR TITLE
feat(leader): always use agent/agents pattern with built-in sub-agents

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -306,7 +306,7 @@ function leaderPlanReviewOrchestrationSection(
 		)
 		.join('\n');
 
-	const allSpecialists =
+	const customSpecialists =
 		helperNames.length > 0
 			? `${reviewerNames.join(', ')}, ${helperNames.join(', ')}`
 			: reviewerNames.join(', ');
@@ -314,7 +314,8 @@ function leaderPlanReviewOrchestrationSection(
 	return `\
 ## Available Specialists (via Task subagent_type)
 
-Custom: ${allSpecialists}
+Built-in: \`leader-explorer\` (codebase exploration), \`leader-fact-checker\` (web-based fact-checking)
+Custom: ${customSpecialists}
 
 ## Plan Review Orchestration Workflow
 
@@ -355,12 +356,16 @@ Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a h
 }
 
 function leaderPlanReviewSimpleSection(helperNames: string[]): string {
-	const helperSection =
-		helperNames.length > 0
-			? `\n## Available Helpers (via Task subagent_type)\n\n${helperNames.join(', ')}\n\nHelpers perform read-only analysis tasks. Use them to delegate heavy analysis and keep your context clean.\n`
-			: '';
+	const userHelperSection =
+		helperNames.length > 0 ? `\nAdditional helpers: ${helperNames.join(', ')}\n` : '';
 	return `\
-${helperSection}## Plan Review Guidelines
+## Available Analysis Tools (via Task subagent_type)
+
+Built-in (always available):
+- \`leader-explorer\`: Read-only codebase explorer — explores files, searches patterns, understands code structure
+- \`leader-fact-checker\`: Web-based fact-checker — validates technical decisions against current docs and best practices
+${userHelperSection}
+## Plan Review Guidelines
 
 **Phase 1 (plan document)**: When you receive \`[PLANNER OUTPUT] — Phase 1 (plan document)\`, follow this workflow:
 1. Read the planner output and extract the PR number/URL.
@@ -405,7 +410,7 @@ function leaderCodeReviewOrchestrationSection(
 		)
 		.join('\n');
 
-	const allSpecialists =
+	const customSpecialists =
 		helperNames.length > 0
 			? `${reviewerNames.join(', ')}, ${helperNames.join(', ')}`
 			: reviewerNames.join(', ');
@@ -413,7 +418,8 @@ function leaderCodeReviewOrchestrationSection(
 	return `\
 ## Available Specialists (via Task subagent_type)
 
-Custom: ${allSpecialists}
+Built-in: \`leader-explorer\` (codebase exploration), \`leader-fact-checker\` (web-based fact-checking)
+Custom: ${customSpecialists}
 
 ## Review Orchestration Workflow
 
@@ -448,12 +454,16 @@ ${prMergeabilityCheckBlock('Step 5', false)}`;
 }
 
 function leaderCodeReviewSimpleSection(helperNames: string[]): string {
-	const helperSection =
-		helperNames.length > 0
-			? `\n## Available Helpers (via Task subagent_type)\n\n${helperNames.join(', ')}\n\nHelpers perform read-only analysis tasks (e.g., "summarize changes in these files"). Use them to delegate heavy analysis and keep your context clean.\n`
-			: '';
+	const userHelperSection =
+		helperNames.length > 0 ? `\nAdditional helpers: ${helperNames.join(', ')}\n` : '';
 	return `\
-${helperSection}## Code Review Guidelines
+## Available Analysis Tools (via Task subagent_type)
+
+Built-in (always available):
+- \`leader-explorer\`: Read-only codebase explorer — explores files, searches patterns, understands code structure
+- \`leader-fact-checker\`: Web-based fact-checker — validates technical decisions against current docs and best practices
+${userHelperSection}
+## Code Review Guidelines
 
 **Every iteration follows the same workflow** — including after the worker addresses feedback.
 1. Read the worker output and extract the PR number/URL.
@@ -1343,11 +1353,32 @@ export function buildReviewerAgents(
 }
 
 /**
+ * Built-in sub-agent names that are always present in the Leader's agents map.
+ * User-configured agents that collide with these names are prefixed with `custom-`.
+ */
+const BUILTIN_LEADER_SUBAGENT_NAMES = new Set(['leader-explorer', 'leader-fact-checker']);
+
+/**
+ * Resolve name collisions between user-configured agents and built-in sub-agents.
+ * If a user agent name matches a built-in name, it is prefixed with `custom-`.
+ */
+export function resolveAgentNameCollisions(
+	agents: Record<string, AgentDefinition>
+): Record<string, AgentDefinition> {
+	const result: Record<string, AgentDefinition> = {};
+	for (const [name, def] of Object.entries(agents)) {
+		result[BUILTIN_LEADER_SUBAGENT_NAMES.has(name) ? `custom-${name}` : name] = def;
+	}
+	return result;
+}
+
+/**
  * Create an AgentSessionInit for a Leader agent session.
  *
- * Uses the agent/agents pattern: the Leader is defined as a named AgentDefinition
+ * Always uses the agent/agents pattern: the Leader is defined as a named AgentDefinition
  * and the session is configured with `agent: 'Leader'` to designate it as the main thread.
- * Reviewer sub-agents (if configured) are merged into the `agents` map alongside Leader.
+ * Built-in sub-agents (`leader-explorer`, `leader-fact-checker`) are always included.
+ * Reviewer and helper sub-agents from room config are merged in if configured.
  *
  * This is analogous to coordinatorMode but custom: we define the Leader agent explicitly
  * rather than using the SDK's built-in coordinator. This preserves the leader's system
@@ -1358,11 +1389,6 @@ export function buildReviewerAgents(
  * via the mcpServers config and should be available to the main agent thread regardless
  * of the agent's tools list. If this assumption is wrong and MCP tools are NOT available,
  * add 'leader-agent-tools__*' to the Leader agent's tools array.
- *
- * To test: Run the server, create a room with reviewer sub-agents configured,
- * trigger autonomous mode, and verify:
- * 1. Leader can call MCP tools (send_to_worker, complete_task, etc.)
- * 2. Leader can dispatch reviewer sub-agents via Task tool
  */
 export function createLeaderAgentInit(
 	config: LeaderAgentConfig,
@@ -1383,73 +1409,46 @@ export function createLeaderAgentInit(
 				}) as unknown as McpServerConfig)
 			: undefined;
 
-	// Build reviewer agents from room config (if any)
+	// Build reviewer agents from room config (if any), resolving name collisions with built-ins
 	const roomConfig = config.room.config ?? {};
 	const reviewerConfigs = getLeaderSubagents(roomConfig);
 	const leaderModel = config.model ?? DEFAULT_LEADER_MODEL;
 	const reviewerAgents =
 		reviewerConfigs && reviewerConfigs.length > 0
-			? buildReviewerAgents(reviewerConfigs, leaderModel)
-			: undefined;
+			? resolveAgentNameCollisions(buildReviewerAgents(reviewerConfigs, leaderModel))
+			: {};
 
-	// Build helper agents from room config (if any)
+	// Build helper agents from room config (if any), resolving name collisions with built-ins
 	const helperConfigs = getLeaderHelperSubagents(roomConfig);
 	const helperAgents =
-		helperConfigs && helperConfigs.length > 0 ? buildLeaderHelperAgents(helperConfigs) : undefined;
+		helperConfigs && helperConfigs.length > 0
+			? resolveAgentNameCollisions(buildLeaderHelperAgents(helperConfigs))
+			: {};
 
-	// Merge reviewers and helpers into a single sub-agents map.
-	// Use the agent/agents pattern when ANY sub-agents are configured.
-	const allSubAgents: Record<string, AgentDefinition> = {
+	// Leader agent definition — orchestrates reviews via MCP tools + Task for sub-agents
+	const leaderAgentDef: AgentDefinition = {
+		description:
+			'Coordinator that orchestrates code review. Dispatches reviewer and helper sub-agents, collects their results, and routes decisions using MCP tools.',
+		prompt: buildLeaderSystemPrompt(config),
+		tools: ['Task', 'TaskOutput', 'TaskStop', 'Read', 'Grep', 'Glob', 'Bash'],
+		model: toAgentModel(config.model ?? DEFAULT_LEADER_MODEL),
+	};
+
+	// Always include built-in sub-agents plus any user-configured reviewers and helpers.
+	const allAgents: Record<string, AgentDefinition> = {
+		Leader: leaderAgentDef,
+		'leader-explorer': buildLeaderExplorerAgentDef(),
+		'leader-fact-checker': buildLeaderFactCheckerAgentDef(),
 		...reviewerAgents,
 		...helperAgents,
 	};
-	const hasSubAgents = Object.keys(allSubAgents).length > 0;
 
-	if (hasSubAgents) {
-		// Leader agent definition — orchestrates reviews via MCP tools + Task for sub-agents
-		const leaderAgentDef: AgentDefinition = {
-			description:
-				'Coordinator that orchestrates code review. Dispatches reviewer and helper sub-agents, collects their results, and routes decisions using MCP tools.',
-			prompt: buildLeaderSystemPrompt(config),
-			tools: ['Task', 'TaskOutput', 'TaskStop', 'Read', 'Grep', 'Glob', 'Bash'],
-			model: toAgentModel(config.model ?? DEFAULT_LEADER_MODEL),
-		};
-
-		const allAgents: Record<string, AgentDefinition> = {
-			Leader: leaderAgentDef,
-			...allSubAgents,
-		};
-
-		return {
-			sessionId: config.sessionId,
-			workspacePath: config.workspacePath,
-			systemPrompt: {
-				type: 'preset',
-				preset: 'claude_code',
-			},
-			mcpServers: {
-				'leader-agent-tools': mcpServer as unknown as McpServerConfig,
-				...(roomAgentTools ? { 'leader-context-tools': roomAgentTools } : {}),
-			},
-			features: LEADER_FEATURES,
-			context: { roomId: config.room.id },
-			type: 'leader' as const,
-			model: config.model ?? DEFAULT_LEADER_MODEL,
-			provider: config.provider,
-			agent: 'Leader',
-			agents: allAgents,
-			contextAutoQueue: false,
-		};
-	}
-
-	// Simple path: no reviewer sub-agents, no agent/agents needed
 	return {
 		sessionId: config.sessionId,
 		workspacePath: config.workspacePath,
 		systemPrompt: {
 			type: 'preset',
 			preset: 'claude_code',
-			append: buildLeaderSystemPrompt(config),
 		},
 		mcpServers: {
 			'leader-agent-tools': mcpServer as unknown as McpServerConfig,
@@ -1457,9 +1456,11 @@ export function createLeaderAgentInit(
 		},
 		features: LEADER_FEATURES,
 		context: { roomId: config.room.id },
-		type: 'leader',
+		type: 'leader' as const,
 		model: config.model ?? DEFAULT_LEADER_MODEL,
 		provider: config.provider,
+		agent: 'Leader',
+		agents: allAgents,
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -11,6 +11,7 @@ import {
 	createLeaderAgentInit,
 	createLeaderToolHandlers,
 	getLeaderHelperSubagents,
+	resolveAgentNameCollisions,
 	toAgentModel,
 	toShortModelName,
 	type LeaderAgentConfig,
@@ -341,8 +342,22 @@ describe('Leader Agent', () => {
 				})
 			);
 			expect(prompt).toContain('Available Specialists (via Task subagent_type)');
+			expect(prompt).toContain('leader-explorer');
+			expect(prompt).toContain('leader-fact-checker');
 			expect(prompt).toContain('reviewer-opus, reviewer-sonnet');
 			expect(prompt).toContain('Dispatch Reviewer Sub-agents');
+		});
+
+		it('always includes built-in sub-agent names in system prompt (no reviewers)', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig());
+			expect(prompt).toContain('leader-explorer');
+			expect(prompt).toContain('leader-fact-checker');
+		});
+
+		it('always includes built-in sub-agent names in system prompt (plan review, no reviewers)', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
+			expect(prompt).toContain('leader-explorer');
+			expect(prompt).toContain('leader-fact-checker');
 		});
 
 		it('recommends submit_for_review in simple review path', () => {
@@ -571,14 +586,21 @@ describe('Leader Agent', () => {
 			expect(init.type).toBe('leader');
 		});
 
-		it('should use Claude Code preset with leader prompt appended', () => {
+		it('should use Claude Code preset without append (prompt is in agent def)', () => {
 			const callbacks = makeCallbacks();
 			const init = createLeaderAgentInit(makeConfig(), callbacks);
 			expect(init.systemPrompt).toEqual({
 				type: 'preset',
 				preset: 'claude_code',
-				append: expect.stringContaining('Leader Agent'),
 			});
+		});
+
+		it('should embed leader system prompt in Leader agent definition prompt field', () => {
+			const callbacks = makeCallbacks();
+			const init = createLeaderAgentInit(makeConfig(), callbacks);
+			const leaderDef = init.agents!['Leader'];
+			expect(leaderDef).toBeDefined();
+			expect(leaderDef.prompt).toContain('Leader Agent');
 		});
 
 		it('should include leader-agent-tools MCP server', () => {
@@ -592,14 +614,16 @@ describe('Leader Agent', () => {
 			const callbacks = makeCallbacks();
 			const init = createLeaderAgentInit(makeConfig(), callbacks);
 			expect(init.mcpServers).toBeDefined();
+			// The SDK MCP server object has shape: { type, name, instance }
+			// Tools are registered in instance._registeredTools (object keyed by tool name)
 			const ctxServer = init.mcpServers!['leader-context-tools'] as unknown as {
 				name: string;
-				tools: Array<{ name: string }>;
+				instance: { _registeredTools: Record<string, unknown> };
 			};
 			expect(ctxServer).toBeDefined();
 			// Verify it is the narrow leader-context server, not the full room-agent server
 			expect(ctxServer.name).toBe('leader-context');
-			const toolNames = ctxServer.tools.map((t) => t.name).sort();
+			const toolNames = Object.keys(ctxServer.instance._registeredTools).sort();
 			// Should include both read-only context tools and task management tools
 			expect(toolNames).toEqual(
 				[
@@ -726,8 +750,10 @@ describe('Leader Agent', () => {
 			// agent: 'Leader' designates Leader as the main thread
 			expect(init.agent).toBe('Leader');
 			expect(init.agents).toBeDefined();
-			// agents map must include both the Leader and reviewer entries
+			// agents map must include Leader, built-ins, and reviewer entries
 			expect(Object.keys(init.agents!)).toContain('Leader');
+			expect(Object.keys(init.agents!)).toContain('leader-explorer');
+			expect(Object.keys(init.agents!)).toContain('leader-fact-checker');
 			expect(Object.keys(init.agents!)).toContain('reviewer-opus');
 		});
 
@@ -747,8 +773,11 @@ describe('Leader Agent', () => {
 			);
 			expect(init.agent).toBe('Leader');
 			expect(init.agents).toBeDefined();
-			expect(Object.keys(init.agents!)).toHaveLength(5); // Leader + 2 reviewers + reviewer-explorer + reviewer-fact-checker
+			// Leader + 2 built-ins + 2 reviewers + reviewer-explorer + reviewer-fact-checker = 7
+			expect(Object.keys(init.agents!)).toHaveLength(7);
 			expect(Object.keys(init.agents!)).toContain('Leader');
+			expect(Object.keys(init.agents!)).toContain('leader-explorer');
+			expect(Object.keys(init.agents!)).toContain('leader-fact-checker');
 			expect(Object.keys(init.agents!)).toContain('reviewer-opus');
 			expect(Object.keys(init.agents!)).toContain('reviewer-sonnet');
 			expect(Object.keys(init.agents!)).toContain('reviewer-explorer');
@@ -757,18 +786,7 @@ describe('Leader Agent', () => {
 
 		it('should include Task tools in Leader agent definition', () => {
 			const callbacks = makeCallbacks();
-			const init = createLeaderAgentInit(
-				makeConfig({
-					room: makeRoom({
-						config: {
-							agentSubagents: {
-								leader: [{ model: 'claude-opus-4-6' }],
-							},
-						},
-					}),
-				}),
-				callbacks
-			);
+			const init = createLeaderAgentInit(makeConfig(), callbacks);
 			const leaderDef = init.agents!['Leader'];
 			expect(leaderDef).toBeDefined();
 			expect(leaderDef.tools).toContain('Task');
@@ -796,16 +814,22 @@ describe('Leader Agent', () => {
 			expect(init.coordinatorMode).toBeUndefined();
 			expect(init.agent).toBe('Leader');
 			expect(Object.keys(init.agents!)).toContain('Leader');
+			expect(Object.keys(init.agents!)).toContain('leader-explorer');
+			expect(Object.keys(init.agents!)).toContain('leader-fact-checker');
 			expect(Object.keys(init.agents!)).toContain('reviewer-sonnet');
 			expect(Object.keys(init.agents!)).toContain('reviewer-haiku');
 		});
 
-		it('should not set agent or agents when no reviewers configured', () => {
+		it('should always set agent: Leader and agents map (even with no reviewers configured)', () => {
 			const callbacks = makeCallbacks();
 			const init = createLeaderAgentInit(makeConfig(), callbacks);
 			expect(init.coordinatorMode).toBeUndefined();
-			expect(init.agent).toBeUndefined();
-			expect(init.agents).toBeUndefined();
+			expect(init.agent).toBe('Leader');
+			expect(init.agents).toBeDefined();
+			// Leader + 2 built-in sub-agents
+			expect(Object.keys(init.agents!)).toContain('Leader');
+			expect(Object.keys(init.agents!)).toContain('leader-explorer');
+			expect(Object.keys(init.agents!)).toContain('leader-fact-checker');
 		});
 	});
 
@@ -1217,6 +1241,79 @@ describe('Leader Agent', () => {
 			expect(reviewerAgent.model).toBe('inherit');
 		});
 	});
+
+	describe('createLeaderAgentInit — built-in sub-agents always present', () => {
+		it('always includes leader-explorer and leader-fact-checker regardless of room config', () => {
+			const callbacks = makeCallbacks();
+			const init = createLeaderAgentInit(makeConfig(), callbacks);
+			expect(init.agents!['leader-explorer']).toBeDefined();
+			expect(init.agents!['leader-fact-checker']).toBeDefined();
+		});
+
+		it('built-in sub-agents have the correct tools (explorer: read-only, fact-checker: web)', () => {
+			const callbacks = makeCallbacks();
+			const init = createLeaderAgentInit(makeConfig(), callbacks);
+			const explorer = init.agents!['leader-explorer'];
+			const factChecker = init.agents!['leader-fact-checker'];
+			expect(explorer.tools).toContain('Read');
+			expect(explorer.tools).toContain('Grep');
+			expect(explorer.tools).toContain('Glob');
+			expect(explorer.tools).not.toContain('Task');
+			expect(factChecker.tools).toContain('WebSearch');
+			expect(factChecker.tools).toContain('WebFetch');
+			expect(factChecker.tools).not.toContain('Task');
+		});
+
+		it('built-in sub-agents are still present when reviewers are configured', () => {
+			const callbacks = makeCallbacks();
+			const init = createLeaderAgentInit(
+				makeConfig({
+					room: makeRoom({
+						config: { agentSubagents: { leader: [{ model: 'claude-opus-4-6' }] } },
+					}),
+				}),
+				callbacks
+			);
+			expect(init.agents!['leader-explorer']).toBeDefined();
+			expect(init.agents!['leader-fact-checker']).toBeDefined();
+		});
+
+		it('resolveAgentNameCollisions: renames agents whose names match built-ins to custom-*', () => {
+			// Directly exercise the collision path: inject an agent named 'leader-explorer'
+			// (a built-in name) and verify it gets renamed to 'custom-leader-explorer'.
+			const collidingAgents = {
+				'leader-explorer': buildLeaderExplorerAgentDef(),
+				'leader-fact-checker': buildLeaderFactCheckerAgentDef(),
+				'reviewer-opus': buildReviewerAgents([{ model: 'claude-opus-4-6' }])['reviewer-opus'],
+			};
+			const resolved = resolveAgentNameCollisions(collidingAgents);
+			// Built-in names must be renamed
+			expect(resolved['leader-explorer']).toBeUndefined();
+			expect(resolved['leader-fact-checker']).toBeUndefined();
+			expect(resolved['custom-leader-explorer']).toBeDefined();
+			expect(resolved['custom-leader-fact-checker']).toBeDefined();
+			// Non-colliding names are unchanged
+			expect(resolved['reviewer-opus']).toBeDefined();
+		});
+
+		it('no code path returns init without agent and agents', () => {
+			const callbacks = makeCallbacks();
+			// No room config — the simplest possible config
+			const init = createLeaderAgentInit(
+				{
+					task: makeTask(),
+					goal: makeGoal(),
+					room: makeRoom(),
+					sessionId: 'test-session',
+					workspacePath: '/ws',
+					groupId: 'g1',
+				},
+				callbacks
+			);
+			expect(init.agent).toBe('Leader');
+			expect(init.agents).toBeDefined();
+		});
+	});
 });
 
 describe('Leader Helper Sub-Agents', () => {
@@ -1444,9 +1541,11 @@ describe('Leader Helper Sub-Agents', () => {
 			expect(init.agents).toBeDefined();
 		});
 
-		it('includes leader helper agents in agents map', () => {
+		it('includes leader helper agents in agents map alongside built-ins', () => {
 			const init = createLeaderAgentInit(makeConfigWithHelpers(), makeCallbacks());
-			const keys = Object.keys(init.agents ?? {}).filter((k) => k !== 'Leader');
+			const keys = Object.keys(init.agents ?? {});
+			expect(keys).toContain('leader-explorer');
+			expect(keys).toContain('leader-fact-checker');
 			expect(keys.some((k) => k.startsWith('leader-helper-'))).toBe(true);
 		});
 
@@ -1465,16 +1564,20 @@ describe('Leader Helper Sub-Agents', () => {
 			const keys = Object.keys(init.agents ?? {}).filter((k) => k !== 'Leader');
 			expect(keys.some((k) => k.startsWith('reviewer-'))).toBe(true);
 			expect(keys.some((k) => k.startsWith('leader-helper-'))).toBe(true);
+			expect(keys).toContain('leader-explorer');
+			expect(keys).toContain('leader-fact-checker');
 		});
 
-		it('uses simple path when neither reviewers nor helpers are configured', () => {
+		it('always uses agent/agents pattern (even when no reviewers nor helpers configured)', () => {
 			const init = createLeaderAgentInit(makeConfig(), makeCallbacks());
-			expect(init.agent).toBeUndefined();
-			expect(init.agents).toBeUndefined();
+			expect(init.agent).toBe('Leader');
+			expect(init.agents).toBeDefined();
+			expect(Object.keys(init.agents!)).toContain('leader-explorer');
+			expect(Object.keys(init.agents!)).toContain('leader-fact-checker');
 		});
 
-		it('Leader agent def includes Task tool when helpers configured', () => {
-			const init = createLeaderAgentInit(makeConfigWithHelpers(), makeCallbacks());
+		it('Leader agent def includes Task tool (always, no reviewers needed)', () => {
+			const init = createLeaderAgentInit(makeConfig(), makeCallbacks());
 			const leaderDef = init.agents?.['Leader'];
 			expect(leaderDef?.tools).toContain('Task');
 		});
@@ -1491,18 +1594,22 @@ describe('Leader Helper Sub-Agents', () => {
 			});
 		}
 
-		it('includes Available Helpers section in code review mode', () => {
+		it('includes Available Analysis Tools section with built-ins and user helpers in code review mode', () => {
 			const config = makeConfigWithHelpers();
 			const prompt = buildLeaderSystemPrompt(config);
-			expect(prompt).toContain('Available Helpers');
+			expect(prompt).toContain('Available Analysis Tools');
+			expect(prompt).toContain('leader-explorer');
+			expect(prompt).toContain('leader-fact-checker');
 			expect(prompt).toContain('leader-helper-');
 		});
 
-		it('includes Available Helpers section in plan review mode', () => {
+		it('includes Available Analysis Tools section with built-ins and user helpers in plan review mode', () => {
 			const config = makeConfigWithHelpers();
 			config.reviewContext = 'plan_review';
 			const prompt = buildLeaderSystemPrompt(config);
-			expect(prompt).toContain('Available Helpers');
+			expect(prompt).toContain('Available Analysis Tools');
+			expect(prompt).toContain('leader-explorer');
+			expect(prompt).toContain('leader-fact-checker');
 			expect(prompt).toContain('leader-helper-');
 		});
 
@@ -1523,7 +1630,7 @@ describe('Leader Helper Sub-Agents', () => {
 			}
 		});
 
-		it('includes helpers alongside reviewers in Available Specialists section', () => {
+		it('includes built-ins and helpers alongside reviewers in Available Specialists section', () => {
 			const config = makeConfig({
 				room: makeRoom({
 					config: {
@@ -1536,6 +1643,8 @@ describe('Leader Helper Sub-Agents', () => {
 			});
 			const prompt = buildLeaderSystemPrompt(config);
 			expect(prompt).toContain('Available Specialists');
+			expect(prompt).toContain('leader-explorer');
+			expect(prompt).toContain('leader-fact-checker');
 			expect(prompt).toContain('reviewer-haiku');
 			expect(prompt).toContain('leader-helper-sonnet');
 		});


### PR DESCRIPTION
Remove the conditional `hasSubAgents` branch in `createLeaderAgentInit()`. The function now always returns an init with `agent: 'Leader'` and an `agents` map containing `leader-explorer`, `leader-fact-checker`, plus any configured reviewer/helper agents.

**Changes:**
- `createLeaderAgentInit()` always uses the agent/agents pattern; no more simple fallback path
- Always includes `leader-explorer` and `leader-fact-checker` in the agents map
- System prompt embedded in Leader agent def's `prompt` field (not `systemPrompt.append`)
- `buildLeaderSystemPrompt()` always mentions built-in sub-agents in review sections
- Name collisions: user-configured agents matching built-in names are prefixed with `custom-`
- Fix pre-existing test bug: SDK MCP server tools live in `instance._registeredTools`, not `.tools`
- Updated/added tests covering all new behavior