### PR TITLE
test(leader): update leader and reviewer unit tests (Task 3.4)

### DIFF
--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -1365,7 +1365,6 @@ describe('Leader Helper Sub-Agents', () => {
 		const stub = async () => ({ content: [{ type: 'text' as const, text: 'ok' }] });
 		return {
 			sendToWorker: stub,
-			handoffToWorker: stub,
 			completeTask: stub,
 			failTask: stub,
 			replanGoal: stub,
@@ -1749,6 +1748,11 @@ describe('Leader Helper Sub-Agents', () => {
 			expect(def.tools).not.toContain('Bash');
 		});
 
+		it('should have ONLY WebSearch and WebFetch tools (exact match)', () => {
+			const def = buildLeaderFactCheckerAgentDef();
+			expect(def.tools).toEqual(['WebSearch', 'WebFetch']);
+		});
+
 		it('should include structured ANALYSIS_RESULT output format in prompt', () => {
 			const def = buildLeaderFactCheckerAgentDef();
 			expect(def.prompt).toContain('---ANALYSIS_RESULT---');
@@ -1866,6 +1870,11 @@ describe('Leader Helper Sub-Agents', () => {
 			expect(def.tools).not.toContain('Grep');
 			expect(def.tools).not.toContain('Glob');
 			expect(def.tools).not.toContain('Bash');
+		});
+
+		it('should have ONLY WebSearch and WebFetch tools (exact match)', () => {
+			const def = buildReviewerFactCheckerAgentDef();
+			expect(def.tools).toEqual(['WebSearch', 'WebFetch']);
 		});
 
 		it('should include FACT_CHECK_RESULT structured output block', () => {

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -112,7 +112,7 @@ function makeCallbacks(): LeaderToolCallbacks & {
 		async sendToWorker(
 			groupId: string,
 			message: string,
-			mode?: 'steer' | 'queue',
+			mode?: 'immediate' | 'defer',
 			progressSummary?: string
 		) {
 			calls.push({ method: 'sendToWorker', args: [groupId, message, mode, progressSummary] });


### PR DESCRIPTION
Update `leader-agent.test.ts` to cover the always-on agent/agents pattern, built-in sub-agent definitions, and reviewer sub-agents added in Tasks 3.1–3.3.

## Changes

- Add exact tool array assertions for `buildLeaderFactCheckerAgentDef` and `buildReviewerFactCheckerAgentDef` — both must have **only** `['WebSearch', 'WebFetch']` (subtask 2)
- Remove stale `handoffToWorker` property from the local `makeCallbacks()` mock in the `Leader Helper Sub-Agents` describe block (not in `LeaderToolCallbacks` interface)

All other acceptance criteria were already covered by tests added during Tasks 3.1–3.3:
- `buildLeaderExplorerAgentDef` / `buildLeaderFactCheckerAgentDef` tests (subtask 1)
- `buildReviewerExplorerAgentDef` / `buildReviewerFactCheckerAgentDef` tests (subtask 2)
- `agent: 'Leader'` always present (subtask 3)
- agents map always contains Leader, leader-explorer, leader-fact-checker (subtask 4)
- No-reviewer/no-helper init still has built-ins (subtask 5)
- Reviewers merged alongside built-ins (subtask 6)
- Helpers merged alongside built-ins (subtask 7)
- Name collisions prefixed with `custom-` (subtask 8)
- `buildReviewerAgents` includes reviewer-explorer and reviewer-fact-checker (subtask 9)
- Reviewer agents have Task/TaskOutput/TaskStop (subtask 10)
- Reviewer prompts mention sub-agents by name (subtask 11)
- Sub-agents lack Task tools (subtask 12)
- System prompt embedded in agent def prompt field (subtask 13)

188 tests pass (up from 186).