### PR TITLE
ci: split online space tests into 2 parallel CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,6 +156,8 @@ jobs:
           - rpc-3
           - rpc-4
           - sdk
+          - space-1
+          - space-2
           - websocket
         include:
           # mock_sdk: true → uses Dev Proxy (NEOKAI_USE_DEV_PROXY) for mocking instead of real API calls.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,8 +283,21 @@ jobs:
           - module: sdk
             test_path: tests/online/sdk
             mock_sdk: true
-          - module: space
-            test_path: tests/online/space
+          # Online space tests - split into 2 parallel jobs to reduce overall CI time.
+          - module: space-1
+            test_path: >-
+              tests/online/space/space-agent-coordination.test.ts
+              tests/online/space/space-edge-cases.test.ts
+              tests/online/space/space-happy-path-code-review.test.ts
+              tests/online/space/space-happy-path-full-pipeline.test.ts
+            mock_sdk: true
+            enable_spaces_agent: true
+          - module: space-2
+            test_path: >-
+              tests/online/space/space-happy-path-plan-to-approve.test.ts
+              tests/online/space/space-happy-path-qa-completion.test.ts
+              tests/online/space/task-agent-lifecycle.test.ts
+              tests/online/space/task-agent-skills.test.ts
             mock_sdk: true
             enable_spaces_agent: true
           - module: websocket

--- a/scripts/validate-online-test-matrix.sh
+++ b/scripts/validate-online-test-matrix.sh
@@ -2,7 +2,7 @@
 # Validates that all daemon online test files are covered by the CI matrix.
 #
 # The CI matrix in .github/workflows/main.yml splits some modules (rpc, room,
-# features) into shards with explicit file lists. This script catches new test
+# features, space) into shards with explicit file lists. This script catches new test
 # files that were added but not included in any shard.
 #
 # NOTE: providers-anthropic-to-codex-bridge shard is disabled (requires OPENAI_API_KEY).
@@ -81,6 +81,17 @@ CROSS_PROVIDER_FILES=(
   cross-provider-model-switch.test.ts
 )
 
+SPACE_FILES=(
+  space-agent-coordination.test.ts
+  space-edge-cases.test.ts
+  space-happy-path-code-review.test.ts
+  space-happy-path-full-pipeline.test.ts
+  space-happy-path-plan-to-approve.test.ts
+  space-happy-path-qa-completion.test.ts
+  task-agent-lifecycle.test.ts
+  task-agent-skills.test.ts
+)
+
 check_split_module() {
   local module_name=$1
   shift
@@ -124,6 +135,7 @@ check_split_module "room" "${ROOM_FILES[@]}"
 check_split_module "features" "${FEATURES_FILES[@]}"
 check_split_module "providers" "${PROVIDERS_FILES[@]}"
 check_split_module "cross-provider" "${CROSS_PROVIDER_FILES[@]}"
+check_split_module "space" "${SPACE_FILES[@]}"
 
 # --- 2. Check for new module directories not in the CI matrix ---
 # These are directories covered by directory-level test_path (auto-discover).


### PR DESCRIPTION
Split the `space` CI job (8 test files, 52 tests) into two parallel jobs:

- **space-1** (24 tests): space-agent-coordination, space-edge-cases, space-happy-path-code-review, space-happy-path-full-pipeline
- **space-2** (28 tests): space-happy-path-plan-to-approve, space-happy-path-qa-completion, task-agent-lifecycle, task-agent-skills

No files were moved — each job lists specific test file paths, matching the existing cross-provider split pattern. All tests are preserved with no duplication.