### PR TITLE
feat(web): add SpaceDetailPanel as space-level ContextPanel (M1.1)

### DIFF
--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -3,6 +3,7 @@ import {
 	navSectionSignal,
 	contextPanelOpenSignal,
 	currentRoomIdSignal,
+	currentSpaceIdSignal,
 	settingsSectionSignal,
 	createRoomModalSignal,
 	type NavSection,
@@ -31,6 +32,7 @@ import { SessionList } from './SessionList.tsx';
 import { RoomList } from './RoomList.tsx';
 import { RoomContextPanel } from './RoomContextPanel.tsx';
 import { SpaceContextPanel } from '../components/space/SpaceContextPanel.tsx';
+import { SpaceDetailPanel } from './SpaceDetailPanel.tsx';
 import { SpaceCreateDialog } from '../components/space/SpaceCreateDialog.tsx';
 import { spaceStore } from '../lib/space-store.ts';
 import { ConnectionNotReadyError } from '../lib/errors.ts';
@@ -172,12 +174,16 @@ export function ContextPanel() {
 	}, [navSection]);
 	const activeSettingsSection = settingsSectionSignal.value;
 	const currentRoomId = currentRoomIdSignal.value;
+	const currentSpaceId = currentSpaceIdSignal.value;
 
 	// Inbox takes full content width — no sidebar needed
 	if (navSection === 'inbox') return null;
 
 	// When a specific room is selected in the rooms section, show room-specific panel
 	const isRoomDetail = navSection === 'rooms' && currentRoomId !== null;
+
+	// When a specific space is selected in the spaces section, show space-specific panel
+	const isSpaceDetail = navSection === 'spaces' && currentSpaceId !== null;
 
 	// Section config
 	const sectionConfig = {
@@ -236,9 +242,11 @@ export function ContextPanel() {
 	const isSpaces = navSection === 'spaces';
 	const headerTitle = isRoomDetail
 		? (roomStore.room.value?.name ?? 'Room')
-		: isSpaces
-			? null
-			: config.title;
+		: isSpaceDetail
+			? (spaceStore.space.value?.name ?? 'Space')
+			: isSpaces
+				? null
+				: config.title;
 
 	const handleCreateSession = async () => {
 		if (connectionState.value !== 'connected') {
@@ -376,7 +384,7 @@ export function ContextPanel() {
 				{/* Header */}
 				<div class={`p-4 border-b ${borderColors.ui.default}`}>
 					<div class="flex items-center justify-between mb-3">
-						{isSpaces ? (
+						{isSpaces && !isSpaceDetail ? (
 							<button
 								onClick={() => navigateToSpaces()}
 								class={cn(
@@ -445,7 +453,9 @@ export function ContextPanel() {
 
 				{/* Content — key triggers fade-in (animate-fadeIn) on section change */}
 				<div
-					key={navSection + (isRoomDetail ? '-detail' : '')}
+					key={
+						navSection + (isRoomDetail ? '-detail' : '') + (isSpaceDetail ? '-space-detail' : '')
+					}
 					class="flex-1 overflow-hidden flex flex-col animate-fadeIn"
 				>
 					{navSection === 'home' && (
@@ -463,7 +473,13 @@ export function ContextPanel() {
 					{navSection === 'rooms' && !isRoomDetail && (
 						<RoomList onRoomSelect={() => (contextPanelOpenSignal.value = false)} />
 					)}
-					{navSection === 'spaces' && (
+					{navSection === 'spaces' && isSpaceDetail && (
+						<SpaceDetailPanel
+							spaceId={currentSpaceId!}
+							onNavigate={() => (contextPanelOpenSignal.value = false)}
+						/>
+					)}
+					{navSection === 'spaces' && !isSpaceDetail && (
 						<SpaceContextPanel
 							onSpaceSelect={() => (contextPanelOpenSignal.value = false)}
 							onCreateSpace={() => setCreateSpaceOpen(true)}

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -1,0 +1,398 @@
+/**
+ * SpaceDetailPanel
+ *
+ * Space-specific context panel for the three-column layout.
+ * Mirrors RoomContextPanel's visual structure for a space:
+ * 1. Task stats strip (active · review · done counts)
+ * 2. Pinned items: Dashboard, Space Agent
+ * 3. Workflow Runs section (active runs with expandable tasks)
+ * 4. Tasks section (standalone tasks with active/review/done tab filter)
+ * 5. Sessions section (collapsible, default collapsed)
+ */
+
+import { useMemo, useState } from 'preact/hooks';
+import { CollapsibleSection } from '../components/room/CollapsibleSection';
+import { spaceStore } from '../lib/space-store';
+import { navigateToSpace, navigateToSpaceSession, navigateToSpaceTask } from '../lib/router';
+import { currentSpaceSessionIdSignal, currentSpaceTaskIdSignal } from '../lib/signals';
+import { cn } from '../lib/utils';
+
+type OrphanTab = 'active' | 'review' | 'done';
+
+const taskStatusColors: Record<string, string> = {
+	draft: 'bg-gray-500',
+	pending: 'bg-yellow-500',
+	in_progress: 'bg-blue-500',
+	review: 'bg-purple-500',
+	needs_attention: 'bg-orange-500',
+	completed: 'bg-green-500',
+	cancelled: 'bg-gray-600',
+	rate_limited: 'bg-orange-500',
+	usage_limited: 'bg-orange-600',
+};
+
+const workflowRunStatusColors: Record<string, string> = {
+	pending: 'bg-yellow-500',
+	in_progress: 'bg-blue-500 animate-pulse',
+	completed: 'bg-green-500',
+	failed: 'bg-red-500',
+	cancelled: 'bg-gray-600',
+	needs_attention: 'bg-orange-500',
+};
+
+function TaskStatusDot({ status }: { status: string }) {
+	return (
+		<div
+			class={cn('w-2 h-2 rounded-full flex-shrink-0', taskStatusColors[status] ?? 'bg-gray-500')}
+		/>
+	);
+}
+
+function RunStatusDot({ status }: { status: string }) {
+	return (
+		<div
+			class={cn(
+				'w-2 h-2 rounded-full flex-shrink-0',
+				workflowRunStatusColors[status] ?? 'bg-gray-500'
+			)}
+		/>
+	);
+}
+
+interface SpaceDetailPanelProps {
+	spaceId: string;
+	onNavigate?: () => void;
+}
+
+export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps) {
+	// Read signal values directly for Preact Signals auto-tracking
+	const tasks = spaceStore.tasks.value;
+	const activeRuns = spaceStore.activeRuns.value;
+	const tasksByRun = spaceStore.tasksByRun.value;
+	const standaloneTasks = spaceStore.standaloneTasks.value;
+	const space = spaceStore.space.value;
+
+	const [expandedRuns, setExpandedRuns] = useState<Set<string>>(() => new Set());
+	const [orphanTab, setOrphanTab] = useState<OrphanTab>('active');
+
+	// Task stats strip counts
+	const activeCount = useMemo(
+		() =>
+			tasks.filter(
+				(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+			).length,
+		[tasks]
+	);
+	const reviewCount = useMemo(
+		() => tasks.filter((t) => t.status === 'review' || t.status === 'needs_attention').length,
+		[tasks]
+	);
+	const doneCount = useMemo(
+		() => tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled').length,
+		[tasks]
+	);
+
+	// Selection state
+	const selectedSessionId = currentSpaceSessionIdSignal.value;
+	const selectedTaskId = currentSpaceTaskIdSignal.value;
+	const spaceAgentSessionId = `space:chat:${spaceId}`;
+
+	const isDashboardSelected = selectedSessionId === null && selectedTaskId === null;
+	const isSpaceAgentSelected = selectedSessionId === spaceAgentSessionId;
+
+	// Workflow run expand/collapse
+	const toggleRun = (runId: string) => {
+		setExpandedRuns((prev) => {
+			const next = new Set(prev);
+			if (next.has(runId)) {
+				next.delete(runId);
+			} else {
+				next.add(runId);
+			}
+			return next;
+		});
+	};
+
+	// Standalone (orphan) tasks filtered by tab — read standaloneTasks directly
+	// so Preact Signals auto-tracking picks up changes when the underlying list updates.
+	const orphanTasksForTab =
+		orphanTab === 'active'
+			? standaloneTasks.filter(
+					(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+				)
+			: orphanTab === 'review'
+				? standaloneTasks.filter((t) => t.status === 'review' || t.status === 'needs_attention')
+				: standaloneTasks.filter((t) => t.status === 'completed' || t.status === 'cancelled');
+
+	// Build sessions list from available data sources
+	// (1) Space agent session — always listed
+	// (2) Task agent sessions linked via SpaceTask.taskAgentSessionId
+	// (3) Manually created sessions from space.sessionIds
+	const sessions = useMemo(() => {
+		const list: { id: string; title: string; isAgent: boolean }[] = [];
+		const seen = new Set<string>();
+
+		// Always include space agent session
+		list.push({ id: spaceAgentSessionId, title: 'Space Agent', isAgent: true });
+		seen.add(spaceAgentSessionId);
+
+		// Task agent sessions
+		for (const task of tasks) {
+			if (task.taskAgentSessionId && !seen.has(task.taskAgentSessionId)) {
+				list.push({
+					id: task.taskAgentSessionId,
+					title: `${task.title} (agent)`,
+					isAgent: true,
+				});
+				seen.add(task.taskAgentSessionId);
+			}
+		}
+
+		// Manually created sessions from space.sessionIds
+		if (space?.sessionIds) {
+			for (const sid of space.sessionIds) {
+				if (!seen.has(sid)) {
+					list.push({ id: sid, title: sid.slice(0, 8), isAgent: false });
+					seen.add(sid);
+				}
+			}
+		}
+
+		return list;
+	}, [tasks, space, spaceAgentSessionId]);
+
+	// Navigation handlers
+	const handleDashboardClick = () => {
+		navigateToSpace(spaceId);
+		onNavigate?.();
+	};
+
+	const handleSpaceAgentClick = () => {
+		navigateToSpaceSession(spaceId, spaceAgentSessionId);
+		onNavigate?.();
+	};
+
+	const handleTaskClick = (taskId: string) => {
+		navigateToSpaceTask(spaceId, taskId);
+		onNavigate?.();
+	};
+
+	const handleSessionClick = (sessionId: string) => {
+		navigateToSpaceSession(spaceId, sessionId);
+		onNavigate?.();
+	};
+
+	const hasTasks = activeCount > 0 || reviewCount > 0 || doneCount > 0;
+
+	return (
+		<div class="flex-1 flex flex-col overflow-hidden">
+			{/* Task stats strip */}
+			<div class="px-3 py-2">
+				{hasTasks ? (
+					<span class="text-xs text-gray-500">
+						{activeCount > 0 && <span class="text-blue-500/80">{activeCount} active</span>}
+						{activeCount > 0 && reviewCount > 0 && <span class="text-gray-600"> · </span>}
+						{reviewCount > 0 && <span class="text-purple-500/80">{reviewCount} review</span>}
+						{(activeCount > 0 || reviewCount > 0) && doneCount > 0 && (
+							<span class="text-gray-600"> · </span>
+						)}
+						{doneCount > 0 && <span>{doneCount} done</span>}
+					</span>
+				) : (
+					<span class="text-xs text-gray-600">No tasks</span>
+				)}
+			</div>
+
+			{/* Pinned items */}
+			<button
+				onClick={handleDashboardClick}
+				class={cn(
+					'w-full px-3 py-2.5 flex items-center gap-2.5 transition-colors',
+					isDashboardSelected ? 'bg-dark-700' : 'hover:bg-dark-800'
+				)}
+			>
+				<div class="w-6 h-6 flex-shrink-0 flex items-center justify-center bg-blue-900/40 rounded">
+					<svg
+						class="w-3.5 h-3.5 text-blue-400"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+						/>
+					</svg>
+				</div>
+				<span class="flex-1 text-sm text-gray-200 text-left truncate">Dashboard</span>
+			</button>
+
+			<button
+				onClick={handleSpaceAgentClick}
+				class={cn(
+					'w-full px-3 py-2.5 flex items-center gap-2.5 transition-colors',
+					isSpaceAgentSelected ? 'bg-dark-700' : 'hover:bg-dark-800'
+				)}
+			>
+				<div class="w-6 h-6 flex-shrink-0 flex items-center justify-center bg-purple-900/40 rounded">
+					<svg
+						class="w-3.5 h-3.5 text-purple-400"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+						/>
+					</svg>
+				</div>
+				<span class="flex-1 text-sm text-gray-200 text-left truncate">Space Agent</span>
+			</button>
+
+			{/* Visual divider after pinned items */}
+			<div class="border-t border-dark-700 mx-3 my-1" />
+
+			{/* Scrollable sections */}
+			<div class="flex-1 overflow-y-auto">
+				{/* Workflow Runs section */}
+				<CollapsibleSection title="Workflow Runs" count={activeRuns.length}>
+					{activeRuns.length === 0 ? (
+						<div class="px-4 py-3 text-xs text-gray-600">No active runs</div>
+					) : (
+						activeRuns.map((run) => {
+							const isExpanded = expandedRuns.has(run.id);
+							const runTasks = tasksByRun.get(run.id) ?? [];
+							return (
+								<div key={run.id}>
+									<button
+										onClick={() => toggleRun(run.id)}
+										class="w-full px-3 py-1.5 flex items-center gap-2 hover:bg-dark-800 transition-colors text-left"
+									>
+										<span class="text-gray-500 text-[10px] leading-none w-3 flex-shrink-0">
+											{isExpanded ? '▼' : '▶'}
+										</span>
+										<RunStatusDot status={run.status} />
+										<span class="flex-1 text-sm text-gray-300 truncate">{run.title}</span>
+									</button>
+									{isExpanded && (
+										<>
+											{runTasks.length === 0 ? (
+												<div class="pl-8 pr-3 py-1.5 text-xs text-gray-600">No tasks</div>
+											) : (
+												runTasks.map((task) => (
+													<button
+														key={task.id}
+														onClick={() => handleTaskClick(task.id)}
+														class={cn(
+															'w-full pl-8 pr-3 py-1.5 flex items-center gap-2 transition-colors text-left',
+															selectedTaskId === task.id ? 'bg-dark-700' : 'hover:bg-dark-800'
+														)}
+													>
+														<TaskStatusDot status={task.status} />
+														<span class="flex-1 text-sm text-gray-400 truncate">{task.title}</span>
+													</button>
+												))
+											)}
+										</>
+									)}
+								</div>
+							);
+						})
+					)}
+				</CollapsibleSection>
+
+				{/* Tasks section (standalone tasks without a workflow run) */}
+				<CollapsibleSection title="Tasks">
+					{/* Tab bar */}
+					<div class="flex items-center gap-1 px-3 py-1.5">
+						{(['active', 'review', 'done'] as const).map((tab) => (
+							<button
+								key={tab}
+								onClick={() => setOrphanTab(tab)}
+								class={cn(
+									'px-2 py-0.5 text-xs rounded transition-colors capitalize',
+									orphanTab === tab
+										? 'bg-dark-600 text-gray-200'
+										: 'text-gray-500 hover:text-gray-300'
+								)}
+							>
+								{tab}
+							</button>
+						))}
+					</div>
+					{orphanTasksForTab.length === 0 ? (
+						<div class="px-4 py-3 text-xs text-gray-600">No tasks</div>
+					) : (
+						orphanTasksForTab.map((task) => (
+							<button
+								key={task.id}
+								onClick={() => handleTaskClick(task.id)}
+								class={cn(
+									'w-full px-3 py-1.5 flex items-center gap-2 transition-colors text-left',
+									selectedTaskId === task.id ? 'bg-dark-700' : 'hover:bg-dark-800'
+								)}
+							>
+								<TaskStatusDot status={task.status} />
+								<span class="flex-1 text-sm text-gray-400 truncate">{task.title}</span>
+							</button>
+						))
+					)}
+				</CollapsibleSection>
+
+				{/* Sessions section */}
+				<CollapsibleSection
+					title="Sessions"
+					count={sessions.length}
+					defaultExpanded={false}
+					headerRight={
+						<button
+							onClick={(e: MouseEvent) => {
+								e.stopPropagation();
+								// Future: create a new session in this space
+							}}
+							class="text-gray-500 hover:text-gray-300 transition-colors p-0.5"
+							aria-label="Create session"
+						>
+							<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M12 4v16m8-8H4"
+								/>
+							</svg>
+						</button>
+					}
+				>
+					{sessions.length === 0 ? (
+						<div class="px-4 py-3 text-xs text-gray-600">No sessions</div>
+					) : (
+						sessions.map((session) => (
+							<button
+								key={session.id}
+								onClick={() => handleSessionClick(session.id)}
+								class={cn(
+									'w-full px-3 py-2 flex items-center gap-2.5 transition-colors',
+									selectedSessionId === session.id ? 'bg-dark-700' : 'hover:bg-dark-800'
+								)}
+							>
+								<div
+									class={cn(
+										'w-2 h-2 rounded-full flex-shrink-0',
+										session.isAgent ? 'bg-purple-500' : 'bg-gray-500'
+									)}
+								/>
+								<span class="flex-1 text-sm text-gray-300 truncate text-left">{session.title}</span>
+							</button>
+						))
+					)}
+				</CollapsibleSection>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -76,10 +76,17 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 	const [orphanTab, setOrphanTab] = useState<OrphanTab>('active');
 
 	// Task stats strip counts
+	// rate_limited/usage_limited are transient throttle states — counted as active (still running).
+	// archived is a terminal state — counted as done.
 	const activeCount = useMemo(
 		() =>
 			tasks.filter(
-				(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+				(t) =>
+					t.status === 'draft' ||
+					t.status === 'pending' ||
+					t.status === 'in_progress' ||
+					t.status === 'rate_limited' ||
+					t.status === 'usage_limited'
 			).length,
 		[tasks]
 	);
@@ -88,7 +95,10 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 		[tasks]
 	);
 	const doneCount = useMemo(
-		() => tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled').length,
+		() =>
+			tasks.filter(
+				(t) => t.status === 'completed' || t.status === 'cancelled' || t.status === 'archived'
+			).length,
 		[tasks]
 	);
 
@@ -113,16 +123,26 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 		});
 	};
 
-	// Standalone (orphan) tasks filtered by tab — read standaloneTasks directly
-	// so Preact Signals auto-tracking picks up changes when the underlying list updates.
-	const orphanTasksForTab =
-		orphanTab === 'active'
-			? standaloneTasks.filter(
-					(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
-				)
-			: orphanTab === 'review'
-				? standaloneTasks.filter((t) => t.status === 'review' || t.status === 'needs_attention')
-				: standaloneTasks.filter((t) => t.status === 'completed' || t.status === 'cancelled');
+	// Standalone tasks filtered by tab.
+	// rate_limited/usage_limited are grouped with active; archived with done.
+	const orphanTasksForTab = useMemo(() => {
+		if (orphanTab === 'active') {
+			return standaloneTasks.filter(
+				(t) =>
+					t.status === 'draft' ||
+					t.status === 'pending' ||
+					t.status === 'in_progress' ||
+					t.status === 'rate_limited' ||
+					t.status === 'usage_limited'
+			);
+		}
+		if (orphanTab === 'review') {
+			return standaloneTasks.filter((t) => t.status === 'review' || t.status === 'needs_attention');
+		}
+		return standaloneTasks.filter(
+			(t) => t.status === 'completed' || t.status === 'cancelled' || t.status === 'archived'
+		);
+	}, [standaloneTasks, orphanTab]);
 
 	// Build sessions list from available data sources
 	// (1) Space agent session — always listed
@@ -353,10 +373,11 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 						<button
 							onClick={(e: MouseEvent) => {
 								e.stopPropagation();
-								// Future: create a new session in this space
 							}}
-							class="text-gray-500 hover:text-gray-300 transition-colors p-0.5"
+							disabled
+							class="text-gray-600 cursor-not-allowed p-0.5"
 							aria-label="Create session"
+							title="Session creation coming soon"
 						>
 							<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 								<path

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -27,6 +27,7 @@ const taskStatusColors: Record<string, string> = {
 	needs_attention: 'bg-orange-500',
 	completed: 'bg-green-500',
 	cancelled: 'bg-gray-600',
+	archived: 'bg-gray-600',
 	rate_limited: 'bg-orange-500',
 	usage_limited: 'bg-orange-600',
 };
@@ -66,11 +67,26 @@ interface SpaceDetailPanelProps {
 
 export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps) {
 	// Read signal values directly for Preact Signals auto-tracking
+	const isLoading = spaceStore.loading.value;
+	const loadedSpaceId = spaceStore.spaceId.value;
 	const tasks = spaceStore.tasks.value;
 	const activeRuns = spaceStore.activeRuns.value;
 	const tasksByRun = spaceStore.tasksByRun.value;
 	const standaloneTasks = spaceStore.standaloneTasks.value;
 	const space = spaceStore.space.value;
+
+	// Show a loading state when the store hasn't loaded data for this space yet.
+	// spaceStore.selectSpace() is called by SpaceIsland; the ContextPanel may render
+	// before that call completes (e.g. on cold navigation before SpaceIsland mounts).
+	const isReady = !isLoading && loadedSpaceId === spaceId;
+
+	if (!isReady) {
+		return (
+			<div class="flex-1 flex items-center justify-center p-6">
+				<span class="text-xs text-gray-600">Loading…</span>
+			</div>
+		);
+	}
 
 	const [expandedRuns, setExpandedRuns] = useState<Set<string>>(() => new Set());
 	const [orphanTab, setOrphanTab] = useState<OrphanTab>('active');

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -1,0 +1,538 @@
+/**
+ * Tests for SpaceDetailPanel component.
+ *
+ * Covers: stats strip counts, pinned item highlighting, workflow run expansion,
+ * task tab filtering, click navigation, sessions section, and empty states.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, screen } from '@testing-library/preact';
+import { signal, computed, type Signal, type ReadonlySignal } from '@preact/signals';
+import type { SpaceTask, SpaceWorkflowRun, Space } from '@neokai/shared';
+
+// -------------------------------------------------------
+// Hoisted mocks
+// -------------------------------------------------------
+
+const { mockNavigateToSpace, mockNavigateToSpaceSession, mockNavigateToSpaceTask } = vi.hoisted(
+	() => ({
+		mockNavigateToSpace: vi.fn(),
+		mockNavigateToSpaceSession: vi.fn(),
+		mockNavigateToSpaceTask: vi.fn(),
+	})
+);
+
+// -------------------------------------------------------
+// Signals used in mocks
+// -------------------------------------------------------
+
+let mockTasksSignal!: Signal<SpaceTask[]>;
+let mockWorkflowRunsSignal!: Signal<SpaceWorkflowRun[]>;
+let mockSpaceSignal!: Signal<Space | null>;
+let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
+let mockCurrentSpaceTaskIdSignal!: Signal<string | null>;
+
+let mockActiveRuns!: ReadonlySignal<SpaceWorkflowRun[]>;
+let mockTasksByRun!: ReadonlySignal<Map<string, SpaceTask[]>>;
+let mockStandaloneTasks!: ReadonlySignal<SpaceTask[]>;
+
+function initSignals() {
+	mockTasksSignal = signal([]);
+	mockWorkflowRunsSignal = signal([]);
+	mockSpaceSignal = signal(null);
+	mockCurrentSpaceSessionIdSignal = signal(null);
+	mockCurrentSpaceTaskIdSignal = signal(null);
+
+	mockActiveRuns = computed(() =>
+		mockWorkflowRunsSignal.value.filter((r) => r.status === 'pending' || r.status === 'in_progress')
+	);
+
+	mockTasksByRun = computed(() => {
+		const map = new Map<string, SpaceTask[]>();
+		for (const task of mockTasksSignal.value) {
+			if (task.workflowRunId) {
+				const existing = map.get(task.workflowRunId) ?? [];
+				map.set(task.workflowRunId, [...existing, task]);
+			}
+		}
+		return map;
+	});
+
+	mockStandaloneTasks = computed(() => mockTasksSignal.value.filter((t) => !t.workflowRunId));
+}
+
+initSignals();
+
+vi.mock('../../lib/space-store.ts', () => ({
+	get spaceStore() {
+		return {
+			tasks: mockTasksSignal,
+			workflowRuns: mockWorkflowRunsSignal,
+			space: mockSpaceSignal,
+			activeRuns: mockActiveRuns,
+			tasksByRun: mockTasksByRun,
+			standaloneTasks: mockStandaloneTasks,
+		};
+	},
+}));
+
+vi.mock('../../lib/router.ts', () => ({
+	navigateToSpace: mockNavigateToSpace,
+	navigateToSpaceSession: mockNavigateToSpaceSession,
+	navigateToSpaceTask: mockNavigateToSpaceTask,
+}));
+
+vi.mock('../../lib/signals.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../lib/signals.ts')>();
+	return {
+		...actual,
+		get currentSpaceSessionIdSignal() {
+			return mockCurrentSpaceSessionIdSignal;
+		},
+		get currentSpaceTaskIdSignal() {
+			return mockCurrentSpaceTaskIdSignal;
+		},
+	};
+});
+
+import { SpaceDetailPanel } from '../SpaceDetailPanel';
+
+// -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+function makeTask(
+	id: string,
+	title: string,
+	status: SpaceTask['status'] = 'pending',
+	overrides: Partial<SpaceTask> = {}
+): SpaceTask {
+	return {
+		id,
+		spaceId: 'space-1',
+		title,
+		status,
+		priority: 'normal',
+		createdAt: 0,
+		updatedAt: 0,
+		...overrides,
+	} as SpaceTask;
+}
+
+function makeRun(
+	id: string,
+	title: string,
+	status: SpaceWorkflowRun['status'] = 'in_progress'
+): SpaceWorkflowRun {
+	return {
+		id,
+		spaceId: 'space-1',
+		workflowId: 'wf-1',
+		title,
+		status,
+		iterationCount: 0,
+		maxIterations: 10,
+		createdAt: 0,
+		updatedAt: 0,
+	} as SpaceWorkflowRun;
+}
+
+// -------------------------------------------------------
+// Tests
+// -------------------------------------------------------
+
+describe('SpaceDetailPanel', () => {
+	beforeEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		initSignals();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	// -- Stats strip --
+
+	it('renders "No tasks" in the stats strip when there are no tasks', () => {
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		// Both the stats strip and Tasks section show "No tasks" when there are no tasks
+		const noTasksEls = screen.getAllByText('No tasks');
+		expect(noTasksEls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('counts active tasks (draft, pending, in_progress)', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'T1', 'draft'),
+			makeTask('t2', 'T2', 'pending'),
+			makeTask('t3', 'T3', 'in_progress'),
+		];
+		const { container } = render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(container.textContent).toContain('3 active');
+	});
+
+	it('counts review tasks (review, needs_attention)', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'T1', 'review'),
+			makeTask('t2', 'T2', 'needs_attention'),
+		];
+		const { container } = render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(container.textContent).toContain('2 review');
+	});
+
+	it('counts done tasks (completed, cancelled)', () => {
+		mockTasksSignal.value = [makeTask('t1', 'T1', 'completed'), makeTask('t2', 'T2', 'cancelled')];
+		const { container } = render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(container.textContent).toContain('2 done');
+	});
+
+	it('renders all three stats together', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'T1', 'in_progress'),
+			makeTask('t2', 'T2', 'review'),
+			makeTask('t3', 'T3', 'completed'),
+		];
+		const { container } = render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(container.textContent).toContain('1 active');
+		expect(container.textContent).toContain('1 review');
+		expect(container.textContent).toContain('1 done');
+	});
+
+	// -- Pinned items --
+
+	it('renders Dashboard and Space Agent buttons', () => {
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Dashboard')).toBeTruthy();
+		expect(screen.getByText('Space Agent')).toBeTruthy();
+	});
+
+	it('navigates to space dashboard and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
+		fireEvent.click(screen.getByText('Dashboard'));
+		expect(mockNavigateToSpace).toHaveBeenCalledWith('space-1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	it('navigates to space agent session and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
+		fireEvent.click(screen.getByText('Space Agent'));
+		expect(mockNavigateToSpaceSession).toHaveBeenCalledWith('space-1', 'space:chat:space-1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	// -- Dashboard highlighting --
+
+	it('highlights Dashboard when both session and task signals are null', () => {
+		mockCurrentSpaceSessionIdSignal.value = null;
+		mockCurrentSpaceTaskIdSignal.value = null;
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		const dashboardBtn = screen.getByText('Dashboard').closest('button');
+		expect(dashboardBtn?.className).toContain('bg-dark-700');
+	});
+
+	it('does NOT highlight Dashboard when a task is selected', () => {
+		mockCurrentSpaceSessionIdSignal.value = null;
+		mockCurrentSpaceTaskIdSignal.value = 'task-1';
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		const dashboardBtn = screen.getByText('Dashboard').closest('button');
+		expect(dashboardBtn?.className).not.toContain('bg-dark-700');
+	});
+
+	it('does NOT highlight Dashboard when a session is selected', () => {
+		mockCurrentSpaceSessionIdSignal.value = 'some-session';
+		mockCurrentSpaceTaskIdSignal.value = null;
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		const dashboardBtn = screen.getByText('Dashboard').closest('button');
+		expect(dashboardBtn?.className).not.toContain('bg-dark-700');
+	});
+
+	// -- Space Agent highlighting --
+
+	it('highlights Space Agent when its synthetic session ID is selected', () => {
+		mockCurrentSpaceSessionIdSignal.value = 'space:chat:space-1';
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		const agentBtn = screen.getByText('Space Agent').closest('button');
+		expect(agentBtn?.className).toContain('bg-dark-700');
+	});
+
+	it('does NOT highlight Space Agent when a different session is selected', () => {
+		mockCurrentSpaceSessionIdSignal.value = 'some-other-session';
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		const agentBtn = screen.getByText('Space Agent').closest('button');
+		expect(agentBtn?.className).not.toContain('bg-dark-700');
+	});
+
+	// -- Workflow Runs section --
+
+	it('shows "No active runs" when there are no active workflow runs', () => {
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('No active runs')).toBeTruthy();
+	});
+
+	it('renders active workflow runs with title', () => {
+		mockWorkflowRunsSignal.value = [makeRun('r1', 'Deploy Run')];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Deploy Run')).toBeTruthy();
+	});
+
+	it('does not render completed workflow runs in the active runs section', () => {
+		mockWorkflowRunsSignal.value = [
+			makeRun('r1', 'Active Run', 'in_progress'),
+			makeRun('r2', 'Done Run', 'completed'),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Active Run')).toBeTruthy();
+		expect(screen.queryByText('Done Run')).toBeNull();
+	});
+
+	it('expands a workflow run to show its tasks on click', () => {
+		mockWorkflowRunsSignal.value = [makeRun('r1', 'My Run')];
+		mockTasksSignal.value = [
+			makeTask('t1', 'Run Task A', 'in_progress', { workflowRunId: 'r1' }),
+			makeTask('t2', 'Run Task B', 'pending', { workflowRunId: 'r1' }),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		// Tasks not visible initially
+		expect(screen.queryByText('Run Task A')).toBeNull();
+
+		// Click the run to expand
+		fireEvent.click(screen.getByText('My Run'));
+		expect(screen.getByText('Run Task A')).toBeTruthy();
+		expect(screen.getByText('Run Task B')).toBeTruthy();
+	});
+
+	it('collapses an expanded workflow run on second click', () => {
+		mockWorkflowRunsSignal.value = [makeRun('r1', 'My Run')];
+		mockTasksSignal.value = [makeTask('t1', 'Run Task', 'in_progress', { workflowRunId: 'r1' })];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		fireEvent.click(screen.getByText('My Run'));
+		expect(screen.getByText('Run Task')).toBeTruthy();
+
+		fireEvent.click(screen.getByText('My Run'));
+		expect(screen.queryByText('Run Task')).toBeNull();
+	});
+
+	it('shows "No tasks" inside expanded run when run has no tasks', () => {
+		mockWorkflowRunsSignal.value = [makeRun('r1', 'Empty Run')];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		fireEvent.click(screen.getByText('Empty Run'));
+		// The "No tasks" text inside the run expansion
+		expect(screen.getAllByText('No tasks').length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('navigates to task when clicking a run task and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		mockWorkflowRunsSignal.value = [makeRun('r1', 'My Run')];
+		mockTasksSignal.value = [makeTask('t1', 'Run Task', 'pending', { workflowRunId: 'r1' })];
+		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
+
+		fireEvent.click(screen.getByText('My Run'));
+		fireEvent.click(screen.getByText('Run Task'));
+
+		expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 't1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	it('highlights selected task inside an expanded run', () => {
+		mockWorkflowRunsSignal.value = [makeRun('r1', 'My Run')];
+		mockTasksSignal.value = [makeTask('t1', 'Run Task', 'in_progress', { workflowRunId: 'r1' })];
+		mockCurrentSpaceTaskIdSignal.value = 't1';
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		fireEvent.click(screen.getByText('My Run'));
+		const taskBtn = screen.getByText('Run Task').closest('button');
+		expect(taskBtn?.className).toContain('bg-dark-700');
+	});
+
+	// -- Tasks section (standalone tasks) --
+
+	it('shows standalone tasks under Active tab by default', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Done Task', 'completed'),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Active Task')).toBeTruthy();
+		expect(screen.queryByText('Done Task')).toBeNull();
+	});
+
+	it('does not show workflow-run tasks in standalone Tasks section', () => {
+		mockWorkflowRunsSignal.value = [makeRun('r1', 'Run')];
+		mockTasksSignal.value = [
+			makeTask('t1', 'Run Task', 'in_progress', { workflowRunId: 'r1' }),
+			makeTask('t2', 'Standalone Task', 'pending'),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Standalone Task')).toBeTruthy();
+		// Run Task only appears when the run is expanded
+		expect(screen.queryByText('Run Task')).toBeNull();
+	});
+
+	it('shows draft and pending tasks under Active tab', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Draft Task', 'draft'),
+			makeTask('t2', 'Pending Task', 'pending'),
+			makeTask('t3', 'Done Task', 'completed'),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Draft Task')).toBeTruthy();
+		expect(screen.getByText('Pending Task')).toBeTruthy();
+		expect(screen.queryByText('Done Task')).toBeNull();
+	});
+
+	it('switches to Review tab to show review tasks', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Review Task', 'review'),
+			makeTask('t3', 'Attention Task', 'needs_attention'),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		const reviewTab = screen.getAllByRole('button').find((b) => b.textContent === 'review');
+		fireEvent.click(reviewTab!);
+
+		expect(screen.getByText('Review Task')).toBeTruthy();
+		expect(screen.getByText('Attention Task')).toBeTruthy();
+		expect(screen.queryByText('Active Task')).toBeNull();
+	});
+
+	it('switches to Done tab to show completed and cancelled tasks', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Done Task', 'completed'),
+			makeTask('t3', 'Cancelled Task', 'cancelled'),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		const doneTab = screen.getAllByRole('button').find((b) => b.textContent === 'done');
+		fireEvent.click(doneTab!);
+
+		expect(screen.getByText('Done Task')).toBeTruthy();
+		expect(screen.getByText('Cancelled Task')).toBeTruthy();
+		expect(screen.queryByText('Active Task')).toBeNull();
+	});
+
+	it('shows "No tasks" in Tasks section when filtered list is empty', () => {
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		// "No active runs" + "No tasks" (Tasks section)
+		const noTasksEls = screen.getAllByText('No tasks');
+		expect(noTasksEls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('navigates to standalone task on click and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		mockTasksSignal.value = [makeTask('t1', 'Click Me', 'pending')];
+		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
+
+		fireEvent.click(screen.getByText('Click Me'));
+		expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 't1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	it('highlights selected task in standalone tasks list', () => {
+		mockTasksSignal.value = [makeTask('t1', 'Selected Task', 'pending')];
+		mockCurrentSpaceTaskIdSignal.value = 't1';
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		const taskBtn = screen.getByText('Selected Task').closest('button');
+		expect(taskBtn?.className).toContain('bg-dark-700');
+	});
+
+	// -- Sessions section --
+
+	it('renders Sessions section collapsed by default', () => {
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Sessions')).toBeTruthy();
+		// Space Agent session is always listed but section is collapsed — content hidden
+		expect(screen.queryByText('Space Agent (session)')).toBeNull();
+	});
+
+	it('always shows space agent session when expanded', () => {
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		// "Space Agent" appears in pinned items and in sessions list
+		const spaceAgentEls = screen.getAllByText('Space Agent');
+		expect(spaceAgentEls.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('shows task agent sessions when tasks have taskAgentSessionId', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'My Task', 'in_progress', { taskAgentSessionId: 'agent-session-1' }),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		expect(screen.getByText('My Task (agent)')).toBeTruthy();
+	});
+
+	it('shows manually created sessions from space.sessionIds', () => {
+		mockSpaceSignal.value = {
+			id: 'space-1',
+			name: 'Test Space',
+			sessionIds: ['manual-session-abc123'],
+			createdAt: 0,
+			updatedAt: 0,
+		} as unknown as Space;
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		// Manually created sessions show first 8 chars of ID
+		expect(screen.getByText('manual-s')).toBeTruthy();
+	});
+
+	it('navigates to session on click and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
+
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		// Click the "Space Agent" session entry in the sessions list
+		const spaceAgentEls = screen.getAllByText('Space Agent');
+		// The one in the sessions list (second occurrence after pinned button)
+		fireEvent.click(spaceAgentEls[spaceAgentEls.length - 1]);
+
+		expect(mockNavigateToSpaceSession).toHaveBeenCalledWith('space-1', 'space:chat:space-1');
+		expect(onNavigate).toHaveBeenCalled();
+	});
+
+	it('highlights selected session in the sessions list', () => {
+		mockCurrentSpaceSessionIdSignal.value = 'space:chat:space-1';
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		const spaceAgentEls = screen.getAllByText('Space Agent');
+		// The one inside the sessions list (last occurrence)
+		const sessionBtn = spaceAgentEls[spaceAgentEls.length - 1].closest('button');
+		expect(sessionBtn?.className).toContain('bg-dark-700');
+	});
+
+	it('deduplicates sessions — space agent not listed twice even if in sessionIds', () => {
+		mockSpaceSignal.value = {
+			id: 'space-1',
+			name: 'Test Space',
+			// Include the space agent session ID in sessionIds — should not appear twice
+			sessionIds: ['space:chat:space-1', 'other-session'],
+			createdAt: 0,
+			updatedAt: 0,
+		} as unknown as Space;
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+
+		// Only one "Space Agent" entry inside the sessions list
+		const spaceAgentEls = screen.getAllByText('Space Agent');
+		// One in pinned items (button), one in sessions list = 2 total
+		expect(spaceAgentEls.length).toBe(2);
+	});
+
+	it('renders session count badge in section header', () => {
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		// Minimum 1 session (space agent always listed)
+		expect(screen.getByText('(1)')).toBeTruthy();
+	});
+
+	it('renders "Create session" button in sessions header', () => {
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByLabelText('Create session')).toBeTruthy();
+	});
+});

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -29,6 +29,8 @@ const { mockNavigateToSpace, mockNavigateToSpaceSession, mockNavigateToSpaceTask
 let mockTasksSignal!: Signal<SpaceTask[]>;
 let mockWorkflowRunsSignal!: Signal<SpaceWorkflowRun[]>;
 let mockSpaceSignal!: Signal<Space | null>;
+let mockLoadingSignal!: Signal<boolean>;
+let mockSpaceIdSignal!: Signal<string | null>;
 let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
 let mockCurrentSpaceTaskIdSignal!: Signal<string | null>;
 
@@ -40,6 +42,9 @@ function initSignals() {
 	mockTasksSignal = signal([]);
 	mockWorkflowRunsSignal = signal([]);
 	mockSpaceSignal = signal(null);
+	// By default simulate loaded state: not loading, spaceId matches
+	mockLoadingSignal = signal(false);
+	mockSpaceIdSignal = signal('space-1');
 	mockCurrentSpaceSessionIdSignal = signal(null);
 	mockCurrentSpaceTaskIdSignal = signal(null);
 
@@ -69,6 +74,8 @@ vi.mock('../../lib/space-store.ts', () => ({
 			tasks: mockTasksSignal,
 			workflowRuns: mockWorkflowRunsSignal,
 			space: mockSpaceSignal,
+			loading: mockLoadingSignal,
+			spaceId: mockSpaceIdSignal,
 			activeRuns: mockActiveRuns,
 			tasksByRun: mockTasksByRun,
 			standaloneTasks: mockStandaloneTasks,
@@ -163,6 +170,30 @@ describe('SpaceDetailPanel', () => {
 
 	afterEach(() => {
 		cleanup();
+	});
+
+	// -- Loading guard --
+
+	it('shows loading state when spaceStore is loading', () => {
+		mockLoadingSignal.value = true;
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Loading…')).toBeTruthy();
+		expect(screen.queryByText('Dashboard')).toBeNull();
+	});
+
+	it('shows loading state when store spaceId does not match prop', () => {
+		mockLoadingSignal.value = false;
+		mockSpaceIdSignal.value = 'other-space';
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Loading…')).toBeTruthy();
+	});
+
+	it('renders panel content when store is loaded for this space', () => {
+		mockLoadingSignal.value = false;
+		mockSpaceIdSignal.value = 'space-1';
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.queryByText('Loading…')).toBeNull();
+		expect(screen.getByText('Dashboard')).toBeTruthy();
 	});
 
 	// -- Stats strip --

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -137,6 +137,19 @@ function makeRun(
 	} as SpaceWorkflowRun;
 }
 
+function makeSpace(id: string, overrides: Partial<Space> = {}): Space {
+	return {
+		id,
+		name: `Space ${id}`,
+		status: 'active',
+		workspacePath: '/workspace',
+		sessionIds: [],
+		createdAt: 0,
+		updatedAt: 0,
+		...overrides,
+	} as unknown as Space;
+}
+
 // -------------------------------------------------------
 // Tests
 // -------------------------------------------------------
@@ -171,6 +184,16 @@ describe('SpaceDetailPanel', () => {
 		expect(container.textContent).toContain('3 active');
 	});
 
+	it('counts rate_limited and usage_limited as active (transient throttle states)', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'T1', 'rate_limited'),
+			makeTask('t2', 'T2', 'usage_limited'),
+			makeTask('t3', 'T3', 'in_progress'),
+		];
+		const { container } = render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(container.textContent).toContain('3 active');
+	});
+
 	it('counts review tasks (review, needs_attention)', () => {
 		mockTasksSignal.value = [
 			makeTask('t1', 'T1', 'review'),
@@ -182,6 +205,12 @@ describe('SpaceDetailPanel', () => {
 
 	it('counts done tasks (completed, cancelled)', () => {
 		mockTasksSignal.value = [makeTask('t1', 'T1', 'completed'), makeTask('t2', 'T2', 'cancelled')];
+		const { container } = render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(container.textContent).toContain('2 done');
+	});
+
+	it('counts archived tasks as done', () => {
+		mockTasksSignal.value = [makeTask('t1', 'T1', 'completed'), makeTask('t2', 'T2', 'archived')];
 		const { container } = render(<SpaceDetailPanel spaceId="space-1" />);
 		expect(container.textContent).toContain('2 done');
 	});
@@ -416,6 +445,28 @@ describe('SpaceDetailPanel', () => {
 		expect(screen.queryByText('Active Task')).toBeNull();
 	});
 
+	it('shows rate_limited tasks under Active tab', () => {
+		mockTasksSignal.value = [makeTask('t1', 'Throttled Task', 'rate_limited')];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Throttled Task')).toBeTruthy();
+	});
+
+	it('shows usage_limited tasks under Active tab', () => {
+		mockTasksSignal.value = [makeTask('t1', 'Limited Task', 'usage_limited')];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.getByText('Limited Task')).toBeTruthy();
+	});
+
+	it('shows archived tasks under Done tab', () => {
+		mockTasksSignal.value = [makeTask('t1', 'Archived Task', 'archived')];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		const doneTab = screen.getAllByRole('button').find((b) => b.textContent === 'done');
+		fireEvent.click(doneTab!);
+
+		expect(screen.getByText('Archived Task')).toBeTruthy();
+	});
+
 	it('shows "No tasks" in Tasks section when filtered list is empty', () => {
 		render(<SpaceDetailPanel spaceId="space-1" />);
 		// "No active runs" + "No tasks" (Tasks section)
@@ -469,13 +520,7 @@ describe('SpaceDetailPanel', () => {
 	});
 
 	it('shows manually created sessions from space.sessionIds', () => {
-		mockSpaceSignal.value = {
-			id: 'space-1',
-			name: 'Test Space',
-			sessionIds: ['manual-session-abc123'],
-			createdAt: 0,
-			updatedAt: 0,
-		} as unknown as Space;
+		mockSpaceSignal.value = makeSpace('space-1', { sessionIds: ['manual-session-abc123'] });
 		render(<SpaceDetailPanel spaceId="space-1" />);
 		fireEvent.click(screen.getByLabelText('Sessions section'));
 		// Manually created sessions show first 8 chars of ID
@@ -508,14 +553,10 @@ describe('SpaceDetailPanel', () => {
 	});
 
 	it('deduplicates sessions — space agent not listed twice even if in sessionIds', () => {
-		mockSpaceSignal.value = {
-			id: 'space-1',
-			name: 'Test Space',
-			// Include the space agent session ID in sessionIds — should not appear twice
+		// Include the space agent session ID in sessionIds — should not appear twice
+		mockSpaceSignal.value = makeSpace('space-1', {
 			sessionIds: ['space:chat:space-1', 'other-session'],
-			createdAt: 0,
-			updatedAt: 0,
-		} as unknown as Space;
+		});
 		render(<SpaceDetailPanel spaceId="space-1" />);
 		fireEvent.click(screen.getByLabelText('Sessions section'));
 


### PR DESCRIPTION
Implements `SpaceDetailPanel` — the space-level context panel mirroring `RoomContextPanel`'s structure.

## What's included

- **Stats strip**: active · review · done task counts from `spaceStore.tasks`
- **Pinned items**: Dashboard (highlights when no session/task selected) and Space Agent (highlights when `currentSpaceSessionIdSignal === 'space:chat:{spaceId}'`)
- **Workflow Runs section**: collapsible, shows `spaceStore.activeRuns` with expandable nested task lists per run
- **Tasks section**: standalone tasks (without `workflowRunId`) with active/review/done tab filter
- **Sessions section**: collapsed by default; always lists space agent session, task agent sessions via `SpaceTask.taskAgentSessionId`, and manually created sessions from `Space.sessionIds`; deduplicates entries

Space Agent navigation uses `navigateToSpaceSession(spaceId, 'space:chat:spaceId')` — `navigateToSpaceAgent` will be added in Task 2.4 and can be swapped in.

## Tests

38 unit tests in `SpaceDetailPanel.test.tsx` covering all sections, highlighting logic, tab filtering, run expansion, click navigation, session deduplication, and empty states.