### PR TITLE
feat(web): add navigateToSpaceAgent() router function and /space/:id/agent URL support

### DIFF
--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -902,28 +902,31 @@ describe('GoalManager.patchGoal — schedule nextRunAt auto-computation', () => 
 	});
 
 	it('auto-computes nextRunAt when updating schedule on a recurring mission', async () => {
+		// Use hour-specific cron expressions to guarantee distinct nextRunAt values.
+		// "0 2 * * *" fires at 02:00 and "0 3 * * *" fires at 03:00 — they can never
+		// produce the same timestamp regardless of when the test runs, unlike @daily vs
+		// @weekly which both resolve to midnight and collide on Saturdays.
 		const goal = await goalManager.createGoal({
 			title: 'Recurring',
 			missionType: 'recurring',
-			schedule: { expression: '@daily', timezone: 'UTC' },
+			schedule: { expression: '0 2 * * *', timezone: 'UTC' },
 		});
 		expect(goal.nextRunAt).toBeDefined();
 		const originalNextRunAt = goal.nextRunAt!;
 
-		// Patch the schedule to @weekly — guaranteed different nextRunAt than @daily
-		// (they can coincide at midnight for @hourly or @daily).
+		// Patch to 03:00 daily — guaranteed different nextRunAt than 02:00 daily
 		const before = Math.floor(Date.now() / 1000);
 		const patched = await goalManager.patchGoal(goal.id, {
-			schedule: { expression: '@weekly', timezone: 'UTC' },
+			schedule: { expression: '0 3 * * *', timezone: 'UTC' },
 		});
-		const after = Math.floor(Date.now() / 1000) + 7 * 24 * 3600 + 100; // @weekly = up to 7 days
+		const after = Math.floor(Date.now() / 1000) + 24 * 3600 + 100; // fires within 24 h
 
-		expect(patched.schedule?.expression).toBe('@weekly');
+		expect(patched.schedule?.expression).toBe('0 3 * * *');
 		expect(patched.nextRunAt).toBeDefined();
 		expect(patched.nextRunAt!).toBeGreaterThan(before);
-		// @weekly fires within the next week
+		// Next 03:00 UTC fires within the next 24 hours
 		expect(patched.nextRunAt!).toBeLessThanOrEqual(after);
-		// nextRunAt should change when the cron expression changes
+		// nextRunAt must change because the fire time moved from 02:00 to 03:00
 		expect(patched.nextRunAt!).not.toBe(originalNextRunAt);
 	});
 

--- a/packages/web/src/lib/__tests__/space-agent-router.test.ts
+++ b/packages/web/src/lib/__tests__/space-agent-router.test.ts
@@ -1,0 +1,254 @@
+// @ts-nocheck
+/**
+ * Tests for Space Agent URL routing
+ *
+ * Tests the /space/:spaceId/agent route pattern including:
+ * - Path extraction and creation
+ * - Navigation function
+ * - popstate handling
+ * - Page-load initialization with correct signals
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	getSpaceIdFromPath,
+	getSpaceAgentFromPath,
+	createSpaceAgentPath,
+	navigateToSpaceAgent,
+	initializeRouter,
+	cleanupRouter,
+} from '../router';
+import {
+	currentSessionIdSignal,
+	currentRoomIdSignal,
+	currentRoomSessionIdSignal,
+	currentRoomTaskIdSignal,
+	currentSpaceIdSignal,
+	currentSpaceSessionIdSignal,
+	currentSpaceTaskIdSignal,
+	navSectionSignal,
+} from '../signals';
+
+let originalHistory: unknown;
+let originalLocation: unknown;
+let mockHistory: unknown;
+let mockLocation: unknown;
+
+describe('Space Agent Router', () => {
+	beforeEach(() => {
+		originalHistory = window.history;
+		originalLocation = window.location;
+
+		mockHistory = {
+			pushState: vi.fn(),
+			replaceState: vi.fn(),
+			state: null,
+		};
+
+		mockLocation = {
+			pathname: '/',
+		};
+
+		Object.defineProperty(window, 'history', {
+			value: mockHistory,
+			writable: true,
+			configurable: true,
+		});
+		Object.defineProperty(window, 'location', {
+			value: mockLocation,
+			writable: true,
+			configurable: true,
+		});
+
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		navSectionSignal.value = 'home';
+
+		vi.clearAllMocks();
+		cleanupRouter();
+	});
+
+	afterEach(() => {
+		Object.defineProperty(window, 'history', {
+			value: originalHistory,
+			writable: true,
+			configurable: true,
+		});
+		Object.defineProperty(window, 'location', {
+			value: originalLocation,
+			writable: true,
+			configurable: true,
+		});
+		cleanupRouter();
+	});
+
+	describe('createSpaceAgentPath', () => {
+		it('creates correct path for UUID spaceId', () => {
+			expect(createSpaceAgentPath('abc-123')).toBe('/space/abc-123/agent');
+		});
+
+		it('creates correct path for slug spaceId', () => {
+			expect(createSpaceAgentPath('my-space')).toBe('/space/my-space/agent');
+		});
+	});
+
+	describe('getSpaceAgentFromPath', () => {
+		it('extracts spaceId from agent route', () => {
+			expect(getSpaceAgentFromPath('/space/abc-def-123/agent')).toBe('abc-def-123');
+		});
+
+		it('extracts spaceId from full UUID agent route', () => {
+			expect(getSpaceAgentFromPath('/space/550e8400-e29b-41d4-a716-446655440000/agent')).toBe(
+				'550e8400-e29b-41d4-a716-446655440000'
+			);
+		});
+
+		it('returns null for non-agent space routes', () => {
+			expect(getSpaceAgentFromPath('/space/abc-123')).toBeNull();
+			expect(getSpaceAgentFromPath('/space/abc-123/session/xyz')).toBeNull();
+			expect(getSpaceAgentFromPath('/space/abc-123/task/xyz')).toBeNull();
+			expect(getSpaceAgentFromPath('/')).toBeNull();
+			expect(getSpaceAgentFromPath('/room/abc-123/agent')).toBeNull();
+		});
+
+		it('rejects paths with trailing content after agent', () => {
+			expect(getSpaceAgentFromPath('/space/abc-123/agent/extra')).toBeNull();
+		});
+
+		it('returns null for empty and malformed paths', () => {
+			expect(getSpaceAgentFromPath('')).toBeNull();
+			expect(getSpaceAgentFromPath('/space//agent')).toBeNull();
+			expect(getSpaceAgentFromPath('/space/agent')).toBeNull();
+		});
+	});
+
+	describe('getSpaceIdFromPath', () => {
+		it('extracts spaceId from agent path', () => {
+			expect(getSpaceIdFromPath('/space/abc-def-123/agent')).toBe('abc-def-123');
+		});
+
+		it('extracts spaceId from plain space path', () => {
+			expect(getSpaceIdFromPath('/space/abc-def-123')).toBe('abc-def-123');
+		});
+	});
+
+	describe('navigateToSpaceAgent', () => {
+		it('pushes correct URL and sets signals', () => {
+			const spaceId = 'abc-def-123';
+			navigateToSpaceAgent(spaceId);
+
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{ spaceId, path: '/space/abc-def-123/agent' },
+				'',
+				'/space/abc-def-123/agent'
+			);
+			expect(currentSpaceIdSignal.value).toBe(spaceId);
+			expect(currentSpaceSessionIdSignal.value).toBe(`space:chat:${spaceId}`);
+			expect(currentSpaceTaskIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
+			expect(currentRoomIdSignal.value).toBeNull();
+			expect(currentRoomSessionIdSignal.value).toBeNull();
+			expect(navSectionSignal.value).toBe('spaces');
+		});
+
+		it('uses replaceState when replace=true', () => {
+			navigateToSpaceAgent('abc-123', true);
+
+			expect(mockHistory.replaceState).toHaveBeenCalled();
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+		});
+
+		it('updates signals even when already on same path', () => {
+			const spaceId = 'abc-def-123';
+			mockLocation.pathname = `/space/${spaceId}/agent`;
+
+			navigateToSpaceAgent(spaceId);
+
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+			expect(currentSpaceIdSignal.value).toBe(spaceId);
+			expect(currentSpaceSessionIdSignal.value).toBe(`space:chat:${spaceId}`);
+			expect(currentSpaceTaskIdSignal.value).toBeNull();
+			expect(navSectionSignal.value).toBe('spaces');
+		});
+
+		it('clears room signals when navigating to space agent', () => {
+			currentRoomIdSignal.value = 'some-room';
+			currentRoomSessionIdSignal.value = 'room:chat:some-room';
+
+			navigateToSpaceAgent('abc-123');
+
+			expect(currentRoomIdSignal.value).toBeNull();
+			expect(currentRoomSessionIdSignal.value).toBeNull();
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('initializeRouter with space agent route', () => {
+		it('sets correct signals on page load for agent route', () => {
+			const spaceId = 'abc-def-123';
+			mockLocation.pathname = `/space/${spaceId}/agent`;
+
+			initializeRouter();
+
+			expect(currentSpaceIdSignal.value).toBe(spaceId);
+			expect(currentSpaceSessionIdSignal.value).toBe(`space:chat:${spaceId}`);
+			expect(currentSpaceTaskIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
+			expect(currentRoomIdSignal.value).toBeNull();
+			expect(navSectionSignal.value).toBe('spaces');
+		});
+
+		it('does not set agent signals for plain space route', () => {
+			const spaceId = 'abc-def-123';
+			mockLocation.pathname = `/space/${spaceId}`;
+
+			initializeRouter();
+
+			expect(currentSpaceIdSignal.value).toBe(spaceId);
+			expect(currentSpaceSessionIdSignal.value).toBeNull();
+			expect(currentSpaceTaskIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('popstate handling for space agent route', () => {
+		it('restores space agent signals on back/forward navigation', () => {
+			const spaceId = 'abc-def-123';
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			// Simulate popstate to space agent route
+			mockLocation.pathname = `/space/${spaceId}/agent`;
+			const event = new PopStateEvent('popstate', {
+				state: { spaceId, path: `/space/${spaceId}/agent` },
+			});
+			window.dispatchEvent(event);
+
+			expect(currentSpaceIdSignal.value).toBe(spaceId);
+			expect(currentSpaceSessionIdSignal.value).toBe(`space:chat:${spaceId}`);
+			expect(currentSpaceTaskIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
+			expect(currentRoomIdSignal.value).toBeNull();
+			expect(navSectionSignal.value).toBe('spaces');
+		});
+
+		it('does not set synthetic session ID for plain space route on popstate', () => {
+			const spaceId = 'abc-def-123';
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			mockLocation.pathname = `/space/${spaceId}`;
+			const event = new PopStateEvent('popstate', {
+				state: { spaceId, path: `/space/${spaceId}` },
+			});
+			window.dispatchEvent(event);
+
+			expect(currentSpaceIdSignal.value).toBe(spaceId);
+			expect(currentSpaceSessionIdSignal.value).toBeNull();
+		});
+	});
+});

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -5,6 +5,7 @@
  * - Sessions: /session/:sessionId
  * - Rooms: /room/:roomId
  * - Room Agent: /room/:roomId/agent
+ * - Space Agent: /space/:spaceId/agent
  *
  * Features:
  * - URL sync: Updates URL when session/room changes
@@ -37,6 +38,7 @@ const SPACES_ROUTE_PATTERN = /^\/spaces$/;
 const ROOM_CHAT_COMPAT_PATTERN = /^\/room\/([a-f0-9-]+)\/chat$/;
 /** Space routes accept both UUIDs (a-f0-9-) and slugs (a-z0-9-) */
 const SPACE_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)$/;
+const SPACE_AGENT_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/agent$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/session\/([a-f0-9-]+)$/;
 const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
 
@@ -126,11 +128,23 @@ export function getSpaceIdFromPath(path: string): string | null {
 	const match = path.match(SPACE_ROUTE_PATTERN);
 	if (match) return match[1];
 
+	const spaceAgentMatch = path.match(SPACE_AGENT_ROUTE_PATTERN);
+	if (spaceAgentMatch) return spaceAgentMatch[1];
+
 	const spaceSessionMatch = path.match(SPACE_SESSION_ROUTE_PATTERN);
 	if (spaceSessionMatch) return spaceSessionMatch[1];
 
 	const spaceTaskMatch = path.match(SPACE_TASK_ROUTE_PATTERN);
 	return spaceTaskMatch ? spaceTaskMatch[1] : null;
+}
+
+/**
+ * Extract space ID from agent route path
+ * Returns null if not on a space agent route
+ */
+export function getSpaceAgentFromPath(path: string): string | null {
+	const match = path.match(SPACE_AGENT_ROUTE_PATTERN);
+	return match ? match[1] : null;
 }
 
 /**
@@ -216,6 +230,13 @@ export function createSpaceSessionPath(spaceId: string, sessionId: string): stri
  */
 export function createSpaceTaskPath(spaceId: string, taskId: string): string {
 	return `/space/${spaceId}/task/${taskId}`;
+}
+
+/**
+ * Create space agent URL path
+ */
+export function createSpaceAgentPath(spaceId: string): string {
+	return `/space/${spaceId}/agent`;
 }
 
 /**
@@ -825,6 +846,54 @@ export function navigateToSpaceTask(spaceId: string, taskId: string, replace = f
 }
 
 /**
+ * Navigate to the Space Agent view
+ * Updates URL to /space/:spaceId/agent and sets signals for ChatContainer rendering
+ *
+ * @param spaceId - The space ID
+ * @param replace - Whether to replace current history entry (default: false)
+ */
+export function navigateToSpaceAgent(spaceId: string, replace = false): void {
+	if (routerState.isNavigating) {
+		return;
+	}
+
+	const targetPath = createSpaceAgentPath(spaceId);
+	const currentPath = getCurrentPath();
+
+	if (currentPath === targetPath) {
+		currentSpaceIdSignal.value = spaceId;
+		currentSpaceSessionIdSignal.value = `space:chat:${spaceId}`;
+		currentSpaceTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+		return;
+	}
+
+	routerState.isNavigating = true;
+
+	try {
+		const historyMethod = replace ? 'replaceState' : 'pushState';
+		window.history[historyMethod]({ spaceId, path: targetPath }, '', targetPath);
+
+		currentSpaceIdSignal.value = spaceId;
+		currentSpaceSessionIdSignal.value = `space:chat:${spaceId}`;
+		currentSpaceTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} finally {
+		setTimeout(() => {
+			routerState.isNavigating = false;
+		}, 0);
+	}
+}
+
+/**
  * Handle popstate event (browser back/forward buttons)
  */
 function handlePopState(_event: PopStateEvent): void {
@@ -840,6 +909,7 @@ function handlePopState(_event: PopStateEvent): void {
 	const roomTask = getRoomTaskIdFromPath(path);
 	const spaceTask = getSpaceTaskIdFromPath(path);
 	const spaceSession = getSpaceSessionIdFromPath(path);
+	const spaceAgent = getSpaceAgentFromPath(path);
 	const spaceId = getSpaceIdFromPath(path);
 
 	// Update the signals to match the URL
@@ -859,6 +929,15 @@ function handlePopState(_event: PopStateEvent): void {
 	} else if (spaceSession) {
 		currentSpaceIdSignal.value = spaceSession.spaceId;
 		currentSpaceSessionIdSignal.value = spaceSession.sessionId;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} else if (spaceAgent) {
+		currentSpaceIdSignal.value = spaceAgent;
+		currentSpaceSessionIdSignal.value = `space:chat:${spaceAgent}`;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
@@ -978,6 +1057,7 @@ export function initializeRouter(): string | null {
 	const initialRoomTask = getRoomTaskIdFromPath(initialPath);
 	const initialSpaceTask = getSpaceTaskIdFromPath(initialPath);
 	const initialSpaceSession = getSpaceSessionIdFromPath(initialPath);
+	const initialSpaceAgent = getSpaceAgentFromPath(initialPath);
 	const initialSpaceId = getSpaceIdFromPath(initialPath);
 
 	// Set initial signals — space routes take priority, then room routes
@@ -994,6 +1074,15 @@ export function initializeRouter(): string | null {
 	} else if (initialSpaceSession) {
 		currentSpaceIdSignal.value = initialSpaceSession.spaceId;
 		currentSpaceSessionIdSignal.value = initialSpaceSession.sessionId;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} else if (initialSpaceAgent) {
+		currentSpaceIdSignal.value = initialSpaceAgent;
+		currentSpaceSessionIdSignal.value = `space:chat:${initialSpaceAgent}`;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;


### PR DESCRIPTION
Adds `navigateToSpaceAgent(spaceId, replace?)` following the exact pattern of `navigateToRoomAgent()`.

Changes:
- Add `SPACE_AGENT_ROUTE_PATTERN` regex for `/space/:id/agent`
- Add `getSpaceAgentFromPath()` extractor helper (exported)
- Add `createSpaceAgentPath()` URL builder (exported)
- Add `navigateToSpaceAgent()` — sets `currentSpaceIdSignal`, `currentSpaceSessionIdSignal` (`space:chat:<id>`), clears task/room signals, pushes URL
- Update `getSpaceIdFromPath()` to also match agent paths
- Handle `/space/:id/agent` in `handlePopState` and `initializeRouter` for deep link support
- 17 unit tests covering path extraction, navigation signals, same-path update, replace mode, popstate restore, and page-load init