### PR TITLE
fix(web): apply safe-area-inset-top to prevent iOS iPad Safari top UI clipping

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -156,7 +156,10 @@ export function App() {
 
 	return (
 		<>
-			<div class="flex h-dvh overflow-hidden bg-dark-950 relative" style={{ height: '100dvh' }}>
+			<div
+				class="flex h-dvh overflow-hidden bg-dark-950 relative pt-safe"
+				style={{ height: '100dvh' }}
+			>
 				{/* Navigation Rail (desktop only) */}
 				<NavRail />
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -156,10 +156,7 @@ export function App() {
 
 	return (
 		<>
-			<div
-				class="flex h-dvh overflow-hidden bg-dark-950 relative pt-safe"
-				style={{ height: '100dvh' }}
-			>
+			<div class="flex h-dvh overflow-hidden bg-dark-950 relative pt-safe">
 				{/* Navigation Rail (desktop only) */}
 				<NavRail />
 

--- a/packages/web/src/assets.d.ts
+++ b/packages/web/src/assets.d.ts
@@ -1,1 +1,17 @@
 declare module '*.css' {}
+declare module '*.css?raw' {
+	const content: string;
+	export default content;
+}
+declare module '*.css?inline' {
+	const content: string;
+	export default content;
+}
+declare module '*.html?raw' {
+	const content: string;
+	export default content;
+}
+declare module '*.tsx?raw' {
+	const content: string;
+	export default content;
+}

--- a/packages/web/src/components/room/SlideOutPanel.tsx
+++ b/packages/web/src/components/room/SlideOutPanel.tsx
@@ -106,7 +106,7 @@ export function SlideOutPanel({
 				aria-modal="true"
 				aria-label={`Session chat for ${displayLabel}`}
 				class={[
-					'fixed top-0 right-0 h-screen z-50',
+					'fixed top-0 right-0 h-dvh pt-safe z-50',
 					widthClass,
 					'flex flex-col',
 					'bg-gray-900 border-l border-gray-700 shadow-2xl',

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -345,12 +345,13 @@ export function ContextPanel() {
 			<div
 				class={`
 					fixed md:relative
+					top-0 left-0 md:left-auto
 					h-dvh md:h-full w-70
 					bg-dark-950 border-r ${borderColors.ui.default}
 					flex flex-col
+					pt-safe md:pt-0
 					z-40 md:z-auto
 					transition-transform duration-300 ease-in-out
-					left-0 md:left-auto
 					${isPanelOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
 				`}
 			>

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -345,7 +345,7 @@ export function ContextPanel() {
 			<div
 				class={`
 					fixed md:relative
-					h-screen w-70
+					h-dvh md:h-full w-70
 					bg-dark-950 border-r ${borderColors.ui.default}
 					flex flex-col
 					z-40 md:z-auto

--- a/packages/web/src/islands/NavRail.tsx
+++ b/packages/web/src/islands/NavRail.tsx
@@ -46,7 +46,7 @@ export function NavRail() {
 		<div
 			class={`
 				hidden md:relative md:flex
-				w-16 h-screen
+				w-16 h-full
 				bg-dark-950 border-r ${borderColors.ui.default}
 				flex-col items-center py-4
 			`}

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -567,11 +567,13 @@ describe('ContextPanel', () => {
 			expect(header).toBeTruthy();
 		});
 
-		it('should have full screen height', () => {
+		it('should use h-dvh on mobile and h-full on desktop to respect safe-area boundary', () => {
 			const { container } = render(<ContextPanel />);
 
 			const panel = container.querySelector('.w-70');
-			expect(panel?.className).toContain('h-screen');
+			expect(panel?.className).toContain('h-dvh');
+			expect(panel?.className).toContain('md:h-full');
+			expect(panel?.className).not.toContain('h-screen');
 		});
 	});
 });

--- a/packages/web/src/islands/__tests__/NavRail.test.tsx
+++ b/packages/web/src/islands/__tests__/NavRail.test.tsx
@@ -181,6 +181,14 @@ describe('NavRail', () => {
 			const navRail = container.querySelector('div');
 			expect(navRail?.className).toContain('w-16');
 		});
+
+		it('should use h-full instead of h-screen to avoid overflowing safe-area-padded parent', () => {
+			const { container } = render(<NavRail />);
+
+			const navRail = container.querySelector('div');
+			expect(navRail?.className).toContain('h-full');
+			expect(navRail?.className).not.toContain('h-screen');
+		});
 	});
 
 	describe('Layout Structure', () => {

--- a/packages/web/src/lib/__tests__/ios-safe-area.test.ts
+++ b/packages/web/src/lib/__tests__/ios-safe-area.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import indexHtml from '../../index.html?raw';
+import appTsx from '../../App.tsx?raw';
+
+/**
+ * iOS iPad Safari safe area support tests.
+ *
+ * These tests verify that the app correctly handles iOS safe areas
+ * to prevent UI from being hidden behind Safari's tab bar/address bar.
+ *
+ * The safe area CSS utilities (pt-safe, pb-safe) using env(safe-area-inset-*)
+ * are defined in src/styles.css — Vite strips CSS content in the test
+ * environment so we verify their usage in source files instead.
+ */
+describe('iOS iPad Safari safe area support', () => {
+	it('viewport meta tag includes viewport-fit=cover', () => {
+		expect(indexHtml).toContain('viewport-fit=cover');
+	});
+
+	it('App.tsx applies pt-safe class to the root container for top safe area', () => {
+		expect(appTsx).toContain('pt-safe');
+	});
+});

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -556,9 +556,9 @@ a:focus-visible {
 
 /* Safe area inset support for iOS notch/home indicator */
 .pb-safe {
-	padding-bottom: env(safe-area-inset-bottom);
+	padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .pt-safe {
-	padding-top: env(safe-area-inset-top);
+	padding-top: env(safe-area-inset-top, 0px);
 }

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -558,3 +558,7 @@ a:focus-visible {
 .pb-safe {
 	padding-bottom: env(safe-area-inset-bottom);
 }
+
+.pt-safe {
+	padding-top: env(safe-area-inset-top);
+}


### PR DESCRIPTION
Apply `env(safe-area-inset-top)` padding to the root app container so content isn't hidden behind Safari's tab bar/address bar on iPad Safari.

- `viewport-fit=cover` was already present in the viewport meta tag
- Added `.pt-safe { padding-top: env(safe-area-inset-top) }` CSS utility to `styles.css` (alongside the existing `.pb-safe`)
- Applied `pt-safe` to the root `<div>` in `App.tsx`
- Added `?raw` type declarations for HTML/TSX imports used in tests
- Unit tests verify: viewport meta has `viewport-fit=cover` and `App.tsx` applies `pt-safe`