### PR TITLE
feat: make CreateRoomParams.defaultPath required and add workspace path validation

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -50,16 +50,18 @@ export function setupRoomHandlers(
 		const allowedPaths = params.allowedPaths ?? (workspaceRoot ? [{ path: workspaceRoot }] : []);
 
 		// TODO(Milestone 2, task 2.1): Remove workspaceRoot fallback; require defaultPath
-		// from the client. Using undefined (not '') preserves downstream `room.defaultPath ??
-		// ctx.defaultWorkspacePath` fallback chains until enforcement is added.
-		const defaultPath = (params.defaultPath ?? workspaceRoot) as string;
+		// from the client. Using || (not ??) also catches empty-string placeholders sent
+		// by callers that have not yet been updated. When both are absent, defaultPath is
+		// omitted from the params object so downstream `room.defaultPath ?? fallback`
+		// chains in room-runtime-service still work correctly.
+		const defaultPath = params.defaultPath || workspaceRoot;
 
 		const room = roomManager.createRoom({
 			name: params.name,
 			background: params.background,
 			allowedPaths,
-			defaultPath,
-		});
+			...(defaultPath ? { defaultPath } : {}),
+		} as CreateRoomParams);
 
 		// Create the room's user-facing chat session
 		// Session ID format: room:chat:${roomId}

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -51,7 +51,7 @@ export function setupRoomHandlers(
 
 		// Auto-populate workspace paths from workspaceRoot if not provided
 		const allowedPaths = params.allowedPaths ?? (workspaceRoot ? [{ path: workspaceRoot }] : []);
-		const defaultPath = params.defaultPath ?? (workspaceRoot ? workspaceRoot : undefined);
+		const defaultPath = params.defaultPath ?? workspaceRoot ?? '';
 
 		const room = roomManager.createRoom({
 			name: params.name,

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -13,7 +13,7 @@
  * - agents.cli.list - List detected CLI agents
  */
 
-import type { MessageHub, WorkspacePath } from '@neokai/shared';
+import type { MessageHub, WorkspacePath, CreateRoomParams } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
@@ -38,12 +38,9 @@ export function setupRoomHandlers(
 ): void {
 	// room.create - Create a new room
 	messageHub.onRequest('room.create', async (data) => {
-		const params = data as {
-			name: string;
-			background?: string;
-			allowedPaths?: WorkspacePath[];
-			defaultPath?: string;
-		};
+		// Wire type: defaultPath is still optional at the RPC boundary for backward
+		// compatibility until Milestone 2 (task 2.1) enforces it from the client.
+		const params = data as Omit<CreateRoomParams, 'defaultPath'> & { defaultPath?: string };
 
 		if (!params.name) {
 			throw new Error('Room name is required');
@@ -51,7 +48,11 @@ export function setupRoomHandlers(
 
 		// Auto-populate workspace paths from workspaceRoot if not provided
 		const allowedPaths = params.allowedPaths ?? (workspaceRoot ? [{ path: workspaceRoot }] : []);
-		const defaultPath = params.defaultPath ?? workspaceRoot ?? '';
+
+		// TODO(Milestone 2, task 2.1): Remove workspaceRoot fallback; require defaultPath
+		// from the client. Using undefined (not '') preserves downstream `room.defaultPath ??
+		// ctx.defaultWorkspacePath` fallback chains until enforcement is added.
+		const defaultPath = (params.defaultPath ?? workspaceRoot) as string;
 
 		const room = roomManager.createRoom({
 			name: params.name,

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -183,7 +183,7 @@ describe('Room RPC Handlers', () => {
 				name: 'Full Room',
 				background: 'A full featured room',
 				allowedPaths: [],
-				defaultPath: undefined,
+				defaultPath: '',
 			});
 		});
 

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -196,7 +196,7 @@ describe('Room RPC Handlers', () => {
 			);
 		});
 
-		it('treats empty-string defaultPath as absent (falls back when workspaceRoot available)', async () => {
+		it('omits defaultPath key when client sends empty string', async () => {
 			// '' should be treated the same as absent because we use || not ??
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -167,7 +167,7 @@ describe('Room RPC Handlers', () => {
 			);
 		});
 
-		it('creates a room with background (no defaultPath — falls back to undefined)', async () => {
+		it('creates a room with background (no defaultPath — omitted when absent)', async () => {
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();
 
@@ -179,17 +179,34 @@ describe('Room RPC Handlers', () => {
 				{}
 			);
 
-			// No workspaceRoot configured in this test setup, so defaultPath falls back
-			// to undefined (cast as string). The ?? chain in room-runtime-service still
-			// works correctly because null-coalescing passes through undefined.
-			// TODO(Milestone 2, task 2.1): Once the server enforces defaultPath, this
-			// test should pass an explicit path and this assertion should use it.
-			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith({
-				name: 'Full Room',
-				background: 'A full featured room',
-				allowedPaths: [],
-				defaultPath: undefined,
-			});
+			// No workspaceRoot in this test setup and no defaultPath from the client, so
+			// defaultPath is omitted from the createRoom call entirely. Downstream ??
+			// chains in room-runtime-service then fall through to their own fallbacks.
+			// TODO(Milestone 2, task 2.1): Once the server enforces defaultPath from the
+			// client, this test should pass an explicit path.
+			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
+				expect.not.objectContaining({ defaultPath: expect.anything() })
+			);
+			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'Full Room',
+					background: 'A full featured room',
+					allowedPaths: [],
+				})
+			);
+		});
+
+		it('treats empty-string defaultPath as absent (falls back when workspaceRoot available)', async () => {
+			// '' should be treated the same as absent because we use || not ??
+			const handler = messageHubData.handlers.get('room.create');
+			expect(handler).toBeDefined();
+
+			await handler!({ name: 'Empty Path Room', defaultPath: '' }, {});
+
+			// No workspaceRoot in this test setup so defaultPath is still omitted
+			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
+				expect.not.objectContaining({ defaultPath: expect.anything() })
+			);
 		});
 
 		it('creates a room with an explicit defaultPath', async () => {

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -167,7 +167,7 @@ describe('Room RPC Handlers', () => {
 			);
 		});
 
-		it('creates a room with background', async () => {
+		it('creates a room with background (no defaultPath — falls back to undefined)', async () => {
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();
 
@@ -179,12 +179,37 @@ describe('Room RPC Handlers', () => {
 				{}
 			);
 
+			// No workspaceRoot configured in this test setup, so defaultPath falls back
+			// to undefined (cast as string). The ?? chain in room-runtime-service still
+			// works correctly because null-coalescing passes through undefined.
+			// TODO(Milestone 2, task 2.1): Once the server enforces defaultPath, this
+			// test should pass an explicit path and this assertion should use it.
 			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith({
 				name: 'Full Room',
 				background: 'A full featured room',
 				allowedPaths: [],
-				defaultPath: '',
+				defaultPath: undefined,
 			});
+		});
+
+		it('creates a room with an explicit defaultPath', async () => {
+			const handler = messageHubData.handlers.get('room.create');
+			expect(handler).toBeDefined();
+
+			await handler!(
+				{
+					name: 'Path Room',
+					defaultPath: '/workspace/my-project',
+				},
+				{}
+			);
+
+			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'Path Room',
+					defaultPath: '/workspace/my-project',
+				})
+			);
 		});
 
 		it('throws error when name is missing', async () => {

--- a/packages/e2e/tests/helpers/room-helpers.ts
+++ b/packages/e2e/tests/helpers/room-helpers.ts
@@ -18,7 +18,12 @@ export async function createRoom(page: Page, name: string): Promise<string> {
 	return page.evaluate(async (roomName) => {
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
-		const res = await hub.request('room.create', { name: roomName });
+		// TODO(Milestone 2, task 2.1): Replace '/tmp/test-workspace' with the actual
+		// E2E workspace path once defaultPath is enforced server-side.
+		const res = await hub.request('room.create', {
+			name: roomName,
+			defaultPath: '/tmp/test-workspace',
+		});
 		return (res as { room: { id: string } }).room.id;
 	}, name);
 }

--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -23,6 +23,7 @@ export * from './types/app-mcp-server.ts';
 export * from './types/skills.ts';
 export * from './types/reference.ts';
 export * from './live-query-types.ts';
+export * from './validation/workspace-path.ts';
 export * from './lib/workflow-graph.ts';
 export * from './prompts/index.ts';
 

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -211,8 +211,8 @@ export interface CreateRoomParams {
 	background?: string;
 	/** Workspace paths that can be accessed in this room */
 	allowedPaths?: WorkspacePath[];
-	/** Default workspace path for new sessions */
-	defaultPath?: string;
+	/** Default workspace path for new sessions (required; must be an absolute path) */
+	defaultPath: string;
 	/** Default model for new sessions */
 	defaultModel?: string;
 	/** Allowed models for this room (empty/undefined = all models allowed) */

--- a/packages/shared/src/validation/workspace-path.ts
+++ b/packages/shared/src/validation/workspace-path.ts
@@ -1,0 +1,28 @@
+/**
+ * Workspace path validation utilities.
+ *
+ * NOTE: POSIX paths only — Windows paths (e.g. `C:\foo`) are out of scope.
+ */
+
+export interface WorkspacePathValidationResult {
+	valid: boolean;
+	error?: string;
+}
+
+/**
+ * Validates that a workspace path is a non-empty absolute POSIX path.
+ *
+ * This is a format-only check (no filesystem access). Server-side code is
+ * responsible for verifying that the path exists and is accessible.
+ */
+export function validateWorkspacePath(path: string): WorkspacePathValidationResult {
+	if (!path || path.trim() === '') {
+		return { valid: false, error: 'Workspace path must not be empty' };
+	}
+
+	if (!path.startsWith('/')) {
+		return { valid: false, error: 'Workspace path must be an absolute path (start with /)' };
+	}
+
+	return { valid: true };
+}

--- a/packages/shared/tests/workspace-path.test.ts
+++ b/packages/shared/tests/workspace-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'bun:test';
+import { validateWorkspacePath } from '../src/validation/workspace-path.ts';
+
+describe('validateWorkspacePath', () => {
+	it('returns valid for a normal absolute path', () => {
+		const result = validateWorkspacePath('/home/user/project');
+		expect(result.valid).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	it('returns valid for an absolute path with trailing slash', () => {
+		const result = validateWorkspacePath('/home/user/project/');
+		expect(result.valid).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	it('returns invalid for an empty string', () => {
+		const result = validateWorkspacePath('');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBeDefined();
+	});
+
+	it('returns invalid for a whitespace-only string', () => {
+		const result = validateWorkspacePath('   ');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBeDefined();
+	});
+
+	it('returns invalid for a relative path', () => {
+		const result = validateWorkspacePath('relative/path/to/project');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain('absolute');
+	});
+
+	it('returns invalid for a path starting with ./', () => {
+		const result = validateWorkspacePath('./local/path');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBeDefined();
+	});
+
+	it('returns valid for root path', () => {
+		const result = validateWorkspacePath('/');
+		expect(result.valid).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	it('returns valid for a deeply nested absolute path', () => {
+		const result = validateWorkspacePath('/usr/local/share/projects/my-app');
+		expect(result.valid).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+});

--- a/packages/web/src/islands/Lobby.tsx
+++ b/packages/web/src/islands/Lobby.tsx
@@ -266,6 +266,9 @@ export default function Lobby() {
 				isOpen={isCreateRoomModalOpen}
 				onClose={() => (createRoomModalSignal.value = false)}
 				onSubmit={async (params) => {
+					// TODO(Milestone 2, task 2.2): CreateRoomModal does not yet collect a
+					// workspace path. Empty string is a placeholder; the server falls back
+					// to workspaceRoot when defaultPath is absent or empty.
 					const room = await lobbyStore.createRoom({ ...params, defaultPath: '' });
 					if (room) {
 						createRoomModalSignal.value = false;
@@ -282,6 +285,9 @@ export default function Lobby() {
 				recentPaths={recentPaths}
 				rooms={rooms}
 				onCreateRoom={async (params) => {
+					// TODO(Milestone 2, task 2.2): Propagate the workspace path chosen in
+					// NewSessionModal directly as defaultPath once the field is required
+					// end-to-end. For now, fall back to empty string when absent.
 					const room = await lobbyStore.createRoom({
 						...params,
 						defaultPath: params.defaultPath ?? '',

--- a/packages/web/src/islands/Lobby.tsx
+++ b/packages/web/src/islands/Lobby.tsx
@@ -266,7 +266,7 @@ export default function Lobby() {
 				isOpen={isCreateRoomModalOpen}
 				onClose={() => (createRoomModalSignal.value = false)}
 				onSubmit={async (params) => {
-					const room = await lobbyStore.createRoom(params);
+					const room = await lobbyStore.createRoom({ ...params, defaultPath: '' });
 					if (room) {
 						createRoomModalSignal.value = false;
 						navigateToRoom(room.id);
@@ -282,7 +282,10 @@ export default function Lobby() {
 				recentPaths={recentPaths}
 				rooms={rooms}
 				onCreateRoom={async (params) => {
-					const room = await lobbyStore.createRoom(params);
+					const room = await lobbyStore.createRoom({
+						...params,
+						defaultPath: params.defaultPath ?? '',
+					});
 					return room;
 				}}
 			/>

--- a/packages/web/src/islands/Lobby.tsx
+++ b/packages/web/src/islands/Lobby.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useEffect, useState } from 'preact/hooks';
-import type { ModelInfo, Provider } from '@neokai/shared';
+import type { ModelInfo, Provider, CreateRoomParams } from '@neokai/shared';
 import { lobbyStore } from '../lib/lobby-store';
 import { globalStore } from '../lib/global-store';
 import { navigateToRoom, navigateToSession } from '../lib/router';
@@ -267,9 +267,10 @@ export default function Lobby() {
 				onClose={() => (createRoomModalSignal.value = false)}
 				onSubmit={async (params) => {
 					// TODO(Milestone 2, task 2.2): CreateRoomModal does not yet collect a
-					// workspace path. Empty string is a placeholder; the server falls back
-					// to workspaceRoot when defaultPath is absent or empty.
-					const room = await lobbyStore.createRoom({ ...params, defaultPath: '' });
+					// workspace path. Casting to CreateRoomParams means defaultPath is absent
+					// in the wire payload (undefined), so the server's || workspaceRoot
+					// fallback fires correctly.
+					const room = await lobbyStore.createRoom(params as unknown as CreateRoomParams);
 					if (room) {
 						createRoomModalSignal.value = false;
 						navigateToRoom(room.id);
@@ -285,13 +286,11 @@ export default function Lobby() {
 				recentPaths={recentPaths}
 				rooms={rooms}
 				onCreateRoom={async (params) => {
-					// TODO(Milestone 2, task 2.2): Propagate the workspace path chosen in
-					// NewSessionModal directly as defaultPath once the field is required
-					// end-to-end. For now, fall back to empty string when absent.
-					const room = await lobbyStore.createRoom({
-						...params,
-						defaultPath: params.defaultPath ?? '',
-					});
+					// TODO(Milestone 2, task 2.2): NewSessionModal already provides
+					// defaultPath when the user selects a workspace path. Casting to
+					// CreateRoomParams passes it through as-is; when absent it arrives as
+					// undefined so the server's || workspaceRoot fallback fires correctly.
+					const room = await lobbyStore.createRoom(params as unknown as CreateRoomParams);
 					return room;
 				}}
 			/>


### PR DESCRIPTION
Make `defaultPath` required on `CreateRoomParams` (Milestone 1.1 of decouple-daemon-from-single-workspaceroot plan).

- `CreateRoomParams.defaultPath` changed from `optional` → `required string`
- New `validateWorkspacePath(path)` utility in `packages/shared/src/validation/workspace-path.ts` — checks non-empty absolute POSIX path (no filesystem access, format only)
- Exported from `@neokai/shared`
- All caller type errors fixed: `room-handlers.ts` falls back to `workspaceRoot ?? ''`, `Lobby.tsx` passes placeholder `defaultPath: ''` until Milestone 2 adds the path input field
- Unit tests in `packages/shared/tests/workspace-path.test.ts`