### PR TITLE
test(web): wire quick action buttons in SpaceIsland — add dialog tests and E2E

### DIFF
--- a/packages/e2e/tests/features/space-settings-crud.e2e.ts
+++ b/packages/e2e/tests/features/space-settings-crud.e2e.ts
@@ -14,45 +14,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
-
-async function createSpaceViaRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	workspacePath: string,
-	name: string
-): Promise<string> {
-	const id = await page.evaluate(
-		async ({ workspacePath, name }) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('MessageHub not available');
-			// space.create returns the Space object directly (not wrapped in { space: ... })
-			const space = (await hub.request('space.create', { workspacePath, name })) as {
-				id: string;
-			};
-			return space.id;
-		},
-		{ workspacePath, name }
-	);
-	if (!id) throw new Error('space.create returned no id');
-	return id;
-}
-
-async function deleteSpaceViaRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	spaceId: string
-): Promise<void> {
-	if (!spaceId) return;
-	try {
-		await page.evaluate(async (id) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			await hub.request('space.delete', { id });
-		}, spaceId);
-	} catch {
-		// Best-effort cleanup
-	}
-}
 
 test.describe('Space Settings CRUD', () => {
 	test.use({ viewport: DESKTOP_VIEWPORT });

--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -110,8 +110,9 @@ test.describe('Space Task Creation', () => {
 		await dialog.getByRole('button', { name: 'Cancel' }).click();
 		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
 
-		// No task pane should appear — the right-column task detail pane only opens
-		// when a task is selected (currentSpaceTaskIdSignal non-null), which Cancel never triggers
-		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeVisible();
+		// The task pane wrapper (data-testid="space-task-pane") is only mounted in SpaceIsland
+		// when activeTaskId is truthy. Cancel never sets a taskId, so the wrapper is absent
+		// from the DOM entirely. not.toBeAttached() fails if the element is unexpectedly mounted.
+		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeAttached();
 	});
 });

--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -5,7 +5,8 @@
  * - "Create Task" quick action button opens SpaceCreateTaskDialog
  * - "Start Workflow Run" quick action button opens WorkflowRunStartDialog
  * - Filling and submitting the Create Task form creates a task
- * - Created task title appears in the SpaceDetailPanel Tasks section
+ * - Created task title appears in SpaceDashboard's Recent Activity section
+ * - Cancelling the dialog dismisses it without creating a task
  *
  * Setup: creates a space via RPC (infrastructure), navigates to its Dashboard tab
  * Cleanup: deletes the space via RPC in afterEach (infrastructure)
@@ -13,44 +14,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
-
-async function createSpaceViaRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	workspacePath: string,
-	name: string
-): Promise<string> {
-	const id = await page.evaluate(
-		async ({ workspacePath, name }) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('MessageHub not available');
-			const space = (await hub.request('space.create', { workspacePath, name })) as {
-				id: string;
-			};
-			return space.id;
-		},
-		{ workspacePath, name }
-	);
-	if (!id) throw new Error('space.create returned no id');
-	return id;
-}
-
-async function deleteSpaceViaRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	spaceId: string
-): Promise<void> {
-	if (!spaceId) return;
-	try {
-		await page.evaluate(async (id) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			await hub.request('space.delete', { id });
-		}, spaceId);
-	} catch {
-		// Best-effort cleanup
-	}
-}
 
 test.describe('Space Task Creation', () => {
 	test.use({ viewport: DESKTOP_VIEWPORT });
@@ -83,15 +49,16 @@ test.describe('Space Task Creation', () => {
 	});
 
 	test('Create Task button opens SpaceCreateTaskDialog', async ({ page }) => {
-		// The SpaceDashboard fallback is shown when no workflows exist (fresh space)
+		// Fresh space has no workflows → SpaceDashboard fallback is shown with quick actions
 		const createTaskBtn = page.getByRole('button', { name: 'Create Task' }).first();
 		await expect(createTaskBtn).toBeVisible({ timeout: 5000 });
 
 		await createTaskBtn.click();
 
-		// The Create Task modal should open
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
-		await expect(page.getByText('Create Task').first()).toBeVisible();
+		// The Create Task modal should open — scope assertions to the dialog itself
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 3000 });
+		await expect(dialog.getByRole('heading', { name: 'Create Task' })).toBeVisible();
 	});
 
 	test('Start Workflow Run button opens WorkflowRunStartDialog', async ({ page }) => {
@@ -100,49 +67,51 @@ test.describe('Space Task Creation', () => {
 
 		await startWorkflowBtn.click();
 
-		// The Start Workflow Run modal should open
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
-		await expect(page.getByText('Start Workflow Run').first()).toBeVisible();
+		// The Start Workflow Run modal should open — scope assertions to the dialog
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 3000 });
+		await expect(dialog.getByRole('heading', { name: 'Start Workflow Run' })).toBeVisible();
 	});
 
-	test('filling and submitting Create Task form creates a task visible in the panel', async ({
-		page,
-	}) => {
+	test('submitting the Create Task form creates a task in Recent Activity', async ({ page }) => {
 		const taskTitle = `E2E Task ${Date.now()}`;
 
-		// Click "Create Task" quick action (the first button with that text — in SpaceDashboard)
+		// Click "Create Task" quick action (the first button with that text in SpaceDashboard)
 		await page.getByRole('button', { name: 'Create Task' }).first().click();
 
-		// Dialog is now open — fill in the title field
+		// Fill in the title field
 		const titleInput = page.getByPlaceholder('e.g., Implement authentication module');
 		await expect(titleInput).toBeVisible({ timeout: 3000 });
 		await titleInput.fill(taskTitle);
 
-		// Submit the form — the submit button inside the dialog also says "Create Task"
-		// Use the dialog scope to disambiguate
+		// Submit via the dialog's "Create Task" button — scope to dialog to disambiguate
 		const dialog = page.getByRole('dialog');
 		await dialog.getByRole('button', { name: 'Create Task' }).click();
 
-		// Toast notification confirming creation
+		// Toast notification confirming creation appears
 		await expect(page.getByText(`Task "${taskTitle}" created`)).toBeVisible({ timeout: 5000 });
 
-		// Dialog should close
+		// Dialog should close after successful submission
 		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
 
-		// The task should appear in the SpaceDetailPanel Tasks section in the right sidebar
-		await expect(page.getByText(taskTitle)).toBeVisible({ timeout: 5000 });
+		// The task title should appear in SpaceDashboard's Recent Activity section.
+		// The store updates reactively via live-query after creation.
+		// Use exact: true to avoid matching the taskTitle substring in the toast.
+		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
 	});
 
-	test('Create Task dialog can be dismissed without creating a task', async ({ page }) => {
+	test('Cancel dismisses the dialog without creating a task', async ({ page }) => {
 		await page.getByRole('button', { name: 'Create Task' }).first().click();
 
 		const dialog = page.getByRole('dialog');
 		await expect(dialog).toBeVisible({ timeout: 3000 });
 
-		// Click Cancel
+		// Click Cancel — dialog should close
 		await dialog.getByRole('button', { name: 'Cancel' }).click();
-
-		// Dialog should close
 		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
+
+		// No task pane should appear — the right-column task detail pane only opens
+		// when a task is selected (currentSpaceTaskIdSignal non-null), which Cancel never triggers
+		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeVisible();
 	});
 });

--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -1,0 +1,148 @@
+/**
+ * Space Task Creation E2E Tests
+ *
+ * Verifies:
+ * - "Create Task" quick action button opens SpaceCreateTaskDialog
+ * - "Start Workflow Run" quick action button opens WorkflowRunStartDialog
+ * - Filling and submitting the Create Task form creates a task
+ * - Created task title appears in the SpaceDetailPanel Tasks section
+ *
+ * Setup: creates a space via RPC (infrastructure), navigates to its Dashboard tab
+ * Cleanup: deletes the space via RPC in afterEach (infrastructure)
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+
+async function createSpaceViaRpc(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	workspacePath: string,
+	name: string
+): Promise<string> {
+	const id = await page.evaluate(
+		async ({ workspacePath, name }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const space = (await hub.request('space.create', { workspacePath, name })) as {
+				id: string;
+			};
+			return space.id;
+		},
+		{ workspacePath, name }
+	);
+	if (!id) throw new Error('space.create returned no id');
+	return id;
+}
+
+async function deleteSpaceViaRpc(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	spaceId: string
+): Promise<void> {
+	if (!spaceId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('space.delete', { id });
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+test.describe('Space Task Creation', () => {
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let spaceId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+
+		const workspaceRoot = await getWorkspaceRoot(page);
+		const spaceName = `E2E Task Creation Test ${Date.now()}`;
+		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
+
+		// Navigate directly to the space (Dashboard tab is default)
+		await page.goto(`/space/${spaceId}`);
+		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
+
+		// Wait for the Dashboard tab to be active
+		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
+			timeout: 5000,
+		});
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (spaceId) {
+			await deleteSpaceViaRpc(page, spaceId);
+			spaceId = '';
+		}
+	});
+
+	test('Create Task button opens SpaceCreateTaskDialog', async ({ page }) => {
+		// The SpaceDashboard fallback is shown when no workflows exist (fresh space)
+		const createTaskBtn = page.getByRole('button', { name: 'Create Task' }).first();
+		await expect(createTaskBtn).toBeVisible({ timeout: 5000 });
+
+		await createTaskBtn.click();
+
+		// The Create Task modal should open
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
+		await expect(page.getByText('Create Task').first()).toBeVisible();
+	});
+
+	test('Start Workflow Run button opens WorkflowRunStartDialog', async ({ page }) => {
+		const startWorkflowBtn = page.getByRole('button', { name: 'Start Workflow Run' }).first();
+		await expect(startWorkflowBtn).toBeVisible({ timeout: 5000 });
+
+		await startWorkflowBtn.click();
+
+		// The Start Workflow Run modal should open
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
+		await expect(page.getByText('Start Workflow Run').first()).toBeVisible();
+	});
+
+	test('filling and submitting Create Task form creates a task visible in the panel', async ({
+		page,
+	}) => {
+		const taskTitle = `E2E Task ${Date.now()}`;
+
+		// Click "Create Task" quick action (the first button with that text — in SpaceDashboard)
+		await page.getByRole('button', { name: 'Create Task' }).first().click();
+
+		// Dialog is now open — fill in the title field
+		const titleInput = page.getByPlaceholder('e.g., Implement authentication module');
+		await expect(titleInput).toBeVisible({ timeout: 3000 });
+		await titleInput.fill(taskTitle);
+
+		// Submit the form — the submit button inside the dialog also says "Create Task"
+		// Use the dialog scope to disambiguate
+		const dialog = page.getByRole('dialog');
+		await dialog.getByRole('button', { name: 'Create Task' }).click();
+
+		// Toast notification confirming creation
+		await expect(page.getByText(`Task "${taskTitle}" created`)).toBeVisible({ timeout: 5000 });
+
+		// Dialog should close
+		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
+
+		// The task should appear in the SpaceDetailPanel Tasks section in the right sidebar
+		await expect(page.getByText(taskTitle)).toBeVisible({ timeout: 5000 });
+	});
+
+	test('Create Task dialog can be dismissed without creating a task', async ({ page }) => {
+		await page.getByRole('button', { name: 'Create Task' }).first().click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 3000 });
+
+		// Click Cancel
+		await dialog.getByRole('button', { name: 'Cancel' }).click();
+
+		// Dialog should close
+		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
+	});
+});

--- a/packages/e2e/tests/helpers/space-helpers.ts
+++ b/packages/e2e/tests/helpers/space-helpers.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared RPC helpers for space setup and teardown in E2E tests.
+ *
+ * These helpers are for test infrastructure only (beforeEach/afterEach).
+ * All test actions and assertions must go through the browser UI.
+ */
+
+import type { Page } from '@playwright/test';
+
+/**
+ * Create a space via RPC. For use in beforeEach setup only.
+ * Returns the new space's id.
+ */
+export async function createSpaceViaRpc(
+	page: Page,
+	workspacePath: string,
+	name: string
+): Promise<string> {
+	const id = await page.evaluate(
+		async ({ workspacePath, name }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			// space.create returns the Space object directly (not wrapped in { space: ... })
+			const space = (await hub.request('space.create', { workspacePath, name })) as {
+				id: string;
+			};
+			return space.id;
+		},
+		{ workspacePath, name }
+	);
+	if (!id) throw new Error('space.create returned no id');
+	return id;
+}
+
+/**
+ * Delete a space via RPC. Best-effort — silently ignores errors so it can be
+ * used safely in afterEach without masking test failures.
+ */
+export async function deleteSpaceViaRpc(page: Page, spaceId: string): Promise<void> {
+	if (!spaceId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('space.delete', { id });
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -154,7 +154,7 @@ export function SpaceTaskPane({ taskId, onClose }: SpaceTaskPaneProps) {
 	}
 
 	return (
-		<div class="flex flex-col h-full overflow-y-auto">
+		<div class="flex flex-col h-full overflow-y-auto" data-testid="space-task-pane">
 			{/* Header */}
 			<div class="flex items-start justify-between px-4 py-3 border-b border-dark-700">
 				<h2 class="text-sm font-semibold text-gray-100 flex-1 mr-2 leading-snug">{task.title}</h2>

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -154,7 +154,7 @@ export function SpaceTaskPane({ taskId, onClose }: SpaceTaskPaneProps) {
 	}
 
 	return (
-		<div class="flex flex-col h-full overflow-y-auto" data-testid="space-task-pane">
+		<div class="flex flex-col h-full overflow-y-auto">
 			{/* Header */}
 			<div class="flex items-start justify-between px-4 py-3 border-b border-dark-700">
 				<h2 class="text-sm font-semibold text-gray-100 flex-1 mr-2 leading-snug">{task.title}</h2>

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -305,7 +305,10 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 
 			{/* Right column — task detail pane / chat panel (conditionally shown) */}
 			{activeTaskId && (
-				<div class="hidden md:flex w-80 flex-shrink-0 border-l border-dark-700 overflow-hidden flex-col">
+				<div
+					class="hidden md:flex w-80 flex-shrink-0 border-l border-dark-700 overflow-hidden flex-col"
+					data-testid="space-task-pane"
+				>
 					<SpaceTaskPane taskId={activeTaskId} onClose={handleTaskPaneClose} />
 				</div>
 			)}

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -175,7 +175,7 @@ vi.mock('../../components/space/SpaceDashboard', () => ({
 	),
 }));
 vi.mock('../../components/space/SpaceTaskPane', () => ({
-	SpaceTaskPane: () => <div data-testid="space-task-pane" />,
+	SpaceTaskPane: () => <div />,
 }));
 
 vi.mock('../../components/space/SpaceCreateTaskDialog', () => ({

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -159,10 +159,49 @@ vi.mock('../../components/space/WorkflowCanvas', () => ({
 }));
 
 vi.mock('../../components/space/SpaceDashboard', () => ({
-	SpaceDashboard: () => <div data-testid="space-dashboard" />,
+	SpaceDashboard: (props: {
+		onCreateTask?: () => void;
+		onStartWorkflow?: () => void;
+		onSelectTask?: (id: string) => void;
+	}) => (
+		<div data-testid="space-dashboard">
+			<button data-testid="quick-create-task" onClick={props.onCreateTask}>
+				Create Task
+			</button>
+			<button data-testid="quick-start-workflow" onClick={props.onStartWorkflow}>
+				Start Workflow Run
+			</button>
+		</div>
+	),
 }));
 vi.mock('../../components/space/SpaceTaskPane', () => ({
 	SpaceTaskPane: () => <div data-testid="space-task-pane" />,
+}));
+
+vi.mock('../../components/space/SpaceCreateTaskDialog', () => ({
+	SpaceCreateTaskDialog: (props: { isOpen: boolean; onClose: () => void }) =>
+		props.isOpen ? (
+			<div data-testid="space-create-task-dialog">
+				<button data-testid="close-create-task-dialog" onClick={props.onClose}>
+					Close
+				</button>
+			</div>
+		) : null,
+}));
+
+vi.mock('../../components/space/WorkflowRunStartDialog', () => ({
+	WorkflowRunStartDialog: (props: {
+		isOpen: boolean;
+		onClose: () => void;
+		onSwitchToWorkflows?: () => void;
+	}) =>
+		props.isOpen ? (
+			<div data-testid="workflow-run-start-dialog">
+				<button data-testid="close-workflow-run-dialog" onClick={props.onClose}>
+					Close
+				</button>
+			</div>
+		) : null,
 }));
 vi.mock('../../components/space/SpaceAgentList', () => ({
 	SpaceAgentList: () => <div data-testid="space-agent-list" />,
@@ -195,6 +234,7 @@ vi.mock('../../lib/signals', () => ({
 
 vi.mock('../../lib/router', () => ({
 	navigateToSpace: vi.fn(),
+	navigateToSpaceTask: vi.fn(),
 }));
 
 vi.mock('../../lib/utils', () => ({
@@ -690,6 +730,82 @@ describe('SpaceIsland — canvas integration (dashboard tab)', () => {
 			const { queryByTestId, getByText } = render(<SpaceIsland spaceId="space-1" />);
 			fireEvent.click(getByText('Workflows'));
 			expect(queryByTestId('canvas-panel')).toBeNull();
+		});
+	});
+});
+
+describe('SpaceIsland — quick action buttons and dialogs', () => {
+	beforeEach(() => {
+		mockLoading = signal(false);
+		mockError = signal(null);
+		mockSpace = signal(makeSpace());
+		mockWorkflows = signal([]);
+		mockAgents = signal([]);
+		mockActiveRuns = signal([]);
+		mockCurrentSpaceTaskId = signal(null);
+		(localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue(null);
+		vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('Create Task dialog', () => {
+		it('dialog is closed by default', () => {
+			const { queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			expect(queryByTestId('space-create-task-dialog')).toBeNull();
+		});
+
+		it('opens SpaceCreateTaskDialog when Create Task button is clicked', () => {
+			const { getByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			fireEvent.click(getByTestId('quick-create-task'));
+			expect(getByTestId('space-create-task-dialog')).toBeTruthy();
+		});
+
+		it('closes SpaceCreateTaskDialog when onClose is called', () => {
+			const { getByTestId, queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			fireEvent.click(getByTestId('quick-create-task'));
+			expect(getByTestId('space-create-task-dialog')).toBeTruthy();
+			fireEvent.click(getByTestId('close-create-task-dialog'));
+			expect(queryByTestId('space-create-task-dialog')).toBeNull();
+		});
+	});
+
+	describe('Start Workflow Run dialog', () => {
+		it('dialog is closed by default', () => {
+			const { queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			expect(queryByTestId('workflow-run-start-dialog')).toBeNull();
+		});
+
+		it('opens WorkflowRunStartDialog when Start Workflow Run button is clicked', () => {
+			const { getByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			fireEvent.click(getByTestId('quick-start-workflow'));
+			expect(getByTestId('workflow-run-start-dialog')).toBeTruthy();
+		});
+
+		it('closes WorkflowRunStartDialog when onClose is called', () => {
+			const { getByTestId, queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			fireEvent.click(getByTestId('quick-start-workflow'));
+			expect(getByTestId('workflow-run-start-dialog')).toBeTruthy();
+			fireEvent.click(getByTestId('close-workflow-run-dialog'));
+			expect(queryByTestId('workflow-run-start-dialog')).toBeNull();
+		});
+	});
+
+	describe('Dialogs are independent', () => {
+		it('opening Create Task does not open Workflow Run dialog', () => {
+			const { getByTestId, queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			fireEvent.click(getByTestId('quick-create-task'));
+			expect(getByTestId('space-create-task-dialog')).toBeTruthy();
+			expect(queryByTestId('workflow-run-start-dialog')).toBeNull();
+		});
+
+		it('opening Start Workflow Run does not open Create Task dialog', () => {
+			const { getByTestId, queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			fireEvent.click(getByTestId('quick-start-workflow'));
+			expect(getByTestId('workflow-run-start-dialog')).toBeTruthy();
+			expect(queryByTestId('space-create-task-dialog')).toBeNull();
 		});
 	});
 });

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -736,19 +736,9 @@ describe('SpaceIsland — canvas integration (dashboard tab)', () => {
 
 describe('SpaceIsland — quick action buttons and dialogs', () => {
 	beforeEach(() => {
-		mockLoading = signal(false);
-		mockError = signal(null);
-		mockSpace = signal(makeSpace());
+		// Override the module-level beforeEach: no workflows → showCanvas is false,
+		// so the SpaceDashboard fallback (with quick-action buttons) is in the DOM.
 		mockWorkflows = signal([]);
-		mockAgents = signal([]);
-		mockActiveRuns = signal([]);
-		mockCurrentSpaceTaskId = signal(null);
-		(localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue(null);
-		vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
-	});
-
-	afterEach(() => {
-		cleanup();
 	});
 
 	describe('Create Task dialog', () => {


### PR DESCRIPTION
## Summary

- SpaceIsland already had `createTaskOpen`/`startWorkflowOpen` state, dialog imports, callbacks wired to `SpaceDashboard`, and both dialogs rendered. This PR adds the missing test coverage for those wired connections.
- **SpaceIsland.test.tsx**: Updated `SpaceDashboard` mock to expose `onCreateTask`/`onStartWorkflow` via testid buttons; added mocks for `SpaceCreateTaskDialog` and `WorkflowRunStartDialog`; added new `SpaceIsland — quick action buttons and dialogs` describe block with 7 tests covering open/close for each dialog and independence.
- **space-task-creation.e2e.ts**: New E2E test with 4 cases — Create Task opens dialog, Start Workflow Run opens dialog, submitting the form creates a task visible in the SpaceDetailPanel, and Cancel dismisses cleanly.

## Test plan

- [x] 55 unit tests pass (`bunx vitest run src/islands/__tests__/SpaceIsland.test.tsx`)
- [x] All pre-commit checks pass (lint, format, typecheck, knip)
- [ ] E2E: `make run-e2e TEST=tests/features/space-task-creation.e2e.ts`