### PR TITLE
feat(neo): add MessageOrigin field to shared types and message pipeline (task 6.1)

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -26,7 +26,7 @@ import { generateUUID, MAX_CONCURRENT_GROUPS_LIMIT, MAX_REVIEW_ROUNDS_LIMIT } fr
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
 import type { Database } from '../../../storage/database';
-import type { MessageHub } from '@neokai/shared';
+import type { MessageHub, MessageOrigin } from '@neokai/shared';
 import type { DaemonHub } from '../../daemon-hub';
 import type { SessionManager } from '../../session-manager';
 import type { SessionFactory } from './task-group-manager';
@@ -407,6 +407,7 @@ export class RoomRuntimeService {
 				}
 
 				const deliveryMode = opts?.deliveryMode ?? 'immediate';
+				const origin: MessageOrigin | undefined = opts?.origin;
 				const state = session.getProcessingState();
 				const isBusy = state.status === 'processing' || state.status === 'queued';
 
@@ -433,7 +434,7 @@ export class RoomRuntimeService {
 				// - otherwise => enqueue now ('enqueued') so worker can start ASAP when idle
 				if (deliveryMode === 'defer' && isBusy) {
 					log.debug(`[injectMessage] Session ${sessionId}: deferring message ${messageId} (busy)`);
-					ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred');
+					ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred', origin);
 					return;
 				}
 
@@ -444,7 +445,7 @@ export class RoomRuntimeService {
 					`[injectMessage] Session ${sessionId}: calling ensureQueryStarted before enqueue`
 				);
 				await session.ensureQueryStarted();
-				ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+				ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
 				log.debug(
 					`[injectMessage] Session ${sessionId}: saved user message ${messageId}, ` +
 						`enqueuing into messageQueue (isRunning=${session.messageQueue.isRunning?.() ?? 'unknown'})`

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -12,7 +12,7 @@
  */
 
 import { generateUUID } from '@neokai/shared';
-import type { Room, RoomGoal, NeoTask, MessageDeliveryMode } from '@neokai/shared';
+import type { Room, RoomGoal, NeoTask, MessageDeliveryMode, MessageOrigin } from '@neokai/shared';
 import type { AgentSessionInit } from '../../agent/agent-session';
 import { Logger } from '../../logger';
 import type {
@@ -56,7 +56,7 @@ export interface SessionFactory {
 	injectMessage(
 		sessionId: string,
 		message: string,
-		opts?: { deliveryMode?: MessageDeliveryMode }
+		opts?: { deliveryMode?: MessageDeliveryMode; origin?: MessageOrigin }
 	): Promise<void>;
 	hasSession(sessionId: string): boolean;
 	/**

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -5,7 +5,7 @@
  * Organized by domain for better maintainability.
  */
 
-import type { MessageHub, MessageDeliveryMode } from '@neokai/shared';
+import type { MessageHub, MessageDeliveryMode, MessageOrigin } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SessionManager } from '../session-manager';
 import type { AuthManager } from '../auth-manager';
@@ -463,7 +463,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			injectMessage: (
 				sessionId: string,
 				message: string,
-				opts?: { deliveryMode?: MessageDeliveryMode }
+				opts?: { deliveryMode?: MessageDeliveryMode; origin?: MessageOrigin }
 			) => deps.sessionManager.injectMessage(sessionId, message, opts),
 			hasSession: (sessionId: string) => deps.sessionManager.getSession(sessionId) !== null,
 			// Remaining SessionFactory methods are not needed for notification injection

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -213,6 +213,12 @@ export class MessagePersistence {
 
 			// 6. Publish to UI immediately only when not currently in-flight.
 			// Busy-turn insertions are shown in the input overlay and rendered in chat once consumed.
+			//
+			// Note: `origin` is intentionally NOT included in the live-push event payload.
+			// `origin` is a DB-level annotation only — the SDK message blob never carries it.
+			// The frontend reads `origin` from the DB (via getSDKMessages) after page load or
+			// on full re-fetch. This means "via Neo" indicators may not appear on first render
+			// of an injected message; they appear after the client re-fetches the message list.
 			if (isManualMode || !isAgentBusy) {
 				try {
 					this.messageHub.event(

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -15,6 +15,7 @@ import type {
 	MessageDeliveryMode,
 	MessageHub,
 	MessageImage,
+	MessageOrigin,
 	ReferenceMetadata,
 	Session,
 } from '@neokai/shared';
@@ -38,6 +39,7 @@ export interface MessagePersistenceData {
 	content: string;
 	images?: MessageImage[];
 	deliveryMode?: MessageDeliveryMode;
+	origin?: MessageOrigin;
 }
 
 export class MessagePersistence {
@@ -123,7 +125,7 @@ export class MessagePersistence {
 	 * 7. Emit 'message.persisted' event for downstream processing
 	 */
 	async persist(data: MessagePersistenceData): Promise<void> {
-		const { sessionId, messageId, content, images, deliveryMode = 'immediate' } = data;
+		const { sessionId, messageId, content, images, deliveryMode = 'immediate', origin } = data;
 
 		const agentSession = await this.sessionCache.getAsync(sessionId);
 		if (!agentSession) {
@@ -207,7 +209,7 @@ export class MessagePersistence {
 						: 'consumed';
 			const shouldDispatchToQuery = !isManualMode && effectiveDeliveryMode === 'immediate';
 
-			const dbMessageId = this.db.saveUserMessage(sessionId, sdkUserMessage, sendStatus);
+			const dbMessageId = this.db.saveUserMessage(sessionId, sdkUserMessage, sendStatus, origin);
 
 			// 6. Publish to UI immediately only when not currently in-flight.
 			// Busy-turn insertions are shown in the input overlay and rendered in chat once consumed.

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -11,7 +11,7 @@
  * - EventBus subscriptions for async message processing
  */
 
-import type { Session, MessageHub, MessageDeliveryMode } from '@neokai/shared';
+import type { Session, MessageHub, MessageDeliveryMode, MessageOrigin } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
@@ -295,13 +295,14 @@ export class SessionManager {
 	async injectMessage(
 		sessionId: string,
 		message: string,
-		opts?: { deliveryMode?: MessageDeliveryMode }
+		opts?: { deliveryMode?: MessageDeliveryMode; origin?: MessageOrigin }
 	): Promise<void> {
 		await this.messagePersistence.persist({
 			sessionId,
 			messageId: generateUUID(),
 			content: message,
 			deliveryMode: opts?.deliveryMode,
+			origin: opts?.origin,
 		});
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -45,6 +45,7 @@ import type {
 	SpaceWorkflowRun,
 	MessageHub,
 	McpServerConfig,
+	MessageOrigin,
 } from '@neokai/shared';
 import type { AppMcpLifecycleManager } from '../../mcp/app-mcp-lifecycle-manager';
 import type { SkillsManager } from '../../skills-manager';
@@ -1231,7 +1232,8 @@ export class TaskAgentManager {
 	private async injectMessageIntoSession(
 		session: AgentSession,
 		message: string,
-		deliveryMode: 'immediate' | 'defer' = 'immediate'
+		deliveryMode: 'immediate' | 'defer' = 'immediate',
+		origin?: MessageOrigin
 	): Promise<void> {
 		const sessionId = session.session.id;
 		const state = session.getProcessingState();
@@ -1264,12 +1266,12 @@ export class TaskAgentManager {
 
 		// defer + busy → persist as deferred for replay after current turn completes
 		if (deliveryMode === 'defer' && isBusy) {
-			this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred');
+			this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred', origin);
 			return;
 		}
 
 		await session.ensureQueryStarted();
-		this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+		this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
 		await session.messageQueue.enqueueWithId(messageId, message);
 	}
 

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -158,7 +158,12 @@ export class Database {
 		limit?: number,
 		before?: number,
 		since?: number
-	): { messages: SDKMessage[]; hasMore: boolean } {
+	): {
+		messages: Array<
+			SDKMessage & { timestamp: number; origin?: MessageOrigin; sendStatus?: string }
+		>;
+		hasMore: boolean;
+	} {
 		return this.sdkMessageRepo.getSDKMessages(sessionId, limit, before, since);
 	}
 

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -13,6 +13,7 @@ import type {
 	RoomGitHubMapping,
 	InboxItem,
 	RoomGoal,
+	MessageOrigin,
 } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import { DatabaseCore } from './database-core';
@@ -148,8 +149,8 @@ export class Database {
 	// SDK Message operations (delegated to SDKMessageRepository)
 	// ============================================================================
 
-	saveSDKMessage(sessionId: string, message: SDKMessage): boolean {
-		return this.sdkMessageRepo.saveSDKMessage(sessionId, message);
+	saveSDKMessage(sessionId: string, message: SDKMessage, origin?: MessageOrigin): boolean {
+		return this.sdkMessageRepo.saveSDKMessage(sessionId, message, origin);
 	}
 
 	getSDKMessages(
@@ -178,9 +179,10 @@ export class Database {
 	saveUserMessage(
 		sessionId: string,
 		message: SDKMessage,
-		sendStatus: SendStatus = 'consumed'
+		sendStatus: SendStatus = 'consumed',
+		origin?: MessageOrigin
 	): string {
-		return this.sdkMessageRepo.saveUserMessage(sessionId, message, sendStatus);
+		return this.sdkMessageRepo.saveUserMessage(sessionId, message, sendStatus, origin);
 	}
 
 	getMessagesByStatus(

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -9,6 +9,7 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
+import type { MessageOrigin } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import { Logger } from '../../lib/logger';
 import type { SQLiteValue } from '../types';
@@ -26,7 +27,7 @@ export class SDKMessageRepository {
 	 * FIX: Enhanced with proper error handling and logging
 	 * Returns true on success, false on failure
 	 */
-	saveSDKMessage(sessionId: string, message: SDKMessage): boolean {
+	saveSDKMessage(sessionId: string, message: SDKMessage, origin?: MessageOrigin): boolean {
 		try {
 			const id = generateUUID();
 			const messageType = message.type;
@@ -34,11 +35,19 @@ export class SDKMessageRepository {
 			const timestamp = new Date().toISOString();
 
 			const stmt = this.db.prepare(
-				`INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp)
-         VALUES (?, ?, ?, ?, ?, ?)`
+				`INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, origin)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
 			);
 
-			stmt.run(id, sessionId, messageType, messageSubtype, JSON.stringify(message), timestamp);
+			stmt.run(
+				id,
+				sessionId,
+				messageType,
+				messageSubtype,
+				JSON.stringify(message),
+				timestamp,
+				origin ?? null
+			);
 			return true;
 		} catch (error) {
 			// Log error but don't throw - prevents stream from dying
@@ -88,7 +97,7 @@ export class SDKMessageRepository {
 	): { messages: SDKMessage[]; hasMore: boolean } {
 		// Step 1: Get top-level messages (excluding subagent messages)
 		// Show user messages that were consumed to SDK, plus any that failed to deliver.
-		let query = `SELECT sdk_message, timestamp, send_status FROM sdk_messages
+		let query = `SELECT sdk_message, timestamp, send_status, origin FROM sdk_messages
       WHERE session_id = ?
         AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
         AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))`;
@@ -113,13 +122,16 @@ export class SDKMessageRepository {
 		const stmt = this.db.prepare(query);
 		const rows = stmt.all(...params) as Record<string, unknown>[];
 
-		// Parse SDK message and inject the timestamp and sendStatus from the database row
+		// Parse SDK message and inject the timestamp, sendStatus, and origin from the database row
 		const messages = rows.map((r) => {
 			const sdkMessage = JSON.parse(r.sdk_message as string) as SDKMessage;
 			const timestamp = new Date(r.timestamp as string).getTime();
 			const extra: Record<string, unknown> = { timestamp };
 			if (r.send_status === 'failed') {
 				extra.sendStatus = 'failed';
+			}
+			if (r.origin != null) {
+				extra.origin = r.origin as MessageOrigin;
 			}
 			return { ...sdkMessage, ...extra } as SDKMessage & { timestamp: number };
 		});
@@ -239,7 +251,8 @@ export class SDKMessageRepository {
 	saveUserMessage(
 		sessionId: string,
 		message: SDKMessage,
-		sendStatus: SendStatus = 'consumed'
+		sendStatus: SendStatus = 'consumed',
+		origin?: MessageOrigin
 	): string {
 		const id = generateUUID();
 		const messageType = message.type;
@@ -247,8 +260,8 @@ export class SDKMessageRepository {
 		const timestamp = new Date().toISOString();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -258,7 +271,8 @@ export class SDKMessageRepository {
 			messageSubtype,
 			JSON.stringify(message),
 			timestamp,
-			sendStatus
+			sendStatus,
+			origin ?? null
 		);
 		return id;
 	}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -81,7 +81,12 @@ export class SDKMessageRepository {
 		limit?: number,
 		before?: number,
 		since?: number
-	): { messages: SDKMessage[]; hasMore: boolean } {
+	): {
+		messages: Array<
+			SDKMessage & { timestamp: number; origin?: MessageOrigin; sendStatus?: string }
+		>;
+		hasMore: boolean;
+	} {
 		return this._getSDKMessagesImpl(sessionId, limit ?? 100, before, since);
 	}
 
@@ -94,7 +99,12 @@ export class SDKMessageRepository {
 		limit: number,
 		before?: number,
 		since?: number
-	): { messages: SDKMessage[]; hasMore: boolean } {
+	): {
+		messages: Array<
+			SDKMessage & { timestamp: number; origin?: MessageOrigin; sendStatus?: string }
+		>;
+		hasMore: boolean;
+	} {
 		// Step 1: Get top-level messages (excluding subagent messages)
 		// Show user messages that were consumed to SDK, plus any that failed to deliver.
 		let query = `SELECT sdk_message, timestamp, send_status, origin FROM sdk_messages
@@ -157,7 +167,7 @@ export class SDKMessageRepository {
 		});
 
 		// Fetch subagent messages that have parent_tool_use_id matching any of the tool use IDs
-		let subagentMessages: SDKMessage[] = [];
+		let subagentMessages: Array<SDKMessage & { timestamp: number }> = [];
 		if (toolUseIds.size > 0) {
 			const placeholders = Array.from(toolUseIds)
 				.map(() => '?')

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -36,8 +36,6 @@ export { runMigration58 } from './migrations';
 // knip-ignore-next-line
 export { runMigration66 } from './migrations';
 // knip-ignore-next-line
-export { runMigration67 } from './migrations';
-// knip-ignore-next-line
 export { runMigration68 } from './migrations';
 
 /**

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -35,6 +35,10 @@ export { runMigration57 } from './migrations';
 export { runMigration58 } from './migrations';
 // knip-ignore-next-line
 export { runMigration66 } from './migrations';
+// knip-ignore-next-line
+export { runMigration67 } from './migrations';
+// knip-ignore-next-line
+export { runMigration68 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -94,6 +98,7 @@ export function createTables(db: BunDatabase): void {
         sdk_message TEXT NOT NULL,
         timestamp TEXT NOT NULL,
         send_status TEXT DEFAULT 'consumed' CHECK(send_status IN ('deferred', 'enqueued', 'consumed', 'failed')),
+        origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'neo', 'system')),
         FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
       )
     `);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -277,6 +277,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 67: Add 'space_chat' to sessions type CHECK constraint.
 	runMigration67(db);
+	// Migration 68: Add 'origin' column to sdk_messages for frontend display of message provenance.
+	// NULL (default) is treated as 'human' by the frontend. 'neo' marks Neo-injected messages.
+	runMigration68(db);
 }
 
 /**
@@ -4448,5 +4451,29 @@ function runMigration67(db: BunDatabase): void {
 		} finally {
 			db.exec('PRAGMA foreign_keys = ON');
 		}
+	}
+}
+
+/**
+ * Migration 68: Add 'origin' column to sdk_messages.
+ *
+ * This is an app-level metadata column alongside the opaque sdk_message blob.
+ * It is NOT part of the SDK message format — room/space agents do not see it.
+ * NULL (default) is treated as 'human' by the frontend.
+ * 'neo' marks messages injected by the Neo global AI agent.
+ * 'system' marks messages injected by the daemon system internally.
+ */
+export function runMigration68(db: BunDatabase): void {
+	if (!tableExists(db, 'sdk_messages')) {
+		return;
+	}
+	try {
+		// Check if column already exists
+		db.prepare(`SELECT origin FROM sdk_messages LIMIT 1`).all();
+	} catch {
+		// Column doesn't exist, add it
+		db.exec(
+			`ALTER TABLE sdk_messages ADD COLUMN origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'neo', 'system'))`
+		);
 	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -4467,11 +4467,10 @@ export function runMigration68(db: BunDatabase): void {
 	if (!tableExists(db, 'sdk_messages')) {
 		return;
 	}
-	try {
-		// Check if column already exists
-		db.prepare(`SELECT origin FROM sdk_messages LIMIT 1`).all();
-	} catch {
-		// Column doesn't exist, add it
+	// Use PRAGMA table_info() to check for the column — consistent with the rest of the codebase
+	const columns = db.prepare(`PRAGMA table_info(sdk_messages)`).all() as Array<{ name: string }>;
+	const hasOrigin = columns.some((col) => col.name === 'origin');
+	if (!hasOrigin) {
 		db.exec(
 			`ALTER TABLE sdk_messages ADD COLUMN origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'neo', 'system'))`
 		);

--- a/packages/daemon/tests/unit/reference-message-persistence.test.ts
+++ b/packages/daemon/tests/unit/reference-message-persistence.test.ts
@@ -303,7 +303,8 @@ describe('MessagePersistence with ReferenceResolver', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.not.objectContaining({ referenceMetadata: expect.anything() }),
-			'consumed'
+			'consumed',
+			undefined
 		);
 	});
 
@@ -336,7 +337,8 @@ describe('MessagePersistence with ReferenceResolver', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.not.objectContaining({ referenceMetadata: expect.anything() }),
-			'consumed'
+			'consumed',
+			undefined
 		);
 	});
 
@@ -388,7 +390,8 @@ describe('MessagePersistence with ReferenceResolver', () => {
 					'@ref{task:t-1}': { type: 'task', id: 't-1', displayText: 'Task one' },
 				},
 			}),
-			'consumed'
+			'consumed',
+			undefined
 		);
 	});
 
@@ -430,7 +433,8 @@ describe('MessagePersistence with ReferenceResolver', () => {
 					},
 				},
 			}),
-			'consumed'
+			'consumed',
+			undefined
 		);
 	});
 
@@ -469,7 +473,8 @@ describe('MessagePersistence with ReferenceResolver', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-5', type: 'user' }),
-			'consumed'
+			'consumed',
+			undefined
 		);
 	});
 
@@ -528,7 +533,8 @@ describe('MessagePersistence with ReferenceResolver', () => {
 					},
 				},
 			}),
-			'consumed'
+			'consumed',
+			undefined
 		);
 	});
 });

--- a/packages/daemon/tests/unit/session/message-persistence.test.ts
+++ b/packages/daemon/tests/unit/session/message-persistence.test.ts
@@ -92,7 +92,8 @@ describe('MessagePersistence', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-1', type: 'user' }),
-			'consumed'
+			'consumed',
+			undefined
 		);
 		expect(messageHubEventSpy).toHaveBeenCalledWith(
 			'state.sdkMessages.delta',
@@ -127,7 +128,8 @@ describe('MessagePersistence', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-2', type: 'user' }),
-			'enqueued'
+			'enqueued',
+			undefined
 		);
 		expect(messageHubEventSpy).not.toHaveBeenCalled();
 		expect(eventBusEmitSpy).toHaveBeenCalledWith(
@@ -153,7 +155,8 @@ describe('MessagePersistence', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-3', type: 'user' }),
-			'deferred'
+			'deferred',
+			undefined
 		);
 		expect(eventBusEmitSpy).not.toHaveBeenCalledWith(
 			'message.persisted',
@@ -174,7 +177,8 @@ describe('MessagePersistence', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-4', type: 'user' }),
-			'consumed'
+			'consumed',
+			undefined
 		);
 		expect(eventBusEmitSpy).toHaveBeenCalledWith(
 			'message.persisted',

--- a/packages/daemon/tests/unit/storage/migrations/migration-68_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-68_test.ts
@@ -1,0 +1,185 @@
+/**
+ * Migration 68 Tests
+ *
+ * Migration 68: Add 'origin' column to sdk_messages.
+ * - NULL default (treated as 'human' by frontend)
+ * - CHECK constraint: NULL or one of ('human', 'neo', 'system')
+ *
+ * Covers:
+ * - origin column is added to an existing sdk_messages table
+ * - origin column defaults to NULL for new rows
+ * - Valid origin values are accepted
+ * - Invalid origin values are rejected by CHECK constraint
+ * - Idempotency: running runMigration68 twice does not error
+ * - Fresh DB via createTables also has origin column
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../../src/storage/schema/index.ts';
+import { runMigration68 } from '../../../../src/storage/schema/migrations.ts';
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+	return rows.some((r) => r.name === column);
+}
+
+/** Create sdk_messages WITHOUT origin column to simulate a pre-migration DB */
+function createLegacySdkMessagesTable(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS sdk_messages (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			message_type TEXT NOT NULL,
+			message_subtype TEXT,
+			sdk_message TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			send_status TEXT DEFAULT 'consumed' CHECK(send_status IN ('deferred', 'enqueued', 'consumed', 'failed'))
+		)
+	`);
+}
+
+describe('Migration 68: Add origin column to sdk_messages', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-68', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = OFF');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('origin column is added to existing sdk_messages table', () => {
+		createLegacySdkMessagesTable(db);
+		expect(columnExists(db, 'sdk_messages', 'origin')).toBe(false);
+
+		runMigration68(db);
+
+		expect(columnExists(db, 'sdk_messages', 'origin')).toBe(true);
+	});
+
+	test('origin column defaults to NULL for new rows after migration', () => {
+		createLegacySdkMessagesTable(db);
+		runMigration68(db);
+
+		db.prepare(
+			`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp)
+			 VALUES (?, ?, ?, ?, ?)`
+		).run('msg-1', 'session-1', 'user', '{}', new Date().toISOString());
+
+		const row = db.prepare(`SELECT origin FROM sdk_messages WHERE id = 'msg-1'`).get() as {
+			origin: string | null;
+		};
+		expect(row.origin).toBeNull();
+	});
+
+	test('origin=neo can be stored after migration', () => {
+		createLegacySdkMessagesTable(db);
+		runMigration68(db);
+
+		db.prepare(
+			`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, origin)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('msg-neo', 'session-1', 'user', '{}', new Date().toISOString(), 'neo');
+
+		const row = db.prepare(`SELECT origin FROM sdk_messages WHERE id = 'msg-neo'`).get() as {
+			origin: string;
+		};
+		expect(row.origin).toBe('neo');
+	});
+
+	test('origin=system can be stored after migration', () => {
+		createLegacySdkMessagesTable(db);
+		runMigration68(db);
+
+		db.prepare(
+			`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, origin)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('msg-sys', 'session-1', 'user', '{}', new Date().toISOString(), 'system');
+
+		const row = db.prepare(`SELECT origin FROM sdk_messages WHERE id = 'msg-sys'`).get() as {
+			origin: string;
+		};
+		expect(row.origin).toBe('system');
+	});
+
+	test('origin=human can be stored after migration', () => {
+		createLegacySdkMessagesTable(db);
+		runMigration68(db);
+
+		db.prepare(
+			`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, origin)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('msg-human', 'session-1', 'user', '{}', new Date().toISOString(), 'human');
+
+		const row = db.prepare(`SELECT origin FROM sdk_messages WHERE id = 'msg-human'`).get() as {
+			origin: string;
+		};
+		expect(row.origin).toBe('human');
+	});
+
+	test('invalid origin value is rejected by CHECK constraint', () => {
+		createLegacySdkMessagesTable(db);
+		runMigration68(db);
+
+		expect(() => {
+			db.prepare(
+				`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, origin)
+				 VALUES (?, ?, ?, ?, ?, ?)`
+			).run('msg-bad', 'session-1', 'user', '{}', new Date().toISOString(), 'robot');
+		}).toThrow();
+	});
+
+	test('runMigration68 is idempotent — running twice does not error', () => {
+		createLegacySdkMessagesTable(db);
+		runMigration68(db);
+		expect(() => runMigration68(db)).not.toThrow();
+		expect(columnExists(db, 'sdk_messages', 'origin')).toBe(true);
+	});
+
+	test('existing rows without origin are NULL after migration', () => {
+		createLegacySdkMessagesTable(db);
+
+		// Insert a row before running migration
+		db.prepare(
+			`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp)
+			 VALUES (?, ?, ?, ?, ?)`
+		).run('old-msg', 'session-1', 'assistant', '{}', new Date().toISOString());
+
+		runMigration68(db);
+
+		// Old row should have NULL origin
+		const row = db.prepare(`SELECT origin FROM sdk_messages WHERE id = 'old-msg'`).get() as {
+			origin: string | null;
+		};
+		expect(row.origin).toBeNull();
+	});
+
+	test('fresh DB via createTables has origin column on sdk_messages', () => {
+		// createTables uses CREATE TABLE IF NOT EXISTS with origin column already in schema
+		createTables(db);
+		expect(columnExists(db, 'sdk_messages', 'origin')).toBe(true);
+	});
+
+	test('runMigration68 is no-op when sdk_messages does not exist', () => {
+		// If sdk_messages doesn't exist, migration should just return without error
+		expect(() => runMigration68(db)).not.toThrow();
+	});
+});

--- a/packages/daemon/tests/unit/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/sdk-message-repository.test.ts
@@ -67,7 +67,8 @@ describe('SDKMessageRepository', () => {
 				message_subtype TEXT,
 				sdk_message TEXT NOT NULL,
 				timestamp TEXT NOT NULL,
-				send_status TEXT
+				send_status TEXT,
+				origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'neo', 'system'))
 			);
 			CREATE INDEX idx_sdk_messages_session ON sdk_messages(session_id);
 			CREATE INDEX idx_sdk_messages_timestamp ON sdk_messages(timestamp);
@@ -669,6 +670,75 @@ describe('SDKMessageRepository', () => {
 			const message = repository.getUserMessageByUuid('session-2', uuid);
 
 			expect(message).toBeUndefined();
+		});
+	});
+
+	describe('origin field persistence and retrieval', () => {
+		it('should save and retrieve origin=neo on saveSDKMessage', () => {
+			const message = createAssistantMessage('Neo response');
+
+			repository.saveSDKMessage('session-1', message, 'neo');
+
+			const { messages } = repository.getSDKMessages('session-1');
+			expect(messages.length).toBe(1);
+			expect((messages[0] as { origin?: string }).origin).toBe('neo');
+		});
+
+		it('should save and retrieve origin=system on saveSDKMessage', () => {
+			const message = createAssistantMessage('System message');
+
+			repository.saveSDKMessage('session-1', message, 'system');
+
+			const { messages } = repository.getSDKMessages('session-1');
+			expect(messages.length).toBe(1);
+			expect((messages[0] as { origin?: string }).origin).toBe('system');
+		});
+
+		it('should not inject origin field when origin is NULL (default human)', () => {
+			const message = createUserMessage('Normal human message');
+
+			repository.saveUserMessage('session-1', message, 'consumed');
+
+			const { messages } = repository.getSDKMessages('session-1');
+			expect(messages.length).toBe(1);
+			expect((messages[0] as { origin?: string }).origin).toBeUndefined();
+		});
+
+		it('should save and retrieve origin=neo on saveUserMessage', () => {
+			const message = createUserMessage('Neo-injected user message');
+
+			repository.saveUserMessage('session-1', message, 'consumed', 'neo');
+
+			const { messages } = repository.getSDKMessages('session-1');
+			expect(messages.length).toBe(1);
+			expect((messages[0] as { origin?: string }).origin).toBe('neo');
+		});
+
+		it('should persist origin independently for each message', async () => {
+			repository.saveUserMessage('session-1', createUserMessage('Human msg'), 'consumed');
+			await new Promise((r) => setTimeout(r, 5));
+			repository.saveUserMessage('session-1', createUserMessage('Neo msg'), 'consumed', 'neo');
+			await new Promise((r) => setTimeout(r, 5));
+			repository.saveSDKMessage('session-1', createAssistantMessage('System msg'), 'system');
+
+			const { messages } = repository.getSDKMessages('session-1');
+			expect(messages.length).toBe(3);
+
+			// Human message — no origin field
+			expect((messages[0] as { origin?: string }).origin).toBeUndefined();
+			// Neo message — origin='neo'
+			expect((messages[1] as { origin?: string }).origin).toBe('neo');
+			// System message — origin='system'
+			expect((messages[2] as { origin?: string }).origin).toBe('system');
+		});
+
+		it('should reject invalid origin values at the DB constraint level', () => {
+			expect(() => {
+				db.prepare(
+					`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, origin)
+					 VALUES (?, ?, ?, ?, ?, ?)`
+				).run('bad-origin-id', 'session-1', 'user', '{}', new Date().toISOString(), 'invalid');
+			}).toThrow();
 		});
 	});
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -609,6 +609,15 @@ export interface MessageImage {
 
 export type MessageDeliveryMode = 'immediate' | 'defer';
 
+/**
+ * Origin of a message — stored as a DB-level annotation on sdk_messages for frontend display.
+ * This is NOT injected into the SDK message JSON blob; room/space agents do not see it.
+ * - 'human': default for user-sent messages (NULL in DB treated as 'human')
+ * - 'neo': message was injected by the Neo global AI agent
+ * - 'system': message was injected by the daemon system internally
+ */
+export type MessageOrigin = 'human' | 'neo' | 'system';
+
 // Tool types
 export interface Tool {
 	name: string;


### PR DESCRIPTION
Add `origin` as a DB-level annotation on `sdk_messages` for frontend display of message provenance ("via Neo" indicators in M9).

**What changed:**
- `MessageOrigin = 'human' | 'neo' | 'system'` type in `packages/shared/src/types.ts`
- Migration 67: nullable `origin TEXT` column on `sdk_messages` with CHECK constraint (backward-compatible, NULL = human)
- `SDKMessageRepository`: `saveSDKMessage`/`saveUserMessage` accept optional `origin`; `getSDKMessages` injects `origin` into returned messages when non-null
- `Database` facade, `MessagePersistenceData`, `MessagePersistence.persist()`, `SessionManager.injectMessage()`, and `SessionFactory` interface all updated to thread `origin` through
- SDK message blob is NOT modified — `origin` is a DB column only

**Tests:** 10 new migration-67 tests + updated sdk-message-repository tests (69 total passing)