### PR TITLE
feat(neo): Attach action tools to Neo session (task 3.5)

### DIFF
--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -19,7 +19,11 @@ import type { McpServerConfig } from '@neokai/shared';
 import type { AgentSession } from '../agent/agent-session';
 import { Logger } from '../logger';
 import { buildNeoSystemPrompt, type NeoSecurityMode } from './neo-system-prompt';
-import { createNeoQueryMcpServer, type NeoToolsConfig } from './tools/neo-query-tools';
+import {
+	createNeoToolsMcpServers,
+	type NeoToolsConfig,
+	type NeoActionToolsConfig,
+} from './tools/neo-tools-server';
 
 export const NEO_SESSION_ID = 'neo:global';
 const NEO_SESSION_TITLE = 'Neo';
@@ -52,6 +56,7 @@ export class NeoAgentManager {
 	private readonly logger = new Logger('NeoAgentManager');
 	private session: AgentSession | null = null;
 	private toolsConfig: NeoToolsConfig | null = null;
+	private actionToolsConfig: NeoActionToolsConfig | null = null;
 	private appMcpManager: NeoAppMcpManager | null = null;
 
 	constructor(
@@ -136,6 +141,18 @@ export class NeoAgentManager {
 	setToolsConfig(toolsConfig: NeoToolsConfig, appMcpManager?: NeoAppMcpManager): void {
 		this.toolsConfig = toolsConfig;
 		this.appMcpManager = appMcpManager ?? null;
+	}
+
+	/**
+	 * Wire in the action tools dependencies.
+	 *
+	 * Must be called before `provision()`. When set, `provision()` will create the
+	 * neo-action MCP server and attach it alongside the neo-query server.
+	 *
+	 * @param actionToolsConfig  All dependencies needed by createNeoActionMcpServer().
+	 */
+	setActionToolsConfig(actionToolsConfig: NeoActionToolsConfig): void {
+		this.actionToolsConfig = actionToolsConfig;
 	}
 
 	/**
@@ -317,31 +334,35 @@ export class NeoAgentManager {
 		const model = this.getModel();
 		this.session.setRuntimeModel(model);
 
-		this.attachQueryTools();
+		this.attachTools();
 	}
 
 	/**
-	 * Attach the neo-query MCP server to the current session, merged with any
-	 * globally-enabled registry servers from AppMcpLifecycleManager.
+	 * Attach the neo-query and (when available) neo-action MCP servers to the
+	 * current session, merged with any globally-enabled registry servers from
+	 * AppMcpLifecycleManager.
 	 *
 	 * Mirrors the pattern used in provisionGlobalSpacesAgent():
 	 *   - Registry servers loaded from appMcpManager (if set).
-	 *   - In-process 'neo-query' server always wins on name collision.
+	 *   - In-process servers ('neo-query', 'neo-action') always win on name collision.
 	 *   - No subscription to mcp.registry.changed — registry changes take effect
 	 *     on the next daemon restart (consistent with the global spaces agent).
 	 *
 	 * No-op when toolsConfig has not been set via setToolsConfig().
 	 */
-	private attachQueryTools(): void {
+	private attachTools(): void {
 		if (!this.session || !this.toolsConfig) return;
 
-		const mcpServer = createNeoQueryMcpServer(this.toolsConfig);
+		const inProcessServers = createNeoToolsMcpServers(
+			this.toolsConfig,
+			this.actionToolsConfig ?? undefined
+		);
 		const registryMcpServers = this.appMcpManager?.getEnabledMcpConfigs() ?? {};
 
 		for (const name of Object.keys(registryMcpServers)) {
-			if (name === 'neo-query') {
+			if (name in inProcessServers) {
 				this.logger.warn(
-					`Neo: MCP server name collision on 'neo-query' — ` +
+					`Neo: MCP server name collision on '${name}' — ` +
 						`in-process server takes precedence over registry entry.`
 				);
 			}
@@ -349,7 +370,7 @@ export class NeoAgentManager {
 
 		this.session.setRuntimeMcpServers({
 			...registryMcpServers,
-			'neo-query': mcpServer as unknown as McpServerConfig,
+			...inProcessServers,
 		});
 	}
 }

--- a/packages/daemon/src/lib/neo/neo-system-prompt.ts
+++ b/packages/daemon/src/lib/neo/neo-system-prompt.ts
@@ -33,18 +33,46 @@ You are **Neo**, the global AI chief-of-staff for the NeoKai system. You have fu
 
 You have access to tools organized into the following categories. Use the most appropriate tool for each request. Prefer targeted reads before broad writes.
 
-### System Queries (read-only)
-Query the live state of any part of the NeoKai system:
-- Rooms, spaces, sessions, goals, tasks, MCP servers, skills, app settings, system info
+### System Queries (read-only, no confirmation needed)
+- \`list_rooms\`, \`get_room_status\`, \`get_room_details\`
+- \`list_spaces\`, \`get_space_status\`, \`get_space_details\`
+- \`list_space_agents\`, \`list_space_workflows\`, \`list_space_runs\`
+- \`list_goals\`, \`get_goal_details\`, \`get_metrics\`
+- \`list_tasks\`, \`get_task_detail\`
+- \`list_mcp_servers\`, \`get_mcp_server_status\`
+- \`list_skills\`, \`get_skill_details\`
+- \`get_app_settings\`, \`get_system_info\`
 
-### Room Operations
-Create, update, or delete rooms; manage goals and tasks within rooms; send messages to room agents; approve or reject tasks; stop or pause scheduled runs.
+### Room Operations — risk levels vary
+**Low risk (auto-execute in balanced/autonomous mode):**
+- \`create_room\`, \`update_room_settings\`
+- \`create_goal\`, \`update_goal\`, \`set_goal_status\`
+- \`create_task\`, \`update_task\`, \`set_task_status\`
+- \`pause_schedule\`, \`resume_schedule\`
 
-### Space Operations
-Create, update, or delete spaces; list agents, workflows, and runs; start or cancel workflow runs; approve or reject gates.
+**Medium risk (confirm in balanced mode):**
+- \`delete_room\` (without active tasks)
+- \`send_message_to_room\`, \`stop_session\`
+- \`approve_task\`, \`reject_task\`
 
-### Configuration Management
-Add, update, delete, or toggle MCP servers and skills; update app-wide settings (model, preferences, etc.).
+**High risk (require explicit phrasing):**
+- \`delete_room\` when the room has active tasks or sessions
+
+### Space Operations — risk levels vary
+**Low risk:**
+- \`create_space\`, \`update_space\`, \`start_workflow_run\`
+
+**Medium risk:**
+- \`delete_space\`, \`cancel_workflow_run\`, \`approve_gate\`, \`reject_gate\`
+- \`send_message_to_task\`
+
+### Configuration Management — risk levels vary
+**Low risk:**
+- \`toggle_mcp_server\`, \`toggle_skill\`, \`update_app_settings\`
+
+**Medium risk:**
+- \`add_mcp_server\`, \`update_mcp_server\`, \`delete_mcp_server\`
+- \`add_skill\`, \`update_skill\`, \`delete_skill\`
 
 ### Meta Operations
 - **undo_last_action** — Reverse the most recent Neo action.

--- a/packages/daemon/src/lib/neo/tools/neo-tools-server.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-tools-server.ts
@@ -1,0 +1,45 @@
+/**
+ * Neo Tools Server
+ *
+ * Creates the combined set of Neo MCP servers (query + action) that are
+ * attached to the Neo session at runtime.
+ *
+ * Two named servers are used so each can be independently identified in
+ * logs and collision warnings:
+ *   - 'neo-query'  — read-only system-state tools (always created)
+ *   - 'neo-action' — write operations with security-tier enforcement (created when actionConfig is provided)
+ *
+ * Usage:
+ *   const servers = createNeoToolsMcpServers(queryConfig, actionConfig);
+ *   session.setRuntimeMcpServers({ ...registryServers, ...servers });
+ */
+
+import type { McpServerConfig } from '@neokai/shared';
+import { createNeoQueryMcpServer, type NeoToolsConfig } from './neo-query-tools';
+import { createNeoActionMcpServer, type NeoActionToolsConfig } from './neo-action-tools';
+
+export type { NeoToolsConfig } from './neo-query-tools';
+export type { NeoActionToolsConfig } from './neo-action-tools';
+
+/**
+ * Create the neo-query and (optionally) neo-action MCP servers and return
+ * them as a named map suitable for session.setRuntimeMcpServers().
+ *
+ * When actionConfig is provided, both servers are created and returned.
+ * When omitted, only the neo-query server is returned (backward-compatible).
+ *
+ * The caller is responsible for merging registry-sourced servers; in-process
+ * servers ('neo-query', 'neo-action') always take precedence on name collision.
+ */
+export function createNeoToolsMcpServers(
+	queryConfig: NeoToolsConfig,
+	actionConfig?: NeoActionToolsConfig
+): Record<string, McpServerConfig> {
+	const servers: Record<string, McpServerConfig> = {
+		'neo-query': createNeoQueryMcpServer(queryConfig) as unknown as McpServerConfig,
+	};
+	if (actionConfig) {
+		servers['neo-action'] = createNeoActionMcpServer(actionConfig) as unknown as McpServerConfig;
+	}
+	return servers;
+}

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -555,9 +555,11 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			injectMessage: (sessionId: string, message: string) =>
 				deps.sessionManager.injectMessage(sessionId, message),
 			getActiveSessionForRoom: (roomId: string) => {
-				// Room sessions use a predictable ID: room:${roomId}
-				// This is the leader session that processes human messages.
-				return `room:${roomId}`;
+				// Room sessions use a predictable ID: room:${roomId}.
+				// Verify the session exists before returning it so callers receive
+				// null (→ clean error) instead of injecting into a non-existent session.
+				const sessionId = `room:${roomId}`;
+				return deps.sessionManager.getSession(sessionId) !== null ? sessionId : null;
 			},
 			getActiveSessionForTask: (taskId: string) => {
 				// Look up the task agent session ID stored on the SpaceTask record.

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -71,7 +71,6 @@ import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-ha
 import { setupSpaceExportImportHandlers } from './space-export-import-handlers';
 import { provisionGlobalSpacesAgent } from '../space/provision-global-agent';
 import { setupGlobalSpacesHandlers } from './global-spaces-handlers';
-import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
 import { setupLiveQueryHandlers } from './live-query-handlers';
 import { setupReferenceHandlers } from './reference-handlers';
 import { FileIndex } from '../file-index';
@@ -84,6 +83,11 @@ import { setupNeoHandlers } from './neo-handlers';
 import type { NeoAgentManager } from '../neo/neo-agent-manager';
 import { PendingActionStore } from '../neo/security-tier';
 import type { NeoToolsConfig } from '../neo/tools/neo-query-tools';
+import type { NeoActionToolsConfig, NeoWorkflowRun } from '../neo/tools/neo-action-tools';
+import {
+	createGlobalSpacesToolHandlers,
+	type GlobalSpacesState,
+} from '../space/tools/global-spaces-tools';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -459,6 +463,110 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// needed SpaceRuntimeService. Both are now created; inject via setter.
 	spaceRuntimeService.setTaskAgentManager(taskAgentManager);
 	spaceRuntimeService.start();
+
+	// Wire Neo action tools — must happen before neoAgentManager.provision() in app.ts.
+	// spaceRuntimeService.start() must be called first so getSharedRuntime() is available.
+	// Neo uses its own GlobalSpacesState (activeSpaceId stays null — Neo always passes
+	// space_id explicitly in tool calls, never relies on an ambient active-space context).
+	const neoSpacesState: GlobalSpacesState = { activeSpaceId: null };
+	const neoActionToolsConfig: NeoActionToolsConfig = {
+		roomManager,
+		managerFactory: {
+			getGoalManager: (roomId: string) =>
+				new GoalManager(
+					deps.db.getDatabase(),
+					roomId,
+					deps.reactiveDb,
+					deps.db.getShortIdAllocator()
+				),
+			getTaskManager: (roomId: string) =>
+				new TaskManager(
+					deps.db.getDatabase(),
+					roomId,
+					deps.reactiveDb,
+					deps.db.getShortIdAllocator()
+				),
+		},
+		runtimeService: roomRuntimeService,
+		pendingStore: neoPendingActions,
+		workspaceRoot: deps.config.workspaceRoot,
+		getSecurityMode: () => deps.neoAgentManager.getSecurityMode(),
+		spaceHandlers: createGlobalSpacesToolHandlers(
+			{
+				spaceManager: deps.spaceManager,
+				spaceAgentManager: deps.spaceAgentManager,
+				runtime: spaceRuntimeService.getSharedRuntime(),
+				workflowManager: spaceWorkflowManager,
+				taskRepo: spaceTaskRepo,
+				workflowRunRepo: spaceWorkflowRunRepo,
+				db: deps.db.getDatabase(),
+			},
+			neoSpacesState
+		),
+		workflowRunRepo: spaceWorkflowRunRepo,
+		spaceTaskManagerFactory: {
+			getTaskManager: (spaceId: string) => new SpaceTaskManager(deps.db.getDatabase(), spaceId),
+		},
+		gateDataRepo,
+		onGateChanged: async (runId: string, gateId: string) => {
+			await spaceRuntimeService.notifyGateDataChanged(runId, gateId);
+		},
+		onWorkflowRunUpdated: (spaceId: string, runId: string, run: NeoWorkflowRun) => {
+			deps.daemonHub
+				.emit('space.workflowRun.updated', {
+					sessionId: 'global',
+					spaceId,
+					runId,
+					// NeoWorkflowRun is a subset of SpaceWorkflowRun — cast for hub emission
+					run: run as unknown as Record<string, unknown>,
+				})
+				.catch((err) => {
+					log.warn('Neo: failed to emit space.workflowRun.updated:', err);
+				});
+		},
+		onGateDataUpdated: (
+			spaceId: string,
+			runId: string,
+			gateId: string,
+			data: Record<string, unknown>
+		) => {
+			deps.daemonHub
+				.emit('space.gateData.updated', {
+					sessionId: 'global',
+					spaceId,
+					runId,
+					gateId,
+					data,
+				})
+				.catch((err) => {
+					log.warn('Neo: failed to emit space.gateData.updated:', err);
+				});
+		},
+		mcpManager: {
+			createMcpServer: (params) => deps.db.appMcpServers.create(params),
+			updateMcpServer: (id, updates) => deps.db.appMcpServers.update(id, updates),
+			deleteMcpServer: (id) => deps.db.appMcpServers.delete(id),
+			getMcpServer: (id) => deps.db.appMcpServers.get(id),
+			getMcpServerByName: (name) => deps.db.appMcpServers.getByName(name),
+		},
+		skillsManager: deps.skillsManager,
+		settingsManager: deps.settingsManager,
+		sessionManager: {
+			injectMessage: (sessionId: string, message: string) =>
+				deps.sessionManager.injectMessage(sessionId, message),
+			getActiveSessionForRoom: (roomId: string) => {
+				// Room sessions use a predictable ID: room:${roomId}
+				// This is the leader session that processes human messages.
+				return `room:${roomId}`;
+			},
+			getActiveSessionForTask: (taskId: string) => {
+				// Look up the task agent session ID stored on the SpaceTask record.
+				const task = spaceTaskRepo.getTask(taskId);
+				return task?.taskAgentSessionId ?? null;
+			},
+		},
+	};
+	deps.neoAgentManager.setActionToolsConfig(neoActionToolsConfig);
 
 	// Human ↔ Task Agent message routing handlers (require taskAgentManager)
 	setupSpaceTaskMessageHandlers(deps.messageHub, taskAgentManager, deps.db);

--- a/packages/daemon/tests/unit/neo/neo-agent-manager-all-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-agent-manager-all-tools.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Integration tests for NeoAgentManager combined query + action tools attachment.
+ *
+ * Covers:
+ * - provision() with both setToolsConfig() + setActionToolsConfig() attaches both servers
+ * - provision() with only setToolsConfig() attaches only neo-query server
+ * - provision() with only setActionToolsConfig() (no query tools) is a no-op
+ * - Both servers survive destroyAndRecreate() (startup health-check failure)
+ * - Both servers are re-attached after clearSession()
+ * - Action config set after query config — both present after provision()
+ * - Registry servers are merged alongside both in-process servers
+ * - In-process 'neo-action' wins on registry name collision
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { NeoAgentManager, NEO_SESSION_ID } from '../../../src/lib/neo/neo-agent-manager';
+import type {
+	NeoSessionManager,
+	NeoSettingsManager,
+	NeoAppMcpManager,
+} from '../../../src/lib/neo/neo-agent-manager';
+import type { AgentSession } from '../../../src/lib/agent/agent-session';
+import type { McpServerConfig } from '@neokai/shared';
+import type {
+	NeoToolsConfig,
+	NeoQueryRoomManager,
+	NeoQueryGoalRepository,
+	NeoQueryTaskRepository,
+	NeoQuerySessionManager,
+	NeoQuerySettingsManager,
+	NeoQueryAuthManager,
+	NeoQueryMcpServerRepository,
+	NeoQuerySkillsManager,
+	NeoQuerySpaceManager,
+	NeoQuerySpaceAgentManager,
+	NeoQuerySpaceWorkflowManager,
+	NeoQueryWorkflowRunRepository,
+	NeoQuerySpaceTaskRepository,
+} from '../../../src/lib/neo/tools/neo-query-tools';
+import type {
+	NeoActionToolsConfig,
+	NeoActionRoomManager,
+	NeoActionManagerFactory,
+	NeoActionGoalManager,
+	NeoActionTaskManager,
+} from '../../../src/lib/neo/tools/neo-action-tools';
+import { PendingActionStore } from '../../../src/lib/neo/security-tier';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(
+	overrides: {
+		processingStatus?: 'idle' | 'processing' | 'queued' | 'waiting_for_input' | 'interrupted';
+		queryPromise?: Promise<void> | null;
+		queryObject?: unknown;
+		cleaningUp?: boolean;
+	} = {}
+): AgentSession {
+	const {
+		processingStatus = 'idle',
+		queryPromise = null,
+		queryObject = null,
+		cleaningUp = false,
+	} = overrides;
+
+	return {
+		getProcessingState: mock(() =>
+			processingStatus === 'processing'
+				? { status: 'processing', messageId: 'msg-1', phase: 'thinking' }
+				: { status: processingStatus }
+		),
+		isCleaningUp: mock(() => cleaningUp),
+		setRuntimeSystemPrompt: mock(() => undefined),
+		setRuntimeModel: mock(() => undefined),
+		setRuntimeMcpServers: mock(() => undefined),
+		cleanup: mock(async () => undefined),
+		queryPromise,
+		queryObject,
+	} as unknown as AgentSession;
+}
+
+function makeSessionManager(
+	opts: {
+		existingSession?: AgentSession | null;
+		createdSessions?: Array<AgentSession | null>;
+		createdSession?: AgentSession | null;
+	} = {}
+): NeoSessionManager & { _createCalls: number } {
+	const sessions = new Map<string, AgentSession | null>();
+	let getCallCount = 0;
+	const sessionQueue: Array<AgentSession | null> = opts.createdSessions
+		? [...opts.createdSessions]
+		: opts.createdSession !== undefined
+			? [opts.createdSession]
+			: [];
+
+	const sm = {
+		_createCalls: 0,
+
+		createSession: mock(async () => {
+			sm._createCalls++;
+			const next = sessionQueue.length > 0 ? sessionQueue.shift()! : makeSession();
+			sessions.set(NEO_SESSION_ID, next);
+			return NEO_SESSION_ID;
+		}),
+
+		getSessionAsync: mock(async (_id: string): Promise<AgentSession | null> => {
+			if (getCallCount === 0) {
+				getCallCount++;
+				if (opts.existingSession !== undefined) {
+					sessions.set(NEO_SESSION_ID, opts.existingSession);
+				}
+			}
+			return sessions.get(NEO_SESSION_ID) ?? null;
+		}),
+
+		deleteSession: mock(async () => {
+			sessions.delete(NEO_SESSION_ID);
+		}),
+
+		unregisterSession: mock(() => {}),
+	};
+
+	return sm;
+}
+
+function makeSettingsManager(): NeoSettingsManager {
+	return {
+		getGlobalSettings: mock(() => ({ neoSecurityMode: 'balanced', model: 'sonnet' })),
+	};
+}
+
+function makeMinimalQueryConfig(overrides: Partial<NeoToolsConfig> = {}): NeoToolsConfig {
+	const noopRoomManager: NeoQueryRoomManager = {
+		listRooms: () => [],
+		getRoom: () => null,
+		getRoomOverview: () => null,
+	};
+	const noopGoalRepo: NeoQueryGoalRepository = {
+		listGoals: () => [],
+		getGoal: () => null,
+		listExecutions: () => [],
+	};
+	const noopTaskRepo: NeoQueryTaskRepository = {
+		listTasks: () => [],
+		getTask: () => null,
+	};
+	const noopSessionManager: NeoQuerySessionManager = {
+		getActiveSessions: () => 0,
+		listSessions: () => [],
+	};
+	const noopSettingsManager: NeoQuerySettingsManager = {
+		getGlobalSettings: () =>
+			({
+				settingSources: [],
+				model: 'sonnet',
+				permissionMode: 'default',
+				thinkingLevel: 'none',
+				autoScroll: true,
+				coordinatorMode: false,
+				maxConcurrentWorkers: 3,
+				neoSecurityMode: 'balanced',
+				neoModel: null,
+				showArchived: false,
+				fallbackModels: [],
+				disabledMcpServers: [],
+			}) as ReturnType<NeoQuerySettingsManager['getGlobalSettings']>,
+	};
+	const noopAuthManager: NeoQueryAuthManager = {
+		getAuthStatus: async () => ({
+			isAuthenticated: false,
+			method: 'none',
+			source: 'env' as const,
+		}),
+	};
+	const noopMcpRepo: NeoQueryMcpServerRepository = {
+		list: () => [],
+		get: () => null,
+	};
+	const noopSkillsManager: NeoQuerySkillsManager = {
+		listSkills: () => [],
+		getSkill: () => null,
+	};
+	const noopSpaceManager: NeoQuerySpaceManager = {
+		listSpaces: () => [],
+		getSpace: () => null,
+	};
+	const noopSpaceAgentManager: NeoQuerySpaceAgentManager = {
+		listBySpaceId: () => [],
+	};
+	const noopSpaceWorkflowManager: NeoQuerySpaceWorkflowManager = {
+		listWorkflows: () => [],
+	};
+	const noopWorkflowRunRepo: NeoQueryWorkflowRunRepository = {
+		listBySpace: () => [],
+	};
+	const noopSpaceTaskRepo: NeoQuerySpaceTaskRepository = {
+		listBySpace: () => [],
+		listByStatus: () => [],
+	};
+
+	return {
+		roomManager: noopRoomManager,
+		goalRepository: noopGoalRepo,
+		taskRepository: noopTaskRepo,
+		sessionManager: noopSessionManager,
+		settingsManager: noopSettingsManager,
+		authManager: noopAuthManager,
+		mcpServerRepository: noopMcpRepo,
+		skillsManager: noopSkillsManager,
+		workspaceRoot: '/workspace',
+		appVersion: '0.1.1',
+		startedAt: Date.now() - 1_000,
+		spaceManager: noopSpaceManager,
+		spaceAgentManager: noopSpaceAgentManager,
+		spaceWorkflowManager: noopSpaceWorkflowManager,
+		workflowRunRepository: noopWorkflowRunRepo,
+		spaceTaskRepository: noopSpaceTaskRepo,
+		...overrides,
+	};
+}
+
+function makeMinimalActionConfig(
+	overrides: Partial<NeoActionToolsConfig> = {}
+): NeoActionToolsConfig {
+	const noopRoomManager: NeoActionRoomManager = {
+		createRoom: mock(() => ({ id: 'r1', name: 'Room 1' }) as never),
+		deleteRoom: mock(() => true),
+		getRoom: mock(() => null),
+		updateRoom: mock(() => null),
+	};
+
+	const noopGoalManager: NeoActionGoalManager = {
+		createGoal: mock(async () => ({ id: 'g1', title: 'Goal 1' }) as never),
+		getGoal: mock(async () => null),
+		patchGoal: mock(async () => ({ id: 'g1', title: 'Goal 1' }) as never),
+		updateGoalStatus: mock(async () => ({ id: 'g1', title: 'Goal 1' }) as never),
+	};
+
+	const noopTaskManager: NeoActionTaskManager = {
+		createTask: mock(async () => ({ id: 't1', title: 'Task 1' }) as never),
+		getTask: mock(async () => null),
+		updateTaskFields: mock(async () => ({ id: 't1', title: 'Task 1' }) as never),
+		setTaskStatus: mock(async () => ({ id: 't1', title: 'Task 1' }) as never),
+	};
+
+	const noopManagerFactory: NeoActionManagerFactory = {
+		getGoalManager: mock(() => noopGoalManager),
+		getTaskManager: mock(() => noopTaskManager),
+	};
+
+	return {
+		roomManager: noopRoomManager,
+		managerFactory: noopManagerFactory,
+		pendingStore: new PendingActionStore(),
+		getSecurityMode: () => 'balanced',
+		...overrides,
+	};
+}
+
+function makeAppMcpManager(configs: Record<string, McpServerConfig> = {}): NeoAppMcpManager {
+	return {
+		getEnabledMcpConfigs: mock(() => configs),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NeoAgentManager — combined query + action tools', () => {
+	describe('setToolsConfig() + setActionToolsConfig() + provision()', () => {
+		test('attaches both neo-query and neo-action servers when both configs are set', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalQueryConfig());
+			mgr.setActionToolsConfig(makeMinimalActionConfig());
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+			expect('neo-action' in servers).toBe(true);
+		});
+
+		test('attaches only neo-query when only query config is set', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalQueryConfig());
+			// No setActionToolsConfig()
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+			expect('neo-action' in servers).toBe(false);
+		});
+
+		test('is a no-op when only action config is set (no query config)', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			// Only action config, no query config
+			mgr.setActionToolsConfig(makeMinimalActionConfig());
+
+			await mgr.provision();
+
+			// Without toolsConfig, setRuntimeMcpServers should NOT be called
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(0);
+		});
+
+		test('merges registry servers alongside both in-process servers', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			const registryServers: Record<string, McpServerConfig> = {
+				'brave-search': { command: 'npx', args: ['-y', 'brave-search-mcp'] } as McpServerConfig,
+			};
+			mgr.setToolsConfig(makeMinimalQueryConfig(), makeAppMcpManager(registryServers));
+			mgr.setActionToolsConfig(makeMinimalActionConfig());
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+			expect('neo-action' in servers).toBe(true);
+			expect('brave-search' in servers).toBe(true);
+		});
+
+		test('in-process neo-action takes precedence over registry entry with same name', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			// Registry has an entry named 'neo-action' — should be overridden
+			const registryNeoAction = {
+				command: 'npx',
+				args: ['-y', 'fake-neo-action'],
+			} as McpServerConfig;
+			const registryServers: Record<string, McpServerConfig> = {
+				'neo-action': registryNeoAction,
+			};
+			mgr.setToolsConfig(makeMinimalQueryConfig(), makeAppMcpManager(registryServers));
+			mgr.setActionToolsConfig(makeMinimalActionConfig());
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			// The in-process server should be an object (MCP server instance), not the registry entry
+			expect(servers['neo-action']).not.toBe(registryNeoAction);
+		});
+	});
+
+	describe('destroyAndRecreate path', () => {
+		test('re-attaches both MCP servers on fresh session after health-check failure', async () => {
+			const stuckSession = makeSession({
+				processingStatus: 'processing',
+				queryPromise: new Promise(() => undefined),
+				queryObject: null,
+			});
+			const freshSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({
+				existingSession: stuckSession,
+				createdSession: freshSession,
+			});
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalQueryConfig());
+			mgr.setActionToolsConfig(makeMinimalActionConfig());
+
+			await mgr.provision();
+
+			// Fresh session should have both servers
+			const freshCalls = (freshSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(freshCalls.length).toBeGreaterThanOrEqual(1);
+			const servers = freshCalls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+			expect('neo-action' in servers).toBe(true);
+		});
+
+		test('re-attaches both servers after clearSession()', async () => {
+			const initialSession = makeSession();
+			const freshSession = makeSession();
+			const sm = makeSessionManager({
+				existingSession: null,
+				createdSessions: [initialSession, freshSession],
+			});
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalQueryConfig());
+			mgr.setActionToolsConfig(makeMinimalActionConfig());
+
+			await mgr.provision();
+			await mgr.clearSession();
+
+			// Both sessions should have both servers attached
+			for (const session of [initialSession, freshSession]) {
+				const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+				expect(calls.length).toBe(1);
+				const servers = calls[0][0] as Record<string, McpServerConfig>;
+				expect('neo-query' in servers).toBe(true);
+				expect('neo-action' in servers).toBe(true);
+			}
+		});
+	});
+
+	describe('restart path', () => {
+		test('re-attaches both servers to existing session on daemon restart', async () => {
+			const existingSession = makeSession({ processingStatus: 'idle' });
+			const sm = makeSessionManager({ existingSession });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalQueryConfig());
+			mgr.setActionToolsConfig(makeMinimalActionConfig());
+
+			await mgr.provision();
+
+			const calls = (existingSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			expect(calls.length).toBe(1);
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+			expect('neo-action' in servers).toBe(true);
+		});
+	});
+
+	describe('setActionToolsConfig() independence', () => {
+		test('can be called after setToolsConfig() — both configs are honoured at provision()', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+
+			// Typical call order in rpc-handlers/index.ts: query first, then action
+			mgr.setToolsConfig(makeMinimalQueryConfig());
+			mgr.setActionToolsConfig(makeMinimalActionConfig());
+
+			await mgr.provision();
+
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+			expect('neo-action' in servers).toBe(true);
+			expect(Object.keys(servers)).toHaveLength(2);
+		});
+
+		test('action config can be updated by calling setActionToolsConfig() again before provision()', async () => {
+			const session = makeSession();
+			const sm = makeSessionManager({ existingSession: null, createdSession: session });
+			const mgr = new NeoAgentManager(sm, makeSettingsManager());
+			mgr.setToolsConfig(makeMinimalQueryConfig());
+
+			const firstConfig = makeMinimalActionConfig();
+			const secondConfig = makeMinimalActionConfig();
+			mgr.setActionToolsConfig(firstConfig);
+			mgr.setActionToolsConfig(secondConfig); // second call wins
+
+			await mgr.provision();
+
+			// Still creates both servers — we just verify it doesn't throw and attaches them
+			const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+			const servers = calls[0][0] as Record<string, McpServerConfig>;
+			expect('neo-query' in servers).toBe(true);
+			expect('neo-action' in servers).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
Wire the neo-action MCP server into Neo's provisioning alongside the existing neo-query server.

## Changes

- **`neo-tools-server.ts`** (new) — `createNeoToolsMcpServers(queryConfig, actionConfig?)` returns a named map of both in-process servers, ready for `session.setRuntimeMcpServers()`
- **`neo-agent-manager.ts`** — adds `setActionToolsConfig()` method; renames `attachQueryTools()` → `attachTools()` which creates both servers when action config is present; in-process servers always win on registry name collision
- **`neo-system-prompt.ts`** — expands Capabilities section with specific tool names grouped by risk classification (low/medium/high)
- **`rpc-handlers/index.ts`** — builds `NeoActionToolsConfig` after `spaceRuntimeService.start()`, wiring space handlers, MCP/skills/settings/session manager adapters, and daemonHub event callbacks; calls `setActionToolsConfig()` before `provision()`
- **`neo-agent-manager-all-tools.test.ts`** (new) — 10 integration tests covering both-server attach, query-only fallback, no-op without query config, registry merge, collision precedence, health recovery, clearSession, and config overwrite