### PR TITLE
ci: split cross-provider online tests into 2 parallel CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,8 @@ jobs:
           # Copilot bridge tests disabled — COPILOT_GITHUB_TOKEN credential issue causing hard-fail
           # - providers-anthropic-copilot
           - rewind
+          - cross-provider-1
+          - cross-provider-2
           # Room tests temporarily disabled during refactoring
           # - room-1
           # - room-multi-agent
@@ -289,8 +291,13 @@ jobs:
             test_path: tests/online/websocket
             mock_sdk: true
           # Cross-provider model switching tests - requires real MiniMax and GLM credentials
-          - module: cross-provider
-            test_path: tests/online/cross-provider
+          # Split into 2 parallel jobs to reduce overall CI time.
+          - module: cross-provider-1
+            test_path: tests/online/cross-provider/conversation-continuity-after-switch.test.ts
+            mock_sdk: false
+            default_provider: minimax
+          - module: cross-provider-2
+            test_path: tests/online/cross-provider/cross-provider-model-switch.test.ts
             mock_sdk: false
             default_provider: minimax
 

--- a/scripts/validate-online-test-matrix.sh
+++ b/scripts/validate-online-test-matrix.sh
@@ -76,6 +76,11 @@ PROVIDERS_FILES=(
   anthropic-to-codex-bridge-provider.test.ts  # CI shard disabled — kept here so validator doesn't flag it
 )
 
+CROSS_PROVIDER_FILES=(
+  conversation-continuity-after-switch.test.ts
+  cross-provider-model-switch.test.ts
+)
+
 check_split_module() {
   local module_name=$1
   shift
@@ -118,6 +123,7 @@ check_split_module "rpc" "${RPC_FILES[@]}"
 check_split_module "room" "${ROOM_FILES[@]}"
 check_split_module "features" "${FEATURES_FILES[@]}"
 check_split_module "providers" "${PROVIDERS_FILES[@]}"
+check_split_module "cross-provider" "${CROSS_PROVIDER_FILES[@]}"
 
 # --- 2. Check for new module directories not in the CI matrix ---
 # These are directories covered by directory-level test_path (auto-discover).


### PR DESCRIPTION
Splits the single `cross-provider` CI job into two parallel jobs to reduce overall CI time.

## Changes
- `cross-provider-1`: runs `conversation-continuity-after-switch.test.ts` (~353 lines, 17 tests)
- `cross-provider-2`: runs `cross-provider-model-switch.test.ts` (~769 lines, 47 tests)
- Updated `scripts/validate-online-test-matrix.sh` to track cross-provider as a split module, so any future test files added to the directory are caught by the coverage validator.

Both jobs use the same credentials (MiniMax/GLM) and run with `mock_sdk: false`.