### PR TITLE
Fix isTerminal to include archived status and add GoalManager.resetGoal()

### DIFF
--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -187,6 +187,31 @@ export class GoalManager {
 	}
 
 	/**
+	 * Reset a goal to its initial state so it can be re-planned from scratch.
+	 * Clears linked tasks, resets all counters, and sets status back to active.
+	 */
+	async resetGoal(goalId: string): Promise<RoomGoal> {
+		const goal = await this.getGoal(goalId);
+		if (!goal) {
+			throw new Error(`Goal not found: ${goalId}`);
+		}
+
+		const updatedGoal = this.goalRepo.updateGoal(goalId, {
+			linkedTaskIds: [],
+			planning_attempts: 0,
+			consecutiveFailures: 0,
+			replanCount: 0,
+			status: 'active',
+		});
+
+		if (!updatedGoal) {
+			throw new Error(`Failed to reset goal: ${goalId}`);
+		}
+
+		return updatedGoal;
+	}
+
+	/**
 	 * Link a task to a goal
 	 */
 	async linkTaskToGoal(goalId: string, taskId: string): Promise<RoomGoal> {

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -3334,7 +3334,10 @@ export class RoomRuntime {
 			if (validTasks.length === 0) continue;
 
 			const isTerminal = (status: string) =>
-				status === 'completed' || status === 'needs_attention' || status === 'cancelled';
+				status === 'completed' ||
+				status === 'needs_attention' ||
+				status === 'cancelled' ||
+				status === 'archived';
 			const allTerminal = validTasks.every((t) => isTerminal(t.status));
 			if (!allTerminal) continue;
 
@@ -3541,7 +3544,7 @@ export class RoomRuntime {
 				);
 				const executionTasks = validTasks.filter((t) => t.taskType !== 'planning');
 				const isTerminal = (status: string) =>
-					status === 'needs_attention' || status === 'cancelled';
+					status === 'needs_attention' || status === 'cancelled' || status === 'archived';
 				const allExecutionFailed =
 					executionTasks.length > 0 && executionTasks.every((t) => isTerminal(t.status));
 				const allFailed = validTasks.length > 0 && validTasks.every((t) => isTerminal(t.status));

--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -1011,3 +1011,109 @@ describe('GoalManager.patchGoal — schedule nextRunAt auto-computation', () => 
 		expect(patched.nextRunAt).toBe(originalNextRunAt);
 	});
 });
+
+describe('GoalManager.resetGoal', () => {
+	let db: Database;
+	let goalManager: GoalManager;
+	let taskManager: TaskManager;
+	let roomManager: RoomManager;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createTables(db);
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS goals (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'needs_human', 'completed', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal'
+					CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				progress INTEGER DEFAULT 0,
+				linked_task_ids TEXT DEFAULT '[]',
+				metrics TEXT DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				completed_at INTEGER,
+				planning_attempts INTEGER DEFAULT 0,
+				goal_review_attempts INTEGER DEFAULT 0,
+				mission_type TEXT, autonomy_level TEXT, structured_metrics TEXT, schedule TEXT,
+				schedule_paused INTEGER DEFAULT 0, next_run_at INTEGER,
+				max_consecutive_failures INTEGER, max_planning_attempts INTEGER,
+				consecutive_failures INTEGER DEFAULT 0, replan_count INTEGER DEFAULT 0,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			)
+		`);
+		roomManager = new RoomManager(db, noOpReactiveDb);
+		const room = roomManager.createRoom({
+			name: 'Reset Test Room',
+			allowedPaths: [{ path: '/workspace/test' }],
+			defaultPath: '/workspace/test',
+		});
+		goalManager = new GoalManager(db, room.id, noOpReactiveDb);
+		taskManager = new TaskManager(db, room.id, { notifyChange: () => {} } as never);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('resets linkedTaskIds, all counters, and sets status to active', async () => {
+		const goal = await goalManager.createGoal({
+			title: 'Reset Test',
+			description: 'Goal to be reset',
+		});
+
+		// Simulate some planning activity
+		const task = await taskManager.createTask({ title: 'Task 1', description: '' });
+		await goalManager.linkTaskToGoal(goal.id, task.id);
+		await goalManager.incrementPlanningAttempts(goal.id);
+		await goalManager.updateConsecutiveFailures(goal.id, 2);
+		// Set replanCount directly via patchGoal
+		await goalManager.patchGoal(goal.id, { replanCount: 3 });
+		// Transition to needs_human
+		await goalManager.needsHumanGoal(goal.id);
+
+		const before = await goalManager.getGoal(goal.id);
+		expect(before?.linkedTaskIds).toHaveLength(1);
+		expect(before?.planning_attempts).toBeGreaterThan(0);
+		expect(before?.consecutiveFailures).toBe(2);
+		expect(before?.replanCount).toBe(3);
+		expect(before?.status).toBe('needs_human');
+
+		const reset = await goalManager.resetGoal(goal.id);
+
+		expect(reset.linkedTaskIds).toEqual([]);
+		expect(reset.planning_attempts).toBe(0);
+		expect(reset.consecutiveFailures).toBe(0);
+		expect(reset.replanCount).toBe(0);
+		expect(reset.status).toBe('active');
+	});
+
+	it('resets a goal in needs_human status back to active', async () => {
+		const goal = await goalManager.createGoal({
+			title: 'Stuck Goal',
+			description: 'Goal stuck in needs_human',
+		});
+		await goalManager.needsHumanGoal(goal.id);
+
+		const stuck = await goalManager.getGoal(goal.id);
+		expect(stuck?.status).toBe('needs_human');
+
+		const reset = await goalManager.resetGoal(goal.id);
+
+		expect(reset.status).toBe('active');
+		expect(reset.linkedTaskIds).toEqual([]);
+		expect(reset.planning_attempts).toBe(0);
+		expect(reset.consecutiveFailures).toBe(0);
+		expect(reset.replanCount).toBe(0);
+	});
+
+	it('throws for non-existent goal ID', async () => {
+		await expect(goalManager.resetGoal('non-existent-id')).rejects.toThrow(
+			'Goal not found: non-existent-id'
+		);
+	});
+});

--- a/packages/daemon/tests/unit/room/mission-system-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/room/mission-system-edge-cases.test.ts
@@ -755,3 +755,138 @@ describe('Autonomy gate: planner exclusion edge cases', () => {
 		expect(escalated.status).toBe('needs_human');
 	});
 });
+
+// ─── 8. isTerminal fix: archived tasks in getNextGoalForPlanning ──────────────
+
+describe('isTerminal fix: archived tasks trigger replanning in getNextGoalForPlanning', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('goal with all-archived linked tasks is eligible for replanning', async () => {
+		// Create a one-shot goal
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Archived tasks goal',
+			description: 'Should replan when all tasks are archived',
+		});
+
+		// Create a task and immediately archive it (simulate a task that was cancelled/archived)
+		const task = await ctx.taskManager.createTask({ title: 'Archived Task', description: '' });
+		await ctx.taskManager.archiveTask(task.id, { mode: 'manual' });
+
+		// Link the archived task to the goal
+		await ctx.goalManager.linkTaskToGoal(goal.id, task.id);
+
+		// Verify task is archived
+		const archivedTask = await ctx.taskManager.getTask(task.id);
+		expect(archivedTask?.status).toBe('archived');
+
+		// Tick — the runtime should detect all linked tasks are terminal (archived)
+		// and spawn a new planning session
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// A planning session should have been spawned, proving isTerminal includes 'archived'
+		const planningCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		expect(planningCalls.length).toBeGreaterThan(0);
+	});
+
+	test('goal with mixed archived and active tasks does NOT add a new planning task', async () => {
+		// Create a one-shot goal
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Mixed tasks goal',
+			description: 'Should NOT replan while active tasks remain',
+		});
+
+		// Create one archived task and one task in_progress (active)
+		const archivedTask = await ctx.taskManager.createTask({
+			title: 'Archived Task',
+			description: '',
+		});
+		await ctx.taskManager.archiveTask(archivedTask.id, { mode: 'manual' });
+
+		const activeTask = await ctx.taskManager.createTask({
+			title: 'Active Task',
+			description: '',
+		});
+		// Set it to in_progress so it counts as active but won't be picked up for execution
+		await ctx.taskManager.updateTaskStatus(activeTask.id, 'in_progress');
+
+		await ctx.goalManager.linkTaskToGoal(goal.id, archivedTask.id);
+		await ctx.goalManager.linkTaskToGoal(goal.id, activeTask.id);
+
+		const beforeGoal = await ctx.goalManager.getGoal(goal.id);
+		const linkedCountBefore = beforeGoal?.linkedTaskIds.length ?? 0;
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// A new planning task should NOT have been added to the goal
+		const afterGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(afterGoal?.linkedTaskIds.length).toBe(linkedCountBefore);
+	});
+});
+
+// ─── 9. isTerminal fix: archived tasks in _doTickRecurringMissions ────────────
+
+describe('isTerminal fix: archived tasks complete recurring executions', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('recurring execution with all-archived tasks is marked failed (not hung)', async () => {
+		// Create a recurring goal
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring with archived tasks',
+			description: 'Execution should complete when all tasks are archived',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+
+		// Start an execution manually
+		// Pass a future nextRunAt so Phase 2 won't re-trigger immediately
+		const futureTime = Math.floor(Date.now() / 1000) + 86400; // 1 day ahead
+		const execution = ctx.goalManager.startExecution(goal.id, futureTime);
+		expect(execution).toBeDefined();
+
+		// Create a task and archive it
+		const task = await ctx.taskManager.createTask({
+			title: 'Archived execution task',
+			description: '',
+		});
+		await ctx.taskManager.archiveTask(task.id, { mode: 'manual' });
+
+		// Link the archived task to both the execution and the goal
+		await ctx.goalManager.linkTaskToExecution(goal.id, execution.id, task.id);
+
+		// Verify execution is active and has the task
+		const activeBefore = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeBefore).not.toBeNull();
+		expect(activeBefore?.taskIds).toContain(task.id);
+
+		// Tick — Phase 1 should detect all tasks are archived (terminal) and complete/fail
+		// the execution. Without the isTerminal fix, it would hang indefinitely.
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// The execution should be completed/failed (no longer active)
+		const activeAfter = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeAfter).toBeNull();
+	});
+});


### PR DESCRIPTION
Fix two `isTerminal` helper bugs and add a `resetGoal()` method to `GoalManager`.

**Changes:**
- `_doTickRecurringMissions`: add `archived` to terminal statuses so recurring executions complete instead of hanging when tasks are archived
- `getNextGoalForPlanning`: add `archived` to terminal statuses so goals with all-archived linked tasks are eligible for re-planning
- `GoalManager.resetGoal()`: new method that clears `linkedTaskIds`, resets `planning_attempts`/`consecutiveFailures`/`replanCount` to 0, and sets status back to `active`

Unit tests added for all three changes.