### PR TITLE
feat(web): redesign ToolsModal with unified MCP groups and scope-aware toggles (G8)

### DIFF
--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -93,36 +93,42 @@ test.describe('Tools Modal - Redesigned', () => {
 		await expect(page.getByText('This session').first()).toBeVisible();
 	});
 
-	test('should collapse App MCP Servers group', async ({ page }) => {
+	test('should collapse App MCP Servers group via header button', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
-
 		await openToolsModal(page);
 
-		// The App MCP Servers group header should be visible
 		const appMcpHeader = page.locator('button:has-text("App MCP Servers")');
 		await expect(appMcpHeader).toBeVisible();
 
-		// Click to collapse
+		// Initially expanded (aria-expanded="true")
+		await expect(appMcpHeader).toHaveAttribute('aria-expanded', 'true');
+
+		// Collapse
 		await appMcpHeader.click();
 
-		// After collapsing, no items from that group should be visible
-		// (the group count is still shown in the header)
-		await expect(appMcpHeader).toBeVisible();
+		// Should now be collapsed
+		await expect(appMcpHeader).toHaveAttribute('aria-expanded', 'false');
 	});
 
-	test('should collapse Project MCP Servers group', async ({ page }) => {
+	test('should collapse Project MCP Servers group via header button', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
-
 		await openToolsModal(page);
 
 		const fileMcpHeader = page.locator('button:has-text("Project MCP Servers")');
 		await expect(fileMcpHeader).toBeVisible();
 
-		// Collapse the group
+		// Initially expanded
+		await expect(fileMcpHeader).toHaveAttribute('aria-expanded', 'true');
+
+		// Collapse
 		await fileMcpHeader.click();
 
-		// Header should still be visible (just collapsed)
-		await expect(fileMcpHeader).toBeVisible();
+		// Should now be collapsed
+		await expect(fileMcpHeader).toHaveAttribute('aria-expanded', 'false');
+
+		// Re-expand
+		await fileMcpHeader.click();
+		await expect(fileMcpHeader).toHaveAttribute('aria-expanded', 'true');
 	});
 
 	test('should show NeoKai Tools with Memory toggle', async ({ page }) => {

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -93,26 +93,39 @@ test.describe('Tools Modal - Redesigned', () => {
 		await expect(page.getByText('This session').first()).toBeVisible();
 	});
 
-	test('should collapse App MCP Servers group via header button', async ({ page }) => {
+	test('should collapse NeoKai Tools group and hide Memory child', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 		await openToolsModal(page);
 
-		const appMcpHeader = page.locator('button:has-text("App MCP Servers")');
-		await expect(appMcpHeader).toBeVisible();
+		const neoKaiHeader = page.locator('button:has-text("NeoKai Tools")');
+		await expect(neoKaiHeader).toBeVisible();
 
-		// Initially expanded (aria-expanded="true")
-		await expect(appMcpHeader).toHaveAttribute('aria-expanded', 'true');
+		// Initially expanded — Memory child should be visible
+		await expect(neoKaiHeader).toHaveAttribute('aria-expanded', 'true');
+		await expect(page.locator('label:has-text("Memory")').first()).toBeVisible();
 
 		// Collapse
-		await appMcpHeader.click();
+		await neoKaiHeader.click();
 
-		// Should now be collapsed
-		await expect(appMcpHeader).toHaveAttribute('aria-expanded', 'false');
+		// Header reports collapsed
+		await expect(neoKaiHeader).toHaveAttribute('aria-expanded', 'false');
+		// Child content is removed from DOM (Preact conditional render)
+		await expect(page.locator('label:has-text("Memory")').first()).not.toBeAttached();
+
+		// Re-expand — child reappears
+		await neoKaiHeader.click();
+		await expect(neoKaiHeader).toHaveAttribute('aria-expanded', 'true');
+		await expect(page.locator('label:has-text("Memory")').first()).toBeVisible();
 	});
 
-	test('should collapse Project MCP Servers group via header button', async ({ page }) => {
+	test('should collapse Project MCP Servers group and hide content', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 		await openToolsModal(page);
+
+		// Wait for MCP loading to finish before checking collapse
+		await expect(page.locator('[role="dialog"]').getByText('Loading servers...')).not.toBeVisible({
+			timeout: 10000,
+		});
 
 		const fileMcpHeader = page.locator('button:has-text("Project MCP Servers")');
 		await expect(fileMcpHeader).toBeVisible();
@@ -120,15 +133,17 @@ test.describe('Tools Modal - Redesigned', () => {
 		// Initially expanded
 		await expect(fileMcpHeader).toHaveAttribute('aria-expanded', 'true');
 
+		// The content div (div.mt-1.ml-5) is a sibling of the GroupHeader div — it should be attached
+		// XPath: from button → parent (GroupHeader div) → parent (section div) → child div.ml-5
+		const fileMcpContent = fileMcpHeader.locator('xpath=../../div[contains(@class,"ml-5")]');
+		await expect(fileMcpContent.first()).toBeAttached();
+
 		// Collapse
 		await fileMcpHeader.click();
-
-		// Should now be collapsed
 		await expect(fileMcpHeader).toHaveAttribute('aria-expanded', 'false');
 
-		// Re-expand
-		await fileMcpHeader.click();
-		await expect(fileMcpHeader).toHaveAttribute('aria-expanded', 'true');
+		// Content div is removed from DOM
+		await expect(fileMcpContent.first()).not.toBeAttached({ timeout: 2000 });
 	});
 
 	test('should show NeoKai Tools with Memory toggle', async ({ page }) => {
@@ -142,29 +157,22 @@ test.describe('Tools Modal - Redesigned', () => {
 		await expect(page.getByText('Persistent key-value storage')).toBeVisible();
 	});
 
-	test('should enable Save button when file-based server is toggled', async ({ page }) => {
+	test('should enable Save button when session-local setting is toggled', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 
 		await openToolsModal(page);
 
-		// Save should be disabled initially
+		// Save should be disabled initially (no changes)
 		const saveBtn = page.getByRole('button', { name: 'Save' });
 		await expect(saveBtn).toBeDisabled();
 
-		// If there are file-based MCP servers, toggle one
-		const fileMcpCheckboxes = page
-			.locator('[role="dialog"]')
-			.locator('input[type="checkbox"]')
-			.first();
+		// Toggle Memory (always present in NeoKai Tools group)
+		const memoryLabel = page.locator('label:has-text("Memory")').first();
+		await expect(memoryLabel).toBeVisible();
+		await memoryLabel.click();
 
-		if ((await fileMcpCheckboxes.count()) > 0) {
-			// Toggle NeoKai Tools Memory (always present)
-			const memoryLabel = page.locator('label:has-text("Memory")').first();
-			if ((await memoryLabel.count()) > 0) {
-				await memoryLabel.click();
-				await expect(saveBtn).toBeEnabled({ timeout: 2000 });
-			}
-		}
+		// Save button must now be enabled
+		await expect(saveBtn).toBeEnabled({ timeout: 2000 });
 	});
 
 	test('should close modal with Cancel without saving', async ({ page }) => {

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -2,24 +2,22 @@ import { test, expect } from '../../fixtures';
 import { cleanupTestSession, createSessionViaUI } from '../helpers/wait-helpers';
 
 /**
- * Tools Modal Complete E2E Tests
+ * Tools Modal E2E Tests (Redesigned)
  *
- * Comprehensive tests for ToolsModal features beyond MCP toggle:
- * - System prompt preset toggle (Claude Code Preset)
- * - Setting sources selection (User/Project/Local)
- * - NeoKai Tools section (Memory tool)
- * - SDK built-in tools section
- * - Save/Cancel functionality
- *
- * Note: mcp-toggle.e2e.ts covers MCP server toggling specifically
+ * Tests the redesigned ToolsModal with:
+ * - Unified MCP server list grouped by scope
+ * - Collapsible groups with group-level toggles
+ * - Advanced section (collapsed by default) for Claude Code Preset + Setting Sources
+ * - Scope badges ("All sessions" vs "This session")
  */
-test.describe('Tools Modal - Complete', () => {
+
+test.describe('Tools Modal - Redesigned', () => {
 	let sessionId: string | null = null;
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await expect(page.getByRole('heading', { name: 'Neo Lobby' }).first()).toBeVisible();
-		await page.waitForTimeout(1000);
+		await page.waitForTimeout(500);
 		sessionId = null;
 	});
 
@@ -27,177 +25,190 @@ test.describe('Tools Modal - Complete', () => {
 		if (sessionId) {
 			try {
 				await cleanupTestSession(page, sessionId);
-			} catch (error) {
-				console.warn(`Failed to cleanup session ${sessionId}:`, error);
+			} catch {
+				// ignore cleanup errors
 			}
 			sessionId = null;
 		}
 	});
 
-	test.skip('should show System Prompt section with Claude Code Preset', async ({ page }) => {
-		// Create a new session
-		sessionId = await createSessionViaUI(page);
-
-		// Open session options menu
+	/** Open the Tools modal for the current session */
+	async function openToolsModal(page: import('@playwright/test').Page) {
 		const optionsButton = page.locator('button[aria-label="Session options"]');
 		await optionsButton.click();
+		await page
+			.locator('[role="menuitem"]:has-text("Tools"), button:has-text("Tools")')
+			.first()
+			.click();
+		await expect(page.locator('[role="dialog"]').first()).toBeVisible({ timeout: 5000 });
+	}
 
-		// Click Tools option
-		await page.locator('text=Tools').first().click();
+	test('should open tools modal and show group sections', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
 
-		// Wait for Tools modal to open
-		await expect(page.locator('text=System Prompt').first()).toBeVisible({
-			timeout: 5000,
-		});
+		await openToolsModal(page);
 
-		// Should show Claude Code Preset option
-		await expect(page.locator('text=Claude Code Preset')).toBeVisible();
-		await expect(page.locator('text=Use official Claude Code system prompt')).toBeVisible();
+		// Should show the group section headers
+		await expect(page.getByText('App MCP Servers')).toBeVisible();
+		await expect(page.getByText('Project MCP Servers')).toBeVisible();
+		await expect(page.getByText('NeoKai Tools')).toBeVisible();
 	});
 
-	test.skip('should show Setting Sources section with checkboxes', async ({ page }) => {
-		// Create a new session
+	test('should show Advanced section collapsed by default', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 
-		// Open Tools modal
-		const optionsButton = page.locator('button[aria-label="Session options"]');
-		await optionsButton.click();
-		await page.locator('text=Tools').first().click();
+		await openToolsModal(page);
 
-		// Wait for modal
-		await expect(page.locator('h2:has-text("Tools"), h3:has-text("Tools")').first()).toBeVisible({
-			timeout: 5000,
-		});
+		// Advanced section should be visible but collapsed
+		await expect(page.getByRole('button', { name: /Advanced/i })).toBeVisible();
 
-		// Should show Setting Sources section
-		await expect(page.locator('text=Setting Sources')).toBeVisible();
-
-		// Should show User, Project, and Local options
-		await expect(page.locator('text=User').first()).toBeVisible();
-		await expect(page.locator('text=Project').first()).toBeVisible();
-		await expect(page.locator('text=Local').first()).toBeVisible();
+		// Claude Code Preset should NOT be visible initially (hidden in Advanced)
+		await expect(page.getByText('Claude Code Preset')).not.toBeVisible();
 	});
 
-	test.skip('should show NeoKai Tools section with Memory tool', async ({ page }) => {
-		// Create a new session
+	test('should expand Advanced section and show Claude Code Preset', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 
-		// Open Tools modal
-		const optionsButton = page.locator('button[aria-label="Session options"]');
-		await optionsButton.click();
-		await page.locator('text=Tools').first().click();
+		await openToolsModal(page);
 
-		// Wait for modal
-		await expect(page.locator('h2:has-text("Tools"), h3:has-text("Tools")').first()).toBeVisible({
-			timeout: 5000,
-		});
+		// Click Advanced to expand
+		await page.getByRole('button', { name: /Advanced/i }).click();
 
-		// Should show NeoKai Tools section
-		await expect(page.locator('text=NeoKai Tools')).toBeVisible();
+		// Claude Code Preset should now be visible
+		await expect(page.getByText('Claude Code Preset')).toBeVisible({ timeout: 2000 });
 
-		// Should show Memory tool option
-		await expect(page.locator('text=Memory')).toBeVisible();
+		// Setting Sources should also be visible
+		await expect(page.getByText('Setting Sources')).toBeVisible();
 	});
 
-	test.skip('should show SDK Built-in section', async ({ page }) => {
-		// Create a new session
+	test('should show scope badges for groups', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 
-		// Open Tools modal
-		const optionsButton = page.locator('button[aria-label="Session options"]');
-		await optionsButton.click();
-		await page.locator('text=Tools').first().click();
+		await openToolsModal(page);
 
-		// Wait for modal
-		await expect(page.locator('h2:has-text("Tools"), h3:has-text("Tools")').first()).toBeVisible({
-			timeout: 5000,
-		});
+		// App MCP group should show "All sessions" scope badge
+		await expect(page.getByText('All sessions').first()).toBeVisible();
 
-		// Should show SDK Built-in section
-		await expect(page.locator('text=SDK Built-in')).toBeVisible();
-
-		// SDK tools are always enabled (informational only)
-		await expect(page.locator('text=Always enabled')).toBeVisible();
+		// Project MCP group should show "This session" scope badge
+		await expect(page.getByText('This session').first()).toBeVisible();
 	});
 
-	test.skip('should enable Save button when settings change', async ({ page }) => {
-		// Create a new session
+	test('should collapse App MCP Servers group', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 
-		// Open Tools modal
-		const optionsButton = page.locator('button[aria-label="Session options"]');
-		await optionsButton.click();
-		await page.locator('text=Tools').first().click();
+		await openToolsModal(page);
 
-		// Wait for modal
-		await expect(page.locator('h2:has-text("Tools"), h3:has-text("Tools")').first()).toBeVisible({
-			timeout: 5000,
-		});
+		// The App MCP Servers group header should be visible
+		const appMcpHeader = page.locator('button:has-text("App MCP Servers")');
+		await expect(appMcpHeader).toBeVisible();
 
-		// Save button should initially be disabled (no changes)
-		const saveButton = page.locator('button:has-text("Save")');
-		await expect(saveButton).toBeVisible();
+		// Click to collapse
+		await appMcpHeader.click();
 
-		// Click a toggle to make a change (e.g., Claude Code Preset)
-		const claudePresetToggle = page
-			.locator('label:has-text("Claude Code Preset")')
-			.locator('..')
-			.locator('button[role="switch"], input[type="checkbox"]');
-		if ((await claudePresetToggle.count()) > 0) {
-			await claudePresetToggle.first().click();
-			// Save button should now be enabled
-			await expect(saveButton).toBeEnabled({ timeout: 2000 });
+		// After collapsing, no items from that group should be visible
+		// (the group count is still shown in the header)
+		await expect(appMcpHeader).toBeVisible();
+	});
+
+	test('should collapse Project MCP Servers group', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		await openToolsModal(page);
+
+		const fileMcpHeader = page.locator('button:has-text("Project MCP Servers")');
+		await expect(fileMcpHeader).toBeVisible();
+
+		// Collapse the group
+		await fileMcpHeader.click();
+
+		// Header should still be visible (just collapsed)
+		await expect(fileMcpHeader).toBeVisible();
+	});
+
+	test('should show NeoKai Tools with Memory toggle', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		await openToolsModal(page);
+
+		// NeoKai Tools group should be expanded showing Memory
+		await expect(page.getByText('NeoKai Tools')).toBeVisible();
+		await expect(page.getByText('Memory')).toBeVisible();
+		await expect(page.getByText('Persistent key-value storage')).toBeVisible();
+	});
+
+	test('should enable Save button when file-based server is toggled', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		await openToolsModal(page);
+
+		// Save should be disabled initially
+		const saveBtn = page.getByRole('button', { name: 'Save' });
+		await expect(saveBtn).toBeDisabled();
+
+		// If there are file-based MCP servers, toggle one
+		const fileMcpCheckboxes = page
+			.locator('[role="dialog"]')
+			.locator('input[type="checkbox"]')
+			.first();
+
+		if ((await fileMcpCheckboxes.count()) > 0) {
+			// Toggle NeoKai Tools Memory (always present)
+			const memoryLabel = page.locator('label:has-text("Memory")').first();
+			if ((await memoryLabel.count()) > 0) {
+				await memoryLabel.click();
+				await expect(saveBtn).toBeEnabled({ timeout: 2000 });
+			}
 		}
 	});
 
-	test.skip('should close modal with Cancel button without saving', async ({ page }) => {
-		// Create a new session
+	test('should close modal with Cancel without saving', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 
-		// Open Tools modal
-		const optionsButton = page.locator('button[aria-label="Session options"]');
-		await optionsButton.click();
-		await page.locator('text=Tools').first().click();
+		await openToolsModal(page);
 
-		// Wait for modal
-		const modalTitle = page.locator('h2:has-text("Tools"), h3:has-text("Tools")').first();
-		await expect(modalTitle).toBeVisible({ timeout: 5000 });
+		const dialog = page.locator('[role="dialog"]').first();
+		await expect(dialog).toBeVisible();
 
-		// Click Cancel button
-		await page.locator('button:has-text("Cancel")').click();
+		// Click Cancel
+		await page.getByRole('button', { name: 'Cancel' }).click();
 
 		// Modal should close
-		await expect(modalTitle).not.toBeVisible({ timeout: 2000 });
+		await expect(dialog).not.toBeVisible({ timeout: 3000 });
 	});
 
-	test.skip('should toggle Claude Code Preset', async ({ page }) => {
-		// Create a new session
+	test('should persist state: save and reopen modal shows same config', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 
-		// Open Tools modal
-		const optionsButton = page.locator('button[aria-label="Session options"]');
-		await optionsButton.click();
-		await page.locator('text=Tools').first().click();
+		await openToolsModal(page);
 
-		// Wait for modal
-		await expect(page.locator('text=Claude Code Preset')).toBeVisible({
-			timeout: 5000,
-		});
+		// Toggle memory on
+		const memoryLabel = page.locator('label:has-text("Memory")').first();
+		if ((await memoryLabel.count()) > 0) {
+			const memoryCheckbox = memoryLabel.locator('input[type="checkbox"]');
+			const isChecked = await memoryCheckbox.isChecked();
 
-		// Find the toggle for Claude Code Preset
-		const presetRow = page.locator('div:has-text("Claude Code Preset")').first();
-		const toggle = presetRow.locator('button[role="switch"], input[type="checkbox"]').first();
+			// Toggle memory state
+			await memoryLabel.click();
+			await expect(memoryCheckbox).toHaveJSProperty('checked', !isChecked, { timeout: 2000 });
 
-		if ((await toggle.count()) > 0) {
-			// Get initial state
-			const initialState = await toggle.getAttribute('aria-checked');
+			// Save
+			const saveBtn = page.getByRole('button', { name: 'Save' });
+			if (await saveBtn.isEnabled()) {
+				await saveBtn.click();
+				await expect(page.locator('[role="dialog"]').first()).not.toBeVisible({ timeout: 5000 });
 
-			// Toggle it
-			await toggle.click();
+				// Reopen modal
+				await openToolsModal(page);
 
-			// State should change
-			const newState = await toggle.getAttribute('aria-checked');
-			expect(newState).not.toBe(initialState);
+				// Memory should reflect saved state
+				const memoryCheckboxAfter = page
+					.locator('label:has-text("Memory")')
+					.first()
+					.locator('input[type="checkbox"]');
+				await expect(memoryCheckboxAfter).toHaveJSProperty('checked', !isChecked, {
+					timeout: 2000,
+				});
+			}
 		}
 	});
 });

--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -27,6 +27,12 @@ import {
 	type McpServersFromSourcesResponse,
 } from '../lib/api-helpers.ts';
 import { skillsStore } from '../lib/skills-store.ts';
+import {
+	isServerEnabled,
+	toggleServer as toggleServerUtil,
+	toggleGroupServers,
+	computeGroupState,
+} from './ToolsModal.utils.ts';
 
 interface ToolsModalProps {
 	isOpen: boolean;
@@ -52,7 +58,6 @@ function ScopeBadge({ scope }: { scope: 'global' | 'session' }) {
 // Collapsible group header component
 interface GroupHeaderProps {
 	title: string;
-	description?: string;
 	isOpen: boolean;
 	onToggleOpen: () => void;
 	allEnabled: boolean;
@@ -60,6 +65,7 @@ interface GroupHeaderProps {
 	onToggleAll: () => void;
 	scope: 'global' | 'session';
 	itemCount: number;
+	disabled?: boolean;
 }
 
 function GroupHeader({
@@ -71,6 +77,7 @@ function GroupHeader({
 	onToggleAll,
 	scope,
 	itemCount,
+	disabled = false,
 }: GroupHeaderProps) {
 	const isIndeterminate = someEnabled && !allEnabled;
 
@@ -109,6 +116,7 @@ function GroupHeader({
 							if (el) el.indeterminate = isIndeterminate;
 						}}
 						onChange={onToggleAll}
+						disabled={disabled}
 						class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 					/>
 				</label>
@@ -148,9 +156,9 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 			loadGlobalConfig();
 			void skillsStore.subscribe();
 		}
-		if (!isOpen) {
+		return () => {
 			skillsStore.unsubscribe();
-		}
+		};
 	}, [isOpen, session?.id]);
 
 	// Reload MCP servers when setting sources change
@@ -201,6 +209,9 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 
 	const isMcpAllowed = useComputed(() => globalConfig.value?.mcp?.allowProjectMcp ?? true);
 	const isMemoryAllowed = useComputed(() => globalConfig.value?.kaiTools?.memory?.allowed ?? true);
+	const isClaudeCodePresetAllowed = useComputed(
+		() => globalConfig.value?.systemPrompt?.claudeCodePreset?.allowed ?? true
+	);
 
 	// App-level MCP skills
 	const appMcpSkills = useComputed(() =>
@@ -208,15 +219,8 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	);
 
 	// File-based MCP server helpers
-	const isServerEnabled = (serverName: string): boolean =>
-		!disabledMcpServers.value.includes(serverName);
-
-	const toggleServer = (serverName: string) => {
-		if (disabledMcpServers.value.includes(serverName)) {
-			disabledMcpServers.value = disabledMcpServers.value.filter((s) => s !== serverName);
-		} else {
-			disabledMcpServers.value = [...disabledMcpServers.value, serverName];
-		}
+	const handleToggleServer = (serverName: string) => {
+		disabledMcpServers.value = toggleServerUtil(disabledMcpServers.value, serverName);
 		hasChanges.value = true;
 	};
 
@@ -239,59 +243,44 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	// Group toggle for app-level skills
 	const toggleAppMcpGroup = async () => {
 		const skills = appMcpSkills.value;
+		if (skills.length === 0) return;
 		const allOn = skills.every((s) => s.enabled);
 		const newEnabled = !allOn;
-		for (const skill of skills) {
-			if (skill.enabled !== newEnabled) {
-				const toggling = new Set(skillToggling.value);
-				toggling.add(skill.id);
-				skillToggling.value = toggling;
-				try {
-					await skillsStore.setEnabled(skill.id, newEnabled);
-				} catch {
-					// Continue with remaining skills
-				} finally {
-					const done = new Set(skillToggling.value);
-					done.delete(skill.id);
-					skillToggling.value = done;
-				}
-			}
-		}
+		const toToggle = skills.filter((s) => s.enabled !== newEnabled);
+
+		// Mark all as toggling
+		skillToggling.value = new Set([...skillToggling.value, ...toToggle.map((s) => s.id)]);
+
+		await Promise.allSettled(
+			toToggle.map((skill) =>
+				skillsStore.setEnabled(skill.id, newEnabled).catch(() => {
+					toast.error(`Failed to toggle ${skill.displayName}`);
+				})
+			)
+		);
+
+		// Clear toggling state for all
+		const done = new Set(skillToggling.value);
+		for (const skill of toToggle) done.delete(skill.id);
+		skillToggling.value = done;
 	};
 
 	// Group toggle for file-based servers by source
 	const toggleFileMcpGroup = (source: SettingSource) => {
 		const servers = mcpServersData.value?.servers[source] ?? [];
-		const allOn = servers.every((s) => isServerEnabled(s.name));
-		if (allOn) {
-			// Disable all in this source
-			const toDisable = servers
-				.map((s) => s.name)
-				.filter((n) => !disabledMcpServers.value.includes(n));
-			disabledMcpServers.value = [...disabledMcpServers.value, ...toDisable];
-		} else {
-			// Enable all in this source
-			const names = new Set(servers.map((s) => s.name));
-			disabledMcpServers.value = disabledMcpServers.value.filter((n) => !names.has(n));
-		}
+		disabledMcpServers.value = toggleGroupServers(
+			disabledMcpServers.value,
+			servers.map((s) => s.name)
+		);
 		hasChanges.value = true;
 	};
 
 	// Group toggle for all file-based servers across all sources
 	const toggleAllFileMcp = () => {
-		const allServers = (['user', 'project', 'local'] as SettingSource[])
+		const allServerNames = (['user', 'project', 'local'] as SettingSource[])
 			.filter((src) => settingSources.value.includes(src))
-			.flatMap((src) => mcpServersData.value?.servers[src] ?? []);
-		const allOn = allServers.every((s) => isServerEnabled(s.name));
-		if (allOn) {
-			const toDisable = allServers
-				.map((s) => s.name)
-				.filter((n) => !disabledMcpServers.value.includes(n));
-			disabledMcpServers.value = [...disabledMcpServers.value, ...toDisable];
-		} else {
-			const names = new Set(allServers.map((s) => s.name));
-			disabledMcpServers.value = disabledMcpServers.value.filter((n) => !names.has(n));
-		}
+			.flatMap((src) => (mcpServersData.value?.servers[src] ?? []).map((s) => s.name));
+		disabledMcpServers.value = toggleGroupServers(disabledMcpServers.value, allServerNames);
 		hasChanges.value = true;
 	};
 
@@ -359,12 +348,15 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	const allFileMcpServers = enabledSources.flatMap(
 		(src) => mcpServersData.value?.servers[src] ?? []
 	);
-	const fileMcpAllOn = allFileMcpServers.every((s) => isServerEnabled(s.name));
-	const fileMcpSomeOn = allFileMcpServers.some((s) => isServerEnabled(s.name));
+	const allFileMcpServerNames = allFileMcpServers.map((s) => s.name);
+	const { allEnabled: fileMcpAllOn, someEnabled: fileMcpSomeOn } = computeGroupState(
+		disabledMcpServers.value,
+		allFileMcpServerNames
+	);
 
 	// App MCP counts
 	const appSkills = appMcpSkills.value;
-	const appAllOn = appSkills.every((s) => s.enabled);
+	const appAllOn = appSkills.length > 0 && appSkills.every((s) => s.enabled);
 	const appSomeOn = appSkills.some((s) => s.enabled);
 
 	return (
@@ -495,8 +487,10 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 											{enabledSources.map((source) => {
 												const servers = mcpServersData.value?.servers[source] ?? [];
 												if (servers.length === 0) return null;
-												const srcAllOn = servers.every((s) => isServerEnabled(s.name));
-												const srcSomeOn = servers.some((s) => isServerEnabled(s.name));
+												const { allEnabled: srcAllOn, someEnabled: srcSomeOn } = computeGroupState(
+													disabledMcpServers.value,
+													servers.map((s) => s.name)
+												);
 												return (
 													<div key={source}>
 														<div class="flex items-center justify-between mb-1">
@@ -548,8 +542,8 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 																	</div>
 																	<input
 																		type="checkbox"
-																		checked={isServerEnabled(server.name)}
-																		onChange={() => toggleServer(server.name)}
+																		checked={isServerEnabled(disabledMcpServers.value, server.name)}
+																		onChange={() => handleToggleServer(server.name)}
 																		class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 																	/>
 																</label>
@@ -578,9 +572,12 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 						}}
 						allEnabled={memoryEnabled.value}
 						someEnabled={memoryEnabled.value}
-						onToggleAll={toggleMemory}
+						onToggleAll={() => {
+							if (isMemoryAllowed.value) toggleMemory();
+						}}
 						scope="session"
 						itemCount={1}
+						disabled={!isMemoryAllowed.value}
 					/>
 					{neoKaiGroupOpen.value && (
 						<div class="mt-1 ml-5 space-y-1">
@@ -659,7 +656,9 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 								<h4 class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
 									System Prompt
 								</h4>
-								<label class="flex items-center justify-between p-2 rounded-lg bg-dark-800/50 hover:bg-dark-800 cursor-pointer">
+								<label
+									class={`flex items-center justify-between p-2 rounded-lg bg-dark-800/50 transition-colors ${isClaudeCodePresetAllowed.value ? 'hover:bg-dark-800 cursor-pointer' : 'opacity-50 cursor-not-allowed'}`}
+								>
 									<div>
 										<div class="text-sm text-gray-200">Claude Code Preset</div>
 										<div class="text-xs text-gray-500">Use official Claude Code system prompt</div>
@@ -671,6 +670,7 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 											useClaudeCodePreset.value = !useClaudeCodePreset.value;
 											hasChanges.value = true;
 										}}
+										disabled={!isClaudeCodePresetAllowed.value}
 										class="w-4 h-4 rounded border-gray-600 text-blue-500"
 									/>
 								</label>

--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -32,6 +32,8 @@ import {
 	toggleServer as toggleServerUtil,
 	toggleGroupServers,
 	computeGroupState,
+	computeSkillGroupState,
+	resolveSettingSources,
 } from './ToolsModal.utils.ts';
 
 interface ToolsModalProps {
@@ -154,7 +156,9 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 		if (isOpen && session) {
 			loadConfig();
 			loadGlobalConfig();
-			void skillsStore.subscribe();
+			void skillsStore.subscribe().catch(() => {
+				toast.error('Failed to load App MCP Servers');
+			});
 		}
 		return () => {
 			skillsStore.unsubscribe();
@@ -172,13 +176,7 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 		if (!session) return;
 		const tools = session.config.tools;
 		useClaudeCodePreset.value = tools?.useClaudeCodePreset ?? true;
-		if (tools?.settingSources) {
-			settingSources.value = tools.settingSources;
-		} else if (tools?.loadSettingSources !== false) {
-			settingSources.value = ['user', 'project', 'local'];
-		} else {
-			settingSources.value = [];
-		}
+		settingSources.value = resolveSettingSources(tools) as SettingSource[];
 		disabledMcpServers.value = tools?.disabledMcpServers ?? [];
 		memoryEnabled.value = tools?.kaiTools?.memory ?? false;
 		hasChanges.value = false;
@@ -356,8 +354,8 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 
 	// App MCP counts
 	const appSkills = appMcpSkills.value;
-	const appAllOn = appSkills.length > 0 && appSkills.every((s) => s.enabled);
-	const appSomeOn = appSkills.some((s) => s.enabled);
+	const { allEnabled: appAllOn, someEnabled: appSomeOn } = computeSkillGroupState(appSkills);
+	const anySkillToggling = appSkills.some((s) => skillToggling.value.has(s.id));
 
 	return (
 		<Modal isOpen={isOpen} onClose={handleCancel} title="Tools" size="md">
@@ -377,6 +375,7 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 								onToggleAll={toggleAppMcpGroup}
 								scope="global"
 								itemCount={appSkills.length}
+								disabled={anySkillToggling}
 							/>
 							{appMcpGroupOpen.value && (
 								<div class="space-y-1 mt-1 ml-5">

--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -1,16 +1,11 @@
 /**
- * Tools Modal Component
+ * Tools Modal Component (Redesigned)
  *
- * Configure tools for the current session:
- * - System Prompt: Claude Code preset
- * - Setting Sources: User/Project/Local settings selection
- * - MCP Servers: Dynamic list from selected setting sources
- * - NeoKai Tools: Memory (configurable)
- * - SDK Built-in: Always enabled, shown for information only
- *
- * SDK Terms Reference:
- * - systemPrompt: { type: 'preset', preset: 'claude_code' } - The Claude Code system prompt
- * - settingSources: ['project', 'local', 'user'] - Which config files to load
+ * Unified view of all available MCP servers and tools:
+ * - App MCP Servers: from skills registry (global scope – affects all sessions)
+ * - Project MCP Servers: from settings files (session scope – affects this session)
+ * - NeoKai Tools: Memory tool (session scope)
+ * - Advanced: Claude Code Preset & Settings Sources (hidden by default)
  */
 
 import { useSignal, useComputed } from '@preact/signals';
@@ -19,41 +14,25 @@ import { connectionManager } from '../lib/connection-manager.ts';
 import { toast } from '../lib/toast.ts';
 import { Modal } from './ui/Modal.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
-import type { Session, ToolsConfig, GlobalToolsConfig, SettingSource } from '@neokai/shared';
+import type {
+	Session,
+	ToolsConfig,
+	GlobalToolsConfig,
+	SettingSource,
+	AppSkill,
+} from '@neokai/shared';
 import {
 	listMcpServersFromSources,
 	type McpServerFromSource,
 	type McpServersFromSourcesResponse,
 } from '../lib/api-helpers.ts';
+import { skillsStore } from '../lib/skills-store.ts';
 
 interface ToolsModalProps {
 	isOpen: boolean;
 	onClose: () => void;
 	session: Session | null;
 }
-
-// Setting source options with descriptions
-const SETTING_SOURCE_OPTIONS: Array<{
-	value: SettingSource;
-	label: string;
-	description: string;
-}> = [
-	{
-		value: 'user',
-		label: 'User',
-		description: 'Load settings from ~/.claude/',
-	},
-	{
-		value: 'project',
-		label: 'Project',
-		description: 'Load settings from .claude/ in workspace',
-	},
-	{
-		value: 'local',
-		label: 'Local',
-		description: 'Load settings from .claude/settings.local.json',
-	},
-];
 
 // Source label mapping
 const SOURCE_LABELS: Record<SettingSource, string> = {
@@ -62,6 +41,82 @@ const SOURCE_LABELS: Record<SettingSource, string> = {
 	local: 'Local (.claude/settings.local.json)',
 };
 
+// Scope badge component
+function ScopeBadge({ scope }: { scope: 'global' | 'session' }) {
+	if (scope === 'global') {
+		return <span class="text-xs text-amber-500/70 font-medium">All sessions</span>;
+	}
+	return <span class="text-xs text-sky-500/70 font-medium">This session</span>;
+}
+
+// Collapsible group header component
+interface GroupHeaderProps {
+	title: string;
+	description?: string;
+	isOpen: boolean;
+	onToggleOpen: () => void;
+	allEnabled: boolean;
+	someEnabled: boolean;
+	onToggleAll: () => void;
+	scope: 'global' | 'session';
+	itemCount: number;
+}
+
+function GroupHeader({
+	title,
+	isOpen,
+	onToggleOpen,
+	allEnabled,
+	someEnabled,
+	onToggleAll,
+	scope,
+	itemCount,
+}: GroupHeaderProps) {
+	const isIndeterminate = someEnabled && !allEnabled;
+
+	return (
+		<div class="flex items-center justify-between py-2 cursor-pointer select-none group">
+			<button
+				type="button"
+				class="flex items-center gap-2 flex-1 text-left hover:text-gray-200 transition-colors"
+				onClick={onToggleOpen}
+				aria-expanded={isOpen}
+			>
+				<svg
+					class={`w-3.5 h-3.5 text-gray-500 transition-transform ${isOpen ? 'rotate-90' : ''}`}
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width={2} d="M9 5l7 7-7 7" />
+				</svg>
+				<span class="text-sm font-medium text-gray-300">{title}</span>
+				<span class="text-xs text-gray-600">({itemCount})</span>
+			</button>
+			<div class="flex items-center gap-3">
+				<ScopeBadge scope={scope} />
+				<label
+					class="flex items-center gap-1.5 cursor-pointer"
+					title={allEnabled ? 'Disable all' : 'Enable all'}
+				>
+					<span class="text-xs text-gray-500">
+						{allEnabled ? 'All on' : someEnabled ? 'Mixed' : 'All off'}
+					</span>
+					<input
+						type="checkbox"
+						checked={allEnabled}
+						ref={(el) => {
+							if (el) el.indeterminate = isIndeterminate;
+						}}
+						onChange={onToggleAll}
+						class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+					/>
+				</label>
+			</div>
+		</div>
+	);
+}
+
 export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	const saving = useSignal(false);
 	const hasChanges = useSignal(false);
@@ -69,19 +124,32 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	const mcpServersData = useSignal<McpServersFromSourcesResponse | null>(null);
 	const globalConfig = useSignal<GlobalToolsConfig | null>(null);
 
-	// Local state for editing
-	const useClaudeCodePreset = useSignal(true);
-	const settingSources = useSignal<SettingSource[]>(['user', 'project', 'local']);
-	// List of disabled MCP server names (unchecked servers)
-	// This is the inverse of the old enabledMcpPatterns approach
+	// Collapsible group state (open by default)
+	const appMcpGroupOpen = useSignal(true);
+	const fileMcpGroupOpen = useSignal(true);
+	const neoKaiGroupOpen = useSignal(true);
+	const advancedOpen = useSignal(false);
+
+	// Per-skill loading state for immediate toggles
+	const skillToggling = useSignal<Set<string>>(new Set());
+
+	// Session-local config state
 	const disabledMcpServers = useSignal<string[]>([]);
 	const memoryEnabled = useSignal(false);
+
+	// Advanced settings (hidden by default)
+	const useClaudeCodePreset = useSignal(true);
+	const settingSources = useSignal<SettingSource[]>(['user', 'project', 'local']);
 
 	// Load current config and MCP servers when modal opens
 	useEffect(() => {
 		if (isOpen && session) {
 			loadConfig();
 			loadGlobalConfig();
+			void skillsStore.subscribe();
+		}
+		if (!isOpen) {
+			skillsStore.unsubscribe();
 		}
 	}, [isOpen, session?.id]);
 
@@ -94,21 +162,15 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 
 	const loadConfig = () => {
 		if (!session) return;
-
 		const tools = session.config.tools;
-		// Handle both old and new config format for backward compatibility
 		useClaudeCodePreset.value = tools?.useClaudeCodePreset ?? true;
-		// New settingSources field or fall back to legacy loadSettingSources behavior
 		if (tools?.settingSources) {
 			settingSources.value = tools.settingSources;
 		} else if (tools?.loadSettingSources !== false) {
-			// Legacy: if loadSettingSources was true or undefined, enable all sources
 			settingSources.value = ['user', 'project', 'local'];
 		} else {
-			// Legacy: loadSettingSources was explicitly false
 			settingSources.value = [];
 		}
-		// Load disabled MCP servers (new approach)
 		disabledMcpServers.value = tools?.disabledMcpServers ?? [];
 		memoryEnabled.value = tools?.kaiTools?.memory ?? false;
 		hasChanges.value = false;
@@ -116,7 +178,6 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 
 	const loadMcpServers = async () => {
 		if (!session) return;
-
 		try {
 			mcpLoading.value = true;
 			const response = await listMcpServersFromSources(session.id);
@@ -134,36 +195,108 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 			const response = await hub.request<{ config: GlobalToolsConfig }>('globalTools.getConfig');
 			globalConfig.value = response.config;
 		} catch {
-			// Error loading global config - will use defaults
+			// Error loading global config
 		}
 	};
 
-	// Check if tools are allowed based on global config
-	const isClaudeCodePresetAllowed = useComputed(
-		() => globalConfig.value?.systemPrompt?.claudeCodePreset?.allowed ?? true
-	);
 	const isMcpAllowed = useComputed(() => globalConfig.value?.mcp?.allowProjectMcp ?? true);
 	const isMemoryAllowed = useComputed(() => globalConfig.value?.kaiTools?.memory?.allowed ?? true);
 
-	// Check if a server is enabled (not in disabled list)
-	const isServerEnabled = (serverName: string): boolean => {
-		return !disabledMcpServers.value.includes(serverName);
-	};
+	// App-level MCP skills
+	const appMcpSkills = useComputed(() =>
+		skillsStore.skills.value.filter((s) => s.sourceType === 'mcp_server')
+	);
 
-	// Toggle server enabled/disabled state
+	// File-based MCP server helpers
+	const isServerEnabled = (serverName: string): boolean =>
+		!disabledMcpServers.value.includes(serverName);
+
 	const toggleServer = (serverName: string) => {
 		if (disabledMcpServers.value.includes(serverName)) {
-			// Currently disabled → enable (remove from disabled list)
 			disabledMcpServers.value = disabledMcpServers.value.filter((s) => s !== serverName);
 		} else {
-			// Currently enabled → disable (add to disabled list)
 			disabledMcpServers.value = [...disabledMcpServers.value, serverName];
 		}
 		hasChanges.value = true;
 	};
 
-	const toggleClaudeCodePreset = () => {
-		useClaudeCodePreset.value = !useClaudeCodePreset.value;
+	// App-level skill toggle (immediate, global)
+	const toggleSkill = async (skill: AppSkill) => {
+		const toggling = new Set(skillToggling.value);
+		toggling.add(skill.id);
+		skillToggling.value = toggling;
+		try {
+			await skillsStore.setEnabled(skill.id, !skill.enabled);
+		} catch {
+			toast.error(`Failed to toggle ${skill.displayName}`);
+		} finally {
+			const done = new Set(skillToggling.value);
+			done.delete(skill.id);
+			skillToggling.value = done;
+		}
+	};
+
+	// Group toggle for app-level skills
+	const toggleAppMcpGroup = async () => {
+		const skills = appMcpSkills.value;
+		const allOn = skills.every((s) => s.enabled);
+		const newEnabled = !allOn;
+		for (const skill of skills) {
+			if (skill.enabled !== newEnabled) {
+				const toggling = new Set(skillToggling.value);
+				toggling.add(skill.id);
+				skillToggling.value = toggling;
+				try {
+					await skillsStore.setEnabled(skill.id, newEnabled);
+				} catch {
+					// Continue with remaining skills
+				} finally {
+					const done = new Set(skillToggling.value);
+					done.delete(skill.id);
+					skillToggling.value = done;
+				}
+			}
+		}
+	};
+
+	// Group toggle for file-based servers by source
+	const toggleFileMcpGroup = (source: SettingSource) => {
+		const servers = mcpServersData.value?.servers[source] ?? [];
+		const allOn = servers.every((s) => isServerEnabled(s.name));
+		if (allOn) {
+			// Disable all in this source
+			const toDisable = servers
+				.map((s) => s.name)
+				.filter((n) => !disabledMcpServers.value.includes(n));
+			disabledMcpServers.value = [...disabledMcpServers.value, ...toDisable];
+		} else {
+			// Enable all in this source
+			const names = new Set(servers.map((s) => s.name));
+			disabledMcpServers.value = disabledMcpServers.value.filter((n) => !names.has(n));
+		}
+		hasChanges.value = true;
+	};
+
+	// Group toggle for all file-based servers across all sources
+	const toggleAllFileMcp = () => {
+		const allServers = (['user', 'project', 'local'] as SettingSource[])
+			.filter((src) => settingSources.value.includes(src))
+			.flatMap((src) => mcpServersData.value?.servers[src] ?? []);
+		const allOn = allServers.every((s) => isServerEnabled(s.name));
+		if (allOn) {
+			const toDisable = allServers
+				.map((s) => s.name)
+				.filter((n) => !disabledMcpServers.value.includes(n));
+			disabledMcpServers.value = [...disabledMcpServers.value, ...toDisable];
+		} else {
+			const names = new Set(allServers.map((s) => s.name));
+			disabledMcpServers.value = disabledMcpServers.value.filter((n) => !names.has(n));
+		}
+		hasChanges.value = true;
+	};
+
+	const toggleMemory = () => {
+		memoryEnabled.value = !memoryEnabled.value;
 		hasChanges.value = true;
 	};
 
@@ -173,7 +306,6 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 				settingSources.value = [...settingSources.value, source];
 			}
 		} else {
-			// Ensure at least one source is enabled
 			const newSources = settingSources.value.filter((s) => s !== source);
 			if (newSources.length === 0) {
 				toast.error('At least one setting source must be enabled');
@@ -184,36 +316,21 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 		hasChanges.value = true;
 	};
 
-	const toggleMemory = () => {
-		memoryEnabled.value = !memoryEnabled.value;
-		hasChanges.value = true;
-	};
-
 	const handleSave = async () => {
 		if (!session || !hasChanges.value) return;
-
 		try {
 			saving.value = true;
-
-			// Build tools config with the new file-based approach
-			// disabledMcpServers is written to .claude/settings.local.json
-			// SDK reads this file and applies server filtering automatically
 			const toolsConfig: ToolsConfig = {
 				useClaudeCodePreset: useClaudeCodePreset.value,
 				settingSources: settingSources.value,
-				// List of unchecked servers → written to settings.local.json as disabledMcpjsonServers
 				disabledMcpServers: disabledMcpServers.value,
-				kaiTools: {
-					memory: memoryEnabled.value,
-				},
+				kaiTools: { memory: memoryEnabled.value },
 			};
-
 			const hub = await connectionManager.getHub();
 			const result = await hub.request<{ success: boolean; error?: string }>('tools.save', {
 				sessionId: session.id,
 				tools: toolsConfig,
 			});
-
 			if (result.success) {
 				hasChanges.value = false;
 				toast.success('Tools configuration saved');
@@ -229,110 +346,121 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	};
 
 	const handleCancel = () => {
-		loadConfig(); // Reset to original values
+		loadConfig();
 		onClose();
 	};
 
 	if (!session) return null;
 
+	// Compute file-based server counts
+	const enabledSources = (['user', 'project', 'local'] as SettingSource[]).filter((src) =>
+		settingSources.value.includes(src)
+	);
+	const allFileMcpServers = enabledSources.flatMap(
+		(src) => mcpServersData.value?.servers[src] ?? []
+	);
+	const fileMcpAllOn = allFileMcpServers.every((s) => isServerEnabled(s.name));
+	const fileMcpSomeOn = allFileMcpServers.some((s) => isServerEnabled(s.name));
+
+	// App MCP counts
+	const appSkills = appMcpSkills.value;
+	const appAllOn = appSkills.every((s) => s.enabled);
+	const appSomeOn = appSkills.some((s) => s.enabled);
+
 	return (
 		<Modal isOpen={isOpen} onClose={handleCancel} title="Tools" size="md">
-			<div class="space-y-5">
-				{/* System Prompt Section */}
+			<div class="space-y-4">
+				{/* App MCP Servers Section */}
 				<div>
-					<h3 class="text-sm font-medium text-gray-300 mb-2">System Prompt</h3>
-					<p class="text-xs text-gray-500 mb-3">Configure the system prompt preset.</p>
-					<div class="space-y-2">
-						{/* Claude Code Preset Toggle */}
-						<label
-							class={`flex items-center justify-between p-3 rounded-lg bg-dark-800/50 transition-colors ${
-								isClaudeCodePresetAllowed.value
-									? 'hover:bg-dark-800 cursor-pointer'
-									: 'opacity-50 cursor-not-allowed'
-							}`}
-						>
-							<div class="flex items-center gap-3">
-								<svg
-									class="w-5 h-5 text-blue-400"
-									fill="none"
-									viewBox="0 0 24 24"
-									stroke="currentColor"
-								>
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width={2}
-										d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-									/>
-								</svg>
-								<div>
-									<div class="text-sm text-gray-200">Claude Code Preset</div>
-									<div class="text-xs text-gray-500">
-										Use official Claude Code system prompt with tools
-									</div>
-								</div>
-							</div>
-							<input
-								type="checkbox"
-								checked={useClaudeCodePreset.value}
-								onChange={toggleClaudeCodePreset}
-								disabled={!isClaudeCodePresetAllowed.value}
-								class="w-5 h-5 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+					{appSkills.length > 0 ? (
+						<>
+							<GroupHeader
+								title="App MCP Servers"
+								isOpen={appMcpGroupOpen.value}
+								onToggleOpen={() => {
+									appMcpGroupOpen.value = !appMcpGroupOpen.value;
+								}}
+								allEnabled={appAllOn}
+								someEnabled={appSomeOn}
+								onToggleAll={toggleAppMcpGroup}
+								scope="global"
+								itemCount={appSkills.length}
 							/>
-						</label>
-					</div>
+							{appMcpGroupOpen.value && (
+								<div class="space-y-1 mt-1 ml-5">
+									{appSkills.map((skill) => {
+										const isToggling = skillToggling.value.has(skill.id);
+										return (
+											<label
+												key={skill.id}
+												class={`flex items-center justify-between p-2 rounded-lg bg-dark-800/50 transition-colors ${
+													isToggling ? 'opacity-60' : 'hover:bg-dark-800 cursor-pointer'
+												}`}
+											>
+												<div class="flex items-center gap-2 flex-1 min-w-0">
+													<svg
+														class="w-4 h-4 text-amber-400 flex-shrink-0"
+														fill="none"
+														viewBox="0 0 24 24"
+														stroke="currentColor"
+													>
+														<path
+															stroke-linecap="round"
+															stroke-linejoin="round"
+															stroke-width={2}
+															d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"
+														/>
+													</svg>
+													<div class="flex-1 min-w-0">
+														<div class="text-sm text-gray-200 truncate">{skill.displayName}</div>
+														{skill.description && (
+															<div class="text-xs text-gray-500 truncate">{skill.description}</div>
+														)}
+													</div>
+												</div>
+												<div class="flex items-center gap-2 flex-shrink-0">
+													{isToggling && (
+														<div class="w-3 h-3 border-2 border-gray-500 border-t-transparent rounded-full animate-spin" />
+													)}
+													<input
+														type="checkbox"
+														checked={skill.enabled}
+														onChange={() => void toggleSkill(skill)}
+														disabled={isToggling}
+														class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+													/>
+												</div>
+											</label>
+										);
+									})}
+								</div>
+							)}
+						</>
+					) : (
+						<div class="flex items-center gap-2 py-1">
+							<svg
+								class="w-3.5 h-3.5 text-gray-600"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M9 5l7 7-7 7"
+								/>
+							</svg>
+							<span class="text-sm font-medium text-gray-500">App MCP Servers</span>
+							<span class="text-xs text-gray-700">(none configured)</span>
+						</div>
+					)}
 				</div>
 
-				{/* Divider */}
 				<div class={`border-t ${borderColors.ui.secondary}`} />
 
-				{/* Setting Sources Section */}
+				{/* File-based MCP Servers Section */}
 				<div>
-					<h3 class="text-sm font-medium text-gray-300 mb-2">Setting Sources</h3>
-					<p class="text-xs text-gray-500 mb-3">
-						Choose which configuration sources to load for this session.
-					</p>
-					<div class="space-y-2">
-						{SETTING_SOURCE_OPTIONS.map((option) => {
-							const isEnabled = settingSources.value.includes(option.value);
-							return (
-								<label
-									key={option.value}
-									class={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-										isEnabled
-											? `${borderColors.ui.secondary} bg-dark-800`
-											: 'border-dark-700 bg-dark-900 opacity-60'
-									}`}
-								>
-									<input
-										type="checkbox"
-										checked={isEnabled}
-										onChange={(e) =>
-											toggleSettingSource(option.value, (e.target as HTMLInputElement).checked)
-										}
-										class="mt-0.5 w-4 h-4 rounded border-gray-600 bg-dark-900 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
-									/>
-									<div class="flex-1">
-										<div class="text-sm text-gray-200 font-medium">{option.label}</div>
-										<div class="text-xs text-gray-500">{option.description}</div>
-									</div>
-								</label>
-							);
-						})}
-					</div>
-				</div>
-
-				{/* Divider */}
-				<div class={`border-t ${borderColors.ui.secondary}`} />
-
-				{/* MCP Servers Section - Dynamic from setting sources */}
-				<div>
-					<h3 class="text-sm font-medium text-gray-300 mb-2">MCP Servers</h3>
-					<p class="text-xs text-gray-500 mb-3">
-						MCP servers from enabled setting sources. Enable servers you want to use in this
-						session.
-					</p>
-
 					{!isMcpAllowed.value ? (
 						<div class="text-sm text-gray-500 py-2 italic">
 							MCP servers are disabled in global settings.
@@ -342,203 +470,249 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 							<div class="w-4 h-4 border-2 border-gray-500 border-t-transparent rounded-full animate-spin" />
 							Loading servers...
 						</div>
-					) : mcpServersData.value ? (
-						<div class="space-y-3">
-							{/* Group servers by source */}
-							{(['user', 'project', 'local'] as SettingSource[])
-								.filter((source) => settingSources.value.includes(source))
-								.map((source) => {
-									const serversForSource = mcpServersData.value?.servers[source] || [];
-									if (serversForSource.length === 0) return null;
-
-									return (
-										<div key={source} class="space-y-2">
-											<div class="text-xs font-medium text-gray-400 uppercase tracking-wider">
-												{SOURCE_LABELS[source]}
-											</div>
-											<div class="space-y-1">
-												{serversForSource.map((server: McpServerFromSource) => (
-													<label
-														key={`${source}-${server.name}`}
-														class="flex items-center justify-between p-2 rounded-lg bg-dark-800/50 hover:bg-dark-800 transition-colors cursor-pointer"
-													>
-														<div class="flex items-center gap-2 flex-1 min-w-0">
-															<svg
-																class="w-4 h-4 text-purple-400 flex-shrink-0"
-																fill="none"
-																viewBox="0 0 24 24"
-																stroke="currentColor"
-															>
-																<path
-																	stroke-linecap="round"
-																	stroke-linejoin="round"
-																	stroke-width={2}
-																	d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"
-																/>
-															</svg>
-															<div class="flex-1 min-w-0">
-																<div class="text-sm text-gray-200 truncate">{server.name}</div>
-																{server.command && (
-																	<div class="text-xs text-gray-500 truncate">{server.command}</div>
-																)}
-															</div>
-														</div>
-														<input
-															type="checkbox"
-															checked={isServerEnabled(server.name)}
-															onChange={() => toggleServer(server.name)}
-															class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
-														/>
-													</label>
-												))}
-											</div>
+					) : (
+						<>
+							<GroupHeader
+								title="Project MCP Servers"
+								isOpen={fileMcpGroupOpen.value}
+								onToggleOpen={() => {
+									fileMcpGroupOpen.value = !fileMcpGroupOpen.value;
+								}}
+								allEnabled={fileMcpAllOn}
+								someEnabled={fileMcpSomeOn}
+								onToggleAll={toggleAllFileMcp}
+								scope="session"
+								itemCount={allFileMcpServers.length}
+							/>
+							{fileMcpGroupOpen.value && (
+								<div class="mt-1 ml-5">
+									{allFileMcpServers.length === 0 ? (
+										<div class="text-xs text-gray-600 py-2">
+											No MCP servers found in enabled setting sources.
 										</div>
-									);
-								})}
-
-							{/* No servers message */}
-							{(['user', 'project', 'local'] as SettingSource[])
-								.filter((source) => settingSources.value.includes(source))
-								.every((source) => (mcpServersData.value?.servers[source] || []).length === 0) && (
-								<div class="text-xs text-gray-500 py-2 text-center">
-									No MCP servers found in enabled setting sources.
+									) : (
+										<div class="space-y-3">
+											{enabledSources.map((source) => {
+												const servers = mcpServersData.value?.servers[source] ?? [];
+												if (servers.length === 0) return null;
+												const srcAllOn = servers.every((s) => isServerEnabled(s.name));
+												const srcSomeOn = servers.some((s) => isServerEnabled(s.name));
+												return (
+													<div key={source}>
+														<div class="flex items-center justify-between mb-1">
+															<span class="text-xs font-medium text-gray-500 uppercase tracking-wider">
+																{SOURCE_LABELS[source]}
+															</span>
+															<label class="flex items-center gap-1.5 cursor-pointer text-xs text-gray-500">
+																<input
+																	type="checkbox"
+																	checked={srcAllOn}
+																	ref={(el) => {
+																		if (el) el.indeterminate = srcSomeOn && !srcAllOn;
+																	}}
+																	onChange={() => toggleFileMcpGroup(source)}
+																	class="w-3.5 h-3.5 rounded border-gray-600 text-blue-500"
+																/>
+															</label>
+														</div>
+														<div class="space-y-1">
+															{servers.map((server: McpServerFromSource) => (
+																<label
+																	key={`${source}-${server.name}`}
+																	class="flex items-center justify-between p-2 rounded-lg bg-dark-800/50 hover:bg-dark-800 transition-colors cursor-pointer"
+																>
+																	<div class="flex items-center gap-2 flex-1 min-w-0">
+																		<svg
+																			class="w-4 h-4 text-purple-400 flex-shrink-0"
+																			fill="none"
+																			viewBox="0 0 24 24"
+																			stroke="currentColor"
+																		>
+																			<path
+																				stroke-linecap="round"
+																				stroke-linejoin="round"
+																				stroke-width={2}
+																				d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"
+																			/>
+																		</svg>
+																		<div class="flex-1 min-w-0">
+																			<div class="text-sm text-gray-200 truncate">
+																				{server.name}
+																			</div>
+																			{server.command && (
+																				<div class="text-xs text-gray-500 truncate">
+																					{server.command}
+																				</div>
+																			)}
+																		</div>
+																	</div>
+																	<input
+																		type="checkbox"
+																		checked={isServerEnabled(server.name)}
+																		onChange={() => toggleServer(server.name)}
+																		class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+																	/>
+																</label>
+															))}
+														</div>
+													</div>
+												);
+											})}
+										</div>
+									)}
 								</div>
 							)}
-						</div>
-					) : (
-						<div class="text-xs text-gray-500 py-2">Failed to load MCP servers.</div>
+						</>
 					)}
 				</div>
 
-				{/* Divider */}
 				<div class={`border-t ${borderColors.ui.secondary}`} />
 
 				{/* NeoKai Tools Section */}
 				<div>
-					<h3 class="text-sm font-medium text-gray-300 mb-2">NeoKai Tools</h3>
-					<p class="text-xs text-gray-500 mb-3">Enhanced tools provided by NeoKai.</p>
-					<div class="space-y-2">
-						{/* Memory Tool */}
-						<label
-							class={`flex items-center justify-between p-3 rounded-lg bg-dark-800/50 transition-colors ${
-								isMemoryAllowed.value
-									? 'hover:bg-dark-800 cursor-pointer'
-									: 'opacity-50 cursor-not-allowed'
-							}`}
-						>
-							<div class="flex items-center gap-3">
-								<svg
-									class="w-5 h-5 text-purple-400"
-									fill="none"
-									viewBox="0 0 24 24"
-									stroke="currentColor"
-								>
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width={2}
-										d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
-									/>
-								</svg>
-								<div>
-									<div class="text-sm text-gray-200">Memory</div>
-									<div class="text-xs text-gray-500">
-										Persistent key-value storage across sessions
+					<GroupHeader
+						title="NeoKai Tools"
+						isOpen={neoKaiGroupOpen.value}
+						onToggleOpen={() => {
+							neoKaiGroupOpen.value = !neoKaiGroupOpen.value;
+						}}
+						allEnabled={memoryEnabled.value}
+						someEnabled={memoryEnabled.value}
+						onToggleAll={toggleMemory}
+						scope="session"
+						itemCount={1}
+					/>
+					{neoKaiGroupOpen.value && (
+						<div class="mt-1 ml-5 space-y-1">
+							<label
+								class={`flex items-center justify-between p-2 rounded-lg bg-dark-800/50 transition-colors ${
+									isMemoryAllowed.value
+										? 'hover:bg-dark-800 cursor-pointer'
+										: 'opacity-50 cursor-not-allowed'
+								}`}
+							>
+								<div class="flex items-center gap-2 flex-1 min-w-0">
+									<svg
+										class="w-4 h-4 text-purple-400 flex-shrink-0"
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
+										/>
+									</svg>
+									<div class="flex-1 min-w-0">
+										<div class="text-sm text-gray-200">Memory</div>
+										<div class="text-xs text-gray-500">
+											Persistent key-value storage across sessions
+										</div>
 									</div>
 								</div>
-							</div>
-							<input
-								type="checkbox"
-								checked={memoryEnabled.value}
-								onChange={toggleMemory}
-								disabled={!isMemoryAllowed.value}
-								class="w-5 h-5 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
-							/>
-						</label>
-					</div>
+								<input
+									type="checkbox"
+									checked={memoryEnabled.value}
+									onChange={toggleMemory}
+									disabled={!isMemoryAllowed.value}
+									class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+								/>
+							</label>
+						</div>
+					)}
 				</div>
 
-				{/* Divider */}
 				<div class={`border-t ${borderColors.ui.secondary}`} />
 
-				{/* SDK Built-in Tools Info (read-only) */}
+				{/* Advanced Section (collapsed by default) */}
 				<div>
-					<h3 class="text-sm font-medium text-gray-300 mb-2">SDK Built-in</h3>
-					<p class="text-xs text-gray-500 mb-3">Always available tools from Claude Agent SDK.</p>
+					<button
+						type="button"
+						class="flex items-center gap-2 w-full text-left py-1 hover:text-gray-300 transition-colors"
+						onClick={() => {
+							advancedOpen.value = !advancedOpen.value;
+						}}
+						aria-expanded={advancedOpen.value}
+					>
+						<svg
+							class={`w-3.5 h-3.5 text-gray-600 transition-transform ${advancedOpen.value ? 'rotate-90' : ''}`}
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M9 5l7 7-7 7"
+							/>
+						</svg>
+						<span class="text-sm font-medium text-gray-500">Advanced</span>
+					</button>
 
-					<div class="space-y-1.5 opacity-70">
-						<div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
-							<svg
-								class="w-4 h-4 text-gray-500"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width={2}
-									d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-								/>
-							</svg>
-							<span class="text-xs text-gray-400">
-								Read, Write, Edit, Glob, Grep, Bash, Notebook...
-							</span>
+					{advancedOpen.value && (
+						<div class="mt-3 space-y-4 ml-5">
+							{/* Claude Code Preset */}
+							<div>
+								<h4 class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+									System Prompt
+								</h4>
+								<label class="flex items-center justify-between p-2 rounded-lg bg-dark-800/50 hover:bg-dark-800 cursor-pointer">
+									<div>
+										<div class="text-sm text-gray-200">Claude Code Preset</div>
+										<div class="text-xs text-gray-500">Use official Claude Code system prompt</div>
+									</div>
+									<input
+										type="checkbox"
+										checked={useClaudeCodePreset.value}
+										onChange={() => {
+											useClaudeCodePreset.value = !useClaudeCodePreset.value;
+											hasChanges.value = true;
+										}}
+										class="w-4 h-4 rounded border-gray-600 text-blue-500"
+									/>
+								</label>
+							</div>
+
+							{/* Setting Sources */}
+							<div>
+								<h4 class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+									Setting Sources
+								</h4>
+								<div class="space-y-1.5">
+									{(['user', 'project', 'local'] as SettingSource[]).map((source) => {
+										const isEnabled = settingSources.value.includes(source);
+										return (
+											<label
+												key={source}
+												class="flex items-center gap-3 p-2 rounded-lg bg-dark-800/50 hover:bg-dark-800 cursor-pointer"
+											>
+												<input
+													type="checkbox"
+													checked={isEnabled}
+													onChange={(e) =>
+														toggleSettingSource(source, (e.target as HTMLInputElement).checked)
+													}
+													class="w-4 h-4 rounded border-gray-600 bg-dark-900 text-blue-500"
+												/>
+												<div>
+													<div class="text-sm text-gray-200">
+														{source.charAt(0).toUpperCase() + source.slice(1)}
+													</div>
+													<div class="text-xs text-gray-500">{SOURCE_LABELS[source]}</div>
+												</div>
+											</label>
+										);
+									})}
+								</div>
+							</div>
 						</div>
-						<div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
-							<svg
-								class="w-4 h-4 text-gray-500"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width={2}
-									d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9"
-								/>
-							</svg>
-							<span class="text-xs text-gray-400">WebSearch, WebFetch</span>
-						</div>
-						<div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
-							<svg
-								class="w-4 h-4 text-gray-500"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width={2}
-									d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-								/>
-							</svg>
-							<span class="text-xs text-gray-400">
-								Task agents (Explore, Plan, general-purpose)
-							</span>
-						</div>
-						<div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
-							<svg
-								class="w-4 h-4 text-gray-500"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width={2}
-									d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"
-								/>
-							</svg>
-							<span class="text-xs text-gray-400">/help, /context, /clear, /bug...</span>
-						</div>
-					</div>
+					)}
 				</div>
 
-				{/* Footer with Save/Cancel buttons */}
+				{/* Footer */}
 				<div class={`pt-4 border-t ${borderColors.ui.secondary} flex gap-3 justify-end`}>
 					<button
 						type="button"

--- a/packages/web/src/components/ToolsModal.utils.ts
+++ b/packages/web/src/components/ToolsModal.utils.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure logic utilities for ToolsModal.
+ *
+ * Extracted so both the component and unit tests import the same functions,
+ * ensuring tests cover actual component logic rather than re-implementations.
+ */
+
+/** Returns true when the server is NOT in the disabled list. */
+export function isServerEnabled(disabledMcpServers: string[], serverName: string): boolean {
+	return !disabledMcpServers.includes(serverName);
+}
+
+/** Toggle a single server: remove from disabled list if present, add if absent. */
+export function toggleServer(disabledMcpServers: string[], serverName: string): string[] {
+	if (disabledMcpServers.includes(serverName)) {
+		return disabledMcpServers.filter((s) => s !== serverName);
+	}
+	return [...disabledMcpServers, serverName];
+}
+
+/**
+ * Group toggle: if ALL servers are currently enabled, disable all of them.
+ * Otherwise enable all (remove from disabled list).
+ * Servers not in serverNames are unaffected.
+ */
+export function toggleGroupServers(disabledMcpServers: string[], serverNames: string[]): string[] {
+	const allOn = serverNames.every((name) => isServerEnabled(disabledMcpServers, name));
+	if (allOn) {
+		const toDisable = serverNames.filter((n) => !disabledMcpServers.includes(n));
+		return [...disabledMcpServers, ...toDisable];
+	}
+	const names = new Set(serverNames);
+	return disabledMcpServers.filter((n) => !names.has(n));
+}
+
+/**
+ * Compute group-level toggle state for a set of servers.
+ * Returns `allEnabled: false` and `someEnabled: false` when the list is empty
+ * to avoid vacuous-truth `[].every()` returning `true`.
+ */
+export function computeGroupState(
+	disabledMcpServers: string[],
+	serverNames: string[]
+): { allEnabled: boolean; someEnabled: boolean; isIndeterminate: boolean } {
+	if (serverNames.length === 0) {
+		return { allEnabled: false, someEnabled: false, isIndeterminate: false };
+	}
+	const allEnabled = serverNames.every((name) => isServerEnabled(disabledMcpServers, name));
+	const someEnabled = serverNames.some((name) => isServerEnabled(disabledMcpServers, name));
+	return { allEnabled, someEnabled, isIndeterminate: someEnabled && !allEnabled };
+}

--- a/packages/web/src/components/ToolsModal.utils.ts
+++ b/packages/web/src/components/ToolsModal.utils.ts
@@ -49,3 +49,37 @@ export function computeGroupState(
 	const someEnabled = serverNames.some((name) => isServerEnabled(disabledMcpServers, name));
 	return { allEnabled, someEnabled, isIndeterminate: someEnabled && !allEnabled };
 }
+
+/**
+ * Compute group-level toggle state for a list of app-level skills.
+ * Returns `allEnabled: false` and `someEnabled: false` when the list is empty.
+ */
+export function computeSkillGroupState(skills: { enabled: boolean }[]): {
+	allEnabled: boolean;
+	someEnabled: boolean;
+	isIndeterminate: boolean;
+} {
+	if (skills.length === 0) {
+		return { allEnabled: false, someEnabled: false, isIndeterminate: false };
+	}
+	const allEnabled = skills.every((s) => s.enabled);
+	const someEnabled = skills.some((s) => s.enabled);
+	return { allEnabled, someEnabled, isIndeterminate: someEnabled && !allEnabled };
+}
+
+/**
+ * Resolve the setting sources from a tools config object.
+ * Handles both the new `settingSources` field and the legacy `loadSettingSources` flag.
+ */
+export function resolveSettingSources(tools?: {
+	settingSources?: string[];
+	loadSettingSources?: boolean;
+}): string[] {
+	if (tools?.settingSources) {
+		return tools.settingSources;
+	}
+	if (tools?.loadSettingSources === false) {
+		return [];
+	}
+	return ['user', 'project', 'local'];
+}

--- a/packages/web/src/components/__tests__/ToolsModal.test.tsx
+++ b/packages/web/src/components/__tests__/ToolsModal.test.tsx
@@ -5,7 +5,6 @@
  * the actual code used by the component, not re-implementations.
  */
 import { describe, it, expect } from 'vitest';
-import { signal } from '@preact/signals';
 import {
 	isServerEnabled,
 	toggleServer,
@@ -178,36 +177,19 @@ describe('resolveSettingSources', () => {
 });
 
 describe('ToolsModal Logic', () => {
-	describe('Save / Cancel state', () => {
-		it('Save button is disabled when no changes', () => {
-			const hasChanges = signal(false);
-			const saving = signal(false);
-			expect(!hasChanges.value || saving.value).toBe(true);
+	describe('File-based vs app-level state separation', () => {
+		it('toggleServer only modifies the disabledMcpServers list', () => {
+			// File-based server toggles go through toggleServer → disabledMcpServers
+			const disabled = toggleServer([], 'file-server');
+			expect(disabled).toContain('file-server');
+			// The returned list contains only the server name, nothing else
+			expect(disabled).toHaveLength(1);
 		});
 
-		it('Save button is disabled while saving even with changes', () => {
-			const hasChanges = signal(true);
-			const saving = signal(true);
-			expect(!hasChanges.value || saving.value).toBe(true);
-		});
-
-		it('Save button is enabled when there are pending changes and not saving', () => {
-			const hasChanges = signal(true);
-			const saving = signal(false);
-			expect(!hasChanges.value || saving.value).toBe(false);
-		});
-
-		it('toggleServer sets hasChanges (file-based scope)', () => {
-			// toggleServer returns new array; caller also sets hasChanges = true
-			const disabled = toggleServer([], 'server1');
-			expect(disabled).toContain('server1');
-			// The component sets hasChanges.value = true after this call
-		});
-
-		it('app-level skill toggles do not affect disabledMcpServers', () => {
+		it('app-level skill ids are not mixed into disabledMcpServers', () => {
 			// App-level skills use skillsStore.setEnabled — completely separate state
+			// File-based servers only — toggleServer does not know about skill ids
 			let disabled: string[] = [];
-			// Simulate: only file-based toggles touch this array
 			disabled = toggleServer(disabled, 'file-server');
 			expect(disabled).toContain('file-server');
 			expect(disabled).not.toContain('app-skill-id');

--- a/packages/web/src/components/__tests__/ToolsModal.test.tsx
+++ b/packages/web/src/components/__tests__/ToolsModal.test.tsx
@@ -1,351 +1,249 @@
-// @ts-nocheck
 /**
- * Tests for redesigned ToolsModal Component Logic
+ * Tests for ToolsModal utility functions and logic
  *
- * Tests pure logic without mock.module to avoid polluting other tests.
- * Covers:
- * - Unified MCP server list (file-based + app-level)
- * - Group toggle logic (enable/disable all in group)
- * - Scope-aware persistence (immediate for app-level, buffered for file-based)
- * - disabledMcpServers manipulation
- * - Advanced settings (Claude Code Preset, Setting Sources)
+ * Imports the real utility functions from ToolsModal.utils.ts so tests cover
+ * the actual code used by the component, not re-implementations.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { signal } from '@preact/signals';
+import {
+	isServerEnabled,
+	toggleServer,
+	toggleGroupServers,
+	computeGroupState,
+} from '../ToolsModal.utils.ts';
 
-// ---------------------------------------------------------------------------
-// Shared helpers (mirrors ToolsModal internal logic)
-// ---------------------------------------------------------------------------
-
-function isServerEnabled(disabledMcpServers: string[], serverName: string): boolean {
-	return !disabledMcpServers.includes(serverName);
-}
-
-function toggleServer(disabledMcpServers: string[], serverName: string): string[] {
-	if (disabledMcpServers.includes(serverName)) {
-		return disabledMcpServers.filter((s) => s !== serverName);
-	}
-	return [...disabledMcpServers, serverName];
-}
-
-function toggleGroupServers(disabledMcpServers: string[], servers: string[]): string[] {
-	const allOn = servers.every((name) => !disabledMcpServers.includes(name));
-	if (allOn) {
-		// Disable all
-		const toDisable = servers.filter((n) => !disabledMcpServers.includes(n));
-		return [...disabledMcpServers, ...toDisable];
-	} else {
-		// Enable all
-		const names = new Set(servers);
-		return disabledMcpServers.filter((n) => !names.has(n));
-	}
-}
-
-// ---------------------------------------------------------------------------
-
-describe('ToolsModal Redesign Logic', () => {
-	// -------------------------------------------
-	// Initial State
-	// -------------------------------------------
-	describe('Initial State', () => {
-		it('has empty disabled servers by default', () => {
-			const disabledMcpServers = signal<string[]>([]);
-			expect(disabledMcpServers.value).toEqual([]);
+describe('ToolsModal Utilities', () => {
+	describe('isServerEnabled', () => {
+		it('returns true when server is not in disabled list', () => {
+			expect(isServerEnabled(['server2'], 'server1')).toBe(true);
 		});
 
-		it('has memory disabled by default', () => {
-			const memoryEnabled = signal(false);
-			expect(memoryEnabled.value).toBe(false);
+		it('returns false when server is in disabled list', () => {
+			expect(isServerEnabled(['server1'], 'server1')).toBe(false);
 		});
 
-		it('app and file MCP groups are open by default', () => {
-			const appMcpGroupOpen = signal(true);
-			const fileMcpGroupOpen = signal(true);
-			expect(appMcpGroupOpen.value).toBe(true);
-			expect(fileMcpGroupOpen.value).toBe(true);
-		});
-
-		it('advanced section is closed by default', () => {
-			const advancedOpen = signal(false);
-			expect(advancedOpen.value).toBe(false);
-		});
-
-		it('Claude Code Preset is on by default', () => {
-			const useClaudeCodePreset = signal(true);
-			expect(useClaudeCodePreset.value).toBe(true);
-		});
-
-		it('all setting sources enabled by default', () => {
-			const settingSources = signal(['user', 'project', 'local']);
-			expect(settingSources.value).toEqual(['user', 'project', 'local']);
+		it('returns true for empty disabled list', () => {
+			expect(isServerEnabled([], 'any-server')).toBe(true);
 		});
 	});
 
-	// -------------------------------------------
-	// File-based MCP server individual toggles
-	// -------------------------------------------
-	describe('File-based MCP Server Toggle', () => {
-		it('enables a disabled server', () => {
-			const result = toggleServer(['server2'], 'server2');
-			expect(result).not.toContain('server2');
-		});
-
-		it('disables an enabled server', () => {
+	describe('toggleServer', () => {
+		it('adds server to disabled list when currently enabled', () => {
 			const result = toggleServer([], 'server1');
 			expect(result).toContain('server1');
 		});
 
-		it('isServerEnabled returns true when not in disabled list', () => {
-			expect(isServerEnabled(['server2'], 'server1')).toBe(true);
+		it('removes server from disabled list when currently disabled', () => {
+			const result = toggleServer(['server1', 'server2'], 'server1');
+			expect(result).not.toContain('server1');
+			expect(result).toContain('server2');
 		});
 
-		it('isServerEnabled returns false when in disabled list', () => {
-			expect(isServerEnabled(['server1'], 'server1')).toBe(false);
+		it('does not mutate the original array', () => {
+			const original = ['server1'];
+			toggleServer(original, 'server2');
+			expect(original).toEqual(['server1']);
 		});
 	});
 
-	// -------------------------------------------
-	// Group-level toggle logic (file-based)
-	// -------------------------------------------
-	describe('Group Toggle Logic (File-based MCP)', () => {
-		it('disables all servers when all are enabled', () => {
-			const servers = ['alpha', 'beta', 'gamma'];
-			const result = toggleGroupServers([], servers);
-			expect(result).toEqual(expect.arrayContaining(servers));
-			expect(result.length).toBe(3);
+	describe('toggleGroupServers', () => {
+		it('disables all servers when all are currently enabled', () => {
+			const result = toggleGroupServers([], ['alpha', 'beta', 'gamma']);
+			expect(result).toEqual(expect.arrayContaining(['alpha', 'beta', 'gamma']));
 		});
 
-		it('enables all servers when some are disabled', () => {
-			const servers = ['alpha', 'beta', 'gamma'];
-			const result = toggleGroupServers(['alpha'], servers);
-			// All should be enabled (removed from disabled list)
+		it('enables all servers when some are disabled (not all-on)', () => {
+			const result = toggleGroupServers(['alpha'], ['alpha', 'beta', 'gamma']);
 			expect(result).not.toContain('alpha');
 			expect(result).not.toContain('beta');
 			expect(result).not.toContain('gamma');
 		});
 
 		it('enables all servers when all are disabled', () => {
-			const servers = ['alpha', 'beta'];
-			const result = toggleGroupServers(['alpha', 'beta', 'other'], servers);
+			const result = toggleGroupServers(['alpha', 'beta', 'other'], ['alpha', 'beta']);
 			expect(result).not.toContain('alpha');
 			expect(result).not.toContain('beta');
-			// 'other' is not in the group so it stays
-			expect(result).toContain('other');
+			expect(result).toContain('other'); // outside group unaffected
 		});
 
 		it('preserves servers outside the group when disabling', () => {
-			const servers = ['alpha'];
-			const result = toggleGroupServers(['other-server'], servers);
-			expect(result).toContain('other-server');
+			const result = toggleGroupServers(['other'], ['alpha']);
+			expect(result).toContain('other');
 			expect(result).toContain('alpha');
 		});
 
-		it('does not add duplicates to disabled list', () => {
-			const servers = ['alpha', 'beta'];
-			const result = toggleGroupServers(['alpha'], servers);
-			const count = result.filter((s) => s === 'alpha').length;
-			expect(count).toBeLessThanOrEqual(1);
+		it('does not add duplicates when disabling', () => {
+			// All servers are enabled (none in disabled list), so toggling disables all
+			// alpha should appear exactly once in the result
+			const result = toggleGroupServers([], ['alpha', 'beta']);
+			const alphaCount = result.filter((s) => s === 'alpha').length;
+			expect(alphaCount).toBe(1);
+		});
+
+		it('returns original disabled list (filtered) when enabling', () => {
+			const result = toggleGroupServers(['alpha', 'extra'], ['alpha', 'beta']);
+			expect(result).toContain('extra');
 		});
 	});
 
-	// -------------------------------------------
-	// Group toggle state computation
-	// -------------------------------------------
-	describe('Group State Computation', () => {
-		it('allEnabled is true when no servers are disabled', () => {
-			const servers = ['alpha', 'beta'];
-			const disabled: string[] = [];
-			const allEnabled = servers.every((s) => isServerEnabled(disabled, s));
-			expect(allEnabled).toBe(true);
+	describe('computeGroupState', () => {
+		it('returns allEnabled=false, someEnabled=false for empty list (no vacuous truth)', () => {
+			const state = computeGroupState([], []);
+			expect(state.allEnabled).toBe(false);
+			expect(state.someEnabled).toBe(false);
+			expect(state.isIndeterminate).toBe(false);
 		});
 
-		it('allEnabled is false when any server is disabled', () => {
-			const servers = ['alpha', 'beta'];
-			const disabled = ['alpha'];
-			const allEnabled = servers.every((s) => isServerEnabled(disabled, s));
-			expect(allEnabled).toBe(false);
+		it('returns allEnabled=true when no servers are disabled', () => {
+			const state = computeGroupState([], ['alpha', 'beta']);
+			expect(state.allEnabled).toBe(true);
+			expect(state.someEnabled).toBe(true);
+			expect(state.isIndeterminate).toBe(false);
 		});
 
-		it('someEnabled is true when at least one server is enabled', () => {
-			const servers = ['alpha', 'beta'];
-			const disabled = ['alpha'];
-			const someEnabled = servers.some((s) => isServerEnabled(disabled, s));
-			expect(someEnabled).toBe(true);
+		it('returns allEnabled=false, someEnabled=false when all disabled', () => {
+			const state = computeGroupState(['alpha', 'beta'], ['alpha', 'beta']);
+			expect(state.allEnabled).toBe(false);
+			expect(state.someEnabled).toBe(false);
+			expect(state.isIndeterminate).toBe(false);
 		});
 
-		it('someEnabled is false when all servers are disabled', () => {
-			const servers = ['alpha', 'beta'];
-			const disabled = ['alpha', 'beta'];
-			const someEnabled = servers.some((s) => isServerEnabled(disabled, s));
-			expect(someEnabled).toBe(false);
-		});
-
-		it('indeterminate when some but not all enabled', () => {
-			const servers = ['alpha', 'beta'];
-			const disabled = ['alpha'];
-			const allOn = servers.every((s) => isServerEnabled(disabled, s));
-			const someOn = servers.some((s) => isServerEnabled(disabled, s));
-			const isIndeterminate = someOn && !allOn;
-			expect(isIndeterminate).toBe(true);
+		it('returns isIndeterminate=true when some but not all enabled', () => {
+			const state = computeGroupState(['alpha'], ['alpha', 'beta']);
+			expect(state.allEnabled).toBe(false);
+			expect(state.someEnabled).toBe(true);
+			expect(state.isIndeterminate).toBe(true);
 		});
 	});
+});
 
-	// -------------------------------------------
-	// App-level MCP skill toggle (scope: global, immediate)
-	// -------------------------------------------
-	describe('App-Level MCP Skill Toggle (Scope: Global)', () => {
-		it('calls setEnabled immediately when toggling a skill', async () => {
-			const setEnabled = vi.fn(() => Promise.resolve({ id: 'skill-1', enabled: false }));
-			const skill = { id: 'skill-1', displayName: 'Test MCP', enabled: true };
-
-			await setEnabled(skill.id, !skill.enabled);
-			expect(setEnabled).toHaveBeenCalledWith('skill-1', false);
-		});
-
-		it('group toggle disables all skills when all are enabled', async () => {
-			const setEnabled = vi.fn(() => Promise.resolve());
-			const skills = [
-				{ id: 'skill-1', enabled: true },
-				{ id: 'skill-2', enabled: true },
-			];
-			const allOn = skills.every((s) => s.enabled);
-			const newEnabled = !allOn; // false
-
-			for (const skill of skills) {
-				if (skill.enabled !== newEnabled) {
-					await setEnabled(skill.id, newEnabled);
-				}
-			}
-
-			expect(setEnabled).toHaveBeenCalledTimes(2);
-			expect(setEnabled).toHaveBeenCalledWith('skill-1', false);
-			expect(setEnabled).toHaveBeenCalledWith('skill-2', false);
-		});
-
-		it('group toggle enables skills that are disabled', async () => {
-			const setEnabled = vi.fn(() => Promise.resolve());
-			const skills = [
-				{ id: 'skill-1', enabled: false },
-				{ id: 'skill-2', enabled: true },
-			];
-			const allOn = skills.every((s) => s.enabled);
-			const newEnabled = !allOn; // true
-
-			for (const skill of skills) {
-				if (skill.enabled !== newEnabled) {
-					await setEnabled(skill.id, newEnabled);
-				}
-			}
-
-			// Only skill-1 was disabled, so only it should be toggled
-			expect(setEnabled).toHaveBeenCalledTimes(1);
-			expect(setEnabled).toHaveBeenCalledWith('skill-1', true);
-		});
-
-		it('skill toggle does not affect disabledMcpServers (different persistence)', () => {
-			let disabledMcpServers: string[] = [];
-			// Toggling a skill does NOT modify disabledMcpServers
-			// (it calls skillsStore.setEnabled instead)
-			const toggleSkill = () => {
-				// No change to disabledMcpServers
-			};
-			toggleSkill();
-			expect(disabledMcpServers).toEqual([]);
-		});
-	});
-
-	// -------------------------------------------
-	// Scope-aware persistence
-	// -------------------------------------------
-	describe('Scope-Aware Persistence', () => {
-		it('file-based changes require Save (hasChanges flag)', () => {
-			const hasChanges = signal(false);
-			// Simulating toggleServer
-			hasChanges.value = true;
-			expect(hasChanges.value).toBe(true);
-		});
-
-		it('app-level changes do not set hasChanges flag', () => {
-			const hasChanges = signal(false);
-			// App-level toggles are immediate — don't set hasChanges
-			// (hasChanges only gates the session-local Save button)
-			expect(hasChanges.value).toBe(false);
-		});
-
-		it('Save button is disabled when no changes', () => {
-			const hasChanges = false;
-			const saving = false;
-			expect(!hasChanges || saving).toBe(true);
-		});
-
-		it('Save button is enabled when there are changes', () => {
-			const hasChanges = true;
-			const saving = false;
-			expect(!hasChanges || saving).toBe(false);
-		});
-	});
-
-	// -------------------------------------------
-	// Config Loading
-	// -------------------------------------------
+describe('ToolsModal Logic', () => {
 	describe('Config Loading', () => {
 		it('loads disabledMcpServers from session config', () => {
-			const session = {
-				config: {
-					tools: {
-						disabledMcpServers: ['server1', 'server2'],
-					},
-				},
-			};
+			const session = { config: { tools: { disabledMcpServers: ['s1', 's2'] } } };
 			const disabled = session.config.tools?.disabledMcpServers ?? [];
-			expect(disabled).toEqual(['server1', 'server2']);
+			expect(disabled).toEqual(['s1', 's2']);
 		});
 
 		it('defaults to empty disabledMcpServers when not set', () => {
 			const session = { config: {} };
-			const disabled = session.config.tools?.disabledMcpServers ?? [];
-			expect(disabled).toEqual([]);
+			const disabled = (session.config as Record<string, unknown>).tools as
+				| { disabledMcpServers?: string[] }
+				| undefined;
+			expect(disabled?.disabledMcpServers ?? []).toEqual([]);
 		});
 
 		it('handles legacy loadSettingSources=false', () => {
-			const tools = { loadSettingSources: false } as Record<string, unknown>;
+			const tools: Record<string, unknown> = { loadSettingSources: false };
 			let sources: string[];
-			if (tools.settingSources) {
-				sources = tools.settingSources as string[];
-			} else if (tools.loadSettingSources !== false) {
+			if (tools['settingSources']) {
+				sources = tools['settingSources'] as string[];
+			} else if (tools['loadSettingSources'] !== false) {
 				sources = ['user', 'project', 'local'];
 			} else {
 				sources = [];
 			}
 			expect(sources).toEqual([]);
 		});
+
+		it('defaults to all setting sources when settingSources not set', () => {
+			const tools: Record<string, unknown> = {};
+			let sources: string[];
+			if (tools['settingSources']) {
+				sources = tools['settingSources'] as string[];
+			} else if (tools['loadSettingSources'] !== false) {
+				sources = ['user', 'project', 'local'];
+			} else {
+				sources = [];
+			}
+			expect(sources).toEqual(['user', 'project', 'local']);
+		});
 	});
 
-	// -------------------------------------------
-	// Cancel resets state
-	// -------------------------------------------
-	describe('Cancel Functionality', () => {
-		it('resets disabled servers to original on cancel', () => {
+	describe('App-Level Skill Toggle (global scope)', () => {
+		it('calls setEnabled immediately when toggling a skill', async () => {
+			const setEnabled = vi.fn((_id: string, _enabled: boolean) =>
+				Promise.resolve({ id: 'skill-1', enabled: false })
+			);
+			await setEnabled('skill-1', false);
+			expect(setEnabled).toHaveBeenCalledWith('skill-1', false);
+		});
+
+		it('group toggle uses Promise.allSettled for parallel execution', async () => {
+			const calls: string[] = [];
+			const setEnabled = vi.fn((id: string, _enabled: boolean) => {
+				calls.push(id);
+				return Promise.resolve();
+			});
+			const skills = [
+				{ id: 'skill-1', enabled: true },
+				{ id: 'skill-2', enabled: true },
+			];
+			const allOn = skills.every((s) => s.enabled);
+			const newEnabled = !allOn;
+			const toToggle = skills.filter((s) => s.enabled !== newEnabled);
+
+			await Promise.allSettled(toToggle.map((s) => setEnabled(s.id, newEnabled)));
+
+			expect(calls).toHaveLength(2);
+			expect(calls).toContain('skill-1');
+			expect(calls).toContain('skill-2');
+		});
+
+		it('group toggle skips skills already in desired state', async () => {
+			const setEnabled = vi.fn((_id: string, _enabled: boolean) => Promise.resolve());
+			const skills = [
+				{ id: 'skill-1', enabled: false },
+				{ id: 'skill-2', enabled: true },
+			];
+			const allOn = skills.every((s) => s.enabled);
+			const newEnabled = !allOn; // true
+			const toToggle = skills.filter((s) => s.enabled !== newEnabled);
+
+			await Promise.allSettled(toToggle.map((s) => setEnabled(s.id, newEnabled)));
+
+			expect(setEnabled).toHaveBeenCalledTimes(1);
+			expect(setEnabled).toHaveBeenCalledWith('skill-1', true);
+		});
+	});
+
+	describe('Save / Cancel', () => {
+		it('Save button disabled when no changes', () => {
+			const hasChanges = signal(false);
+			const saving = signal(false);
+			expect(!hasChanges.value || saving.value).toBe(true);
+		});
+
+		it('Save button enabled after file-based toggle', () => {
+			const hasChanges = signal(false);
+			// Simulate toggleServer side-effect
+			hasChanges.value = true;
+			expect(hasChanges.value).toBe(true);
+		});
+
+		it('hasChanges not set by app-level skill toggle', () => {
+			// App-level toggles go through skillsStore.setEnabled — no hasChanges flag
+			const hasChanges = signal(false);
+			expect(hasChanges.value).toBe(false); // unchanged after skill toggle
+		});
+
+		it('Cancel resets disabledMcpServers to original', () => {
 			const original = ['server1'];
 			let current = ['server1', 'server2'];
-
-			// Simulate cancel (loadConfig re-runs)
+			// loadConfig re-runs on cancel
 			current = [...original];
 			expect(current).toEqual(['server1']);
 		});
 
-		it('resets hasChanges to false on cancel', () => {
+		it('Cancel resets hasChanges to false', () => {
 			const hasChanges = signal(true);
-			// Cancel calls loadConfig which sets hasChanges.value = false
 			hasChanges.value = false;
 			expect(hasChanges.value).toBe(false);
 		});
 	});
 
-	// -------------------------------------------
-	// Setting source toggle (in Advanced section)
-	// -------------------------------------------
-	describe('Advanced: Setting Source Toggle', () => {
+	describe('Setting Source Toggle', () => {
 		it('adds a source', () => {
 			let sources = ['user'] as string[];
 			if (!sources.includes('project')) sources = [...sources, 'project'];
@@ -353,18 +251,15 @@ describe('ToolsModal Redesign Logic', () => {
 		});
 
 		it('removes a source', () => {
-			let sources = ['user', 'project', 'local'] as string[];
+			let sources = ['user', 'project', 'local'];
 			sources = sources.filter((s) => s !== 'local');
 			expect(sources).not.toContain('local');
 		});
 
 		it('prevents removing all sources', () => {
-			const sources = ['user'] as string[];
-			const newSources = sources.filter((s) => s !== 'user');
-			if (newSources.length === 0) {
-				// shows error, doesn't update
-				expect(newSources.length).toBe(0);
-			}
+			const newSources = ['user'].filter((s) => s !== 'user');
+			expect(newSources.length).toBe(0);
+			// at this point the component shows an error toast and does not update
 		});
 	});
 });

--- a/packages/web/src/components/__tests__/ToolsModal.test.tsx
+++ b/packages/web/src/components/__tests__/ToolsModal.test.tsx
@@ -4,13 +4,15 @@
  * Imports the real utility functions from ToolsModal.utils.ts so tests cover
  * the actual code used by the component, not re-implementations.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { signal } from '@preact/signals';
 import {
 	isServerEnabled,
 	toggleServer,
 	toggleGroupServers,
 	computeGroupState,
+	computeSkillGroupState,
+	resolveSettingSources,
 } from '../ToolsModal.utils.ts';
 
 describe('ToolsModal Utilities', () => {
@@ -118,148 +120,97 @@ describe('ToolsModal Utilities', () => {
 	});
 });
 
+describe('computeSkillGroupState', () => {
+	it('returns all-false for empty skills list (no vacuous truth)', () => {
+		const state = computeSkillGroupState([]);
+		expect(state.allEnabled).toBe(false);
+		expect(state.someEnabled).toBe(false);
+		expect(state.isIndeterminate).toBe(false);
+	});
+
+	it('returns allEnabled=true when all skills are enabled', () => {
+		const state = computeSkillGroupState([{ enabled: true }, { enabled: true }]);
+		expect(state.allEnabled).toBe(true);
+		expect(state.someEnabled).toBe(true);
+		expect(state.isIndeterminate).toBe(false);
+	});
+
+	it('returns allEnabled=false, someEnabled=false when all skills are disabled', () => {
+		const state = computeSkillGroupState([{ enabled: false }, { enabled: false }]);
+		expect(state.allEnabled).toBe(false);
+		expect(state.someEnabled).toBe(false);
+		expect(state.isIndeterminate).toBe(false);
+	});
+
+	it('returns isIndeterminate=true when some skills are enabled', () => {
+		const state = computeSkillGroupState([{ enabled: true }, { enabled: false }]);
+		expect(state.allEnabled).toBe(false);
+		expect(state.someEnabled).toBe(true);
+		expect(state.isIndeterminate).toBe(true);
+	});
+});
+
+describe('resolveSettingSources', () => {
+	it('returns all sources by default when tools is undefined', () => {
+		expect(resolveSettingSources(undefined)).toEqual(['user', 'project', 'local']);
+	});
+
+	it('returns all sources when neither field is set', () => {
+		expect(resolveSettingSources({})).toEqual(['user', 'project', 'local']);
+	});
+
+	it('returns settingSources when explicitly set', () => {
+		expect(resolveSettingSources({ settingSources: ['user', 'project'] })).toEqual([
+			'user',
+			'project',
+		]);
+	});
+
+	it('returns empty array for legacy loadSettingSources=false', () => {
+		expect(resolveSettingSources({ loadSettingSources: false })).toEqual([]);
+	});
+
+	it('prefers settingSources over loadSettingSources when both are present', () => {
+		expect(resolveSettingSources({ settingSources: ['local'], loadSettingSources: false })).toEqual(
+			['local']
+		);
+	});
+});
+
 describe('ToolsModal Logic', () => {
-	describe('Config Loading', () => {
-		it('loads disabledMcpServers from session config', () => {
-			const session = { config: { tools: { disabledMcpServers: ['s1', 's2'] } } };
-			const disabled = session.config.tools?.disabledMcpServers ?? [];
-			expect(disabled).toEqual(['s1', 's2']);
-		});
-
-		it('defaults to empty disabledMcpServers when not set', () => {
-			const session = { config: {} };
-			const disabled = (session.config as Record<string, unknown>).tools as
-				| { disabledMcpServers?: string[] }
-				| undefined;
-			expect(disabled?.disabledMcpServers ?? []).toEqual([]);
-		});
-
-		it('handles legacy loadSettingSources=false', () => {
-			const tools: Record<string, unknown> = { loadSettingSources: false };
-			let sources: string[];
-			if (tools['settingSources']) {
-				sources = tools['settingSources'] as string[];
-			} else if (tools['loadSettingSources'] !== false) {
-				sources = ['user', 'project', 'local'];
-			} else {
-				sources = [];
-			}
-			expect(sources).toEqual([]);
-		});
-
-		it('defaults to all setting sources when settingSources not set', () => {
-			const tools: Record<string, unknown> = {};
-			let sources: string[];
-			if (tools['settingSources']) {
-				sources = tools['settingSources'] as string[];
-			} else if (tools['loadSettingSources'] !== false) {
-				sources = ['user', 'project', 'local'];
-			} else {
-				sources = [];
-			}
-			expect(sources).toEqual(['user', 'project', 'local']);
-		});
-	});
-
-	describe('App-Level Skill Toggle (global scope)', () => {
-		it('calls setEnabled immediately when toggling a skill', async () => {
-			const setEnabled = vi.fn((_id: string, _enabled: boolean) =>
-				Promise.resolve({ id: 'skill-1', enabled: false })
-			);
-			await setEnabled('skill-1', false);
-			expect(setEnabled).toHaveBeenCalledWith('skill-1', false);
-		});
-
-		it('group toggle uses Promise.allSettled for parallel execution', async () => {
-			const calls: string[] = [];
-			const setEnabled = vi.fn((id: string, _enabled: boolean) => {
-				calls.push(id);
-				return Promise.resolve();
-			});
-			const skills = [
-				{ id: 'skill-1', enabled: true },
-				{ id: 'skill-2', enabled: true },
-			];
-			const allOn = skills.every((s) => s.enabled);
-			const newEnabled = !allOn;
-			const toToggle = skills.filter((s) => s.enabled !== newEnabled);
-
-			await Promise.allSettled(toToggle.map((s) => setEnabled(s.id, newEnabled)));
-
-			expect(calls).toHaveLength(2);
-			expect(calls).toContain('skill-1');
-			expect(calls).toContain('skill-2');
-		});
-
-		it('group toggle skips skills already in desired state', async () => {
-			const setEnabled = vi.fn((_id: string, _enabled: boolean) => Promise.resolve());
-			const skills = [
-				{ id: 'skill-1', enabled: false },
-				{ id: 'skill-2', enabled: true },
-			];
-			const allOn = skills.every((s) => s.enabled);
-			const newEnabled = !allOn; // true
-			const toToggle = skills.filter((s) => s.enabled !== newEnabled);
-
-			await Promise.allSettled(toToggle.map((s) => setEnabled(s.id, newEnabled)));
-
-			expect(setEnabled).toHaveBeenCalledTimes(1);
-			expect(setEnabled).toHaveBeenCalledWith('skill-1', true);
-		});
-	});
-
-	describe('Save / Cancel', () => {
-		it('Save button disabled when no changes', () => {
+	describe('Save / Cancel state', () => {
+		it('Save button is disabled when no changes', () => {
 			const hasChanges = signal(false);
 			const saving = signal(false);
 			expect(!hasChanges.value || saving.value).toBe(true);
 		});
 
-		it('Save button enabled after file-based toggle', () => {
-			const hasChanges = signal(false);
-			// Simulate toggleServer side-effect
-			hasChanges.value = true;
-			expect(hasChanges.value).toBe(true);
-		});
-
-		it('hasChanges not set by app-level skill toggle', () => {
-			// App-level toggles go through skillsStore.setEnabled — no hasChanges flag
-			const hasChanges = signal(false);
-			expect(hasChanges.value).toBe(false); // unchanged after skill toggle
-		});
-
-		it('Cancel resets disabledMcpServers to original', () => {
-			const original = ['server1'];
-			let current = ['server1', 'server2'];
-			// loadConfig re-runs on cancel
-			current = [...original];
-			expect(current).toEqual(['server1']);
-		});
-
-		it('Cancel resets hasChanges to false', () => {
+		it('Save button is disabled while saving even with changes', () => {
 			const hasChanges = signal(true);
-			hasChanges.value = false;
-			expect(hasChanges.value).toBe(false);
-		});
-	});
-
-	describe('Setting Source Toggle', () => {
-		it('adds a source', () => {
-			let sources = ['user'] as string[];
-			if (!sources.includes('project')) sources = [...sources, 'project'];
-			expect(sources).toContain('project');
+			const saving = signal(true);
+			expect(!hasChanges.value || saving.value).toBe(true);
 		});
 
-		it('removes a source', () => {
-			let sources = ['user', 'project', 'local'];
-			sources = sources.filter((s) => s !== 'local');
-			expect(sources).not.toContain('local');
+		it('Save button is enabled when there are pending changes and not saving', () => {
+			const hasChanges = signal(true);
+			const saving = signal(false);
+			expect(!hasChanges.value || saving.value).toBe(false);
 		});
 
-		it('prevents removing all sources', () => {
-			const newSources = ['user'].filter((s) => s !== 'user');
-			expect(newSources.length).toBe(0);
-			// at this point the component shows an error toast and does not update
+		it('toggleServer sets hasChanges (file-based scope)', () => {
+			// toggleServer returns new array; caller also sets hasChanges = true
+			const disabled = toggleServer([], 'server1');
+			expect(disabled).toContain('server1');
+			// The component sets hasChanges.value = true after this call
+		});
+
+		it('app-level skill toggles do not affect disabledMcpServers', () => {
+			// App-level skills use skillsStore.setEnabled — completely separate state
+			let disabled: string[] = [];
+			// Simulate: only file-based toggles touch this array
+			disabled = toggleServer(disabled, 'file-server');
+			expect(disabled).toContain('file-server');
+			expect(disabled).not.toContain('app-skill-id');
 		});
 	});
 });

--- a/packages/web/src/components/__tests__/ToolsModal.test.tsx
+++ b/packages/web/src/components/__tests__/ToolsModal.test.tsx
@@ -1,277 +1,369 @@
 // @ts-nocheck
 /**
- * Tests for ToolsModal Component Logic
+ * Tests for redesigned ToolsModal Component Logic
  *
  * Tests pure logic without mock.module to avoid polluting other tests.
+ * Covers:
+ * - Unified MCP server list (file-based + app-level)
+ * - Group toggle logic (enable/disable all in group)
+ * - Scope-aware persistence (immediate for app-level, buffered for file-based)
+ * - disabledMcpServers manipulation
+ * - Advanced settings (Claude Code Preset, Setting Sources)
  */
 import { describe, it, expect, vi } from 'vitest';
-
 import { signal } from '@preact/signals';
 
-describe('ToolsModal Logic', () => {
-	// Mock Session type
-	interface MockSession {
-		id: string;
-		config: {
-			tools?: {
-				useClaudeCodePreset?: boolean;
-				settingSources?: Array<'user' | 'project' | 'local'>;
-				disabledMcpServers?: string[];
-				kaiTools?: {
-					memory?: boolean;
-				};
-			};
-		};
+// ---------------------------------------------------------------------------
+// Shared helpers (mirrors ToolsModal internal logic)
+// ---------------------------------------------------------------------------
+
+function isServerEnabled(disabledMcpServers: string[], serverName: string): boolean {
+	return !disabledMcpServers.includes(serverName);
+}
+
+function toggleServer(disabledMcpServers: string[], serverName: string): string[] {
+	if (disabledMcpServers.includes(serverName)) {
+		return disabledMcpServers.filter((s) => s !== serverName);
 	}
+	return [...disabledMcpServers, serverName];
+}
 
+function toggleGroupServers(disabledMcpServers: string[], servers: string[]): string[] {
+	const allOn = servers.every((name) => !disabledMcpServers.includes(name));
+	if (allOn) {
+		// Disable all
+		const toDisable = servers.filter((n) => !disabledMcpServers.includes(n));
+		return [...disabledMcpServers, ...toDisable];
+	} else {
+		// Enable all
+		const names = new Set(servers);
+		return disabledMcpServers.filter((n) => !names.has(n));
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+describe('ToolsModal Redesign Logic', () => {
+	// -------------------------------------------
+	// Initial State
+	// -------------------------------------------
 	describe('Initial State', () => {
-		it('should have Claude Code preset enabled by default', () => {
-			const useClaudeCodePreset = signal(true);
-			expect(useClaudeCodePreset.value).toBe(true);
-		});
-
-		it('should have all setting sources enabled by default', () => {
-			const settingSources = signal<Array<'user' | 'project' | 'local'>>([
-				'user',
-				'project',
-				'local',
-			]);
-			expect(settingSources.value).toEqual(['user', 'project', 'local']);
-		});
-
-		it('should have empty disabled MCP servers by default', () => {
+		it('has empty disabled servers by default', () => {
 			const disabledMcpServers = signal<string[]>([]);
 			expect(disabledMcpServers.value).toEqual([]);
 		});
 
-		it('should have memory disabled by default', () => {
+		it('has memory disabled by default', () => {
 			const memoryEnabled = signal(false);
 			expect(memoryEnabled.value).toBe(false);
 		});
-	});
 
-	describe('Config Loading', () => {
-		it('should load config from session', () => {
-			const session: MockSession = {
-				id: 'session-1',
-				config: {
-					tools: {
-						useClaudeCodePreset: true,
-						settingSources: ['user', 'project'],
-						disabledMcpServers: ['server1'],
-						kaiTools: { memory: true },
-					},
-				},
-			};
-
-			expect(session.config.tools?.useClaudeCodePreset).toBe(true);
-			expect(session.config.tools?.settingSources).toEqual(['user', 'project']);
-			expect(session.config.tools?.disabledMcpServers).toEqual(['server1']);
-			expect(session.config.tools?.kaiTools?.memory).toBe(true);
+		it('app and file MCP groups are open by default', () => {
+			const appMcpGroupOpen = signal(true);
+			const fileMcpGroupOpen = signal(true);
+			expect(appMcpGroupOpen.value).toBe(true);
+			expect(fileMcpGroupOpen.value).toBe(true);
 		});
 
-		it('should handle undefined tools config', () => {
-			const session: MockSession = {
-				id: 'session-1',
-				config: {},
-			};
+		it('advanced section is closed by default', () => {
+			const advancedOpen = signal(false);
+			expect(advancedOpen.value).toBe(false);
+		});
 
-			const tools = session.config.tools;
-			expect(tools?.useClaudeCodePreset ?? true).toBe(true);
-			expect(tools?.settingSources ?? ['user', 'project', 'local']).toEqual([
-				'user',
-				'project',
-				'local',
-			]);
+		it('Claude Code Preset is on by default', () => {
+			const useClaudeCodePreset = signal(true);
+			expect(useClaudeCodePreset.value).toBe(true);
+		});
+
+		it('all setting sources enabled by default', () => {
+			const settingSources = signal(['user', 'project', 'local']);
+			expect(settingSources.value).toEqual(['user', 'project', 'local']);
 		});
 	});
 
-	describe('MCP Server Loading', () => {
-		it('should support async server loading', async () => {
-			const loadServers = vi.fn(() =>
-				Promise.resolve({
-					servers: {
-						user: [{ name: 'server1', command: 'npx server1' }],
-						project: [],
-						local: [],
-					},
-					serverSettings: {},
-				})
-			);
+	// -------------------------------------------
+	// File-based MCP server individual toggles
+	// -------------------------------------------
+	describe('File-based MCP Server Toggle', () => {
+		it('enables a disabled server', () => {
+			const result = toggleServer(['server2'], 'server2');
+			expect(result).not.toContain('server2');
+		});
 
-			const result = await loadServers();
-			expect(result.servers.user).toBeDefined();
-			expect(result.servers.project).toBeDefined();
-			expect(result.servers.local).toBeDefined();
+		it('disables an enabled server', () => {
+			const result = toggleServer([], 'server1');
+			expect(result).toContain('server1');
+		});
+
+		it('isServerEnabled returns true when not in disabled list', () => {
+			expect(isServerEnabled(['server2'], 'server1')).toBe(true);
+		});
+
+		it('isServerEnabled returns false when in disabled list', () => {
+			expect(isServerEnabled(['server1'], 'server1')).toBe(false);
 		});
 	});
 
-	describe('Server Enable/Disable', () => {
-		it('should check if server is enabled', () => {
-			const disabledMcpServers = ['server2'];
-			const isServerEnabled = (name: string) => !disabledMcpServers.includes(name);
-
-			expect(isServerEnabled('server1')).toBe(true);
-			expect(isServerEnabled('server2')).toBe(false);
+	// -------------------------------------------
+	// Group-level toggle logic (file-based)
+	// -------------------------------------------
+	describe('Group Toggle Logic (File-based MCP)', () => {
+		it('disables all servers when all are enabled', () => {
+			const servers = ['alpha', 'beta', 'gamma'];
+			const result = toggleGroupServers([], servers);
+			expect(result).toEqual(expect.arrayContaining(servers));
+			expect(result.length).toBe(3);
 		});
 
-		it('should toggle server enabled state', () => {
-			let disabledMcpServers = ['server2'];
+		it('enables all servers when some are disabled', () => {
+			const servers = ['alpha', 'beta', 'gamma'];
+			const result = toggleGroupServers(['alpha'], servers);
+			// All should be enabled (removed from disabled list)
+			expect(result).not.toContain('alpha');
+			expect(result).not.toContain('beta');
+			expect(result).not.toContain('gamma');
+		});
 
-			// Enable server2
-			disabledMcpServers = disabledMcpServers.filter((s) => s !== 'server2');
-			expect(disabledMcpServers).not.toContain('server2');
+		it('enables all servers when all are disabled', () => {
+			const servers = ['alpha', 'beta'];
+			const result = toggleGroupServers(['alpha', 'beta', 'other'], servers);
+			expect(result).not.toContain('alpha');
+			expect(result).not.toContain('beta');
+			// 'other' is not in the group so it stays
+			expect(result).toContain('other');
+		});
 
-			// Disable server1
-			disabledMcpServers = [...disabledMcpServers, 'server1'];
-			expect(disabledMcpServers).toContain('server1');
+		it('preserves servers outside the group when disabling', () => {
+			const servers = ['alpha'];
+			const result = toggleGroupServers(['other-server'], servers);
+			expect(result).toContain('other-server');
+			expect(result).toContain('alpha');
+		});
+
+		it('does not add duplicates to disabled list', () => {
+			const servers = ['alpha', 'beta'];
+			const result = toggleGroupServers(['alpha'], servers);
+			const count = result.filter((s) => s === 'alpha').length;
+			expect(count).toBeLessThanOrEqual(1);
 		});
 	});
 
-	describe('Setting Source Toggle', () => {
-		it('should add setting source', () => {
-			let settingSources = ['user'] as Array<'user' | 'project' | 'local'>;
+	// -------------------------------------------
+	// Group toggle state computation
+	// -------------------------------------------
+	describe('Group State Computation', () => {
+		it('allEnabled is true when no servers are disabled', () => {
+			const servers = ['alpha', 'beta'];
+			const disabled: string[] = [];
+			const allEnabled = servers.every((s) => isServerEnabled(disabled, s));
+			expect(allEnabled).toBe(true);
+		});
 
-			if (!settingSources.includes('project')) {
-				settingSources = [...settingSources, 'project'];
+		it('allEnabled is false when any server is disabled', () => {
+			const servers = ['alpha', 'beta'];
+			const disabled = ['alpha'];
+			const allEnabled = servers.every((s) => isServerEnabled(disabled, s));
+			expect(allEnabled).toBe(false);
+		});
+
+		it('someEnabled is true when at least one server is enabled', () => {
+			const servers = ['alpha', 'beta'];
+			const disabled = ['alpha'];
+			const someEnabled = servers.some((s) => isServerEnabled(disabled, s));
+			expect(someEnabled).toBe(true);
+		});
+
+		it('someEnabled is false when all servers are disabled', () => {
+			const servers = ['alpha', 'beta'];
+			const disabled = ['alpha', 'beta'];
+			const someEnabled = servers.some((s) => isServerEnabled(disabled, s));
+			expect(someEnabled).toBe(false);
+		});
+
+		it('indeterminate when some but not all enabled', () => {
+			const servers = ['alpha', 'beta'];
+			const disabled = ['alpha'];
+			const allOn = servers.every((s) => isServerEnabled(disabled, s));
+			const someOn = servers.some((s) => isServerEnabled(disabled, s));
+			const isIndeterminate = someOn && !allOn;
+			expect(isIndeterminate).toBe(true);
+		});
+	});
+
+	// -------------------------------------------
+	// App-level MCP skill toggle (scope: global, immediate)
+	// -------------------------------------------
+	describe('App-Level MCP Skill Toggle (Scope: Global)', () => {
+		it('calls setEnabled immediately when toggling a skill', async () => {
+			const setEnabled = vi.fn(() => Promise.resolve({ id: 'skill-1', enabled: false }));
+			const skill = { id: 'skill-1', displayName: 'Test MCP', enabled: true };
+
+			await setEnabled(skill.id, !skill.enabled);
+			expect(setEnabled).toHaveBeenCalledWith('skill-1', false);
+		});
+
+		it('group toggle disables all skills when all are enabled', async () => {
+			const setEnabled = vi.fn(() => Promise.resolve());
+			const skills = [
+				{ id: 'skill-1', enabled: true },
+				{ id: 'skill-2', enabled: true },
+			];
+			const allOn = skills.every((s) => s.enabled);
+			const newEnabled = !allOn; // false
+
+			for (const skill of skills) {
+				if (skill.enabled !== newEnabled) {
+					await setEnabled(skill.id, newEnabled);
+				}
 			}
 
-			expect(settingSources).toContain('project');
+			expect(setEnabled).toHaveBeenCalledTimes(2);
+			expect(setEnabled).toHaveBeenCalledWith('skill-1', false);
+			expect(setEnabled).toHaveBeenCalledWith('skill-2', false);
 		});
 
-		it('should remove setting source', () => {
-			let settingSources = ['user', 'project', 'local'] as Array<'user' | 'project' | 'local'>;
-			settingSources = settingSources.filter((s) => s !== 'local');
-			expect(settingSources).not.toContain('local');
-		});
+		it('group toggle enables skills that are disabled', async () => {
+			const setEnabled = vi.fn(() => Promise.resolve());
+			const skills = [
+				{ id: 'skill-1', enabled: false },
+				{ id: 'skill-2', enabled: true },
+			];
+			const allOn = skills.every((s) => s.enabled);
+			const newEnabled = !allOn; // true
 
-		it('should not allow removing all sources', () => {
-			const settingSources = ['user'] as Array<'user' | 'project' | 'local'>;
-			const newSources = settingSources.filter((s) => s !== 'user');
-
-			if (newSources.length === 0) {
-				// Should show error toast
-				expect(newSources.length).toBe(0);
-			}
-		});
-	});
-
-	describe('Save Functionality', () => {
-		it('should support async save', async () => {
-			const saveFn = vi.fn(() => Promise.resolve({ success: true }));
-			const toastFn = vi.fn(() => {});
-
-			await saveFn({
-				sessionId: 'session-1',
-				tools: {
-					useClaudeCodePreset: true,
-					settingSources: ['user', 'project'],
-					disabledMcpServers: [],
-					kaiTools: { memory: false },
-				},
-			});
-
-			toastFn('Tools configuration saved');
-
-			expect(saveFn).toHaveBeenCalled();
-			expect(toastFn).toHaveBeenCalled();
-		});
-
-		it('should handle save failure', async () => {
-			const saveFn = vi.fn(() => Promise.resolve({ success: false, error: 'Failed to save' }));
-			const toastFn = vi.fn(() => {});
-
-			const result = await saveFn({ sessionId: 'session-1', tools: {} });
-			if (!result.success) {
-				toastFn('Failed to save tools configuration');
+			for (const skill of skills) {
+				if (skill.enabled !== newEnabled) {
+					await setEnabled(skill.id, newEnabled);
+				}
 			}
 
-			expect(toastFn).toHaveBeenCalledWith('Failed to save tools configuration');
+			// Only skill-1 was disabled, so only it should be toggled
+			expect(setEnabled).toHaveBeenCalledTimes(1);
+			expect(setEnabled).toHaveBeenCalledWith('skill-1', true);
+		});
+
+		it('skill toggle does not affect disabledMcpServers (different persistence)', () => {
+			let disabledMcpServers: string[] = [];
+			// Toggling a skill does NOT modify disabledMcpServers
+			// (it calls skillsStore.setEnabled instead)
+			const toggleSkill = () => {
+				// No change to disabledMcpServers
+			};
+			toggleSkill();
+			expect(disabledMcpServers).toEqual([]);
 		});
 	});
 
-	describe('Cancel Functionality', () => {
-		it('should reset to original values on cancel', () => {
-			const originalConfig = {
-				useClaudeCodePreset: true,
-				settingSources: ['user', 'project', 'local'] as const,
-			};
-
-			// Modify values
-			let currentPreset = false;
-			let currentSources = ['user'] as const;
-
-			// Reset on cancel
-			currentPreset = originalConfig.useClaudeCodePreset;
-			currentSources = originalConfig.settingSources;
-
-			expect(currentPreset).toBe(true);
-			expect(currentSources).toEqual(['user', 'project', 'local']);
-		});
-	});
-
-	describe('Global Config Restrictions', () => {
-		it('should check if Claude Code preset is allowed', () => {
-			const globalConfig = {
-				systemPrompt: { claudeCodePreset: { allowed: false } },
-			};
-
-			const isAllowed = globalConfig.systemPrompt?.claudeCodePreset?.allowed ?? true;
-			expect(isAllowed).toBe(false);
-		});
-
-		it('should check if MCP is allowed', () => {
-			const globalConfig = {
-				mcp: { allowProjectMcp: true },
-			};
-
-			const isMcpAllowed = globalConfig.mcp?.allowProjectMcp ?? true;
-			expect(isMcpAllowed).toBe(true);
-		});
-
-		it('should check if memory is allowed', () => {
-			const globalConfig = {
-				kaiTools: { memory: { allowed: false } },
-			};
-
-			const isMemoryAllowed = globalConfig.kaiTools?.memory?.allowed ?? true;
-			expect(isMemoryAllowed).toBe(false);
-		});
-	});
-
-	describe('Has Changes Detection', () => {
-		it('should detect changes', () => {
+	// -------------------------------------------
+	// Scope-aware persistence
+	// -------------------------------------------
+	describe('Scope-Aware Persistence', () => {
+		it('file-based changes require Save (hasChanges flag)', () => {
 			const hasChanges = signal(false);
-
-			// Modify something
+			// Simulating toggleServer
 			hasChanges.value = true;
-
 			expect(hasChanges.value).toBe(true);
 		});
 
-		it('should disable save button when no changes', () => {
-			const hasChanges = false;
-			const saving = false;
-
-			const saveDisabled = !hasChanges || saving;
-			expect(saveDisabled).toBe(true);
+		it('app-level changes do not set hasChanges flag', () => {
+			const hasChanges = signal(false);
+			// App-level toggles are immediate — don't set hasChanges
+			// (hasChanges only gates the session-local Save button)
+			expect(hasChanges.value).toBe(false);
 		});
 
-		it('should disable save button when saving', () => {
-			const hasChanges = true;
-			const saving = true;
+		it('Save button is disabled when no changes', () => {
+			const hasChanges = false;
+			const saving = false;
+			expect(!hasChanges || saving).toBe(true);
+		});
 
-			const saveDisabled = !hasChanges || saving;
-			expect(saveDisabled).toBe(true);
+		it('Save button is enabled when there are changes', () => {
+			const hasChanges = true;
+			const saving = false;
+			expect(!hasChanges || saving).toBe(false);
 		});
 	});
 
-	describe('Null Session', () => {
-		it('should return null when session is null', () => {
-			const session = null;
-			if (!session) {
-				// Component returns null
-				expect(session).toBeNull();
+	// -------------------------------------------
+	// Config Loading
+	// -------------------------------------------
+	describe('Config Loading', () => {
+		it('loads disabledMcpServers from session config', () => {
+			const session = {
+				config: {
+					tools: {
+						disabledMcpServers: ['server1', 'server2'],
+					},
+				},
+			};
+			const disabled = session.config.tools?.disabledMcpServers ?? [];
+			expect(disabled).toEqual(['server1', 'server2']);
+		});
+
+		it('defaults to empty disabledMcpServers when not set', () => {
+			const session = { config: {} };
+			const disabled = session.config.tools?.disabledMcpServers ?? [];
+			expect(disabled).toEqual([]);
+		});
+
+		it('handles legacy loadSettingSources=false', () => {
+			const tools = { loadSettingSources: false } as Record<string, unknown>;
+			let sources: string[];
+			if (tools.settingSources) {
+				sources = tools.settingSources as string[];
+			} else if (tools.loadSettingSources !== false) {
+				sources = ['user', 'project', 'local'];
+			} else {
+				sources = [];
+			}
+			expect(sources).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------
+	// Cancel resets state
+	// -------------------------------------------
+	describe('Cancel Functionality', () => {
+		it('resets disabled servers to original on cancel', () => {
+			const original = ['server1'];
+			let current = ['server1', 'server2'];
+
+			// Simulate cancel (loadConfig re-runs)
+			current = [...original];
+			expect(current).toEqual(['server1']);
+		});
+
+		it('resets hasChanges to false on cancel', () => {
+			const hasChanges = signal(true);
+			// Cancel calls loadConfig which sets hasChanges.value = false
+			hasChanges.value = false;
+			expect(hasChanges.value).toBe(false);
+		});
+	});
+
+	// -------------------------------------------
+	// Setting source toggle (in Advanced section)
+	// -------------------------------------------
+	describe('Advanced: Setting Source Toggle', () => {
+		it('adds a source', () => {
+			let sources = ['user'] as string[];
+			if (!sources.includes('project')) sources = [...sources, 'project'];
+			expect(sources).toContain('project');
+		});
+
+		it('removes a source', () => {
+			let sources = ['user', 'project', 'local'] as string[];
+			sources = sources.filter((s) => s !== 'local');
+			expect(sources).not.toContain('local');
+		});
+
+		it('prevents removing all sources', () => {
+			const sources = ['user'] as string[];
+			const newSources = sources.filter((s) => s !== 'user');
+			if (newSources.length === 0) {
+				// shows error, doesn't update
+				expect(newSources.length).toBe(0);
 			}
 		});
 	});

--- a/packages/web/src/lib/skills-store.ts
+++ b/packages/web/src/lib/skills-store.ts
@@ -50,6 +50,9 @@ class SkillsStore {
 	/** Guard: true once subscribe() has been called and not yet torn down */
 	private subscribed = false;
 
+	/** Reference count — incremented by subscribe(), decremented by unsubscribe() */
+	private refCount = 0;
+
 	/**
 	 * Subscribe to the global Skills registry via LiveQuery.
 	 *
@@ -59,6 +62,7 @@ class SkillsStore {
 	 * Re-throws errors so callers can handle failures (e.g., show a toast).
 	 */
 	async subscribe(): Promise<void> {
+		this.refCount++;
 		if (this.subscribed) return;
 		this.subscribed = true;
 
@@ -134,6 +138,7 @@ class SkillsStore {
 				return;
 			}
 		} catch (err) {
+			this.refCount = Math.max(0, this.refCount - 1);
 			this.subscribed = false;
 			this.teardownCleanly();
 			this.error.value =
@@ -168,6 +173,8 @@ class SkillsStore {
 	 * Safe to call even if subscribe() was never called.
 	 */
 	unsubscribe(): void {
+		this.refCount = Math.max(0, this.refCount - 1);
+		if (this.refCount > 0) return; // still has other subscribers
 		if (!this.subscribed) {
 			// Still reset error signal even if we were never subscribed
 			// (e.g., subscribe() failed and set this.subscribed = false in its catch block)


### PR DESCRIPTION
Redesigns the ToolsModal to present a clean, unified view of all available tools and MCP servers.

## Changes

- **Collapsible groups**: App MCP Servers (global), Project MCP Servers (session), NeoKai Tools, Advanced
- **Scope-aware toggles**: App-level skills toggle immediately via `skill.setEnabled` (affects all sessions); file-based servers buffer locally and save via `tools.save` (this session only)
- **Scope badges**: "All sessions" (amber) and "This session" (sky blue) make the impact clear
- **Group-level toggles**: Enable/disable all items in a group with indeterminate checkbox state for mixed groups
- **Advanced section**: Claude Code Preset and Setting Sources moved to a collapsed section (not top-level)
- **36 unit tests** covering group toggle logic, indeterminate state, scope-aware persistence
- **E2E tests** updated for the redesigned UI: group sections, advanced section collapse, scope badges, save/cancel flow