### PR TITLE
test(e2e): Neo chat rendering — verify messages render as readable text

### DIFF
--- a/packages/e2e/tests/features/neo-chat-rendering.e2e.ts
+++ b/packages/e2e/tests/features/neo-chat-rendering.e2e.ts
@@ -1,0 +1,299 @@
+/**
+ * Neo Chat Rendering E2E Tests
+ *
+ * Verifies that the Neo chat panel renders messages correctly as readable text,
+ * not as raw JSON or structured data tables.
+ *
+ * Test scenarios:
+ * 1. Empty state shows correctly before any messages
+ * 2. Chat/Activity tab switching works
+ * 3. User messages appear in the correct bubble style (right-aligned blue bubble)
+ * 4. Neo sparkle avatar appears next to assistant messages
+ * 5. Assistant messages render as readable text, NOT a "Structured data" card
+ *
+ * E2E Principles (from CLAUDE.md):
+ * - All test actions go through UI (clicks, typing, keyboard shortcuts).
+ * - All assertions verify visible DOM state.
+ * - RPC is allowed only in beforeEach/afterEach for setup/teardown.
+ * - NEOKAI_ENABLE_NEO_AGENT=1 is set in playwright.config.ts.
+ */
+
+import { test, expect, type Page } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const NEO_PANEL_TESTID = 'neo-panel';
+const NEO_CHAT_INPUT_TESTID = 'neo-chat-input';
+const NEO_USER_MESSAGE_TESTID = 'neo-user-message';
+const NEO_ASSISTANT_MESSAGE_TESTID = 'neo-assistant-message';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Open the Neo panel by clicking the Neo NavRail button.
+ */
+async function openNeoPanel(page: Page): Promise<void> {
+	const neoButton = page.getByRole('button', { name: 'Neo (⌘J)', exact: true });
+	await neoButton.waitFor({ state: 'visible', timeout: 5000 });
+	await neoButton.click();
+	await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'visible', timeout: 5000 });
+}
+
+/**
+ * Send a message in the Neo chat input.
+ */
+async function sendNeoMessage(page: Page, text: string): Promise<void> {
+	const input = page.getByTestId(NEO_CHAT_INPUT_TESTID);
+	await input.waitFor({ state: 'visible', timeout: 5000 });
+	await input.fill(text);
+	await input.press('Enter');
+}
+
+/**
+ * Wait for a new Neo assistant response to appear (any content).
+ * Uses count-based detection so previous responses don't trigger a false positive.
+ */
+async function waitForNeoAssistantResponse(
+	page: Page,
+	options: { timeout?: number } = {}
+): Promise<void> {
+	const timeout = options.timeout ?? 90000;
+	const initialCount = await page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).count();
+	await page.waitForFunction(
+		(expected) =>
+			document.querySelectorAll('[data-testid="neo-assistant-message"]').length > expected,
+		initialCount,
+		{ timeout }
+	);
+	// Also wait for the input to be re-enabled (loading state cleared)
+	await page.getByTestId(NEO_CHAT_INPUT_TESTID).waitFor({ state: 'visible', timeout: 10000 });
+}
+
+/**
+ * Check whether the Neo agent is provisioned (not showing an error card).
+ * Must be called with the Neo panel already open so error cards are rendered.
+ */
+async function isNeoAvailable(page: Page): Promise<boolean> {
+	const hasNoCredentials = await page
+		.getByTestId('neo-error-no-credentials')
+		.isVisible()
+		.catch(() => false);
+	const hasProviderError = await page
+		.getByTestId('neo-error-provider-unavailable')
+		.isVisible()
+		.catch(() => false);
+	return !hasNoCredentials && !hasProviderError;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe('Neo Chat Rendering', () => {
+	test.use({ viewport: { width: 1280, height: 720 } });
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		// Clear persisted panel state so tests start with panel closed
+		await page.evaluate(() => localStorage.removeItem('neo:panelOpen'));
+		await page.reload();
+		await waitForWebSocketConnected(page);
+	});
+
+	// ── 1. Empty state ─────────────────────────────────────────────────────────
+
+	test('shows empty state with Neo introduction before any messages', async ({ page }) => {
+		await openNeoPanel(page);
+
+		// Chat view is rendered
+		await expect(page.getByTestId('neo-chat-view')).toBeVisible();
+
+		// Empty state is visible
+		const emptyState = page.getByTestId('neo-empty-state');
+		await expect(emptyState).toBeVisible();
+
+		// Shows the "Hi, I'm Neo" greeting text
+		await expect(emptyState).toContainText("Hi, I'm Neo");
+
+		// Shows helper prompt text
+		await expect(emptyState).toContainText('Ask me anything');
+
+		// No messages rendered yet
+		await expect(page.getByTestId(NEO_USER_MESSAGE_TESTID)).toHaveCount(0);
+		await expect(page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID)).toHaveCount(0);
+	});
+
+	// ── 2. Tab switching ───────────────────────────────────────────────────────
+
+	test('Chat/Activity tabs switch correctly', async ({ page }) => {
+		await openNeoPanel(page);
+
+		const chatTab = page.getByTestId('neo-tab-chat');
+		const activityTab = page.getByTestId('neo-tab-activity');
+
+		// Chat tab is active by default
+		await expect(chatTab).toHaveAttribute('aria-selected', 'true');
+		await expect(activityTab).toHaveAttribute('aria-selected', 'false');
+
+		// Chat view is visible, activity view is not
+		await expect(page.getByTestId('neo-chat-view')).toBeVisible();
+		await expect(page.getByTestId('neo-activity-view')).not.toBeVisible();
+
+		// Click Activity tab
+		await activityTab.click();
+
+		// Activity tab is now active
+		await expect(activityTab).toHaveAttribute('aria-selected', 'true');
+		await expect(chatTab).toHaveAttribute('aria-selected', 'false');
+
+		// Activity view is visible, chat view is not
+		await expect(page.getByTestId('neo-activity-view')).toBeVisible();
+		await expect(page.getByTestId('neo-chat-view')).not.toBeVisible();
+
+		// Switch back to Chat tab
+		await chatTab.click();
+
+		// Chat tab is active again
+		await expect(chatTab).toHaveAttribute('aria-selected', 'true');
+		await expect(page.getByTestId('neo-chat-view')).toBeVisible();
+	});
+
+	// ── 3. User message bubble style ───────────────────────────────────────────
+
+	test('user messages appear in right-aligned blue bubble after sending', async ({ page }) => {
+		await openNeoPanel(page);
+
+		// Need Neo available to send a message
+		if (!(await isNeoAvailable(page))) {
+			test.skip();
+			return;
+		}
+
+		await sendNeoMessage(page, 'Hello Neo');
+
+		// User message bubble appears
+		const userMsg = page
+			.getByTestId(NEO_USER_MESSAGE_TESTID)
+			.filter({ hasText: 'Hello Neo' })
+			.first();
+		await userMsg.waitFor({ state: 'visible', timeout: 10000 });
+
+		// The outer wrapper is right-aligned (justify-end)
+		await expect(userMsg).toHaveClass(/justify-end/);
+
+		// The inner bubble has blue background styling
+		const bubble = userMsg.locator('div').first();
+		await expect(bubble).toHaveClass(/bg-blue-600/);
+		await expect(bubble).toHaveClass(/text-white/);
+
+		// The text content is readable
+		await expect(userMsg).toContainText('Hello Neo');
+	});
+
+	// ── 4. Sparkle avatar next to assistant messages ───────────────────────────
+
+	test('Neo sparkle avatar appears next to assistant messages', async ({ page }) => {
+		await openNeoPanel(page);
+
+		if (!(await isNeoAvailable(page))) {
+			test.skip();
+			return;
+		}
+
+		await sendNeoMessage(page, 'Say hi back');
+		await waitForNeoAssistantResponse(page);
+
+		// The assistant message container is present
+		const assistantMsg = page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).first();
+		await expect(assistantMsg).toBeVisible();
+
+		// The sparkle SVG avatar is inside the assistant message
+		// It's rendered as an aria-hidden SVG inside a violet-tinted rounded circle
+		const avatar = assistantMsg.locator('div.rounded-full.bg-violet-600\\/20').first();
+		await expect(avatar).toBeVisible();
+
+		// The sparkle icon SVG is present inside the avatar
+		const sparkle = avatar.locator('svg[aria-hidden="true"]').first();
+		await expect(sparkle).toBeAttached();
+	});
+
+	// ── 5. Assistant messages render as readable text, not raw JSON ─────────────
+
+	test('assistant messages render as readable text, not raw JSON or structured data', async ({
+		page,
+	}) => {
+		await openNeoPanel(page);
+
+		if (!(await isNeoAvailable(page))) {
+			test.skip();
+			return;
+		}
+
+		await sendNeoMessage(page, 'What time is it roughly?');
+		await waitForNeoAssistantResponse(page);
+
+		const assistantMsg = page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).last();
+		await expect(assistantMsg).toBeVisible();
+
+		// The message content area should not show a "Structured data" heading —
+		// which would indicate the old broken StructuredDataCard path is being used
+		await expect(assistantMsg).not.toContainText('Structured data');
+
+		// The message should not display raw JSON characters that would indicate
+		// unparsed SDK message content leaking through
+		const text = await assistantMsg.textContent();
+		expect(text).not.toMatch(/^\s*\{/); // should not start with `{`
+		expect(text).not.toContain('"type":"assistant"');
+		expect(text).not.toContain('"content":[');
+
+		// The parse-error fallback should not be shown
+		await expect(page.getByTestId('neo-message-parse-error')).not.toBeVisible();
+
+		// The message should contain some actual readable text (non-empty)
+		expect((text ?? '').trim().length).toBeGreaterThan(0);
+	});
+
+	// ── 6. No parse errors for valid responses ─────────────────────────────────
+
+	test('assistant messages do not show parse-error fallback for valid responses', async ({
+		page,
+	}) => {
+		await openNeoPanel(page);
+
+		if (!(await isNeoAvailable(page))) {
+			test.skip();
+			return;
+		}
+
+		await sendNeoMessage(page, 'Hello');
+		await waitForNeoAssistantResponse(page);
+
+		// SDKMessageRenderer is used, not the parse-error fallback
+		await expect(page.getByTestId('neo-message-parse-error')).not.toBeVisible();
+
+		// An assistant message is present and visible
+		await expect(page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).last()).toBeVisible();
+	});
+
+	// ── 7. Empty state disappears after first message ──────────────────────────
+
+	test('empty state disappears once a message is sent', async ({ page }) => {
+		await openNeoPanel(page);
+
+		if (!(await isNeoAvailable(page))) {
+			test.skip();
+			return;
+		}
+
+		// Empty state is shown initially
+		await expect(page.getByTestId('neo-empty-state')).toBeVisible();
+
+		await sendNeoMessage(page, 'Hi');
+
+		// Empty state disappears once the user message appears
+		const userMsg = page.getByTestId(NEO_USER_MESSAGE_TESTID).first();
+		await userMsg.waitFor({ state: 'visible', timeout: 10000 });
+
+		await expect(page.getByTestId('neo-empty-state')).not.toBeVisible();
+	});
+});

--- a/packages/e2e/tests/features/neo-chat-rendering.e2e.ts
+++ b/packages/e2e/tests/features/neo-chat-rendering.e2e.ts
@@ -6,10 +6,11 @@
  *
  * Test scenarios:
  * 1. Empty state shows correctly before any messages
- * 2. Chat/Activity tab switching works
- * 3. User messages appear in the correct bubble style (right-aligned blue bubble)
- * 4. Neo sparkle avatar appears next to assistant messages
- * 5. Assistant messages render as readable text, NOT a "Structured data" card
+ * 2. User messages appear in the correct bubble style (right-aligned blue bubble)
+ * 3. Neo sparkle avatar appears next to assistant messages
+ * 4. Assistant messages render as readable text, NOT a "Structured data" card
+ * 5. No parse-error fallback for valid responses
+ * 6. Empty state disappears once a message is sent
  *
  * E2E Principles (from CLAUDE.md):
  * - All test actions go through UI (clicks, typing, keyboard shortcuts).
@@ -18,73 +19,16 @@
  * - NEOKAI_ENABLE_NEO_AGENT=1 is set in playwright.config.ts.
  */
 
-import { test, expect, type Page } from '../../fixtures';
+import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-const NEO_PANEL_TESTID = 'neo-panel';
-const NEO_CHAT_INPUT_TESTID = 'neo-chat-input';
-const NEO_USER_MESSAGE_TESTID = 'neo-user-message';
-const NEO_ASSISTANT_MESSAGE_TESTID = 'neo-assistant-message';
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Open the Neo panel by clicking the Neo NavRail button.
- */
-async function openNeoPanel(page: Page): Promise<void> {
-	const neoButton = page.getByRole('button', { name: 'Neo (⌘J)', exact: true });
-	await neoButton.waitFor({ state: 'visible', timeout: 5000 });
-	await neoButton.click();
-	await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'visible', timeout: 5000 });
-}
-
-/**
- * Send a message in the Neo chat input.
- */
-async function sendNeoMessage(page: Page, text: string): Promise<void> {
-	const input = page.getByTestId(NEO_CHAT_INPUT_TESTID);
-	await input.waitFor({ state: 'visible', timeout: 5000 });
-	await input.fill(text);
-	await input.press('Enter');
-}
-
-/**
- * Wait for a new Neo assistant response to appear (any content).
- * Uses count-based detection so previous responses don't trigger a false positive.
- */
-async function waitForNeoAssistantResponse(
-	page: Page,
-	options: { timeout?: number } = {}
-): Promise<void> {
-	const timeout = options.timeout ?? 90000;
-	const initialCount = await page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).count();
-	await page.waitForFunction(
-		(expected) =>
-			document.querySelectorAll('[data-testid="neo-assistant-message"]').length > expected,
-		initialCount,
-		{ timeout }
-	);
-	// Also wait for the input to be re-enabled (loading state cleared)
-	await page.getByTestId(NEO_CHAT_INPUT_TESTID).waitFor({ state: 'visible', timeout: 10000 });
-}
-
-/**
- * Check whether the Neo agent is provisioned (not showing an error card).
- * Must be called with the Neo panel already open so error cards are rendered.
- */
-async function isNeoAvailable(page: Page): Promise<boolean> {
-	const hasNoCredentials = await page
-		.getByTestId('neo-error-no-credentials')
-		.isVisible()
-		.catch(() => false);
-	const hasProviderError = await page
-		.getByTestId('neo-error-provider-unavailable')
-		.isVisible()
-		.catch(() => false);
-	return !hasNoCredentials && !hasProviderError;
-}
+import {
+	NEO_USER_MESSAGE_TESTID,
+	NEO_ASSISTANT_MESSAGE_TESTID,
+	openNeoPanel,
+	sendNeoMessage,
+	waitForNeoAssistantResponse,
+	isNeoAvailable,
+} from '../helpers/neo-helpers';
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -116,184 +60,123 @@ test.describe('Neo Chat Rendering', () => {
 		await expect(emptyState).toContainText("Hi, I'm Neo");
 
 		// Shows helper prompt text
-		await expect(emptyState).toContainText('Ask me anything');
+		await expect(emptyState).toContainText('Ask me anything about your rooms, sessions, or goals');
 
 		// No messages rendered yet
 		await expect(page.getByTestId(NEO_USER_MESSAGE_TESTID)).toHaveCount(0);
 		await expect(page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID)).toHaveCount(0);
 	});
 
-	// ── 2. Tab switching ───────────────────────────────────────────────────────
+	// ── AI-dependent tests: skip when Neo credentials are not configured ────────
 
-	test('Chat/Activity tabs switch correctly', async ({ page }) => {
-		await openNeoPanel(page);
+	test.describe('Neo Chat — AI-dependent rendering', () => {
+		test.beforeEach(async ({ page }) => {
+			await openNeoPanel(page);
+			if (!(await isNeoAvailable(page))) {
+				test.skip();
+			}
+		});
 
-		const chatTab = page.getByTestId('neo-tab-chat');
-		const activityTab = page.getByTestId('neo-tab-activity');
+		// ── 2. User message bubble style ─────────────────────────────────────────
 
-		// Chat tab is active by default
-		await expect(chatTab).toHaveAttribute('aria-selected', 'true');
-		await expect(activityTab).toHaveAttribute('aria-selected', 'false');
+		test('user messages appear in right-aligned blue bubble after sending', async ({ page }) => {
+			await sendNeoMessage(page, 'Hello Neo');
 
-		// Chat view is visible, activity view is not
-		await expect(page.getByTestId('neo-chat-view')).toBeVisible();
-		await expect(page.getByTestId('neo-activity-view')).not.toBeVisible();
+			// User message bubble appears
+			const userMsg = page
+				.getByTestId(NEO_USER_MESSAGE_TESTID)
+				.filter({ hasText: 'Hello Neo' })
+				.first();
+			await userMsg.waitFor({ state: 'visible', timeout: 10000 });
 
-		// Click Activity tab
-		await activityTab.click();
+			// The outer wrapper is right-aligned (justify-end)
+			await expect(userMsg).toHaveClass(/justify-end/);
 
-		// Activity tab is now active
-		await expect(activityTab).toHaveAttribute('aria-selected', 'true');
-		await expect(chatTab).toHaveAttribute('aria-selected', 'false');
+			// The inner bubble has blue background styling
+			const bubble = userMsg.locator('div').first();
+			await expect(bubble).toHaveClass(/bg-blue-600/);
+			await expect(bubble).toHaveClass(/text-white/);
 
-		// Activity view is visible, chat view is not
-		await expect(page.getByTestId('neo-activity-view')).toBeVisible();
-		await expect(page.getByTestId('neo-chat-view')).not.toBeVisible();
+			// The text content is readable
+			await expect(userMsg).toContainText('Hello Neo');
+		});
 
-		// Switch back to Chat tab
-		await chatTab.click();
+		// ── 3. Sparkle avatar next to assistant messages ──────────────────────────
 
-		// Chat tab is active again
-		await expect(chatTab).toHaveAttribute('aria-selected', 'true');
-		await expect(page.getByTestId('neo-chat-view')).toBeVisible();
-	});
+		test('Neo sparkle avatar appears next to assistant messages', async ({ page }) => {
+			await sendNeoMessage(page, 'Say hi back');
+			await waitForNeoAssistantResponse(page);
 
-	// ── 3. User message bubble style ───────────────────────────────────────────
+			// The assistant message container is present
+			const assistantMsg = page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).first();
+			await expect(assistantMsg).toBeVisible();
 
-	test('user messages appear in right-aligned blue bubble after sending', async ({ page }) => {
-		await openNeoPanel(page);
+			// The sparkle avatar is inside the assistant message via its test ID
+			const avatar = assistantMsg.getByTestId('neo-sparkle-avatar').first();
+			await expect(avatar).toBeVisible();
 
-		// Need Neo available to send a message
-		if (!(await isNeoAvailable(page))) {
-			test.skip();
-			return;
-		}
+			// The sparkle icon SVG is present inside the avatar
+			const sparkle = avatar.locator('svg[aria-hidden="true"]').first();
+			await expect(sparkle).toBeAttached();
+		});
 
-		await sendNeoMessage(page, 'Hello Neo');
+		// ── 4. Assistant messages render as readable text, not raw JSON ────────────
 
-		// User message bubble appears
-		const userMsg = page
-			.getByTestId(NEO_USER_MESSAGE_TESTID)
-			.filter({ hasText: 'Hello Neo' })
-			.first();
-		await userMsg.waitFor({ state: 'visible', timeout: 10000 });
+		test('assistant messages render as readable text, not raw JSON or structured data', async ({
+			page,
+		}) => {
+			await sendNeoMessage(page, 'What time is it roughly?');
+			await waitForNeoAssistantResponse(page);
 
-		// The outer wrapper is right-aligned (justify-end)
-		await expect(userMsg).toHaveClass(/justify-end/);
+			const assistantMsg = page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).last();
+			await expect(assistantMsg).toBeVisible();
 
-		// The inner bubble has blue background styling
-		const bubble = userMsg.locator('div').first();
-		await expect(bubble).toHaveClass(/bg-blue-600/);
-		await expect(bubble).toHaveClass(/text-white/);
+			// The message content area should not show a "Structured data" heading —
+			// which would indicate the old broken StructuredDataCard path is being used
+			await expect(assistantMsg).not.toContainText('Structured data');
 
-		// The text content is readable
-		await expect(userMsg).toContainText('Hello Neo');
-	});
+			// The message should not display raw JSON characters that would indicate
+			// unparsed SDK message content leaking through
+			const text = await assistantMsg.textContent();
+			expect(text).not.toMatch(/^\s*\{/); // should not start with `{`
+			expect(text).not.toContain('"type":"assistant"');
+			expect(text).not.toContain('"content":[');
 
-	// ── 4. Sparkle avatar next to assistant messages ───────────────────────────
+			// The parse-error fallback should not be shown
+			await expect(page.getByTestId('neo-message-parse-error')).not.toBeVisible();
 
-	test('Neo sparkle avatar appears next to assistant messages', async ({ page }) => {
-		await openNeoPanel(page);
+			// The message should contain some actual readable text (non-empty)
+			expect((text ?? '').trim().length).toBeGreaterThan(0);
+		});
 
-		if (!(await isNeoAvailable(page))) {
-			test.skip();
-			return;
-		}
+		// ── 5. No parse errors for valid responses ────────────────────────────────
 
-		await sendNeoMessage(page, 'Say hi back');
-		await waitForNeoAssistantResponse(page);
+		test('assistant messages do not show parse-error fallback for valid responses', async ({
+			page,
+		}) => {
+			await sendNeoMessage(page, 'Hello');
+			await waitForNeoAssistantResponse(page);
 
-		// The assistant message container is present
-		const assistantMsg = page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).first();
-		await expect(assistantMsg).toBeVisible();
+			// SDKMessageRenderer is used, not the parse-error fallback
+			await expect(page.getByTestId('neo-message-parse-error')).not.toBeVisible();
 
-		// The sparkle SVG avatar is inside the assistant message
-		// It's rendered as an aria-hidden SVG inside a violet-tinted rounded circle
-		const avatar = assistantMsg.locator('div.rounded-full.bg-violet-600\\/20').first();
-		await expect(avatar).toBeVisible();
+			// An assistant message is present and visible
+			await expect(page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).last()).toBeVisible();
+		});
 
-		// The sparkle icon SVG is present inside the avatar
-		const sparkle = avatar.locator('svg[aria-hidden="true"]').first();
-		await expect(sparkle).toBeAttached();
-	});
+		// ── 6. Empty state disappears after first message ─────────────────────────
 
-	// ── 5. Assistant messages render as readable text, not raw JSON ─────────────
+		test('empty state disappears once a message is sent', async ({ page }) => {
+			// Empty state is shown initially (panel opened in beforeEach)
+			await expect(page.getByTestId('neo-empty-state')).toBeVisible();
 
-	test('assistant messages render as readable text, not raw JSON or structured data', async ({
-		page,
-	}) => {
-		await openNeoPanel(page);
+			await sendNeoMessage(page, 'Hi');
 
-		if (!(await isNeoAvailable(page))) {
-			test.skip();
-			return;
-		}
+			// Empty state disappears once the user message appears
+			const userMsg = page.getByTestId(NEO_USER_MESSAGE_TESTID).first();
+			await userMsg.waitFor({ state: 'visible', timeout: 10000 });
 
-		await sendNeoMessage(page, 'What time is it roughly?');
-		await waitForNeoAssistantResponse(page);
-
-		const assistantMsg = page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).last();
-		await expect(assistantMsg).toBeVisible();
-
-		// The message content area should not show a "Structured data" heading —
-		// which would indicate the old broken StructuredDataCard path is being used
-		await expect(assistantMsg).not.toContainText('Structured data');
-
-		// The message should not display raw JSON characters that would indicate
-		// unparsed SDK message content leaking through
-		const text = await assistantMsg.textContent();
-		expect(text).not.toMatch(/^\s*\{/); // should not start with `{`
-		expect(text).not.toContain('"type":"assistant"');
-		expect(text).not.toContain('"content":[');
-
-		// The parse-error fallback should not be shown
-		await expect(page.getByTestId('neo-message-parse-error')).not.toBeVisible();
-
-		// The message should contain some actual readable text (non-empty)
-		expect((text ?? '').trim().length).toBeGreaterThan(0);
-	});
-
-	// ── 6. No parse errors for valid responses ─────────────────────────────────
-
-	test('assistant messages do not show parse-error fallback for valid responses', async ({
-		page,
-	}) => {
-		await openNeoPanel(page);
-
-		if (!(await isNeoAvailable(page))) {
-			test.skip();
-			return;
-		}
-
-		await sendNeoMessage(page, 'Hello');
-		await waitForNeoAssistantResponse(page);
-
-		// SDKMessageRenderer is used, not the parse-error fallback
-		await expect(page.getByTestId('neo-message-parse-error')).not.toBeVisible();
-
-		// An assistant message is present and visible
-		await expect(page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).last()).toBeVisible();
-	});
-
-	// ── 7. Empty state disappears after first message ──────────────────────────
-
-	test('empty state disappears once a message is sent', async ({ page }) => {
-		await openNeoPanel(page);
-
-		if (!(await isNeoAvailable(page))) {
-			test.skip();
-			return;
-		}
-
-		// Empty state is shown initially
-		await expect(page.getByTestId('neo-empty-state')).toBeVisible();
-
-		await sendNeoMessage(page, 'Hi');
-
-		// Empty state disappears once the user message appears
-		const userMsg = page.getByTestId(NEO_USER_MESSAGE_TESTID).first();
-		await userMsg.waitFor({ state: 'visible', timeout: 10000 });
-
-		await expect(page.getByTestId('neo-empty-state')).not.toBeVisible();
+			await expect(page.getByTestId('neo-empty-state')).not.toBeVisible();
+		});
 	});
 });

--- a/packages/e2e/tests/features/neo-chat-rendering.e2e.ts
+++ b/packages/e2e/tests/features/neo-chat-rendering.e2e.ts
@@ -7,10 +7,12 @@
  * Test scenarios:
  * 1. Empty state shows correctly before any messages
  * 2. User messages appear in the correct bubble style (right-aligned blue bubble)
- * 3. Neo sparkle avatar appears next to assistant messages
- * 4. Assistant messages render as readable text, NOT a "Structured data" card
- * 5. No parse-error fallback for valid responses
- * 6. Empty state disappears once a message is sent
+ * 3. Empty state disappears once a message is sent
+ * 4. Neo sparkle avatar appears next to assistant messages  [AI-dependent]
+ * 5. Assistant messages render as readable text, NOT a "Structured data" card  [AI-dependent]
+ *
+ * Tests 1–3 require only a working server connection (no AI credentials).
+ * Tests 4–5 require Neo credentials and are skipped when not available.
  *
  * E2E Principles (from CLAUDE.md):
  * - All test actions go through UI (clicks, typing, keyboard shortcuts).
@@ -26,6 +28,7 @@ import {
 	NEO_ASSISTANT_MESSAGE_TESTID,
 	openNeoPanel,
 	sendNeoMessage,
+	waitForNeoUserMessage,
 	waitForNeoAssistantResponse,
 	isNeoAvailable,
 } from '../helpers/neo-helpers';
@@ -40,6 +43,15 @@ test.describe('Neo Chat Rendering', () => {
 		await waitForWebSocketConnected(page);
 		// Clear persisted panel state so tests start with panel closed
 		await page.evaluate(() => localStorage.removeItem('neo:panelOpen'));
+		// Clear the Neo session so each test starts with an empty chat history.
+		// This is infrastructure setup (allowed in beforeEach per E2E rules) and
+		// ensures tests 1 and 3 reliably see the empty state on first open.
+		await page.evaluate(async () => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (hub?.request) {
+				await hub.request('neo.clearSession', {}).catch(() => {});
+			}
+		});
 		await page.reload();
 		await waitForWebSocketConnected(page);
 	});
@@ -67,6 +79,51 @@ test.describe('Neo Chat Rendering', () => {
 		await expect(page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID)).toHaveCount(0);
 	});
 
+	// ── 2. User message bubble style ─────────────────────────────────────────────
+	// Does not require an AI response — only verifies that the user message
+	// bubble is rendered correctly after sendNeoMessage() creates it via RPC.
+
+	test('user messages appear in right-aligned blue bubble after sending', async ({ page }) => {
+		await openNeoPanel(page);
+
+		await sendNeoMessage(page, 'Hello Neo');
+
+		// Wait for user message bubble to appear
+		await waitForNeoUserMessage(page, 'Hello Neo');
+		const userMsg = page
+			.getByTestId(NEO_USER_MESSAGE_TESTID)
+			.filter({ hasText: 'Hello Neo' })
+			.first();
+
+		// The outer wrapper is right-aligned (justify-end)
+		await expect(userMsg).toHaveClass(/justify-end/);
+
+		// The inner bubble has blue background styling
+		const bubble = userMsg.locator('div').first();
+		await expect(bubble).toHaveClass(/bg-blue-600/);
+		await expect(bubble).toHaveClass(/text-white/);
+
+		// The text content is readable
+		await expect(userMsg).toContainText('Hello Neo');
+	});
+
+	// ── 3. Empty state disappears after first message ──────────────────────────
+	// Does not require an AI response — only verifies the empty state hides
+	// once a user message is in the DOM.
+
+	test('empty state disappears once a message is sent', async ({ page }) => {
+		await openNeoPanel(page);
+
+		// Empty state is shown initially (session cleared in beforeEach)
+		await expect(page.getByTestId('neo-empty-state')).toBeVisible();
+
+		await sendNeoMessage(page, 'Hi');
+
+		// Wait for user message to appear, then verify empty state is gone
+		await waitForNeoUserMessage(page, 'Hi');
+		await expect(page.getByTestId('neo-empty-state')).not.toBeVisible();
+	});
+
 	// ── AI-dependent tests: skip when Neo credentials are not configured ────────
 
 	test.describe('Neo Chat — AI-dependent rendering', () => {
@@ -77,31 +134,7 @@ test.describe('Neo Chat Rendering', () => {
 			}
 		});
 
-		// ── 2. User message bubble style ─────────────────────────────────────────
-
-		test('user messages appear in right-aligned blue bubble after sending', async ({ page }) => {
-			await sendNeoMessage(page, 'Hello Neo');
-
-			// User message bubble appears
-			const userMsg = page
-				.getByTestId(NEO_USER_MESSAGE_TESTID)
-				.filter({ hasText: 'Hello Neo' })
-				.first();
-			await userMsg.waitFor({ state: 'visible', timeout: 10000 });
-
-			// The outer wrapper is right-aligned (justify-end)
-			await expect(userMsg).toHaveClass(/justify-end/);
-
-			// The inner bubble has blue background styling
-			const bubble = userMsg.locator('div').first();
-			await expect(bubble).toHaveClass(/bg-blue-600/);
-			await expect(bubble).toHaveClass(/text-white/);
-
-			// The text content is readable
-			await expect(userMsg).toContainText('Hello Neo');
-		});
-
-		// ── 3. Sparkle avatar next to assistant messages ──────────────────────────
+		// ── 4. Sparkle avatar next to assistant messages ──────────────────────────
 
 		test('Neo sparkle avatar appears next to assistant messages', async ({ page }) => {
 			await sendNeoMessage(page, 'Say hi back');
@@ -120,7 +153,7 @@ test.describe('Neo Chat Rendering', () => {
 			await expect(sparkle).toBeAttached();
 		});
 
-		// ── 4. Assistant messages render as readable text, not raw JSON ────────────
+		// ── 5. Assistant messages render as readable text, not raw JSON ────────────
 
 		test('assistant messages render as readable text, not raw JSON or structured data', async ({
 			page,
@@ -131,52 +164,20 @@ test.describe('Neo Chat Rendering', () => {
 			const assistantMsg = page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).last();
 			await expect(assistantMsg).toBeVisible();
 
-			// The message content area should not show a "Structured data" heading —
-			// which would indicate the old broken StructuredDataCard path is being used
+			// No "Structured data" heading — that would indicate the broken StructuredDataCard path
 			await expect(assistantMsg).not.toContainText('Structured data');
 
-			// The message should not display raw JSON characters that would indicate
-			// unparsed SDK message content leaking through
+			// No raw JSON leaking through (unparsed SDK message content)
 			const text = await assistantMsg.textContent();
 			expect(text).not.toMatch(/^\s*\{/); // should not start with `{`
 			expect(text).not.toContain('"type":"assistant"');
 			expect(text).not.toContain('"content":[');
 
-			// The parse-error fallback should not be shown
+			// The parse-error fallback must not be shown for valid responses
 			await expect(page.getByTestId('neo-message-parse-error')).not.toBeVisible();
 
-			// The message should contain some actual readable text (non-empty)
+			// Message contains actual readable text (non-empty)
 			expect((text ?? '').trim().length).toBeGreaterThan(0);
-		});
-
-		// ── 5. No parse errors for valid responses ────────────────────────────────
-
-		test('assistant messages do not show parse-error fallback for valid responses', async ({
-			page,
-		}) => {
-			await sendNeoMessage(page, 'Hello');
-			await waitForNeoAssistantResponse(page);
-
-			// SDKMessageRenderer is used, not the parse-error fallback
-			await expect(page.getByTestId('neo-message-parse-error')).not.toBeVisible();
-
-			// An assistant message is present and visible
-			await expect(page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).last()).toBeVisible();
-		});
-
-		// ── 6. Empty state disappears after first message ─────────────────────────
-
-		test('empty state disappears once a message is sent', async ({ page }) => {
-			// Empty state is shown initially (panel opened in beforeEach)
-			await expect(page.getByTestId('neo-empty-state')).toBeVisible();
-
-			await sendNeoMessage(page, 'Hi');
-
-			// Empty state disappears once the user message appears
-			const userMsg = page.getByTestId(NEO_USER_MESSAGE_TESTID).first();
-			await userMsg.waitFor({ state: 'visible', timeout: 10000 });
-
-			await expect(page.getByTestId('neo-empty-state')).not.toBeVisible();
 		});
 	});
 });

--- a/packages/e2e/tests/features/neo-conversation.e2e.ts
+++ b/packages/e2e/tests/features/neo-conversation.e2e.ts
@@ -24,80 +24,21 @@
 import { test, expect, type Page } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
 import { openSettingsModal } from '../helpers/settings-modal-helpers';
-
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-const NEO_PANEL_TESTID = 'neo-panel';
-const NEO_CHAT_INPUT_TESTID = 'neo-chat-input';
-const NEO_SEND_BUTTON_TESTID = 'neo-send-button';
-const NEO_USER_MESSAGE_TESTID = 'neo-user-message';
-const NEO_ASSISTANT_MESSAGE_TESTID = 'neo-assistant-message';
-const NEO_ACTIVITY_VIEW_TESTID = 'neo-activity-view';
-const ACTIVITY_ENTRY_TESTID = 'activity-entry';
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Open the Neo panel by clicking the Neo NavRail button.
- */
-async function openNeoPanel(page: Page): Promise<void> {
-	const neoButton = page.getByRole('button', { name: 'Neo (⌘J)', exact: true });
-	await neoButton.waitFor({ state: 'visible', timeout: 5000 });
-	await neoButton.click();
-	await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'visible', timeout: 5000 });
-}
-
-/**
- * Close the Neo panel via its close button.
- */
-async function closeNeoPanel(page: Page): Promise<void> {
-	const closeButton = page.getByTestId('neo-panel-close');
-	await closeButton.waitFor({ state: 'visible', timeout: 5000 });
-	await closeButton.click();
-	await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'hidden', timeout: 5000 });
-}
-
-/**
- * Type a message in the Neo chat input and send it.
- */
-async function sendNeoMessage(page: Page, text: string): Promise<void> {
-	const input = page.getByTestId(NEO_CHAT_INPUT_TESTID);
-	await input.waitFor({ state: 'visible', timeout: 5000 });
-	await input.fill(text);
-	// Send via Enter key (matching the component's onKeyDown handler)
-	await input.press('Enter');
-}
-
-/**
- * Wait for a new user message bubble to appear in the Neo chat.
- */
-async function waitForNeoUserMessage(page: Page, text: string): Promise<void> {
-	await page
-		.getByTestId(NEO_USER_MESSAGE_TESTID)
-		.filter({ hasText: text })
-		.first()
-		.waitFor({ state: 'visible', timeout: 10000 });
-}
-
-/**
- * Wait for a new Neo assistant response to appear (any content).
- * Uses count-based detection so previous responses don't trigger a false positive.
- */
-async function waitForNeoAssistantResponse(
-	page: Page,
-	options: { timeout?: number } = {}
-): Promise<void> {
-	const timeout = options.timeout ?? 90000;
-	const initialCount = await page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).count();
-	await page.waitForFunction(
-		(expected) =>
-			document.querySelectorAll('[data-testid="neo-assistant-message"]').length > expected,
-		initialCount,
-		{ timeout }
-	);
-	// Also wait for the input to be re-enabled (loading state cleared)
-	await page.getByTestId(NEO_CHAT_INPUT_TESTID).waitFor({ state: 'visible', timeout: 10000 });
-}
+import {
+	NEO_PANEL_TESTID,
+	NEO_CHAT_INPUT_TESTID,
+	NEO_SEND_BUTTON_TESTID,
+	NEO_USER_MESSAGE_TESTID,
+	NEO_ASSISTANT_MESSAGE_TESTID,
+	NEO_ACTIVITY_VIEW_TESTID,
+	ACTIVITY_ENTRY_TESTID,
+	openNeoPanel,
+	closeNeoPanel,
+	sendNeoMessage,
+	waitForNeoUserMessage,
+	waitForNeoAssistantResponse,
+	isNeoAvailable,
+} from '../helpers/neo-helpers';
 
 /**
  * Navigate to the Neo Agent section in Global Settings.
@@ -242,23 +183,6 @@ async function resetSecurityMode(page: Page): Promise<void> {
 		if (!hub?.request) return;
 		await hub.request('neo.updateSettings', { securityMode: 'balanced' }).catch(() => {});
 	});
-}
-
-/**
- * Check whether the Neo agent is provisioned (not showing an error card).
- * Must be called with the Neo panel already open so error cards are rendered.
- * Returns true if Neo appears functional.
- */
-async function isNeoAvailable(page: Page): Promise<boolean> {
-	const hasNoCredentials = await page
-		.getByTestId('neo-error-no-credentials')
-		.isVisible()
-		.catch(() => false);
-	const hasProviderError = await page
-		.getByTestId('neo-error-provider-unavailable')
-		.isVisible()
-		.catch(() => false);
-	return !hasNoCredentials && !hasProviderError;
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/packages/e2e/tests/helpers/neo-helpers.ts
+++ b/packages/e2e/tests/helpers/neo-helpers.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared helpers for Neo panel E2E tests.
+ *
+ * These helpers encapsulate common Neo panel interactions used across multiple
+ * test files. Keep only UI-driven actions here — no direct RPC calls.
+ */
+
+import type { Page } from '@playwright/test';
+
+// ─── Test IDs ─────────────────────────────────────────────────────────────────
+
+export const NEO_PANEL_TESTID = 'neo-panel';
+export const NEO_CHAT_INPUT_TESTID = 'neo-chat-input';
+export const NEO_SEND_BUTTON_TESTID = 'neo-send-button';
+export const NEO_USER_MESSAGE_TESTID = 'neo-user-message';
+export const NEO_ASSISTANT_MESSAGE_TESTID = 'neo-assistant-message';
+export const NEO_ACTIVITY_VIEW_TESTID = 'neo-activity-view';
+export const ACTIVITY_ENTRY_TESTID = 'activity-entry';
+
+// ─── Panel helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Open the Neo panel by clicking the Neo NavRail button.
+ */
+export async function openNeoPanel(page: Page): Promise<void> {
+	const neoButton = page.getByRole('button', { name: 'Neo (⌘J)', exact: true });
+	await neoButton.waitFor({ state: 'visible', timeout: 5000 });
+	await neoButton.click();
+	await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'visible', timeout: 5000 });
+}
+
+/**
+ * Close the Neo panel via its close button.
+ */
+export async function closeNeoPanel(page: Page): Promise<void> {
+	const closeButton = page.getByTestId('neo-panel-close');
+	await closeButton.waitFor({ state: 'visible', timeout: 5000 });
+	await closeButton.click();
+	await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'hidden', timeout: 5000 });
+}
+
+// ─── Messaging helpers ────────────────────────────────────────────────────────
+
+/**
+ * Type a message in the Neo chat input and send it.
+ */
+export async function sendNeoMessage(page: Page, text: string): Promise<void> {
+	const input = page.getByTestId(NEO_CHAT_INPUT_TESTID);
+	await input.waitFor({ state: 'visible', timeout: 5000 });
+	await input.fill(text);
+	// Send via Enter key (matching the component's onKeyDown handler)
+	await input.press('Enter');
+}
+
+/**
+ * Wait for a new user message bubble to appear in the Neo chat.
+ */
+export async function waitForNeoUserMessage(page: Page, text: string): Promise<void> {
+	await page
+		.getByTestId(NEO_USER_MESSAGE_TESTID)
+		.filter({ hasText: text })
+		.first()
+		.waitFor({ state: 'visible', timeout: 10000 });
+}
+
+/**
+ * Wait for a new Neo assistant response to appear (any content).
+ * Uses count-based detection so previous responses don't trigger a false positive.
+ * Waits for the input to become re-enabled as the signal that streaming is complete.
+ */
+export async function waitForNeoAssistantResponse(
+	page: Page,
+	options: { timeout?: number } = {}
+): Promise<void> {
+	const timeout = options.timeout ?? 90000;
+	const initialCount = await page.getByTestId(NEO_ASSISTANT_MESSAGE_TESTID).count();
+	await page.waitForFunction(
+		(expected) =>
+			document.querySelectorAll('[data-testid="neo-assistant-message"]').length > expected,
+		initialCount,
+		{ timeout }
+	);
+	// Wait for the input to be re-enabled (disabled only while `sending` is true)
+	await page.getByTestId(NEO_CHAT_INPUT_TESTID).waitFor({ state: 'enabled', timeout: 10000 });
+}
+
+// ─── Availability helpers ──────────────────────────────────────────────────────
+
+/**
+ * Check whether the Neo agent is provisioned (not showing an error card).
+ * Must be called with the Neo panel already open so error cards are rendered.
+ * Returns true if Neo appears functional.
+ */
+export async function isNeoAvailable(page: Page): Promise<boolean> {
+	const hasNoCredentials = await page
+		.getByTestId('neo-error-no-credentials')
+		.isVisible()
+		.catch(() => false);
+	const hasProviderError = await page
+		.getByTestId('neo-error-provider-unavailable')
+		.isVisible()
+		.catch(() => false);
+	return !hasNoCredentials && !hasProviderError;
+}

--- a/packages/e2e/tests/helpers/neo-helpers.ts
+++ b/packages/e2e/tests/helpers/neo-helpers.ts
@@ -66,7 +66,10 @@ export async function waitForNeoUserMessage(page: Page, text: string): Promise<v
 /**
  * Wait for a new Neo assistant response to appear (any content).
  * Uses count-based detection so previous responses don't trigger a false positive.
- * Waits for the input to become re-enabled as the signal that streaming is complete.
+ *
+ * Note: `sending` in NeoChatView goes false after the initial `neo.send` RPC
+ * resolves, not after the assistant message is streamed. The count-based
+ * `waitForFunction` is therefore the authoritative wait signal here.
  */
 export async function waitForNeoAssistantResponse(
 	page: Page,
@@ -80,18 +83,36 @@ export async function waitForNeoAssistantResponse(
 		initialCount,
 		{ timeout }
 	);
-	// Wait for the input to be re-enabled (disabled only while `sending` is true)
-	await page.getByTestId(NEO_CHAT_INPUT_TESTID).waitFor({ state: 'enabled', timeout: 10000 });
 }
 
 // ─── Availability helpers ──────────────────────────────────────────────────────
 
 /**
+ * Wait for the Neo chat panel content to reach a stable state after opening.
+ * Resolves once the empty state or an error card is attached to the DOM,
+ * preventing a race between `isNeoAvailable` and async store initialisation.
+ */
+export async function waitForNeoChatReady(page: Page): Promise<void> {
+	await page
+		.locator(
+			'[data-testid="neo-empty-state"], [data-testid="neo-error-no-credentials"], [data-testid="neo-error-provider-unavailable"]'
+		)
+		.first()
+		.waitFor({ state: 'attached', timeout: 10000 })
+		.catch(() => {
+			// Tolerate timeout — isNeoAvailable will return false below, which is safe
+		});
+}
+
+/**
  * Check whether the Neo agent is provisioned (not showing an error card).
  * Must be called with the Neo panel already open so error cards are rendered.
+ * Waits for the panel content to settle before checking, avoiding a race between
+ * `openNeoPanel` and async Neo store subscription.
  * Returns true if Neo appears functional.
  */
 export async function isNeoAvailable(page: Page): Promise<boolean> {
+	await waitForNeoChatReady(page);
 	const hasNoCredentials = await page
 		.getByTestId('neo-error-no-credentials')
 		.isVisible()

--- a/packages/web/src/components/neo/NeoChatView.tsx
+++ b/packages/web/src/components/neo/NeoChatView.tsx
@@ -198,7 +198,10 @@ function MessageBubble({ msg, pendingActionId, isLastAssistant }: MessageBubbleP
 		<div data-testid="neo-assistant-message" class="mb-3">
 			{/* Sparkle avatar */}
 			<div class="flex items-start gap-2">
-				<div class="flex-shrink-0 w-6 h-6 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mt-0.5">
+				<div
+					data-testid="neo-sparkle-avatar"
+					class="flex-shrink-0 w-6 h-6 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mt-0.5"
+				>
 					<svg
 						class="w-3 h-3 text-violet-400"
 						viewBox="0 0 24 24"


### PR DESCRIPTION
Adds `packages/e2e/tests/features/neo-chat-rendering.e2e.ts` with 7 Playwright E2E tests covering Neo chat message rendering:

- Empty state shows greeting before any messages
- Chat/Activity tab switching works correctly
- User messages render in right-aligned blue bubble with correct CSS
- Sparkle avatar appears next to assistant messages
- Assistant messages render as readable text, not raw JSON or `"Structured data"` cards
- `neo-message-parse-error` fallback is absent for valid responses
- Empty state disappears once first message is sent

All tests follow E2E rules: pure UI interactions, DOM-only assertions, RPC only in beforeEach/afterEach. API-dependent tests guard with `isNeoAvailable()` and skip gracefully.