### PR TITLE
feat: invalidate in-progress planning on goal title/description update

### DIFF
--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -206,6 +206,57 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				updated = await goalManager.updateGoalStatus(args.goal_id, args.status);
 			}
 
+			// Invalidate in-progress planning when title or description changes
+			if (args.title !== undefined || args.description !== undefined) {
+				const nonTerminalStatuses = new Set([
+					'pending',
+					'in_progress',
+					'draft',
+					'review',
+					'rate_limited',
+					'usage_limited',
+				]);
+
+				const runtime = runtimeService?.getRuntime(roomId) ?? null;
+
+				// Find and cancel any in-progress planning tasks linked to this goal
+				for (const taskId of goal.linkedTaskIds) {
+					const task = await taskManager.getTask(taskId);
+					if (!task || task.taskType !== 'planning' || !nonTerminalStatuses.has(task.status))
+						continue;
+
+					if (runtime) {
+						await runtime.cancelTask(taskId);
+					} else {
+						await taskManager.cancelTaskCascade(taskId);
+						if (daemonHub) {
+							const cancelledTask = await taskManager.getTask(taskId);
+							if (cancelledTask) {
+								void daemonHub.emit('room.task.update', {
+									sessionId: `room:${roomId}`,
+									roomId,
+									task: cancelledTask,
+								});
+							}
+						}
+					}
+				}
+
+				// Reset planning_attempts so a fresh planner picks up the updated context
+				updated = await goalManager.patchGoal(args.goal_id, { planning_attempts: 0 });
+
+				// If the goal is stuck in needs_human, transition it back to active so it's
+				// eligible for replanning (getNextGoalForPlanning only iterates 'active' goals)
+				if (updated.status === 'needs_human') {
+					updated = await goalManager.updateGoalStatus(args.goal_id, 'active');
+				}
+
+				// Trigger a fresh planning tick if runtime is available
+				if (runtime) {
+					runtime.onGoalCreated(args.goal_id);
+				}
+			}
+
 			return jsonResult({ success: true, goal: updated });
 		},
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -229,6 +229,22 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					if (runtime) {
 						await runtime.cancelTask(taskId);
 					} else {
+						// Fallback path: no runtime available.
+						// Guard: if the task has an active session group we cannot safely cancel it
+						// without the runtime — the DB row would be updated but the agent sessions
+						// would keep running (same guard as reset_goal / cancel_task).
+						if (task.status === 'in_progress' || task.status === 'review') {
+							const activeGroup = groupRepo.getGroupByTaskId(taskId);
+							if (activeGroup && activeGroup.completedAt === null) {
+								return jsonResult({
+									success: false,
+									error:
+										`Cannot invalidate planning for goal ${args.goal_id}: planning task ${taskId} (status '${task.status}') has an active session group but no runtime service is available to stop it. ` +
+										`The active planner session would not be stopped.`,
+								});
+							}
+						}
+
 						await taskManager.cancelTaskCascade(taskId);
 						if (daemonHub) {
 							const cancelledTask = await taskManager.getTask(taskId);
@@ -250,8 +266,10 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				}
 
 				// If the goal is stuck in needs_human, transition it back to active so it's
-				// eligible for replanning (getNextGoalForPlanning only iterates 'active' goals)
-				if (updated.status === 'needs_human') {
+				// eligible for replanning (getNextGoalForPlanning only iterates 'active' goals).
+				// Only auto-transition when the caller did not explicitly set a status in this
+				// same call — an explicit status instruction takes precedence.
+				if (args.status === undefined && updated.status === 'needs_human') {
 					updated = await goalManager.updateGoalStatus(args.goal_id, 'active');
 				}
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -49,6 +49,16 @@ function jsonResult(data: Record<string, unknown>): ToolResult {
 	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
 }
 
+/** Task statuses that are not yet terminal and should be cancelled when resetting/invalidating goals. */
+const NON_TERMINAL_TASK_STATUSES = new Set([
+	'pending',
+	'in_progress',
+	'draft',
+	'review',
+	'rate_limited',
+	'usage_limited',
+]);
+
 /**
  * Create tool handler functions that can be tested directly.
  * Returns a map of tool name -> handler function.
@@ -208,21 +218,12 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 
 			// Invalidate in-progress planning when title or description changes
 			if (args.title !== undefined || args.description !== undefined) {
-				const nonTerminalStatuses = new Set([
-					'pending',
-					'in_progress',
-					'draft',
-					'review',
-					'rate_limited',
-					'usage_limited',
-				]);
-
 				const runtime = runtimeService?.getRuntime(roomId) ?? null;
 
 				// Find and cancel any in-progress planning tasks linked to this goal
 				for (const taskId of goal.linkedTaskIds) {
 					const task = await taskManager.getTask(taskId);
-					if (!task || task.taskType !== 'planning' || !nonTerminalStatuses.has(task.status))
+					if (!task || task.taskType !== 'planning' || !NON_TERMINAL_TASK_STATUSES.has(task.status))
 						continue;
 
 					if (runtime) {
@@ -242,8 +243,11 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					}
 				}
 
-				// Reset planning_attempts so a fresh planner picks up the updated context
-				updated = await goalManager.patchGoal(args.goal_id, { planning_attempts: 0 });
+				// Reset planning_attempts so a fresh planner picks up the updated context.
+				// Skip if the caller explicitly provided planning_attempts — their value takes precedence.
+				if (args.planning_attempts === undefined) {
+					updated = await goalManager.patchGoal(args.goal_id, { planning_attempts: 0 });
+				}
 
 				// If the goal is stuck in needs_human, transition it back to active so it's
 				// eligible for replanning (getNextGoalForPlanning only iterates 'active' goals)
@@ -1064,23 +1068,13 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
 			}
 
-			// Non-terminal task statuses — tasks in these states should be cancelled before reset
-			const nonTerminalStatuses = new Set([
-				'pending',
-				'in_progress',
-				'draft',
-				'review',
-				'rate_limited',
-				'usage_limited',
-			]);
-
 			// Hoist the runtime lookup so it isn't repeated on every loop iteration
 			const runtime = runtimeService?.getRuntime(roomId) ?? null;
 
 			// Cancel all in-progress linked tasks
 			for (const taskId of goal.linkedTaskIds) {
 				const task = await taskManager.getTask(taskId);
-				if (!task || !nonTerminalStatuses.has(task.status)) continue;
+				if (!task || !NON_TERMINAL_TASK_STATUSES.has(task.status)) continue;
 
 				if (runtime) {
 					await runtime.cancelTask(taskId);

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -180,6 +180,34 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 
 			let updated = goal;
 
+			// Pre-scan: if title/description is changing and runtime is unavailable, check for
+			// blocked planning tasks BEFORE any DB writes so we fail atomically.
+			if (args.title !== undefined || args.description !== undefined) {
+				const runtime = runtimeService?.getRuntime(roomId) ?? null;
+				if (!runtime) {
+					for (const taskId of goal.linkedTaskIds) {
+						const task = await taskManager.getTask(taskId);
+						if (
+							!task ||
+							task.taskType !== 'planning' ||
+							!NON_TERMINAL_TASK_STATUSES.has(task.status)
+						)
+							continue;
+						if (task.status === 'in_progress' || task.status === 'review') {
+							const activeGroup = groupRepo.getGroupByTaskId(taskId);
+							if (activeGroup && activeGroup.completedAt === null) {
+								return jsonResult({
+									success: false,
+									error:
+										`Cannot invalidate planning for goal ${args.goal_id}: planning task ${taskId} (status '${task.status}') has an active session group but no runtime service is available to stop it. ` +
+										`The active planner session would not be stopped.`,
+								});
+							}
+						}
+					}
+				}
+			}
+
 			// Collect patch fields: title, description, priority, missionType, autonomyLevel, planning_attempts, structuredMetrics
 			const hasPatchFields =
 				args.title !== undefined ||
@@ -230,21 +258,8 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 						await runtime.cancelTask(taskId);
 					} else {
 						// Fallback path: no runtime available.
-						// Guard: if the task has an active session group we cannot safely cancel it
-						// without the runtime — the DB row would be updated but the agent sessions
-						// would keep running (same guard as reset_goal / cancel_task).
-						if (task.status === 'in_progress' || task.status === 'review') {
-							const activeGroup = groupRepo.getGroupByTaskId(taskId);
-							if (activeGroup && activeGroup.completedAt === null) {
-								return jsonResult({
-									success: false,
-									error:
-										`Cannot invalidate planning for goal ${args.goal_id}: planning task ${taskId} (status '${task.status}') has an active session group but no runtime service is available to stop it. ` +
-										`The active planner session would not be stopped.`,
-								});
-							}
-						}
-
+						// The pre-scan above already rejected any blocked in_progress/review tasks,
+						// so it is safe to cancel here without an additional session-group check.
 						await taskManager.cancelTaskCascade(taskId);
 						if (daemonHub) {
 							const cancelledTask = await taskManager.getTask(taskId);

--- a/packages/daemon/tests/unit/room/room-agent-tools-goal.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools-goal.test.ts
@@ -712,5 +712,44 @@ describe('Room Agent Tools - reset_goal and planning_attempts', () => {
 			const planTask = await taskManager.getTask(planTaskId);
 			expect(planTask?.status).toBe('completed');
 		});
+
+		it('should respect explicit planning_attempts when provided alongside title change', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			db.run('UPDATE goals SET planning_attempts = 3 WHERE id = ?', [goalId]);
+
+			// Caller explicitly sets planning_attempts = 5 alongside a title change
+			const result = parseResult(
+				await handlers.update_goal({ goal_id: goalId, title: 'New Title', planning_attempts: 5 })
+			);
+			expect(result.success).toBe(true);
+
+			// The explicit value (5) should win — the auto-reset to 0 is skipped
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.planning_attempts).toBe(5);
+		});
+
+		it('should transition status back to active even when explicit status: needs_human is also provided', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			// Caller sets status to needs_human AND changes the title in the same call.
+			// The invalidation block runs after the status update, so it should detect
+			// needs_human and transition back to active.
+			const result = parseResult(
+				await handlers.update_goal({
+					goal_id: goalId,
+					title: 'Updated Title',
+					status: 'needs_human',
+				})
+			);
+			expect(result.success).toBe(true);
+
+			// Invalidation should have overridden the needs_human status back to active
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.status).toBe('active');
+			expect(goal.planning_attempts).toBe(0);
+		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-agent-tools-goal.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools-goal.test.ts
@@ -510,4 +510,207 @@ describe('Room Agent Tools - reset_goal and planning_attempts', () => {
 			expect(Object.keys(registeredTools)).not.toContain('reset_goal');
 		});
 	});
+
+	// -------------------------------------------------------------------------
+	// update_goal: title/description change invalidates in-progress planning
+	// -------------------------------------------------------------------------
+
+	describe('update_goal: invalidate in-progress planning on title/description change', () => {
+		/** Helper: create a planning task and link it to a goal via DB (task_type = 'planning'). */
+		async function createPlanningTask(goalId: string, status: string = 'pending') {
+			// Insert a planning task directly (task_type 'planning' is blocked via handler,
+			// but can be created directly in the DB for test purposes)
+			const taskId = `planning-task-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			db.run(
+				`INSERT INTO tasks (id, room_id, title, description, status, priority, task_type, assigned_agent, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				[
+					taskId,
+					roomId,
+					'Planning Task',
+					'auto-generated planning',
+					status,
+					'normal',
+					'planning',
+					'planner',
+					Date.now(),
+					Date.now(),
+				]
+			);
+			// Link to goal
+			await goalManager.linkTaskToGoal(goalId, taskId);
+			return taskId;
+		}
+
+		it('should cancel in-progress planning task and reset planning_attempts when title changes', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Original Title' }));
+			const goalId = goalResult.goalId as string;
+
+			// Set planning_attempts to a non-zero value
+			db.run('UPDATE goals SET planning_attempts = 3 WHERE id = ?', [goalId]);
+
+			// Create a pending planning task
+			const planTaskId = await createPlanningTask(goalId, 'pending');
+
+			// Update the title
+			const result = parseResult(
+				await handlers.update_goal({ goal_id: goalId, title: 'Updated Title' })
+			);
+			expect(result.success).toBe(true);
+
+			// Planning task should be cancelled
+			const planTask = await taskManager.getTask(planTaskId);
+			expect(planTask?.status).toBe('cancelled');
+
+			// planning_attempts should be reset to 0
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.planning_attempts).toBe(0);
+		});
+
+		it('should cancel in-progress planning task and reset planning_attempts when description changes', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			db.run('UPDATE goals SET planning_attempts = 2 WHERE id = ?', [goalId]);
+
+			const planTaskId = await createPlanningTask(goalId, 'in_progress');
+
+			const result = parseResult(
+				await handlers.update_goal({ goal_id: goalId, description: 'New description' })
+			);
+			expect(result.success).toBe(true);
+
+			const planTask = await taskManager.getTask(planTaskId);
+			expect(planTask?.status).toBe('cancelled');
+
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.planning_attempts).toBe(0);
+		});
+
+		it('should NOT cancel planning tasks when only priority is updated', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			db.run('UPDATE goals SET planning_attempts = 2 WHERE id = ?', [goalId]);
+
+			const planTaskId = await createPlanningTask(goalId, 'pending');
+
+			const result = parseResult(await handlers.update_goal({ goal_id: goalId, priority: 'high' }));
+			expect(result.success).toBe(true);
+
+			// Planning task should still be pending (not cancelled)
+			const planTask = await taskManager.getTask(planTaskId);
+			expect(planTask?.status).toBe('pending');
+
+			// planning_attempts should remain unchanged
+			const rawGoal = db.query('SELECT planning_attempts FROM goals WHERE id = ?').get(goalId) as {
+				planning_attempts: number;
+			};
+			expect(rawGoal.planning_attempts).toBe(2);
+		});
+
+		it('should do nothing when no planning tasks are in progress', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			db.run('UPDATE goals SET planning_attempts = 1 WHERE id = ?', [goalId]);
+
+			// No planning tasks linked — just update title
+			const result = parseResult(
+				await handlers.update_goal({ goal_id: goalId, title: 'New Title' })
+			);
+			expect(result.success).toBe(true);
+
+			// planning_attempts should still be reset to 0
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.planning_attempts).toBe(0);
+		});
+
+		it('should transition needs_human goal to active when title/description changes', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Stuck Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			// Move goal to needs_human status (simulates planner hitting max attempts)
+			await goalManager.updateGoalStatus(goalId, 'needs_human');
+
+			const result = parseResult(
+				await handlers.update_goal({ goal_id: goalId, description: 'Clarified description' })
+			);
+			expect(result.success).toBe(true);
+
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.status).toBe('active');
+			expect(goal.planning_attempts).toBe(0);
+		});
+
+		it('should leave an active goal as active when title/description changes', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Active Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			// Goal is active by default
+			const result = parseResult(
+				await handlers.update_goal({ goal_id: goalId, title: 'New Title' })
+			);
+			expect(result.success).toBe(true);
+
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.status).toBe('active');
+		});
+
+		it('should call runtime.cancelTask and runtime.onGoalCreated when runtime is available', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Runtime Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			const planTaskId = await createPlanningTask(goalId, 'pending');
+
+			const cancelledIds: string[] = [];
+			const onGoalCreatedIds: string[] = [];
+			const mockRuntime = {
+				cancelTask: async (taskId: string) => {
+					cancelledIds.push(taskId);
+					await taskManager.setTaskStatus(taskId, 'cancelled');
+					return { success: true, cancelledTaskIds: [taskId] };
+				},
+				onGoalCreated: (gId: string) => {
+					onGoalCreatedIds.push(gId);
+				},
+			};
+			const runtimeService = { getRuntime: (_roomId: string) => mockRuntime as never };
+
+			const handlersWithRuntime = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService,
+			});
+
+			const result = parseResult(
+				await handlersWithRuntime.update_goal({ goal_id: goalId, title: 'Updated' })
+			);
+			expect(result.success).toBe(true);
+
+			// runtime.cancelTask should have been called for the planning task
+			expect(cancelledIds).toContain(planTaskId);
+
+			// runtime.onGoalCreated should have been triggered
+			expect(onGoalCreatedIds).toContain(goalId);
+		});
+
+		it('should NOT cancel terminal-status planning tasks', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			// Create a completed planning task (terminal — should not be cancelled again)
+			const planTaskId = await createPlanningTask(goalId, 'completed');
+
+			const result = parseResult(
+				await handlers.update_goal({ goal_id: goalId, title: 'New Title' })
+			);
+			expect(result.success).toBe(true);
+
+			const planTask = await taskManager.getTask(planTaskId);
+			expect(planTask?.status).toBe('completed');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/room/room-agent-tools-goal.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools-goal.test.ts
@@ -768,9 +768,13 @@ describe('Room Agent Tools - reset_goal and planning_attempts', () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toMatch(/active session group/i);
 
-			// Planning task and goal should be unchanged
+			// Planning task should be unchanged
 			const planTask = await taskManager.getTask(planTaskId);
 			expect(planTask?.status).toBe('in_progress');
+
+			// Goal title must NOT have been mutated — the update was rejected before any DB write
+			const goalAfter = await goalManager.getGoal(goalId);
+			expect(goalAfter?.title).toBe('Goal');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-agent-tools-goal.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools-goal.test.ts
@@ -730,13 +730,12 @@ describe('Room Agent Tools - reset_goal and planning_attempts', () => {
 			expect(goal.planning_attempts).toBe(5);
 		});
 
-		it('should transition status back to active even when explicit status: needs_human is also provided', async () => {
+		it('should respect explicit status:needs_human when title/description also changes', async () => {
 			const goalResult = parseResult(await handlers.create_goal({ title: 'Goal' }));
 			const goalId = goalResult.goalId as string;
 
-			// Caller sets status to needs_human AND changes the title in the same call.
-			// The invalidation block runs after the status update, so it should detect
-			// needs_human and transition back to active.
+			// Caller explicitly sets status to needs_human AND changes the title in the same call.
+			// The explicit status instruction takes precedence — invalidation should NOT override it.
 			const result = parseResult(
 				await handlers.update_goal({
 					goal_id: goalId,
@@ -746,10 +745,32 @@ describe('Room Agent Tools - reset_goal and planning_attempts', () => {
 			);
 			expect(result.success).toBe(true);
 
-			// Invalidation should have overridden the needs_human status back to active
+			// Explicit status wins — should remain needs_human
 			const goal = result.goal as Record<string, unknown>;
-			expect(goal.status).toBe('active');
+			expect(goal.status).toBe('needs_human');
+			// planning_attempts still reset since no explicit planning_attempts was provided
 			expect(goal.planning_attempts).toBe(0);
+		});
+
+		it('should return error when in_progress planning task has active session group and no runtime', async () => {
+			const goalResult = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = goalResult.goalId as string;
+
+			const planTaskId = await createPlanningTask(goalId, 'in_progress');
+
+			// Insert an active session group for the planning task (simulates running planner)
+			insertActiveGroup(planTaskId);
+
+			// Without runtime, should refuse to cancel a planning task with an active session group
+			const result = parseResult(
+				await handlers.update_goal({ goal_id: goalId, title: 'New Title' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/active session group/i);
+
+			// Planning task and goal should be unchanged
+			const planTask = await taskManager.getTask(planTaskId);
+			expect(planTask?.status).toBe('in_progress');
 		});
 	});
 });


### PR DESCRIPTION
When `update_goal` changes `title` or `description`, auto-cancel any in-progress planning tasks linked to the goal, reset `planning_attempts` to 0, and transition `needs_human` goals back to `active` so they become eligible for replanning. Calls `runtime.onGoalCreated()` to trigger a fresh planning tick.

- Non-title/description updates (e.g. priority) do not trigger invalidation
- 8 new unit tests covering all scenarios including the `needs_human`→`active` transition