### PR TITLE
fix(e2e): resolve WorkflowCanvas channel name-to-UUID mismatch

### DIFF
--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -142,9 +142,10 @@ test.describe('Space Creation UX', () => {
 
 		// Tabbed dashboard should be visible with Dashboard tab active
 		await expect(page.locator('text=Dashboard')).toBeVisible({ timeout: 5000 });
-		await expect(page.locator('text=Quick Actions')).toBeVisible({ timeout: 5000 });
-		await expect(page.locator('text=Start Workflow Run')).toBeVisible({ timeout: 3000 });
-		await expect(page.locator('text=Create Task')).toBeVisible({ timeout: 3000 });
+
+		// On desktop, the workflow canvas panel replaces the dashboard quick actions
+		// Workflows load async after space creation; wait for the canvas SVG to appear
+		await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 15000 });
 	});
 
 	test('dialog can be closed with Cancel button', async ({ page }) => {

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -178,6 +178,26 @@ function evalConditionStatus(condition: GateCondition, data: Record<string, unkn
 // ============================================================================
 
 /**
+ * Build a map from node name → node UUID.
+ * Channels use node names for from/to, but layout uses UUIDs.
+ */
+function buildNameToIdMap(nodes: WorkflowNode[]): Map<string, string> {
+	const map = new Map<string, string>();
+	for (const node of nodes) {
+		if (node.name) map.set(node.name, node.id);
+	}
+	return map;
+}
+
+/**
+ * Resolve a channel endpoint (name or UUID) to a node UUID.
+ * Falls back to the original value if it's already a UUID.
+ */
+function resolveNodeId(ref: string, nameToId: Map<string, string>): string {
+	return nameToId.get(ref) ?? ref;
+}
+
+/**
  * Compute node positions using a layered DAG layout.
  * Returns a map from node ID → {x, y, width, height}.
  */
@@ -188,16 +208,20 @@ function computeLayout(workflow: SpaceWorkflow): Map<string, NodeLayout> {
 
 	if (nodes.length === 0) return new Map();
 
-	// Build successor map from channels
+	const nameToId = buildNameToIdMap(nodes);
+
+	// Build successor map from channels (resolving names to UUIDs)
 	const successors = new Map<string, Set<string>>();
 	for (const node of nodes) {
 		successors.set(node.id, new Set());
 	}
 	for (const ch of channels) {
+		const fromId = resolveNodeId(ch.from, nameToId);
 		const targets = Array.isArray(ch.to) ? ch.to : [ch.to];
 		for (const t of targets) {
-			if (successors.has(ch.from) && successors.has(t)) {
-				successors.get(ch.from)!.add(t);
+			const toId = resolveNodeId(t, nameToId);
+			if (successors.has(fromId) && successors.has(toId)) {
+				successors.get(fromId)!.add(toId);
 			}
 		}
 	}
@@ -1048,6 +1072,12 @@ export function WorkflowCanvas({
 		};
 	}, [layout]);
 
+	// ---- Name-to-ID map for channel endpoint resolution ----
+	const nameToId = useMemo(() => {
+		if (!workflow) return new Map<string, string>();
+		return buildNameToIdMap(workflow.nodes);
+	}, [workflow]);
+
 	// ---- Rendered channels ----
 	const renderedChannels = useMemo((): RenderedChannel[] => {
 		if (!workflow) return [];
@@ -1057,12 +1087,12 @@ export function WorkflowCanvas({
 				const targets = Array.isArray(ch.to) ? ch.to : [ch.to];
 				return targets.map((to) => ({
 					id: ch.id!,
-					fromId: ch.from,
-					toId: to,
+					fromId: resolveNodeId(ch.from, nameToId),
+					toId: resolveNodeId(to, nameToId),
 					gateId: isRuntimeMode ? ch.gateId : (localGateAssignments.get(ch.id!) ?? ch.gateId),
 				}));
 			});
-	}, [workflow, isRuntimeMode, localGateAssignments]);
+	}, [workflow, isRuntimeMode, localGateAssignments, nameToId]);
 
 	// ---- Gates by ID ----
 	const gatesById = useMemo(() => {


### PR DESCRIPTION
## Summary
- **WorkflowCanvas.tsx**: Added `buildNameToIdMap`/`resolveNodeId` helpers to translate channel `from`/`to` node names (e.g. "Planning", "Reviewer 1") to node UUIDs. The layout engine and channel renderer used UUID keys but channels reference nodes by name, causing all channel lines, gate icons, and DAG layering to silently fail.
- **space-creation.e2e.ts**: Updated test to verify `workflow-canvas-svg` instead of `SpaceDashboard` quick actions ("Quick Actions", "Start Workflow Run", "Create Task"), which are now hidden by `md:hidden` CSS when the canvas panel renders on desktop.

## Root Cause
`seedBuiltInWorkflows` persists channels with node names as `from`/`to` (by design — see doc comment in `built-in-workflows.ts`), but `WorkflowCanvas.tsx` used node UUIDs for layout map keys and channel endpoint lookups. This mismatch meant:
- `computeLayout` successor map was always empty → all nodes placed in one layer
- `renderedChannels` couldn't find node positions → no channel lines drawn
- Gate icons rendered on channel midpoints → never appeared (channels were null)

## Fixes 4 failing E2E jobs
- features-space-approval-gate-rejection (gate icons not found)
- features-space-happy-path-pipeline (gate icons + node labels not visible)
- features-space-creation (dashboard content hidden by CSS)
- features-reviewer-feedback-loop (gate icons not found)

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 9337 daemon unit tests pass
- [ ] CI E2E validation on dev