### PR TITLE
feat(web): add WorkflowRunStartDialog component

### DIFF
--- a/packages/web/src/components/space/WorkflowRunStartDialog.tsx
+++ b/packages/web/src/components/space/WorkflowRunStartDialog.tsx
@@ -1,0 +1,172 @@
+/**
+ * WorkflowRunStartDialog — modal form to start a workflow run from the dashboard.
+ * Reads available workflows from spaceStore and delegates to spaceStore.startWorkflowRun().
+ */
+
+import { useState, useEffect } from 'preact/hooks';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { spaceStore } from '../../lib/space-store';
+import { toast } from '../../lib/toast';
+import type { SpaceWorkflowRun } from '@neokai/shared';
+
+interface WorkflowRunStartDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	onSwitchToWorkflows?: () => void;
+	onStarted?: (run: SpaceWorkflowRun) => void;
+}
+
+function buildAutoTitle(workflowName: string): string {
+	const now = new Date();
+	const stamp = now.toISOString().slice(0, 16).replace('T', ' ');
+	return `${workflowName} — ${stamp}`;
+}
+
+export function WorkflowRunStartDialog({
+	isOpen,
+	onClose,
+	onSwitchToWorkflows,
+	onStarted,
+}: WorkflowRunStartDialogProps) {
+	const workflows = spaceStore.workflows.value;
+	const [workflowId, setWorkflowId] = useState<string>(workflows[0]?.id ?? '');
+	const [title, setTitle] = useState('');
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// Keep workflowId in sync when workflows load asynchronously
+	useEffect(() => {
+		if (!workflowId && workflows.length > 0) {
+			setWorkflowId(workflows[0].id);
+		}
+	}, [workflows, workflowId]);
+
+	const handleClose = () => {
+		setTitle('');
+		setWorkflowId(workflows[0]?.id ?? '');
+		setError(null);
+		onClose();
+	};
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+
+		if (!workflowId) {
+			setError('Please select a workflow');
+			return;
+		}
+
+		const selectedWorkflow = workflows.find((w) => w.id === workflowId);
+		const resolvedTitle = title.trim() || buildAutoTitle(selectedWorkflow?.name ?? 'Run');
+
+		try {
+			setSubmitting(true);
+			setError(null);
+
+			const run = await spaceStore.startWorkflowRun({
+				workflowId,
+				title: resolvedTitle,
+			});
+
+			toast.success(`Workflow run "${run.title}" started`);
+			onStarted?.(run);
+			handleClose();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to start workflow run');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const hasWorkflows = workflows.length > 0;
+
+	return (
+		<Modal isOpen={isOpen} onClose={handleClose} title="Start Workflow Run" size="md">
+			<form onSubmit={handleSubmit} class="space-y-4">
+				{error && (
+					<div class="bg-red-900/20 border border-red-800 rounded-lg px-4 py-3 text-red-400 text-sm">
+						{error}
+					</div>
+				)}
+
+				{!hasWorkflows && (
+					<div class="bg-amber-900/20 border border-amber-800 rounded-lg px-4 py-3 text-amber-300 text-sm space-y-2">
+						<p>No workflows available. Create one in the Workflows tab.</p>
+						{onSwitchToWorkflows && (
+							<button
+								type="button"
+								onClick={() => {
+									handleClose();
+									onSwitchToWorkflows();
+								}}
+								class="text-blue-400 hover:text-blue-300 underline text-xs"
+							>
+								Go to Workflows tab
+							</button>
+						)}
+					</div>
+				)}
+
+				{/* Workflow selector — shown only when multiple workflows exist */}
+				{workflows.length > 1 && (
+					<div>
+						<label class="block text-sm font-medium text-gray-200 mb-1.5">Workflow</label>
+						<select
+							value={workflowId}
+							onChange={(e) => setWorkflowId((e.target as HTMLSelectElement).value)}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100
+								focus:outline-none focus:border-blue-500 text-sm"
+						>
+							{workflows.map((wf) => (
+								<option key={wf.id} value={wf.id}>
+									{wf.name}
+								</option>
+							))}
+						</select>
+					</div>
+				)}
+
+				{/* Single workflow indicator */}
+				{workflows.length === 1 && (
+					<div class="flex items-center gap-2 text-sm text-gray-400">
+						<span class="text-gray-500">Workflow:</span>
+						<span class="text-gray-200">{workflows[0].name}</span>
+					</div>
+				)}
+
+				{/* Run title — optional; auto-suggested from workflow name + timestamp */}
+				<div>
+					<label class="block text-sm font-medium text-gray-200 mb-1.5">
+						Run Title
+						<span class="text-gray-500 text-xs ml-2">(optional)</span>
+					</label>
+					<input
+						type="text"
+						value={title}
+						onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+						placeholder={
+							hasWorkflows
+								? buildAutoTitle(workflows.find((w) => w.id === workflowId)?.name ?? 'Run')
+								: 'Select a workflow first'
+						}
+						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-gray-100
+							placeholder-gray-600 focus:outline-none focus:border-blue-500 text-sm"
+						autoFocus
+						disabled={!hasWorkflows}
+					/>
+					<p class="text-xs text-gray-500 mt-1">Leave blank to use an auto-generated title.</p>
+				</div>
+
+				<div class="flex gap-3 pt-1">
+					<Button type="button" variant="secondary" onClick={handleClose} fullWidth>
+						Cancel
+					</Button>
+					<Button type="submit" loading={submitting} disabled={!hasWorkflows} fullWidth>
+						Start Run
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/space/__tests__/WorkflowRunStartDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowRunStartDialog.test.tsx
@@ -1,0 +1,253 @@
+// @ts-nocheck
+/**
+ * Unit tests for WorkflowRunStartDialog
+ *
+ * Tests:
+ * - Renders nothing when dialog is closed
+ * - Shows empty state with "Go to Workflows" button when no workflows configured
+ * - Calls onSwitchToWorkflows and closes when "Go to Workflows" is clicked
+ * - Shows single workflow name (no select) when only one workflow
+ * - Shows workflow dropdown when multiple workflows exist
+ * - Title is optional — auto-generated when left blank
+ * - Submit calls spaceStore.startWorkflowRun with correct params
+ * - Shows success toast and calls onStarted on success
+ * - Shows error message on failure
+ * - Cancel closes the dialog
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+
+const mockStartWorkflowRun = vi.fn();
+const mockWorkflowsSignal = signal([]);
+const mockToastSuccess = vi.fn();
+
+vi.mock('../../../lib/space-store', () => ({
+	spaceStore: {
+		get workflows() {
+			return mockWorkflowsSignal;
+		},
+		get startWorkflowRun() {
+			return mockStartWorkflowRun;
+		},
+	},
+}));
+
+vi.mock('../../../lib/toast', () => ({
+	toast: {
+		get success() {
+			return mockToastSuccess;
+		},
+	},
+}));
+
+vi.mock('../../ui/Modal', () => ({
+	Modal: ({ isOpen, children, title, onClose }) => {
+		if (!isOpen) return null;
+		return (
+			<div role="dialog" aria-label={title}>
+				<button onClick={onClose} aria-label="Close modal">
+					X
+				</button>
+				{children}
+			</div>
+		);
+	},
+}));
+
+vi.mock('../../ui/Button', () => ({
+	Button: ({ children, onClick, type, loading, disabled }) => (
+		<button type={type ?? 'button'} onClick={onClick} disabled={disabled || loading}>
+			{loading ? 'Loading...' : children}
+		</button>
+	),
+}));
+
+import { WorkflowRunStartDialog } from '../WorkflowRunStartDialog';
+
+function makeWorkflow(id: string, name: string) {
+	return {
+		id,
+		spaceId: 'space-1',
+		name,
+		description: '',
+		nodes: [],
+		gates: [],
+		rules: [],
+		channels: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+const RUN_MOCK = {
+	id: 'run-1',
+	spaceId: 'space-1',
+	workflowId: 'wf-1',
+	title: 'My Flow — 2024-01-15 10:30',
+	status: 'pending',
+	createdAt: Date.now(),
+	updatedAt: Date.now(),
+};
+
+describe('WorkflowRunStartDialog', () => {
+	let onClose: ReturnType<typeof vi.fn>;
+	let onStarted: ReturnType<typeof vi.fn>;
+	let onSwitchToWorkflows: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		cleanup();
+		onClose = vi.fn();
+		onStarted = vi.fn();
+		onSwitchToWorkflows = vi.fn();
+		mockStartWorkflowRun.mockReset();
+		mockToastSuccess.mockReset();
+		mockWorkflowsSignal.value = [];
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders nothing when isOpen is false', () => {
+		const { container } = render(<WorkflowRunStartDialog isOpen={false} onClose={onClose} />);
+		expect(container.querySelector('[role="dialog"]')).toBeNull();
+	});
+
+	it('shows empty state when no workflows configured', () => {
+		mockWorkflowsSignal.value = [];
+		const { getByText } = render(<WorkflowRunStartDialog isOpen={true} onClose={onClose} />);
+		expect(getByText(/No workflows available/)).toBeTruthy();
+	});
+
+	it('shows "Go to Workflows tab" button in empty state when onSwitchToWorkflows provided', () => {
+		mockWorkflowsSignal.value = [];
+		const { getByText } = render(
+			<WorkflowRunStartDialog
+				isOpen={true}
+				onClose={onClose}
+				onSwitchToWorkflows={onSwitchToWorkflows}
+			/>
+		);
+		expect(getByText('Go to Workflows tab')).toBeTruthy();
+	});
+
+	it('calls onSwitchToWorkflows and closes when "Go to Workflows tab" clicked', () => {
+		mockWorkflowsSignal.value = [];
+		const { getByText } = render(
+			<WorkflowRunStartDialog
+				isOpen={true}
+				onClose={onClose}
+				onSwitchToWorkflows={onSwitchToWorkflows}
+			/>
+		);
+		fireEvent.click(getByText('Go to Workflows tab'));
+		expect(onClose).toHaveBeenCalled();
+		expect(onSwitchToWorkflows).toHaveBeenCalled();
+	});
+
+	it('does not show workflow select when only one workflow', () => {
+		mockWorkflowsSignal.value = [makeWorkflow('wf-1', 'Main Flow')];
+		const { queryByRole } = render(<WorkflowRunStartDialog isOpen={true} onClose={onClose} />);
+		expect(queryByRole('combobox')).toBeNull();
+	});
+
+	it('shows single workflow name when only one workflow', () => {
+		mockWorkflowsSignal.value = [makeWorkflow('wf-1', 'Main Flow')];
+		const { getByText } = render(<WorkflowRunStartDialog isOpen={true} onClose={onClose} />);
+		expect(getByText('Main Flow')).toBeTruthy();
+	});
+
+	it('shows workflow dropdown when multiple workflows exist', () => {
+		mockWorkflowsSignal.value = [makeWorkflow('wf-1', 'Flow A'), makeWorkflow('wf-2', 'Flow B')];
+		const { getAllByRole } = render(<WorkflowRunStartDialog isOpen={true} onClose={onClose} />);
+		expect(getAllByRole('combobox').length).toBeGreaterThan(0);
+	});
+
+	it('auto-generates title when title field is left blank', async () => {
+		mockWorkflowsSignal.value = [makeWorkflow('wf-1', 'Main Flow')];
+		mockStartWorkflowRun.mockResolvedValue(RUN_MOCK);
+
+		const { getByRole } = render(
+			<WorkflowRunStartDialog isOpen={true} onClose={onClose} onStarted={onStarted} />
+		);
+
+		// Submit without filling in a title
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(mockStartWorkflowRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workflowId: 'wf-1',
+					title: expect.stringContaining('Main Flow'),
+				})
+			);
+		});
+	});
+
+	it('uses provided title when filled in', async () => {
+		mockWorkflowsSignal.value = [makeWorkflow('wf-1', 'Main Flow')];
+		mockStartWorkflowRun.mockResolvedValue(RUN_MOCK);
+
+		const { getByRole, getByPlaceholderText } = render(
+			<WorkflowRunStartDialog isOpen={true} onClose={onClose} onStarted={onStarted} />
+		);
+
+		// The placeholder reflects the auto-suggested title
+		const input = getByRole('dialog').querySelector('input[type="text"]');
+		fireEvent.input(input, { target: { value: 'Custom title' } });
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(mockStartWorkflowRun).toHaveBeenCalledWith(
+				expect.objectContaining({ title: 'Custom title' })
+			);
+		});
+	});
+
+	it('calls onStarted and closes on success', async () => {
+		mockWorkflowsSignal.value = [makeWorkflow('wf-1', 'Main Flow')];
+		mockStartWorkflowRun.mockResolvedValue(RUN_MOCK);
+
+		const { getByRole } = render(
+			<WorkflowRunStartDialog isOpen={true} onClose={onClose} onStarted={onStarted} />
+		);
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(onStarted).toHaveBeenCalledWith(RUN_MOCK);
+			expect(onClose).toHaveBeenCalled();
+			expect(mockToastSuccess).toHaveBeenCalledWith(expect.stringContaining(RUN_MOCK.title));
+		});
+	});
+
+	it('shows error message when startWorkflowRun fails', async () => {
+		mockWorkflowsSignal.value = [makeWorkflow('wf-1', 'Main Flow')];
+		mockStartWorkflowRun.mockRejectedValue(new Error('Server error'));
+
+		const { getByRole, findByText } = render(
+			<WorkflowRunStartDialog isOpen={true} onClose={onClose} />
+		);
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		expect(await findByText('Server error')).toBeTruthy();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('calls onClose when Cancel is clicked', () => {
+		mockWorkflowsSignal.value = [makeWorkflow('wf-1', 'Main Flow')];
+		const { getByText } = render(<WorkflowRunStartDialog isOpen={true} onClose={onClose} />);
+		fireEvent.click(getByText('Cancel'));
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('disables Start Run button when no workflows available', () => {
+		mockWorkflowsSignal.value = [];
+		const { getByText } = render(<WorkflowRunStartDialog isOpen={true} onClose={onClose} />);
+		const startBtn = getByText('Start Run');
+		expect(startBtn.disabled).toBe(true);
+	});
+});

--- a/packages/web/src/components/space/index.ts
+++ b/packages/web/src/components/space/index.ts
@@ -8,6 +8,7 @@ export { SpaceContextPanel } from './SpaceContextPanel';
 export { SpaceCreateDialog } from './SpaceCreateDialog';
 export { SpaceCreateTaskDialog } from './SpaceCreateTaskDialog';
 export { SpaceStartWorkflowDialog } from './SpaceStartWorkflowDialog';
+export { WorkflowRunStartDialog } from './WorkflowRunStartDialog';
 export { SpaceDashboard } from './SpaceDashboard';
 export { SpaceNavPanel } from './SpaceNavPanel';
 export { SpaceSettings } from './SpaceSettings';

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -27,7 +27,7 @@ import { VisualWorkflowEditor } from '../components/space/visual-editor/VisualWo
 import { WorkflowCanvas } from '../components/space/WorkflowCanvas';
 import { SpaceSettings } from '../components/space/SpaceSettings';
 import { SpaceCreateTaskDialog } from '../components/space/SpaceCreateTaskDialog';
-import { SpaceStartWorkflowDialog } from '../components/space/SpaceStartWorkflowDialog';
+import { WorkflowRunStartDialog } from '../components/space/WorkflowRunStartDialog';
 import { cn } from '../lib/utils';
 
 interface SpaceIslandProps {
@@ -308,11 +308,13 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 
 			{/* Quick action dialogs */}
 			<SpaceCreateTaskDialog isOpen={createTaskOpen} onClose={() => setCreateTaskOpen(false)} />
-			<SpaceStartWorkflowDialog
+			{/* onStarted is intentionally omitted: spaceStore subscribes to
+				space.workflowRun.created events and updates activeRuns reactively,
+				so the canvas re-renders automatically without an explicit callback. */}
+			<WorkflowRunStartDialog
 				isOpen={startWorkflowOpen}
-				spaceId={spaceId}
-				workflows={workflows}
 				onClose={() => setStartWorkflowOpen(false)}
+				onSwitchToWorkflows={() => setActiveTab('workflows')}
 			/>
 		</div>
 	);

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -814,6 +814,15 @@ describe('SpaceStore — CRUD methods', () => {
 		});
 	});
 
+	it('startWorkflowRun throws when server returns no run data', async () => {
+		await spaceStore.selectSpace('space-1');
+		mockHub.request.mockResolvedValueOnce({ run: null } as unknown as { run: SpaceWorkflowRun });
+
+		await expect(
+			spaceStore.startWorkflowRun({ workflowId: 'wf-1', title: 'Run 1' })
+		).rejects.toThrow('Server returned no run data');
+	});
+
 	it('createAgent calls spaceAgent.create RPC', async () => {
 		await spaceStore.selectSpace('space-1');
 		await spaceStore.createAgent({ name: 'Coder', role: 'coder' });

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -852,6 +852,7 @@ class SpaceStore {
 			...params,
 			spaceId,
 		});
+		if (!run) throw new Error('Server returned no run data');
 		return run;
 	}
 


### PR DESCRIPTION
Adds `WorkflowRunStartDialog` — a dashboard quick-action dialog for starting a workflow run.

**Key differences from `SpaceStartWorkflowDialog`:**
- Reads workflows from `spaceStore.workflows` signal (no prop drilling)
- Title is **optional**: auto-generated as `<WorkflowName> — <ISO timestamp>` when left blank
- Empty state includes a **"Go to Workflows tab"** button that triggers `onSwitchToWorkflows` and closes the dialog
- Delegates to `spaceStore.startWorkflowRun()` instead of calling the hub directly

**Changes:**
- `WorkflowRunStartDialog.tsx` — new component
- `__tests__/WorkflowRunStartDialog.test.tsx` — 13 unit tests (all scenarios)
- `space/index.ts` — barrel export
- `SpaceIsland.tsx` — wires the dialog to the "Start Workflow Run" quick action with `onSwitchToWorkflows → setActiveTab('workflows')`