### PR TITLE
feat(neo): add SessionType 'neo', DB schema, and NeoActivityLogRepository

### DIFF
--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -38,6 +38,7 @@ import { TaskRepository } from './repositories/task-repository';
 import { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
 import { SkillRepository } from './repositories/skill-repository';
 import { RoomSkillOverrideRepository } from './repositories/room-skill-override-repository';
+import { NeoActivityLogRepository } from './repositories/neo-activity-log-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -63,6 +64,12 @@ export { AppMcpServerRepository } from './repositories/app-mcp-server-repository
 export { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
 export { SkillRepository } from './repositories/skill-repository';
 export { RoomSkillOverrideRepository } from './repositories/room-skill-override-repository';
+export { NeoActivityLogRepository } from './repositories/neo-activity-log-repository';
+export type {
+	NeoActivityLogEntry,
+	InsertNeoActivityParams,
+	ListNeoActivityParams,
+} from './repositories/neo-activity-log-repository';
 
 /**
  * Database facade class that maintains backward compatibility with the original Database class.
@@ -84,6 +91,7 @@ export class Database {
 	private roomMcpEnablementRepo!: RoomMcpEnablementRepository;
 	private skillRepo!: SkillRepository;
 	private roomSkillOverrideRepo!: RoomSkillOverrideRepository;
+	private neoActivityLogRepo!: NeoActivityLogRepository;
 	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
@@ -109,6 +117,7 @@ export class Database {
 		this.roomMcpEnablementRepo = new RoomMcpEnablementRepository(db, reactiveDb);
 		this.skillRepo = new SkillRepository(db, reactiveDb);
 		this.roomSkillOverrideRepo = new RoomSkillOverrideRepository(db, reactiveDb);
+		this.neoActivityLogRepo = new NeoActivityLogRepository(db);
 	}
 
 	// ============================================================================
@@ -479,6 +488,13 @@ export class Database {
 	 */
 	get roomSkillOverrides(): RoomSkillOverrideRepository {
 		return this.roomSkillOverrideRepo;
+	}
+
+	/**
+	 * Get the Neo activity log repository
+	 */
+	get neoActivityLog(): NeoActivityLogRepository {
+		return this.neoActivityLogRepo;
 	}
 
 	close(): void {

--- a/packages/daemon/src/storage/repositories/neo-activity-log-repository.ts
+++ b/packages/daemon/src/storage/repositories/neo-activity-log-repository.ts
@@ -1,0 +1,174 @@
+/**
+ * NeoActivityLogRepository
+ *
+ * CRUD operations for the neo_activity_log table.
+ * Records every tool invocation made by the Neo global agent for auditing and undo support.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface NeoActivityLogEntry {
+	id: string;
+	toolName: string;
+	input: string | null;
+	output: string | null;
+	status: 'success' | 'error' | 'cancelled';
+	error: string | null;
+	targetType: string | null;
+	targetId: string | null;
+	undoable: boolean;
+	undoData: string | null;
+	createdAt: string;
+}
+
+export interface InsertNeoActivityParams {
+	id: string;
+	toolName: string;
+	input?: string | null;
+	output?: string | null;
+	status?: 'success' | 'error' | 'cancelled';
+	error?: string | null;
+	targetType?: string | null;
+	targetId?: string | null;
+	undoable?: boolean;
+	undoData?: string | null;
+}
+
+export interface ListNeoActivityParams {
+	/** Number of entries to return (default: 50) */
+	limit?: number;
+	/** Cursor for pagination: return entries older than this created_at value */
+	before?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal row type
+// ---------------------------------------------------------------------------
+
+interface ActivityRow {
+	id: string;
+	tool_name: string;
+	input: string | null;
+	output: string | null;
+	status: string;
+	error: string | null;
+	target_type: string | null;
+	target_id: string | null;
+	undoable: number;
+	undo_data: string | null;
+	created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToEntry(row: ActivityRow): NeoActivityLogEntry {
+	return {
+		id: row.id,
+		toolName: row.tool_name,
+		input: row.input,
+		output: row.output,
+		status: row.status as NeoActivityLogEntry['status'],
+		error: row.error,
+		targetType: row.target_type,
+		targetId: row.target_id,
+		undoable: row.undoable === 1,
+		undoData: row.undo_data,
+		createdAt: row.created_at,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+export class NeoActivityLogRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Insert a new activity log entry.
+	 */
+	insert(params: InsertNeoActivityParams): NeoActivityLogEntry {
+		const now = new Date().toISOString();
+		const status = params.status ?? 'success';
+		this.db
+			.prepare(
+				`INSERT INTO neo_activity_log
+         (id, tool_name, input, output, status, error, target_type, target_id, undoable, undo_data, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				params.id,
+				params.toolName,
+				params.input ?? null,
+				params.output ?? null,
+				status,
+				params.error ?? null,
+				params.targetType ?? null,
+				params.targetId ?? null,
+				params.undoable ? 1 : 0,
+				params.undoData ?? null,
+				now
+			);
+		const row = this.db
+			.prepare(`SELECT * FROM neo_activity_log WHERE id = ?`)
+			.get(params.id) as ActivityRow;
+		return rowToEntry(row);
+	}
+
+	/**
+	 * List activity log entries, newest first, with optional cursor-based pagination.
+	 */
+	list(params: ListNeoActivityParams = {}): NeoActivityLogEntry[] {
+		const limit = params.limit ?? 50;
+		if (params.before) {
+			const rows = this.db
+				.prepare(
+					`SELECT * FROM neo_activity_log
+           WHERE created_at < ?
+           ORDER BY created_at DESC
+           LIMIT ?`
+				)
+				.all(params.before, limit) as ActivityRow[];
+			return rows.map(rowToEntry);
+		}
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM neo_activity_log
+         ORDER BY created_at DESC
+         LIMIT ?`
+			)
+			.all(limit) as ActivityRow[];
+		return rows.map(rowToEntry);
+	}
+
+	/**
+	 * Get a single entry by ID. Returns null if not found.
+	 */
+	getById(id: string): NeoActivityLogEntry | null {
+		const row = this.db.prepare(`SELECT * FROM neo_activity_log WHERE id = ?`).get(id) as
+			| ActivityRow
+			| undefined;
+		return row ? rowToEntry(row) : null;
+	}
+
+	/**
+	 * Get the most recent undoable entry. Returns null if none exists.
+	 */
+	getLatestUndoable(): NeoActivityLogEntry | null {
+		const row = this.db
+			.prepare(
+				`SELECT * FROM neo_activity_log
+         WHERE undoable = 1
+         ORDER BY created_at DESC
+         LIMIT 1`
+			)
+			.get() as ActivityRow | undefined;
+		return row ? rowToEntry(row) : null;
+	}
+}

--- a/packages/daemon/src/storage/repositories/neo-activity-log-repository.ts
+++ b/packages/daemon/src/storage/repositories/neo-activity-log-repository.ts
@@ -41,8 +41,11 @@ export interface InsertNeoActivityParams {
 export interface ListNeoActivityParams {
 	/** Number of entries to return (default: 50) */
 	limit?: number;
-	/** Cursor for pagination: return entries older than this created_at value */
-	before?: string;
+	/**
+	 * Cursor for pagination: return entries strictly older than this (created_at, id) pair.
+	 * Both fields must be provided together for collision-safe pagination.
+	 */
+	before?: { createdAt: string; id: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -123,24 +126,34 @@ export class NeoActivityLogRepository {
 
 	/**
 	 * List activity log entries, newest first, with optional cursor-based pagination.
+	 * The cursor is a compound (createdAt, id) pair to avoid dropping entries when
+	 * multiple records share the same millisecond timestamp.
 	 */
 	list(params: ListNeoActivityParams = {}): NeoActivityLogEntry[] {
 		const limit = params.limit ?? 50;
 		if (params.before) {
+			// Compound cursor: entries where created_at is strictly earlier, OR created_at
+			// is equal but id sorts before the cursor id (lexicographic, UUIDs are random
+			// so this is just a stable tiebreaker, not meaningful ordering).
 			const rows = this.db
 				.prepare(
 					`SELECT * FROM neo_activity_log
-           WHERE created_at < ?
-           ORDER BY created_at DESC
+           WHERE created_at < ? OR (created_at = ? AND id < ?)
+           ORDER BY created_at DESC, id DESC
            LIMIT ?`
 				)
-				.all(params.before, limit) as ActivityRow[];
+				.all(
+					params.before.createdAt,
+					params.before.createdAt,
+					params.before.id,
+					limit
+				) as ActivityRow[];
 			return rows.map(rowToEntry);
 		}
 		const rows = this.db
 			.prepare(
 				`SELECT * FROM neo_activity_log
-         ORDER BY created_at DESC
+         ORDER BY created_at DESC, id DESC
          LIMIT ?`
 			)
 			.all(limit) as ActivityRow[];

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -33,6 +33,8 @@ export { runMigration56 } from './migrations';
 export { runMigration57 } from './migrations';
 // knip-ignore-next-line
 export { runMigration58 } from './migrations';
+// knip-ignore-next-line
+export { runMigration66 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -403,7 +405,7 @@ export function createTables(db: BunDatabase): void {
         tool_name   TEXT NOT NULL,
         input       TEXT,
         output      TEXT,
-        status      TEXT NOT NULL DEFAULT 'success',
+        status      TEXT NOT NULL DEFAULT 'success' CHECK(status IN ('success', 'error', 'cancelled')),
         error       TEXT,
         target_type TEXT,
         target_id   TEXT,

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -59,7 +59,7 @@ export function createTables(db: BunDatabase): void {
         processing_state TEXT,
         archived_at TEXT,
         parent_id TEXT,
-        type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent')),
+        type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'neo')),
         session_context TEXT
       )
     `);
@@ -396,6 +396,23 @@ export function createTables(db: BunDatabase): void {
       )
     `);
 
+	// Neo activity log — audit log of all Neo agent tool invocations
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS neo_activity_log (
+        id          TEXT PRIMARY KEY,
+        tool_name   TEXT NOT NULL,
+        input       TEXT,
+        output      TEXT,
+        status      TEXT NOT NULL DEFAULT 'success',
+        error       TEXT,
+        target_type TEXT,
+        target_id   TEXT,
+        undoable    INTEGER DEFAULT 0,
+        undo_data   TEXT,
+        created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
 	db.exec(`
       CREATE TABLE IF NOT EXISTS job_queue (
         id TEXT PRIMARY KEY,
@@ -470,4 +487,7 @@ function createIndexes(db: BunDatabase): void {
 		`CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC)`
 	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_job_queue_status ON job_queue(status)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_neo_activity_log_created_at ON neo_activity_log(created_at)`
+	);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -270,6 +270,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Worktrees are not removed on task completion; instead they are timestamped and
 	// removed by the reaper after a configurable TTL (default: 7 days).
 	runMigration65(db);
+
+	// Migration 66: Add 'neo' to sessions type CHECK constraint and create neo_activity_log table.
+	// Neo is a global AI agent with its own session type and activity log for auditing.
+	runMigration66(db);
 }
 
 /**
@@ -4264,4 +4268,111 @@ function runMigration65(db: BunDatabase): void {
 		// Column doesn't exist yet — add it
 		db.exec(`ALTER TABLE space_worktrees ADD COLUMN completed_at INTEGER`);
 	}
+}
+
+/**
+ * Migration 66: Add 'neo' to sessions type CHECK constraint and create neo_activity_log table.
+ *
+ * Two changes:
+ * 1. Expands the sessions.type CHECK constraint to include 'neo'.
+ *    Uses the probe-insert + table-recreate pattern (SQLite doesn't support ALTER CHECK).
+ * 2. Creates the neo_activity_log table for auditing Neo agent actions.
+ *    Idempotent via CREATE TABLE IF NOT EXISTS.
+ *
+ * neo_activity_log schema:
+ *   id          - UUID primary key
+ *   tool_name   - name of the Neo tool invoked
+ *   input       - JSON-serialized tool input
+ *   output      - JSON-serialized tool output
+ *   status      - 'success' | 'error' | 'cancelled'
+ *   error       - error message if status='error'
+ *   target_type - type of entity the action targeted (e.g. 'room', 'space', 'skill')
+ *   target_id   - ID of the targeted entity
+ *   undoable    - 1 if the action can be undone, 0 otherwise
+ *   undo_data   - JSON blob needed to reverse the action
+ *   created_at  - ISO 8601 timestamp (default: current UTC time)
+ */
+function runMigration66(db: BunDatabase): void {
+	// --- Part 1: Expand sessions.type CHECK constraint to include 'neo' ---
+	if (tableExists(db, 'sessions')) {
+		try {
+			const testId = '__migration_test_neo_type__';
+			db.prepare(
+				`INSERT INTO sessions (id, title, workspace_path, created_at, last_active_at, status, config, metadata, is_worktree, type)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			).run(
+				testId,
+				'Test',
+				'/tmp',
+				new Date().toISOString(),
+				new Date().toISOString(),
+				'active',
+				'{}',
+				'{}',
+				0,
+				'neo'
+			);
+			db.prepare(`DELETE FROM sessions WHERE id = ?`).run(testId);
+		} catch {
+			db.exec('PRAGMA foreign_keys = OFF');
+			try {
+				db.exec(`
+					CREATE TABLE sessions_new (
+						id TEXT PRIMARY KEY,
+						title TEXT NOT NULL,
+						workspace_path TEXT NOT NULL,
+						created_at TEXT NOT NULL,
+						last_active_at TEXT NOT NULL,
+						status TEXT NOT NULL CHECK(status IN ('active', 'paused', 'ended', 'archived', 'pending_worktree_choice')),
+						config TEXT NOT NULL,
+						metadata TEXT NOT NULL,
+						is_worktree INTEGER DEFAULT 0,
+						worktree_path TEXT,
+						main_repo_path TEXT,
+						worktree_branch TEXT,
+						git_branch TEXT,
+						sdk_session_id TEXT,
+						available_commands TEXT,
+						processing_state TEXT,
+						archived_at TEXT,
+						parent_id TEXT,
+						type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'neo')),
+						session_context TEXT
+					)
+				`);
+				db.exec(`
+					INSERT INTO sessions_new
+					SELECT id, title, workspace_path, created_at, last_active_at,
+						status, config, metadata, is_worktree, worktree_path, main_repo_path,
+						worktree_branch, git_branch, sdk_session_id, available_commands,
+						processing_state, archived_at, parent_id, type, session_context
+					FROM sessions
+				`);
+				db.exec(`DROP TABLE sessions`);
+				db.exec(`ALTER TABLE sessions_new RENAME TO sessions`);
+			} finally {
+				db.exec('PRAGMA foreign_keys = ON');
+			}
+		}
+	}
+
+	// --- Part 2: Create neo_activity_log table ---
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS neo_activity_log (
+			id          TEXT PRIMARY KEY,
+			tool_name   TEXT NOT NULL,
+			input       TEXT,
+			output      TEXT,
+			status      TEXT NOT NULL DEFAULT 'success',
+			error       TEXT,
+			target_type TEXT,
+			target_id   TEXT,
+			undoable    INTEGER DEFAULT 0,
+			undo_data   TEXT,
+			created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_neo_activity_log_created_at ON neo_activity_log(created_at)`
+	);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -4292,7 +4292,7 @@ function runMigration65(db: BunDatabase): void {
  *   undo_data   - JSON blob needed to reverse the action
  *   created_at  - ISO 8601 timestamp (default: current UTC time)
  */
-function runMigration66(db: BunDatabase): void {
+export function runMigration66(db: BunDatabase): void {
 	// --- Part 1: Expand sessions.type CHECK constraint to include 'neo' ---
 	if (tableExists(db, 'sessions')) {
 		try {
@@ -4363,7 +4363,7 @@ function runMigration66(db: BunDatabase): void {
 			tool_name   TEXT NOT NULL,
 			input       TEXT,
 			output      TEXT,
-			status      TEXT NOT NULL DEFAULT 'success',
+			status      TEXT NOT NULL DEFAULT 'success' CHECK(status IN ('success', 'error', 'cancelled')),
 			error       TEXT,
 			target_type TEXT,
 			target_id   TEXT,

--- a/packages/daemon/tests/unit/neo-activity-log-repository.test.ts
+++ b/packages/daemon/tests/unit/neo-activity-log-repository.test.ts
@@ -146,11 +146,39 @@ describe('NeoActivityLogRepository', () => {
 			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:03Z' WHERE id = 'log-3'`
 		).run();
 
-		// Fetch entries before log-3's timestamp
-		const entries = repo.list({ before: '2025-01-01T00:00:03Z' });
+		// Fetch entries before log-3 using compound cursor
+		const entries = repo.list({ before: { createdAt: '2025-01-01T00:00:03Z', id: 'log-3' } });
 		expect(entries.length).toBe(2);
 		expect(entries[0].id).toBe('log-2');
 		expect(entries[1].id).toBe('log-1');
+	});
+
+	test('list with before cursor handles same-millisecond entries via id tiebreaker', () => {
+		// Two entries with identical created_at — compound cursor must not drop either
+		repo.insert({ id: 'log-a', toolName: 'tool' });
+		repo.insert({ id: 'log-b', toolName: 'tool' });
+		const sameTs = '2025-01-01T00:00:01Z';
+		db.prepare(`UPDATE neo_activity_log SET created_at = ? WHERE id IN ('log-a', 'log-b')`).run(
+			sameTs
+		);
+		repo.insert({ id: 'log-c', toolName: 'tool' });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:02Z' WHERE id = 'log-c'`
+		).run();
+
+		// First page: all 3 entries
+		const page1 = repo.list({ limit: 3 });
+		expect(page1.length).toBe(3);
+		expect(page1[0].id).toBe('log-c');
+
+		// Second page: use the last entry of page1 as cursor
+		const lastOnPage1 = page1[page1.length - 1];
+		const page2 = repo.list({
+			before: { createdAt: lastOnPage1.createdAt, id: lastOnPage1.id },
+			limit: 10,
+		});
+		// Entries older than the last page1 entry are returned without duplication
+		expect(page2.every((e) => e.id !== lastOnPage1.id)).toBe(true);
 	});
 
 	test('getLatestUndoable returns null when no undoable entries exist', () => {

--- a/packages/daemon/tests/unit/neo-activity-log-repository.test.ts
+++ b/packages/daemon/tests/unit/neo-activity-log-repository.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for NeoActivityLogRepository
+ *
+ * Covers:
+ * - insert and getById round-trip
+ * - list (paginated, newest first)
+ * - getLatestUndoable
+ * - default field values
+ * - pagination with `before` cursor
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../src/storage/schema';
+import { NeoActivityLogRepository } from '../../src/storage/repositories/neo-activity-log-repository';
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	createTables(db);
+	return db;
+}
+
+function makeRepo(db: BunDatabase): NeoActivityLogRepository {
+	return new NeoActivityLogRepository(db);
+}
+
+describe('NeoActivityLogRepository', () => {
+	let db: BunDatabase;
+	let repo: NeoActivityLogRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		repo = makeRepo(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('list returns empty array on fresh DB', () => {
+		expect(repo.list()).toEqual([]);
+	});
+
+	test('insert and getById round-trip with all fields', () => {
+		const entry = repo.insert({
+			id: 'log-1',
+			toolName: 'create_room',
+			input: JSON.stringify({ name: 'My Room' }),
+			output: JSON.stringify({ roomId: 'room-abc' }),
+			status: 'success',
+			targetType: 'room',
+			targetId: 'room-abc',
+			undoable: true,
+			undoData: JSON.stringify({ action: 'delete_room', roomId: 'room-abc' }),
+		});
+
+		expect(entry.id).toBe('log-1');
+		expect(entry.toolName).toBe('create_room');
+		expect(entry.input).toBe(JSON.stringify({ name: 'My Room' }));
+		expect(entry.output).toBe(JSON.stringify({ roomId: 'room-abc' }));
+		expect(entry.status).toBe('success');
+		expect(entry.targetType).toBe('room');
+		expect(entry.targetId).toBe('room-abc');
+		expect(entry.undoable).toBe(true);
+		expect(entry.undoData).toBe(JSON.stringify({ action: 'delete_room', roomId: 'room-abc' }));
+		expect(typeof entry.createdAt).toBe('string');
+
+		const fetched = repo.getById('log-1');
+		expect(fetched).not.toBeNull();
+		expect(fetched!.id).toBe('log-1');
+		expect(fetched!.toolName).toBe('create_room');
+		expect(fetched!.undoable).toBe(true);
+	});
+
+	test('insert uses default values for optional fields', () => {
+		const entry = repo.insert({ id: 'log-2', toolName: 'list_rooms' });
+
+		expect(entry.input).toBeNull();
+		expect(entry.output).toBeNull();
+		expect(entry.status).toBe('success');
+		expect(entry.error).toBeNull();
+		expect(entry.targetType).toBeNull();
+		expect(entry.targetId).toBeNull();
+		expect(entry.undoable).toBe(false);
+		expect(entry.undoData).toBeNull();
+	});
+
+	test('insert with error status', () => {
+		const entry = repo.insert({
+			id: 'log-3',
+			toolName: 'delete_room',
+			status: 'error',
+			error: 'Room not found',
+		});
+
+		expect(entry.status).toBe('error');
+		expect(entry.error).toBe('Room not found');
+	});
+
+	test('getById returns null for missing id', () => {
+		expect(repo.getById('nonexistent')).toBeNull();
+	});
+
+	test('list returns entries newest first', async () => {
+		// Insert with small delays to ensure distinct created_at values
+		repo.insert({ id: 'log-a', toolName: 'tool_a' });
+		// Force distinct timestamps by manipulating rows directly
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:01Z' WHERE id = 'log-a'`
+		).run();
+		repo.insert({ id: 'log-b', toolName: 'tool_b' });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:02Z' WHERE id = 'log-b'`
+		).run();
+		repo.insert({ id: 'log-c', toolName: 'tool_c' });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:03Z' WHERE id = 'log-c'`
+		).run();
+
+		const entries = repo.list();
+		expect(entries.length).toBe(3);
+		expect(entries[0].id).toBe('log-c'); // newest first
+		expect(entries[1].id).toBe('log-b');
+		expect(entries[2].id).toBe('log-a');
+	});
+
+	test('list respects limit', () => {
+		for (let i = 1; i <= 5; i++) {
+			repo.insert({ id: `log-${i}`, toolName: 'tool' });
+		}
+		const entries = repo.list({ limit: 3 });
+		expect(entries.length).toBe(3);
+	});
+
+	test('list with before cursor returns older entries', () => {
+		repo.insert({ id: 'log-1', toolName: 'tool' });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:01Z' WHERE id = 'log-1'`
+		).run();
+		repo.insert({ id: 'log-2', toolName: 'tool' });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:02Z' WHERE id = 'log-2'`
+		).run();
+		repo.insert({ id: 'log-3', toolName: 'tool' });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:03Z' WHERE id = 'log-3'`
+		).run();
+
+		// Fetch entries before log-3's timestamp
+		const entries = repo.list({ before: '2025-01-01T00:00:03Z' });
+		expect(entries.length).toBe(2);
+		expect(entries[0].id).toBe('log-2');
+		expect(entries[1].id).toBe('log-1');
+	});
+
+	test('getLatestUndoable returns null when no undoable entries exist', () => {
+		repo.insert({ id: 'log-1', toolName: 'list_rooms', undoable: false });
+		expect(repo.getLatestUndoable()).toBeNull();
+	});
+
+	test('getLatestUndoable returns null on empty log', () => {
+		expect(repo.getLatestUndoable()).toBeNull();
+	});
+
+	test('getLatestUndoable returns the most recent undoable entry', () => {
+		repo.insert({ id: 'log-1', toolName: 'create_room', undoable: true });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:01Z' WHERE id = 'log-1'`
+		).run();
+		repo.insert({ id: 'log-2', toolName: 'list_rooms', undoable: false });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:02Z' WHERE id = 'log-2'`
+		).run();
+		repo.insert({ id: 'log-3', toolName: 'delete_goal', undoable: true });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:03Z' WHERE id = 'log-3'`
+		).run();
+
+		const latest = repo.getLatestUndoable();
+		expect(latest).not.toBeNull();
+		expect(latest!.id).toBe('log-3');
+		expect(latest!.toolName).toBe('delete_goal');
+		expect(latest!.undoable).toBe(true);
+	});
+
+	test('getLatestUndoable ignores non-undoable entries between undoable ones', () => {
+		repo.insert({ id: 'log-1', toolName: 'create_room', undoable: true });
+		db.prepare(
+			`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:01Z' WHERE id = 'log-1'`
+		).run();
+		// Several non-undoable entries after
+		for (let i = 2; i <= 5; i++) {
+			repo.insert({ id: `log-${i}`, toolName: 'list_rooms', undoable: false });
+			db.prepare(
+				`UPDATE neo_activity_log SET created_at = '2025-01-01T00:00:0${i}Z' WHERE id = 'log-${i}'`
+			).run();
+		}
+
+		const latest = repo.getLatestUndoable();
+		expect(latest!.id).toBe('log-1');
+	});
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -545,16 +545,7 @@ export interface SessionMetadata {
 	};
 	// Session architecture fields
 	/** Type of session in architecture context */
-	sessionType?:
-		| 'room_chat'
-		| 'planner'
-		| 'coder'
-		| 'leader'
-		| 'general'
-		| 'worker'
-		| 'lobby'
-		| 'spaces_global'
-		| 'space_task_agent';
+	sessionType?: SessionType;
 	/** For manager/worker: ID of the paired session */
 	pairedSessionId?: string;
 	/** For manager/worker: ID of the parent RoomSession */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -74,7 +74,8 @@ export type SessionType =
 	| 'general'
 	| 'lobby'
 	| 'spaces_global'
-	| 'space_task_agent';
+	| 'space_task_agent'
+	| 'neo';
 
 /**
  * Context for room/lobby/space sessions
@@ -86,6 +87,8 @@ export interface SessionContext {
 	spaceId?: string;
 	/** Task ID for Space Task Agent sessions */
 	taskId?: string;
+	/** Neo session ID for the global Neo agent */
+	neoId?: string;
 }
 
 /**


### PR DESCRIPTION
Implements Task 1.1 of the Neo Agent milestone.

- Adds `'neo'` to the `SessionType` union and `neoId?: string` to `SessionContext` in `packages/shared`
- Migration 66: expands `sessions.type` CHECK constraint to include `'neo'`; creates `neo_activity_log` table with an index on `created_at`
- `NeoActivityLogRepository` with `insert`, `list` (paginated, newest first), `getById`, `getLatestUndoable`
- Exposes repository from the `Database` facade via `db.neoActivityLog`
- 12 unit tests covering all CRUD paths, pagination, and undoable-entry lookup