### PR TITLE
feat(neo): Configuration and messaging action tools (task 3.4)

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -434,6 +434,26 @@ export interface NeoActionToolsConfig {
 // ---------------------------------------------------------------------------
 
 /**
+ * Well-known sensitive environment variable names that must not be stored
+ * in the MCP registry.  Secret values should live in the host process
+ * environment (process.env) and are inherited by MCP child processes
+ * automatically — they must never be persisted to SQLite.
+ */
+const SENSITIVE_ENV_VARS = new Set([
+	'ANTHROPIC_API_KEY',
+	'CLAUDE_CODE_OAUTH_TOKEN',
+	'ANTHROPIC_AUTH_TOKEN',
+	'GLM_API_KEY',
+	'ZHIPU_API_KEY',
+	'OPENAI_API_KEY',
+	'BRAVE_API_KEY',
+	'COPILOT_GITHUB_TOKEN',
+	'GITHUB_TOKEN',
+	'AWS_SECRET_ACCESS_KEY',
+	'AWS_SESSION_TOKEN',
+]);
+
+/**
  * Approval message sent to the worker agent when a task is approved.
  * The worker is expected to merge the PR as its final step.
  */
@@ -1092,6 +1112,18 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			if (!mcpManager) {
 				return errorResult('MCP manager not available');
 			}
+			// Reject well-known sensitive env vars to prevent credential injection.
+			// Raw secret values must never be stored in the MCP registry — they
+			// should be pre-set in the host process environment and referenced by key.
+			if (args.env) {
+				const rejected = Object.keys(args.env).filter((k) => SENSITIVE_ENV_VARS.has(k));
+				if (rejected.length > 0) {
+					return errorResult(
+						`Refusing to store sensitive env var(s): ${rejected.join(', ')}. ` +
+							'Set these in the host environment instead; the MCP process inherits them automatically.'
+					);
+				}
+			}
 			return withSecurityCheck(
 				'add_mcp_server',
 				args as Record<string, unknown>,
@@ -1127,6 +1159,9 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			url?: string;
 			headers?: Record<string, string>;
 		}): Promise<ToolResult> {
+			// Note: `source_type` is intentionally omitted from update params — it is
+			// immutable after creation (similar to skill.name).  To change transport
+			// type, delete and re-create the entry.
 			if (!mcpManager) {
 				return errorResult('MCP manager not available');
 			}
@@ -1370,6 +1405,10 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 		// ── Messaging & session control ───────────────────────────────────────
 
 		async send_message_to_room(args: { room_id: string; message: string }): Promise<ToolResult> {
+			// Validate before the security check so we don't waste a pending action slot.
+			if (!args.message?.trim()) {
+				return errorResult('Message must not be empty');
+			}
 			if (!sessionManager) {
 				return errorResult('Session manager not available');
 			}
@@ -1397,6 +1436,10 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			task_id: string;
 			message: string;
 		}): Promise<ToolResult> {
+			// Validate before the security check so we don't waste a pending action slot.
+			if (!args.message?.trim()) {
+				return errorResult('Message must not be empty');
+			}
 			if (!sessionManager) {
 				return errorResult('Session manager not available');
 			}
@@ -1539,6 +1582,10 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 						return errorResult(`Goal ${args.goal_id} is not a recurring mission`);
 					}
 
+					if (goal.schedulePaused) {
+						return successResult({ goal, alreadyPaused: true });
+					}
+
 					const updated = await goalManager.updateGoalStatus(args.goal_id, goal.status, {
 						schedulePaused: true,
 					});
@@ -1568,6 +1615,10 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 					}
 					if (!goal.schedule) {
 						return errorResult(`Goal ${args.goal_id} has no schedule set. Set a schedule first.`);
+					}
+
+					if (!goal.schedulePaused) {
+						return successResult({ goal, alreadyResumed: true });
 					}
 
 					const updated = await goalManager.updateGoalStatus(args.goal_id, goal.status, {

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -1,10 +1,10 @@
 /**
  * Neo Action Tools - MCP tools for write operations
  *
- * Implements room, goal, task, space, and workflow write operations with
- * security-tier enforcement.  Each tool checks whether the current security
- * mode requires confirmation before execution and either runs immediately or
- * returns a `confirmationRequired` payload.
+ * Implements room, goal, task, space, workflow, configuration, and messaging
+ * write operations with security-tier enforcement. Each tool checks whether
+ * the current security mode requires confirmation before execution and either
+ * runs immediately or returns a `confirmationRequired` payload.
  *
  * Pattern: two-layer design (testable handlers + MCP server wrapper)
  *   createNeoActionToolHandlers(config) → plain handler functions
@@ -39,6 +39,24 @@
  *   - cancel_workflow_run
  *   - approve_gate
  *   - reject_gate
+ *
+ *   Configuration management
+ *   - add_mcp_server
+ *   - update_mcp_server
+ *   - delete_mcp_server
+ *   - toggle_mcp_server
+ *   - add_skill
+ *   - update_skill
+ *   - delete_skill
+ *   - toggle_skill
+ *   - update_app_settings
+ *
+ *   Messaging & session control
+ *   - send_message_to_room
+ *   - send_message_to_task
+ *   - stop_session
+ *   - pause_schedule
+ *   - resume_schedule
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
@@ -55,6 +73,12 @@ import type {
 	AutonomyLevel,
 	WorkspacePath,
 	SpaceAutonomyLevel,
+	AppMcpServer,
+	AppMcpServerSourceType,
+	AppSkill,
+	AppSkillConfig,
+	SkillSourceType,
+	GlobalSettings,
 } from '@neokai/shared';
 import {
 	ActionClassification,
@@ -114,7 +138,11 @@ export interface NeoActionGoalManager {
 			autonomyLevel?: AutonomyLevel;
 		}
 	): Promise<RoomGoal>;
-	updateGoalStatus(id: string, status: GoalStatus): Promise<RoomGoal>;
+	updateGoalStatus(
+		id: string,
+		status: GoalStatus,
+		updates?: { schedulePaused?: boolean }
+	): Promise<RoomGoal>;
 }
 
 export interface NeoActionTaskManager {
@@ -149,6 +177,7 @@ export interface NeoActionRuntime {
 		message: string,
 		opts: { approved: boolean }
 	): Promise<boolean>;
+	interruptTaskSession(taskId: string): Promise<{ success: boolean }>;
 }
 
 export interface NeoActionRuntimeService {
@@ -254,6 +283,95 @@ export interface NeoActionGateDataRepository {
 /** Optional callback to notify the runtime that gate data changed. */
 export type NeoGateChangedNotifier = (runId: string, gateId: string) => Promise<void> | void;
 
+// ---------------------------------------------------------------------------
+// Configuration management interfaces
+// ---------------------------------------------------------------------------
+
+export interface NeoMcpManager {
+	/** Create a new app-level MCP server entry */
+	createMcpServer(params: {
+		name: string;
+		sourceType: AppMcpServerSourceType;
+		description?: string;
+		command?: string;
+		args?: string[];
+		env?: Record<string, string>;
+		url?: string;
+		headers?: Record<string, string>;
+		enabled?: boolean;
+	}): AppMcpServer;
+	/** Update an existing MCP server entry */
+	updateMcpServer(
+		id: string,
+		updates: {
+			name?: string;
+			description?: string;
+			command?: string;
+			args?: string[];
+			env?: Record<string, string>;
+			url?: string;
+			headers?: Record<string, string>;
+			enabled?: boolean;
+		}
+	): AppMcpServer | null;
+	/** Delete an MCP server entry, returns true if deleted */
+	deleteMcpServer(id: string): boolean;
+	/** Get an MCP server entry by id */
+	getMcpServer(id: string): AppMcpServer | null;
+	/** Get an MCP server entry by name (for lookups) */
+	getMcpServerByName(name: string): AppMcpServer | null;
+}
+
+export interface NeoSkillsManager {
+	/** Add a new skill */
+	addSkill(params: {
+		name: string;
+		displayName: string;
+		description: string;
+		sourceType: SkillSourceType;
+		config: AppSkillConfig;
+		enabled?: boolean;
+		validationStatus?: 'pending' | 'valid' | 'invalid' | 'unknown';
+	}): AppSkill;
+	/** Update an existing skill (user-editable fields only) */
+	updateSkill(
+		id: string,
+		params: { displayName?: string; description?: string; config?: AppSkillConfig }
+	): AppSkill;
+	/** Toggle skill enabled state */
+	setSkillEnabled(id: string, enabled: boolean): AppSkill;
+	/** Remove a skill by ID, returns false if built-in or not found */
+	removeSkill(id: string): boolean;
+	/** Get a skill by ID */
+	getSkill(id: string): AppSkill | null;
+}
+
+export interface NeoSettingsManager {
+	getGlobalSettings(): GlobalSettings;
+	updateGlobalSettings(updates: Partial<GlobalSettings>): GlobalSettings;
+}
+
+// ---------------------------------------------------------------------------
+// Messaging & session control interfaces
+// ---------------------------------------------------------------------------
+
+export interface NeoSessionManager {
+	/**
+	 * Inject a message into a session. `sessionId` is the target session.
+	 * Used by send_message_to_room and send_message_to_task.
+	 */
+	injectMessage(sessionId: string, message: string): Promise<void>;
+	/**
+	 * Find the active session ID for a room. Returns the first active session
+	 * or null if there are none.
+	 */
+	getActiveSessionForRoom(roomId: string): string | null;
+	/**
+	 * Find the active worker session ID for a task. Returns null if not found.
+	 */
+	getActiveSessionForTask(taskId: string): string | null;
+}
+
 export interface NeoActionToolsConfig {
 	roomManager: NeoActionRoomManager;
 	managerFactory: NeoActionManagerFactory;
@@ -301,6 +419,14 @@ export interface NeoActionToolsConfig {
 		gateId: string,
 		data: Record<string, unknown>
 	) => void | Promise<void>;
+	/** MCP server CRUD operations (optional — config tools disabled if absent) */
+	mcpManager?: NeoMcpManager;
+	/** Skills CRUD operations (optional — skill tools disabled if absent) */
+	skillsManager?: NeoSkillsManager;
+	/** App settings manager (optional — update_app_settings disabled if absent) */
+	settingsManager?: NeoSettingsManager;
+	/** Session manager for message injection (optional — messaging tools disabled if absent) */
+	sessionManager?: NeoSessionManager;
 }
 
 // ---------------------------------------------------------------------------
@@ -379,6 +505,10 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 		onGateChanged,
 		onWorkflowRunUpdated,
 		onGateDataUpdated,
+		mcpManager,
+		skillsManager,
+		settingsManager,
+		sessionManager,
 	} = config;
 
 	return {
@@ -946,6 +1076,398 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			);
 		},
 
+		// ── MCP server configuration ──────────────────────────────────────────
+
+		async add_mcp_server(args: {
+			name: string;
+			source_type: string;
+			description?: string;
+			command?: string;
+			args?: string[];
+			env?: Record<string, string>;
+			url?: string;
+			headers?: Record<string, string>;
+			enabled?: boolean;
+		}): Promise<ToolResult> {
+			if (!mcpManager) {
+				return errorResult('MCP manager not available');
+			}
+			return withSecurityCheck(
+				'add_mcp_server',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					try {
+						const server = mcpManager.createMcpServer({
+							name: args.name,
+							sourceType: args.source_type as AppMcpServerSourceType,
+							description: args.description,
+							command: args.command,
+							args: args.args,
+							env: args.env,
+							url: args.url,
+							headers: args.headers,
+							enabled: args.enabled,
+						});
+						return successResult({ server });
+					} catch (err) {
+						return errorResult(err instanceof Error ? err.message : String(err));
+					}
+				}
+			);
+		},
+
+		async update_mcp_server(args: {
+			server_id: string;
+			name?: string;
+			description?: string;
+			command?: string;
+			args?: string[];
+			env?: Record<string, string>;
+			url?: string;
+			headers?: Record<string, string>;
+		}): Promise<ToolResult> {
+			if (!mcpManager) {
+				return errorResult('MCP manager not available');
+			}
+
+			const hasUpdates =
+				args.name !== undefined ||
+				args.description !== undefined ||
+				args.command !== undefined ||
+				args.args !== undefined ||
+				args.env !== undefined ||
+				args.url !== undefined ||
+				args.headers !== undefined;
+			if (!hasUpdates) {
+				return errorResult('No update fields provided');
+			}
+
+			return withSecurityCheck(
+				'update_mcp_server',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					try {
+						const server = mcpManager.updateMcpServer(args.server_id, {
+							name: args.name,
+							description: args.description,
+							command: args.command,
+							args: args.args,
+							env: args.env,
+							url: args.url,
+							headers: args.headers,
+						});
+						if (!server) {
+							return errorResult(`MCP server not found: ${args.server_id}`);
+						}
+						return successResult({ server });
+					} catch (err) {
+						return errorResult(err instanceof Error ? err.message : String(err));
+					}
+				}
+			);
+		},
+
+		async delete_mcp_server(args: { server_id: string }): Promise<ToolResult> {
+			if (!mcpManager) {
+				return errorResult('MCP manager not available');
+			}
+			return withSecurityCheck(
+				'delete_mcp_server',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const server = mcpManager.getMcpServer(args.server_id);
+					if (!server) {
+						return errorResult(`MCP server not found: ${args.server_id}`);
+					}
+					const deleted = mcpManager.deleteMcpServer(args.server_id);
+					if (!deleted) {
+						return errorResult(`Failed to delete MCP server: ${args.server_id}`);
+					}
+					return successResult({ serverId: args.server_id });
+				}
+			);
+		},
+
+		async toggle_mcp_server(args: { server_id: string; enabled: boolean }): Promise<ToolResult> {
+			if (!mcpManager) {
+				return errorResult('MCP manager not available');
+			}
+			return withSecurityCheck(
+				'toggle_mcp_server',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const server = mcpManager.updateMcpServer(args.server_id, {
+						enabled: args.enabled,
+					});
+					if (!server) {
+						return errorResult(`MCP server not found: ${args.server_id}`);
+					}
+					return successResult({ server });
+				}
+			);
+		},
+
+		// ── Skill configuration ───────────────────────────────────────────────
+
+		async add_skill(args: {
+			name: string;
+			display_name: string;
+			description: string;
+			source_type: string;
+			config: Record<string, unknown>;
+			enabled?: boolean;
+		}): Promise<ToolResult> {
+			if (!skillsManager) {
+				return errorResult('Skills manager not available');
+			}
+			return withSecurityCheck('add_skill', args as Record<string, unknown>, config, async () => {
+				try {
+					const skill = skillsManager.addSkill({
+						name: args.name,
+						displayName: args.display_name,
+						description: args.description,
+						sourceType: args.source_type as SkillSourceType,
+						config: args.config as unknown as AppSkillConfig,
+						enabled: args.enabled,
+					});
+					return successResult({ skill });
+				} catch (err) {
+					return errorResult(err instanceof Error ? err.message : String(err));
+				}
+			});
+		},
+
+		async update_skill(args: {
+			skill_id: string;
+			display_name?: string;
+			description?: string;
+			config?: Record<string, unknown>;
+		}): Promise<ToolResult> {
+			if (!skillsManager) {
+				return errorResult('Skills manager not available');
+			}
+
+			const hasUpdates =
+				args.display_name !== undefined ||
+				args.description !== undefined ||
+				args.config !== undefined;
+			if (!hasUpdates) {
+				return errorResult('No update fields provided');
+			}
+
+			return withSecurityCheck(
+				'update_skill',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					try {
+						const existing = skillsManager.getSkill(args.skill_id);
+						if (!existing) {
+							return errorResult(`Skill not found: ${args.skill_id}`);
+						}
+						const skill = skillsManager.updateSkill(args.skill_id, {
+							displayName: args.display_name,
+							description: args.description,
+							config: args.config as unknown as AppSkillConfig | undefined,
+						});
+						return successResult({ skill });
+					} catch (err) {
+						return errorResult(err instanceof Error ? err.message : String(err));
+					}
+				}
+			);
+		},
+
+		async delete_skill(args: { skill_id: string }): Promise<ToolResult> {
+			if (!skillsManager) {
+				return errorResult('Skills manager not available');
+			}
+			return withSecurityCheck(
+				'delete_skill',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const existing = skillsManager.getSkill(args.skill_id);
+					if (!existing) {
+						return errorResult(`Skill not found: ${args.skill_id}`);
+					}
+					if (existing.builtIn) {
+						return errorResult(
+							`Cannot delete built-in skill "${existing.name}". Use toggle_skill to disable it instead.`
+						);
+					}
+					const deleted = skillsManager.removeSkill(args.skill_id);
+					if (!deleted) {
+						return errorResult(`Failed to delete skill: ${args.skill_id}`);
+					}
+					return successResult({ skillId: args.skill_id });
+				}
+			);
+		},
+
+		async toggle_skill(args: { skill_id: string; enabled: boolean }): Promise<ToolResult> {
+			if (!skillsManager) {
+				return errorResult('Skills manager not available');
+			}
+			return withSecurityCheck(
+				'toggle_skill',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					try {
+						const skill = skillsManager.setSkillEnabled(args.skill_id, args.enabled);
+						return successResult({ skill });
+					} catch (err) {
+						return errorResult(err instanceof Error ? err.message : String(err));
+					}
+				}
+			);
+		},
+
+		// ── App settings ──────────────────────────────────────────────────────
+
+		async update_app_settings(args: {
+			model?: string;
+			thinking_level?: string;
+			auto_scroll?: boolean;
+			max_concurrent_workers?: number;
+		}): Promise<ToolResult> {
+			if (!settingsManager) {
+				return errorResult('Settings manager not available');
+			}
+
+			const hasUpdates =
+				args.model !== undefined ||
+				args.thinking_level !== undefined ||
+				args.auto_scroll !== undefined ||
+				args.max_concurrent_workers !== undefined;
+			if (!hasUpdates) {
+				return errorResult('No update fields provided');
+			}
+
+			return withSecurityCheck(
+				'update_app_settings',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const updates: Partial<GlobalSettings> = {};
+					if (args.model !== undefined) updates.model = args.model;
+					if (args.thinking_level !== undefined)
+						updates.thinkingLevel = args.thinking_level as GlobalSettings['thinkingLevel'];
+					if (args.auto_scroll !== undefined) updates.autoScroll = args.auto_scroll;
+					if (args.max_concurrent_workers !== undefined)
+						updates.maxConcurrentWorkers = args.max_concurrent_workers;
+					const settings = settingsManager.updateGlobalSettings(updates);
+					return successResult({ settings });
+				}
+			);
+		},
+
+		// ── Messaging & session control ───────────────────────────────────────
+
+		async send_message_to_room(args: { room_id: string; message: string }): Promise<ToolResult> {
+			if (!sessionManager) {
+				return errorResult('Session manager not available');
+			}
+			return withSecurityCheck(
+				'send_message_to_room',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+					const sessionId = sessionManager.getActiveSessionForRoom(args.room_id);
+					if (!sessionId) {
+						return errorResult(`No active session found for room: ${args.room_id}`);
+					}
+					await sessionManager.injectMessage(sessionId, args.message);
+					return successResult({ sessionId });
+				}
+			);
+		},
+
+		async send_message_to_task(args: {
+			room_id: string;
+			task_id: string;
+			message: string;
+		}): Promise<ToolResult> {
+			if (!sessionManager) {
+				return errorResult('Session manager not available');
+			}
+			return withSecurityCheck(
+				'send_message_to_task',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+					const taskManager = managerFactory.getTaskManager(args.room_id);
+					const task = await taskManager.getTask(args.task_id);
+					if (!task) {
+						return errorResult(`Task not found: ${args.task_id}`);
+					}
+					const sessionId = sessionManager.getActiveSessionForTask(args.task_id);
+					if (!sessionId) {
+						return errorResult(`No active session found for task: ${args.task_id}`);
+					}
+					await sessionManager.injectMessage(sessionId, args.message);
+					return successResult({ sessionId });
+				}
+			);
+		},
+
+		async stop_session(args: { room_id: string; task_id: string }): Promise<ToolResult> {
+			return withSecurityCheck(
+				'stop_session',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+
+					if (!runtimeService) {
+						return errorResult('Runtime service not available');
+					}
+					const runtime = runtimeService.getRuntime(args.room_id);
+					if (!runtime) {
+						return errorResult(`No runtime found for room: ${args.room_id}`);
+					}
+
+					const taskManager = managerFactory.getTaskManager(args.room_id);
+					const task = await taskManager.getTask(args.task_id);
+					if (!task) {
+						return errorResult(`Task not found: ${args.task_id}`);
+					}
+
+					if (task.status !== 'in_progress' && task.status !== 'review') {
+						return errorResult(
+							`Task cannot be interrupted (current status: ${task.status}). Only in_progress or review tasks can be interrupted.`
+						);
+					}
+
+					const result = await runtime.interruptTaskSession(args.task_id);
+					if (!result.success) {
+						return errorResult(`Failed to interrupt session for task ${args.task_id}`);
+					}
+
+					return successResult({
+						taskId: args.task_id,
+						message: `Generation interrupted for task ${args.task_id}. Task remains active and awaiting input.`,
+					});
+				}
+			);
+		},
+
 		async reject_gate(args: {
 			run_id: string;
 			gate_id: string;
@@ -995,6 +1517,65 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 					gateData: gateData.data,
 				});
 			});
+		},
+
+		async pause_schedule(args: { room_id: string; goal_id: string }): Promise<ToolResult> {
+			return withSecurityCheck(
+				'pause_schedule',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+
+					const goalManager = managerFactory.getGoalManager(args.room_id);
+					const goal = await goalManager.getGoal(args.goal_id);
+					if (!goal) {
+						return errorResult(`Goal not found: ${args.goal_id}`);
+					}
+					if (goal.missionType !== 'recurring') {
+						return errorResult(`Goal ${args.goal_id} is not a recurring mission`);
+					}
+
+					const updated = await goalManager.updateGoalStatus(args.goal_id, goal.status, {
+						schedulePaused: true,
+					});
+					return successResult({ goal: updated });
+				}
+			);
+		},
+
+		async resume_schedule(args: { room_id: string; goal_id: string }): Promise<ToolResult> {
+			return withSecurityCheck(
+				'resume_schedule',
+				args as Record<string, unknown>,
+				config,
+				async () => {
+					const room = roomManager.getRoom(args.room_id);
+					if (!room) {
+						return errorResult(`Room not found: ${args.room_id}`);
+					}
+
+					const goalManager = managerFactory.getGoalManager(args.room_id);
+					const goal = await goalManager.getGoal(args.goal_id);
+					if (!goal) {
+						return errorResult(`Goal not found: ${args.goal_id}`);
+					}
+					if (goal.missionType !== 'recurring') {
+						return errorResult(`Goal ${args.goal_id} is not a recurring mission`);
+					}
+					if (!goal.schedule) {
+						return errorResult(`Goal ${args.goal_id} has no schedule set. Set a schedule first.`);
+					}
+
+					const updated = await goalManager.updateGoalStatus(args.goal_id, goal.status, {
+						schedulePaused: false,
+					});
+					return successResult({ goal: updated });
+				}
+			);
 		},
 	};
 }
@@ -1282,6 +1863,208 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 				reason: z.string().optional().describe('Reason for the rejection'),
 			},
 			(args) => handlers.reject_gate(args)
+		),
+
+		// ── MCP server configuration ──────────────────────────────────────────
+		tool(
+			'add_mcp_server',
+			'Register a new MCP server in the application registry. Medium risk — requires confirmation in balanced mode.',
+			{
+				name: z.string().describe('Unique name for the MCP server'),
+				source_type: z
+					.enum(['stdio', 'sse', 'http'])
+					.describe('Transport type: stdio, sse, or http'),
+				description: z.string().optional().describe('Description of what the server provides'),
+				command: z.string().optional().describe('Executable command (stdio servers)'),
+				args: z.array(z.string()).optional().describe('Command arguments (stdio servers)'),
+				env: z
+					.record(z.string(), z.string())
+					.optional()
+					.describe('Environment variable overrides (stdio servers)'),
+				url: z.string().optional().describe('Server URL (sse or http servers)'),
+				headers: z
+					.record(z.string(), z.string())
+					.optional()
+					.describe('Additional HTTP headers (sse or http servers)'),
+				enabled: z.boolean().optional().describe('Whether to enable immediately (default: false)'),
+			},
+			(args) => handlers.add_mcp_server(args)
+		),
+
+		tool(
+			'update_mcp_server',
+			'Update an existing MCP server entry. Medium risk — requires confirmation in balanced mode.',
+			{
+				server_id: z.string().describe('ID of the MCP server to update'),
+				name: z.string().optional().describe('New name for the server'),
+				description: z.string().optional().describe('New description'),
+				command: z.string().optional().describe('New command (stdio servers)'),
+				args: z.array(z.string()).optional().describe('New command arguments (stdio servers)'),
+				env: z
+					.record(z.string(), z.string())
+					.optional()
+					.describe('New environment variables (stdio servers)'),
+				url: z.string().optional().describe('New URL (sse or http servers)'),
+				headers: z
+					.record(z.string(), z.string())
+					.optional()
+					.describe('New headers (sse or http servers)'),
+			},
+			(args) => handlers.update_mcp_server(args)
+		),
+
+		tool(
+			'delete_mcp_server',
+			'Remove an MCP server from the registry. Medium risk — requires confirmation in balanced mode.',
+			{
+				server_id: z.string().describe('ID of the MCP server to delete'),
+			},
+			(args) => handlers.delete_mcp_server(args)
+		),
+
+		tool(
+			'toggle_mcp_server',
+			'Enable or disable an MCP server globally. Low risk — auto-executes in balanced mode.',
+			{
+				server_id: z.string().describe('ID of the MCP server to toggle'),
+				enabled: z.boolean().describe('Whether to enable or disable the server'),
+			},
+			(args) => handlers.toggle_mcp_server(args)
+		),
+
+		// ── Skill configuration ───────────────────────────────────────────────
+		tool(
+			'add_skill',
+			'Register a new skill in the application registry. Medium risk — requires confirmation in balanced mode.',
+			{
+				name: z
+					.string()
+					.describe(
+						'Unique internal name (slug-style, e.g. "my-skill"). Immutable after creation.'
+					),
+				display_name: z.string().describe('Human-readable display name shown in the UI'),
+				description: z.string().describe('Short description of what the skill does'),
+				source_type: z
+					.enum(['builtin', 'plugin', 'mcp_server'])
+					.describe('Where the skill comes from'),
+				config: z
+					.record(z.string(), z.unknown())
+					.describe(
+						'Source-type-specific configuration (e.g. {"type":"plugin","pluginPath":"/path/to/plugin"})'
+					),
+				enabled: z.boolean().optional().describe('Whether to enable immediately (default: false)'),
+			},
+			(args) => handlers.add_skill(args)
+		),
+
+		tool(
+			'update_skill',
+			'Update an existing skill entry. Low risk — auto-executes in balanced mode.',
+			{
+				skill_id: z.string().describe('ID of the skill to update'),
+				display_name: z.string().optional().describe('New human-readable display name'),
+				description: z.string().optional().describe('New description'),
+				config: z
+					.record(z.string(), z.unknown())
+					.optional()
+					.describe('New source-type-specific configuration'),
+			},
+			(args) => handlers.update_skill(args)
+		),
+
+		tool(
+			'delete_skill',
+			'Remove a skill from the registry. Built-in skills cannot be deleted — use toggle_skill instead. Medium risk — requires confirmation in balanced mode.',
+			{
+				skill_id: z.string().describe('ID of the skill to delete'),
+			},
+			(args) => handlers.delete_skill(args)
+		),
+
+		tool(
+			'toggle_skill',
+			'Enable or disable a skill globally. Low risk — auto-executes in balanced mode.',
+			{
+				skill_id: z.string().describe('ID of the skill to toggle'),
+				enabled: z.boolean().describe('Whether to enable or disable the skill'),
+			},
+			(args) => handlers.toggle_skill(args)
+		),
+
+		// ── App settings ──────────────────────────────────────────────────────
+		tool(
+			'update_app_settings',
+			'Update global application settings such as model, thinking level, or max workers. Low risk — auto-executes in balanced mode.',
+			{
+				model: z
+					.string()
+					.optional()
+					.describe('Default model ID for new sessions (e.g. "sonnet", "opus")'),
+				thinking_level: z
+					.enum(['none', 'low', 'medium', 'high'])
+					.optional()
+					.describe('Default thinking level for new sessions'),
+				auto_scroll: z.boolean().optional().describe('Whether to auto-scroll chat to new messages'),
+				max_concurrent_workers: z
+					.number()
+					.int()
+					.min(1)
+					.optional()
+					.describe('Maximum number of concurrent worker sessions per room agent'),
+			},
+			(args) => handlers.update_app_settings(args)
+		),
+
+		// ── Messaging & session control ───────────────────────────────────────
+		tool(
+			'send_message_to_room',
+			'Inject a message into the active session of a room. Medium risk — requires confirmation in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room to send the message to'),
+				message: z.string().describe('Message content to inject into the session'),
+			},
+			(args) => handlers.send_message_to_room(args)
+		),
+
+		tool(
+			'send_message_to_task',
+			'Inject a message into the active worker session for a specific task. Medium risk — requires confirmation in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the task'),
+				task_id: z.string().describe('ID of the task whose session to send the message to'),
+				message: z.string().describe('Message content to inject into the task session'),
+			},
+			(args) => handlers.send_message_to_task(args)
+		),
+
+		tool(
+			'stop_session',
+			'Interrupt the running agent session for a task. Only works for in_progress or review tasks. Medium risk — requires confirmation in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the task'),
+				task_id: z.string().describe('ID of the task whose session to stop'),
+			},
+			(args) => handlers.stop_session(args)
+		),
+
+		tool(
+			'pause_schedule',
+			'Pause the schedule for a recurring mission. While paused, the mission will not trigger automatically. Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the goal'),
+				goal_id: z.string().describe('ID of the recurring goal to pause'),
+			},
+			(args) => handlers.pause_schedule(args)
+		),
+
+		tool(
+			'resume_schedule',
+			'Resume a paused recurring mission schedule. Low risk — auto-executes in balanced mode.',
+			{
+				room_id: z.string().describe('ID of the room containing the goal'),
+				goal_id: z.string().describe('ID of the recurring goal to resume'),
+			},
+			(args) => handlers.resume_schedule(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -1178,6 +1178,15 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				return errorResult('No update fields provided');
 			}
 
+			if (args.env) {
+				const rejected = Object.keys(args.env).filter((k) => SENSITIVE_ENV_VARS.has(k));
+				if (rejected.length > 0) {
+					return errorResult(
+						`Refusing to store sensitive env var(s): ${rejected.join(', ')}. Use a secrets manager or set them in the process environment instead.`
+					);
+				}
+			}
+
 			return withSecurityCheck(
 				'update_mcp_server',
 				args as Record<string, unknown>,
@@ -2010,7 +2019,7 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 
 		tool(
 			'update_skill',
-			'Update an existing skill entry. Low risk — auto-executes in balanced mode.',
+			'Update an existing skill entry. Medium risk — requires confirmation in balanced mode.',
 			{
 				skill_id: z.string().describe('ID of the skill to update'),
 				display_name: z.string().optional().describe('New human-readable display name'),

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -25,7 +25,7 @@
  * - approve_gate: happy path, idempotent, rejection override, terminal-run error
  * - reject_gate: happy path, idempotent, reason propagation, terminal-run error
  * - add_mcp_server: happy path, manager unavailable, error propagation, confirmation paths
- * - update_mcp_server: field patching, no-op guard, manager unavailable
+ * - update_mcp_server: field patching, no-op guard, manager unavailable, sensitive env var rejection
  * - delete_mcp_server: happy path, not found error, manager unavailable
  * - toggle_mcp_server: enable/disable, not found, manager unavailable
  * - add_skill: happy path, manager unavailable, error propagation
@@ -1453,6 +1453,24 @@ describe('update_mcp_server', () => {
 		const result = parseResult(await update_mcp_server({ server_id: 'x', name: 'y' }));
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('MCP manager not available');
+	});
+
+	it('rejects sensitive env var names before security check', async () => {
+		const existing: AppMcpServer = {
+			id: 'mcp-1',
+			name: 'x',
+			sourceType: 'stdio',
+			enabled: false,
+		};
+		const config = makeConfig({ mcpManager: makeMcpManager([existing]) });
+		const { update_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_mcp_server({ server_id: 'mcp-1', env: { ANTHROPIC_API_KEY: 'sk-secret' } })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('ANTHROPIC_API_KEY');
+		expect(result.error).toContain('Refusing to store sensitive env var');
+		expect(config.pendingStore.size).toBe(0);
 	});
 });
 

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -24,7 +24,21 @@
  * - cancel_workflow_run: happy path, already-cancelled, completed error, unavailable guard
  * - approve_gate: happy path, idempotent, rejection override, terminal-run error
  * - reject_gate: happy path, idempotent, reason propagation, terminal-run error
- * - MCP server: all 18 tools are registered
+ * - add_mcp_server: happy path, manager unavailable, error propagation, confirmation paths
+ * - update_mcp_server: field patching, no-op guard, manager unavailable
+ * - delete_mcp_server: happy path, not found error, manager unavailable
+ * - toggle_mcp_server: enable/disable, not found, manager unavailable
+ * - add_skill: happy path, manager unavailable, error propagation
+ * - update_skill: field patching, no-op guard, not found, manager unavailable
+ * - delete_skill: happy path, built-in guard, not found, manager unavailable
+ * - toggle_skill: enable/disable, manager unavailable
+ * - update_app_settings: field updates, no-op guard, manager unavailable
+ * - send_message_to_room: happy path, no active session, room not found, manager unavailable
+ * - send_message_to_task: happy path, task not found, no active session, manager unavailable
+ * - stop_session: happy path, wrong status, runtime unavailable, task not found
+ * - pause_schedule: happy path, non-recurring goal, goal not found
+ * - resume_schedule: happy path, no schedule, non-recurring goal
+ * - MCP server: all 32 tools are registered
  */
 
 import { describe, expect, it, beforeEach } from 'bun:test';
@@ -43,9 +57,20 @@ import {
 	type NeoActionGateDataRepository,
 	type NeoWorkflowRun,
 	type NeoSpaceTask,
+	type NeoMcpManager,
+	type NeoSkillsManager,
+	type NeoSettingsManager,
+	type NeoSessionManager,
 } from '../../../src/lib/neo/tools/neo-action-tools';
 import { PendingActionStore } from '../../../src/lib/neo/security-tier';
-import type { Room, RoomGoal, NeoTask } from '@neokai/shared';
+import type {
+	Room,
+	RoomGoal,
+	NeoTask,
+	AppMcpServer,
+	AppSkill,
+	GlobalSettings,
+} from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -159,10 +184,10 @@ function makeGoalManager(goals: RoomGoal[] = []): NeoActionGoalManager {
 			store.set(id, updated);
 			return updated;
 		},
-		updateGoalStatus: async (id, status) => {
+		updateGoalStatus: async (id, status, updates) => {
 			const goal = store.get(id);
 			if (!goal) throw new Error(`Goal not found: ${id}`);
-			const updated = { ...goal, status, updatedAt: NOW + 1 };
+			const updated = { ...goal, status, ...updates, updatedAt: NOW + 1 };
 			store.set(id, updated);
 			return updated;
 		},
@@ -201,10 +226,11 @@ function makeTaskManager(tasks: NeoTask[] = []): NeoActionTaskManager {
 	};
 }
 
-function makeRuntimeService(resumeResult = true): NeoActionRuntimeService {
+function makeRuntimeService(resumeResult = true, interruptResult = true): NeoActionRuntimeService {
 	return {
 		getRuntime: (_roomId) => ({
 			resumeWorkerFromHuman: async (_taskId, _message, _opts) => resumeResult,
+			interruptTaskSession: async (_taskId) => ({ success: interruptResult }),
 		}),
 	};
 }
@@ -218,10 +244,6 @@ function makeManagerFactory(
 		getTaskManager: (roomId) => taskManagers.get(roomId) ?? makeTaskManager(),
 	};
 }
-
-// ---------------------------------------------------------------------------
-// Config builder
-// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // Space/Workflow mock factories
@@ -248,6 +270,58 @@ function makeWorkflowRun(overrides: Partial<NeoWorkflowRun> = {}): NeoWorkflowRu
 		spaceId: 'space-1',
 		status: 'in_progress',
 		failureReason: null,
+		...overrides,
+	};
+}
+
+function makeMcpManager(servers: AppMcpServer[] = []): NeoMcpManager {
+	const store = new Map<string, AppMcpServer>(servers.map((s) => [s.id, s]));
+	return {
+		createMcpServer: (params) => {
+			const server: AppMcpServer = {
+				id: `mcp-${Date.now()}`,
+				name: params.name,
+				sourceType: params.sourceType,
+				description: params.description,
+				command: params.command,
+				args: params.args,
+				env: params.env,
+				url: params.url,
+				headers: params.headers,
+				enabled: params.enabled ?? false,
+			};
+			store.set(server.id, server);
+			return server;
+		},
+		updateMcpServer: (id, updates) => {
+			const s = store.get(id);
+			if (!s) return null;
+			const updated = { ...s, ...updates };
+			store.set(id, updated);
+			return updated;
+		},
+		deleteMcpServer: (id) => {
+			if (!store.has(id)) return false;
+			store.delete(id);
+			return true;
+		},
+		getMcpServer: (id) => store.get(id) ?? null,
+		getMcpServerByName: (name) => Array.from(store.values()).find((s) => s.name === name) ?? null,
+	};
+}
+
+function makeAppSkill(overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id: 'skill-1',
+		name: 'test-skill',
+		displayName: 'Test Skill',
+		description: 'A test skill',
+		sourceType: 'plugin',
+		config: { type: 'plugin', pluginPath: '/path/to/plugin' },
+		enabled: false,
+		builtIn: false,
+		validationStatus: 'pending',
+		createdAt: NOW,
 		...overrides,
 	};
 }
@@ -312,8 +386,79 @@ function makeGateDataRepo(): NeoActionGateDataRepository & {
 			const merged = { ...existing, ...partial };
 			store.set(key, merged);
 			return { data: merged };
+function makeSkillsManager(skills: AppSkill[] = []): NeoSkillsManager {
+	const store = new Map<string, AppSkill>(skills.map((s) => [s.id, s]));
+	return {
+		addSkill: (params) => {
+			const skill: AppSkill = {
+				id: `skill-${Date.now()}`,
+				name: params.name,
+				displayName: params.displayName,
+				description: params.description,
+				sourceType: params.sourceType,
+				config: params.config,
+				enabled: params.enabled ?? false,
+				builtIn: false,
+				validationStatus: params.validationStatus ?? 'pending',
+				createdAt: NOW,
+			};
+			store.set(skill.id, skill);
+			return skill;
+		},
+		updateSkill: (id, params) => {
+			const s = store.get(id);
+			if (!s) throw new Error(`Skill not found: ${id}`);
+			const updated = { ...s, ...params };
+			store.set(id, updated);
+			return updated;
+		},
+		setSkillEnabled: (id, enabled) => {
+			const s = store.get(id);
+			if (!s) throw new Error(`Skill not found: ${id}`);
+			const updated = { ...s, enabled };
+			store.set(id, updated);
+			return updated;
+		},
+		removeSkill: (id) => {
+			const s = store.get(id);
+			if (!s || s.builtIn) return false;
+			store.delete(id);
+			return true;
+		},
+		getSkill: (id) => store.get(id) ?? null,
+	};
+}
+
+function makeSettingsManager(initial: Partial<GlobalSettings> = {}): NeoSettingsManager {
+	let settings: GlobalSettings = {
+		settingSources: ['user', 'project', 'local'],
+		permissionMode: 'default',
+		model: 'sonnet',
+		disabledMcpServers: [],
+		...initial,
+	} as GlobalSettings;
+	return {
+		getGlobalSettings: () => settings,
+		updateGlobalSettings: (updates) => {
+			settings = { ...settings, ...updates };
+			return settings;
 		},
 	};
+}
+
+function makeSessionManager(
+	roomSessions: Map<string, string> = new Map(),
+	taskSessions: Map<string, string> = new Map()
+): NeoSessionManager {
+	const injectedMessages: Array<{ sessionId: string; message: string }> = [];
+	return {
+		injectMessage: async (sessionId, message) => {
+			injectedMessages.push({ sessionId, message });
+		},
+		getActiveSessionForRoom: (roomId) => roomSessions.get(roomId) ?? null,
+		getActiveSessionForTask: (taskId) => taskSessions.get(taskId) ?? null,
+		_injectedMessages: injectedMessages,
+	} as NeoSessionManager & { _injectedMessages: typeof injectedMessages };
 }
 
 function makeConfig(
@@ -342,6 +487,10 @@ function makeConfig(
 			gateId: string,
 			data: Record<string, unknown>
 		) => void | Promise<void>;
+		mcpManager?: NeoMcpManager;
+		skillsManager?: NeoSkillsManager;
+		settingsManager?: NeoSettingsManager;
+		sessionManager?: NeoSessionManager;
 	} = {}
 ): NeoActionToolsConfig {
 	const room = makeRoom();
@@ -375,6 +524,10 @@ function makeConfig(
 		onGateChanged: opts.onGateChanged,
 		onWorkflowRunUpdated: opts.onWorkflowRunUpdated,
 		onGateDataUpdated: opts.onGateDataUpdated,
+		mcpManager: opts.mcpManager,
+		skillsManager: opts.skillsManager,
+		settingsManager: opts.settingsManager,
+		sessionManager: opts.sessionManager,
 	};
 }
 
@@ -1121,6 +1274,57 @@ describe('create_space', () => {
 		const result = parseResult(await create_space({ name: 'Test', workspace_path: '/ws' }));
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('not available');
+// add_mcp_server
+// ---------------------------------------------------------------------------
+
+describe('add_mcp_server', () => {
+	it('creates a stdio MCP server entry', async () => {
+		const config = makeConfig({ mcpManager: makeMcpManager() });
+		const { add_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await add_mcp_server({
+				name: 'my-mcp',
+				source_type: 'stdio',
+				command: 'node',
+				enabled: false,
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.server.name).toBe('my-mcp');
+		expect(result.server.sourceType).toBe('stdio');
+	});
+
+	it('returns error when mcpManager not available', async () => {
+		const config = makeConfig();
+		const { add_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await add_mcp_server({ name: 'x', source_type: 'stdio' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('MCP manager not available');
+	});
+
+	it('propagates manager errors', async () => {
+		const badManager: NeoMcpManager = {
+			createMcpServer: () => {
+				throw new Error('duplicate name');
+			},
+			updateMcpServer: () => null,
+			deleteMcpServer: () => false,
+			getMcpServer: () => null,
+			getMcpServerByName: () => null,
+		};
+		const config = makeConfig({ mcpManager: badManager });
+		const { add_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await add_mcp_server({ name: 'x', source_type: 'stdio' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('duplicate name');
+	});
+
+	it('returns confirmationRequired in conservative mode', async () => {
+		const config = makeConfig({ mcpManager: makeMcpManager(), securityMode: 'conservative' });
+		const { add_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await add_mcp_server({ name: 'x', source_type: 'stdio' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
 	});
 });
 
@@ -1165,6 +1369,47 @@ describe('update_space', () => {
 		const { update_space } = createNeoActionToolHandlers(config);
 		const result = parseResult(await update_space({ space_id: 'space-1', name: 'New Name' }));
 		expect(result.success).toBe(true);
+// update_mcp_server
+// ---------------------------------------------------------------------------
+
+describe('update_mcp_server', () => {
+	it('updates server fields', async () => {
+		const existing: AppMcpServer = {
+			id: 'mcp-1',
+			name: 'old-name',
+			sourceType: 'stdio',
+			command: 'node',
+			enabled: false,
+		};
+		const config = makeConfig({ mcpManager: makeMcpManager([existing]) });
+		const { update_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_mcp_server({ server_id: 'mcp-1', name: 'new-name' }));
+		expect(result.success).toBe(true);
+		expect(result.server.name).toBe('new-name');
+	});
+
+	it('returns error when server not found', async () => {
+		const config = makeConfig({ mcpManager: makeMcpManager() });
+		const { update_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_mcp_server({ server_id: 'missing', name: 'x' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('MCP server not found');
+	});
+
+	it('returns error when no update fields provided', async () => {
+		const config = makeConfig({ mcpManager: makeMcpManager() });
+		const { update_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_mcp_server({ server_id: 'mcp-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No update fields provided');
+	});
+
+	it('returns error when mcpManager not available', async () => {
+		const config = makeConfig();
+		const { update_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_mcp_server({ server_id: 'x', name: 'y' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('MCP manager not available');
 	});
 });
 
@@ -1404,6 +1649,164 @@ describe('cancel_workflow_run', () => {
 		expect(updatedSpaceId).toBe('space-1');
 		expect(updatedRunId).toBe('run-1');
 		expect(updatedStatus).toBe('cancelled');
+// delete_mcp_server
+// ---------------------------------------------------------------------------
+
+describe('delete_mcp_server', () => {
+	it('deletes an existing server', async () => {
+		const existing: AppMcpServer = { id: 'mcp-1', name: 'x', sourceType: 'stdio', enabled: false };
+		const config = makeConfig({ mcpManager: makeMcpManager([existing]) });
+		const { delete_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_mcp_server({ server_id: 'mcp-1' }));
+		expect(result.success).toBe(true);
+		expect(result.serverId).toBe('mcp-1');
+	});
+
+	it('returns error when server not found', async () => {
+		const config = makeConfig({ mcpManager: makeMcpManager() });
+		const { delete_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_mcp_server({ server_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('MCP server not found');
+	});
+
+	it('returns error when mcpManager not available', async () => {
+		const config = makeConfig();
+		const { delete_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_mcp_server({ server_id: 'x' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('MCP manager not available');
+	});
+
+	it('returns confirmationRequired in balanced mode (medium risk)', async () => {
+		const existing: AppMcpServer = { id: 'mcp-1', name: 'x', sourceType: 'stdio', enabled: false };
+		const config = makeConfig({
+			mcpManager: makeMcpManager([existing]),
+			securityMode: 'balanced',
+		});
+		const { delete_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_mcp_server({ server_id: 'mcp-1' }));
+		expect(result.confirmationRequired).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// toggle_mcp_server
+// ---------------------------------------------------------------------------
+
+describe('toggle_mcp_server', () => {
+	it('enables a server', async () => {
+		const existing: AppMcpServer = { id: 'mcp-1', name: 'x', sourceType: 'stdio', enabled: false };
+		const config = makeConfig({ mcpManager: makeMcpManager([existing]) });
+		const { toggle_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_mcp_server({ server_id: 'mcp-1', enabled: true }));
+		expect(result.success).toBe(true);
+		expect(result.server.enabled).toBe(true);
+	});
+
+	it('disables a server', async () => {
+		const existing: AppMcpServer = { id: 'mcp-1', name: 'x', sourceType: 'stdio', enabled: true };
+		const config = makeConfig({ mcpManager: makeMcpManager([existing]) });
+		const { toggle_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_mcp_server({ server_id: 'mcp-1', enabled: false }));
+		expect(result.success).toBe(true);
+		expect(result.server.enabled).toBe(false);
+	});
+
+	it('returns error when server not found', async () => {
+		const config = makeConfig({ mcpManager: makeMcpManager() });
+		const { toggle_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_mcp_server({ server_id: 'missing', enabled: true }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('MCP server not found');
+	});
+
+	it('returns error when mcpManager not available', async () => {
+		const config = makeConfig();
+		const { toggle_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_mcp_server({ server_id: 'x', enabled: true }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('MCP manager not available');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const existing: AppMcpServer = { id: 'mcp-1', name: 'x', sourceType: 'stdio', enabled: false };
+		const config = makeConfig({
+			mcpManager: makeMcpManager([existing]),
+			securityMode: 'balanced',
+		});
+		const { toggle_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_mcp_server({ server_id: 'mcp-1', enabled: true }));
+		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// add_skill
+// ---------------------------------------------------------------------------
+
+describe('add_skill', () => {
+	it('creates a plugin skill', async () => {
+		const config = makeConfig({ skillsManager: makeSkillsManager() });
+		const { add_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await add_skill({
+				name: 'my-skill',
+				display_name: 'My Skill',
+				description: 'desc',
+				source_type: 'plugin',
+				config: { type: 'plugin', pluginPath: '/path/to/plugin' },
+				enabled: false,
+			})
+		);
+		expect(result.success).toBe(true);
+		expect(result.skill.name).toBe('my-skill');
+		expect(result.skill.sourceType).toBe('plugin');
+	});
+
+	it('returns error when skillsManager not available', async () => {
+		const config = makeConfig();
+		const { add_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await add_skill({
+				name: 'x',
+				display_name: 'X',
+				description: 'x',
+				source_type: 'plugin',
+				config: { type: 'plugin', pluginPath: '/x' },
+			})
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Skills manager not available');
+	});
+
+	it('propagates manager errors', async () => {
+		const badManager: NeoSkillsManager = {
+			addSkill: () => {
+				throw new Error('duplicate skill name');
+			},
+			updateSkill: () => {
+				throw new Error('not found');
+			},
+			setSkillEnabled: () => {
+				throw new Error('not found');
+			},
+			removeSkill: () => false,
+			getSkill: () => null,
+		};
+		const config = makeConfig({ skillsManager: badManager });
+		const { add_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await add_skill({
+				name: 'x',
+				display_name: 'X',
+				description: 'x',
+				source_type: 'plugin',
+				config: { type: 'plugin', pluginPath: '/x' },
+			})
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('duplicate skill name');
 	});
 });
 
@@ -1714,6 +2117,484 @@ describe('reject_gate', () => {
 		expect(runUpdates[0].failureReason).toBe('humanRejected');
 		expect(gateUpdates).toHaveLength(1);
 		expect(gateUpdates[0].gateId).toBe('gate-1');
+// update_skill
+// ---------------------------------------------------------------------------
+
+describe('update_skill', () => {
+	it('updates skill display name', async () => {
+		const skill = makeAppSkill({ id: 'skill-1' });
+		const config = makeConfig({ skillsManager: makeSkillsManager([skill]) });
+		const { update_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_skill({ skill_id: 'skill-1', display_name: 'New Name' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.skill.displayName).toBe('New Name');
+	});
+
+	it('returns error when skill not found', async () => {
+		const config = makeConfig({ skillsManager: makeSkillsManager() });
+		const { update_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_skill({ skill_id: 'missing', display_name: 'X' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Skill not found');
+	});
+
+	it('returns error when no update fields provided', async () => {
+		const config = makeConfig({ skillsManager: makeSkillsManager() });
+		const { update_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_skill({ skill_id: 'skill-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No update fields provided');
+	});
+
+	it('returns error when skillsManager not available', async () => {
+		const config = makeConfig();
+		const { update_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_skill({ skill_id: 'x', display_name: 'Y' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Skills manager not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// delete_skill
+// ---------------------------------------------------------------------------
+
+describe('delete_skill', () => {
+	it('deletes a non-built-in skill', async () => {
+		const skill = makeAppSkill({ id: 'skill-1' });
+		const config = makeConfig({ skillsManager: makeSkillsManager([skill]) });
+		const { delete_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_skill({ skill_id: 'skill-1' }));
+		expect(result.success).toBe(true);
+		expect(result.skillId).toBe('skill-1');
+	});
+
+	it('returns error for built-in skills', async () => {
+		const skill = makeAppSkill({ id: 'skill-1', builtIn: true });
+		const config = makeConfig({ skillsManager: makeSkillsManager([skill]) });
+		const { delete_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_skill({ skill_id: 'skill-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Cannot delete built-in skill');
+	});
+
+	it('returns error when skill not found', async () => {
+		const config = makeConfig({ skillsManager: makeSkillsManager() });
+		const { delete_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_skill({ skill_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Skill not found');
+	});
+
+	it('returns error when skillsManager not available', async () => {
+		const config = makeConfig();
+		const { delete_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await delete_skill({ skill_id: 'x' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Skills manager not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// toggle_skill
+// ---------------------------------------------------------------------------
+
+describe('toggle_skill', () => {
+	it('enables a skill', async () => {
+		const skill = makeAppSkill({ id: 'skill-1', enabled: false });
+		const config = makeConfig({ skillsManager: makeSkillsManager([skill]) });
+		const { toggle_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_skill({ skill_id: 'skill-1', enabled: true }));
+		expect(result.success).toBe(true);
+		expect(result.skill.enabled).toBe(true);
+	});
+
+	it('disables a skill', async () => {
+		const skill = makeAppSkill({ id: 'skill-1', enabled: true });
+		const config = makeConfig({ skillsManager: makeSkillsManager([skill]) });
+		const { toggle_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_skill({ skill_id: 'skill-1', enabled: false }));
+		expect(result.success).toBe(true);
+		expect(result.skill.enabled).toBe(false);
+	});
+
+	it('returns error when skill not found (via manager throw)', async () => {
+		const config = makeConfig({ skillsManager: makeSkillsManager() });
+		const { toggle_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_skill({ skill_id: 'missing', enabled: true }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Skill not found');
+	});
+
+	it('returns error when skillsManager not available', async () => {
+		const config = makeConfig();
+		const { toggle_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_skill({ skill_id: 'x', enabled: true }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Skills manager not available');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const skill = makeAppSkill({ id: 'skill-1' });
+		const config = makeConfig({
+			skillsManager: makeSkillsManager([skill]),
+			securityMode: 'balanced',
+		});
+		const { toggle_skill } = createNeoActionToolHandlers(config);
+		const result = parseResult(await toggle_skill({ skill_id: 'skill-1', enabled: true }));
+		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// update_app_settings
+// ---------------------------------------------------------------------------
+
+describe('update_app_settings', () => {
+	it('updates model', async () => {
+		const config = makeConfig({ settingsManager: makeSettingsManager() });
+		const { update_app_settings } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_app_settings({ model: 'opus' }));
+		expect(result.success).toBe(true);
+		expect(result.settings.model).toBe('opus');
+	});
+
+	it('updates autoScroll and maxConcurrentWorkers', async () => {
+		const config = makeConfig({ settingsManager: makeSettingsManager() });
+		const { update_app_settings } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await update_app_settings({ auto_scroll: false, max_concurrent_workers: 5 })
+		);
+		expect(result.success).toBe(true);
+		expect(result.settings.autoScroll).toBe(false);
+		expect(result.settings.maxConcurrentWorkers).toBe(5);
+	});
+
+	it('returns error when no fields provided', async () => {
+		const config = makeConfig({ settingsManager: makeSettingsManager() });
+		const { update_app_settings } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_app_settings({}));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No update fields provided');
+	});
+
+	it('returns error when settingsManager not available', async () => {
+		const config = makeConfig();
+		const { update_app_settings } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_app_settings({ model: 'opus' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Settings manager not available');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const config = makeConfig({
+			settingsManager: makeSettingsManager(),
+			securityMode: 'balanced',
+		});
+		const { update_app_settings } = createNeoActionToolHandlers(config);
+		const result = parseResult(await update_app_settings({ model: 'haiku' }));
+		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// send_message_to_room
+// ---------------------------------------------------------------------------
+
+describe('send_message_to_room', () => {
+	it('injects message into the active room session', async () => {
+		const roomSessions = new Map([['room-1', 'session-abc']]);
+		const sessionMgr = makeSessionManager(roomSessions);
+		const config = makeConfig({ sessionManager: sessionMgr });
+		const { send_message_to_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await send_message_to_room({ room_id: 'room-1', message: 'Hello agent!' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.sessionId).toBe('session-abc');
+	});
+
+	it('returns error when room not found', async () => {
+		const config = makeConfig({ sessionManager: makeSessionManager() });
+		const { send_message_to_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await send_message_to_room({ room_id: 'missing', message: 'Hi' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error when no active session for room', async () => {
+		const config = makeConfig({ sessionManager: makeSessionManager() });
+		const { send_message_to_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await send_message_to_room({ room_id: 'room-1', message: 'Hi' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No active session found for room');
+	});
+
+	it('returns error when sessionManager not available', async () => {
+		const config = makeConfig();
+		const { send_message_to_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await send_message_to_room({ room_id: 'room-1', message: 'Hi' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Session manager not available');
+	});
+
+	it('returns confirmationRequired in balanced mode (medium risk)', async () => {
+		const roomSessions = new Map([['room-1', 'session-abc']]);
+		const config = makeConfig({
+			sessionManager: makeSessionManager(roomSessions),
+			securityMode: 'balanced',
+		});
+		const { send_message_to_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await send_message_to_room({ room_id: 'room-1', message: 'Hi' }));
+		expect(result.confirmationRequired).toBe(true);
+		expect(result.riskLevel).toBe('medium');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// send_message_to_task
+// ---------------------------------------------------------------------------
+
+describe('send_message_to_task', () => {
+	it('injects message into the active task session', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1' });
+		const taskSessions = new Map([['task-1', 'session-xyz']]);
+		const sessionMgr = makeSessionManager(new Map(), taskSessions);
+		const config = makeConfig({ tasks: [task], sessionManager: sessionMgr });
+		const { send_message_to_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await send_message_to_task({ room_id: 'room-1', task_id: 'task-1', message: 'Fix this' })
+		);
+		expect(result.success).toBe(true);
+		expect(result.sessionId).toBe('session-xyz');
+	});
+
+	it('returns error when room not found', async () => {
+		const config = makeConfig({ sessionManager: makeSessionManager() });
+		const { send_message_to_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await send_message_to_task({ room_id: 'missing', task_id: 'task-1', message: 'Hi' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error when task not found', async () => {
+		const config = makeConfig({ tasks: [], sessionManager: makeSessionManager() });
+		const { send_message_to_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await send_message_to_task({ room_id: 'room-1', task_id: 'missing', message: 'Hi' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Task not found');
+	});
+
+	it('returns error when no active session for task', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1' });
+		const config = makeConfig({ tasks: [task], sessionManager: makeSessionManager() });
+		const { send_message_to_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await send_message_to_task({ room_id: 'room-1', task_id: 'task-1', message: 'Hi' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('No active session found for task');
+	});
+
+	it('returns error when sessionManager not available', async () => {
+		const config = makeConfig();
+		const { send_message_to_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await send_message_to_task({ room_id: 'room-1', task_id: 'task-1', message: 'Hi' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Session manager not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// stop_session
+// ---------------------------------------------------------------------------
+
+describe('stop_session', () => {
+	it('interrupts an in_progress task session', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'in_progress' });
+		const config = makeConfig({
+			tasks: [task],
+			runtimeService: makeRuntimeService(true, true),
+		});
+		const { stop_session } = createNeoActionToolHandlers(config);
+		const result = parseResult(await stop_session({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(true);
+		expect(result.message).toContain('interrupted');
+	});
+
+	it('interrupts a review task session', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'review' });
+		const config = makeConfig({
+			tasks: [task],
+			runtimeService: makeRuntimeService(true, true),
+		});
+		const { stop_session } = createNeoActionToolHandlers(config);
+		const result = parseResult(await stop_session({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(true);
+	});
+
+	it('returns error when task is not in_progress or review', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'pending' });
+		const config = makeConfig({
+			tasks: [task],
+			runtimeService: makeRuntimeService(true, true),
+		});
+		const { stop_session } = createNeoActionToolHandlers(config);
+		const result = parseResult(await stop_session({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('cannot be interrupted');
+	});
+
+	it('returns error when room not found', async () => {
+		const config = makeConfig({ runtimeService: makeRuntimeService() });
+		const { stop_session } = createNeoActionToolHandlers(config);
+		const result = parseResult(await stop_session({ room_id: 'missing', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('returns error when task not found', async () => {
+		const config = makeConfig({ tasks: [], runtimeService: makeRuntimeService() });
+		const { stop_session } = createNeoActionToolHandlers(config);
+		const result = parseResult(await stop_session({ room_id: 'room-1', task_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Task not found');
+	});
+
+	it('returns error when runtimeService not available', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'in_progress' });
+		const config = makeConfig({ tasks: [task] });
+		const { stop_session } = createNeoActionToolHandlers(config);
+		const result = parseResult(await stop_session({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Runtime service not available');
+	});
+
+	it('returns error when interrupt fails', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'in_progress' });
+		const config = makeConfig({
+			tasks: [task],
+			runtimeService: makeRuntimeService(true, false),
+		});
+		const { stop_session } = createNeoActionToolHandlers(config);
+		const result = parseResult(await stop_session({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Failed to interrupt session');
+	});
+
+	it('returns confirmationRequired in balanced mode (medium risk)', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1', status: 'in_progress' });
+		const config = makeConfig({
+			tasks: [task],
+			runtimeService: makeRuntimeService(),
+			securityMode: 'balanced',
+		});
+		const { stop_session } = createNeoActionToolHandlers(config);
+		const result = parseResult(await stop_session({ room_id: 'room-1', task_id: 'task-1' }));
+		expect(result.confirmationRequired).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// pause_schedule
+// ---------------------------------------------------------------------------
+
+describe('pause_schedule', () => {
+	it('pauses a recurring mission', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1', missionType: 'recurring' });
+		const config = makeConfig({ goals: [goal] });
+		const { pause_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await pause_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(true);
+		expect(result.goal.schedulePaused).toBe(true);
+	});
+
+	it('returns error for non-recurring goals', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1', missionType: 'one_shot' });
+		const config = makeConfig({ goals: [goal] });
+		const { pause_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await pause_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not a recurring mission');
+	});
+
+	it('returns error when goal not found', async () => {
+		const config = makeConfig({ goals: [] });
+		const { pause_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await pause_schedule({ room_id: 'room-1', goal_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Goal not found');
+	});
+
+	it('returns error when room not found', async () => {
+		const config = makeConfig();
+		const { pause_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await pause_schedule({ room_id: 'missing', goal_id: 'goal-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Room not found');
+	});
+
+	it('auto-executes in balanced mode (low risk)', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1', missionType: 'recurring' });
+		const config = makeConfig({ goals: [goal], securityMode: 'balanced' });
+		const { pause_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await pause_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// resume_schedule
+// ---------------------------------------------------------------------------
+
+describe('resume_schedule', () => {
+	it('resumes a paused recurring mission', async () => {
+		const goal = makeGoal({
+			id: 'goal-1',
+			roomId: 'room-1',
+			missionType: 'recurring',
+			schedulePaused: true,
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+		const config = makeConfig({ goals: [goal] });
+		const { resume_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await resume_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(true);
+		expect(result.goal.schedulePaused).toBe(false);
+	});
+
+	it('returns error when goal has no schedule', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1', missionType: 'recurring' });
+		const config = makeConfig({ goals: [goal] });
+		const { resume_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await resume_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('no schedule set');
+	});
+
+	it('returns error for non-recurring goals', async () => {
+		const goal = makeGoal({ id: 'goal-1', roomId: 'room-1', missionType: 'one_shot' });
+		const config = makeConfig({ goals: [goal] });
+		const { resume_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await resume_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not a recurring mission');
+	});
+
+	it('returns error when goal not found', async () => {
+		const config = makeConfig({ goals: [] });
+		const { resume_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await resume_schedule({ room_id: 'room-1', goal_id: 'missing' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Goal not found');
 	});
 });
 
@@ -1804,7 +2685,63 @@ describe('createNeoActionMcpServer', () => {
 		expect(server.instance._registeredTools).toHaveProperty('reject_gate');
 	});
 
-	it('registers exactly 18 tools', () => {
-		expect(Object.keys(server.instance._registeredTools)).toHaveLength(18);
+	it('registers add_mcp_server tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('add_mcp_server');
+	});
+
+	it('registers update_mcp_server tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('update_mcp_server');
+	});
+
+	it('registers delete_mcp_server tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('delete_mcp_server');
+	});
+
+	it('registers toggle_mcp_server tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('toggle_mcp_server');
+	});
+
+	it('registers add_skill tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('add_skill');
+	});
+
+	it('registers update_skill tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('update_skill');
+	});
+
+	it('registers delete_skill tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('delete_skill');
+	});
+
+	it('registers toggle_skill tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('toggle_skill');
+	});
+
+	it('registers update_app_settings tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('update_app_settings');
+	});
+
+	it('registers send_message_to_room tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('send_message_to_room');
+	});
+
+	it('registers send_message_to_task tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('send_message_to_task');
+	});
+
+	it('registers stop_session tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('stop_session');
+	});
+
+	it('registers pause_schedule tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('pause_schedule');
+	});
+
+	it('registers resume_schedule tool', () => {
+		expect(server.instance._registeredTools).toHaveProperty('resume_schedule');
+	});
+
+	it('registers exactly 32 tools', () => {
+		expect(Object.keys(server.instance._registeredTools)).toHaveLength(32);
 	});
 });

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -33,11 +33,11 @@
  * - delete_skill: happy path, built-in guard, not found, manager unavailable
  * - toggle_skill: enable/disable, manager unavailable
  * - update_app_settings: field updates, no-op guard, manager unavailable
- * - send_message_to_room: happy path, no active session, room not found, manager unavailable
- * - send_message_to_task: happy path, task not found, no active session, manager unavailable
+ * - send_message_to_room: happy path, no active session, room not found, manager unavailable, empty message
+ * - send_message_to_task: happy path, task not found, no active session, manager unavailable, empty message
  * - stop_session: happy path, wrong status, runtime unavailable, task not found
- * - pause_schedule: happy path, non-recurring goal, goal not found
- * - resume_schedule: happy path, no schedule, non-recurring goal
+ * - pause_schedule: happy path, non-recurring goal, goal not found, already paused (idempotent)
+ * - resume_schedule: happy path, no schedule, non-recurring goal, already active (idempotent)
  * - MCP server: all 32 tools are registered
  */
 
@@ -386,6 +386,10 @@ function makeGateDataRepo(): NeoActionGateDataRepository & {
 			const merged = { ...existing, ...partial };
 			store.set(key, merged);
 			return { data: merged };
+		},
+	};
+}
+
 function makeSkillsManager(skills: AppSkill[] = []): NeoSkillsManager {
 	const store = new Map<string, AppSkill>(skills.map((s) => [s.id, s]));
 	return {
@@ -1274,6 +1278,10 @@ describe('create_space', () => {
 		const result = parseResult(await create_space({ name: 'Test', workspace_path: '/ws' }));
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // add_mcp_server
 // ---------------------------------------------------------------------------
 
@@ -1326,6 +1334,37 @@ describe('add_mcp_server', () => {
 		expect(result.confirmationRequired).toBe(true);
 		expect(result.riskLevel).toBe('medium');
 	});
+
+	it('rejects sensitive env var names before security check', async () => {
+		const config = makeConfig({ mcpManager: makeMcpManager() });
+		const { add_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await add_mcp_server({
+				name: 'x',
+				source_type: 'stdio',
+				env: { ANTHROPIC_API_KEY: 'sk-secret' },
+			})
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('ANTHROPIC_API_KEY');
+		expect(result.error).toContain('Refusing to store sensitive env var');
+		// Confirm the pending store is empty — validation ran before security check
+		expect(config.pendingStore.size).toBe(0);
+	});
+
+	it('allows non-sensitive env vars', async () => {
+		const config = makeConfig({ mcpManager: makeMcpManager() });
+		const { add_mcp_server } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await add_mcp_server({
+				name: 'x',
+				source_type: 'stdio',
+				command: 'node',
+				env: { MY_SETTING: 'value' },
+			})
+		);
+		expect(result.success).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -1369,6 +1408,10 @@ describe('update_space', () => {
 		const { update_space } = createNeoActionToolHandlers(config);
 		const result = parseResult(await update_space({ space_id: 'space-1', name: 'New Name' }));
 		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // update_mcp_server
 // ---------------------------------------------------------------------------
 
@@ -1649,6 +1692,10 @@ describe('cancel_workflow_run', () => {
 		expect(updatedSpaceId).toBe('space-1');
 		expect(updatedRunId).toBe('run-1');
 		expect(updatedStatus).toBe('cancelled');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // delete_mcp_server
 // ---------------------------------------------------------------------------
 
@@ -2117,6 +2164,10 @@ describe('reject_gate', () => {
 		expect(runUpdates[0].failureReason).toBe('humanRejected');
 		expect(gateUpdates).toHaveLength(1);
 		expect(gateUpdates[0].gateId).toBe('gate-1');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // update_skill
 // ---------------------------------------------------------------------------
 
@@ -2351,6 +2402,16 @@ describe('send_message_to_room', () => {
 		expect(result.confirmationRequired).toBe(true);
 		expect(result.riskLevel).toBe('medium');
 	});
+
+	it('returns error when message is empty', async () => {
+		const roomSessions = new Map([['room-1', 'session-abc']]);
+		const config = makeConfig({ sessionManager: makeSessionManager(roomSessions) });
+		const { send_message_to_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await send_message_to_room({ room_id: 'room-1', message: '   ' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Message must not be empty');
+		expect(config.pendingStore.size).toBe(0);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -2410,6 +2471,22 @@ describe('send_message_to_task', () => {
 		);
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('Session manager not available');
+	});
+
+	it('returns error when message is empty', async () => {
+		const task = makeTask({ id: 'task-1', roomId: 'room-1' });
+		const taskSessions = new Map([['task-1', 'session-xyz']]);
+		const config = makeConfig({
+			tasks: [task],
+			sessionManager: makeSessionManager(new Map(), taskSessions),
+		});
+		const { send_message_to_task } = createNeoActionToolHandlers(config);
+		const result = parseResult(
+			await send_message_to_task({ room_id: 'room-1', task_id: 'task-1', message: '' })
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Message must not be empty');
+		expect(config.pendingStore.size).toBe(0);
 	});
 });
 
@@ -2549,6 +2626,20 @@ describe('pause_schedule', () => {
 		const result = parseResult(await pause_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
 		expect(result.success).toBe(true);
 	});
+
+	it('returns success with alreadyPaused flag when already paused', async () => {
+		const goal = makeGoal({
+			id: 'goal-1',
+			roomId: 'room-1',
+			missionType: 'recurring',
+			schedulePaused: true,
+		});
+		const config = makeConfig({ goals: [goal] });
+		const { pause_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await pause_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(true);
+		expect(result.alreadyPaused).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -2595,6 +2686,21 @@ describe('resume_schedule', () => {
 		const result = parseResult(await resume_schedule({ room_id: 'room-1', goal_id: 'missing' }));
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('Goal not found');
+	});
+
+	it('returns success with alreadyResumed flag when already active', async () => {
+		const goal = makeGoal({
+			id: 'goal-1',
+			roomId: 'room-1',
+			missionType: 'recurring',
+			schedulePaused: false,
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+		const config = makeConfig({ goals: [goal] });
+		const { resume_schedule } = createNeoActionToolHandlers(config);
+		const result = parseResult(await resume_schedule({ room_id: 'room-1', goal_id: 'goal-1' }));
+		expect(result.success).toBe(true);
+		expect(result.alreadyResumed).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Adds 14 new MCP action tools to `neo-action-tools.ts` organized into two categories
- **Configuration management**: `add_mcp_server`, `update_mcp_server`, `delete_mcp_server`, `toggle_mcp_server`, `add_skill`, `update_skill`, `delete_skill`, `toggle_skill`, `update_app_settings`
- **Messaging & session control**: `send_message_to_room`, `send_message_to_task`, `stop_session`, `pause_schedule`, `resume_schedule`
- Adds 4 new dependency interfaces (`NeoMcpManager`, `NeoSkillsManager`, `NeoSettingsManager`, `NeoSessionManager`) — all optional so existing callers are unaffected
- Extends `NeoActionRuntime` with `interruptTaskSession()` and `NeoActionGoalManager.updateGoalStatus()` with optional updates param
- 79 new unit tests (151 total), all passing; all CI checks green

## Security tiers
- Low risk (auto-executes in balanced mode): toggle, update, pause/resume schedule, update_app_settings
- Medium risk (requires confirmation in balanced): add, delete, send_message, stop_session