### PR TITLE
feat(neo): Neo system prompt and NeoAgentManager (task 1.2)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -448,6 +448,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	jobProcessor.start();
 	logInfo('[Daemon] Job queue processor started');
 
+	// TODO(neo-task-1.3): Wire NeoAgentManager here.
+	// Instantiate NeoAgentManager(sessionManager, settingsManager), call provision()
+	// at startup, and call cleanup() in the graceful-shutdown block below.
+	// See packages/daemon/src/lib/neo/neo-agent-manager.ts.
+
 	// On startup: clean up orphaned worktrees (directories missing from disk) and run the TTL reaper.
 	// Both are non-blocking — errors are logged but never propagate to block server start.
 	let reaperTimer: ReturnType<typeof setInterval> | null = null;

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -692,6 +692,18 @@ export class AgentSession
 		};
 	}
 
+	/**
+	 * Apply a runtime model override to in-memory session config only.
+	 * Used by singleton sessions (e.g. Neo) that have a model setting independent
+	 * of the global default. Not persisted to the database.
+	 */
+	setRuntimeModel(model: string): void {
+		this.session.config = {
+			...this.session.config,
+			model,
+		};
+	}
+
 	updateMetadata(updates: Partial<Session>): void {
 		this.sessionConfigHandler.updateMetadata(updates);
 	}

--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -1,0 +1,276 @@
+/**
+ * NeoAgentManager
+ *
+ * Manages the singleton `neo:global` agent session.
+ *
+ * Responsibilities:
+ * - provision(): Create or re-attach the Neo session on daemon startup.
+ *   Includes a startup health-check that destroys and re-provisions stale/
+ *   crashed sessions from a previous daemon run.
+ * - getSession(): Return the active AgentSession instance.
+ * - healthCheck(): Detect crashed or unresponsive sessions and auto-recover.
+ * - cleanup(): Gracefully shut down the Neo session.
+ *
+ * Neo settings (security mode and model) are read from SettingsManager via the
+ * `neoSecurityMode` and `neoModel` keys in GlobalSettings.
+ */
+
+import type { AgentSession } from '../agent/agent-session';
+import { Logger } from '../logger';
+import { buildNeoSystemPrompt, type NeoSecurityMode } from './neo-system-prompt';
+
+export const NEO_SESSION_ID = 'neo:global';
+const NEO_SESSION_TITLE = 'Neo';
+
+/**
+ * Subset of SessionManager used by NeoAgentManager — allows easy mocking in tests.
+ */
+export interface NeoSessionManager {
+	createSession(params: { sessionId: string; sessionType: 'neo'; title: string }): Promise<string>;
+	getSessionAsync(sessionId: string): Promise<AgentSession | null>;
+	deleteSession(sessionId: string): Promise<void>;
+	unregisterSession(sessionId: string): void;
+}
+
+/**
+ * Subset of SettingsManager used by NeoAgentManager — allows easy mocking in tests.
+ */
+export interface NeoSettingsManager {
+	getGlobalSettings(): { neoSecurityMode?: string; neoModel?: string; model?: string };
+}
+
+export class NeoAgentManager {
+	private readonly logger = new Logger('NeoAgentManager');
+	private session: AgentSession | null = null;
+
+	constructor(
+		private readonly sessionManager: NeoSessionManager,
+		private readonly settingsManager: NeoSettingsManager
+	) {}
+
+	// ============================================================================
+	// Public API
+	// ============================================================================
+
+	/**
+	 * Provision the Neo session.
+	 *
+	 * Called once at daemon startup. If a session already exists in the DB
+	 * (daemon restart), it is re-attached rather than re-created. A startup
+	 * health-check runs immediately after re-attach to discard stale/crashed
+	 * sessions from the previous daemon run.
+	 */
+	async provision(): Promise<void> {
+		this.logger.info(`Provisioning Neo session (${NEO_SESSION_ID})`);
+
+		// Try to re-attach an existing session from the DB (daemon restart path).
+		let agentSession = await this.sessionManager.getSessionAsync(NEO_SESSION_ID);
+
+		if (agentSession) {
+			this.logger.info('Re-attached existing Neo session from DB');
+			this.session = agentSession;
+
+			// Startup health-check: the previous daemon run may have left the session
+			// in an inconsistent state (in-flight queries, corrupted state, etc.).
+			// If unhealthy, destroy and re-provision.
+			const healthy = await this.healthCheck({ source: 'startup' });
+			if (!healthy) {
+				this.logger.info('Startup health-check failed — re-provisioning Neo session');
+				await this.destroyAndRecreate();
+			}
+		} else {
+			// First run — create the session.
+			try {
+				await this.sessionManager.createSession({
+					sessionId: NEO_SESSION_ID,
+					sessionType: 'neo',
+					title: NEO_SESSION_TITLE,
+				});
+				this.logger.info('Created new Neo session');
+			} catch (error) {
+				this.logger.error('Failed to create Neo session:', error);
+				throw error;
+			}
+
+			agentSession = await this.sessionManager.getSessionAsync(NEO_SESSION_ID);
+			if (!agentSession) {
+				throw new Error(`Failed to get AgentSession for ${NEO_SESSION_ID} after creation`);
+			}
+			this.session = agentSession;
+		}
+
+		// Apply runtime configuration (system prompt, model).
+		this.applyRuntimeConfig();
+		this.logger.info('Neo session provisioned');
+	}
+
+	/**
+	 * Return the active AgentSession, or null if not yet provisioned.
+	 */
+	getSession(): AgentSession | null {
+		return this.session;
+	}
+
+	/**
+	 * Health-check the Neo session.
+	 *
+	 * Detects:
+	 * - No active session in memory (null).
+	 * - Session that has been stopped or is in an error/corrupted state.
+	 * - In-flight queries from a previous run that will never complete.
+	 *
+	 * Returns `true` if the session is healthy, `false` otherwise.
+	 * When called with `source: 'runtime'`, auto-recovers on failure.
+	 *
+	 * @param opts.source - 'startup' (called from provision) or 'runtime' (called before neo.send).
+	 */
+	async healthCheck(
+		opts: { source: 'startup' | 'runtime' } = { source: 'runtime' }
+	): Promise<boolean> {
+		if (!this.session) {
+			this.logger.warn(`[healthCheck:${opts.source}] No session in memory`);
+			if (opts.source === 'runtime') {
+				await this.destroyAndRecreate();
+			}
+			return false;
+		}
+
+		// Check for in-flight queries that will never complete (leftover from a crash).
+		// If queryPromise is set but queryObject is null the session is in a stuck state.
+		const processingState = this.session.getProcessingState();
+		const isStuck =
+			processingState.status === 'processing' &&
+			this.session.queryPromise !== null &&
+			this.session.queryObject === null;
+
+		if (isStuck) {
+			this.logger.warn(
+				`[healthCheck:${opts.source}] Session has stuck in-flight query — marking unhealthy`
+			);
+			if (opts.source === 'runtime') {
+				await this.destroyAndRecreate();
+			}
+			return false;
+		}
+
+		// Check for sessions that errored out and are no longer accepting messages.
+		// A stopped AgentSession sets its internal cleanup flag which prevents future queries.
+		if (this.session.isCleaningUp()) {
+			this.logger.warn(`[healthCheck:${opts.source}] Session is cleaning up — marking unhealthy`);
+			if (opts.source === 'runtime') {
+				await this.destroyAndRecreate();
+			}
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gracefully shut down the Neo session.
+	 *
+	 * Called during daemon shutdown. Delegates to AgentSession.cleanup().
+	 */
+	async cleanup(): Promise<void> {
+		if (!this.session) return;
+
+		this.logger.info('Cleaning up Neo session');
+		try {
+			await this.session.cleanup();
+		} catch (error) {
+			this.logger.error('Error during Neo session cleanup:', error);
+		}
+		this.session = null;
+	}
+
+	// ============================================================================
+	// Settings accessors
+	// ============================================================================
+
+	/**
+	 * Return the active Neo security mode from GlobalSettings.
+	 * Defaults to 'balanced' if not set.
+	 */
+	getSecurityMode(): NeoSecurityMode {
+		const settings = this.settingsManager.getGlobalSettings();
+		const mode = settings.neoSecurityMode;
+		if (mode === 'conservative' || mode === 'balanced' || mode === 'autonomous') {
+			return mode;
+		}
+		return 'balanced';
+	}
+
+	/**
+	 * Return the Neo-specific model from GlobalSettings.
+	 * Falls back to the global default model, then to 'sonnet'.
+	 */
+	getModel(): string {
+		const settings = this.settingsManager.getGlobalSettings();
+		return settings.neoModel ?? settings.model ?? 'sonnet';
+	}
+
+	// ============================================================================
+	// Internal helpers
+	// ============================================================================
+
+	/**
+	 * Destroy the current Neo session and create a fresh one.
+	 *
+	 * Recovery flow:
+	 * 1. Stop any in-flight SDK queries (cleanup).
+	 * 2. Unregister the session from the session cache.
+	 * 3. Delete the session from DB.
+	 * 4. Create a fresh session and re-attach.
+	 */
+	private async destroyAndRecreate(): Promise<void> {
+		this.logger.info('Destroying and re-creating Neo session');
+
+		// Step 1: Stop any in-flight SDK queries.
+		if (this.session) {
+			try {
+				await this.session.cleanup();
+			} catch (error) {
+				this.logger.warn('Error cleaning up stale Neo session (ignoring):', error);
+			}
+			this.session = null;
+		}
+
+		// Step 2 & 3: Unregister from cache and delete from DB.
+		this.sessionManager.unregisterSession(NEO_SESSION_ID);
+		try {
+			await this.sessionManager.deleteSession(NEO_SESSION_ID);
+		} catch (error) {
+			this.logger.warn('Error deleting stale Neo session from DB (ignoring):', error);
+		}
+
+		// Step 4: Create a fresh session.
+		await this.sessionManager.createSession({
+			sessionId: NEO_SESSION_ID,
+			sessionType: 'neo',
+			title: NEO_SESSION_TITLE,
+		});
+
+		const agentSession = await this.sessionManager.getSessionAsync(NEO_SESSION_ID);
+		if (!agentSession) {
+			throw new Error(`Failed to get AgentSession for ${NEO_SESSION_ID} after recovery`);
+		}
+		this.session = agentSession;
+		this.applyRuntimeConfig();
+		this.logger.info('Neo session re-created successfully');
+	}
+
+	/**
+	 * Apply runtime configuration to the current session.
+	 *
+	 * Sets the system prompt based on the active security mode and the model
+	 * from settings. These values are runtime-only (not persisted to DB).
+	 */
+	private applyRuntimeConfig(): void {
+		if (!this.session) return;
+
+		const securityMode = this.getSecurityMode();
+		const systemPromptText = buildNeoSystemPrompt(securityMode);
+
+		this.session.setRuntimeSystemPrompt(systemPromptText);
+	}
+}

--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -262,15 +262,17 @@ export class NeoAgentManager {
 	/**
 	 * Apply runtime configuration to the current session.
 	 *
-	 * Sets the system prompt based on the active security mode and the model
-	 * from settings. These values are runtime-only (not persisted to DB).
+	 * Sets the system prompt (based on the active security mode) and the model
+	 * override from settings. Both values are in-memory only (not persisted to DB).
 	 */
 	private applyRuntimeConfig(): void {
 		if (!this.session) return;
 
 		const securityMode = this.getSecurityMode();
 		const systemPromptText = buildNeoSystemPrompt(securityMode);
-
 		this.session.setRuntimeSystemPrompt(systemPromptText);
+
+		const model = this.getModel();
+		this.session.setRuntimeModel(model);
 	}
 }

--- a/packages/daemon/src/lib/neo/neo-system-prompt.ts
+++ b/packages/daemon/src/lib/neo/neo-system-prompt.ts
@@ -1,0 +1,139 @@
+/**
+ * Neo System Prompt
+ *
+ * Defines Neo's identity, role, personality, tool categories, security tier
+ * behavior, and activity logging instructions.
+ */
+
+/**
+ * Security mode values for Neo.
+ *
+ * - conservative: Confirm every write action before executing.
+ * - balanced: Auto-execute low-risk reads/settings; confirm medium-risk; require
+ *   explicit phrasing for irreversible/destructive operations.
+ * - autonomous: Execute all actions immediately without confirmation.
+ */
+export type NeoSecurityMode = 'conservative' | 'balanced' | 'autonomous';
+
+/**
+ * Build the system prompt for Neo.
+ *
+ * @param securityMode - Active security tier that shapes confirmation behavior.
+ */
+export function buildNeoSystemPrompt(securityMode: NeoSecurityMode = 'balanced'): string {
+	const securitySection = buildSecuritySection(securityMode);
+
+	return `# Neo — Chief-of-Staff for NeoKai
+
+You are **Neo**, the global AI chief-of-staff for the NeoKai system. You have full visibility into every room, space, session, goal, task, MCP server, and skill in the user's NeoKai instance. Your purpose is to let the user manage their entire AI-assisted development environment through natural conversation — replacing tedious multi-click workflows with a single, powerful interface.
+
+## Identity & Personality
+
+- You are knowledgeable, concise, and action-oriented.
+- You never pad responses with filler. Answer directly, then act.
+- You acknowledge uncertainty honestly and ask for clarification when needed.
+- You remember the context of the current conversation and build on it naturally.
+- You think of yourself as the user's chief-of-staff: proactive, organized, and always aware of the big picture.
+
+## Capabilities
+
+You have access to tools organized into the following categories. Use the most appropriate tool for each request. Prefer targeted reads before broad writes.
+
+### System Queries (read-only)
+Query the live state of any part of the NeoKai system:
+- Rooms, spaces, sessions, goals, tasks, MCP servers, skills, app settings, system info
+
+### Room Operations
+Create, update, or delete rooms; manage goals and tasks within rooms; send messages to room agents; approve or reject tasks; stop or pause scheduled runs.
+
+### Space Operations
+Create, update, or delete spaces; list agents, workflows, and runs; start or cancel workflow runs; approve or reject gates.
+
+### Configuration Management
+Add, update, delete, or toggle MCP servers and skills; update app-wide settings (model, preferences, etc.).
+
+### Meta Operations
+- **undo_last_action** — Reverse the most recent Neo action.
+- **explain** — Show what you are about to do before doing it (relevant when confirming actions in conservative mode).
+
+## Action Attribution
+
+When you take actions on behalf of the user (send a message to a room, create a goal, etc.) those actions appear in the system attributed to the user. Every tool invocation you make is also recorded in the Neo Activity Log — an audit trail the user can review at any time. The Activity Log records the tool name, inputs, outputs, status, and whether the action can be undone.
+
+${securitySection}
+
+## Logging & Audit Trail
+
+Every tool call you make is automatically recorded in the Neo Activity Log. You do not need to explicitly log actions — this happens transparently. The log captures:
+- **Tool name** — which tool was invoked
+- **Input** — the parameters passed to the tool
+- **Output** — the result returned
+- **Status** — success, error, or cancelled
+- **Undoable** — whether the action can be reversed
+
+If you encounter an error during a tool call, report it clearly to the user. Do not silently swallow errors or retry without notifying the user.
+
+## Response Format
+
+- Prefer short, direct answers.
+- When presenting data (rooms, tasks, goals), use concise tables or bullet lists.
+- For action confirmations (when required by the security mode), format the confirmation request as:
+  > **Action:** \`<tool_name>\`
+  > **Target:** \`<target description>\`
+  > **Details:** \`<key parameters>\`
+  > Reply **confirm** or **cancel**.
+- After successfully executing an action, confirm with a one-line "Done." or a brief summary of what changed.
+- After an undo, confirm what was reversed.
+
+## Constraints
+
+- You only operate within the NeoKai system. Do not perform arbitrary shell commands or file operations outside of the provided tools.
+- You do not have access to the internet or external services beyond what MCP servers provide.
+- If a requested action is outside your tool set, say so clearly.
+`;
+}
+
+/**
+ * Build the security-tier section of the system prompt based on the active mode.
+ */
+function buildSecuritySection(mode: NeoSecurityMode): string {
+	if (mode === 'conservative') {
+		return `## Security Mode: Conservative
+
+You must **confirm every write action** before executing it — even low-risk toggles and preference changes. Present a confirmation card for each action and wait for the user to reply "confirm" or "cancel" before proceeding. Never execute a write action without explicit confirmation.
+
+Read-only queries (listing rooms, checking status, etc.) do not require confirmation.`;
+	}
+
+	if (mode === 'autonomous') {
+		return `## Security Mode: Autonomous
+
+Execute all actions immediately without asking for confirmation. Do not present confirmation cards. Clearly report what you did and its outcome after each action.
+
+Use this mode responsibly — irreversible actions (e.g., deleting a room with active tasks, bulk deletions) should be mentioned explicitly in your response so the user is aware.`;
+	}
+
+	// balanced (default)
+	return `## Security Mode: Balanced (default)
+
+Apply a three-tier confirmation model based on action risk:
+
+**Auto-execute (no confirmation needed):**
+- Toggle settings, enable/disable skills or MCP servers
+- Create goals, update preferences, change app settings
+- Read-only queries of any kind
+
+**Confirm before executing (show confirmation card):**
+- Delete a space or room (when no active tasks are present)
+- Cancel a running session or workflow
+- Send a message to a room agent
+- Approve or reject task gates
+- Add or remove MCP servers
+
+**Require explicit user phrasing before proceeding:**
+- Delete a room that has active tasks or sessions
+- Bulk operations affecting multiple rooms/spaces at once
+- Any action the user themselves labels as irreversible
+
+When in doubt, escalate to the next tier and ask for confirmation.`;
+}

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -59,7 +59,8 @@ export interface CreateSessionParams {
 		| 'worker'
 		| 'lobby'
 		| 'spaces_global'
-		| 'space_chat';
+		| 'space_chat'
+		| 'neo';
 	pairedSessionId?: string;
 	parentSessionId?: string;
 	currentTaskId?: string;

--- a/packages/daemon/src/storage/repositories/session-repository.ts
+++ b/packages/daemon/src/storage/repositories/session-repository.ts
@@ -68,7 +68,7 @@ export class SessionRepository {
 	 * @param options.includeArchived - If true, returns all sessions regardless of status.
 	 */
 	listSessions(options?: { status?: string; includeArchived?: boolean }): Session[] {
-		let sql = `SELECT * FROM sessions WHERE type != 'lobby' AND type != 'spaces_global'`;
+		let sql = `SELECT * FROM sessions WHERE type != 'lobby' AND type != 'spaces_global' AND type != 'neo'`;
 		const params: string[] = [];
 
 		if (options?.status) {

--- a/packages/daemon/tests/unit/neo-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/neo-agent-manager.test.ts
@@ -51,6 +51,7 @@ function makeSession(
 		}),
 		isCleaningUp: mock(() => cleaningUp),
 		setRuntimeSystemPrompt: mock(() => undefined),
+		setRuntimeModel: mock(() => undefined),
 		setRuntimeMcpServers: mock(() => undefined),
 		cleanup: mock(async () => undefined),
 		queryPromise,
@@ -382,6 +383,34 @@ describe('NeoAgentManager', () => {
 		test('falls back to sonnet when neither neoModel nor model is set', () => {
 			const mgr = new NeoAgentManager(makeSessionManager(), makeSettingsManager({}));
 			expect(mgr.getModel()).toBe('sonnet');
+		});
+	});
+
+	describe('applyRuntimeConfig()', () => {
+		test('sets model on session from neoModel setting', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(
+				sm,
+				makeSettingsManager({ neoModel: 'claude-opus-4', model: 'sonnet' })
+			);
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeModel as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			expect(calls[0][0]).toBe('claude-opus-4');
+		});
+
+		test('falls back to global model when neoModel is absent', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager({ model: 'haiku' }));
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeModel as ReturnType<typeof mock>).mock.calls;
+			expect(calls[0][0]).toBe('haiku');
 		});
 	});
 

--- a/packages/daemon/tests/unit/neo-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/neo-agent-manager.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Unit tests for NeoAgentManager
+ *
+ * Covers:
+ * - provision(): first-run creates session
+ * - provision(): restart re-attaches existing session and runs startup health-check
+ * - provision(): startup health-check destroys and re-provisions a crashed session
+ * - healthCheck(): healthy session returns true
+ * - healthCheck(): null session returns false and triggers recovery (runtime)
+ * - healthCheck(): stuck in-flight query detected and recovered (runtime)
+ * - healthCheck(): cleaning-up session detected and recovered (runtime)
+ * - cleanup(): delegates to AgentSession.cleanup()
+ * - getSecurityMode(): reads from settings, defaults to 'balanced'
+ * - getModel(): reads neoModel, falls back to model, then 'sonnet'
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { NeoAgentManager, NEO_SESSION_ID } from '../../src/lib/neo/neo-agent-manager';
+import type { NeoSessionManager, NeoSettingsManager } from '../../src/lib/neo/neo-agent-manager';
+import type { AgentSession } from '../../src/lib/agent/agent-session';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ProcessingStatus = 'idle' | 'processing' | 'queued' | 'waiting_for_input' | 'interrupted';
+
+function makeSession(
+	overrides: {
+		processingStatus?: ProcessingStatus;
+		isProcessingPhase?: 'thinking' | 'streaming' | 'initializing' | 'finalizing';
+		queryPromise?: Promise<void> | null;
+		queryObject?: unknown;
+		cleaningUp?: boolean;
+	} = {}
+): AgentSession {
+	const {
+		processingStatus = 'idle',
+		isProcessingPhase = 'thinking',
+		queryPromise = null,
+		queryObject = null,
+		cleaningUp = false,
+	} = overrides;
+
+	return {
+		getProcessingState: mock(() => {
+			if (processingStatus === 'processing') {
+				return { status: 'processing', messageId: 'msg-1', phase: isProcessingPhase };
+			}
+			return { status: processingStatus };
+		}),
+		isCleaningUp: mock(() => cleaningUp),
+		setRuntimeSystemPrompt: mock(() => undefined),
+		setRuntimeMcpServers: mock(() => undefined),
+		cleanup: mock(async () => undefined),
+		queryPromise,
+		queryObject,
+	} as unknown as AgentSession;
+}
+
+function makeSessionManager(
+	opts: {
+		existingSession?: AgentSession | null;
+		/** Sessions to return from successive createSession() calls (one per call, in order). */
+		createdSessions?: Array<AgentSession | null>;
+		/** Convenience alias for a single created session (ignored when createdSessions is set). */
+		createdSession?: AgentSession | null;
+	} = {}
+): NeoSessionManager & {
+	_sessions: Map<string, AgentSession | null>;
+	_createCalls: number;
+	_deleteCalls: number;
+	_unregisterCalls: number;
+} {
+	const sessions = new Map<string, AgentSession | null>();
+	let getCallCount = 0;
+	const sessionQueue: Array<AgentSession | null> = opts.createdSessions
+		? [...opts.createdSessions]
+		: opts.createdSession !== undefined
+			? [opts.createdSession]
+			: [];
+
+	const sm = {
+		_sessions: sessions,
+		_createCalls: 0,
+		_deleteCalls: 0,
+		_unregisterCalls: 0,
+
+		createSession: mock(async (_params: unknown) => {
+			sm._createCalls++;
+			// Pop the next session from the queue; fall back to a fresh makeSession().
+			const next = sessionQueue.length > 0 ? sessionQueue.shift()! : makeSession();
+			sessions.set(NEO_SESSION_ID, next);
+			return NEO_SESSION_ID;
+		}),
+
+		getSessionAsync: mock(async (_id: string): Promise<AgentSession | null> => {
+			// First call seeds with the "existing" (restart) session.
+			if (getCallCount === 0) {
+				getCallCount++;
+				if (opts.existingSession !== undefined) {
+					sessions.set(NEO_SESSION_ID, opts.existingSession);
+				}
+			}
+			return sessions.get(NEO_SESSION_ID) ?? null;
+		}),
+
+		deleteSession: mock(async (_id: string) => {
+			sm._deleteCalls++;
+			sessions.delete(NEO_SESSION_ID);
+		}),
+
+		unregisterSession: mock((_id: string) => {
+			sm._unregisterCalls++;
+		}),
+	};
+
+	return sm;
+}
+
+function makeSettingsManager(
+	settings: { neoSecurityMode?: string; neoModel?: string; model?: string } = {}
+): NeoSettingsManager {
+	return {
+		getGlobalSettings: mock(() => settings),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoAgentManager', () => {
+	describe('provision()', () => {
+		test('first run: creates session when none exists in DB', async () => {
+			const sm = makeSessionManager({ existingSession: null });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			await mgr.provision();
+
+			expect(sm._createCalls).toBe(1);
+			expect(mgr.getSession()).not.toBeNull();
+		});
+
+		test('first run: throws if session cannot be retrieved after creation', async () => {
+			// getSessionAsync always returns null — simulates a DB write failure.
+			const sm = makeSessionManager({ existingSession: null, createdSession: null });
+			// Override to always return null after creation too.
+			sm.getSessionAsync = mock(async () => null);
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			await expect(mgr.provision()).rejects.toThrow(/Failed to get AgentSession/);
+		});
+
+		test('restart: re-attaches existing session without re-creating', async () => {
+			const existingSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({ existingSession });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			await mgr.provision();
+
+			expect(sm._createCalls).toBe(0);
+			expect(mgr.getSession()).toBe(existingSession);
+		});
+
+		test('restart: applies runtime system prompt to re-attached session', async () => {
+			const existingSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({ existingSession });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			await mgr.provision();
+
+			expect(existingSession.setRuntimeSystemPrompt).toHaveBeenCalledTimes(1);
+			const prompt = (existingSession.setRuntimeSystemPrompt as ReturnType<typeof mock>).mock
+				.calls[0][0] as string;
+			expect(typeof prompt).toBe('string');
+			expect(prompt.length).toBeGreaterThan(100);
+		});
+
+		test('startup health-check: destroys and re-provisions a stuck session', async () => {
+			// Session has an in-flight query (stuck state): queryPromise set but queryObject null.
+			const stuckSession = makeSession({
+				processingStatus: 'processing',
+				queryPromise: new Promise(() => undefined), // never resolves
+				queryObject: null,
+			});
+			const freshSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({
+				existingSession: stuckSession,
+				createdSession: freshSession,
+			});
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			await mgr.provision();
+
+			// Should have cleaned up the stuck session and created a fresh one.
+			expect(stuckSession.cleanup).toHaveBeenCalledTimes(1);
+			expect(sm._deleteCalls).toBe(1);
+			expect(sm._createCalls).toBe(1);
+			expect(mgr.getSession()).toBe(freshSession);
+		});
+
+		test('startup health-check: destroys and re-provisions a cleaning-up session', async () => {
+			const stalledSession = makeSession({ cleaningUp: true });
+			const freshSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({
+				existingSession: stalledSession,
+				createdSession: freshSession,
+			});
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			await mgr.provision();
+
+			expect(sm._createCalls).toBe(1);
+			expect(mgr.getSession()).toBe(freshSession);
+		});
+
+		test('startup health-check: passes for a healthy idle session', async () => {
+			const healthySession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({ existingSession: healthySession });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			await mgr.provision();
+
+			// No destroy/recreate — same session remains.
+			expect(sm._createCalls).toBe(0);
+			expect(sm._deleteCalls).toBe(0);
+			expect(mgr.getSession()).toBe(healthySession);
+		});
+	});
+
+	describe('healthCheck()', () => {
+		test('returns true for a healthy idle session', async () => {
+			const session = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({ existingSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			await mgr.provision();
+
+			const healthy = await mgr.healthCheck({ source: 'runtime' });
+
+			expect(healthy).toBe(true);
+		});
+
+		test('returns false and auto-recovers when session is null (runtime)', async () => {
+			const sm = makeSessionManager({ existingSession: null });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			// Provision to create initial session.
+			await mgr.provision();
+			// Force null session to simulate a memory corruption scenario.
+			// @ts-expect-error — accessing private field for test purposes
+			mgr.session = null;
+
+			const healthy = await mgr.healthCheck({ source: 'runtime' });
+
+			expect(healthy).toBe(false);
+			// Recovery should have created a fresh session.
+			expect(sm._createCalls).toBe(2);
+		});
+
+		test('returns false for stuck in-flight query (runtime) and recovers', async () => {
+			const stuckSession = makeSession({
+				processingStatus: 'processing',
+				queryPromise: new Promise(() => undefined),
+				queryObject: null,
+			});
+			const freshSession = makeSession({ processingStatus: 'idle' });
+			// First createSession (from provision) returns stuckSession;
+			// second (from destroyAndRecreate in healthCheck) returns freshSession.
+			const sm = makeSessionManager({
+				existingSession: null,
+				createdSessions: [stuckSession, freshSession],
+			});
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			await mgr.provision();
+
+			const healthy = await mgr.healthCheck({ source: 'runtime' });
+
+			expect(healthy).toBe(false);
+			expect(mgr.getSession()).toBe(freshSession);
+		});
+
+		test('returns false for cleaning-up session (runtime) and recovers', async () => {
+			const stalledSession = makeSession({ cleaningUp: true });
+			const freshSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({
+				existingSession: null,
+				createdSessions: [stalledSession, freshSession],
+			});
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			await mgr.provision();
+
+			const healthy = await mgr.healthCheck({ source: 'runtime' });
+
+			expect(healthy).toBe(false);
+			expect(mgr.getSession()).toBe(freshSession);
+		});
+
+		test('startup source: returns false but does NOT auto-recover', async () => {
+			const stuckSession = makeSession({
+				processingStatus: 'processing',
+				queryPromise: new Promise(() => undefined),
+				queryObject: null,
+			});
+			const sm = makeSessionManager({ existingSession: stuckSession });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			// Manually put the session in place without calling provision() to avoid
+			// the automatic startup health-check recovery.
+			// @ts-expect-error — accessing private field for test purposes
+			mgr.session = stuckSession;
+
+			const healthy = await mgr.healthCheck({ source: 'startup' });
+
+			expect(healthy).toBe(false);
+			// Startup mode does NOT auto-recover — that is the caller's (provision's) job.
+			expect(sm._createCalls).toBe(0);
+			expect(sm._deleteCalls).toBe(0);
+		});
+	});
+
+	describe('cleanup()', () => {
+		test('delegates to AgentSession.cleanup()', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			await mgr.provision();
+
+			await mgr.cleanup();
+
+			expect(session.cleanup).toHaveBeenCalledTimes(1);
+			expect(mgr.getSession()).toBeNull();
+		});
+
+		test('is idempotent when no session is active', async () => {
+			const mgr = new NeoAgentManager(makeSessionManager(), makeSettingsManager());
+
+			// Should not throw.
+			await mgr.cleanup();
+			await mgr.cleanup();
+		});
+	});
+
+	describe('getSecurityMode()', () => {
+		test('returns balanced by default when neoSecurityMode is not set', () => {
+			const mgr = new NeoAgentManager(makeSessionManager(), makeSettingsManager({}));
+			expect(mgr.getSecurityMode()).toBe('balanced');
+		});
+
+		test('returns the configured security mode', () => {
+			const mgr = new NeoAgentManager(
+				makeSessionManager(),
+				makeSettingsManager({ neoSecurityMode: 'conservative' })
+			);
+			expect(mgr.getSecurityMode()).toBe('conservative');
+		});
+
+		test('ignores unknown security mode values and returns balanced', () => {
+			const mgr = new NeoAgentManager(
+				makeSessionManager(),
+				makeSettingsManager({ neoSecurityMode: 'unknown-mode' })
+			);
+			expect(mgr.getSecurityMode()).toBe('balanced');
+		});
+	});
+
+	describe('getModel()', () => {
+		test('returns neoModel when set', () => {
+			const mgr = new NeoAgentManager(
+				makeSessionManager(),
+				makeSettingsManager({ neoModel: 'claude-opus-4', model: 'sonnet' })
+			);
+			expect(mgr.getModel()).toBe('claude-opus-4');
+		});
+
+		test('falls back to global model when neoModel is not set', () => {
+			const mgr = new NeoAgentManager(
+				makeSessionManager(),
+				makeSettingsManager({ model: 'haiku' })
+			);
+			expect(mgr.getModel()).toBe('haiku');
+		});
+
+		test('falls back to sonnet when neither neoModel nor model is set', () => {
+			const mgr = new NeoAgentManager(makeSessionManager(), makeSettingsManager({}));
+			expect(mgr.getModel()).toBe('sonnet');
+		});
+	});
+
+	describe('system prompt', () => {
+		test('includes security mode instructions in provisioned session prompt', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager({ neoSecurityMode: 'autonomous' }));
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeSystemPrompt as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			const prompt = calls[0][0] as string;
+			expect(prompt).toContain('Autonomous');
+		});
+
+		test('uses balanced section when neoSecurityMode is not set', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager({}));
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeSystemPrompt as ReturnType<typeof mock>).mock.calls;
+			const prompt = calls[0][0] as string;
+			expect(prompt).toContain('Balanced');
+		});
+	});
+});

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -158,6 +158,22 @@ export interface GlobalSettings extends SDKSupportedSettings, FileOnlySettings {
 	 * Values are ordered fallback chains, same format as `fallbackModels`.
 	 */
 	modelFallbackMap?: Record<string, FallbackModelEntry[]>;
+
+	// Neo global agent settings
+	/**
+	 * Security mode for Neo's action confirmation behavior.
+	 * - conservative: Confirm every write action.
+	 * - balanced: Auto-execute low-risk, confirm medium-risk, require explicit for irreversible.
+	 * - autonomous: Execute all actions immediately without confirmation.
+	 * Defaults to 'balanced'.
+	 */
+	neoSecurityMode?: 'conservative' | 'balanced' | 'autonomous';
+
+	/**
+	 * Model override for the Neo agent session.
+	 * If unset, Neo inherits the global default model.
+	 */
+	neoModel?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `packages/daemon/src/lib/neo/neo-system-prompt.ts` — builds Neo's identity, personality, tool-category overview, and tiered security-mode instructions (conservative / balanced / autonomous)
- Adds `packages/daemon/src/lib/neo/neo-agent-manager.ts` — `NeoAgentManager` manages the singleton `neo:global` session: `provision()`, `getSession()`, `healthCheck()`, `cleanup()`
- Health check runs at **startup** (detects stale/crashed sessions from previous daemon runs) and at **runtime** (called before `neo.send`); auto-recovers via destroy-and-reprovision
- Adds `neoSecurityMode` and `neoModel` to `GlobalSettings` (shared settings type)
- Adds `'neo'` to `CreateSessionParams.sessionType` union in session lifecycle
- Excludes `neo` sessions from `listSessions()` (alongside `lobby` / `spaces_global`)
- 22 unit tests covering: first-run provision, daemon-restart re-attach, startup health-check recovery, runtime recovery flows, settings accessors, and system prompt content

## Test plan

- [x] `bun test tests/unit/neo-agent-manager.test.ts` — 22/22 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `knip` — no dead code