### PR TITLE
feat(neo): Undo tool implementation (task 5.2)

### DIFF
--- a/packages/daemon/src/lib/neo/activity-logger.ts
+++ b/packages/daemon/src/lib/neo/activity-logger.ts
@@ -104,6 +104,14 @@ export class NeoActivityLogger {
 		return this.repo.getLatestUndoable();
 	}
 
+	/**
+	 * Mark a log entry as no longer undoable (e.g. after it has been reversed).
+	 * Safe to call with a non-existent ID — no-op in that case.
+	 */
+	markUndone(id: string): void {
+		this.repo.update(id, { undoable: false });
+	}
+
 	// ── Maintenance ───────────────────────────────────────────────────────────
 
 	/**

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -57,6 +57,9 @@
  *   - stop_session
  *   - pause_schedule
  *   - resume_schedule
+ *
+ *   Undo
+ *   - undo_last_action
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
@@ -144,6 +147,8 @@ export interface NeoActionGoalManager {
 		status: GoalStatus,
 		updates?: { schedulePaused?: boolean }
 	): Promise<RoomGoal>;
+	/** Hard-delete a goal by ID. Used by undo of create_goal. */
+	deleteGoal?(id: string): Promise<boolean>;
 }
 
 export interface NeoActionTaskManager {
@@ -169,6 +174,8 @@ export interface NeoActionTaskManager {
 		status: TaskStatus,
 		opts?: { result?: string; error?: string }
 	): Promise<NeoTask>;
+	/** Hard-delete a task by ID. Used by undo of create_task. */
+	deleteTask?(id: string): Promise<boolean>;
 }
 
 /** Optional runtime — if not provided, approve/reject fallback gracefully */
@@ -1640,7 +1647,187 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				}
 			);
 		},
+		// ── Undo ─────────────────────────────────────────────────────────────
+
+		async undo_last_action(): Promise<ToolResult> {
+			const activityLogger = config.activityLogger;
+			if (!activityLogger) {
+				return errorResult(
+					'Activity logging is not available — undo requires activity logging to be enabled'
+				);
+			}
+
+			return withSecurityCheck('undo_last_action', {}, config, async () => {
+				const entry = activityLogger.getLatestUndoable();
+				if (!entry) {
+					return errorResult('Nothing to undo — no undoable actions in the activity log');
+				}
+
+				let undoData: Record<string, unknown>;
+				try {
+					undoData = JSON.parse(entry.undoData ?? '{}') as Record<string, unknown>;
+				} catch {
+					return errorResult(`Undo data is corrupt for action: ${entry.toolName}`);
+				}
+
+				// Execute the reverse operation
+				let message: string;
+				try {
+					message = await executeUndo(entry.toolName, undoData);
+				} catch (err) {
+					return errorResult(
+						`Undo failed for ${entry.toolName}: ${err instanceof Error ? err.message : String(err)}`
+					);
+				}
+
+				// Mark original entry as no longer undoable (prevents double-undo)
+				activityLogger.markUndone(entry.id);
+
+				return successResult({
+					undoneActionId: entry.id,
+					undoneToolName: entry.toolName,
+					message,
+				});
+			});
+		},
 	};
+
+	// ---------------------------------------------------------------------------
+	// Internal undo dispatch
+	// ---------------------------------------------------------------------------
+
+	async function executeUndo(toolName: string, undoData: Record<string, unknown>): Promise<string> {
+		switch (toolName) {
+			case 'create_room': {
+				const roomId = undoData.roomId as string | undefined;
+				if (!roomId) throw new Error('Missing roomId in undo data');
+				const room = roomManager.getRoom(roomId);
+				if (!room) throw new Error(`Room ${roomId} no longer exists — already deleted`);
+				roomManager.deleteRoom(roomId);
+				return `Deleted room: ${roomId}`;
+			}
+
+			case 'update_room_settings': {
+				const roomId = undoData.roomId as string | undefined;
+				if (!roomId) throw new Error('Missing roomId in undo data');
+				const room = roomManager.getRoom(roomId);
+				if (!room) throw new Error(`Room ${roomId} no longer exists`);
+				const updateParams: Parameters<typeof roomManager.updateRoom>[1] = {};
+				if ('previousName' in undoData) updateParams.name = undoData.previousName as string;
+				if ('previousBackground' in undoData)
+					updateParams.background = undoData.previousBackground as string | null;
+				if ('previousInstructions' in undoData)
+					updateParams.instructions = undoData.previousInstructions as string | null;
+				if ('previousDefaultModel' in undoData)
+					updateParams.defaultModel = undoData.previousDefaultModel as string | null;
+				if ('previousAllowedModels' in undoData)
+					updateParams.allowedModels = undoData.previousAllowedModels as string[];
+				const updated = roomManager.updateRoom(roomId, updateParams);
+				if (!updated) throw new Error(`Failed to restore room ${roomId} settings`);
+				return `Restored previous settings for room: ${roomId}`;
+			}
+
+			case 'create_goal': {
+				const goalId = undoData.goalId as string | undefined;
+				const goalRoomId = undoData.roomId as string | undefined;
+				if (!goalId || !goalRoomId) throw new Error('Missing goalId or roomId in undo data');
+				const goalManager = managerFactory.getGoalManager(goalRoomId);
+				const goal = await goalManager.getGoal(goalId);
+				if (!goal) throw new Error(`Goal ${goalId} no longer exists — already deleted`);
+				if (goalManager.deleteGoal) {
+					await goalManager.deleteGoal(goalId);
+				} else {
+					await goalManager.updateGoalStatus(goalId, 'archived');
+				}
+				return `Deleted goal: ${goalId}`;
+			}
+
+			case 'set_goal_status': {
+				const goalId = undoData.goalId as string | undefined;
+				const goalRoomId = undoData.roomId as string | undefined;
+				const previousGoalStatus = undoData.previousStatus as GoalStatus | undefined;
+				if (!goalId || !goalRoomId || !previousGoalStatus)
+					throw new Error('Missing goalId, roomId, or previousStatus in undo data');
+				const goalManager = managerFactory.getGoalManager(goalRoomId);
+				const goal = await goalManager.getGoal(goalId);
+				if (!goal) throw new Error(`Goal ${goalId} no longer exists`);
+				await goalManager.updateGoalStatus(goalId, previousGoalStatus);
+				return `Restored goal ${goalId} status to: ${previousGoalStatus}`;
+			}
+
+			case 'create_task': {
+				const taskId = undoData.taskId as string | undefined;
+				const taskRoomId = undoData.roomId as string | undefined;
+				if (!taskId || !taskRoomId) throw new Error('Missing taskId or roomId in undo data');
+				const taskManager = managerFactory.getTaskManager(taskRoomId);
+				const task = await taskManager.getTask(taskId);
+				if (!task) throw new Error(`Task ${taskId} no longer exists — already deleted`);
+				if (taskManager.deleteTask) {
+					await taskManager.deleteTask(taskId);
+				} else {
+					await taskManager.setTaskStatus(taskId, 'cancelled');
+				}
+				return `Deleted task: ${taskId}`;
+			}
+
+			case 'set_task_status': {
+				const taskId = undoData.taskId as string | undefined;
+				const taskRoomId = undoData.roomId as string | undefined;
+				const previousTaskStatus = undoData.previousStatus as TaskStatus | undefined;
+				if (!taskId || !taskRoomId || !previousTaskStatus)
+					throw new Error('Missing taskId, roomId, or previousStatus in undo data');
+				const taskManager = managerFactory.getTaskManager(taskRoomId);
+				const task = await taskManager.getTask(taskId);
+				if (!task) throw new Error(`Task ${taskId} no longer exists`);
+				await taskManager.setTaskStatus(taskId, previousTaskStatus);
+				return `Restored task ${taskId} status to: ${previousTaskStatus}`;
+			}
+
+			case 'toggle_skill': {
+				const skillId = undoData.skillId as string | undefined;
+				const previousEnabled = undoData.previousEnabled as boolean | undefined;
+				if (!skillId || previousEnabled === undefined)
+					throw new Error('Missing skillId or previousEnabled in undo data');
+				if (!skillsManager) throw new Error('Skills manager not available for undo');
+				const skill = skillsManager.getSkill(skillId);
+				if (!skill) throw new Error(`Skill ${skillId} no longer exists`);
+				skillsManager.setSkillEnabled(skillId, previousEnabled);
+				return `Restored skill ${skillId} enabled state to: ${previousEnabled}`;
+			}
+
+			case 'toggle_mcp_server': {
+				const serverId = undoData.serverId as string | undefined;
+				const previousServerEnabled = undoData.previousEnabled as boolean | undefined;
+				if (!serverId || previousServerEnabled === undefined)
+					throw new Error('Missing serverId or previousEnabled in undo data');
+				if (!mcpManager) throw new Error('MCP manager not available for undo');
+				const server = mcpManager.getMcpServer(serverId);
+				if (!server) throw new Error(`MCP server ${serverId} no longer exists`);
+				mcpManager.updateMcpServer(serverId, { enabled: previousServerEnabled });
+				return `Restored MCP server ${serverId} enabled state to: ${previousServerEnabled}`;
+			}
+
+			case 'update_app_settings': {
+				const previousSettings = undoData.previousSettings as Record<string, unknown> | undefined;
+				if (!previousSettings) throw new Error('Missing previousSettings in undo data');
+				if (!settingsManager) throw new Error('Settings manager not available for undo');
+				const settingsUpdates: Partial<GlobalSettings> = {};
+				if ('model' in previousSettings) settingsUpdates.model = previousSettings.model as string;
+				if ('thinkingLevel' in previousSettings)
+					settingsUpdates.thinkingLevel =
+						previousSettings.thinkingLevel as GlobalSettings['thinkingLevel'];
+				if ('autoScroll' in previousSettings)
+					settingsUpdates.autoScroll = previousSettings.autoScroll as boolean;
+				if ('maxConcurrentWorkers' in previousSettings)
+					settingsUpdates.maxConcurrentWorkers = previousSettings.maxConcurrentWorkers as number;
+				settingsManager.updateGlobalSettings(settingsUpdates);
+				return 'Restored previous app settings';
+			}
+
+			default:
+				throw new Error(`No undo handler for tool: ${toolName}`);
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1883,10 +2070,10 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 					targetType: 'goal',
 					getTargetId: (_, d) => ((d.goal as Record<string, unknown>)?.id as string) ?? null,
 					undoable: true,
-					// Undo = delete the created goal; capture its ID from the result.
+					// Undo = delete the created goal; capture its ID + roomId from the result.
 					postCapture: (d) => {
 						const id = (d.goal as Record<string, unknown>)?.id as string | undefined;
-						return id ? { goalId: id } : null;
+						return id ? { goalId: id, roomId: args.room_id } : null;
 					},
 				})
 		),
@@ -1939,7 +2126,9 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 						preCapture: async () => {
 							const goalManager = config.managerFactory.getGoalManager(args.room_id);
 							const goal = await goalManager.getGoal(args.goal_id);
-							return goal ? { goalId: goal.id, previousStatus: goal.status } : null;
+							return goal
+								? { goalId: goal.id, roomId: args.room_id, previousStatus: goal.status }
+								: null;
 						},
 					}
 				)
@@ -1964,10 +2153,10 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 					targetType: 'task',
 					getTargetId: (_, d) => ((d.task as Record<string, unknown>)?.id as string) ?? null,
 					undoable: true,
-					// Undo = delete the created task; capture its ID from the result.
+					// Undo = delete the created task; capture its ID + roomId from the result.
 					postCapture: (d) => {
 						const id = (d.task as Record<string, unknown>)?.id as string | undefined;
-						return id ? { taskId: id } : null;
+						return id ? { taskId: id, roomId: args.room_id } : null;
 					},
 				})
 		),
@@ -2027,7 +2216,9 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 						preCapture: async () => {
 							const taskManager = config.managerFactory.getTaskManager(args.room_id);
 							const task = await taskManager.getTask(args.task_id);
-							return task ? { taskId: task.id, previousStatus: task.status } : null;
+							return task
+								? { taskId: task.id, roomId: args.room_id, previousStatus: task.status }
+								: null;
 						},
 					}
 				)
@@ -2530,6 +2721,18 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 						getTargetId: (a) => (a.goal_id as string) ?? null,
 					}
 				)
+		),
+		// ── Undo ─────────────────────────────────────────────────────────────
+		tool(
+			'undo_last_action',
+			'Reverse the most recent undoable Neo action (e.g. undo a toggle, status change, settings update, or created entity). High risk — requires confirmation in balanced mode.',
+			{},
+			(_args) =>
+				logged('undo_last_action', {}, () => handlers.undo_last_action(), {
+					// targetType is null because it depends on the action being undone;
+					// the relevant context is in the output JSON (undoneToolName).
+					undoable: false,
+				})
 		),
 	];
 

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -1736,10 +1736,11 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				if (!goal) throw new Error(`Goal ${goalId} no longer exists — already deleted`);
 				if (goalManager.deleteGoal) {
 					await goalManager.deleteGoal(goalId);
+					return `Deleted goal: ${goalId}`;
 				} else {
 					await goalManager.updateGoalStatus(goalId, 'archived');
+					return `Archived goal: ${goalId} (hard delete unavailable)`;
 				}
-				return `Deleted goal: ${goalId}`;
 			}
 
 			case 'set_goal_status': {
@@ -1764,10 +1765,11 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				if (!task) throw new Error(`Task ${taskId} no longer exists — already deleted`);
 				if (taskManager.deleteTask) {
 					await taskManager.deleteTask(taskId);
+					return `Deleted task: ${taskId}`;
 				} else {
 					await taskManager.setTaskStatus(taskId, 'cancelled');
+					return `Cancelled task: ${taskId} (hard delete unavailable)`;
 				}
-				return `Deleted task: ${taskId}`;
 			}
 
 			case 'set_task_status': {
@@ -1803,7 +1805,11 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				if (!mcpManager) throw new Error('MCP manager not available for undo');
 				const server = mcpManager.getMcpServer(serverId);
 				if (!server) throw new Error(`MCP server ${serverId} no longer exists`);
-				mcpManager.updateMcpServer(serverId, { enabled: previousServerEnabled });
+				const restoredServer = mcpManager.updateMcpServer(serverId, {
+					enabled: previousServerEnabled,
+				});
+				if (!restoredServer)
+					throw new Error(`Failed to restore MCP server ${serverId} — it may have been deleted`);
 				return `Restored MCP server ${serverId} enabled state to: ${previousServerEnabled}`;
 			}
 

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -1703,6 +1703,11 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 				if (!roomId) throw new Error('Missing roomId in undo data');
 				const room = roomManager.getRoom(roomId);
 				if (!room) throw new Error(`Room ${roomId} no longer exists — already deleted`);
+				const activeSessions = roomManager.getActiveSessionCount?.(roomId) ?? 0;
+				if (activeSessions > 0)
+					throw new Error(
+						`Cannot undo room creation: room ${roomId} has ${activeSessions} active session(s)`
+					);
 				roomManager.deleteRoom(roomId);
 				return `Deleted room: ${roomId}`;
 			}

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -38,7 +38,7 @@
  * - stop_session: happy path, wrong status, runtime unavailable, task not found
  * - pause_schedule: happy path, non-recurring goal, goal not found, already paused (idempotent)
  * - resume_schedule: happy path, no schedule, non-recurring goal, already active (idempotent)
- * - MCP server: all 32 tools are registered
+ * - MCP server: all 33 tools are registered
  */
 
 import { describe, expect, it, beforeEach } from 'bun:test';
@@ -2865,7 +2865,7 @@ describe('createNeoActionMcpServer', () => {
 		expect(server.instance._registeredTools).toHaveProperty('resume_schedule');
 	});
 
-	it('registers exactly 32 tools', () => {
-		expect(Object.keys(server.instance._registeredTools)).toHaveLength(32);
+	it('registers exactly 33 tools', () => {
+		expect(Object.keys(server.instance._registeredTools)).toHaveLength(33);
 	});
 });

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -41,6 +41,43 @@
  * - MCP server: all 33 tools are registered
  */
 
+import { mock } from 'bun:test';
+
+// Re-declare the SDK mock so it survives Bun's module isolation.
+// Ensures neo-action-tools.ts is cached with a handler-preserving mock,
+// preventing interference with neo-activity-logger.test.ts which relies
+// on _registeredTools[name].handler being defined.
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+	query: mock(async () => ({ interrupt: () => {} })),
+	interrupt: mock(async () => {}),
+	supportedModels: mock(async () => {
+		throw new Error('SDK unavailable');
+	}),
+	createSdkMcpServer: mock((_opts: { name: string; tools: unknown[] }) => {
+		const registeredTools: Record<string, unknown> = {};
+		for (const t of _opts.tools ?? []) {
+			const name = (t as { name: string }).name;
+			const handler = (t as { handler: unknown }).handler;
+			if (name) registeredTools[name] = { handler };
+		}
+		return {
+			type: 'sdk' as const,
+			name: _opts.name,
+			version: '1.0.0',
+			tools: _opts.tools ?? [],
+			instance: {
+				connect() {},
+				disconnect() {},
+				_registeredTools: registeredTools,
+			},
+		};
+	}),
+	tool: mock((_name: string, _desc: string, _schema: unknown, _handler: unknown) => ({
+		name: _name,
+		handler: _handler,
+	})),
+}));
+
 import { describe, expect, it, beforeEach } from 'bun:test';
 import {
 	createNeoActionToolHandlers,

--- a/packages/daemon/tests/unit/neo/neo-activity-logger.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-activity-logger.test.ts
@@ -13,6 +13,42 @@
  * - pruneOldEntries(): age-based deletion and row-count cap
  */
 
+import { mock } from 'bun:test';
+
+// Re-declare the SDK mock so it survives Bun's module isolation.
+// Without this, a preceding test file's mock.module() override (e.g. room-agent-tools.test.ts)
+// returns a 'tool()' that discards the handler, causing callTool() to fail.
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+	query: mock(async () => ({ interrupt: () => {} })),
+	interrupt: mock(async () => {}),
+	supportedModels: mock(async () => {
+		throw new Error('SDK unavailable');
+	}),
+	createSdkMcpServer: mock((_opts: { name: string; tools: unknown[] }) => {
+		const registeredTools: Record<string, unknown> = {};
+		for (const t of _opts.tools ?? []) {
+			const name = (t as { name: string }).name;
+			const handler = (t as { handler: unknown }).handler;
+			if (name) registeredTools[name] = { handler };
+		}
+		return {
+			type: 'sdk' as const,
+			name: _opts.name,
+			version: '1.0.0',
+			tools: _opts.tools ?? [],
+			instance: {
+				connect() {},
+				disconnect() {},
+				_registeredTools: registeredTools,
+			},
+		};
+	}),
+	tool: mock((_name: string, _desc: string, _schema: unknown, _handler: unknown) => ({
+		name: _name,
+		handler: _handler,
+	})),
+}));
+
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { createTables } from '../../../src/storage/schema';

--- a/packages/daemon/tests/unit/neo/neo-undo-tool.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-undo-tool.test.ts
@@ -154,7 +154,10 @@ function makeMcpServer(overrides: Partial<AppMcpServer> = {}): AppMcpServer {
 // Mock manager factories
 // ---------------------------------------------------------------------------
 
-function makeRoomManager(rooms: Room[] = []): NeoActionRoomManager {
+function makeRoomManager(
+	rooms: Room[] = [],
+	opts: { activeSessions?: Map<string, number> } = {}
+): NeoActionRoomManager {
 	const store = new Map<string, Room>(rooms.map((r) => [r.id, r]));
 	return {
 		createRoom: (params) => {
@@ -168,6 +171,9 @@ function makeRoomManager(rooms: Room[] = []): NeoActionRoomManager {
 			return true;
 		},
 		getRoom: (id) => store.get(id) ?? null,
+		getActiveSessionCount: opts.activeSessions
+			? (id) => opts.activeSessions!.get(id) ?? 0
+			: undefined,
 		updateRoom: (id, params) => {
 			const room = store.get(id);
 			if (!room) return null;
@@ -354,6 +360,7 @@ function makeConfig(
 	opts: {
 		db?: BunDatabase;
 		rooms?: Room[];
+		activeSessions?: Map<string, number>;
 		goals?: RoomGoal[];
 		tasks?: NeoTask[];
 		skills?: AppSkill[];
@@ -376,7 +383,9 @@ function makeConfig(
 } {
 	const db = opts.db ?? makeDb();
 	const logger = opts.noLogger ? undefined : makeLogger(db);
-	const roomManager = makeRoomManager(opts.rooms ?? [makeRoom()]);
+	const roomManager = makeRoomManager(opts.rooms ?? [makeRoom()], {
+		activeSessions: opts.activeSessions,
+	});
 	const goalManager = makeGoalManager(opts.goals ?? [], opts.goalManagerOpts);
 	const taskManager = makeTaskManager(opts.tasks ?? [], opts.taskManagerOpts);
 	const skillsManager = makeSkillsManager(opts.skills ?? []);
@@ -530,6 +539,27 @@ describe('undo_last_action', () => {
 			const result = parseResult(await handlers.undo_last_action());
 			expect(result.success).toBe(false);
 			expect(result.error).toMatch(/no longer exists/i);
+		});
+
+		it('returns error when room has active sessions (mirrors delete_room safety check)', async () => {
+			const room = makeRoom({ id: 'busy-room' });
+			const { config, roomManager, logger } = makeConfig({
+				rooms: [room],
+				activeSessions: new Map([['busy-room', 2]]),
+			});
+			logger!.logAction({
+				toolName: 'create_room',
+				input: { name: 'Busy Room' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'busy-room' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/active session/i);
+			// Room must NOT be deleted
+			expect(roomManager.getRoom('busy-room')).not.toBeNull();
 		});
 
 		it('returns error when roomId missing from undoData', async () => {

--- a/packages/daemon/tests/unit/neo/neo-undo-tool.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-undo-tool.test.ts
@@ -1096,4 +1096,41 @@ describe('createNeoActionMcpServer: undo_last_action registration', () => {
 		const server = createNeoActionMcpServer(config);
 		expect(server.instance._registeredTools).toHaveProperty('undo_last_action');
 	});
+
+	it('undo_last_action produces an activity log entry via the logged() wrapper', async () => {
+		const db = makeDb();
+		const logger = makeLogger(db);
+		const room = makeRoom({ id: 'room-to-undo' });
+		const { config } = makeConfig({ db, rooms: [room] });
+		config.activityLogger = logger;
+
+		// Seed a create_room entry so there is something to undo.
+		logger.logAction({
+			toolName: 'create_room',
+			input: { name: 'Room To Undo' },
+			status: 'success',
+			undoable: true,
+			undoData: { roomId: 'room-to-undo' },
+		});
+
+		// Call undo through the MCP server so the logged() wrapper runs.
+		const server = createNeoActionMcpServer(config);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const reg = (server as any).instance._registeredTools as Record<
+			string,
+			{ handler: (args: Record<string, unknown>) => Promise<unknown> }
+		>;
+		await reg['undo_last_action'].handler({});
+
+		// Should now have 2 entries: original create_room (undoable=false) + undo_last_action.
+		const entries = logger.getRecentActivity(10);
+		expect(entries).toHaveLength(2);
+		// Newest first — the undo action itself is entry 0.
+		expect(entries[0].toolName).toBe('undo_last_action');
+		expect(entries[0].undoable).toBe(false);
+		// The original create_room entry was marked as undone.
+		expect(entries[1].toolName).toBe('create_room');
+		expect(entries[1].undoable).toBe(false);
+		db.close();
+	});
 });

--- a/packages/daemon/tests/unit/neo/neo-undo-tool.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-undo-tool.test.ts
@@ -1,0 +1,1099 @@
+/**
+ * Unit tests for undo_last_action tool
+ *
+ * Covers:
+ * - no activity logger → error
+ * - no undoable entries → error
+ * - corrupt undo data → error
+ * - create_room undo → deletes room
+ * - update_room_settings undo → restores previous settings
+ * - create_goal undo with deleteGoal → deletes goal
+ * - create_goal undo without deleteGoal → archives goal
+ * - set_goal_status undo → restores previous status
+ * - create_task undo with deleteTask → deletes task
+ * - create_task undo without deleteTask → cancels task
+ * - set_task_status undo → restores previous status
+ * - toggle_skill undo → restores previous enabled state
+ * - toggle_mcp_server undo → restores previous enabled state
+ * - update_app_settings undo → restores previous settings
+ * - undo marks original entry as non-undoable (prevents double-undo)
+ * - undo logs the undo action as activity entry
+ * - target no longer exists → error (room, goal, task, skill, mcp server)
+ * - unknown toolName → error
+ * - missing required fields in undoData → error
+ * - security check: confirmation required in balanced mode
+ * - security check: auto-execute in autonomous mode
+ * - MCP server: undo_last_action tool is registered
+ * - NeoActivityLogger.markUndone() sets undoable to false
+ */
+
+import { describe, expect, it, beforeEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { NeoActivityLogRepository } from '../../../src/storage/repositories/neo-activity-log-repository';
+import { NeoActivityLogger } from '../../../src/lib/neo/activity-logger';
+import {
+	createNeoActionToolHandlers,
+	createNeoActionMcpServer, // used in MCP registration test
+	type NeoActionToolsConfig,
+	type NeoActionRoomManager,
+	type NeoActionGoalManager,
+	type NeoActionTaskManager,
+	type NeoActionManagerFactory,
+	type NeoMcpManager,
+	type NeoSkillsManager,
+	type NeoSettingsManager,
+} from '../../../src/lib/neo/tools/neo-action-tools';
+import { PendingActionStore } from '../../../src/lib/neo/security-tier';
+import type {
+	Room,
+	RoomGoal,
+	NeoTask,
+	AppMcpServer,
+	AppSkill,
+	GlobalSettings,
+} from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB + Logger helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	createTables(db);
+	return db;
+}
+
+function makeLogger(db: BunDatabase): NeoActivityLogger {
+	return new NeoActivityLogger(new NeoActivityLogRepository(db));
+}
+
+// ---------------------------------------------------------------------------
+// Fixture factories
+// ---------------------------------------------------------------------------
+
+const NOW = 1_700_000_000_000;
+
+function makeRoom(overrides: Partial<Room> = {}): Room {
+	return {
+		id: 'room-1',
+		name: 'Test Room',
+		status: 'active',
+		sessionIds: [],
+		allowedPaths: [],
+		createdAt: NOW - 10_000,
+		updatedAt: NOW,
+		...overrides,
+	};
+}
+
+function makeGoal(overrides: Partial<RoomGoal> = {}): RoomGoal {
+	return {
+		id: 'goal-1',
+		roomId: 'room-1',
+		title: 'Test Goal',
+		description: 'A test goal',
+		status: 'active',
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		metrics: {},
+		createdAt: NOW - 5_000,
+		updatedAt: NOW,
+		missionType: 'one_shot',
+		autonomyLevel: 'supervised',
+		...overrides,
+	};
+}
+
+function makeTask(overrides: Partial<NeoTask> = {}): NeoTask {
+	return {
+		id: 'task-1',
+		roomId: 'room-1',
+		title: 'Test Task',
+		description: 'A test task',
+		status: 'pending',
+		priority: 'normal',
+		progress: 0,
+		dependsOn: [],
+		createdAt: NOW - 3_000,
+		updatedAt: NOW,
+		taskType: 'coding',
+		assignedAgent: 'coder',
+		...overrides,
+	} as NeoTask;
+}
+
+function makeAppSkill(overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id: 'skill-1',
+		name: 'test-skill',
+		displayName: 'Test Skill',
+		description: 'A test skill',
+		sourceType: 'plugin',
+		config: { type: 'plugin', pluginPath: '/path/to/plugin' },
+		enabled: false,
+		builtIn: false,
+		validationStatus: 'pending',
+		createdAt: NOW,
+		...overrides,
+	};
+}
+
+function makeMcpServer(overrides: Partial<AppMcpServer> = {}): AppMcpServer {
+	return {
+		id: 'mcp-1',
+		name: 'test-server',
+		sourceType: 'stdio',
+		enabled: false,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Mock manager factories
+// ---------------------------------------------------------------------------
+
+function makeRoomManager(rooms: Room[] = []): NeoActionRoomManager {
+	const store = new Map<string, Room>(rooms.map((r) => [r.id, r]));
+	return {
+		createRoom: (params) => {
+			const room = makeRoom({ id: `room-${Date.now()}`, name: params.name });
+			store.set(room.id, room);
+			return room;
+		},
+		deleteRoom: (id) => {
+			if (!store.has(id)) return false;
+			store.delete(id);
+			return true;
+		},
+		getRoom: (id) => store.get(id) ?? null,
+		updateRoom: (id, params) => {
+			const room = store.get(id);
+			if (!room) return null;
+			const updated = { ...room, ...params, updatedAt: NOW + 1 } as Room;
+			store.set(id, updated);
+			return updated;
+		},
+	};
+}
+
+function makeGoalManager(
+	goals: RoomGoal[] = [],
+	opts: { hasDelete?: boolean } = {}
+): NeoActionGoalManager {
+	const store = new Map<string, RoomGoal>(goals.map((g) => [g.id, g]));
+	const mgr: NeoActionGoalManager = {
+		createGoal: async (params) => {
+			const goal = makeGoal({ id: `goal-${Date.now()}`, ...params });
+			store.set(goal.id, goal);
+			return goal;
+		},
+		getGoal: async (id) => store.get(id) ?? null,
+		patchGoal: async (id, patch) => {
+			const goal = store.get(id);
+			if (!goal) throw new Error(`Goal not found: ${id}`);
+			const updated = { ...goal, ...patch, updatedAt: NOW + 1 };
+			store.set(id, updated);
+			return updated;
+		},
+		updateGoalStatus: async (id, status, updates) => {
+			const goal = store.get(id);
+			if (!goal) throw new Error(`Goal not found: ${id}`);
+			const updated = { ...goal, status, ...updates, updatedAt: NOW + 1 };
+			store.set(id, updated);
+			return updated;
+		},
+	};
+	if (opts.hasDelete) {
+		mgr.deleteGoal = async (id) => {
+			if (!store.has(id)) return false;
+			store.delete(id);
+			return true;
+		};
+	}
+	return mgr;
+}
+
+function makeTaskManager(
+	tasks: NeoTask[] = [],
+	opts: { hasDelete?: boolean } = {}
+): NeoActionTaskManager {
+	const store = new Map<string, NeoTask>(tasks.map((t) => [t.id, t]));
+	const mgr: NeoActionTaskManager = {
+		createTask: async (params) => {
+			const task = makeTask({ id: `task-${Date.now()}`, ...params });
+			store.set(task.id, task);
+			return task;
+		},
+		getTask: async (id) => store.get(id) ?? null,
+		updateTaskFields: async (id, updates) => {
+			const task = store.get(id);
+			if (!task) throw new Error(`Task not found: ${id}`);
+			const updated = { ...task, ...updates, updatedAt: NOW + 1 };
+			store.set(id, updated);
+			return updated;
+		},
+		setTaskStatus: async (id, status, opts) => {
+			const task = store.get(id);
+			if (!task) throw new Error(`Task not found: ${id}`);
+			const updated = {
+				...task,
+				status,
+				result: opts?.result ?? task.result,
+				error: opts?.error ?? task.error,
+				updatedAt: NOW + 1,
+			} as NeoTask;
+			store.set(id, updated);
+			return updated;
+		},
+	};
+	if (opts.hasDelete) {
+		mgr.deleteTask = async (id) => {
+			if (!store.has(id)) return false;
+			store.delete(id);
+			return true;
+		};
+	}
+	return mgr;
+}
+
+function makeManagerFactory(
+	goalManagers: Map<string, NeoActionGoalManager> = new Map(),
+	taskManagers: Map<string, NeoActionTaskManager> = new Map()
+): NeoActionManagerFactory {
+	return {
+		getGoalManager: (roomId) => goalManagers.get(roomId) ?? makeGoalManager(),
+		getTaskManager: (roomId) => taskManagers.get(roomId) ?? makeTaskManager(),
+	};
+}
+
+function makeSkillsManager(skills: AppSkill[] = []): NeoSkillsManager {
+	const store = new Map<string, AppSkill>(skills.map((s) => [s.id, s]));
+	return {
+		addSkill: (params) => {
+			const skill = makeAppSkill({ id: `skill-${Date.now()}`, ...params });
+			store.set(skill.id, skill);
+			return skill;
+		},
+		updateSkill: (id, params) => {
+			const skill = store.get(id);
+			if (!skill) throw new Error(`Skill not found: ${id}`);
+			const updated = { ...skill, ...params };
+			store.set(id, updated);
+			return updated;
+		},
+		setSkillEnabled: (id, enabled) => {
+			const skill = store.get(id);
+			if (!skill) throw new Error(`Skill not found: ${id}`);
+			const updated = { ...skill, enabled };
+			store.set(id, updated);
+			return updated;
+		},
+		removeSkill: (id) => {
+			if (!store.has(id)) return false;
+			store.delete(id);
+			return true;
+		},
+		getSkill: (id) => store.get(id) ?? null,
+	};
+}
+
+function makeMcpManager(servers: AppMcpServer[] = []): NeoMcpManager {
+	const store = new Map<string, AppMcpServer>(servers.map((s) => [s.id, s]));
+	return {
+		createMcpServer: (params) => {
+			const server: AppMcpServer = {
+				id: `mcp-${Date.now()}`,
+				name: params.name,
+				sourceType: params.sourceType,
+				enabled: params.enabled ?? false,
+			};
+			store.set(server.id, server);
+			return server;
+		},
+		updateMcpServer: (id, updates) => {
+			const s = store.get(id);
+			if (!s) return null;
+			const updated = { ...s, ...updates };
+			store.set(id, updated);
+			return updated;
+		},
+		deleteMcpServer: (id) => {
+			if (!store.has(id)) return false;
+			store.delete(id);
+			return true;
+		},
+		getMcpServer: (id) => store.get(id) ?? null,
+		getMcpServerByName: (name) => Array.from(store.values()).find((s) => s.name === name) ?? null,
+	};
+}
+
+function makeSettingsManager(initial: Partial<GlobalSettings> = {}): NeoSettingsManager {
+	let settings: GlobalSettings = {
+		model: 'claude-sonnet-4-6',
+		thinkingLevel: 'none',
+		autoScroll: true,
+		maxConcurrentWorkers: 3,
+		...initial,
+	} as GlobalSettings;
+	return {
+		getGlobalSettings: () => settings,
+		updateGlobalSettings: (updates) => {
+			settings = { ...settings, ...updates };
+			return settings;
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Helper to build config with an activity logger
+// ---------------------------------------------------------------------------
+
+function makeConfig(
+	opts: {
+		db?: BunDatabase;
+		rooms?: Room[];
+		goals?: RoomGoal[];
+		tasks?: NeoTask[];
+		skills?: AppSkill[];
+		servers?: AppMcpServer[];
+		goalManagerOpts?: { hasDelete?: boolean };
+		taskManagerOpts?: { hasDelete?: boolean };
+		settingsOpts?: Partial<GlobalSettings>;
+		noLogger?: boolean;
+		mode?: 'balanced' | 'autonomous' | 'conservative';
+	} = {}
+): {
+	config: NeoActionToolsConfig;
+	roomManager: NeoActionRoomManager;
+	goalManager: NeoActionGoalManager;
+	taskManager: NeoActionTaskManager;
+	skillsManager: NeoSkillsManager;
+	mcpManager: NeoMcpManager;
+	settingsManager: NeoSettingsManager;
+	logger: NeoActivityLogger | undefined;
+} {
+	const db = opts.db ?? makeDb();
+	const logger = opts.noLogger ? undefined : makeLogger(db);
+	const roomManager = makeRoomManager(opts.rooms ?? [makeRoom()]);
+	const goalManager = makeGoalManager(opts.goals ?? [], opts.goalManagerOpts);
+	const taskManager = makeTaskManager(opts.tasks ?? [], opts.taskManagerOpts);
+	const skillsManager = makeSkillsManager(opts.skills ?? []);
+	const mcpManager = makeMcpManager(opts.servers ?? []);
+	const settingsManager = makeSettingsManager(opts.settingsOpts);
+	const managerFactory = makeManagerFactory(
+		new Map([['room-1', goalManager]]),
+		new Map([['room-1', taskManager]])
+	);
+	const config: NeoActionToolsConfig = {
+		roomManager,
+		managerFactory,
+		pendingStore: new PendingActionStore(),
+		getSecurityMode: () => opts.mode ?? 'autonomous',
+		skillsManager,
+		mcpManager,
+		settingsManager,
+		activityLogger: logger,
+	};
+	return {
+		config,
+		roomManager,
+		goalManager,
+		taskManager,
+		skillsManager,
+		mcpManager,
+		settingsManager,
+		logger,
+	};
+}
+
+// Helper to parse tool result JSON
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+	return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// NeoActivityLogger.markUndone()
+// ---------------------------------------------------------------------------
+
+describe('NeoActivityLogger.markUndone()', () => {
+	it('sets undoable to false on an existing entry', () => {
+		const db = makeDb();
+		const repo = new NeoActivityLogRepository(db);
+		const logger = new NeoActivityLogger(repo);
+
+		logger.logAction({
+			toolName: 'toggle_skill',
+			input: { skill_id: 'sk-1', enabled: true },
+			status: 'success',
+			undoable: true,
+			undoData: { skillId: 'sk-1', previousEnabled: false },
+		});
+
+		const entry = logger.getLatestUndoable();
+		expect(entry).not.toBeNull();
+
+		logger.markUndone(entry!.id);
+
+		expect(logger.getLatestUndoable()).toBeNull();
+		db.close();
+	});
+
+	it('is a no-op for a non-existent ID', () => {
+		const db = makeDb();
+		const logger = makeLogger(db);
+		// Should not throw
+		expect(() => logger.markUndone('nonexistent-id')).not.toThrow();
+		db.close();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// undo_last_action handler
+// ---------------------------------------------------------------------------
+
+describe('undo_last_action', () => {
+	describe('pre-conditions', () => {
+		it('returns error when activity logger is not configured', async () => {
+			const { config } = makeConfig({ noLogger: true });
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/activity logging/i);
+		});
+
+		it('returns error when there are no undoable entries', async () => {
+			const { config, logger } = makeConfig();
+			// Log a non-undoable entry
+			logger!.logAction({ toolName: 'delete_room', input: {}, status: 'success', undoable: false });
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/nothing to undo/i);
+		});
+
+		it('returns error when undo data is corrupt JSON', async () => {
+			const db = makeDb();
+			const repo = new NeoActivityLogRepository(db);
+			const logger = new NeoActivityLogger(repo);
+			// Manually insert an entry with invalid undo data
+			repo.insert({
+				id: 'bad-entry',
+				toolName: 'toggle_skill',
+				input: '{}',
+				status: 'success',
+				undoable: true,
+				undoData: 'INVALID_JSON{{{',
+			});
+
+			const { config } = makeConfig({ db });
+			// Override with this specific logger
+			config.activityLogger = logger;
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/corrupt/i);
+			db.close();
+		});
+	});
+
+	describe('create_room undo', () => {
+		it('deletes the created room', async () => {
+			const room = makeRoom({ id: 'new-room' });
+			const { config, roomManager, logger } = makeConfig({ rooms: [room] });
+			logger!.logAction({
+				toolName: 'create_room',
+				input: { name: 'New Room' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'new-room' },
+			});
+			expect(roomManager.getRoom('new-room')).not.toBeNull();
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			expect(result.undoneToolName).toBe('create_room');
+			expect(roomManager.getRoom('new-room')).toBeNull();
+		});
+
+		it('returns error when room no longer exists', async () => {
+			const { config, logger } = makeConfig({ rooms: [] });
+			logger!.logAction({
+				toolName: 'create_room',
+				input: { name: 'Gone Room' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'gone-room' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no longer exists/i);
+		});
+
+		it('returns error when roomId missing from undoData', async () => {
+			const { config, logger } = makeConfig();
+			logger!.logAction({
+				toolName: 'create_room',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: {},
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/missing roomid/i);
+		});
+	});
+
+	describe('update_room_settings undo', () => {
+		it('restores previous room settings', async () => {
+			const room = makeRoom({ id: 'room-1', name: 'New Name', background: 'New Bg' });
+			const { config, roomManager, logger } = makeConfig({ rooms: [room] });
+			logger!.logAction({
+				toolName: 'update_room_settings',
+				input: { room_id: 'room-1', name: 'New Name' },
+				status: 'success',
+				undoable: true,
+				undoData: {
+					roomId: 'room-1',
+					previousName: 'Old Name',
+					previousBackground: 'Old Bg',
+					previousInstructions: null,
+					previousDefaultModel: null,
+					previousAllowedModels: [],
+				},
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			const restored = roomManager.getRoom('room-1');
+			expect(restored?.name).toBe('Old Name');
+			expect(restored?.background).toBe('Old Bg');
+		});
+
+		it('returns error when room no longer exists', async () => {
+			const { config, logger } = makeConfig({ rooms: [] });
+			logger!.logAction({
+				toolName: 'update_room_settings',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'gone-room', previousName: 'Old' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no longer exists/i);
+		});
+	});
+
+	describe('create_goal undo', () => {
+		it('hard-deletes goal when deleteGoal is available', async () => {
+			const goal = makeGoal({ id: 'goal-1' });
+			const { config, goalManager, logger } = makeConfig({
+				goals: [goal],
+				goalManagerOpts: { hasDelete: true },
+			});
+			logger!.logAction({
+				toolName: 'create_goal',
+				input: { room_id: 'room-1', title: 'My Goal' },
+				status: 'success',
+				undoable: true,
+				undoData: { goalId: 'goal-1', roomId: 'room-1' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			expect(await goalManager.getGoal('goal-1')).toBeNull();
+		});
+
+		it('archives goal when deleteGoal is not available', async () => {
+			const goal = makeGoal({ id: 'goal-1', status: 'active' });
+			const { config, goalManager, logger } = makeConfig({ goals: [goal] });
+			logger!.logAction({
+				toolName: 'create_goal',
+				input: { room_id: 'room-1', title: 'My Goal' },
+				status: 'success',
+				undoable: true,
+				undoData: { goalId: 'goal-1', roomId: 'room-1' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			const restored = await goalManager.getGoal('goal-1');
+			expect(restored?.status).toBe('archived');
+		});
+
+		it('returns error when goal no longer exists', async () => {
+			const { config, logger } = makeConfig({ goals: [] });
+			logger!.logAction({
+				toolName: 'create_goal',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { goalId: 'gone-goal', roomId: 'room-1' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no longer exists/i);
+		});
+	});
+
+	describe('set_goal_status undo', () => {
+		it('restores previous goal status', async () => {
+			const goal = makeGoal({ id: 'goal-1', status: 'completed' });
+			const { config, goalManager, logger } = makeConfig({ goals: [goal] });
+			logger!.logAction({
+				toolName: 'set_goal_status',
+				input: { room_id: 'room-1', goal_id: 'goal-1', status: 'completed' },
+				status: 'success',
+				undoable: true,
+				undoData: { goalId: 'goal-1', roomId: 'room-1', previousStatus: 'active' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			const restored = await goalManager.getGoal('goal-1');
+			expect(restored?.status).toBe('active');
+		});
+
+		it('returns error when goal no longer exists', async () => {
+			const { config, logger } = makeConfig({ goals: [] });
+			logger!.logAction({
+				toolName: 'set_goal_status',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { goalId: 'gone-goal', roomId: 'room-1', previousStatus: 'active' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no longer exists/i);
+		});
+	});
+
+	describe('create_task undo', () => {
+		it('hard-deletes task when deleteTask is available', async () => {
+			const task = makeTask({ id: 'task-1' });
+			const { config, taskManager, logger } = makeConfig({
+				tasks: [task],
+				taskManagerOpts: { hasDelete: true },
+			});
+			logger!.logAction({
+				toolName: 'create_task',
+				input: { room_id: 'room-1', title: 'My Task', description: 'Do stuff' },
+				status: 'success',
+				undoable: true,
+				undoData: { taskId: 'task-1', roomId: 'room-1' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			expect(await taskManager.getTask('task-1')).toBeNull();
+		});
+
+		it('cancels task when deleteTask is not available', async () => {
+			const task = makeTask({ id: 'task-1', status: 'pending' });
+			const { config, taskManager, logger } = makeConfig({ tasks: [task] });
+			logger!.logAction({
+				toolName: 'create_task',
+				input: { room_id: 'room-1', title: 'My Task', description: 'Do stuff' },
+				status: 'success',
+				undoable: true,
+				undoData: { taskId: 'task-1', roomId: 'room-1' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			const restored = await taskManager.getTask('task-1');
+			expect(restored?.status).toBe('cancelled');
+		});
+
+		it('returns error when task no longer exists', async () => {
+			const { config, logger } = makeConfig({ tasks: [] });
+			logger!.logAction({
+				toolName: 'create_task',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { taskId: 'gone-task', roomId: 'room-1' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no longer exists/i);
+		});
+	});
+
+	describe('set_task_status undo', () => {
+		it('restores previous task status', async () => {
+			const task = makeTask({ id: 'task-1', status: 'completed' });
+			const { config, taskManager, logger } = makeConfig({ tasks: [task] });
+			logger!.logAction({
+				toolName: 'set_task_status',
+				input: { room_id: 'room-1', task_id: 'task-1', status: 'completed' },
+				status: 'success',
+				undoable: true,
+				undoData: { taskId: 'task-1', roomId: 'room-1', previousStatus: 'in_progress' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			const restored = await taskManager.getTask('task-1');
+			expect(restored?.status).toBe('in_progress');
+		});
+
+		it('returns error when task no longer exists', async () => {
+			const { config, logger } = makeConfig({ tasks: [] });
+			logger!.logAction({
+				toolName: 'set_task_status',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { taskId: 'gone-task', roomId: 'room-1', previousStatus: 'pending' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no longer exists/i);
+		});
+	});
+
+	describe('toggle_skill undo', () => {
+		it('restores previous enabled state (true → false)', async () => {
+			const skill = makeAppSkill({ id: 'skill-1', enabled: true });
+			const { config, skillsManager, logger } = makeConfig({ skills: [skill] });
+			logger!.logAction({
+				toolName: 'toggle_skill',
+				input: { skill_id: 'skill-1', enabled: true },
+				status: 'success',
+				undoable: true,
+				undoData: { skillId: 'skill-1', previousEnabled: false },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			expect(skillsManager.getSkill('skill-1')?.enabled).toBe(false);
+		});
+
+		it('restores previous enabled state (false → true)', async () => {
+			const skill = makeAppSkill({ id: 'skill-1', enabled: false });
+			const { config, skillsManager, logger } = makeConfig({ skills: [skill] });
+			logger!.logAction({
+				toolName: 'toggle_skill',
+				input: { skill_id: 'skill-1', enabled: false },
+				status: 'success',
+				undoable: true,
+				undoData: { skillId: 'skill-1', previousEnabled: true },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			expect(skillsManager.getSkill('skill-1')?.enabled).toBe(true);
+		});
+
+		it('returns error when skills manager not available', async () => {
+			const { config, logger } = makeConfig();
+			config.skillsManager = undefined;
+			logger!.logAction({
+				toolName: 'toggle_skill',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { skillId: 'skill-1', previousEnabled: false },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/skills manager not available/i);
+		});
+
+		it('returns error when skill no longer exists', async () => {
+			const { config, logger } = makeConfig({ skills: [] });
+			logger!.logAction({
+				toolName: 'toggle_skill',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { skillId: 'gone-skill', previousEnabled: false },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no longer exists/i);
+		});
+	});
+
+	describe('toggle_mcp_server undo', () => {
+		it('restores previous enabled state', async () => {
+			const server = makeMcpServer({ id: 'mcp-1', enabled: true });
+			const { config, mcpManager, logger } = makeConfig({ servers: [server] });
+			logger!.logAction({
+				toolName: 'toggle_mcp_server',
+				input: { server_id: 'mcp-1', enabled: true },
+				status: 'success',
+				undoable: true,
+				undoData: { serverId: 'mcp-1', previousEnabled: false },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			expect(mcpManager.getMcpServer('mcp-1')?.enabled).toBe(false);
+		});
+
+		it('returns error when MCP manager not available', async () => {
+			const { config, logger } = makeConfig();
+			config.mcpManager = undefined;
+			logger!.logAction({
+				toolName: 'toggle_mcp_server',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { serverId: 'mcp-1', previousEnabled: false },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/mcp manager not available/i);
+		});
+
+		it('returns error when server no longer exists', async () => {
+			const { config, logger } = makeConfig({ servers: [] });
+			logger!.logAction({
+				toolName: 'toggle_mcp_server',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { serverId: 'gone-server', previousEnabled: false },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no longer exists/i);
+		});
+	});
+
+	describe('update_app_settings undo', () => {
+		it('restores previous settings values', async () => {
+			const { config, settingsManager, logger } = makeConfig({
+				settingsOpts: { model: 'claude-opus-4-6', autoScroll: false },
+			});
+			logger!.logAction({
+				toolName: 'update_app_settings',
+				input: { model: 'claude-opus-4-6' },
+				status: 'success',
+				undoable: true,
+				undoData: { previousSettings: { model: 'claude-sonnet-4-6' } },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			expect(settingsManager.getGlobalSettings().model).toBe('claude-sonnet-4-6');
+		});
+
+		it('restores multiple settings fields', async () => {
+			const { config, settingsManager, logger } = makeConfig({
+				settingsOpts: { autoScroll: false, maxConcurrentWorkers: 10 },
+			});
+			logger!.logAction({
+				toolName: 'update_app_settings',
+				input: { auto_scroll: false, max_concurrent_workers: 10 },
+				status: 'success',
+				undoable: true,
+				undoData: {
+					previousSettings: { autoScroll: true, maxConcurrentWorkers: 3 },
+				},
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			const settings = settingsManager.getGlobalSettings();
+			expect(settings.autoScroll).toBe(true);
+			expect(settings.maxConcurrentWorkers).toBe(3);
+		});
+
+		it('returns error when settings manager not available', async () => {
+			const { config, logger } = makeConfig();
+			config.settingsManager = undefined;
+			logger!.logAction({
+				toolName: 'update_app_settings',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { previousSettings: { model: 'claude-sonnet-4-6' } },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/settings manager not available/i);
+		});
+
+		it('returns error when previousSettings missing from undoData', async () => {
+			const { config, logger } = makeConfig();
+			logger!.logAction({
+				toolName: 'update_app_settings',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: {},
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/missing previoussettings/i);
+		});
+	});
+
+	describe('unknown toolName', () => {
+		it('returns error for unrecognized tool name', async () => {
+			const { config, logger } = makeConfig();
+			logger!.logAction({
+				toolName: 'some_future_tool',
+				input: {},
+				status: 'success',
+				undoable: true,
+				undoData: { some: 'data' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/no undo handler/i);
+		});
+	});
+
+	describe('side effects after undo', () => {
+		it('marks the original entry as non-undoable after successful undo', async () => {
+			const room = makeRoom({ id: 'new-room' });
+			const { config, logger } = makeConfig({ rooms: [room] });
+			logger!.logAction({
+				toolName: 'create_room',
+				input: { name: 'New Room' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'new-room' },
+			});
+
+			expect(logger!.getLatestUndoable()).not.toBeNull();
+
+			const handlers = createNeoActionToolHandlers(config);
+			await handlers.undo_last_action();
+
+			// After undo, the entry should no longer be undoable
+			expect(logger!.getLatestUndoable()).toBeNull();
+		});
+
+		it('does NOT mark original as undone when undo fails', async () => {
+			const { config, logger } = makeConfig({ rooms: [] });
+			// Log an entry that will fail to undo (room doesn't exist)
+			logger!.logAction({
+				toolName: 'create_room',
+				input: { name: 'Gone' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'gone-room' },
+			});
+
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(false);
+
+			// The entry should still be undoable (user can investigate and retry manually)
+			expect(logger!.getLatestUndoable()).not.toBeNull();
+		});
+
+		it('original create_room entry remains in feed (not deleted) after undo', async () => {
+			const db = makeDb();
+			const logger = makeLogger(db);
+			const room = makeRoom({ id: 'new-room' });
+			const { config } = makeConfig({ db, rooms: [room] });
+			config.activityLogger = logger;
+
+			logger.logAction({
+				toolName: 'create_room',
+				input: { name: 'New Room' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'new-room' },
+			});
+
+			const handlers = createNeoActionToolHandlers(config);
+			await handlers.undo_last_action();
+
+			// The original create_room entry is still in the feed (activity entries are not deleted),
+			// but it is now marked as non-undoable.
+			const entries = logger.getRecentActivity(10);
+			expect(entries).toHaveLength(1);
+			expect(entries[0].toolName).toBe('create_room');
+			expect(entries[0].undoable).toBe(false);
+			db.close();
+		});
+	});
+
+	describe('security tier enforcement', () => {
+		it('returns confirmationRequired in balanced mode (high risk)', async () => {
+			const room = makeRoom({ id: 'room-new' });
+			const { config, logger } = makeConfig({ rooms: [room], mode: 'balanced' });
+			logger!.logAction({
+				toolName: 'create_room',
+				input: { name: 'New Room' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'room-new' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.confirmationRequired).toBe(true);
+			expect(result.pendingActionId).toBeDefined();
+			// Room should NOT be deleted yet
+			expect(config.roomManager.getRoom('room-new')).not.toBeNull();
+		});
+
+		it('auto-executes in autonomous mode', async () => {
+			const room = makeRoom({ id: 'room-auto' });
+			const { config, logger } = makeConfig({ rooms: [room], mode: 'autonomous' });
+			logger!.logAction({
+				toolName: 'create_room',
+				input: { name: 'New Room' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'room-auto' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.success).toBe(true);
+			expect(config.roomManager.getRoom('room-auto')).toBeNull();
+		});
+
+		it('returns confirmationRequired in conservative mode', async () => {
+			const room = makeRoom({ id: 'room-cons' });
+			const { config, logger } = makeConfig({ rooms: [room], mode: 'conservative' });
+			logger!.logAction({
+				toolName: 'create_room',
+				input: { name: 'New Room' },
+				status: 'success',
+				undoable: true,
+				undoData: { roomId: 'room-cons' },
+			});
+			const handlers = createNeoActionToolHandlers(config);
+			const result = parseResult(await handlers.undo_last_action());
+			expect(result.confirmationRequired).toBe(true);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// MCP server registration
+// ---------------------------------------------------------------------------
+
+describe('createNeoActionMcpServer: undo_last_action registration', () => {
+	it('registers the undo_last_action tool', () => {
+		const { config } = makeConfig();
+		const server = createNeoActionMcpServer(config);
+		expect(server.instance._registeredTools).toHaveProperty('undo_last_action');
+	});
+});


### PR DESCRIPTION
Implements the `undo_last_action` MCP tool that reverses Neo's most recent undoable action.

## Changes

- **`activity-logger.ts`** — Added `markUndone(id)` method to set an entry's `undoable` flag to false after reversal
- **`neo-action-tools.ts`** — Added `undo_last_action` handler + `executeUndo` internal dispatcher; added optional `deleteGoal?`/`deleteTask?` to manager interfaces; updated `create_goal`, `create_task`, `set_goal_status`, `set_task_status` preCapture/postCapture to include `roomId` in undoData so undo can look up the right manager
- **`neo-undo-tool.test.ts`** (new) — 39 unit tests covering all 9 undoable tool handlers, edge cases (missing targets, corrupt data, missing managers, missing undoData fields), security tier enforcement (balanced → confirmation required, autonomous → auto-execute), and `markUndone()` behavior
- **`neo-action-tools.test.ts`** — Updated tool count assertion from 32 → 33

## Undo handlers

| Original tool | Undo operation |
|---|---|
| `create_room` | `deleteRoom()` |
| `update_room_settings` | `updateRoom()` with previous values |
| `create_goal` | `deleteGoal()` if available, else archive |
| `set_goal_status` | `updateGoalStatus()` with previous status |
| `create_task` | `deleteTask()` if available, else cancel |
| `set_task_status` | `setTaskStatus()` with previous status |
| `toggle_skill` | `setSkillEnabled()` with previous state |
| `toggle_mcp_server` | `updateMcpServer()` with previous enabled state |
| `update_app_settings` | `updateGlobalSettings()` with previous values |