### PR TITLE
fix(daemon): preserve autonomyLevel when combined with status in goal.update

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -206,7 +206,33 @@ export function setupGoalHandlers(
 		const hasV2Fields = v2Fields.some((f) => f in params.updates);
 
 		let goal: RoomGoal;
-		if (status) {
+		if (hasV2Fields) {
+			// Apply V2 patch fields (title, description, missionType, autonomyLevel,
+			// structuredMetrics, schedule) and priority via patchGoal first.
+			// This ensures autonomyLevel and other V2 fields are never silently dropped
+			// when a status update is present in the same request.
+			const patch: Record<string, unknown> = {};
+			if (priority) patch.priority = priority;
+			for (const f of v2Fields) {
+				if (f in params.updates) patch[f] = params.updates[f as keyof typeof params.updates];
+			}
+			goal = await goalManager.patchGoal(goalId, patch);
+
+			// Apply status/progress if also present in this request.
+			if (status) {
+				goal = await goalManager.updateGoalStatus(
+					goalId,
+					status,
+					progress !== undefined ? { progress } : {}
+				);
+			} else if (progress !== undefined) {
+				goal = await goalManager.updateGoalProgress(
+					goalId,
+					progress,
+					metrics as Record<string, number> | undefined
+				);
+			}
+		} else if (status) {
 			goal = await goalManager.updateGoalStatus(goalId, status, {
 				...(progress !== undefined ? { progress } : {}),
 				...(priority ? { priority } : {}),
@@ -218,15 +244,6 @@ export function setupGoalHandlers(
 				progress,
 				metrics as Record<string, number> | undefined
 			);
-		} else if (hasV2Fields) {
-			// General patch: handles title, description, missionType, autonomyLevel,
-			// structuredMetrics, schedule. Also picks up priority when present alongside V2 fields.
-			const patch: Record<string, unknown> = {};
-			if (priority) patch.priority = priority;
-			for (const f of v2Fields) {
-				if (f in params.updates) patch[f] = params.updates[f as keyof typeof params.updates];
-			}
-			goal = await goalManager.patchGoal(goalId, patch);
 		} else if (priority) {
 			goal = await goalManager.updateGoalPriority(goalId, priority);
 		} else {

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -211,7 +211,7 @@ export function setupGoalHandlers(
 			// structuredMetrics, schedule) and priority via patchGoal first.
 			// This ensures autonomyLevel and other V2 fields are never silently dropped
 			// when a status update is present in the same request.
-			const patch: Record<string, unknown> = {};
+			const patch: Record<string, unknown> = { ...rest };
 			if (priority) patch.priority = priority;
 			for (const f of v2Fields) {
 				if (f in params.updates) patch[f] = params.updates[f as keyof typeof params.updates];
@@ -219,6 +219,8 @@ export function setupGoalHandlers(
 			goal = await goalManager.patchGoal(goalId, patch);
 
 			// Apply status/progress if also present in this request.
+			// Note: two sequential DB writes -- if the second fails, V2 fields are already
+			// persisted but status is not. Both are local SQLite calls so partial failure is unlikely.
 			if (status) {
 				goal = await goalManager.updateGoalStatus(
 					goalId,

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -22,6 +22,8 @@ import {
 	type GoalPriority,
 	type NeoTask,
 	type MissionExecution,
+	type AutonomyLevel,
+	type MissionType,
 } from '@neokai/shared';
 import {
 	setupGoalHandlers,
@@ -686,16 +688,14 @@ describe('Goal RPC Handlers', () => {
 				updatedAt: Date.now(),
 			};
 			const callOrder: string[] = [];
-			(mockGoalManager.patchGoal as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			(mockGoalManager.patchGoal as ReturnType<typeof mock>).mockImplementation(async () => {
 				callOrder.push('patchGoal');
 				return stubGoal;
 			});
-			(mockGoalManager.updateGoalStatus as ReturnType<typeof vi.fn>).mockImplementation(
-				async () => {
-					callOrder.push('updateGoalStatus');
-					return stubGoal;
-				}
-			);
+			(mockGoalManager.updateGoalStatus as ReturnType<typeof mock>).mockImplementation(async () => {
+				callOrder.push('updateGoalStatus');
+				return stubGoal;
+			});
 
 			await handler!(
 				{

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -618,6 +618,101 @@ describe('Goal RPC Handlers', () => {
 			});
 		});
 
+		it('preserves autonomyLevel when status + autonomyLevel are combined in same update', async () => {
+			// Regression: combined status + V2 fields must apply both via patchGoal then updateGoalStatus.
+			// Previously, the status branch ran first and V2 fields (including autonomyLevel) were
+			// silently bypassed — causing semi_autonomous goals to appear unchanged when expected.
+			const handler = messageHubData.handlers.get('goal.update');
+			expect(handler).toBeDefined();
+
+			await handler!(
+				{
+					roomId: 'room-123',
+					goalId: 'goal-123',
+					updates: {
+						status: 'active' as GoalStatus,
+						autonomyLevel: 'semi_autonomous' as AutonomyLevel,
+					},
+				},
+				{}
+			);
+
+			// patchGoal must be called with autonomyLevel first
+			expect(mockGoalManager.patchGoal).toHaveBeenCalledWith('goal-123', {
+				autonomyLevel: 'semi_autonomous',
+			});
+			// updateGoalStatus must be called after to apply the status change
+			expect(mockGoalManager.updateGoalStatus).toHaveBeenCalledWith('goal-123', 'active', {});
+		});
+
+		it('preserves autonomyLevel when status + autonomyLevel + priority are combined', async () => {
+			const handler = messageHubData.handlers.get('goal.update');
+			expect(handler).toBeDefined();
+
+			await handler!(
+				{
+					roomId: 'room-123',
+					goalId: 'goal-123',
+					updates: {
+						status: 'completed' as GoalStatus,
+						autonomyLevel: 'semi_autonomous' as AutonomyLevel,
+						priority: 'high' as GoalPriority,
+					},
+				},
+				{}
+			);
+
+			expect(mockGoalManager.patchGoal).toHaveBeenCalledWith('goal-123', {
+				priority: 'high',
+				autonomyLevel: 'semi_autonomous',
+			});
+			expect(mockGoalManager.updateGoalStatus).toHaveBeenCalledWith('goal-123', 'completed', {});
+		});
+
+		it('applies patchGoal before updateGoalStatus when both V2 fields and status present', async () => {
+			const handler = messageHubData.handlers.get('goal.update');
+			expect(handler).toBeDefined();
+
+			const stubGoal: RoomGoal = {
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Test Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			};
+			const callOrder: string[] = [];
+			(mockGoalManager.patchGoal as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+				callOrder.push('patchGoal');
+				return stubGoal;
+			});
+			(mockGoalManager.updateGoalStatus as ReturnType<typeof vi.fn>).mockImplementation(
+				async () => {
+					callOrder.push('updateGoalStatus');
+					return stubGoal;
+				}
+			);
+
+			await handler!(
+				{
+					roomId: 'room-123',
+					goalId: 'goal-123',
+					updates: {
+						status: 'active' as GoalStatus,
+						missionType: 'measurable' as MissionType,
+						autonomyLevel: 'semi_autonomous' as AutonomyLevel,
+					},
+				},
+				{}
+			);
+
+			expect(callOrder).toEqual(['patchGoal', 'updateGoalStatus']);
+		});
+
 		it('throws error when updates has truly no recognized fields', async () => {
 			const handler = messageHubData.handlers.get('goal.update');
 			expect(handler).toBeDefined();


### PR DESCRIPTION
## Summary

- **Root cause**: In `goal.update` RPC handler, when a request contained both `status` and V2 fields (e.g. `autonomyLevel`, `missionType`), the `if (status)` branch ran first and forwarded V2 fields via `...rest` into `updateGoalStatus`, bypassing `patchGoal`. This silently dropped `autonomyLevel: 'semi_autonomous'`, reverting goals to the DB default `'supervised'`.
- **Fix**: V2 fields now always route through `patchGoal` first; `updateGoalStatus` is called afterward only when `status` is also present in the same request.
- **Tests**: Added 3 regression tests covering combined `status + autonomyLevel`, `status + autonomyLevel + priority`, and call-order verification.