### PR TITLE
fix(room): restore MCP servers and skills for recovered worker sessions (G5)

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -299,6 +299,48 @@ export class RoomRuntimeService {
 		return null;
 	}
 
+	/**
+	 * Merge file-based and registry MCP servers for a worker (coder / general) session.
+	 *
+	 * Precedence (highest to lowest): file-based > registry.
+	 * File-based servers are project-local config (.mcp.json / settings.json) and are
+	 * considered more specific than the global application-level registry. When the same
+	 * server name appears in both sources, the project's local definition wins.
+	 *
+	 * Used by both createSessionFactory() (fresh sessions) and restoreSession() (recovery
+	 * after daemon restart) to avoid duplication.
+	 */
+	private static applyWorkerMcpServers(
+		session: AgentSession,
+		ctx: Pick<RoomRuntimeServiceConfig, 'settingsManager' | 'appMcpManager'>,
+		sessionId: string
+	): void {
+		const fileMcpServers = ctx.settingsManager.getEnabledMcpServersConfig();
+		const registryMcpServers = ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
+
+		// Detect and warn on name collisions (file-based wins)
+		for (const name of Object.keys(fileMcpServers)) {
+			if (Object.prototype.hasOwnProperty.call(registryMcpServers, name)) {
+				log.warn(
+					`Worker session ${sessionId}: MCP server name collision on '${name}' — ` +
+						`file-based config takes precedence over registry entry.`
+				);
+			}
+		}
+
+		// Merge: registry first, then file-based overwrites on collision.
+		// Only call setRuntimeMcpServers when there is at least one server to inject —
+		// an undefined config lets the SDK use its own default discovery, while an
+		// empty map would suppress it entirely with no benefit.
+		const merged: Record<string, McpServerConfig> = {
+			...registryMcpServers,
+			...fileMcpServers,
+		};
+		if (Object.keys(merged).length > 0) {
+			session.setRuntimeMcpServers(merged);
+		}
+	}
+
 	private createSessionFactory(): SessionFactory {
 		const ctx = this.ctx;
 		const agentSessions = this.agentSessions;
@@ -346,37 +388,8 @@ export class RoomRuntimeService {
 				// (one task per session) so a registry change mid-task would not be useful. The
 				// updated map is applied on the next session creation.
 				//
-				// Known limitation after daemon restart: recovered worker sessions re-created by
-				// restoreSession() will NOT have the merged (file + registry) MCP map reapplied —
-				// restoreMcpServersForGroup() only restores role-specific in-process tools
-				// (planner-tools, leader-agent-tools). Workers resumed from a crash will therefore
-				// run without user-configured MCP servers for the remainder of their task. This is
-				// accepted given the short-lived nature of worker sessions.
 				if (role === 'coder' || role === 'general') {
-					const fileMcpServers = ctx.settingsManager.getEnabledMcpServersConfig();
-					const registryMcpServers = ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
-
-					// Detect and warn on name collisions (file-based wins)
-					for (const name of Object.keys(fileMcpServers)) {
-						if (Object.prototype.hasOwnProperty.call(registryMcpServers, name)) {
-							log.warn(
-								`Worker session ${init.sessionId}: MCP server name collision on '${name}' — ` +
-									`file-based config takes precedence over registry entry.`
-							);
-						}
-					}
-
-					// Merge: registry first, then file-based overwrites on collision.
-					// Only call setRuntimeMcpServers when there is at least one server to inject —
-					// an undefined config lets the SDK use its own default discovery, while an
-					// empty map would suppress it entirely with no benefit.
-					const merged: Record<string, McpServerConfig> = {
-						...registryMcpServers,
-						...fileMcpServers,
-					};
-					if (Object.keys(merged).length > 0) {
-						session.setRuntimeMcpServers(merged);
-					}
+					RoomRuntimeService.applyWorkerMcpServers(session, ctx, init.sessionId);
 				}
 
 				// Leader sessions are started lazily: injectMessage() calls ensureQueryStarted()
@@ -467,22 +480,27 @@ export class RoomRuntimeService {
 				// Idempotent: already in cache
 				if (agentSessions.has(sessionId)) return true;
 
-				// TODO(G5): pass ctx.skillsManager and ctx.appMcpServerRepo so that rehydrated
-				// room worker sessions receive skills injection on daemon restart, matching the
-				// behaviour of freshly created workers (fromInit at line ~320 already passes them).
-				// Tracked as a separate task: "Restore MCP servers and skills for recovered room
-				// worker sessions".
 				const session = AgentSession.restore(
 					sessionId,
 					ctx.db,
 					ctx.messageHub,
 					ctx.daemonHub,
-					ctx.getApiKey
+					ctx.getApiKey,
+					ctx.skillsManager,
+					ctx.appMcpServerRepo
 				);
 				if (!session) return false;
 
 				agentSessions.set(sessionId, session);
 				ctx.sessionManager.registerSession(session);
+
+				// Re-apply the file + registry MCP merge for recovered worker sessions,
+				// matching the behaviour of freshly created coder/general workers.
+				const role = sessionId.split(':')[0];
+				if (role === 'coder' || role === 'general') {
+					RoomRuntimeService.applyWorkerMcpServers(session, ctx, sessionId);
+				}
+
 				// Don't call startStreamingQuery() here — the SDK query will be
 				// started lazily when injectMessage() is called. Eagerly starting
 				// without a queued message causes a 15s startup timeout because the

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -971,11 +971,10 @@ export class RoomRuntimeService {
 						runtime.restoreRecoveredGroupMirroring(group);
 
 						// Restore role-specific in-process MCP servers (planner-tools, leader-agent-tools).
-						// Note: file-based and registry-sourced MCP servers are NOT restored here for
-						// worker sessions (coder/general). This is a known limitation — recovered workers
-						// run without user-configured MCP servers for the remainder of their task.
-						// Workers are short-lived (one task per session) so this is accepted behaviour;
-						// the merged map is applied on the next session creation via createSessionFactory().
+						// Note: file-based and registry-sourced MCP servers for coder/general workers are
+						// restored earlier in the recovery path — inside sessionFactory.restoreSession(),
+						// called by recoverRuntime() above — via the shared applyWorkerMcpServers() helper.
+						// This call only handles role-specific in-process tools that are not covered there.
 						await runtime.restoreMcpServersForGroup(group);
 
 						if (!resumeAgents) {

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -773,6 +773,27 @@ describe('SessionFactory.restoreSession — worker MCP injection and skills', ()
 		}
 	});
 
+	it('does NOT apply worker MCP merge for a restored planner session', async () => {
+		const { session, setRuntimeMcpServersSpy } = makeMockSession();
+		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(session);
+
+		try {
+			const config = makeConfig({
+				fileMcpServers: { 'file-server': { command: 'npx', args: ['file-mcp'] } },
+			});
+			const service = new RoomRuntimeService(config);
+			const factory = (
+				service as unknown as { createSessionFactory: () => FactoryType }
+			).createSessionFactory();
+
+			await factory.restoreSession('planner:room-1:task-1:abc12345');
+
+			expect(setRuntimeMcpServersSpy).not.toHaveBeenCalled();
+		} finally {
+			restoreSpy.mockRestore();
+		}
+	});
+
 	it('does NOT apply worker MCP merge for a restored leader session', async () => {
 		const { session, setRuntimeMcpServersSpy } = makeMockSession();
 		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(session);

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { describe, expect, it, beforeEach, mock, afterEach, spyOn } from 'bun:test';
+import { AgentSession } from '../../../src/lib/agent/agent-session';
 import { Database } from 'bun:sqlite';
 import {
 	RoomRuntimeService,
@@ -624,5 +625,214 @@ describe('SessionFactory.getCurrentModel', () => {
 			currentModel: 'cached-model',
 			provider: 'glm',
 		});
+	});
+});
+
+describe('SessionFactory.restoreSession — worker MCP injection and skills', () => {
+	type FactoryType = ReturnType<
+		typeof import('../../../src/lib/room/runtime/room-runtime-service').RoomRuntimeService.prototype.createSessionFactory
+	>;
+
+	function makeConfig(overrides: {
+		fileMcpServers?: Record<string, unknown>;
+		registryMcpServers?: Record<string, unknown>;
+		skillsManager?: unknown;
+		appMcpServerRepo?: unknown;
+	}): RoomRuntimeServiceConfig {
+		return {
+			db: { getSession: mock(() => null) } as never,
+			messageHub: {} as never,
+			daemonHub: {} as never,
+			getApiKey: async () => null,
+			roomManager: { getRoom: () => null } as never,
+			sessionManager: { registerSession: () => {}, unregisterSession: () => {} } as never,
+			defaultWorkspacePath: '/tmp',
+			defaultModel: 'default',
+			getGlobalSettings: () => ({}) as never,
+			settingsManager: {
+				getEnabledMcpServersConfig: mock(() => overrides.fileMcpServers ?? {}),
+			} as never,
+			appMcpManager: overrides.registryMcpServers
+				? { getEnabledMcpConfigs: mock(() => overrides.registryMcpServers) }
+				: undefined,
+			skillsManager: overrides.skillsManager as never,
+			appMcpServerRepo: overrides.appMcpServerRepo as never,
+			reactiveDb: {} as never,
+		};
+	}
+
+	function makeMockSession() {
+		const setRuntimeMcpServersSpy = mock((_servers: unknown) => {});
+		return {
+			session: {
+				contextAutoQueueEnabled: true,
+				setRuntimeMcpServers: setRuntimeMcpServersSpy,
+			} as unknown as AgentSession,
+			setRuntimeMcpServersSpy,
+		};
+	}
+
+	it('passes skillsManager and appMcpServerRepo to AgentSession.restore()', async () => {
+		const mockSkillsManager = { name: 'skillsManager' };
+		const mockAppMcpServerRepo = { name: 'appMcpServerRepo' };
+		const { session } = makeMockSession();
+		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(session);
+
+		try {
+			const config = makeConfig({
+				skillsManager: mockSkillsManager,
+				appMcpServerRepo: mockAppMcpServerRepo,
+			});
+			const service = new RoomRuntimeService(config);
+			const factory = (
+				service as unknown as { createSessionFactory: () => FactoryType }
+			).createSessionFactory();
+
+			await factory.restoreSession('coder:room-1:task-1:abc12345');
+
+			expect(restoreSpy).toHaveBeenCalledTimes(1);
+			const callArgs = restoreSpy.mock.calls[0];
+			expect(callArgs[5]).toBe(mockSkillsManager);
+			expect(callArgs[6]).toBe(mockAppMcpServerRepo);
+		} finally {
+			restoreSpy.mockRestore();
+		}
+	});
+
+	it('applies file + registry MCP merge for a restored coder session', async () => {
+		const { session, setRuntimeMcpServersSpy } = makeMockSession();
+		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(session);
+
+		try {
+			const config = makeConfig({
+				fileMcpServers: { 'file-server': { command: 'npx', args: ['file-mcp'] } },
+				registryMcpServers: { 'registry-server': { command: 'npx', args: ['registry-mcp'] } },
+			});
+			const service = new RoomRuntimeService(config);
+			const factory = (
+				service as unknown as { createSessionFactory: () => FactoryType }
+			).createSessionFactory();
+
+			await factory.restoreSession('coder:room-1:task-1:abc12345');
+
+			expect(setRuntimeMcpServersSpy).toHaveBeenCalledTimes(1);
+			const merged = setRuntimeMcpServersSpy.mock.calls[0][0] as Record<string, unknown>;
+			expect(merged).toHaveProperty('file-server');
+			expect(merged).toHaveProperty('registry-server');
+		} finally {
+			restoreSpy.mockRestore();
+		}
+	});
+
+	it('applies file + registry MCP merge for a restored general session', async () => {
+		const { session, setRuntimeMcpServersSpy } = makeMockSession();
+		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(session);
+
+		try {
+			const config = makeConfig({
+				fileMcpServers: { 'file-server': { command: 'npx', args: ['file-mcp'] } },
+			});
+			const service = new RoomRuntimeService(config);
+			const factory = (
+				service as unknown as { createSessionFactory: () => FactoryType }
+			).createSessionFactory();
+
+			await factory.restoreSession('general:room-1:task-1:abc12345');
+
+			expect(setRuntimeMcpServersSpy).toHaveBeenCalledTimes(1);
+			const merged = setRuntimeMcpServersSpy.mock.calls[0][0] as Record<string, unknown>;
+			expect(merged).toHaveProperty('file-server');
+		} finally {
+			restoreSpy.mockRestore();
+		}
+	});
+
+	it('file-based MCP servers take precedence over registry on name collision', async () => {
+		const { session, setRuntimeMcpServersSpy } = makeMockSession();
+		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(session);
+
+		try {
+			const config = makeConfig({
+				fileMcpServers: { 'shared-name': { command: 'file-cmd', args: [] } },
+				registryMcpServers: { 'shared-name': { command: 'registry-cmd', args: [] } },
+			});
+			const service = new RoomRuntimeService(config);
+			const factory = (
+				service as unknown as { createSessionFactory: () => FactoryType }
+			).createSessionFactory();
+
+			await factory.restoreSession('coder:room-1:task-1:abc12345');
+
+			const merged = setRuntimeMcpServersSpy.mock.calls[0][0] as Record<
+				string,
+				{ command: string }
+			>;
+			expect(merged['shared-name'].command).toBe('file-cmd');
+		} finally {
+			restoreSpy.mockRestore();
+		}
+	});
+
+	it('does NOT apply worker MCP merge for a restored leader session', async () => {
+		const { session, setRuntimeMcpServersSpy } = makeMockSession();
+		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(session);
+
+		try {
+			const config = makeConfig({
+				fileMcpServers: { 'file-server': { command: 'npx', args: ['file-mcp'] } },
+			});
+			const service = new RoomRuntimeService(config);
+			const factory = (
+				service as unknown as { createSessionFactory: () => FactoryType }
+			).createSessionFactory();
+
+			await factory.restoreSession('leader:room-1:task-1:abc12345');
+
+			expect(setRuntimeMcpServersSpy).not.toHaveBeenCalled();
+		} finally {
+			restoreSpy.mockRestore();
+		}
+	});
+
+	it('does not call setRuntimeMcpServers when no MCP servers are configured', async () => {
+		const { session, setRuntimeMcpServersSpy } = makeMockSession();
+		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(session);
+
+		try {
+			const config = makeConfig({
+				fileMcpServers: {},
+				registryMcpServers: {},
+			});
+			const service = new RoomRuntimeService(config);
+			const factory = (
+				service as unknown as { createSessionFactory: () => FactoryType }
+			).createSessionFactory();
+
+			await factory.restoreSession('coder:room-1:task-1:abc12345');
+
+			expect(setRuntimeMcpServersSpy).not.toHaveBeenCalled();
+		} finally {
+			restoreSpy.mockRestore();
+		}
+	});
+
+	it('returns false and does not inject MCPs when AgentSession.restore returns null', async () => {
+		const restoreSpy = spyOn(AgentSession, 'restore').mockReturnValue(null);
+
+		try {
+			const config = makeConfig({
+				fileMcpServers: { 'file-server': { command: 'npx', args: [] } },
+			});
+			const service = new RoomRuntimeService(config);
+			const factory = (
+				service as unknown as { createSessionFactory: () => FactoryType }
+			).createSessionFactory();
+
+			const result = await factory.restoreSession('coder:room-1:task-1:abc12345');
+
+			expect(result).toBe(false);
+		} finally {
+			restoreSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- Extract MCP merge logic into `applyWorkerMcpServers()` private static helper shared by both the fresh-create and restore paths
- Pass `skillsManager` and `appMcpServerRepo` through `AgentSession.restore()` in `restoreSession()`
- Apply file + registry MCP merge for recovered coder/general sessions by extracting role from session ID
- Remove the stale "known limitation" comment describing this gap

## Tests

7 new unit tests in `room-runtime-service.test.ts`:
- Skills params (`skillsManager`/`appMcpServerRepo`) forwarded to `AgentSession.restore()`
- File + registry MCP merge applied for restored coder/general sessions
- File-based MCP wins on name collision
- Leader sessions skipped (no merge)
- No `setRuntimeMcpServers` call when both sources empty
- Returns false when session not in DB