### PR TITLE
feat(neo): ViaNeoIndicator badge + chat/gate/task integration (task 9.1)

### DIFF
--- a/packages/web/src/components/neo/ViaNeoIndicator.test.tsx
+++ b/packages/web/src/components/neo/ViaNeoIndicator.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Tests for ViaNeoIndicator component
+ *
+ * Verifies:
+ * - Default render: shows sparkle icon and "via Neo" text
+ * - Correct data-testid attribute for targeting in larger component tests
+ * - Size variants: 'sm' (default) and 'xs'
+ * - Custom className is applied
+ * - Title/tooltip text is present for accessibility
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { ViaNeoIndicator } from './ViaNeoIndicator.tsx';
+
+describe('ViaNeoIndicator', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the "via Neo" text', () => {
+		const { getByTestId } = render(<ViaNeoIndicator />);
+		const el = getByTestId('via-neo-indicator');
+		expect(el.textContent).toContain('via Neo');
+	});
+
+	it('renders with data-testid="via-neo-indicator"', () => {
+		const { getByTestId } = render(<ViaNeoIndicator />);
+		expect(getByTestId('via-neo-indicator')).toBeTruthy();
+	});
+
+	it('has an accessible title attribute', () => {
+		const { getByTestId } = render(<ViaNeoIndicator />);
+		const el = getByTestId('via-neo-indicator');
+		expect(el.getAttribute('title')).toBeTruthy();
+	});
+
+	it('renders an SVG sparkle icon inside', () => {
+		const { getByTestId } = render(<ViaNeoIndicator />);
+		const el = getByTestId('via-neo-indicator');
+		expect(el.querySelector('svg')).toBeTruthy();
+	});
+
+	it('applies violet color class by default', () => {
+		const { getByTestId } = render(<ViaNeoIndicator />);
+		const el = getByTestId('via-neo-indicator');
+		expect(el.className).toContain('text-violet-400');
+	});
+
+	it('accepts and applies a custom class', () => {
+		const { getByTestId } = render(<ViaNeoIndicator class="my-custom-class" />);
+		const el = getByTestId('via-neo-indicator');
+		expect(el.className).toContain('my-custom-class');
+	});
+
+	it('sm size (default) uses text-xs', () => {
+		const { getByTestId } = render(<ViaNeoIndicator size="sm" />);
+		const el = getByTestId('via-neo-indicator');
+		expect(el.className).toContain('text-xs');
+	});
+
+	it('xs size uses text-[10px]', () => {
+		const { getByTestId } = render(<ViaNeoIndicator size="xs" />);
+		const el = getByTestId('via-neo-indicator');
+		expect(el.className).toContain('text-[10px]');
+	});
+
+	it('defaults to sm size when size prop is omitted', () => {
+		const { getByTestId } = render(<ViaNeoIndicator />);
+		const el = getByTestId('via-neo-indicator');
+		expect(el.className).toContain('text-xs');
+		expect(el.className).not.toContain('text-[10px]');
+	});
+});

--- a/packages/web/src/components/neo/ViaNeoIndicator.tsx
+++ b/packages/web/src/components/neo/ViaNeoIndicator.tsx
@@ -1,0 +1,47 @@
+/**
+ * ViaNeoIndicator
+ *
+ * A small, always-visible badge indicating that an action was taken by Neo.
+ * Subtle sparkle icon + "via Neo" muted text — non-intrusive but visible.
+ */
+
+import { cn } from '../../lib/utils.ts';
+
+interface Props {
+	/** Optional extra CSS class */
+	class?: string;
+	/** Size variant — 'sm' (default) or 'xs' for tighter contexts */
+	size?: 'xs' | 'sm';
+}
+
+export function ViaNeoIndicator({ class: className, size = 'sm' }: Props) {
+	const isXs = size === 'xs';
+	return (
+		<span
+			class={cn(
+				'inline-flex items-center gap-0.5 select-none shrink-0',
+				isXs ? 'text-[10px]' : 'text-xs',
+				'text-violet-400/70',
+				className
+			)}
+			data-testid="via-neo-indicator"
+			title="This action was taken by Neo"
+		>
+			{/* Sparkle icon */}
+			<svg
+				class={cn(isXs ? 'w-2.5 h-2.5' : 'w-3 h-3', 'flex-shrink-0')}
+				viewBox="0 0 24 24"
+				fill="currentColor"
+				aria-hidden="true"
+			>
+				<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+				<path d="M5 3l.75 2.25L8 6l-2.25.75L5 9l-.75-2.25L2 6l2.25-.75L5 3z" opacity={0.5} />
+				<path
+					d="M19 15l.6 1.8L21.4 17l-1.8.6L19 19.4l-.6-1.8L16.6 17l1.8-.6L19 15z"
+					opacity={0.5}
+				/>
+			</svg>
+			<span>via Neo</span>
+		</span>
+	);
+}

--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -75,7 +75,7 @@ export interface TaskInfoPanelProps {
 	/** Pull request number */
 	prNumber?: number | null;
 	/** Whether this task was created or last status-changed by Neo */
-	viaNeо?: boolean;
+	viaNeo?: boolean;
 	/** Worktree path to display (full path shown on hover) */
 	worktreePath?: string;
 	/** Worker session info */
@@ -123,7 +123,7 @@ export function TaskInfoPanel({
 	worktreePath,
 	workerSession,
 	leaderSession,
-	viaNeо,
+	viaNeo,
 	actions,
 	visibleActions,
 	disabledActions,
@@ -171,7 +171,7 @@ export function TaskInfoPanel({
 					<div>
 						<div class="flex items-center gap-2 mb-2">
 							<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Info</h3>
-							{viaNeо && <ViaNeoIndicator size="xs" />}
+							{viaNeo && <ViaNeoIndicator size="xs" />}
 						</div>
 						<div class="space-y-1.5 text-xs">
 							{/* Task ID */}

--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -19,6 +19,7 @@
 
 import type { SessionInfo } from '@neokai/shared';
 import { borderColors } from '../../lib/design-tokens.ts';
+import { ViaNeoIndicator } from '../neo/ViaNeoIndicator.tsx';
 import { CopyButton } from '../ui/CopyButton.tsx';
 import { TaskViewModelSelector } from './TaskViewModelSelector.tsx';
 
@@ -73,6 +74,8 @@ export interface TaskInfoPanelProps {
 	prUrl?: string | null;
 	/** Pull request number */
 	prNumber?: number | null;
+	/** Whether this task was created or last status-changed by Neo */
+	viaNeо?: boolean;
 	/** Worktree path to display (full path shown on hover) */
 	worktreePath?: string;
 	/** Worker session info */
@@ -120,6 +123,7 @@ export function TaskInfoPanel({
 	worktreePath,
 	workerSession,
 	leaderSession,
+	viaNeо,
 	actions,
 	visibleActions,
 	disabledActions,
@@ -165,7 +169,10 @@ export function TaskInfoPanel({
 				{/* Info section */}
 				{hasWorktreeInfo && (
 					<div>
-						<h3 class="text-xs font-semibold text-gray-500 mb-2 uppercase tracking-wide">Info</h3>
+						<div class="flex items-center gap-2 mb-2">
+							<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Info</h3>
+							{viaNeо && <ViaNeoIndicator size="xs" />}
+						</div>
 						<div class="space-y-1.5 text-xs">
 							{/* Task ID */}
 							{taskId && (

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -290,6 +290,8 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				taskCreatedAt={task.createdAt}
 				prUrl={task.prUrl}
 				prNumber={task.prNumber}
+				// Future: populate from task.origin once NeoTask gains that field (task M6/M3)
+				viaNeo={(task as typeof task & { origin?: string }).origin === 'neo'}
 				worktreePath={workerSession?.worktree?.worktreePath ?? workerSession?.workspacePath}
 				workerSession={workerSession}
 				leaderSession={leaderSession}

--- a/packages/web/src/components/room/TaskViewV2.tsx
+++ b/packages/web/src/components/room/TaskViewV2.tsx
@@ -302,6 +302,8 @@ export function TaskViewV2({ roomId, taskId }: TaskViewV2Props) {
 				roomId={roomId}
 				taskId={task.id}
 				groupId={group?.id}
+				// Future: populate from task.origin once NeoTask gains that field (task M6/M3)
+				viaNeo={(task as typeof task & { origin?: string }).origin === 'neo'}
 				feedbackIteration={group?.feedbackIteration}
 				taskCreatedAt={task.createdAt}
 				prUrl={task.prUrl}

--- a/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
+++ b/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
@@ -748,4 +748,56 @@ describe('TaskInfoPanel', () => {
 			expect(container.textContent).toContain('short/path');
 		});
 	});
+
+	describe('viaNeo indicator', () => {
+		it('should render ViaNeoIndicator when viaNeo=true and taskId is provided', () => {
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					taskId="task-123"
+					viaNeo={true}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeTruthy();
+		});
+
+		it('should not render ViaNeoIndicator when viaNeo=false', () => {
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					taskId="task-123"
+					viaNeo={false}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeNull();
+		});
+
+		it('should not render ViaNeoIndicator when viaNeo is omitted', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} taskId="task-123" actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeNull();
+		});
+
+		it('should not render ViaNeoIndicator when panel is closed even if viaNeo=true', () => {
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={false}
+					taskId="task-123"
+					viaNeo={true}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeNull();
+		});
+	});
 });

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -13,6 +13,7 @@ import { Dropdown } from '../ui/Dropdown.tsx';
 import { IconButton } from '../ui/IconButton.tsx';
 import { Spinner } from '../ui/Spinner.tsx';
 import { Tooltip } from '../ui/Tooltip.tsx';
+import { ViaNeoIndicator } from '../neo/ViaNeoIndicator.tsx';
 import { ErrorOutput, hasErrorOutput } from './ErrorOutput.tsx';
 import { MentionToken, parseTextWithReferences } from './MentionToken.tsx';
 import { MessageInfoButton } from './MessageInfoButton.tsx';
@@ -272,6 +273,9 @@ export function SDKUserMessage({
 		);
 	}
 
+	// Check if this message was originated by Neo (stored in DB, injected when loading history)
+	const isNeoOrigin = (message as SDKMessage & { origin?: string }).origin === 'neo';
+
 	// Get message metadata for E2E tests
 	const messageWithTimestamp = message as SDKMessage & { timestamp?: number };
 
@@ -338,6 +342,7 @@ export function SDKUserMessage({
 				messageSpacing.actions.padding
 			)}
 		>
+			{isNeoOrigin && <ViaNeoIndicator />}
 			<Tooltip content={getFullTimestamp()} position="left">
 				<span class="text-xs text-gray-500">{getTimestamp()}</span>
 			</Tooltip>

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -682,4 +682,27 @@ describe('SDKUserMessage', () => {
 			expect(container.querySelector('[data-testid="mention-token"]')).toBeNull();
 		});
 	});
+
+	describe('Neo origin indicator', () => {
+		it('renders ViaNeoIndicator when message.origin is "neo"', () => {
+			const message = Object.assign(createTextMessage('Hello'), { origin: 'neo' });
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeTruthy();
+		});
+
+		it('does not render ViaNeoIndicator when message.origin is "human"', () => {
+			const message = Object.assign(createTextMessage('Hello'), { origin: 'human' });
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeNull();
+		});
+
+		it('does not render ViaNeoIndicator when message.origin is absent', () => {
+			const message = createTextMessage('Hello');
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeNull();
+		});
+	});
 });

--- a/packages/web/src/components/space/GateArtifactsView.tsx
+++ b/packages/web/src/components/space/GateArtifactsView.tsx
@@ -81,6 +81,9 @@ export function GateArtifactsView({
 	// ---- Extract PR info from gate data ----
 	const prUrl = typeof gateData?.pr_url === 'string' ? gateData.pr_url : null;
 	const prNumber = typeof gateData?.pr_number === 'number' ? gateData.pr_number : null;
+	// Future integration point: when Neo's approve_gate / reject_gate tool is implemented
+	// (task M3 action tools), it should write `origin: 'neo'` into the gate data record.
+	// Until then this will always be false.
 	const isNeoDecision = gateData?.origin === 'neo';
 
 	// ---- Fetch artifacts ----

--- a/packages/web/src/components/space/GateArtifactsView.tsx
+++ b/packages/web/src/components/space/GateArtifactsView.tsx
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback } from 'preact/hooks';
 import { connectionManager } from '../../lib/connection-manager';
 import { cn } from '../../lib/utils';
+import { ViaNeoIndicator } from '../neo/ViaNeoIndicator.tsx';
 import { FileDiffView } from './FileDiffView';
 
 // ============================================================================
@@ -80,6 +81,7 @@ export function GateArtifactsView({
 	// ---- Extract PR info from gate data ----
 	const prUrl = typeof gateData?.pr_url === 'string' ? gateData.pr_url : null;
 	const prNumber = typeof gateData?.pr_number === 'number' ? gateData.pr_number : null;
+	const isNeoDecision = gateData?.origin === 'neo';
 
 	// ---- Fetch artifacts ----
 	useEffect(() => {
@@ -159,7 +161,10 @@ export function GateArtifactsView({
 			{/* Header */}
 			<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700 flex-shrink-0 bg-dark-850">
 				<div>
-					<h2 class="text-sm font-semibold text-gray-100">Review Changes</h2>
+					<div class="flex items-center gap-2">
+						<h2 class="text-sm font-semibold text-gray-100">Review Changes</h2>
+						{isNeoDecision && <ViaNeoIndicator size="xs" />}
+					</div>
 					<p class="text-xs text-gray-500 mt-0.5">Approve or reject the proposed changes</p>
 				</div>
 				{onClose && (

--- a/packages/web/src/components/space/__tests__/GateArtifactsView.test.tsx
+++ b/packages/web/src/components/space/__tests__/GateArtifactsView.test.tsx
@@ -306,4 +306,34 @@ describe('GateArtifactsView', () => {
 		);
 		await waitFor(() => expect(queryByTestId('pr-link')).toBeNull());
 	});
+
+	describe('Neo origin indicator', () => {
+		it('renders ViaNeoIndicator in header when gateData.origin is "neo"', async () => {
+			mockRequest.mockResolvedValue(makeArtifacts());
+			const { container } = render(
+				<GateArtifactsView {...defaultProps()} gateData={{ origin: 'neo' }} />
+			);
+			await waitFor(() =>
+				expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeTruthy()
+			);
+		});
+
+		it('does not render ViaNeoIndicator when gateData.origin is absent', async () => {
+			mockRequest.mockResolvedValue(makeArtifacts());
+			const { container } = render(
+				<GateArtifactsView {...defaultProps()} gateData={{ pr_url: 'https://example.com' }} />
+			);
+			await waitFor(() =>
+				expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeNull()
+			);
+		});
+
+		it('does not render ViaNeoIndicator when gateData is undefined', async () => {
+			mockRequest.mockResolvedValue(makeArtifacts());
+			const { container } = render(<GateArtifactsView {...defaultProps()} />);
+			await waitFor(() =>
+				expect(container.querySelector('[data-testid="via-neo-indicator"]')).toBeNull()
+			);
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- New `ViaNeoIndicator` component (`packages/web/src/components/neo/`) — sparkle icon + "via Neo" muted text, `sm`/`xs` size variants, always-visible violet badge
- `SDKUserMessage`: renders indicator when `message.origin === 'neo'` (field injected from DB on history load)
- `GateArtifactsView`: renders indicator in header when `gateData.origin === 'neo'`
- `TaskInfoPanel`: new optional `viaNeо` prop; renders indicator in Info section header when truthy
- 9 unit tests for the new component (render, size variants, custom class, accessibility title)