### PR TITLE
feat(tools): add filtering, pagination, and compact mode to list_goals and list_tasks

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -735,16 +735,17 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 			if (args.compact) {
 				const compactGoals = paged.map((g) => ({
 					id: g.id,
+					roomId: g.roomId,
 					title: g.title,
 					status: g.status,
 					priority: g.priority,
 					missionType: g.missionType,
 					createdAt: g.createdAt,
 				}));
-				return jsonResult({ total, goals: compactGoals });
+				return jsonResult({ success: true, total, goals: compactGoals });
 			}
 
-			return jsonResult({ total, goals: paged });
+			return jsonResult({ success: true, total, goals: paged });
 		},
 
 		/**
@@ -927,10 +928,10 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 					assignedAgent: t.assignedAgent,
 					createdAt: t.createdAt,
 				}));
-				return jsonResult({ total, tasks: compactTasks });
+				return jsonResult({ success: true, total, tasks: compactTasks });
 			}
 
-			return jsonResult({ total, tasks: paged });
+			return jsonResult({ success: true, total, tasks: paged });
 		},
 
 		/**
@@ -1131,7 +1132,7 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 		// Goal and task query tools
 		tool(
 			'list_goals',
-			'List goals across all rooms or a specific room. Use compact:true and limit/offset to reduce payload size.',
+			'List goals across all rooms or a specific room. Filterable by room, status, and mission type. Use compact:true and limit/offset to reduce payload size.',
 			{
 				room_id: z
 					.string()
@@ -1198,7 +1199,7 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 
 		tool(
 			'list_tasks',
-			'List tasks across all rooms or a specific room. Use compact:true and limit/offset to reduce payload size.',
+			'List tasks across all rooms or a specific room. Filterable by room, status, and assigned agent. Use compact:true and limit/offset to reduce payload size.',
 			{
 				room_id: z
 					.string()

--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -675,6 +675,10 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 			room_id?: string;
 			status?: string;
 			mission_type?: string;
+			search?: string;
+			limit?: number;
+			offset?: number;
+			compact?: boolean;
 		}): Promise<ToolResult> {
 			// Determine which rooms to query
 			const rooms = args.room_id
@@ -716,7 +720,31 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 				}
 			}
 
-			return jsonResult(allGoals);
+			// Search filter (applied after cross-room aggregation)
+			const filtered = args.search
+				? allGoals.filter((g) =>
+						(g.title as string).toLowerCase().includes(args.search!.toLowerCase())
+					)
+				: allGoals;
+
+			const total = filtered.length;
+			const limit = args.limit ?? 50;
+			const offset = args.offset ?? 0;
+			const paged = filtered.slice(offset, offset + limit);
+
+			if (args.compact) {
+				const compactGoals = paged.map((g) => ({
+					id: g.id,
+					title: g.title,
+					status: g.status,
+					priority: g.priority,
+					missionType: g.missionType,
+					createdAt: g.createdAt,
+				}));
+				return jsonResult({ total, goals: compactGoals });
+			}
+
+			return jsonResult({ total, goals: paged });
 		},
 
 		/**
@@ -821,6 +849,10 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 			status?: string;
 			assigned_agent?: string;
 			include_archived?: boolean;
+			search?: string;
+			limit?: number;
+			offset?: number;
+			compact?: boolean;
 		}): Promise<ToolResult> {
 			// Auto-include archived tasks when the caller explicitly requests archived status,
 			// otherwise the repository filter would hide them and return zero results.
@@ -872,7 +904,33 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 				}
 			}
 
-			return jsonResult(allTasks);
+			// Search filter (applied after cross-room aggregation)
+			const filtered = args.search
+				? allTasks.filter((t) =>
+						(t.title as string).toLowerCase().includes(args.search!.toLowerCase())
+					)
+				: allTasks;
+
+			const total = filtered.length;
+			const limit = args.limit ?? 50;
+			const offset = args.offset ?? 0;
+			const paged = filtered.slice(offset, offset + limit);
+
+			if (args.compact) {
+				const compactTasks = paged.map((t) => ({
+					id: t.id,
+					shortId: t.shortId,
+					title: t.title,
+					status: t.status,
+					priority: t.priority,
+					taskType: t.taskType,
+					assignedAgent: t.assignedAgent,
+					createdAt: t.createdAt,
+				}));
+				return jsonResult({ total, tasks: compactTasks });
+			}
+
+			return jsonResult({ total, tasks: paged });
 		},
 
 		/**
@@ -1073,7 +1131,7 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 		// Goal and task query tools
 		tool(
 			'list_goals',
-			'List goals across all rooms or a specific room. Filterable by room, status, and mission type.',
+			'List goals across all rooms or a specific room. Use compact:true and limit/offset to reduce payload size.',
 			{
 				room_id: z
 					.string()
@@ -1087,6 +1145,28 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 					.enum(['one_shot', 'measurable', 'recurring'])
 					.optional()
 					.describe('Filter by mission type'),
+				search: z.string().optional().describe('Substring match on goal title'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(50)
+					.describe('Maximum number of goals to return (default: 50)'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe('Number of goals to skip for pagination (default: 0)'),
+				compact: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe(
+						'Return only summary fields (id, title, status, priority, missionType, createdAt) to reduce payload size'
+					),
 			},
 			(args) => handlers.list_goals(args)
 		),
@@ -1118,7 +1198,7 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 
 		tool(
 			'list_tasks',
-			'List tasks across all rooms or a specific room. Filterable by room, status, and assigned agent.',
+			'List tasks across all rooms or a specific room. Use compact:true and limit/offset to reduce payload size.',
 			{
 				room_id: z
 					.string()
@@ -1148,6 +1228,28 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 					.optional()
 					.default(false)
 					.describe('Include archived tasks (default: false)'),
+				search: z.string().optional().describe('Substring match on task title'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(50)
+					.describe('Maximum number of tasks to return (default: 50)'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe('Number of tasks to skip for pagination (default: 0)'),
+				compact: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe(
+						'Return only summary fields (id, shortId, title, status, priority, taskType, assignedAgent, createdAt) to reduce payload size'
+					),
 			},
 			(args) => handlers.list_tasks(args)
 		),

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -1055,7 +1055,7 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 		),
 		tool(
 			'list_goals',
-			'List goals in this room. Use compact:true and limit/offset to reduce payload size when there are many goals.',
+			'List goals in this room. Filterable by status. Use compact:true and limit/offset to reduce payload size when there are many goals.',
 			{
 				status: z
 					.enum(['active', 'needs_human', 'completed', 'archived'])
@@ -1153,7 +1153,7 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 		),
 		tool(
 			'list_tasks',
-			'List tasks in this room, optionally filtered by goal. Use compact:true and limit/offset to reduce payload size.',
+			'List tasks in this room. Filterable by goal, status. Use compact:true and limit/offset to reduce payload size.',
 			{
 				goal_id: z.string().optional().describe('Filter to tasks linked to this goal'),
 				status: z
@@ -1387,7 +1387,7 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 	const tools = [
 		tool(
 			'list_goals',
-			'List goals in this room. Use compact:true and limit/offset to reduce payload size when there are many goals.',
+			'List goals in this room. Filterable by status. Use compact:true and limit/offset to reduce payload size when there are many goals.',
 			{
 				status: z
 					.enum(['active', 'needs_human', 'completed', 'archived'])
@@ -1420,7 +1420,7 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 		),
 		tool(
 			'list_tasks',
-			'List tasks in this room, optionally filtered by goal. Use compact:true and limit/offset to reduce payload size.',
+			'List tasks in this room. Filterable by goal, status. Use compact:true and limit/offset to reduce payload size.',
 			{
 				goal_id: z.string().optional().describe('Filter to tasks linked to this goal'),
 				status: z

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -99,9 +99,36 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			return jsonResult({ success: true, goalId: goal.id, goal });
 		},
 
-		async list_goals(): Promise<ToolResult> {
-			const goals = await goalManager.listGoals();
-			return jsonResult({ success: true, goals });
+		async list_goals(
+			args: {
+				status?: 'active' | 'needs_human' | 'completed' | 'archived';
+				search?: string;
+				limit?: number;
+				offset?: number;
+				compact?: boolean;
+			} = {}
+		): Promise<ToolResult> {
+			let goals = await goalManager.listGoals(args.status);
+			if (args.search) {
+				const q = args.search.toLowerCase();
+				goals = goals.filter((g) => g.title.toLowerCase().includes(q));
+			}
+			const total = goals.length;
+			const limit = args.limit ?? 50;
+			const offset = args.offset ?? 0;
+			goals = goals.slice(offset, offset + limit);
+			if (args.compact) {
+				const compactGoals = goals.map((g) => ({
+					id: g.id,
+					title: g.title,
+					status: g.status,
+					priority: g.priority,
+					missionType: g.missionType ?? 'one_shot',
+					createdAt: g.createdAt,
+				}));
+				return jsonResult({ success: true, total, goals: compactGoals });
+			}
+			return jsonResult({ success: true, total, goals });
 		},
 
 		async update_goal(args: {
@@ -238,7 +265,14 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			return jsonResult({ success: true, taskId: task.id, task });
 		},
 
-		async list_tasks(args: { goal_id?: string; status?: TaskStatus }): Promise<ToolResult> {
+		async list_tasks(args: {
+			goal_id?: string;
+			status?: TaskStatus;
+			search?: string;
+			limit?: number;
+			offset?: number;
+			compact?: boolean;
+		}): Promise<ToolResult> {
 			// When explicitly filtering by 'archived', we must pass includeArchived:true
 			// because listTasks excludes archived tasks by default.
 			const filter = args.status
@@ -252,7 +286,29 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					tasks = tasks.filter((t) => linkedIds.has(t.id));
 				}
 			}
-			return jsonResult({ success: true, tasks });
+			if (args.search) {
+				const q = args.search.toLowerCase();
+				tasks = tasks.filter((t) => t.title.toLowerCase().includes(q));
+			}
+			const total = tasks.length;
+			const limit = args.limit ?? 50;
+			const offset = args.offset ?? 0;
+			tasks = tasks.slice(offset, offset + limit);
+			if (args.compact) {
+				const compactTasks = tasks.map((t) => ({
+					id: t.id,
+					shortId: t.shortId,
+					title: t.title,
+					status: t.status,
+					priority: t.priority,
+					taskType: t.taskType,
+					assignedAgent: t.assignedAgent,
+					dependsOn: t.dependsOn,
+					createdAt: t.createdAt,
+				}));
+				return jsonResult({ success: true, total, tasks: compactTasks });
+			}
+			return jsonResult({ success: true, total, tasks });
 		},
 
 		async update_task(args: {
@@ -997,7 +1053,39 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 			},
 			(args) => handlers.create_goal(args)
 		),
-		tool('list_goals', 'List all goals in this room', {}, () => handlers.list_goals()),
+		tool(
+			'list_goals',
+			'List goals in this room. Use compact:true and limit/offset to reduce payload size when there are many goals.',
+			{
+				status: z
+					.enum(['active', 'needs_human', 'completed', 'archived'])
+					.optional()
+					.describe('Filter by goal status'),
+				search: z.string().optional().describe('Substring match on goal title'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(50)
+					.describe('Maximum number of goals to return (default: 50)'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe('Number of goals to skip for pagination (default: 0)'),
+				compact: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe(
+						'Return only summary fields (id, title, status, priority, missionType, createdAt) to reduce payload size'
+					),
+			},
+			(args) => handlers.list_goals(args)
+		),
 		tool(
 			'update_goal',
 			'Update an existing goal. Provide only the fields you want to change; omitted fields keep their current values.',
@@ -1065,7 +1153,7 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 		),
 		tool(
 			'list_tasks',
-			'List tasks in this room, optionally filtered by goal',
+			'List tasks in this room, optionally filtered by goal. Use compact:true and limit/offset to reduce payload size.',
 			{
 				goal_id: z.string().optional().describe('Filter to tasks linked to this goal'),
 				status: z
@@ -1081,6 +1169,28 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 					])
 					.optional()
 					.describe('Filter by status'),
+				search: z.string().optional().describe('Substring match on task title'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(50)
+					.describe('Maximum number of tasks to return (default: 50)'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe('Number of tasks to skip for pagination (default: 0)'),
+				compact: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe(
+						'Return only summary fields (id, shortId, title, status, priority, taskType, assignedAgent, dependsOn, createdAt) to reduce payload size'
+					),
 			},
 			(args) => handlers.list_tasks(args)
 		),
@@ -1275,10 +1385,42 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 	const handlers = createRoomAgentToolHandlers(config);
 
 	const tools = [
-		tool('list_goals', 'List all goals in this room', {}, () => handlers.list_goals()),
+		tool(
+			'list_goals',
+			'List goals in this room. Use compact:true and limit/offset to reduce payload size when there are many goals.',
+			{
+				status: z
+					.enum(['active', 'needs_human', 'completed', 'archived'])
+					.optional()
+					.describe('Filter by goal status'),
+				search: z.string().optional().describe('Substring match on goal title'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(50)
+					.describe('Maximum number of goals to return (default: 50)'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe('Number of goals to skip for pagination (default: 0)'),
+				compact: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe(
+						'Return only summary fields (id, title, status, priority, missionType, createdAt) to reduce payload size'
+					),
+			},
+			(args) => handlers.list_goals(args)
+		),
 		tool(
 			'list_tasks',
-			'List tasks in this room, optionally filtered by goal',
+			'List tasks in this room, optionally filtered by goal. Use compact:true and limit/offset to reduce payload size.',
 			{
 				goal_id: z.string().optional().describe('Filter to tasks linked to this goal'),
 				status: z
@@ -1294,6 +1436,28 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 					])
 					.optional()
 					.describe('Filter by status'),
+				search: z.string().optional().describe('Substring match on task title'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(50)
+					.describe('Maximum number of tasks to return (default: 50)'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe('Number of tasks to skip for pagination (default: 0)'),
+				compact: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe(
+						'Return only summary fields (id, shortId, title, status, priority, taskType, assignedAgent, dependsOn, createdAt) to reduce payload size'
+					),
 			},
 			(args) => handlers.list_tasks(args)
 		),

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -622,7 +622,7 @@ export function createGlobalSpacesMcpServer(
 		),
 		tool(
 			'list_tasks',
-			'List tasks in a space. Use compact:true and limit/offset to reduce payload size.',
+			'List tasks in a space. Filterable by space, status, and workflow run. Use compact:true and limit/offset to reduce payload size.',
 			{
 				space_id: z
 					.string()

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -260,6 +260,10 @@ export function createGlobalSpacesToolHandlers(
 			space_id?: string;
 			status?: SpaceTaskStatus;
 			workflow_run_id?: string;
+			search?: string;
+			limit?: number;
+			offset?: number;
+			compact?: boolean;
 		}): Promise<ToolResult> {
 			const resolved = resolveSpaceId(args?.space_id);
 			if ('error' in resolved) return jsonResult({ success: false, error: resolved.error });
@@ -274,7 +278,30 @@ export function createGlobalSpacesToolHandlers(
 			} else {
 				tasks = taskRepo.listBySpace(resolved.spaceId);
 			}
-			return jsonResult({ success: true, space_id: resolved.spaceId, tasks });
+			if (args?.search) {
+				const q = args.search.toLowerCase();
+				tasks = tasks.filter((t) => t.title.toLowerCase().includes(q));
+			}
+			const total = tasks.length;
+			const limit = args?.limit ?? 50;
+			const offset = args?.offset ?? 0;
+			tasks = tasks.slice(offset, offset + limit);
+			if (args?.compact) {
+				const compactTasks = tasks.map((t) => ({
+					id: t.id,
+					title: t.title,
+					status: t.status,
+					priority: t.priority,
+					createdAt: t.createdAt,
+				}));
+				return jsonResult({
+					success: true,
+					space_id: resolved.spaceId,
+					total,
+					tasks: compactTasks,
+				});
+			}
+			return jsonResult({ success: true, space_id: resolved.spaceId, total, tasks });
 		},
 
 		async suggest_workflow(args: { space_id?: string; description: string }): Promise<ToolResult> {
@@ -595,7 +622,7 @@ export function createGlobalSpacesMcpServer(
 		),
 		tool(
 			'list_tasks',
-			'List tasks in a space. Optionally filter by status or workflow run.',
+			'List tasks in a space. Use compact:true and limit/offset to reduce payload size.',
 			{
 				space_id: z
 					.string()
@@ -614,6 +641,28 @@ export function createGlobalSpacesMcpServer(
 					.optional()
 					.describe('Filter by task status'),
 				workflow_run_id: z.string().optional().describe('Filter by workflow run ID'),
+				search: z.string().optional().describe('Substring match on task title'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(50)
+					.describe('Maximum number of tasks to return (default: 50)'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe('Number of tasks to skip for pagination (default: 0)'),
+				compact: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe(
+						'Return only summary fields (id, title, status, priority, createdAt) to reduce payload size'
+					),
 			},
 			(args) => handlers.list_tasks(args)
 		),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -580,7 +580,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'list_tasks',
-			'List SpaceTasks for this space. Use compact:true and limit/offset to reduce payload size.',
+			'List SpaceTasks for this space. Filterable by status and workflow run. Use compact:true and limit/offset to reduce payload size.',
 			{
 				status: z
 					.enum([

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -284,6 +284,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		async list_tasks(args: {
 			status?: SpaceTaskStatus;
 			workflow_run_id?: string;
+			search?: string;
+			limit?: number;
+			offset?: number;
+			compact?: boolean;
 		}): Promise<ToolResult> {
 			let tasks;
 			if (args.workflow_run_id) {
@@ -296,7 +300,25 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			} else {
 				tasks = taskRepo.listBySpace(spaceId);
 			}
-			return jsonResult({ success: true, tasks });
+			if (args.search) {
+				const q = args.search.toLowerCase();
+				tasks = tasks.filter((t) => t.title.toLowerCase().includes(q));
+			}
+			const total = tasks.length;
+			const limit = args.limit ?? 50;
+			const offset = args.offset ?? 0;
+			tasks = tasks.slice(offset, offset + limit);
+			if (args.compact) {
+				const compactTasks = tasks.map((t) => ({
+					id: t.id,
+					title: t.title,
+					status: t.status,
+					priority: t.priority,
+					createdAt: t.createdAt,
+				}));
+				return jsonResult({ success: true, total, tasks: compactTasks });
+			}
+			return jsonResult({ success: true, total, tasks });
 		},
 
 		/**
@@ -558,7 +580,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'list_tasks',
-			'List SpaceTasks for this space. Optionally filter by status or by a specific workflow run.',
+			'List SpaceTasks for this space. Use compact:true and limit/offset to reduce payload size.',
 			{
 				status: z
 					.enum([
@@ -576,6 +598,28 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.string()
 					.optional()
 					.describe('Filter to only tasks belonging to a specific workflow run'),
+				search: z.string().optional().describe('Substring match on task title'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(50)
+					.describe('Maximum number of tasks to return (default: 50)'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe('Number of tasks to skip for pagination (default: 0)'),
+				compact: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe(
+						'Return only summary fields (id, title, status, priority, createdAt) to reduce payload size'
+					),
 			},
 			(args) => handlers.list_tasks(args)
 		),

--- a/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
@@ -1425,7 +1425,8 @@ describe('list_goals', () => {
 	it('returns empty array when no goals exist', async () => {
 		const handlers = createNeoQueryToolHandlers(makeConfig());
 		const result = parseResult(await handlers.list_goals({}));
-		expect(result).toEqual([]);
+		expect(result.total).toBe(0);
+		expect(result.goals).toEqual([]);
 	});
 
 	it('returns goals across all rooms when no room_id filter', async () => {
@@ -1441,8 +1442,10 @@ describe('list_goals', () => {
 		);
 
 		const result = parseResult(await handlers.list_goals({}));
-		expect(result).toHaveLength(2);
-		expect(result.map((g: { id: string }) => g.id)).toEqual(expect.arrayContaining(['g1', 'g2']));
+		expect(result.total).toBe(2);
+		expect((result.goals as Array<{ id: string }>).map((g) => g.id)).toEqual(
+			expect.arrayContaining(['g1', 'g2'])
+		);
 	});
 
 	it('includes roomName in each goal', async () => {
@@ -1456,7 +1459,7 @@ describe('list_goals', () => {
 		);
 
 		const result = parseResult(await handlers.list_goals({}));
-		expect(result[0].roomName).toBe('My Room');
+		expect((result.goals as Array<{ roomName: string }>)[0].roomName).toBe('My Room');
 	});
 
 	it('filters to a specific room when room_id is provided', async () => {
@@ -1472,8 +1475,8 @@ describe('list_goals', () => {
 		);
 
 		const result = parseResult(await handlers.list_goals({ room_id: 'room-1' }));
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('g1');
+		expect(result.total).toBe(1);
+		expect((result.goals as Array<{ id: string }>)[0].id).toBe('g1');
 	});
 
 	it('returns error when room_id refers to non-existent room', async () => {
@@ -1498,8 +1501,8 @@ describe('list_goals', () => {
 		);
 
 		const result = parseResult(await handlers.list_goals({ mission_type: 'measurable' }));
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('g2');
+		expect(result.total).toBe(1);
+		expect((result.goals as Array<{ id: string }>)[0].id).toBe('g2');
 	});
 
 	it('includes nextRunAt and schedulePaused for recurring goals', async () => {
@@ -1518,8 +1521,75 @@ describe('list_goals', () => {
 		);
 
 		const result = parseResult(await handlers.list_goals({}));
-		expect(result[0].nextRunAt).toBe(9999);
-		expect(result[0].schedulePaused).toBe(true);
+		const goals = result.goals as Array<{ nextRunAt: number; schedulePaused: boolean }>;
+		expect(goals[0].nextRunAt).toBe(9999);
+		expect(goals[0].schedulePaused).toBe(true);
+	});
+
+	it('filters by search substring', async () => {
+		const room = makeRoom();
+		const goals = [
+			makeGoal({ id: 'g1', title: 'Add health check' }),
+			makeGoal({ id: 'g2', title: 'Fix login bug' }),
+			makeGoal({ id: 'g3', title: 'Add logging' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': goals }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_goals({ search: 'Add' }));
+		expect(result.total).toBe(2);
+		const ids = (result.goals as Array<{ id: string }>).map((g) => g.id);
+		expect(ids).toContain('g1');
+		expect(ids).toContain('g3');
+	});
+
+	it('paginates with limit and offset', async () => {
+		const room = makeRoom();
+		const goals = Array.from({ length: 5 }, (_, i) =>
+			makeGoal({ id: `g${i + 1}`, title: `Goal ${i + 1}` })
+		);
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': goals }),
+			})
+		);
+
+		const page1 = parseResult(await handlers.list_goals({ limit: 2, offset: 0 }));
+		expect(page1.total).toBe(5);
+		expect((page1.goals as unknown[]).length).toBe(2);
+
+		const page3 = parseResult(await handlers.list_goals({ limit: 2, offset: 4 }));
+		expect(page3.total).toBe(5);
+		expect((page3.goals as unknown[]).length).toBe(1);
+	});
+
+	it('returns compact fields when compact:true', async () => {
+		const room = makeRoom();
+		const goal = makeGoal({ id: 'g1', title: 'My Goal' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				goalRepository: makeGoalRepository({ 'room-1': [goal] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_goals({ compact: true }));
+		expect(result.total).toBe(1);
+		const goals = result.goals as Array<Record<string, unknown>>;
+		expect(goals[0].id).toBe('g1');
+		expect(goals[0].title).toBe('My Goal');
+		expect(goals[0].status).toBeDefined();
+		expect(goals[0].priority).toBeDefined();
+		expect(goals[0].missionType).toBeDefined();
+		expect(goals[0].createdAt).toBeDefined();
+		// Large fields excluded in compact mode
+		expect(goals[0].roomName).toBeUndefined();
+		expect(goals[0].linkedTaskCount).toBeUndefined();
 	});
 });
 
@@ -1723,7 +1793,8 @@ describe('list_tasks', () => {
 	it('returns empty array when no tasks exist', async () => {
 		const handlers = createNeoQueryToolHandlers(makeConfig());
 		const result = parseResult(await handlers.list_tasks({}));
-		expect(result).toEqual([]);
+		expect(result.total).toBe(0);
+		expect(result.tasks).toEqual([]);
 	});
 
 	it('returns tasks across all rooms when no room_id filter', async () => {
@@ -1739,8 +1810,10 @@ describe('list_tasks', () => {
 		);
 
 		const result = parseResult(await handlers.list_tasks({}));
-		expect(result).toHaveLength(2);
-		expect(result.map((t: { id: string }) => t.id)).toEqual(expect.arrayContaining(['t1', 't2']));
+		expect(result.total).toBe(2);
+		expect((result.tasks as Array<{ id: string }>).map((t) => t.id)).toEqual(
+			expect.arrayContaining(['t1', 't2'])
+		);
 	});
 
 	it('includes roomName in each task', async () => {
@@ -1754,7 +1827,7 @@ describe('list_tasks', () => {
 		);
 
 		const result = parseResult(await handlers.list_tasks({}));
-		expect(result[0].roomName).toBe('My Room');
+		expect((result.tasks as Array<{ roomName: string }>)[0].roomName).toBe('My Room');
 	});
 
 	it('filters to a specific room when room_id is provided', async () => {
@@ -1770,8 +1843,8 @@ describe('list_tasks', () => {
 		);
 
 		const result = parseResult(await handlers.list_tasks({ room_id: 'room-1' }));
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('t1');
+		expect(result.total).toBe(1);
+		expect((result.tasks as Array<{ id: string }>)[0].id).toBe('t1');
 	});
 
 	it('returns error when room_id refers to non-existent room', async () => {
@@ -1796,8 +1869,8 @@ describe('list_tasks', () => {
 		);
 
 		const result = parseResult(await handlers.list_tasks({ status: 'pending' }));
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('t1');
+		expect(result.total).toBe(1);
+		expect((result.tasks as Array<{ id: string }>)[0].id).toBe('t1');
 	});
 
 	it('filters by assigned_agent', async () => {
@@ -1815,8 +1888,8 @@ describe('list_tasks', () => {
 		);
 
 		const result = parseResult(await handlers.list_tasks({ assigned_agent: 'planner' }));
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('t3');
+		expect(result.total).toBe(1);
+		expect((result.tasks as Array<{ id: string }>)[0].id).toBe('t3');
 	});
 
 	it('excludes archived tasks by default', async () => {
@@ -1833,8 +1906,8 @@ describe('list_tasks', () => {
 		);
 
 		const result = parseResult(await handlers.list_tasks({}));
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('t1');
+		expect(result.total).toBe(1);
+		expect((result.tasks as Array<{ id: string }>)[0].id).toBe('t1');
 	});
 
 	it('includes archived tasks when include_archived is true', async () => {
@@ -1851,7 +1924,7 @@ describe('list_tasks', () => {
 		);
 
 		const result = parseResult(await handlers.list_tasks({ include_archived: true }));
-		expect(result).toHaveLength(2);
+		expect(result.total).toBe(2);
 	});
 
 	it('auto-enables include_archived when status="archived" to avoid zero results', async () => {
@@ -1869,8 +1942,76 @@ describe('list_tasks', () => {
 
 		// Without auto-include fix, requesting archived status would return zero results
 		const result = parseResult(await handlers.list_tasks({ status: 'archived' }));
-		expect(result).toHaveLength(1);
-		expect(result[0].id).toBe('t2');
+		expect(result.total).toBe(1);
+		expect((result.tasks as Array<{ id: string }>)[0].id).toBe('t2');
+	});
+
+	it('filters by search substring', async () => {
+		const room = makeRoom();
+		const tasks = [
+			makeTask({ id: 't1', title: 'Implement login' }),
+			makeTask({ id: 't2', title: 'Fix login bug' }),
+			makeTask({ id: 't3', title: 'Add tests' }),
+		];
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': tasks }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({ search: 'login' }));
+		expect(result.total).toBe(2);
+		const ids = (result.tasks as Array<{ id: string }>).map((t) => t.id);
+		expect(ids).toContain('t1');
+		expect(ids).toContain('t2');
+	});
+
+	it('paginates with limit and offset', async () => {
+		const room = makeRoom();
+		const tasks = Array.from({ length: 5 }, (_, i) =>
+			makeTask({ id: `t${i + 1}`, title: `Task ${i + 1}` })
+		);
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': tasks }),
+			})
+		);
+
+		const page1 = parseResult(await handlers.list_tasks({ limit: 2, offset: 0 }));
+		expect(page1.total).toBe(5);
+		expect((page1.tasks as unknown[]).length).toBe(2);
+
+		const page3 = parseResult(await handlers.list_tasks({ limit: 2, offset: 4 }));
+		expect(page3.total).toBe(5);
+		expect((page3.tasks as unknown[]).length).toBe(1);
+	});
+
+	it('returns compact fields when compact:true', async () => {
+		const room = makeRoom();
+		const task = makeTask({ id: 't1', title: 'My Task' });
+		const handlers = createNeoQueryToolHandlers(
+			makeConfig({
+				roomManager: makeRoomManager([room]),
+				taskRepository: makeTaskRepository({ 'room-1': [task] }),
+			})
+		);
+
+		const result = parseResult(await handlers.list_tasks({ compact: true }));
+		expect(result.total).toBe(1);
+		const tasks = result.tasks as Array<Record<string, unknown>>;
+		expect(tasks[0].id).toBe('t1');
+		expect(tasks[0].title).toBe('My Task');
+		expect(tasks[0].status).toBeDefined();
+		expect(tasks[0].priority).toBeDefined();
+		expect(tasks[0].taskType).toBeDefined();
+		expect(tasks[0].assignedAgent).toBeDefined();
+		expect(tasks[0].createdAt).toBeDefined();
+		// Large fields excluded in compact mode
+		expect(tasks[0].roomName).toBeUndefined();
+		expect(tasks[0].prUrl).toBeUndefined();
+		expect(tasks[0].progress).toBeUndefined();
 	});
 });
 

--- a/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
@@ -1425,6 +1425,7 @@ describe('list_goals', () => {
 	it('returns empty array when no goals exist', async () => {
 		const handlers = createNeoQueryToolHandlers(makeConfig());
 		const result = parseResult(await handlers.list_goals({}));
+		expect(result.success).toBe(true);
 		expect(result.total).toBe(0);
 		expect(result.goals).toEqual([]);
 	});
@@ -1569,8 +1570,8 @@ describe('list_goals', () => {
 	});
 
 	it('returns compact fields when compact:true', async () => {
-		const room = makeRoom();
-		const goal = makeGoal({ id: 'g1', title: 'My Goal' });
+		const room = makeRoom({ id: 'room-1' });
+		const goal = makeGoal({ id: 'g1', title: 'My Goal', roomId: 'room-1' });
 		const handlers = createNeoQueryToolHandlers(
 			makeConfig({
 				roomManager: makeRoomManager([room]),
@@ -1582,6 +1583,7 @@ describe('list_goals', () => {
 		expect(result.total).toBe(1);
 		const goals = result.goals as Array<Record<string, unknown>>;
 		expect(goals[0].id).toBe('g1');
+		expect(goals[0].roomId).toBe('room-1');
 		expect(goals[0].title).toBe('My Goal');
 		expect(goals[0].status).toBeDefined();
 		expect(goals[0].priority).toBeDefined();
@@ -1793,6 +1795,7 @@ describe('list_tasks', () => {
 	it('returns empty array when no tasks exist', async () => {
 		const handlers = createNeoQueryToolHandlers(makeConfig());
 		const result = parseResult(await handlers.list_tasks({}));
+		expect(result.success).toBe(true);
 		expect(result.total).toBe(0);
 		expect(result.tasks).toEqual([]);
 	});

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -243,6 +243,82 @@ describe('Room Agent Tools', () => {
 			const result = parseResult(await handlers.list_goals());
 			expect(result.success).toBe(true);
 			expect((result.goals as unknown[]).length).toBe(2);
+			expect(result.total).toBe(2);
+		});
+
+		it('should filter by status', async () => {
+			await handlers.create_goal({ title: 'Active Goal' });
+			const created = parseResult(await handlers.create_goal({ title: 'Completed Goal' }));
+			await handlers.update_goal({ goal_id: created.goalId as string, status: 'completed' });
+			const result = parseResult(await handlers.list_goals({ status: 'active' }));
+			expect(result.success).toBe(true);
+			expect((result.goals as unknown[]).length).toBe(1);
+			expect(result.total).toBe(1);
+		});
+
+		it('should filter by search substring', async () => {
+			await handlers.create_goal({ title: 'Add health check' });
+			await handlers.create_goal({ title: 'Fix login bug' });
+			await handlers.create_goal({ title: 'Add logging' });
+			const result = parseResult(await handlers.list_goals({ search: 'Add' }));
+			expect(result.success).toBe(true);
+			expect(result.total).toBe(2);
+			expect((result.goals as unknown[]).length).toBe(2);
+		});
+
+		it('should paginate with limit and offset', async () => {
+			for (let i = 1; i <= 5; i++) {
+				await handlers.create_goal({ title: `Goal ${i}` });
+			}
+			const page1 = parseResult(await handlers.list_goals({ limit: 2, offset: 0 }));
+			expect(page1.success).toBe(true);
+			expect(page1.total).toBe(5);
+			expect((page1.goals as unknown[]).length).toBe(2);
+
+			const page2 = parseResult(await handlers.list_goals({ limit: 2, offset: 2 }));
+			expect(page2.total).toBe(5);
+			expect((page2.goals as unknown[]).length).toBe(2);
+
+			const page3 = parseResult(await handlers.list_goals({ limit: 2, offset: 4 }));
+			expect(page3.total).toBe(5);
+			expect((page3.goals as unknown[]).length).toBe(1);
+		});
+
+		it('should return compact fields when compact:true', async () => {
+			await handlers.create_goal({ title: 'Compact Goal', description: 'Large description here' });
+			const result = parseResult(await handlers.list_goals({ compact: true }));
+			expect(result.success).toBe(true);
+			const goals = result.goals as Array<Record<string, unknown>>;
+			expect(goals.length).toBe(1);
+			// Compact fields present
+			expect(goals[0].id).toBeDefined();
+			expect(goals[0].title).toBe('Compact Goal');
+			expect(goals[0].status).toBeDefined();
+			expect(goals[0].priority).toBeDefined();
+			expect(goals[0].missionType).toBeDefined();
+			expect(goals[0].createdAt).toBeDefined();
+			// Large fields excluded
+			expect(goals[0].description).toBeUndefined();
+			expect(goals[0].linkedTaskIds).toBeUndefined();
+			expect(goals[0].structuredMetrics).toBeUndefined();
+		});
+
+		it('should return total=0 when no goals match search', async () => {
+			await handlers.create_goal({ title: 'My goal' });
+			const result = parseResult(await handlers.list_goals({ search: 'zzz-nomatch' }));
+			expect(result.success).toBe(true);
+			expect(result.total).toBe(0);
+			expect((result.goals as unknown[]).length).toBe(0);
+		});
+
+		it('should default limit to 50', async () => {
+			// Create 3 goals and verify all returned when within default limit
+			for (let i = 1; i <= 3; i++) {
+				await handlers.create_goal({ title: `Goal ${i}` });
+			}
+			const result = parseResult(await handlers.list_goals());
+			expect(result.total).toBe(3);
+			expect((result.goals as unknown[]).length).toBe(3);
 		});
 	});
 
@@ -465,6 +541,7 @@ describe('Room Agent Tools', () => {
 			await handlers.create_task({ title: 'T2', description: 'd2' });
 			const result = parseResult(await handlers.list_tasks({}));
 			expect((result.tasks as unknown[]).length).toBe(2);
+			expect(result.total).toBe(2);
 		});
 
 		it('should filter by goal_id', async () => {
@@ -478,6 +555,75 @@ describe('Room Agent Tools', () => {
 			await handlers.create_task({ title: 'Unlinked', description: 'd' });
 
 			const result = parseResult(await handlers.list_tasks({ goal_id: goalId }));
+			expect((result.tasks as unknown[]).length).toBe(1);
+			expect(result.total).toBe(1);
+		});
+
+		it('should filter by search substring', async () => {
+			await handlers.create_task({ title: 'Implement login', description: 'd' });
+			await handlers.create_task({ title: 'Fix login bug', description: 'd' });
+			await handlers.create_task({ title: 'Add tests', description: 'd' });
+			const result = parseResult(await handlers.list_tasks({ search: 'login' }));
+			expect(result.total).toBe(2);
+			expect((result.tasks as unknown[]).length).toBe(2);
+		});
+
+		it('should paginate with limit and offset', async () => {
+			for (let i = 1; i <= 5; i++) {
+				await handlers.create_task({ title: `Task ${i}`, description: `d${i}` });
+			}
+			const page1 = parseResult(await handlers.list_tasks({ limit: 2, offset: 0 }));
+			expect(page1.total).toBe(5);
+			expect((page1.tasks as unknown[]).length).toBe(2);
+
+			const page2 = parseResult(await handlers.list_tasks({ limit: 2, offset: 2 }));
+			expect(page2.total).toBe(5);
+			expect((page2.tasks as unknown[]).length).toBe(2);
+
+			const page3 = parseResult(await handlers.list_tasks({ limit: 2, offset: 4 }));
+			expect(page3.total).toBe(5);
+			expect((page3.tasks as unknown[]).length).toBe(1);
+		});
+
+		it('should return compact fields when compact:true', async () => {
+			await handlers.create_task({
+				title: 'Compact Task',
+				description: 'A very long description that should not appear in compact mode',
+			});
+			const result = parseResult(await handlers.list_tasks({ compact: true }));
+			expect(result.total).toBe(1);
+			const tasks = result.tasks as Array<Record<string, unknown>>;
+			expect(tasks.length).toBe(1);
+			// Compact fields present
+			expect(tasks[0].id).toBeDefined();
+			expect(tasks[0].title).toBe('Compact Task');
+			expect(tasks[0].status).toBeDefined();
+			expect(tasks[0].priority).toBeDefined();
+			expect(tasks[0].taskType).toBeDefined();
+			expect(tasks[0].assignedAgent).toBeDefined();
+			expect(tasks[0].createdAt).toBeDefined();
+			// Large fields excluded
+			expect(tasks[0].description).toBeUndefined();
+			expect(tasks[0].result).toBeUndefined();
+			expect(tasks[0].error).toBeUndefined();
+			expect(tasks[0].currentStep).toBeUndefined();
+		});
+
+		it('should return total=0 when no tasks match search', async () => {
+			await handlers.create_task({ title: 'My task', description: 'd' });
+			const result = parseResult(await handlers.list_tasks({ search: 'zzz-nomatch' }));
+			expect(result.total).toBe(0);
+			expect((result.tasks as unknown[]).length).toBe(0);
+		});
+
+		it('total should reflect filters before pagination', async () => {
+			await handlers.create_task({ title: 'Search match 1', description: 'd' });
+			await handlers.create_task({ title: 'Search match 2', description: 'd' });
+			await handlers.create_task({ title: 'Other task', description: 'd' });
+			const result = parseResult(
+				await handlers.list_tasks({ search: 'Search', limit: 1, offset: 0 })
+			);
+			expect(result.total).toBe(2); // 2 match, even though only 1 returned
 			expect((result.tasks as unknown[]).length).toBe(1);
 		});
 	});

--- a/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
@@ -1100,3 +1100,127 @@ describe('createGlobalSpacesToolHandlers — reassign_task', () => {
 		expect(parsed.task.customAgentId).toBe('agent-via-context');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// list_tasks — search, pagination, compact mode, total
+// ---------------------------------------------------------------------------
+
+describe('createGlobalSpacesToolHandlers — list_tasks search/pagination/compact', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns total count in response', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+		await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Task 1',
+			description: 'd1',
+		});
+		await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Task 2',
+			description: 'd2',
+		});
+
+		const result = await handlers.list_tasks({ space_id: ctx.spaceId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.total).toBe(2);
+		expect(parsed.tasks).toHaveLength(2);
+	});
+
+	test('filters tasks by search substring', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+		await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Review PR #42',
+			description: 'd',
+		});
+		await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Deploy service',
+			description: 'd',
+		});
+
+		const result = await handlers.list_tasks({ space_id: ctx.spaceId, search: 'Review' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.total).toBe(1);
+		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.tasks[0].title).toBe('Review PR #42');
+	});
+
+	test('paginates with limit and offset', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+		for (let i = 1; i <= 4; i++) {
+			await handlers.create_standalone_task({
+				space_id: ctx.spaceId,
+				title: `Task ${i}`,
+				description: 'd',
+			});
+		}
+
+		const page1 = JSON.parse(
+			(await handlers.list_tasks({ space_id: ctx.spaceId, limit: 2, offset: 0 })).content[0].text
+		);
+		expect(page1.total).toBe(4);
+		expect(page1.tasks).toHaveLength(2);
+
+		const page2 = JSON.parse(
+			(await handlers.list_tasks({ space_id: ctx.spaceId, limit: 2, offset: 2 })).content[0].text
+		);
+		expect(page2.total).toBe(4);
+		expect(page2.tasks).toHaveLength(2);
+	});
+
+	test('returns compact fields when compact:true', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+		await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Compact task',
+			description: 'A very long description that should not appear in compact mode',
+		});
+
+		const result = await handlers.list_tasks({ space_id: ctx.spaceId, compact: true });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.total).toBe(1);
+		const task = parsed.tasks[0] as Record<string, unknown>;
+		expect(task.id).toBeDefined();
+		expect(task.title).toBe('Compact task');
+		expect(task.status).toBeDefined();
+		expect(task.priority).toBeDefined();
+		expect(task.createdAt).toBeDefined();
+		// Large fields excluded
+		expect(task.description).toBeUndefined();
+		expect(task.spaceId).toBeUndefined();
+	});
+
+	test('total reflects post-filter count before pagination', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+		for (let i = 1; i <= 4; i++) {
+			const title = i <= 2 ? `Match task ${i}` : `Other task ${i}`;
+			await handlers.create_standalone_task({
+				space_id: ctx.spaceId,
+				title,
+				description: 'd',
+			});
+		}
+
+		const result = await handlers.list_tasks({
+			space_id: ctx.spaceId,
+			search: 'Match',
+			limit: 1,
+			offset: 0,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.total).toBe(2); // 2 match, even though only 1 returned
+		expect(parsed.tasks).toHaveLength(1);
+	});
+});

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -1575,3 +1575,109 @@ describe('createSpaceAgentToolHandlers — task creation and planning node activ
 		expect(parsed.workflows[0].name).toBe('Coding Workflow V2');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// list_tasks — search, pagination, compact mode, total
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — list_tasks search/pagination/compact', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns total count in response', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF');
+		await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 1' });
+		await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 2' });
+
+		const result = await makeHandlers(ctx).list_tasks({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.total).toBe(2);
+		expect(parsed.tasks).toHaveLength(2);
+	});
+
+	test('filters tasks by search substring', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF');
+		const r1 = await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 1' });
+		const r2 = await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 2' });
+		const task1Id = JSON.parse(r1.content[0].text).tasks[0].id;
+		const task2Id = JSON.parse(r2.content[0].text).tasks[0].id;
+
+		// Rename one task to have a unique searchable title
+		ctx.taskRepo.updateTask(task1Id, { title: 'Review PR #42' });
+		ctx.taskRepo.updateTask(task2Id, { title: 'Deploy service' });
+
+		const result = await makeHandlers(ctx).list_tasks({ search: 'Review' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.total).toBe(1);
+		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.tasks[0].title).toBe('Review PR #42');
+	});
+
+	test('paginates with limit and offset', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF');
+		for (let i = 0; i < 4; i++) {
+			await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: `run ${i + 1}` });
+		}
+
+		const page1 = JSON.parse(
+			(await makeHandlers(ctx).list_tasks({ limit: 2, offset: 0 })).content[0].text
+		);
+		expect(page1.total).toBe(4);
+		expect(page1.tasks).toHaveLength(2);
+
+		const page2 = JSON.parse(
+			(await makeHandlers(ctx).list_tasks({ limit: 2, offset: 2 })).content[0].text
+		);
+		expect(page2.total).toBe(4);
+		expect(page2.tasks).toHaveLength(2);
+	});
+
+	test('returns compact fields when compact:true', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF');
+		await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 1' });
+
+		const result = await makeHandlers(ctx).list_tasks({ compact: true });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.total).toBe(1);
+		const task = parsed.tasks[0] as Record<string, unknown>;
+		// Compact fields present
+		expect(task.id).toBeDefined();
+		expect(task.title).toBeDefined();
+		expect(task.status).toBeDefined();
+		expect(task.priority).toBeDefined();
+		expect(task.createdAt).toBeDefined();
+		// Large fields excluded
+		expect(task.workflowRunId).toBeUndefined();
+		expect(task.description).toBeUndefined();
+	});
+
+	test('total reflects post-filter count before pagination', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF');
+		for (let i = 0; i < 4; i++) {
+			const r = await makeHandlers(ctx).start_workflow_run({
+				workflow_id: wf.id,
+				title: `run ${i + 1}`,
+			});
+			const taskId = JSON.parse(r.content[0].text).tasks[0].id;
+			if (i < 2) {
+				ctx.taskRepo.updateTask(taskId, { title: `Match task ${i}` });
+			} else {
+				ctx.taskRepo.updateTask(taskId, { title: `Other task ${i}` });
+			}
+		}
+
+		const result = await makeHandlers(ctx).list_tasks({ search: 'Match', limit: 1, offset: 0 });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.total).toBe(2); // 2 match, even though only 1 returned
+		expect(parsed.tasks).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Adds `search`, `limit`/`offset` pagination, `compact` mode, and `total` count to all `list_goals` and `list_tasks` MCP tool handlers across four files.

**Changes:**
- `list_goals`: accepts `status`, `search`, `limit`, `offset`, `compact`; returns `{ total, goals }`
- `list_tasks`: accepts `search`, `limit`, `offset`, `compact`; returns `{ total, tasks }`
- Compact mode returns only summary fields to reduce payload size
- Applied consistently in `room-agent-tools.ts`, `neo-query-tools.ts`, `space-agent-tools.ts`, and `global-spaces-tools.ts`