### PR TITLE
feat: dynamic bottom padding via --bottom-bar-height CSS custom property

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -182,8 +182,8 @@ export function App() {
 				{/* Context Panel - always visible */}
 				<ContextPanel />
 
-				{/* Main Content — add bottom padding on mobile to avoid tab bar overlap */}
-				<div class="flex-1 flex flex-col overflow-hidden pb-16 md:pb-0 min-w-0">
+				{/* Main Content — bottom padding matches actual BottomTabBar height via --bottom-bar-height */}
+				<div class="flex-1 flex flex-col overflow-hidden pb-bottom-bar min-w-0">
 					<MainContent />
 				</div>
 			</div>

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'preact';
+import { useEffect, useRef } from 'preact/hooks';
 import {
 	navSectionSignal,
 	currentRoomIdSignal,
@@ -124,6 +125,39 @@ const ROOM_BOTTOM_TABS: TabItem[] = [
 ];
 
 export function BottomTabBar() {
+	const rootRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const el = rootRef.current;
+		if (!el) return;
+
+		const updateHeight = () => {
+			const h = el.offsetHeight;
+			document.documentElement.style.setProperty('--bottom-bar-height', h + 'px');
+		};
+
+		// ResizeObserver fires when the element itself resizes
+		const ro = new ResizeObserver(updateHeight);
+		ro.observe(el);
+
+		// window resize listener handles breakpoint transitions (md:hidden causes
+		// display:none, which ResizeObserver does not fire for).
+		// requestAnimationFrame ensures the browser applies the new display value first.
+		const onResize = () => {
+			requestAnimationFrame(updateHeight);
+		};
+		window.addEventListener('resize', onResize);
+
+		// Initial measurement
+		updateHeight();
+
+		return () => {
+			ro.disconnect();
+			window.removeEventListener('resize', onResize);
+			document.documentElement.style.setProperty('--bottom-bar-height', '0px');
+		};
+	}, []);
+
 	const navSection = navSectionSignal.value;
 	const roomId = currentRoomIdSignal.value;
 	const roomSessionId = currentRoomSessionIdSignal.value;
@@ -186,6 +220,7 @@ export function BottomTabBar() {
 
 	return (
 		<div
+			ref={rootRef}
 			class="flex md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark-900/90 backdrop-blur-md border-t border-dark-700 pb-safe"
 			role="tablist"
 			aria-label="Main navigation"

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -143,8 +143,11 @@ export function BottomTabBar() {
 		// window resize listener handles breakpoint transitions (md:hidden causes
 		// display:none, which ResizeObserver does not fire for).
 		// requestAnimationFrame ensures the browser applies the new display value first.
+		// The cancelled-rAF guard prevents queuing multiple callbacks during rapid resize.
+		let rafId = 0;
 		const onResize = () => {
-			requestAnimationFrame(updateHeight);
+			cancelAnimationFrame(rafId);
+			rafId = requestAnimationFrame(updateHeight);
 		};
 		window.addEventListener('resize', onResize);
 

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -157,6 +157,7 @@ export function BottomTabBar() {
 		return () => {
 			ro.disconnect();
 			window.removeEventListener('resize', onResize);
+			cancelAnimationFrame(rafId);
 			document.documentElement.style.setProperty('--bottom-bar-height', '0px');
 		};
 	}, []);

--- a/packages/web/src/lib/__tests__/ios-safe-area.test.ts
+++ b/packages/web/src/lib/__tests__/ios-safe-area.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import indexHtml from '../../index.html?raw';
 import appTsx from '../../App.tsx?raw';
 import useViewportSafetyTs from '../../hooks/useViewportSafety.ts?raw';
+import bottomTabBarTsx from '../../islands/BottomTabBar.tsx?raw';
 
 /**
  * iOS iPad Safari safe area support tests.
@@ -32,5 +33,33 @@ describe('iOS iPad Safari safe area support', () => {
 		// that useViewportSafety sets the --safe-height custom property which
 		// is consumed by the .h-safe-screen utility defined in styles.css.
 		expect(useViewportSafetyTs).toContain('--safe-height');
+	});
+
+	it('App.tsx uses pb-bottom-bar utility class for dynamic bottom padding', () => {
+		expect(appTsx).toContain('pb-bottom-bar');
+	});
+
+	it('App.tsx does not use hardcoded pb-16 for main content bottom padding', () => {
+		// The main content div should not have pb-16 — dynamic approach is used instead
+		expect(appTsx).not.toContain('pb-16');
+	});
+
+	it('BottomTabBar sets --bottom-bar-height CSS custom property', () => {
+		expect(bottomTabBarTsx).toContain('--bottom-bar-height');
+	});
+
+	it('BottomTabBar uses ResizeObserver to measure actual height', () => {
+		expect(bottomTabBarTsx).toContain('ResizeObserver');
+	});
+
+	it('BottomTabBar adds a window resize listener for breakpoint transitions', () => {
+		expect(bottomTabBarTsx).toContain("window.addEventListener('resize'");
+	});
+
+	it('BottomTabBar cleans up observers and resets --bottom-bar-height on unmount', () => {
+		expect(bottomTabBarTsx).toContain('ro.disconnect()');
+		expect(bottomTabBarTsx).toContain("window.removeEventListener('resize'");
+		expect(bottomTabBarTsx).toContain('cancelAnimationFrame');
+		expect(bottomTabBarTsx).toContain("'--bottom-bar-height', '0px'");
 	});
 });


### PR DESCRIPTION
Replace hardcoded `pb-16 md:pb-0` on the main content div with a `pb-bottom-bar` utility class driven by the `--bottom-bar-height` CSS custom property.

- `BottomTabBar` gains a `ResizeObserver` on its root `div` to measure actual height and write `--bottom-bar-height` to `document.documentElement`
- A supplementary `window.resize` listener (with `requestAnimationFrame`) handles breakpoint transitions where `md:hidden` flips `display:none` — a case `ResizeObserver` doesn't fire for
- On unmount, resets `--bottom-bar-height` to `0px` and cleans up both listeners
- `App.tsx` uses `pb-bottom-bar` instead of `pb-16 md:pb-0`; the dynamic approach handles desktop (0px) and mobile (actual height) automatically
- 6 new source-level assertions added to `ios-safe-area.test.ts`