### PR TITLE
feat(neo): Room and session query tools (task 2.1)

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -1,0 +1,330 @@
+/**
+ * Neo Query Tools - MCP tools for querying system state
+ *
+ * Read-only tools that give Neo full visibility into the NeoKai system:
+ * - list_rooms
+ * - get_room_status
+ * - get_room_details
+ * - get_system_info
+ * - get_app_settings
+ *
+ * Pattern: two-layer design (testable handlers + MCP server wrapper)
+ *   createNeoQueryToolHandlers(config) → plain handler functions
+ *   createNeoQueryMcpServer(config)    → MCP server wrapping those handlers
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import type { GlobalSettings, AuthStatus, Room, RoomGoal } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Minimal interfaces — only the surface used by these tools
+// ---------------------------------------------------------------------------
+
+export interface NeoQueryRoomManager {
+	listRooms(includeArchived?: boolean): Room[];
+	getRoom(id: string): Room | null;
+	getRoomOverview(roomId: string): {
+		room: Room;
+		sessions: { id: string; title: string; status: string; lastActiveAt: number }[];
+		activeTasks: unknown[];
+		allTasks?: unknown[];
+	} | null;
+}
+
+export interface NeoQueryGoalRepository {
+	/** List goals for a specific room, optionally filtered by status */
+	listGoals(roomId: string, status?: string): RoomGoal[];
+}
+
+export interface NeoQuerySessionManager {
+	getActiveSessions(): number;
+	listSessions(opts?: {
+		includeArchived?: boolean;
+		status?: string;
+	}): { id: string; status: string }[];
+}
+
+export interface NeoQuerySettingsManager {
+	getGlobalSettings(): GlobalSettings;
+}
+
+export interface NeoQueryAuthManager {
+	getAuthStatus(): Promise<AuthStatus>;
+}
+
+/**
+ * All dependencies required by the Neo query tools.
+ */
+export interface NeoToolsConfig {
+	roomManager: NeoQueryRoomManager;
+	goalRepository: NeoQueryGoalRepository;
+	sessionManager: NeoQuerySessionManager;
+	settingsManager: NeoQuerySettingsManager;
+	authManager: NeoQueryAuthManager;
+	/** Absolute path to the workspace root */
+	workspaceRoot: string;
+	/** Human-readable app version string, e.g. "0.1.1" */
+	appVersion: string;
+	/** Unix timestamp (ms) when the daemon process started */
+	startedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface ToolResult {
+	content: Array<{ type: 'text'; text: string }>;
+}
+
+function jsonResult(data: Record<string, unknown> | unknown[]): ToolResult {
+	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+function errorResult(message: string): ToolResult {
+	return jsonResult({ success: false, error: message });
+}
+
+// ---------------------------------------------------------------------------
+// Handler functions (testable without MCP plumbing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create pure handler functions for Neo query tools.
+ * Each handler accepts typed args and returns a ToolResult.
+ * No MCP wiring — suitable for direct unit testing.
+ */
+export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
+	const {
+		roomManager,
+		goalRepository,
+		sessionManager,
+		settingsManager,
+		authManager,
+		workspaceRoot,
+		appVersion,
+		startedAt,
+	} = config;
+
+	return {
+		/**
+		 * List all active rooms with summary information.
+		 */
+		async list_rooms(args: { include_archived?: boolean }): Promise<ToolResult> {
+			const includeArchived = args.include_archived ?? false;
+			const rooms = roomManager.listRooms(includeArchived);
+
+			const result = rooms.map((room) => {
+				const goals = goalRepository.listGoals(room.id);
+				return {
+					id: room.id,
+					name: room.name,
+					status: room.status,
+					sessionCount: room.sessionIds.filter(
+						(id) =>
+							!id.startsWith('room:chat:') &&
+							!id.startsWith('room:self:') &&
+							!id.startsWith('room:craft:') &&
+							!id.startsWith('room:lead:')
+					).length,
+					goalCount: goals.length,
+					activeGoalCount: goals.filter((g) => g.status === 'active' || g.status === 'needs_human')
+						.length,
+					defaultModel: room.defaultModel ?? null,
+					createdAt: room.createdAt,
+					updatedAt: room.updatedAt,
+				};
+			});
+
+			return jsonResult(result);
+		},
+
+		/**
+		 * Get a room's current operational status.
+		 */
+		async get_room_status(args: { room_id: string }): Promise<ToolResult> {
+			const room = roomManager.getRoom(args.room_id);
+			if (!room) {
+				return errorResult(`Room not found: ${args.room_id}`);
+			}
+
+			const goals = goalRepository.listGoals(room.id);
+			const activeGoals = goals.filter((g) => g.status === 'active' || g.status === 'needs_human');
+
+			// Worker sessions (exclude internal room:* management sessions)
+			const workerSessionIds = room.sessionIds.filter(
+				(id) =>
+					!id.startsWith('room:chat:') &&
+					!id.startsWith('room:self:') &&
+					!id.startsWith('room:craft:') &&
+					!id.startsWith('room:lead:')
+			);
+
+			const activeSessions = sessionManager
+				.listSessions({ status: 'active' })
+				.filter((s) => workerSessionIds.includes(s.id));
+
+			return jsonResult({
+				id: room.id,
+				name: room.name,
+				status: room.status,
+				defaultModel: room.defaultModel ?? null,
+				sessionCount: workerSessionIds.length,
+				activeSessionCount: activeSessions.length,
+				goalCount: goals.length,
+				activeGoalCount: activeGoals.length,
+				updatedAt: room.updatedAt,
+			});
+		},
+
+		/**
+		 * Get full room details including goals summary and tasks summary.
+		 */
+		async get_room_details(args: { room_id: string }): Promise<ToolResult> {
+			const overview = roomManager.getRoomOverview(args.room_id);
+			if (!overview) {
+				return errorResult(`Room not found: ${args.room_id}`);
+			}
+
+			const { room, sessions, activeTasks, allTasks } = overview;
+			const goals = goalRepository.listGoals(room.id);
+
+			const goalsSummary = goals.map((g) => ({
+				id: g.id,
+				shortId: g.shortId ?? null,
+				title: g.title,
+				status: g.status,
+				priority: g.priority,
+				progress: g.progress,
+				missionType: g.missionType ?? 'one_shot',
+				linkedTaskCount: g.linkedTaskIds.length,
+			}));
+
+			return jsonResult({
+				id: room.id,
+				name: room.name,
+				status: room.status,
+				defaultModel: room.defaultModel ?? null,
+				allowedModels: room.allowedModels ?? [],
+				instructions: room.instructions ?? null,
+				background: room.background ?? null,
+				sessions,
+				goals: goalsSummary,
+				activeTasks,
+				allTaskCount: allTasks?.length ?? activeTasks.length,
+				createdAt: room.createdAt,
+				updatedAt: room.updatedAt,
+			});
+		},
+
+		/**
+		 * Get system-wide information about the NeoKai instance.
+		 */
+		async get_system_info(): Promise<ToolResult> {
+			const authStatus = await authManager.getAuthStatus();
+			const uptimeMs = Date.now() - startedAt;
+			const uptimeSec = Math.floor(uptimeMs / 1000);
+
+			const rooms = roomManager.listRooms(false);
+			const activeSessions = sessionManager.getActiveSessions();
+
+			return jsonResult({
+				appVersion,
+				workspaceRoot,
+				uptimeSeconds: uptimeSec,
+				startedAt,
+				auth: {
+					isAuthenticated: authStatus.isAuthenticated,
+					method: authStatus.method,
+				},
+				roomCount: rooms.length,
+				activeSessionCount: activeSessions,
+			});
+		},
+
+		/**
+		 * Get the current global application settings.
+		 */
+		async get_app_settings(): Promise<ToolResult> {
+			const settings = settingsManager.getGlobalSettings();
+
+			// Return a safe subset — exclude raw mcpServerSettings (potentially large/noisy)
+			return jsonResult({
+				model: settings.model ?? null,
+				permissionMode: settings.permissionMode ?? null,
+				thinkingLevel: settings.thinkingLevel ?? null,
+				autoScroll: settings.autoScroll ?? true,
+				coordinatorMode: settings.coordinatorMode ?? false,
+				maxConcurrentWorkers: settings.maxConcurrentWorkers ?? 3,
+				neoSecurityMode: settings.neoSecurityMode ?? 'balanced',
+				neoModel: settings.neoModel ?? null,
+				settingSources: settings.settingSources,
+				showArchived: settings.showArchived ?? false,
+				fallbackModels: settings.fallbackModels ?? [],
+				disabledMcpServers: settings.disabledMcpServers ?? [],
+			});
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// MCP server wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the MCP server that exposes all Neo query tools.
+ * The server wraps the handlers returned by createNeoQueryToolHandlers.
+ */
+export function createNeoQueryMcpServer(config: NeoToolsConfig) {
+	const handlers = createNeoQueryToolHandlers(config);
+
+	const tools = [
+		tool(
+			'list_rooms',
+			'List all rooms in the NeoKai system with summary info (id, name, status, session count, goal count).',
+			{
+				include_archived: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe('Include archived rooms in the results (default: false)'),
+			},
+			(args) => handlers.list_rooms(args)
+		),
+
+		tool(
+			'get_room_status',
+			'Get the current operational status of a specific room, including active sessions, goal count, and current model.',
+			{
+				room_id: z.string().describe('ID of the room to query'),
+			},
+			(args) => handlers.get_room_status(args)
+		),
+
+		tool(
+			'get_room_details',
+			'Get full details for a room including goals summary, active tasks summary, and session list.',
+			{
+				room_id: z.string().describe('ID of the room to query'),
+			},
+			(args) => handlers.get_room_details(args)
+		),
+
+		tool(
+			'get_system_info',
+			'Get system-wide information about the NeoKai instance: app version, uptime, auth status, workspace root, and active session count.',
+			{},
+			() => handlers.get_system_info()
+		),
+
+		tool(
+			'get_app_settings',
+			'Get the current global application settings including model, permission mode, Neo security mode, and other preferences.',
+			{},
+			() => handlers.get_app_settings()
+		),
+	];
+
+	return createSdkMcpServer({ name: 'neo-query', tools });
+}

--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -15,7 +15,8 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { GlobalSettings, AuthStatus, Room, RoomGoal } from '@neokai/shared';
+import type { GlobalSettings, AuthStatus, Room, RoomGoal, TaskSummary } from '@neokai/shared';
+import { isWorkerSessionId } from '../../room/session-utils';
 
 // ---------------------------------------------------------------------------
 // Minimal interfaces — only the surface used by these tools
@@ -27,8 +28,8 @@ export interface NeoQueryRoomManager {
 	getRoomOverview(roomId: string): {
 		room: Room;
 		sessions: { id: string; title: string; status: string; lastActiveAt: number }[];
-		activeTasks: unknown[];
-		allTasks?: unknown[];
+		activeTasks: TaskSummary[];
+		allTasks?: TaskSummary[];
 	} | null;
 }
 
@@ -121,13 +122,7 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 					id: room.id,
 					name: room.name,
 					status: room.status,
-					sessionCount: room.sessionIds.filter(
-						(id) =>
-							!id.startsWith('room:chat:') &&
-							!id.startsWith('room:self:') &&
-							!id.startsWith('room:craft:') &&
-							!id.startsWith('room:lead:')
-					).length,
+					sessionCount: room.sessionIds.filter(isWorkerSessionId).length,
 					goalCount: goals.length,
 					activeGoalCount: goals.filter((g) => g.status === 'active' || g.status === 'needs_human')
 						.length,
@@ -153,13 +148,7 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 			const activeGoals = goals.filter((g) => g.status === 'active' || g.status === 'needs_human');
 
 			// Worker sessions (exclude internal room:* management sessions)
-			const workerSessionIds = room.sessionIds.filter(
-				(id) =>
-					!id.startsWith('room:chat:') &&
-					!id.startsWith('room:self:') &&
-					!id.startsWith('room:craft:') &&
-					!id.startsWith('room:lead:')
-			);
+			const workerSessionIds = room.sessionIds.filter(isWorkerSessionId);
 
 			const activeSessions = sessionManager
 				.listSessions({ status: 'active' })

--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -16,6 +16,7 @@ import { RoomRepository } from '../../../storage/repositories/room-repository';
 import { TaskRepository } from '../../../storage/repositories/task-repository';
 import { SessionRepository } from '../../../storage/repositories/session-repository';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
+import { isWorkerSessionId } from '../session-utils';
 import type {
 	Room,
 	CreateRoomParams,
@@ -152,38 +153,30 @@ export class RoomManager {
 
 		// Build session summaries from actual session data
 		// Filter out room-specific sessions (chat, craft, lead) and archived (deleted) sessions
-		const sessions = room.sessionIds
-			.filter(
-				(id) =>
-					!id.startsWith('room:chat:') &&
-					!id.startsWith('room:self:') &&
-					!id.startsWith('room:craft:') &&
-					!id.startsWith('room:lead:')
-			)
-			.flatMap((id) => {
-				const session = this.sessionRepo.getSession(id);
-				if (!session) {
-					return [
-						{
-							id,
-							title: `Session ${id.slice(0, 8)}`,
-							status: 'ended' as const,
-							lastActiveAt: 0,
-						},
-					];
-				}
-				if (session.status === 'archived') {
-					return [];
-				}
+		const sessions = room.sessionIds.filter(isWorkerSessionId).flatMap((id) => {
+			const session = this.sessionRepo.getSession(id);
+			if (!session) {
 				return [
 					{
-						id: session.id,
-						title: session.title,
-						status: session.status,
-						lastActiveAt: new Date(session.lastActiveAt).getTime(),
+						id,
+						title: `Session ${id.slice(0, 8)}`,
+						status: 'ended' as const,
+						lastActiveAt: 0,
 					},
 				];
-			});
+			}
+			if (session.status === 'archived') {
+				return [];
+			}
+			return [
+				{
+					id: session.id,
+					title: session.title,
+					status: session.status,
+					lastActiveAt: new Date(session.lastActiveAt).getTime(),
+				},
+			];
+		});
 
 		return {
 			room,

--- a/packages/daemon/src/lib/room/session-utils.ts
+++ b/packages/daemon/src/lib/room/session-utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Room session utilities
+ *
+ * Shared helpers for working with room session IDs.
+ */
+
+/**
+ * Internal room-management session prefixes that are NOT worker sessions.
+ * Any session ID that starts with one of these belongs to the room's internal
+ * infrastructure (chat agent, self-reflection, craft, leader) and should be
+ * excluded when counting or listing worker sessions.
+ *
+ * Add new prefixes here when new internal session types are introduced.
+ */
+const INTERNAL_SESSION_PREFIXES = [
+	'room:chat:',
+	'room:self:',
+	'room:craft:',
+	'room:lead:',
+] as const;
+
+/**
+ * Returns true when `sessionId` is a worker (non-internal) session.
+ * Internal management sessions (chat, self, craft, lead) return false.
+ */
+export function isWorkerSessionId(sessionId: string): boolean {
+	return INTERNAL_SESSION_PREFIXES.every((prefix) => !sessionId.startsWith(prefix));
+}

--- a/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Unit tests for Neo Query Tools
+ *
+ * Tests the two-layer pattern:
+ *   - createNeoQueryToolHandlers: handler functions (no MCP wiring)
+ *   - createNeoQueryMcpServer: registers all tools on an MCP server
+ *
+ * Covers:
+ * - list_rooms: happy path, empty list, include_archived flag
+ * - get_room_status: found, not found
+ * - get_room_details: found with goals/tasks, not found
+ * - get_system_info: auth authenticated, auth not authenticated
+ * - get_app_settings: returns safe subset of GlobalSettings
+ * - MCP server: all 5 tools are registered
+ */
+
+import { describe, expect, it, beforeEach } from 'bun:test';
+import {
+	createNeoQueryToolHandlers,
+	createNeoQueryMcpServer,
+	type NeoToolsConfig,
+	type NeoQueryRoomManager,
+	type NeoQueryGoalRepository,
+	type NeoQuerySessionManager,
+	type NeoQuerySettingsManager,
+	type NeoQueryAuthManager,
+} from '../../../src/lib/neo/tools/neo-query-tools';
+import type { Room, RoomGoal } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = 1_700_000_000_000;
+
+function makeRoom(overrides: Partial<Room> = {}): Room {
+	return {
+		id: 'room-1',
+		name: 'Test Room',
+		status: 'active',
+		sessionIds: [],
+		allowedPaths: [],
+		createdAt: NOW - 10_000,
+		updatedAt: NOW,
+		...overrides,
+	};
+}
+
+function makeGoal(overrides: Partial<RoomGoal> = {}): RoomGoal {
+	return {
+		id: 'goal-1',
+		roomId: 'room-1',
+		title: 'Test Goal',
+		description: 'A test goal',
+		status: 'active',
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		metrics: {},
+		createdAt: NOW - 5_000,
+		updatedAt: NOW,
+		missionType: 'one_shot',
+		autonomyLevel: 'supervised',
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeRoomManager(
+	rooms: Room[] = [],
+	overview: ReturnType<NeoQueryRoomManager['getRoomOverview']> = null
+): NeoQueryRoomManager {
+	return {
+		listRooms: (includeArchived = false) => {
+			if (includeArchived) return rooms;
+			return rooms.filter((r) => r.status !== 'archived');
+		},
+		getRoom: (id) => rooms.find((r) => r.id === id) ?? null,
+		getRoomOverview: (roomId) => {
+			if (overview && overview.room.id === roomId) return overview;
+			const room = rooms.find((r) => r.id === roomId);
+			if (!room) return null;
+			return { room, sessions: [], activeTasks: [], allTasks: [] };
+		},
+	};
+}
+
+function makeGoalRepository(goalsByRoom: Record<string, RoomGoal[]> = {}): NeoQueryGoalRepository {
+	return {
+		listGoals: (roomId) => goalsByRoom[roomId] ?? [],
+	};
+}
+
+function makeSessionManager(
+	activeSessions = 0,
+	sessions: { id: string; status: string }[] = []
+): NeoQuerySessionManager {
+	return {
+		getActiveSessions: () => activeSessions,
+		listSessions: (opts) => {
+			if (opts?.status) {
+				return sessions.filter((s) => s.status === opts.status);
+			}
+			return sessions;
+		},
+	};
+}
+
+function makeSettingsManager(overrides: Record<string, unknown> = {}): NeoQuerySettingsManager {
+	return {
+		getGlobalSettings: () =>
+			({
+				settingSources: ['user', 'project', 'local'],
+				model: 'claude-sonnet-4',
+				permissionMode: 'default',
+				thinkingLevel: 'none',
+				autoScroll: true,
+				coordinatorMode: false,
+				maxConcurrentWorkers: 3,
+				neoSecurityMode: 'balanced',
+				neoModel: null,
+				showArchived: false,
+				fallbackModels: [],
+				disabledMcpServers: [],
+				...overrides,
+			}) as ReturnType<NeoQuerySettingsManager['getGlobalSettings']>,
+	};
+}
+
+function makeAuthManager(isAuthenticated: boolean, method = 'api_key'): NeoQueryAuthManager {
+	return {
+		getAuthStatus: async () => ({
+			isAuthenticated,
+			method: method as 'api_key' | 'oauth_token' | 'none',
+			source: 'env' as const,
+		}),
+	};
+}
+
+function makeConfig(overrides: Partial<NeoToolsConfig> = {}): NeoToolsConfig {
+	return {
+		roomManager: makeRoomManager(),
+		goalRepository: makeGoalRepository(),
+		sessionManager: makeSessionManager(),
+		settingsManager: makeSettingsManager(),
+		authManager: makeAuthManager(true),
+		workspaceRoot: '/workspace',
+		appVersion: '0.1.1',
+		startedAt: NOW - 60_000,
+		...overrides,
+	};
+}
+
+function parseResult(result: { content: Array<{ type: 'text'; text: string }> }) {
+	return JSON.parse(result.content[0].text);
+}
+
+// ---------------------------------------------------------------------------
+// list_rooms
+// ---------------------------------------------------------------------------
+
+describe('list_rooms', () => {
+	it('returns empty array when no rooms exist', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.list_rooms({}));
+		expect(result).toEqual([]);
+	});
+
+	it('returns active rooms with summary fields', async () => {
+		const room = makeRoom({ sessionIds: ['worker-1', 'worker-2', 'room:chat:room-1'] });
+		const goal = makeGoal({ status: 'active' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': [goal] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_rooms({}));
+		expect(result).toHaveLength(1);
+		const r = result[0];
+		expect(r.id).toBe('room-1');
+		expect(r.name).toBe('Test Room');
+		expect(r.status).toBe('active');
+		// room:chat:room-1 is filtered out → 2 worker sessions
+		expect(r.sessionCount).toBe(2);
+		expect(r.goalCount).toBe(1);
+		expect(r.activeGoalCount).toBe(1);
+	});
+
+	it('excludes archived rooms by default', async () => {
+		const active = makeRoom({ id: 'room-a', name: 'Active', status: 'active' });
+		const archived = makeRoom({ id: 'room-b', name: 'Archived', status: 'archived' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ roomManager: makeRoomManager([active, archived]) })
+		);
+
+		const result = parseResult(await handlers.list_rooms({}));
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('room-a');
+	});
+
+	it('includes archived rooms when include_archived is true', async () => {
+		const active = makeRoom({ id: 'room-a', name: 'Active', status: 'active' });
+		const archived = makeRoom({ id: 'room-b', name: 'Archived', status: 'archived' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ roomManager: makeRoomManager([active, archived]) })
+		);
+
+		const result = parseResult(await handlers.list_rooms({ include_archived: true }));
+		expect(result).toHaveLength(2);
+	});
+
+	it('counts only active/needs_human goals as activeGoalCount', async () => {
+		const room = makeRoom();
+		const goals = [
+			makeGoal({ id: 'g1', status: 'active' }),
+			makeGoal({ id: 'g2', status: 'needs_human' }),
+			makeGoal({ id: 'g3', status: 'completed' }),
+			makeGoal({ id: 'g4', status: 'archived' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': goals }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_rooms({}));
+		expect(result[0].goalCount).toBe(4);
+		expect(result[0].activeGoalCount).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_room_status
+// ---------------------------------------------------------------------------
+
+describe('get_room_status', () => {
+	it('returns error when room not found', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.get_room_status({ room_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('returns room status with correct counts', async () => {
+		const room = makeRoom({
+			sessionIds: ['worker-1', 'worker-2', 'room:lead:room-1'],
+			defaultModel: 'claude-opus-4',
+		});
+		const goals = [
+			makeGoal({ id: 'g1', status: 'active' }),
+			makeGoal({ id: 'g2', status: 'completed' }),
+		];
+		const sessions = [
+			{ id: 'worker-1', status: 'active' },
+			{ id: 'worker-2', status: 'ended' },
+		];
+
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': goals }),
+				sessionManager: makeSessionManager(1, sessions),
+			})
+		);
+
+		const result = parseResult(await handlers.get_room_status({ room_id: 'room-1' }));
+		expect(result.id).toBe('room-1');
+		expect(result.name).toBe('Test Room');
+		expect(result.defaultModel).toBe('claude-opus-4');
+		// room:lead:room-1 is filtered → 2 worker session IDs
+		expect(result.sessionCount).toBe(2);
+		// only worker-1 has status 'active'
+		expect(result.activeSessionCount).toBe(1);
+		expect(result.goalCount).toBe(2);
+		expect(result.activeGoalCount).toBe(1);
+	});
+
+	it('returns null defaultModel when not set', async () => {
+		const room = makeRoom({ defaultModel: undefined });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ roomManager: makeRoomManager([room]) })
+		);
+		const result = parseResult(await handlers.get_room_status({ room_id: 'room-1' }));
+		expect(result.defaultModel).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_room_details
+// ---------------------------------------------------------------------------
+
+describe('get_room_details', () => {
+	it('returns error when room not found', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.get_room_details({ room_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('returns full room details with goals and tasks', async () => {
+		const room = makeRoom({
+			instructions: 'Focus on testing',
+			background: 'This is a background',
+			allowedModels: ['claude-sonnet-4', 'claude-opus-4'],
+		});
+		const goals = [
+			makeGoal({ id: 'g1', title: 'Goal 1', status: 'active', progress: 50 }),
+			makeGoal({ id: 'g2', title: 'Goal 2', status: 'completed', progress: 100 }),
+		];
+		const activeTasks = [{ id: 'task-1', title: 'Task 1', status: 'in_progress' }];
+		const sessions = [{ id: 'session-1', title: 'Session 1', status: 'active', lastActiveAt: NOW }];
+
+		const overview = { room, sessions, activeTasks, allTasks: activeTasks };
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room], overview),
+				goalRepository: makeGoalRepository({ 'room-1': goals }),
+			})
+		);
+
+		const result = parseResult(await handlers.get_room_details({ room_id: 'room-1' }));
+		expect(result.id).toBe('room-1');
+		expect(result.instructions).toBe('Focus on testing');
+		expect(result.background).toBe('This is a background');
+		expect(result.allowedModels).toEqual(['claude-sonnet-4', 'claude-opus-4']);
+		expect(result.goals).toHaveLength(2);
+		expect(result.goals[0].id).toBe('g1');
+		expect(result.goals[0].progress).toBe(50);
+		expect(result.goals[0].missionType).toBe('one_shot');
+		expect(result.goals[1].id).toBe('g2');
+		expect(result.sessions).toHaveLength(1);
+		expect(result.activeTasks).toHaveLength(1);
+		expect(result.allTaskCount).toBe(1);
+	});
+
+	it('returns empty goals and tasks when none exist', async () => {
+		const room = makeRoom();
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ roomManager: makeRoomManager([room]) })
+		);
+
+		const result = parseResult(await handlers.get_room_details({ room_id: 'room-1' }));
+		expect(result.goals).toHaveLength(0);
+		expect(result.activeTasks).toHaveLength(0);
+		expect(result.allTaskCount).toBe(0);
+	});
+
+	it('includes shortId in goal summary when present', async () => {
+		const room = makeRoom();
+		const goal = makeGoal({ shortId: 'G001' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': [goal] }),
+			})
+		);
+
+		const result = parseResult(await handlers.get_room_details({ room_id: 'room-1' }));
+		expect(result.goals[0].shortId).toBe('G001');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_system_info
+// ---------------------------------------------------------------------------
+
+describe('get_system_info', () => {
+	it('returns system info when authenticated', async () => {
+		const startedAt = NOW - 120_000; // 2 minutes ago
+		const rooms = [makeRoom({ id: 'r1' }), makeRoom({ id: 'r2' })];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager(rooms),
+				sessionManager: makeSessionManager(3),
+				authManager: makeAuthManager(true, 'api_key'),
+				workspaceRoot: '/my/workspace',
+				appVersion: '1.2.3',
+				startedAt,
+			})
+		);
+
+		const result = parseResult(await handlers.get_system_info());
+		expect(result.appVersion).toBe('1.2.3');
+		expect(result.workspaceRoot).toBe('/my/workspace');
+		expect(result.startedAt).toBe(startedAt);
+		// uptime should be at least 120 seconds
+		expect(result.uptimeSeconds).toBeGreaterThanOrEqual(120);
+		expect(result.auth.isAuthenticated).toBe(true);
+		expect(result.auth.method).toBe('api_key');
+		expect(result.roomCount).toBe(2);
+		expect(result.activeSessionCount).toBe(3);
+	});
+
+	it('reports unauthenticated state correctly', async () => {
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ authManager: makeAuthManager(false, 'none') })
+		);
+
+		const result = parseResult(await handlers.get_system_info());
+		expect(result.auth.isAuthenticated).toBe(false);
+		expect(result.auth.method).toBe('none');
+	});
+
+	it('reports oauth_token auth method', async () => {
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ authManager: makeAuthManager(true, 'oauth_token') })
+		);
+
+		const result = parseResult(await handlers.get_system_info());
+		expect(result.auth.method).toBe('oauth_token');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_app_settings
+// ---------------------------------------------------------------------------
+
+describe('get_app_settings', () => {
+	it('returns safe subset of global settings', async () => {
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				settingsManager: makeSettingsManager({
+					model: 'claude-opus-4',
+					neoSecurityMode: 'autonomous',
+					neoModel: 'claude-sonnet-4',
+					maxConcurrentWorkers: 5,
+				}),
+			})
+		);
+
+		const result = parseResult(await handlers.get_app_settings());
+		expect(result.model).toBe('claude-opus-4');
+		expect(result.neoSecurityMode).toBe('autonomous');
+		expect(result.neoModel).toBe('claude-sonnet-4');
+		expect(result.maxConcurrentWorkers).toBe(5);
+		expect(result.autoScroll).toBe(true);
+		expect(result.coordinatorMode).toBe(false);
+		expect(result.settingSources).toEqual(['user', 'project', 'local']);
+	});
+
+	it('uses defaults for optional fields when unset', async () => {
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				settingsManager: {
+					getGlobalSettings: () =>
+						({
+							settingSources: ['user'],
+						}) as ReturnType<NeoQuerySettingsManager['getGlobalSettings']>,
+				},
+			})
+		);
+
+		const result = parseResult(await handlers.get_app_settings());
+		expect(result.model).toBeNull();
+		expect(result.neoSecurityMode).toBe('balanced');
+		expect(result.neoModel).toBeNull();
+		expect(result.autoScroll).toBe(true);
+		expect(result.coordinatorMode).toBe(false);
+		expect(result.maxConcurrentWorkers).toBe(3);
+		expect(result.fallbackModels).toEqual([]);
+		expect(result.disabledMcpServers).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// MCP server — tool registration
+// ---------------------------------------------------------------------------
+
+describe('createNeoQueryMcpServer', () => {
+	let server: ReturnType<typeof createNeoQueryMcpServer>;
+
+	beforeEach(() => {
+		server = createNeoQueryMcpServer(makeConfig());
+	});
+
+	it('names the MCP server "neo-query"', () => {
+		expect(server.name).toBe('neo-query');
+	});
+
+	it('registers list_rooms tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('list_rooms');
+	});
+
+	it('registers get_room_status tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_room_status');
+	});
+
+	it('registers get_room_details tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_room_details');
+	});
+
+	it('registers get_system_info tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_system_info');
+	});
+
+	it('registers get_app_settings tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_app_settings');
+	});
+
+	it('registers exactly 5 tools', () => {
+		expect(Object.keys(server.instance._registeredTools)).toHaveLength(5);
+	});
+});

--- a/packages/daemon/tests/unit/room/session-utils.test.ts
+++ b/packages/daemon/tests/unit/room/session-utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { isWorkerSessionId } from '../../../src/lib/room/session-utils';
+
+describe('isWorkerSessionId', () => {
+	it('returns true for plain worker session IDs', () => {
+		expect(isWorkerSessionId('session-abc123')).toBe(true);
+		expect(isWorkerSessionId('worker-1')).toBe(true);
+		expect(isWorkerSessionId('abc')).toBe(true);
+	});
+
+	it('returns false for room:chat: sessions', () => {
+		expect(isWorkerSessionId('room:chat:room-1')).toBe(false);
+	});
+
+	it('returns false for room:self: sessions', () => {
+		expect(isWorkerSessionId('room:self:room-1')).toBe(false);
+	});
+
+	it('returns false for room:craft: sessions', () => {
+		expect(isWorkerSessionId('room:craft:room-1')).toBe(false);
+	});
+
+	it('returns false for room:lead: sessions', () => {
+		expect(isWorkerSessionId('room:lead:room-1')).toBe(false);
+	});
+
+	it('returns true for IDs that contain but do not start with an internal prefix', () => {
+		// e.g. a session whose ID happens to contain "room:chat:" mid-string
+		expect(isWorkerSessionId('prefix-room:chat:room-1')).toBe(true);
+	});
+});


### PR DESCRIPTION
Add five read-only MCP tools for Neo to query NeoKai system state.

**New file:** `packages/daemon/src/lib/neo/tools/neo-query-tools.ts`
- `NeoToolsConfig` — interface with minimal dep abstractions (RoomManager, GoalRepository, SessionManager, SettingsManager, AuthManager, plus workspaceRoot/appVersion/startedAt scalars)
- `createNeoQueryToolHandlers(config)` — pure handler functions, testable without MCP
- `createNeoQueryMcpServer(config)` — MCP server wrapping the handlers

**Tools implemented:**
- `list_rooms` — all rooms with id, name, status, session count, goal count, activeGoalCount
- `get_room_status` — room + active session count + active/total goal count + current model
- `get_room_details` — full room overview: goals summary, tasks summary, session list
- `get_system_info` — app version, uptime, auth status, workspace root, active session count
- `get_app_settings` — safe subset of GlobalSettings (excludes raw mcpServerSettings)

**Tests:** `packages/daemon/tests/unit/neo/neo-query-tools.test.ts` — 24 tests covering normal and error paths for every handler plus MCP server registration.