### PR TITLE
feat(space): provision space:chat session on space creation and daemon startup

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -337,7 +337,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceWorkflowRunRepo,
 		deps.daemonHub,
 		deps.spaceAgentManager,
-		spaceWorkflowManager
+		spaceWorkflowManager,
+		deps.sessionManager
 	);
 
 	const spaceTaskManagerFactory: SpaceTaskManagerFactory = (spaceId: string) => {
@@ -365,6 +366,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Not started yet: TaskAgentManager is created next and injected before start().
 	// gateDataRepo is injected so notifyGateDataChanged() can trigger lazy node activation
 	// after gate data is written externally (e.g. approveGate RPC, writeGateData RPC).
+	// sessionManager and daemonHub are injected so space:chat:${spaceId} sessions are
+	// provisioned with MCP tools and system prompts on startup and on space.created.
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		spaceManager: deps.spaceManager,
@@ -373,6 +376,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		workflowRunRepo: spaceWorkflowRunRepo,
 		taskRepo: spaceTaskRepo,
 		gateDataRepo,
+		sessionManager: deps.sessionManager,
+		daemonHub: deps.daemonHub,
 	});
 
 	// Space Worktree Manager — one worktree per task, shared by all node agents.

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -330,17 +330,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	};
 	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo, agentLookup);
 
-	setupSpaceHandlers(
-		deps.messageHub,
-		deps.spaceManager,
-		spaceTaskRepo,
-		spaceWorkflowRunRepo,
-		deps.daemonHub,
-		deps.spaceAgentManager,
-		spaceWorkflowManager,
-		deps.sessionManager
-	);
-
 	const spaceTaskManagerFactory: SpaceTaskManagerFactory = (spaceId: string) => {
 		return new SpaceTaskManager(deps.db.getDatabase(), spaceId);
 	};
@@ -379,6 +368,21 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		sessionManager: deps.sessionManager,
 		daemonHub: deps.daemonHub,
 	});
+
+	// Register Space RPC handlers now that spaceRuntimeService exists.
+	// spaceRuntimeService is passed so space.create can call setupSpaceAgentSession()
+	// directly after session creation, avoiding reliance on the daemonHub event.
+	setupSpaceHandlers(
+		deps.messageHub,
+		deps.spaceManager,
+		spaceTaskRepo,
+		spaceWorkflowRunRepo,
+		deps.daemonHub,
+		deps.spaceAgentManager,
+		spaceWorkflowManager,
+		deps.sessionManager,
+		spaceRuntimeService
+	);
 
 	// Space Worktree Manager — one worktree per task, shared by all node agents.
 	const spaceWorktreeManager = new SpaceWorktreeManager(deps.db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -26,6 +26,7 @@ import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import type { SessionManager } from '../session-manager';
 import { seedPresetAgents } from '../space/agents/seed-agents';
 import { seedBuiltInWorkflows } from '../space/workflows/built-in-workflows';
 import { Logger } from '../logger';
@@ -47,7 +48,8 @@ export function setupSpaceHandlers(
 	workflowRunRepo: SpaceWorkflowRunRepository,
 	daemonHub: DaemonHub,
 	spaceAgentManager: SpaceAgentManager,
-	spaceWorkflowManager: SpaceWorkflowManager
+	spaceWorkflowManager: SpaceWorkflowManager,
+	sessionManager?: SessionManager
 ): void {
 	// ─── space.create ───────────────────────────────────────────────────────────
 	messageHub.onRequest('space.create', async (data) => {
@@ -89,6 +91,28 @@ export function setupSpaceHandlers(
 			);
 		} catch (err) {
 			log.warn('Failed to seed built-in workflows for space', space.id, err);
+		}
+
+		// Create the space's user-facing chat session.
+		// Session ID format: space:chat:${spaceId}
+		// Mirrors the room:chat:${roomId} pattern from room-handlers.ts.
+		if (sessionManager) {
+			const spaceChatSessionId = `space:chat:${space.id}`;
+			try {
+				await sessionManager.createSession({
+					sessionId: spaceChatSessionId,
+					title: space.name,
+					workspacePath: space.workspacePath,
+					config: {
+						model: space.defaultModel,
+					},
+					sessionType: 'space_chat',
+					spaceId: space.id,
+					createdBy: 'neo',
+				});
+			} catch (error) {
+				log.warn(`Failed to create space chat session for space ${space.id}:`, error);
+			}
 		}
 
 		daemonHub

--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -27,6 +27,7 @@ import type { SpaceWorkflowManager } from '../space/managers/space-workflow-mana
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import type { SessionManager } from '../session-manager';
+import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { seedPresetAgents } from '../space/agents/seed-agents';
 import { seedBuiltInWorkflows } from '../space/workflows/built-in-workflows';
 import { Logger } from '../logger';
@@ -49,7 +50,8 @@ export function setupSpaceHandlers(
 	daemonHub: DaemonHub,
 	spaceAgentManager: SpaceAgentManager,
 	spaceWorkflowManager: SpaceWorkflowManager,
-	sessionManager?: SessionManager
+	sessionManager?: SessionManager,
+	spaceRuntimeService?: SpaceRuntimeService
 ): void {
 	// ─── space.create ───────────────────────────────────────────────────────────
 	messageHub.onRequest('space.create', async (data) => {
@@ -110,6 +112,16 @@ export function setupSpaceHandlers(
 					spaceId: space.id,
 					createdBy: 'neo',
 				});
+				// Register the session on the space so it appears in space.sessionIds.
+				// Mirrors roomManager.assignSession() in room-handlers.ts.
+				await spaceManager.addSession(space.id, spaceChatSessionId);
+				// Attach MCP tools and system prompt directly (session is in DB now).
+				// This avoids relying on the space.created event which fires asynchronously.
+				if (spaceRuntimeService) {
+					await spaceRuntimeService.setupSpaceAgentSession(space).catch((err) => {
+						log.warn(`Failed to provision space chat session for space ${space.id}:`, err);
+					});
+				}
 			} catch (error) {
 				log.warn(`Failed to create space chat session for space ${space.id}:`, error);
 			}

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -38,6 +38,8 @@ export interface CreateSessionParams {
 	sessionId?: string; // Optional custom session ID (for room chat/self sessions)
 	roomId?: string; // Optional room ID to assign session to
 	lobbyId?: string; // Optional lobby ID to assign session to
+	/** Optional Space ID for space_chat sessions (space:chat:${spaceId}) */
+	spaceId?: string;
 	createdBy?: 'human' | 'neo'; // Creator type (defaults to 'human')
 	// Session types:
 	// - 'worker': Standard coding session with Claude Code system prompt
@@ -47,6 +49,7 @@ export interface CreateSessionParams {
 	// - 'leader': Leader agent session (Room Runtime)
 	// - 'general': General agent session (Room Runtime)
 	// - 'lobby': Instance-level agent session
+	// - 'space_chat': Per-space coordinator session (space:chat:${spaceId})
 	sessionType?:
 		| 'room_chat'
 		| 'planner'
@@ -55,7 +58,8 @@ export interface CreateSessionParams {
 		| 'general'
 		| 'worker'
 		| 'lobby'
-		| 'spaces_global';
+		| 'spaces_global'
+		| 'space_chat';
 	pairedSessionId?: string;
 	parentSessionId?: string;
 	currentTaskId?: string;
@@ -225,12 +229,13 @@ export class SessionLifecycle {
 			// Worktree set during creation (if enabled)
 			worktree: worktreeMetadata,
 			gitBranch: currentBranch ?? undefined,
-			// Context for room/lobby sessions (includes links between chat and self sessions)
+			// Context for room/lobby/space sessions (includes links between chat and self sessions)
 			context:
-				params.roomId || params.lobbyId
+				params.roomId || params.lobbyId || params.spaceId
 					? {
 							...(params.roomId && { roomId: params.roomId }),
 							...(params.lobbyId && { lobbyId: params.lobbyId }),
+							...(params.spaceId && { spaceId: params.spaceId }),
 						}
 					: undefined,
 		};

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
-import type { SpaceTask } from '@neokai/shared';
+import type { McpServerConfig, Space, SpaceTask } from '@neokai/shared';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
@@ -19,8 +19,13 @@ import type { SpaceTaskRepository } from '../../../storage/repositories/space-ta
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { NotificationSink } from './notification-sink';
 import type { TaskAgentManager } from './task-agent-manager';
+import type { SessionManager } from '../../session-manager';
+import type { DaemonHub } from '../../daemon-hub';
 import { SpaceRuntime } from './space-runtime';
 import { ChannelRouter } from './channel-router';
+import { SpaceTaskManager } from '../managers/space-task-manager';
+import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
+import { buildSpaceChatSystemPrompt } from '../agents/space-chat-agent';
 import { Logger } from '../../logger';
 
 const log = new Logger('space-runtime-service');
@@ -48,11 +53,27 @@ export interface SpaceRuntimeServiceConfig {
 	 * activation after gate data is written externally (e.g. human approval via RPC).
 	 */
 	gateDataRepo?: GateDataRepository;
+	/**
+	 * Optional SessionManager for provisioning space:chat:${spaceId} sessions.
+	 * When provided, setupSpaceAgentSession() attaches MCP tools and system prompts
+	 * to space chat sessions on startup and on space.created events.
+	 */
+	sessionManager?: SessionManager;
+	/**
+	 * Optional DaemonHub for subscribing to space.created events.
+	 * When provided together with sessionManager, new spaces get their chat sessions
+	 * provisioned automatically.
+	 */
+	daemonHub?: DaemonHub;
 }
 
 export class SpaceRuntimeService {
 	private readonly runtime: SpaceRuntime;
 	private started = false;
+	/** Unsubscribe handles for DaemonHub event subscriptions (daemon-lifetime). */
+	private readonly unsubscribers: Array<() => void> = [];
+	/** Reference to TaskAgentManager, stored when injected via setTaskAgentManager(). */
+	private taskAgentManager: TaskAgentManager | null = null;
 
 	constructor(private readonly config: SpaceRuntimeServiceConfig) {
 		this.runtime = new SpaceRuntime(config);
@@ -68,6 +89,7 @@ export class SpaceRuntimeService {
 	 * Mirrors the setNotificationSink() pattern.
 	 */
 	setTaskAgentManager(manager: TaskAgentManager): void {
+		this.taskAgentManager = manager;
 		this.runtime.setTaskAgentManager(manager);
 	}
 
@@ -76,6 +98,8 @@ export class SpaceRuntimeService {
 		if (this.started) return;
 		this.started = true;
 		this.runtime.start();
+		this.subscribeToSpaceEvents();
+		this.provisionExistingSpaces();
 		log.info('SpaceRuntimeService started');
 	}
 
@@ -84,7 +108,127 @@ export class SpaceRuntimeService {
 		if (!this.started) return;
 		this.started = false;
 		this.runtime.stop();
+		for (const unsub of this.unsubscribers) {
+			unsub();
+		}
+		this.unsubscribers.length = 0;
 		log.info('SpaceRuntimeService stopped');
+	}
+
+	/**
+	 * Subscribe to space.created events so newly created spaces get their chat
+	 * sessions provisioned with MCP tools and system prompt.
+	 *
+	 * Called once during start(). No-op when sessionManager or daemonHub are absent.
+	 */
+	private subscribeToSpaceEvents(): void {
+		const { sessionManager, daemonHub } = this.config;
+		if (!sessionManager || !daemonHub) return;
+
+		const unsubCreated = daemonHub.on(
+			'space.created',
+			(event) => {
+				void this.setupSpaceAgentSession(event.space).catch((err) => {
+					log.error(`Failed to provision space chat session for space ${event.spaceId}:`, err);
+				});
+			},
+			{ sessionId: 'global' }
+		);
+		this.unsubscribers.push(unsubCreated);
+	}
+
+	/**
+	 * Provision space:chat:${spaceId} sessions for all existing spaces.
+	 *
+	 * Called during start() to re-attach MCP tools and system prompts to existing
+	 * space chat sessions after a daemon restart. The sessions already exist in DB;
+	 * only the runtime configuration (MCP server, system prompt) needs re-attaching.
+	 *
+	 * No-op when sessionManager is absent.
+	 */
+	private provisionExistingSpaces(): void {
+		const { sessionManager } = this.config;
+		if (!sessionManager) return;
+
+		void this.config.spaceManager.listSpaces().then((spaces) => {
+			return Promise.all(
+				spaces.map((space) =>
+					this.setupSpaceAgentSession(space).catch((err) => {
+						log.error(`Failed to provision space chat session for space ${space.id}:`, err);
+					})
+				)
+			);
+		});
+	}
+
+	/**
+	 * Attach MCP tools and system prompt to a space's chat session.
+	 *
+	 * Mirrors RoomRuntimeService.setupRoomAgentSession(). Called:
+	 *   - On startup for all existing spaces (re-attaches after daemon restart)
+	 *   - On space.created event for newly created spaces
+	 *
+	 * No-op when sessionManager is absent.
+	 */
+	async setupSpaceAgentSession(space: Space): Promise<void> {
+		const {
+			sessionManager,
+			db,
+			spaceWorkflowManager,
+			spaceAgentManager,
+			taskRepo,
+			workflowRunRepo,
+		} = this.config;
+		if (!sessionManager) return;
+
+		const spaceChatSessionId = `space:chat:${space.id}`;
+		const session = await sessionManager.getSessionAsync(spaceChatSessionId);
+		if (!session) {
+			log.warn(`Space chat session not found for space ${space.id} (${spaceChatSessionId})`);
+			return;
+		}
+
+		// Build context for the system prompt.
+		const agents = spaceAgentManager.listBySpaceId(space.id);
+		const workflows = spaceWorkflowManager.listWorkflows(space.id);
+
+		const mcpServer = createSpaceAgentMcpServer({
+			spaceId: space.id,
+			runtime: this.runtime,
+			workflowManager: spaceWorkflowManager,
+			taskRepo,
+			workflowRunRepo,
+			taskManager: new SpaceTaskManager(db, space.id),
+			spaceAgentManager,
+			taskAgentManager: this.taskAgentManager,
+		});
+
+		session.setRuntimeMcpServers({
+			'space-agent-tools': mcpServer as unknown as McpServerConfig,
+		});
+
+		session.setRuntimeSystemPrompt(
+			buildSpaceChatSystemPrompt({
+				background: space.backgroundContext,
+				instructions: space.instructions,
+				autonomyLevel: space.autonomyLevel,
+				workflows: workflows.map((w) => ({
+					id: w.id,
+					name: w.name,
+					description: w.description,
+					tags: w.tags ?? [],
+					stepCount: w.nodes?.length ?? 0,
+				})),
+				agents: agents.map((a) => ({
+					id: a.id,
+					name: a.name,
+					role: a.role,
+					description: a.description,
+				})),
+			})
+		);
+
+		log.info(`Space chat session provisioned for space ${space.id}`);
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -150,15 +150,20 @@ export class SpaceRuntimeService {
 		const { sessionManager } = this.config;
 		if (!sessionManager) return;
 
-		void this.config.spaceManager.listSpaces().then((spaces) => {
-			return Promise.all(
-				spaces.map((space) =>
-					this.setupSpaceAgentSession(space).catch((err) => {
-						log.error(`Failed to provision space chat session for space ${space.id}:`, err);
-					})
-				)
-			);
-		});
+		void this.config.spaceManager
+			.listSpaces()
+			.then((spaces) => {
+				return Promise.all(
+					spaces.map((space) =>
+						this.setupSpaceAgentSession(space).catch((err) => {
+							log.error(`Failed to provision space chat session for space ${space.id}:`, err);
+						})
+					)
+				);
+			})
+			.catch((err) => {
+				log.error('Failed to list spaces for session provisioning:', err);
+			});
 	}
 
 	/**

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -61,7 +61,7 @@ export function createTables(db: BunDatabase): void {
         processing_state TEXT,
         archived_at TEXT,
         parent_id TEXT,
-        type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'neo')),
+        type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'space_chat', 'neo')),
         session_context TEXT
       )
     `);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -274,6 +274,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 66: Add 'neo' to sessions type CHECK constraint and create neo_activity_log table.
 	// Neo is a global AI agent with its own session type and activity log for auditing.
 	runMigration66(db);
+
+	// Migration 67: Add 'space_chat' to sessions type CHECK constraint.
+	runMigration67(db);
 }
 
 /**
@@ -4375,4 +4378,75 @@ export function runMigration66(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_neo_activity_log_created_at ON neo_activity_log(created_at)`
 	);
+}
+
+/**
+ * Migration 67: Add 'space_chat' to sessions type CHECK constraint.
+ *
+ * Uses the same probe-insert + table-recreate pattern as Migration 31.
+ * Attempts to insert a row with type='space_chat'; if the constraint rejects it,
+ * recreates the sessions table with the expanded CHECK list (including 'neo' from M66).
+ */
+function runMigration67(db: BunDatabase): void {
+	if (!tableExists(db, 'sessions')) return;
+
+	try {
+		const testId = '__migration_test_space_chat_type__';
+		db.prepare(
+			`INSERT INTO sessions (id, title, workspace_path, created_at, last_active_at, status, config, metadata, is_worktree, type)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		).run(
+			testId,
+			'Test',
+			'/tmp',
+			new Date().toISOString(),
+			new Date().toISOString(),
+			'active',
+			'{}',
+			'{}',
+			0,
+			'space_chat'
+		);
+		db.prepare(`DELETE FROM sessions WHERE id = ?`).run(testId);
+	} catch {
+		db.exec('PRAGMA foreign_keys = OFF');
+		try {
+			db.exec(`
+				CREATE TABLE sessions_new (
+					id TEXT PRIMARY KEY,
+					title TEXT NOT NULL,
+					workspace_path TEXT NOT NULL,
+					created_at TEXT NOT NULL,
+					last_active_at TEXT NOT NULL,
+					status TEXT NOT NULL CHECK(status IN ('active', 'paused', 'ended', 'archived', 'pending_worktree_choice')),
+					config TEXT NOT NULL,
+					metadata TEXT NOT NULL,
+					is_worktree INTEGER DEFAULT 0,
+					worktree_path TEXT,
+					main_repo_path TEXT,
+					worktree_branch TEXT,
+					git_branch TEXT,
+					sdk_session_id TEXT,
+					available_commands TEXT,
+					processing_state TEXT,
+					archived_at TEXT,
+					parent_id TEXT,
+					type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'neo', 'space_chat')),
+					session_context TEXT
+				)
+			`);
+			db.exec(`
+				INSERT INTO sessions_new
+				SELECT id, title, workspace_path, created_at, last_active_at,
+					status, config, metadata, is_worktree, worktree_path, main_repo_path,
+					worktree_branch, git_branch, sdk_session_id, available_commands,
+					processing_state, archived_at, parent_id, type, session_context
+				FROM sessions
+			`);
+			db.exec(`DROP TABLE sessions`);
+			db.exec(`ALTER TABLE sessions_new RENAME TO sessions`);
+		} finally {
+			db.exec('PRAGMA foreign_keys = ON');
+		}
+	}
 }

--- a/packages/daemon/tests/online/space/space-chat-session.test.ts
+++ b/packages/daemon/tests/online/space/space-chat-session.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Space Chat Session Provisioning — Online Tests
+ *
+ * Verifies that a space:chat:${spaceId} session is provisioned end-to-end:
+ * 1. space.create creates a space:chat:${spaceId} session in the DB
+ * 2. The session has type='space_chat' and the correct spaceId in its context
+ * 3. The session appears in space.sessionIds (via spaceManager.addSession)
+ * 4. On daemon restart, the existing space:chat session persists in the DB
+ *    (provisionExistingSpaces re-attaches MCP tools and system prompt on startup)
+ *
+ * ## Running
+ *
+ *   NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/space/space-chat-session.test.ts
+ *
+ * MODES:
+ * - Dev Proxy (recommended): Set NEOKAI_USE_DEV_PROXY=1 for offline testing
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { DaemonServerContext } from '../../helpers/daemon-server';
+import { createDaemonServer } from '../../helpers/daemon-server';
+import { restartDaemon } from './helpers/space-test-helpers';
+import type { Space } from '@neokai/shared';
+
+const IS_MOCK = !!process.env.NEOKAI_USE_DEV_PROXY;
+const SETUP_TIMEOUT = IS_MOCK ? 20_000 : 60_000;
+const TEST_TIMEOUT = IS_MOCK ? 30_000 : 120_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createSpace(daemon: DaemonServerContext): Promise<Space> {
+	const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+	return (await daemon.messageHub.request('space.create', {
+		name: `Chat Session Test Space ${suffix}`,
+		description: 'Online test space for space:chat provisioning',
+		workspacePath: process.cwd(),
+		autonomyLevel: 'supervised',
+	})) as Space;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('space:chat session provisioning', () => {
+	let daemon: DaemonServerContext;
+
+	beforeEach(async () => {
+		daemon = await createDaemonServer();
+	}, SETUP_TIMEOUT);
+
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, SETUP_TIMEOUT);
+
+	test(
+		'space.create provisions a space:chat session with type=space_chat',
+		async () => {
+			const space = await createSpace(daemon);
+			const spaceChatSessionId = `space:chat:${space.id}`;
+
+			// session.get returns { session, activeTools, context }
+			const result = (await daemon.messageHub.request('session.get', {
+				sessionId: spaceChatSessionId,
+			})) as { session: Record<string, unknown> };
+
+			const session = result.session;
+			expect(session).toBeDefined();
+			expect(session.id).toBe(spaceChatSessionId);
+			expect(session.type).toBe('space_chat');
+		},
+		TEST_TIMEOUT
+	);
+
+	test(
+		'space:chat session context contains the spaceId',
+		async () => {
+			const space = await createSpace(daemon);
+			const spaceChatSessionId = `space:chat:${space.id}`;
+
+			const result = (await daemon.messageHub.request('session.get', {
+				sessionId: spaceChatSessionId,
+			})) as { session: Record<string, unknown> };
+
+			// session_context is stored as JSON in the session row
+			const sessionContext = result.session.context as { spaceId?: string } | undefined;
+			expect(sessionContext?.spaceId).toBe(space.id);
+		},
+		TEST_TIMEOUT
+	);
+
+	test(
+		'space:chat session appears in space.sessionIds',
+		async () => {
+			const space = await createSpace(daemon);
+			const spaceChatSessionId = `space:chat:${space.id}`;
+
+			const fetchedSpace = (await daemon.messageHub.request('space.get', {
+				id: space.id,
+			})) as Space;
+
+			expect(fetchedSpace.sessionIds).toContain(spaceChatSessionId);
+		},
+		TEST_TIMEOUT
+	);
+
+	test(
+		'space:chat session persists and is retrievable after daemon restart',
+		async () => {
+			const space = await createSpace(daemon);
+			const spaceChatSessionId = `space:chat:${space.id}`;
+
+			// Verify session exists before restart
+			const beforeRestart = (await daemon.messageHub.request('session.get', {
+				sessionId: spaceChatSessionId,
+			})) as { session: Record<string, unknown> };
+			expect(beforeRestart.session.id).toBe(spaceChatSessionId);
+
+			// Restart daemon reusing the same workspace/DB
+			daemon = await restartDaemon(daemon);
+
+			// Session must still be retrievable — provisionExistingSpaces re-attaches runtime config
+			const afterRestart = (await daemon.messageHub.request('session.get', {
+				sessionId: spaceChatSessionId,
+			})) as { session: Record<string, unknown> };
+			expect(afterRestart.session).toBeDefined();
+			expect(afterRestart.session.id).toBe(spaceChatSessionId);
+			expect(afterRestart.session.type).toBe('space_chat');
+		},
+		TEST_TIMEOUT
+	);
+});

--- a/packages/daemon/tests/online/space/space-chat-session.test.ts
+++ b/packages/daemon/tests/online/space/space-chat-session.test.ts
@@ -113,25 +113,39 @@ describe('space:chat session provisioning', () => {
 	test(
 		'space:chat session persists and is retrievable after daemon restart',
 		async () => {
-			const space = await createSpace(daemon);
-			const spaceChatSessionId = `space:chat:${space.id}`;
+			// Use an externally-owned workspace so waitForExit() does NOT delete the DB.
+			// Mirrors the pattern in space-edge-cases.test.ts restart tests.
+			const restartWorkspace = `/tmp/neokai-space-chat-restart-${Date.now()}`;
+			await Bun.$`mkdir -p ${restartWorkspace}`.quiet();
 
-			// Verify session exists before restart
-			const beforeRestart = (await daemon.messageHub.request('session.get', {
-				sessionId: spaceChatSessionId,
-			})) as { session: Record<string, unknown> };
-			expect(beforeRestart.session.id).toBe(spaceChatSessionId);
+			try {
+				// Replace the default daemon with one that owns an external workspace.
+				daemon.kill('SIGTERM');
+				await daemon.waitForExit();
+				daemon = await createDaemonServer({ workspacePath: restartWorkspace });
 
-			// Restart daemon reusing the same workspace/DB
-			daemon = await restartDaemon(daemon);
+				const space = await createSpace(daemon);
+				const spaceChatSessionId = `space:chat:${space.id}`;
 
-			// Session must still be retrievable — provisionExistingSpaces re-attaches runtime config
-			const afterRestart = (await daemon.messageHub.request('session.get', {
-				sessionId: spaceChatSessionId,
-			})) as { session: Record<string, unknown> };
-			expect(afterRestart.session).toBeDefined();
-			expect(afterRestart.session.id).toBe(spaceChatSessionId);
-			expect(afterRestart.session.type).toBe('space_chat');
+				// Verify session exists before restart
+				const beforeRestart = (await daemon.messageHub.request('session.get', {
+					sessionId: spaceChatSessionId,
+				})) as { session: Record<string, unknown> };
+				expect(beforeRestart.session.id).toBe(spaceChatSessionId);
+
+				// Restart daemon — workspace is preserved, DB persists
+				daemon = await restartDaemon(daemon);
+
+				// Session must still be retrievable after restart
+				const afterRestart = (await daemon.messageHub.request('session.get', {
+					sessionId: spaceChatSessionId,
+				})) as { session: Record<string, unknown> };
+				expect(afterRestart.session).toBeDefined();
+				expect(afterRestart.session.id).toBe(spaceChatSessionId);
+				expect(afterRestart.session.type).toBe('space_chat');
+			} finally {
+				await Bun.$`rm -rf ${restartWorkspace}`.quiet();
+			}
 		},
 		TEST_TIMEOUT
 	);

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -22,6 +22,7 @@ import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space
 import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
+import type { SessionManager } from '../../../src/lib/session-manager';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
 
@@ -146,6 +147,13 @@ function createMockSpaceWorkflowManager(): SpaceWorkflowManager {
 	} as unknown as SpaceWorkflowManager;
 }
 
+function createMockSessionManager(): SessionManager {
+	return {
+		createSession: mock(async () => 'space:chat:space-1'),
+		getSessionAsync: mock(async () => null),
+	} as unknown as SessionManager;
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('space-handlers', () => {
@@ -156,7 +164,7 @@ describe('space-handlers', () => {
 	let taskRepo: SpaceTaskRepository;
 	let runRepo: SpaceWorkflowRunRepository;
 
-	function setup(space: Space | null = mockSpace) {
+	function setup(space: Space | null = mockSpace, sessionManager?: SessionManager) {
 		const mh = createMockMessageHub();
 		hub = mh.hub;
 		handlers = mh.handlers;
@@ -171,7 +179,8 @@ describe('space-handlers', () => {
 			runRepo,
 			daemonHub,
 			createMockSpaceAgentManager(),
-			createMockSpaceWorkflowManager()
+			createMockSpaceWorkflowManager(),
+			sessionManager
 		);
 	}
 
@@ -277,6 +286,48 @@ describe('space-handlers', () => {
 
 			const [params] = (spaceManager.createSpace as ReturnType<typeof mock>).mock.calls[0];
 			expect(params.autonomyLevel).toBeUndefined();
+		});
+
+		it('creates space:chat:${spaceId} session when sessionManager is provided', async () => {
+			const sessionManager = createMockSessionManager();
+			setup(mockSpace, sessionManager);
+
+			await call('space.create', { workspacePath: '/tmp/x', name: 'X' });
+
+			expect(sessionManager.createSession).toHaveBeenCalledTimes(1);
+			const [params] = (sessionManager.createSession as ReturnType<typeof mock>).mock.calls[0];
+			expect(params.sessionId).toBe(`space:chat:${mockSpace.id}`);
+			expect(params.sessionType).toBe('space_chat');
+			expect(params.spaceId).toBe(mockSpace.id);
+			expect(params.title).toBe(mockSpace.name);
+			expect(params.workspacePath).toBe(mockSpace.workspacePath);
+			expect(params.createdBy).toBe('neo');
+		});
+
+		it('does not create a session when sessionManager is omitted', async () => {
+			setup(mockSpace); // no sessionManager
+
+			await call('space.create', { workspacePath: '/tmp/x', name: 'X' });
+
+			// No sessionManager means no session creation — just verify the space was created
+			expect(spaceManager.createSpace).toHaveBeenCalledTimes(1);
+		});
+
+		it('still creates space and emits event even if session creation fails', async () => {
+			const sessionManager = createMockSessionManager();
+			(sessionManager.createSession as ReturnType<typeof mock>).mockImplementation(async () => {
+				throw new Error('Session creation failed');
+			});
+			setup(mockSpace, sessionManager);
+
+			// Should not throw — session creation failure is non-fatal
+			const result = await call('space.create', { workspacePath: '/tmp/x', name: 'X' });
+			expect(result).toEqual(mockSpace);
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.created', {
+				sessionId: 'global',
+				spaceId: mockSpace.id,
+				space: mockSpace,
+			});
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -23,6 +23,7 @@ import type { SpaceTaskRepository } from '../../../src/storage/repositories/spac
 import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 import type { SessionManager } from '../../../src/lib/session-manager';
+import type { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
 
@@ -154,6 +155,12 @@ function createMockSessionManager(): SessionManager {
 	} as unknown as SessionManager;
 }
 
+function createMockSpaceRuntimeService(): SpaceRuntimeService {
+	return {
+		setupSpaceAgentSession: mock(async () => {}),
+	} as unknown as SpaceRuntimeService;
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('space-handlers', () => {
@@ -164,7 +171,11 @@ describe('space-handlers', () => {
 	let taskRepo: SpaceTaskRepository;
 	let runRepo: SpaceWorkflowRunRepository;
 
-	function setup(space: Space | null = mockSpace, sessionManager?: SessionManager) {
+	function setup(
+		space: Space | null = mockSpace,
+		sessionManager?: SessionManager,
+		spaceRuntimeService?: SpaceRuntimeService
+	) {
 		const mh = createMockMessageHub();
 		hub = mh.hub;
 		handlers = mh.handlers;
@@ -180,7 +191,8 @@ describe('space-handlers', () => {
 			daemonHub,
 			createMockSpaceAgentManager(),
 			createMockSpaceWorkflowManager(),
-			sessionManager
+			sessionManager,
+			spaceRuntimeService
 		);
 	}
 
@@ -311,6 +323,28 @@ describe('space-handlers', () => {
 
 			// No sessionManager means no session creation — just verify the space was created
 			expect(spaceManager.createSpace).toHaveBeenCalledTimes(1);
+		});
+
+		it('calls spaceManager.addSession to register the session on the space', async () => {
+			const sessionManager = createMockSessionManager();
+			setup(mockSpace, sessionManager);
+
+			await call('space.create', { workspacePath: '/tmp/x', name: 'X' });
+
+			expect(spaceManager.addSession).toHaveBeenCalledWith(
+				mockSpace.id,
+				`space:chat:${mockSpace.id}`
+			);
+		});
+
+		it('calls setupSpaceAgentSession when spaceRuntimeService is provided', async () => {
+			const sessionManager = createMockSessionManager();
+			const runtimeService = createMockSpaceRuntimeService();
+			setup(mockSpace, sessionManager, runtimeService);
+
+			await call('space.create', { workspacePath: '/tmp/x', name: 'X' });
+
+			expect(runtimeService.setupSpaceAgentSession).toHaveBeenCalledWith(mockSpace);
 		});
 
 		it('still creates space and emits event even if session creation fails', async () => {

--- a/packages/daemon/tests/unit/space/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-service.test.ts
@@ -10,7 +10,7 @@
  * - setTaskAgentManager(): wires TaskAgentManager into the underlying SpaceRuntime
  */
 
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock, type Mock } from 'bun:test';
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
@@ -26,6 +26,9 @@ import type {
 	NotificationSink,
 	SpaceNotificationEvent,
 } from '../../../src/lib/space/runtime/notification-sink.ts';
+import type { SessionManager } from '../../../src/lib/session-manager.ts';
+import type { AgentSession } from '../../../src/lib/agent/agent-session.ts';
+import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
 import type { Space } from '@neokai/shared';
 import { runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
@@ -245,6 +248,152 @@ describe('SpaceRuntimeService', () => {
 			// createOrGetRuntime should still work after restart
 			const runtime = await service.createOrGetRuntime('space-1');
 			expect(runtime).toBeDefined();
+		});
+	});
+
+	// ─── setupSpaceAgentSession ──────────────────────────────────────────────
+
+	describe('setupSpaceAgentSession()', () => {
+		function makeSession() {
+			return {
+				setRuntimeMcpServers: mock(() => {}),
+				setRuntimeSystemPrompt: mock(() => {}),
+			} as unknown as AgentSession;
+		}
+
+		function makeSessionManager(session: AgentSession | null = makeSession()): SessionManager {
+			return {
+				getSessionAsync: mock(async () => session),
+				createSession: mock(async () => 'space:chat:space-1'),
+			} as unknown as SessionManager;
+		}
+
+		function makeWorkflowManager(): SpaceWorkflowManager {
+			return {
+				listWorkflows: mock(() => []),
+			} as unknown as SpaceWorkflowManager;
+		}
+
+		function makeAgentManager(): SpaceAgentManager {
+			return {
+				listBySpaceId: mock(() => []),
+			} as unknown as SpaceAgentManager;
+		}
+
+		function buildConfigWithSession(
+			sessionManager: SessionManager,
+			spaceManager: SpaceManager = createMockSpaceManager()
+		): SpaceRuntimeServiceConfig {
+			return {
+				db: {} as BunDatabase,
+				spaceManager,
+				spaceAgentManager: makeAgentManager(),
+				spaceWorkflowManager: makeWorkflowManager(),
+				workflowRunRepo: {} as SpaceWorkflowRunRepository,
+				taskRepo: {} as SpaceTaskRepository,
+				tickIntervalMs: 60_000,
+				sessionManager,
+			};
+		}
+
+		test('attaches MCP server and system prompt to the space:chat session', async () => {
+			const session = makeSession();
+			const sessionManager = makeSessionManager(session);
+			const svc = new SpaceRuntimeService(buildConfigWithSession(sessionManager));
+
+			await svc.setupSpaceAgentSession(mockSpace);
+
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith(`space:chat:${mockSpace.id}`);
+			expect(session.setRuntimeMcpServers).toHaveBeenCalledTimes(1);
+			const [mcpArg] = (session.setRuntimeMcpServers as Mock<typeof session.setRuntimeMcpServers>)
+				.mock.calls[0];
+			expect(mcpArg).toHaveProperty('space-agent-tools');
+
+			expect(session.setRuntimeSystemPrompt).toHaveBeenCalledTimes(1);
+			const [promptArg] = (
+				session.setRuntimeSystemPrompt as Mock<typeof session.setRuntimeSystemPrompt>
+			).mock.calls[0];
+			expect(typeof promptArg).toBe('string');
+			expect(promptArg.length).toBeGreaterThan(0);
+		});
+
+		test('no-op when session does not exist in DB', async () => {
+			const sessionManager = makeSessionManager(null); // session not found
+			const svc = new SpaceRuntimeService(buildConfigWithSession(sessionManager));
+
+			// Should not throw
+			await expect(svc.setupSpaceAgentSession(mockSpace)).resolves.toBeUndefined();
+		});
+
+		test('no-op when sessionManager is not configured', async () => {
+			// buildConfig (no sessionManager)
+			const svc = new SpaceRuntimeService(buildConfig(createMockSpaceManager()));
+
+			// Should not throw and silently skip
+			await expect(svc.setupSpaceAgentSession(mockSpace)).resolves.toBeUndefined();
+		});
+
+		test('start() provisions existing spaces', async () => {
+			const session = makeSession();
+			const sessionManager = makeSessionManager(session);
+			const spaceMgr: SpaceManager = {
+				getSpace: mock(async () => mockSpace),
+				listSpaces: mock(async () => [mockSpace]),
+			} as unknown as SpaceManager;
+			const svc = new SpaceRuntimeService(buildConfigWithSession(sessionManager, spaceMgr));
+
+			svc.start();
+			// Allow async provisioning microtasks to run
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+			expect(spaceMgr.listSpaces).toHaveBeenCalled();
+			// getSessionAsync was called for the existing space
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith(`space:chat:${mockSpace.id}`);
+
+			svc.stop();
+		});
+
+		test('start() subscribes to space.created events when daemonHub provided', () => {
+			const session = makeSession();
+			const sessionManager = makeSessionManager(session);
+			const daemonHub: DaemonHub = {
+				on: mock(() => () => {}),
+				emit: mock(async () => {}),
+			} as unknown as DaemonHub;
+			const config: SpaceRuntimeServiceConfig = {
+				...buildConfigWithSession(sessionManager),
+				daemonHub,
+			};
+			const svc = new SpaceRuntimeService(config);
+
+			svc.start();
+
+			// DaemonHub.on should have been called with 'space.created'
+			const onCalls = (daemonHub.on as Mock<typeof daemonHub.on>).mock.calls;
+			const spaceCreatedCall = onCalls.find(([event]) => event === 'space.created');
+			expect(spaceCreatedCall).toBeDefined();
+
+			svc.stop();
+		});
+
+		test('stop() unsubscribes from space.created events', () => {
+			const unsubFn = mock(() => {});
+			const session = makeSession();
+			const sessionManager = makeSessionManager(session);
+			const daemonHub: DaemonHub = {
+				on: mock(() => unsubFn as unknown as () => void),
+				emit: mock(async () => {}),
+			} as unknown as DaemonHub;
+			const config: SpaceRuntimeServiceConfig = {
+				...buildConfigWithSession(sessionManager),
+				daemonHub,
+			};
+			const svc = new SpaceRuntimeService(config);
+
+			svc.start();
+			svc.stop();
+
+			expect(unsubFn).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -64,6 +64,7 @@ export type {
  * - 'general': General-purpose agent session (Room Runtime)
  * - 'lobby': Instance-level agent session
  * - 'space_task_agent': Task Agent session that orchestrates a single SpaceTask's workflow
+ * - 'space_chat': Per-space coordinator session (space:chat:${spaceId}) — the human-facing interface for a Space
  */
 export type SessionType =
 	| 'worker'
@@ -75,6 +76,7 @@ export type SessionType =
 	| 'lobby'
 	| 'spaces_global'
 	| 'space_task_agent'
+	| 'space_chat'
 	| 'neo';
 
 /**


### PR DESCRIPTION
Mirrors the `room:chat:${roomId}` pattern for Spaces — each Space now gets a dedicated coordinator session (`space:chat:${spaceId}`) with MCP tools and a system prompt.

Changes:
- `shared/types.ts`: add `space_chat` to `SessionType` and `SessionMetadata.sessionType`
- `session-lifecycle.ts`: add `spaceId` field and `space_chat` to `CreateSessionParams`
- `space-handlers.ts`: create `space:chat:${spaceId}` session after `space.create` RPC
- `space-runtime-service.ts`: add `setupSpaceAgentSession()`, `subscribeToSpaceEvents()`, `provisionExistingSpaces()`; accept `sessionManager` and `daemonHub` in config
- `rpc-handlers/index.ts`: wire `sessionManager` and `daemonHub` into `SpaceRuntimeService`
- Unit tests updated for both `space-handlers` and `space-runtime-service`