### PR TITLE
feat(neo): Room and goal action tools (task 3.2)

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -66,6 +66,8 @@ export interface NeoActionRoomManager {
 	}): Room;
 	deleteRoom(id: string): boolean;
 	getRoom(id: string): Room | null;
+	/** Count of worker sessions currently assigned to a room */
+	getActiveSessionCount?(roomId: string): number;
 	updateRoom(
 		id: string,
 		params: {
@@ -161,6 +163,13 @@ export interface NeoActionToolsConfig {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Approval message sent to the worker agent when a task is approved.
+ * The worker is expected to merge the PR as its final step.
+ */
+const APPROVE_TASK_MESSAGE =
+	'Human has approved the PR. Merge it now by running `gh pr merge` (do NOT use --delete-branch). After the merge completes, your work is done.';
+
 interface ToolResult {
 	content: Array<{ type: 'text'; text: string }>;
 }
@@ -246,7 +255,13 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 		},
 
 		async delete_room(args: { room_id: string }): Promise<ToolResult> {
-			return withSecurityCheck('delete_room', args as Record<string, unknown>, config, async () => {
+			// If the room has active sessions, escalate to high risk.
+			// ActionClassification maps `delete_room` (medium) and
+			// `delete_room_with_active_tasks` (high) separately — pick the right key.
+			const activeSessions = roomManager.getActiveSessionCount?.(args.room_id) ?? 0;
+			const toolName = activeSessions > 0 ? 'delete_room_with_active_tasks' : 'delete_room';
+
+			return withSecurityCheck(toolName, args as Record<string, unknown>, config, async () => {
 				const room = roomManager.getRoom(args.room_id);
 				if (!room) {
 					return errorResult(`Room not found: ${args.room_id}`);
@@ -267,6 +282,17 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			default_model?: string;
 			allowed_models?: string[];
 		}): Promise<ToolResult> {
+			// Guard: require at least one field beyond room_id
+			const hasUpdates =
+				args.name !== undefined ||
+				args.description !== undefined ||
+				args.instructions !== undefined ||
+				args.default_model !== undefined ||
+				args.allowed_models !== undefined;
+			if (!hasUpdates) {
+				return errorResult('No update fields provided');
+			}
+
 			return withSecurityCheck(
 				'update_room_settings',
 				args as Record<string, unknown>,
@@ -512,15 +538,15 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 					if (!task) {
 						return errorResult(`Task not found: ${args.task_id}`);
 					}
+					// Explicit pre-check: gives a clear error before we hit resumeWorkerFromHuman,
+					// which would return false with a less specific "no group found" message.
 					if (task.status !== 'review') {
 						return errorResult(`Task is not in review status (current: ${task.status})`);
 					}
 
-					const resumed = await runtime.resumeWorkerFromHuman(
-						args.task_id,
-						'Human has approved the PR. Merge it now by running `gh pr merge` (do NOT use --delete-branch). After the merge completes, your work is done.',
-						{ approved: true }
-					);
+					const resumed = await runtime.resumeWorkerFromHuman(args.task_id, APPROVE_TASK_MESSAGE, {
+						approved: true,
+					});
 
 					if (!resumed) {
 						return errorResult(
@@ -538,6 +564,12 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			task_id: string;
 			feedback: string;
 		}): Promise<ToolResult> {
+			// Validate feedback before the security check to avoid storing a pending action
+			// with empty feedback that would produce a useless rejection message.
+			if (!args.feedback?.trim()) {
+				return errorResult('Feedback is required for task rejection');
+			}
+
 			return withSecurityCheck('reject_task', args as Record<string, unknown>, config, async () => {
 				const room = roomManager.getRoom(args.room_id);
 				if (!room) {
@@ -558,6 +590,8 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				if (!task) {
 					return errorResult(`Task not found: ${args.task_id}`);
 				}
+				// Explicit pre-check: gives a clear error before we hit resumeWorkerFromHuman,
+				// which would return false with a less specific "no group found" message.
 				if (task.status !== 'review') {
 					return errorResult(`Task is not in review status (current: ${task.status})`);
 				}
@@ -724,6 +758,9 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 			{
 				room_id: z.string().describe('ID of the room containing the task'),
 				task_id: z.string().describe('ID of the task'),
+				// `rate_limited` and `usage_limited` are intentionally excluded: those
+				// statuses are set by the runtime in response to API errors and cannot
+				// be meaningfully set by a human or agent action.
 				status: z
 					.enum([
 						'draft',

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -1,0 +1,768 @@
+/**
+ * Neo Action Tools - MCP tools for write operations
+ *
+ * Implements room, goal, and task write operations with security-tier enforcement.
+ * Each tool checks whether the current security mode requires confirmation before
+ * execution and either runs immediately or returns a `confirmationRequired` payload.
+ *
+ * Pattern: two-layer design (testable handlers + MCP server wrapper)
+ *   createNeoActionToolHandlers(config) → plain handler functions
+ *   createNeoActionMcpServer(config)    → MCP server wrapping those handlers
+ *
+ * Supported tools:
+ *
+ *   Room operations
+ *   - create_room
+ *   - delete_room
+ *   - update_room_settings
+ *
+ *   Goal operations
+ *   - create_goal
+ *   - update_goal
+ *   - set_goal_status
+ *
+ *   Task operations
+ *   - create_task
+ *   - update_task
+ *   - set_task_status
+ *   - approve_task
+ *   - reject_task
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import type {
+	Room,
+	RoomGoal,
+	NeoTask,
+	GoalStatus,
+	TaskStatus,
+	GoalPriority,
+	TaskPriority,
+	MissionType,
+	AutonomyLevel,
+	WorkspacePath,
+} from '@neokai/shared';
+import {
+	ActionClassification,
+	shouldAutoExecute,
+	type NeoSecurityMode,
+	type NeoActionResult,
+	type PendingActionStore,
+} from '../security-tier';
+
+// ---------------------------------------------------------------------------
+// Minimal dependency interfaces
+// ---------------------------------------------------------------------------
+
+export interface NeoActionRoomManager {
+	createRoom(params: {
+		name: string;
+		background?: string;
+		allowedPaths?: WorkspacePath[];
+		defaultPath?: string;
+		defaultModel?: string;
+		allowedModels?: string[];
+	}): Room;
+	deleteRoom(id: string): boolean;
+	getRoom(id: string): Room | null;
+	updateRoom(
+		id: string,
+		params: {
+			name?: string;
+			background?: string | null;
+			instructions?: string | null;
+			defaultModel?: string | null;
+			allowedModels?: string[];
+			allowedPaths?: WorkspacePath[];
+			defaultPath?: string | null;
+		}
+	): Room | null;
+}
+
+export interface NeoActionGoalManager {
+	createGoal(params: {
+		title: string;
+		description?: string;
+		priority?: GoalPriority;
+		missionType?: MissionType;
+		autonomyLevel?: AutonomyLevel;
+	}): Promise<RoomGoal>;
+	getGoal(id: string): Promise<RoomGoal | null>;
+	patchGoal(
+		id: string,
+		patch: {
+			title?: string;
+			description?: string;
+			priority?: GoalPriority;
+			missionType?: MissionType;
+			autonomyLevel?: AutonomyLevel;
+		}
+	): Promise<RoomGoal>;
+	updateGoalStatus(id: string, status: GoalStatus): Promise<RoomGoal>;
+}
+
+export interface NeoActionTaskManager {
+	createTask(params: {
+		title: string;
+		description: string;
+		priority?: TaskPriority;
+		dependsOn?: string[];
+		status?: TaskStatus;
+	}): Promise<NeoTask>;
+	getTask(id: string): Promise<NeoTask | null>;
+	updateTaskFields(
+		id: string,
+		updates: {
+			title?: string;
+			description?: string;
+			priority?: TaskPriority;
+			dependsOn?: string[];
+		}
+	): Promise<NeoTask>;
+	setTaskStatus(
+		id: string,
+		status: TaskStatus,
+		opts?: { result?: string; error?: string }
+	): Promise<NeoTask>;
+}
+
+/** Optional runtime — if not provided, approve/reject fallback gracefully */
+export interface NeoActionRuntime {
+	resumeWorkerFromHuman(
+		taskId: string,
+		message: string,
+		opts: { approved: boolean }
+	): Promise<boolean>;
+}
+
+export interface NeoActionRuntimeService {
+	getRuntime(roomId: string): NeoActionRuntime | null;
+}
+
+/** Factory that returns managers scoped to a given room ID */
+export interface NeoActionManagerFactory {
+	getGoalManager(roomId: string): NeoActionGoalManager;
+	getTaskManager(roomId: string): NeoActionTaskManager;
+}
+
+export interface NeoActionToolsConfig {
+	roomManager: NeoActionRoomManager;
+	managerFactory: NeoActionManagerFactory;
+	runtimeService?: NeoActionRuntimeService;
+	pendingStore: PendingActionStore;
+	/** Workspace root — auto-applied as allowedPaths when not provided */
+	workspaceRoot?: string;
+	/** Returns the current security mode (looked up at call time) */
+	getSecurityMode(): NeoSecurityMode;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface ToolResult {
+	content: Array<{ type: 'text'; text: string }>;
+}
+
+function jsonResult(data: Record<string, unknown> | unknown[]): ToolResult {
+	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+function errorResult(message: string): ToolResult {
+	return jsonResult({ success: false, error: message });
+}
+
+function successResult(data: Record<string, unknown> = {}): ToolResult {
+	return jsonResult({ success: true, ...data });
+}
+
+/**
+ * Wrap a write operation with security-tier enforcement.
+ *
+ * If the current mode allows auto-execution for the given tool, the executor
+ * runs immediately.  Otherwise the input is stored in the pending store and a
+ * `confirmationRequired` payload is returned for the user to confirm.
+ */
+async function withSecurityCheck(
+	toolName: string,
+	input: Record<string, unknown>,
+	config: Pick<NeoActionToolsConfig, 'pendingStore' | 'getSecurityMode'>,
+	executor: () => Promise<ToolResult>
+): Promise<ToolResult> {
+	const mode = config.getSecurityMode();
+	const riskLevel = ActionClassification[toolName] ?? 'medium';
+
+	if (shouldAutoExecute(mode, riskLevel)) {
+		return executor();
+	}
+
+	// Confirmation required — store the pending action and return a structured payload
+	const pendingActionId = config.pendingStore.store({ toolName, input });
+	const result: NeoActionResult = {
+		success: false,
+		confirmationRequired: true,
+		pendingActionId,
+		actionDescription: `Execute ${toolName}`,
+		riskLevel,
+	};
+	return jsonResult(result as unknown as Record<string, unknown>);
+}
+
+// ---------------------------------------------------------------------------
+// Handler functions (testable without MCP plumbing)
+// ---------------------------------------------------------------------------
+
+export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
+	const { roomManager, managerFactory, runtimeService, workspaceRoot } = config;
+
+	return {
+		// ── Room ──────────────────────────────────────────────────────────────
+
+		async create_room(args: {
+			name: string;
+			description?: string;
+			workspace_path?: string;
+			default_model?: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck('create_room', args as Record<string, unknown>, config, async () => {
+				const allowedPaths: WorkspacePath[] = args.workspace_path
+					? [{ path: args.workspace_path }]
+					: workspaceRoot
+						? [{ path: workspaceRoot }]
+						: [];
+				const defaultPath = args.workspace_path ?? workspaceRoot;
+
+				const room = roomManager.createRoom({
+					name: args.name,
+					background: args.description,
+					allowedPaths,
+					defaultPath,
+					defaultModel: args.default_model,
+				});
+
+				return successResult({ room });
+			});
+		},
+
+		async delete_room(args: { room_id: string }): Promise<ToolResult> {
+			return withSecurityCheck('delete_room', args as Record<string, unknown>, config, async () => {
+				const room = roomManager.getRoom(args.room_id);
+				if (!room) {
+					return errorResult(`Room not found: ${args.room_id}`);
+				}
+				const deleted = roomManager.deleteRoom(args.room_id);
+				if (!deleted) {
+					return errorResult(`Failed to delete room: ${args.room_id}`);
+				}
+				return successResult({ roomId: args.room_id });
+			});
+		},
+
+		async update_room_settings(args: {
+			room_id: string;
+			name?: string;
+			description?: string;
+			instructions?: string;
+			default_model?: string;
+			allowed_models?: string[];
+		}): Promise<ToolResult> {
+			return withSecurityCheck(
+				'update_room_settings',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+
+					const updated = roomManager.updateRoom(args.room_id, {
+						name: args.name,
+						background: args.description,
+						instructions: args.instructions,
+						defaultModel: args.default_model,
+						allowedModels: args.allowed_models,
+					});
+
+					if (!updated) {
+						return errorResult(`Failed to update room: ${args.room_id}`);
+					}
+
+					return successResult({ room: updated });
+				}
+			);
+		},
+
+		// ── Goal ─────────────────────────────────────────────────────────────
+
+		async create_goal(args: {
+			room_id: string;
+			title: string;
+			description?: string;
+			priority?: string;
+			mission_type?: string;
+			autonomy_level?: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck('create_goal', args as Record<string, unknown>, config, async () => {
+				const room = roomManager.getRoom(args.room_id);
+				if (!room) {
+					return errorResult(`Room not found: ${args.room_id}`);
+				}
+
+				const goalManager = managerFactory.getGoalManager(args.room_id);
+				const goal = await goalManager.createGoal({
+					title: args.title,
+					description: args.description,
+					priority: args.priority as GoalPriority | undefined,
+					missionType: args.mission_type as MissionType | undefined,
+					autonomyLevel: args.autonomy_level as AutonomyLevel | undefined,
+				});
+
+				return successResult({ goal });
+			});
+		},
+
+		async update_goal(args: {
+			room_id: string;
+			goal_id: string;
+			title?: string;
+			description?: string;
+			priority?: string;
+			mission_type?: string;
+			autonomy_level?: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck('update_goal', args as Record<string, unknown>, config, async () => {
+				const room = roomManager.getRoom(args.room_id);
+				if (!room) {
+					return errorResult(`Room not found: ${args.room_id}`);
+				}
+
+				const goalManager = managerFactory.getGoalManager(args.room_id);
+				const existing = await goalManager.getGoal(args.goal_id);
+				if (!existing) {
+					return errorResult(`Goal not found: ${args.goal_id}`);
+				}
+
+				const patch: Record<string, unknown> = {};
+				if (args.title !== undefined) patch.title = args.title;
+				if (args.description !== undefined) patch.description = args.description;
+				if (args.priority !== undefined) patch.priority = args.priority as GoalPriority;
+				if (args.mission_type !== undefined) patch.missionType = args.mission_type as MissionType;
+				if (args.autonomy_level !== undefined)
+					patch.autonomyLevel = args.autonomy_level as AutonomyLevel;
+
+				if (Object.keys(patch).length === 0) {
+					return errorResult('No update fields provided');
+				}
+
+				const goal = await goalManager.patchGoal(args.goal_id, patch);
+				return successResult({ goal });
+			});
+		},
+
+		async set_goal_status(args: {
+			room_id: string;
+			goal_id: string;
+			status: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck(
+				'set_goal_status',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+
+					const goalManager = managerFactory.getGoalManager(args.room_id);
+					const existing = await goalManager.getGoal(args.goal_id);
+					if (!existing) {
+						return errorResult(`Goal not found: ${args.goal_id}`);
+					}
+
+					const goal = await goalManager.updateGoalStatus(args.goal_id, args.status as GoalStatus);
+					return successResult({ goal });
+				}
+			);
+		},
+
+		// ── Task ─────────────────────────────────────────────────────────────
+
+		async create_task(args: {
+			room_id: string;
+			title: string;
+			description: string;
+			priority?: string;
+			depends_on?: string[];
+		}): Promise<ToolResult> {
+			return withSecurityCheck('create_task', args as Record<string, unknown>, config, async () => {
+				const room = roomManager.getRoom(args.room_id);
+				if (!room) {
+					return errorResult(`Room not found: ${args.room_id}`);
+				}
+
+				const taskManager = managerFactory.getTaskManager(args.room_id);
+				const task = await taskManager.createTask({
+					title: args.title,
+					description: args.description,
+					priority: args.priority as TaskPriority | undefined,
+					dependsOn: args.depends_on,
+				});
+
+				return successResult({ task });
+			});
+		},
+
+		async update_task(args: {
+			room_id: string;
+			task_id: string;
+			title?: string;
+			description?: string;
+			priority?: string;
+			depends_on?: string[];
+		}): Promise<ToolResult> {
+			return withSecurityCheck('update_task', args as Record<string, unknown>, config, async () => {
+				const room = roomManager.getRoom(args.room_id);
+				if (!room) {
+					return errorResult(`Room not found: ${args.room_id}`);
+				}
+
+				const taskManager = managerFactory.getTaskManager(args.room_id);
+				const existing = await taskManager.getTask(args.task_id);
+				if (!existing) {
+					return errorResult(`Task not found: ${args.task_id}`);
+				}
+
+				const updates: {
+					title?: string;
+					description?: string;
+					priority?: TaskPriority;
+					dependsOn?: string[];
+				} = {};
+				if (args.title !== undefined) updates.title = args.title;
+				if (args.description !== undefined) updates.description = args.description;
+				if (args.priority !== undefined) updates.priority = args.priority as TaskPriority;
+				if (args.depends_on !== undefined) updates.dependsOn = args.depends_on;
+
+				if (Object.keys(updates).length === 0) {
+					return errorResult('No update fields provided');
+				}
+
+				const task = await taskManager.updateTaskFields(args.task_id, updates);
+				return successResult({ task });
+			});
+		},
+
+		async set_task_status(args: {
+			room_id: string;
+			task_id: string;
+			status: string;
+			result?: string;
+			error?: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck(
+				'set_task_status',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+
+					const taskManager = managerFactory.getTaskManager(args.room_id);
+					const existing = await taskManager.getTask(args.task_id);
+					if (!existing) {
+						return errorResult(`Task not found: ${args.task_id}`);
+					}
+
+					const task = await taskManager.setTaskStatus(args.task_id, args.status as TaskStatus, {
+						result: args.result,
+						error: args.error,
+					});
+					return successResult({ task });
+				}
+			);
+		},
+
+		async approve_task(args: { room_id: string; task_id: string }): Promise<ToolResult> {
+			return withSecurityCheck(
+				'approve_task',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+
+					if (!runtimeService) {
+						return errorResult('Runtime service not available');
+					}
+
+					const runtime = runtimeService.getRuntime(args.room_id);
+					if (!runtime) {
+						return errorResult(`No runtime found for room: ${args.room_id}`);
+					}
+
+					const taskManager = managerFactory.getTaskManager(args.room_id);
+					const task = await taskManager.getTask(args.task_id);
+					if (!task) {
+						return errorResult(`Task not found: ${args.task_id}`);
+					}
+					if (task.status !== 'review') {
+						return errorResult(`Task is not in review status (current: ${task.status})`);
+					}
+
+					const resumed = await runtime.resumeWorkerFromHuman(
+						args.task_id,
+						'Human has approved the PR. Merge it now by running `gh pr merge` (do NOT use --delete-branch). After the merge completes, your work is done.',
+						{ approved: true }
+					);
+
+					if (!resumed) {
+						return errorResult(
+							`Failed to approve task ${args.task_id} — no submitted-for-review group found`
+						);
+					}
+
+					return successResult({ taskId: args.task_id });
+				}
+			);
+		},
+
+		async reject_task(args: {
+			room_id: string;
+			task_id: string;
+			feedback: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck('reject_task', args as Record<string, unknown>, config, async () => {
+				const room = roomManager.getRoom(args.room_id);
+				if (!room) {
+					return errorResult(`Room not found: ${args.room_id}`);
+				}
+
+				if (!runtimeService) {
+					return errorResult('Runtime service not available');
+				}
+
+				const runtime = runtimeService.getRuntime(args.room_id);
+				if (!runtime) {
+					return errorResult(`No runtime found for room: ${args.room_id}`);
+				}
+
+				const taskManager = managerFactory.getTaskManager(args.room_id);
+				const task = await taskManager.getTask(args.task_id);
+				if (!task) {
+					return errorResult(`Task not found: ${args.task_id}`);
+				}
+				if (task.status !== 'review') {
+					return errorResult(`Task is not in review status (current: ${task.status})`);
+				}
+
+				const message = `[Human Rejection]\n\n${args.feedback.trim()}`;
+				const resumed = await runtime.resumeWorkerFromHuman(args.task_id, message, {
+					approved: false,
+				});
+
+				if (!resumed) {
+					return errorResult(
+						`Failed to reject task ${args.task_id} — no submitted-for-review group found`
+					);
+				}
+
+				return successResult({ taskId: args.task_id });
+			});
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// MCP server wrapper
+// ---------------------------------------------------------------------------
+
+export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
+	const handlers = createNeoActionToolHandlers(config);
+
+	const tools = [
+		// ── Room ─────────────────────────────────────────────────────────────
+		tool(
+			'create_room',
+			'Create a new room with an optional description and workspace path. Low risk — auto-executes in balanced mode.',
+			{
+				name: z.string().describe('Room name'),
+				description: z.string().optional().describe('Background context for the room'),
+				workspace_path: z
+					.string()
+					.optional()
+					.describe('Absolute path to the workspace directory for this room'),
+				default_model: z.string().optional().describe('Default model ID for new sessions'),
+			},
+			(args) => handlers.create_room(args)
+		),
+
+		tool(
+			'delete_room',
+			'Delete a room permanently. Medium risk — requires confirmation in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room to delete'),
+			},
+			(args) => handlers.delete_room(args)
+		),
+
+		tool(
+			'update_room_settings',
+			'Update room settings such as name, description, instructions, or default model. Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room to update'),
+				name: z.string().optional().describe('New room name'),
+				description: z.string().optional().describe('New background context'),
+				instructions: z.string().optional().describe('Custom instructions for the room agent'),
+				default_model: z.string().optional().describe('Default model ID for new sessions'),
+				allowed_models: z
+					.array(z.string())
+					.optional()
+					.describe('Allowed model IDs (empty = all allowed)'),
+			},
+			(args) => handlers.update_room_settings(args)
+		),
+
+		// ── Goal ─────────────────────────────────────────────────────────────
+		tool(
+			'create_goal',
+			'Create a new goal (mission) in the specified room. Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room to create the goal in'),
+				title: z.string().describe('Goal title'),
+				description: z.string().optional().describe('Detailed goal description'),
+				priority: z
+					.enum(['low', 'normal', 'high', 'urgent'])
+					.optional()
+					.describe('Goal priority (default: normal)'),
+				mission_type: z
+					.enum(['one_shot', 'measurable', 'recurring'])
+					.optional()
+					.describe('Mission type (default: one_shot)'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe('Autonomy level (default: supervised)'),
+			},
+			(args) => handlers.create_goal(args)
+		),
+
+		tool(
+			'update_goal',
+			'Update goal fields such as title, description, priority, mission type, or autonomy level. Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the goal'),
+				goal_id: z.string().describe('ID of the goal to update'),
+				title: z.string().optional().describe('New goal title'),
+				description: z.string().optional().describe('New goal description'),
+				priority: z.enum(['low', 'normal', 'high', 'urgent']).optional().describe('New priority'),
+				mission_type: z
+					.enum(['one_shot', 'measurable', 'recurring'])
+					.optional()
+					.describe('New mission type'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe('New autonomy level'),
+			},
+			(args) => handlers.update_goal(args)
+		),
+
+		tool(
+			'set_goal_status',
+			'Transition a goal to a new status (active, completed, needs_human, archived). Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the goal'),
+				goal_id: z.string().describe('ID of the goal'),
+				status: z
+					.enum(['active', 'completed', 'needs_human', 'archived'])
+					.describe('New goal status'),
+			},
+			(args) => handlers.set_goal_status(args)
+		),
+
+		// ── Task ─────────────────────────────────────────────────────────────
+		tool(
+			'create_task',
+			'Create a new task in the specified room. Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room to create the task in'),
+				title: z.string().describe('Task title'),
+				description: z.string().describe('Detailed task description'),
+				priority: z
+					.enum(['low', 'normal', 'high', 'urgent'])
+					.optional()
+					.describe('Task priority (default: normal)'),
+				depends_on: z.array(z.string()).optional().describe('IDs of tasks this task depends on'),
+			},
+			(args) => handlers.create_task(args)
+		),
+
+		tool(
+			'update_task',
+			'Update task fields such as title, description, priority, or dependencies. Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the task'),
+				task_id: z.string().describe('ID of the task to update'),
+				title: z.string().optional().describe('New task title'),
+				description: z.string().optional().describe('New task description'),
+				priority: z.enum(['low', 'normal', 'high', 'urgent']).optional().describe('New priority'),
+				depends_on: z.array(z.string()).optional().describe('New dependency task IDs'),
+			},
+			(args) => handlers.update_task(args)
+		),
+
+		tool(
+			'set_task_status',
+			'Transition a task to a new status. Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the task'),
+				task_id: z.string().describe('ID of the task'),
+				status: z
+					.enum([
+						'draft',
+						'pending',
+						'in_progress',
+						'review',
+						'completed',
+						'needs_attention',
+						'cancelled',
+						'archived',
+					])
+					.describe('New task status'),
+				result: z.string().optional().describe('Result summary (for completed/review statuses)'),
+				error: z.string().optional().describe('Error message (for needs_attention status)'),
+			},
+			(args) => handlers.set_task_status(args)
+		),
+
+		tool(
+			'approve_task',
+			'Approve a task PR that is currently in review status. Medium risk — requires confirmation in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the task'),
+				task_id: z.string().describe('ID of the task to approve'),
+			},
+			(args) => handlers.approve_task(args)
+		),
+
+		tool(
+			'reject_task',
+			'Reject a task PR that is currently in review status, providing feedback for revision. Medium risk — requires confirmation in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the task'),
+				task_id: z.string().describe('ID of the task to reject'),
+				feedback: z.string().describe('Feedback explaining why the task was rejected'),
+			},
+			(args) => handlers.reject_task(args)
+		),
+	];
+
+	return createSdkMcpServer({ name: 'neo-action', tools });
+}

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -94,7 +94,10 @@ function makeTask(overrides: Partial<NeoTask> = {}): NeoTask {
 // Mock factories
 // ---------------------------------------------------------------------------
 
-function makeRoomManager(rooms: Room[] = []): NeoActionRoomManager {
+function makeRoomManager(
+	rooms: Room[] = [],
+	activeSessionCounts: Map<string, number> = new Map()
+): NeoActionRoomManager {
 	const store = new Map<string, Room>(rooms.map((r) => [r.id, r]));
 	return {
 		createRoom: (params) => {
@@ -123,6 +126,7 @@ function makeRoomManager(rooms: Room[] = []): NeoActionRoomManager {
 			store.set(id, updated);
 			return updated;
 		},
+		getActiveSessionCount: (id) => activeSessionCounts.get(id) ?? 0,
 	};
 }
 
@@ -214,6 +218,8 @@ function makeConfig(
 		securityMode?: 'conservative' | 'balanced' | 'autonomous';
 		runtimeService?: NeoActionRuntimeService;
 		workspaceRoot?: string;
+		/** Simulate active session counts per room ID for delete_room escalation tests */
+		activeSessionCounts?: Map<string, number>;
 	} = {}
 ): NeoActionToolsConfig {
 	const room = makeRoom();
@@ -234,7 +240,7 @@ function makeConfig(
 	}
 
 	return {
-		roomManager: makeRoomManager(rooms),
+		roomManager: makeRoomManager(rooms, opts.activeSessionCounts),
 		managerFactory: makeManagerFactory(goalManagers, taskManagers),
 		runtimeService: opts.runtimeService,
 		pendingStore: new PendingActionStore(),
@@ -288,6 +294,16 @@ describe('create_room', () => {
 		expect(result.room.allowedPaths[0].path).toBe('/home/user/ws');
 	});
 
+	it('workspace_path takes precedence over workspaceRoot', async () => {
+		const config = makeConfig({ workspaceRoot: '/default/ws' });
+		const { create_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_room({ name: 'Custom WS Room', workspace_path: '/custom/path' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.room.allowedPaths[0].path).toBe('/custom/path');
+	});
+
 	it('stores pending action so it can be confirmed later', async () => {
 		const config = makeConfig({ securityMode: 'conservative' });
 		const { create_room } = createNeoActionToolHandlers(config);
@@ -328,6 +344,35 @@ describe('delete_room', () => {
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('Room not found');
 	});
+
+	it('escalates to high risk (delete_room_with_active_tasks) when room has active sessions', async () => {
+		const room = makeRoom({ id: 'busy-room' });
+		// balanced: delete_room (medium) would require confirmation, but active sessions
+		// escalate to delete_room_with_active_tasks (high) which also requires confirmation in balanced
+		const config = makeConfig({
+			rooms: [room],
+			securityMode: 'balanced',
+			activeSessionCounts: new Map([['busy-room', 2]]),
+		});
+		const { delete_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_room({ room_id: 'busy-room' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('high');
+	});
+
+	it('does NOT escalate when room has no active sessions', async () => {
+		// In autonomous mode, delete_room (medium) with 0 active sessions should still execute
+		const room = makeRoom({ id: 'quiet-room' });
+		const config = makeConfig({
+			rooms: [room],
+			securityMode: 'autonomous',
+			activeSessionCounts: new Map([['quiet-room', 0]]),
+		});
+		const { delete_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_room({ room_id: 'quiet-room' }));
+		expect(result.success).toBe(true);
+		expect(result.roomId).toBe('quiet-room');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -364,6 +409,16 @@ describe('update_room_settings', () => {
 		const { update_room_settings } = createNeoActionToolHandlers(config);
 		const result = parseResult(await update_room_settings({ room_id: 'room-1', name: 'X' }));
 		expect(result.confirmationRequired).toBe(true);
+	});
+
+	it('returns error when no update fields provided (no-op guard)', async () => {
+		const room = makeRoom();
+		const config = makeConfig({ rooms: [room] });
+		const { update_room_settings } = createNeoActionToolHandlers(config);
+		// Only room_id provided, no update fields
+		const result = parseResult(await update_room_settings({ room_id: 'room-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No update fields provided');
 	});
 });
 
@@ -838,6 +893,51 @@ describe('reject_task', () => {
 		);
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('Task not found');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig({ runtimeService: makeRuntimeService(true) });
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'missing', task_id: 'task-1', feedback: 'Feedback' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error for empty feedback', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({ tasks: [task], runtimeService: makeRuntimeService(true) });
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'room-1', task_id: 'task-1', feedback: '' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Feedback is required');
+	});
+
+	it('returns error for whitespace-only feedback', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({ tasks: [task], runtimeService: makeRuntimeService(true) });
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'room-1', task_id: 'task-1', feedback: '   ' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Feedback is required');
+	});
+
+	it('empty feedback error fires before security check (no pending action stored)', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({
+			tasks: [task],
+			runtimeService: makeRuntimeService(true),
+			securityMode: 'conservative',
+		});
+		const { reject_task } = createNeoActionToolHandlers(config);
+		await reject_task({ room_id: 'room-1', task_id: 'task-1', feedback: '' });
+		// Nothing should have been stored in the pending store
+		expect(config.pendingStore.size).toBe(0);
 	});
 });
 

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -1,0 +1,906 @@
+/**
+ * Unit tests for Neo Action Tools
+ *
+ * Tests the two-layer pattern:
+ *   - createNeoActionToolHandlers: handler functions (no MCP wiring)
+ *   - createNeoActionMcpServer: registers all tools on an MCP server
+ *
+ * Covers:
+ * - create_room: auto-execute and confirmation paths, workspace path handling
+ * - delete_room: auto-execute and confirmation paths, missing room error
+ * - update_room_settings: field patching, missing room error, no-op guard
+ * - create_goal: auto-execute and confirmation paths, missing room error
+ * - update_goal: field patching, no-op guard
+ * - set_goal_status: happy path, missing room/goal errors
+ * - create_task: auto-execute and confirmation paths, missing room error
+ * - update_task: field patching, no-op guard
+ * - set_task_status: status transition
+ * - approve_task: happy path, task not in review error, runtime unavailable
+ * - reject_task: happy path, task not in review error, runtime unavailable
+ * - MCP server: all 11 tools are registered
+ */
+
+import { describe, expect, it, beforeEach } from 'bun:test';
+import {
+	createNeoActionToolHandlers,
+	createNeoActionMcpServer,
+	type NeoActionToolsConfig,
+	type NeoActionRoomManager,
+	type NeoActionGoalManager,
+	type NeoActionTaskManager,
+	type NeoActionRuntimeService,
+	type NeoActionManagerFactory,
+} from '../../../src/lib/neo/tools/neo-action-tools';
+import { PendingActionStore } from '../../../src/lib/neo/security-tier';
+import type { Room, RoomGoal, NeoTask } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = 1_700_000_000_000;
+
+function makeRoom(overrides: Partial<Room> = {}): Room {
+	return {
+		id: 'room-1',
+		name: 'Test Room',
+		status: 'active',
+		sessionIds: [],
+		allowedPaths: [],
+		createdAt: NOW - 10_000,
+		updatedAt: NOW,
+		...overrides,
+	};
+}
+
+function makeGoal(overrides: Partial<RoomGoal> = {}): RoomGoal {
+	return {
+		id: 'goal-1',
+		roomId: 'room-1',
+		title: 'Test Goal',
+		description: 'A test goal',
+		status: 'active',
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		metrics: {},
+		createdAt: NOW - 5_000,
+		updatedAt: NOW,
+		missionType: 'one_shot',
+		autonomyLevel: 'supervised',
+		...overrides,
+	};
+}
+
+function makeTask(overrides: Partial<NeoTask> = {}): NeoTask {
+	return {
+		id: 'task-1',
+		roomId: 'room-1',
+		title: 'Test Task',
+		description: 'A test task',
+		status: 'pending',
+		priority: 'normal',
+		progress: 0,
+		dependsOn: [],
+		createdAt: NOW - 3_000,
+		updatedAt: NOW,
+		taskType: 'coding',
+		assignedAgent: 'coder',
+		...overrides,
+	} as NeoTask;
+}
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeRoomManager(rooms: Room[] = []): NeoActionRoomManager {
+	const store = new Map<string, Room>(rooms.map((r) => [r.id, r]));
+	return {
+		createRoom: (params) => {
+			const room = makeRoom({
+				id: `room-${Date.now()}`,
+				name: params.name,
+				allowedPaths: params.allowedPaths ?? [],
+			});
+			store.set(room.id, room);
+			return room;
+		},
+		deleteRoom: (id) => {
+			if (!store.has(id)) return false;
+			store.delete(id);
+			return true;
+		},
+		getRoom: (id) => store.get(id) ?? null,
+		updateRoom: (id, params) => {
+			const room = store.get(id);
+			if (!room) return null;
+			const updated = {
+				...room,
+				...params,
+				updatedAt: NOW + 1,
+			} as Room;
+			store.set(id, updated);
+			return updated;
+		},
+	};
+}
+
+function makeGoalManager(goals: RoomGoal[] = []): NeoActionGoalManager {
+	const store = new Map<string, RoomGoal>(goals.map((g) => [g.id, g]));
+	return {
+		createGoal: async (params) => {
+			const goal = makeGoal({ id: `goal-${Date.now()}`, ...params });
+			store.set(goal.id, goal);
+			return goal;
+		},
+		getGoal: async (id) => store.get(id) ?? null,
+		patchGoal: async (id, patch) => {
+			const goal = store.get(id);
+			if (!goal) throw new Error(`Goal not found: ${id}`);
+			const updated = { ...goal, ...patch, updatedAt: NOW + 1 };
+			store.set(id, updated);
+			return updated;
+		},
+		updateGoalStatus: async (id, status) => {
+			const goal = store.get(id);
+			if (!goal) throw new Error(`Goal not found: ${id}`);
+			const updated = { ...goal, status, updatedAt: NOW + 1 };
+			store.set(id, updated);
+			return updated;
+		},
+	};
+}
+
+function makeTaskManager(tasks: NeoTask[] = []): NeoActionTaskManager {
+	const store = new Map<string, NeoTask>(tasks.map((t) => [t.id, t]));
+	return {
+		createTask: async (params) => {
+			const task = makeTask({ id: `task-${Date.now()}`, ...params });
+			store.set(task.id, task);
+			return task;
+		},
+		getTask: async (id) => store.get(id) ?? null,
+		updateTaskFields: async (id, updates) => {
+			const task = store.get(id);
+			if (!task) throw new Error(`Task not found: ${id}`);
+			const updated = { ...task, ...updates, updatedAt: NOW + 1 };
+			store.set(id, updated);
+			return updated;
+		},
+		setTaskStatus: async (id, status, opts) => {
+			const task = store.get(id);
+			if (!task) throw new Error(`Task not found: ${id}`);
+			const updated = {
+				...task,
+				status,
+				result: opts?.result ?? task.result,
+				error: opts?.error ?? task.error,
+				updatedAt: NOW + 1,
+			} as NeoTask;
+			store.set(id, updated);
+			return updated;
+		},
+	};
+}
+
+function makeRuntimeService(resumeResult = true): NeoActionRuntimeService {
+	return {
+		getRuntime: (_roomId) => ({
+			resumeWorkerFromHuman: async (_taskId, _message, _opts) => resumeResult,
+		}),
+	};
+}
+
+function makeManagerFactory(
+	goalManagers: Map<string, NeoActionGoalManager> = new Map(),
+	taskManagers: Map<string, NeoActionTaskManager> = new Map()
+): NeoActionManagerFactory {
+	return {
+		getGoalManager: (roomId) => goalManagers.get(roomId) ?? makeGoalManager(),
+		getTaskManager: (roomId) => taskManagers.get(roomId) ?? makeTaskManager(),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Config builder
+// ---------------------------------------------------------------------------
+
+function makeConfig(
+	opts: {
+		rooms?: Room[];
+		goals?: RoomGoal[];
+		tasks?: NeoTask[];
+		securityMode?: 'conservative' | 'balanced' | 'autonomous';
+		runtimeService?: NeoActionRuntimeService;
+		workspaceRoot?: string;
+	} = {}
+): NeoActionToolsConfig {
+	const room = makeRoom();
+	const rooms = opts.rooms ?? [room];
+	const goals = opts.goals ?? [makeGoal()];
+	const tasks = opts.tasks ?? [makeTask()];
+
+	const goalManager = makeGoalManager(goals);
+	const taskManager = makeTaskManager(tasks);
+
+	const goalManagers = new Map<string, NeoActionGoalManager>([[room.id, goalManager]]);
+	const taskManagers = new Map<string, NeoActionTaskManager>([[room.id, taskManager]]);
+
+	// Re-register all provided rooms
+	for (const r of rooms) {
+		goalManagers.set(r.id, makeGoalManager(goals.filter((g) => g.roomId === r.id)));
+		taskManagers.set(r.id, makeTaskManager(tasks.filter((t) => t.roomId === r.id)));
+	}
+
+	return {
+		roomManager: makeRoomManager(rooms),
+		managerFactory: makeManagerFactory(goalManagers, taskManagers),
+		runtimeService: opts.runtimeService,
+		pendingStore: new PendingActionStore(),
+		workspaceRoot: opts.workspaceRoot,
+		getSecurityMode: () => opts.securityMode ?? 'autonomous',
+	};
+}
+
+// Helper to parse JSON result
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+	return JSON.parse(result.content[0].text);
+}
+
+// ---------------------------------------------------------------------------
+// create_room
+// ---------------------------------------------------------------------------
+
+describe('create_room', () => {
+	it('auto-executes in autonomous mode', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { create_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_room({ name: 'My Room' }));
+		expect(result.success).toBe(true);
+		expect(result.room.name).toBe('My Room');
+	});
+
+	it('requires confirmation in balanced mode', async () => {
+		// create_room is 'low' risk — balanced auto-executes low
+		const config = makeConfig({ securityMode: 'balanced' });
+		const { create_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_room({ name: 'My Room' }));
+		// low risk → auto-executes in balanced
+		expect(result.success).toBe(true);
+		expect(result.room.name).toBe('My Room');
+	});
+
+	it('returns confirmationRequired in conservative mode', async () => {
+		const config = makeConfig({ securityMode: 'conservative' });
+		const { create_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_room({ name: 'My Room' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.pendingActionId).toBeTruthy();
+		expect(result.riskLevel).toBe('low');
+	});
+
+	it('uses workspace root as allowedPaths when no path provided', async () => {
+		const config = makeConfig({ workspaceRoot: '/home/user/ws' });
+		const { create_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_room({ name: 'WS Room' }));
+		expect(result.success).toBe(true);
+		expect(result.room.allowedPaths[0].path).toBe('/home/user/ws');
+	});
+
+	it('stores pending action so it can be confirmed later', async () => {
+		const config = makeConfig({ securityMode: 'conservative' });
+		const { create_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_room({ name: 'Pending Room' }));
+		const pendingAction = config.pendingStore.retrieve(result.pendingActionId);
+		expect(pendingAction?.toolName).toBe('create_room');
+		expect((pendingAction?.input as { name: string }).name).toBe('Pending Room');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// delete_room
+// ---------------------------------------------------------------------------
+
+describe('delete_room', () => {
+	it('auto-executes in autonomous mode', async () => {
+		const room = makeRoom({ id: 'del-room' });
+		const config = makeConfig({ rooms: [room], securityMode: 'autonomous' });
+		const { delete_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_room({ room_id: 'del-room' }));
+		expect(result.success).toBe(true);
+		expect(result.roomId).toBe('del-room');
+	});
+
+	it('returns confirmationRequired in balanced mode (medium risk)', async () => {
+		const room = makeRoom({ id: 'del-room' });
+		const config = makeConfig({ rooms: [room], securityMode: 'balanced' });
+		const { delete_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_room({ room_id: 'del-room' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { delete_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_room({ room_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// update_room_settings
+// ---------------------------------------------------------------------------
+
+describe('update_room_settings', () => {
+	it('updates room fields', async () => {
+		const room = makeRoom();
+		const config = makeConfig({ rooms: [room] });
+		const { update_room_settings } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_room_settings({
+				room_id: 'room-1',
+				name: 'Renamed Room',
+				description: 'New context',
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.room.name).toBe('Renamed Room');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig();
+		const { update_room_settings } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_room_settings({ room_id: 'missing', name: 'X' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('requires confirmation in conservative mode (low risk auto-executes in balanced)', async () => {
+		const room = makeRoom();
+		const config = makeConfig({ rooms: [room], securityMode: 'conservative' });
+		const { update_room_settings } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_room_settings({ room_id: 'room-1', name: 'X' }));
+		expect(result.confirmationRequired).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// create_goal
+// ---------------------------------------------------------------------------
+
+describe('create_goal', () => {
+	it('creates a goal in autonomous mode', async () => {
+		const config = makeConfig();
+		const { create_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_goal({ room_id: 'room-1', title: 'Big Goal', description: 'Desc' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.goal.title).toBe('Big Goal');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const config = makeConfig({ securityMode: 'balanced' });
+		const { create_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_goal({ room_id: 'room-1', title: 'Goal' }));
+		expect(result.success).toBe(true);
+	});
+
+	it('returns confirmationRequired in conservative mode', async () => {
+		const config = makeConfig({ securityMode: 'conservative' });
+		const { create_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_goal({ room_id: 'room-1', title: 'Goal' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('low');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig();
+		const { create_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_goal({ room_id: 'missing', title: 'Goal' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('passes priority and mission_type to goal manager', async () => {
+		const config = makeConfig();
+		const { create_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_goal({
+				room_id: 'room-1',
+				title: 'KPI Goal',
+				priority: 'high',
+				mission_type: 'measurable',
+				autonomy_level: 'semi_autonomous',
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.goal.priority).toBe('high');
+		expect(result.goal.missionType).toBe('measurable');
+		expect(result.goal.autonomyLevel).toBe('semi_autonomous');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// update_goal
+// ---------------------------------------------------------------------------
+
+describe('update_goal', () => {
+	it('patches goal fields', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1' });
+		const config = makeConfig({ goals: [goal] });
+		const { update_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_goal({ room_id: 'room-1', goal_id: 'goal-1', title: 'Updated Title' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.goal.title).toBe('Updated Title');
+	});
+
+	it('returns error when no update fields provided', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1' });
+		const config = makeConfig({ goals: [goal] });
+		const { update_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_goal({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No update fields provided');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig();
+		const { update_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_goal({ room_id: 'missing', goal_id: 'goal-1', title: 'X' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error for non-existent goal', async () => {
+		const config = makeConfig({ goals: [] });
+		const { update_goal } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_goal({ room_id: 'room-1', goal_id: 'missing', title: 'X' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Goal not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// set_goal_status
+// ---------------------------------------------------------------------------
+
+describe('set_goal_status', () => {
+	it('transitions goal status', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1', status: 'active' });
+		const config = makeConfig({ goals: [goal] });
+		const { set_goal_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_goal_status({ room_id: 'room-1', goal_id: 'goal-1', status: 'completed' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.goal.status).toBe('completed');
+	});
+
+	it('returns confirmationRequired in conservative mode', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1' });
+		const config = makeConfig({ goals: [goal], securityMode: 'conservative' });
+		const { set_goal_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_goal_status({ room_id: 'room-1', goal_id: 'goal-1', status: 'archived' })
+		);
+		expect(result.confirmationRequired).toBe(true);
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig();
+		const { set_goal_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_goal_status({ room_id: 'missing', goal_id: 'goal-1', status: 'completed' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error for non-existent goal', async () => {
+		const config = makeConfig({ goals: [] });
+		const { set_goal_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_goal_status({ room_id: 'room-1', goal_id: 'missing', status: 'completed' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Goal not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// create_task
+// ---------------------------------------------------------------------------
+
+describe('create_task', () => {
+	it('creates a task in autonomous mode', async () => {
+		const config = makeConfig();
+		const { create_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_task({ room_id: 'room-1', title: 'Implement X', description: 'Do the thing' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.task.title).toBe('Implement X');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const config = makeConfig({ securityMode: 'balanced' });
+		const { create_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_task({ room_id: 'room-1', title: 'Task', description: 'Desc' })
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it('returns confirmationRequired in conservative mode', async () => {
+		const config = makeConfig({ securityMode: 'conservative' });
+		const { create_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_task({ room_id: 'room-1', title: 'Task', description: 'Desc' })
+		);
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('low');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig();
+		const { create_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_task({ room_id: 'missing', title: 'Task', description: 'Desc' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('passes priority and depends_on to task manager', async () => {
+		const dep = makeTask({ id: 'dep-task', roomId: 'room-1' });
+		const config = makeConfig({ tasks: [dep] });
+		const { create_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_task({
+				room_id: 'room-1',
+				title: 'Dependent Task',
+				description: 'Desc',
+				priority: 'high',
+				depends_on: ['dep-task'],
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.task.priority).toBe('high');
+		expect(result.task.dependsOn).toContain('dep-task');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// update_task
+// ---------------------------------------------------------------------------
+
+describe('update_task', () => {
+	it('updates task fields', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1' });
+		const config = makeConfig({ tasks: [task] });
+		const { update_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_task({
+				room_id: 'room-1',
+				task_id: 'task-1',
+				title: 'Updated Task',
+				priority: 'urgent',
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.task.title).toBe('Updated Task');
+		expect(result.task.priority).toBe('urgent');
+	});
+
+	it('returns error when no update fields provided', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1' });
+		const config = makeConfig({ tasks: [task] });
+		const { update_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_task({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No update fields provided');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig();
+		const { update_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_task({ room_id: 'missing', task_id: 'task-1', title: 'X' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error for non-existent task', async () => {
+		const config = makeConfig({ tasks: [] });
+		const { update_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_task({ room_id: 'room-1', task_id: 'missing', title: 'X' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Task not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// set_task_status
+// ---------------------------------------------------------------------------
+
+describe('set_task_status', () => {
+	it('transitions task status', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'pending' });
+		const config = makeConfig({ tasks: [task] });
+		const { set_task_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_task_status({ room_id: 'room-1', task_id: 'task-1', status: 'in_progress' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.task.status).toBe('in_progress');
+	});
+
+	it('passes result and error fields', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'in_progress' });
+		const config = makeConfig({ tasks: [task] });
+		const { set_task_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_task_status({
+				room_id: 'room-1',
+				task_id: 'task-1',
+				status: 'completed',
+				result: 'All done',
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.task.result).toBe('All done');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig();
+		const { set_task_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_task_status({ room_id: 'missing', task_id: 'task-1', status: 'completed' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error for non-existent task', async () => {
+		const config = makeConfig({ tasks: [] });
+		const { set_task_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_task_status({ room_id: 'room-1', task_id: 'missing', status: 'completed' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Task not found');
+	});
+
+	it('returns confirmationRequired in conservative mode', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1' });
+		const config = makeConfig({ tasks: [task], securityMode: 'conservative' });
+		const { set_task_status } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await set_task_status({ room_id: 'room-1', task_id: 'task-1', status: 'completed' })
+		);
+		expect(result.confirmationRequired).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// approve_task
+// ---------------------------------------------------------------------------
+
+describe('approve_task', () => {
+	it('approves a task in review status', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({ tasks: [task], runtimeService: makeRuntimeService(true) });
+		const { approve_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_task({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(true);
+		expect(result.taskId).toBe('task-1');
+	});
+
+	it('returns error when task is not in review', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'pending' });
+		const config = makeConfig({ tasks: [task], runtimeService: makeRuntimeService(true) });
+		const { approve_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_task({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not in review status');
+	});
+
+	it('returns error when runtime service not available', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({ tasks: [task] }); // no runtimeService
+		const { approve_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_task({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Runtime service not available');
+	});
+
+	it('returns error when resumeWorkerFromHuman returns false', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({ tasks: [task], runtimeService: makeRuntimeService(false) });
+		const { approve_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_task({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Failed to approve');
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({
+			tasks: [task],
+			runtimeService: makeRuntimeService(true),
+			securityMode: 'balanced',
+		});
+		const { approve_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_task({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error for non-existent room', async () => {
+		const config = makeConfig({ runtimeService: makeRuntimeService(true) });
+		const { approve_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_task({ room_id: 'missing', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error for non-existent task', async () => {
+		const config = makeConfig({ tasks: [], runtimeService: makeRuntimeService(true) });
+		const { approve_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_task({ room_id: 'room-1', task_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Task not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reject_task
+// ---------------------------------------------------------------------------
+
+describe('reject_task', () => {
+	it('rejects a task in review status', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({ tasks: [task], runtimeService: makeRuntimeService(true) });
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'room-1', task_id: 'task-1', feedback: 'Fix the tests' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.taskId).toBe('task-1');
+	});
+
+	it('returns error when task is not in review', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'in_progress' });
+		const config = makeConfig({ tasks: [task], runtimeService: makeRuntimeService(true) });
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'room-1', task_id: 'task-1', feedback: 'Nope' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not in review status');
+	});
+
+	it('returns error when runtime service not available', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({ tasks: [task] }); // no runtimeService
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'room-1', task_id: 'task-1', feedback: 'Nope' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Runtime service not available');
+	});
+
+	it('returns error when resumeWorkerFromHuman returns false', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({ tasks: [task], runtimeService: makeRuntimeService(false) });
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'room-1', task_id: 'task-1', feedback: 'Not good enough' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Failed to reject');
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({
+			tasks: [task],
+			runtimeService: makeRuntimeService(true),
+			securityMode: 'balanced',
+		});
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'room-1', task_id: 'task-1', feedback: 'Feedback here' })
+		);
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error for non-existent task', async () => {
+		const config = makeConfig({ tasks: [], runtimeService: makeRuntimeService(true) });
+		const { reject_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_task({ room_id: 'room-1', task_id: 'missing', feedback: 'Feedback' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Task not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// MCP server — tool registration
+// ---------------------------------------------------------------------------
+
+describe('createNeoActionMcpServer', () => {
+	let server: ReturnType<typeof createNeoActionMcpServer>;
+
+	beforeEach(() => {
+		server = createNeoActionMcpServer(makeConfig());
+	});
+
+	it('names the MCP server "neo-action"', () => {
+		expect(server.name).toBe('neo-action');
+	});
+
+	it('registers create_room tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('create_room');
+	});
+
+	it('registers delete_room tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('delete_room');
+	});
+
+	it('registers update_room_settings tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('update_room_settings');
+	});
+
+	it('registers create_goal tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('create_goal');
+	});
+
+	it('registers update_goal tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('update_goal');
+	});
+
+	it('registers set_goal_status tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('set_goal_status');
+	});
+
+	it('registers create_task tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('create_task');
+	});
+
+	it('registers update_task tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('update_task');
+	});
+
+	it('registers set_task_status tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('set_task_status');
+	});
+
+	it('registers approve_task tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('approve_task');
+	});
+
+	it('registers reject_task tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('reject_task');
+	});
+
+	it('registers exactly 11 tools', () => {
+		expect(Object.keys(server.instance._registeredTools)).toHaveLength(11);
+	});
+});


### PR DESCRIPTION
Implements `neo-action-tools.ts` with the two-layer pattern for task 3.2.

**11 write tools with security-tier enforcement:**

Room operations:
- `create_room` (low risk — auto-executes in balanced)
- `delete_room` (medium risk — confirmation required in balanced)
- `update_room_settings` (low risk)

Goal operations:
- `create_goal` (low risk)
- `update_goal` (low risk)
- `set_goal_status` (low risk)

Task operations:
- `create_task` (low risk)
- `update_task` (low risk)
- `set_task_status` (low risk)
- `approve_task` (medium risk)
- `reject_task` (medium risk)

Each tool passes through `withSecurityCheck()` which either auto-executes or returns a `confirmationRequired` payload with a `pendingActionId` for later confirmation via the existing `PendingActionStore`.

**Tests:** 64 unit tests covering all tools, auto-execute and confirmation code paths, missing-entity errors, no-op guards, and MCP server registration.