### PR TITLE
feat(neo): slide-out panel with Chat, Activity, and Confirmation UI (task 7.3)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'preact/hooks';
 import { effect, batch } from '@preact/signals';
 import { useNeoKeyboardShortcut } from './hooks/useNeoKeyboardShortcut.ts';
+import { NeoPanel } from './components/neo/NeoPanel.tsx';
 import { NavRail } from './islands/NavRail.tsx';
 import { BottomTabBar } from './islands/BottomTabBar.tsx';
 import { ContextPanel } from './islands/ContextPanel.tsx';
@@ -192,6 +193,9 @@ export function App() {
 
 			{/* Connection Overlay - blocks UI when disconnected */}
 			<ConnectionOverlay />
+
+			{/* Neo AI Assistant Panel */}
+			<NeoPanel />
 		</>
 	);
 }

--- a/packages/web/src/components/neo/NeoActivityView.test.tsx
+++ b/packages/web/src/components/neo/NeoActivityView.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Tests for NeoActivityView
+ *
+ * Verifies:
+ * - Loading state when activity is empty and loading=true
+ * - Empty state when no activity and not loading
+ * - Renders activity entries
+ * - Each entry shows tool name, relative timestamp, status badge
+ * - Clicking entry expands details
+ * - Clicking again collapses details
+ * - Status badge shows correct variant (success / error / cancelled)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import type { NeoActivityEntry } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore — signals defined inside factory to avoid hoisting issues
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', async () => {
+	const { signal: s } = await import('@preact/signals');
+	const activity = s<NeoActivityEntry[]>([]);
+	const loading = s(false);
+	return {
+		neoStore: { activity, loading },
+	};
+});
+
+import { NeoActivityView } from './NeoActivityView.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(
+	partial: Partial<NeoActivityEntry> & { id: string; toolName: string }
+): NeoActivityEntry {
+	return {
+		input: null,
+		output: null,
+		status: 'success',
+		error: null,
+		targetType: null,
+		targetId: null,
+		undoable: false,
+		undoData: null,
+		createdAt: new Date().toISOString(),
+		...partial,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoActivityView', () => {
+	beforeEach(() => {
+		neoStore.activity.value = [];
+		neoStore.loading.value = false;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows loading state when activity empty and loading=true', () => {
+		neoStore.loading.value = true;
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('neo-activity-loading')).toBeTruthy();
+	});
+
+	it('shows empty state when no activity and not loading', () => {
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('neo-activity-empty')).toBeTruthy();
+	});
+
+	it('does not show empty state when entries exist', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'create_room' })];
+		const { queryByTestId } = render(<NeoActivityView />);
+		expect(queryByTestId('neo-activity-empty')).toBeNull();
+	});
+
+	it('renders activity entries', () => {
+		neoStore.activity.value = [
+			makeEntry({ id: '1', toolName: 'create_room' }),
+			makeEntry({ id: '2', toolName: 'delete_room', status: 'error' }),
+		];
+		const { getAllByTestId } = render(<NeoActivityView />);
+		expect(getAllByTestId('activity-entry')).toHaveLength(2);
+	});
+
+	it('formats tool_name to title case', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'create_room' })];
+		const { getByText } = render(<NeoActivityView />);
+		expect(getByText('Create Room')).toBeTruthy();
+	});
+
+	it('shows success badge for successful entry', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'create_room', status: 'success' })];
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('activity-status-success')).toBeTruthy();
+	});
+
+	it('shows error badge for failed entry', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'delete_room', status: 'error' })];
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('activity-status-error')).toBeTruthy();
+	});
+
+	it('shows cancelled badge for cancelled entry', () => {
+		neoStore.activity.value = [
+			makeEntry({ id: '1', toolName: 'stop_session', status: 'cancelled' }),
+		];
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('activity-status-cancelled')).toBeTruthy();
+	});
+
+	it('expands details when entry is clicked', () => {
+		neoStore.activity.value = [
+			makeEntry({
+				id: '1',
+				toolName: 'create_room',
+				input: JSON.stringify({ name: 'my-room' }),
+				output: JSON.stringify({ id: 'room-123' }),
+			}),
+		];
+		const { getByTestId, queryByTestId } = render(<NeoActivityView />);
+		expect(queryByTestId('activity-entry-details')).toBeNull();
+
+		act(() => {
+			fireEvent.click(getByTestId('activity-entry').querySelector('button')!);
+		});
+		expect(getByTestId('activity-entry-details')).toBeTruthy();
+	});
+
+	it('collapses details on second click', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'create_room' })];
+		const { getByTestId, queryByTestId } = render(<NeoActivityView />);
+		const btn = getByTestId('activity-entry').querySelector('button')!;
+
+		act(() => {
+			fireEvent.click(btn);
+		});
+		expect(getByTestId('activity-entry-details')).toBeTruthy();
+
+		act(() => {
+			fireEvent.click(btn);
+		});
+		expect(queryByTestId('activity-entry-details')).toBeNull();
+	});
+
+	it('shows target from targetType + targetId', () => {
+		neoStore.activity.value = [
+			makeEntry({
+				id: '1',
+				toolName: 'get_room_status',
+				targetType: 'room',
+				targetId: 'prod-api',
+			}),
+		];
+		const { getByText } = render(<NeoActivityView />);
+		expect(getByText('room prod-api')).toBeTruthy();
+	});
+
+	it('shows error text in summary for error status', () => {
+		neoStore.activity.value = [
+			makeEntry({
+				id: '1',
+				toolName: 'delete_room',
+				status: 'error',
+				error: 'Room has active sessions',
+			}),
+		];
+		const { getByText } = render(<NeoActivityView />);
+		expect(getByText('Room has active sessions')).toBeTruthy();
+	});
+
+	it('shows all entries when multiple provided', () => {
+		neoStore.activity.value = Array.from({ length: 5 }, (_, i) =>
+			makeEntry({ id: String(i), toolName: `tool_${i}` })
+		);
+		const { getAllByTestId } = render(<NeoActivityView />);
+		expect(getAllByTestId('activity-entry')).toHaveLength(5);
+	});
+});

--- a/packages/web/src/components/neo/NeoActivityView.tsx
+++ b/packages/web/src/components/neo/NeoActivityView.tsx
@@ -1,0 +1,319 @@
+/**
+ * NeoActivityView
+ *
+ * Scrollable list of Neo's past actions from neoStore.activity.
+ * Each entry shows: timestamp, tool name, target description, status, outcome.
+ * Click to expand for full details.
+ */
+
+import { useState } from 'preact/hooks';
+import { neoStore, type NeoActivityEntry } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTimestamp(isoString: string): string {
+	try {
+		const date = new Date(isoString);
+		const now = new Date();
+		const diffMs = now.getTime() - date.getTime();
+		const diffSecs = Math.floor(diffMs / 1000);
+		const diffMins = Math.floor(diffSecs / 60);
+		const diffHours = Math.floor(diffMins / 60);
+		const diffDays = Math.floor(diffHours / 24);
+
+		if (diffSecs < 60) return 'just now';
+		if (diffMins < 60) return `${diffMins}m ago`;
+		if (diffHours < 24) return `${diffHours}h ago`;
+		if (diffDays < 7) return `${diffDays}d ago`;
+		return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	} catch {
+		return isoString;
+	}
+}
+
+/** Format tool_name → "Tool Name" */
+function formatToolName(toolName: string): string {
+	return toolName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Try to extract a human-readable target description from JSON input. */
+function extractTarget(entry: NeoActivityEntry): string {
+	if (entry.targetType && entry.targetId) {
+		return `${entry.targetType} ${entry.targetId}`;
+	}
+	if (entry.input) {
+		try {
+			const parsed = JSON.parse(entry.input) as Record<string, unknown>;
+			// Look for common naming fields
+			const name =
+				parsed['name'] ??
+				parsed['title'] ??
+				parsed['id'] ??
+				parsed['roomId'] ??
+				parsed['spaceId'] ??
+				parsed['goalId'] ??
+				parsed['taskId'];
+			if (typeof name === 'string' && name.length > 0) return name;
+		} catch {
+			/* ignore */
+		}
+	}
+	return '';
+}
+
+/** Extract outcome summary from JSON output string. */
+function extractOutcome(entry: NeoActivityEntry): string {
+	if (entry.error) return entry.error;
+	if (!entry.output) return '';
+	try {
+		const parsed = JSON.parse(entry.output) as Record<string, unknown>;
+		if (typeof parsed['summary'] === 'string') return parsed['summary'];
+		if (typeof parsed['message'] === 'string') return parsed['message'];
+		if (typeof parsed['error'] === 'string') return parsed['error'];
+	} catch {
+		if (entry.output.length < 120) return entry.output;
+	}
+	return '';
+}
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }: { status: NeoActivityEntry['status'] }) {
+	if (status === 'success') {
+		return (
+			<span
+				data-testid="activity-status-success"
+				class="inline-flex items-center gap-1 text-xs text-green-400"
+			>
+				<svg
+					class="w-3 h-3"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2.5}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+				</svg>
+				Done
+			</span>
+		);
+	}
+	if (status === 'error') {
+		return (
+			<span
+				data-testid="activity-status-error"
+				class="inline-flex items-center gap-1 text-xs text-red-400"
+			>
+				<svg
+					class="w-3 h-3"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2.5}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+				</svg>
+				Failed
+			</span>
+		);
+	}
+	return (
+		<span
+			data-testid="activity-status-cancelled"
+			class="inline-flex items-center gap-1 text-xs text-gray-500"
+		>
+			<svg
+				class="w-3 h-3"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth={2.5}
+				aria-hidden="true"
+			>
+				<path
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+				/>
+			</svg>
+			Cancelled
+		</span>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// ActivityEntry
+// ---------------------------------------------------------------------------
+
+function ActivityEntry({ entry }: { entry: NeoActivityEntry }) {
+	const [expanded, setExpanded] = useState(false);
+
+	const target = extractTarget(entry);
+	const outcome = extractOutcome(entry);
+
+	return (
+		<div data-testid="activity-entry" class="border-b border-gray-800/80 last:border-0">
+			{/* Summary row (always visible) */}
+			<button
+				type="button"
+				class="w-full text-left px-3 py-2.5 hover:bg-gray-800/40 transition-colors flex items-start gap-2"
+				onClick={() => setExpanded((v) => !v)}
+				aria-expanded={expanded}
+			>
+				{/* Status dot */}
+				<div
+					class={`flex-shrink-0 mt-1.5 w-1.5 h-1.5 rounded-full ${
+						entry.status === 'success'
+							? 'bg-green-400'
+							: entry.status === 'error'
+								? 'bg-red-400'
+								: 'bg-gray-600'
+					}`}
+				/>
+
+				<div class="flex-1 min-w-0">
+					<div class="flex items-baseline gap-2 justify-between">
+						<span class="text-xs font-semibold text-gray-200 truncate">
+							{formatToolName(entry.toolName)}
+						</span>
+						<div class="flex items-center gap-2 flex-shrink-0">
+							<StatusBadge status={entry.status} />
+							<span class="text-xs text-gray-600">{formatTimestamp(entry.createdAt)}</span>
+						</div>
+					</div>
+
+					{target && <p class="text-xs text-gray-500 truncate mt-0.5">{target}</p>}
+
+					{outcome && (
+						<p
+							class={`text-xs mt-0.5 truncate ${entry.status === 'error' ? 'text-red-400/80' : 'text-gray-400'}`}
+						>
+							{outcome}
+						</p>
+					)}
+				</div>
+
+				{/* Chevron */}
+				<svg
+					class={`flex-shrink-0 w-3 h-3 text-gray-600 mt-1 transition-transform ${expanded ? 'rotate-180' : ''}`}
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+				</svg>
+			</button>
+
+			{/* Expanded details */}
+			{expanded && (
+				<div data-testid="activity-entry-details" class="px-3 pb-3 space-y-2 bg-gray-800/20">
+					<div class="flex items-center justify-between pt-1">
+						<span class="text-xs text-gray-600">Status</span>
+						<StatusBadge status={entry.status} />
+					</div>
+
+					{entry.input && (
+						<div>
+							<p class="text-xs text-gray-600 mb-1">Input</p>
+							<pre class="text-xs text-gray-400 bg-gray-900/60 rounded-lg p-2 overflow-x-auto whitespace-pre-wrap break-all font-mono">
+								{(() => {
+									try {
+										return JSON.stringify(JSON.parse(entry.input), null, 2);
+									} catch {
+										return entry.input;
+									}
+								})()}
+							</pre>
+						</div>
+					)}
+
+					{entry.output && (
+						<div>
+							<p class="text-xs text-gray-600 mb-1">Output</p>
+							<pre class="text-xs text-gray-400 bg-gray-900/60 rounded-lg p-2 overflow-x-auto whitespace-pre-wrap break-all font-mono">
+								{(() => {
+									try {
+										return JSON.stringify(JSON.parse(entry.output), null, 2);
+									} catch {
+										return entry.output;
+									}
+								})()}
+							</pre>
+						</div>
+					)}
+
+					{entry.error && (
+						<div>
+							<p class="text-xs text-gray-600 mb-1">Error</p>
+							<p class="text-xs text-red-400 bg-red-950/20 rounded-lg p-2">{entry.error}</p>
+						</div>
+					)}
+
+					<p class="text-xs text-gray-700">{new Date(entry.createdAt).toLocaleString()}</p>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// NeoActivityView
+// ---------------------------------------------------------------------------
+
+export function NeoActivityView() {
+	const activity = neoStore.activity.value;
+	const loading = neoStore.loading.value;
+
+	if (loading && activity.length === 0) {
+		return (
+			<div class="flex items-center justify-center h-full" data-testid="neo-activity-loading">
+				<div class="flex items-center gap-2 text-gray-500 text-xs">
+					<div class="w-3 h-3 rounded-full border-2 border-gray-600 border-t-violet-400 animate-spin" />
+					Loading activity…
+				</div>
+			</div>
+		);
+	}
+
+	if (activity.length === 0) {
+		return (
+			<div
+				data-testid="neo-activity-empty"
+				class="flex flex-col items-center justify-center h-full gap-2 text-center px-4"
+			>
+				<svg
+					class="w-8 h-8 text-gray-700"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z"
+					/>
+				</svg>
+				<p class="text-xs text-gray-600">No activity yet</p>
+				<p class="text-xs text-gray-700">Actions Neo takes will appear here.</p>
+			</div>
+		);
+	}
+
+	return (
+		<div data-testid="neo-activity-view" class="flex flex-col h-full min-h-0 overflow-y-auto">
+			{activity.map((entry) => (
+				<ActivityEntry key={entry.id} entry={entry} />
+			))}
+		</div>
+	);
+}

--- a/packages/web/src/components/neo/NeoChatView.test.tsx
+++ b/packages/web/src/components/neo/NeoChatView.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * Tests for NeoChatView
+ *
+ * Verifies:
+ * - Empty state renders when no messages
+ * - User messages render as right-aligned bubbles
+ * - Assistant messages render with sparkle avatar
+ * - Sending a message calls neoStore.sendMessage
+ * - Enter key submits; Shift+Enter does not
+ * - Send button disabled when input is empty or sending
+ * - Typing indicator shown while sending
+ * - Error cards rendered for provider_unavailable, no_credentials, model_unavailable
+ * - NeoConfirmationCard shown when pendingConfirmation exists
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, waitFor, act } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore — all signals defined inside factory using async import
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', async () => {
+	const { signal: s } = await import('@preact/signals');
+	const messages = s<unknown[]>([]);
+	const loading = s(false);
+	const pendingConfirmation = s<{ actionId: string; description: string } | null>(null);
+	const sendMessage = vi.fn();
+	return {
+		neoStore: { messages, loading, pendingConfirmation, sendMessage },
+	};
+});
+
+// Mock NeoConfirmationCard to avoid deep dependency
+vi.mock('./NeoConfirmationCard.tsx', () => ({
+	NeoConfirmationCard: ({ actionId, description }: { actionId: string; description: string }) => (
+		<div data-testid="mock-confirmation-card" data-action-id={actionId}>
+			{description}
+		</div>
+	),
+}));
+
+// Mock MarkdownRenderer
+vi.mock('../chat/MarkdownRenderer.tsx', () => ({
+	default: ({ content }: { content: string }) => (
+		<div data-testid="markdown-renderer">{content}</div>
+	),
+}));
+
+import { NeoChatView } from './NeoChatView.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUserMsg(id: string, text: string) {
+	return {
+		id,
+		sessionId: 'sess-1',
+		messageType: 'user',
+		messageSubtype: null,
+		content: JSON.stringify([{ type: 'text', text }]),
+		createdAt: Date.now(),
+		sendStatus: null,
+		origin: 'human',
+	};
+}
+
+function makeAssistantMsg(id: string, text: string) {
+	return {
+		id,
+		sessionId: 'sess-1',
+		messageType: 'assistant',
+		messageSubtype: null,
+		content: JSON.stringify([{ type: 'text', text }]),
+		createdAt: Date.now(),
+		sendStatus: null,
+		origin: null,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoChatView', () => {
+	beforeEach(() => {
+		neoStore.messages.value = [];
+		neoStore.loading.value = false;
+		neoStore.pendingConfirmation.value = null;
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders empty state when no messages', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		expect(getByTestId('neo-empty-state')).toBeTruthy();
+	});
+
+	it('does not show empty state when messages exist', () => {
+		neoStore.messages.value = [makeUserMsg('1', 'Hello')];
+		const { queryByTestId } = render(<NeoChatView />);
+		expect(queryByTestId('neo-empty-state')).toBeNull();
+	});
+
+	it('renders user message as right-aligned bubble', () => {
+		neoStore.messages.value = [makeUserMsg('1', 'Hi there')];
+		const { getByTestId, getByText } = render(<NeoChatView />);
+		expect(getByTestId('neo-user-message')).toBeTruthy();
+		expect(getByText('Hi there')).toBeTruthy();
+	});
+
+	it('renders assistant message with sparkle avatar', () => {
+		neoStore.messages.value = [makeAssistantMsg('1', 'Hello from Neo')];
+		const { getByTestId, getByText } = render(<NeoChatView />);
+		expect(getByTestId('neo-assistant-message')).toBeTruthy();
+		expect(getByText('Hello from Neo')).toBeTruthy();
+	});
+
+	it('skips result and system messages', () => {
+		neoStore.messages.value = [
+			{ ...makeUserMsg('1', 'hi'), messageType: 'result' },
+			{ ...makeUserMsg('2', 'hi'), messageType: 'system' },
+		];
+		const { queryByTestId } = render(<NeoChatView />);
+		expect(queryByTestId('neo-user-message')).toBeNull();
+		expect(queryByTestId('neo-assistant-message')).toBeNull();
+	});
+
+	it('renders the chat input', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		expect(getByTestId('neo-chat-input')).toBeTruthy();
+	});
+
+	it('send button is disabled when input is empty', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		const btn = getByTestId('neo-send-button') as HTMLButtonElement;
+		expect(btn.disabled).toBe(true);
+	});
+
+	it('send button is enabled when input has text', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		const btn = getByTestId('neo-send-button') as HTMLButtonElement;
+		expect(btn.disabled).toBe(false);
+	});
+
+	it('calls sendMessage on send button click', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'What rooms do I have?' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		expect(neoStore.sendMessage).toHaveBeenCalledWith('What rooms do I have?');
+	});
+
+	it('clears input after send', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		expect(input.value).toBe('');
+	});
+
+	it('submits on Enter key', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		await act(async () => {
+			fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+		});
+		expect(neoStore.sendMessage).toHaveBeenCalledWith('hello');
+	});
+
+	it('does NOT submit on Shift+Enter', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+		expect(neoStore.sendMessage).not.toHaveBeenCalled();
+	});
+
+	it('shows typing indicator while sending', async () => {
+		let resolveSend!: (v: { success: boolean }) => void;
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(
+			new Promise((res) => (resolveSend = res))
+		);
+
+		const { getByTestId, queryByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		fireEvent.click(getByTestId('neo-send-button'));
+
+		await waitFor(() => {
+			expect(queryByTestId('neo-typing-indicator')).toBeTruthy();
+		});
+
+		await act(async () => {
+			resolveSend({ success: true });
+		});
+
+		await waitFor(() => {
+			expect(queryByTestId('neo-typing-indicator')).toBeNull();
+		});
+	});
+
+	it('renders provider_unavailable error card', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'provider_unavailable',
+			error: 'Rate limited',
+		});
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hi' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-error-provider-unavailable')).toBeTruthy();
+		});
+	});
+
+	it('renders no_credentials error card', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'no_credentials',
+			error: 'No API key',
+		});
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hi' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-error-no-credentials')).toBeTruthy();
+		});
+	});
+
+	it('renders model_unavailable error card', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'model_unavailable',
+			error: 'Model not found',
+		});
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hi' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-error-model-unavailable')).toBeTruthy();
+		});
+	});
+
+	it('shows NeoConfirmationCard when pendingConfirmation exists', () => {
+		neoStore.messages.value = [makeAssistantMsg('1', 'Please confirm the action')];
+		neoStore.pendingConfirmation.value = { actionId: 'action-123', description: 'Delete room' };
+		const { getByTestId } = render(<NeoChatView />);
+		const card = getByTestId('mock-confirmation-card');
+		expect(card).toBeTruthy();
+		expect(card.getAttribute('data-action-id')).toBe('action-123');
+	});
+});

--- a/packages/web/src/components/neo/NeoChatView.test.tsx
+++ b/packages/web/src/components/neo/NeoChatView.test.tsx
@@ -274,4 +274,53 @@ describe('NeoChatView', () => {
 		expect(card).toBeTruthy();
 		expect(card.getAttribute('data-action-id')).toBe('action-123');
 	});
+
+	it('confirmation card only appears on the last assistant message', () => {
+		neoStore.messages.value = [
+			makeAssistantMsg('1', 'First response'),
+			makeAssistantMsg('2', 'Second response'),
+		];
+		neoStore.pendingConfirmation.value = { actionId: 'act-1', description: 'Do something' };
+		const { getAllByTestId, queryAllByTestId } = render(<NeoChatView />);
+		// Two assistant messages but only one confirmation card
+		expect(getAllByTestId('neo-assistant-message')).toHaveLength(2);
+		expect(queryAllByTestId('mock-confirmation-card')).toHaveLength(1);
+	});
+
+	it('preserves input text when send fails', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'provider_unavailable',
+			error: 'Rate limited',
+		});
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'my important message' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		// Input should NOT be cleared on failure
+		expect(input.value).toBe('my important message');
+	});
+
+	it('error card can be dismissed', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'provider_unavailable',
+			error: 'Rate limited',
+		});
+		const { getByTestId, queryByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hi' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-error-provider-unavailable')).toBeTruthy();
+		});
+		act(() => {
+			fireEvent.click(getByTestId('neo-error-dismiss'));
+		});
+		expect(queryByTestId('neo-error-provider-unavailable')).toBeNull();
+	});
 });

--- a/packages/web/src/components/neo/NeoChatView.tsx
+++ b/packages/web/src/components/neo/NeoChatView.tsx
@@ -1,0 +1,452 @@
+/**
+ * NeoChatView
+ *
+ * The main chat interface inside the Neo panel.
+ * - Renders user messages and Neo (assistant) responses
+ * - Auto-scrolls to the newest message
+ * - Renders structured JSON responses as formatted cards
+ * - Shows inline NeoConfirmationCard when Neo needs user input
+ * - Displays error states as styled cards (not alerts/modals)
+ * - Input bar at the bottom
+ */
+
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { neoStore, type NeoMessage } from '../../lib/neo-store.ts';
+import { NeoConfirmationCard } from './NeoConfirmationCard.tsx';
+import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
+
+// ---------------------------------------------------------------------------
+// Error state helpers
+// ---------------------------------------------------------------------------
+
+type ErrorCode = 'provider_unavailable' | 'no_credentials' | 'model_unavailable' | string;
+
+interface ErrorCardProps {
+	errorCode: ErrorCode;
+}
+
+function ErrorCard({ errorCode }: ErrorCardProps) {
+	if (errorCode === 'no_credentials') {
+		return (
+			<div
+				data-testid="neo-error-no-credentials"
+				class="my-2 rounded-xl border border-amber-700/40 bg-amber-950/20 px-3 py-2.5"
+			>
+				<p class="text-sm font-medium text-amber-300">API key not configured</p>
+				<p class="text-xs text-amber-400/80 mt-0.5">
+					Please set up your provider in{' '}
+					<a href="/settings" class="underline hover:text-amber-300 transition-colors">
+						Settings
+					</a>
+					.
+				</p>
+			</div>
+		);
+	}
+	if (errorCode === 'model_unavailable') {
+		return (
+			<div
+				data-testid="neo-error-model-unavailable"
+				class="my-2 rounded-xl border border-amber-700/40 bg-amber-950/20 px-3 py-2.5"
+			>
+				<p class="text-sm font-medium text-amber-300">Model unavailable</p>
+				<p class="text-xs text-amber-400/80 mt-0.5">
+					The selected model is not available. Please update Neo&apos;s model in{' '}
+					<a href="/settings" class="underline hover:text-amber-300 transition-colors">
+						Settings
+					</a>
+					.
+				</p>
+			</div>
+		);
+	}
+	// Default: provider_unavailable or unknown
+	return (
+		<div
+			data-testid="neo-error-provider-unavailable"
+			class="my-2 rounded-xl border border-gray-700 bg-gray-800/60 px-3 py-2.5"
+		>
+			<p class="text-sm font-medium text-gray-300">Neo is temporarily unavailable</p>
+			<p class="text-xs text-gray-500 mt-0.5">Please try again.</p>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Message content parsers
+// ---------------------------------------------------------------------------
+
+/** Extract displayable text from a raw SDK message content JSON string. */
+function extractTextContent(content: string): string {
+	try {
+		const parsed: unknown = JSON.parse(content);
+		if (typeof parsed === 'string') return parsed;
+		// SDK messages use content arrays: [{ type: 'text', text: '...' }, ...]
+		if (Array.isArray(parsed)) {
+			return parsed
+				.filter(
+					(block): block is { type: string; text: string } =>
+						typeof block === 'object' &&
+						block !== null &&
+						'type' in block &&
+						(block as { type: string }).type === 'text' &&
+						'text' in block
+				)
+				.map((block) => block.text)
+				.join('\n');
+		}
+		// Fallback: some messages store content as a direct string field
+		if (typeof parsed === 'object' && parsed !== null && 'text' in parsed) {
+			const text = (parsed as { text: unknown }).text;
+			if (typeof text === 'string') return text;
+		}
+		return '';
+	} catch {
+		return content;
+	}
+}
+
+/** Try to parse content as structured JSON data (object/array). Returns null if plain text. */
+function tryParseStructured(content: string): unknown | null {
+	try {
+		const parsed: unknown = JSON.parse(content);
+		if (Array.isArray(parsed)) return parsed;
+		if (typeof parsed === 'object' && parsed !== null) return parsed;
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Structured data renderer
+// ---------------------------------------------------------------------------
+
+function StructuredDataCard({ data }: { data: unknown }) {
+	const [expanded, setExpanded] = useState(false);
+
+	if (Array.isArray(data)) {
+		return (
+			<div class="my-1 rounded-lg border border-gray-700 overflow-hidden text-xs">
+				<div
+					class="flex items-center justify-between px-2 py-1.5 bg-gray-800/80 cursor-pointer hover:bg-gray-700/60 transition-colors"
+					onClick={() => setExpanded((v) => !v)}
+				>
+					<span class="text-gray-400 font-medium">
+						Array ({data.length} item{data.length !== 1 ? 's' : ''})
+					</span>
+					<svg
+						class={`w-3 h-3 text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`}
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth={2}
+						aria-hidden="true"
+					>
+						<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+					</svg>
+				</div>
+				{expanded && (
+					<div class="overflow-x-auto">
+						<table class="w-full text-xs">
+							<tbody>
+								{data.map((item, i) => (
+									<tr key={i} class="border-t border-gray-700/50 hover:bg-gray-800/40">
+										<td class="px-2 py-1 text-gray-600 font-mono w-8">{i}</td>
+										<td class="px-2 py-1 text-gray-300 font-mono whitespace-pre-wrap break-all">
+											{typeof item === 'object' ? JSON.stringify(item, null, 2) : String(item)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	// Plain object
+	const entries = Object.entries(data as Record<string, unknown>);
+	return (
+		<div class="my-1 rounded-lg border border-gray-700 overflow-hidden text-xs">
+			<div
+				class="flex items-center justify-between px-2 py-1.5 bg-gray-800/80 cursor-pointer hover:bg-gray-700/60 transition-colors"
+				onClick={() => setExpanded((v) => !v)}
+			>
+				<span class="text-gray-400 font-medium">Structured data</span>
+				<svg
+					class={`w-3 h-3 text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`}
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+				</svg>
+			</div>
+			{expanded && (
+				<div class="overflow-x-auto">
+					<table class="w-full text-xs">
+						<tbody>
+							{entries.map(([k, v]) => (
+								<tr key={k} class="border-t border-gray-700/50 hover:bg-gray-800/40">
+									<td class="px-2 py-1 text-gray-500 font-mono whitespace-nowrap align-top">{k}</td>
+									<td class="px-2 py-1 text-gray-300 font-mono whitespace-pre-wrap break-all">
+										{typeof v === 'object' ? JSON.stringify(v, null, 2) : String(v)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Individual message bubble
+// ---------------------------------------------------------------------------
+
+interface MessageBubbleProps {
+	msg: NeoMessage;
+	pendingActionId?: string | null;
+}
+
+function MessageBubble({ msg, pendingActionId }: MessageBubbleProps) {
+	const isUser = msg.messageType === 'user';
+	const isResult = msg.messageType === 'result';
+	const isSystem = msg.messageType === 'system';
+
+	// Skip internal result/system messages in this simplified view
+	if (isResult || isSystem) return null;
+
+	const rawText = extractTextContent(msg.content);
+
+	// If this is an assistant message and there's a pending confirmation,
+	// render the confirmation card instead of (or after) text content.
+	const hasPendingConfirmation = !isUser && pendingActionId;
+
+	if (isUser) {
+		return (
+			<div data-testid="neo-user-message" class="flex justify-end mb-3">
+				<div class="max-w-[85%] bg-blue-600 text-white rounded-[20px] rounded-br-md px-3.5 py-2 text-sm leading-relaxed break-words">
+					{rawText}
+				</div>
+			</div>
+		);
+	}
+
+	// Assistant message
+	const structured = rawText ? null : tryParseStructured(msg.content);
+
+	return (
+		<div data-testid="neo-assistant-message" class="mb-3">
+			{/* Sparkle avatar */}
+			<div class="flex items-start gap-2">
+				<div class="flex-shrink-0 w-6 h-6 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mt-0.5">
+					<svg
+						class="w-3 h-3 text-violet-400"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+						aria-hidden="true"
+					>
+						<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+					</svg>
+				</div>
+				<div class="flex-1 min-w-0">
+					{rawText && (
+						<div class="text-sm text-gray-200 leading-relaxed">
+							<MarkdownRenderer content={rawText} class="text-sm text-gray-200" />
+						</div>
+					)}
+					{structured && <StructuredDataCard data={structured} />}
+					{hasPendingConfirmation && (
+						<NeoConfirmationCard
+							actionId={pendingActionId}
+							description={neoStore.pendingConfirmation.value?.description ?? ''}
+						/>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Loading indicator
+// ---------------------------------------------------------------------------
+
+function TypingIndicator() {
+	return (
+		<div data-testid="neo-typing-indicator" class="flex items-start gap-2 mb-3">
+			<div class="flex-shrink-0 w-6 h-6 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center">
+				<svg
+					class="w-3 h-3 text-violet-400"
+					viewBox="0 0 24 24"
+					fill="currentColor"
+					aria-hidden="true"
+				>
+					<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+				</svg>
+			</div>
+			<div class="flex items-center gap-1 py-1.5 px-1">
+				{[0, 1, 2].map((i) => (
+					<span
+						key={i}
+						class="w-1.5 h-1.5 rounded-full bg-gray-500 animate-bounce"
+						style={{ animationDelay: `${i * 150}ms` }}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// NeoChatView
+// ---------------------------------------------------------------------------
+
+export function NeoChatView() {
+	const [inputValue, setInputValue] = useState('');
+	const [sending, setSending] = useState(false);
+	const [sendError, setSendError] = useState<{ code: string; message: string } | null>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLTextAreaElement>(null);
+
+	const messages = neoStore.messages.value;
+	const loading = neoStore.loading.value;
+	const pendingConfirmation = neoStore.pendingConfirmation.value;
+
+	// Auto-scroll to newest message
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+	}, [messages.length]);
+
+	// Focus input when the panel opens
+	useEffect(() => {
+		inputRef.current?.focus();
+	}, []);
+
+	const handleSend = async () => {
+		const text = inputValue.trim();
+		if (!text || sending) return;
+
+		setInputValue('');
+		setSendError(null);
+		setSending(true);
+
+		try {
+			const result = await neoStore.sendMessage(text);
+			if (!result.success) {
+				setSendError({
+					code: result.errorCode ?? 'provider_unavailable',
+					message: result.error ?? 'Failed to send message',
+				});
+			}
+		} finally {
+			setSending(false);
+		}
+	};
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			handleSend();
+		}
+	};
+
+	const isEmpty = messages.length === 0 && !loading;
+
+	return (
+		<div class="flex flex-col h-full min-h-0" data-testid="neo-chat-view">
+			{/* Message list */}
+			<div class="flex-1 min-h-0 overflow-y-auto px-3 py-3 scroll-smooth">
+				{/* Empty state */}
+				{isEmpty && (
+					<div
+						data-testid="neo-empty-state"
+						class="flex flex-col items-center justify-center h-full gap-3 text-center px-4"
+					>
+						<div class="w-10 h-10 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center">
+							<svg
+								class="w-5 h-5 text-violet-400"
+								viewBox="0 0 24 24"
+								fill="currentColor"
+								aria-hidden="true"
+							>
+								<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+								<path
+									d="M5 3l.75 2.25L8 6l-2.25.75L5 9l-.75-2.25L2 6l2.25-.75L5 3z"
+									opacity={0.5}
+								/>
+							</svg>
+						</div>
+						<div>
+							<p class="text-sm font-medium text-gray-300">Hi, I&apos;m Neo</p>
+							<p class="text-xs text-gray-500 mt-1">
+								Ask me anything about your rooms, sessions, or goals.
+							</p>
+						</div>
+					</div>
+				)}
+
+				{/* Messages */}
+				{messages.map((msg) => (
+					<MessageBubble key={msg.id} msg={msg} pendingActionId={pendingConfirmation?.actionId} />
+				))}
+
+				{/* Typing indicator when sending */}
+				{sending && <TypingIndicator />}
+
+				{/* Send error */}
+				{sendError && <ErrorCard errorCode={sendError.code} />}
+
+				{/* Scroll anchor */}
+				<div ref={messagesEndRef} />
+			</div>
+
+			{/* Input bar */}
+			<div class="flex-shrink-0 border-t border-gray-700 px-3 py-2.5 bg-gray-900/50">
+				<div class="flex items-end gap-2">
+					<textarea
+						ref={inputRef}
+						data-testid="neo-chat-input"
+						value={inputValue}
+						onInput={(e) => setInputValue((e.target as HTMLTextAreaElement).value)}
+						onKeyDown={handleKeyDown}
+						placeholder="Ask Neo…"
+						rows={1}
+						disabled={sending}
+						class="flex-1 resize-none bg-gray-800 border border-gray-700 rounded-xl px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:ring-1 focus:ring-violet-500/50 focus:border-violet-500/50 transition-colors disabled:opacity-50 min-h-[36px] max-h-[120px] overflow-y-auto"
+						style="field-sizing: content;"
+					/>
+					<button
+						data-testid="neo-send-button"
+						onClick={handleSend}
+						disabled={sending || !inputValue.trim()}
+						aria-label="Send message"
+						class="flex-shrink-0 w-8 h-8 rounded-xl bg-violet-600 hover:bg-violet-500 text-white flex items-center justify-center transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+					>
+						<svg
+							class="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth={2}
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
+							/>
+						</svg>
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/neo/NeoChatView.tsx
+++ b/packages/web/src/components/neo/NeoChatView.tsx
@@ -23,23 +23,52 @@ type ErrorCode = 'provider_unavailable' | 'no_credentials' | 'model_unavailable'
 
 interface ErrorCardProps {
 	errorCode: ErrorCode;
+	onDismiss: () => void;
 }
 
-function ErrorCard({ errorCode }: ErrorCardProps) {
+function DismissButton({ onDismiss }: { onDismiss: () => void }) {
+	return (
+		<button
+			type="button"
+			onClick={onDismiss}
+			data-testid="neo-error-dismiss"
+			aria-label="Dismiss error"
+			class="ml-auto p-0.5 rounded text-current opacity-60 hover:opacity-100 transition-opacity"
+		>
+			<svg
+				class="w-3 h-3"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth={2}
+				aria-hidden="true"
+			>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+			</svg>
+		</button>
+	);
+}
+
+function ErrorCard({ errorCode, onDismiss }: ErrorCardProps) {
 	if (errorCode === 'no_credentials') {
 		return (
 			<div
 				data-testid="neo-error-no-credentials"
 				class="my-2 rounded-xl border border-amber-700/40 bg-amber-950/20 px-3 py-2.5"
 			>
-				<p class="text-sm font-medium text-amber-300">API key not configured</p>
-				<p class="text-xs text-amber-400/80 mt-0.5">
-					Please set up your provider in{' '}
-					<a href="/settings" class="underline hover:text-amber-300 transition-colors">
-						Settings
-					</a>
-					.
-				</p>
+				<div class="flex items-start gap-1">
+					<div class="flex-1 min-w-0">
+						<p class="text-sm font-medium text-amber-300">API key not configured</p>
+						<p class="text-xs text-amber-400/80 mt-0.5">
+							Please set up your provider in{' '}
+							<a href="/settings" class="underline hover:text-amber-300 transition-colors">
+								Settings
+							</a>
+							.
+						</p>
+					</div>
+					<DismissButton onDismiss={onDismiss} />
+				</div>
 			</div>
 		);
 	}
@@ -49,14 +78,19 @@ function ErrorCard({ errorCode }: ErrorCardProps) {
 				data-testid="neo-error-model-unavailable"
 				class="my-2 rounded-xl border border-amber-700/40 bg-amber-950/20 px-3 py-2.5"
 			>
-				<p class="text-sm font-medium text-amber-300">Model unavailable</p>
-				<p class="text-xs text-amber-400/80 mt-0.5">
-					The selected model is not available. Please update Neo&apos;s model in{' '}
-					<a href="/settings" class="underline hover:text-amber-300 transition-colors">
-						Settings
-					</a>
-					.
-				</p>
+				<div class="flex items-start gap-1">
+					<div class="flex-1 min-w-0">
+						<p class="text-sm font-medium text-amber-300">Model unavailable</p>
+						<p class="text-xs text-amber-400/80 mt-0.5">
+							The selected model is not available. Please update Neo&apos;s model in{' '}
+							<a href="/settings" class="underline hover:text-amber-300 transition-colors">
+								Settings
+							</a>
+							.
+						</p>
+					</div>
+					<DismissButton onDismiss={onDismiss} />
+				</div>
 			</div>
 		);
 	}
@@ -66,8 +100,13 @@ function ErrorCard({ errorCode }: ErrorCardProps) {
 			data-testid="neo-error-provider-unavailable"
 			class="my-2 rounded-xl border border-gray-700 bg-gray-800/60 px-3 py-2.5"
 		>
-			<p class="text-sm font-medium text-gray-300">Neo is temporarily unavailable</p>
-			<p class="text-xs text-gray-500 mt-0.5">Please try again.</p>
+			<div class="flex items-start gap-1">
+				<div class="flex-1 min-w-0">
+					<p class="text-sm font-medium text-gray-300">Neo is temporarily unavailable</p>
+					<p class="text-xs text-gray-500 mt-0.5">Please try again.</p>
+				</div>
+				<DismissButton onDismiss={onDismiss} />
+			</div>
 		</div>
 	);
 }
@@ -213,9 +252,11 @@ function StructuredDataCard({ data }: { data: unknown }) {
 interface MessageBubbleProps {
 	msg: NeoMessage;
 	pendingActionId?: string | null;
+	/** Whether this is the last assistant message — only this one renders the confirmation card. */
+	isLastAssistant?: boolean;
 }
 
-function MessageBubble({ msg, pendingActionId }: MessageBubbleProps) {
+function MessageBubble({ msg, pendingActionId, isLastAssistant }: MessageBubbleProps) {
 	const isUser = msg.messageType === 'user';
 	const isResult = msg.messageType === 'result';
 	const isSystem = msg.messageType === 'system';
@@ -225,9 +266,8 @@ function MessageBubble({ msg, pendingActionId }: MessageBubbleProps) {
 
 	const rawText = extractTextContent(msg.content);
 
-	// If this is an assistant message and there's a pending confirmation,
-	// render the confirmation card instead of (or after) text content.
-	const hasPendingConfirmation = !isUser && pendingActionId;
+	// Only the last assistant message should render the confirmation card.
+	const hasPendingConfirmation = !isUser && isLastAssistant && pendingActionId;
 
 	if (isUser) {
 		return (
@@ -267,6 +307,7 @@ function MessageBubble({ msg, pendingActionId }: MessageBubbleProps) {
 						<NeoConfirmationCard
 							actionId={pendingActionId}
 							description={neoStore.pendingConfirmation.value?.description ?? ''}
+							riskLevel={neoStore.pendingConfirmation.value?.riskLevel}
 						/>
 					)}
 				</div>
@@ -320,10 +361,11 @@ export function NeoChatView() {
 	const loading = neoStore.loading.value;
 	const pendingConfirmation = neoStore.pendingConfirmation.value;
 
-	// Auto-scroll to newest message
+	// Auto-scroll to newest message — depend on last message id so updates trigger correctly
+	const lastMessageId = messages[messages.length - 1]?.id;
 	useEffect(() => {
 		messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-	}, [messages.length]);
+	}, [lastMessageId]);
 
 	// Focus input when the panel opens
 	useEffect(() => {
@@ -334,13 +376,15 @@ export function NeoChatView() {
 		const text = inputValue.trim();
 		if (!text || sending) return;
 
-		setInputValue('');
 		setSendError(null);
 		setSending(true);
 
 		try {
 			const result = await neoStore.sendMessage(text);
-			if (!result.success) {
+			if (result.success) {
+				// Only clear input on success so the user can retry on failure
+				setInputValue('');
+			} else {
 				setSendError({
 					code: result.errorCode ?? 'provider_unavailable',
 					message: result.error ?? 'Failed to send message',
@@ -394,15 +438,27 @@ export function NeoChatView() {
 				)}
 
 				{/* Messages */}
-				{messages.map((msg) => (
-					<MessageBubble key={msg.id} msg={msg} pendingActionId={pendingConfirmation?.actionId} />
-				))}
+				{(() => {
+					// Find the last assistant message so only it renders the confirmation card
+					const lastAssistantIdx = messages.reduce(
+						(last, m, i) => (m.messageType === 'assistant' ? i : last),
+						-1
+					);
+					return messages.map((msg, i) => (
+						<MessageBubble
+							key={msg.id}
+							msg={msg}
+							pendingActionId={pendingConfirmation?.actionId}
+							isLastAssistant={i === lastAssistantIdx}
+						/>
+					));
+				})()}
 
 				{/* Typing indicator when sending */}
 				{sending && <TypingIndicator />}
 
 				{/* Send error */}
-				{sendError && <ErrorCard errorCode={sendError.code} />}
+				{sendError && <ErrorCard errorCode={sendError.code} onDismiss={() => setSendError(null)} />}
 
 				{/* Scroll anchor */}
 				<div ref={messagesEndRef} />

--- a/packages/web/src/components/neo/NeoConfirmationCard.test.tsx
+++ b/packages/web/src/components/neo/NeoConfirmationCard.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Tests for NeoConfirmationCard
+ *
+ * Verifies:
+ * - Renders with description and risk level
+ * - Confirm button calls neoStore.confirmAction(actionId)
+ * - Cancel button calls neoStore.cancelAction(actionId)
+ * - Shows loading state while awaiting RPC
+ * - Shows error when RPC fails
+ * - Resolved state: shows resolution, buttons hidden
+ * - Risk levels render correct badge text
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, waitFor, act } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore — define fns inside factory to avoid hoisting issues
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', () => {
+	const confirmAction = vi.fn();
+	const cancelAction = vi.fn();
+	return {
+		neoStore: { confirmAction, cancelAction },
+	};
+});
+
+import { NeoConfirmationCard } from './NeoConfirmationCard.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoConfirmationCard', () => {
+	beforeEach(() => {
+		(neoStore.confirmAction as ReturnType<typeof vi.fn>).mockReset();
+		(neoStore.cancelAction as ReturnType<typeof vi.fn>).mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the action description', () => {
+		const { getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Delete room prod-api" />
+		);
+		expect(getByText('Delete room prod-api')).toBeTruthy();
+	});
+
+	it('renders Confirm and Cancel buttons', () => {
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-1" description="Create goal" />
+		);
+		expect(getByTestId('neo-confirm-button')).toBeTruthy();
+		expect(getByTestId('neo-cancel-button')).toBeTruthy();
+	});
+
+	it('calls confirmAction with actionId on Confirm click', async () => {
+		(neoStore.confirmAction as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-42" description="Enable skill" />
+		);
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-confirm-button'));
+		});
+		expect(neoStore.confirmAction).toHaveBeenCalledWith('act-42');
+	});
+
+	it('calls cancelAction with actionId on Cancel click', async () => {
+		(neoStore.cancelAction as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-99" description="Delete space" />
+		);
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-cancel-button'));
+		});
+		expect(neoStore.cancelAction).toHaveBeenCalledWith('act-99');
+	});
+
+	it('disables buttons while loading', async () => {
+		let resolveConfirm!: (v: { success: boolean }) => void;
+		(neoStore.confirmAction as ReturnType<typeof vi.fn>).mockReturnValue(
+			new Promise((res) => (resolveConfirm = res))
+		);
+
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do something" />
+		);
+		fireEvent.click(getByTestId('neo-confirm-button'));
+
+		await waitFor(() => {
+			expect(getByTestId('neo-confirm-button').hasAttribute('disabled')).toBe(true);
+			expect(getByTestId('neo-cancel-button').hasAttribute('disabled')).toBe(true);
+		});
+
+		await act(async () => {
+			resolveConfirm({ success: true });
+		});
+	});
+
+	it('shows error message when confirmAction fails', async () => {
+		(neoStore.confirmAction as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			error: 'Action expired',
+		});
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do something" />
+		);
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-confirm-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-confirmation-error').textContent).toContain('Action expired');
+		});
+	});
+
+	it('shows error message when cancelAction fails', async () => {
+		(neoStore.cancelAction as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			error: 'Network error',
+		});
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do something" />
+		);
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-cancel-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-confirmation-error').textContent).toContain('Network error');
+		});
+	});
+
+	it('shows "Confirmed" label when resolved with confirmed', () => {
+		const { queryByTestId, getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Done" resolved resolution="confirmed" />
+		);
+		expect(queryByTestId('neo-confirm-button')).toBeNull();
+		expect(queryByTestId('neo-cancel-button')).toBeNull();
+		expect(getByText('✓ Confirmed')).toBeTruthy();
+	});
+
+	it('shows "Cancelled" label when resolved with cancelled', () => {
+		const { queryByTestId, getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Done" resolved resolution="cancelled" />
+		);
+		expect(queryByTestId('neo-confirm-button')).toBeNull();
+		expect(queryByTestId('neo-cancel-button')).toBeNull();
+		expect(getByText('✕ Cancelled')).toBeTruthy();
+	});
+
+	it('shows "Requires confirmation" badge for medium risk (default)', () => {
+		const { getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do it" riskLevel="medium" />
+		);
+		expect(getByText('Requires confirmation')).toBeTruthy();
+	});
+
+	it('shows "Low risk" badge', () => {
+		const { getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do it" riskLevel="low" />
+		);
+		expect(getByText('Low risk')).toBeTruthy();
+	});
+
+	it('shows "High risk — irreversible" badge', () => {
+		const { getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do it" riskLevel="high" />
+		);
+		expect(getByText('High risk — irreversible')).toBeTruthy();
+	});
+
+	it('does not call confirm/cancel when already resolved', () => {
+		render(
+			<NeoConfirmationCard actionId="act-1" description="Done" resolved resolution="confirmed" />
+		);
+		expect(neoStore.confirmAction).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/components/neo/NeoConfirmationCard.tsx
+++ b/packages/web/src/components/neo/NeoConfirmationCard.tsx
@@ -1,0 +1,146 @@
+/**
+ * NeoConfirmationCard
+ *
+ * Inline card rendered in the Neo chat when Neo needs user confirmation
+ * for a pending action. Confirm/Cancel call the RPC directly (bypasses LLM
+ * for reliability). Remains interactive until the action's TTL expires.
+ */
+
+import { useState } from 'preact/hooks';
+import { neoStore } from '../../lib/neo-store.ts';
+
+export interface NeoConfirmationCardProps {
+	actionId: string;
+	description: string;
+	/** Risk level of the action: low | medium | high */
+	riskLevel?: 'low' | 'medium' | 'high';
+	/** Whether the action has already been resolved (TTL expired or acted on) */
+	resolved?: boolean;
+	/** 'confirmed' | 'cancelled' — only set once resolved */
+	resolution?: 'confirmed' | 'cancelled';
+}
+
+const riskColors = {
+	low: {
+		badge: 'bg-green-500/10 text-green-400 border border-green-500/20',
+		label: 'Low risk',
+	},
+	medium: {
+		badge: 'bg-amber-500/10 text-amber-400 border border-amber-500/20',
+		label: 'Requires confirmation',
+	},
+	high: {
+		badge: 'bg-red-500/10 text-red-400 border border-red-500/20',
+		label: 'High risk — irreversible',
+	},
+} as const;
+
+export function NeoConfirmationCard({
+	actionId,
+	description,
+	riskLevel = 'medium',
+	resolved = false,
+	resolution,
+}: NeoConfirmationCardProps) {
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const risk = riskColors[riskLevel];
+
+	const handleConfirm = async () => {
+		if (loading || resolved) return;
+		setLoading(true);
+		setError(null);
+		const result = await neoStore.confirmAction(actionId);
+		if (!result.success) {
+			setError(result.error ?? 'Failed to confirm action');
+		}
+		setLoading(false);
+	};
+
+	const handleCancel = async () => {
+		if (loading || resolved) return;
+		setLoading(true);
+		setError(null);
+		const result = await neoStore.cancelAction(actionId);
+		if (!result.success) {
+			setError(result.error ?? 'Failed to cancel action');
+		}
+		setLoading(false);
+	};
+
+	return (
+		<div
+			data-testid="neo-confirmation-card"
+			class="my-2 rounded-xl border border-gray-700 bg-gray-800/60 overflow-hidden"
+		>
+			{/* Header */}
+			<div class="flex items-center gap-2 px-3 py-2 border-b border-gray-700/50">
+				{/* Shield icon */}
+				<svg
+					class="w-4 h-4 text-violet-400 flex-shrink-0"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					aria-hidden="true"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+					/>
+				</svg>
+				<span class="text-xs font-semibold text-violet-300 flex-1">Neo needs your approval</span>
+				<span class={`text-xs px-1.5 py-0.5 rounded-md font-medium ${risk.badge}`}>
+					{risk.label}
+				</span>
+			</div>
+
+			{/* Description */}
+			<div class="px-3 py-2.5">
+				<p class="text-sm text-gray-200 leading-relaxed">{description}</p>
+			</div>
+
+			{/* Error */}
+			{error && (
+				<div class="px-3 pb-2 text-xs text-red-400" data-testid="neo-confirmation-error">
+					{error}
+				</div>
+			)}
+
+			{/* Actions */}
+			<div class="flex items-center gap-2 px-3 py-2 border-t border-gray-700/50 bg-gray-900/30">
+				{resolved ? (
+					<span
+						class={`text-xs font-medium ${
+							resolution === 'confirmed' ? 'text-green-400' : 'text-gray-500'
+						}`}
+					>
+						{resolution === 'confirmed' ? '✓ Confirmed' : '✕ Cancelled'}
+					</span>
+				) : (
+					<>
+						<button
+							data-testid="neo-confirm-button"
+							onClick={handleConfirm}
+							disabled={loading}
+							class="px-3 py-1.5 text-xs font-semibold rounded-lg bg-violet-600 hover:bg-violet-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							{loading ? 'Working…' : 'Confirm'}
+						</button>
+						<button
+							data-testid="neo-cancel-button"
+							onClick={handleCancel}
+							disabled={loading}
+							class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-gray-600 hover:border-gray-500 text-gray-300 hover:text-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Cancel
+						</button>
+						<span class="ml-auto text-xs text-gray-600">You can also type "yes" or "no"</span>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/neo/NeoPanel.test.tsx
+++ b/packages/web/src/components/neo/NeoPanel.test.tsx
@@ -186,4 +186,47 @@ describe('NeoPanel', () => {
 		const header = getByTestId('neo-panel-header');
 		expect(header.textContent).toContain('Neo');
 	});
+
+	it('Tab key focus trap: focus cycles back to first focusable element from last', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		const panel = getByTestId('neo-panel');
+
+		// Get all focusable elements within the panel
+		const focusable = panel.querySelectorAll<HTMLElement>(
+			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		);
+		expect(focusable.length).toBeGreaterThan(0);
+
+		const last = focusable[focusable.length - 1];
+		const first = focusable[0];
+
+		// Focus last element, then press Tab — should wrap to first
+		last.focus();
+		act(() => {
+			fireEvent.keyDown(document, { key: 'Tab', shiftKey: false });
+		});
+		expect(document.activeElement).toBe(first);
+	});
+
+	it('Shift+Tab focus trap: focus cycles back to last focusable element from first', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		const panel = getByTestId('neo-panel');
+
+		const focusable = panel.querySelectorAll<HTMLElement>(
+			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		);
+		expect(focusable.length).toBeGreaterThan(0);
+
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+
+		// Focus first element, then press Shift+Tab — should wrap to last
+		first.focus();
+		act(() => {
+			fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+		});
+		expect(document.activeElement).toBe(last);
+	});
 });

--- a/packages/web/src/components/neo/NeoPanel.test.tsx
+++ b/packages/web/src/components/neo/NeoPanel.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Tests for NeoPanel
+ *
+ * Verifies:
+ * - Renders with correct aria attributes
+ * - Panel is off-screen when panelOpen=false (-translate-x-full)
+ * - Panel is on-screen when panelOpen=true (translate-x-0)
+ * - Backdrop rendered; click dismisses panel
+ * - Escape key closes panel
+ * - Close button calls neoStore.closePanel
+ * - Tab switching: Chat tab and Activity tab
+ * - subscribe() called on mount; unsubscribe() on unmount
+ * - Renders NeoChatView by default (chat tab)
+ * - Renders NeoActivityView when activity tab is active
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore — signals inside factory to avoid hoisting issues
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', async () => {
+	const { signal: s } = await import('@preact/signals');
+	const panelOpen = s(false);
+	const activeTab = s<'chat' | 'activity'>('chat');
+	const subscribe = vi.fn().mockResolvedValue(undefined);
+	const unsubscribe = vi.fn();
+	const closePanel = vi.fn(() => {
+		panelOpen.value = false;
+	});
+	return {
+		neoStore: { panelOpen, activeTab, subscribe, unsubscribe, closePanel },
+	};
+});
+
+// Mock child views
+vi.mock('./NeoChatView.tsx', () => ({
+	NeoChatView: () => <div data-testid="mock-chat-view">Chat</div>,
+}));
+
+vi.mock('./NeoActivityView.tsx', () => ({
+	NeoActivityView: () => <div data-testid="mock-activity-view">Activity</div>,
+}));
+
+import { NeoPanel } from './NeoPanel.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoPanel', () => {
+	beforeEach(() => {
+		neoStore.panelOpen.value = false;
+		neoStore.activeTab.value = 'chat';
+		(neoStore.subscribe as ReturnType<typeof vi.fn>).mockClear();
+		(neoStore.unsubscribe as ReturnType<typeof vi.fn>).mockClear();
+		(neoStore.closePanel as ReturnType<typeof vi.fn>).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the panel with role=dialog', () => {
+		const { getByTestId } = render(<NeoPanel />);
+		const panel = getByTestId('neo-panel');
+		expect(panel.getAttribute('role')).toBe('dialog');
+	});
+
+	it('panel has aria-modal=true', () => {
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-panel').getAttribute('aria-modal')).toBe('true');
+	});
+
+	it('panel is off-screen when closed (-translate-x-full)', () => {
+		neoStore.panelOpen.value = false;
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-panel').className).toContain('-translate-x-full');
+	});
+
+	it('panel is on-screen when open (translate-x-0)', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-panel').className).toContain('translate-x-0');
+	});
+
+	it('renders backdrop', () => {
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-panel-backdrop')).toBeTruthy();
+	});
+
+	it('backdrop click calls closePanel', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		fireEvent.click(getByTestId('neo-panel-backdrop'));
+		expect(neoStore.closePanel).toHaveBeenCalledOnce();
+	});
+
+	it('close button calls closePanel', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		fireEvent.click(getByTestId('neo-panel-close'));
+		expect(neoStore.closePanel).toHaveBeenCalledOnce();
+	});
+
+	it('Escape key calls closePanel when panel is open', () => {
+		neoStore.panelOpen.value = true;
+		render(<NeoPanel />);
+		act(() => {
+			fireEvent.keyDown(document, { key: 'Escape' });
+		});
+		expect(neoStore.closePanel).toHaveBeenCalledOnce();
+	});
+
+	it('Escape key does NOT close when panel is closed', () => {
+		neoStore.panelOpen.value = false;
+		render(<NeoPanel />);
+		act(() => {
+			fireEvent.keyDown(document, { key: 'Escape' });
+		});
+		expect(neoStore.closePanel).not.toHaveBeenCalled();
+	});
+
+	it('subscribe() is called on mount', () => {
+		render(<NeoPanel />);
+		expect(neoStore.subscribe).toHaveBeenCalledOnce();
+	});
+
+	it('unsubscribe() is called on unmount', () => {
+		const { unmount } = render(<NeoPanel />);
+		unmount();
+		expect(neoStore.unsubscribe).toHaveBeenCalledOnce();
+	});
+
+	it('renders NeoChatView when activeTab=chat', () => {
+		neoStore.activeTab.value = 'chat';
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('mock-chat-view')).toBeTruthy();
+	});
+
+	it('renders NeoActivityView when activeTab=activity', () => {
+		neoStore.activeTab.value = 'activity';
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('mock-activity-view')).toBeTruthy();
+	});
+
+	it('chat tab button is aria-selected=true when on chat', () => {
+		neoStore.activeTab.value = 'chat';
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-tab-chat').getAttribute('aria-selected')).toBe('true');
+		expect(getByTestId('neo-tab-activity').getAttribute('aria-selected')).toBe('false');
+	});
+
+	it('activity tab button is aria-selected=true when on activity', () => {
+		neoStore.activeTab.value = 'activity';
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-tab-activity').getAttribute('aria-selected')).toBe('true');
+		expect(getByTestId('neo-tab-chat').getAttribute('aria-selected')).toBe('false');
+	});
+
+	it('clicking activity tab switches to activity view', () => {
+		neoStore.activeTab.value = 'chat';
+		const { getByTestId } = render(<NeoPanel />);
+		act(() => {
+			fireEvent.click(getByTestId('neo-tab-activity'));
+		});
+		expect(neoStore.activeTab.value).toBe('activity');
+		expect(getByTestId('mock-activity-view')).toBeTruthy();
+	});
+
+	it('clicking chat tab switches to chat view from activity', () => {
+		neoStore.activeTab.value = 'activity';
+		const { getByTestId } = render(<NeoPanel />);
+		act(() => {
+			fireEvent.click(getByTestId('neo-tab-chat'));
+		});
+		expect(neoStore.activeTab.value).toBe('chat');
+		expect(getByTestId('mock-chat-view')).toBeTruthy();
+	});
+
+	it('header has "Neo" text', () => {
+		const { getByTestId } = render(<NeoPanel />);
+		const header = getByTestId('neo-panel-header');
+		expect(header.textContent).toContain('Neo');
+	});
+});

--- a/packages/web/src/components/neo/NeoPanel.tsx
+++ b/packages/web/src/components/neo/NeoPanel.tsx
@@ -1,0 +1,223 @@
+/**
+ * NeoPanel
+ *
+ * Global slide-out panel for the Neo AI assistant.
+ * - Slides in from the left, overlapping other content
+ * - Header with "Neo" title, Chat / Activity tab switcher, close button
+ * - Controlled by neoStore.panelOpen signal
+ * - Subscribes to neo.messages and neo.activity LiveQueries on mount
+ * - Click-outside-to-dismiss (backdrop click)
+ * - Escape key closes
+ * - Smooth 300ms CSS transition
+ */
+
+import { useEffect, useRef } from 'preact/hooks';
+import { neoStore, type NeoActiveTab } from '../../lib/neo-store.ts';
+import { NeoChatView } from './NeoChatView.tsx';
+import { NeoActivityView } from './NeoActivityView.tsx';
+
+// ---------------------------------------------------------------------------
+// Sparkle icon (matches NeoNavButton)
+// ---------------------------------------------------------------------------
+
+function SparkleIcon() {
+	return (
+		<svg class="w-4 h-4 text-violet-400" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+			<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+			<path d="M5 3l.75 2.25L8 6l-2.25.75L5 9l-.75-2.25L2 6l2.25-.75L5 3z" opacity={0.5} />
+		</svg>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tab button
+// ---------------------------------------------------------------------------
+
+interface TabButtonProps {
+	tab: NeoActiveTab;
+	activeTab: NeoActiveTab;
+	label: string;
+	onSelect: (tab: NeoActiveTab) => void;
+}
+
+function TabButton({ tab, activeTab, label, onSelect }: TabButtonProps) {
+	const isActive = activeTab === tab;
+	return (
+		<button
+			type="button"
+			onClick={() => onSelect(tab)}
+			data-testid={`neo-tab-${tab}`}
+			aria-selected={isActive}
+			class={[
+				'px-3 py-1.5 text-xs font-medium rounded-lg transition-colors',
+				isActive
+					? 'bg-violet-500/20 text-violet-300'
+					: 'text-gray-500 hover:text-gray-300 hover:bg-white/5',
+			].join(' ')}
+		>
+			{label}
+		</button>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// NeoPanel
+// ---------------------------------------------------------------------------
+
+export function NeoPanel() {
+	const isOpen = neoStore.panelOpen.value;
+	const activeTab = neoStore.activeTab.value;
+
+	const panelRef = useRef<HTMLDivElement>(null);
+	const closeButtonRef = useRef<HTMLButtonElement>(null);
+	const triggerRef = useRef<Element | null>(null);
+
+	// Subscribe to LiveQuery on mount; unsubscribe on unmount
+	useEffect(() => {
+		neoStore.subscribe().catch(() => {
+			// Error is captured in neoStore.error signal — no action needed here
+		});
+		return () => {
+			neoStore.unsubscribe();
+		};
+	}, []);
+
+	// Focus management
+	useEffect(() => {
+		if (isOpen) {
+			triggerRef.current = document.activeElement;
+			requestAnimationFrame(() => {
+				closeButtonRef.current?.focus();
+			});
+		} else {
+			if (triggerRef.current instanceof HTMLElement) {
+				triggerRef.current.focus();
+			}
+			triggerRef.current = null;
+		}
+	}, [isOpen]);
+
+	// Escape key closes panel; focus trap
+	useEffect(() => {
+		if (!isOpen) return;
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				neoStore.closePanel();
+				return;
+			}
+			if (e.key === 'Tab' && panelRef.current) {
+				const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+					'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+				);
+				if (focusable.length === 0) return;
+				const first = focusable[0];
+				const last = focusable[focusable.length - 1];
+				if (e.shiftKey) {
+					if (document.activeElement === first) {
+						e.preventDefault();
+						last.focus();
+					}
+				} else {
+					if (document.activeElement === last) {
+						e.preventDefault();
+						first.focus();
+					}
+				}
+			}
+		};
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, [isOpen]);
+
+	const handleTabSelect = (tab: NeoActiveTab) => {
+		neoStore.activeTab.value = tab;
+	};
+
+	return (
+		<>
+			{/* Backdrop */}
+			<div
+				data-testid="neo-panel-backdrop"
+				class={[
+					'fixed inset-0 bg-black/40 z-40 transition-opacity duration-300',
+					isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none',
+				].join(' ')}
+				onClick={() => neoStore.closePanel()}
+				aria-hidden="true"
+			/>
+
+			{/* Panel */}
+			<div
+				ref={panelRef}
+				data-testid="neo-panel"
+				role="dialog"
+				aria-modal="true"
+				aria-label="Neo AI assistant"
+				class={[
+					'fixed top-0 left-0 h-dvh pt-safe z-50',
+					'w-full sm:w-80 md:w-96',
+					'flex flex-col',
+					'bg-gray-900 border-r border-gray-700 shadow-2xl',
+					'transition-transform duration-300',
+					isOpen ? 'translate-x-0' : '-translate-x-full',
+				].join(' ')}
+			>
+				{/* Header */}
+				<div
+					data-testid="neo-panel-header"
+					class="flex-shrink-0 flex items-center justify-between px-3 py-2.5 border-b border-gray-700"
+				>
+					{/* Title */}
+					<div class="flex items-center gap-2">
+						<SparkleIcon />
+						<span class="text-sm font-semibold text-gray-100">Neo</span>
+					</div>
+
+					{/* Tab switcher */}
+					<div class="flex items-center gap-1" role="tablist" aria-label="Neo panel tabs">
+						<TabButton tab="chat" activeTab={activeTab} label="Chat" onSelect={handleTabSelect} />
+						<TabButton
+							tab="activity"
+							activeTab={activeTab}
+							label="Activity"
+							onSelect={handleTabSelect}
+						/>
+					</div>
+
+					{/* Close button */}
+					<button
+						ref={closeButtonRef}
+						data-testid="neo-panel-close"
+						onClick={() => neoStore.closePanel()}
+						class="p-1 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 transition-colors"
+						aria-label="Close Neo panel"
+					>
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				</div>
+
+				{/* Body */}
+				<div
+					class="flex-1 min-h-0"
+					role="tabpanel"
+					aria-label={activeTab === 'chat' ? 'Chat' : 'Activity'}
+				>
+					{activeTab === 'chat' ? <NeoChatView /> : <NeoActivityView />}
+				</div>
+			</div>
+		</>
+	);
+}

--- a/packages/web/src/lib/neo-store.ts
+++ b/packages/web/src/lib/neo-store.ts
@@ -67,6 +67,7 @@ export interface NeoActivityEntry {
 export interface PendingConfirmation {
 	actionId: string;
 	description: string;
+	riskLevel?: 'low' | 'medium' | 'high';
 }
 
 export type NeoActiveTab = 'chat' | 'activity';


### PR DESCRIPTION
Implements the Neo slide-out panel (task 7.3).

## What's included

- **NeoPanel** — left slide-out (300ms transition), Chat/Activity tabs, close button, Escape key + backdrop click to dismiss. Subscribes to LiveQuery on mount, unsubscribes on unmount.
- **NeoChatView** — message list with auto-scroll, user bubbles (blue) and assistant bubbles (sparkle avatar + MarkdownRenderer), StructuredDataCard for JSON responses, typing indicator, and three error state cards rendered inline: `provider_unavailable`, `no_credentials` (with Settings link), `model_unavailable` (with Settings link).
- **NeoActivityView** — scrollable feed from `neoStore.activity` with status badges (Done/Failed/Cancelled) always visible in summary row, relative timestamps, click-to-expand for full input/output/error details.
- **NeoConfirmationCard** — inline card in chat for pending actions; risk level badge (low/medium/high), Confirm/Cancel buttons calling `neo.confirmAction`/`neo.cancelAction` RPC directly, loading/error states, resolved state showing confirmation outcome.
- **App.tsx** — mounts `<NeoPanel />` alongside other global overlays.
- **78 unit tests** across all 4 new components.

## Tests

78 new tests passing; pre-existing failures in `skills-store.test.ts` and `VisualWorkflowEditor.test.tsx` are unrelated to this PR (confirmed present on base branch).