### PR TITLE
feat(web): wire SpaceIsland to render ChatContainer for agent/session views

### DIFF
--- a/packages/e2e/tests/features/space-agent-chat.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-chat.e2e.ts
@@ -1,0 +1,120 @@
+/**
+ * Space Agent Chat E2E Tests
+ *
+ * Verifies that clicking "Space Agent" in SpaceDetailPanel renders ChatContainer
+ * in the ContentPanel, and that navigating away returns to the tab view.
+ *
+ * Setup: creates a space via RPC (infrastructure), navigates to it
+ * Cleanup: deletes the space via RPC in afterEach (infrastructure)
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+
+async function createSpaceViaRpc(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	workspacePath: string,
+	name: string
+): Promise<string> {
+	const id = await page.evaluate(
+		async ({ workspacePath, name }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const space = (await hub.request('space.create', { workspacePath, name })) as {
+				id: string;
+			};
+			return space.id;
+		},
+		{ workspacePath, name }
+	);
+	if (!id) throw new Error('space.create returned no id');
+	return id;
+}
+
+async function deleteSpaceViaRpc(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	spaceId: string
+): Promise<void> {
+	if (!spaceId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('space.delete', { id });
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+test.describe('Space Agent Chat', () => {
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let spaceId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+
+		const workspaceRoot = await getWorkspaceRoot(page);
+		const spaceName = `E2E Agent Chat Test ${Date.now()}`;
+		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
+
+		// Navigate to the space
+		await page.goto(`/space/${spaceId}`);
+		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (spaceId) {
+			await deleteSpaceViaRpc(page, spaceId);
+			spaceId = '';
+		}
+	});
+
+	test('clicking Space Agent in SpaceDetailPanel renders ChatContainer with message input', async ({
+		page,
+	}) => {
+		// The space tab view should be visible by default
+		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
+			timeout: 5000,
+		});
+
+		// Click "Space Agent" in the SpaceDetailPanel (context panel)
+		await page.getByRole('button', { name: 'Space Agent', exact: true }).click();
+
+		// URL should update to the agent route
+		await page.waitForURL(`/space/${spaceId}/agent`, { timeout: 10000 });
+
+		// ChatContainer should render — message input textarea should be visible
+		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
+		await expect(messageInput).toBeVisible({ timeout: 10000 });
+
+		// The tab bar should no longer be visible (ChatContainer replaces it)
+		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).not.toBeVisible();
+	});
+
+	test('navigating back to space base route returns to tab view', async ({ page }) => {
+		// Click Space Agent to enter chat view
+		await page.getByRole('button', { name: 'Space Agent', exact: true }).click();
+		await page.waitForURL(`/space/${spaceId}/agent`, { timeout: 10000 });
+
+		// Message input should be visible
+		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
+		await expect(messageInput).toBeVisible({ timeout: 10000 });
+
+		// Click Dashboard to return to space tab view
+		await page.goto(`/space/${spaceId}`);
+		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
+
+		// Tab bar should be back
+		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
+			timeout: 5000,
+		});
+
+		// Message input should no longer be visible
+		await expect(messageInput).not.toBeVisible();
+	});
+});

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -4,6 +4,8 @@ import {
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
 	currentSpaceIdSignal,
+	currentSpaceSessionIdSignal,
+	currentSpaceTaskIdSignal,
 	navSectionSignal,
 	settingsSectionSignal,
 } from '../lib/signals.ts';
@@ -33,6 +35,8 @@ export default function MainContent() {
 	const roomSessionId = currentRoomSessionIdSignal.value;
 	const roomTaskId = currentRoomTaskIdSignal.value;
 	const spaceId = currentSpaceIdSignal.value;
+	const spaceSessionViewId = currentSpaceSessionIdSignal.value;
+	const spaceTaskViewId = currentSpaceTaskIdSignal.value;
 	const sessionsList = sessions.value;
 	const navSection = navSectionSignal.value;
 	const settingsSection = settingsSectionSignal.value;
@@ -66,7 +70,13 @@ export default function MainContent() {
 	function renderContent() {
 		// Space route takes priority
 		if (spaceId) {
-			return <SpaceIsland spaceId={spaceId} />;
+			return (
+				<SpaceIsland
+					spaceId={spaceId}
+					sessionViewId={spaceSessionViewId}
+					taskViewId={spaceTaskViewId}
+				/>
+			);
 		}
 
 		// /spaces route: show standalone spaces page (no sidebar)

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -16,7 +16,6 @@
 
 import { useState, useEffect } from 'preact/hooks';
 import { spaceStore } from '../lib/space-store';
-import { currentSpaceTaskIdSignal } from '../lib/signals';
 import { navigateToSpace, navigateToSpaceTask } from '../lib/router';
 import { SpaceDashboard } from '../components/space/SpaceDashboard';
 import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
@@ -28,10 +27,13 @@ import { WorkflowCanvas } from '../components/space/WorkflowCanvas';
 import { SpaceSettings } from '../components/space/SpaceSettings';
 import { SpaceCreateTaskDialog } from '../components/space/SpaceCreateTaskDialog';
 import { WorkflowRunStartDialog } from '../components/space/WorkflowRunStartDialog';
+import ChatContainer from './ChatContainer';
 import { cn } from '../lib/utils';
 
 interface SpaceIslandProps {
 	spaceId: string;
+	sessionViewId?: string | null; // When set, show this session content instead of space tabs
+	taskViewId?: string | null; // When set, show SpaceTaskPane for this task
 }
 
 type SpaceTab = 'dashboard' | 'agents' | 'workflows' | 'settings';
@@ -59,7 +61,7 @@ function readStoredEditorMode(): EditorMode {
 	}
 }
 
-export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
+export default function SpaceIsland({ spaceId, sessionViewId, taskViewId }: SpaceIslandProps) {
 	const [activeTab, setActiveTab] = useState<SpaceTab>('dashboard');
 	/** null = list view; 'new' = create editor; <id> = edit editor */
 	const [workflowEditId, setWorkflowEditId] = useState<string | null>(null);
@@ -68,9 +70,6 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 	const [startWorkflowOpen, setStartWorkflowOpen] = useState(false);
 	const loading = spaceStore.loading.value;
 	const error = spaceStore.error.value;
-
-	// Derive active task ID from the global signal
-	const activeTaskId = currentSpaceTaskIdSignal.value;
 
 	// Canvas mode: pick the first active run (runtime) or first workflow (template)
 	const activeRuns = spaceStore.activeRuns.value;
@@ -156,6 +155,11 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 			: undefined;
 
 	const showWorkflowEditor = activeTab === 'workflows' && workflowEditId !== null;
+
+	// Session view: render ChatContainer instead of tabs
+	if (sessionViewId) {
+		return <ChatContainer key={sessionViewId} sessionId={sessionViewId} />;
+	}
 
 	return (
 		<div class="flex-1 flex overflow-hidden bg-dark-900">
@@ -303,13 +307,13 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 				</div>
 			</div>
 
-			{/* Right column — task detail pane / chat panel (conditionally shown) */}
-			{activeTaskId && (
+			{/* Right column — task detail pane (conditionally shown) */}
+			{taskViewId && (
 				<div
 					class="hidden md:flex w-80 flex-shrink-0 border-l border-dark-700 overflow-hidden flex-col"
 					data-testid="space-task-pane"
 				>
-					<SpaceTaskPane taskId={activeTaskId} onClose={handleTaskPaneClose} />
+					<SpaceTaskPane taskId={taskViewId} onClose={handleTaskPaneClose} />
 				</div>
 			)}
 

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -70,7 +70,6 @@ let mockSpace = signal<Space | null>(null);
 let mockWorkflows = signal<SpaceWorkflow[]>([]);
 let mockAgents = signal<SpaceAgent[]>([]);
 let mockActiveRuns = signal<SpaceWorkflowRun[]>([]);
-let mockCurrentSpaceTaskId = signal<string | null>(null);
 
 const mockSelectSpace = vi.fn().mockResolvedValue(undefined);
 
@@ -209,6 +208,11 @@ vi.mock('../../components/space/SpaceAgentList', () => ({
 vi.mock('../../components/space/SpaceSettings', () => ({
 	SpaceSettings: () => <div data-testid="space-settings" />,
 }));
+vi.mock('../ChatContainer', () => ({
+	default: ({ sessionId }: { sessionId: string }) => (
+		<div data-testid="chat-container" data-session-id={sessionId} />
+	),
+}));
 
 vi.mock('../../lib/space-store', () => ({
 	get spaceStore() {
@@ -225,9 +229,6 @@ vi.mock('../../lib/space-store', () => ({
 }));
 
 vi.mock('../../lib/signals', () => ({
-	get currentSpaceTaskIdSignal() {
-		return mockCurrentSpaceTaskId;
-	},
 	currentSessionIdSignal: signal(null),
 	slashCommandsSignal: signal([]),
 }));
@@ -336,7 +337,6 @@ beforeEach(() => {
 	mockWorkflows = signal([makeWorkflow()]);
 	mockAgents = signal([]);
 	mockActiveRuns = signal([]);
-	mockCurrentSpaceTaskId = signal(null);
 	capturedWorkflowEditorProps = {};
 	capturedVisualEditorProps = {};
 	capturedCanvasProps = {};
@@ -796,6 +796,64 @@ describe('SpaceIsland — quick action buttons and dialogs', () => {
 			fireEvent.click(getByTestId('quick-start-workflow'));
 			expect(getByTestId('workflow-run-start-dialog')).toBeTruthy();
 			expect(queryByTestId('space-create-task-dialog')).toBeNull();
+		});
+	});
+});
+
+describe('SpaceIsland — content priority chain', () => {
+	describe('sessionViewId prop', () => {
+		it('renders ChatContainer when sessionViewId is set', () => {
+			const { getByTestId } = render(<SpaceIsland spaceId="space-1" sessionViewId="session-abc" />);
+			expect(getByTestId('chat-container')).toBeTruthy();
+		});
+
+		it('passes sessionId to ChatContainer', () => {
+			const { getByTestId } = render(<SpaceIsland spaceId="space-1" sessionViewId="session-abc" />);
+			expect(getByTestId('chat-container').getAttribute('data-session-id')).toBe('session-abc');
+		});
+
+		it('does not render tab bar when sessionViewId is set', () => {
+			const { queryByText } = render(<SpaceIsland spaceId="space-1" sessionViewId="session-abc" />);
+			expect(queryByText('Dashboard')).toBeNull();
+		});
+
+		it('renders tab view when sessionViewId is null', () => {
+			const { getByText, queryByTestId } = render(
+				<SpaceIsland spaceId="space-1" sessionViewId={null} />
+			);
+			expect(getByText('Dashboard')).toBeTruthy();
+			expect(queryByTestId('chat-container')).toBeNull();
+		});
+
+		it('renders tab view when neither sessionViewId nor taskViewId is set', () => {
+			const { getByText, queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
+			expect(getByText('Dashboard')).toBeTruthy();
+			expect(queryByTestId('chat-container')).toBeNull();
+		});
+	});
+
+	describe('taskViewId prop', () => {
+		it('shows SpaceTaskPane when taskViewId is set', () => {
+			const { getByTestId } = render(<SpaceIsland spaceId="space-1" taskViewId="task-xyz" />);
+			expect(getByTestId('space-task-pane')).toBeTruthy();
+		});
+
+		it('still shows tab bar when only taskViewId is set', () => {
+			const { getByText } = render(<SpaceIsland spaceId="space-1" taskViewId="task-xyz" />);
+			expect(getByText('Dashboard')).toBeTruthy();
+		});
+
+		it('does not show SpaceTaskPane when taskViewId is null', () => {
+			const { queryByTestId } = render(<SpaceIsland spaceId="space-1" taskViewId={null} />);
+			expect(queryByTestId('space-task-pane')).toBeNull();
+		});
+
+		it('sessionViewId takes priority over taskViewId — renders ChatContainer', () => {
+			const { getByTestId, queryByTestId } = render(
+				<SpaceIsland spaceId="space-1" sessionViewId="session-abc" taskViewId="task-xyz" />
+			);
+			expect(getByTestId('chat-container')).toBeTruthy();
+			expect(queryByTestId('space-task-pane')).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
Wire `SpaceIsland` to the content priority pattern established in `Room.tsx`.

## Changes

- **SpaceIsland**: accepts `sessionViewId` and `taskViewId` props; renders `ChatContainer` when `sessionViewId` is set, `SpaceTaskPane` side-pane when `taskViewId` is set, otherwise the existing tab view. Removes direct signal reads from component body.
- **MainContent**: derives `spaceSessionViewId`/`spaceTaskViewId` from `currentSpaceSessionIdSignal`/`currentSpaceTaskIdSignal` and passes them as props to `SpaceIsland`.
- **Tests**: 10 new unit tests covering ChatContainer rendering, tab view fallback, and task pane; E2E test for clicking "Space Agent" and verifying ChatContainer + message input appear.