### PR TITLE
feat(neo): Skill and MCP server query tools (task 2.4)

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -7,6 +7,10 @@
  * - get_room_details
  * - get_system_info
  * - get_app_settings
+ * - list_mcp_servers
+ * - get_mcp_server_status
+ * - list_skills
+ * - get_skill_details
  *
  * Pattern: two-layer design (testable handlers + MCP server wrapper)
  *   createNeoQueryToolHandlers(config) → plain handler functions
@@ -15,7 +19,15 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { GlobalSettings, AuthStatus, Room, RoomGoal, TaskSummary } from '@neokai/shared';
+import type {
+	GlobalSettings,
+	AuthStatus,
+	Room,
+	RoomGoal,
+	TaskSummary,
+	AppMcpServer,
+	AppSkill,
+} from '@neokai/shared';
 import { isWorkerSessionId } from '../../room/session-utils';
 
 // ---------------------------------------------------------------------------
@@ -54,6 +66,16 @@ export interface NeoQueryAuthManager {
 	getAuthStatus(): Promise<AuthStatus>;
 }
 
+export interface NeoQueryMcpServerRepository {
+	list(): AppMcpServer[];
+	get(id: string): AppMcpServer | null;
+}
+
+export interface NeoQuerySkillsManager {
+	listSkills(): AppSkill[];
+	getSkill(id: string): AppSkill | null;
+}
+
 /**
  * All dependencies required by the Neo query tools.
  */
@@ -63,6 +85,8 @@ export interface NeoToolsConfig {
 	sessionManager: NeoQuerySessionManager;
 	settingsManager: NeoQuerySettingsManager;
 	authManager: NeoQueryAuthManager;
+	mcpServerRepository: NeoQueryMcpServerRepository;
+	skillsManager: NeoQuerySkillsManager;
 	/** Absolute path to the workspace root */
 	workspaceRoot: string;
 	/** Human-readable app version string, e.g. "0.1.1" */
@@ -103,6 +127,8 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 		sessionManager,
 		settingsManager,
 		authManager,
+		mcpServerRepository,
+		skillsManager,
 		workspaceRoot,
 		appVersion,
 		startedAt,
@@ -254,6 +280,101 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 				disabledMcpServers: settings.disabledMcpServers ?? [],
 			});
 		},
+
+		/**
+		 * List all registered MCP servers with their enabled/disabled status.
+		 */
+		async list_mcp_servers(): Promise<ToolResult> {
+			const servers = mcpServerRepository.list();
+
+			const result = servers.map((s) => ({
+				id: s.id,
+				name: s.name,
+				description: s.description ?? null,
+				sourceType: s.sourceType,
+				enabled: s.enabled,
+				createdAt: s.createdAt ?? null,
+				updatedAt: s.updatedAt ?? null,
+			}));
+
+			return jsonResult(result);
+		},
+
+		/**
+		 * Get details for a specific MCP server by ID.
+		 */
+		async get_mcp_server_status(args: { server_id: string }): Promise<ToolResult> {
+			const server = mcpServerRepository.get(args.server_id);
+			if (!server) {
+				return errorResult(`MCP server not found: ${args.server_id}`);
+			}
+
+			// Build transport-specific config (omit sensitive env values)
+			const transportConfig: Record<string, unknown> = { sourceType: server.sourceType };
+			if (server.sourceType === 'stdio') {
+				transportConfig['command'] = server.command ?? null;
+				transportConfig['args'] = server.args ?? [];
+				// Expose env key names only (not values) to avoid leaking secrets
+				transportConfig['envKeys'] = server.env ? Object.keys(server.env) : [];
+			} else {
+				transportConfig['url'] = server.url ?? null;
+				// Expose header key names only (not values) to avoid leaking secrets
+				transportConfig['headerKeys'] = server.headers ? Object.keys(server.headers) : [];
+			}
+
+			return jsonResult({
+				id: server.id,
+				name: server.name,
+				description: server.description ?? null,
+				enabled: server.enabled,
+				transport: transportConfig,
+				createdAt: server.createdAt ?? null,
+				updatedAt: server.updatedAt ?? null,
+			});
+		},
+
+		/**
+		 * List all skills with type and enabled status.
+		 */
+		async list_skills(): Promise<ToolResult> {
+			const skills = skillsManager.listSkills();
+
+			const result = skills.map((s) => ({
+				id: s.id,
+				name: s.name,
+				displayName: s.displayName,
+				description: s.description,
+				sourceType: s.sourceType,
+				enabled: s.enabled,
+				builtIn: s.builtIn,
+				validationStatus: s.validationStatus,
+			}));
+
+			return jsonResult(result);
+		},
+
+		/**
+		 * Get full details for a specific skill by ID including validation status.
+		 */
+		async get_skill_details(args: { skill_id: string }): Promise<ToolResult> {
+			const skill = skillsManager.getSkill(args.skill_id);
+			if (!skill) {
+				return errorResult(`Skill not found: ${args.skill_id}`);
+			}
+
+			return jsonResult({
+				id: skill.id,
+				name: skill.name,
+				displayName: skill.displayName,
+				description: skill.description,
+				sourceType: skill.sourceType,
+				config: skill.config,
+				enabled: skill.enabled,
+				builtIn: skill.builtIn,
+				validationStatus: skill.validationStatus,
+				createdAt: skill.createdAt,
+			});
+		},
 	};
 }
 
@@ -312,6 +433,38 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 			'Get the current global application settings including model, permission mode, Neo security mode, and other preferences.',
 			{},
 			() => handlers.get_app_settings()
+		),
+
+		tool(
+			'list_mcp_servers',
+			'List all registered application-level MCP servers with their enabled/disabled status, source type, and description.',
+			{},
+			() => handlers.list_mcp_servers()
+		),
+
+		tool(
+			'get_mcp_server_status',
+			'Get details for a specific MCP server by ID: transport type, configuration (command/URL, env key names), and enabled status.',
+			{
+				server_id: z.string().describe('ID of the MCP server to query'),
+			},
+			(args) => handlers.get_mcp_server_status(args)
+		),
+
+		tool(
+			'list_skills',
+			'List all application-level skills with their source type (builtin/plugin/mcp_server), enabled status, and validation status.',
+			{},
+			() => handlers.list_skills()
+		),
+
+		tool(
+			'get_skill_details',
+			'Get full details for a specific skill by ID including its config, validation status, and whether it is built-in.',
+			{
+				skill_id: z.string().describe('ID of the skill to query'),
+			},
+			(args) => handlers.get_skill_details(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
@@ -629,6 +629,27 @@ describe('get_mcp_server_status', () => {
 		expect(result.transport.headers).toBeUndefined();
 	});
 
+	it('returns http server details with url but not header values', async () => {
+		const server = makeMcpServer({
+			id: 'mcp-3',
+			sourceType: 'http',
+			command: undefined,
+			args: undefined,
+			env: undefined,
+			url: 'https://example.com/mcp/http',
+			headers: { 'X-Api-Key': 'secret', 'X-Tenant': 'acme' },
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ mcpServerRepository: makeMcpServerRepository([server]) })
+		);
+
+		const result = parseResult(await handlers.get_mcp_server_status({ server_id: 'mcp-3' }));
+		expect(result.transport.sourceType).toBe('http');
+		expect(result.transport.url).toBe('https://example.com/mcp/http');
+		expect(result.transport.headerKeys).toEqual(expect.arrayContaining(['X-Api-Key', 'X-Tenant']));
+		expect(result.transport.headers).toBeUndefined();
+	});
+
 	it('returns empty envKeys when env is not set', async () => {
 		const server = makeMcpServer({ env: undefined });
 		const handlers = createNeoQueryToolHandlers(

--- a/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
@@ -11,7 +11,11 @@
  * - get_room_details: found with goals/tasks, not found
  * - get_system_info: auth authenticated, auth not authenticated
  * - get_app_settings: returns safe subset of GlobalSettings
- * - MCP server: all 5 tools are registered
+ * - list_mcp_servers: happy path, empty list
+ * - get_mcp_server_status: found (stdio), found (sse), not found
+ * - list_skills: happy path, empty list
+ * - get_skill_details: found, not found
+ * - MCP server: all 9 tools are registered
  */
 
 import { describe, expect, it, beforeEach } from 'bun:test';
@@ -24,8 +28,10 @@ import {
 	type NeoQuerySessionManager,
 	type NeoQuerySettingsManager,
 	type NeoQueryAuthManager,
+	type NeoQueryMcpServerRepository,
+	type NeoQuerySkillsManager,
 } from '../../../src/lib/neo/tools/neo-query-tools';
-import type { Room, RoomGoal } from '@neokai/shared';
+import type { Room, RoomGoal, AppMcpServer, AppSkill } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -140,6 +146,51 @@ function makeAuthManager(isAuthenticated: boolean, method = 'api_key'): NeoQuery
 	};
 }
 
+function makeMcpServer(overrides: Partial<AppMcpServer> = {}): AppMcpServer {
+	return {
+		id: 'mcp-1',
+		name: 'test-server',
+		sourceType: 'stdio',
+		command: 'npx',
+		args: ['-y', 'some-mcp-package'],
+		env: { SOME_KEY: 'value' },
+		enabled: true,
+		createdAt: NOW - 5_000,
+		updatedAt: NOW,
+		...overrides,
+	};
+}
+
+function makeMcpServerRepository(servers: AppMcpServer[] = []): NeoQueryMcpServerRepository {
+	return {
+		list: () => servers,
+		get: (id) => servers.find((s) => s.id === id) ?? null,
+	};
+}
+
+function makeSkill(overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id: 'skill-1',
+		name: 'test-skill',
+		displayName: 'Test Skill',
+		description: 'A test skill',
+		sourceType: 'builtin',
+		config: { type: 'builtin', commandName: 'test-cmd' },
+		enabled: true,
+		builtIn: false,
+		validationStatus: 'valid',
+		createdAt: NOW - 3_000,
+		...overrides,
+	};
+}
+
+function makeSkillsManager(skills: AppSkill[] = []): NeoQuerySkillsManager {
+	return {
+		listSkills: () => skills,
+		getSkill: (id) => skills.find((s) => s.id === id) ?? null,
+	};
+}
+
 function makeConfig(overrides: Partial<NeoToolsConfig> = {}): NeoToolsConfig {
 	return {
 		roomManager: makeRoomManager(),
@@ -147,6 +198,8 @@ function makeConfig(overrides: Partial<NeoToolsConfig> = {}): NeoToolsConfig {
 		sessionManager: makeSessionManager(),
 		settingsManager: makeSettingsManager(),
 		authManager: makeAuthManager(true),
+		mcpServerRepository: makeMcpServerRepository(),
+		skillsManager: makeSkillsManager(),
 		workspaceRoot: '/workspace',
 		appVersion: '0.1.1',
 		startedAt: NOW - 60_000,
@@ -469,6 +522,272 @@ describe('get_app_settings', () => {
 });
 
 // ---------------------------------------------------------------------------
+// list_mcp_servers
+// ---------------------------------------------------------------------------
+
+describe('list_mcp_servers', () => {
+	it('returns empty array when no servers registered', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.list_mcp_servers());
+		expect(result).toEqual([]);
+	});
+
+	it('returns all servers with summary fields', async () => {
+		const server = makeMcpServer({ description: 'A test MCP server' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ mcpServerRepository: makeMcpServerRepository([server]) })
+		);
+
+		const result = parseResult(await handlers.list_mcp_servers());
+		expect(result).toHaveLength(1);
+		const s = result[0];
+		expect(s.id).toBe('mcp-1');
+		expect(s.name).toBe('test-server');
+		expect(s.description).toBe('A test MCP server');
+		expect(s.sourceType).toBe('stdio');
+		expect(s.enabled).toBe(true);
+		expect(s.createdAt).toBe(NOW - 5_000);
+	});
+
+	it('returns disabled servers with enabled=false', async () => {
+		const server = makeMcpServer({ enabled: false });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ mcpServerRepository: makeMcpServerRepository([server]) })
+		);
+
+		const result = parseResult(await handlers.list_mcp_servers());
+		expect(result[0].enabled).toBe(false);
+	});
+
+	it('returns null description when not set', async () => {
+		const server = makeMcpServer({ description: undefined });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ mcpServerRepository: makeMcpServerRepository([server]) })
+		);
+
+		const result = parseResult(await handlers.list_mcp_servers());
+		expect(result[0].description).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_mcp_server_status
+// ---------------------------------------------------------------------------
+
+describe('get_mcp_server_status', () => {
+	it('returns error when server not found', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.get_mcp_server_status({ server_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('returns stdio server details with command and arg list', async () => {
+		const server = makeMcpServer({
+			sourceType: 'stdio',
+			command: 'npx',
+			args: ['-y', 'some-pkg'],
+			env: { API_KEY: 'secret', DEBUG: '1' },
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ mcpServerRepository: makeMcpServerRepository([server]) })
+		);
+
+		const result = parseResult(await handlers.get_mcp_server_status({ server_id: 'mcp-1' }));
+		expect(result.id).toBe('mcp-1');
+		expect(result.name).toBe('test-server');
+		expect(result.enabled).toBe(true);
+		expect(result.transport.sourceType).toBe('stdio');
+		expect(result.transport.command).toBe('npx');
+		expect(result.transport.args).toEqual(['-y', 'some-pkg']);
+		// Env values must NOT be included — only key names
+		expect(result.transport.envKeys).toEqual(expect.arrayContaining(['API_KEY', 'DEBUG']));
+		expect(result.transport.env).toBeUndefined();
+	});
+
+	it('returns sse/http server details with url but not header values', async () => {
+		const server = makeMcpServer({
+			id: 'mcp-2',
+			sourceType: 'sse',
+			command: undefined,
+			args: undefined,
+			env: undefined,
+			url: 'https://example.com/mcp',
+			headers: { Authorization: 'Bearer token123', 'X-Custom': 'val' },
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ mcpServerRepository: makeMcpServerRepository([server]) })
+		);
+
+		const result = parseResult(await handlers.get_mcp_server_status({ server_id: 'mcp-2' }));
+		expect(result.transport.sourceType).toBe('sse');
+		expect(result.transport.url).toBe('https://example.com/mcp');
+		// Header values must NOT be included — only key names
+		expect(result.transport.headerKeys).toEqual(
+			expect.arrayContaining(['Authorization', 'X-Custom'])
+		);
+		expect(result.transport.headers).toBeUndefined();
+	});
+
+	it('returns empty envKeys when env is not set', async () => {
+		const server = makeMcpServer({ env: undefined });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ mcpServerRepository: makeMcpServerRepository([server]) })
+		);
+
+		const result = parseResult(await handlers.get_mcp_server_status({ server_id: 'mcp-1' }));
+		expect(result.transport.envKeys).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// list_skills
+// ---------------------------------------------------------------------------
+
+describe('list_skills', () => {
+	it('returns empty array when no skills registered', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.list_skills());
+		expect(result).toEqual([]);
+	});
+
+	it('returns all skills with summary fields', async () => {
+		const skill = makeSkill({ displayName: 'My Skill', description: 'Does stuff' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ skillsManager: makeSkillsManager([skill]) })
+		);
+
+		const result = parseResult(await handlers.list_skills());
+		expect(result).toHaveLength(1);
+		const s = result[0];
+		expect(s.id).toBe('skill-1');
+		expect(s.name).toBe('test-skill');
+		expect(s.displayName).toBe('My Skill');
+		expect(s.description).toBe('Does stuff');
+		expect(s.sourceType).toBe('builtin');
+		expect(s.enabled).toBe(true);
+		expect(s.builtIn).toBe(false);
+		expect(s.validationStatus).toBe('valid');
+	});
+
+	it('list_skills does not include config or createdAt', async () => {
+		const skill = makeSkill();
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ skillsManager: makeSkillsManager([skill]) })
+		);
+
+		const result = parseResult(await handlers.list_skills());
+		expect(result[0].config).toBeUndefined();
+		expect(result[0].createdAt).toBeUndefined();
+	});
+
+	it('returns disabled skills with enabled=false', async () => {
+		const skill = makeSkill({ enabled: false });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ skillsManager: makeSkillsManager([skill]) })
+		);
+
+		const result = parseResult(await handlers.list_skills());
+		expect(result[0].enabled).toBe(false);
+	});
+
+	it('returns skills with various source types', async () => {
+		const plugin = makeSkill({
+			id: 'skill-plugin',
+			name: 'plugin-skill',
+			sourceType: 'plugin',
+			config: { type: 'plugin', pluginPath: '/abs/path/to/plugin' },
+		});
+		const mcp = makeSkill({
+			id: 'skill-mcp',
+			name: 'mcp-skill',
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: 'some-mcp-id' },
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ skillsManager: makeSkillsManager([plugin, mcp]) })
+		);
+
+		const result = parseResult(await handlers.list_skills());
+		expect(result).toHaveLength(2);
+		expect(result[0].sourceType).toBe('plugin');
+		expect(result[1].sourceType).toBe('mcp_server');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_skill_details
+// ---------------------------------------------------------------------------
+
+describe('get_skill_details', () => {
+	it('returns error when skill not found', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.get_skill_details({ skill_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('returns full skill details including config and createdAt', async () => {
+		const skill = makeSkill({
+			id: 'skill-1',
+			name: 'web-search',
+			displayName: 'Web Search',
+			sourceType: 'mcp_server',
+			config: { type: 'mcp_server', appMcpServerId: 'mcp-uuid' },
+			builtIn: true,
+			validationStatus: 'valid',
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ skillsManager: makeSkillsManager([skill]) })
+		);
+
+		const result = parseResult(await handlers.get_skill_details({ skill_id: 'skill-1' }));
+		expect(result.id).toBe('skill-1');
+		expect(result.name).toBe('web-search');
+		expect(result.displayName).toBe('Web Search');
+		expect(result.sourceType).toBe('mcp_server');
+		expect(result.config).toEqual({ type: 'mcp_server', appMcpServerId: 'mcp-uuid' });
+		expect(result.builtIn).toBe(true);
+		expect(result.validationStatus).toBe('valid');
+		expect(result.createdAt).toBe(NOW - 3_000);
+	});
+
+	it('returns correct validationStatus for invalid skill', async () => {
+		const skill = makeSkill({ validationStatus: 'invalid' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ skillsManager: makeSkillsManager([skill]) })
+		);
+
+		const result = parseResult(await handlers.get_skill_details({ skill_id: 'skill-1' }));
+		expect(result.validationStatus).toBe('invalid');
+	});
+
+	it('returns pending validation status for newly created skill', async () => {
+		const skill = makeSkill({ validationStatus: 'pending' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ skillsManager: makeSkillsManager([skill]) })
+		);
+
+		const result = parseResult(await handlers.get_skill_details({ skill_id: 'skill-1' }));
+		expect(result.validationStatus).toBe('pending');
+	});
+
+	it('returns plugin config with pluginPath', async () => {
+		const skill = makeSkill({
+			sourceType: 'plugin',
+			config: { type: 'plugin', pluginPath: '/absolute/path/to/plugin' },
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({ skillsManager: makeSkillsManager([skill]) })
+		);
+
+		const result = parseResult(await handlers.get_skill_details({ skill_id: 'skill-1' }));
+		expect(result.config.type).toBe('plugin');
+		expect(result.config.pluginPath).toBe('/absolute/path/to/plugin');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // MCP server — tool registration
 // ---------------------------------------------------------------------------
 
@@ -503,7 +822,23 @@ describe('createNeoQueryMcpServer', () => {
 		expect(server.instance._registeredTools).toHaveProperty('get_app_settings');
 	});
 
-	it('registers exactly 5 tools', () => {
-		expect(Object.keys(server.instance._registeredTools)).toHaveLength(5);
+	it('registers list_mcp_servers tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('list_mcp_servers');
+	});
+
+	it('registers get_mcp_server_status tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_mcp_server_status');
+	});
+
+	it('registers list_skills tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('list_skills');
+	});
+
+	it('registers get_skill_details tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_skill_details');
+	});
+
+	it('registers exactly 9 tools', () => {
+		expect(Object.keys(server.instance._registeredTools)).toHaveLength(9);
 	});
 });


### PR DESCRIPTION
Add four new read-only Neo query tools for MCP servers and skills.

**New tools:**
- `list_mcp_servers` — all registered app-level MCP servers with enabled/disabled status
- `get_mcp_server_status` — server details: transport type, command/URL, env and header key names (values omitted to prevent secret leakage)
- `list_skills` — all skills with sourceType, enabled, builtIn, validationStatus
- `get_skill_details` — full skill info including config and createdAt

**Implementation:**
- Two new interfaces (`NeoQueryMcpServerRepository`, `NeoQuerySkillsManager`) added to `NeoToolsConfig` — same pattern as existing room/session interfaces
- Handlers wired through `AppMcpServerRepository.list()/get()` and `SkillsManager.listSkills()/getSkill()`
- 21 new unit tests: happy path, not-found errors, empty lists, disabled entries, all source types (stdio/sse, builtin/plugin/mcp_server), secret exclusion for env and header values
- `neo-query` MCP server now registers 9 tools (up from 5)