### PR TITLE
feat: use h-safe-screen for root layout and overlay panels

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -175,7 +175,7 @@ export function App() {
 
 	return (
 		<>
-			<div class="flex h-dvh overflow-hidden bg-dark-950 relative pt-safe">
+			<div class="flex h-safe-screen overflow-hidden bg-dark-950 relative pt-safe">
 				{/* Navigation Rail (desktop only) */}
 				<NavRail />
 

--- a/packages/web/src/assets.d.ts
+++ b/packages/web/src/assets.d.ts
@@ -15,3 +15,7 @@ declare module '*.tsx?raw' {
 	const content: string;
 	export default content;
 }
+declare module '*.ts?raw' {
+	const content: string;
+	export default content;
+}

--- a/packages/web/src/components/neo/NeoPanel.tsx
+++ b/packages/web/src/components/neo/NeoPanel.tsx
@@ -154,7 +154,7 @@ export function NeoPanel() {
 				aria-modal="true"
 				aria-label="Neo AI assistant"
 				class={[
-					'fixed top-0 left-0 h-dvh pt-safe z-50',
+					'fixed top-0 left-0 h-safe-screen pt-safe z-50',
 					'w-full sm:w-80 md:w-96',
 					'flex flex-col',
 					'bg-gray-900 border-r border-gray-700 shadow-2xl',

--- a/packages/web/src/components/room/SlideOutPanel.tsx
+++ b/packages/web/src/components/room/SlideOutPanel.tsx
@@ -106,7 +106,7 @@ export function SlideOutPanel({
 				aria-modal="true"
 				aria-label={`Session chat for ${displayLabel}`}
 				class={[
-					'fixed top-0 right-0 h-dvh pt-safe z-50',
+					'fixed top-0 right-0 h-safe-screen pt-safe z-50',
 					widthClass,
 					'flex flex-col',
 					'bg-gray-900 border-l border-gray-700 shadow-2xl',

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -355,7 +355,7 @@ export function ContextPanel() {
 				class={`
 					fixed md:relative
 					top-0 left-0 md:left-auto
-					h-dvh md:h-full w-70
+					h-safe-screen md:h-full w-70
 					bg-dark-950 border-r ${borderColors.ui.default}
 					flex flex-col
 					pt-safe md:pt-0

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -604,11 +604,11 @@ describe('ContextPanel', () => {
 			expect(header).toBeTruthy();
 		});
 
-		it('should use h-dvh on mobile and h-full on desktop to respect safe-area boundary', () => {
+		it('should use h-safe-screen on mobile and h-full on desktop to respect safe-area boundary', () => {
 			const { container } = render(<ContextPanel />);
 
 			const panel = container.querySelector('.w-70');
-			expect(panel?.className).toContain('h-dvh');
+			expect(panel?.className).toContain('h-safe-screen');
 			expect(panel?.className).toContain('md:h-full');
 			expect(panel?.className).not.toContain('h-screen');
 		});

--- a/packages/web/src/lib/__tests__/ios-safe-area.test.ts
+++ b/packages/web/src/lib/__tests__/ios-safe-area.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import indexHtml from '../../index.html?raw';
 import appTsx from '../../App.tsx?raw';
+import useViewportSafetyTs from '../../hooks/useViewportSafety.ts?raw';
 
 /**
  * iOS iPad Safari safe area support tests.
@@ -19,5 +20,17 @@ describe('iOS iPad Safari safe area support', () => {
 
 	it('App.tsx applies pt-safe class to the root container for top safe area', () => {
 		expect(appTsx).toContain('pt-safe');
+	});
+
+	it('App.tsx uses h-safe-screen instead of h-dvh for the root container', () => {
+		expect(appTsx).toContain('h-safe-screen');
+		expect(appTsx).not.toContain('h-dvh');
+	});
+
+	it('styles.css defines the .h-safe-screen utility class (verified via hook referencing --safe-height)', () => {
+		// CSS content is stripped in Vite's test environment; instead we verify
+		// that useViewportSafety sets the --safe-height custom property which
+		// is consumed by the .h-safe-screen utility defined in styles.css.
+		expect(useViewportSafetyTs).toContain('--safe-height');
 	});
 });


### PR DESCRIPTION
Replace `h-dvh` with `h-safe-screen` in App.tsx, NeoPanel, SlideOutPanel, and ContextPanel so the height falls back to the `--safe-height` CSS custom property set by `useViewportSafety` on iPad Safari. ContextPanel keeps its `md:h-full` responsive modifier. `pt-safe` is preserved on the root container for notched devices.

Tests updated: ios-safe-area assertions now check for `h-safe-screen` and verify the `useViewportSafety` hook sets `--safe-height`; ContextPanel test updated to expect `h-safe-screen` instead of `h-dvh`.