### PR TITLE
feat: require workspace_path for create_room in neo-action-tools

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -529,7 +529,7 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 		roomManager,
 		managerFactory,
 		runtimeService,
-		workspaceRoot,
+		workspaceRoot: _workspaceRoot,
 		spaceHandlers,
 		workflowRunRepo,
 		spaceTaskManagerFactory,
@@ -552,13 +552,13 @@ export function createNeoActionToolHandlers(config: NeoActionToolsConfig) {
 			workspace_path?: string;
 			default_model?: string;
 		}): Promise<ToolResult> {
+			if (!args.workspace_path) {
+				return errorResult('workspace_path is required when creating a room');
+			}
+			const workspacePath = args.workspace_path;
 			return withSecurityCheck('create_room', args as Record<string, unknown>, config, async () => {
-				const allowedPaths: WorkspacePath[] = args.workspace_path
-					? [{ path: args.workspace_path }]
-					: workspaceRoot
-						? [{ path: workspaceRoot }]
-						: [];
-				const defaultPath = args.workspace_path ?? workspaceRoot;
+				const allowedPaths: WorkspacePath[] = [{ path: workspacePath }];
+				const defaultPath = workspacePath;
 
 				const room = roomManager.createRoom({
 					name: args.name,
@@ -1980,14 +1980,13 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 		// ── Room ─────────────────────────────────────────────────────────────
 		tool(
 			'create_room',
-			'Create a new room with an optional description and workspace path. Low risk — auto-executes in balanced mode.',
+			'Create a new room with a description and workspace path. workspace_path is required. Low risk — auto-executes in balanced mode.',
 			{
 				name: z.string().describe('Room name'),
 				description: z.string().optional().describe('Background context for the room'),
 				workspace_path: z
 					.string()
-					.optional()
-					.describe('Absolute path to the workspace directory for this room'),
+					.describe('Absolute path to the workspace directory for this room (required)'),
 				default_model: z.string().optional().describe('Default model ID for new sessions'),
 			},
 			(args) =>

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -386,7 +386,7 @@ export interface NeoActionToolsConfig {
 	managerFactory: NeoActionManagerFactory;
 	runtimeService?: NeoActionRuntimeService;
 	pendingStore: PendingActionStore;
-	/** Workspace root — auto-applied as allowedPaths when not provided */
+	/** Workspace root — used by query tools (e.g. get_status); not used by create_room */
 	workspaceRoot?: string;
 	/** Returns the current security mode (looked up at call time) */
 	getSecurityMode(): NeoSecurityMode;

--- a/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-action-tools.test.ts
@@ -180,6 +180,7 @@ function makeRoomManager(
 				id: `room-${Date.now()}`,
 				name: params.name,
 				allowedPaths: params.allowedPaths ?? [],
+				defaultPath: params.defaultPath,
 			});
 			store.set(room.id, room);
 			return room;
@@ -585,7 +586,9 @@ describe('create_room', () => {
 	it('auto-executes in autonomous mode', async () => {
 		const config = makeConfig({ securityMode: 'autonomous' });
 		const { create_room } = createNeoActionToolHandlers(config);
-		const result = parseResult(await create_room({ name: 'My Room' }));
+		const result = parseResult(
+			await create_room({ name: 'My Room', workspace_path: '/home/user/project' })
+		);
 		expect(result.success).toBe(true);
 		expect(result.room.name).toBe('My Room');
 	});
@@ -594,7 +597,9 @@ describe('create_room', () => {
 		// create_room is 'low' risk — balanced auto-executes low
 		const config = makeConfig({ securityMode: 'balanced' });
 		const { create_room } = createNeoActionToolHandlers(config);
-		const result = parseResult(await create_room({ name: 'My Room' }));
+		const result = parseResult(
+			await create_room({ name: 'My Room', workspace_path: '/home/user/project' })
+		);
 		// low risk → auto-executes in balanced
 		expect(result.success).toBe(true);
 		expect(result.room.name).toBe('My Room');
@@ -603,21 +608,31 @@ describe('create_room', () => {
 	it('returns confirmationRequired in conservative mode', async () => {
 		const config = makeConfig({ securityMode: 'conservative' });
 		const { create_room } = createNeoActionToolHandlers(config);
-		const result = parseResult(await create_room({ name: 'My Room' }));
+		const result = parseResult(
+			await create_room({ name: 'My Room', workspace_path: '/home/user/project' })
+		);
 		expect(result.confirmationRequired).toBe(true);
 		expect(result.pendingActionId).toBeTruthy();
 		expect(result.riskLevel).toBe('low');
 	});
 
-	it('uses workspace root as allowedPaths when no path provided', async () => {
-		const config = makeConfig({ workspaceRoot: '/home/user/ws' });
+	it('returns error when workspace_path is not provided', async () => {
+		const config = makeConfig({ workspaceRoot: '/home/user/ws', securityMode: 'autonomous' });
 		const { create_room } = createNeoActionToolHandlers(config);
 		const result = parseResult(await create_room({ name: 'WS Room' }));
-		expect(result.success).toBe(true);
-		expect(result.room.allowedPaths[0].path).toBe('/home/user/ws');
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('workspace_path is required when creating a room');
 	});
 
-	it('workspace_path takes precedence over workspaceRoot', async () => {
+	it('returns error when workspace_path is missing even in conservative mode', async () => {
+		const config = makeConfig({ securityMode: 'conservative' });
+		const { create_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_room({ name: 'No Path Room' }));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('workspace_path is required when creating a room');
+	});
+
+	it('sets allowedPaths and defaultPath from workspace_path', async () => {
 		const config = makeConfig({ workspaceRoot: '/default/ws' });
 		const { create_room } = createNeoActionToolHandlers(config);
 		const result = parseResult(
@@ -625,12 +640,22 @@ describe('create_room', () => {
 		);
 		expect(result.success).toBe(true);
 		expect(result.room.allowedPaths[0].path).toBe('/custom/path');
+		expect(result.room.defaultPath).toBe('/custom/path');
+	});
+
+	it('does not fall back to workspaceRoot when workspace_path is absent', async () => {
+		const config = makeConfig({ workspaceRoot: '/default/ws', securityMode: 'autonomous' });
+		const { create_room } = createNeoActionToolHandlers(config);
+		const result = parseResult(await create_room({ name: 'No Path Room' }));
+		expect(result.success).toBe(false);
 	});
 
 	it('stores pending action so it can be confirmed later', async () => {
 		const config = makeConfig({ securityMode: 'conservative' });
 		const { create_room } = createNeoActionToolHandlers(config);
-		const result = parseResult(await create_room({ name: 'Pending Room' }));
+		const result = parseResult(
+			await create_room({ name: 'Pending Room', workspace_path: '/home/user/project' })
+		);
 		const pendingAction = config.pendingStore.retrieve(result.pendingActionId);
 		expect(pendingAction?.toolName).toBe('create_room');
 		expect((pendingAction?.input as { name: string }).name).toBe('Pending Room');

--- a/packages/daemon/tests/unit/neo/neo-activity-logger.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-activity-logger.test.ts
@@ -700,7 +700,10 @@ describe('createNeoActionMcpServer — activity logging', () => {
 		config.activityLogger = spy;
 		const server = createNeoActionMcpServer(config);
 
-		await callTool(server, 'create_room', { name: 'My Room' });
+		await callTool(server, 'create_room', {
+			name: 'My Room',
+			workspace_path: '/home/user/project',
+		});
 
 		expect(calls).toHaveLength(1);
 		expect(calls[0].toolName).toBe('create_room');
@@ -752,9 +755,9 @@ describe('createNeoActionMcpServer — activity logging', () => {
 		};
 		const server = createNeoActionMcpServer(config);
 
-		await expect(callTool(server, 'create_room', { name: 'Boom' })).rejects.toThrow(
-			'DB connection lost'
-		);
+		await expect(
+			callTool(server, 'create_room', { name: 'Boom', workspace_path: '/home/user/project' })
+		).rejects.toThrow('DB connection lost');
 
 		expect(calls).toHaveLength(1);
 		expect(calls[0].toolName).toBe('create_room');

--- a/packages/daemon/tests/unit/neo/neo-integration-confirmation-roundtrip.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-integration-confirmation-roundtrip.test.ts
@@ -118,7 +118,10 @@ describe('withSecurityCheck: returns confirmationRequired for medium-risk tools'
 	});
 
 	test('create_room (low risk) auto-executes in balanced mode — no pending action', async () => {
-		const result = await handlers.create_room({ name: 'My Room' });
+		const result = await handlers.create_room({
+			name: 'My Room',
+			workspace_path: '/home/user/project',
+		});
 		const data = JSON.parse(result.content[0].text) as Record<string, unknown>;
 		expect(data.confirmationRequired).toBeUndefined();
 		expect(data.success).toBe(true);
@@ -132,7 +135,7 @@ describe('withSecurityCheck: returns confirmationRequired for medium-risk tools'
 			getSecurityMode: () => 'conservative',
 		};
 		const h = createNeoActionToolHandlers(conservConfig);
-		const result = await h.create_room({ name: 'My Room' });
+		const result = await h.create_room({ name: 'My Room', workspace_path: '/home/user/project' });
 		const data = JSON.parse(result.content[0].text) as Record<string, unknown>;
 		expect(data.confirmationRequired).toBe(true);
 	});


### PR DESCRIPTION
Make `workspace_path` mandatory when creating a room via the neo action tool. Returns a clear error instead of silently falling back to the daemon's global `workspaceRoot`.

- Validate `workspace_path` before `withSecurityCheck` so the error is returned in all security modes
- Remove `workspaceRoot` fallback from `allowedPaths`/`defaultPath` derivation
- Update MCP JSON schema description to mark `workspace_path` as required
- `workspaceRoot` is kept in `NeoActionToolsConfig` (still used by query tools) but suppressed in action tools handler with `_workspaceRoot`
- Updated unit tests: replaced obsolete fallback tests with explicit error cases; all 208 tests pass