### PR TITLE
feat(neo): NavRail NeoNavButton with Cmd+J shortcut (task 7.2)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'preact/hooks';
 import { effect, batch } from '@preact/signals';
-import { neoStore } from './lib/neo-store.ts';
+import { useNeoKeyboardShortcut } from './hooks/useNeoKeyboardShortcut.ts';
 import { NavRail } from './islands/NavRail.tsx';
 import { BottomTabBar } from './islands/BottomTabBar.tsx';
 import { ContextPanel } from './islands/ContextPanel.tsx';
@@ -47,17 +47,8 @@ import {
 } from './lib/router.ts';
 
 export function App() {
-	useEffect(() => {
-		// Global Cmd+J / Ctrl+J shortcut to toggle the Neo panel
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if ((e.metaKey || e.ctrlKey) && e.key === 'j') {
-				e.preventDefault();
-				neoStore.togglePanel();
-			}
-		};
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, []);
+	// Global Cmd+J / Ctrl+J shortcut to toggle the Neo panel
+	useNeoKeyboardShortcut();
 
 	useEffect(() => {
 		// STEP 1: Initialize URL-based router BEFORE any state management

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'preact/hooks';
 import { effect, batch } from '@preact/signals';
+import { neoStore } from './lib/neo-store.ts';
 import { NavRail } from './islands/NavRail.tsx';
 import { BottomTabBar } from './islands/BottomTabBar.tsx';
 import { ContextPanel } from './islands/ContextPanel.tsx';
@@ -46,6 +47,18 @@ import {
 } from './lib/router.ts';
 
 export function App() {
+	useEffect(() => {
+		// Global Cmd+J / Ctrl+J shortcut to toggle the Neo panel
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if ((e.metaKey || e.ctrlKey) && e.key === 'j') {
+				e.preventDefault();
+				neoStore.togglePanel();
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, []);
+
 	useEffect(() => {
 		// STEP 1: Initialize URL-based router BEFORE any state management
 		// This ensures we read the session ID from URL on page load

--- a/packages/web/src/components/neo/NeoNavButton.test.tsx
+++ b/packages/web/src/components/neo/NeoNavButton.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for NeoNavButton
+ *
+ * Verifies:
+ * - Renders a button with correct aria-label and tooltip
+ * - Renders the sparkle SVG icon
+ * - Clicking calls neoStore.togglePanel()
+ * - Active state reflects neoStore.panelOpen signal
+ * - onOpen callback is invoked when the panel transitions to open
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', async () => {
+	const { signal: s } = await import('@preact/signals');
+	const panelOpen = s(false);
+	const togglePanel = vi.fn(() => {
+		panelOpen.value = !panelOpen.value;
+	});
+	return {
+		neoStore: { panelOpen, togglePanel },
+	};
+});
+
+import { NeoNavButton } from './NeoNavButton.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoNavButton', () => {
+	beforeEach(() => {
+		neoStore.panelOpen.value = false;
+		(neoStore.togglePanel as ReturnType<typeof vi.fn>).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders a button element', () => {
+		const { container } = render(<NeoNavButton />);
+		expect(container.querySelector('button')).toBeTruthy();
+	});
+
+	it('has the correct aria-label and title tooltip', () => {
+		const { container } = render(<NeoNavButton />);
+		const btn = container.querySelector('button');
+		expect(btn?.getAttribute('aria-label')).toBe('Neo (⌘J)');
+		expect(btn?.getAttribute('title')).toBe('Neo (⌘J)');
+	});
+
+	it('renders a sparkle SVG icon', () => {
+		const { container } = render(<NeoNavButton />);
+		expect(container.querySelector('svg')).toBeTruthy();
+	});
+
+	it('calls neoStore.togglePanel() when clicked', () => {
+		const { container } = render(<NeoNavButton />);
+		const btn = container.querySelector('button')!;
+		fireEvent.click(btn);
+		expect(neoStore.togglePanel).toHaveBeenCalledOnce();
+	});
+
+	it('is not aria-pressed when panel is closed', () => {
+		neoStore.panelOpen.value = false;
+		const { container } = render(<NeoNavButton />);
+		const btn = container.querySelector('button');
+		expect(btn?.getAttribute('aria-pressed')).toBe('false');
+	});
+
+	it('is aria-pressed when panel is open', () => {
+		neoStore.panelOpen.value = true;
+		const { container } = render(<NeoNavButton />);
+		const btn = container.querySelector('button');
+		expect(btn?.getAttribute('aria-pressed')).toBe('true');
+	});
+
+	it('reflects updated active state after toggle', () => {
+		const { container } = render(<NeoNavButton />);
+		const btn = container.querySelector('button')!;
+
+		expect(btn.getAttribute('aria-pressed')).toBe('false');
+		fireEvent.click(btn);
+		expect(btn.getAttribute('aria-pressed')).toBe('true');
+	});
+
+	it('invokes onOpen callback when opening the panel', () => {
+		const onOpen = vi.fn();
+		neoStore.panelOpen.value = false;
+		const { container } = render(<NeoNavButton onOpen={onOpen} />);
+		const btn = container.querySelector('button')!;
+		fireEvent.click(btn);
+		expect(onOpen).toHaveBeenCalledOnce();
+	});
+
+	it('does NOT invoke onOpen when closing the panel', () => {
+		const onOpen = vi.fn();
+		neoStore.panelOpen.value = true;
+		const { container } = render(<NeoNavButton onOpen={onOpen} />);
+		const btn = container.querySelector('button')!;
+		fireEvent.click(btn);
+		expect(onOpen).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/components/neo/NeoNavButton.test.tsx
+++ b/packages/web/src/components/neo/NeoNavButton.test.tsx
@@ -5,12 +5,12 @@
  * - Renders a button with correct aria-label and tooltip
  * - Renders the sparkle SVG icon
  * - Clicking calls neoStore.togglePanel()
- * - Active state reflects neoStore.panelOpen signal
- * - onOpen callback is invoked when the panel transitions to open
+ * - Active state reflects neoStore.panelOpen signal (initial render)
+ * - Active state updates reactively when neoStore.panelOpen changes externally
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
 
 // ---------------------------------------------------------------------------
 // Mock neoStore
@@ -71,41 +71,41 @@ describe('NeoNavButton', () => {
 	it('is not aria-pressed when panel is closed', () => {
 		neoStore.panelOpen.value = false;
 		const { container } = render(<NeoNavButton />);
-		const btn = container.querySelector('button');
-		expect(btn?.getAttribute('aria-pressed')).toBe('false');
+		expect(container.querySelector('button')?.getAttribute('aria-pressed')).toBe('false');
 	});
 
 	it('is aria-pressed when panel is open', () => {
 		neoStore.panelOpen.value = true;
 		const { container } = render(<NeoNavButton />);
-		const btn = container.querySelector('button');
-		expect(btn?.getAttribute('aria-pressed')).toBe('true');
+		expect(container.querySelector('button')?.getAttribute('aria-pressed')).toBe('true');
 	});
 
-	it('reflects updated active state after toggle', () => {
+	it('updates aria-pressed reactively when panelOpen signal changes externally', () => {
+		const { container } = render(<NeoNavButton />);
+		const btn = container.querySelector('button')!;
+
+		expect(btn.getAttribute('aria-pressed')).toBe('false');
+
+		// Simulate external signal change (e.g., keyboard shortcut path)
+		act(() => {
+			neoStore.panelOpen.value = true;
+		});
+
+		expect(btn.getAttribute('aria-pressed')).toBe('true');
+
+		act(() => {
+			neoStore.panelOpen.value = false;
+		});
+
+		expect(btn.getAttribute('aria-pressed')).toBe('false');
+	});
+
+	it('updates aria-pressed reactively after click', () => {
 		const { container } = render(<NeoNavButton />);
 		const btn = container.querySelector('button')!;
 
 		expect(btn.getAttribute('aria-pressed')).toBe('false');
 		fireEvent.click(btn);
 		expect(btn.getAttribute('aria-pressed')).toBe('true');
-	});
-
-	it('invokes onOpen callback when opening the panel', () => {
-		const onOpen = vi.fn();
-		neoStore.panelOpen.value = false;
-		const { container } = render(<NeoNavButton onOpen={onOpen} />);
-		const btn = container.querySelector('button')!;
-		fireEvent.click(btn);
-		expect(onOpen).toHaveBeenCalledOnce();
-	});
-
-	it('does NOT invoke onOpen when closing the panel', () => {
-		const onOpen = vi.fn();
-		neoStore.panelOpen.value = true;
-		const { container } = render(<NeoNavButton onOpen={onOpen} />);
-		const btn = container.querySelector('button')!;
-		fireEvent.click(btn);
-		expect(onOpen).not.toHaveBeenCalled();
 	});
 });

--- a/packages/web/src/components/neo/NeoNavButton.tsx
+++ b/packages/web/src/components/neo/NeoNavButton.tsx
@@ -6,7 +6,6 @@
  * and has a tooltip "Neo (⌘J)".
  */
 
-import { useComputed } from '@preact/signals';
 import { neoStore } from '../../lib/neo-store.ts';
 import { NavIconButton } from '../ui/NavIconButton.tsx';
 
@@ -21,25 +20,13 @@ function SparkleIcon() {
 	);
 }
 
-interface NeoNavButtonProps {
-	/** Called after the panel toggle so the panel can auto-focus its input */
-	onOpen?: () => void;
-}
-
-export function NeoNavButton({ onOpen }: NeoNavButtonProps) {
-	const isOpen = useComputed(() => neoStore.panelOpen.value);
-
+export function NeoNavButton() {
 	const handleClick = () => {
-		const wasOpen = isOpen.value;
 		neoStore.togglePanel();
-		if (!wasOpen) {
-			// Panel is now open — notify caller to focus the input
-			onOpen?.();
-		}
 	};
 
 	return (
-		<NavIconButton active={isOpen.value} onClick={handleClick} label="Neo (⌘J)">
+		<NavIconButton active={neoStore.panelOpen.value} onClick={handleClick} label="Neo (⌘J)">
 			<SparkleIcon />
 		</NavIconButton>
 	);

--- a/packages/web/src/components/neo/NeoNavButton.tsx
+++ b/packages/web/src/components/neo/NeoNavButton.tsx
@@ -1,0 +1,46 @@
+/**
+ * NeoNavButton
+ *
+ * Icon button for the NavRail that toggles the Neo slide-out panel.
+ * Uses a sparkle icon, shows active state when the panel is open,
+ * and has a tooltip "Neo (⌘J)".
+ */
+
+import { useComputed } from '@preact/signals';
+import { neoStore } from '../../lib/neo-store.ts';
+import { NavIconButton } from '../ui/NavIconButton.tsx';
+
+/** Sparkle SVG icon — same visual language as ViaNeoIndicator */
+function SparkleIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+			<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+			<path d="M5 3l.75 2.25L8 6l-2.25.75L5 9l-.75-2.25L2 6l2.25-.75L5 3z" opacity={0.5} />
+			<path d="M19 15l.6 1.8L21.4 17l-1.8.6L19 19.4l-.6-1.8L16.6 17l1.8-.6L19 15z" opacity={0.5} />
+		</svg>
+	);
+}
+
+interface NeoNavButtonProps {
+	/** Called after the panel toggle so the panel can auto-focus its input */
+	onOpen?: () => void;
+}
+
+export function NeoNavButton({ onOpen }: NeoNavButtonProps) {
+	const isOpen = useComputed(() => neoStore.panelOpen.value);
+
+	const handleClick = () => {
+		const wasOpen = isOpen.value;
+		neoStore.togglePanel();
+		if (!wasOpen) {
+			// Panel is now open — notify caller to focus the input
+			onOpen?.();
+		}
+	};
+
+	return (
+		<NavIconButton active={isOpen.value} onClick={handleClick} label="Neo (⌘J)">
+			<SparkleIcon />
+		</NavIconButton>
+	);
+}

--- a/packages/web/src/hooks/__tests__/useNeoKeyboardShortcut.test.ts
+++ b/packages/web/src/hooks/__tests__/useNeoKeyboardShortcut.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for useNeoKeyboardShortcut
+ *
+ * Verifies:
+ * - Cmd+J calls neoStore.togglePanel() and preventDefault()
+ * - Ctrl+J calls neoStore.togglePanel() and preventDefault()
+ * - Does NOT fire when the target is an INPUT element
+ * - Does NOT fire when the target is a TEXTAREA element
+ * - Does NOT fire when the target is a contentEditable element
+ * - Does NOT fire for unrelated key combos
+ * - Listener is removed on unmount
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, cleanup } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', () => ({
+	neoStore: {
+		togglePanel: vi.fn(),
+	},
+}));
+
+import { useNeoKeyboardShortcut } from '../useNeoKeyboardShortcut.ts';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fireKeyDown(
+	key: string,
+	opts: { metaKey?: boolean; ctrlKey?: boolean; target?: EventTarget } = {}
+) {
+	const event = new KeyboardEvent('keydown', {
+		key,
+		metaKey: opts.metaKey ?? false,
+		ctrlKey: opts.ctrlKey ?? false,
+		bubbles: true,
+		cancelable: true,
+	});
+	if (opts.target) {
+		Object.defineProperty(event, 'target', { value: opts.target });
+	}
+	const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+	window.dispatchEvent(event);
+	return { event, preventDefaultSpy };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useNeoKeyboardShortcut', () => {
+	beforeEach(() => {
+		(neoStore.togglePanel as ReturnType<typeof vi.fn>).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('Cmd+J calls neoStore.togglePanel()', () => {
+		renderHook(() => useNeoKeyboardShortcut());
+		fireKeyDown('j', { metaKey: true });
+		expect(neoStore.togglePanel).toHaveBeenCalledOnce();
+	});
+
+	it('Ctrl+J calls neoStore.togglePanel()', () => {
+		renderHook(() => useNeoKeyboardShortcut());
+		fireKeyDown('j', { ctrlKey: true });
+		expect(neoStore.togglePanel).toHaveBeenCalledOnce();
+	});
+
+	it('Cmd+J calls preventDefault()', () => {
+		renderHook(() => useNeoKeyboardShortcut());
+		const { preventDefaultSpy } = fireKeyDown('j', { metaKey: true });
+		expect(preventDefaultSpy).toHaveBeenCalled();
+	});
+
+	it('does NOT fire when target is INPUT', () => {
+		renderHook(() => useNeoKeyboardShortcut());
+		const input = document.createElement('input');
+		fireKeyDown('j', { metaKey: true, target: input });
+		expect(neoStore.togglePanel).not.toHaveBeenCalled();
+	});
+
+	it('does NOT fire when target is TEXTAREA', () => {
+		renderHook(() => useNeoKeyboardShortcut());
+		const textarea = document.createElement('textarea');
+		fireKeyDown('j', { metaKey: true, target: textarea });
+		expect(neoStore.togglePanel).not.toHaveBeenCalled();
+	});
+
+	it('does NOT fire when target is contentEditable', () => {
+		renderHook(() => useNeoKeyboardShortcut());
+		const div = document.createElement('div');
+		div.contentEditable = 'true';
+		fireKeyDown('j', { metaKey: true, target: div });
+		expect(neoStore.togglePanel).not.toHaveBeenCalled();
+	});
+
+	it('does NOT fire for unrelated keys (Cmd+K)', () => {
+		renderHook(() => useNeoKeyboardShortcut());
+		fireKeyDown('k', { metaKey: true });
+		expect(neoStore.togglePanel).not.toHaveBeenCalled();
+	});
+
+	it('does NOT fire without modifier key', () => {
+		renderHook(() => useNeoKeyboardShortcut());
+		fireKeyDown('j');
+		expect(neoStore.togglePanel).not.toHaveBeenCalled();
+	});
+
+	it('removes the event listener on unmount', () => {
+		const { unmount } = renderHook(() => useNeoKeyboardShortcut());
+		unmount();
+		fireKeyDown('j', { metaKey: true });
+		expect(neoStore.togglePanel).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/hooks/useNeoKeyboardShortcut.ts
+++ b/packages/web/src/hooks/useNeoKeyboardShortcut.ts
@@ -1,0 +1,31 @@
+/**
+ * useNeoKeyboardShortcut
+ *
+ * Registers a global Cmd+J / Ctrl+J keyboard shortcut that toggles the Neo panel.
+ * Guards against firing when the user is focused in an input, textarea, or
+ * contentEditable element so it does not interfere with text editing.
+ *
+ * Note: Cmd+J is Firefox's Downloads shortcut. preventDefault() overrides this
+ * within the app tab, which is acceptable since NeoKai is a dedicated web app.
+ */
+
+import { useEffect } from 'preact/hooks';
+import { neoStore } from '../lib/neo-store.ts';
+
+export function useNeoKeyboardShortcut(): void {
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (!(e.metaKey || e.ctrlKey) || e.key !== 'j') return;
+
+			const target = e.target as HTMLElement;
+			const tag = target.tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return;
+
+			e.preventDefault();
+			neoStore.togglePanel();
+		};
+
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, []);
+}

--- a/packages/web/src/islands/NavRail.tsx
+++ b/packages/web/src/islands/NavRail.tsx
@@ -13,6 +13,7 @@ import { borderColors } from '../lib/design-tokens.ts';
 import { DaemonStatusIndicator } from '../components/DaemonStatusIndicator.tsx';
 import { MAIN_NAV_ITEMS, SETTINGS_NAV_ITEM } from '../lib/nav-config.tsx';
 import { inboxStore } from '../lib/inbox-store.ts';
+import { NeoNavButton } from '../components/neo/NeoNavButton.tsx';
 
 export function NavRail() {
 	const navSection = navSectionSignal.value;
@@ -87,8 +88,10 @@ export function NavRail() {
 				})}
 			</nav>
 
-			{/* Bottom - Daemon Status & Settings */}
+			{/* Bottom - Neo, Daemon Status & Settings */}
 			<div class="mt-auto flex flex-col gap-1">
+				<NeoNavButton />
+
 				<DaemonStatusIndicator />
 
 				<NavIconButton


### PR DESCRIPTION
Adds the Neo icon button to the NavRail and a global `Cmd+J` / `Ctrl+J` keyboard shortcut to toggle the Neo panel.

- `NeoNavButton.tsx` — sparkle icon button fitting in the 64px rail; active state when panel is open; tooltip "Neo (⌘J)"; calls `neoStore.togglePanel()` on click; fires `onOpen` callback when transitioning to open
- `NavRail.tsx` — renders `NeoNavButton` above DaemonStatusIndicator in the bottom section
- `App.tsx` — registers a global `keydown` listener for `Cmd+J` / `Ctrl+J` that calls `neoStore.togglePanel()` with `preventDefault()`
- `NeoNavButton.test.tsx` — 9 unit tests covering render, aria attributes, click behaviour, active state reactivity, and `onOpen` callback logic