### PR TITLE
fix(web): wire space Quick Actions, add space editing and delete UI

### DIFF
--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { getNextRunAt } from '../../../src/lib/room/runtime/cron-utils';
 import { Database } from 'bun:sqlite';
 import { createTables } from '../../../src/storage/schema';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
@@ -910,8 +911,9 @@ describe('GoalManager.patchGoal — schedule nextRunAt auto-computation', () => 
 		expect(goal.nextRunAt).toBeDefined();
 		const originalNextRunAt = goal.nextRunAt!;
 
-		// Patch the schedule to @weekly — guaranteed different nextRunAt than @daily
-		// (they can coincide at midnight for @hourly or @daily).
+		// Patch the schedule to @weekly.
+		// Capture the expected nextRunAt immediately before patching so it uses the same clock tick.
+		const expectedWeeklyNextRunAt = getNextRunAt('@weekly', 'UTC');
 		const before = Math.floor(Date.now() / 1000);
 		const patched = await goalManager.patchGoal(goal.id, {
 			schedule: { expression: '@weekly', timezone: 'UTC' },
@@ -923,8 +925,11 @@ describe('GoalManager.patchGoal — schedule nextRunAt auto-computation', () => 
 		expect(patched.nextRunAt!).toBeGreaterThan(before);
 		// @weekly fires within the next week
 		expect(patched.nextRunAt!).toBeLessThanOrEqual(after);
-		// nextRunAt should change when the cron expression changes
-		expect(patched.nextRunAt!).not.toBe(originalNextRunAt);
+		// nextRunAt must match what getNextRunAt('@weekly') computes — verifies patchGoal
+		// correctly recomputed nextRunAt for the new schedule expression.
+		// (Asserting `not.toBe(originalNextRunAt)` is fragile: on Saturdays, @daily and @weekly
+		// both fire at Sunday midnight and produce the same timestamp.)
+		expect(patched.nextRunAt!).toBe(expectedWeeklyNextRunAt);
 	});
 
 	it('auto-computes nextRunAt when changing missionType to recurring with a schedule', async () => {

--- a/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
@@ -1,0 +1,188 @@
+/**
+ * SpaceCreateTaskDialog — modal form to create a standalone task in a Space.
+ */
+
+import { useState } from 'preact/hooks';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { connectionManager } from '../../lib/connection-manager';
+import { spaceStore } from '../../lib/space-store';
+import { toast } from '../../lib/toast';
+import type { SpaceTask, SpaceTaskPriority, SpaceTaskType } from '@neokai/shared';
+
+interface SpaceCreateTaskDialogProps {
+	isOpen: boolean;
+	spaceId: string;
+	onClose: () => void;
+	onCreated?: (task: SpaceTask) => void;
+}
+
+const PRIORITY_OPTIONS: { value: SpaceTaskPriority; label: string }[] = [
+	{ value: 'low', label: 'Low' },
+	{ value: 'normal', label: 'Normal' },
+	{ value: 'high', label: 'High' },
+	{ value: 'urgent', label: 'Urgent' },
+];
+
+const TASK_TYPE_OPTIONS: { value: SpaceTaskType; label: string }[] = [
+	{ value: 'coding', label: 'Coding' },
+	{ value: 'planning', label: 'Planning' },
+	{ value: 'research', label: 'Research' },
+	{ value: 'design', label: 'Design' },
+	{ value: 'review', label: 'Review' },
+];
+
+export function SpaceCreateTaskDialog({
+	isOpen,
+	spaceId,
+	onClose,
+	onCreated,
+}: SpaceCreateTaskDialogProps) {
+	const [title, setTitle] = useState('');
+	const [description, setDescription] = useState('');
+	const [priority, setPriority] = useState<SpaceTaskPriority>('normal');
+	const [taskType, setTaskType] = useState<SpaceTaskType>('coding');
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleClose = () => {
+		setTitle('');
+		setDescription('');
+		setPriority('normal');
+		setTaskType('coding');
+		setError(null);
+		onClose();
+	};
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+
+		if (!title.trim()) {
+			setError('Task title is required');
+			return;
+		}
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setError('Not connected to server');
+			return;
+		}
+
+		try {
+			setSubmitting(true);
+			setError(null);
+
+			const task = await hub.request<SpaceTask>('spaceTask.create', {
+				spaceId,
+				title: title.trim(),
+				description: description.trim(),
+				priority,
+				taskType,
+			});
+
+			if (!task) {
+				throw new Error('Server returned no data');
+			}
+
+			toast.success(`Task "${task.title}" created`);
+			onCreated?.(task);
+			// Refresh space data so the dashboard shows the new task
+			await spaceStore.selectSpace(spaceId).catch(() => {});
+			handleClose();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to create task');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<Modal isOpen={isOpen} onClose={handleClose} title="Create Task" size="md">
+			<form onSubmit={handleSubmit} class="space-y-4">
+				{error && (
+					<div class="bg-red-900/20 border border-red-800 rounded-lg px-4 py-3 text-red-400 text-sm">
+						{error}
+					</div>
+				)}
+
+				{/* Title */}
+				<div>
+					<label class="block text-sm font-medium text-gray-200 mb-1.5">
+						Title
+						<span class="text-red-400 ml-1">*</span>
+					</label>
+					<input
+						type="text"
+						value={title}
+						onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+						placeholder="e.g., Implement authentication module"
+						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-gray-100
+							placeholder-gray-600 focus:outline-none focus:border-blue-500 text-sm"
+						autoFocus
+					/>
+				</div>
+
+				{/* Description */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1.5">
+						Description
+						<span class="text-gray-500 text-xs ml-2">(optional)</span>
+					</label>
+					<textarea
+						value={description}
+						onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
+						placeholder="Describe what this task should accomplish..."
+						rows={3}
+						class="w-full bg-dark-800 border border-dark-700 rounded-lg px-4 py-2.5 text-gray-100
+							placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-none text-sm"
+					/>
+				</div>
+
+				{/* Priority + Type row */}
+				<div class="grid grid-cols-2 gap-3">
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1.5">Priority</label>
+						<select
+							value={priority}
+							onChange={(e) =>
+								setPriority((e.target as HTMLSelectElement).value as SpaceTaskPriority)
+							}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100
+								focus:outline-none focus:border-blue-500 text-sm"
+						>
+							{PRIORITY_OPTIONS.map((opt) => (
+								<option key={opt.value} value={opt.value}>
+									{opt.label}
+								</option>
+							))}
+						</select>
+					</div>
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1.5">Type</label>
+						<select
+							value={taskType}
+							onChange={(e) => setTaskType((e.target as HTMLSelectElement).value as SpaceTaskType)}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100
+								focus:outline-none focus:border-blue-500 text-sm"
+						>
+							{TASK_TYPE_OPTIONS.map((opt) => (
+								<option key={opt.value} value={opt.value}>
+									{opt.label}
+								</option>
+							))}
+						</select>
+					</div>
+				</div>
+
+				<div class="flex gap-3 pt-1">
+					<Button type="button" variant="secondary" onClick={handleClose} fullWidth>
+						Cancel
+					</Button>
+					<Button type="submit" loading={submitting} fullWidth>
+						Create Task
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
@@ -86,9 +86,9 @@ export function SpaceCreateTaskDialog({
 
 			toast.success(`Task "${task.title}" created`);
 			onCreated?.(task);
-			// Refresh space data so the dashboard shows the new task
-			await spaceStore.selectSpace(spaceId).catch(() => {});
 			handleClose();
+			// Refresh space data in the background so the dashboard shows the new task
+			spaceStore.selectSpace(spaceId).catch(() => {});
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to create task');
 		} finally {

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -12,6 +12,8 @@ interface SpaceDashboardProps {
 	spaceId: string;
 	onStartWorkflow?: () => void;
 	onCreateTask?: () => void;
+	/** Navigate to a task's detail pane */
+	onSelectTask?: (taskId: string) => void;
 }
 
 /**
@@ -80,6 +82,7 @@ export function SpaceDashboard({
 	spaceId: _spaceId,
 	onStartWorkflow,
 	onCreateTask,
+	onSelectTask,
 }: SpaceDashboardProps) {
 	const space = spaceStore.space.value;
 	const loading = spaceStore.loading.value;
@@ -146,7 +149,6 @@ export function SpaceDashboard({
 			)}
 
 			{/* Quick actions */}
-			{/* TODO: onStartWorkflow and onCreateTask are unwired scaffolding — will be connected once workflow/task creation dialogs are implemented */}
 			<div>
 				<h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
 					Quick Actions
@@ -185,16 +187,21 @@ export function SpaceDashboard({
 							</div>
 						))}
 						{recentTasks.map((task) => (
-							<div
+							<button
 								key={task.id}
-								class="flex items-center gap-3 px-3 py-2 rounded-md bg-dark-850 border border-dark-800"
+								type="button"
+								onClick={() => onSelectTask?.(task.id)}
+								class="flex items-center gap-3 px-3 py-2 rounded-md bg-dark-850 border border-dark-800 w-full text-left hover:bg-dark-800 hover:border-dark-700 transition-colors group"
+								disabled={!onSelectTask}
 							>
 								<span class="text-xs text-gray-600 font-medium w-16 flex-shrink-0">Task</span>
-								<span class="text-xs text-gray-300 truncate flex-1">{task.title}</span>
+								<span class="text-xs text-gray-300 truncate flex-1 group-hover:text-gray-100 transition-colors">
+									{task.title}
+								</span>
 								<span class="text-xs text-gray-600 capitalize">
 									{task.status.replace('_', ' ')}
 								</span>
-							</div>
+							</button>
 						))}
 					</div>
 				</div>

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -25,6 +25,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 	const [description, setDescription] = useState(space.description ?? '');
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
+	const [isArchiving, setIsArchiving] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
 
 	// Keep local state in sync when space prop changes (e.g. after save)
 	useEffect(() => {
@@ -92,11 +94,14 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 			return;
 		}
 		try {
+			setIsArchiving(true);
 			await hub.request('space.archive', { id: space.id });
 			toast.success(`Space "${space.name}" archived`);
 			navigateToSpaces();
 		} catch (err) {
 			toast.error(`Archive failed: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			setIsArchiving(false);
 		}
 	}
 
@@ -114,11 +119,14 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 			return;
 		}
 		try {
+			setIsDeleting(true);
 			await hub.request('space.delete', { id: space.id });
 			toast.success(`Space "${space.name}" deleted`);
 			navigateToSpaces();
 		} catch (err) {
 			toast.error(`Delete failed: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			setIsDeleting(false);
 		}
 	}
 
@@ -248,7 +256,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 						variant="secondary"
 						size="sm"
 						onClick={handleArchive}
-						disabled={space.status === 'archived'}
+						disabled={space.status === 'archived' || isArchiving}
+						loading={isArchiving}
 					>
 						Archive
 					</Button>
@@ -261,7 +270,14 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 							Permanently remove this space and all its data.
 						</p>
 					</div>
-					<Button type="button" variant="danger" size="sm" onClick={handleDelete}>
+					<Button
+						type="button"
+						variant="danger"
+						size="sm"
+						onClick={handleDelete}
+						disabled={isDeleting}
+						loading={isDeleting}
+					>
 						Delete
 					</Button>
 				</div>

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -1,17 +1,66 @@
 /**
- * SpaceSettings — settings panel for a Space with "Export Bundle" action.
+ * SpaceSettings — settings panel for a Space.
+ *
+ * Provides:
+ * - Inline editing of name and description
+ * - Export Bundle action
+ * - Archive / Delete space (danger zone)
  */
 
+import { useState, useEffect } from 'preact/hooks';
 import type { Space, SpaceExportBundle } from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager.ts';
 import { toast } from '../../lib/toast.ts';
 import { downloadBundle } from './export-import-utils.ts';
+import { navigateToSpaces } from '../../lib/router.ts';
+import { Button } from '../ui/Button.tsx';
 
 interface SpaceSettingsProps {
 	space: Space;
 }
 
 export function SpaceSettings({ space }: SpaceSettingsProps) {
+	// Edit state
+	const [name, setName] = useState(space.name);
+	const [description, setDescription] = useState(space.description ?? '');
+	const [saving, setSaving] = useState(false);
+	const [saveError, setSaveError] = useState<string | null>(null);
+
+	// Keep local state in sync when space prop changes (e.g. after save)
+	useEffect(() => {
+		setName(space.name);
+		setDescription(space.description ?? '');
+	}, [space.id, space.name, space.description]);
+
+	const isDirty = name !== space.name || description !== (space.description ?? '');
+
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		if (!name.trim()) {
+			setSaveError('Space name is required');
+			return;
+		}
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setSaveError('Not connected to server');
+			return;
+		}
+		try {
+			setSaving(true);
+			setSaveError(null);
+			await hub.request('space.update', {
+				id: space.id,
+				name: name.trim(),
+				description: description.trim() || undefined,
+			});
+			toast.success('Space updated');
+		} catch (err) {
+			setSaveError(err instanceof Error ? err.message : 'Failed to save changes');
+		} finally {
+			setSaving(false);
+		}
+	}
+
 	async function exportBundle() {
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) {
@@ -29,13 +78,116 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		}
 	}
 
+	async function handleArchive() {
+		if (
+			!confirm(
+				`Archive "${space.name}"? The space will be hidden from the main list but can be restored later.`
+			)
+		) {
+			return;
+		}
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Not connected to server');
+			return;
+		}
+		try {
+			await hub.request('space.archive', { id: space.id });
+			toast.success(`Space "${space.name}" archived`);
+			navigateToSpaces();
+		} catch (err) {
+			toast.error(`Archive failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	async function handleDelete() {
+		if (
+			!confirm(
+				`Permanently delete "${space.name}"? This will remove all agents, workflows, tasks, and runs. This cannot be undone.`
+			)
+		) {
+			return;
+		}
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Not connected to server');
+			return;
+		}
+		try {
+			await hub.request('space.delete', { id: space.id });
+			toast.success(`Space "${space.name}" deleted`);
+			navigateToSpaces();
+		} catch (err) {
+			toast.error(`Delete failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
 	return (
-		<div class="flex flex-col h-full p-6 space-y-6">
-			<div>
-				<h2 class="text-base font-semibold text-gray-100 mb-1">{space.name}</h2>
-				{space.description && <p class="text-sm text-gray-400">{space.description}</p>}
-				<p class="text-xs text-gray-600 font-mono mt-1">{space.workspacePath}</p>
-			</div>
+		<div class="flex flex-col h-full overflow-y-auto p-6 space-y-6">
+			{/* Edit name & description */}
+			<section class="space-y-4">
+				<h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">General</h3>
+
+				<form onSubmit={handleSave} class="space-y-3">
+					{saveError && (
+						<div class="bg-red-900/20 border border-red-800 rounded-lg px-4 py-2 text-red-400 text-sm">
+							{saveError}
+						</div>
+					)}
+
+					<div>
+						<label class="block text-xs font-medium text-gray-400 mb-1">Name</label>
+						<input
+							type="text"
+							value={name}
+							onInput={(e) => setName((e.target as HTMLInputElement).value)}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100
+								placeholder-gray-600 focus:outline-none focus:border-blue-500 text-sm"
+						/>
+					</div>
+
+					<div>
+						<label class="block text-xs font-medium text-gray-400 mb-1">
+							Description
+							<span class="text-gray-600 ml-1">(optional)</span>
+						</label>
+						<textarea
+							value={description}
+							onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
+							placeholder="Brief description of this space..."
+							rows={3}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100
+								placeholder-gray-600 focus:outline-none focus:border-blue-500 resize-none text-sm"
+						/>
+					</div>
+
+					{isDirty && (
+						<div class="flex gap-2 justify-end">
+							<Button
+								type="button"
+								variant="secondary"
+								size="sm"
+								onClick={() => {
+									setName(space.name);
+									setDescription(space.description ?? '');
+									setSaveError(null);
+								}}
+							>
+								Discard
+							</Button>
+							<Button type="submit" size="sm" loading={saving}>
+								Save Changes
+							</Button>
+						</div>
+					)}
+				</form>
+
+				{/* Workspace path — read-only */}
+				<div>
+					<label class="block text-xs font-medium text-gray-400 mb-1">Workspace Path</label>
+					<p class="text-xs text-gray-500 font-mono break-all">{space.workspacePath}</p>
+				</div>
+			</section>
 
 			{/* Export section */}
 			<section class="space-y-3">
@@ -78,6 +230,41 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 						<dd class="text-xs text-gray-300">{new Date(space.createdAt).toLocaleDateString()}</dd>
 					</div>
 				</dl>
+			</section>
+
+			{/* Danger zone */}
+			<section class="space-y-3 border border-red-900/40 rounded-lg p-4">
+				<h3 class="text-xs font-semibold text-red-400 uppercase tracking-wider">Danger Zone</h3>
+
+				<div class="flex items-center justify-between gap-4">
+					<div>
+						<p class="text-sm text-gray-300">Archive space</p>
+						<p class="text-xs text-gray-500 mt-0.5">
+							Hide from the main list. Can be restored later.
+						</p>
+					</div>
+					<Button
+						type="button"
+						variant="secondary"
+						size="sm"
+						onClick={handleArchive}
+						disabled={space.status === 'archived'}
+					>
+						Archive
+					</Button>
+				</div>
+
+				<div class="border-t border-red-900/30 pt-3 flex items-center justify-between gap-4">
+					<div>
+						<p class="text-sm text-gray-300">Delete space</p>
+						<p class="text-xs text-gray-500 mt-0.5">
+							Permanently remove this space and all its data.
+						</p>
+					</div>
+					<Button type="button" variant="danger" size="sm" onClick={handleDelete}>
+						Delete
+					</Button>
+				</div>
 			</section>
 		</div>
 	);

--- a/packages/web/src/components/space/SpaceStartWorkflowDialog.tsx
+++ b/packages/web/src/components/space/SpaceStartWorkflowDialog.tsx
@@ -2,7 +2,7 @@
  * SpaceStartWorkflowDialog — modal form to start a new workflow run in a Space.
  */
 
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { connectionManager } from '../../lib/connection-manager';
@@ -30,6 +30,13 @@ export function SpaceStartWorkflowDialog({
 	const [workflowId, setWorkflowId] = useState<string>(workflows[0]?.id ?? '');
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+
+	// Sync workflowId when workflows load asynchronously (store starts as [] then populates)
+	useEffect(() => {
+		if (!workflowId && workflows.length > 0) {
+			setWorkflowId(workflows[0].id);
+		}
+	}, [workflows, workflowId]);
 
 	const handleClose = () => {
 		setTitle('');
@@ -75,9 +82,9 @@ export function SpaceStartWorkflowDialog({
 
 			toast.success(`Workflow run "${run.title}" started`);
 			onStarted?.(run);
-			// Refresh space data so the dashboard reflects the new run
-			await spaceStore.selectSpace(spaceId).catch(() => {});
 			handleClose();
+			// Refresh space data in the background so the dashboard reflects the new run
+			spaceStore.selectSpace(spaceId).catch(() => {});
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to start workflow run');
 		} finally {

--- a/packages/web/src/components/space/SpaceStartWorkflowDialog.tsx
+++ b/packages/web/src/components/space/SpaceStartWorkflowDialog.tsx
@@ -1,0 +1,178 @@
+/**
+ * SpaceStartWorkflowDialog — modal form to start a new workflow run in a Space.
+ */
+
+import { useState } from 'preact/hooks';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { connectionManager } from '../../lib/connection-manager';
+import { spaceStore } from '../../lib/space-store';
+import { toast } from '../../lib/toast';
+import type { SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
+
+interface SpaceStartWorkflowDialogProps {
+	isOpen: boolean;
+	spaceId: string;
+	workflows: SpaceWorkflow[];
+	onClose: () => void;
+	onStarted?: (run: SpaceWorkflowRun) => void;
+}
+
+export function SpaceStartWorkflowDialog({
+	isOpen,
+	spaceId,
+	workflows,
+	onClose,
+	onStarted,
+}: SpaceStartWorkflowDialogProps) {
+	const [title, setTitle] = useState('');
+	const [description, setDescription] = useState('');
+	const [workflowId, setWorkflowId] = useState<string>(workflows[0]?.id ?? '');
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleClose = () => {
+		setTitle('');
+		setDescription('');
+		setWorkflowId(workflows[0]?.id ?? '');
+		setError(null);
+		onClose();
+	};
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+
+		if (!title.trim()) {
+			setError('Run title is required');
+			return;
+		}
+
+		if (workflows.length > 0 && !workflowId) {
+			setError('Please select a workflow');
+			return;
+		}
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setError('Not connected to server');
+			return;
+		}
+
+		try {
+			setSubmitting(true);
+			setError(null);
+
+			const { run } = await hub.request<{ run: SpaceWorkflowRun }>('spaceWorkflowRun.start', {
+				spaceId,
+				workflowId: workflowId || undefined,
+				title: title.trim(),
+				description: description.trim() || undefined,
+			});
+
+			if (!run) {
+				throw new Error('Server returned no data');
+			}
+
+			toast.success(`Workflow run "${run.title}" started`);
+			onStarted?.(run);
+			// Refresh space data so the dashboard reflects the new run
+			await spaceStore.selectSpace(spaceId).catch(() => {});
+			handleClose();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to start workflow run');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const hasWorkflows = workflows.length > 0;
+
+	return (
+		<Modal isOpen={isOpen} onClose={handleClose} title="Start Workflow Run" size="md">
+			<form onSubmit={handleSubmit} class="space-y-4">
+				{error && (
+					<div class="bg-red-900/20 border border-red-800 rounded-lg px-4 py-3 text-red-400 text-sm">
+						{error}
+					</div>
+				)}
+
+				{!hasWorkflows && (
+					<div class="bg-amber-900/20 border border-amber-800 rounded-lg px-4 py-3 text-amber-300 text-sm">
+						No workflows configured for this space. Create a workflow in the Workflows tab first.
+					</div>
+				)}
+
+				{/* Workflow selector — only shown when multiple workflows exist */}
+				{workflows.length > 1 && (
+					<div>
+						<label class="block text-sm font-medium text-gray-200 mb-1.5">Workflow</label>
+						<select
+							value={workflowId}
+							onChange={(e) => setWorkflowId((e.target as HTMLSelectElement).value)}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100
+								focus:outline-none focus:border-blue-500 text-sm"
+						>
+							{workflows.map((wf) => (
+								<option key={wf.id} value={wf.id}>
+									{wf.name}
+								</option>
+							))}
+						</select>
+					</div>
+				)}
+
+				{/* Single workflow indicator */}
+				{workflows.length === 1 && (
+					<div class="flex items-center gap-2 text-sm text-gray-400">
+						<span class="text-gray-500">Workflow:</span>
+						<span class="text-gray-200">{workflows[0].name}</span>
+					</div>
+				)}
+
+				{/* Run title */}
+				<div>
+					<label class="block text-sm font-medium text-gray-200 mb-1.5">
+						Run Title
+						<span class="text-red-400 ml-1">*</span>
+					</label>
+					<input
+						type="text"
+						value={title}
+						onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+						placeholder="e.g., Sprint 12 feature implementation"
+						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-gray-100
+							placeholder-gray-600 focus:outline-none focus:border-blue-500 text-sm"
+						autoFocus
+						disabled={!hasWorkflows}
+					/>
+				</div>
+
+				{/* Description */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1.5">
+						Description
+						<span class="text-gray-500 text-xs ml-2">(optional)</span>
+					</label>
+					<textarea
+						value={description}
+						onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
+						placeholder="Describe the goal of this workflow run..."
+						rows={3}
+						class="w-full bg-dark-800 border border-dark-700 rounded-lg px-4 py-2.5 text-gray-100
+							placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-none text-sm"
+						disabled={!hasWorkflows}
+					/>
+				</div>
+
+				<div class="flex gap-3 pt-1">
+					<Button type="button" variant="secondary" onClick={handleClose} fullWidth>
+						Cancel
+					</Button>
+					<Button type="submit" loading={submitting} disabled={!hasWorkflows} fullWidth>
+						Start Run
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
@@ -1,0 +1,257 @@
+// @ts-nocheck
+/**
+ * Unit tests for SpaceCreateTaskDialog
+ *
+ * Tests:
+ * - Dialog renders when open / hidden when closed
+ * - Title required validation
+ * - Submit calls spaceTask.create RPC with correct params
+ * - Shows toast and calls onCreated on success
+ * - Shows error message on failure
+ * - Cancel closes and resets form
+ * - Priority and type selectors update form state
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+
+const mockRequest = vi.fn();
+const mockGetHubIfConnected = vi.fn();
+const mockSelectSpace = vi.fn().mockResolvedValue(undefined);
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		get getHubIfConnected() {
+			return mockGetHubIfConnected;
+		},
+	},
+}));
+
+vi.mock('../../../lib/space-store', () => ({
+	spaceStore: {
+		get selectSpace() {
+			return mockSelectSpace;
+		},
+	},
+}));
+
+vi.mock('../../../lib/toast', () => ({
+	toast: {
+		get success() {
+			return mockToastSuccess;
+		},
+		get error() {
+			return mockToastError;
+		},
+	},
+}));
+
+vi.mock('../../ui/Modal', () => ({
+	Modal: ({ isOpen, children, title, onClose }) => {
+		if (!isOpen) return null;
+		return (
+			<div role="dialog" aria-label={title}>
+				<button onClick={onClose} aria-label="Close modal">
+					X
+				</button>
+				{children}
+			</div>
+		);
+	},
+}));
+
+vi.mock('../../ui/Button', () => ({
+	Button: ({ children, onClick, type, loading, disabled }) => (
+		<button type={type ?? 'button'} onClick={onClick} disabled={disabled || loading}>
+			{loading ? 'Loading...' : children}
+		</button>
+	),
+}));
+
+import { SpaceCreateTaskDialog } from '../SpaceCreateTaskDialog';
+
+const TASK_MOCK = {
+	id: 'task-1',
+	spaceId: 'space-1',
+	title: 'Test task',
+	description: '',
+	status: 'pending',
+	priority: 'normal',
+	taskType: 'coding',
+	dependsOn: [],
+	createdAt: Date.now(),
+	updatedAt: Date.now(),
+};
+
+describe('SpaceCreateTaskDialog', () => {
+	let onClose: ReturnType<typeof vi.fn>;
+	let onCreated: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		cleanup();
+		onClose = vi.fn();
+		onCreated = vi.fn();
+		mockRequest.mockReset();
+		mockGetHubIfConnected.mockReset();
+		mockToastSuccess.mockReset();
+		mockToastError.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders nothing when isOpen is false', () => {
+		const { container } = render(
+			<SpaceCreateTaskDialog isOpen={false} spaceId="space-1" onClose={onClose} />
+		);
+		expect(container.querySelector('[role="dialog"]')).toBeNull();
+	});
+
+	it('renders dialog when isOpen is true', () => {
+		const { getByRole } = render(
+			<SpaceCreateTaskDialog isOpen={true} spaceId="space-1" onClose={onClose} />
+		);
+		expect(getByRole('dialog')).toBeTruthy();
+	});
+
+	it('shows title required indicator', () => {
+		const { getByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} spaceId="space-1" onClose={onClose} />
+		);
+		expect(getByText('Title')).toBeTruthy();
+		expect(getByText('*')).toBeTruthy();
+	});
+
+	it('shows validation error when title is empty', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		const { getByRole, findByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} spaceId="space-1" onClose={onClose} />
+		);
+		const form = getByRole('dialog').querySelector('form');
+		fireEvent.submit(form);
+		expect(await findByText('Task title is required')).toBeTruthy();
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('shows error when not connected', async () => {
+		mockGetHubIfConnected.mockReturnValue(null);
+		const { getByPlaceholderText, getByRole, findByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} spaceId="space-1" onClose={onClose} />
+		);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My task' },
+		});
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+		expect(await findByText('Not connected to server')).toBeTruthy();
+	});
+
+	it('calls spaceTask.create with correct params on submit', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue(TASK_MOCK);
+
+		const { getByPlaceholderText, getByRole } = render(
+			<SpaceCreateTaskDialog
+				isOpen={true}
+				spaceId="space-1"
+				onClose={onClose}
+				onCreated={onCreated}
+			/>
+		);
+
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My new task' },
+		});
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('spaceTask.create', {
+				spaceId: 'space-1',
+				title: 'My new task',
+				description: '',
+				priority: 'normal',
+				taskType: 'coding',
+			});
+		});
+	});
+
+	it('calls onCreated and closes on success', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue(TASK_MOCK);
+
+		const { getByPlaceholderText, getByRole } = render(
+			<SpaceCreateTaskDialog
+				isOpen={true}
+				spaceId="space-1"
+				onClose={onClose}
+				onCreated={onCreated}
+			/>
+		);
+
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My task' },
+		});
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(onCreated).toHaveBeenCalledWith(TASK_MOCK);
+			expect(onClose).toHaveBeenCalled();
+			expect(mockToastSuccess).toHaveBeenCalledWith(expect.stringContaining('Test task'));
+		});
+	});
+
+	it('shows error message when spaceTask.create fails', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockRejectedValue(new Error('Server error'));
+
+		const { getByPlaceholderText, getByRole, findByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} spaceId="space-1" onClose={onClose} />
+		);
+
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'Failing task' },
+		});
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		expect(await findByText('Server error')).toBeTruthy();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('calls onClose when Cancel is clicked', () => {
+		const { getByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} spaceId="space-1" onClose={onClose} />
+		);
+		fireEvent.click(getByText('Cancel'));
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('sends correct priority when changed', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue(TASK_MOCK);
+
+		const { getByPlaceholderText, getByRole, getAllByRole } = render(
+			<SpaceCreateTaskDialog isOpen={true} spaceId="space-1" onClose={onClose} />
+		);
+
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'Urgent task' },
+		});
+
+		const selects = getAllByRole('combobox');
+		fireEvent.change(selects[0], { target: { value: 'urgent' } });
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith(
+				'spaceTask.create',
+				expect.objectContaining({
+					priority: 'urgent',
+				})
+			);
+		});
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -206,4 +206,13 @@ describe('SpaceDashboard', () => {
 		// Path should be truncated (starts with ellipsis)
 		expect(pathEl?.textContent?.startsWith('…')).toBe(true);
 	});
+
+	it('calls onSelectTask when a recent task row is clicked', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [makeTask('t1', 'completed')];
+		const onSelectTask = vi.fn();
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" onSelectTask={onSelectTask} />);
+		fireEvent.click(getByText('Task t1').closest('button')!);
+		expect(onSelectTask).toHaveBeenCalledWith('t1');
+	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceSettings.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceSettings.test.tsx
@@ -239,6 +239,61 @@ describe('SpaceSettings', () => {
 		expect(mockRequest).not.toHaveBeenCalled();
 	});
 
+	it('shows validation error when saving with empty name', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		const space = makeSpace();
+		const { getByDisplayValue, getByText, findByText } = render(<SpaceSettings space={space} />);
+		// Clear the name field
+		fireEvent.input(getByDisplayValue('My Space'), { target: { value: '' } });
+		fireEvent.click(getByText('Save Changes'));
+		expect(await findByText('Space name is required')).toBeTruthy();
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('Archive button is disabled during archiving', async () => {
+		mockConfirm.mockReturnValue(true);
+		let resolveArchive: () => void;
+		const archivePromise = new Promise<{}>((res) => {
+			resolveArchive = () => res({});
+		});
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockReturnValue(archivePromise);
+
+		const space = makeSpace();
+		const { getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.click(getByText('Archive'));
+
+		// Button should be disabled while in-flight
+		await waitFor(() => {
+			const btn = getByText('Loading...').closest('button')!;
+			expect(btn.disabled).toBe(true);
+		});
+
+		resolveArchive!();
+	});
+
+	it('Delete button is disabled during deletion', async () => {
+		mockConfirm.mockReturnValue(true);
+		let resolveDelete: () => void;
+		const deletePromise = new Promise<{}>((res) => {
+			resolveDelete = () => res({});
+		});
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockReturnValue(deletePromise);
+
+		const space = makeSpace();
+		const { getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.click(getByText('Delete'));
+
+		// Button should be disabled while in-flight
+		await waitFor(() => {
+			const btns = document.querySelectorAll('button[disabled]');
+			expect(btns.length).toBeGreaterThan(0);
+		});
+
+		resolveDelete!();
+	});
+
 	it('calls spaceExport.bundle when Export Bundle is clicked', async () => {
 		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
 		mockRequest.mockResolvedValue({ bundle: { version: '1', spaces: [] } });

--- a/packages/web/src/components/space/__tests__/SpaceSettings.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceSettings.test.tsx
@@ -1,0 +1,254 @@
+// @ts-nocheck
+/**
+ * Unit tests for SpaceSettings
+ *
+ * Tests:
+ * - Renders space name, description, workspace path
+ * - Save Changes button only shown when form is dirty
+ * - Calls space.update RPC with trimmed values on save
+ * - Discard button resets form to original values
+ * - Shows error when not connected
+ * - Archive button calls space.archive and navigates away
+ * - Delete button calls space.delete and navigates away
+ * - Archive button is disabled when space is already archived
+ * - Export bundle button calls spaceExport.bundle
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+
+const mockRequest = vi.fn();
+const mockGetHubIfConnected = vi.fn();
+const mockNavigateToSpaces = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+const mockDownloadBundle = vi.fn();
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		get getHubIfConnected() {
+			return mockGetHubIfConnected;
+		},
+	},
+}));
+
+vi.mock('../../../lib/router', () => ({
+	get navigateToSpaces() {
+		return mockNavigateToSpaces;
+	},
+}));
+
+vi.mock('../../../lib/toast', () => ({
+	toast: {
+		get success() {
+			return mockToastSuccess;
+		},
+		get error() {
+			return mockToastError;
+		},
+	},
+}));
+
+vi.mock('../export-import-utils', () => ({
+	downloadBundle: (...args) => mockDownloadBundle(...args),
+}));
+
+vi.mock('../../ui/Button', () => ({
+	Button: ({ children, onClick, type, loading, disabled, variant }) => (
+		<button
+			type={type ?? 'button'}
+			onClick={onClick}
+			disabled={disabled || loading}
+			data-variant={variant}
+		>
+			{loading ? 'Loading...' : children}
+		</button>
+	),
+}));
+
+import { SpaceSettings } from '../SpaceSettings';
+import type { Space } from '@neokai/shared';
+
+function makeSpace(overrides: Partial<Space> = {}): Space {
+	return {
+		id: 'space-1',
+		name: 'My Space',
+		workspacePath: '/projects/my-space',
+		description: 'Original description',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+// Mock window.confirm globally
+const mockConfirm = vi.fn();
+beforeEach(() => {
+	(globalThis as unknown as { confirm: unknown }).confirm = mockConfirm;
+});
+
+describe('SpaceSettings', () => {
+	beforeEach(() => {
+		cleanup();
+		mockRequest.mockReset();
+		mockGetHubIfConnected.mockReset();
+		mockNavigateToSpaces.mockReset();
+		mockToastSuccess.mockReset();
+		mockToastError.mockReset();
+		mockConfirm.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders space name and description', () => {
+		const space = makeSpace();
+		const { getByDisplayValue, getByText } = render(<SpaceSettings space={space} />);
+		expect(getByDisplayValue('My Space')).toBeTruthy();
+		expect(getByDisplayValue('Original description')).toBeTruthy();
+	});
+
+	it('renders workspace path as read-only text', () => {
+		const space = makeSpace();
+		const { getByText } = render(<SpaceSettings space={space} />);
+		expect(getByText('/projects/my-space')).toBeTruthy();
+	});
+
+	it('does not show Save Changes button when form is clean', () => {
+		const space = makeSpace();
+		const { queryByText } = render(<SpaceSettings space={space} />);
+		expect(queryByText('Save Changes')).toBeNull();
+	});
+
+	it('shows Save Changes button when name is changed', () => {
+		const space = makeSpace();
+		const { getByDisplayValue, getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.input(getByDisplayValue('My Space'), { target: { value: 'New Name' } });
+		expect(getByText('Save Changes')).toBeTruthy();
+	});
+
+	it('calls space.update with trimmed values on save', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({});
+
+		const space = makeSpace();
+		const { getByDisplayValue, getByText } = render(<SpaceSettings space={space} />);
+
+		fireEvent.input(getByDisplayValue('My Space'), { target: { value: '  Updated Name  ' } });
+		fireEvent.click(getByText('Save Changes'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('space.update', {
+				id: 'space-1',
+				name: 'Updated Name',
+				description: 'Original description',
+			});
+		});
+	});
+
+	it('shows toast on successful save', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({});
+
+		const space = makeSpace();
+		const { getByDisplayValue, getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.input(getByDisplayValue('My Space'), { target: { value: 'Changed' } });
+		fireEvent.click(getByText('Save Changes'));
+
+		await waitFor(() => {
+			expect(mockToastSuccess).toHaveBeenCalledWith('Space updated');
+		});
+	});
+
+	it('Discard resets form to original values', () => {
+		const space = makeSpace();
+		const { getByDisplayValue, getByText, queryByText } = render(<SpaceSettings space={space} />);
+		fireEvent.input(getByDisplayValue('My Space'), { target: { value: 'Changed' } });
+		expect(getByText('Discard')).toBeTruthy();
+
+		fireEvent.click(getByText('Discard'));
+		// After discard, form should be clean
+		expect(queryByText('Save Changes')).toBeNull();
+		expect((getByDisplayValue('My Space') as HTMLInputElement).value).toBe('My Space');
+	});
+
+	it('shows error when not connected on save', async () => {
+		mockGetHubIfConnected.mockReturnValue(null);
+		const space = makeSpace();
+		const { getByDisplayValue, getByText, findByText } = render(<SpaceSettings space={space} />);
+		fireEvent.input(getByDisplayValue('My Space'), { target: { value: 'Changed' } });
+		fireEvent.click(getByText('Save Changes'));
+		expect(await findByText('Not connected to server')).toBeTruthy();
+	});
+
+	it('calls space.archive and navigates on confirm', async () => {
+		mockConfirm.mockReturnValue(true);
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({});
+
+		const space = makeSpace();
+		const { getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.click(getByText('Archive'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('space.archive', { id: 'space-1' });
+			expect(mockNavigateToSpaces).toHaveBeenCalled();
+		});
+	});
+
+	it('does not archive when confirm is dismissed', async () => {
+		mockConfirm.mockReturnValue(false);
+		const space = makeSpace();
+		const { getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.click(getByText('Archive'));
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('Archive button is disabled when space is already archived', () => {
+		const space = makeSpace({ status: 'archived' });
+		const { getByText } = render(<SpaceSettings space={space} />);
+		const archiveBtn = getByText('Archive').closest('button')!;
+		expect(archiveBtn.disabled).toBe(true);
+	});
+
+	it('calls space.delete and navigates on confirm', async () => {
+		mockConfirm.mockReturnValue(true);
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({});
+
+		const space = makeSpace();
+		const { getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.click(getByText('Delete'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('space.delete', { id: 'space-1' });
+			expect(mockNavigateToSpaces).toHaveBeenCalled();
+		});
+	});
+
+	it('does not delete when confirm is dismissed', async () => {
+		mockConfirm.mockReturnValue(false);
+		const space = makeSpace();
+		const { getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.click(getByText('Delete'));
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('calls spaceExport.bundle when Export Bundle is clicked', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({ bundle: { version: '1', spaces: [] } });
+
+		const space = makeSpace();
+		const { getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.click(getByText('Export Bundle'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('spaceExport.bundle', { spaceId: 'space-1' });
+		});
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceStartWorkflowDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceStartWorkflowDialog.test.tsx
@@ -1,0 +1,275 @@
+// @ts-nocheck
+/**
+ * Unit tests for SpaceStartWorkflowDialog
+ *
+ * Tests:
+ * - Renders nothing when closed
+ * - Renders warning when no workflows configured
+ * - Shows workflow selector only when multiple workflows exist
+ * - Shows single workflow name when only one workflow
+ * - Title required validation
+ * - Submit calls spaceWorkflowRun.start with correct params
+ * - Toast and onStarted callback on success
+ * - Error message on failure
+ * - Cancel closes dialog
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+
+const mockRequest = vi.fn();
+const mockGetHubIfConnected = vi.fn();
+const mockSelectSpace = vi.fn().mockResolvedValue(undefined);
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		get getHubIfConnected() {
+			return mockGetHubIfConnected;
+		},
+	},
+}));
+
+vi.mock('../../../lib/space-store', () => ({
+	spaceStore: {
+		get selectSpace() {
+			return mockSelectSpace;
+		},
+	},
+}));
+
+vi.mock('../../../lib/toast', () => ({
+	toast: {
+		get success() {
+			return mockToastSuccess;
+		},
+		get error() {
+			return mockToastError;
+		},
+	},
+}));
+
+vi.mock('../../ui/Modal', () => ({
+	Modal: ({ isOpen, children, title, onClose }) => {
+		if (!isOpen) return null;
+		return (
+			<div role="dialog" aria-label={title}>
+				<button onClick={onClose} aria-label="Close modal">
+					X
+				</button>
+				{children}
+			</div>
+		);
+	},
+}));
+
+vi.mock('../../ui/Button', () => ({
+	Button: ({ children, onClick, type, loading, disabled }) => (
+		<button type={type ?? 'button'} onClick={onClick} disabled={disabled || loading}>
+			{loading ? 'Loading...' : children}
+		</button>
+	),
+}));
+
+import { SpaceStartWorkflowDialog } from '../SpaceStartWorkflowDialog';
+
+function makeWorkflow(id: string, name: string) {
+	return {
+		id,
+		spaceId: 'space-1',
+		name,
+		description: '',
+		nodes: [],
+		gates: [],
+		rules: [],
+		channels: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+const RUN_MOCK = {
+	id: 'run-1',
+	spaceId: 'space-1',
+	workflowId: 'wf-1',
+	title: 'Sprint run',
+	status: 'pending',
+	createdAt: Date.now(),
+	updatedAt: Date.now(),
+};
+
+describe('SpaceStartWorkflowDialog', () => {
+	let onClose: ReturnType<typeof vi.fn>;
+	let onStarted: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		cleanup();
+		onClose = vi.fn();
+		onStarted = vi.fn();
+		mockRequest.mockReset();
+		mockGetHubIfConnected.mockReset();
+		mockToastSuccess.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders nothing when isOpen is false', () => {
+		const { container } = render(
+			<SpaceStartWorkflowDialog isOpen={false} spaceId="space-1" workflows={[]} onClose={onClose} />
+		);
+		expect(container.querySelector('[role="dialog"]')).toBeNull();
+	});
+
+	it('shows warning when no workflows configured', () => {
+		const { getByText } = render(
+			<SpaceStartWorkflowDialog isOpen={true} spaceId="space-1" workflows={[]} onClose={onClose} />
+		);
+		expect(getByText(/No workflows configured/)).toBeTruthy();
+	});
+
+	it('does not show workflow selector when only one workflow', () => {
+		const { queryByRole } = render(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Main Flow')]}
+				onClose={onClose}
+			/>
+		);
+		// No combobox/select for single workflow
+		expect(queryByRole('combobox')).toBeNull();
+	});
+
+	it('shows single workflow name when only one workflow', () => {
+		const { getByText } = render(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Main Flow')]}
+				onClose={onClose}
+			/>
+		);
+		expect(getByText('Main Flow')).toBeTruthy();
+	});
+
+	it('shows workflow selector when multiple workflows exist', () => {
+		const { getAllByRole } = render(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Flow A'), makeWorkflow('wf-2', 'Flow B')]}
+				onClose={onClose}
+			/>
+		);
+		const selects = getAllByRole('combobox');
+		expect(selects.length).toBeGreaterThan(0);
+	});
+
+	it('shows validation error when title is empty', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		const { getByRole, findByText } = render(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Flow A')]}
+				onClose={onClose}
+			/>
+		);
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+		expect(await findByText('Run title is required')).toBeTruthy();
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('calls spaceWorkflowRun.start with correct params on submit', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({ run: RUN_MOCK });
+
+		const { getByPlaceholderText, getByRole } = render(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Main Flow')]}
+				onClose={onClose}
+				onStarted={onStarted}
+			/>
+		);
+
+		fireEvent.input(getByPlaceholderText('e.g., Sprint 12 feature implementation'), {
+			target: { value: 'Sprint run' },
+		});
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.start', {
+				spaceId: 'space-1',
+				workflowId: 'wf-1',
+				title: 'Sprint run',
+				description: undefined,
+			});
+		});
+	});
+
+	it('calls onStarted and closes on success', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({ run: RUN_MOCK });
+
+		const { getByPlaceholderText, getByRole } = render(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Main Flow')]}
+				onClose={onClose}
+				onStarted={onStarted}
+			/>
+		);
+
+		fireEvent.input(getByPlaceholderText('e.g., Sprint 12 feature implementation'), {
+			target: { value: 'Sprint run' },
+		});
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(onStarted).toHaveBeenCalledWith(RUN_MOCK);
+			expect(onClose).toHaveBeenCalled();
+			expect(mockToastSuccess).toHaveBeenCalledWith(expect.stringContaining('Sprint run'));
+		});
+	});
+
+	it('shows error message when spaceWorkflowRun.start fails', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockRejectedValue(new Error('Workflow not found'));
+
+		const { getByPlaceholderText, getByRole, findByText } = render(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Main Flow')]}
+				onClose={onClose}
+			/>
+		);
+
+		fireEvent.input(getByPlaceholderText('e.g., Sprint 12 feature implementation'), {
+			target: { value: 'Failing run' },
+		});
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		expect(await findByText('Workflow not found')).toBeTruthy();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('calls onClose when Cancel is clicked', () => {
+		const { getByText } = render(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Main Flow')]}
+				onClose={onClose}
+			/>
+		);
+		fireEvent.click(getByText('Cancel'));
+		expect(onClose).toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceStartWorkflowDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceStartWorkflowDialog.test.tsx
@@ -272,4 +272,28 @@ describe('SpaceStartWorkflowDialog', () => {
 		fireEvent.click(getByText('Cancel'));
 		expect(onClose).toHaveBeenCalled();
 	});
+
+	it('syncs workflowId via useEffect when workflows load asynchronously', async () => {
+		// Start with empty workflows (simulates async store state)
+		const { rerender, queryByRole } = render(
+			<SpaceStartWorkflowDialog isOpen={true} spaceId="space-1" workflows={[]} onClose={onClose} />
+		);
+		// No select visible yet
+		expect(queryByRole('combobox')).toBeNull();
+
+		// Workflows arrive later (e.g., after selectSpace resolves)
+		rerender(
+			<SpaceStartWorkflowDialog
+				isOpen={true}
+				spaceId="space-1"
+				workflows={[makeWorkflow('wf-1', 'Main Flow')]}
+				onClose={onClose}
+			/>
+		);
+
+		// workflowId should now be set — single-workflow indicator appears
+		await waitFor(() => {
+			expect(queryByRole('combobox')).toBeNull(); // still single-workflow path
+		});
+	});
 });

--- a/packages/web/src/components/space/index.ts
+++ b/packages/web/src/components/space/index.ts
@@ -6,6 +6,8 @@ export { SpaceAgentEditor } from './SpaceAgentEditor';
 export { SpaceAgentList } from './SpaceAgentList';
 export { SpaceContextPanel } from './SpaceContextPanel';
 export { SpaceCreateDialog } from './SpaceCreateDialog';
+export { SpaceCreateTaskDialog } from './SpaceCreateTaskDialog';
+export { SpaceStartWorkflowDialog } from './SpaceStartWorkflowDialog';
 export { SpaceDashboard } from './SpaceDashboard';
 export { SpaceNavPanel } from './SpaceNavPanel';
 export { SpaceSettings } from './SpaceSettings';

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -17,7 +17,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { spaceStore } from '../lib/space-store';
 import { currentSpaceTaskIdSignal } from '../lib/signals';
-import { navigateToSpace } from '../lib/router';
+import { navigateToSpace, navigateToSpaceTask } from '../lib/router';
 import { SpaceDashboard } from '../components/space/SpaceDashboard';
 import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
 import { SpaceAgentList } from '../components/space/SpaceAgentList';
@@ -26,6 +26,8 @@ import { WorkflowEditor } from '../components/space/WorkflowEditor';
 import { VisualWorkflowEditor } from '../components/space/visual-editor/VisualWorkflowEditor';
 import { WorkflowCanvas } from '../components/space/WorkflowCanvas';
 import { SpaceSettings } from '../components/space/SpaceSettings';
+import { SpaceCreateTaskDialog } from '../components/space/SpaceCreateTaskDialog';
+import { SpaceStartWorkflowDialog } from '../components/space/SpaceStartWorkflowDialog';
 import { cn } from '../lib/utils';
 
 interface SpaceIslandProps {
@@ -62,6 +64,8 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 	/** null = list view; 'new' = create editor; <id> = edit editor */
 	const [workflowEditId, setWorkflowEditId] = useState<string | null>(null);
 	const [editorMode, setEditorMode] = useState<EditorMode>(readStoredEditorMode);
+	const [createTaskOpen, setCreateTaskOpen] = useState(false);
+	const [startWorkflowOpen, setStartWorkflowOpen] = useState(false);
 	const loading = spaceStore.loading.value;
 	const error = spaceStore.error.value;
 
@@ -270,7 +274,12 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 										class={cn('flex flex-col h-full overflow-y-auto', showCanvas && 'md:hidden')}
 										data-testid="dashboard-fallback"
 									>
-										<SpaceDashboard spaceId={spaceId} />
+										<SpaceDashboard
+											spaceId={spaceId}
+											onCreateTask={() => setCreateTaskOpen(true)}
+											onStartWorkflow={() => setStartWorkflowOpen(true)}
+											onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
+										/>
 									</div>
 								</>
 							)}
@@ -296,6 +305,19 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 					<SpaceTaskPane taskId={activeTaskId} onClose={handleTaskPaneClose} />
 				</div>
 			)}
+
+			{/* Quick action dialogs */}
+			<SpaceCreateTaskDialog
+				isOpen={createTaskOpen}
+				spaceId={spaceId}
+				onClose={() => setCreateTaskOpen(false)}
+			/>
+			<SpaceStartWorkflowDialog
+				isOpen={startWorkflowOpen}
+				spaceId={spaceId}
+				workflows={workflows}
+				onClose={() => setStartWorkflowOpen(false)}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Fixes P1/P2 space UI/UX gaps discovered during audit:

- **Quick Actions wired**: "Start Workflow Run" and "Create Task" buttons in SpaceDashboard now open real dialogs (`SpaceStartWorkflowDialog`, `SpaceCreateTaskDialog`) that call the appropriate RPC endpoints
- **Task creation**: New `SpaceCreateTaskDialog` modal — title, description, priority, task type — calls `spaceTask.create`
- **Workflow run creation**: New `SpaceStartWorkflowDialog` modal — run title, description, workflow selector (when multiple exist) — calls `spaceWorkflowRun.start`
- **Space editing**: `SpaceSettings` now has inline name/description edit form calling `space.update`, with dirty-state tracking and discard
- **Delete/archive**: Danger zone added to `SpaceSettings` with archive (`space.archive`) and permanent delete (`space.delete`) actions, both gated by `confirm()`
- **Clickable recent activity**: Task rows in SpaceDashboard now navigate to the task detail pane via `onSelectTask` → `navigateToSpaceTask`

34 new unit tests; all 426 space component tests pass.