### PR TITLE
fix(neo): render SDK messages using SDKMessageRenderer in NeoChatView

### DIFF
--- a/packages/web/src/components/neo/NeoChatView.test.tsx
+++ b/packages/web/src/components/neo/NeoChatView.test.tsx
@@ -457,4 +457,62 @@ describe('NeoChatView', () => {
 		expect(getByTestId('neo-user-message')).toBeTruthy();
 		expect(getByText('Hello as a string')).toBeTruthy();
 	});
+
+	it('renders parse-error fallback when assistant message has invalid JSON', () => {
+		neoStore.messages.value = [
+			{
+				...makeAssistantMsg('1', 'ignored'),
+				content: 'not valid json at all',
+			},
+		];
+		const { getByTestId, queryByTestId } = render(<NeoChatView />);
+		expect(getByTestId('neo-assistant-message')).toBeTruthy();
+		expect(getByTestId('neo-message-parse-error')).toBeTruthy();
+		expect(queryByTestId('sdk-message-renderer')).toBeNull();
+	});
+
+	it('renders parse-error fallback when assistant content is a non-assistant SDK type', () => {
+		// A user-type SDK message inadvertently stored for an assistant message row
+		const sdkMsg = {
+			type: 'user',
+			message: { role: 'user', content: [{ type: 'text', text: 'unexpected' }] },
+			parent_tool_use_id: null,
+			session_id: 'sess-1',
+		};
+		neoStore.messages.value = [
+			{
+				...makeAssistantMsg('1', 'ignored'),
+				content: JSON.stringify(sdkMsg),
+			},
+		];
+		const { getByTestId, queryByTestId } = render(<NeoChatView />);
+		expect(getByTestId('neo-assistant-message')).toBeTruthy();
+		expect(getByTestId('neo-message-parse-error')).toBeTruthy();
+		expect(queryByTestId('sdk-message-renderer')).toBeNull();
+	});
+
+	it('renders parse-error fallback when assistant content lacks type field', () => {
+		neoStore.messages.value = [
+			{
+				...makeAssistantMsg('1', 'ignored'),
+				content: JSON.stringify({ foo: 'bar' }),
+			},
+		];
+		const { getByTestId, queryByTestId } = render(<NeoChatView />);
+		expect(getByTestId('neo-assistant-message')).toBeTruthy();
+		expect(getByTestId('neo-message-parse-error')).toBeTruthy();
+		expect(queryByTestId('sdk-message-renderer')).toBeNull();
+	});
+
+	it('renders empty string (not raw JSON) for user message with invalid content', () => {
+		neoStore.messages.value = [
+			{
+				...makeUserMsg('1', 'ignored'),
+				content: 'not-valid-json',
+			},
+		];
+		const { getByTestId } = render(<NeoChatView />);
+		const bubble = getByTestId('neo-user-message');
+		expect(bubble.textContent).toBe('');
+	});
 });

--- a/packages/web/src/components/neo/NeoChatView.test.tsx
+++ b/packages/web/src/components/neo/NeoChatView.test.tsx
@@ -3,8 +3,10 @@
  *
  * Verifies:
  * - Empty state renders when no messages
- * - User messages render as right-aligned bubbles
- * - Assistant messages render with sparkle avatar
+ * - User messages render as right-aligned bubbles with correct text
+ * - Assistant messages render with sparkle avatar using SDKMessageRenderer
+ * - SDK messages with content arrays are parsed and rendered correctly
+ * - Tool call messages render via SDKMessageRenderer
  * - Sending a message calls neoStore.sendMessage
  * - Enter key submits; Shift+Enter does not
  * - Send button disabled when input is empty or sending
@@ -40,27 +42,56 @@ vi.mock('./NeoConfirmationCard.tsx', () => ({
 	),
 }));
 
-// Mock MarkdownRenderer
-vi.mock('../chat/MarkdownRenderer.tsx', () => ({
-	default: ({ content }: { content: string }) => (
-		<div data-testid="markdown-renderer">{content}</div>
-	),
+// Mock SDKMessageRenderer — renders text content from the SDK message for assertions
+vi.mock('../sdk/SDKMessageRenderer.tsx', () => ({
+	SDKMessageRenderer: ({ message }: { message: unknown }) => {
+		const msg = message as {
+			type: string;
+			message?: {
+				content?: Array<{ type: string; text?: string }> | string;
+			};
+		};
+		let text = '';
+		if (msg.type === 'assistant') {
+			const content = msg.message?.content;
+			if (Array.isArray(content)) {
+				text = content
+					.filter((b) => b.type === 'text')
+					.map((b) => b.text ?? '')
+					.join('\n');
+			}
+		}
+		return (
+			<div data-testid="sdk-message-renderer" data-message-type={msg.type}>
+				{text}
+			</div>
+		);
+	},
 }));
 
 import { NeoChatView } from './NeoChatView.tsx';
 import { neoStore } from '../../lib/neo-store.ts';
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers — build realistic SDK message JSON strings
 // ---------------------------------------------------------------------------
 
 function makeUserMsg(id: string, text: string) {
+	const sdkMsg = {
+		type: 'user',
+		message: {
+			role: 'user',
+			content: [{ type: 'text', text }],
+		},
+		parent_tool_use_id: null,
+		session_id: 'sess-1',
+	};
 	return {
 		id,
 		sessionId: 'sess-1',
 		messageType: 'user',
 		messageSubtype: null,
-		content: JSON.stringify([{ type: 'text', text }]),
+		content: JSON.stringify(sdkMsg),
 		createdAt: Date.now(),
 		sendStatus: null,
 		origin: 'human',
@@ -68,12 +99,60 @@ function makeUserMsg(id: string, text: string) {
 }
 
 function makeAssistantMsg(id: string, text: string) {
+	const sdkMsg = {
+		type: 'assistant',
+		message: {
+			id: `msg-${id}`,
+			content: [{ type: 'text', text }],
+			model: 'claude-3-5-sonnet-20241022',
+			role: 'assistant',
+			stop_reason: 'end_turn',
+			usage: { input_tokens: 10, output_tokens: 5 },
+		},
+		parent_tool_use_id: null,
+		uuid: id,
+		session_id: 'sess-1',
+	};
 	return {
 		id,
 		sessionId: 'sess-1',
 		messageType: 'assistant',
 		messageSubtype: null,
-		content: JSON.stringify([{ type: 'text', text }]),
+		content: JSON.stringify(sdkMsg),
+		createdAt: Date.now(),
+		sendStatus: null,
+		origin: null,
+	};
+}
+
+function makeAssistantMsgWithToolCall(id: string, toolName: string) {
+	const sdkMsg = {
+		type: 'assistant',
+		message: {
+			id: `msg-${id}`,
+			content: [
+				{
+					type: 'tool_use',
+					id: `tool-${id}`,
+					name: toolName,
+					input: { query: 'test' },
+				},
+			],
+			model: 'claude-3-5-sonnet-20241022',
+			role: 'assistant',
+			stop_reason: 'tool_use',
+			usage: { input_tokens: 10, output_tokens: 5 },
+		},
+		parent_tool_use_id: null,
+		uuid: id,
+		session_id: 'sess-1',
+	};
+	return {
+		id,
+		sessionId: 'sess-1',
+		messageType: 'assistant',
+		messageSubtype: null,
+		content: JSON.stringify(sdkMsg),
 		createdAt: Date.now(),
 		sendStatus: null,
 		origin: null,
@@ -114,11 +193,31 @@ describe('NeoChatView', () => {
 		expect(getByText('Hi there')).toBeTruthy();
 	});
 
-	it('renders assistant message with sparkle avatar', () => {
+	it('renders assistant message with sparkle avatar and SDKMessageRenderer', () => {
 		neoStore.messages.value = [makeAssistantMsg('1', 'Hello from Neo')];
-		const { getByTestId, getByText } = render(<NeoChatView />);
+		const { getByTestId } = render(<NeoChatView />);
 		expect(getByTestId('neo-assistant-message')).toBeTruthy();
+		expect(getByTestId('sdk-message-renderer')).toBeTruthy();
+	});
+
+	it('renders assistant text content via SDKMessageRenderer', () => {
+		neoStore.messages.value = [makeAssistantMsg('1', 'Hello from Neo')];
+		const { getByText } = render(<NeoChatView />);
 		expect(getByText('Hello from Neo')).toBeTruthy();
+	});
+
+	it('passes correct SDK message type to SDKMessageRenderer', () => {
+		neoStore.messages.value = [makeAssistantMsg('1', 'Hey!')];
+		const { getByTestId } = render(<NeoChatView />);
+		const renderer = getByTestId('sdk-message-renderer');
+		expect(renderer.getAttribute('data-message-type')).toBe('assistant');
+	});
+
+	it('renders tool call messages via SDKMessageRenderer', () => {
+		neoStore.messages.value = [makeAssistantMsgWithToolCall('1', 'list_rooms')];
+		const { getByTestId } = render(<NeoChatView />);
+		expect(getByTestId('neo-assistant-message')).toBeTruthy();
+		expect(getByTestId('sdk-message-renderer')).toBeTruthy();
 	});
 
 	it('skips result and system messages', () => {
@@ -322,5 +421,40 @@ describe('NeoChatView', () => {
 			fireEvent.click(getByTestId('neo-error-dismiss'));
 		});
 		expect(queryByTestId('neo-error-provider-unavailable')).toBeNull();
+	});
+
+	it('renders multiple messages in order', () => {
+		neoStore.messages.value = [
+			makeUserMsg('1', 'What rooms do I have?'),
+			makeAssistantMsg('2', 'You have 3 rooms: Alpha, Beta, Gamma.'),
+		];
+		const { getAllByTestId } = render(<NeoChatView />);
+		expect(getAllByTestId('neo-user-message')).toHaveLength(1);
+		expect(getAllByTestId('neo-assistant-message')).toHaveLength(1);
+	});
+
+	it('renders user message with string content from SDK message', () => {
+		// User message with string content (not array)
+		const sdkMsg = {
+			type: 'user',
+			message: { role: 'user', content: 'Hello as a string' },
+			parent_tool_use_id: null,
+			session_id: 'sess-1',
+		};
+		neoStore.messages.value = [
+			{
+				id: '1',
+				sessionId: 'sess-1',
+				messageType: 'user',
+				messageSubtype: null,
+				content: JSON.stringify(sdkMsg),
+				createdAt: Date.now(),
+				sendStatus: null,
+				origin: 'human',
+			},
+		];
+		const { getByTestId, getByText } = render(<NeoChatView />);
+		expect(getByTestId('neo-user-message')).toBeTruthy();
+		expect(getByText('Hello as a string')).toBeTruthy();
 	});
 });

--- a/packages/web/src/components/neo/NeoChatView.tsx
+++ b/packages/web/src/components/neo/NeoChatView.tsx
@@ -4,16 +4,17 @@
  * The main chat interface inside the Neo panel.
  * - Renders user messages and Neo (assistant) responses
  * - Auto-scrolls to the newest message
- * - Renders structured JSON responses as formatted cards
+ * - Uses SDKMessageRenderer for proper assistant message rendering
  * - Shows inline NeoConfirmationCard when Neo needs user input
  * - Displays error states as styled cards (not alerts/modals)
  * - Input bar at the bottom
  */
 
 import { useEffect, useRef, useState } from 'preact/hooks';
+import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { neoStore, type NeoMessage } from '../../lib/neo-store.ts';
 import { NeoConfirmationCard } from './NeoConfirmationCard.tsx';
-import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
+import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer.tsx';
 
 // ---------------------------------------------------------------------------
 // Error state helpers
@@ -112,137 +113,43 @@ function ErrorCard({ errorCode, onDismiss }: ErrorCardProps) {
 }
 
 // ---------------------------------------------------------------------------
-// Message content parsers
+// SDK message parsing helpers
 // ---------------------------------------------------------------------------
 
-/** Extract displayable text from a raw SDK message content JSON string. */
-function extractTextContent(content: string): string {
+/** Safely parse a raw sdk_message JSON string into an SDKMessage. Returns null on failure. */
+function parseSDKMessage(content: string): SDKMessage | null {
 	try {
 		const parsed: unknown = JSON.parse(content);
-		if (typeof parsed === 'string') return parsed;
-		// SDK messages use content arrays: [{ type: 'text', text: '...' }, ...]
-		if (Array.isArray(parsed)) {
-			return parsed
-				.filter(
-					(block): block is { type: string; text: string } =>
-						typeof block === 'object' &&
-						block !== null &&
-						'type' in block &&
-						(block as { type: string }).type === 'text' &&
-						'text' in block
-				)
-				.map((block) => block.text)
-				.join('\n');
+		if (typeof parsed === 'object' && parsed !== null && 'type' in parsed) {
+			return parsed as SDKMessage;
 		}
-		// Fallback: some messages store content as a direct string field
-		if (typeof parsed === 'object' && parsed !== null && 'text' in parsed) {
-			const text = (parsed as { text: unknown }).text;
-			if (typeof text === 'string') return text;
-		}
-		return '';
-	} catch {
-		return content;
-	}
-}
-
-/** Try to parse content as structured JSON data (object/array). Returns null if plain text. */
-function tryParseStructured(content: string): unknown | null {
-	try {
-		const parsed: unknown = JSON.parse(content);
-		if (Array.isArray(parsed)) return parsed;
-		if (typeof parsed === 'object' && parsed !== null) return parsed;
 		return null;
 	} catch {
 		return null;
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Structured data renderer
-// ---------------------------------------------------------------------------
+type UserSDKMessage = Extract<SDKMessage, { type: 'user' }>;
 
-function StructuredDataCard({ data }: { data: unknown }) {
-	const [expanded, setExpanded] = useState(false);
-
-	if (Array.isArray(data)) {
-		return (
-			<div class="my-1 rounded-lg border border-gray-700 overflow-hidden text-xs">
-				<div
-					class="flex items-center justify-between px-2 py-1.5 bg-gray-800/80 cursor-pointer hover:bg-gray-700/60 transition-colors"
-					onClick={() => setExpanded((v) => !v)}
-				>
-					<span class="text-gray-400 font-medium">
-						Array ({data.length} item{data.length !== 1 ? 's' : ''})
-					</span>
-					<svg
-						class={`w-3 h-3 text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`}
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth={2}
-						aria-hidden="true"
-					>
-						<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-					</svg>
-				</div>
-				{expanded && (
-					<div class="overflow-x-auto">
-						<table class="w-full text-xs">
-							<tbody>
-								{data.map((item, i) => (
-									<tr key={i} class="border-t border-gray-700/50 hover:bg-gray-800/40">
-										<td class="px-2 py-1 text-gray-600 font-mono w-8">{i}</td>
-										<td class="px-2 py-1 text-gray-300 font-mono whitespace-pre-wrap break-all">
-											{typeof item === 'object' ? JSON.stringify(item, null, 2) : String(item)}
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				)}
-			</div>
-		);
+/** Extract plain text from a user SDK message for rendering in the chat bubble. */
+function extractUserText(sdkMsg: UserSDKMessage): string {
+	const content = sdkMsg.message.content;
+	if (typeof content === 'string') return content;
+	if (Array.isArray(content)) {
+		return content
+			.filter(
+				(block): block is { type: 'text'; text: string } =>
+					typeof block === 'object' &&
+					block !== null &&
+					'type' in block &&
+					(block as { type: string }).type === 'text' &&
+					'text' in block &&
+					typeof (block as { type: string; text: unknown }).text === 'string'
+			)
+			.map((block) => block.text)
+			.join('\n');
 	}
-
-	// Plain object
-	const entries = Object.entries(data as Record<string, unknown>);
-	return (
-		<div class="my-1 rounded-lg border border-gray-700 overflow-hidden text-xs">
-			<div
-				class="flex items-center justify-between px-2 py-1.5 bg-gray-800/80 cursor-pointer hover:bg-gray-700/60 transition-colors"
-				onClick={() => setExpanded((v) => !v)}
-			>
-				<span class="text-gray-400 font-medium">Structured data</span>
-				<svg
-					class={`w-3 h-3 text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`}
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					strokeWidth={2}
-					aria-hidden="true"
-				>
-					<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-				</svg>
-			</div>
-			{expanded && (
-				<div class="overflow-x-auto">
-					<table class="w-full text-xs">
-						<tbody>
-							{entries.map(([k, v]) => (
-								<tr key={k} class="border-t border-gray-700/50 hover:bg-gray-800/40">
-									<td class="px-2 py-1 text-gray-500 font-mono whitespace-nowrap align-top">{k}</td>
-									<td class="px-2 py-1 text-gray-300 font-mono whitespace-pre-wrap break-all">
-										{typeof v === 'object' ? JSON.stringify(v, null, 2) : String(v)}
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
-			)}
-		</div>
-	);
+	return '';
 }
 
 // ---------------------------------------------------------------------------
@@ -264,24 +171,26 @@ function MessageBubble({ msg, pendingActionId, isLastAssistant }: MessageBubbleP
 	// Skip internal result/system messages in this simplified view
 	if (isResult || isSystem) return null;
 
-	const rawText = extractTextContent(msg.content);
+	// Parse the raw sdk_message JSON into a typed SDK message
+	const parsedMsg = parseSDKMessage(msg.content);
 
 	// Only the last assistant message should render the confirmation card.
 	const hasPendingConfirmation = !isUser && isLastAssistant && pendingActionId;
 
 	if (isUser) {
+		// Extract text from the parsed user SDK message for the chat bubble
+		const userText =
+			parsedMsg?.type === 'user' ? extractUserText(parsedMsg as UserSDKMessage) : msg.content;
 		return (
 			<div data-testid="neo-user-message" class="flex justify-end mb-3">
 				<div class="max-w-[85%] bg-blue-600 text-white rounded-[20px] rounded-br-md px-3.5 py-2 text-sm leading-relaxed break-words">
-					{rawText}
+					{userText}
 				</div>
 			</div>
 		);
 	}
 
-	// Assistant message
-	const structured = rawText ? null : tryParseStructured(msg.content);
-
+	// Assistant message — use SDKMessageRenderer for proper SDK message rendering
 	return (
 		<div data-testid="neo-assistant-message" class="mb-3">
 			{/* Sparkle avatar */}
@@ -297,12 +206,7 @@ function MessageBubble({ msg, pendingActionId, isLastAssistant }: MessageBubbleP
 					</svg>
 				</div>
 				<div class="flex-1 min-w-0">
-					{rawText && (
-						<div class="text-sm text-gray-200 leading-relaxed">
-							<MarkdownRenderer content={rawText} class="text-sm text-gray-200" />
-						</div>
-					)}
-					{structured && <StructuredDataCard data={structured} />}
+					{parsedMsg && <SDKMessageRenderer message={parsedMsg} />}
 					{hasPendingConfirmation && (
 						<NeoConfirmationCard
 							actionId={pendingActionId}

--- a/packages/web/src/components/neo/NeoChatView.tsx
+++ b/packages/web/src/components/neo/NeoChatView.tsx
@@ -178,9 +178,9 @@ function MessageBubble({ msg, pendingActionId, isLastAssistant }: MessageBubbleP
 	const hasPendingConfirmation = !isUser && isLastAssistant && pendingActionId;
 
 	if (isUser) {
-		// Extract text from the parsed user SDK message for the chat bubble
-		const userText =
-			parsedMsg?.type === 'user' ? extractUserText(parsedMsg as UserSDKMessage) : msg.content;
+		// Extract text from the parsed user SDK message for the chat bubble.
+		// Fall back to empty string (not raw JSON) when the message cannot be parsed.
+		const userText = parsedMsg?.type === 'user' ? extractUserText(parsedMsg as UserSDKMessage) : '';
 		return (
 			<div data-testid="neo-user-message" class="flex justify-end mb-3">
 				<div class="max-w-[85%] bg-blue-600 text-white rounded-[20px] rounded-br-md px-3.5 py-2 text-sm leading-relaxed break-words">
@@ -190,7 +190,10 @@ function MessageBubble({ msg, pendingActionId, isLastAssistant }: MessageBubbleP
 		);
 	}
 
-	// Assistant message — use SDKMessageRenderer for proper SDK message rendering
+	// Assistant message — use SDKMessageRenderer for proper SDK message rendering.
+	// Only pass messages with type 'assistant' to SDKMessageRenderer; show a
+	// fallback for null (parse failure) or unexpected SDK message types.
+	const isAssistantSDKMsg = parsedMsg?.type === 'assistant';
 	return (
 		<div data-testid="neo-assistant-message" class="mb-3">
 			{/* Sparkle avatar */}
@@ -206,7 +209,13 @@ function MessageBubble({ msg, pendingActionId, isLastAssistant }: MessageBubbleP
 					</svg>
 				</div>
 				<div class="flex-1 min-w-0">
-					{parsedMsg && <SDKMessageRenderer message={parsedMsg} />}
+					{isAssistantSDKMsg ? (
+						<SDKMessageRenderer message={parsedMsg} />
+					) : (
+						<div data-testid="neo-message-parse-error" class="text-sm text-gray-500 italic">
+							Unable to display message
+						</div>
+					)}
 					{hasPendingConfirmation && (
 						<NeoConfirmationCard
 							actionId={pendingActionId}


### PR DESCRIPTION
Fixes broken message rendering in NeoChatView where assistant messages were displayed as raw `StructuredDataCard` tables (showing model name, token counts, session IDs) instead of actual chat text.

**Root cause:** `msg.content` holds the full `sdk_message` JSON (`{ type: 'assistant', message: { content: [...], model: '...', usage: {...} }, ... }`), but the old `extractTextContent()` only handled plain content arrays, so it returned empty string — causing `tryParseStructured()` to render the whole API response object as a table.

**Changes:**
- Remove `extractTextContent`, `tryParseStructured`, `StructuredDataCard`
- Add `parseSDKMessage()` to safely parse the raw JSON into a typed `SDKMessage`
- Assistant messages: render via `SDKMessageRenderer` (handles text, tool calls, markdown, thinking blocks) inside the existing Neo sparkle avatar wrapper
- User messages: extract text from `SDKUserMessage.message.content` (supports both string and `ContentBlock[]` formats)
- Update tests to use realistic SDK message format; mock `SDKMessageRenderer` for unit isolation