### PR TITLE
feat(neo): Neo Settings section (task 8.1)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/neo-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/neo-handlers.ts
@@ -203,7 +203,7 @@ export function setupNeoHandlers(
 	messageHub.onRequest('neo.updateSettings', async (data) => {
 		const { securityMode, model } = (data ?? {}) as {
 			securityMode?: string;
-			model?: string;
+			model?: string | null;
 		};
 
 		const updates: Record<string, unknown> = {};
@@ -218,10 +218,14 @@ export function setupNeoHandlers(
 		}
 
 		if (model !== undefined) {
-			if (typeof model !== 'string' || model.trim() === '') {
-				throw new Error('model must be a non-empty string');
+			if (model === null) {
+				// null clears the override — Neo falls back to the app's primary model
+				updates.neoModel = null;
+			} else if (typeof model !== 'string' || model.trim() === '') {
+				throw new Error('model must be a non-empty string or null');
+			} else {
+				updates.neoModel = model.trim();
 			}
-			updates.neoModel = model.trim();
 		}
 
 		if (Object.keys(updates).length === 0) {

--- a/packages/daemon/tests/unit/rpc-handlers/neo-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/neo-handlers.test.ts
@@ -406,10 +406,18 @@ describe('Neo RPC Handlers', () => {
 			);
 		});
 
+		it('clears neoModel override when model is null', async () => {
+			const handler = hubData.handlers.get('neo.updateSettings');
+			await handler!({ model: null }, {});
+			expect(settingsManager.updateGlobalSettings).toHaveBeenCalledWith(
+				expect.objectContaining({ neoModel: null })
+			);
+		});
+
 		it('throws for empty model string', async () => {
 			const handler = hubData.handlers.get('neo.updateSettings');
 			await expect(handler!({ model: '   ' }, {})).rejects.toThrow(
-				'model must be a non-empty string'
+				'model must be a non-empty string or null'
 			);
 		});
 

--- a/packages/web/src/components/settings/NeoSettings.tsx
+++ b/packages/web/src/components/settings/NeoSettings.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from 'preact/hooks';
+import { connectionManager } from '../../lib/connection-manager';
+import { neoStore } from '../../lib/neo-store';
+import { toast } from '../../lib/toast.ts';
+import { SettingsSection, SettingsRow, SettingsSelect } from './SettingsSection.tsx';
+
+type NeoSecurityMode = 'conservative' | 'balanced' | 'autonomous';
+
+const SECURITY_MODE_OPTIONS: Array<{ value: NeoSecurityMode; label: string; description: string }> =
+	[
+		{
+			value: 'conservative',
+			label: 'Conservative',
+			description: 'Confirm every write action before executing',
+		},
+		{
+			value: 'balanced',
+			label: 'Balanced (default)',
+			description:
+				'Auto-execute low-risk actions; confirm medium-risk; require explicit phrasing for irreversible changes',
+		},
+		{
+			value: 'autonomous',
+			label: 'Autonomous',
+			description: 'Execute all actions immediately without confirmation',
+		},
+	];
+
+const MODEL_OPTIONS = [
+	{ value: '', label: 'App default' },
+	{ value: 'sonnet', label: 'Claude Sonnet 4' },
+	{ value: 'opus', label: 'Claude Opus 4' },
+	{ value: 'haiku', label: 'Claude Haiku 3.5' },
+];
+
+interface NeoSettingsState {
+	securityMode: NeoSecurityMode;
+	model: string | null;
+}
+
+export function NeoSettings() {
+	const [settings, setSettings] = useState<NeoSettingsState>({
+		securityMode: 'balanced',
+		model: null,
+	});
+	const [isUpdating, setIsUpdating] = useState(false);
+	const [isLoading, setIsLoading] = useState(true);
+	const [showClearConfirm, setShowClearConfirm] = useState(false);
+	const [isClearing, setIsClearing] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		const load = async () => {
+			try {
+				const hub = await connectionManager.getHub();
+				const response = await hub.request<{ securityMode: NeoSecurityMode; model: string | null }>(
+					'neo.getSettings',
+					{}
+				);
+				if (!cancelled) {
+					setSettings({
+						securityMode: response.securityMode ?? 'balanced',
+						model: response.model ?? null,
+					});
+				}
+			} catch {
+				if (!cancelled) {
+					toast.error('Failed to load Neo settings');
+				}
+			} finally {
+				if (!cancelled) {
+					setIsLoading(false);
+				}
+			}
+		};
+		load();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const handleSecurityModeChange = async (value: string) => {
+		const mode = value as NeoSecurityMode;
+		const prev = settings.securityMode;
+		setSettings((s) => ({ ...s, securityMode: mode }));
+		setIsUpdating(true);
+		try {
+			const hub = await connectionManager.getHub();
+			await hub.request('neo.updateSettings', { securityMode: mode });
+		} catch {
+			toast.error('Failed to update security mode');
+			setSettings((s) => ({ ...s, securityMode: prev }));
+		} finally {
+			setIsUpdating(false);
+		}
+	};
+
+	const handleModelChange = async (value: string) => {
+		const model = value === '' ? null : value;
+		const prev = settings.model;
+		setSettings((s) => ({ ...s, model }));
+		setIsUpdating(true);
+		try {
+			const hub = await connectionManager.getHub();
+			await hub.request('neo.updateSettings', { model });
+		} catch {
+			toast.error('Failed to update Neo model');
+			setSettings((s) => ({ ...s, model: prev }));
+		} finally {
+			setIsUpdating(false);
+		}
+	};
+
+	const handleClearSession = async () => {
+		setIsClearing(true);
+		try {
+			const result = await neoStore.clearSession();
+			if (result.success) {
+				toast.success('Neo session cleared');
+			} else {
+				toast.error(result.error ?? 'Failed to clear session');
+			}
+		} catch {
+			toast.error('Failed to clear Neo session');
+		} finally {
+			setIsClearing(false);
+			setShowClearConfirm(false);
+		}
+	};
+
+	const selectedMode = SECURITY_MODE_OPTIONS.find((o) => o.value === settings.securityMode);
+
+	return (
+		<SettingsSection title="Neo Agent">
+			<SettingsRow
+				label="Security Mode"
+				description={
+					selectedMode?.description ?? 'Controls how Neo confirms actions before executing them'
+				}
+			>
+				<SettingsSelect
+					value={settings.securityMode}
+					onChange={handleSecurityModeChange}
+					options={SECURITY_MODE_OPTIONS}
+					disabled={isUpdating || isLoading}
+				/>
+			</SettingsRow>
+
+			<SettingsRow label="Model" description="Model used by Neo (overrides app default when set)">
+				<SettingsSelect
+					value={settings.model ?? ''}
+					onChange={handleModelChange}
+					options={MODEL_OPTIONS}
+					disabled={isUpdating || isLoading}
+				/>
+			</SettingsRow>
+
+			<SettingsRow
+				label="Clear Session"
+				description="Erase Neo's conversation history and start fresh"
+			>
+				{showClearConfirm ? (
+					<div class="flex items-center gap-2">
+						<span class="text-xs text-gray-400">Are you sure?</span>
+						<button
+							type="button"
+							onClick={handleClearSession}
+							disabled={isClearing}
+							class="px-3 py-1.5 text-xs font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white disabled:opacity-50 transition-colors"
+						>
+							{isClearing ? 'Clearing…' : 'Confirm'}
+						</button>
+						<button
+							type="button"
+							onClick={() => setShowClearConfirm(false)}
+							disabled={isClearing}
+							class="px-3 py-1.5 text-xs font-medium rounded-lg bg-dark-700 hover:bg-dark-600 text-gray-300 disabled:opacity-50 transition-colors"
+						>
+							Cancel
+						</button>
+					</div>
+				) : (
+					<button
+						type="button"
+						onClick={() => setShowClearConfirm(true)}
+						class="px-3 py-1.5 text-xs font-medium rounded-lg bg-dark-700 hover:bg-dark-600 text-gray-300 transition-colors"
+					>
+						Clear Session
+					</button>
+				)}
+			</SettingsRow>
+		</SettingsSection>
+	);
+}

--- a/packages/web/src/components/settings/NeoSettings.tsx
+++ b/packages/web/src/components/settings/NeoSettings.tsx
@@ -43,7 +43,8 @@ export function NeoSettings() {
 		securityMode: 'balanced',
 		model: null,
 	});
-	const [isUpdating, setIsUpdating] = useState(false);
+	const [isUpdatingMode, setIsUpdatingMode] = useState(false);
+	const [isUpdatingModel, setIsUpdatingModel] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
 	const [showClearConfirm, setShowClearConfirm] = useState(false);
 	const [isClearing, setIsClearing] = useState(false);
@@ -83,31 +84,34 @@ export function NeoSettings() {
 		const mode = value as NeoSecurityMode;
 		const prev = settings.securityMode;
 		setSettings((s) => ({ ...s, securityMode: mode }));
-		setIsUpdating(true);
+		setIsUpdatingMode(true);
 		try {
 			const hub = await connectionManager.getHub();
 			await hub.request('neo.updateSettings', { securityMode: mode });
+			toast.success('Security mode updated');
 		} catch {
 			toast.error('Failed to update security mode');
 			setSettings((s) => ({ ...s, securityMode: prev }));
 		} finally {
-			setIsUpdating(false);
+			setIsUpdatingMode(false);
 		}
 	};
 
 	const handleModelChange = async (value: string) => {
+		// Empty string means "app default" — send null to clear the override
 		const model = value === '' ? null : value;
 		const prev = settings.model;
 		setSettings((s) => ({ ...s, model }));
-		setIsUpdating(true);
+		setIsUpdatingModel(true);
 		try {
 			const hub = await connectionManager.getHub();
 			await hub.request('neo.updateSettings', { model });
+			toast.success('Model updated');
 		} catch {
 			toast.error('Failed to update Neo model');
 			setSettings((s) => ({ ...s, model: prev }));
 		} finally {
-			setIsUpdating(false);
+			setIsUpdatingModel(false);
 		}
 	};
 
@@ -130,6 +134,14 @@ export function NeoSettings() {
 
 	const selectedMode = SECURITY_MODE_OPTIONS.find((o) => o.value === settings.securityMode);
 
+	if (isLoading) {
+		return (
+			<SettingsSection title="Neo Agent">
+				<div class="text-sm text-gray-500">Loading…</div>
+			</SettingsSection>
+		);
+	}
+
 	return (
 		<SettingsSection title="Neo Agent">
 			<SettingsRow
@@ -142,7 +154,7 @@ export function NeoSettings() {
 					value={settings.securityMode}
 					onChange={handleSecurityModeChange}
 					options={SECURITY_MODE_OPTIONS}
-					disabled={isUpdating || isLoading}
+					disabled={isUpdatingMode}
 				/>
 			</SettingsRow>
 
@@ -151,7 +163,7 @@ export function NeoSettings() {
 					value={settings.model ?? ''}
 					onChange={handleModelChange}
 					options={MODEL_OPTIONS}
-					disabled={isUpdating || isLoading}
+					disabled={isUpdatingModel}
 				/>
 			</SettingsRow>
 

--- a/packages/web/src/components/settings/__tests__/NeoSettings.test.tsx
+++ b/packages/web/src/components/settings/__tests__/NeoSettings.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * Tests for NeoSettings component.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockRequest, mockGetHub, mockClearSession, mockToastError, mockToastSuccess } = vi.hoisted(
+	() => {
+		const mockRequest = vi.fn();
+		const mockGetHub = vi.fn();
+		const mockClearSession = vi.fn();
+		const mockToastError = vi.fn();
+		const mockToastSuccess = vi.fn();
+		return { mockRequest, mockGetHub, mockClearSession, mockToastError, mockToastSuccess };
+	}
+);
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHub: () => mockGetHub(),
+	},
+}));
+
+vi.mock('../../../lib/neo-store', () => ({
+	neoStore: {
+		clearSession: () => mockClearSession(),
+	},
+}));
+
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		error: (msg: string) => mockToastError(msg),
+		success: (msg: string) => mockToastSuccess(msg),
+		info: vi.fn(),
+		warning: vi.fn(),
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeHub(requestImpl?: (method: string, params: unknown) => unknown) {
+	return {
+		request: requestImpl ? vi.fn().mockImplementation(requestImpl) : mockRequest,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+import { NeoSettings } from '../NeoSettings.tsx';
+
+describe('NeoSettings', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Default: getSettings returns balanced + null model
+		const hub = makeHub((method) => {
+			if (method === 'neo.getSettings') {
+				return Promise.resolve({ securityMode: 'balanced', model: null });
+			}
+			return Promise.resolve({ success: true, securityMode: 'balanced', model: null });
+		});
+		mockGetHub.mockResolvedValue(hub);
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the Neo Agent section heading', async () => {
+		render(<NeoSettings />);
+		await waitFor(() => {
+			expect(screen.getByText('Neo Agent')).toBeTruthy();
+		});
+	});
+
+	it('renders security mode selector', async () => {
+		render(<NeoSettings />);
+		await waitFor(() => {
+			expect(screen.getByText('Security Mode')).toBeTruthy();
+		});
+	});
+
+	it('renders model selector', async () => {
+		render(<NeoSettings />);
+		await waitFor(() => {
+			expect(screen.getByText('Model')).toBeTruthy();
+		});
+	});
+
+	it('renders clear session button', async () => {
+		render(<NeoSettings />);
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: 'Clear Session' })).toBeTruthy();
+		});
+	});
+
+	it('loads settings on mount and sets security mode', async () => {
+		const hub = makeHub((method) => {
+			if (method === 'neo.getSettings') {
+				return Promise.resolve({ securityMode: 'conservative', model: null });
+			}
+			return Promise.resolve({});
+		});
+		mockGetHub.mockResolvedValue(hub);
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			const selects = screen.getAllByRole('combobox');
+			// First select is security mode
+			expect((selects[0] as HTMLSelectElement).value).toBe('conservative');
+		});
+	});
+
+	it('loads settings on mount and sets model', async () => {
+		const hub = makeHub((method) => {
+			if (method === 'neo.getSettings') {
+				return Promise.resolve({ securityMode: 'balanced', model: 'opus' });
+			}
+			return Promise.resolve({});
+		});
+		mockGetHub.mockResolvedValue(hub);
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			const selects = screen.getAllByRole('combobox');
+			const modelSelect = selects[1] as HTMLSelectElement;
+			expect(modelSelect.value).toBe('opus');
+		});
+	});
+
+	it('calls neo.updateSettings when security mode changes', async () => {
+		const requestFn = vi.fn().mockImplementation((method) => {
+			if (method === 'neo.getSettings') {
+				return Promise.resolve({ securityMode: 'balanced', model: null });
+			}
+			return Promise.resolve({ success: true });
+		});
+		const hub = { request: requestFn };
+		mockGetHub.mockResolvedValue(hub);
+
+		render(<NeoSettings />);
+
+		// Wait for settings to load
+		await waitFor(() => {
+			expect(screen.getByText('Security Mode')).toBeTruthy();
+		});
+
+		const selects = screen.getAllByRole('combobox');
+		fireEvent.change(selects[0], { target: { value: 'autonomous' } });
+
+		await waitFor(() => {
+			expect(requestFn).toHaveBeenCalledWith('neo.updateSettings', { securityMode: 'autonomous' });
+		});
+	});
+
+	it('calls neo.updateSettings when model changes', async () => {
+		const requestFn = vi.fn().mockImplementation((method) => {
+			if (method === 'neo.getSettings') {
+				return Promise.resolve({ securityMode: 'balanced', model: null });
+			}
+			return Promise.resolve({ success: true });
+		});
+		const hub = { request: requestFn };
+		mockGetHub.mockResolvedValue(hub);
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Model')).toBeTruthy();
+		});
+
+		const selects = screen.getAllByRole('combobox');
+		fireEvent.change(selects[1], { target: { value: 'sonnet' } });
+
+		await waitFor(() => {
+			expect(requestFn).toHaveBeenCalledWith('neo.updateSettings', { model: 'sonnet' });
+		});
+	});
+
+	it('treats empty string model value as null when persisting', async () => {
+		const requestFn = vi.fn().mockImplementation((method) => {
+			if (method === 'neo.getSettings') {
+				return Promise.resolve({ securityMode: 'balanced', model: 'opus' });
+			}
+			return Promise.resolve({ success: true });
+		});
+		const hub = { request: requestFn };
+		mockGetHub.mockResolvedValue(hub);
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			const selects = screen.getAllByRole('combobox');
+			expect((selects[1] as HTMLSelectElement).value).toBe('opus');
+		});
+
+		const selects = screen.getAllByRole('combobox');
+		fireEvent.change(selects[1], { target: { value: '' } });
+
+		await waitFor(() => {
+			expect(requestFn).toHaveBeenCalledWith('neo.updateSettings', { model: null });
+		});
+	});
+
+	it('shows confirmation UI when Clear Session is clicked', async () => {
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: 'Clear Session' })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
+
+		expect(screen.getByText('Are you sure?')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Confirm' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+	});
+
+	it('cancels clear session dialog when Cancel is clicked', async () => {
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: 'Clear Session' })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
+		expect(screen.getByText('Are you sure?')).toBeTruthy();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+		expect(screen.queryByText('Are you sure?')).toBeNull();
+		expect(screen.getByRole('button', { name: 'Clear Session' })).toBeTruthy();
+	});
+
+	it('calls neoStore.clearSession() on confirm and shows success toast', async () => {
+		mockClearSession.mockResolvedValue({ success: true });
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: 'Clear Session' })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
+		fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+		await waitFor(() => {
+			expect(mockClearSession).toHaveBeenCalledOnce();
+			expect(mockToastSuccess).toHaveBeenCalledWith('Neo session cleared');
+		});
+
+		// Confirmation dialog should be dismissed
+		expect(screen.queryByText('Are you sure?')).toBeNull();
+	});
+
+	it('shows error toast when clearSession fails', async () => {
+		mockClearSession.mockResolvedValue({ success: false, error: 'Session not found' });
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: 'Clear Session' })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
+		fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalledWith('Session not found');
+		});
+	});
+
+	it('shows error toast when getSettings throws', async () => {
+		mockGetHub.mockRejectedValue(new Error('Connection error'));
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalledWith('Failed to load Neo settings');
+		});
+	});
+
+	it('reverts security mode on update failure', async () => {
+		const requestFn = vi.fn().mockImplementation((method) => {
+			if (method === 'neo.getSettings') {
+				return Promise.resolve({ securityMode: 'balanced', model: null });
+			}
+			return Promise.reject(new Error('Network error'));
+		});
+		const hub = { request: requestFn };
+		mockGetHub.mockResolvedValue(hub);
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			const selects = screen.getAllByRole('combobox');
+			expect((selects[0] as HTMLSelectElement).value).toBe('balanced');
+		});
+
+		const selects = screen.getAllByRole('combobox');
+		fireEvent.change(selects[0], { target: { value: 'autonomous' } });
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalledWith('Failed to update security mode');
+		});
+
+		// Should revert to 'balanced'
+		await waitFor(() => {
+			const afterSelects = screen.getAllByRole('combobox');
+			expect((afterSelects[0] as HTMLSelectElement).value).toBe('balanced');
+		});
+	});
+});

--- a/packages/web/src/components/settings/__tests__/NeoSettings.test.tsx
+++ b/packages/web/src/components/settings/__tests__/NeoSettings.test.tsx
@@ -81,21 +81,28 @@ describe('NeoSettings', () => {
 		});
 	});
 
-	it('renders security mode selector', async () => {
+	it('shows loading state before settings are fetched', () => {
+		// Never resolves — stays in loading state
+		mockGetHub.mockReturnValue(new Promise(() => {}));
+		render(<NeoSettings />);
+		expect(screen.getByText('Loading…')).toBeTruthy();
+	});
+
+	it('renders security mode selector after load', async () => {
 		render(<NeoSettings />);
 		await waitFor(() => {
 			expect(screen.getByText('Security Mode')).toBeTruthy();
 		});
 	});
 
-	it('renders model selector', async () => {
+	it('renders model selector after load', async () => {
 		render(<NeoSettings />);
 		await waitFor(() => {
 			expect(screen.getByText('Model')).toBeTruthy();
 		});
 	});
 
-	it('renders clear session button', async () => {
+	it('renders clear session button after load', async () => {
 		render(<NeoSettings />);
 		await waitFor(() => {
 			expect(screen.getByRole('button', { name: 'Clear Session' })).toBeTruthy();
@@ -138,7 +145,7 @@ describe('NeoSettings', () => {
 		});
 	});
 
-	it('calls neo.updateSettings when security mode changes', async () => {
+	it('calls neo.updateSettings and shows success toast when security mode changes', async () => {
 		const requestFn = vi.fn().mockImplementation((method) => {
 			if (method === 'neo.getSettings') {
 				return Promise.resolve({ securityMode: 'balanced', model: null });
@@ -150,7 +157,6 @@ describe('NeoSettings', () => {
 
 		render(<NeoSettings />);
 
-		// Wait for settings to load
 		await waitFor(() => {
 			expect(screen.getByText('Security Mode')).toBeTruthy();
 		});
@@ -160,10 +166,11 @@ describe('NeoSettings', () => {
 
 		await waitFor(() => {
 			expect(requestFn).toHaveBeenCalledWith('neo.updateSettings', { securityMode: 'autonomous' });
+			expect(mockToastSuccess).toHaveBeenCalledWith('Security mode updated');
 		});
 	});
 
-	it('calls neo.updateSettings when model changes', async () => {
+	it('calls neo.updateSettings and shows success toast when model changes', async () => {
 		const requestFn = vi.fn().mockImplementation((method) => {
 			if (method === 'neo.getSettings') {
 				return Promise.resolve({ securityMode: 'balanced', model: null });
@@ -184,10 +191,11 @@ describe('NeoSettings', () => {
 
 		await waitFor(() => {
 			expect(requestFn).toHaveBeenCalledWith('neo.updateSettings', { model: 'sonnet' });
+			expect(mockToastSuccess).toHaveBeenCalledWith('Model updated');
 		});
 	});
 
-	it('treats empty string model value as null when persisting', async () => {
+	it('sends model: null when "App default" is selected (clears override)', async () => {
 		const requestFn = vi.fn().mockImplementation((method) => {
 			if (method === 'neo.getSettings') {
 				return Promise.resolve({ securityMode: 'balanced', model: 'opus' });
@@ -208,7 +216,9 @@ describe('NeoSettings', () => {
 		fireEvent.change(selects[1], { target: { value: '' } });
 
 		await waitFor(() => {
+			// null is sent so the backend clears the neoModel override
 			expect(requestFn).toHaveBeenCalledWith('neo.updateSettings', { model: null });
+			expect(mockToastSuccess).toHaveBeenCalledWith('Model updated');
 		});
 	});
 
@@ -318,5 +328,33 @@ describe('NeoSettings', () => {
 			const afterSelects = screen.getAllByRole('combobox');
 			expect((afterSelects[0] as HTMLSelectElement).value).toBe('balanced');
 		});
+	});
+
+	it('model select stays enabled after a security mode update completes', async () => {
+		const requestFn = vi.fn().mockImplementation((method) => {
+			if (method === 'neo.getSettings') {
+				return Promise.resolve({ securityMode: 'balanced', model: null });
+			}
+			return Promise.resolve({ success: true });
+		});
+		const hub = { request: requestFn };
+		mockGetHub.mockResolvedValue(hub);
+
+		render(<NeoSettings />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Security Mode')).toBeTruthy();
+		});
+
+		const selects = screen.getAllByRole('combobox');
+		fireEvent.change(selects[0], { target: { value: 'autonomous' } });
+
+		// After the security mode update completes, the model select should not be disabled
+		await waitFor(() => {
+			expect(mockToastSuccess).toHaveBeenCalledWith('Security mode updated');
+		});
+
+		const afterSelects = screen.getAllByRole('combobox');
+		expect((afterSelects[1] as HTMLSelectElement).disabled).toBe(false);
 	});
 });

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -49,6 +49,7 @@ const SETTINGS_SECTIONS: Array<{
 	{ id: 'app-mcp-servers', label: 'Application MCP Servers', icon: 'app-server' },
 	{ id: 'skills', label: 'Skills', icon: 'skills' },
 	{ id: 'fallback-models', label: 'Fallback Models', icon: 'swap' },
+	{ id: 'neo', label: 'Neo Agent', icon: 'neo' },
 	{ id: 'usage', label: 'Usage', icon: 'chart' },
 	{ id: 'about', label: 'About', icon: 'info' },
 ];
@@ -149,6 +150,17 @@ function SectionIcon({ type }: { type: string }) {
 						stroke-linejoin="round"
 						stroke-width={2}
 						d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18"
+					/>
+				</svg>
+			);
+		case 'neo':
+			return (
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width={2}
+						d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
 					/>
 				</svg>
 			);

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -24,6 +24,7 @@ import { SkillsRegistry } from '../components/settings/SkillsRegistry.tsx';
 import { FallbackModelsSettings } from '../components/settings/FallbackModelsSettings.tsx';
 import { UsageAnalytics } from '../components/settings/UsageAnalytics.tsx';
 import { AboutSection } from '../components/settings/AboutSection.tsx';
+import { NeoSettings } from '../components/settings/NeoSettings.tsx';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton.tsx';
 import { Inbox } from '../components/inbox/Inbox.tsx';
 
@@ -121,6 +122,7 @@ export default function MainContent() {
 						{settingsSection === 'app-mcp-servers' && <AppMcpServersSettings />}
 						{settingsSection === 'skills' && <SkillsRegistry />}
 						{settingsSection === 'fallback-models' && <FallbackModelsSettings />}
+						{settingsSection === 'neo' && <NeoSettings />}
 						{settingsSection === 'usage' && <UsageAnalytics />}
 						{settingsSection === 'about' && <AboutSection />}
 					</div>

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -62,6 +62,7 @@ export type SettingsSection =
 	| 'app-mcp-servers'
 	| 'skills'
 	| 'fallback-models'
+	| 'neo'
 	| 'usage'
 	| 'about';
 export const settingsSectionSignal = signal<SettingsSection>('general');


### PR DESCRIPTION
Add a Neo Agent section to Global Settings with three controls:

- **Security mode** dropdown (Conservative / Balanced (default) / Autonomous) — reads from `neo.getSettings`, persists via `neo.updateSettings`
- **Model** dropdown (App default / Sonnet / Opus / Haiku) — reads and persists the same way
- **Clear Session** button — shows inline confirmation dialog, calls `neoStore.clearSession()` on confirm

Wired into `ContextPanel` navigation (between Fallback Models and Usage) and `MainContent` renderer. Includes 15 unit tests covering load, change, RPC calls, error reversal, confirmation dialog, and clear session flow.