### PR TITLE
feat(neo): Space and workflow action tools (task 3.3)

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -279,6 +279,28 @@ export interface NeoActionToolsConfig {
 	 * activate if the gate is now open (mirrors fireGateChanged in the RPC layer).
 	 */
 	onGateChanged?: NeoGateChangedNotifier;
+	/**
+	 * Optional callback invoked after a workflow run's status changes.
+	 * Mirrors the `space.workflowRun.updated` event emitted by the RPC layer
+	 * so that the frontend LiveQuery subscriptions receive the update.
+	 * Called by cancel_workflow_run, approve_gate, and reject_gate.
+	 */
+	onWorkflowRunUpdated?: (
+		spaceId: string,
+		runId: string,
+		run: NeoWorkflowRun
+	) => void | Promise<void>;
+	/**
+	 * Optional callback invoked after gate data is written.
+	 * Mirrors the `space.gateData.updated` event emitted by the RPC layer.
+	 * Called by approve_gate and reject_gate.
+	 */
+	onGateDataUpdated?: (
+		spaceId: string,
+		runId: string,
+		gateId: string,
+		data: Record<string, unknown>
+	) => void | Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -355,6 +377,8 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 		spaceTaskManagerFactory,
 		gateDataRepo,
 		onGateChanged,
+		onWorkflowRunUpdated,
+		onGateDataUpdated,
 	} = config;
 
 	return {
@@ -752,12 +776,12 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			instructions?: string;
 			autonomy_level?: SpaceAutonomyLevel;
 		}): Promise<ToolResult> {
-			if (!spaceHandlers) {
-				return errorResult('Space operations are not available');
-			}
-			return withSecurityCheck('create_space', args as Record<string, unknown>, config, () =>
-				spaceHandlers.create_space(args)
-			);
+			return withSecurityCheck('create_space', args as Record<string, unknown>, config, () => {
+				if (!spaceHandlers) {
+					return Promise.resolve(errorResult('Space operations are not available'));
+				}
+				return spaceHandlers.create_space(args);
+			});
 		},
 
 		async update_space(args: {
@@ -769,9 +793,7 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			default_model?: string;
 			autonomy_level?: SpaceAutonomyLevel;
 		}): Promise<ToolResult> {
-			if (!spaceHandlers) {
-				return errorResult('Space operations are not available');
-			}
+			// Input validation — stays outside the security check (no backend needed to validate)
 			const hasUpdates =
 				args.name !== undefined ||
 				args.description !== undefined ||
@@ -782,18 +804,21 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			if (!hasUpdates) {
 				return errorResult('No update fields provided');
 			}
-			return withSecurityCheck('update_space', args as Record<string, unknown>, config, () =>
-				spaceHandlers.update_space(args)
-			);
+			return withSecurityCheck('update_space', args as Record<string, unknown>, config, () => {
+				if (!spaceHandlers) {
+					return Promise.resolve(errorResult('Space operations are not available'));
+				}
+				return spaceHandlers.update_space(args);
+			});
 		},
 
 		async delete_space(args: { space_id: string }): Promise<ToolResult> {
-			if (!spaceHandlers) {
-				return errorResult('Space operations are not available');
-			}
-			return withSecurityCheck('delete_space', args as Record<string, unknown>, config, () =>
-				spaceHandlers.delete_space(args)
-			);
+			return withSecurityCheck('delete_space', args as Record<string, unknown>, config, () => {
+				if (!spaceHandlers) {
+					return Promise.resolve(errorResult('Space operations are not available'));
+				}
+				return spaceHandlers.delete_space(args);
+			});
 		},
 
 		// ── Workflow ──────────────────────────────────────────────────────────
@@ -805,23 +830,29 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			description?: string;
 			goal_id?: string;
 		}): Promise<ToolResult> {
-			if (!spaceHandlers) {
-				return errorResult('Workflow operations are not available');
-			}
-			return withSecurityCheck('start_workflow_run', args as Record<string, unknown>, config, () =>
-				spaceHandlers.start_workflow_run(args)
+			return withSecurityCheck(
+				'start_workflow_run',
+				args as Record<string, unknown>,
+				config,
+				() => {
+					if (!spaceHandlers) {
+						return Promise.resolve(errorResult('Workflow operations are not available'));
+					}
+					return spaceHandlers.start_workflow_run(args);
+				}
 			);
 		},
 
 		async cancel_workflow_run(args: { run_id: string }): Promise<ToolResult> {
-			if (!workflowRunRepo || !spaceTaskManagerFactory) {
-				return errorResult('Workflow run operations are not available');
-			}
 			return withSecurityCheck(
 				'cancel_workflow_run',
 				args as Record<string, unknown>,
 				config,
 				async () => {
+					if (!workflowRunRepo || !spaceTaskManagerFactory) {
+						return errorResult('Workflow run operations are not available');
+					}
+
 					const run = workflowRunRepo.getRun(args.run_id);
 					if (!run) {
 						return errorResult(`Workflow run not found: ${args.run_id}`);
@@ -839,12 +870,13 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 					for (const task of tasks) {
 						if (task.status === 'pending' || task.status === 'in_progress') {
 							await taskManager.cancelTask(task.id).catch(() => {
-								/* best-effort */
+								/* best-effort — individual task failures do not abort run cancellation */
 							});
 						}
 					}
 
-					workflowRunRepo.transitionStatus(args.run_id, 'cancelled');
+					const updated = workflowRunRepo.transitionStatus(args.run_id, 'cancelled');
+					await onWorkflowRunUpdated?.(run.spaceId, run.id, updated);
 					return successResult({ runId: args.run_id });
 				}
 			);
@@ -857,14 +889,15 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			gate_id: string;
 			reason?: string;
 		}): Promise<ToolResult> {
-			if (!workflowRunRepo || !gateDataRepo) {
-				return errorResult('Gate operations are not available');
-			}
 			return withSecurityCheck(
 				'approve_gate',
 				args as Record<string, unknown>,
 				config,
 				async () => {
+					if (!workflowRunRepo || !gateDataRepo) {
+						return errorResult('Gate operations are not available');
+					}
+
 					const run = workflowRunRepo.getRun(args.run_id);
 					if (!run) {
 						return errorResult(`Workflow run not found: ${args.run_id}`);
@@ -892,12 +925,16 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 						approvedAt: Date.now(),
 					});
 
-					// If previously rejected, transition back to in_progress
+					// If previously rejected, transition back to in_progress and clear failure reason
+					let currentRun = run;
 					if (run.status === 'needs_attention' && run.failureReason === 'humanRejected') {
-						workflowRunRepo.transitionStatus(args.run_id, 'in_progress');
-						workflowRunRepo.updateRun(args.run_id, { failureReason: null });
+						currentRun = workflowRunRepo.transitionStatus(args.run_id, 'in_progress');
+						currentRun =
+							workflowRunRepo.updateRun(args.run_id, { failureReason: null }) ?? currentRun;
+						await onWorkflowRunUpdated?.(run.spaceId, run.id, currentRun);
 					}
 
+					await onGateDataUpdated?.(run.spaceId, run.id, args.gate_id, gateData.data);
 					await onGateChanged?.(args.run_id, args.gate_id);
 
 					return successResult({
@@ -914,10 +951,11 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			gate_id: string;
 			reason?: string;
 		}): Promise<ToolResult> {
-			if (!workflowRunRepo || !gateDataRepo) {
-				return errorResult('Gate operations are not available');
-			}
 			return withSecurityCheck('reject_gate', args as Record<string, unknown>, config, async () => {
+				if (!workflowRunRepo || !gateDataRepo) {
+					return errorResult('Gate operations are not available');
+				}
+
 				const run = workflowRunRepo.getRun(args.run_id);
 				if (!run) {
 					return errorResult(`Workflow run not found: ${args.run_id}`);
@@ -945,7 +983,11 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				if (run.status !== 'needs_attention') {
 					workflowRunRepo.transitionStatus(args.run_id, 'needs_attention');
 				}
-				workflowRunRepo.updateRun(args.run_id, { failureReason: 'humanRejected' });
+				const updatedRun =
+					workflowRunRepo.updateRun(args.run_id, { failureReason: 'humanRejected' }) ?? run;
+
+				await onWorkflowRunUpdated?.(run.spaceId, run.id, updatedRun);
+				await onGateDataUpdated?.(run.spaceId, run.id, args.gate_id, gateData.data);
 
 				return successResult({
 					runId: args.run_id,

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -1,9 +1,10 @@
 /**
  * Neo Action Tools - MCP tools for write operations
  *
- * Implements room, goal, and task write operations with security-tier enforcement.
- * Each tool checks whether the current security mode requires confirmation before
- * execution and either runs immediately or returns a `confirmationRequired` payload.
+ * Implements room, goal, task, space, and workflow write operations with
+ * security-tier enforcement.  Each tool checks whether the current security
+ * mode requires confirmation before execution and either runs immediately or
+ * returns a `confirmationRequired` payload.
  *
  * Pattern: two-layer design (testable handlers + MCP server wrapper)
  *   createNeoActionToolHandlers(config) → plain handler functions
@@ -27,6 +28,17 @@
  *   - set_task_status
  *   - approve_task
  *   - reject_task
+ *
+ *   Space operations (delegated to GlobalSpaces handler layer)
+ *   - create_space
+ *   - update_space
+ *   - delete_space
+ *
+ *   Workflow operations
+ *   - start_workflow_run  (delegated to GlobalSpaces handler layer)
+ *   - cancel_workflow_run
+ *   - approve_gate
+ *   - reject_gate
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
@@ -42,6 +54,7 @@ import type {
 	MissionType,
 	AutonomyLevel,
 	WorkspacePath,
+	SpaceAutonomyLevel,
 } from '@neokai/shared';
 import {
 	ActionClassification,
@@ -148,6 +161,99 @@ export interface NeoActionManagerFactory {
 	getTaskManager(roomId: string): NeoActionTaskManager;
 }
 
+// ---------------------------------------------------------------------------
+// Space / Workflow interfaces (delegated to global-spaces handler layer)
+// ---------------------------------------------------------------------------
+
+/** Minimal ToolResult shape shared with global-spaces handlers. */
+interface SharedToolResult {
+	content: Array<{ type: 'text'; text: string }>;
+}
+
+/**
+ * Handlers from the GlobalSpaces layer that Neo delegates space/workflow
+ * operations to.  Neo wraps each call with a security-tier check before
+ * delegating.
+ *
+ * Pass `createGlobalSpacesToolHandlers(config, state)` as this value when
+ * wiring up the real daemon.  Use a mock object in unit tests.
+ */
+export interface NeoActionSpaceHandlers {
+	create_space(args: {
+		name: string;
+		workspace_path: string;
+		description?: string;
+		instructions?: string;
+		autonomy_level?: SpaceAutonomyLevel;
+	}): Promise<SharedToolResult>;
+
+	update_space(args: {
+		space_id: string;
+		name?: string;
+		description?: string;
+		instructions?: string;
+		background_context?: string;
+		default_model?: string;
+		autonomy_level?: SpaceAutonomyLevel;
+	}): Promise<SharedToolResult>;
+
+	delete_space(args: { space_id: string }): Promise<SharedToolResult>;
+
+	start_workflow_run(args: {
+		space_id?: string;
+		workflow_id: string;
+		title: string;
+		description?: string;
+		goal_id?: string;
+	}): Promise<SharedToolResult>;
+}
+
+/** Minimal workflow-run record needed by cancel/gate handlers. */
+export interface NeoWorkflowRun {
+	id: string;
+	spaceId: string;
+	status: string;
+	failureReason?: string | null;
+}
+
+/** Repository for reading and transitioning workflow run state. */
+export interface NeoActionWorkflowRunRepository {
+	getRun(id: string): NeoWorkflowRun | null;
+	transitionStatus(id: string, to: string): NeoWorkflowRun;
+	updateRun(id: string, params: { failureReason?: string | null }): NeoWorkflowRun | null;
+}
+
+/** Minimal space task record for cancellation. */
+export interface NeoSpaceTask {
+	id: string;
+	status: string;
+}
+
+/** Manager for space tasks within a single workflow run. */
+export interface NeoActionSpaceTaskManager {
+	listTasksByWorkflowRun(runId: string): Promise<NeoSpaceTask[]>;
+	cancelTask(taskId: string): Promise<unknown>;
+}
+
+/** Factory that creates a SpaceTaskManager scoped to a space. */
+export interface NeoActionSpaceTaskManagerFactory {
+	getTaskManager(spaceId: string): NeoActionSpaceTaskManager;
+}
+
+/** Gate data record returned by the repository. */
+export interface NeoGateDataRecord {
+	data: Record<string, unknown>;
+}
+
+/** Repository for reading and writing gate approval data. */
+export interface NeoActionGateDataRepository {
+	get(runId: string, gateId: string): NeoGateDataRecord | null;
+	merge(runId: string, gateId: string, partial: Record<string, unknown>): NeoGateDataRecord;
+}
+
+/** Optional callback to notify the runtime that gate data changed. */
+export type NeoGateChangedNotifier = (runId: string, gateId: string) => Promise<void> | void;
+
 export interface NeoActionToolsConfig {
 	roomManager: NeoActionRoomManager;
 	managerFactory: NeoActionManagerFactory;
@@ -157,6 +263,22 @@ export interface NeoActionToolsConfig {
 	workspaceRoot?: string;
 	/** Returns the current security mode (looked up at call time) */
 	getSecurityMode(): NeoSecurityMode;
+
+	// ── Space / Workflow dependencies ──────────────────────────────────────
+	/** Pre-constructed GlobalSpaces handlers — Neo delegates CRUD and run ops to these. */
+	spaceHandlers?: NeoActionSpaceHandlers;
+	/** Repository for reading and transitioning workflow-run state. */
+	workflowRunRepo?: NeoActionWorkflowRunRepository;
+	/** Factory for per-space task managers (used by cancel_workflow_run). */
+	spaceTaskManagerFactory?: NeoActionSpaceTaskManagerFactory;
+	/** Repository for gate approval data. */
+	gateDataRepo?: NeoActionGateDataRepository;
+	/**
+	 * Optional callback invoked after gate data is written.
+	 * When provided, triggers channel re-evaluation so downstream nodes
+	 * activate if the gate is now open (mirrors fireGateChanged in the RPC layer).
+	 */
+	onGateChanged?: NeoGateChangedNotifier;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +345,17 @@ async function withSecurityCheck(
 // ---------------------------------------------------------------------------
 
 export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
-	const { roomManager, managerFactory, runtimeService, workspaceRoot } = config;
+	const {
+		roomManager,
+		managerFactory,
+		runtimeService,
+		workspaceRoot,
+		spaceHandlers,
+		workflowRunRepo,
+		spaceTaskManagerFactory,
+		gateDataRepo,
+		onGateChanged,
+	} = config;
 
 	return {
 		// ── Room ──────────────────────────────────────────────────────────────
@@ -610,6 +742,218 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				return successResult({ taskId: args.task_id });
 			});
 		},
+
+		// ── Space ─────────────────────────────────────────────────────────────
+
+		async create_space(args: {
+			name: string;
+			workspace_path: string;
+			description?: string;
+			instructions?: string;
+			autonomy_level?: SpaceAutonomyLevel;
+		}): Promise<ToolResult> {
+			if (!spaceHandlers) {
+				return errorResult('Space operations are not available');
+			}
+			return withSecurityCheck('create_space', args as Record<string, unknown>, config, () =>
+				spaceHandlers.create_space(args)
+			);
+		},
+
+		async update_space(args: {
+			space_id: string;
+			name?: string;
+			description?: string;
+			instructions?: string;
+			background_context?: string;
+			default_model?: string;
+			autonomy_level?: SpaceAutonomyLevel;
+		}): Promise<ToolResult> {
+			if (!spaceHandlers) {
+				return errorResult('Space operations are not available');
+			}
+			const hasUpdates =
+				args.name !== undefined ||
+				args.description !== undefined ||
+				args.instructions !== undefined ||
+				args.background_context !== undefined ||
+				args.default_model !== undefined ||
+				args.autonomy_level !== undefined;
+			if (!hasUpdates) {
+				return errorResult('No update fields provided');
+			}
+			return withSecurityCheck('update_space', args as Record<string, unknown>, config, () =>
+				spaceHandlers.update_space(args)
+			);
+		},
+
+		async delete_space(args: { space_id: string }): Promise<ToolResult> {
+			if (!spaceHandlers) {
+				return errorResult('Space operations are not available');
+			}
+			return withSecurityCheck('delete_space', args as Record<string, unknown>, config, () =>
+				spaceHandlers.delete_space(args)
+			);
+		},
+
+		// ── Workflow ──────────────────────────────────────────────────────────
+
+		async start_workflow_run(args: {
+			space_id?: string;
+			workflow_id: string;
+			title: string;
+			description?: string;
+			goal_id?: string;
+		}): Promise<ToolResult> {
+			if (!spaceHandlers) {
+				return errorResult('Workflow operations are not available');
+			}
+			return withSecurityCheck('start_workflow_run', args as Record<string, unknown>, config, () =>
+				spaceHandlers.start_workflow_run(args)
+			);
+		},
+
+		async cancel_workflow_run(args: { run_id: string }): Promise<ToolResult> {
+			if (!workflowRunRepo || !spaceTaskManagerFactory) {
+				return errorResult('Workflow run operations are not available');
+			}
+			return withSecurityCheck(
+				'cancel_workflow_run',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const run = workflowRunRepo.getRun(args.run_id);
+					if (!run) {
+						return errorResult(`Workflow run not found: ${args.run_id}`);
+					}
+					if (run.status === 'cancelled') {
+						return successResult({ runId: args.run_id, alreadyCancelled: true });
+					}
+					if (run.status === 'completed') {
+						return errorResult('Cannot cancel a completed workflow run');
+					}
+
+					// Cancel all pending/in_progress tasks for this run (best-effort)
+					const taskManager = spaceTaskManagerFactory.getTaskManager(run.spaceId);
+					const tasks = await taskManager.listTasksByWorkflowRun(run.id);
+					for (const task of tasks) {
+						if (task.status === 'pending' || task.status === 'in_progress') {
+							await taskManager.cancelTask(task.id).catch(() => {
+								/* best-effort */
+							});
+						}
+					}
+
+					workflowRunRepo.transitionStatus(args.run_id, 'cancelled');
+					return successResult({ runId: args.run_id });
+				}
+			);
+		},
+
+		// ── Gate ──────────────────────────────────────────────────────────────
+
+		async approve_gate(args: {
+			run_id: string;
+			gate_id: string;
+			reason?: string;
+		}): Promise<ToolResult> {
+			if (!workflowRunRepo || !gateDataRepo) {
+				return errorResult('Gate operations are not available');
+			}
+			return withSecurityCheck(
+				'approve_gate',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const run = workflowRunRepo.getRun(args.run_id);
+					if (!run) {
+						return errorResult(`Workflow run not found: ${args.run_id}`);
+					}
+					if (
+						run.status === 'completed' ||
+						run.status === 'cancelled' ||
+						run.status === 'pending'
+					) {
+						return errorResult(`Cannot approve gate on a ${run.status} workflow run`);
+					}
+
+					// Idempotent: already approved
+					const existing = gateDataRepo.get(args.run_id, args.gate_id);
+					if (existing?.data?.approved === true) {
+						return successResult({
+							runId: args.run_id,
+							gateId: args.gate_id,
+							gateData: existing.data,
+						});
+					}
+
+					const gateData = gateDataRepo.merge(args.run_id, args.gate_id, {
+						approved: true,
+						approvedAt: Date.now(),
+					});
+
+					// If previously rejected, transition back to in_progress
+					if (run.status === 'needs_attention' && run.failureReason === 'humanRejected') {
+						workflowRunRepo.transitionStatus(args.run_id, 'in_progress');
+						workflowRunRepo.updateRun(args.run_id, { failureReason: null });
+					}
+
+					await onGateChanged?.(args.run_id, args.gate_id);
+
+					return successResult({
+						runId: args.run_id,
+						gateId: args.gate_id,
+						gateData: gateData.data,
+					});
+				}
+			);
+		},
+
+		async reject_gate(args: {
+			run_id: string;
+			gate_id: string;
+			reason?: string;
+		}): Promise<ToolResult> {
+			if (!workflowRunRepo || !gateDataRepo) {
+				return errorResult('Gate operations are not available');
+			}
+			return withSecurityCheck('reject_gate', args as Record<string, unknown>, config, async () => {
+				const run = workflowRunRepo.getRun(args.run_id);
+				if (!run) {
+					return errorResult(`Workflow run not found: ${args.run_id}`);
+				}
+				if (run.status === 'completed' || run.status === 'cancelled' || run.status === 'pending') {
+					return errorResult(`Cannot reject gate on a ${run.status} workflow run`);
+				}
+
+				// Idempotent: already rejected
+				const existing = gateDataRepo.get(args.run_id, args.gate_id);
+				if (existing?.data?.approved === false) {
+					return successResult({
+						runId: args.run_id,
+						gateId: args.gate_id,
+						gateData: existing.data,
+					});
+				}
+
+				const gateData = gateDataRepo.merge(args.run_id, args.gate_id, {
+					approved: false,
+					rejectedAt: Date.now(),
+					reason: args.reason ?? null,
+				});
+
+				if (run.status !== 'needs_attention') {
+					workflowRunRepo.transitionStatus(args.run_id, 'needs_attention');
+				}
+				workflowRunRepo.updateRun(args.run_id, { failureReason: 'humanRejected' });
+
+				return successResult({
+					runId: args.run_id,
+					gateId: args.gate_id,
+					gateData: gateData.data,
+				});
+			});
+		},
 	};
 }
 
@@ -798,6 +1142,104 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 				feedback: z.string().describe('Feedback explaining why the task was rejected'),
 			},
 			(args) => handlers.reject_task(args)
+		),
+
+		// ── Space ─────────────────────────────────────────────────────────────
+		tool(
+			'create_space',
+			'Create a new space with a name and workspace path. Low risk — auto-executes in balanced mode.',
+			{
+				name: z.string().describe('Name for the new space'),
+				workspace_path: z.string().describe('Absolute path to the workspace directory'),
+				description: z.string().optional().describe('Description of the space'),
+				instructions: z
+					.string()
+					.optional()
+					.describe('Instructions for agents working in this space'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe(
+						'Autonomy level: "supervised" (default) waits for human approval on judgment calls; "semi_autonomous" handles simple cases independently'
+					),
+			},
+			(args) => handlers.create_space(args)
+		),
+
+		tool(
+			'update_space',
+			'Update space metadata such as name, description, instructions, or autonomy level. Low risk — auto-executes in balanced mode.',
+			{
+				space_id: z.string().describe('ID of the space to update'),
+				name: z.string().optional().describe('New name'),
+				description: z.string().optional().describe('New description'),
+				instructions: z.string().optional().describe('New instructions for agents'),
+				background_context: z.string().optional().describe('New background context'),
+				default_model: z.string().optional().describe('New default model ID'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe('New autonomy level'),
+			},
+			(args) => handlers.update_space(args)
+		),
+
+		tool(
+			'delete_space',
+			'Permanently delete a space and all its data. Medium risk — requires confirmation in balanced mode.',
+			{
+				space_id: z.string().describe('ID of the space to delete'),
+			},
+			(args) => handlers.delete_space(args)
+		),
+
+		// ── Workflow ──────────────────────────────────────────────────────────
+		tool(
+			'start_workflow_run',
+			'Begin a workflow run in a space. Low risk — auto-executes in balanced mode.',
+			{
+				space_id: z
+					.string()
+					.optional()
+					.describe('Target space ID (defaults to the active space context)'),
+				workflow_id: z.string().describe('ID of the workflow to run'),
+				title: z.string().describe('Short title for this workflow run'),
+				description: z.string().optional().describe('Description of the work'),
+				goal_id: z.string().optional().describe('Goal/mission ID to associate with this run'),
+			},
+			(args) => handlers.start_workflow_run(args)
+		),
+
+		tool(
+			'cancel_workflow_run',
+			'Cancel an active workflow run and all its pending tasks. Medium risk — requires confirmation in balanced mode.',
+			{
+				run_id: z.string().describe('ID of the workflow run to cancel'),
+			},
+			(args) => handlers.cancel_workflow_run(args)
+		),
+
+		// ── Gate ──────────────────────────────────────────────────────────────
+		tool(
+			'approve_gate',
+			'Approve a human-approval gate in a workflow run, allowing the workflow to proceed. Medium risk — requires confirmation in balanced mode.',
+			{
+				run_id: z.string().describe('ID of the workflow run'),
+				gate_id: z.string().describe('ID of the gate to approve'),
+				reason: z.string().optional().describe('Optional reason for the approval'),
+			},
+			(args) => handlers.approve_gate(args)
+		),
+
+		tool(
+			'reject_gate',
+			'Reject a human-approval gate in a workflow run, halting it for revision. Medium risk — requires confirmation in balanced mode.',
+			{
+				run_id: z.string().describe('ID of the workflow run'),
+				gate_id: z.string().describe('ID of the gate to reject'),
+				reason: z.string().optional().describe('Reason for the rejection'),
+			},
+			(args) => handlers.reject_gate(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -17,6 +17,11 @@
  * - list_space_agents
  * - list_space_workflows
  * - list_space_runs
+ * - list_goals
+ * - get_goal_details
+ * - get_metrics
+ * - list_tasks
+ * - get_task_detail
  *
  * Pattern: two-layer design (testable handlers + MCP server wrapper)
  *   createNeoQueryToolHandlers(config) → plain handler functions
@@ -38,6 +43,8 @@ import type {
 	SpaceWorkflow,
 	SpaceWorkflowRun,
 	SpaceTask,
+	NeoTask,
+	MissionExecution,
 } from '@neokai/shared';
 import { isWorkerSessionId } from '../../room/session-utils';
 
@@ -59,6 +66,21 @@ export interface NeoQueryRoomManager {
 export interface NeoQueryGoalRepository {
 	/** List goals for a specific room, optionally filtered by status */
 	listGoals(roomId: string, status?: string): RoomGoal[];
+	/** Get a single goal by ID */
+	getGoal(id: string): RoomGoal | null;
+	/** List execution history for a goal (most recent first) */
+	listExecutions(goalId: string, limit?: number): MissionExecution[];
+}
+
+export interface NeoQueryTaskRepository {
+	/**
+	 * List tasks for a specific room, optionally filtered by status and archived state.
+	 * Note: assignedAgent filtering is NOT in the real TaskFilter; it is applied in-memory
+	 * by the tool handler after calling this method.
+	 */
+	listTasks(roomId: string, filter?: { status?: string; includeArchived?: boolean }): NeoTask[];
+	/** Get a single task by ID */
+	getTask(id: string): NeoTask | null;
 }
 
 export interface NeoQuerySessionManager {
@@ -122,6 +144,7 @@ export interface NeoQuerySpaceTaskRepository {
 export interface NeoToolsConfig {
 	roomManager: NeoQueryRoomManager;
 	goalRepository: NeoQueryGoalRepository;
+	taskRepository: NeoQueryTaskRepository;
 	sessionManager: NeoQuerySessionManager;
 	settingsManager: NeoQuerySettingsManager;
 	authManager: NeoQueryAuthManager;
@@ -170,6 +193,7 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 	const {
 		roomManager,
 		goalRepository,
+		taskRepository,
 		sessionManager,
 		settingsManager,
 		authManager,
@@ -639,6 +663,258 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 				}))
 			);
 		},
+
+		// -----------------------------------------------------------------------
+		// Goal and task query tools
+		// -----------------------------------------------------------------------
+
+		/**
+		 * List goals across all rooms (or a specific room), with optional filters.
+		 */
+		async list_goals(args: {
+			room_id?: string;
+			status?: string;
+			mission_type?: string;
+		}): Promise<ToolResult> {
+			// Determine which rooms to query
+			const rooms = args.room_id
+				? (() => {
+						const r = roomManager.getRoom(args.room_id);
+						return r ? [r] : null;
+					})()
+				: roomManager.listRooms(true); // include archived rooms for cross-room visibility
+
+			if (rooms === null) {
+				return errorResult(`Room not found: ${args.room_id}`);
+			}
+
+			const allGoals: Record<string, unknown>[] = [];
+			for (const room of rooms) {
+				const goals = goalRepository.listGoals(room.id, args.status as string | undefined);
+				for (const g of goals) {
+					// Filter by mission_type if provided (repository does not support this natively)
+					if (args.mission_type && (g.missionType ?? 'one_shot') !== args.mission_type) {
+						continue;
+					}
+					allGoals.push({
+						id: g.id,
+						shortId: g.shortId ?? null,
+						roomId: g.roomId,
+						roomName: room.name,
+						title: g.title,
+						status: g.status,
+						priority: g.priority,
+						progress: g.progress,
+						missionType: g.missionType ?? 'one_shot',
+						autonomyLevel: g.autonomyLevel ?? 'supervised',
+						linkedTaskCount: g.linkedTaskIds.length,
+						nextRunAt: g.nextRunAt ?? null,
+						schedulePaused: g.schedulePaused ?? false,
+						createdAt: g.createdAt,
+						updatedAt: g.updatedAt,
+					});
+				}
+			}
+
+			return jsonResult(allGoals);
+		},
+
+		/**
+		 * Get full details for a goal including metrics and execution history.
+		 */
+		async get_goal_details(args: {
+			goal_id: string;
+			execution_limit?: number;
+		}): Promise<ToolResult> {
+			const goal = goalRepository.getGoal(args.goal_id);
+			if (!goal) {
+				return errorResult(`Goal not found: ${args.goal_id}`);
+			}
+
+			const room = roomManager.getRoom(goal.roomId);
+			const executions = goalRepository.listExecutions(goal.id, args.execution_limit ?? 10);
+
+			return jsonResult({
+				id: goal.id,
+				shortId: goal.shortId ?? null,
+				roomId: goal.roomId,
+				roomName: room?.name ?? null,
+				title: goal.title,
+				description: goal.description,
+				status: goal.status,
+				priority: goal.priority,
+				progress: goal.progress,
+				missionType: goal.missionType ?? 'one_shot',
+				autonomyLevel: goal.autonomyLevel ?? 'supervised',
+				linkedTaskIds: goal.linkedTaskIds,
+				metrics: goal.metrics ?? {},
+				structuredMetrics: goal.structuredMetrics ?? [],
+				schedule: goal.schedule ?? null,
+				schedulePaused: goal.schedulePaused ?? false,
+				nextRunAt: goal.nextRunAt ?? null,
+				consecutiveFailures: goal.consecutiveFailures ?? 0,
+				maxConsecutiveFailures: goal.maxConsecutiveFailures ?? 3,
+				replanCount: goal.replanCount ?? 0,
+				createdAt: goal.createdAt,
+				updatedAt: goal.updatedAt,
+				completedAt: goal.completedAt ?? null,
+				executions: executions.map((e) => ({
+					id: e.id,
+					executionNumber: e.executionNumber,
+					status: e.status,
+					startedAt: e.startedAt,
+					completedAt: e.completedAt ?? null,
+					resultSummary: e.resultSummary ?? null,
+					taskCount: e.taskIds.length,
+				})),
+			});
+		},
+
+		/**
+		 * Get current metric values for a measurable goal.
+		 */
+		async get_metrics(args: { goal_id: string }): Promise<ToolResult> {
+			const goal = goalRepository.getGoal(args.goal_id);
+			if (!goal) {
+				return errorResult(`Goal not found: ${args.goal_id}`);
+			}
+
+			if ((goal.missionType ?? 'one_shot') !== 'measurable') {
+				return errorResult(
+					`Goal ${args.goal_id} is not a measurable mission (type: ${goal.missionType ?? 'one_shot'})`
+				);
+			}
+
+			const structuredMetrics = goal.structuredMetrics ?? [];
+
+			return jsonResult({
+				goalId: goal.id,
+				goalTitle: goal.title,
+				missionType: goal.missionType ?? 'one_shot',
+				metrics: structuredMetrics.map((m) => ({
+					name: m.name,
+					target: m.target,
+					current: m.current,
+					unit: m.unit ?? null,
+					direction: m.direction ?? 'increase',
+					baseline: m.baseline ?? null,
+					progressPct: (() => {
+						if (m.direction === 'decrease' && m.baseline !== undefined) {
+							// baseline === target means the goal is already at target; treat as 100%
+							if (m.baseline === m.target) return 100;
+							return Math.round(((m.baseline - m.current) / (m.baseline - m.target)) * 100);
+						}
+						// increase direction (default)
+						if (m.target !== 0) return Math.round((m.current / m.target) * 100);
+						return m.current >= m.target ? 100 : 0;
+					})(),
+				})),
+				legacyMetrics: goal.metrics ?? {},
+			});
+		},
+
+		/**
+		 * List tasks across all rooms (or a specific room), with optional filters.
+		 */
+		async list_tasks(args: {
+			room_id?: string;
+			status?: string;
+			assigned_agent?: string;
+			include_archived?: boolean;
+		}): Promise<ToolResult> {
+			// Auto-include archived tasks when the caller explicitly requests archived status,
+			// otherwise the repository filter would hide them and return zero results.
+			const includeArchived = args.include_archived ?? args.status === 'archived';
+
+			// Determine which rooms to query
+			const rooms = args.room_id
+				? (() => {
+						const r = roomManager.getRoom(args.room_id);
+						return r ? [r] : null;
+					})()
+				: roomManager.listRooms(true); // include archived rooms for cross-room visibility
+
+			if (rooms === null) {
+				return errorResult(`Room not found: ${args.room_id}`);
+			}
+
+			const allTasks: Record<string, unknown>[] = [];
+			for (const room of rooms) {
+				// Note: assignedAgent is not in real TaskFilter, so we filter in-memory below.
+				const filter: { status?: string; includeArchived?: boolean } = { includeArchived };
+				if (args.status) filter.status = args.status;
+
+				let tasks = taskRepository.listTasks(room.id, filter);
+
+				// In-memory filter for assignedAgent (not supported at the SQL level in TaskFilter)
+				if (args.assigned_agent) {
+					tasks = tasks.filter((t) => (t.assignedAgent ?? 'coder') === args.assigned_agent);
+				}
+
+				for (const t of tasks) {
+					allTasks.push({
+						id: t.id,
+						shortId: t.shortId ?? null,
+						roomId: t.roomId,
+						roomName: room.name,
+						title: t.title,
+						status: t.status,
+						priority: t.priority,
+						taskType: t.taskType ?? 'coding',
+						assignedAgent: t.assignedAgent ?? 'coder',
+						progress: t.progress ?? null,
+						activeSession: t.activeSession,
+						prUrl: t.prUrl ?? null,
+						prNumber: t.prNumber ?? null,
+						createdAt: t.createdAt,
+						updatedAt: t.updatedAt,
+					});
+				}
+			}
+
+			return jsonResult(allTasks);
+		},
+
+		/**
+		 * Get full details for a specific task.
+		 */
+		async get_task_detail(args: { task_id: string }): Promise<ToolResult> {
+			const task = taskRepository.getTask(args.task_id);
+			if (!task) {
+				return errorResult(`Task not found: ${args.task_id}`);
+			}
+
+			const room = roomManager.getRoom(task.roomId);
+
+			return jsonResult({
+				id: task.id,
+				shortId: task.shortId ?? null,
+				roomId: task.roomId,
+				roomName: room?.name ?? null,
+				title: task.title,
+				description: task.description,
+				status: task.status,
+				priority: task.priority,
+				taskType: task.taskType ?? 'coding',
+				assignedAgent: task.assignedAgent ?? 'coder',
+				createdByTaskId: task.createdByTaskId ?? null,
+				progress: task.progress ?? null,
+				currentStep: task.currentStep ?? null,
+				result: task.result ?? null,
+				error: task.error ?? null,
+				dependsOn: task.dependsOn,
+				activeSession: task.activeSession,
+				prUrl: task.prUrl ?? null,
+				prNumber: task.prNumber ?? null,
+				prCreatedAt: task.prCreatedAt ?? null,
+				restrictions: task.restrictions ?? null,
+				createdAt: task.createdAt,
+				startedAt: task.startedAt ?? null,
+				completedAt: task.completedAt ?? null,
+				archivedAt: task.archivedAt ?? null,
+				updatedAt: task.updatedAt,
+			});
+		},
 	};
 }
 
@@ -792,6 +1068,97 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 					.describe('Filter runs by status'),
 			},
 			(args) => handlers.list_space_runs(args)
+		),
+
+		// Goal and task query tools
+		tool(
+			'list_goals',
+			'List goals across all rooms or a specific room. Filterable by room, status, and mission type.',
+			{
+				room_id: z
+					.string()
+					.optional()
+					.describe('Filter to goals in a specific room (omit for all rooms)'),
+				status: z
+					.enum(['active', 'needs_human', 'completed', 'archived'])
+					.optional()
+					.describe('Filter by goal status'),
+				mission_type: z
+					.enum(['one_shot', 'measurable', 'recurring'])
+					.optional()
+					.describe('Filter by mission type'),
+			},
+			(args) => handlers.list_goals(args)
+		),
+
+		tool(
+			'get_goal_details',
+			'Get full details for a goal including structured metrics, execution history, and schedule information.',
+			{
+				goal_id: z.string().describe('ID of the goal to query'),
+				execution_limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(10)
+					.describe('Maximum number of executions to return (default: 10)'),
+			},
+			(args) => handlers.get_goal_details(args)
+		),
+
+		tool(
+			'get_metrics',
+			'Get current metric values for a measurable goal, including target vs current values and computed progress percentages.',
+			{
+				goal_id: z.string().describe('ID of the measurable goal to query'),
+			},
+			(args) => handlers.get_metrics(args)
+		),
+
+		tool(
+			'list_tasks',
+			'List tasks across all rooms or a specific room. Filterable by room, status, and assigned agent.',
+			{
+				room_id: z
+					.string()
+					.optional()
+					.describe('Filter to tasks in a specific room (omit for all rooms)'),
+				status: z
+					.enum([
+						'draft',
+						'pending',
+						'in_progress',
+						'review',
+						'completed',
+						'needs_attention',
+						'cancelled',
+						'archived',
+						'rate_limited',
+						'usage_limited',
+					])
+					.optional()
+					.describe('Filter by task status'),
+				assigned_agent: z
+					.enum(['coder', 'general', 'planner'])
+					.optional()
+					.describe('Filter by assigned agent type'),
+				include_archived: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe('Include archived tasks (default: false)'),
+			},
+			(args) => handlers.list_tasks(args)
+		),
+
+		tool(
+			'get_task_detail',
+			'Get full details for a specific task including description, result, error, dependencies, and PR information.',
+			{
+				task_id: z.string().describe('ID of the task to query'),
+			},
+			(args) => handlers.get_task_detail(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -17,7 +17,14 @@
  * - set_task_status: status transition
  * - approve_task: happy path, task not in review error, runtime unavailable
  * - reject_task: happy path, task not in review error, runtime unavailable
- * - MCP server: all 11 tools are registered
+ * - create_space: auto-execute and confirmation paths, unavailable guard
+ * - update_space: auto-execute and no-op guard
+ * - delete_space: auto-execute and confirmation paths
+ * - start_workflow_run: auto-execute and confirmation paths
+ * - cancel_workflow_run: happy path, already-cancelled, completed error, unavailable guard
+ * - approve_gate: happy path, idempotent, rejection override, terminal-run error
+ * - reject_gate: happy path, idempotent, reason propagation, terminal-run error
+ * - MCP server: all 18 tools are registered
  */
 
 import { describe, expect, it, beforeEach } from 'bun:test';
@@ -30,6 +37,12 @@ import {
 	type NeoActionTaskManager,
 	type NeoActionRuntimeService,
 	type NeoActionManagerFactory,
+	type NeoActionSpaceHandlers,
+	type NeoActionWorkflowRunRepository,
+	type NeoActionSpaceTaskManagerFactory,
+	type NeoActionGateDataRepository,
+	type NeoWorkflowRun,
+	type NeoSpaceTask,
 } from '../../../src/lib/neo/tools/neo-action-tools';
 import { PendingActionStore } from '../../../src/lib/neo/security-tier';
 import type { Room, RoomGoal, NeoTask } from '@neokai/shared';
@@ -210,6 +223,99 @@ function makeManagerFactory(
 // Config builder
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Space/Workflow mock factories
+// ---------------------------------------------------------------------------
+
+type SpaceToolResult = { content: Array<{ type: 'text'; text: string }> };
+
+function makeSpaceHandlers(override: Partial<NeoActionSpaceHandlers> = {}): NeoActionSpaceHandlers {
+	const defaultResult = (): Promise<SpaceToolResult> =>
+		Promise.resolve({
+			content: [{ type: 'text', text: JSON.stringify({ success: true }) }],
+		});
+	return {
+		create_space: override.create_space ?? ((_args) => defaultResult()),
+		update_space: override.update_space ?? ((_args) => defaultResult()),
+		delete_space: override.delete_space ?? ((_args) => defaultResult()),
+		start_workflow_run: override.start_workflow_run ?? ((_args) => defaultResult()),
+	};
+}
+
+function makeWorkflowRun(overrides: Partial<NeoWorkflowRun> = {}): NeoWorkflowRun {
+	return {
+		id: 'run-1',
+		spaceId: 'space-1',
+		status: 'in_progress',
+		failureReason: null,
+		...overrides,
+	};
+}
+
+function makeWorkflowRunRepo(
+	runs: NeoWorkflowRun[] = []
+): NeoActionWorkflowRunRepository & { _runs: Map<string, NeoWorkflowRun> } {
+	const store = new Map<string, NeoWorkflowRun>(runs.map((r) => [r.id, r]));
+	return {
+		_runs: store,
+		getRun: (id) => store.get(id) ?? null,
+		transitionStatus: (id, to) => {
+			const run = store.get(id);
+			if (!run) throw new Error(`Run not found: ${id}`);
+			const updated = { ...run, status: to };
+			store.set(id, updated);
+			return updated;
+		},
+		updateRun: (id, params) => {
+			const run = store.get(id);
+			if (!run) return null;
+			const updated = { ...run, ...params };
+			store.set(id, updated);
+			return updated;
+		},
+	};
+}
+
+function makeSpaceTask(overrides: Partial<NeoSpaceTask> = {}): NeoSpaceTask {
+	return { id: 'stask-1', status: 'pending', ...overrides };
+}
+
+function makeSpaceTaskManagerFactory(
+	tasks: NeoSpaceTask[] = []
+): NeoActionSpaceTaskManagerFactory & { _cancelledIds: string[] } {
+	const cancelledIds: string[] = [];
+	return {
+		_cancelledIds: cancelledIds,
+		getTaskManager: (_spaceId) => ({
+			listTasksByWorkflowRun: async (_runId) => tasks,
+			cancelTask: async (taskId) => {
+				cancelledIds.push(taskId);
+			},
+		}),
+	};
+}
+
+function makeGateDataRepo(): NeoActionGateDataRepository & {
+	_store: Map<string, Record<string, unknown>>;
+} {
+	const store = new Map<string, Record<string, unknown>>();
+	return {
+		_store: store,
+		get: (runId, gateId) => {
+			const key = `${runId}:${gateId}`;
+			const data = store.get(key);
+			return data ? { data } : null;
+		},
+		merge: (runId, gateId, partial) => {
+			const key = `${runId}:${gateId}`;
+			const existing = store.get(key) ?? {};
+			const merged = { ...existing, ...partial };
+			store.set(key, merged);
+			return { data: merged };
+		},
+	};
+}
+
 function makeConfig(
 	opts: {
 		rooms?: Room[];
@@ -220,6 +326,11 @@ function makeConfig(
 		workspaceRoot?: string;
 		/** Simulate active session counts per room ID for delete_room escalation tests */
 		activeSessionCounts?: Map<string, number>;
+		spaceHandlers?: NeoActionSpaceHandlers;
+		workflowRunRepo?: NeoActionWorkflowRunRepository;
+		spaceTaskManagerFactory?: NeoActionSpaceTaskManagerFactory;
+		gateDataRepo?: NeoActionGateDataRepository;
+		onGateChanged?: (runId: string, gateId: string) => Promise<void> | void;
 	} = {}
 ): NeoActionToolsConfig {
 	const room = makeRoom();
@@ -246,6 +357,11 @@ function makeConfig(
 		pendingStore: new PendingActionStore(),
 		workspaceRoot: opts.workspaceRoot,
 		getSecurityMode: () => opts.securityMode ?? 'autonomous',
+		spaceHandlers: opts.spaceHandlers,
+		workflowRunRepo: opts.workflowRunRepo,
+		spaceTaskManagerFactory: opts.spaceTaskManagerFactory,
+		gateDataRepo: opts.gateDataRepo,
+		onGateChanged: opts.onGateChanged,
 	};
 }
 
@@ -942,6 +1058,525 @@ describe('reject_task', () => {
 });
 
 // ---------------------------------------------------------------------------
+// create_space
+// ---------------------------------------------------------------------------
+
+describe('create_space', () => {
+	it('delegates to spaceHandlers in autonomous mode', async () => {
+		let called = false;
+		const handlers = makeSpaceHandlers({
+			create_space: async (args) => {
+				called = true;
+				return {
+					content: [{ type: 'text', text: JSON.stringify({ success: true, name: args.name }) }],
+				};
+			},
+		});
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'autonomous' });
+		const { create_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_space({ name: 'My Space', workspace_path: '/ws' }));
+		expect(called).toBe(true);
+		expect(result.success).toBe(true);
+		expect(result.name).toBe('My Space');
+	});
+
+	it('returns confirmation in balanced mode (low risk — auto-executes)', async () => {
+		// create_space is low risk, so balanced mode auto-executes it too
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'balanced' });
+		const { create_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_space({ name: 'Test Space', workspace_path: '/workspace' })
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it('requires confirmation in conservative mode', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'conservative' });
+		const { create_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_space({ name: 'Test Space', workspace_path: '/workspace' })
+		);
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.pendingActionId).toBeTruthy();
+	});
+
+	it('returns error when spaceHandlers not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { create_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_space({ name: 'Test', workspace_path: '/ws' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// update_space
+// ---------------------------------------------------------------------------
+
+describe('update_space', () => {
+	it('delegates to spaceHandlers in autonomous mode', async () => {
+		let calledWith: unknown;
+		const handlers = makeSpaceHandlers({
+			update_space: async (args) => {
+				calledWith = args;
+				return { content: [{ type: 'text', text: JSON.stringify({ success: true }) }] };
+			},
+		});
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'autonomous' });
+		const { update_space } = createNeoActionToolHandlers(config);
+		await update_space({ space_id: 'space-1', name: 'New Name' });
+		expect((calledWith as Record<string, unknown>).name).toBe('New Name');
+	});
+
+	it('returns error when no update fields provided', async () => {
+		const config = makeConfig({ spaceHandlers: makeSpaceHandlers(), securityMode: 'autonomous' });
+		const { update_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_space({ space_id: 'space-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No update fields');
+	});
+
+	it('returns error when spaceHandlers not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { update_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_space({ space_id: 'space-1', name: 'x' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'balanced' });
+		const { update_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_space({ space_id: 'space-1', name: 'New Name' }));
+		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// delete_space
+// ---------------------------------------------------------------------------
+
+describe('delete_space', () => {
+	it('delegates to spaceHandlers in autonomous mode', async () => {
+		let calledId = '';
+		const handlers = makeSpaceHandlers({
+			delete_space: async (args) => {
+				calledId = args.space_id;
+				return {
+					content: [{ type: 'text', text: JSON.stringify({ success: true, deleted: true }) }],
+				};
+			},
+		});
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'autonomous' });
+		const { delete_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_space({ space_id: 'space-42' }));
+		expect(calledId).toBe('space-42');
+		expect(result.success).toBe(true);
+		expect(result.deleted).toBe(true);
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'balanced' });
+		const { delete_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_space({ space_id: 'space-1' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error when spaceHandlers not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { delete_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_space({ space_id: 'space-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// start_workflow_run
+// ---------------------------------------------------------------------------
+
+describe('start_workflow_run', () => {
+	it('delegates to spaceHandlers in autonomous mode', async () => {
+		let calledArgs: unknown;
+		const handlers = makeSpaceHandlers({
+			start_workflow_run: async (args) => {
+				calledArgs = args;
+				return {
+					content: [
+						{ type: 'text', text: JSON.stringify({ success: true, run: { id: 'run-1' } }) },
+					],
+				};
+			},
+		});
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'autonomous' });
+		const { start_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await start_workflow_run({ workflow_id: 'wf-1', title: 'Test Run', space_id: 'space-1' })
+		);
+		expect((calledArgs as Record<string, unknown>).workflow_id).toBe('wf-1');
+		expect(result.run.id).toBe('run-1');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'balanced' });
+		const { start_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await start_workflow_run({ workflow_id: 'wf-1', title: 'Test Run' })
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it('requires confirmation in conservative mode', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'conservative' });
+		const { start_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await start_workflow_run({ workflow_id: 'wf-1', title: 'Test Run' })
+		);
+		expect(result.confirmationRequired).toBe(true);
+	});
+
+	it('returns error when spaceHandlers not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { start_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await start_workflow_run({ workflow_id: 'wf-1', title: 'x' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cancel_workflow_run
+// ---------------------------------------------------------------------------
+
+describe('cancel_workflow_run', () => {
+	it('cancels active tasks and transitions run to cancelled', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const tasks = [
+			makeSpaceTask({ id: 'st-1', status: 'pending' }),
+			makeSpaceTask({ id: 'st-2', status: 'in_progress' }),
+			makeSpaceTask({ id: 'st-3', status: 'completed' }),
+		];
+		const taskFactory = makeSpaceTaskManagerFactory(tasks);
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: taskFactory,
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.success).toBe(true);
+		expect(result.runId).toBe('run-1');
+		// pending and in_progress should be cancelled; completed is skipped
+		expect(taskFactory._cancelledIds).toContain('st-1');
+		expect(taskFactory._cancelledIds).toContain('st-2');
+		expect(taskFactory._cancelledIds).not.toContain('st-3');
+		expect(runRepo._runs.get('run-1')?.status).toBe('cancelled');
+	});
+
+	it('returns success with alreadyCancelled when run is already cancelled', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'cancelled' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const taskFactory = makeSpaceTaskManagerFactory();
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: taskFactory,
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.success).toBe(true);
+		expect(result.alreadyCancelled).toBe(true);
+	});
+
+	it('returns error when run is completed', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'completed' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: makeSpaceTaskManagerFactory(),
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Cannot cancel a completed');
+	});
+
+	it('returns error when run not found', async () => {
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo(),
+			spaceTaskManagerFactory: makeSpaceTaskManagerFactory(),
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not found');
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const config = makeConfig({
+			securityMode: 'balanced',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			spaceTaskManagerFactory: makeSpaceTaskManagerFactory(),
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error when workflowRunRepo not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// approve_gate
+// ---------------------------------------------------------------------------
+
+describe('approve_gate', () => {
+	it('writes approved gate data', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const gateRepo = makeGateDataRepo();
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			gateDataRepo: gateRepo,
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(true);
+		expect(result.gateData.approved).toBe(true);
+		expect(result.gateData.approvedAt).toBeDefined();
+	});
+
+	it('calls onGateChanged after approval', async () => {
+		let notifiedRun = '';
+		let notifiedGate = '';
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+			onGateChanged: (runId, gateId) => {
+				notifiedRun = runId;
+				notifiedGate = gateId;
+			},
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		expect(notifiedRun).toBe('run-1');
+		expect(notifiedGate).toBe('gate-1');
+	});
+
+	it('transitions rejected run back to in_progress', async () => {
+		const run = makeWorkflowRun({
+			id: 'run-1',
+			status: 'needs_attention',
+			failureReason: 'humanRejected',
+		});
+		const runRepo = makeWorkflowRunRepo([run]);
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		expect(runRepo._runs.get('run-1')?.status).toBe('in_progress');
+		expect(runRepo._runs.get('run-1')?.failureReason).toBeNull();
+	});
+
+	it('is idempotent when already approved', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const gateRepo = makeGateDataRepo();
+		// Pre-populate approved state
+		gateRepo.merge('run-1', 'gate-1', { approved: true, approvedAt: 123 });
+		let delegateCalls = 0;
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: gateRepo,
+			onGateChanged: () => {
+				delegateCalls++;
+			},
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(true);
+		// onGateChanged should NOT be called for an idempotent approval
+		expect(delegateCalls).toBe(0);
+	});
+
+	it('returns error for terminal run status', async () => {
+		for (const status of ['completed', 'cancelled', 'pending']) {
+			const run = makeWorkflowRun({ id: 'run-1', status });
+			const config = makeConfig({
+				securityMode: 'autonomous',
+				workflowRunRepo: makeWorkflowRunRepo([run]),
+				gateDataRepo: makeGateDataRepo(),
+			});
+			const { approve_gate } = createNeoActionToolHandlers(config);
+			const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain(status);
+		}
+	});
+
+	it('returns error when run not found', async () => {
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo(),
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'missing', gate_id: 'gate-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not found');
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const config = makeConfig({
+			securityMode: 'balanced',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error when dependencies not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reject_gate
+// ---------------------------------------------------------------------------
+
+describe('reject_gate', () => {
+	it('writes rejected gate data and transitions run to needs_attention', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const gateRepo = makeGateDataRepo();
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			gateDataRepo: gateRepo,
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_gate({ run_id: 'run-1', gate_id: 'gate-1', reason: 'Not ready' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.gateData.approved).toBe(false);
+		expect(result.gateData.reason).toBe('Not ready');
+		expect(runRepo._runs.get('run-1')?.status).toBe('needs_attention');
+		expect(runRepo._runs.get('run-1')?.failureReason).toBe('humanRejected');
+	});
+
+	it('is idempotent when already rejected', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'needs_attention' });
+		const gateRepo = makeGateDataRepo();
+		gateRepo.merge('run-1', 'gate-1', { approved: false, rejectedAt: 123 });
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: gateRepo,
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(true);
+		expect(result.gateData.approved).toBe(false);
+	});
+
+	it('does not call transitionStatus when run is already needs_attention', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'needs_attention' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		// Status remains needs_attention (not changed by the handler)
+		expect(runRepo._runs.get('run-1')?.status).toBe('needs_attention');
+		expect(runRepo._runs.get('run-1')?.failureReason).toBe('humanRejected');
+	});
+
+	it('stores null reason when not provided', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const gateRepo = makeGateDataRepo();
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: gateRepo,
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.gateData.reason).toBeNull();
+	});
+
+	it('returns error for terminal run status', async () => {
+		for (const status of ['completed', 'cancelled', 'pending']) {
+			const run = makeWorkflowRun({ id: 'run-1', status });
+			const config = makeConfig({
+				securityMode: 'autonomous',
+				workflowRunRepo: makeWorkflowRunRepo([run]),
+				gateDataRepo: makeGateDataRepo(),
+			});
+			const { reject_gate } = createNeoActionToolHandlers(config);
+			const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain(status);
+		}
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const config = makeConfig({
+			securityMode: 'balanced',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.confirmationRequired).toBe(true);
+	});
+
+	it('returns error when dependencies not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // MCP server — tool registration
 // ---------------------------------------------------------------------------
 
@@ -1000,7 +1635,35 @@ describe('createNeoActionMcpServer', () => {
 		expect(server.instance._registeredTools).toHaveProperty('reject_task');
 	});
 
-	it('registers exactly 11 tools', () => {
-		expect(Object.keys(server.instance._registeredTools)).toHaveLength(11);
+	it('registers create_space tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('create_space');
+	});
+
+	it('registers update_space tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('update_space');
+	});
+
+	it('registers delete_space tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('delete_space');
+	});
+
+	it('registers start_workflow_run tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('start_workflow_run');
+	});
+
+	it('registers cancel_workflow_run tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('cancel_workflow_run');
+	});
+
+	it('registers approve_gate tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('approve_gate');
+	});
+
+	it('registers reject_gate tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('reject_gate');
+	});
+
+	it('registers exactly 18 tools', () => {
+		expect(Object.keys(server.instance._registeredTools)).toHaveLength(18);
 	});
 });

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -331,6 +331,17 @@ function makeConfig(
 		spaceTaskManagerFactory?: NeoActionSpaceTaskManagerFactory;
 		gateDataRepo?: NeoActionGateDataRepository;
 		onGateChanged?: (runId: string, gateId: string) => Promise<void> | void;
+		onWorkflowRunUpdated?: (
+			spaceId: string,
+			runId: string,
+			run: NeoWorkflowRun
+		) => void | Promise<void>;
+		onGateDataUpdated?: (
+			spaceId: string,
+			runId: string,
+			gateId: string,
+			data: Record<string, unknown>
+		) => void | Promise<void>;
 	} = {}
 ): NeoActionToolsConfig {
 	const room = makeRoom();
@@ -362,6 +373,8 @@ function makeConfig(
 		spaceTaskManagerFactory: opts.spaceTaskManagerFactory,
 		gateDataRepo: opts.gateDataRepo,
 		onGateChanged: opts.onGateChanged,
+		onWorkflowRunUpdated: opts.onWorkflowRunUpdated,
+		onGateDataUpdated: opts.onGateDataUpdated,
 	};
 }
 
@@ -1342,6 +1355,56 @@ describe('cancel_workflow_run', () => {
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('not available');
 	});
+
+	it('still cancels run when individual cancelTask throws (best-effort)', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		// All task cancellations throw
+		const failingTaskFactory: NeoActionSpaceTaskManagerFactory = {
+			getTaskManager: () => ({
+				listTasksByWorkflowRun: async () => [
+					makeSpaceTask({ id: 'st-1', status: 'pending' }),
+					makeSpaceTask({ id: 'st-2', status: 'in_progress' }),
+				],
+				cancelTask: async () => {
+					throw new Error('cancel failed');
+				},
+			}),
+		};
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: failingTaskFactory,
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		// Run is still cancelled despite task failures
+		expect(result.success).toBe(true);
+		expect(runRepo._runs.get('run-1')?.status).toBe('cancelled');
+	});
+
+	it('calls onWorkflowRunUpdated after cancellation', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', spaceId: 'space-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		let updatedSpaceId = '';
+		let updatedRunId = '';
+		let updatedStatus = '';
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: makeSpaceTaskManagerFactory(),
+			onWorkflowRunUpdated: (_spaceId, _runId, updatedRun) => {
+				updatedSpaceId = _spaceId;
+				updatedRunId = _runId;
+				updatedStatus = updatedRun.status;
+			},
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		await cancel_workflow_run({ run_id: 'run-1' });
+		expect(updatedSpaceId).toBe('space-1');
+		expect(updatedRunId).toBe('run-1');
+		expect(updatedStatus).toBe('cancelled');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -1470,6 +1533,56 @@ describe('approve_gate', () => {
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('not available');
 	});
+
+	it('calls onWorkflowRunUpdated and onGateDataUpdated after approving a rejected gate', async () => {
+		const run = makeWorkflowRun({
+			id: 'run-1',
+			spaceId: 'space-1',
+			status: 'needs_attention',
+			failureReason: 'humanRejected',
+		});
+		const runUpdates: Array<{ spaceId: string; runId: string; status: string }> = [];
+		const gateUpdates: Array<{ spaceId: string; runId: string; gateId: string }> = [];
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+			onWorkflowRunUpdated: (spaceId, runId, updatedRun) => {
+				runUpdates.push({ spaceId, runId, status: updatedRun.status });
+			},
+			onGateDataUpdated: (spaceId, runId, gateId) => {
+				gateUpdates.push({ spaceId, runId, gateId });
+			},
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		expect(runUpdates).toHaveLength(1);
+		expect(runUpdates[0].status).toBe('in_progress');
+		expect(gateUpdates).toHaveLength(1);
+		expect(gateUpdates[0].gateId).toBe('gate-1');
+	});
+
+	it('calls onGateDataUpdated but not onWorkflowRunUpdated for in_progress approval', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', spaceId: 'space-1', status: 'in_progress' });
+		let runUpdateCalls = 0;
+		let gateUpdateCalls = 0;
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+			onWorkflowRunUpdated: () => {
+				runUpdateCalls++;
+			},
+			onGateDataUpdated: () => {
+				gateUpdateCalls++;
+			},
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		// No run status change — onWorkflowRunUpdated should NOT be called
+		expect(runUpdateCalls).toBe(0);
+		expect(gateUpdateCalls).toBe(1);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -1573,6 +1686,34 @@ describe('reject_gate', () => {
 		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('not available');
+	});
+
+	it('calls onWorkflowRunUpdated and onGateDataUpdated after rejection', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', spaceId: 'space-1', status: 'in_progress' });
+		const runUpdates: Array<{ spaceId: string; status: string; failureReason: unknown }> = [];
+		const gateUpdates: Array<{ spaceId: string; gateId: string }> = [];
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+			onWorkflowRunUpdated: (spaceId, _runId, updatedRun) => {
+				runUpdates.push({
+					spaceId,
+					status: updatedRun.status,
+					failureReason: updatedRun.failureReason,
+				});
+			},
+			onGateDataUpdated: (spaceId, _runId, gateId) => {
+				gateUpdates.push({ spaceId, gateId });
+			},
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		await reject_gate({ run_id: 'run-1', gate_id: 'gate-1', reason: 'Not ready' });
+		expect(runUpdates).toHaveLength(1);
+		expect(runUpdates[0].status).toBe('needs_attention');
+		expect(runUpdates[0].failureReason).toBe('humanRejected');
+		expect(gateUpdates).toHaveLength(1);
+		expect(gateUpdates[0].gateId).toBe('gate-1');
 	});
 });
 

--- a/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
@@ -21,7 +21,12 @@
  * - list_space_agents: found, not found, agent fields
  * - list_space_workflows: found, not found, workflow fields
  * - list_space_runs: found, not found, status filter, sort order
- * - MCP server: all 15 tools are registered
+ * - list_goals: cross-room, room filter, status filter, mission_type filter
+ * - get_goal_details: found, not found, execution history
+ * - get_metrics: measurable goal, non-measurable goal, not found
+ * - list_tasks: cross-room, room filter, status filter, assigned_agent filter
+ * - get_task_detail: found, not found
+ * - MCP server: all 20 tools are registered
  */
 
 import { describe, expect, it, beforeEach } from 'bun:test';
@@ -31,6 +36,7 @@ import {
 	type NeoToolsConfig,
 	type NeoQueryRoomManager,
 	type NeoQueryGoalRepository,
+	type NeoQueryTaskRepository,
 	type NeoQuerySessionManager,
 	type NeoQuerySettingsManager,
 	type NeoQueryAuthManager,
@@ -52,6 +58,8 @@ import type {
 	SpaceWorkflow,
 	SpaceWorkflowRun,
 	SpaceTask,
+	NeoTask,
+	MissionExecution,
 } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
@@ -92,6 +100,38 @@ function makeGoal(overrides: Partial<RoomGoal> = {}): RoomGoal {
 	};
 }
 
+function makeTask(overrides: Partial<NeoTask> = {}): NeoTask {
+	return {
+		id: 'task-1',
+		roomId: 'room-1',
+		title: 'Test Task',
+		description: 'A test task',
+		status: 'pending',
+		priority: 'normal',
+		taskType: 'coding',
+		assignedAgent: 'coder',
+		dependsOn: [],
+		activeSession: null,
+		restrictions: null,
+		createdAt: NOW - 3_000,
+		updatedAt: NOW,
+		...overrides,
+	};
+}
+
+function makeExecution(overrides: Partial<MissionExecution> = {}): MissionExecution {
+	return {
+		id: 'exec-1',
+		goalId: 'goal-1',
+		executionNumber: 1,
+		startedAt: Math.floor((NOW - 5_000) / 1000),
+		status: 'running',
+		taskIds: [],
+		planningAttempts: 0,
+		...overrides,
+	};
+}
+
 // ---------------------------------------------------------------------------
 // Mock factories
 // ---------------------------------------------------------------------------
@@ -115,9 +155,38 @@ function makeRoomManager(
 	};
 }
 
-function makeGoalRepository(goalsByRoom: Record<string, RoomGoal[]> = {}): NeoQueryGoalRepository {
+function makeGoalRepository(
+	goalsByRoom: Record<string, RoomGoal[]> = {},
+	goalsById: Record<string, RoomGoal> = {},
+	executionsByGoal: Record<string, MissionExecution[]> = {}
+): NeoQueryGoalRepository {
 	return {
 		listGoals: (roomId) => goalsByRoom[roomId] ?? [],
+		getGoal: (id) => goalsById[id] ?? null,
+		listExecutions: (goalId, limit) => {
+			const execs = executionsByGoal[goalId] ?? [];
+			return limit !== undefined ? execs.slice(0, limit) : execs;
+		},
+	};
+}
+
+function makeTaskRepository(
+	tasksByRoom: Record<string, NeoTask[]> = {},
+	tasksById: Record<string, NeoTask> = {}
+): NeoQueryTaskRepository {
+	return {
+		listTasks: (roomId, filter) => {
+			let tasks = tasksByRoom[roomId] ?? [];
+			if (!filter?.includeArchived) {
+				tasks = tasks.filter((t) => t.status !== 'archived');
+			}
+			if (filter?.status) {
+				tasks = tasks.filter((t) => t.status === filter.status);
+			}
+			// Note: no assignedAgent in real TaskFilter — handler filters in-memory
+			return tasks;
+		},
+		getTask: (id) => tasksById[id] ?? null,
 	};
 }
 
@@ -342,6 +411,7 @@ function makeConfig(overrides: Partial<NeoToolsConfig> = {}): NeoToolsConfig {
 	return {
 		roomManager: makeRoomManager(),
 		goalRepository: makeGoalRepository(),
+		taskRepository: makeTaskRepository(),
 		sessionManager: makeSessionManager(),
 		settingsManager: makeSettingsManager(),
 		authManager: makeAuthManager(true),
@@ -960,7 +1030,6 @@ describe('get_skill_details', () => {
 	});
 });
 
-// ---------------------------------------------------------------------------
 // list_spaces
 // ---------------------------------------------------------------------------
 
@@ -1349,6 +1418,546 @@ describe('list_space_runs', () => {
 });
 
 // ---------------------------------------------------------------------------
+// list_goals
+// ---------------------------------------------------------------------------
+
+describe('list_goals', () => {
+	it('returns empty array when no goals exist', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.list_goals({}));
+		expect(result).toEqual([]);
+	});
+
+	it('returns goals across all rooms when no room_id filter', async () => {
+		const room1 = makeRoom({ id: 'room-1', name: 'Room 1' });
+		const room2 = makeRoom({ id: 'room-2', name: 'Room 2' });
+		const goal1 = makeGoal({ id: 'g1', roomId: 'room-1' });
+		const goal2 = makeGoal({ id: 'g2', roomId: 'room-2' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room1, room2]),
+				goalRepository: makeGoalRepository({ 'room-1': [goal1], 'room-2': [goal2] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_goals({}));
+		expect(result).toHaveLength(2);
+		expect(result.map((g: { id: string }) => g.id)).toEqual(expect.arrayContaining(['g1', 'g2']));
+	});
+
+	it('includes roomName in each goal', async () => {
+		const room = makeRoom({ id: 'room-1', name: 'My Room' });
+		const goal = makeGoal({ id: 'g1', roomId: 'room-1' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': [goal] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_goals({}));
+		expect(result[0].roomName).toBe('My Room');
+	});
+
+	it('filters to a specific room when room_id is provided', async () => {
+		const room1 = makeRoom({ id: 'room-1', name: 'Room 1' });
+		const room2 = makeRoom({ id: 'room-2', name: 'Room 2' });
+		const goal1 = makeGoal({ id: 'g1', roomId: 'room-1' });
+		const goal2 = makeGoal({ id: 'g2', roomId: 'room-2' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room1, room2]),
+				goalRepository: makeGoalRepository({ 'room-1': [goal1], 'room-2': [goal2] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_goals({ room_id: 'room-1' }));
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('g1');
+	});
+
+	it('returns error when room_id refers to non-existent room', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.list_goals({ room_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('filters by mission_type', async () => {
+		const room = makeRoom();
+		const goals = [
+			makeGoal({ id: 'g1', missionType: 'one_shot' }),
+			makeGoal({ id: 'g2', missionType: 'measurable' }),
+			makeGoal({ id: 'g3', missionType: 'recurring' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': goals }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_goals({ mission_type: 'measurable' }));
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('g2');
+	});
+
+	it('includes nextRunAt and schedulePaused for recurring goals', async () => {
+		const room = makeRoom();
+		const goal = makeGoal({
+			id: 'g1',
+			missionType: 'recurring',
+			nextRunAt: 9999,
+			schedulePaused: true,
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': [goal] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_goals({}));
+		expect(result[0].nextRunAt).toBe(9999);
+		expect(result[0].schedulePaused).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_goal_details
+// ---------------------------------------------------------------------------
+
+describe('get_goal_details', () => {
+	it('returns error when goal not found', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.get_goal_details({ goal_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('returns full goal details', async () => {
+		const room = makeRoom({ id: 'room-1', name: 'Test Room' });
+		const goal = makeGoal({
+			id: 'g1',
+			shortId: 'G001',
+			title: 'My Goal',
+			description: 'Goal description',
+			status: 'active',
+			structuredMetrics: [{ name: 'coverage', target: 80, current: 60, unit: '%' }],
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({}, { g1: goal }, {}),
+			})
+		);
+
+		const result = parseResult(await handlers.get_goal_details({ goal_id: 'g1' }));
+		expect(result.id).toBe('g1');
+		expect(result.shortId).toBe('G001');
+		expect(result.roomName).toBe('Test Room');
+		expect(result.title).toBe('My Goal');
+		expect(result.description).toBe('Goal description');
+		expect(result.structuredMetrics).toHaveLength(1);
+		expect(result.structuredMetrics[0].name).toBe('coverage');
+		expect(result.executions).toEqual([]);
+	});
+
+	it('includes execution history', async () => {
+		const room = makeRoom();
+		const goal = makeGoal({ id: 'g1' });
+		const executions = [
+			makeExecution({ id: 'e1', executionNumber: 2, status: 'completed', completedAt: 9999 }),
+			makeExecution({ id: 'e2', executionNumber: 1, status: 'completed' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({}, { g1: goal }, { g1: executions }),
+			})
+		);
+
+		const result = parseResult(await handlers.get_goal_details({ goal_id: 'g1' }));
+		expect(result.executions).toHaveLength(2);
+		expect(result.executions[0].id).toBe('e1');
+		expect(result.executions[0].executionNumber).toBe(2);
+		expect(result.executions[0].completedAt).toBe(9999);
+	});
+
+	it('respects execution_limit', async () => {
+		const room = makeRoom();
+		const goal = makeGoal({ id: 'g1' });
+		const executions = [1, 2, 3, 4, 5].map((n) =>
+			makeExecution({ id: `e${n}`, executionNumber: n })
+		);
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({}, { g1: goal }, { g1: executions }),
+			})
+		);
+
+		const result = parseResult(
+			await handlers.get_goal_details({ goal_id: 'g1', execution_limit: 2 })
+		);
+		expect(result.executions).toHaveLength(2);
+	});
+
+	it('returns null roomName when room is not found', async () => {
+		const goal = makeGoal({ id: 'g1', roomId: 'deleted-room' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				goalRepository: makeGoalRepository({}, { g1: goal }, {}),
+			})
+		);
+
+		const result = parseResult(await handlers.get_goal_details({ goal_id: 'g1' }));
+		expect(result.roomName).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_metrics
+// ---------------------------------------------------------------------------
+
+describe('get_metrics', () => {
+	it('returns error when goal not found', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.get_metrics({ goal_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('returns error for non-measurable goal', async () => {
+		const goal = makeGoal({ id: 'g1', missionType: 'one_shot' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				goalRepository: makeGoalRepository({}, { g1: goal }, {}),
+			})
+		);
+
+		const result = parseResult(await handlers.get_metrics({ goal_id: 'g1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not a measurable mission');
+	});
+
+	it('returns metrics for measurable goal', async () => {
+		const goal = makeGoal({
+			id: 'g1',
+			missionType: 'measurable',
+			structuredMetrics: [
+				{ name: 'coverage', target: 80, current: 60, unit: '%' },
+				{
+					name: 'errors',
+					target: 0,
+					current: 5,
+					unit: 'count',
+					direction: 'decrease',
+					baseline: 20,
+				},
+			],
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				goalRepository: makeGoalRepository({}, { g1: goal }, {}),
+			})
+		);
+
+		const result = parseResult(await handlers.get_metrics({ goal_id: 'g1' }));
+		expect(result.goalId).toBe('g1');
+		expect(result.missionType).toBe('measurable');
+		expect(result.metrics).toHaveLength(2);
+
+		const coverage = result.metrics[0];
+		expect(coverage.name).toBe('coverage');
+		expect(coverage.target).toBe(80);
+		expect(coverage.current).toBe(60);
+		expect(coverage.unit).toBe('%');
+		// progress: 60/80 * 100 = 75
+		expect(coverage.progressPct).toBe(75);
+
+		const errors = result.metrics[1];
+		expect(errors.name).toBe('errors');
+		expect(errors.direction).toBe('decrease');
+		// progress: (20-5)/(20-0) * 100 = 75
+		expect(errors.progressPct).toBe(75);
+	});
+
+	it('handles goal with no structuredMetrics', async () => {
+		const goal = makeGoal({ id: 'g1', missionType: 'measurable', structuredMetrics: [] });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				goalRepository: makeGoalRepository({}, { g1: goal }, {}),
+			})
+		);
+
+		const result = parseResult(await handlers.get_metrics({ goal_id: 'g1' }));
+		expect(result.metrics).toEqual([]);
+	});
+
+	it('returns 100% progress when decrease metric baseline equals target', async () => {
+		const goal = makeGoal({
+			id: 'g1',
+			missionType: 'measurable',
+			// baseline === target means the goal was already at its target when created
+			structuredMetrics: [
+				{ name: 'errors', target: 0, current: 0, direction: 'decrease', baseline: 0 },
+			],
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				goalRepository: makeGoalRepository({}, { g1: goal }, {}),
+			})
+		);
+
+		const result = parseResult(await handlers.get_metrics({ goal_id: 'g1' }));
+		expect(result.metrics[0].progressPct).toBe(100);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// list_tasks
+// ---------------------------------------------------------------------------
+
+describe('list_tasks', () => {
+	it('returns empty array when no tasks exist', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.list_tasks({}));
+		expect(result).toEqual([]);
+	});
+
+	it('returns tasks across all rooms when no room_id filter', async () => {
+		const room1 = makeRoom({ id: 'room-1', name: 'Room 1' });
+		const room2 = makeRoom({ id: 'room-2', name: 'Room 2' });
+		const task1 = makeTask({ id: 't1', roomId: 'room-1' });
+		const task2 = makeTask({ id: 't2', roomId: 'room-2' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room1, room2]),
+				taskRepository: makeTaskRepository({ 'room-1': [task1], 'room-2': [task2] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({}));
+		expect(result).toHaveLength(2);
+		expect(result.map((t: { id: string }) => t.id)).toEqual(expect.arrayContaining(['t1', 't2']));
+	});
+
+	it('includes roomName in each task', async () => {
+		const room = makeRoom({ id: 'room-1', name: 'My Room' });
+		const task = makeTask({ id: 't1', roomId: 'room-1' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': [task] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({}));
+		expect(result[0].roomName).toBe('My Room');
+	});
+
+	it('filters to a specific room when room_id is provided', async () => {
+		const room1 = makeRoom({ id: 'room-1', name: 'Room 1' });
+		const room2 = makeRoom({ id: 'room-2', name: 'Room 2' });
+		const task1 = makeTask({ id: 't1', roomId: 'room-1' });
+		const task2 = makeTask({ id: 't2', roomId: 'room-2' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room1, room2]),
+				taskRepository: makeTaskRepository({ 'room-1': [task1], 'room-2': [task2] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({ room_id: 'room-1' }));
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('t1');
+	});
+
+	it('returns error when room_id refers to non-existent room', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.list_tasks({ room_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('filters by status', async () => {
+		const room = makeRoom();
+		const tasks = [
+			makeTask({ id: 't1', status: 'pending' }),
+			makeTask({ id: 't2', status: 'in_progress' }),
+			makeTask({ id: 't3', status: 'completed' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': tasks }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({ status: 'pending' }));
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('t1');
+	});
+
+	it('filters by assigned_agent', async () => {
+		const room = makeRoom();
+		const tasks = [
+			makeTask({ id: 't1', assignedAgent: 'coder' }),
+			makeTask({ id: 't2', assignedAgent: 'general' }),
+			makeTask({ id: 't3', assignedAgent: 'planner' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': tasks }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({ assigned_agent: 'planner' }));
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('t3');
+	});
+
+	it('excludes archived tasks by default', async () => {
+		const room = makeRoom();
+		const tasks = [
+			makeTask({ id: 't1', status: 'pending' }),
+			makeTask({ id: 't2', status: 'archived' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': tasks }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({}));
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('t1');
+	});
+
+	it('includes archived tasks when include_archived is true', async () => {
+		const room = makeRoom();
+		const tasks = [
+			makeTask({ id: 't1', status: 'pending' }),
+			makeTask({ id: 't2', status: 'archived' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': tasks }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({ include_archived: true }));
+		expect(result).toHaveLength(2);
+	});
+
+	it('auto-enables include_archived when status="archived" to avoid zero results', async () => {
+		const room = makeRoom();
+		const tasks = [
+			makeTask({ id: 't1', status: 'pending' }),
+			makeTask({ id: 't2', status: 'archived' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': tasks }),
+			})
+		);
+
+		// Without auto-include fix, requesting archived status would return zero results
+		const result = parseResult(await handlers.list_tasks({ status: 'archived' }));
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('t2');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_task_detail
+// ---------------------------------------------------------------------------
+
+describe('get_task_detail', () => {
+	it('returns error when task not found', async () => {
+		const handlers = createNeoQueryToolHandlers(makeConfig());
+		const result = parseResult(await handlers.get_task_detail({ task_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('missing');
+	});
+
+	it('returns full task details', async () => {
+		const room = makeRoom({ id: 'room-1', name: 'Test Room' });
+		const task = makeTask({
+			id: 't1',
+			shortId: 'T001',
+			title: 'My Task',
+			description: 'Task description',
+			status: 'in_progress',
+			priority: 'high',
+			taskType: 'coding',
+			assignedAgent: 'coder',
+			dependsOn: ['dep-1'],
+			prUrl: 'https://github.com/org/repo/pulls/42',
+			prNumber: 42,
+		});
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({}, { t1: task }),
+			})
+		);
+
+		const result = parseResult(await handlers.get_task_detail({ task_id: 't1' }));
+		expect(result.id).toBe('t1');
+		expect(result.shortId).toBe('T001');
+		expect(result.roomName).toBe('Test Room');
+		expect(result.title).toBe('My Task');
+		expect(result.description).toBe('Task description');
+		expect(result.status).toBe('in_progress');
+		expect(result.priority).toBe('high');
+		expect(result.dependsOn).toEqual(['dep-1']);
+		expect(result.prUrl).toBe('https://github.com/org/repo/pulls/42');
+		expect(result.prNumber).toBe(42);
+	});
+
+	it('returns null for optional fields when unset', async () => {
+		const task = makeTask({ id: 't1' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				taskRepository: makeTaskRepository({}, { t1: task }),
+			})
+		);
+
+		const result = parseResult(await handlers.get_task_detail({ task_id: 't1' }));
+		expect(result.shortId).toBeNull();
+		expect(result.roomName).toBeNull();
+		expect(result.progress).toBeNull();
+		expect(result.currentStep).toBeNull();
+		expect(result.result).toBeNull();
+		expect(result.error).toBeNull();
+		expect(result.prUrl).toBeNull();
+		expect(result.prNumber).toBeNull();
+		expect(result.startedAt).toBeNull();
+		expect(result.completedAt).toBeNull();
+		expect(result.archivedAt).toBeNull();
+		expect(result.restrictions).toBeNull();
+	});
+
+	it('includes createdByTaskId when set', async () => {
+		const task = makeTask({ id: 't1', createdByTaskId: 'parent-task' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				taskRepository: makeTaskRepository({}, { t1: task }),
+			})
+		);
+
+		const result = parseResult(await handlers.get_task_detail({ task_id: 't1' }));
+		expect(result.createdByTaskId).toBe('parent-task');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // MCP server — tool registration
 // ---------------------------------------------------------------------------
 
@@ -1423,7 +2032,27 @@ describe('createNeoQueryMcpServer', () => {
 		expect(server.instance._registeredTools).toHaveProperty('list_space_runs');
 	});
 
-	it('registers exactly 15 tools', () => {
-		expect(Object.keys(server.instance._registeredTools)).toHaveLength(15);
+	it('registers list_goals tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('list_goals');
+	});
+
+	it('registers get_goal_details tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_goal_details');
+	});
+
+	it('registers get_metrics tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_metrics');
+	});
+
+	it('registers list_tasks tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('list_tasks');
+	});
+
+	it('registers get_task_detail tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('get_task_detail');
+	});
+
+	it('registers exactly 20 tools', () => {
+		expect(Object.keys(server.instance._registeredTools)).toHaveLength(20);
 	});
 });

--- a/packages/e2e/tests/features/neo-panel.e2e.ts
+++ b/packages/e2e/tests/features/neo-panel.e2e.ts
@@ -1,0 +1,222 @@
+/**
+ * Neo Panel E2E Tests
+ *
+ * Tests for the core Neo panel interaction flow:
+ * - NavRail Neo button visibility, clickability, and active state
+ * - Panel open/close behavior (button, close button, backdrop, Escape key)
+ * - Tab switching (Chat / Activity)
+ * - localStorage state persistence across page reload
+ * - Cmd+J / Ctrl+J keyboard shortcut toggle
+ */
+
+import { test, expect } from '../../fixtures';
+import type { Page } from '@playwright/test';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Locate the Neo NavRail button by its aria-label */
+function getNeoNavButton(page: Page) {
+	return page.locator('button[aria-label="Neo (⌘J)"]');
+}
+
+/** Locate the Neo panel container */
+function getNeoPanel(page: Page) {
+	return page.locator('[data-testid="neo-panel"]');
+}
+
+/** Locate the Neo panel backdrop */
+function getNeoBackdrop(page: Page) {
+	return page.locator('[data-testid="neo-panel-backdrop"]');
+}
+
+/** Wait for the panel to be visible (translated into view) */
+async function waitForPanelOpen(page: Page) {
+	// Panel is open when -translate-x-full class is NOT applied
+	await expect(getNeoPanel(page)).not.toHaveClass(/-translate-x-full/, { timeout: 3000 });
+}
+
+/** Wait for the panel to be hidden (translated out of view) */
+async function waitForPanelClosed(page: Page) {
+	await expect(getNeoPanel(page)).toHaveClass(/-translate-x-full/, { timeout: 3000 });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Neo Panel — Core Interaction', () => {
+	test.use({ viewport: { width: 1280, height: 720 } });
+
+	test.beforeEach(async ({ page }) => {
+		// Navigate first so localStorage is accessible, then clear the persisted panel state.
+		// Using page.evaluate() (not addInitScript) so that page.reload() calls inside tests
+		// do NOT re-clear localStorage — the persistence test depends on this.
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		await page.evaluate(() => localStorage.removeItem('neo:panelOpen'));
+		// Reload so the app initialises with the cleared localStorage value
+		await page.reload();
+		await waitForWebSocketConnected(page);
+	});
+
+	// ── 1. NavRail Neo button visible ──────────────────────────────────────
+
+	test('NavRail Neo button is visible', async ({ page }) => {
+		await expect(getNeoNavButton(page)).toBeVisible({ timeout: 5000 });
+	});
+
+	// ── 2. NavRail button shows active state when panel is open ───────────
+
+	test('NavRail Neo button shows active state (aria-pressed) when panel is open', async ({
+		page,
+	}) => {
+		const btn = getNeoNavButton(page);
+		await expect(btn).toHaveAttribute('aria-pressed', 'false');
+
+		await btn.click();
+		await waitForPanelOpen(page);
+		await expect(btn).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	// ── 3. Clicking button opens panel ────────────────────────────────────
+
+	test('clicking Neo button opens the panel and focuses the close button', async ({ page }) => {
+		await getNeoNavButton(page).click();
+		await waitForPanelOpen(page);
+
+		// NeoPanel.tsx focuses the close button via requestAnimationFrame for accessibility
+		const closeBtn = page.locator('[data-testid="neo-panel-close"]');
+		await expect(closeBtn).toBeVisible({ timeout: 3000 });
+		await expect(closeBtn).toBeFocused({ timeout: 3000 });
+	});
+
+	// ── 4. Chat tab active by default ─────────────────────────────────────
+
+	test('Neo panel displays with Chat tab active by default', async ({ page }) => {
+		await getNeoNavButton(page).click();
+		await waitForPanelOpen(page);
+
+		const chatTab = page.locator('[data-testid="neo-tab-chat"]');
+		await expect(chatTab).toBeVisible({ timeout: 3000 });
+		await expect(chatTab).toHaveAttribute('aria-selected', 'true');
+
+		const activityTab = page.locator('[data-testid="neo-tab-activity"]');
+		await expect(activityTab).toHaveAttribute('aria-selected', 'false');
+
+		// Chat view should be present
+		await expect(page.locator('[data-testid="neo-chat-view"]')).toBeVisible({ timeout: 3000 });
+	});
+
+	// ── 5. Tab switching ───────────────────────────────────────────────────
+
+	test('can switch between Chat and Activity tabs', async ({ page }) => {
+		await getNeoNavButton(page).click();
+		await waitForPanelOpen(page);
+
+		// Switch to Activity tab
+		const activityTab = page.locator('[data-testid="neo-tab-activity"]');
+		await activityTab.click();
+		await expect(activityTab).toHaveAttribute('aria-selected', 'true');
+		await expect(page.locator('[data-testid="neo-tab-chat"]')).toHaveAttribute(
+			'aria-selected',
+			'false'
+		);
+		// Chat view is conditionally rendered — not present in DOM when Activity is active
+		await expect(page.locator('[data-testid="neo-chat-view"]')).not.toBeVisible({ timeout: 2000 });
+
+		// Switch back to Chat tab
+		const chatTab = page.locator('[data-testid="neo-tab-chat"]');
+		await chatTab.click();
+		await expect(chatTab).toHaveAttribute('aria-selected', 'true');
+		await expect(page.locator('[data-testid="neo-chat-view"]')).toBeVisible({ timeout: 2000 });
+	});
+
+	// ── 6. Close button dismisses panel ───────────────────────────────────
+
+	test('close button dismisses the Neo panel', async ({ page }) => {
+		await getNeoNavButton(page).click();
+		await waitForPanelOpen(page);
+
+		const closeBtn = page.locator('[data-testid="neo-panel-close"]');
+		await expect(closeBtn).toBeVisible({ timeout: 3000 });
+		await closeBtn.click();
+
+		await waitForPanelClosed(page);
+	});
+
+	// ── 7. Escape key dismisses panel ─────────────────────────────────────
+
+	test('Escape key dismisses the Neo panel', async ({ page }) => {
+		await getNeoNavButton(page).click();
+		await waitForPanelOpen(page);
+
+		await page.keyboard.press('Escape');
+		await waitForPanelClosed(page);
+	});
+
+	// ── 8. Click outside (backdrop) dismisses panel ────────────────────────
+
+	test('clicking outside (backdrop) dismisses the Neo panel', async ({ page }) => {
+		await getNeoNavButton(page).click();
+		await waitForPanelOpen(page);
+
+		// Click the backdrop overlay
+		const backdrop = getNeoBackdrop(page);
+		await expect(backdrop).toBeVisible({ timeout: 3000 });
+		await backdrop.click({ position: { x: 5, y: 5 } });
+
+		await waitForPanelClosed(page);
+	});
+
+	// ── 9. Panel state persists across page reload ─────────────────────────
+
+	test('panel open state persists across page navigation via localStorage', async ({ page }) => {
+		// Open the panel — DOM confirms it is open
+		await getNeoNavButton(page).click();
+		await waitForPanelOpen(page);
+
+		// Reload (addInitScript does NOT run on reload, so localStorage survives)
+		await page.reload();
+		await waitForWebSocketConnected(page);
+
+		// Panel should still be open after reload — DOM-based assertion
+		await waitForPanelOpen(page);
+
+		// Close the panel
+		await page.locator('[data-testid="neo-panel-close"]').click();
+		await waitForPanelClosed(page);
+
+		// Reload again — panel should remain closed
+		await page.reload();
+		await waitForWebSocketConnected(page);
+
+		await waitForPanelClosed(page);
+	});
+
+	// ── 10. Cmd+J / Ctrl+J keyboard shortcut toggles panel ────────────────
+
+	test('Cmd+J / Ctrl+J keyboard shortcut toggles the Neo panel', async ({ page }) => {
+		// Determine platform modifier (Meta on macOS, Control otherwise)
+		const isMac = process.platform === 'darwin';
+		const modifier = isMac ? 'Meta' : 'Control';
+
+		// Ensure focus is not on an input element — the shortcut handler guards against
+		// firing when focus is inside INPUT / TEXTAREA / contentEditable
+		await page.locator('body').click();
+
+		// Panel should start closed
+		await waitForPanelClosed(page);
+
+		// Press shortcut to open
+		await page.keyboard.press(`${modifier}+j`);
+		await waitForPanelOpen(page);
+
+		// Press shortcut again to close (body has focus; panel close button had it — click body first)
+		await page.locator('body').click();
+		await page.keyboard.press(`${modifier}+j`);
+		await waitForPanelClosed(page);
+	});
+});

--- a/packages/e2e/tests/features/neo-settings.e2e.ts
+++ b/packages/e2e/tests/features/neo-settings.e2e.ts
@@ -1,0 +1,286 @@
+/**
+ * Neo Settings E2E Tests
+ *
+ * Tests the Neo settings section in Global Settings:
+ * - Neo section is visible in Settings navigation
+ * - Security mode selector changes and persists across page reload
+ * - Model selector shows available models and persists selection
+ * - Clear Session button shows confirmation dialog
+ * - Confirming clear session resets the Neo chat (toast confirmation)
+ * - Canceling clear session preserves the chat (dialog dismissed)
+ *
+ * Note: Full verification of Neo chat content reset/preservation (subtasks 5–6)
+ * requires the Neo Panel slide-out UI (task 7.3), which is not yet implemented.
+ * Those tests are marked fixme until the panel renders messages.
+ *
+ * Setup: no room needed; tests the Global Settings > Neo Agent panel directly.
+ */
+
+import { test, expect } from '../../fixtures';
+import type { Page } from '@playwright/test';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { openSettingsModal } from '../helpers/settings-modal-helpers';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Navigate to the Neo Agent section inside the Global Settings panel.
+ * Assumes Global Settings is already open.
+ */
+async function navigateToNeoSection(page: Page): Promise<void> {
+	await page.getByRole('button', { name: 'Neo Agent', exact: true }).click();
+	await expect(page.locator('h3:has-text("Neo Agent")')).toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * Open Global Settings and navigate straight to the Neo Agent section.
+ */
+async function openNeoSettings(page: Page): Promise<void> {
+	await openSettingsModal(page);
+	await navigateToNeoSection(page);
+}
+
+/**
+ * Return a locator for the Neo Agent section container (h3's parent div).
+ * Scoping selectors to this container prevents cross-section interference.
+ */
+function getNeoSectionLocator(page: Page) {
+	return page.locator('h3:has-text("Neo Agent")').locator('..');
+}
+
+/**
+ * Return the select for a given SettingsRow label within the Neo Agent section.
+ *
+ * SettingsRow structure:
+ *   div.flex                   ← row
+ *     div.flex-1
+ *       div.text-sm "label"    ← matched by hasText; navigate up to div.flex-1
+ *       div.text-xs "desc"
+ *     div.flex-shrink-0        ← following-sibling of div.flex-1
+ *       select                 ← the control
+ *
+ * The XPath `../following-sibling::div` walks from the label div up one level
+ * (to div.flex-1) and then to its sibling (div.flex-shrink-0), so the result
+ * is resilient to row reordering within the Neo section.
+ */
+function getSelectByLabel(page: Page, label: string) {
+	return getNeoSectionLocator(page)
+		.locator('div', { hasText: new RegExp(`^${label}$`) })
+		.locator('xpath=../following-sibling::div')
+		.locator('select');
+}
+
+/** Security Mode <select> — identified by its row label. */
+function getSecurityModeSelect(page: Page) {
+	return getSelectByLabel(page, 'Security Mode');
+}
+
+/** Model <select> — identified by its row label. */
+function getModelSelect(page: Page) {
+	return getSelectByLabel(page, 'Model');
+}
+
+// ─── Navigation ───────────────────────────────────────────────────────────────
+
+test.describe('Neo Settings - Navigation', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+	});
+
+	test('should show Neo Agent section in Settings navigation', async ({ page }) => {
+		await openSettingsModal(page);
+		await expect(page.getByRole('button', { name: 'Neo Agent', exact: true })).toBeVisible();
+	});
+
+	test('should display Neo Agent settings content when section is selected', async ({ page }) => {
+		await openNeoSettings(page);
+
+		// Section heading
+		await expect(page.locator('h3:has-text("Neo Agent")')).toBeVisible();
+
+		// All three setting rows should be present (scoped to avoid sidebar matches)
+		const neoSection = getNeoSectionLocator(page);
+		await expect(neoSection.locator('text=Security Mode')).toBeVisible();
+		await expect(neoSection.locator('div', { hasText: /^Model$/ })).toBeVisible();
+		await expect(neoSection.locator('text=Clear Session')).toBeVisible();
+	});
+});
+
+// ─── Security Mode ────────────────────────────────────────────────────────────
+
+test.describe('Neo Settings - Security Mode', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		await openNeoSettings(page);
+	});
+
+	test('should show security mode selector with expected options', async ({ page }) => {
+		const select = getSecurityModeSelect(page);
+		await expect(select).toBeVisible();
+		await expect(select.locator('option:has-text("Conservative")')).toBeAttached();
+		await expect(select.locator('option:has-text("Balanced (default)")')).toBeAttached();
+		await expect(select.locator('option:has-text("Autonomous")')).toBeAttached();
+	});
+
+	test('should change security mode and show success toast', async ({ page }) => {
+		const select = getSecurityModeSelect(page);
+		await select.selectOption('conservative');
+		await expect(page.locator('text=Security mode updated')).toBeVisible({ timeout: 5000 });
+		await expect(select).toHaveValue('conservative');
+	});
+
+	test('should persist security mode selection across page reload', async ({ page }) => {
+		// Change to autonomous
+		await getSecurityModeSelect(page).selectOption('autonomous');
+		await expect(page.locator('text=Security mode updated')).toBeVisible({ timeout: 5000 });
+
+		// Reload and re-open Neo settings
+		await page.reload();
+		await waitForWebSocketConnected(page);
+		await openNeoSettings(page);
+
+		// Value should be persisted
+		await expect(getSecurityModeSelect(page)).toHaveValue('autonomous');
+	});
+
+	test.afterEach(async ({ page }) => {
+		// Restore to balanced regardless of test outcome
+		try {
+			await openNeoSettings(page);
+			const select = getSecurityModeSelect(page);
+			const current = await select.inputValue();
+			if (current !== 'balanced') {
+				await select.selectOption('balanced');
+				await page
+					.locator('text=Security mode updated')
+					.waitFor({ state: 'visible', timeout: 5000 });
+			}
+		} catch {
+			// Best-effort cleanup; don't fail the test on cleanup errors
+		}
+	});
+});
+
+// ─── Model Selector ───────────────────────────────────────────────────────────
+
+test.describe('Neo Settings - Model Selector', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		await openNeoSettings(page);
+	});
+
+	test('should show model selector with available options', async ({ page }) => {
+		const select = getModelSelect(page);
+		await expect(select).toBeVisible();
+		await expect(select.locator('option:has-text("App default")')).toBeAttached();
+		await expect(select.locator('option:has-text("Claude Sonnet 4")')).toBeAttached();
+		await expect(select.locator('option:has-text("Claude Opus 4")')).toBeAttached();
+		await expect(select.locator('option:has-text("Claude Haiku 3.5")')).toBeAttached();
+	});
+
+	test('should change model and show success toast', async ({ page }) => {
+		const select = getModelSelect(page);
+		await select.selectOption('sonnet');
+		await expect(page.locator('text=Model updated')).toBeVisible({ timeout: 5000 });
+		await expect(select).toHaveValue('sonnet');
+	});
+
+	test('should persist model selection across page reload', async ({ page }) => {
+		// Pick a target value different from whatever is currently set
+		const select = getModelSelect(page);
+		const current = await select.inputValue();
+		const target = current === 'opus' ? 'sonnet' : 'opus';
+
+		await select.selectOption(target);
+		await expect(page.locator('text=Model updated')).toBeVisible({ timeout: 5000 });
+
+		// Reload and re-open Neo settings
+		await page.reload();
+		await waitForWebSocketConnected(page);
+		await openNeoSettings(page);
+
+		// Value should be persisted
+		await expect(getModelSelect(page)).toHaveValue(target);
+	});
+
+	test.afterEach(async ({ page }) => {
+		// Restore to app default (empty string) regardless of test outcome
+		try {
+			await openNeoSettings(page);
+			const select = getModelSelect(page);
+			const current = await select.inputValue();
+			if (current !== '') {
+				await select.selectOption('');
+				await page.locator('text=Model updated').waitFor({ state: 'visible', timeout: 5000 });
+			}
+		} catch {
+			// Best-effort cleanup; don't fail the test on cleanup errors
+		}
+	});
+});
+
+// ─── Clear Session ────────────────────────────────────────────────────────────
+
+test.describe('Neo Settings - Clear Session', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		await openNeoSettings(page);
+	});
+
+	test('should show confirmation dialog when Clear Session is clicked', async ({ page }) => {
+		await page.getByRole('button', { name: 'Clear Session', exact: true }).click();
+
+		// Confirmation elements should appear
+		await expect(page.locator('text=Are you sure?')).toBeVisible({ timeout: 3000 });
+		await expect(page.getByRole('button', { name: 'Confirm', exact: true })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Cancel', exact: true })).toBeVisible();
+
+		// Original button should be replaced
+		await expect(page.getByRole('button', { name: 'Clear Session', exact: true })).toBeHidden();
+	});
+
+	test('should clear Neo session and show success toast when Confirm is clicked', async ({
+		page,
+	}) => {
+		await page.getByRole('button', { name: 'Clear Session', exact: true }).click();
+		await expect(page.locator('text=Are you sure?')).toBeVisible({ timeout: 3000 });
+
+		await page.getByRole('button', { name: 'Confirm', exact: true }).click();
+
+		// Success toast confirms the server-side clear succeeded
+		await expect(page.locator('text=Neo session cleared')).toBeVisible({ timeout: 5000 });
+
+		// Dialog dismisses; button restores
+		await expect(page.locator('text=Are you sure?')).toBeHidden({ timeout: 3000 });
+		await expect(page.getByRole('button', { name: 'Clear Session', exact: true })).toBeVisible({
+			timeout: 3000,
+		});
+
+		// TODO: once the Neo Panel slide-out (task 7.3) is implemented, add:
+		//   1. Send a message via the Neo panel before clicking Clear Session
+		//   2. After confirming, open the Neo panel and assert no messages are visible
+	});
+
+	test('should dismiss confirmation dialog when Cancel is clicked', async ({ page }) => {
+		await page.getByRole('button', { name: 'Clear Session', exact: true }).click();
+		await expect(page.locator('text=Are you sure?')).toBeVisible({ timeout: 3000 });
+
+		await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+
+		// Dialog should be dismissed without clearing
+		await expect(page.locator('text=Are you sure?')).toBeHidden({ timeout: 3000 });
+		await expect(page.getByRole('button', { name: 'Clear Session', exact: true })).toBeVisible({
+			timeout: 3000,
+		});
+		// No toast means no session was cleared
+		await expect(page.locator('text=Neo session cleared')).toBeHidden();
+
+		// TODO: once the Neo Panel slide-out (task 7.3) is implemented, add:
+		//   1. Send a message via the Neo panel before clicking Clear Session
+		//   2. After cancelling, open the Neo panel and assert the message is still present
+	});
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'preact/hooks';
 import { effect, batch } from '@preact/signals';
 import { useNeoKeyboardShortcut } from './hooks/useNeoKeyboardShortcut.ts';
+import { NeoPanel } from './components/neo/NeoPanel.tsx';
 import { NavRail } from './islands/NavRail.tsx';
 import { BottomTabBar } from './islands/BottomTabBar.tsx';
 import { ContextPanel } from './islands/ContextPanel.tsx';
@@ -192,6 +193,9 @@ export function App() {
 
 			{/* Connection Overlay - blocks UI when disconnected */}
 			<ConnectionOverlay />
+
+			{/* Neo AI Assistant Panel */}
+			<NeoPanel />
 		</>
 	);
 }

--- a/packages/web/src/components/neo/NeoActivityView.test.tsx
+++ b/packages/web/src/components/neo/NeoActivityView.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Tests for NeoActivityView
+ *
+ * Verifies:
+ * - Loading state when activity is empty and loading=true
+ * - Empty state when no activity and not loading
+ * - Renders activity entries
+ * - Each entry shows tool name, relative timestamp, status badge
+ * - Clicking entry expands details
+ * - Clicking again collapses details
+ * - Status badge shows correct variant (success / error / cancelled)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import type { NeoActivityEntry } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore — signals defined inside factory to avoid hoisting issues
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', async () => {
+	const { signal: s } = await import('@preact/signals');
+	const activity = s<NeoActivityEntry[]>([]);
+	const loading = s(false);
+	return {
+		neoStore: { activity, loading },
+	};
+});
+
+import { NeoActivityView } from './NeoActivityView.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(
+	partial: Partial<NeoActivityEntry> & { id: string; toolName: string }
+): NeoActivityEntry {
+	return {
+		input: null,
+		output: null,
+		status: 'success',
+		error: null,
+		targetType: null,
+		targetId: null,
+		undoable: false,
+		undoData: null,
+		createdAt: new Date().toISOString(),
+		...partial,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoActivityView', () => {
+	beforeEach(() => {
+		neoStore.activity.value = [];
+		neoStore.loading.value = false;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows loading state when activity empty and loading=true', () => {
+		neoStore.loading.value = true;
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('neo-activity-loading')).toBeTruthy();
+	});
+
+	it('shows empty state when no activity and not loading', () => {
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('neo-activity-empty')).toBeTruthy();
+	});
+
+	it('does not show empty state when entries exist', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'create_room' })];
+		const { queryByTestId } = render(<NeoActivityView />);
+		expect(queryByTestId('neo-activity-empty')).toBeNull();
+	});
+
+	it('renders activity entries', () => {
+		neoStore.activity.value = [
+			makeEntry({ id: '1', toolName: 'create_room' }),
+			makeEntry({ id: '2', toolName: 'delete_room', status: 'error' }),
+		];
+		const { getAllByTestId } = render(<NeoActivityView />);
+		expect(getAllByTestId('activity-entry')).toHaveLength(2);
+	});
+
+	it('formats tool_name to title case', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'create_room' })];
+		const { getByText } = render(<NeoActivityView />);
+		expect(getByText('Create Room')).toBeTruthy();
+	});
+
+	it('shows success badge for successful entry', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'create_room', status: 'success' })];
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('activity-status-success')).toBeTruthy();
+	});
+
+	it('shows error badge for failed entry', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'delete_room', status: 'error' })];
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('activity-status-error')).toBeTruthy();
+	});
+
+	it('shows cancelled badge for cancelled entry', () => {
+		neoStore.activity.value = [
+			makeEntry({ id: '1', toolName: 'stop_session', status: 'cancelled' }),
+		];
+		const { getByTestId } = render(<NeoActivityView />);
+		expect(getByTestId('activity-status-cancelled')).toBeTruthy();
+	});
+
+	it('expands details when entry is clicked', () => {
+		neoStore.activity.value = [
+			makeEntry({
+				id: '1',
+				toolName: 'create_room',
+				input: JSON.stringify({ name: 'my-room' }),
+				output: JSON.stringify({ id: 'room-123' }),
+			}),
+		];
+		const { getByTestId, queryByTestId } = render(<NeoActivityView />);
+		expect(queryByTestId('activity-entry-details')).toBeNull();
+
+		act(() => {
+			fireEvent.click(getByTestId('activity-entry').querySelector('button')!);
+		});
+		expect(getByTestId('activity-entry-details')).toBeTruthy();
+	});
+
+	it('collapses details on second click', () => {
+		neoStore.activity.value = [makeEntry({ id: '1', toolName: 'create_room' })];
+		const { getByTestId, queryByTestId } = render(<NeoActivityView />);
+		const btn = getByTestId('activity-entry').querySelector('button')!;
+
+		act(() => {
+			fireEvent.click(btn);
+		});
+		expect(getByTestId('activity-entry-details')).toBeTruthy();
+
+		act(() => {
+			fireEvent.click(btn);
+		});
+		expect(queryByTestId('activity-entry-details')).toBeNull();
+	});
+
+	it('shows target from targetType + targetId', () => {
+		neoStore.activity.value = [
+			makeEntry({
+				id: '1',
+				toolName: 'get_room_status',
+				targetType: 'room',
+				targetId: 'prod-api',
+			}),
+		];
+		const { getByText } = render(<NeoActivityView />);
+		expect(getByText('room prod-api')).toBeTruthy();
+	});
+
+	it('shows error text in summary for error status', () => {
+		neoStore.activity.value = [
+			makeEntry({
+				id: '1',
+				toolName: 'delete_room',
+				status: 'error',
+				error: 'Room has active sessions',
+			}),
+		];
+		const { getByText } = render(<NeoActivityView />);
+		expect(getByText('Room has active sessions')).toBeTruthy();
+	});
+
+	it('shows all entries when multiple provided', () => {
+		neoStore.activity.value = Array.from({ length: 5 }, (_, i) =>
+			makeEntry({ id: String(i), toolName: `tool_${i}` })
+		);
+		const { getAllByTestId } = render(<NeoActivityView />);
+		expect(getAllByTestId('activity-entry')).toHaveLength(5);
+	});
+});

--- a/packages/web/src/components/neo/NeoActivityView.tsx
+++ b/packages/web/src/components/neo/NeoActivityView.tsx
@@ -1,0 +1,319 @@
+/**
+ * NeoActivityView
+ *
+ * Scrollable list of Neo's past actions from neoStore.activity.
+ * Each entry shows: timestamp, tool name, target description, status, outcome.
+ * Click to expand for full details.
+ */
+
+import { useState } from 'preact/hooks';
+import { neoStore, type NeoActivityEntry } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTimestamp(isoString: string): string {
+	try {
+		const date = new Date(isoString);
+		const now = new Date();
+		const diffMs = now.getTime() - date.getTime();
+		const diffSecs = Math.floor(diffMs / 1000);
+		const diffMins = Math.floor(diffSecs / 60);
+		const diffHours = Math.floor(diffMins / 60);
+		const diffDays = Math.floor(diffHours / 24);
+
+		if (diffSecs < 60) return 'just now';
+		if (diffMins < 60) return `${diffMins}m ago`;
+		if (diffHours < 24) return `${diffHours}h ago`;
+		if (diffDays < 7) return `${diffDays}d ago`;
+		return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	} catch {
+		return isoString;
+	}
+}
+
+/** Format tool_name → "Tool Name" */
+function formatToolName(toolName: string): string {
+	return toolName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Try to extract a human-readable target description from JSON input. */
+function extractTarget(entry: NeoActivityEntry): string {
+	if (entry.targetType && entry.targetId) {
+		return `${entry.targetType} ${entry.targetId}`;
+	}
+	if (entry.input) {
+		try {
+			const parsed = JSON.parse(entry.input) as Record<string, unknown>;
+			// Look for common naming fields
+			const name =
+				parsed['name'] ??
+				parsed['title'] ??
+				parsed['id'] ??
+				parsed['roomId'] ??
+				parsed['spaceId'] ??
+				parsed['goalId'] ??
+				parsed['taskId'];
+			if (typeof name === 'string' && name.length > 0) return name;
+		} catch {
+			/* ignore */
+		}
+	}
+	return '';
+}
+
+/** Extract outcome summary from JSON output string. */
+function extractOutcome(entry: NeoActivityEntry): string {
+	if (entry.error) return entry.error;
+	if (!entry.output) return '';
+	try {
+		const parsed = JSON.parse(entry.output) as Record<string, unknown>;
+		if (typeof parsed['summary'] === 'string') return parsed['summary'];
+		if (typeof parsed['message'] === 'string') return parsed['message'];
+		if (typeof parsed['error'] === 'string') return parsed['error'];
+	} catch {
+		if (entry.output.length < 120) return entry.output;
+	}
+	return '';
+}
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }: { status: NeoActivityEntry['status'] }) {
+	if (status === 'success') {
+		return (
+			<span
+				data-testid="activity-status-success"
+				class="inline-flex items-center gap-1 text-xs text-green-400"
+			>
+				<svg
+					class="w-3 h-3"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2.5}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+				</svg>
+				Done
+			</span>
+		);
+	}
+	if (status === 'error') {
+		return (
+			<span
+				data-testid="activity-status-error"
+				class="inline-flex items-center gap-1 text-xs text-red-400"
+			>
+				<svg
+					class="w-3 h-3"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2.5}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+				</svg>
+				Failed
+			</span>
+		);
+	}
+	return (
+		<span
+			data-testid="activity-status-cancelled"
+			class="inline-flex items-center gap-1 text-xs text-gray-500"
+		>
+			<svg
+				class="w-3 h-3"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth={2.5}
+				aria-hidden="true"
+			>
+				<path
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+				/>
+			</svg>
+			Cancelled
+		</span>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// ActivityEntry
+// ---------------------------------------------------------------------------
+
+function ActivityEntry({ entry }: { entry: NeoActivityEntry }) {
+	const [expanded, setExpanded] = useState(false);
+
+	const target = extractTarget(entry);
+	const outcome = extractOutcome(entry);
+
+	return (
+		<div data-testid="activity-entry" class="border-b border-gray-800/80 last:border-0">
+			{/* Summary row (always visible) */}
+			<button
+				type="button"
+				class="w-full text-left px-3 py-2.5 hover:bg-gray-800/40 transition-colors flex items-start gap-2"
+				onClick={() => setExpanded((v) => !v)}
+				aria-expanded={expanded}
+			>
+				{/* Status dot */}
+				<div
+					class={`flex-shrink-0 mt-1.5 w-1.5 h-1.5 rounded-full ${
+						entry.status === 'success'
+							? 'bg-green-400'
+							: entry.status === 'error'
+								? 'bg-red-400'
+								: 'bg-gray-600'
+					}`}
+				/>
+
+				<div class="flex-1 min-w-0">
+					<div class="flex items-baseline gap-2 justify-between">
+						<span class="text-xs font-semibold text-gray-200 truncate">
+							{formatToolName(entry.toolName)}
+						</span>
+						<div class="flex items-center gap-2 flex-shrink-0">
+							<StatusBadge status={entry.status} />
+							<span class="text-xs text-gray-600">{formatTimestamp(entry.createdAt)}</span>
+						</div>
+					</div>
+
+					{target && <p class="text-xs text-gray-500 truncate mt-0.5">{target}</p>}
+
+					{outcome && (
+						<p
+							class={`text-xs mt-0.5 truncate ${entry.status === 'error' ? 'text-red-400/80' : 'text-gray-400'}`}
+						>
+							{outcome}
+						</p>
+					)}
+				</div>
+
+				{/* Chevron */}
+				<svg
+					class={`flex-shrink-0 w-3 h-3 text-gray-600 mt-1 transition-transform ${expanded ? 'rotate-180' : ''}`}
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+				</svg>
+			</button>
+
+			{/* Expanded details */}
+			{expanded && (
+				<div data-testid="activity-entry-details" class="px-3 pb-3 space-y-2 bg-gray-800/20">
+					<div class="flex items-center justify-between pt-1">
+						<span class="text-xs text-gray-600">Status</span>
+						<StatusBadge status={entry.status} />
+					</div>
+
+					{entry.input && (
+						<div>
+							<p class="text-xs text-gray-600 mb-1">Input</p>
+							<pre class="text-xs text-gray-400 bg-gray-900/60 rounded-lg p-2 overflow-x-auto whitespace-pre-wrap break-all font-mono">
+								{(() => {
+									try {
+										return JSON.stringify(JSON.parse(entry.input), null, 2);
+									} catch {
+										return entry.input;
+									}
+								})()}
+							</pre>
+						</div>
+					)}
+
+					{entry.output && (
+						<div>
+							<p class="text-xs text-gray-600 mb-1">Output</p>
+							<pre class="text-xs text-gray-400 bg-gray-900/60 rounded-lg p-2 overflow-x-auto whitespace-pre-wrap break-all font-mono">
+								{(() => {
+									try {
+										return JSON.stringify(JSON.parse(entry.output), null, 2);
+									} catch {
+										return entry.output;
+									}
+								})()}
+							</pre>
+						</div>
+					)}
+
+					{entry.error && (
+						<div>
+							<p class="text-xs text-gray-600 mb-1">Error</p>
+							<p class="text-xs text-red-400 bg-red-950/20 rounded-lg p-2">{entry.error}</p>
+						</div>
+					)}
+
+					<p class="text-xs text-gray-700">{new Date(entry.createdAt).toLocaleString()}</p>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// NeoActivityView
+// ---------------------------------------------------------------------------
+
+export function NeoActivityView() {
+	const activity = neoStore.activity.value;
+	const loading = neoStore.loading.value;
+
+	if (loading && activity.length === 0) {
+		return (
+			<div class="flex items-center justify-center h-full" data-testid="neo-activity-loading">
+				<div class="flex items-center gap-2 text-gray-500 text-xs">
+					<div class="w-3 h-3 rounded-full border-2 border-gray-600 border-t-violet-400 animate-spin" />
+					Loading activity…
+				</div>
+			</div>
+		);
+	}
+
+	if (activity.length === 0) {
+		return (
+			<div
+				data-testid="neo-activity-empty"
+				class="flex flex-col items-center justify-center h-full gap-2 text-center px-4"
+			>
+				<svg
+					class="w-8 h-8 text-gray-700"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z"
+					/>
+				</svg>
+				<p class="text-xs text-gray-600">No activity yet</p>
+				<p class="text-xs text-gray-700">Actions Neo takes will appear here.</p>
+			</div>
+		);
+	}
+
+	return (
+		<div data-testid="neo-activity-view" class="flex flex-col h-full min-h-0 overflow-y-auto">
+			{activity.map((entry) => (
+				<ActivityEntry key={entry.id} entry={entry} />
+			))}
+		</div>
+	);
+}

--- a/packages/web/src/components/neo/NeoChatView.test.tsx
+++ b/packages/web/src/components/neo/NeoChatView.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * Tests for NeoChatView
+ *
+ * Verifies:
+ * - Empty state renders when no messages
+ * - User messages render as right-aligned bubbles
+ * - Assistant messages render with sparkle avatar
+ * - Sending a message calls neoStore.sendMessage
+ * - Enter key submits; Shift+Enter does not
+ * - Send button disabled when input is empty or sending
+ * - Typing indicator shown while sending
+ * - Error cards rendered for provider_unavailable, no_credentials, model_unavailable
+ * - NeoConfirmationCard shown when pendingConfirmation exists
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, waitFor, act } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore — all signals defined inside factory using async import
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', async () => {
+	const { signal: s } = await import('@preact/signals');
+	const messages = s<unknown[]>([]);
+	const loading = s(false);
+	const pendingConfirmation = s<{ actionId: string; description: string } | null>(null);
+	const sendMessage = vi.fn();
+	return {
+		neoStore: { messages, loading, pendingConfirmation, sendMessage },
+	};
+});
+
+// Mock NeoConfirmationCard to avoid deep dependency
+vi.mock('./NeoConfirmationCard.tsx', () => ({
+	NeoConfirmationCard: ({ actionId, description }: { actionId: string; description: string }) => (
+		<div data-testid="mock-confirmation-card" data-action-id={actionId}>
+			{description}
+		</div>
+	),
+}));
+
+// Mock MarkdownRenderer
+vi.mock('../chat/MarkdownRenderer.tsx', () => ({
+	default: ({ content }: { content: string }) => (
+		<div data-testid="markdown-renderer">{content}</div>
+	),
+}));
+
+import { NeoChatView } from './NeoChatView.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUserMsg(id: string, text: string) {
+	return {
+		id,
+		sessionId: 'sess-1',
+		messageType: 'user',
+		messageSubtype: null,
+		content: JSON.stringify([{ type: 'text', text }]),
+		createdAt: Date.now(),
+		sendStatus: null,
+		origin: 'human',
+	};
+}
+
+function makeAssistantMsg(id: string, text: string) {
+	return {
+		id,
+		sessionId: 'sess-1',
+		messageType: 'assistant',
+		messageSubtype: null,
+		content: JSON.stringify([{ type: 'text', text }]),
+		createdAt: Date.now(),
+		sendStatus: null,
+		origin: null,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoChatView', () => {
+	beforeEach(() => {
+		neoStore.messages.value = [];
+		neoStore.loading.value = false;
+		neoStore.pendingConfirmation.value = null;
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders empty state when no messages', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		expect(getByTestId('neo-empty-state')).toBeTruthy();
+	});
+
+	it('does not show empty state when messages exist', () => {
+		neoStore.messages.value = [makeUserMsg('1', 'Hello')];
+		const { queryByTestId } = render(<NeoChatView />);
+		expect(queryByTestId('neo-empty-state')).toBeNull();
+	});
+
+	it('renders user message as right-aligned bubble', () => {
+		neoStore.messages.value = [makeUserMsg('1', 'Hi there')];
+		const { getByTestId, getByText } = render(<NeoChatView />);
+		expect(getByTestId('neo-user-message')).toBeTruthy();
+		expect(getByText('Hi there')).toBeTruthy();
+	});
+
+	it('renders assistant message with sparkle avatar', () => {
+		neoStore.messages.value = [makeAssistantMsg('1', 'Hello from Neo')];
+		const { getByTestId, getByText } = render(<NeoChatView />);
+		expect(getByTestId('neo-assistant-message')).toBeTruthy();
+		expect(getByText('Hello from Neo')).toBeTruthy();
+	});
+
+	it('skips result and system messages', () => {
+		neoStore.messages.value = [
+			{ ...makeUserMsg('1', 'hi'), messageType: 'result' },
+			{ ...makeUserMsg('2', 'hi'), messageType: 'system' },
+		];
+		const { queryByTestId } = render(<NeoChatView />);
+		expect(queryByTestId('neo-user-message')).toBeNull();
+		expect(queryByTestId('neo-assistant-message')).toBeNull();
+	});
+
+	it('renders the chat input', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		expect(getByTestId('neo-chat-input')).toBeTruthy();
+	});
+
+	it('send button is disabled when input is empty', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		const btn = getByTestId('neo-send-button') as HTMLButtonElement;
+		expect(btn.disabled).toBe(true);
+	});
+
+	it('send button is enabled when input has text', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		const btn = getByTestId('neo-send-button') as HTMLButtonElement;
+		expect(btn.disabled).toBe(false);
+	});
+
+	it('calls sendMessage on send button click', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'What rooms do I have?' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		expect(neoStore.sendMessage).toHaveBeenCalledWith('What rooms do I have?');
+	});
+
+	it('clears input after send', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		expect(input.value).toBe('');
+	});
+
+	it('submits on Enter key', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		await act(async () => {
+			fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+		});
+		expect(neoStore.sendMessage).toHaveBeenCalledWith('hello');
+	});
+
+	it('does NOT submit on Shift+Enter', () => {
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+		expect(neoStore.sendMessage).not.toHaveBeenCalled();
+	});
+
+	it('shows typing indicator while sending', async () => {
+		let resolveSend!: (v: { success: boolean }) => void;
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(
+			new Promise((res) => (resolveSend = res))
+		);
+
+		const { getByTestId, queryByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hello' } });
+		fireEvent.click(getByTestId('neo-send-button'));
+
+		await waitFor(() => {
+			expect(queryByTestId('neo-typing-indicator')).toBeTruthy();
+		});
+
+		await act(async () => {
+			resolveSend({ success: true });
+		});
+
+		await waitFor(() => {
+			expect(queryByTestId('neo-typing-indicator')).toBeNull();
+		});
+	});
+
+	it('renders provider_unavailable error card', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'provider_unavailable',
+			error: 'Rate limited',
+		});
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hi' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-error-provider-unavailable')).toBeTruthy();
+		});
+	});
+
+	it('renders no_credentials error card', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'no_credentials',
+			error: 'No API key',
+		});
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hi' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-error-no-credentials')).toBeTruthy();
+		});
+	});
+
+	it('renders model_unavailable error card', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'model_unavailable',
+			error: 'Model not found',
+		});
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hi' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-error-model-unavailable')).toBeTruthy();
+		});
+	});
+
+	it('shows NeoConfirmationCard when pendingConfirmation exists', () => {
+		neoStore.messages.value = [makeAssistantMsg('1', 'Please confirm the action')];
+		neoStore.pendingConfirmation.value = { actionId: 'action-123', description: 'Delete room' };
+		const { getByTestId } = render(<NeoChatView />);
+		const card = getByTestId('mock-confirmation-card');
+		expect(card).toBeTruthy();
+		expect(card.getAttribute('data-action-id')).toBe('action-123');
+	});
+
+	it('confirmation card only appears on the last assistant message', () => {
+		neoStore.messages.value = [
+			makeAssistantMsg('1', 'First response'),
+			makeAssistantMsg('2', 'Second response'),
+		];
+		neoStore.pendingConfirmation.value = { actionId: 'act-1', description: 'Do something' };
+		const { getAllByTestId, queryAllByTestId } = render(<NeoChatView />);
+		// Two assistant messages but only one confirmation card
+		expect(getAllByTestId('neo-assistant-message')).toHaveLength(2);
+		expect(queryAllByTestId('mock-confirmation-card')).toHaveLength(1);
+	});
+
+	it('preserves input text when send fails', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'provider_unavailable',
+			error: 'Rate limited',
+		});
+		const { getByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'my important message' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		// Input should NOT be cleared on failure
+		expect(input.value).toBe('my important message');
+	});
+
+	it('error card can be dismissed', async () => {
+		(neoStore.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			errorCode: 'provider_unavailable',
+			error: 'Rate limited',
+		});
+		const { getByTestId, queryByTestId } = render(<NeoChatView />);
+		const input = getByTestId('neo-chat-input') as HTMLTextAreaElement;
+		fireEvent.input(input, { target: { value: 'hi' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-send-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-error-provider-unavailable')).toBeTruthy();
+		});
+		act(() => {
+			fireEvent.click(getByTestId('neo-error-dismiss'));
+		});
+		expect(queryByTestId('neo-error-provider-unavailable')).toBeNull();
+	});
+});

--- a/packages/web/src/components/neo/NeoChatView.tsx
+++ b/packages/web/src/components/neo/NeoChatView.tsx
@@ -1,0 +1,508 @@
+/**
+ * NeoChatView
+ *
+ * The main chat interface inside the Neo panel.
+ * - Renders user messages and Neo (assistant) responses
+ * - Auto-scrolls to the newest message
+ * - Renders structured JSON responses as formatted cards
+ * - Shows inline NeoConfirmationCard when Neo needs user input
+ * - Displays error states as styled cards (not alerts/modals)
+ * - Input bar at the bottom
+ */
+
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { neoStore, type NeoMessage } from '../../lib/neo-store.ts';
+import { NeoConfirmationCard } from './NeoConfirmationCard.tsx';
+import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
+
+// ---------------------------------------------------------------------------
+// Error state helpers
+// ---------------------------------------------------------------------------
+
+type ErrorCode = 'provider_unavailable' | 'no_credentials' | 'model_unavailable' | string;
+
+interface ErrorCardProps {
+	errorCode: ErrorCode;
+	onDismiss: () => void;
+}
+
+function DismissButton({ onDismiss }: { onDismiss: () => void }) {
+	return (
+		<button
+			type="button"
+			onClick={onDismiss}
+			data-testid="neo-error-dismiss"
+			aria-label="Dismiss error"
+			class="ml-auto p-0.5 rounded text-current opacity-60 hover:opacity-100 transition-opacity"
+		>
+			<svg
+				class="w-3 h-3"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth={2}
+				aria-hidden="true"
+			>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+			</svg>
+		</button>
+	);
+}
+
+function ErrorCard({ errorCode, onDismiss }: ErrorCardProps) {
+	if (errorCode === 'no_credentials') {
+		return (
+			<div
+				data-testid="neo-error-no-credentials"
+				class="my-2 rounded-xl border border-amber-700/40 bg-amber-950/20 px-3 py-2.5"
+			>
+				<div class="flex items-start gap-1">
+					<div class="flex-1 min-w-0">
+						<p class="text-sm font-medium text-amber-300">API key not configured</p>
+						<p class="text-xs text-amber-400/80 mt-0.5">
+							Please set up your provider in{' '}
+							<a href="/settings" class="underline hover:text-amber-300 transition-colors">
+								Settings
+							</a>
+							.
+						</p>
+					</div>
+					<DismissButton onDismiss={onDismiss} />
+				</div>
+			</div>
+		);
+	}
+	if (errorCode === 'model_unavailable') {
+		return (
+			<div
+				data-testid="neo-error-model-unavailable"
+				class="my-2 rounded-xl border border-amber-700/40 bg-amber-950/20 px-3 py-2.5"
+			>
+				<div class="flex items-start gap-1">
+					<div class="flex-1 min-w-0">
+						<p class="text-sm font-medium text-amber-300">Model unavailable</p>
+						<p class="text-xs text-amber-400/80 mt-0.5">
+							The selected model is not available. Please update Neo&apos;s model in{' '}
+							<a href="/settings" class="underline hover:text-amber-300 transition-colors">
+								Settings
+							</a>
+							.
+						</p>
+					</div>
+					<DismissButton onDismiss={onDismiss} />
+				</div>
+			</div>
+		);
+	}
+	// Default: provider_unavailable or unknown
+	return (
+		<div
+			data-testid="neo-error-provider-unavailable"
+			class="my-2 rounded-xl border border-gray-700 bg-gray-800/60 px-3 py-2.5"
+		>
+			<div class="flex items-start gap-1">
+				<div class="flex-1 min-w-0">
+					<p class="text-sm font-medium text-gray-300">Neo is temporarily unavailable</p>
+					<p class="text-xs text-gray-500 mt-0.5">Please try again.</p>
+				</div>
+				<DismissButton onDismiss={onDismiss} />
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Message content parsers
+// ---------------------------------------------------------------------------
+
+/** Extract displayable text from a raw SDK message content JSON string. */
+function extractTextContent(content: string): string {
+	try {
+		const parsed: unknown = JSON.parse(content);
+		if (typeof parsed === 'string') return parsed;
+		// SDK messages use content arrays: [{ type: 'text', text: '...' }, ...]
+		if (Array.isArray(parsed)) {
+			return parsed
+				.filter(
+					(block): block is { type: string; text: string } =>
+						typeof block === 'object' &&
+						block !== null &&
+						'type' in block &&
+						(block as { type: string }).type === 'text' &&
+						'text' in block
+				)
+				.map((block) => block.text)
+				.join('\n');
+		}
+		// Fallback: some messages store content as a direct string field
+		if (typeof parsed === 'object' && parsed !== null && 'text' in parsed) {
+			const text = (parsed as { text: unknown }).text;
+			if (typeof text === 'string') return text;
+		}
+		return '';
+	} catch {
+		return content;
+	}
+}
+
+/** Try to parse content as structured JSON data (object/array). Returns null if plain text. */
+function tryParseStructured(content: string): unknown | null {
+	try {
+		const parsed: unknown = JSON.parse(content);
+		if (Array.isArray(parsed)) return parsed;
+		if (typeof parsed === 'object' && parsed !== null) return parsed;
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Structured data renderer
+// ---------------------------------------------------------------------------
+
+function StructuredDataCard({ data }: { data: unknown }) {
+	const [expanded, setExpanded] = useState(false);
+
+	if (Array.isArray(data)) {
+		return (
+			<div class="my-1 rounded-lg border border-gray-700 overflow-hidden text-xs">
+				<div
+					class="flex items-center justify-between px-2 py-1.5 bg-gray-800/80 cursor-pointer hover:bg-gray-700/60 transition-colors"
+					onClick={() => setExpanded((v) => !v)}
+				>
+					<span class="text-gray-400 font-medium">
+						Array ({data.length} item{data.length !== 1 ? 's' : ''})
+					</span>
+					<svg
+						class={`w-3 h-3 text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`}
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth={2}
+						aria-hidden="true"
+					>
+						<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+					</svg>
+				</div>
+				{expanded && (
+					<div class="overflow-x-auto">
+						<table class="w-full text-xs">
+							<tbody>
+								{data.map((item, i) => (
+									<tr key={i} class="border-t border-gray-700/50 hover:bg-gray-800/40">
+										<td class="px-2 py-1 text-gray-600 font-mono w-8">{i}</td>
+										<td class="px-2 py-1 text-gray-300 font-mono whitespace-pre-wrap break-all">
+											{typeof item === 'object' ? JSON.stringify(item, null, 2) : String(item)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	// Plain object
+	const entries = Object.entries(data as Record<string, unknown>);
+	return (
+		<div class="my-1 rounded-lg border border-gray-700 overflow-hidden text-xs">
+			<div
+				class="flex items-center justify-between px-2 py-1.5 bg-gray-800/80 cursor-pointer hover:bg-gray-700/60 transition-colors"
+				onClick={() => setExpanded((v) => !v)}
+			>
+				<span class="text-gray-400 font-medium">Structured data</span>
+				<svg
+					class={`w-3 h-3 text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`}
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+				</svg>
+			</div>
+			{expanded && (
+				<div class="overflow-x-auto">
+					<table class="w-full text-xs">
+						<tbody>
+							{entries.map(([k, v]) => (
+								<tr key={k} class="border-t border-gray-700/50 hover:bg-gray-800/40">
+									<td class="px-2 py-1 text-gray-500 font-mono whitespace-nowrap align-top">{k}</td>
+									<td class="px-2 py-1 text-gray-300 font-mono whitespace-pre-wrap break-all">
+										{typeof v === 'object' ? JSON.stringify(v, null, 2) : String(v)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Individual message bubble
+// ---------------------------------------------------------------------------
+
+interface MessageBubbleProps {
+	msg: NeoMessage;
+	pendingActionId?: string | null;
+	/** Whether this is the last assistant message — only this one renders the confirmation card. */
+	isLastAssistant?: boolean;
+}
+
+function MessageBubble({ msg, pendingActionId, isLastAssistant }: MessageBubbleProps) {
+	const isUser = msg.messageType === 'user';
+	const isResult = msg.messageType === 'result';
+	const isSystem = msg.messageType === 'system';
+
+	// Skip internal result/system messages in this simplified view
+	if (isResult || isSystem) return null;
+
+	const rawText = extractTextContent(msg.content);
+
+	// Only the last assistant message should render the confirmation card.
+	const hasPendingConfirmation = !isUser && isLastAssistant && pendingActionId;
+
+	if (isUser) {
+		return (
+			<div data-testid="neo-user-message" class="flex justify-end mb-3">
+				<div class="max-w-[85%] bg-blue-600 text-white rounded-[20px] rounded-br-md px-3.5 py-2 text-sm leading-relaxed break-words">
+					{rawText}
+				</div>
+			</div>
+		);
+	}
+
+	// Assistant message
+	const structured = rawText ? null : tryParseStructured(msg.content);
+
+	return (
+		<div data-testid="neo-assistant-message" class="mb-3">
+			{/* Sparkle avatar */}
+			<div class="flex items-start gap-2">
+				<div class="flex-shrink-0 w-6 h-6 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mt-0.5">
+					<svg
+						class="w-3 h-3 text-violet-400"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+						aria-hidden="true"
+					>
+						<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+					</svg>
+				</div>
+				<div class="flex-1 min-w-0">
+					{rawText && (
+						<div class="text-sm text-gray-200 leading-relaxed">
+							<MarkdownRenderer content={rawText} class="text-sm text-gray-200" />
+						</div>
+					)}
+					{structured && <StructuredDataCard data={structured} />}
+					{hasPendingConfirmation && (
+						<NeoConfirmationCard
+							actionId={pendingActionId}
+							description={neoStore.pendingConfirmation.value?.description ?? ''}
+							riskLevel={neoStore.pendingConfirmation.value?.riskLevel}
+						/>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Loading indicator
+// ---------------------------------------------------------------------------
+
+function TypingIndicator() {
+	return (
+		<div data-testid="neo-typing-indicator" class="flex items-start gap-2 mb-3">
+			<div class="flex-shrink-0 w-6 h-6 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center">
+				<svg
+					class="w-3 h-3 text-violet-400"
+					viewBox="0 0 24 24"
+					fill="currentColor"
+					aria-hidden="true"
+				>
+					<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+				</svg>
+			</div>
+			<div class="flex items-center gap-1 py-1.5 px-1">
+				{[0, 1, 2].map((i) => (
+					<span
+						key={i}
+						class="w-1.5 h-1.5 rounded-full bg-gray-500 animate-bounce"
+						style={{ animationDelay: `${i * 150}ms` }}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// NeoChatView
+// ---------------------------------------------------------------------------
+
+export function NeoChatView() {
+	const [inputValue, setInputValue] = useState('');
+	const [sending, setSending] = useState(false);
+	const [sendError, setSendError] = useState<{ code: string; message: string } | null>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLTextAreaElement>(null);
+
+	const messages = neoStore.messages.value;
+	const loading = neoStore.loading.value;
+	const pendingConfirmation = neoStore.pendingConfirmation.value;
+
+	// Auto-scroll to newest message — depend on last message id so updates trigger correctly
+	const lastMessageId = messages[messages.length - 1]?.id;
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+	}, [lastMessageId]);
+
+	// Focus input when the panel opens
+	useEffect(() => {
+		inputRef.current?.focus();
+	}, []);
+
+	const handleSend = async () => {
+		const text = inputValue.trim();
+		if (!text || sending) return;
+
+		setSendError(null);
+		setSending(true);
+
+		try {
+			const result = await neoStore.sendMessage(text);
+			if (result.success) {
+				// Only clear input on success so the user can retry on failure
+				setInputValue('');
+			} else {
+				setSendError({
+					code: result.errorCode ?? 'provider_unavailable',
+					message: result.error ?? 'Failed to send message',
+				});
+			}
+		} finally {
+			setSending(false);
+		}
+	};
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			handleSend();
+		}
+	};
+
+	const isEmpty = messages.length === 0 && !loading;
+
+	return (
+		<div class="flex flex-col h-full min-h-0" data-testid="neo-chat-view">
+			{/* Message list */}
+			<div class="flex-1 min-h-0 overflow-y-auto px-3 py-3 scroll-smooth">
+				{/* Empty state */}
+				{isEmpty && (
+					<div
+						data-testid="neo-empty-state"
+						class="flex flex-col items-center justify-center h-full gap-3 text-center px-4"
+					>
+						<div class="w-10 h-10 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center">
+							<svg
+								class="w-5 h-5 text-violet-400"
+								viewBox="0 0 24 24"
+								fill="currentColor"
+								aria-hidden="true"
+							>
+								<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+								<path
+									d="M5 3l.75 2.25L8 6l-2.25.75L5 9l-.75-2.25L2 6l2.25-.75L5 3z"
+									opacity={0.5}
+								/>
+							</svg>
+						</div>
+						<div>
+							<p class="text-sm font-medium text-gray-300">Hi, I&apos;m Neo</p>
+							<p class="text-xs text-gray-500 mt-1">
+								Ask me anything about your rooms, sessions, or goals.
+							</p>
+						</div>
+					</div>
+				)}
+
+				{/* Messages */}
+				{(() => {
+					// Find the last assistant message so only it renders the confirmation card
+					const lastAssistantIdx = messages.reduce(
+						(last, m, i) => (m.messageType === 'assistant' ? i : last),
+						-1
+					);
+					return messages.map((msg, i) => (
+						<MessageBubble
+							key={msg.id}
+							msg={msg}
+							pendingActionId={pendingConfirmation?.actionId}
+							isLastAssistant={i === lastAssistantIdx}
+						/>
+					));
+				})()}
+
+				{/* Typing indicator when sending */}
+				{sending && <TypingIndicator />}
+
+				{/* Send error */}
+				{sendError && <ErrorCard errorCode={sendError.code} onDismiss={() => setSendError(null)} />}
+
+				{/* Scroll anchor */}
+				<div ref={messagesEndRef} />
+			</div>
+
+			{/* Input bar */}
+			<div class="flex-shrink-0 border-t border-gray-700 px-3 py-2.5 bg-gray-900/50">
+				<div class="flex items-end gap-2">
+					<textarea
+						ref={inputRef}
+						data-testid="neo-chat-input"
+						value={inputValue}
+						onInput={(e) => setInputValue((e.target as HTMLTextAreaElement).value)}
+						onKeyDown={handleKeyDown}
+						placeholder="Ask Neo…"
+						rows={1}
+						disabled={sending}
+						class="flex-1 resize-none bg-gray-800 border border-gray-700 rounded-xl px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:ring-1 focus:ring-violet-500/50 focus:border-violet-500/50 transition-colors disabled:opacity-50 min-h-[36px] max-h-[120px] overflow-y-auto"
+						style="field-sizing: content;"
+					/>
+					<button
+						data-testid="neo-send-button"
+						onClick={handleSend}
+						disabled={sending || !inputValue.trim()}
+						aria-label="Send message"
+						class="flex-shrink-0 w-8 h-8 rounded-xl bg-violet-600 hover:bg-violet-500 text-white flex items-center justify-center transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+					>
+						<svg
+							class="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth={2}
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
+							/>
+						</svg>
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/neo/NeoConfirmationCard.test.tsx
+++ b/packages/web/src/components/neo/NeoConfirmationCard.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Tests for NeoConfirmationCard
+ *
+ * Verifies:
+ * - Renders with description and risk level
+ * - Confirm button calls neoStore.confirmAction(actionId)
+ * - Cancel button calls neoStore.cancelAction(actionId)
+ * - Shows loading state while awaiting RPC
+ * - Shows error when RPC fails
+ * - Resolved state: shows resolution, buttons hidden
+ * - Risk levels render correct badge text
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, waitFor, act } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore — define fns inside factory to avoid hoisting issues
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', () => {
+	const confirmAction = vi.fn();
+	const cancelAction = vi.fn();
+	return {
+		neoStore: { confirmAction, cancelAction },
+	};
+});
+
+import { NeoConfirmationCard } from './NeoConfirmationCard.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoConfirmationCard', () => {
+	beforeEach(() => {
+		(neoStore.confirmAction as ReturnType<typeof vi.fn>).mockReset();
+		(neoStore.cancelAction as ReturnType<typeof vi.fn>).mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the action description', () => {
+		const { getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Delete room prod-api" />
+		);
+		expect(getByText('Delete room prod-api')).toBeTruthy();
+	});
+
+	it('renders Confirm and Cancel buttons', () => {
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-1" description="Create goal" />
+		);
+		expect(getByTestId('neo-confirm-button')).toBeTruthy();
+		expect(getByTestId('neo-cancel-button')).toBeTruthy();
+	});
+
+	it('calls confirmAction with actionId on Confirm click', async () => {
+		(neoStore.confirmAction as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-42" description="Enable skill" />
+		);
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-confirm-button'));
+		});
+		expect(neoStore.confirmAction).toHaveBeenCalledWith('act-42');
+	});
+
+	it('calls cancelAction with actionId on Cancel click', async () => {
+		(neoStore.cancelAction as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-99" description="Delete space" />
+		);
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-cancel-button'));
+		});
+		expect(neoStore.cancelAction).toHaveBeenCalledWith('act-99');
+	});
+
+	it('disables buttons while loading', async () => {
+		let resolveConfirm!: (v: { success: boolean }) => void;
+		(neoStore.confirmAction as ReturnType<typeof vi.fn>).mockReturnValue(
+			new Promise((res) => (resolveConfirm = res))
+		);
+
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do something" />
+		);
+		fireEvent.click(getByTestId('neo-confirm-button'));
+
+		await waitFor(() => {
+			expect(getByTestId('neo-confirm-button').hasAttribute('disabled')).toBe(true);
+			expect(getByTestId('neo-cancel-button').hasAttribute('disabled')).toBe(true);
+		});
+
+		await act(async () => {
+			resolveConfirm({ success: true });
+		});
+	});
+
+	it('shows error message when confirmAction fails', async () => {
+		(neoStore.confirmAction as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			error: 'Action expired',
+		});
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do something" />
+		);
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-confirm-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-confirmation-error').textContent).toContain('Action expired');
+		});
+	});
+
+	it('shows error message when cancelAction fails', async () => {
+		(neoStore.cancelAction as ReturnType<typeof vi.fn>).mockResolvedValue({
+			success: false,
+			error: 'Network error',
+		});
+		const { getByTestId } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do something" />
+		);
+		await act(async () => {
+			fireEvent.click(getByTestId('neo-cancel-button'));
+		});
+		await waitFor(() => {
+			expect(getByTestId('neo-confirmation-error').textContent).toContain('Network error');
+		});
+	});
+
+	it('shows "Confirmed" label when resolved with confirmed', () => {
+		const { queryByTestId, getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Done" resolved resolution="confirmed" />
+		);
+		expect(queryByTestId('neo-confirm-button')).toBeNull();
+		expect(queryByTestId('neo-cancel-button')).toBeNull();
+		expect(getByText('✓ Confirmed')).toBeTruthy();
+	});
+
+	it('shows "Cancelled" label when resolved with cancelled', () => {
+		const { queryByTestId, getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Done" resolved resolution="cancelled" />
+		);
+		expect(queryByTestId('neo-confirm-button')).toBeNull();
+		expect(queryByTestId('neo-cancel-button')).toBeNull();
+		expect(getByText('✕ Cancelled')).toBeTruthy();
+	});
+
+	it('shows "Requires confirmation" badge for medium risk (default)', () => {
+		const { getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do it" riskLevel="medium" />
+		);
+		expect(getByText('Requires confirmation')).toBeTruthy();
+	});
+
+	it('shows "Low risk" badge', () => {
+		const { getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do it" riskLevel="low" />
+		);
+		expect(getByText('Low risk')).toBeTruthy();
+	});
+
+	it('shows "High risk — irreversible" badge', () => {
+		const { getByText } = render(
+			<NeoConfirmationCard actionId="act-1" description="Do it" riskLevel="high" />
+		);
+		expect(getByText('High risk — irreversible')).toBeTruthy();
+	});
+
+	it('does not call confirm/cancel when already resolved', () => {
+		render(
+			<NeoConfirmationCard actionId="act-1" description="Done" resolved resolution="confirmed" />
+		);
+		expect(neoStore.confirmAction).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/components/neo/NeoConfirmationCard.tsx
+++ b/packages/web/src/components/neo/NeoConfirmationCard.tsx
@@ -1,0 +1,146 @@
+/**
+ * NeoConfirmationCard
+ *
+ * Inline card rendered in the Neo chat when Neo needs user confirmation
+ * for a pending action. Confirm/Cancel call the RPC directly (bypasses LLM
+ * for reliability). Remains interactive until the action's TTL expires.
+ */
+
+import { useState } from 'preact/hooks';
+import { neoStore } from '../../lib/neo-store.ts';
+
+export interface NeoConfirmationCardProps {
+	actionId: string;
+	description: string;
+	/** Risk level of the action: low | medium | high */
+	riskLevel?: 'low' | 'medium' | 'high';
+	/** Whether the action has already been resolved (TTL expired or acted on) */
+	resolved?: boolean;
+	/** 'confirmed' | 'cancelled' — only set once resolved */
+	resolution?: 'confirmed' | 'cancelled';
+}
+
+const riskColors = {
+	low: {
+		badge: 'bg-green-500/10 text-green-400 border border-green-500/20',
+		label: 'Low risk',
+	},
+	medium: {
+		badge: 'bg-amber-500/10 text-amber-400 border border-amber-500/20',
+		label: 'Requires confirmation',
+	},
+	high: {
+		badge: 'bg-red-500/10 text-red-400 border border-red-500/20',
+		label: 'High risk — irreversible',
+	},
+} as const;
+
+export function NeoConfirmationCard({
+	actionId,
+	description,
+	riskLevel = 'medium',
+	resolved = false,
+	resolution,
+}: NeoConfirmationCardProps) {
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const risk = riskColors[riskLevel];
+
+	const handleConfirm = async () => {
+		if (loading || resolved) return;
+		setLoading(true);
+		setError(null);
+		const result = await neoStore.confirmAction(actionId);
+		if (!result.success) {
+			setError(result.error ?? 'Failed to confirm action');
+		}
+		setLoading(false);
+	};
+
+	const handleCancel = async () => {
+		if (loading || resolved) return;
+		setLoading(true);
+		setError(null);
+		const result = await neoStore.cancelAction(actionId);
+		if (!result.success) {
+			setError(result.error ?? 'Failed to cancel action');
+		}
+		setLoading(false);
+	};
+
+	return (
+		<div
+			data-testid="neo-confirmation-card"
+			class="my-2 rounded-xl border border-gray-700 bg-gray-800/60 overflow-hidden"
+		>
+			{/* Header */}
+			<div class="flex items-center gap-2 px-3 py-2 border-b border-gray-700/50">
+				{/* Shield icon */}
+				<svg
+					class="w-4 h-4 text-violet-400 flex-shrink-0"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					aria-hidden="true"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+					/>
+				</svg>
+				<span class="text-xs font-semibold text-violet-300 flex-1">Neo needs your approval</span>
+				<span class={`text-xs px-1.5 py-0.5 rounded-md font-medium ${risk.badge}`}>
+					{risk.label}
+				</span>
+			</div>
+
+			{/* Description */}
+			<div class="px-3 py-2.5">
+				<p class="text-sm text-gray-200 leading-relaxed">{description}</p>
+			</div>
+
+			{/* Error */}
+			{error && (
+				<div class="px-3 pb-2 text-xs text-red-400" data-testid="neo-confirmation-error">
+					{error}
+				</div>
+			)}
+
+			{/* Actions */}
+			<div class="flex items-center gap-2 px-3 py-2 border-t border-gray-700/50 bg-gray-900/30">
+				{resolved ? (
+					<span
+						class={`text-xs font-medium ${
+							resolution === 'confirmed' ? 'text-green-400' : 'text-gray-500'
+						}`}
+					>
+						{resolution === 'confirmed' ? '✓ Confirmed' : '✕ Cancelled'}
+					</span>
+				) : (
+					<>
+						<button
+							data-testid="neo-confirm-button"
+							onClick={handleConfirm}
+							disabled={loading}
+							class="px-3 py-1.5 text-xs font-semibold rounded-lg bg-violet-600 hover:bg-violet-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							{loading ? 'Working…' : 'Confirm'}
+						</button>
+						<button
+							data-testid="neo-cancel-button"
+							onClick={handleCancel}
+							disabled={loading}
+							class="px-3 py-1.5 text-xs font-semibold rounded-lg border border-gray-600 hover:border-gray-500 text-gray-300 hover:text-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Cancel
+						</button>
+						<span class="ml-auto text-xs text-gray-600">You can also type "yes" or "no"</span>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/neo/NeoPanel.test.tsx
+++ b/packages/web/src/components/neo/NeoPanel.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for NeoPanel
+ *
+ * Verifies:
+ * - Renders with correct aria attributes
+ * - Panel is off-screen when panelOpen=false (-translate-x-full)
+ * - Panel is on-screen when panelOpen=true (translate-x-0)
+ * - Backdrop rendered; click dismisses panel
+ * - Escape key closes panel
+ * - Close button calls neoStore.closePanel
+ * - Tab switching: Chat tab and Activity tab
+ * - subscribe() called on mount; unsubscribe() on unmount
+ * - Renders NeoChatView by default (chat tab)
+ * - Renders NeoActivityView when activity tab is active
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Mock neoStore — signals inside factory to avoid hoisting issues
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/neo-store.ts', async () => {
+	const { signal: s } = await import('@preact/signals');
+	const panelOpen = s(false);
+	const activeTab = s<'chat' | 'activity'>('chat');
+	const subscribe = vi.fn().mockResolvedValue(undefined);
+	const unsubscribe = vi.fn();
+	const closePanel = vi.fn(() => {
+		panelOpen.value = false;
+	});
+	return {
+		neoStore: { panelOpen, activeTab, subscribe, unsubscribe, closePanel },
+	};
+});
+
+// Mock child views
+vi.mock('./NeoChatView.tsx', () => ({
+	NeoChatView: () => <div data-testid="mock-chat-view">Chat</div>,
+}));
+
+vi.mock('./NeoActivityView.tsx', () => ({
+	NeoActivityView: () => <div data-testid="mock-activity-view">Activity</div>,
+}));
+
+import { NeoPanel } from './NeoPanel.tsx';
+import { neoStore } from '../../lib/neo-store.ts';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoPanel', () => {
+	beforeEach(() => {
+		neoStore.panelOpen.value = false;
+		neoStore.activeTab.value = 'chat';
+		(neoStore.subscribe as ReturnType<typeof vi.fn>).mockClear();
+		(neoStore.unsubscribe as ReturnType<typeof vi.fn>).mockClear();
+		(neoStore.closePanel as ReturnType<typeof vi.fn>).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the panel with role=dialog', () => {
+		const { getByTestId } = render(<NeoPanel />);
+		const panel = getByTestId('neo-panel');
+		expect(panel.getAttribute('role')).toBe('dialog');
+	});
+
+	it('panel has aria-modal=true', () => {
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-panel').getAttribute('aria-modal')).toBe('true');
+	});
+
+	it('panel is off-screen when closed (-translate-x-full)', () => {
+		neoStore.panelOpen.value = false;
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-panel').className).toContain('-translate-x-full');
+	});
+
+	it('panel is on-screen when open (translate-x-0)', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-panel').className).toContain('translate-x-0');
+	});
+
+	it('renders backdrop', () => {
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-panel-backdrop')).toBeTruthy();
+	});
+
+	it('backdrop click calls closePanel', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		fireEvent.click(getByTestId('neo-panel-backdrop'));
+		expect(neoStore.closePanel).toHaveBeenCalledOnce();
+	});
+
+	it('close button calls closePanel', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		fireEvent.click(getByTestId('neo-panel-close'));
+		expect(neoStore.closePanel).toHaveBeenCalledOnce();
+	});
+
+	it('Escape key calls closePanel when panel is open', () => {
+		neoStore.panelOpen.value = true;
+		render(<NeoPanel />);
+		act(() => {
+			fireEvent.keyDown(document, { key: 'Escape' });
+		});
+		expect(neoStore.closePanel).toHaveBeenCalledOnce();
+	});
+
+	it('Escape key does NOT close when panel is closed', () => {
+		neoStore.panelOpen.value = false;
+		render(<NeoPanel />);
+		act(() => {
+			fireEvent.keyDown(document, { key: 'Escape' });
+		});
+		expect(neoStore.closePanel).not.toHaveBeenCalled();
+	});
+
+	it('subscribe() is called on mount', () => {
+		render(<NeoPanel />);
+		expect(neoStore.subscribe).toHaveBeenCalledOnce();
+	});
+
+	it('unsubscribe() is called on unmount', () => {
+		const { unmount } = render(<NeoPanel />);
+		unmount();
+		expect(neoStore.unsubscribe).toHaveBeenCalledOnce();
+	});
+
+	it('renders NeoChatView when activeTab=chat', () => {
+		neoStore.activeTab.value = 'chat';
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('mock-chat-view')).toBeTruthy();
+	});
+
+	it('renders NeoActivityView when activeTab=activity', () => {
+		neoStore.activeTab.value = 'activity';
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('mock-activity-view')).toBeTruthy();
+	});
+
+	it('chat tab button is aria-selected=true when on chat', () => {
+		neoStore.activeTab.value = 'chat';
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-tab-chat').getAttribute('aria-selected')).toBe('true');
+		expect(getByTestId('neo-tab-activity').getAttribute('aria-selected')).toBe('false');
+	});
+
+	it('activity tab button is aria-selected=true when on activity', () => {
+		neoStore.activeTab.value = 'activity';
+		const { getByTestId } = render(<NeoPanel />);
+		expect(getByTestId('neo-tab-activity').getAttribute('aria-selected')).toBe('true');
+		expect(getByTestId('neo-tab-chat').getAttribute('aria-selected')).toBe('false');
+	});
+
+	it('clicking activity tab switches to activity view', () => {
+		neoStore.activeTab.value = 'chat';
+		const { getByTestId } = render(<NeoPanel />);
+		act(() => {
+			fireEvent.click(getByTestId('neo-tab-activity'));
+		});
+		expect(neoStore.activeTab.value).toBe('activity');
+		expect(getByTestId('mock-activity-view')).toBeTruthy();
+	});
+
+	it('clicking chat tab switches to chat view from activity', () => {
+		neoStore.activeTab.value = 'activity';
+		const { getByTestId } = render(<NeoPanel />);
+		act(() => {
+			fireEvent.click(getByTestId('neo-tab-chat'));
+		});
+		expect(neoStore.activeTab.value).toBe('chat');
+		expect(getByTestId('mock-chat-view')).toBeTruthy();
+	});
+
+	it('header has "Neo" text', () => {
+		const { getByTestId } = render(<NeoPanel />);
+		const header = getByTestId('neo-panel-header');
+		expect(header.textContent).toContain('Neo');
+	});
+
+	it('Tab key focus trap: focus cycles back to first focusable element from last', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		const panel = getByTestId('neo-panel');
+
+		// Get all focusable elements within the panel
+		const focusable = panel.querySelectorAll<HTMLElement>(
+			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		);
+		expect(focusable.length).toBeGreaterThan(0);
+
+		const last = focusable[focusable.length - 1];
+		const first = focusable[0];
+
+		// Focus last element, then press Tab — should wrap to first
+		last.focus();
+		act(() => {
+			fireEvent.keyDown(document, { key: 'Tab', shiftKey: false });
+		});
+		expect(document.activeElement).toBe(first);
+	});
+
+	it('Shift+Tab focus trap: focus cycles back to last focusable element from first', () => {
+		neoStore.panelOpen.value = true;
+		const { getByTestId } = render(<NeoPanel />);
+		const panel = getByTestId('neo-panel');
+
+		const focusable = panel.querySelectorAll<HTMLElement>(
+			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		);
+		expect(focusable.length).toBeGreaterThan(0);
+
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+
+		// Focus first element, then press Shift+Tab — should wrap to last
+		first.focus();
+		act(() => {
+			fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+		});
+		expect(document.activeElement).toBe(last);
+	});
+});

--- a/packages/web/src/components/neo/NeoPanel.tsx
+++ b/packages/web/src/components/neo/NeoPanel.tsx
@@ -1,0 +1,223 @@
+/**
+ * NeoPanel
+ *
+ * Global slide-out panel for the Neo AI assistant.
+ * - Slides in from the left, overlapping other content
+ * - Header with "Neo" title, Chat / Activity tab switcher, close button
+ * - Controlled by neoStore.panelOpen signal
+ * - Subscribes to neo.messages and neo.activity LiveQueries on mount
+ * - Click-outside-to-dismiss (backdrop click)
+ * - Escape key closes
+ * - Smooth 300ms CSS transition
+ */
+
+import { useEffect, useRef } from 'preact/hooks';
+import { neoStore, type NeoActiveTab } from '../../lib/neo-store.ts';
+import { NeoChatView } from './NeoChatView.tsx';
+import { NeoActivityView } from './NeoActivityView.tsx';
+
+// ---------------------------------------------------------------------------
+// Sparkle icon (matches NeoNavButton)
+// ---------------------------------------------------------------------------
+
+function SparkleIcon() {
+	return (
+		<svg class="w-4 h-4 text-violet-400" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+			<path d="M12 2l2.09 6.41L20.5 10l-6.41 2.09L12 18.5l-2.09-6.41L4 10l6.41-2.09L12 2z" />
+			<path d="M5 3l.75 2.25L8 6l-2.25.75L5 9l-.75-2.25L2 6l2.25-.75L5 3z" opacity={0.5} />
+		</svg>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tab button
+// ---------------------------------------------------------------------------
+
+interface TabButtonProps {
+	tab: NeoActiveTab;
+	activeTab: NeoActiveTab;
+	label: string;
+	onSelect: (tab: NeoActiveTab) => void;
+}
+
+function TabButton({ tab, activeTab, label, onSelect }: TabButtonProps) {
+	const isActive = activeTab === tab;
+	return (
+		<button
+			type="button"
+			onClick={() => onSelect(tab)}
+			data-testid={`neo-tab-${tab}`}
+			aria-selected={isActive}
+			class={[
+				'px-3 py-1.5 text-xs font-medium rounded-lg transition-colors',
+				isActive
+					? 'bg-violet-500/20 text-violet-300'
+					: 'text-gray-500 hover:text-gray-300 hover:bg-white/5',
+			].join(' ')}
+		>
+			{label}
+		</button>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// NeoPanel
+// ---------------------------------------------------------------------------
+
+export function NeoPanel() {
+	const isOpen = neoStore.panelOpen.value;
+	const activeTab = neoStore.activeTab.value;
+
+	const panelRef = useRef<HTMLDivElement>(null);
+	const closeButtonRef = useRef<HTMLButtonElement>(null);
+	const triggerRef = useRef<Element | null>(null);
+
+	// Subscribe to LiveQuery on mount; unsubscribe on unmount
+	useEffect(() => {
+		neoStore.subscribe().catch(() => {
+			// Error is captured in neoStore.error signal — no action needed here
+		});
+		return () => {
+			neoStore.unsubscribe();
+		};
+	}, []);
+
+	// Focus management
+	useEffect(() => {
+		if (isOpen) {
+			triggerRef.current = document.activeElement;
+			requestAnimationFrame(() => {
+				closeButtonRef.current?.focus();
+			});
+		} else {
+			if (triggerRef.current instanceof HTMLElement) {
+				triggerRef.current.focus();
+			}
+			triggerRef.current = null;
+		}
+	}, [isOpen]);
+
+	// Escape key closes panel; focus trap
+	useEffect(() => {
+		if (!isOpen) return;
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				neoStore.closePanel();
+				return;
+			}
+			if (e.key === 'Tab' && panelRef.current) {
+				const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+					'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+				);
+				if (focusable.length === 0) return;
+				const first = focusable[0];
+				const last = focusable[focusable.length - 1];
+				if (e.shiftKey) {
+					if (document.activeElement === first) {
+						e.preventDefault();
+						last.focus();
+					}
+				} else {
+					if (document.activeElement === last) {
+						e.preventDefault();
+						first.focus();
+					}
+				}
+			}
+		};
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, [isOpen]);
+
+	const handleTabSelect = (tab: NeoActiveTab) => {
+		neoStore.activeTab.value = tab;
+	};
+
+	return (
+		<>
+			{/* Backdrop */}
+			<div
+				data-testid="neo-panel-backdrop"
+				class={[
+					'fixed inset-0 bg-black/40 z-40 transition-opacity duration-300',
+					isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none',
+				].join(' ')}
+				onClick={() => neoStore.closePanel()}
+				aria-hidden="true"
+			/>
+
+			{/* Panel */}
+			<div
+				ref={panelRef}
+				data-testid="neo-panel"
+				role="dialog"
+				aria-modal="true"
+				aria-label="Neo AI assistant"
+				class={[
+					'fixed top-0 left-0 h-dvh pt-safe z-50',
+					'w-full sm:w-80 md:w-96',
+					'flex flex-col',
+					'bg-gray-900 border-r border-gray-700 shadow-2xl',
+					'transition-transform duration-300',
+					isOpen ? 'translate-x-0' : '-translate-x-full',
+				].join(' ')}
+			>
+				{/* Header */}
+				<div
+					data-testid="neo-panel-header"
+					class="flex-shrink-0 flex items-center justify-between px-3 py-2.5 border-b border-gray-700"
+				>
+					{/* Title */}
+					<div class="flex items-center gap-2">
+						<SparkleIcon />
+						<span class="text-sm font-semibold text-gray-100">Neo</span>
+					</div>
+
+					{/* Tab switcher */}
+					<div class="flex items-center gap-1" role="tablist" aria-label="Neo panel tabs">
+						<TabButton tab="chat" activeTab={activeTab} label="Chat" onSelect={handleTabSelect} />
+						<TabButton
+							tab="activity"
+							activeTab={activeTab}
+							label="Activity"
+							onSelect={handleTabSelect}
+						/>
+					</div>
+
+					{/* Close button */}
+					<button
+						ref={closeButtonRef}
+						data-testid="neo-panel-close"
+						onClick={() => neoStore.closePanel()}
+						class="p-1 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 transition-colors"
+						aria-label="Close Neo panel"
+					>
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				</div>
+
+				{/* Body */}
+				<div
+					class="flex-1 min-h-0"
+					role="tabpanel"
+					aria-label={activeTab === 'chat' ? 'Chat' : 'Activity'}
+				>
+					{activeTab === 'chat' ? <NeoChatView /> : <NeoActivityView />}
+				</div>
+			</div>
+		</>
+	);
+}

--- a/packages/web/src/lib/neo-store.ts
+++ b/packages/web/src/lib/neo-store.ts
@@ -67,6 +67,7 @@ export interface NeoActivityEntry {
 export interface PendingConfirmation {
 	actionId: string;
 	description: string;
+	riskLevel?: 'low' | 'medium' | 'high';
 }
 
 export type NeoActiveTab = 'chat' | 'activity';


### PR DESCRIPTION
Adds 7 new MCP action tools to `neo-action-tools.ts` for space and workflow write operations.

## Tools added

**Space operations** (low/medium risk, delegated to GlobalSpaces handler layer):
- `create_space` — low risk, auto-executes in balanced mode
- `update_space` — low risk, auto-executes in balanced mode  
- `delete_space` — medium risk, requires confirmation in balanced mode

**Workflow operations**:
- `start_workflow_run` — low risk, delegated to GlobalSpaces handlers
- `cancel_workflow_run` — medium risk, cancels active tasks then transitions run to cancelled
- `approve_gate` — medium risk, idempotent, transitions rejected runs back to in_progress
- `reject_gate` — medium risk, idempotent, transitions run to needs_attention with humanRejected reason

## Design

- `NeoActionSpaceHandlers` interface — thin wrapper the caller fills with `createGlobalSpacesToolHandlers()` output, so Neo delegates without duplicating business logic
- `NeoActionWorkflowRunRepository` + `NeoActionGateDataRepository` — minimal interfaces for cancel/gate operations
- `onGateChanged` optional callback triggers channel re-evaluation after approval (mirrors `fireGateChanged` in RPC layer)
- All tools go through `withSecurityCheck()` for security tier enforcement

## Tests

43 new unit tests (115 total): happy paths, idempotency, security tier enforcement (balanced/conservative/autonomous), error cases, dependency-unavailable guards, and MCP server registration check (11 → 18 tools).