### PR TITLE
refactor: slim down neoStore — remove dead loadHistory and historyLoaded

### DIFF
--- a/packages/web/src/lib/neo-store.test.ts
+++ b/packages/web/src/lib/neo-store.test.ts
@@ -16,7 +16,6 @@
  * - openPanel / closePanel / togglePanel update panelOpen signal
  * - panelOpen state persists in localStorage
  * - sendMessage() calls neo.send RPC
- * - loadHistory() calls neo.history RPC and hydrates messages (skips if subscribed)
  * - clearSession() calls neo.clearSession RPC and resets messages signal
  * - confirmAction() / cancelAction() call RPC and clear pendingConfirmation
  */
@@ -143,7 +142,6 @@ describe('NeoStore', () => {
 		store.subscribed = false;
 		store.cleanups = [];
 		store.activeSubscriptionIds = new Set();
-		store.historyLoaded = false;
 
 		// Reset signals
 		neoStore.messages.value = [];
@@ -640,45 +638,6 @@ describe('NeoStore', () => {
 			vi.mocked(mockHub.request).mockRejectedValue(new Error('hub error'));
 
 			await expect(neoStore.sendMessage('hi')).rejects.toThrow('hub error');
-		});
-	});
-
-	// ---------------------------------------------------------------------------
-	// loadHistory()
-	// ---------------------------------------------------------------------------
-
-	describe('loadHistory()', () => {
-		it('should call neo.history RPC', async () => {
-			vi.mocked(mockHub.request).mockResolvedValue({ messages: [], hasMore: false });
-
-			await neoStore.loadHistory();
-
-			expect(mockHub.request).toHaveBeenCalledWith('neo.history', { limit: 100 });
-		});
-
-		it('should populate messages when not subscribed', async () => {
-			const msgs = [makeMessage('h1'), makeMessage('h2')];
-			vi.mocked(mockHub.request).mockResolvedValue({ messages: msgs, hasMore: false });
-
-			await neoStore.loadHistory();
-
-			expect(neoStore.messages.value).toHaveLength(2);
-		});
-
-		it('should skip RPC call when already subscribed (LiveQuery owns state)', async () => {
-			vi.mocked(mockHub.request).mockResolvedValue({ ok: true });
-			await neoStore.subscribe();
-			mockHub.request.mockClear();
-
-			await neoStore.loadHistory();
-
-			expect(mockHub.request).not.toHaveBeenCalled();
-		});
-
-		it('should silently ignore errors', async () => {
-			vi.mocked(mockHub.request).mockRejectedValue(new Error('history failed'));
-
-			await expect(neoStore.loadHistory()).resolves.toBeUndefined();
 		});
 	});
 

--- a/packages/web/src/lib/neo-store.ts
+++ b/packages/web/src/lib/neo-store.ts
@@ -114,8 +114,6 @@ class NeoStore {
 	private activeSubscriptionIds = new Set<string>();
 	private subscribed = false;
 	private refCount = 0;
-	/** Set to true after loadHistory() completes so a concurrent LiveQuery snapshot won't race it. */
-	private historyLoaded = false;
 
 	// ---------------------------------------------------------------------------
 	// Panel open/close helpers (with localStorage persistence)
@@ -356,39 +354,6 @@ class NeoStore {
 	}
 
 	// ---------------------------------------------------------------------------
-	// loadHistory() — one-shot history fetch before LiveQuery snapshot
-	// ---------------------------------------------------------------------------
-
-	/**
-	 * Load initial message history via `neo.history` RPC.
-	 *
-	 * Intended to be called before subscribe() to show history immediately while
-	 * LiveQuery is initialising. Guards against both:
-	 * - Concurrent LiveQuery snapshots overwriting (via `historyLoaded` flag)
-	 * - Overwriting data already populated by LiveQuery (skips if subscribed)
-	 *
-	 * The LiveQuery snapshot will merge seamlessly once it arrives.
-	 */
-	async loadHistory(): Promise<void> {
-		// If already subscribed, LiveQuery owns message state — skip.
-		if (this.subscribed) return;
-		try {
-			const hub = await connectionManager.getHub();
-			const response = await hub.request<{ messages: NeoMessage[]; hasMore: boolean }>(
-				'neo.history',
-				{ limit: 100 }
-			);
-			// Guard: LiveQuery snapshot arrived or subscribe() completed while we awaited.
-			if (!this.subscribed) {
-				this.messages.value = response.messages ?? [];
-				this.historyLoaded = true;
-			}
-		} catch (err) {
-			logger.warn('NeoStore loadHistory failed:', err);
-		}
-	}
-
-	// ---------------------------------------------------------------------------
 	// sendMessage()
 	// ---------------------------------------------------------------------------
 
@@ -428,7 +393,6 @@ class NeoStore {
 		);
 		if (response.success) {
 			this.messages.value = [];
-			this.historyLoaded = false;
 		}
 		return response;
 	}


### PR DESCRIPTION
Remove `loadHistory()` and `historyLoaded` from `NeoStore` — both were unreachable dead code after LiveQuery took over message hydration.

- `loadHistory()` was never called in the web app; the `liveQuery.snapshot` handler fully populates `messages` on subscribe
- `historyLoaded` was set in `loadHistory()` and reset in `clearSession()` but never read in any conditional — it had no effect
- 4 `loadHistory()` unit tests and the `beforeEach` `historyLoaded` reset are removed accordingly
- `NeoChatView.tsx` already uses `SDKMessageRenderer` (t-712); no remaining dead code found there