### PR TITLE
test(agent): verify QueryOptionsBuilder propagates always-on agents correctly

### DIFF
--- a/packages/daemon/tests/unit/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/agent/query-options-builder.test.ts
@@ -1467,4 +1467,166 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.allowedTools).not.toContain('disabled-server__*');
 		});
 	});
+
+	describe('always-on agent/agents propagation (room agents)', () => {
+		const coderExplorerDef = {
+			description: 'Read-only codebase explorer.',
+			tools: ['Read', 'Grep', 'Glob', 'Bash'],
+			model: 'inherit' as const,
+			prompt: 'You are an Explorer Agent.',
+		};
+		const coderTesterDef = {
+			description: 'Test writer and runner.',
+			tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
+			model: 'inherit' as const,
+			prompt: 'You are a Tester Agent.',
+		};
+		const coderAgentDef = {
+			description: 'Implementation agent.',
+			tools: ['Task', 'TaskOutput', 'TaskStop', 'Read', 'Write', 'Edit', 'Bash'],
+			model: 'inherit' as const,
+			prompt: 'You are a Coder Agent.',
+		};
+
+		it('preserves config.agent exactly when coordinatorMode is off', async () => {
+			mockSession.config.agent = 'Coder';
+			mockSession.config.agents = {
+				Coder: coderAgentDef,
+				'coder-explorer': coderExplorerDef,
+				'coder-tester': coderTesterDef,
+			};
+			mockSession.config.coordinatorMode = false;
+
+			const options = await builder.build();
+
+			expect(options.agent).toBe('Coder');
+		});
+
+		it('preserves config.agents map exactly when coordinatorMode is off', async () => {
+			mockSession.config.agent = 'Coder';
+			mockSession.config.agents = {
+				Coder: coderAgentDef,
+				'coder-explorer': coderExplorerDef,
+				'coder-tester': coderTesterDef,
+			};
+			mockSession.config.coordinatorMode = false;
+
+			const options = await builder.build();
+
+			expect(Object.keys(options.agents!)).toEqual(['Coder', 'coder-explorer', 'coder-tester']);
+			expect(options.agents!['Coder']).toEqual(coderAgentDef);
+			expect(options.agents!['coder-explorer']).toEqual(coderExplorerDef);
+			expect(options.agents!['coder-tester']).toEqual(coderTesterDef);
+		});
+
+		it('preserves config.agents when coordinatorMode is undefined (always-on default)', async () => {
+			// coordinatorMode is never set — the always-on pattern default
+			mockSession.config.agent = 'Coder';
+			mockSession.config.agents = {
+				Coder: coderAgentDef,
+				'coder-explorer': coderExplorerDef,
+				'coder-tester': coderTesterDef,
+			};
+
+			const options = await builder.build();
+
+			expect(options.agent).toBe('Coder');
+			expect(Object.keys(options.agents!)).toHaveLength(3);
+			expect(options.agents!['coder-explorer']).toEqual(coderExplorerDef);
+		});
+
+		it('coordinatorMode ON overwrites room agent config with coordinator agents', async () => {
+			// Even if room agent config is set, coordinator mode takes over
+			mockSession.config.agent = 'Coder';
+			mockSession.config.agents = {
+				Coder: coderAgentDef,
+				'coder-explorer': coderExplorerDef,
+			};
+			mockSession.config.coordinatorMode = true;
+
+			const options = await builder.build();
+
+			// Coordinator mode overwrites agent to 'Coordinator'
+			expect(options.agent).toBe('Coordinator');
+			// Coordinator specialists are present
+			expect(options.agents!['Coordinator']).toBeDefined();
+			expect(options.agents!['Debugger']).toBeDefined();
+			// The coordinator's Coder specialist wins over the room-agent Coder def
+			expect(options.agents!['Coder']).toBeDefined();
+		});
+
+		it('coordinatorMode ON merges room custom agents into coordinator agents map', async () => {
+			// Custom non-conflicting agents from room config are preserved in coordinator mode
+			mockSession.config.agents = {
+				'my-custom': { description: 'Custom agent', prompt: 'Custom.' },
+			};
+			mockSession.config.coordinatorMode = true;
+
+			const options = await builder.build();
+
+			expect(options.agent).toBe('Coordinator');
+			// Custom agent is merged in (no name conflict with specialist names)
+			expect(options.agents!['my-custom']).toBeDefined();
+			// Built-in specialists are also present
+			expect(options.agents!['Coordinator']).toBeDefined();
+			expect(options.agents!['Coder']).toBeDefined();
+		});
+
+		it('worktree isolation is in system prompt but NOT injected into room agent sub-agents', async () => {
+			mockSession.config.agent = 'Coder';
+			mockSession.config.agents = {
+				Coder: coderAgentDef,
+				'coder-explorer': coderExplorerDef,
+				'coder-tester': coderTesterDef,
+			};
+			// coordinatorMode is off (room agent mode)
+			mockSession.worktree = {
+				worktreePath: '/worktree/path',
+				mainRepoPath: '/main/repo',
+				branch: 'task/my-task',
+			};
+			const newBuilder = new QueryOptionsBuilder({
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+			});
+
+			const options = await newBuilder.build();
+
+			// System prompt gets worktree isolation (session-level protection)
+			const systemPrompt = options.systemPrompt as { append?: string };
+			expect(systemPrompt.append).toContain('Git Worktree Isolation');
+
+			// Sub-agent prompts are NOT modified — cwd is the worktree path,
+			// which provides the actual directory isolation for sub-agents
+			expect((options.agents!['coder-explorer'] as { prompt: string }).prompt).toBe(
+				coderExplorerDef.prompt
+			);
+			expect((options.agents!['coder-tester'] as { prompt: string }).prompt).toBe(
+				coderTesterDef.prompt
+			);
+		});
+
+		it('coordinator mode injects worktree isolation into specialist agent prompts', async () => {
+			mockSession.config.coordinatorMode = true;
+			mockSession.worktree = {
+				worktreePath: '/worktree/path',
+				mainRepoPath: '/main/repo',
+				branch: 'task/my-task',
+			};
+			const newBuilder = new QueryOptionsBuilder({
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+			});
+
+			const options = await newBuilder.build();
+
+			// Coordinator mode injects worktree isolation into specialist agents
+			const coderPrompt = (options.agents!['Coder'] as { prompt: string }).prompt;
+			expect(coderPrompt).toContain('Git Worktree Isolation');
+
+			// But NOT into the Coordinator itself
+			const coordinatorPrompt = (options.agents!['Coordinator'] as { prompt: string }).prompt;
+			expect(coordinatorPrompt).not.toContain('Git Worktree Isolation');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- Reviewed `QueryOptionsBuilder.build()` lines 147-169: agent/agents are passed through directly from `session.config` — no bugs found
- When `coordinatorMode` is false/undefined (room agents), `config.agent` and `config.agents` are used as-is
- When `coordinatorMode` is true, agent is overwritten to `'Coordinator'` and agents are replaced via `getCoordinatorAgents(config.agents)` — correct, unchanged behavior
- Worktree isolation is injected into the session system prompt for all sessions; coordinator mode additionally injects it into each specialist agent's prompt; room agents rely on `cwd` pointing to the worktree path for directory isolation

Added 7 unit tests covering the always-on agent/agents pattern:
1. `config.agent` exact value preserved when coordinatorMode off
2. `config.agents` map exact values preserved when coordinatorMode off
3. coordinatorMode undefined (always-on default) preserves room agent config
4. coordinatorMode ON overwrites room agent config with coordinator agents
5. coordinatorMode ON merges non-conflicting custom agents into coordinator map
6. Worktree isolation is in system prompt but NOT in room sub-agent prompts (by design — cwd handles isolation)
7. Coordinator mode injects worktree isolation into specialist agents but not Coordinator itself