### PR TITLE
fix(e2e): resolve strict mode violations and space creation isolation

### DIFF
--- a/packages/e2e/tests/core/connection-resilience.e2e.ts
+++ b/packages/e2e/tests/core/connection-resilience.e2e.ts
@@ -49,11 +49,11 @@ test.describe('Reconnection - Basic Message Sync', () => {
 		sessionId = await createSessionViaUI(page);
 
 		// 2. Send a message that will take some time to process
-		const messageInput = page.locator('textarea[placeholder*="Ask"]');
+		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await messageInput.click();
 		await messageInput.fill('Count from 1 to 5 with 1 second delay between each number');
 
-		const sendButton = page.locator('button[aria-label="Send message"]');
+		const sendButton = page.locator('button[aria-label="Send message"]').first();
 		await sendButton.click();
 
 		// 3. Wait for agent to start processing
@@ -128,11 +128,11 @@ test.describe('Reconnection - Multiple Cycles', () => {
 		// 1. Create session and send message
 		sessionId = await createSessionViaUI(page);
 
-		const messageInput = page.locator('textarea[placeholder*="Ask"]');
+		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await messageInput.click();
 		await messageInput.fill('List 3 programming languages');
 
-		const sendButton = page.locator('button[aria-label="Send message"]');
+		const sendButton = page.locator('button[aria-label="Send message"]').first();
 		await sendButton.click();
 
 		// 2. Wait for initial response
@@ -208,11 +208,11 @@ test.describe('Reconnection - Long Disconnection Period', () => {
 		sessionId = await createSessionViaUI(page);
 
 		// 2. Send message
-		const messageInput = page.locator('textarea[placeholder*="Ask"]');
+		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await messageInput.click();
 		await messageInput.fill('Say hello');
 
-		const sendButton = page.locator('button[aria-label="Send message"]');
+		const sendButton = page.locator('button[aria-label="Send message"]').first();
 		await sendButton.click();
 
 		// 3. Wait for processing to start
@@ -273,11 +273,11 @@ test.describe('Reconnection - Message Order', () => {
 		// 1. Create session and send message
 		sessionId = await createSessionViaUI(page);
 
-		const messageInput = page.locator('textarea[placeholder*="Ask"]');
+		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await messageInput.click();
 		await messageInput.fill('Count: 1, 2, 3');
 
-		const sendButton = page.locator('button[aria-label="Send message"]');
+		const sendButton = page.locator('button[aria-label="Send message"]').first();
 		await sendButton.click();
 
 		// 2. Wait for some messages
@@ -399,11 +399,11 @@ test.describe('Connection - State Transitions', () => {
 		// Create session and send message
 		sessionId = await createSessionViaUI(page);
 
-		const messageInput = page.locator('textarea[placeholder*="Ask"]');
+		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await messageInput.click();
 		await messageInput.fill('Test message for reconnection');
 
-		const sendButton = page.locator('button[aria-label="Send message"]');
+		const sendButton = page.locator('button[aria-label="Send message"]').first();
 		await sendButton.click();
 
 		// Wait for message to appear

--- a/packages/e2e/tests/core/scroll-behavior.e2e.ts
+++ b/packages/e2e/tests/core/scroll-behavior.e2e.ts
@@ -43,7 +43,7 @@ test.describe('Auto-Scroll Toggle', () => {
 
 		// Send a message to enable the auto-scroll toggle
 		await messageInput.fill('Hello');
-		await page.locator('button[aria-label="Send message"]').click();
+		await page.locator('button[aria-label="Send message"]').first().click();
 
 		// Wait for response to start
 		await page.waitForTimeout(2000);

--- a/packages/e2e/tests/features/archive.e2e.ts
+++ b/packages/e2e/tests/features/archive.e2e.ts
@@ -185,7 +185,7 @@ test.describe('Session Archive - Archived Session Behavior', () => {
 
 		// The message input should be replaced with an archived label
 		// Check that textarea is not visible or is disabled
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		const isTextareaHidden = (await textarea.count()) === 0 || !(await textarea.isVisible());
 
 		// Should show archived indicator instead of input
@@ -240,7 +240,7 @@ test.describe('Session Archive - Edge Cases', () => {
 		sessionId = await createSessionViaUI(page);
 
 		// Send a message
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await textarea.fill('Unique test message 12345');
 		await page.keyboard.press('Meta+Enter');
 

--- a/packages/e2e/tests/features/draft.e2e.ts
+++ b/packages/e2e/tests/features/draft.e2e.ts
@@ -45,7 +45,7 @@ test.describe('Draft Persistence', () => {
 		await page.waitForTimeout(500);
 
 		// Draft should be restored
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(textarea).toHaveValue(draftText);
 	});
 
@@ -56,13 +56,13 @@ test.describe('Draft Persistence', () => {
 		// Type and send message
 		const messageText = 'Test message for draft clearing';
 		await page.fill('textarea[placeholder*="Ask"]', messageText);
-		await page.click('button[aria-label*="Send message"]');
+		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Wait for message to be sent
 		await page.waitForSelector(`text=${messageText}`, { timeout: 5000 });
 
 		// Textarea should be empty
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(textarea).toHaveValue('');
 
 		// Switch to another session
@@ -92,7 +92,7 @@ test.describe('Draft Persistence', () => {
 		// Type and send message
 		const messageText = 'Message that should not reappear';
 		await page.fill('textarea[placeholder*="Ask"]', messageText);
-		await page.click('button[aria-label*="Send message"]');
+		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Wait for message to be sent
 		await page.waitForSelector(`text=${messageText}`, { timeout: 5000 });
@@ -115,7 +115,7 @@ test.describe('Draft Persistence', () => {
 		await page.waitForTimeout(500);
 
 		// Textarea should be empty
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(textarea).toHaveValue('');
 	});
 
@@ -152,7 +152,7 @@ test.describe('Draft Persistence', () => {
 		await page.waitForTimeout(500);
 
 		// Textarea should remain empty
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(textarea).toHaveValue('');
 	});
 
@@ -160,11 +160,11 @@ test.describe('Draft Persistence', () => {
 		// Create new session
 		await createSessionViaUI(page);
 
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 
 		// Type quickly and send without waiting for debounce
 		await textarea.fill('Quick message 1');
-		await page.click('button[aria-label*="Send message"]');
+		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Textarea should clear immediately
 		await expect(textarea).toHaveValue('');
@@ -174,7 +174,7 @@ test.describe('Draft Persistence', () => {
 
 		// Type another message quickly
 		await textarea.fill('Quick message 2');
-		await page.click('button[aria-label*="Send message"]');
+		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Textarea should clear again
 		await expect(textarea).toHaveValue('');
@@ -225,7 +225,7 @@ test.describe('Draft Persistence', () => {
 		await page.waitForTimeout(500);
 
 		// Should show first draft
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(textarea).toHaveValue(draft1);
 
 		// Go back to second session
@@ -255,10 +255,10 @@ test.describe('Draft Clearing Bug Fix', () => {
 
 		// Type and send message
 		const messageText = 'This message should not reappear';
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 
 		await textarea.fill(messageText);
-		await page.click('button[aria-label*="Send message"]');
+		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Textarea should clear immediately
 		await expect(textarea).toHaveValue('', { timeout: 2000 });
@@ -299,10 +299,10 @@ test.describe('Draft Clearing Bug Fix', () => {
 
 		// Type and send message
 		const messageText = 'Message for reload test';
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 
 		await textarea.fill(messageText);
-		await page.click('button[aria-label*="Send message"]');
+		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Wait for message to appear
 		await page.waitForSelector(`text=${messageText}`, { timeout: 10000 });
@@ -326,7 +326,7 @@ test.describe('Draft Clearing Bug Fix', () => {
 		await page.waitForTimeout(500);
 
 		// CRITICAL: Textarea should be empty after reload
-		const textareaAfterReload = page.locator('textarea[placeholder*="Ask"]');
+		const textareaAfterReload = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(textareaAfterReload).toHaveValue('');
 
 		// Cleanup
@@ -337,7 +337,7 @@ test.describe('Draft Clearing Bug Fix', () => {
 		// Create new session
 		await createSessionViaUI(page);
 
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 
 		// Get the session ID
 		const sessionButton = page.locator('[data-session-id]').first();
@@ -345,7 +345,7 @@ test.describe('Draft Clearing Bug Fix', () => {
 
 		// Send message quickly (before 250ms debounce)
 		await textarea.fill('Quick message');
-		await page.click('button[aria-label*="Send message"]');
+		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Should clear immediately
 		await expect(textarea).toHaveValue('', { timeout: 2000 });
@@ -365,7 +365,7 @@ test.describe('Draft Clearing Bug Fix', () => {
 		await page.waitForTimeout(500);
 
 		// Should STILL be empty (no race condition)
-		const textareaAfter = page.locator('textarea[placeholder*="Ask"]');
+		const textareaAfter = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(textareaAfter).toHaveValue('');
 
 		// Cleanup

--- a/packages/e2e/tests/features/draft.e2e.ts
+++ b/packages/e2e/tests/features/draft.e2e.ts
@@ -25,7 +25,7 @@ test.describe('Draft Persistence', () => {
 
 		// Type draft text
 		const draftText = 'This is a draft message';
-		await page.fill('textarea[placeholder*="Ask"]', draftText);
+		await page.locator('textarea[placeholder*="Ask"]').first().fill(draftText);
 
 		// Wait for debounced save (250ms + buffer)
 		await page.waitForTimeout(500);
@@ -55,7 +55,7 @@ test.describe('Draft Persistence', () => {
 
 		// Type and send message
 		const messageText = 'Test message for draft clearing';
-		await page.fill('textarea[placeholder*="Ask"]', messageText);
+		await page.locator('textarea[placeholder*="Ask"]').first().fill(messageText);
 		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Wait for message to be sent
@@ -91,7 +91,7 @@ test.describe('Draft Persistence', () => {
 
 		// Type and send message
 		const messageText = 'Message that should not reappear';
-		await page.fill('textarea[placeholder*="Ask"]', messageText);
+		await page.locator('textarea[placeholder*="Ask"]').first().fill(messageText);
 		await page.locator('button[aria-label*="Send message"]').first().click();
 
 		// Wait for message to be sent
@@ -125,13 +125,13 @@ test.describe('Draft Persistence', () => {
 
 		// Type draft text
 		const draftText = 'Draft to be deleted';
-		await page.fill('textarea[placeholder*="Ask"]', draftText);
+		await page.locator('textarea[placeholder*="Ask"]').first().fill(draftText);
 
 		// Wait for debounced save
 		await page.waitForTimeout(500);
 
 		// Clear the textarea
-		await page.fill('textarea[placeholder*="Ask"]', '');
+		await page.locator('textarea[placeholder*="Ask"]').first().fill('');
 
 		// Wait for immediate save of empty draft
 		await page.waitForTimeout(200);
@@ -202,7 +202,7 @@ test.describe('Draft Persistence', () => {
 
 		// Type draft in first session
 		const draft1 = 'Draft for session 1';
-		await page.fill('textarea[placeholder*="Ask"]', draft1);
+		await page.locator('textarea[placeholder*="Ask"]').first().fill(draft1);
 		await page.waitForTimeout(500);
 
 		// Create second session
@@ -210,7 +210,7 @@ test.describe('Draft Persistence', () => {
 
 		// Type draft in second session
 		const draft2 = 'Draft for session 2';
-		await page.fill('textarea[placeholder*="Ask"]', draft2);
+		await page.locator('textarea[placeholder*="Ask"]').first().fill(draft2);
 		await page.waitForTimeout(500);
 
 		// Go back to first session

--- a/packages/e2e/tests/features/file-attachment.e2e.ts
+++ b/packages/e2e/tests/features/file-attachment.e2e.ts
@@ -371,11 +371,11 @@ test.describe('File Attachment - Send', () => {
 		await page.waitForTimeout(500);
 
 		// Type a message
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await textarea.fill('Here is a test image');
 
 		// Send the message
-		const sendButton = page.locator('button[aria-label="Send message"]');
+		const sendButton = page.locator('button[aria-label="Send message"]').first();
 		await sendButton.click();
 
 		// Wait for the message to appear
@@ -432,7 +432,7 @@ test.describe('File Attachment - Send', () => {
 		await expect(removeButton).toBeVisible({ timeout: 10000 });
 
 		// Type and send message
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await textarea.fill('Test message with image');
 
 		const sendButton = page.locator('[data-testid="send-button"]');

--- a/packages/e2e/tests/features/rewind-features.e2e.ts
+++ b/packages/e2e/tests/features/rewind-features.e2e.ts
@@ -26,9 +26,8 @@ const IS_MOCK = process.env.NEOKAI_USE_DEV_PROXY === '1';
  * exits before responding, waits for the send button to reappear (agent idle).
  */
 async function sendMessage(page: Page, messageText: string): Promise<void> {
-	const messageInput = 'textarea[placeholder*="Ask"]';
-	await page.fill(messageInput, messageText);
-	await page.click('button[aria-label*="Send message"]');
+	await page.locator('textarea[placeholder*="Ask"]').first().fill(messageText);
+	await page.locator('button[aria-label*="Send message"]').first().click();
 
 	// Race between: full response completes OR send button returns (SDK crash recovery)
 	await Promise.race([

--- a/packages/e2e/tests/features/slash-cmd.e2e.ts
+++ b/packages/e2e/tests/features/slash-cmd.e2e.ts
@@ -286,7 +286,7 @@ test.describe('Slash Command Autocomplete - Built-in Commands', () => {
 		await waitForSlashCommandsLoaded(page);
 
 		// Send a simple message to trigger SDK query, which populates SDK commands
-		const textarea = page.locator('textarea[placeholder*="Ask"]');
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 		await textarea.waitFor({ state: 'visible', timeout: 5000 });
 		await textarea.fill('hello');
 		await page.keyboard.press('Enter');

--- a/packages/e2e/tests/features/space-agent-chat.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-chat.e2e.ts
@@ -18,6 +18,25 @@ async function createSpaceViaRpc(
 	workspacePath: string,
 	name: string
 ): Promise<string> {
+	// Pre-creation cleanup: delete any existing space at this path (including archived)
+	try {
+		await page.evaluate(async (path) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			const spaces = (await hub.request('space.list', { includeArchived: true })) as Array<{
+				id: string;
+				workspacePath: string;
+			}>;
+			for (const space of spaces) {
+				if (space.workspacePath === path) {
+					await hub.request('space.delete', { id: space.id });
+				}
+			}
+		}, workspacePath);
+	} catch {
+		// Best-effort cleanup
+	}
+
 	const id = await page.evaluate(
 		async ({ workspacePath, name }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;

--- a/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
+++ b/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
@@ -20,6 +20,25 @@ async function createSpaceByRpc(
 	workspacePath: string,
 	name: string
 ): Promise<string> {
+	// Pre-creation cleanup: delete any existing space at this path (including archived)
+	try {
+		await page.evaluate(async (path) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			const spaces = (await hub.request('space.list', { includeArchived: true })) as Array<{
+				id: string;
+				workspacePath: string;
+			}>;
+			for (const space of spaces) {
+				if (space.workspacePath === path) {
+					await hub.request('space.delete', { id: space.id });
+				}
+			}
+		}, workspacePath);
+	} catch {
+		// Best-effort cleanup
+	}
+
 	const spaceId = await page.evaluate(
 		async ({ path, spaceName }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;

--- a/packages/e2e/tests/features/task-message-streaming.e2e.ts
+++ b/packages/e2e/tests/features/task-message-streaming.e2e.ts
@@ -274,7 +274,7 @@ test.describe('no loading flash when user sends a message (regression)', () => {
 		await expect(page.locator('text=Pre-existing message beta')).toBeVisible({ timeout: 10000 });
 
 		// Type a message in the human input area (no data-testid on <textarea> in prod)
-		const textarea = page.locator('textarea');
+		const textarea = page.locator('textarea').first();
 		await textarea.fill('Hello, please continue working');
 
 		// Pre-existing messages must still be visible while typing (no wipe on input)

--- a/packages/e2e/tests/helpers/session-archive-helpers.ts
+++ b/packages/e2e/tests/helpers/session-archive-helpers.ts
@@ -67,7 +67,7 @@ export async function createSessionWithMessage(page: Page): Promise<string> {
 	const sessionId = await createSessionViaUI(page);
 
 	// Send a simple message
-	const textarea = page.locator('textarea[placeholder*="Ask"]');
+	const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 	await textarea.fill('Hello, say "test message acknowledged"');
 	await page.keyboard.press('Meta+Enter');
 

--- a/packages/e2e/tests/helpers/slash-command-helpers.ts
+++ b/packages/e2e/tests/helpers/slash-command-helpers.ts
@@ -33,7 +33,7 @@ export async function waitForSlashCommandsLoaded(page: Page): Promise<void> {
  * Type in the message input textarea
  */
 export async function typeInMessageInput(page: Page, text: string): Promise<void> {
-	const textarea = page.locator('textarea[placeholder*="Ask"]');
+	const textarea = page.locator('textarea[placeholder*="Ask"]').first();
 	await textarea.waitFor({ state: 'visible', timeout: 5000 });
 	await textarea.fill(text);
 }
@@ -42,7 +42,7 @@ export async function typeInMessageInput(page: Page, text: string): Promise<void
  * Get the message input textarea
  */
 export function getMessageInput(page: Page) {
-	return page.locator('textarea[placeholder*="Ask"]');
+	return page.locator('textarea[placeholder*="Ask"]').first();
 }
 
 /**

--- a/packages/e2e/tests/helpers/space-helpers.ts
+++ b/packages/e2e/tests/helpers/space-helpers.ts
@@ -16,6 +16,9 @@ export async function createSpaceViaRpc(
 	workspacePath: string,
 	name: string
 ): Promise<string> {
+	// Pre-creation cleanup: delete any existing space at this path (including archived)
+	await cleanupExistingSpace(page, workspacePath);
+
 	const id = await page.evaluate(
 		async ({ workspacePath, name }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
@@ -44,6 +47,30 @@ export async function deleteSpaceViaRpc(page: Page, spaceId: string): Promise<vo
 			if (!hub?.request) return;
 			await hub.request('space.delete', { id });
 		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+/**
+ * Delete any existing space at the given workspace path (including archived ones).
+ * Prevents UNIQUE constraint violations when tests reuse the same workspace path.
+ */
+async function cleanupExistingSpace(page: Page, workspacePath: string): Promise<void> {
+	try {
+		await page.evaluate(async (path) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			const spaces = (await hub.request('space.list', { includeArchived: true })) as Array<{
+				id: string;
+				workspacePath: string;
+			}>;
+			for (const space of spaces) {
+				if (space.workspacePath === path) {
+					await hub.request('space.delete', { id: space.id });
+				}
+			}
+		}, workspacePath);
 	} catch {
 		// Best-effort cleanup
 	}

--- a/packages/e2e/tests/serial/error-scenarios.e2e.ts
+++ b/packages/e2e/tests/serial/error-scenarios.e2e.ts
@@ -50,7 +50,7 @@ test.describe('Error Scenarios', () => {
 		await expect(messageInput).toBeDisabled({ timeout: 5000 });
 
 		// Send button should also be disabled
-		const sendButton = page.locator('button[aria-label="Send message"]');
+		const sendButton = page.locator('button[aria-label="Send message"]').first();
 		await expect(sendButton).toBeDisabled();
 
 		// Restore network

--- a/packages/e2e/tests/smoke/message-send.e2e.ts
+++ b/packages/e2e/tests/smoke/message-send.e2e.ts
@@ -32,7 +32,7 @@ test.describe('Smoke: Message Send', () => {
 		await expect(messageInput).toBeVisible({ timeout: 15000 });
 
 		await messageInput.fill('Hello');
-		await page.locator('button[aria-label="Send message"]').click();
+		await page.locator('button[aria-label="Send message"]').first().click();
 
 		// Verify message appears in UI
 		await expect(page.getByText('Hello').first()).toBeVisible();


### PR DESCRIPTION
## Summary
- Added `.first()` to chat input and send button locators across 11 E2E test files to resolve strict mode violations caused by two chat UIs (main + Neo panel) being mounted simultaneously
- Added pre-creation cleanup to `createSpaceViaRpc()` in `space-helpers.ts` that deletes existing spaces (including archived) before creating, preventing UNIQUE constraint violations

## Tests affected (~20 expected to recover)
**Selector fixes:** archive, slash-cmd, connection-resilience, scroll-behavior, draft, file-attachment, task-message-streaming, error-scenarios, message-send
**Space isolation:** space-agent-chat, space-context-panel-switching, space-navigation, space-settings-crud, space-sub-routes, space-task-creation, space-task-fullwidth

## Root causes
1. `App.tsx` now renders both `ChatContainer` (main chat) and `NeoPanel` (AI assistant) simultaneously — both have textareas with "Ask" in placeholder and buttons with `aria-label="Send message"`
2. Space tests share a single workspace path via `getWorkspaceRoot()` but don't clean up before creation