### PR TITLE
feat(neo): wire NeoAgentManager into daemon app lifecycle (task 1.3)

### DIFF
--- a/packages/daemon/.env.example
+++ b/packages/daemon/.env.example
@@ -87,6 +87,15 @@ MAX_SESSIONS=10
 # NEOKAI_JOB_QUEUE_MAX_CONCURRENT=5
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Neo Agent Configuration
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# Set to 1 to enable Neo agent provisioning in NODE_ENV=test environments
+# (e.g., online tests that exercise the neo.* RPC surface).
+# In production/development, Neo is always provisioned at startup.
+# NEOKAI_ENABLE_NEO_AGENT=1
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Test Configuration
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -463,6 +463,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			await neoAgentManager.provision();
 			logInfo('[Daemon] Neo agent provisioned');
 		} catch (err) {
+			// Non-fatal: daemon continues without Neo. The Neo session will be null
+			// and the frontend will receive no responses from neo.* RPC calls.
+			// TODO(neo): publish a status channel event so the frontend can surface
+			// a "Neo unavailable" indicator when provisioning fails.
 			logError('[Daemon] Neo agent provisioning failed (non-fatal):', err);
 		}
 	}

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -29,6 +29,7 @@ import { JOB_QUEUE_CLEANUP, SKILL_VALIDATE } from './lib/job-queue-constants';
 import { AppMcpLifecycleManager, seedDefaultMcpEntries } from './lib/mcp';
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
+import { NeoAgentManager } from './lib/neo/neo-agent-manager';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -82,6 +83,8 @@ export interface DaemonAppContext {
 	appMcpManager: AppMcpLifecycleManager;
 	/** Application-level Skills manager — registry CRUD and validation */
 	skillsManager: SkillsManager;
+	/** Neo agent manager — singleton global AI assistant */
+	neoAgentManager: NeoAgentManager;
 	/** Workspace file index for fast fuzzy file/folder search */
 	fileIndex: FileIndex;
 	/**
@@ -237,6 +240,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Register session title generation handler before jobProcessor starts
 	sessionManager.start();
+
+	// Initialize Neo agent manager (singleton global AI assistant).
+	// Instantiated after sessionManager so it can be passed as the NeoSessionManager.
+	const neoAgentManager = new NeoAgentManager(sessionManager, settingsManager);
 
 	// Initialize State Manager (listens to EventBus, clean dependency graph!)
 	const stateManager = new StateManager(
@@ -448,10 +455,17 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	jobProcessor.start();
 	logInfo('[Daemon] Job queue processor started');
 
-	// TODO(neo-task-1.3): Wire NeoAgentManager here.
-	// Instantiate NeoAgentManager(sessionManager, settingsManager), call provision()
-	// at startup, and call cleanup() in the graceful-shutdown block below.
-	// See packages/daemon/src/lib/neo/neo-agent-manager.ts.
+	// Provision the Neo agent session (skip in test mode unless explicitly enabled).
+	// Mirrors the spaces agent guard: test runs are clean by default; online/e2e
+	// tests that need Neo set NEOKAI_ENABLE_NEO_AGENT=1.
+	if (process.env.NODE_ENV !== 'test' || process.env.NEOKAI_ENABLE_NEO_AGENT === '1') {
+		try {
+			await neoAgentManager.provision();
+			logInfo('[Daemon] Neo agent provisioned');
+		} catch (err) {
+			logError('[Daemon] Neo agent provisioning failed (non-fatal):', err);
+		}
+	}
 
 	// On startup: clean up orphaned worktrees (directories missing from disk) and run the TTL reaper.
 	// Both are non-blocking — errors are logged but never propagate to block server start.
@@ -567,6 +581,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			// Task Agent sessions are interrupted cleanly before the session pool drains.
 			await taskAgentManager.cleanupAll();
 
+			// Shut down the Neo agent session before the session pool drains.
+			await neoAgentManager.cleanup();
+			logInfo('[Daemon] Neo agent stopped');
+
 			// Stop all agent sessions first — this closes any open SSE connections
 			// that are held by providers (e.g. AnthropicToCopilotBridgeProvider's embedded
 			// HTTP server). Provider shutdown must follow so server.close() is not
@@ -616,6 +634,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		jobProcessor,
 		appMcpManager,
 		skillsManager,
+		neoAgentManager,
 		fileIndex,
 		cleanup,
 	};

--- a/packages/daemon/tests/unit/core/neo-daemon-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/core/neo-daemon-lifecycle.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Neo Daemon Lifecycle Tests
+ *
+ * Integration tests verifying that NeoAgentManager is correctly wired into
+ * createDaemonApp:
+ *
+ * - neoAgentManager is present in DaemonAppContext
+ * - Neo session is NOT provisioned in test mode (default)
+ * - Neo session IS provisioned when NEOKAI_ENABLE_NEO_AGENT=1
+ * - neoAgentManager.cleanup() is called during shutdown
+ *
+ * OFFLINE TESTS — No API calls required.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { createDaemonApp } from '../../../src/app';
+import { NeoAgentManager, NEO_SESSION_ID } from '../../../src/lib/neo/neo-agent-manager';
+import type { Config } from '../../../src/config';
+
+/** Build a minimal test config using an in-memory database. */
+function makeConfig(suffix = Date.now()): Config {
+	const tmpDir = process.env.TMPDIR || '/tmp';
+	return {
+		host: 'localhost',
+		port: 0,
+		defaultModel: 'claude-sonnet-4-5-20250929',
+		maxTokens: 8192,
+		temperature: 1.0,
+		dbPath: ':memory:',
+		maxSessions: 10,
+		nodeEnv: 'test',
+		workspaceRoot: `${tmpDir}/neokai-test-neo-lifecycle-${suffix}`,
+		disableWorktrees: true,
+	};
+}
+
+describe('Neo Daemon Lifecycle', () => {
+	let bunServeSpy: ReturnType<typeof spyOn> | null = null;
+	let originalNeoAgent: string | undefined;
+	let originalNodeEnv: string | undefined;
+	// Silence console noise from createDaemonApp startup logs.
+	let originalConsoleLog: typeof console.log;
+	let originalConsoleError: typeof console.error;
+
+	beforeEach(() => {
+		originalNeoAgent = process.env.NEOKAI_ENABLE_NEO_AGENT;
+		delete process.env.NEOKAI_ENABLE_NEO_AGENT;
+
+		// Ensure NODE_ENV=test so the Neo provisioning guard skips by default.
+		originalNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'test';
+
+		originalConsoleLog = console.log;
+		originalConsoleError = console.error;
+		console.log = () => {};
+		console.error = () => {};
+
+		// Avoid real socket binding in unit tests.
+		bunServeSpy = spyOn(Bun, 'serve').mockImplementation(
+			(_opts: Parameters<typeof Bun.serve>[0]) =>
+				({
+					stop() {},
+				}) as never
+		);
+	});
+
+	afterEach(() => {
+		if (originalNeoAgent !== undefined) {
+			process.env.NEOKAI_ENABLE_NEO_AGENT = originalNeoAgent;
+		} else {
+			delete process.env.NEOKAI_ENABLE_NEO_AGENT;
+		}
+
+		if (originalNodeEnv !== undefined) {
+			process.env.NODE_ENV = originalNodeEnv;
+		} else {
+			delete process.env.NODE_ENV;
+		}
+		console.log = originalConsoleLog;
+		console.error = originalConsoleError;
+		if (bunServeSpy) {
+			bunServeSpy.mockRestore();
+			bunServeSpy = null;
+		}
+	});
+
+	test('neoAgentManager is present in DaemonAppContext', async () => {
+		const ctx = await createDaemonApp({ config: makeConfig(), verbose: false });
+		try {
+			expect(ctx.neoAgentManager).toBeInstanceOf(NeoAgentManager);
+		} finally {
+			await ctx.cleanup();
+		}
+	});
+
+	test('Neo session is NOT provisioned in test mode by default', async () => {
+		// NODE_ENV=test and NEOKAI_ENABLE_NEO_AGENT is unset → provision() must not run.
+		const ctx = await createDaemonApp({ config: makeConfig(), verbose: false });
+		try {
+			// getSession() returns null because provision() was skipped.
+			expect(ctx.neoAgentManager.getSession()).toBeNull();
+		} finally {
+			await ctx.cleanup();
+		}
+	});
+
+	test('Neo session IS provisioned when NEOKAI_ENABLE_NEO_AGENT=1', async () => {
+		process.env.NEOKAI_ENABLE_NEO_AGENT = '1';
+
+		const ctx = await createDaemonApp({ config: makeConfig(), verbose: false });
+		try {
+			// After provision() the session is live in memory.
+			const session = ctx.neoAgentManager.getSession();
+			expect(session).not.toBeNull();
+			expect(session!.session.id).toBe(NEO_SESSION_ID);
+		} finally {
+			await ctx.cleanup();
+		}
+	});
+
+	test('Neo session persists in DB and is re-attached on a second startup', async () => {
+		process.env.NEOKAI_ENABLE_NEO_AGENT = '1';
+
+		// Use a shared on-disk DB so the session persists across two daemon instances.
+		const tmpDir = process.env.TMPDIR || '/tmp';
+		const dbPath = `${tmpDir}/neokai-test-neo-restart-${Date.now()}.db`;
+		const workspaceRoot = `${tmpDir}/neokai-test-neo-restart-ws-${Date.now()}`;
+		const sharedConfig: Config = {
+			host: 'localhost',
+			port: 0,
+			defaultModel: 'claude-sonnet-4-5-20250929',
+			maxTokens: 8192,
+			temperature: 1.0,
+			dbPath,
+			maxSessions: 10,
+			nodeEnv: 'test',
+			workspaceRoot,
+			disableWorktrees: true,
+		};
+
+		// First startup — Neo session is created.
+		const ctx1 = await createDaemonApp({ config: sharedConfig, verbose: false });
+		const session1 = ctx1.neoAgentManager.getSession();
+		expect(session1).not.toBeNull();
+		expect(session1!.session.id).toBe(NEO_SESSION_ID);
+		await ctx1.cleanup();
+
+		// Second startup — Neo session should be re-attached from DB, not re-created.
+		const ctx2 = await createDaemonApp({ config: sharedConfig, verbose: false });
+		try {
+			const session2 = ctx2.neoAgentManager.getSession();
+			expect(session2).not.toBeNull();
+			expect(session2!.session.id).toBe(NEO_SESSION_ID);
+		} finally {
+			await ctx2.cleanup();
+		}
+
+		// Clean up on-disk DB.
+		try {
+			await Bun.file(dbPath).arrayBuffer(); // exists check
+			const fs = await import('fs/promises');
+			await fs.unlink(dbPath);
+		} catch {
+			// ignore if file doesn't exist
+		}
+	});
+
+	test('cleanup() shuts down Neo agent without error', async () => {
+		process.env.NEOKAI_ENABLE_NEO_AGENT = '1';
+
+		const ctx = await createDaemonApp({ config: makeConfig(), verbose: false });
+
+		// Spy on neoAgentManager.cleanup to verify it was called.
+		const cleanupSpy = spyOn(ctx.neoAgentManager, 'cleanup');
+
+		await ctx.cleanup();
+
+		expect(cleanupSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test('neoAgentManager.getSecurityMode() defaults to balanced', async () => {
+		const ctx = await createDaemonApp({ config: makeConfig(), verbose: false });
+		try {
+			expect(ctx.neoAgentManager.getSecurityMode()).toBe('balanced');
+		} finally {
+			await ctx.cleanup();
+		}
+	});
+});

--- a/packages/daemon/tests/unit/core/neo-daemon-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/core/neo-daemon-lifecycle.test.ts
@@ -170,7 +170,9 @@ describe('Neo Daemon Lifecycle', () => {
 
 		const ctx = await createDaemonApp({ config: makeConfig(), verbose: false });
 
-		// Spy on neoAgentManager.cleanup to verify it was called.
+		// Spy is attached here (before ctx.cleanup() runs), so it captures
+		// the single cleanup() call that ctx.cleanup() delegates to.
+		// It does NOT retroactively track any calls made before this line.
 		const cleanupSpy = spyOn(ctx.neoAgentManager, 'cleanup');
 
 		await ctx.cleanup();


### PR DESCRIPTION
Wire `NeoAgentManager` into `createDaemonApp` and `DaemonAppContext`.

## Changes

- **`DaemonAppContext`** — adds `neoAgentManager: NeoAgentManager` field
- **`createDaemonApp`** — instantiates `NeoAgentManager(sessionManager, settingsManager)` after `sessionManager.start()`; calls `provision()` at startup (guarded by `NODE_ENV !== 'test' || NEOKAI_ENABLE_NEO_AGENT=1`); calls `cleanup()` in shutdown before `sessionManager.cleanup()`; returns `neoAgentManager` in context
- **`neo-daemon-lifecycle.test.ts`** — 6 new unit tests covering: context field presence, test-mode skip, `NEOKAI_ENABLE_NEO_AGENT=1` provision, DB-persistent restart re-attach, cleanup invocation, default security mode

Closes task 1.3 of the Neo Agent goal.