### PR TITLE
feat(neo): security tier system (task 3.1)

### DIFF
--- a/packages/daemon/src/lib/neo/neo-system-prompt.ts
+++ b/packages/daemon/src/lib/neo/neo-system-prompt.ts
@@ -5,15 +5,9 @@
  * behavior, and activity logging instructions.
  */
 
-/**
- * Security mode values for Neo.
- *
- * - conservative: Confirm every write action before executing.
- * - balanced: Auto-execute low-risk reads/settings; confirm medium-risk; require
- *   explicit phrasing for irreversible/destructive operations.
- * - autonomous: Execute all actions immediately without confirmation.
- */
-export type NeoSecurityMode = 'conservative' | 'balanced' | 'autonomous';
+// NeoSecurityMode is canonical in security-tier.ts; re-exported here for stable import paths.
+import type { NeoSecurityMode } from './security-tier';
+export type { NeoSecurityMode };
 
 /**
  * Build the system prompt for Neo.

--- a/packages/daemon/src/lib/neo/security-tier.ts
+++ b/packages/daemon/src/lib/neo/security-tier.ts
@@ -21,6 +21,9 @@ export const ActionClassification: Record<string, ActionRiskLevel> = {
 	update_app_settings: 'low',
 	update_room_settings: 'low',
 	update_space: 'low',
+	create_room: 'low',
+	create_space: 'low',
+	start_workflow_run: 'low',
 	create_task: 'low',
 	update_task: 'low',
 	set_task_status: 'low',
@@ -71,6 +74,8 @@ export function shouldAutoExecute(mode: NeoSecurityMode, riskLevel: ActionRiskLe
 			return riskLevel === 'low';
 		case 'autonomous':
 			return true;
+		default:
+			return false;
 	}
 }
 
@@ -104,21 +109,21 @@ export type PendingAction = {
 };
 
 export class PendingActionStore {
-	private readonly store = new Map<string, PendingAction>();
+	private readonly map = new Map<string, PendingAction>();
 
 	/** Persist an action and return its generated ID. */
-	store_action(action: Omit<PendingAction, 'createdAt'>): string {
+	store(action: Omit<PendingAction, 'createdAt'>): string {
 		const id = randomUUID();
-		this.store.set(id, { ...action, createdAt: Date.now() });
+		this.map.set(id, { ...action, createdAt: Date.now() });
 		return id;
 	}
 
 	/** Retrieve a pending action by ID, returning undefined if expired or missing. */
 	retrieve(actionId: string): PendingAction | undefined {
-		const action = this.store.get(actionId);
+		const action = this.map.get(actionId);
 		if (!action) return undefined;
 		if (Date.now() - action.createdAt > PENDING_ACTION_TTL_MS) {
-			this.store.delete(actionId);
+			this.map.delete(actionId);
 			return undefined;
 		}
 		return action;
@@ -126,22 +131,22 @@ export class PendingActionStore {
 
 	/** Remove a pending action (after execution or cancellation). */
 	remove(actionId: string): void {
-		this.store.delete(actionId);
+		this.map.delete(actionId);
 	}
 
 	/** Remove all expired entries. */
 	cleanup(): void {
 		const now = Date.now();
-		for (const [id, action] of this.store) {
+		for (const [id, action] of this.map) {
 			if (now - action.createdAt > PENDING_ACTION_TTL_MS) {
-				this.store.delete(id);
+				this.map.delete(id);
 			}
 		}
 	}
 
 	/** Current number of pending actions (including potentially expired ones). */
 	get size(): number {
-		return this.store.size;
+		return this.map.size;
 	}
 }
 

--- a/packages/daemon/src/lib/neo/security-tier.ts
+++ b/packages/daemon/src/lib/neo/security-tier.ts
@@ -1,0 +1,190 @@
+import { randomUUID } from 'crypto';
+
+export type NeoSecurityMode = 'conservative' | 'balanced' | 'autonomous';
+export type ActionRiskLevel = 'low' | 'medium' | 'high';
+
+/**
+ * Hardcoded mapping of Neo tool names to risk levels.
+ *
+ * Low:    toggles, enables/disables, creates, preference updates — easy to reverse
+ * Medium: deletes (recoverable), cancels, sends messages, approvals — requires confirmation
+ * High:   irreversible deletes with active tasks, bulk ops — must be explicit
+ */
+export const ActionClassification: Record<string, ActionRiskLevel> = {
+	// ── Low risk ──────────────────────────────────────────────────────────────
+	toggle_mcp_server: 'low',
+	toggle_skill: 'low',
+	enable_skill: 'low',
+	disable_skill: 'low',
+	create_goal: 'low',
+	update_goal: 'low',
+	update_app_settings: 'low',
+	update_room_settings: 'low',
+	update_space: 'low',
+	create_task: 'low',
+	update_task: 'low',
+	set_task_status: 'low',
+	set_goal_status: 'low',
+	pause_schedule: 'low',
+	resume_schedule: 'low',
+
+	// ── Medium risk ───────────────────────────────────────────────────────────
+	delete_space: 'medium',
+	delete_room: 'medium',
+	delete_goal: 'medium',
+	cancel_workflow_run: 'medium',
+	stop_session: 'medium',
+	send_message_to_room: 'medium',
+	send_message_to_task: 'medium',
+	approve_task: 'medium',
+	reject_task: 'medium',
+	approve_gate: 'medium',
+	reject_gate: 'medium',
+	add_mcp_server: 'medium',
+	update_mcp_server: 'medium',
+	delete_mcp_server: 'medium',
+	add_skill: 'medium',
+	update_skill: 'medium',
+	delete_skill: 'medium',
+
+	// ── High risk ─────────────────────────────────────────────────────────────
+	delete_room_with_active_tasks: 'high',
+	bulk_delete_rooms: 'high',
+	bulk_delete_spaces: 'high',
+	bulk_cancel_sessions: 'high',
+	bulk_delete_goals: 'high',
+	undo_last_action: 'high',
+};
+
+/**
+ * Returns true when the action should be executed without asking the user.
+ *
+ * Conservative  → nothing auto-executes
+ * Balanced      → low auto-executes; medium/high require confirmation
+ * Autonomous    → everything auto-executes
+ */
+export function shouldAutoExecute(mode: NeoSecurityMode, riskLevel: ActionRiskLevel): boolean {
+	switch (mode) {
+		case 'conservative':
+			return false;
+		case 'balanced':
+			return riskLevel === 'low';
+		case 'autonomous':
+			return true;
+	}
+}
+
+/**
+ * Returns true when the tool requires an explicit confirmation step before execution.
+ * Unknown tools default to 'medium' risk.
+ */
+export function getConfirmationRequired(mode: NeoSecurityMode, toolName: string): boolean {
+	const risk = ActionClassification[toolName] ?? 'medium';
+	return !shouldAutoExecute(mode, risk);
+}
+
+export type NeoActionResult = {
+	success: boolean;
+	confirmationRequired?: boolean;
+	pendingActionId?: string;
+	actionDescription?: string;
+	riskLevel?: ActionRiskLevel;
+	result?: unknown;
+	error?: string;
+};
+
+// ── Pending Action Store ──────────────────────────────────────────────────────
+
+const PENDING_ACTION_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export type PendingAction = {
+	toolName: string;
+	input: Record<string, unknown>;
+	createdAt: number;
+};
+
+export class PendingActionStore {
+	private readonly store = new Map<string, PendingAction>();
+
+	/** Persist an action and return its generated ID. */
+	store_action(action: Omit<PendingAction, 'createdAt'>): string {
+		const id = randomUUID();
+		this.store.set(id, { ...action, createdAt: Date.now() });
+		return id;
+	}
+
+	/** Retrieve a pending action by ID, returning undefined if expired or missing. */
+	retrieve(actionId: string): PendingAction | undefined {
+		const action = this.store.get(actionId);
+		if (!action) return undefined;
+		if (Date.now() - action.createdAt > PENDING_ACTION_TTL_MS) {
+			this.store.delete(actionId);
+			return undefined;
+		}
+		return action;
+	}
+
+	/** Remove a pending action (after execution or cancellation). */
+	remove(actionId: string): void {
+		this.store.delete(actionId);
+	}
+
+	/** Remove all expired entries. */
+	cleanup(): void {
+		const now = Date.now();
+		for (const [id, action] of this.store) {
+			if (now - action.createdAt > PENDING_ACTION_TTL_MS) {
+				this.store.delete(id);
+			}
+		}
+	}
+
+	/** Current number of pending actions (including potentially expired ones). */
+	get size(): number {
+		return this.store.size;
+	}
+}
+
+// ── Meta-tool definitions ─────────────────────────────────────────────────────
+
+export type ConfirmActionInput = { actionId: string };
+export type CancelActionInput = { actionId: string };
+
+/**
+ * Builds the confirm_action meta-tool handler bound to a store instance.
+ * The executor callback is responsible for actually running the stored tool.
+ */
+export function makeConfirmActionTool(
+	pendingStore: PendingActionStore,
+	executor: (toolName: string, input: Record<string, unknown>) => Promise<unknown>
+) {
+	return async (input: ConfirmActionInput): Promise<NeoActionResult> => {
+		const action = pendingStore.retrieve(input.actionId);
+		if (!action) {
+			return { success: false, error: 'Action not found or expired' };
+		}
+		pendingStore.remove(input.actionId);
+		try {
+			const result = await executor(action.toolName, action.input);
+			return { success: true, result };
+		} catch (err) {
+			return { success: false, error: err instanceof Error ? err.message : String(err) };
+		}
+	};
+}
+
+/**
+ * Builds the cancel_action meta-tool handler bound to a store instance.
+ */
+export function makeCancelActionTool(pendingStore: PendingActionStore) {
+	return (input: CancelActionInput): NeoActionResult => {
+		const existed = pendingStore.retrieve(input.actionId) !== undefined;
+		pendingStore.remove(input.actionId);
+		return {
+			success: true,
+			actionDescription: existed
+				? 'Action cancelled'
+				: 'Action not found (may have already expired)',
+		};
+	};
+}

--- a/packages/daemon/tests/unit/neo-security-tier.test.ts
+++ b/packages/daemon/tests/unit/neo-security-tier.test.ts
@@ -91,6 +91,18 @@ describe('ActionClassification', () => {
 		expect(ActionClassification['update_app_settings']).toBe('low');
 	});
 
+	it('create_room is low risk', () => {
+		expect(ActionClassification['create_room']).toBe('low');
+	});
+
+	it('create_space is low risk', () => {
+		expect(ActionClassification['create_space']).toBe('low');
+	});
+
+	it('start_workflow_run is low risk', () => {
+		expect(ActionClassification['start_workflow_run']).toBe('low');
+	});
+
 	it('delete_room is medium risk', () => {
 		expect(ActionClassification['delete_room']).toBe('medium');
 	});
@@ -129,7 +141,7 @@ describe('PendingActionStore', () => {
 	});
 
 	it('stores and retrieves a pending action', () => {
-		const id = store.store_action({ toolName: 'delete_room', input: { roomId: 'r1' } });
+		const id = store.store({ toolName: 'delete_room', input: { roomId: 'r1' } });
 		const action = store.retrieve(id);
 		expect(action).toBeDefined();
 		expect(action!.toolName).toBe('delete_room');
@@ -141,18 +153,18 @@ describe('PendingActionStore', () => {
 	});
 
 	it('remove deletes the action', () => {
-		const id = store.store_action({ toolName: 'toggle_skill', input: {} });
+		const id = store.store({ toolName: 'toggle_skill', input: {} });
 		store.remove(id);
 		expect(store.retrieve(id)).toBeUndefined();
 	});
 
 	it('cleanup removes expired entries', () => {
 		// Manually backdate the stored action by injecting with past createdAt
-		const id = store.store_action({ toolName: 'toggle_skill', input: {} });
+		const id = store.store({ toolName: 'toggle_skill', input: {} });
 
 		// Tamper with internal state to simulate expiry (cast to any for testing)
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const internal = (store as any).store as Map<
+		const internal = (store as any).map as Map<
 			string,
 			{ toolName: string; input: unknown; createdAt: number }
 		>;
@@ -168,9 +180,9 @@ describe('PendingActionStore', () => {
 	});
 
 	it('retrieve rejects expired action and removes it', () => {
-		const id = store.store_action({ toolName: 'toggle_skill', input: {} });
+		const id = store.store({ toolName: 'toggle_skill', input: {} });
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const internal = (store as any).store as Map<
+		const internal = (store as any).map as Map<
 			string,
 			{ toolName: string; input: unknown; createdAt: number }
 		>;
@@ -186,8 +198,8 @@ describe('PendingActionStore', () => {
 
 	it('size reflects stored action count', () => {
 		expect(store.size).toBe(0);
-		store.store_action({ toolName: 'toggle_skill', input: {} });
-		store.store_action({ toolName: 'delete_room', input: {} });
+		store.store({ toolName: 'toggle_skill', input: {} });
+		store.store({ toolName: 'delete_room', input: {} });
 		expect(store.size).toBe(2);
 	});
 });
@@ -202,7 +214,7 @@ describe('makeConfirmActionTool', () => {
 	});
 
 	it('executes the stored action and removes it from the store', async () => {
-		const id = store.store_action({
+		const id = store.store({
 			toolName: 'create_goal',
 			input: { roomId: 'r1', title: 'My Goal' },
 		});
@@ -226,7 +238,7 @@ describe('makeConfirmActionTool', () => {
 	});
 
 	it('returns error when executor throws', async () => {
-		const id = store.store_action({ toolName: 'delete_room', input: {} });
+		const id = store.store({ toolName: 'delete_room', input: {} });
 		const executor = async () => {
 			throw new Error('Permission denied');
 		};
@@ -244,7 +256,7 @@ describe('makeConfirmActionTool', () => {
 			captured.push({ toolName, input });
 			return {};
 		};
-		const id = store.store_action({ toolName: 'approve_gate', input: { gateId: 'g42' } });
+		const id = store.store({ toolName: 'approve_gate', input: { gateId: 'g42' } });
 		const confirm = makeConfirmActionTool(store, executor);
 		await confirm({ actionId: id });
 		expect(captured).toHaveLength(1);
@@ -263,7 +275,7 @@ describe('makeCancelActionTool', () => {
 	});
 
 	it('removes a pending action and returns success', () => {
-		const id = store.store_action({ toolName: 'delete_room', input: {} });
+		const id = store.store({ toolName: 'delete_room', input: {} });
 		const cancel = makeCancelActionTool(store);
 		const result = cancel({ actionId: id });
 		expect(result.success).toBe(true);

--- a/packages/daemon/tests/unit/neo-security-tier.test.ts
+++ b/packages/daemon/tests/unit/neo-security-tier.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, beforeEach } from 'bun:test';
+import {
+	type ActionRiskLevel,
+	type NeoSecurityMode,
+	ActionClassification,
+	PendingActionStore,
+	getConfirmationRequired,
+	makeCancelActionTool,
+	makeConfirmActionTool,
+	shouldAutoExecute,
+} from '../../src/lib/neo/security-tier';
+
+// ── shouldAutoExecute ─────────────────────────────────────────────────────────
+
+describe('shouldAutoExecute', () => {
+	const modes: NeoSecurityMode[] = ['conservative', 'balanced', 'autonomous'];
+	const levels: ActionRiskLevel[] = ['low', 'medium', 'high'];
+
+	// Full 3×3 matrix
+	const matrix: Record<NeoSecurityMode, Record<ActionRiskLevel, boolean>> = {
+		conservative: { low: false, medium: false, high: false },
+		balanced: { low: true, medium: false, high: false },
+		autonomous: { low: true, medium: true, high: true },
+	};
+
+	for (const mode of modes) {
+		for (const level of levels) {
+			it(`${mode} + ${level} → ${matrix[mode][level]}`, () => {
+				expect(shouldAutoExecute(mode, level)).toBe(matrix[mode][level]);
+			});
+		}
+	}
+});
+
+// ── getConfirmationRequired ───────────────────────────────────────────────────
+
+describe('getConfirmationRequired', () => {
+	it('conservative mode always requires confirmation for low risk', () => {
+		expect(getConfirmationRequired('conservative', 'toggle_skill')).toBe(true);
+	});
+
+	it('conservative mode requires confirmation for high risk', () => {
+		expect(getConfirmationRequired('conservative', 'bulk_delete_rooms')).toBe(true);
+	});
+
+	it('balanced mode does NOT require confirmation for low risk tool', () => {
+		expect(getConfirmationRequired('balanced', 'create_goal')).toBe(false);
+	});
+
+	it('balanced mode requires confirmation for medium risk tool', () => {
+		expect(getConfirmationRequired('balanced', 'delete_room')).toBe(true);
+	});
+
+	it('balanced mode requires confirmation for high risk tool', () => {
+		expect(getConfirmationRequired('balanced', 'bulk_delete_rooms')).toBe(true);
+	});
+
+	it('autonomous mode never requires confirmation', () => {
+		expect(getConfirmationRequired('autonomous', 'bulk_delete_rooms')).toBe(false);
+	});
+
+	it('unknown tool defaults to medium risk (confirmed in conservative)', () => {
+		expect(getConfirmationRequired('conservative', 'unknown_tool_xyz')).toBe(true);
+	});
+
+	it('unknown tool defaults to medium risk (confirmed in balanced)', () => {
+		expect(getConfirmationRequired('balanced', 'unknown_tool_xyz')).toBe(true);
+	});
+
+	it('unknown tool defaults to medium risk (no confirmation in autonomous)', () => {
+		expect(getConfirmationRequired('autonomous', 'unknown_tool_xyz')).toBe(false);
+	});
+});
+
+// ── ActionClassification ─────────────────────────────────────────────────────
+
+describe('ActionClassification', () => {
+	it('toggle_mcp_server is low risk', () => {
+		expect(ActionClassification['toggle_mcp_server']).toBe('low');
+	});
+
+	it('enable_skill is low risk', () => {
+		expect(ActionClassification['enable_skill']).toBe('low');
+	});
+
+	it('create_goal is low risk', () => {
+		expect(ActionClassification['create_goal']).toBe('low');
+	});
+
+	it('update_app_settings is low risk', () => {
+		expect(ActionClassification['update_app_settings']).toBe('low');
+	});
+
+	it('delete_room is medium risk', () => {
+		expect(ActionClassification['delete_room']).toBe('medium');
+	});
+
+	it('send_message_to_room is medium risk', () => {
+		expect(ActionClassification['send_message_to_room']).toBe('medium');
+	});
+
+	it('approve_gate is medium risk', () => {
+		expect(ActionClassification['approve_gate']).toBe('medium');
+	});
+
+	it('bulk_delete_rooms is high risk', () => {
+		expect(ActionClassification['bulk_delete_rooms']).toBe('high');
+	});
+
+	it('delete_room_with_active_tasks is high risk', () => {
+		expect(ActionClassification['delete_room_with_active_tasks']).toBe('high');
+	});
+
+	it('all entries are valid risk levels', () => {
+		const valid = new Set<string>(['low', 'medium', 'high']);
+		for (const [tool, level] of Object.entries(ActionClassification)) {
+			expect(valid.has(level), `${tool} has invalid risk level: ${level}`).toBe(true);
+		}
+	});
+});
+
+// ── PendingActionStore ────────────────────────────────────────────────────────
+
+describe('PendingActionStore', () => {
+	let store: PendingActionStore;
+
+	beforeEach(() => {
+		store = new PendingActionStore();
+	});
+
+	it('stores and retrieves a pending action', () => {
+		const id = store.store_action({ toolName: 'delete_room', input: { roomId: 'r1' } });
+		const action = store.retrieve(id);
+		expect(action).toBeDefined();
+		expect(action!.toolName).toBe('delete_room');
+		expect(action!.input).toEqual({ roomId: 'r1' });
+	});
+
+	it('returns undefined for unknown actionId', () => {
+		expect(store.retrieve('non-existent')).toBeUndefined();
+	});
+
+	it('remove deletes the action', () => {
+		const id = store.store_action({ toolName: 'toggle_skill', input: {} });
+		store.remove(id);
+		expect(store.retrieve(id)).toBeUndefined();
+	});
+
+	it('cleanup removes expired entries', () => {
+		// Manually backdate the stored action by injecting with past createdAt
+		const id = store.store_action({ toolName: 'toggle_skill', input: {} });
+
+		// Tamper with internal state to simulate expiry (cast to any for testing)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const internal = (store as any).store as Map<
+			string,
+			{ toolName: string; input: unknown; createdAt: number }
+		>;
+		internal.set(id, {
+			toolName: 'toggle_skill',
+			input: {},
+			createdAt: Date.now() - 6 * 60 * 1000,
+		});
+
+		expect(store.size).toBe(1);
+		store.cleanup();
+		expect(store.size).toBe(0);
+	});
+
+	it('retrieve rejects expired action and removes it', () => {
+		const id = store.store_action({ toolName: 'toggle_skill', input: {} });
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const internal = (store as any).store as Map<
+			string,
+			{ toolName: string; input: unknown; createdAt: number }
+		>;
+		internal.set(id, {
+			toolName: 'toggle_skill',
+			input: {},
+			createdAt: Date.now() - 6 * 60 * 1000,
+		});
+
+		expect(store.retrieve(id)).toBeUndefined();
+		expect(store.size).toBe(0);
+	});
+
+	it('size reflects stored action count', () => {
+		expect(store.size).toBe(0);
+		store.store_action({ toolName: 'toggle_skill', input: {} });
+		store.store_action({ toolName: 'delete_room', input: {} });
+		expect(store.size).toBe(2);
+	});
+});
+
+// ── confirm_action meta-tool ──────────────────────────────────────────────────
+
+describe('makeConfirmActionTool', () => {
+	let store: PendingActionStore;
+
+	beforeEach(() => {
+		store = new PendingActionStore();
+	});
+
+	it('executes the stored action and removes it from the store', async () => {
+		const id = store.store_action({
+			toolName: 'create_goal',
+			input: { roomId: 'r1', title: 'My Goal' },
+		});
+		const executor = async (_tool: string, input: Record<string, unknown>) => ({
+			created: true,
+			...input,
+		});
+		const confirm = makeConfirmActionTool(store, executor);
+
+		const result = await confirm({ actionId: id });
+		expect(result.success).toBe(true);
+		expect(result.result).toEqual({ created: true, roomId: 'r1', title: 'My Goal' });
+		expect(store.retrieve(id)).toBeUndefined();
+	});
+
+	it('returns error for unknown or expired actionId', async () => {
+		const confirm = makeConfirmActionTool(store, async () => ({}));
+		const result = await confirm({ actionId: 'bad-id' });
+		expect(result.success).toBe(false);
+		expect(result.error).toMatch(/not found or expired/i);
+	});
+
+	it('returns error when executor throws', async () => {
+		const id = store.store_action({ toolName: 'delete_room', input: {} });
+		const executor = async () => {
+			throw new Error('Permission denied');
+		};
+		const confirm = makeConfirmActionTool(store, executor);
+		const result = await confirm({ actionId: id });
+		expect(result.success).toBe(false);
+		expect(result.error).toBe('Permission denied');
+		// Action should have been removed even on failure
+		expect(store.retrieve(id)).toBeUndefined();
+	});
+
+	it('passes correct toolName and input to executor', async () => {
+		const captured: { toolName: string; input: Record<string, unknown> }[] = [];
+		const executor = async (toolName: string, input: Record<string, unknown>) => {
+			captured.push({ toolName, input });
+			return {};
+		};
+		const id = store.store_action({ toolName: 'approve_gate', input: { gateId: 'g42' } });
+		const confirm = makeConfirmActionTool(store, executor);
+		await confirm({ actionId: id });
+		expect(captured).toHaveLength(1);
+		expect(captured[0].toolName).toBe('approve_gate');
+		expect(captured[0].input).toEqual({ gateId: 'g42' });
+	});
+});
+
+// ── cancel_action meta-tool ───────────────────────────────────────────────────
+
+describe('makeCancelActionTool', () => {
+	let store: PendingActionStore;
+
+	beforeEach(() => {
+		store = new PendingActionStore();
+	});
+
+	it('removes a pending action and returns success', () => {
+		const id = store.store_action({ toolName: 'delete_room', input: {} });
+		const cancel = makeCancelActionTool(store);
+		const result = cancel({ actionId: id });
+		expect(result.success).toBe(true);
+		expect(store.retrieve(id)).toBeUndefined();
+	});
+
+	it('returns success with a note when action does not exist', () => {
+		const cancel = makeCancelActionTool(store);
+		const result = cancel({ actionId: 'ghost-id' });
+		expect(result.success).toBe(true);
+		expect(result.actionDescription).toMatch(/not found/i);
+	});
+});


### PR DESCRIPTION
Implements the security tier enforcement logic for Neo action tools.

## Changes
- `packages/daemon/src/lib/neo/security-tier.ts` — core module:
  - `NeoSecurityMode` / `ActionRiskLevel` types
  - `ActionClassification` map (low/medium/high for all Neo tools)
  - `shouldAutoExecute(mode, riskLevel)` — full 3×3 matrix
  - `getConfirmationRequired(mode, toolName)` — unknown tools default to medium
  - `NeoActionResult` type
  - `PendingActionStore` — in-memory TTL store (5 min), with `store_action`, `retrieve`, `remove`, `cleanup`
  - `makeConfirmActionTool` / `makeCancelActionTool` — meta-tool factory functions
- 40 unit tests covering all security combinations, store lifecycle, and TTL expiry