### PR TITLE
fix(web): rename spaceWorkflowRun RPC call from .create to .start

### DIFF
--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -134,8 +134,8 @@ function makeMockHub() {
 			// Daemon returns SpaceTask directly (not wrapped)
 			if (method === 'spaceTask.create') return makeTask('new-task');
 			if (method === 'spaceTask.update') return makeTask('t1', 'in_progress');
-			// spaceWorkflowRun.create is a stub — would return SpaceWorkflowRun directly
-			if (method === 'spaceWorkflowRun.create') return makeRun('new-run');
+			// spaceWorkflowRun.start returns wrapped { run: SpaceWorkflowRun }
+			if (method === 'spaceWorkflowRun.start') return { run: makeRun('new-run') };
 			// spaceAgent handlers return wrapped { agent }
 			if (method === 'spaceAgent.create') return { agent: makeAgent('new-agent') };
 			if (method === 'spaceAgent.update') return { agent: makeAgent('a1') };
@@ -803,11 +803,11 @@ describe('SpaceStore — CRUD methods', () => {
 		expect(task.status).toBe('in_progress');
 	});
 
-	it('startWorkflowRun calls spaceWorkflowRun.create RPC', async () => {
+	it('startWorkflowRun calls spaceWorkflowRun.start RPC', async () => {
 		await spaceStore.selectSpace('space-1');
 		await spaceStore.startWorkflowRun({ workflowId: 'wf-1', title: 'Run 1' });
 
-		expect(mockHub.request).toHaveBeenCalledWith('spaceWorkflowRun.create', {
+		expect(mockHub.request).toHaveBeenCalledWith('spaceWorkflowRun.start', {
 			spaceId: 'space-1',
 			workflowId: 'wf-1',
 			title: 'Run 1',

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -838,12 +838,6 @@ class SpaceStore {
 
 	/**
 	 * Start a new workflow run.
-	 *
-	 * TODO(M6): The `spaceWorkflowRun.create` RPC handler is not yet registered
-	 * in the daemon — workflow runs are currently created internally by the
-	 * SpaceRuntime. This method is a stub for the future client-initiated API.
-	 * The event subscriptions for space.workflowRun.created/updated are already
-	 * active and will reflect runs created by the runtime.
 	 */
 	async startWorkflowRun(
 		params: Omit<CreateWorkflowRunParams, 'spaceId'>
@@ -854,7 +848,7 @@ class SpaceStore {
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) throw new Error('Not connected');
 
-		const run = await hub.request<SpaceWorkflowRun>('spaceWorkflowRun.create', {
+		const { run } = await hub.request<{ run: SpaceWorkflowRun }>('spaceWorkflowRun.start', {
 			...params,
 			spaceId,
 		});


### PR DESCRIPTION
The daemon registers the handler as `spaceWorkflowRun.start` (returning `{ run: SpaceWorkflowRun }`), but `space-store.ts` was calling `spaceWorkflowRun.create` and treating the response as a plain `SpaceWorkflowRun`.

- Rename RPC call from `spaceWorkflowRun.create` to `spaceWorkflowRun.start`
- Destructure `{ run }` from the response
- Remove stale TODO(M6) comment
- Update unit test mock and assertion to match