### PR TITLE
feat: add useViewportSafety hook and CSS custom properties

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'preact/hooks';
 import { effect, batch } from '@preact/signals';
 import { useNeoKeyboardShortcut } from './hooks/useNeoKeyboardShortcut.ts';
+import { useViewportSafety } from './hooks/useViewportSafety.ts';
 import { NeoPanel } from './components/neo/NeoPanel.tsx';
 import { NavRail } from './islands/NavRail.tsx';
 import { BottomTabBar } from './islands/BottomTabBar.tsx';
@@ -50,6 +51,8 @@ import {
 export function App() {
 	// Global Cmd+J / Ctrl+J shortcut to toggle the Neo panel
 	useNeoKeyboardShortcut();
+	// Set --safe-height CSS custom property on iPad Safari for correct viewport sizing
+	useViewportSafety();
 
 	useEffect(() => {
 		// STEP 1: Initialize URL-based router BEFORE any state management

--- a/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
+++ b/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
@@ -1,0 +1,253 @@
+// @ts-nocheck
+/**
+ * Tests for useViewportSafety Hook
+ *
+ * Tests iPad Safari detection logic, --safe-height CSS property management,
+ * and event listener cleanup.
+ */
+
+import { renderHook } from '@testing-library/preact';
+import { useViewportSafety } from '../useViewportSafety.ts';
+
+// Store original navigator/window properties so we can restore them.
+const originalNavigator = {
+	maxTouchPoints: navigator.maxTouchPoints,
+	userAgent: navigator.userAgent,
+};
+
+const originalVisualViewport = window.visualViewport;
+
+function setNavigator(maxTouchPoints: number, userAgent: string) {
+	Object.defineProperty(navigator, 'maxTouchPoints', {
+		configurable: true,
+		get: () => maxTouchPoints,
+	});
+	Object.defineProperty(navigator, 'userAgent', {
+		configurable: true,
+		get: () => userAgent,
+	});
+}
+
+function restoreNavigator() {
+	Object.defineProperty(navigator, 'maxTouchPoints', {
+		configurable: true,
+		get: () => originalNavigator.maxTouchPoints,
+	});
+	Object.defineProperty(navigator, 'userAgent', {
+		configurable: true,
+		get: () => originalNavigator.userAgent,
+	});
+}
+
+function setVisualViewport(vv: VisualViewport | null) {
+	Object.defineProperty(window, 'visualViewport', {
+		configurable: true,
+		get: () => vv,
+	});
+}
+
+function restoreVisualViewport() {
+	Object.defineProperty(window, 'visualViewport', {
+		configurable: true,
+		get: () => originalVisualViewport,
+	});
+}
+
+function createMockVisualViewport(height: number) {
+	const listeners: Record<string, Array<() => void>> = {};
+	const vv = {
+		height,
+		addEventListener: vi.fn((event: string, cb: () => void) => {
+			listeners[event] = listeners[event] ?? [];
+			listeners[event].push(cb);
+		}),
+		removeEventListener: vi.fn((event: string, cb: () => void) => {
+			if (listeners[event]) {
+				listeners[event] = listeners[event].filter((l) => l !== cb);
+			}
+		}),
+		_trigger: (event: string) => {
+			(listeners[event] ?? []).forEach((cb) => cb());
+		},
+	};
+	return vv;
+}
+
+// iPad Safari UA string (iPadOS 16 masquerades as macOS Safari)
+const IPAD_SAFARI_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15';
+
+// Desktop macOS Safari UA
+const DESKTOP_SAFARI_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15';
+
+// Desktop Chrome UA
+const DESKTOP_CHROME_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+// Chrome on iOS (CriOS)
+const CRIOS_UA =
+	'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1';
+
+// Firefox on iOS (FxiOS)
+const FXIOS_UA =
+	'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/605.1.15';
+
+afterEach(() => {
+	restoreNavigator();
+	restoreVisualViewport();
+	// Clear any --safe-height set during tests
+	document.documentElement.style.removeProperty('--safe-height');
+});
+
+describe('useViewportSafety — iPad Safari detection', () => {
+	it('detects iPad Safari: maxTouchPoints > 1 + Safari UA without Chrome/CriOS/FxiOS', () => {
+		setNavigator(5, IPAD_SAFARI_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('900px');
+	});
+
+	it('does NOT detect iPad Safari when maxTouchPoints is 0 (desktop Mac)', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+	});
+
+	it('does NOT detect iPad Safari for desktop Chrome (UA contains Chrome)', () => {
+		setNavigator(5, DESKTOP_CHROME_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+	});
+
+	it('does NOT detect iPad Safari for CriOS (Chrome on iOS)', () => {
+		setNavigator(5, CRIOS_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+	});
+
+	it('does NOT detect iPad Safari for FxiOS (Firefox on iOS)', () => {
+		setNavigator(5, FXIOS_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+	});
+});
+
+describe('useViewportSafety — --safe-height property', () => {
+	it('sets --safe-height to visualViewport.height on iPad Safari', () => {
+		setNavigator(5, IPAD_SAFARI_UA);
+		const mockVV = createMockVisualViewport(768);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('768px');
+	});
+
+	it('does NOT set --safe-height on non-iPad-Safari browsers', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		// --safe-height must be absent so the CSS fallback (100svh) takes effect
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+	});
+
+	it('does nothing when visualViewport is unavailable on iPad Safari', () => {
+		setNavigator(5, IPAD_SAFARI_UA);
+		setVisualViewport(null);
+
+		// Should not throw
+		expect(() => renderHook(() => useViewportSafety())).not.toThrow();
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+	});
+});
+
+describe('useViewportSafety — event listeners', () => {
+	it('attaches resize listeners on iPad Safari', () => {
+		setNavigator(5, IPAD_SAFARI_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+		const windowAddSpy = vi.spyOn(window, 'addEventListener');
+
+		renderHook(() => useViewportSafety());
+
+		expect(mockVV.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+		expect(windowAddSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+
+		windowAddSpy.mockRestore();
+	});
+
+	it('does NOT attach listeners on non-iPad-Safari', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		expect(mockVV.addEventListener).not.toHaveBeenCalled();
+	});
+
+	it('removes event listeners on unmount', () => {
+		setNavigator(5, IPAD_SAFARI_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+		const windowRemoveSpy = vi.spyOn(window, 'removeEventListener');
+
+		const { unmount } = renderHook(() => useViewportSafety());
+		unmount();
+
+		expect(mockVV.removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+		expect(windowRemoveSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+
+		windowRemoveSpy.mockRestore();
+	});
+
+	it('updates --safe-height when visualViewport resize fires', () => {
+		setNavigator(5, IPAD_SAFARI_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		// Simulate height change then fire resize
+		mockVV.height = 700;
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('700px');
+	});
+
+	it('updates --safe-height when window resize fires', () => {
+		setNavigator(5, IPAD_SAFARI_UA);
+		const mockVV = createMockVisualViewport(900);
+		setVisualViewport(mockVV as unknown as VisualViewport);
+
+		renderHook(() => useViewportSafety());
+
+		mockVV.height = 600;
+		window.dispatchEvent(new Event('resize'));
+
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('600px');
+	});
+});

--- a/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
+++ b/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Tests for useViewportSafety Hook
  *
@@ -9,15 +8,41 @@
 import { renderHook } from '@testing-library/preact';
 import { useViewportSafety } from '../useViewportSafety.ts';
 
-// Store original navigator/window properties so we can restore them.
-const originalNavigator = {
-	maxTouchPoints: navigator.maxTouchPoints,
-	userAgent: navigator.userAgent,
-};
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
 
-const originalVisualViewport = window.visualViewport;
+/** Partial VisualViewport mock with trackable event listeners. */
+interface MockVisualViewport {
+	height: number;
+	addEventListener: ReturnType<typeof vi.fn>;
+	removeEventListener: ReturnType<typeof vi.fn>;
+	/** Fire all registered listeners for an event (test helper). */
+	_trigger(event: string): void;
+}
 
-function setNavigator(maxTouchPoints: number, userAgent: string) {
+function createMockVisualViewport(height: number): MockVisualViewport {
+	const listeners: Record<string, Array<EventListenerOrEventListenerObject>> = {};
+	return {
+		height,
+		addEventListener: vi.fn((event: string, cb: EventListenerOrEventListenerObject) => {
+			listeners[event] = listeners[event] ?? [];
+			listeners[event].push(cb);
+		}),
+		removeEventListener: vi.fn((event: string, cb: EventListenerOrEventListenerObject) => {
+			if (listeners[event]) {
+				listeners[event] = listeners[event].filter((l) => l !== cb);
+			}
+		}),
+		_trigger(event: string) {
+			(listeners[event] ?? []).forEach((cb) => {
+				if (typeof cb === 'function') cb(new Event(event));
+			});
+		},
+	};
+}
+
+function setNavigator(maxTouchPoints: number, userAgent: string): void {
 	Object.defineProperty(navigator, 'maxTouchPoints', {
 		configurable: true,
 		get: () => maxTouchPoints,
@@ -28,83 +53,75 @@ function setNavigator(maxTouchPoints: number, userAgent: string) {
 	});
 }
 
-function restoreNavigator() {
+function restoreNavigator(): void {
+	// Restore to jsdom defaults
 	Object.defineProperty(navigator, 'maxTouchPoints', {
 		configurable: true,
-		get: () => originalNavigator.maxTouchPoints,
+		get: () => 0,
 	});
 	Object.defineProperty(navigator, 'userAgent', {
 		configurable: true,
-		get: () => originalNavigator.userAgent,
+		// Keep the existing value from jsdom
+		get: () => 'Mozilla/5.0 (linux) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3',
 	});
 }
 
-function setVisualViewport(vv: VisualViewport | null) {
+function setVisualViewport(vv: MockVisualViewport | null): void {
 	Object.defineProperty(window, 'visualViewport', {
 		configurable: true,
 		get: () => vv,
 	});
 }
 
-function restoreVisualViewport() {
+function restoreVisualViewport(): void {
 	Object.defineProperty(window, 'visualViewport', {
 		configurable: true,
-		get: () => originalVisualViewport,
+		get: () => null,
 	});
 }
 
-function createMockVisualViewport(height: number) {
-	const listeners: Record<string, Array<() => void>> = {};
-	const vv = {
-		height,
-		addEventListener: vi.fn((event: string, cb: () => void) => {
-			listeners[event] = listeners[event] ?? [];
-			listeners[event].push(cb);
-		}),
-		removeEventListener: vi.fn((event: string, cb: () => void) => {
-			if (listeners[event]) {
-				listeners[event] = listeners[event].filter((l) => l !== cb);
-			}
-		}),
-		_trigger: (event: string) => {
-			(listeners[event] ?? []).forEach((cb) => cb());
-		},
-	};
-	return vv;
-}
+// ---------------------------------------------------------------------------
+// UA fixtures
+// ---------------------------------------------------------------------------
 
-// iPad Safari UA string (iPadOS 16 masquerades as macOS Safari)
+/** iPadOS 16 — masquerades as macOS Safari */
 const IPAD_SAFARI_UA =
 	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15';
 
-// Desktop macOS Safari UA
+/** Desktop macOS Safari (no touch) */
 const DESKTOP_SAFARI_UA =
 	'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15';
 
-// Desktop Chrome UA
+/** Desktop Chrome */
 const DESKTOP_CHROME_UA =
 	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
-// Chrome on iOS (CriOS)
+/** Chrome on iOS */
 const CRIOS_UA =
 	'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1';
 
-// Firefox on iOS (FxiOS)
+/** Firefox on iOS */
 const FXIOS_UA =
 	'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/605.1.15';
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
 
 afterEach(() => {
 	restoreNavigator();
 	restoreVisualViewport();
-	// Clear any --safe-height set during tests
 	document.documentElement.style.removeProperty('--safe-height');
 });
+
+// ---------------------------------------------------------------------------
+// iPad Safari detection
+// ---------------------------------------------------------------------------
 
 describe('useViewportSafety — iPad Safari detection', () => {
 	it('detects iPad Safari: maxTouchPoints > 1 + Safari UA without Chrome/CriOS/FxiOS', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
-		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(createMockVisualViewport(900));
 
 		renderHook(() => useViewportSafety());
 
@@ -113,8 +130,7 @@ describe('useViewportSafety — iPad Safari detection', () => {
 
 	it('does NOT detect iPad Safari when maxTouchPoints is 0 (desktop Mac)', () => {
 		setNavigator(0, DESKTOP_SAFARI_UA);
-		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(createMockVisualViewport(900));
 
 		renderHook(() => useViewportSafety());
 
@@ -123,8 +139,7 @@ describe('useViewportSafety — iPad Safari detection', () => {
 
 	it('does NOT detect iPad Safari for desktop Chrome (UA contains Chrome)', () => {
 		setNavigator(5, DESKTOP_CHROME_UA);
-		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(createMockVisualViewport(900));
 
 		renderHook(() => useViewportSafety());
 
@@ -133,8 +148,7 @@ describe('useViewportSafety — iPad Safari detection', () => {
 
 	it('does NOT detect iPad Safari for CriOS (Chrome on iOS)', () => {
 		setNavigator(5, CRIOS_UA);
-		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(createMockVisualViewport(900));
 
 		renderHook(() => useViewportSafety());
 
@@ -143,8 +157,7 @@ describe('useViewportSafety — iPad Safari detection', () => {
 
 	it('does NOT detect iPad Safari for FxiOS (Firefox on iOS)', () => {
 		setNavigator(5, FXIOS_UA);
-		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(createMockVisualViewport(900));
 
 		renderHook(() => useViewportSafety());
 
@@ -152,25 +165,26 @@ describe('useViewportSafety — iPad Safari detection', () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// --safe-height property
+// ---------------------------------------------------------------------------
+
 describe('useViewportSafety — --safe-height property', () => {
 	it('sets --safe-height to visualViewport.height on iPad Safari', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
-		const mockVV = createMockVisualViewport(768);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(createMockVisualViewport(768));
 
 		renderHook(() => useViewportSafety());
 
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('768px');
 	});
 
-	it('does NOT set --safe-height on non-iPad-Safari browsers', () => {
+	it('does NOT set --safe-height on non-iPad-Safari (CSS 100svh fallback applies)', () => {
 		setNavigator(0, DESKTOP_SAFARI_UA);
-		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(createMockVisualViewport(900));
 
 		renderHook(() => useViewportSafety());
 
-		// --safe-height must be absent so the CSS fallback (100svh) takes effect
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
 	});
 
@@ -178,17 +192,20 @@ describe('useViewportSafety — --safe-height property', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
 		setVisualViewport(null);
 
-		// Should not throw
 		expect(() => renderHook(() => useViewportSafety())).not.toThrow();
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
 	});
 });
 
+// ---------------------------------------------------------------------------
+// Event listeners
+// ---------------------------------------------------------------------------
+
 describe('useViewportSafety — event listeners', () => {
 	it('attaches resize listeners on iPad Safari', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
 		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(mockVV);
 		const windowAddSpy = vi.spyOn(window, 'addEventListener');
 
 		renderHook(() => useViewportSafety());
@@ -202,7 +219,7 @@ describe('useViewportSafety — event listeners', () => {
 	it('does NOT attach listeners on non-iPad-Safari', () => {
 		setNavigator(0, DESKTOP_SAFARI_UA);
 		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(mockVV);
 
 		renderHook(() => useViewportSafety());
 
@@ -212,7 +229,7 @@ describe('useViewportSafety — event listeners', () => {
 	it('removes event listeners on unmount', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
 		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(mockVV);
 		const windowRemoveSpy = vi.spyOn(window, 'removeEventListener');
 
 		const { unmount } = renderHook(() => useViewportSafety());
@@ -227,11 +244,10 @@ describe('useViewportSafety — event listeners', () => {
 	it('updates --safe-height when visualViewport resize fires', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
 		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(mockVV);
 
 		renderHook(() => useViewportSafety());
 
-		// Simulate height change then fire resize
 		mockVV.height = 700;
 		mockVV._trigger('resize');
 
@@ -241,7 +257,7 @@ describe('useViewportSafety — event listeners', () => {
 	it('updates --safe-height when window resize fires', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
 		const mockVV = createMockVisualViewport(900);
-		setVisualViewport(mockVV as unknown as VisualViewport);
+		setVisualViewport(mockVV);
 
 		renderHook(() => useViewportSafety());
 

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -68,3 +68,4 @@ export {
 	type UseReferenceAutocompleteOptions,
 	type UseReferenceAutocompleteResult,
 } from './useReferenceAutocomplete';
+export { useViewportSafety } from './useViewportSafety';

--- a/packages/web/src/hooks/useViewportSafety.ts
+++ b/packages/web/src/hooks/useViewportSafety.ts
@@ -78,6 +78,11 @@ export function useViewportSafety(): void {
 
 		const handleResize = () => updateSafeHeight(vv);
 
+		// `visualViewport.resize` fires whenever the visible area changes
+		// (address bar show/hide, keyboard appearance, etc.).
+		// `window.resize` fires on device rotation — iPadOS also fires
+		// `orientationchange`, but `resize` subsumes it so no separate
+		// `orientationchange` listener is needed.
 		vv.addEventListener('resize', handleResize);
 		window.addEventListener('resize', handleResize);
 

--- a/packages/web/src/hooks/useViewportSafety.ts
+++ b/packages/web/src/hooks/useViewportSafety.ts
@@ -1,0 +1,89 @@
+/**
+ * useViewportSafety Hook
+ *
+ * Manages CSS custom properties for safe layout dimensions on iPad Safari.
+ *
+ * On iPad Safari, `window.visualViewport.height` is the actual visible content
+ * area after all browser chrome (tab bar, address bar) is subtracted. This hook
+ * sets `--safe-height` on `document.documentElement` so layout components can
+ * use it instead of `100svh` which does not account for Safari's tab bar overlay.
+ *
+ * On all other browsers, `--safe-height` is NOT set — the CSS fallback (`100svh`)
+ * takes effect automatically.
+ *
+ * **IMPORTANT**: This hook must only be called **once globally** in `App.tsx`.
+ * Downstream components must NOT call it themselves — doing so would create
+ * duplicate event listeners and redundant DOM writes.
+ */
+
+import { useEffect } from 'preact/hooks';
+
+/**
+ * Detect iPad Safari.
+ *
+ * Strategy:
+ * - `navigator.maxTouchPoints > 1` distinguishes iPadOS from macOS on
+ *   non-touch Macs (iPadOS always reports ≥ 5 touch points; desktop Macs
+ *   report 0). The deprecated `navigator.platform` API is intentionally avoided.
+ * - User agent contains "Safari" but NOT "Chrome", "CriOS" (Chrome on iOS),
+ *   or "FxiOS" (Firefox on iOS) because iPadOS masquerades as macOS Safari.
+ */
+function isIpadSafari(): boolean {
+	if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+		return false;
+	}
+	const ua = navigator.userAgent;
+	const hasTouch = navigator.maxTouchPoints > 1;
+	const isSafariUA =
+		ua.includes('Safari') &&
+		!ua.includes('Chrome') &&
+		!ua.includes('CriOS') &&
+		!ua.includes('FxiOS');
+	return hasTouch && isSafariUA;
+}
+
+/**
+ * Update the `--safe-height` CSS custom property on `document.documentElement`
+ * using the current `visualViewport.height`.
+ */
+function updateSafeHeight(vv: VisualViewport): void {
+	document.documentElement.style.setProperty('--safe-height', `${vv.height}px`);
+}
+
+/**
+ * Hook that detects iPad Safari and sets `--safe-height` CSS custom property
+ * from `window.visualViewport.height`. Listens to `visualViewport.resize` and
+ * `window.resize` to keep the value current (e.g. when the address bar shows
+ * or hides, or the device rotates).
+ *
+ * On non-iPad-Safari browsers this hook is a no-op — the CSS fallback (`100svh`)
+ * handles those environments.
+ *
+ * Must be called **once globally** in `App.tsx` only.
+ */
+export function useViewportSafety(): void {
+	useEffect(() => {
+		if (!isIpadSafari()) {
+			return;
+		}
+
+		const vv = window.visualViewport;
+		if (!vv) {
+			// No VisualViewport API — CSS fallback handles it.
+			return;
+		}
+
+		// Set initial value immediately.
+		updateSafeHeight(vv);
+
+		const handleResize = () => updateSafeHeight(vv);
+
+		vv.addEventListener('resize', handleResize);
+		window.addEventListener('resize', handleResize);
+
+		return () => {
+			vv.removeEventListener('resize', handleResize);
+			window.removeEventListener('resize', handleResize);
+		};
+	}, []);
+}

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -51,6 +51,13 @@
 	--duration-quick: 150ms;
 	--duration-smooth: 250ms;
 	--duration-deliberate: 400ms;
+
+	/* Viewport safety custom properties.
+	   --safe-height: set by useViewportSafety hook on iPad Safari to
+	   window.visualViewport.height (px). On other browsers the CSS fallback
+	   (100svh) applies via the .h-safe-screen utility class.
+	   --bottom-bar-height: overridden by JS when BottomTabBar is visible. */
+	--bottom-bar-height: 0px;
 }
 
 /*
@@ -71,9 +78,11 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 	/* Prevent page-level scrolling - only message container should scroll */
 	overflow: hidden;
-	/* Use dynamic viewport height for mobile Safari (accounts for address bar) */
-	height: 100dvh;
-	/* Fallback for browsers that don't support dvh */
+	/* Use static small viewport height — dvh causes layout recalculation jank
+	   when the browser toolbar animates in/out. svh is stable; the root
+	   container height is managed via .h-safe-screen on iPad Safari. */
+	height: 100svh;
+	/* Fallback for browsers that don't support svh */
 	height: 100vh;
 	/* Prevent overscroll bounce on body - scrollable children handle their own */
 	overscroll-behavior: none;
@@ -561,4 +570,19 @@ a:focus-visible {
 
 .pt-safe {
 	padding-top: env(safe-area-inset-top, 0px);
+}
+
+/* Safe viewport height.
+   On iPad Safari, useViewportSafety sets --safe-height = visualViewport.height.
+   On all other browsers, falls back to 100svh. */
+.h-safe-screen {
+	height: var(--safe-height, 100svh);
+}
+
+/* Bottom bar padding utility.
+   Uses --bottom-bar-height custom property (default 0px).
+   Downstream components that need bottom padding matching the BottomTabBar
+   height should use this class instead of hardcoded pb-16. */
+.pb-bottom-bar {
+	padding-bottom: var(--bottom-bar-height, 0px);
 }

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -78,12 +78,14 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 	/* Prevent page-level scrolling - only message container should scroll */
 	overflow: hidden;
-	/* Use static small viewport height — dvh causes layout recalculation jank
-	   when the browser toolbar animates in/out. svh is stable; the root
-	   container height is managed via .h-safe-screen on iPad Safari. */
-	height: 100svh;
-	/* Fallback for browsers that don't support svh */
+	/* Fallback for older browsers that don't support svh */
 	height: 100vh;
+	/* Static small viewport height — dvh causes layout recalculation jank
+	   when the browser toolbar animates in/out. svh is stable; the root
+	   container height is managed via .h-safe-screen on iPad Safari.
+	   Tradeoff: on mobile browsers a small gap may appear when the address
+	   bar collapses — intentional, as .h-safe-screen handles that case. */
+	height: 100svh;
 	/* Prevent overscroll bounce on body - scrollable children handle their own */
 	overscroll-behavior: none;
 	/* Allow touch manipulation (zoom, pan) but let children control scroll */


### PR DESCRIPTION
Implements Task 1 of the iPad Safari layout fix plan.

- `useViewportSafety` hook detects iPad Safari via `maxTouchPoints > 1` + Safari UA string (excludes Chrome/CriOS/FxiOS), then sets `--safe-height` from `window.visualViewport.height`. No-op on all other browsers.
- `.h-safe-screen` utility: `height: var(--safe-height, 100svh)` — JS sets the property on iPad Safari; other browsers use the `100svh` fallback.
- `.pb-bottom-bar` utility: `padding-bottom: var(--bottom-bar-height, 0px)` — Tailwind-consistent replacement for hardcoded `pb-16`.
- Body height changed from `100dvh` → `100svh` to eliminate toolbar-animation jank.
- 13 unit tests covering detection logic, CSS property management, and event listener cleanup.