### PR TITLE
feat(neo): Attach query tools MCP server to Neo session (task 2.5)

### DIFF
--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -15,9 +15,11 @@
  * `neoSecurityMode` and `neoModel` keys in GlobalSettings.
  */
 
+import type { McpServerConfig } from '@neokai/shared';
 import type { AgentSession } from '../agent/agent-session';
 import { Logger } from '../logger';
 import { buildNeoSystemPrompt, type NeoSecurityMode } from './neo-system-prompt';
+import { createNeoQueryMcpServer, type NeoToolsConfig } from './tools/neo-query-tools';
 
 export const NEO_SESSION_ID = 'neo:global';
 const NEO_SESSION_TITLE = 'Neo';
@@ -39,9 +41,18 @@ export interface NeoSettingsManager {
 	getGlobalSettings(): { neoSecurityMode?: string; neoModel?: string; model?: string };
 }
 
+/**
+ * Minimal interface for the AppMcpLifecycleManager — only the surface used by NeoAgentManager.
+ */
+export interface NeoAppMcpManager {
+	getEnabledMcpConfigs(): Record<string, McpServerConfig>;
+}
+
 export class NeoAgentManager {
 	private readonly logger = new Logger('NeoAgentManager');
 	private session: AgentSession | null = null;
+	private toolsConfig: NeoToolsConfig | null = null;
+	private appMcpManager: NeoAppMcpManager | null = null;
 
 	constructor(
 		private readonly sessionManager: NeoSessionManager,
@@ -109,6 +120,22 @@ export class NeoAgentManager {
 	 */
 	getSession(): AgentSession | null {
 		return this.session;
+	}
+
+	/**
+	 * Wire in the query tools dependencies and optional MCP registry manager.
+	 *
+	 * Must be called before `provision()`. When set, `provision()` will create the
+	 * neo-query MCP server and attach it to the session alongside any registry-sourced
+	 * servers from AppMcpLifecycleManager (same pattern as provisionGlobalSpacesAgent).
+	 *
+	 * @param toolsConfig  All dependencies needed by createNeoQueryMcpServer().
+	 * @param appMcpManager  Optional registry manager; when provided, its globally-enabled
+	 *   servers are merged in. The in-process neo-query server always wins on collision.
+	 */
+	setToolsConfig(toolsConfig: NeoToolsConfig, appMcpManager?: NeoAppMcpManager): void {
+		this.toolsConfig = toolsConfig;
+		this.appMcpManager = appMcpManager ?? null;
 	}
 
 	/**
@@ -275,8 +302,10 @@ export class NeoAgentManager {
 	/**
 	 * Apply runtime configuration to the current session.
 	 *
-	 * Sets the system prompt (based on the active security mode) and the model
-	 * override from settings. Both values are in-memory only (not persisted to DB).
+	 * Sets the system prompt (based on the active security mode), the model
+	 * override from settings, and — when toolsConfig has been provided via
+	 * setToolsConfig() — the neo-query MCP server merged with any registry-
+	 * sourced servers. All values are in-memory only (not persisted to DB).
 	 */
 	private applyRuntimeConfig(): void {
 		if (!this.session) return;
@@ -287,5 +316,40 @@ export class NeoAgentManager {
 
 		const model = this.getModel();
 		this.session.setRuntimeModel(model);
+
+		this.attachQueryTools();
+	}
+
+	/**
+	 * Attach the neo-query MCP server to the current session, merged with any
+	 * globally-enabled registry servers from AppMcpLifecycleManager.
+	 *
+	 * Mirrors the pattern used in provisionGlobalSpacesAgent():
+	 *   - Registry servers loaded from appMcpManager (if set).
+	 *   - In-process 'neo-query' server always wins on name collision.
+	 *   - No subscription to mcp.registry.changed — registry changes take effect
+	 *     on the next daemon restart (consistent with the global spaces agent).
+	 *
+	 * No-op when toolsConfig has not been set via setToolsConfig().
+	 */
+	private attachQueryTools(): void {
+		if (!this.session || !this.toolsConfig) return;
+
+		const mcpServer = createNeoQueryMcpServer(this.toolsConfig);
+		const registryMcpServers = this.appMcpManager?.getEnabledMcpConfigs() ?? {};
+
+		for (const name of Object.keys(registryMcpServers)) {
+			if (name === 'neo-query') {
+				this.logger.warn(
+					`Neo: MCP server name collision on 'neo-query' — ` +
+						`in-process server takes precedence over registry entry.`
+				);
+			}
+		}
+
+		this.session.setRuntimeMcpServers({
+			...registryMcpServers,
+			'neo-query': mcpServer as unknown as McpServerConfig,
+		});
 	}
 }

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -1,9 +1,10 @@
 /**
  * Neo Action Tools - MCP tools for write operations
  *
- * Implements room, goal, and task write operations with security-tier enforcement.
- * Each tool checks whether the current security mode requires confirmation before
- * execution and either runs immediately or returns a `confirmationRequired` payload.
+ * Implements room, goal, task, space, and workflow write operations with
+ * security-tier enforcement.  Each tool checks whether the current security
+ * mode requires confirmation before execution and either runs immediately or
+ * returns a `confirmationRequired` payload.
  *
  * Pattern: two-layer design (testable handlers + MCP server wrapper)
  *   createNeoActionToolHandlers(config) → plain handler functions
@@ -27,6 +28,17 @@
  *   - set_task_status
  *   - approve_task
  *   - reject_task
+ *
+ *   Space operations (delegated to GlobalSpaces handler layer)
+ *   - create_space
+ *   - update_space
+ *   - delete_space
+ *
+ *   Workflow operations
+ *   - start_workflow_run  (delegated to GlobalSpaces handler layer)
+ *   - cancel_workflow_run
+ *   - approve_gate
+ *   - reject_gate
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
@@ -42,6 +54,7 @@ import type {
 	MissionType,
 	AutonomyLevel,
 	WorkspacePath,
+	SpaceAutonomyLevel,
 } from '@neokai/shared';
 import {
 	ActionClassification,
@@ -148,6 +161,99 @@ export interface NeoActionManagerFactory {
 	getTaskManager(roomId: string): NeoActionTaskManager;
 }
 
+// ---------------------------------------------------------------------------
+// Space / Workflow interfaces (delegated to global-spaces handler layer)
+// ---------------------------------------------------------------------------
+
+/** Minimal ToolResult shape shared with global-spaces handlers. */
+interface SharedToolResult {
+	content: Array<{ type: 'text'; text: string }>;
+}
+
+/**
+ * Handlers from the GlobalSpaces layer that Neo delegates space/workflow
+ * operations to.  Neo wraps each call with a security-tier check before
+ * delegating.
+ *
+ * Pass `createGlobalSpacesToolHandlers(config, state)` as this value when
+ * wiring up the real daemon.  Use a mock object in unit tests.
+ */
+export interface NeoActionSpaceHandlers {
+	create_space(args: {
+		name: string;
+		workspace_path: string;
+		description?: string;
+		instructions?: string;
+		autonomy_level?: SpaceAutonomyLevel;
+	}): Promise<SharedToolResult>;
+
+	update_space(args: {
+		space_id: string;
+		name?: string;
+		description?: string;
+		instructions?: string;
+		background_context?: string;
+		default_model?: string;
+		autonomy_level?: SpaceAutonomyLevel;
+	}): Promise<SharedToolResult>;
+
+	delete_space(args: { space_id: string }): Promise<SharedToolResult>;
+
+	start_workflow_run(args: {
+		space_id?: string;
+		workflow_id: string;
+		title: string;
+		description?: string;
+		goal_id?: string;
+	}): Promise<SharedToolResult>;
+}
+
+/** Minimal workflow-run record needed by cancel/gate handlers. */
+export interface NeoWorkflowRun {
+	id: string;
+	spaceId: string;
+	status: string;
+	failureReason?: string | null;
+}
+
+/** Repository for reading and transitioning workflow run state. */
+export interface NeoActionWorkflowRunRepository {
+	getRun(id: string): NeoWorkflowRun | null;
+	transitionStatus(id: string, to: string): NeoWorkflowRun;
+	updateRun(id: string, params: { failureReason?: string | null }): NeoWorkflowRun | null;
+}
+
+/** Minimal space task record for cancellation. */
+export interface NeoSpaceTask {
+	id: string;
+	status: string;
+}
+
+/** Manager for space tasks within a single workflow run. */
+export interface NeoActionSpaceTaskManager {
+	listTasksByWorkflowRun(runId: string): Promise<NeoSpaceTask[]>;
+	cancelTask(taskId: string): Promise<unknown>;
+}
+
+/** Factory that creates a SpaceTaskManager scoped to a space. */
+export interface NeoActionSpaceTaskManagerFactory {
+	getTaskManager(spaceId: string): NeoActionSpaceTaskManager;
+}
+
+/** Gate data record returned by the repository. */
+export interface NeoGateDataRecord {
+	data: Record<string, unknown>;
+}
+
+/** Repository for reading and writing gate approval data. */
+export interface NeoActionGateDataRepository {
+	get(runId: string, gateId: string): NeoGateDataRecord | null;
+	merge(runId: string, gateId: string, partial: Record<string, unknown>): NeoGateDataRecord;
+}
+
+/** Optional callback to notify the runtime that gate data changed. */
+export type NeoGateChangedNotifier = (runId: string, gateId: string) => Promise<void> | void;
+
 export interface NeoActionToolsConfig {
 	roomManager: NeoActionRoomManager;
 	managerFactory: NeoActionManagerFactory;
@@ -157,6 +263,44 @@ export interface NeoActionToolsConfig {
 	workspaceRoot?: string;
 	/** Returns the current security mode (looked up at call time) */
 	getSecurityMode(): NeoSecurityMode;
+
+	// ── Space / Workflow dependencies ──────────────────────────────────────
+	/** Pre-constructed GlobalSpaces handlers — Neo delegates CRUD and run ops to these. */
+	spaceHandlers?: NeoActionSpaceHandlers;
+	/** Repository for reading and transitioning workflow-run state. */
+	workflowRunRepo?: NeoActionWorkflowRunRepository;
+	/** Factory for per-space task managers (used by cancel_workflow_run). */
+	spaceTaskManagerFactory?: NeoActionSpaceTaskManagerFactory;
+	/** Repository for gate approval data. */
+	gateDataRepo?: NeoActionGateDataRepository;
+	/**
+	 * Optional callback invoked after gate data is written.
+	 * When provided, triggers channel re-evaluation so downstream nodes
+	 * activate if the gate is now open (mirrors fireGateChanged in the RPC layer).
+	 */
+	onGateChanged?: NeoGateChangedNotifier;
+	/**
+	 * Optional callback invoked after a workflow run's status changes.
+	 * Mirrors the `space.workflowRun.updated` event emitted by the RPC layer
+	 * so that the frontend LiveQuery subscriptions receive the update.
+	 * Called by cancel_workflow_run, approve_gate, and reject_gate.
+	 */
+	onWorkflowRunUpdated?: (
+		spaceId: string,
+		runId: string,
+		run: NeoWorkflowRun
+	) => void | Promise<void>;
+	/**
+	 * Optional callback invoked after gate data is written.
+	 * Mirrors the `space.gateData.updated` event emitted by the RPC layer.
+	 * Called by approve_gate and reject_gate.
+	 */
+	onGateDataUpdated?: (
+		spaceId: string,
+		runId: string,
+		gateId: string,
+		data: Record<string, unknown>
+	) => void | Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +367,19 @@ async function withSecurityCheck(
 // ---------------------------------------------------------------------------
 
 export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
-	const { roomManager, managerFactory, runtimeService, workspaceRoot } = config;
+	const {
+		roomManager,
+		managerFactory,
+		runtimeService,
+		workspaceRoot,
+		spaceHandlers,
+		workflowRunRepo,
+		spaceTaskManagerFactory,
+		gateDataRepo,
+		onGateChanged,
+		onWorkflowRunUpdated,
+		onGateDataUpdated,
+	} = config;
 
 	return {
 		// ── Room ──────────────────────────────────────────────────────────────
@@ -610,6 +766,236 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				return successResult({ taskId: args.task_id });
 			});
 		},
+
+		// ── Space ─────────────────────────────────────────────────────────────
+
+		async create_space(args: {
+			name: string;
+			workspace_path: string;
+			description?: string;
+			instructions?: string;
+			autonomy_level?: SpaceAutonomyLevel;
+		}): Promise<ToolResult> {
+			return withSecurityCheck('create_space', args as Record<string, unknown>, config, () => {
+				if (!spaceHandlers) {
+					return Promise.resolve(errorResult('Space operations are not available'));
+				}
+				return spaceHandlers.create_space(args);
+			});
+		},
+
+		async update_space(args: {
+			space_id: string;
+			name?: string;
+			description?: string;
+			instructions?: string;
+			background_context?: string;
+			default_model?: string;
+			autonomy_level?: SpaceAutonomyLevel;
+		}): Promise<ToolResult> {
+			// Input validation — stays outside the security check (no backend needed to validate)
+			const hasUpdates =
+				args.name !== undefined ||
+				args.description !== undefined ||
+				args.instructions !== undefined ||
+				args.background_context !== undefined ||
+				args.default_model !== undefined ||
+				args.autonomy_level !== undefined;
+			if (!hasUpdates) {
+				return errorResult('No update fields provided');
+			}
+			return withSecurityCheck('update_space', args as Record<string, unknown>, config, () => {
+				if (!spaceHandlers) {
+					return Promise.resolve(errorResult('Space operations are not available'));
+				}
+				return spaceHandlers.update_space(args);
+			});
+		},
+
+		async delete_space(args: { space_id: string }): Promise<ToolResult> {
+			return withSecurityCheck('delete_space', args as Record<string, unknown>, config, () => {
+				if (!spaceHandlers) {
+					return Promise.resolve(errorResult('Space operations are not available'));
+				}
+				return spaceHandlers.delete_space(args);
+			});
+		},
+
+		// ── Workflow ──────────────────────────────────────────────────────────
+
+		async start_workflow_run(args: {
+			space_id?: string;
+			workflow_id: string;
+			title: string;
+			description?: string;
+			goal_id?: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck(
+				'start_workflow_run',
+				args as Record<string, unknown>,
+				config,
+				() => {
+					if (!spaceHandlers) {
+						return Promise.resolve(errorResult('Workflow operations are not available'));
+					}
+					return spaceHandlers.start_workflow_run(args);
+				}
+			);
+		},
+
+		async cancel_workflow_run(args: { run_id: string }): Promise<ToolResult> {
+			return withSecurityCheck(
+				'cancel_workflow_run',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					if (!workflowRunRepo || !spaceTaskManagerFactory) {
+						return errorResult('Workflow run operations are not available');
+					}
+
+					const run = workflowRunRepo.getRun(args.run_id);
+					if (!run) {
+						return errorResult(`Workflow run not found: ${args.run_id}`);
+					}
+					if (run.status === 'cancelled') {
+						return successResult({ runId: args.run_id, alreadyCancelled: true });
+					}
+					if (run.status === 'completed') {
+						return errorResult('Cannot cancel a completed workflow run');
+					}
+
+					// Cancel all pending/in_progress tasks for this run (best-effort)
+					const taskManager = spaceTaskManagerFactory.getTaskManager(run.spaceId);
+					const tasks = await taskManager.listTasksByWorkflowRun(run.id);
+					for (const task of tasks) {
+						if (task.status === 'pending' || task.status === 'in_progress') {
+							await taskManager.cancelTask(task.id).catch(() => {
+								/* best-effort — individual task failures do not abort run cancellation */
+							});
+						}
+					}
+
+					const updated = workflowRunRepo.transitionStatus(args.run_id, 'cancelled');
+					await onWorkflowRunUpdated?.(run.spaceId, run.id, updated);
+					return successResult({ runId: args.run_id });
+				}
+			);
+		},
+
+		// ── Gate ──────────────────────────────────────────────────────────────
+
+		async approve_gate(args: {
+			run_id: string;
+			gate_id: string;
+			reason?: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck(
+				'approve_gate',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					if (!workflowRunRepo || !gateDataRepo) {
+						return errorResult('Gate operations are not available');
+					}
+
+					const run = workflowRunRepo.getRun(args.run_id);
+					if (!run) {
+						return errorResult(`Workflow run not found: ${args.run_id}`);
+					}
+					if (
+						run.status === 'completed' ||
+						run.status === 'cancelled' ||
+						run.status === 'pending'
+					) {
+						return errorResult(`Cannot approve gate on a ${run.status} workflow run`);
+					}
+
+					// Idempotent: already approved
+					const existing = gateDataRepo.get(args.run_id, args.gate_id);
+					if (existing?.data?.approved === true) {
+						return successResult({
+							runId: args.run_id,
+							gateId: args.gate_id,
+							gateData: existing.data,
+						});
+					}
+
+					const gateData = gateDataRepo.merge(args.run_id, args.gate_id, {
+						approved: true,
+						approvedAt: Date.now(),
+					});
+
+					// If previously rejected, transition back to in_progress and clear failure reason
+					let currentRun = run;
+					if (run.status === 'needs_attention' && run.failureReason === 'humanRejected') {
+						currentRun = workflowRunRepo.transitionStatus(args.run_id, 'in_progress');
+						currentRun =
+							workflowRunRepo.updateRun(args.run_id, { failureReason: null }) ?? currentRun;
+						await onWorkflowRunUpdated?.(run.spaceId, run.id, currentRun);
+					}
+
+					await onGateDataUpdated?.(run.spaceId, run.id, args.gate_id, gateData.data);
+					await onGateChanged?.(args.run_id, args.gate_id);
+
+					return successResult({
+						runId: args.run_id,
+						gateId: args.gate_id,
+						gateData: gateData.data,
+					});
+				}
+			);
+		},
+
+		async reject_gate(args: {
+			run_id: string;
+			gate_id: string;
+			reason?: string;
+		}): Promise<ToolResult> {
+			return withSecurityCheck('reject_gate', args as Record<string, unknown>, config, async () => {
+				if (!workflowRunRepo || !gateDataRepo) {
+					return errorResult('Gate operations are not available');
+				}
+
+				const run = workflowRunRepo.getRun(args.run_id);
+				if (!run) {
+					return errorResult(`Workflow run not found: ${args.run_id}`);
+				}
+				if (run.status === 'completed' || run.status === 'cancelled' || run.status === 'pending') {
+					return errorResult(`Cannot reject gate on a ${run.status} workflow run`);
+				}
+
+				// Idempotent: already rejected
+				const existing = gateDataRepo.get(args.run_id, args.gate_id);
+				if (existing?.data?.approved === false) {
+					return successResult({
+						runId: args.run_id,
+						gateId: args.gate_id,
+						gateData: existing.data,
+					});
+				}
+
+				const gateData = gateDataRepo.merge(args.run_id, args.gate_id, {
+					approved: false,
+					rejectedAt: Date.now(),
+					reason: args.reason ?? null,
+				});
+
+				if (run.status !== 'needs_attention') {
+					workflowRunRepo.transitionStatus(args.run_id, 'needs_attention');
+				}
+				const updatedRun =
+					workflowRunRepo.updateRun(args.run_id, { failureReason: 'humanRejected' }) ?? run;
+
+				await onWorkflowRunUpdated?.(run.spaceId, run.id, updatedRun);
+				await onGateDataUpdated?.(run.spaceId, run.id, args.gate_id, gateData.data);
+
+				return successResult({
+					runId: args.run_id,
+					gateId: args.gate_id,
+					gateData: gateData.data,
+				});
+			});
+		},
 	};
 }
 
@@ -798,6 +1184,104 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 				feedback: z.string().describe('Feedback explaining why the task was rejected'),
 			},
 			(args) => handlers.reject_task(args)
+		),
+
+		// ── Space ─────────────────────────────────────────────────────────────
+		tool(
+			'create_space',
+			'Create a new space with a name and workspace path. Low risk — auto-executes in balanced mode.',
+			{
+				name: z.string().describe('Name for the new space'),
+				workspace_path: z.string().describe('Absolute path to the workspace directory'),
+				description: z.string().optional().describe('Description of the space'),
+				instructions: z
+					.string()
+					.optional()
+					.describe('Instructions for agents working in this space'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe(
+						'Autonomy level: "supervised" (default) waits for human approval on judgment calls; "semi_autonomous" handles simple cases independently'
+					),
+			},
+			(args) => handlers.create_space(args)
+		),
+
+		tool(
+			'update_space',
+			'Update space metadata such as name, description, instructions, or autonomy level. Low risk — auto-executes in balanced mode.',
+			{
+				space_id: z.string().describe('ID of the space to update'),
+				name: z.string().optional().describe('New name'),
+				description: z.string().optional().describe('New description'),
+				instructions: z.string().optional().describe('New instructions for agents'),
+				background_context: z.string().optional().describe('New background context'),
+				default_model: z.string().optional().describe('New default model ID'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe('New autonomy level'),
+			},
+			(args) => handlers.update_space(args)
+		),
+
+		tool(
+			'delete_space',
+			'Permanently delete a space and all its data. Medium risk — requires confirmation in balanced mode.',
+			{
+				space_id: z.string().describe('ID of the space to delete'),
+			},
+			(args) => handlers.delete_space(args)
+		),
+
+		// ── Workflow ──────────────────────────────────────────────────────────
+		tool(
+			'start_workflow_run',
+			'Begin a workflow run in a space. Low risk — auto-executes in balanced mode.',
+			{
+				space_id: z
+					.string()
+					.optional()
+					.describe('Target space ID (defaults to the active space context)'),
+				workflow_id: z.string().describe('ID of the workflow to run'),
+				title: z.string().describe('Short title for this workflow run'),
+				description: z.string().optional().describe('Description of the work'),
+				goal_id: z.string().optional().describe('Goal/mission ID to associate with this run'),
+			},
+			(args) => handlers.start_workflow_run(args)
+		),
+
+		tool(
+			'cancel_workflow_run',
+			'Cancel an active workflow run and all its pending tasks. Medium risk — requires confirmation in balanced mode.',
+			{
+				run_id: z.string().describe('ID of the workflow run to cancel'),
+			},
+			(args) => handlers.cancel_workflow_run(args)
+		),
+
+		// ── Gate ──────────────────────────────────────────────────────────────
+		tool(
+			'approve_gate',
+			'Approve a human-approval gate in a workflow run, allowing the workflow to proceed. Medium risk — requires confirmation in balanced mode.',
+			{
+				run_id: z.string().describe('ID of the workflow run'),
+				gate_id: z.string().describe('ID of the gate to approve'),
+				reason: z.string().optional().describe('Optional reason for the approval'),
+			},
+			(args) => handlers.approve_gate(args)
+		),
+
+		tool(
+			'reject_gate',
+			'Reject a human-approval gate in a workflow run, halting it for revision. Medium risk — requires confirmation in balanced mode.',
+			{
+				run_id: z.string().describe('ID of the workflow run'),
+				gate_id: z.string().describe('ID of the gate to reject'),
+				reason: z.string().optional().describe('Reason for the rejection'),
+			},
+			(args) => handlers.reject_gate(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -83,6 +83,7 @@ import type { SkillsManager } from '../skills-manager';
 import { setupNeoHandlers } from './neo-handlers';
 import type { NeoAgentManager } from '../neo/neo-agent-manager';
 import { PendingActionStore } from '../neo/security-tier';
+import type { NeoToolsConfig } from '../neo/tools/neo-query-tools';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -347,6 +348,29 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		},
 	};
 	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo, agentLookup);
+
+	// Wire Neo query tools — must happen before neoAgentManager.provision() is called
+	// in app.ts (setupRPCHandlers runs first). The in-process neo-query server is merged
+	// with registry-sourced servers; in-process wins on name collision.
+	const neoToolsConfig: NeoToolsConfig = {
+		roomManager,
+		goalRepository: deps.db.getGoalRepo(),
+		taskRepository: deps.db.getTaskRepo(),
+		sessionManager: deps.sessionManager,
+		settingsManager: deps.settingsManager,
+		authManager: deps.authManager,
+		mcpServerRepository: deps.db.appMcpServers,
+		skillsManager: deps.skillsManager,
+		workspaceRoot: deps.config.workspaceRoot,
+		appVersion: '0.1.1',
+		startedAt: Date.now(),
+		spaceManager: deps.spaceManager,
+		spaceAgentManager: deps.spaceAgentManager,
+		spaceWorkflowManager,
+		workflowRunRepository: spaceWorkflowRunRepo,
+		spaceTaskRepository: spaceTaskRepo,
+	};
+	deps.neoAgentManager.setToolsConfig(neoToolsConfig, deps.appMcpManager);
 
 	const spaceTaskManagerFactory: SpaceTaskManagerFactory = (spaceId: string) => {
 		return new SpaceTaskManager(deps.db.getDatabase(), spaceId);

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -362,7 +362,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		mcpServerRepository: deps.db.appMcpServers,
 		skillsManager: deps.skillsManager,
 		workspaceRoot: deps.config.workspaceRoot,
-		appVersion: '0.1.1',
+		appVersion: '0.1.1', // TODO: centralise into a shared VERSION constant (same value in system-handlers.ts and state-manager.ts)
 		startedAt: Date.now(),
 		spaceManager: deps.spaceManager,
 		spaceAgentManager: deps.spaceAgentManager,

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -17,7 +17,14 @@
  * - set_task_status: status transition
  * - approve_task: happy path, task not in review error, runtime unavailable
  * - reject_task: happy path, task not in review error, runtime unavailable
- * - MCP server: all 11 tools are registered
+ * - create_space: auto-execute and confirmation paths, unavailable guard
+ * - update_space: auto-execute and no-op guard
+ * - delete_space: auto-execute and confirmation paths
+ * - start_workflow_run: auto-execute and confirmation paths
+ * - cancel_workflow_run: happy path, already-cancelled, completed error, unavailable guard
+ * - approve_gate: happy path, idempotent, rejection override, terminal-run error
+ * - reject_gate: happy path, idempotent, reason propagation, terminal-run error
+ * - MCP server: all 18 tools are registered
  */
 
 import { describe, expect, it, beforeEach } from 'bun:test';
@@ -30,6 +37,12 @@ import {
 	type NeoActionTaskManager,
 	type NeoActionRuntimeService,
 	type NeoActionManagerFactory,
+	type NeoActionSpaceHandlers,
+	type NeoActionWorkflowRunRepository,
+	type NeoActionSpaceTaskManagerFactory,
+	type NeoActionGateDataRepository,
+	type NeoWorkflowRun,
+	type NeoSpaceTask,
 } from '../../../src/lib/neo/tools/neo-action-tools';
 import { PendingActionStore } from '../../../src/lib/neo/security-tier';
 import type { Room, RoomGoal, NeoTask } from '@neokai/shared';
@@ -210,6 +223,99 @@ function makeManagerFactory(
 // Config builder
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Space/Workflow mock factories
+// ---------------------------------------------------------------------------
+
+type SpaceToolResult = { content: Array<{ type: 'text'; text: string }> };
+
+function makeSpaceHandlers(override: Partial<NeoActionSpaceHandlers> = {}): NeoActionSpaceHandlers {
+	const defaultResult = (): Promise<SpaceToolResult> =>
+		Promise.resolve({
+			content: [{ type: 'text', text: JSON.stringify({ success: true }) }],
+		});
+	return {
+		create_space: override.create_space ?? ((_args) => defaultResult()),
+		update_space: override.update_space ?? ((_args) => defaultResult()),
+		delete_space: override.delete_space ?? ((_args) => defaultResult()),
+		start_workflow_run: override.start_workflow_run ?? ((_args) => defaultResult()),
+	};
+}
+
+function makeWorkflowRun(overrides: Partial<NeoWorkflowRun> = {}): NeoWorkflowRun {
+	return {
+		id: 'run-1',
+		spaceId: 'space-1',
+		status: 'in_progress',
+		failureReason: null,
+		...overrides,
+	};
+}
+
+function makeWorkflowRunRepo(
+	runs: NeoWorkflowRun[] = []
+): NeoActionWorkflowRunRepository & { _runs: Map<string, NeoWorkflowRun> } {
+	const store = new Map<string, NeoWorkflowRun>(runs.map((r) => [r.id, r]));
+	return {
+		_runs: store,
+		getRun: (id) => store.get(id) ?? null,
+		transitionStatus: (id, to) => {
+			const run = store.get(id);
+			if (!run) throw new Error(`Run not found: ${id}`);
+			const updated = { ...run, status: to };
+			store.set(id, updated);
+			return updated;
+		},
+		updateRun: (id, params) => {
+			const run = store.get(id);
+			if (!run) return null;
+			const updated = { ...run, ...params };
+			store.set(id, updated);
+			return updated;
+		},
+	};
+}
+
+function makeSpaceTask(overrides: Partial<NeoSpaceTask> = {}): NeoSpaceTask {
+	return { id: 'stask-1', status: 'pending', ...overrides };
+}
+
+function makeSpaceTaskManagerFactory(
+	tasks: NeoSpaceTask[] = []
+): NeoActionSpaceTaskManagerFactory & { _cancelledIds: string[] } {
+	const cancelledIds: string[] = [];
+	return {
+		_cancelledIds: cancelledIds,
+		getTaskManager: (_spaceId) => ({
+			listTasksByWorkflowRun: async (_runId) => tasks,
+			cancelTask: async (taskId) => {
+				cancelledIds.push(taskId);
+			},
+		}),
+	};
+}
+
+function makeGateDataRepo(): NeoActionGateDataRepository & {
+	_store: Map<string, Record<string, unknown>>;
+} {
+	const store = new Map<string, Record<string, unknown>>();
+	return {
+		_store: store,
+		get: (runId, gateId) => {
+			const key = `${runId}:${gateId}`;
+			const data = store.get(key);
+			return data ? { data } : null;
+		},
+		merge: (runId, gateId, partial) => {
+			const key = `${runId}:${gateId}`;
+			const existing = store.get(key) ?? {};
+			const merged = { ...existing, ...partial };
+			store.set(key, merged);
+			return { data: merged };
+		},
+	};
+}
+
 function makeConfig(
 	opts: {
 		rooms?: Room[];
@@ -220,6 +326,22 @@ function makeConfig(
 		workspaceRoot?: string;
 		/** Simulate active session counts per room ID for delete_room escalation tests */
 		activeSessionCounts?: Map<string, number>;
+		spaceHandlers?: NeoActionSpaceHandlers;
+		workflowRunRepo?: NeoActionWorkflowRunRepository;
+		spaceTaskManagerFactory?: NeoActionSpaceTaskManagerFactory;
+		gateDataRepo?: NeoActionGateDataRepository;
+		onGateChanged?: (runId: string, gateId: string) => Promise<void> | void;
+		onWorkflowRunUpdated?: (
+			spaceId: string,
+			runId: string,
+			run: NeoWorkflowRun
+		) => void | Promise<void>;
+		onGateDataUpdated?: (
+			spaceId: string,
+			runId: string,
+			gateId: string,
+			data: Record<string, unknown>
+		) => void | Promise<void>;
 	} = {}
 ): NeoActionToolsConfig {
 	const room = makeRoom();
@@ -246,6 +368,13 @@ function makeConfig(
 		pendingStore: new PendingActionStore(),
 		workspaceRoot: opts.workspaceRoot,
 		getSecurityMode: () => opts.securityMode ?? 'autonomous',
+		spaceHandlers: opts.spaceHandlers,
+		workflowRunRepo: opts.workflowRunRepo,
+		spaceTaskManagerFactory: opts.spaceTaskManagerFactory,
+		gateDataRepo: opts.gateDataRepo,
+		onGateChanged: opts.onGateChanged,
+		onWorkflowRunUpdated: opts.onWorkflowRunUpdated,
+		onGateDataUpdated: opts.onGateDataUpdated,
 	};
 }
 
@@ -942,6 +1071,653 @@ describe('reject_task', () => {
 });
 
 // ---------------------------------------------------------------------------
+// create_space
+// ---------------------------------------------------------------------------
+
+describe('create_space', () => {
+	it('delegates to spaceHandlers in autonomous mode', async () => {
+		let called = false;
+		const handlers = makeSpaceHandlers({
+			create_space: async (args) => {
+				called = true;
+				return {
+					content: [{ type: 'text', text: JSON.stringify({ success: true, name: args.name }) }],
+				};
+			},
+		});
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'autonomous' });
+		const { create_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_space({ name: 'My Space', workspace_path: '/ws' }));
+		expect(called).toBe(true);
+		expect(result.success).toBe(true);
+		expect(result.name).toBe('My Space');
+	});
+
+	it('returns confirmation in balanced mode (low risk — auto-executes)', async () => {
+		// create_space is low risk, so balanced mode auto-executes it too
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'balanced' });
+		const { create_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_space({ name: 'Test Space', workspace_path: '/workspace' })
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it('requires confirmation in conservative mode', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'conservative' });
+		const { create_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await create_space({ name: 'Test Space', workspace_path: '/workspace' })
+		);
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.pendingActionId).toBeTruthy();
+	});
+
+	it('returns error when spaceHandlers not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { create_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_space({ name: 'Test', workspace_path: '/ws' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// update_space
+// ---------------------------------------------------------------------------
+
+describe('update_space', () => {
+	it('delegates to spaceHandlers in autonomous mode', async () => {
+		let calledWith: unknown;
+		const handlers = makeSpaceHandlers({
+			update_space: async (args) => {
+				calledWith = args;
+				return { content: [{ type: 'text', text: JSON.stringify({ success: true }) }] };
+			},
+		});
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'autonomous' });
+		const { update_space } = createNeoActionToolHandlers(config);
+		await update_space({ space_id: 'space-1', name: 'New Name' });
+		expect((calledWith as Record<string, unknown>).name).toBe('New Name');
+	});
+
+	it('returns error when no update fields provided', async () => {
+		const config = makeConfig({ spaceHandlers: makeSpaceHandlers(), securityMode: 'autonomous' });
+		const { update_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_space({ space_id: 'space-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No update fields');
+	});
+
+	it('returns error when spaceHandlers not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { update_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_space({ space_id: 'space-1', name: 'x' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'balanced' });
+		const { update_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_space({ space_id: 'space-1', name: 'New Name' }));
+		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// delete_space
+// ---------------------------------------------------------------------------
+
+describe('delete_space', () => {
+	it('delegates to spaceHandlers in autonomous mode', async () => {
+		let calledId = '';
+		const handlers = makeSpaceHandlers({
+			delete_space: async (args) => {
+				calledId = args.space_id;
+				return {
+					content: [{ type: 'text', text: JSON.stringify({ success: true, deleted: true }) }],
+				};
+			},
+		});
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'autonomous' });
+		const { delete_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_space({ space_id: 'space-42' }));
+		expect(calledId).toBe('space-42');
+		expect(result.success).toBe(true);
+		expect(result.deleted).toBe(true);
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'balanced' });
+		const { delete_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_space({ space_id: 'space-1' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error when spaceHandlers not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { delete_space } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_space({ space_id: 'space-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// start_workflow_run
+// ---------------------------------------------------------------------------
+
+describe('start_workflow_run', () => {
+	it('delegates to spaceHandlers in autonomous mode', async () => {
+		let calledArgs: unknown;
+		const handlers = makeSpaceHandlers({
+			start_workflow_run: async (args) => {
+				calledArgs = args;
+				return {
+					content: [
+						{ type: 'text', text: JSON.stringify({ success: true, run: { id: 'run-1' } }) },
+					],
+				};
+			},
+		});
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'autonomous' });
+		const { start_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await start_workflow_run({ workflow_id: 'wf-1', title: 'Test Run', space_id: 'space-1' })
+		);
+		expect((calledArgs as Record<string, unknown>).workflow_id).toBe('wf-1');
+		expect(result.run.id).toBe('run-1');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'balanced' });
+		const { start_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await start_workflow_run({ workflow_id: 'wf-1', title: 'Test Run' })
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it('requires confirmation in conservative mode', async () => {
+		const handlers = makeSpaceHandlers();
+		const config = makeConfig({ spaceHandlers: handlers, securityMode: 'conservative' });
+		const { start_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await start_workflow_run({ workflow_id: 'wf-1', title: 'Test Run' })
+		);
+		expect(result.confirmationRequired).toBe(true);
+	});
+
+	it('returns error when spaceHandlers not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { start_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await start_workflow_run({ workflow_id: 'wf-1', title: 'x' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cancel_workflow_run
+// ---------------------------------------------------------------------------
+
+describe('cancel_workflow_run', () => {
+	it('cancels active tasks and transitions run to cancelled', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const tasks = [
+			makeSpaceTask({ id: 'st-1', status: 'pending' }),
+			makeSpaceTask({ id: 'st-2', status: 'in_progress' }),
+			makeSpaceTask({ id: 'st-3', status: 'completed' }),
+		];
+		const taskFactory = makeSpaceTaskManagerFactory(tasks);
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: taskFactory,
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.success).toBe(true);
+		expect(result.runId).toBe('run-1');
+		// pending and in_progress should be cancelled; completed is skipped
+		expect(taskFactory._cancelledIds).toContain('st-1');
+		expect(taskFactory._cancelledIds).toContain('st-2');
+		expect(taskFactory._cancelledIds).not.toContain('st-3');
+		expect(runRepo._runs.get('run-1')?.status).toBe('cancelled');
+	});
+
+	it('returns success with alreadyCancelled when run is already cancelled', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'cancelled' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const taskFactory = makeSpaceTaskManagerFactory();
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: taskFactory,
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.success).toBe(true);
+		expect(result.alreadyCancelled).toBe(true);
+	});
+
+	it('returns error when run is completed', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'completed' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: makeSpaceTaskManagerFactory(),
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Cannot cancel a completed');
+	});
+
+	it('returns error when run not found', async () => {
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo(),
+			spaceTaskManagerFactory: makeSpaceTaskManagerFactory(),
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not found');
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const config = makeConfig({
+			securityMode: 'balanced',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			spaceTaskManagerFactory: makeSpaceTaskManagerFactory(),
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error when workflowRunRepo not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+
+	it('still cancels run when individual cancelTask throws (best-effort)', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		// All task cancellations throw
+		const failingTaskFactory: NeoActionSpaceTaskManagerFactory = {
+			getTaskManager: () => ({
+				listTasksByWorkflowRun: async () => [
+					makeSpaceTask({ id: 'st-1', status: 'pending' }),
+					makeSpaceTask({ id: 'st-2', status: 'in_progress' }),
+				],
+				cancelTask: async () => {
+					throw new Error('cancel failed');
+				},
+			}),
+		};
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: failingTaskFactory,
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		const result = parseResult(await cancel_workflow_run({ run_id: 'run-1' }));
+		// Run is still cancelled despite task failures
+		expect(result.success).toBe(true);
+		expect(runRepo._runs.get('run-1')?.status).toBe('cancelled');
+	});
+
+	it('calls onWorkflowRunUpdated after cancellation', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', spaceId: 'space-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		let updatedSpaceId = '';
+		let updatedRunId = '';
+		let updatedStatus = '';
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			spaceTaskManagerFactory: makeSpaceTaskManagerFactory(),
+			onWorkflowRunUpdated: (_spaceId, _runId, updatedRun) => {
+				updatedSpaceId = _spaceId;
+				updatedRunId = _runId;
+				updatedStatus = updatedRun.status;
+			},
+		});
+		const { cancel_workflow_run } = createNeoActionToolHandlers(config);
+		await cancel_workflow_run({ run_id: 'run-1' });
+		expect(updatedSpaceId).toBe('space-1');
+		expect(updatedRunId).toBe('run-1');
+		expect(updatedStatus).toBe('cancelled');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// approve_gate
+// ---------------------------------------------------------------------------
+
+describe('approve_gate', () => {
+	it('writes approved gate data', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const gateRepo = makeGateDataRepo();
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			gateDataRepo: gateRepo,
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(true);
+		expect(result.gateData.approved).toBe(true);
+		expect(result.gateData.approvedAt).toBeDefined();
+	});
+
+	it('calls onGateChanged after approval', async () => {
+		let notifiedRun = '';
+		let notifiedGate = '';
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+			onGateChanged: (runId, gateId) => {
+				notifiedRun = runId;
+				notifiedGate = gateId;
+			},
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		expect(notifiedRun).toBe('run-1');
+		expect(notifiedGate).toBe('gate-1');
+	});
+
+	it('transitions rejected run back to in_progress', async () => {
+		const run = makeWorkflowRun({
+			id: 'run-1',
+			status: 'needs_attention',
+			failureReason: 'humanRejected',
+		});
+		const runRepo = makeWorkflowRunRepo([run]);
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		expect(runRepo._runs.get('run-1')?.status).toBe('in_progress');
+		expect(runRepo._runs.get('run-1')?.failureReason).toBeNull();
+	});
+
+	it('is idempotent when already approved', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const gateRepo = makeGateDataRepo();
+		// Pre-populate approved state
+		gateRepo.merge('run-1', 'gate-1', { approved: true, approvedAt: 123 });
+		let delegateCalls = 0;
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: gateRepo,
+			onGateChanged: () => {
+				delegateCalls++;
+			},
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(true);
+		// onGateChanged should NOT be called for an idempotent approval
+		expect(delegateCalls).toBe(0);
+	});
+
+	it('returns error for terminal run status', async () => {
+		for (const status of ['completed', 'cancelled', 'pending']) {
+			const run = makeWorkflowRun({ id: 'run-1', status });
+			const config = makeConfig({
+				securityMode: 'autonomous',
+				workflowRunRepo: makeWorkflowRunRepo([run]),
+				gateDataRepo: makeGateDataRepo(),
+			});
+			const { approve_gate } = createNeoActionToolHandlers(config);
+			const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain(status);
+		}
+	});
+
+	it('returns error when run not found', async () => {
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo(),
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'missing', gate_id: 'gate-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not found');
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const config = makeConfig({
+			securityMode: 'balanced',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+
+	it('returns error when dependencies not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+
+	it('calls onWorkflowRunUpdated and onGateDataUpdated after approving a rejected gate', async () => {
+		const run = makeWorkflowRun({
+			id: 'run-1',
+			spaceId: 'space-1',
+			status: 'needs_attention',
+			failureReason: 'humanRejected',
+		});
+		const runUpdates: Array<{ spaceId: string; runId: string; status: string }> = [];
+		const gateUpdates: Array<{ spaceId: string; runId: string; gateId: string }> = [];
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+			onWorkflowRunUpdated: (spaceId, runId, updatedRun) => {
+				runUpdates.push({ spaceId, runId, status: updatedRun.status });
+			},
+			onGateDataUpdated: (spaceId, runId, gateId) => {
+				gateUpdates.push({ spaceId, runId, gateId });
+			},
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		expect(runUpdates).toHaveLength(1);
+		expect(runUpdates[0].status).toBe('in_progress');
+		expect(gateUpdates).toHaveLength(1);
+		expect(gateUpdates[0].gateId).toBe('gate-1');
+	});
+
+	it('calls onGateDataUpdated but not onWorkflowRunUpdated for in_progress approval', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', spaceId: 'space-1', status: 'in_progress' });
+		let runUpdateCalls = 0;
+		let gateUpdateCalls = 0;
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+			onWorkflowRunUpdated: () => {
+				runUpdateCalls++;
+			},
+			onGateDataUpdated: () => {
+				gateUpdateCalls++;
+			},
+		});
+		const { approve_gate } = createNeoActionToolHandlers(config);
+		await approve_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		// No run status change — onWorkflowRunUpdated should NOT be called
+		expect(runUpdateCalls).toBe(0);
+		expect(gateUpdateCalls).toBe(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reject_gate
+// ---------------------------------------------------------------------------
+
+describe('reject_gate', () => {
+	it('writes rejected gate data and transitions run to needs_attention', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const gateRepo = makeGateDataRepo();
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			gateDataRepo: gateRepo,
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await reject_gate({ run_id: 'run-1', gate_id: 'gate-1', reason: 'Not ready' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.gateData.approved).toBe(false);
+		expect(result.gateData.reason).toBe('Not ready');
+		expect(runRepo._runs.get('run-1')?.status).toBe('needs_attention');
+		expect(runRepo._runs.get('run-1')?.failureReason).toBe('humanRejected');
+	});
+
+	it('is idempotent when already rejected', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'needs_attention' });
+		const gateRepo = makeGateDataRepo();
+		gateRepo.merge('run-1', 'gate-1', { approved: false, rejectedAt: 123 });
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: gateRepo,
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(true);
+		expect(result.gateData.approved).toBe(false);
+	});
+
+	it('does not call transitionStatus when run is already needs_attention', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'needs_attention' });
+		const runRepo = makeWorkflowRunRepo([run]);
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: runRepo,
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' });
+		// Status remains needs_attention (not changed by the handler)
+		expect(runRepo._runs.get('run-1')?.status).toBe('needs_attention');
+		expect(runRepo._runs.get('run-1')?.failureReason).toBe('humanRejected');
+	});
+
+	it('stores null reason when not provided', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const gateRepo = makeGateDataRepo();
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: gateRepo,
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.gateData.reason).toBeNull();
+	});
+
+	it('returns error for terminal run status', async () => {
+		for (const status of ['completed', 'cancelled', 'pending']) {
+			const run = makeWorkflowRun({ id: 'run-1', status });
+			const config = makeConfig({
+				securityMode: 'autonomous',
+				workflowRunRepo: makeWorkflowRunRepo([run]),
+				gateDataRepo: makeGateDataRepo(),
+			});
+			const { reject_gate } = createNeoActionToolHandlers(config);
+			const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain(status);
+		}
+	});
+
+	it('requires confirmation in balanced mode (medium risk)', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', status: 'in_progress' });
+		const config = makeConfig({
+			securityMode: 'balanced',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.confirmationRequired).toBe(true);
+	});
+
+	it('returns error when dependencies not configured', async () => {
+		const config = makeConfig({ securityMode: 'autonomous' });
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		const result = parseResult(await reject_gate({ run_id: 'run-1', gate_id: 'gate-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not available');
+	});
+
+	it('calls onWorkflowRunUpdated and onGateDataUpdated after rejection', async () => {
+		const run = makeWorkflowRun({ id: 'run-1', spaceId: 'space-1', status: 'in_progress' });
+		const runUpdates: Array<{ spaceId: string; status: string; failureReason: unknown }> = [];
+		const gateUpdates: Array<{ spaceId: string; gateId: string }> = [];
+		const config = makeConfig({
+			securityMode: 'autonomous',
+			workflowRunRepo: makeWorkflowRunRepo([run]),
+			gateDataRepo: makeGateDataRepo(),
+			onWorkflowRunUpdated: (spaceId, _runId, updatedRun) => {
+				runUpdates.push({
+					spaceId,
+					status: updatedRun.status,
+					failureReason: updatedRun.failureReason,
+				});
+			},
+			onGateDataUpdated: (spaceId, _runId, gateId) => {
+				gateUpdates.push({ spaceId, gateId });
+			},
+		});
+		const { reject_gate } = createNeoActionToolHandlers(config);
+		await reject_gate({ run_id: 'run-1', gate_id: 'gate-1', reason: 'Not ready' });
+		expect(runUpdates).toHaveLength(1);
+		expect(runUpdates[0].status).toBe('needs_attention');
+		expect(runUpdates[0].failureReason).toBe('humanRejected');
+		expect(gateUpdates).toHaveLength(1);
+		expect(gateUpdates[0].gateId).toBe('gate-1');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // MCP server — tool registration
 // ---------------------------------------------------------------------------
 
@@ -1000,7 +1776,35 @@ describe('createNeoActionMcpServer', () => {
 		expect(server.instance._registeredTools).toHaveProperty('reject_task');
 	});
 
-	it('registers exactly 11 tools', () => {
-		expect(Object.keys(server.instance._registeredTools)).toHaveLength(11);
+	it('registers create_space tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('create_space');
+	});
+
+	it('registers update_space tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('update_space');
+	});
+
+	it('registers delete_space tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('delete_space');
+	});
+
+	it('registers start_workflow_run tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('start_workflow_run');
+	});
+
+	it('registers cancel_workflow_run tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('cancel_workflow_run');
+	});
+
+	it('registers approve_gate tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('approve_gate');
+	});
+
+	it('registers reject_gate tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('reject_gate');
+	});
+
+	it('registers exactly 18 tools', () => {
+		expect(Object.keys(server.instance._registeredTools)).toHaveLength(18);
 	});
 });

--- a/packages/daemon/tests/unit/neo/neo-agent-manager-query-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-agent-manager-query-tools.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Integration tests for NeoAgentManager query tools attachment.
+ *
+ * Covers:
+ * - provision() with setToolsConfig() calls setRuntimeMcpServers() with neo-query server
+ * - provision() without setToolsConfig() does NOT call setRuntimeMcpServers()
+ * - Registry MCP servers are merged with the in-process neo-query server
+ * - In-process 'neo-query' takes precedence on name collision with registry entry
+ * - MCP tools are re-attached after destroyAndRecreate() (startup health-check failure)
+ * - clearSession() re-attaches MCP tools on the fresh session
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { NeoAgentManager, NEO_SESSION_ID } from '../../../src/lib/neo/neo-agent-manager';
+import type {
+	NeoSessionManager,
+	NeoSettingsManager,
+	NeoAppMcpManager,
+} from '../../../src/lib/neo/neo-agent-manager';
+import type { AgentSession } from '../../../src/lib/agent/agent-session';
+import type { McpServerConfig } from '@neokai/shared';
+import type {
+	NeoToolsConfig,
+	NeoQueryRoomManager,
+	NeoQueryGoalRepository,
+	NeoQueryTaskRepository,
+	NeoQuerySessionManager,
+	NeoQuerySettingsManager,
+	NeoQueryAuthManager,
+	NeoQueryMcpServerRepository,
+	NeoQuerySkillsManager,
+	NeoQuerySpaceManager,
+	NeoQuerySpaceAgentManager,
+	NeoQuerySpaceWorkflowManager,
+	NeoQueryWorkflowRunRepository,
+	NeoQuerySpaceTaskRepository,
+} from '../../../src/lib/neo/tools/neo-query-tools';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(
+	overrides: {
+		processingStatus?: 'idle' | 'processing' | 'queued' | 'waiting_for_input' | 'interrupted';
+		queryPromise?: Promise<void> | null;
+		queryObject?: unknown;
+		cleaningUp?: boolean;
+	} = {}
+): AgentSession {
+	const {
+		processingStatus = 'idle',
+		queryPromise = null,
+		queryObject = null,
+		cleaningUp = false,
+	} = overrides;
+
+	return {
+		getProcessingState: mock(() =>
+			processingStatus === 'processing'
+				? { status: 'processing', messageId: 'msg-1', phase: 'thinking' }
+				: { status: processingStatus }
+		),
+		isCleaningUp: mock(() => cleaningUp),
+		setRuntimeSystemPrompt: mock(() => undefined),
+		setRuntimeModel: mock(() => undefined),
+		setRuntimeMcpServers: mock(() => undefined),
+		cleanup: mock(async () => undefined),
+		queryPromise,
+		queryObject,
+	} as unknown as AgentSession;
+}
+
+function makeSessionManager(
+	opts: {
+		existingSession?: AgentSession | null;
+		createdSessions?: Array<AgentSession | null>;
+		createdSession?: AgentSession | null;
+	} = {}
+): NeoSessionManager & { _createCalls: number } {
+	const sessions = new Map<string, AgentSession | null>();
+	let getCallCount = 0;
+	const sessionQueue: Array<AgentSession | null> = opts.createdSessions
+		? [...opts.createdSessions]
+		: opts.createdSession !== undefined
+			? [opts.createdSession]
+			: [];
+
+	const sm = {
+		_createCalls: 0,
+
+		createSession: mock(async () => {
+			sm._createCalls++;
+			const next = sessionQueue.length > 0 ? sessionQueue.shift()! : makeSession();
+			sessions.set(NEO_SESSION_ID, next);
+			return NEO_SESSION_ID;
+		}),
+
+		getSessionAsync: mock(async (_id: string): Promise<AgentSession | null> => {
+			if (getCallCount === 0) {
+				getCallCount++;
+				if (opts.existingSession !== undefined) {
+					sessions.set(NEO_SESSION_ID, opts.existingSession);
+				}
+			}
+			return sessions.get(NEO_SESSION_ID) ?? null;
+		}),
+
+		deleteSession: mock(async () => {
+			sessions.delete(NEO_SESSION_ID);
+		}),
+
+		unregisterSession: mock(() => {}),
+	};
+
+	return sm;
+}
+
+function makeSettingsManager(): NeoSettingsManager {
+	return {
+		getGlobalSettings: mock(() => ({ neoSecurityMode: 'balanced', model: 'sonnet' })),
+	};
+}
+
+function makeMinimalToolsConfig(overrides: Partial<NeoToolsConfig> = {}): NeoToolsConfig {
+	const noopRoomManager: NeoQueryRoomManager = {
+		listRooms: () => [],
+		getRoom: () => null,
+		getRoomOverview: () => null,
+	};
+	const noopGoalRepo: NeoQueryGoalRepository = {
+		listGoals: () => [],
+		getGoal: () => null,
+		listExecutions: () => [],
+	};
+	const noopTaskRepo: NeoQueryTaskRepository = {
+		listTasks: () => [],
+		getTask: () => null,
+	};
+	const noopSessionManager: NeoQuerySessionManager = {
+		getActiveSessions: () => 0,
+		listSessions: () => [],
+	};
+	const noopSettingsManager: NeoQuerySettingsManager = {
+		getGlobalSettings: () =>
+			({
+				settingSources: [],
+				model: 'sonnet',
+				permissionMode: 'default',
+				thinkingLevel: 'none',
+				autoScroll: true,
+				coordinatorMode: false,
+				maxConcurrentWorkers: 3,
+				neoSecurityMode: 'balanced',
+				neoModel: null,
+				showArchived: false,
+				fallbackModels: [],
+				disabledMcpServers: [],
+			}) as ReturnType<NeoQuerySettingsManager['getGlobalSettings']>,
+	};
+	const noopAuthManager: NeoQueryAuthManager = {
+		getAuthStatus: async () => ({
+			isAuthenticated: false,
+			method: 'none',
+			source: 'env' as const,
+		}),
+	};
+	const noopMcpRepo: NeoQueryMcpServerRepository = {
+		list: () => [],
+		get: () => null,
+	};
+	const noopSkillsManager: NeoQuerySkillsManager = {
+		listSkills: () => [],
+		getSkill: () => null,
+	};
+	const noopSpaceManager: NeoQuerySpaceManager = {
+		listSpaces: () => [],
+		getSpace: () => null,
+	};
+	const noopSpaceAgentManager: NeoQuerySpaceAgentManager = {
+		listBySpaceId: () => [],
+	};
+	const noopSpaceWorkflowManager: NeoQuerySpaceWorkflowManager = {
+		listWorkflows: () => [],
+	};
+	const noopWorkflowRunRepo: NeoQueryWorkflowRunRepository = {
+		listBySpace: () => [],
+	};
+	const noopSpaceTaskRepo: NeoQuerySpaceTaskRepository = {
+		listBySpace: () => [],
+		listByStatus: () => [],
+	};
+
+	return {
+		roomManager: noopRoomManager,
+		goalRepository: noopGoalRepo,
+		taskRepository: noopTaskRepo,
+		sessionManager: noopSessionManager,
+		settingsManager: noopSettingsManager,
+		authManager: noopAuthManager,
+		mcpServerRepository: noopMcpRepo,
+		skillsManager: noopSkillsManager,
+		workspaceRoot: '/workspace',
+		appVersion: '0.1.1',
+		startedAt: Date.now() - 1_000,
+		spaceManager: noopSpaceManager,
+		spaceAgentManager: noopSpaceAgentManager,
+		spaceWorkflowManager: noopSpaceWorkflowManager,
+		workflowRunRepository: noopWorkflowRunRepo,
+		spaceTaskRepository: noopSpaceTaskRepo,
+		...overrides,
+	};
+}
+
+function makeAppMcpManager(configs: Record<string, McpServerConfig> = {}): NeoAppMcpManager {
+	return {
+		getEnabledMcpConfigs: mock(() => configs),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoAgentManager — query tools attachment', () => {
+	describe('setToolsConfig() + provision()', () => {
+		test('attaches neo-query MCP server when toolsConfig is set before provision()', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalToolsConfig());
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+		});
+
+		test('does NOT call setRuntimeMcpServers when toolsConfig is not set', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			// No setToolsConfig() call
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(0);
+		});
+
+		test('merges registry MCP servers with neo-query server', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			const registryServers: Record<string, McpServerConfig> = {
+				'brave-search': { command: 'npx', args: ['-y', 'brave-search-mcp'] } as McpServerConfig,
+				'fetch-mcp': { command: 'npx', args: ['-y', 'fetch-mcp'] } as McpServerConfig,
+			};
+			mgr.setToolsConfig(makeMinimalToolsConfig(), makeAppMcpManager(registryServers));
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+			expect('brave-search' in servers).toBe(true);
+			expect('fetch-mcp' in servers).toBe(true);
+		});
+
+		test('in-process neo-query takes precedence over registry entry with same name', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			// Registry has an entry named 'neo-query' — should be overridden
+			const registryNeoQuery = {
+				command: 'npx',
+				args: ['-y', 'fake-neo-query'],
+			} as McpServerConfig;
+			const registryServers: Record<string, McpServerConfig> = {
+				'neo-query': registryNeoQuery,
+			};
+			mgr.setToolsConfig(makeMinimalToolsConfig(), makeAppMcpManager(registryServers));
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			// The in-process server should be an object (MCP server instance), not the registry entry
+			expect(servers['neo-query']).not.toBe(registryNeoQuery);
+		});
+
+		test('works without appMcpManager — only neo-query server is set', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			// No appMcpManager passed
+			mgr.setToolsConfig(makeMinimalToolsConfig());
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			const keys = Object.keys(servers);
+			expect(keys).toEqual(['neo-query']);
+		});
+	});
+
+	describe('destroyAndRecreate path', () => {
+		test('re-attaches MCP tools on fresh session after startup health-check failure', async () => {
+			// Stuck session from previous daemon run → destroyAndRecreate() fires
+			const stuckSession = makeSession({
+				processingStatus: 'processing',
+				queryPromise: new Promise(() => undefined),
+				queryObject: null,
+			});
+			const freshSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({
+				existingSession: stuckSession,
+				createdSession: freshSession,
+			});
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalToolsConfig());
+
+			await mgr.provision();
+
+			// Stuck session should not have setRuntimeMcpServers called (it was never healthy)
+			expect((stuckSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls.length).toBe(
+				0
+			);
+			// Fresh session has applyRuntimeConfig() called twice: once inside destroyAndRecreate()
+			// and once at the end of provision(). Both calls should include neo-query.
+			const freshCalls = (freshSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(freshCalls.length).toBeGreaterThanOrEqual(1);
+			expect('neo-query' in (freshCalls[0][0] as Record<string, McpServerConfig>)).toBe(true);
+		});
+
+		test('re-attaches MCP tools after clearSession()', async () => {
+			const initialSession = makeSession();
+			const freshSession = makeSession();
+			const sm = makeSessionManager({
+				existingSession: null,
+				createdSessions: [initialSession, freshSession],
+			});
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalToolsConfig());
+
+			await mgr.provision();
+			await mgr.clearSession();
+
+			// Both sessions should have had setRuntimeMcpServers called
+			expect(
+				(initialSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls.length
+			).toBe(1);
+			expect((freshSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls.length).toBe(
+				1
+			);
+		});
+	});
+
+	describe('restart path', () => {
+		test('re-attaches MCP tools to existing session on daemon restart', async () => {
+			const existingSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({ existingSession });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalToolsConfig());
+
+			await mgr.provision();
+
+			const calls = (existingSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			expect('neo-query' in (calls[0][0] as Record<string, McpServerConfig>)).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
Wires the `neo-query` in-process MCP server into Neo's provisioning flow.

## Changes

**`NeoAgentManager`** — new `setToolsConfig()` + `attachQueryTools()`:
- `setToolsConfig(toolsConfig, appMcpManager?)` — called before `provision()` to inject all query tool dependencies and an optional registry manager
- `attachQueryTools()` — private helper called from `applyRuntimeConfig()`; creates the `neo-query` MCP server and merges registry-sourced servers. In-process wins on name collision (same pattern as `provisionGlobalSpacesAgent`)
- `NeoAppMcpManager` interface — minimal subset of `AppMcpLifecycleManager` for easy mocking

**`setupRPCHandlers/index.ts`** — builds `NeoToolsConfig` from all available managers and repos (roomManager, goalRepo, taskRepo, spaceWorkflowManager, etc.) and calls `neoAgentManager.setToolsConfig()` after space repos are created. This runs before `neoAgentManager.provision()` in `app.ts`.

**New test file** — `neo-agent-manager-query-tools.test.ts` with 8 integration tests covering: first-run attachment, no-op when config absent, registry merge, name collision precedence, destroy+recreate re-attach, clearSession re-attach, restart path.

## Acceptance Criteria
- Neo session has all query tools available ✓
- Registry MCP servers are merged without conflicts ✓
- Neo's in-process tools take precedence on name collision ✓
- Integration tests pass ✓