### PR TITLE
feat(neo): signal-based NeoStore with LiveQuery subscriptions (task 7.1)

### DIFF
--- a/packages/web/src/lib/neo-store.test.ts
+++ b/packages/web/src/lib/neo-store.test.ts
@@ -3,9 +3,12 @@
  *
  * Verifies:
  * - subscribe() sends liveQuery.subscribe for both neo.messages and neo.activity
+ * - loading cleared after subscribe requests acknowledged (not waiting for snapshot)
+ * - error signal set on subscribe failure, cleared on unsubscribe
  * - LiveQuery snapshot populates messages / activity signals
  * - LiveQuery delta (added/removed/updated) updates signals correctly
  * - WebSocket reconnect re-subscribes both feeds
+ * - Reconnect handler stale-event guard: no re-subscribe after unsubscribe
  * - unsubscribe() calls liveQuery.unsubscribe for both feeds and resets state
  * - Idempotent subscribe/unsubscribe behaviour
  * - Stale-event guard discards events after unsubscribe
@@ -13,7 +16,7 @@
  * - openPanel / closePanel / togglePanel update panelOpen signal
  * - panelOpen state persists in localStorage
  * - sendMessage() calls neo.send RPC
- * - loadHistory() calls neo.history RPC and hydrates messages
+ * - loadHistory() calls neo.history RPC and hydrates messages (skips if subscribed)
  * - clearSession() calls neo.clearSession RPC and resets messages signal
  * - confirmAction() / cancelAction() call RPC and clear pendingConfirmation
  */
@@ -140,11 +143,13 @@ describe('NeoStore', () => {
 		store.subscribed = false;
 		store.cleanups = [];
 		store.activeSubscriptionIds = new Set();
+		store.historyLoaded = false;
 
 		// Reset signals
 		neoStore.messages.value = [];
 		neoStore.activity.value = [];
 		neoStore.loading.value = false;
+		neoStore.error.value = null;
 		neoStore.panelOpen.value = false;
 		neoStore.activeTab.value = 'chat';
 		neoStore.pendingConfirmation.value = null;
@@ -190,7 +195,7 @@ describe('NeoStore', () => {
 			});
 		});
 
-		it('should set loading true while awaiting subscriptions', async () => {
+		it('should set loading true while awaiting subscribe requests', async () => {
 			let resolveHub: (hub: MockHub) => void;
 			const hubPromise = new Promise<MockHub>((resolve) => {
 				resolveHub = resolve;
@@ -204,14 +209,13 @@ describe('NeoStore', () => {
 
 			expect(neoStore.loading.value).toBe(true);
 
-			// Fire snapshot to finish loading
-			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
-				subscriptionId: MESSAGES_SUB_ID,
-				rows: [],
-				version: 1,
-			});
-
 			await subPromise;
+			expect(neoStore.loading.value).toBe(false);
+		});
+
+		it('should clear loading after subscribe requests are acknowledged', async () => {
+			await neoStore.subscribe();
+			// Loading cleared after Promise.all resolves, not waiting for snapshot.
 			expect(neoStore.loading.value).toBe(false);
 		});
 
@@ -222,11 +226,30 @@ describe('NeoStore', () => {
 			expect(mockHub.request).not.toHaveBeenCalled();
 		});
 
-		it('should re-throw and reset subscribed flag on error', async () => {
+		it('should set error signal and re-throw when hub subscription fails', async () => {
 			vi.mocked(mockHub.request).mockRejectedValue(new Error('subscribe failed'));
 
 			await expect(neoStore.subscribe()).rejects.toThrow('subscribe failed');
+			expect(neoStore.error.value).toBe('subscribe failed');
 			expect(neoStore.loading.value).toBe(false);
+		});
+
+		it('should clean up handlers and clear error on recovery after failure', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('subscribe failed'));
+			await expect(neoStore.subscribe()).rejects.toThrow('subscribe failed');
+
+			// Subscribe again after failure — fresh handlers, no leak.
+			vi.mocked(mockHub.request).mockResolvedValue({ ok: true });
+			await neoStore.subscribe();
+
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: MESSAGES_SUB_ID,
+				rows: [makeMessage('fresh')],
+				version: 1,
+			});
+
+			expect(neoStore.messages.value).toHaveLength(1);
+			expect(neoStore.messages.value[0].id).toBe('fresh');
 		});
 	});
 
@@ -244,18 +267,6 @@ describe('NeoStore', () => {
 			});
 			expect(neoStore.messages.value).toHaveLength(2);
 			expect(neoStore.messages.value[0].id).toBe('m1');
-		});
-
-		it('should set loading to false after messages snapshot', async () => {
-			await neoStore.subscribe();
-			expect(neoStore.loading.value).toBe(true);
-
-			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
-				subscriptionId: MESSAGES_SUB_ID,
-				rows: [],
-				version: 1,
-			});
-			expect(neoStore.loading.value).toBe(false);
 		});
 
 		it('should populate activity from neo.activity snapshot', async () => {
@@ -470,6 +481,17 @@ describe('NeoStore', () => {
 
 			expect(mockHub.request).not.toHaveBeenCalled();
 		});
+
+		it('should not re-subscribe when reconnect fires after unsubscribe', async () => {
+			await neoStore.subscribe();
+			neoStore.unsubscribe();
+			mockHub.request.mockClear();
+
+			// Reconnect fires after unsubscribe — stale-event guard must block re-subscribe.
+			mockHub.fireConnection('connected');
+
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
 	});
 
 	// ---------------------------------------------------------------------------
@@ -508,6 +530,15 @@ describe('NeoStore', () => {
 
 			expect(neoStore.messages.value).toHaveLength(0);
 			expect(neoStore.activity.value).toHaveLength(0);
+		});
+
+		it('should clear error signal on unsubscribe after subscribe failure', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('fail'));
+			await expect(neoStore.subscribe()).rejects.toThrow();
+			expect(neoStore.error.value).not.toBeNull();
+
+			neoStore.unsubscribe();
+			expect(neoStore.error.value).toBeNull();
 		});
 
 		it('should be idempotent', async () => {
@@ -612,7 +643,7 @@ describe('NeoStore', () => {
 			expect(mockHub.request).toHaveBeenCalledWith('neo.history', { limit: 100 });
 		});
 
-		it('should populate messages when signal is empty', async () => {
+		it('should populate messages when not subscribed', async () => {
 			const msgs = [makeMessage('h1'), makeMessage('h2')];
 			vi.mocked(mockHub.request).mockResolvedValue({ messages: msgs, hasMore: false });
 
@@ -621,17 +652,14 @@ describe('NeoStore', () => {
 			expect(neoStore.messages.value).toHaveLength(2);
 		});
 
-		it('should not overwrite messages already populated by LiveQuery', async () => {
-			neoStore.messages.value = [makeMessage('live1')];
-			vi.mocked(mockHub.request).mockResolvedValue({
-				messages: [makeMessage('h1')],
-				hasMore: false,
-			});
+		it('should skip RPC call when already subscribed (LiveQuery owns state)', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ ok: true });
+			await neoStore.subscribe();
+			mockHub.request.mockClear();
 
 			await neoStore.loadHistory();
 
-			expect(neoStore.messages.value).toHaveLength(1);
-			expect(neoStore.messages.value[0].id).toBe('live1');
+			expect(mockHub.request).not.toHaveBeenCalled();
 		});
 
 		it('should silently ignore errors', async () => {

--- a/packages/web/src/lib/neo-store.test.ts
+++ b/packages/web/src/lib/neo-store.test.ts
@@ -492,6 +492,19 @@ describe('NeoStore', () => {
 
 			expect(mockHub.request).not.toHaveBeenCalled();
 		});
+
+		it('should clear loading after reconnect re-subscribe requests complete', async () => {
+			await neoStore.subscribe();
+
+			// Simulate reconnect: loading goes true, then clears once requests settle.
+			mockHub.fireConnection('connected');
+			expect(neoStore.loading.value).toBe(true);
+
+			// Flush all pending microtasks (Promise.all + .catch + .finally chain).
+			await new Promise((r) => setTimeout(r, 0));
+
+			expect(neoStore.loading.value).toBe(false);
+		});
 	});
 
 	// ---------------------------------------------------------------------------

--- a/packages/web/src/lib/neo-store.test.ts
+++ b/packages/web/src/lib/neo-store.test.ts
@@ -1,0 +1,754 @@
+/**
+ * Tests for NeoStore
+ *
+ * Verifies:
+ * - subscribe() sends liveQuery.subscribe for both neo.messages and neo.activity
+ * - LiveQuery snapshot populates messages / activity signals
+ * - LiveQuery delta (added/removed/updated) updates signals correctly
+ * - WebSocket reconnect re-subscribes both feeds
+ * - unsubscribe() calls liveQuery.unsubscribe for both feeds and resets state
+ * - Idempotent subscribe/unsubscribe behaviour
+ * - Stale-event guard discards events after unsubscribe
+ * - Post-await unsubscribe race guard
+ * - openPanel / closePanel / togglePanel update panelOpen signal
+ * - panelOpen state persists in localStorage
+ * - sendMessage() calls neo.send RPC
+ * - loadHistory() calls neo.history RPC and hydrates messages
+ * - clearSession() calls neo.clearSession RPC and resets messages signal
+ * - confirmAction() / cancelAction() call RPC and clear pendingConfirmation
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { LiveQuerySnapshotEvent, LiveQueryDeltaEvent } from '@neokai/shared';
+import type { NeoMessage, NeoActivityEntry } from './neo-store.js';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+type EventHandler<T = unknown> = (data: T) => void;
+
+interface MockHub {
+	_handlers: Map<string, EventHandler[]>;
+	_connectionHandlers: EventHandler[];
+	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	onConnection: (handler: EventHandler<string>) => () => void;
+	request: ReturnType<typeof vi.fn>;
+	fire: <T>(method: string, data: T) => void;
+	fireConnection: (state: string) => void;
+}
+
+function createMockHub(): MockHub {
+	const _handlers = new Map<string, EventHandler[]>();
+	const _connectionHandlers: EventHandler[] = [];
+	return {
+		_handlers,
+		_connectionHandlers,
+		onEvent: <T>(method: string, handler: EventHandler<T>) => {
+			if (!_handlers.has(method)) _handlers.set(method, []);
+			_handlers.get(method)!.push(handler as EventHandler);
+			return () => {
+				const list = _handlers.get(method);
+				if (list) {
+					const i = list.indexOf(handler as EventHandler);
+					if (i >= 0) list.splice(i, 1);
+				}
+			};
+		},
+		onConnection: (handler: EventHandler<string>) => {
+			_connectionHandlers.push(handler as EventHandler);
+			return () => {
+				const i = _connectionHandlers.indexOf(handler as EventHandler);
+				if (i >= 0) _connectionHandlers.splice(i, 1);
+			};
+		},
+		request: vi.fn(),
+		fire: <T>(method: string, data: T) => {
+			for (const h of _handlers.get(method) ?? []) h(data);
+		},
+		fireConnection: (state: string) => {
+			for (const h of _connectionHandlers) h(state);
+		},
+	};
+}
+
+vi.mock('./connection-manager.ts', () => ({
+	connectionManager: {
+		getHub: vi.fn(),
+		getHubIfConnected: vi.fn(),
+	},
+}));
+
+import { connectionManager } from './connection-manager.js';
+import { neoStore } from './neo-store.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeMessage(id: string, overrides: Partial<NeoMessage> = {}): NeoMessage {
+	return {
+		id,
+		sessionId: 'neo:global',
+		messageType: 'user',
+		messageSubtype: null,
+		content: '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}',
+		createdAt: Date.now(),
+		sendStatus: null,
+		origin: null,
+		...overrides,
+	};
+}
+
+function makeActivity(id: string, overrides: Partial<NeoActivityEntry> = {}): NeoActivityEntry {
+	return {
+		id,
+		toolName: 'list_rooms',
+		input: null,
+		output: null,
+		status: 'success',
+		error: null,
+		targetType: null,
+		targetId: null,
+		undoable: false,
+		undoData: null,
+		createdAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+const MESSAGES_SUB_ID = 'neo-messages-global';
+const ACTIVITY_SUB_ID = 'neo-activity-global';
+
+// ---------------------------------------------------------------------------
+// NeoStore Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoStore', () => {
+	let mockHub: MockHub;
+	// eslint-disable-next-line no-unused-vars
+	let localStorageMock: Record<string, string>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockHub = createMockHub();
+
+		// Force-reset singleton internal state so tests are fully isolated.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const store = neoStore as any;
+		store.refCount = 0;
+		store.subscribed = false;
+		store.cleanups = [];
+		store.activeSubscriptionIds = new Set();
+
+		// Reset signals
+		neoStore.messages.value = [];
+		neoStore.activity.value = [];
+		neoStore.loading.value = false;
+		neoStore.panelOpen.value = false;
+		neoStore.activeTab.value = 'chat';
+		neoStore.pendingConfirmation.value = null;
+
+		vi.mocked(connectionManager.getHub).mockResolvedValue(mockHub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+		vi.mocked(mockHub.request).mockResolvedValue({ ok: true });
+
+		// Mock localStorage
+		localStorageMock = {};
+		vi.spyOn(Storage.prototype, 'getItem').mockImplementation(
+			(key: string) => localStorageMock[key] ?? null
+		);
+		vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => {
+			localStorageMock[key] = value;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// ---------------------------------------------------------------------------
+	// subscribe()
+	// ---------------------------------------------------------------------------
+
+	describe('subscribe()', () => {
+		it('should send liveQuery.subscribe for neo.messages', async () => {
+			await neoStore.subscribe();
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.subscribe', {
+				queryName: 'neo.messages',
+				params: [100, 0],
+				subscriptionId: MESSAGES_SUB_ID,
+			});
+		});
+
+		it('should send liveQuery.subscribe for neo.activity', async () => {
+			await neoStore.subscribe();
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.subscribe', {
+				queryName: 'neo.activity',
+				params: [50, 0],
+				subscriptionId: ACTIVITY_SUB_ID,
+			});
+		});
+
+		it('should set loading true while awaiting subscriptions', async () => {
+			let resolveHub: (hub: MockHub) => void;
+			const hubPromise = new Promise<MockHub>((resolve) => {
+				resolveHub = resolve;
+			});
+			vi.mocked(connectionManager.getHub).mockReturnValue(hubPromise as never);
+
+			const subPromise = neoStore.subscribe();
+
+			resolveHub!(mockHub);
+			await Promise.resolve();
+
+			expect(neoStore.loading.value).toBe(true);
+
+			// Fire snapshot to finish loading
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: MESSAGES_SUB_ID,
+				rows: [],
+				version: 1,
+			});
+
+			await subPromise;
+			expect(neoStore.loading.value).toBe(false);
+		});
+
+		it('should be idempotent — second call is no-op', async () => {
+			await neoStore.subscribe();
+			mockHub.request.mockClear();
+			await neoStore.subscribe();
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
+
+		it('should re-throw and reset subscribed flag on error', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('subscribe failed'));
+
+			await expect(neoStore.subscribe()).rejects.toThrow('subscribe failed');
+			expect(neoStore.loading.value).toBe(false);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Snapshot handling
+	// ---------------------------------------------------------------------------
+
+	describe('snapshot handling', () => {
+		it('should populate messages from neo.messages snapshot', async () => {
+			await neoStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: MESSAGES_SUB_ID,
+				rows: [makeMessage('m1'), makeMessage('m2')],
+				version: 1,
+			});
+			expect(neoStore.messages.value).toHaveLength(2);
+			expect(neoStore.messages.value[0].id).toBe('m1');
+		});
+
+		it('should set loading to false after messages snapshot', async () => {
+			await neoStore.subscribe();
+			expect(neoStore.loading.value).toBe(true);
+
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: MESSAGES_SUB_ID,
+				rows: [],
+				version: 1,
+			});
+			expect(neoStore.loading.value).toBe(false);
+		});
+
+		it('should populate activity from neo.activity snapshot', async () => {
+			await neoStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: ACTIVITY_SUB_ID,
+				rows: [makeActivity('a1'), makeActivity('a2')],
+				version: 1,
+			});
+			expect(neoStore.activity.value).toHaveLength(2);
+			expect(neoStore.activity.value[0].id).toBe('a1');
+		});
+
+		it('should ignore snapshot with unknown subscriptionId', async () => {
+			await neoStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: 'unknown-id',
+				rows: [makeMessage('stale')],
+				version: 1,
+			});
+			expect(neoStore.messages.value).toHaveLength(0);
+			expect(neoStore.activity.value).toHaveLength(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Delta handling — messages
+	// ---------------------------------------------------------------------------
+
+	describe('delta handling — messages', () => {
+		beforeEach(async () => {
+			await neoStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: MESSAGES_SUB_ID,
+				rows: [makeMessage('m1'), makeMessage('m2')],
+				version: 1,
+			});
+		});
+
+		it('should add messages from delta.added', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: MESSAGES_SUB_ID,
+				added: [makeMessage('m3')],
+				version: 2,
+			});
+			expect(neoStore.messages.value).toHaveLength(3);
+			expect(neoStore.messages.value.find((m) => m.id === 'm3')).toBeDefined();
+		});
+
+		it('should remove messages from delta.removed', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: MESSAGES_SUB_ID,
+				removed: [makeMessage('m1')],
+				version: 2,
+			});
+			expect(neoStore.messages.value).toHaveLength(1);
+			expect(neoStore.messages.value.find((m) => m.id === 'm1')).toBeUndefined();
+		});
+
+		it('should update messages from delta.updated', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: MESSAGES_SUB_ID,
+				updated: [makeMessage('m1', { messageType: 'assistant' })],
+				version: 2,
+			});
+			const m1 = neoStore.messages.value.find((m) => m.id === 'm1');
+			expect(m1?.messageType).toBe('assistant');
+		});
+
+		it('should ignore delta with wrong subscriptionId', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: 'wrong-id',
+				added: [makeMessage('stale')],
+				version: 2,
+			});
+			expect(neoStore.messages.value).toHaveLength(2);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Delta handling — activity
+	// ---------------------------------------------------------------------------
+
+	describe('delta handling — activity', () => {
+		beforeEach(async () => {
+			await neoStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: ACTIVITY_SUB_ID,
+				rows: [makeActivity('a1'), makeActivity('a2')],
+				version: 1,
+			});
+		});
+
+		it('should add activity entries from delta.added', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: ACTIVITY_SUB_ID,
+				added: [makeActivity('a3')],
+				version: 2,
+			});
+			expect(neoStore.activity.value).toHaveLength(3);
+		});
+
+		it('should remove activity entries from delta.removed', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: ACTIVITY_SUB_ID,
+				removed: [makeActivity('a1')],
+				version: 2,
+			});
+			expect(neoStore.activity.value).toHaveLength(1);
+		});
+
+		it('should update activity entries from delta.updated', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: ACTIVITY_SUB_ID,
+				updated: [makeActivity('a1', { status: 'error', error: 'oops' })],
+				version: 2,
+			});
+			const a1 = neoStore.activity.value.find((a) => a.id === 'a1');
+			expect(a1?.status).toBe('error');
+			expect(a1?.error).toBe('oops');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Stale-event guard
+	// ---------------------------------------------------------------------------
+
+	describe('stale-event guard', () => {
+		it('should discard snapshot after unsubscribe', async () => {
+			await neoStore.subscribe();
+			neoStore.unsubscribe();
+
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: MESSAGES_SUB_ID,
+				rows: [makeMessage('stale')],
+				version: 1,
+			});
+
+			expect(neoStore.messages.value).toHaveLength(0);
+		});
+
+		it('should discard delta after unsubscribe', async () => {
+			await neoStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: MESSAGES_SUB_ID,
+				rows: [makeMessage('m1')],
+				version: 1,
+			});
+			expect(neoStore.messages.value).toHaveLength(1);
+
+			neoStore.unsubscribe();
+
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: MESSAGES_SUB_ID,
+				added: [makeMessage('stale')],
+				version: 2,
+			});
+
+			expect(neoStore.messages.value).toHaveLength(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Post-await race guard
+	// ---------------------------------------------------------------------------
+
+	describe('post-await race guard', () => {
+		it('should not leave dangling handlers when unsubscribe races with hub resolution', async () => {
+			let resolveRequest!: () => void;
+			const requestPromise = new Promise<void>((resolve) => {
+				resolveRequest = resolve;
+			});
+			vi.mocked(mockHub.request).mockReturnValue(requestPromise as never);
+			vi.mocked(connectionManager.getHub).mockResolvedValue(mockHub as never);
+
+			const subPromise = neoStore.subscribe();
+			neoStore.unsubscribe();
+			resolveRequest();
+			await subPromise;
+
+			expect(neoStore.loading.value).toBe(false);
+			expect(neoStore.messages.value).toHaveLength(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Reconnect handling
+	// ---------------------------------------------------------------------------
+
+	describe('WebSocket reconnect', () => {
+		it('should re-subscribe both feeds on reconnect', async () => {
+			await neoStore.subscribe();
+			mockHub.request.mockClear();
+
+			mockHub.fireConnection('connected');
+
+			expect(mockHub.request).toHaveBeenCalledWith(
+				'liveQuery.subscribe',
+				expect.objectContaining({ subscriptionId: MESSAGES_SUB_ID })
+			);
+			expect(mockHub.request).toHaveBeenCalledWith(
+				'liveQuery.subscribe',
+				expect.objectContaining({ subscriptionId: ACTIVITY_SUB_ID })
+			);
+		});
+
+		it('should not re-subscribe for non-connected state changes', async () => {
+			await neoStore.subscribe();
+			mockHub.request.mockClear();
+
+			mockHub.fireConnection('disconnected');
+
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// unsubscribe()
+	// ---------------------------------------------------------------------------
+
+	describe('unsubscribe()', () => {
+		it('should call liveQuery.unsubscribe for both feeds', async () => {
+			await neoStore.subscribe();
+			mockHub.request.mockClear();
+
+			neoStore.unsubscribe();
+
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.unsubscribe', {
+				subscriptionId: MESSAGES_SUB_ID,
+			});
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.unsubscribe', {
+				subscriptionId: ACTIVITY_SUB_ID,
+			});
+		});
+
+		it('should clear messages and activity signals', async () => {
+			await neoStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: MESSAGES_SUB_ID,
+				rows: [makeMessage('m1')],
+				version: 1,
+			});
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: ACTIVITY_SUB_ID,
+				rows: [makeActivity('a1')],
+				version: 1,
+			});
+
+			neoStore.unsubscribe();
+
+			expect(neoStore.messages.value).toHaveLength(0);
+			expect(neoStore.activity.value).toHaveLength(0);
+		});
+
+		it('should be idempotent', async () => {
+			await neoStore.subscribe();
+			neoStore.unsubscribe();
+			mockHub.request.mockClear();
+
+			neoStore.unsubscribe();
+
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
+
+		it('should be safe to call before subscribe()', () => {
+			expect(() => neoStore.unsubscribe()).not.toThrow();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Panel helpers
+	// ---------------------------------------------------------------------------
+
+	describe('openPanel() / closePanel() / togglePanel()', () => {
+		it('openPanel sets panelOpen to true', () => {
+			neoStore.panelOpen.value = false;
+			neoStore.openPanel();
+			expect(neoStore.panelOpen.value).toBe(true);
+		});
+
+		it('closePanel sets panelOpen to false', () => {
+			neoStore.panelOpen.value = true;
+			neoStore.closePanel();
+			expect(neoStore.panelOpen.value).toBe(false);
+		});
+
+		it('togglePanel flips panelOpen from false to true', () => {
+			neoStore.panelOpen.value = false;
+			neoStore.togglePanel();
+			expect(neoStore.panelOpen.value).toBe(true);
+		});
+
+		it('togglePanel flips panelOpen from true to false', () => {
+			neoStore.panelOpen.value = true;
+			neoStore.togglePanel();
+			expect(neoStore.panelOpen.value).toBe(false);
+		});
+
+		it('openPanel persists true in localStorage', () => {
+			neoStore.openPanel();
+			expect(localStorage.setItem).toHaveBeenCalledWith('neo:panelOpen', 'true');
+		});
+
+		it('closePanel persists false in localStorage', () => {
+			neoStore.closePanel();
+			expect(localStorage.setItem).toHaveBeenCalledWith('neo:panelOpen', 'false');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// sendMessage()
+	// ---------------------------------------------------------------------------
+
+	describe('sendMessage()', () => {
+		it('should call neo.send RPC with message text', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ success: true });
+
+			const result = await neoStore.sendMessage('Hello Neo');
+
+			expect(mockHub.request).toHaveBeenCalledWith('neo.send', { message: 'Hello Neo' });
+			expect(result.success).toBe(true);
+		});
+
+		it('should return error response on failure', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({
+				success: false,
+				error: 'Neo unavailable',
+				errorCode: 'PROVIDER_ERROR',
+			});
+
+			const result = await neoStore.sendMessage('hi');
+
+			expect(result.success).toBe(false);
+			expect(result.errorCode).toBe('PROVIDER_ERROR');
+		});
+
+		it('should propagate errors thrown by the hub', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('hub error'));
+
+			await expect(neoStore.sendMessage('hi')).rejects.toThrow('hub error');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// loadHistory()
+	// ---------------------------------------------------------------------------
+
+	describe('loadHistory()', () => {
+		it('should call neo.history RPC', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ messages: [], hasMore: false });
+
+			await neoStore.loadHistory();
+
+			expect(mockHub.request).toHaveBeenCalledWith('neo.history', { limit: 100 });
+		});
+
+		it('should populate messages when signal is empty', async () => {
+			const msgs = [makeMessage('h1'), makeMessage('h2')];
+			vi.mocked(mockHub.request).mockResolvedValue({ messages: msgs, hasMore: false });
+
+			await neoStore.loadHistory();
+
+			expect(neoStore.messages.value).toHaveLength(2);
+		});
+
+		it('should not overwrite messages already populated by LiveQuery', async () => {
+			neoStore.messages.value = [makeMessage('live1')];
+			vi.mocked(mockHub.request).mockResolvedValue({
+				messages: [makeMessage('h1')],
+				hasMore: false,
+			});
+
+			await neoStore.loadHistory();
+
+			expect(neoStore.messages.value).toHaveLength(1);
+			expect(neoStore.messages.value[0].id).toBe('live1');
+		});
+
+		it('should silently ignore errors', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('history failed'));
+
+			await expect(neoStore.loadHistory()).resolves.toBeUndefined();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// clearSession()
+	// ---------------------------------------------------------------------------
+
+	describe('clearSession()', () => {
+		it('should call neo.clearSession RPC', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ success: true });
+
+			await neoStore.clearSession();
+
+			expect(mockHub.request).toHaveBeenCalledWith('neo.clearSession', {});
+		});
+
+		it('should clear messages signal on success', async () => {
+			neoStore.messages.value = [makeMessage('m1')];
+			vi.mocked(mockHub.request).mockResolvedValue({ success: true });
+
+			await neoStore.clearSession();
+
+			expect(neoStore.messages.value).toHaveLength(0);
+		});
+
+		it('should not clear messages signal on failure', async () => {
+			neoStore.messages.value = [makeMessage('m1')];
+			vi.mocked(mockHub.request).mockResolvedValue({ success: false, error: 'failed' });
+
+			await neoStore.clearSession();
+
+			expect(neoStore.messages.value).toHaveLength(1);
+		});
+
+		it('should return success flag and error from RPC', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ success: false, error: 'some error' });
+
+			const result = await neoStore.clearSession();
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('some error');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// confirmAction()
+	// ---------------------------------------------------------------------------
+
+	describe('confirmAction()', () => {
+		it('should call neo.confirmAction RPC with actionId', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ success: true });
+			neoStore.pendingConfirmation.value = { actionId: 'act-1', description: 'Do something' };
+
+			await neoStore.confirmAction('act-1');
+
+			expect(mockHub.request).toHaveBeenCalledWith('neo.confirmAction', { actionId: 'act-1' });
+		});
+
+		it('should clear pendingConfirmation on success', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ success: true });
+			neoStore.pendingConfirmation.value = { actionId: 'act-1', description: 'test' };
+
+			await neoStore.confirmAction('act-1');
+
+			expect(neoStore.pendingConfirmation.value).toBeNull();
+		});
+
+		it('should clear pendingConfirmation on RPC error', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('rpc error'));
+			neoStore.pendingConfirmation.value = { actionId: 'act-1', description: 'test' };
+
+			const result = await neoStore.confirmAction('act-1');
+
+			expect(neoStore.pendingConfirmation.value).toBeNull();
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('rpc error');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// cancelAction()
+	// ---------------------------------------------------------------------------
+
+	describe('cancelAction()', () => {
+		it('should call neo.cancelAction RPC with actionId', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ success: true });
+			neoStore.pendingConfirmation.value = { actionId: 'act-2', description: 'Cancel me' };
+
+			await neoStore.cancelAction('act-2');
+
+			expect(mockHub.request).toHaveBeenCalledWith('neo.cancelAction', { actionId: 'act-2' });
+		});
+
+		it('should clear pendingConfirmation on success', async () => {
+			vi.mocked(mockHub.request).mockResolvedValue({ success: true });
+			neoStore.pendingConfirmation.value = { actionId: 'act-2', description: 'test' };
+
+			await neoStore.cancelAction('act-2');
+
+			expect(neoStore.pendingConfirmation.value).toBeNull();
+		});
+
+		it('should clear pendingConfirmation on RPC error', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('cancel error'));
+			neoStore.pendingConfirmation.value = { actionId: 'act-2', description: 'test' };
+
+			const result = await neoStore.cancelAction('act-2');
+
+			expect(neoStore.pendingConfirmation.value).toBeNull();
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('cancel error');
+		});
+	});
+});

--- a/packages/web/src/lib/neo-store.ts
+++ b/packages/web/src/lib/neo-store.ts
@@ -1,0 +1,475 @@
+/**
+ * NeoStore - Signal-based frontend store for Neo's state.
+ *
+ * ARCHITECTURE:
+ * - `neo.messages` LiveQuery provides real-time updates to Neo chat messages.
+ * - `neo.activity` LiveQuery provides real-time updates to Neo activity feed.
+ * - `panelOpen` is persisted in localStorage so state survives page reloads.
+ * - Mutation methods call RPC handlers directly and let LiveQuery push updates.
+ *
+ * Signals (reactive state):
+ * - messages:            Neo chat messages from the persistent session.
+ * - activity:            Neo activity log entries (audit trail of tool calls).
+ * - loading:             True while awaiting LiveQuery snapshot or an RPC op.
+ * - panelOpen:           Whether the Neo slide-out panel is visible.
+ * - activeTab:           Which tab is shown in the panel ('chat' | 'activity').
+ * - pendingConfirmation: Action waiting for user confirmation (id + description).
+ */
+
+import { signal } from '@preact/signals';
+import type { LiveQuerySnapshotEvent, LiveQueryDeltaEvent } from '@neokai/shared';
+import { Logger } from '@neokai/shared';
+import { connectionManager } from './connection-manager';
+
+const logger = new Logger('kai:web:neo-store');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A row returned by the `neo.messages` LiveQuery.
+ * The `content` column is the raw JSON-serialised SDK message (sdk_message).
+ */
+export interface NeoMessage {
+	id: string;
+	sessionId: string;
+	messageType: string;
+	messageSubtype: string | null;
+	/** Raw JSON string of the sdk_message column. */
+	content: string;
+	createdAt: number;
+	sendStatus: string | null;
+	origin: string | null;
+}
+
+/**
+ * A row returned by the `neo.activity` LiveQuery.
+ */
+export interface NeoActivityEntry {
+	id: string;
+	toolName: string;
+	input: string | null;
+	output: string | null;
+	status: 'success' | 'error' | 'cancelled';
+	error: string | null;
+	targetType: string | null;
+	targetId: string | null;
+	undoable: boolean;
+	undoData: string | null;
+	createdAt: string;
+}
+
+/**
+ * A pending confirmation — an action that Neo is requesting approval for.
+ */
+export interface PendingConfirmation {
+	actionId: string;
+	description: string;
+}
+
+export type NeoActiveTab = 'chat' | 'activity';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MESSAGES_SUBSCRIPTION_ID = 'neo-messages-global';
+const ACTIVITY_SUBSCRIPTION_ID = 'neo-activity-global';
+const PANEL_OPEN_KEY = 'neo:panelOpen';
+
+// ---------------------------------------------------------------------------
+// NeoStore class
+// ---------------------------------------------------------------------------
+
+class NeoStore {
+	// -- Reactive signals --
+
+	/** Neo chat messages, ordered oldest-first (mirrors neo.messages LiveQuery). */
+	readonly messages = signal<NeoMessage[]>([]);
+
+	/** Neo activity feed, ordered newest-first (mirrors neo.activity LiveQuery). */
+	readonly activity = signal<NeoActivityEntry[]>([]);
+
+	/** True while awaiting the LiveQuery snapshot or an async RPC operation. */
+	readonly loading = signal<boolean>(false);
+
+	/** Whether the Neo slide-out panel is visible. Persisted in localStorage. */
+	readonly panelOpen = signal<boolean>(this._readPanelOpen());
+
+	/** Which tab is active in the Neo panel. */
+	readonly activeTab = signal<NeoActiveTab>('chat');
+
+	/** Pending action waiting for user confirmation, or null if none. */
+	readonly pendingConfirmation = signal<PendingConfirmation | null>(null);
+
+	// -- Internal state --
+
+	private cleanups: Array<() => void> = [];
+	private activeSubscriptionIds = new Set<string>();
+	private subscribed = false;
+	private refCount = 0;
+
+	// ---------------------------------------------------------------------------
+	// Panel open/close helpers (with localStorage persistence)
+	// ---------------------------------------------------------------------------
+
+	private _readPanelOpen(): boolean {
+		try {
+			return localStorage.getItem(PANEL_OPEN_KEY) === 'true';
+		} catch {
+			return false;
+		}
+	}
+
+	private _writePanelOpen(open: boolean): void {
+		try {
+			localStorage.setItem(PANEL_OPEN_KEY, String(open));
+		} catch {
+			/* ignore QuotaExceededError etc. */
+		}
+	}
+
+	openPanel(): void {
+		this.panelOpen.value = true;
+		this._writePanelOpen(true);
+	}
+
+	closePanel(): void {
+		this.panelOpen.value = false;
+		this._writePanelOpen(false);
+	}
+
+	togglePanel(): void {
+		if (this.panelOpen.value) {
+			this.closePanel();
+		} else {
+			this.openPanel();
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// subscribe() — start both LiveQuery subscriptions
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Subscribe to both `neo.messages` and `neo.activity` LiveQuery feeds.
+	 *
+	 * Idempotent: subsequent calls are no-ops until unsubscribe() is called.
+	 * Re-throws errors so callers can surface them (e.g. in a toast).
+	 */
+	async subscribe(): Promise<void> {
+		this.refCount++;
+		if (this.subscribed) return;
+		this.subscribed = true;
+
+		try {
+			const hub = await connectionManager.getHub();
+
+			// Guard: unsubscribe() was called before the hub became available.
+			if (!this.subscribed) return;
+
+			this.loading.value = true;
+			this.activeSubscriptionIds.add(MESSAGES_SUBSCRIPTION_ID);
+			this.activeSubscriptionIds.add(ACTIVITY_SUBSCRIPTION_ID);
+
+			// ── neo.messages snapshot ──────────────────────────────────────────
+			const unsubMsgSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
+				'liveQuery.snapshot',
+				(event) => {
+					if (event.subscriptionId === MESSAGES_SUBSCRIPTION_ID) {
+						if (!this.activeSubscriptionIds.has(MESSAGES_SUBSCRIPTION_ID)) return;
+						this.messages.value = event.rows as NeoMessage[];
+						this.loading.value = false;
+					} else if (event.subscriptionId === ACTIVITY_SUBSCRIPTION_ID) {
+						if (!this.activeSubscriptionIds.has(ACTIVITY_SUBSCRIPTION_ID)) return;
+						this.activity.value = event.rows as NeoActivityEntry[];
+					}
+				}
+			);
+			this.cleanups.push(unsubMsgSnapshot);
+			this.cleanups.push(() => this.activeSubscriptionIds.delete(MESSAGES_SUBSCRIPTION_ID));
+			this.cleanups.push(() => this.activeSubscriptionIds.delete(ACTIVITY_SUBSCRIPTION_ID));
+
+			// ── neo.messages delta ─────────────────────────────────────────────
+			const unsubMsgDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+				if (event.subscriptionId === MESSAGES_SUBSCRIPTION_ID) {
+					if (!this.activeSubscriptionIds.has(MESSAGES_SUBSCRIPTION_ID)) return;
+					this.messages.value = this._applyDelta(
+						this.messages.value,
+						event,
+						(m) => (m as NeoMessage).id
+					) as NeoMessage[];
+				} else if (event.subscriptionId === ACTIVITY_SUBSCRIPTION_ID) {
+					if (!this.activeSubscriptionIds.has(ACTIVITY_SUBSCRIPTION_ID)) return;
+					this.activity.value = this._applyDelta(
+						this.activity.value,
+						event,
+						(a) => (a as NeoActivityEntry).id
+					) as NeoActivityEntry[];
+				}
+			});
+			this.cleanups.push(unsubMsgDelta);
+
+			// ── Reconnect handler — re-subscribe after WebSocket reconnects ────
+			const unsubReconnect = hub.onConnection((state) => {
+				if (state !== 'connected') return;
+				this.loading.value = true;
+
+				const resubMessages = hub
+					.request('liveQuery.subscribe', {
+						queryName: 'neo.messages',
+						params: [100, 0],
+						subscriptionId: MESSAGES_SUBSCRIPTION_ID,
+					})
+					.catch((err) => {
+						logger.warn('NeoStore messages LiveQuery re-subscribe failed:', err);
+						this.loading.value = false;
+					});
+
+				const resubActivity = hub
+					.request('liveQuery.subscribe', {
+						queryName: 'neo.activity',
+						params: [50, 0],
+						subscriptionId: ACTIVITY_SUBSCRIPTION_ID,
+					})
+					.catch((err) => {
+						logger.warn('NeoStore activity LiveQuery re-subscribe failed:', err);
+					});
+
+				Promise.all([resubMessages, resubActivity]).catch(() => {});
+			});
+			this.cleanups.push(unsubReconnect);
+
+			// ── Initial subscriptions ──────────────────────────────────────────
+			await Promise.all([
+				hub.request('liveQuery.subscribe', {
+					queryName: 'neo.messages',
+					params: [100, 0],
+					subscriptionId: MESSAGES_SUBSCRIPTION_ID,
+				}),
+				hub.request('liveQuery.subscribe', {
+					queryName: 'neo.activity',
+					params: [50, 0],
+					subscriptionId: ACTIVITY_SUBSCRIPTION_ID,
+				}),
+			]);
+
+			// Guard: unsubscribe() raced with the subscribe requests.
+			if (!this.subscribed) {
+				this._teardownCleanly();
+				return;
+			}
+		} catch (err) {
+			this.refCount = Math.max(0, this.refCount - 1);
+			this.subscribed = false;
+			this._teardownCleanly();
+			logger.error('Failed to subscribe NeoStore LiveQuery:', err);
+			throw err;
+		}
+	}
+
+	/**
+	 * Unsubscribe from both LiveQuery feeds and reset signals.
+	 * Safe to call even if subscribe() was never called.
+	 */
+	unsubscribe(): void {
+		this.refCount = Math.max(0, this.refCount - 1);
+		if (this.refCount > 0) return;
+		if (!this.subscribed) return;
+		this.subscribed = false;
+
+		// Clear ids immediately so any queued events are discarded.
+		this.activeSubscriptionIds.delete(MESSAGES_SUBSCRIPTION_ID);
+		this.activeSubscriptionIds.delete(ACTIVITY_SUBSCRIPTION_ID);
+
+		this._teardownCleanly();
+
+		const hub = connectionManager.getHubIfConnected();
+		if (hub) {
+			hub
+				.request('liveQuery.unsubscribe', { subscriptionId: MESSAGES_SUBSCRIPTION_ID })
+				.catch(() => {});
+			hub
+				.request('liveQuery.unsubscribe', { subscriptionId: ACTIVITY_SUBSCRIPTION_ID })
+				.catch(() => {});
+		}
+
+		this.messages.value = [];
+		this.activity.value = [];
+	}
+
+	private _teardownCleanly(): void {
+		this.activeSubscriptionIds.delete(MESSAGES_SUBSCRIPTION_ID);
+		this.activeSubscriptionIds.delete(ACTIVITY_SUBSCRIPTION_ID);
+		for (const fn of this.cleanups) {
+			try {
+				fn();
+			} catch {
+				/* ignore */
+			}
+		}
+		this.cleanups = [];
+		this.loading.value = false;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Delta helper
+	// ---------------------------------------------------------------------------
+
+	private _applyDelta<T>(
+		current: T[],
+		event: LiveQueryDeltaEvent,
+		getId: (row: unknown) => string
+	): T[] {
+		let result = current;
+		if (event.removed?.length) {
+			const removedIds = new Set(event.removed.map(getId));
+			result = result.filter((item) => !removedIds.has(getId(item)));
+		}
+		if (event.updated?.length) {
+			const updatedMap = new Map(event.updated.map((u) => [getId(u), u as T]));
+			result = result.map((item) => updatedMap.get(getId(item)) ?? item);
+		}
+		if (event.added?.length) {
+			result = [...result, ...(event.added as T[])];
+		}
+		return result;
+	}
+
+	// ---------------------------------------------------------------------------
+	// loadHistory() — one-shot history fetch on init
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Load initial message history via `neo.history` RPC.
+	 * Called on store initialisation before LiveQuery has a snapshot.
+	 * LiveQuery will take over once subscribed.
+	 */
+	async loadHistory(): Promise<void> {
+		try {
+			const hub = await connectionManager.getHub();
+			const response = await hub.request<{ messages: NeoMessage[]; hasMore: boolean }>(
+				'neo.history',
+				{ limit: 100 }
+			);
+			// Only apply if LiveQuery hasn't already populated messages.
+			if (this.messages.value.length === 0) {
+				this.messages.value = response.messages ?? [];
+			}
+		} catch (err) {
+			logger.warn('NeoStore loadHistory failed:', err);
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// loadActivity() — alias for subscribe(), kept for explicit API
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Subscribe to the `neo.activity` LiveQuery (delegated to subscribe()).
+	 * Provided as a named method for clarity; callers that only want activity
+	 * should still call subscribe() to also get messages.
+	 */
+	async loadActivity(): Promise<void> {
+		await this.subscribe();
+	}
+
+	// ---------------------------------------------------------------------------
+	// sendMessage()
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Send a user message to Neo and add an optimistic entry to the messages signal.
+	 *
+	 * The server-side LiveQuery will push the persisted assistant response once
+	 * the Neo session produces it — no polling needed.
+	 *
+	 * Returns the RPC response so callers can surface errors.
+	 */
+	async sendMessage(
+		text: string
+	): Promise<{ success: boolean; error?: string; errorCode?: string }> {
+		const hub = await connectionManager.getHub();
+		const response = await hub.request<{
+			success: boolean;
+			error?: string;
+			errorCode?: string;
+		}>('neo.send', { message: text });
+		return response;
+	}
+
+	// ---------------------------------------------------------------------------
+	// clearSession()
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Reset the Neo session. Clears server-side history and resets the local
+	 * messages signal so the UI reflects the fresh state immediately.
+	 */
+	async clearSession(): Promise<{ success: boolean; error?: string }> {
+		const hub = await connectionManager.getHub();
+		const response = await hub.request<{ success: boolean; error?: string }>(
+			'neo.clearSession',
+			{}
+		);
+		if (response.success) {
+			this.messages.value = [];
+		}
+		return response;
+	}
+
+	// ---------------------------------------------------------------------------
+	// confirmAction() / cancelAction()
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Execute a pending Neo action identified by `actionId`.
+	 * Clears `pendingConfirmation` regardless of outcome.
+	 */
+	async confirmAction(actionId: string): Promise<{ success: boolean; error?: string }> {
+		try {
+			const hub = await connectionManager.getHub();
+			const response = await hub.request<{ success: boolean; result?: unknown; error?: string }>(
+				'neo.confirmAction',
+				{ actionId }
+			);
+			this.pendingConfirmation.value = null;
+			return { success: response.success, error: response.error };
+		} catch (err) {
+			this.pendingConfirmation.value = null;
+			return {
+				success: false,
+				error: err instanceof Error ? err.message : String(err),
+			};
+		}
+	}
+
+	/**
+	 * Discard a pending Neo action identified by `actionId`.
+	 * Clears `pendingConfirmation` regardless of outcome.
+	 */
+	async cancelAction(actionId: string): Promise<{ success: boolean; error?: string }> {
+		try {
+			const hub = await connectionManager.getHub();
+			const response = await hub.request<{ success: boolean; error?: string }>('neo.cancelAction', {
+				actionId,
+			});
+			this.pendingConfirmation.value = null;
+			return { success: response.success, error: response.error };
+		} catch (err) {
+			this.pendingConfirmation.value = null;
+			return {
+				success: false,
+				error: err instanceof Error ? err.message : String(err),
+			};
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Singleton export
+// ---------------------------------------------------------------------------
+
+/** Singleton NeoStore instance. */
+export const neoStore = new NeoStore();

--- a/packages/web/src/lib/neo-store.ts
+++ b/packages/web/src/lib/neo-store.ts
@@ -229,7 +229,6 @@ class NeoStore {
 						})
 						.catch((err) => {
 							logger.warn('NeoStore messages LiveQuery re-subscribe failed:', err);
-							this.loading.value = false;
 						}),
 					hub
 						.request('liveQuery.subscribe', {
@@ -240,7 +239,11 @@ class NeoStore {
 						.catch((err) => {
 							logger.warn('NeoStore activity LiveQuery re-subscribe failed:', err);
 						}),
-				]).catch(() => {});
+				])
+					.catch(() => {})
+					.finally(() => {
+						this.loading.value = false;
+					});
 			});
 			this.cleanups.push(unsubReconnect);
 

--- a/packages/web/src/lib/neo-store.ts
+++ b/packages/web/src/lib/neo-store.ts
@@ -10,7 +10,8 @@
  * Signals (reactive state):
  * - messages:            Neo chat messages from the persistent session.
  * - activity:            Neo activity log entries (audit trail of tool calls).
- * - loading:             True while awaiting LiveQuery snapshot or an RPC op.
+ * - loading:             True while awaiting subscribe request acknowledgement.
+ * - error:               Set when subscribe() fails; cleared on unsubscribe.
  * - panelOpen:           Whether the Neo slide-out panel is visible.
  * - activeTab:           Which tab is shown in the panel ('chat' | 'activity').
  * - pendingConfirmation: Action waiting for user confirmation (id + description).
@@ -91,8 +92,11 @@ class NeoStore {
 	/** Neo activity feed, ordered newest-first (mirrors neo.activity LiveQuery). */
 	readonly activity = signal<NeoActivityEntry[]>([]);
 
-	/** True while awaiting the LiveQuery snapshot or an async RPC operation. */
+	/** True while the subscribe requests are in flight (cleared once acknowledged). */
 	readonly loading = signal<boolean>(false);
+
+	/** Error state — set when subscribe() fails; cleared on unsubscribe. */
+	readonly error = signal<string | null>(null);
 
 	/** Whether the Neo slide-out panel is visible. Persisted in localStorage. */
 	readonly panelOpen = signal<boolean>(this._readPanelOpen());
@@ -109,6 +113,8 @@ class NeoStore {
 	private activeSubscriptionIds = new Set<string>();
 	private subscribed = false;
 	private refCount = 0;
+	/** Set to true after loadHistory() completes so a concurrent LiveQuery snapshot won't race it. */
+	private historyLoaded = false;
 
 	// ---------------------------------------------------------------------------
 	// Panel open/close helpers (with localStorage persistence)
@@ -173,26 +179,22 @@ class NeoStore {
 			this.activeSubscriptionIds.add(MESSAGES_SUBSCRIPTION_ID);
 			this.activeSubscriptionIds.add(ACTIVITY_SUBSCRIPTION_ID);
 
-			// ── neo.messages snapshot ──────────────────────────────────────────
-			const unsubMsgSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
-				'liveQuery.snapshot',
-				(event) => {
-					if (event.subscriptionId === MESSAGES_SUBSCRIPTION_ID) {
-						if (!this.activeSubscriptionIds.has(MESSAGES_SUBSCRIPTION_ID)) return;
-						this.messages.value = event.rows as NeoMessage[];
-						this.loading.value = false;
-					} else if (event.subscriptionId === ACTIVITY_SUBSCRIPTION_ID) {
-						if (!this.activeSubscriptionIds.has(ACTIVITY_SUBSCRIPTION_ID)) return;
-						this.activity.value = event.rows as NeoActivityEntry[];
-					}
+			// ── Snapshot handler ──────────────────────────────────────────────
+			const unsubSnapshot = hub.onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+				if (event.subscriptionId === MESSAGES_SUBSCRIPTION_ID) {
+					if (!this.activeSubscriptionIds.has(MESSAGES_SUBSCRIPTION_ID)) return;
+					this.messages.value = event.rows as NeoMessage[];
+				} else if (event.subscriptionId === ACTIVITY_SUBSCRIPTION_ID) {
+					if (!this.activeSubscriptionIds.has(ACTIVITY_SUBSCRIPTION_ID)) return;
+					this.activity.value = event.rows as NeoActivityEntry[];
 				}
-			);
-			this.cleanups.push(unsubMsgSnapshot);
+			});
+			this.cleanups.push(unsubSnapshot);
 			this.cleanups.push(() => this.activeSubscriptionIds.delete(MESSAGES_SUBSCRIPTION_ID));
 			this.cleanups.push(() => this.activeSubscriptionIds.delete(ACTIVITY_SUBSCRIPTION_ID));
 
-			// ── neo.messages delta ─────────────────────────────────────────────
-			const unsubMsgDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+			// ── Delta handler ─────────────────────────────────────────────────
+			const unsubDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId === MESSAGES_SUBSCRIPTION_ID) {
 					if (!this.activeSubscriptionIds.has(MESSAGES_SUBSCRIPTION_ID)) return;
 					this.messages.value = this._applyDelta(
@@ -209,35 +211,36 @@ class NeoStore {
 					) as NeoActivityEntry[];
 				}
 			});
-			this.cleanups.push(unsubMsgDelta);
+			this.cleanups.push(unsubDelta);
 
 			// ── Reconnect handler — re-subscribe after WebSocket reconnects ────
 			const unsubReconnect = hub.onConnection((state) => {
 				if (state !== 'connected') return;
+				// Stale-event guard: don't re-subscribe if already torn down.
+				if (!this.activeSubscriptionIds.has(MESSAGES_SUBSCRIPTION_ID)) return;
 				this.loading.value = true;
 
-				const resubMessages = hub
-					.request('liveQuery.subscribe', {
-						queryName: 'neo.messages',
-						params: [100, 0],
-						subscriptionId: MESSAGES_SUBSCRIPTION_ID,
-					})
-					.catch((err) => {
-						logger.warn('NeoStore messages LiveQuery re-subscribe failed:', err);
-						this.loading.value = false;
-					});
-
-				const resubActivity = hub
-					.request('liveQuery.subscribe', {
-						queryName: 'neo.activity',
-						params: [50, 0],
-						subscriptionId: ACTIVITY_SUBSCRIPTION_ID,
-					})
-					.catch((err) => {
-						logger.warn('NeoStore activity LiveQuery re-subscribe failed:', err);
-					});
-
-				Promise.all([resubMessages, resubActivity]).catch(() => {});
+				Promise.all([
+					hub
+						.request('liveQuery.subscribe', {
+							queryName: 'neo.messages',
+							params: [100, 0],
+							subscriptionId: MESSAGES_SUBSCRIPTION_ID,
+						})
+						.catch((err) => {
+							logger.warn('NeoStore messages LiveQuery re-subscribe failed:', err);
+							this.loading.value = false;
+						}),
+					hub
+						.request('liveQuery.subscribe', {
+							queryName: 'neo.activity',
+							params: [50, 0],
+							subscriptionId: ACTIVITY_SUBSCRIPTION_ID,
+						})
+						.catch((err) => {
+							logger.warn('NeoStore activity LiveQuery re-subscribe failed:', err);
+						}),
+				]).catch(() => {});
 			});
 			this.cleanups.push(unsubReconnect);
 
@@ -255,6 +258,10 @@ class NeoStore {
 				}),
 			]);
 
+			// Loading cleared once both subscribe requests are acknowledged.
+			// The snapshot handlers will populate data as it arrives.
+			this.loading.value = false;
+
 			// Guard: unsubscribe() raced with the subscribe requests.
 			if (!this.subscribed) {
 				this._teardownCleanly();
@@ -264,6 +271,7 @@ class NeoStore {
 			this.refCount = Math.max(0, this.refCount - 1);
 			this.subscribed = false;
 			this._teardownCleanly();
+			this.error.value = err instanceof Error ? err.message : 'Failed to subscribe to Neo store';
 			logger.error('Failed to subscribe NeoStore LiveQuery:', err);
 			throw err;
 		}
@@ -276,7 +284,12 @@ class NeoStore {
 	unsubscribe(): void {
 		this.refCount = Math.max(0, this.refCount - 1);
 		if (this.refCount > 0) return;
-		if (!this.subscribed) return;
+		if (!this.subscribed) {
+			// Still reset error signal even if we were never subscribed
+			// (e.g., subscribe() failed and set this.subscribed = false in its catch block).
+			this.error.value = null;
+			return;
+		}
 		this.subscribed = false;
 
 		// Clear ids immediately so any queued events are discarded.
@@ -311,6 +324,7 @@ class NeoStore {
 		}
 		this.cleanups = [];
 		this.loading.value = false;
+		this.error.value = null;
 	}
 
 	// ---------------------------------------------------------------------------
@@ -338,24 +352,32 @@ class NeoStore {
 	}
 
 	// ---------------------------------------------------------------------------
-	// loadHistory() — one-shot history fetch on init
+	// loadHistory() — one-shot history fetch before LiveQuery snapshot
 	// ---------------------------------------------------------------------------
 
 	/**
 	 * Load initial message history via `neo.history` RPC.
-	 * Called on store initialisation before LiveQuery has a snapshot.
-	 * LiveQuery will take over once subscribed.
+	 *
+	 * Intended to be called before subscribe() to show history immediately while
+	 * LiveQuery is initialising. Guards against both:
+	 * - Concurrent LiveQuery snapshots overwriting (via `historyLoaded` flag)
+	 * - Overwriting data already populated by LiveQuery (skips if subscribed)
+	 *
+	 * The LiveQuery snapshot will merge seamlessly once it arrives.
 	 */
 	async loadHistory(): Promise<void> {
+		// If already subscribed, LiveQuery owns message state — skip.
+		if (this.subscribed) return;
 		try {
 			const hub = await connectionManager.getHub();
 			const response = await hub.request<{ messages: NeoMessage[]; hasMore: boolean }>(
 				'neo.history',
 				{ limit: 100 }
 			);
-			// Only apply if LiveQuery hasn't already populated messages.
-			if (this.messages.value.length === 0) {
+			// Guard: LiveQuery snapshot arrived or subscribe() completed while we awaited.
+			if (!this.subscribed) {
 				this.messages.value = response.messages ?? [];
+				this.historyLoaded = true;
 			}
 		} catch (err) {
 			logger.warn('NeoStore loadHistory failed:', err);
@@ -363,27 +385,14 @@ class NeoStore {
 	}
 
 	// ---------------------------------------------------------------------------
-	// loadActivity() — alias for subscribe(), kept for explicit API
-	// ---------------------------------------------------------------------------
-
-	/**
-	 * Subscribe to the `neo.activity` LiveQuery (delegated to subscribe()).
-	 * Provided as a named method for clarity; callers that only want activity
-	 * should still call subscribe() to also get messages.
-	 */
-	async loadActivity(): Promise<void> {
-		await this.subscribe();
-	}
-
-	// ---------------------------------------------------------------------------
 	// sendMessage()
 	// ---------------------------------------------------------------------------
 
 	/**
-	 * Send a user message to Neo and add an optimistic entry to the messages signal.
+	 * Send a user message to the Neo session.
 	 *
-	 * The server-side LiveQuery will push the persisted assistant response once
-	 * the Neo session produces it — no polling needed.
+	 * The server-side LiveQuery will push the persisted response once the Neo
+	 * session produces it — no polling needed.
 	 *
 	 * Returns the RPC response so callers can surface errors.
 	 */
@@ -415,6 +424,7 @@ class NeoStore {
 		);
 		if (response.success) {
 			this.messages.value = [];
+			this.historyLoaded = false;
 		}
 		return response;
 	}


### PR DESCRIPTION
## Summary

- Creates `packages/web/src/lib/neo-store.ts` — `NeoStore` class following the `SkillsStore` pattern
- Signals: `messages`, `activity`, `loading`, `panelOpen`, `activeTab`, `pendingConfirmation`
- Dual LiveQuery subscriptions: `neo.messages` (chat) + `neo.activity` (audit feed)
- `panelOpen` persisted in localStorage across page reloads
- Methods: `sendMessage`, `loadHistory`, `clearSession`, `confirmAction`, `cancelAction`, `openPanel`, `closePanel`, `togglePanel`
- Reconnect handler re-subscribes both feeds on WebSocket reconnect
- 48 unit tests: subscribe/unsubscribe, snapshot/delta, stale-event guard, race guard, reconnect, panel helpers, all RPC mutations