### PR TITLE
test(coder): strengthen coder-agent unit tests for always-on pattern

### DIFF
--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -364,6 +364,16 @@ describe('Coder Agent', () => {
 			expect(init.agents).toHaveProperty('coder-tester');
 		});
 
+		it('agents map has exactly 3 entries (built-ins only) when no worker sub-agents configured', () => {
+			// Verifies the always-on pattern: no conditional branching — Coder, coder-explorer,
+			// coder-tester are always present; no extra agents without worker config.
+			const init = createCoderAgentInit(makeConfig());
+			expect(Object.keys(init.agents ?? {})).toHaveLength(3);
+			expect(Object.keys(init.agents ?? {})).toEqual(
+				expect.arrayContaining(['Coder', 'coder-explorer', 'coder-tester'])
+			);
+		});
+
 		it('Coder agent def includes Task, TaskOutput, TaskStop tools', () => {
 			const init = createCoderAgentInit(makeConfig());
 			const coderDef = init.agents?.['Coder'];
@@ -444,6 +454,18 @@ describe('Coder Agent', () => {
 		it('coder-explorer agent uses inherit model', () => {
 			const init = createCoderAgentInit(makeConfig());
 			expect(init.agents?.['coder-explorer']?.model).toBe('inherit');
+		});
+
+		it('coder-explorer in agents map is the canonical buildCoderExplorerAgentDef() output', () => {
+			// Ensures createCoderAgentInit delegates to the builder rather than inlining
+			// a different definition — keeps the two in sync.
+			const init = createCoderAgentInit(makeConfig());
+			const inMap = init.agents?.['coder-explorer'];
+			const standalone = buildCoderExplorerAgentDef();
+			expect(inMap?.tools).toEqual(standalone.tools);
+			expect(inMap?.model).toBe(standalone.model);
+			expect(inMap?.prompt).toBe(standalone.prompt);
+			expect(inMap?.description).toBe(standalone.description);
 		});
 
 		describe('with worker sub-agents configured', () => {
@@ -656,10 +678,11 @@ describe('Coder Agent', () => {
 			expect(def.model).toBe('inherit');
 		});
 
-		it('has a non-empty description', () => {
+		it('description identifies the agent as read-only codebase explorer', () => {
 			const def = buildCoderExplorerAgentDef();
 			expect(def.description).toBeTruthy();
-			expect(def.description.length).toBeGreaterThan(10);
+			expect(def.description.toLowerCase()).toContain('read-only');
+			expect(def.description.toLowerCase()).toContain('codebase');
 		});
 
 		it('prompt requires ---EXPLORE_RESULT--- structured output block', () => {


### PR DESCRIPTION
Pins the acceptance criteria for Task 1.3 with 2 net-new tests and 1 improved assertion in `coder-agent.test.ts`:

- Exact agents map size (3 built-ins) when no worker sub-agents configured — verifies no conditional branching survives
- `coder-explorer` in agents map equals `buildCoderExplorerAgentDef()` output — keeps inline usage and builder in sync
- Improved description test: asserts "read-only" and "codebase" are present (was just `length > 10`)

89 tests pass (was 87). All pre-commit checks green.