### PR TITLE
feat: add workspace path field to CreateRoomModal

### DIFF
--- a/packages/web/src/components/lobby/CreateRoomModal.tsx
+++ b/packages/web/src/components/lobby/CreateRoomModal.tsx
@@ -3,12 +3,12 @@
  *
  * Modal form for creating a new room with:
  * - Room name (required)
- * - Workspace path (required)
+ * - Workspace path (required, pre-filled from daemon workspaceRoot)
  * - Background context (optional)
  * - Form validation and error handling
  */
 
-import { useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { validateWorkspacePath } from '@neokai/shared';
 import { systemState } from '../../lib/state';
 import { Modal } from '../ui/Modal';
@@ -27,6 +27,21 @@ export function CreateRoomModal({ isOpen, onClose, onSubmit }: CreateRoomModalPr
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [pathError, setPathError] = useState<string | null>(null);
+
+	// Track whether the user has manually edited the path so we don't overwrite it
+	// when systemState arrives late (WebSocket delivers state after mount).
+	const userEditedPath = useRef(false);
+
+	// Sync workspacePath with daemon workspaceRoot when it first becomes available.
+	// Only updates the field if the user has not yet typed in it.
+	useEffect(() => {
+		const unsub = systemState.subscribe((state) => {
+			if (!userEditedPath.current) {
+				setWorkspacePath(state?.workspaceRoot ?? '');
+			}
+		});
+		return unsub;
+	}, []);
 
 	const handleSubmit = async (e: Event) => {
 		e.preventDefault();
@@ -56,6 +71,7 @@ export function CreateRoomModal({ isOpen, onClose, onSubmit }: CreateRoomModalPr
 			setName('');
 			setBackground('');
 			setWorkspacePath(systemState.value?.workspaceRoot ?? '');
+			userEditedPath.current = false;
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to create room');
 		} finally {
@@ -67,12 +83,14 @@ export function CreateRoomModal({ isOpen, onClose, onSubmit }: CreateRoomModalPr
 		setName('');
 		setBackground('');
 		setWorkspacePath(systemState.value?.workspaceRoot ?? '');
+		userEditedPath.current = false;
 		setError(null);
 		setPathError(null);
 		onClose();
 	};
 
 	const handlePathInput = (value: string) => {
+		userEditedPath.current = true;
 		setWorkspacePath(value);
 		if (pathError) {
 			// Clear inline error as user types
@@ -106,7 +124,9 @@ export function CreateRoomModal({ isOpen, onClose, onSubmit }: CreateRoomModalPr
 				</div>
 
 				<div>
-					<label class="block text-sm font-medium text-gray-300 mb-1.5">Workspace Path</label>
+					<label class="block text-sm font-medium text-gray-300 mb-1.5">
+						Workspace Path <span class="text-red-400">*</span>
+					</label>
 					<p class="text-xs text-gray-500 mb-2">Filesystem path for this room's workspace</p>
 					<input
 						type="text"

--- a/packages/web/src/components/lobby/CreateRoomModal.tsx
+++ b/packages/web/src/components/lobby/CreateRoomModal.tsx
@@ -3,25 +3,30 @@
  *
  * Modal form for creating a new room with:
  * - Room name (required)
+ * - Workspace path (required)
  * - Background context (optional)
  * - Form validation and error handling
  */
 
 import { useState } from 'preact/hooks';
+import { validateWorkspacePath } from '@neokai/shared';
+import { systemState } from '../../lib/state';
 import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 
 interface CreateRoomModalProps {
 	isOpen: boolean;
 	onClose: () => void;
-	onSubmit: (params: { name: string; background?: string }) => Promise<void>;
+	onSubmit: (params: { name: string; background?: string; defaultPath: string }) => Promise<void>;
 }
 
 export function CreateRoomModal({ isOpen, onClose, onSubmit }: CreateRoomModalProps) {
 	const [name, setName] = useState('');
+	const [workspacePath, setWorkspacePath] = useState(() => systemState.value?.workspaceRoot ?? '');
 	const [background, setBackground] = useState('');
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [pathError, setPathError] = useState<string | null>(null);
 
 	const handleSubmit = async (e: Event) => {
 		e.preventDefault();
@@ -30,18 +35,27 @@ export function CreateRoomModal({ isOpen, onClose, onSubmit }: CreateRoomModalPr
 			return;
 		}
 
+		const pathValidation = validateWorkspacePath(workspacePath);
+		if (!pathValidation.valid) {
+			setPathError(pathValidation.error ?? 'Invalid workspace path');
+			return;
+		}
+
 		try {
 			setSubmitting(true);
 			setError(null);
+			setPathError(null);
 
 			await onSubmit({
 				name: name.trim(),
 				background: background.trim() || undefined,
+				defaultPath: workspacePath.trim(),
 			});
 
 			// Reset form on success
 			setName('');
 			setBackground('');
+			setWorkspacePath(systemState.value?.workspaceRoot ?? '');
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to create room');
 		} finally {
@@ -52,8 +66,21 @@ export function CreateRoomModal({ isOpen, onClose, onSubmit }: CreateRoomModalPr
 	const handleClose = () => {
 		setName('');
 		setBackground('');
+		setWorkspacePath(systemState.value?.workspaceRoot ?? '');
 		setError(null);
+		setPathError(null);
 		onClose();
+	};
+
+	const handlePathInput = (value: string) => {
+		setWorkspacePath(value);
+		if (pathError) {
+			// Clear inline error as user types
+			const result = validateWorkspacePath(value);
+			if (result.valid) {
+				setPathError(null);
+			}
+		}
 	};
 
 	return (
@@ -76,6 +103,22 @@ export function CreateRoomModal({ isOpen, onClose, onSubmit }: CreateRoomModalPr
               placeholder-gray-500 focus:outline-none focus:border-blue-500"
 						autoFocus
 					/>
+				</div>
+
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1.5">Workspace Path</label>
+					<p class="text-xs text-gray-500 mb-2">Filesystem path for this room's workspace</p>
+					<input
+						type="text"
+						value={workspacePath}
+						onInput={(e) => handlePathInput((e.target as HTMLInputElement).value)}
+						placeholder="/path/to/workspace"
+						class={`w-full bg-dark-800 border rounded-lg px-4 py-2.5 text-gray-100
+              placeholder-gray-500 focus:outline-none focus:border-blue-500 ${
+								pathError ? 'border-red-700' : 'border-dark-700'
+							}`}
+					/>
+					{pathError && <p class="mt-1 text-xs text-red-400">{pathError}</p>}
 				</div>
 
 				<div>

--- a/packages/web/src/components/lobby/__tests__/CreateRoomModal.test.tsx
+++ b/packages/web/src/components/lobby/__tests__/CreateRoomModal.test.tsx
@@ -1,0 +1,225 @@
+// @ts-nocheck
+/**
+ * Tests for CreateRoomModal — workspace path collection and validation
+ */
+
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { signal } from '@preact/signals';
+import { CreateRoomModal } from '../CreateRoomModal';
+
+// Mock Portal to render inline
+vi.mock('../../ui/Portal.tsx', () => ({
+	Portal: ({ children }) => <div data-portal="true">{children}</div>,
+}));
+
+// Mock systemState — controls what workspaceRoot is pre-filled with
+const mockSystemStateSignal = signal<{ workspaceRoot?: string } | null>(null);
+
+vi.mock('../../../lib/state', () => ({
+	get systemState() {
+		return mockSystemStateSignal;
+	},
+}));
+
+const DEFAULT_PROPS = {
+	isOpen: true,
+	onClose: vi.fn(),
+	onSubmit: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('CreateRoomModal', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		mockSystemStateSignal.value = { workspaceRoot: '/home/user/projects' };
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.resetAllMocks();
+	});
+
+	describe('rendering', () => {
+		it('renders with workspace path field', () => {
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			const labels = Array.from(document.querySelectorAll('label'));
+			expect(labels.some((l) => l.textContent?.includes('Workspace Path'))).toBe(true);
+		});
+
+		it('pre-fills workspace path from systemState workspaceRoot', () => {
+			mockSystemStateSignal.value = { workspaceRoot: '/home/user/projects' };
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
+			const pathInput = inputs.find((i) => (i as HTMLInputElement).value === '/home/user/projects');
+			expect(pathInput).toBeTruthy();
+		});
+
+		it('pre-fills empty string when systemState has no workspaceRoot', () => {
+			mockSystemStateSignal.value = null;
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
+			// Should have a workspace path input (possibly empty)
+			expect(inputs.length).toBeGreaterThanOrEqual(2);
+		});
+
+		it('shows helper text for workspace path', () => {
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			expect(document.body.textContent).toContain("Filesystem path for this room's workspace");
+		});
+	});
+
+	describe('form validation', () => {
+		it('shows error if room name is empty on submit', async () => {
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('Room name is required');
+			});
+		});
+
+		it('shows inline error if workspace path is empty on submit', async () => {
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+
+			// Fill in room name
+			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(nameInput, { target: { value: 'My Room' } });
+
+			// Clear workspace path
+			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
+			const pathInput = inputs[1] as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: '' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('Workspace path must not be empty');
+			});
+		});
+
+		it('shows inline error if workspace path is relative on submit', async () => {
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+
+			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(nameInput, { target: { value: 'My Room' } });
+
+			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
+			const pathInput = inputs[1] as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: 'relative/path' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(document.body.textContent).toContain('absolute path');
+			});
+		});
+
+		it('does not call onSubmit when workspace path is invalid', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<CreateRoomModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(nameInput, { target: { value: 'My Room' } });
+
+			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
+			const pathInput = inputs[1] as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: '' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(onSubmit).not.toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe('successful submission', () => {
+		it('calls onSubmit with name, defaultPath, and background', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<CreateRoomModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			// Fill name
+			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(nameInput, { target: { value: 'My Room' } });
+
+			// Path is already pre-filled with /home/user/projects
+
+			// Fill background
+			const textarea = document.querySelector('textarea') as HTMLTextAreaElement;
+			fireEvent.input(textarea, { target: { value: 'Project background' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(onSubmit).toHaveBeenCalledWith({
+					name: 'My Room',
+					defaultPath: '/home/user/projects',
+					background: 'Project background',
+				});
+			});
+		});
+
+		it('calls onSubmit without background when background is empty', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<CreateRoomModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(nameInput, { target: { value: 'My Room' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(onSubmit).toHaveBeenCalledWith({
+					name: 'My Room',
+					defaultPath: '/home/user/projects',
+					background: undefined,
+				});
+			});
+		});
+
+		it('calls onSubmit with custom workspace path', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<CreateRoomModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(nameInput, { target: { value: 'My Room' } });
+
+			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
+			const pathInput = inputs[1] as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: '/custom/workspace' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(onSubmit).toHaveBeenCalledWith(
+					expect.objectContaining({ defaultPath: '/custom/workspace' })
+				);
+			});
+		});
+	});
+
+	describe('form reset on close', () => {
+		it('resets all fields when closed', async () => {
+			const onClose = vi.fn();
+			render(<CreateRoomModal {...DEFAULT_PROPS} onClose={onClose} />);
+
+			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(nameInput, { target: { value: 'My Room' } });
+
+			// Click cancel button
+			const cancelBtn = Array.from(document.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Cancel'
+			);
+			expect(cancelBtn).toBeTruthy();
+			fireEvent.click(cancelBtn!);
+
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/web/src/components/lobby/__tests__/CreateRoomModal.test.tsx
+++ b/packages/web/src/components/lobby/__tests__/CreateRoomModal.test.tsx
@@ -1,20 +1,23 @@
-// @ts-nocheck
 /**
  * Tests for CreateRoomModal — workspace path collection and validation
  */
 
-import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
+import { render, cleanup, fireEvent, waitFor, act } from '@testing-library/preact';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { signal } from '@preact/signals';
+import type { SystemState } from '@neokai/shared';
 import { CreateRoomModal } from '../CreateRoomModal';
 
 // Mock Portal to render inline
 vi.mock('../../ui/Portal.tsx', () => ({
-	Portal: ({ children }) => <div data-portal="true">{children}</div>,
+	Portal: ({ children }: { children: unknown }) => (
+		<div data-portal="true">{children as never}</div>
+	),
 }));
 
-// Mock systemState — controls what workspaceRoot is pre-filled with
-const mockSystemStateSignal = signal<{ workspaceRoot?: string } | null>(null);
+// Mock systemState — controls what workspaceRoot is pre-filled with.
+// Typed as a plain writable signal so tests can update it directly.
+const mockSystemStateSignal = signal<SystemState | null>(null);
 
 vi.mock('../../../lib/state', () => ({
 	get systemState() {
@@ -28,10 +31,19 @@ const DEFAULT_PROPS = {
 	onSubmit: vi.fn().mockResolvedValue(undefined),
 };
 
+/** Returns the workspace path input (second text input after the name field). */
+function getPathInput(): HTMLInputElement {
+	const inputs = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="text"]'));
+	// inputs[0] = Room Name, inputs[1] = Workspace Path
+	const pathInput = inputs[1];
+	if (!pathInput) throw new Error('Workspace path input not found');
+	return pathInput;
+}
+
 describe('CreateRoomModal', () => {
 	beforeEach(() => {
 		document.body.innerHTML = '';
-		mockSystemStateSignal.value = { workspaceRoot: '/home/user/projects' };
+		mockSystemStateSignal.value = { workspaceRoot: '/home/user/projects' } as SystemState;
 	});
 
 	afterEach(() => {
@@ -47,24 +59,61 @@ describe('CreateRoomModal', () => {
 		});
 
 		it('pre-fills workspace path from systemState workspaceRoot', () => {
-			mockSystemStateSignal.value = { workspaceRoot: '/home/user/projects' };
+			mockSystemStateSignal.value = { workspaceRoot: '/home/user/projects' } as SystemState;
 			render(<CreateRoomModal {...DEFAULT_PROPS} />);
-			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
-			const pathInput = inputs.find((i) => (i as HTMLInputElement).value === '/home/user/projects');
-			expect(pathInput).toBeTruthy();
+			expect(getPathInput().value).toBe('/home/user/projects');
 		});
 
 		it('pre-fills empty string when systemState has no workspaceRoot', () => {
 			mockSystemStateSignal.value = null;
 			render(<CreateRoomModal {...DEFAULT_PROPS} />);
-			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
-			// Should have a workspace path input (possibly empty)
-			expect(inputs.length).toBeGreaterThanOrEqual(2);
+			expect(getPathInput().value).toBe('');
 		});
 
 		it('shows helper text for workspace path', () => {
 			render(<CreateRoomModal {...DEFAULT_PROPS} />);
 			expect(document.body.textContent).toContain("Filesystem path for this room's workspace");
+		});
+
+		it('shows required asterisk on workspace path label', () => {
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			const labels = Array.from(document.querySelectorAll('label'));
+			const pathLabel = labels.find((l) => l.textContent?.includes('Workspace Path'));
+			expect(pathLabel).toBeTruthy();
+			expect(pathLabel?.querySelector('span')?.textContent).toBe('*');
+		});
+	});
+
+	describe('systemState late-arrival sync', () => {
+		it('updates workspace path when systemState arrives after mount', async () => {
+			mockSystemStateSignal.value = null;
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			// Initially empty
+			expect(getPathInput().value).toBe('');
+
+			// systemState arrives
+			await act(async () => {
+				mockSystemStateSignal.value = { workspaceRoot: '/late/arrival' } as SystemState;
+			});
+
+			expect(getPathInput().value).toBe('/late/arrival');
+		});
+
+		it('does not overwrite user-edited path when systemState changes', async () => {
+			mockSystemStateSignal.value = null;
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+
+			// User types a custom path
+			const pathInput = getPathInput();
+			fireEvent.input(pathInput, { target: { value: '/my/custom/path' } });
+			expect(pathInput.value).toBe('/my/custom/path');
+
+			// systemState arrives — must not overwrite user's input
+			await act(async () => {
+				mockSystemStateSignal.value = { workspaceRoot: '/server/path' } as SystemState;
+			});
+
+			expect(getPathInput().value).toBe('/my/custom/path');
 		});
 	});
 
@@ -82,13 +131,11 @@ describe('CreateRoomModal', () => {
 			render(<CreateRoomModal {...DEFAULT_PROPS} />);
 
 			// Fill in room name
-			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			const nameInput = document.querySelector<HTMLInputElement>('input[type="text"]')!;
 			fireEvent.input(nameInput, { target: { value: 'My Room' } });
 
 			// Clear workspace path
-			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
-			const pathInput = inputs[1] as HTMLInputElement;
-			fireEvent.input(pathInput, { target: { value: '' } });
+			fireEvent.input(getPathInput(), { target: { value: '' } });
 
 			const form = document.querySelector('form') as HTMLFormElement;
 			fireEvent.submit(form);
@@ -101,12 +148,10 @@ describe('CreateRoomModal', () => {
 		it('shows inline error if workspace path is relative on submit', async () => {
 			render(<CreateRoomModal {...DEFAULT_PROPS} />);
 
-			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			const nameInput = document.querySelector<HTMLInputElement>('input[type="text"]')!;
 			fireEvent.input(nameInput, { target: { value: 'My Room' } });
 
-			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
-			const pathInput = inputs[1] as HTMLInputElement;
-			fireEvent.input(pathInput, { target: { value: 'relative/path' } });
+			fireEvent.input(getPathInput(), { target: { value: 'relative/path' } });
 
 			const form = document.querySelector('form') as HTMLFormElement;
 			fireEvent.submit(form);
@@ -120,12 +165,10 @@ describe('CreateRoomModal', () => {
 			const onSubmit = vi.fn().mockResolvedValue(undefined);
 			render(<CreateRoomModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
 
-			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			const nameInput = document.querySelector<HTMLInputElement>('input[type="text"]')!;
 			fireEvent.input(nameInput, { target: { value: 'My Room' } });
 
-			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
-			const pathInput = inputs[1] as HTMLInputElement;
-			fireEvent.input(pathInput, { target: { value: '' } });
+			fireEvent.input(getPathInput(), { target: { value: '' } });
 
 			const form = document.querySelector('form') as HTMLFormElement;
 			fireEvent.submit(form);
@@ -142,7 +185,7 @@ describe('CreateRoomModal', () => {
 			render(<CreateRoomModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
 
 			// Fill name
-			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			const nameInput = document.querySelector<HTMLInputElement>('input[type="text"]')!;
 			fireEvent.input(nameInput, { target: { value: 'My Room' } });
 
 			// Path is already pre-filled with /home/user/projects
@@ -167,7 +210,7 @@ describe('CreateRoomModal', () => {
 			const onSubmit = vi.fn().mockResolvedValue(undefined);
 			render(<CreateRoomModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
 
-			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			const nameInput = document.querySelector<HTMLInputElement>('input[type="text"]')!;
 			fireEvent.input(nameInput, { target: { value: 'My Room' } });
 
 			const form = document.querySelector('form') as HTMLFormElement;
@@ -186,12 +229,10 @@ describe('CreateRoomModal', () => {
 			const onSubmit = vi.fn().mockResolvedValue(undefined);
 			render(<CreateRoomModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
 
-			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			const nameInput = document.querySelector<HTMLInputElement>('input[type="text"]')!;
 			fireEvent.input(nameInput, { target: { value: 'My Room' } });
 
-			const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
-			const pathInput = inputs[1] as HTMLInputElement;
-			fireEvent.input(pathInput, { target: { value: '/custom/workspace' } });
+			fireEvent.input(getPathInput(), { target: { value: '/custom/workspace' } });
 
 			const form = document.querySelector('form') as HTMLFormElement;
 			fireEvent.submit(form);
@@ -205,14 +246,10 @@ describe('CreateRoomModal', () => {
 	});
 
 	describe('form reset on close', () => {
-		it('resets all fields when closed', async () => {
+		it('calls onClose when cancel is clicked', () => {
 			const onClose = vi.fn();
 			render(<CreateRoomModal {...DEFAULT_PROPS} onClose={onClose} />);
 
-			const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
-			fireEvent.input(nameInput, { target: { value: 'My Room' } });
-
-			// Click cancel button
 			const cancelBtn = Array.from(document.querySelectorAll('button')).find(
 				(b) => b.textContent?.trim() === 'Cancel'
 			);

--- a/packages/web/src/islands/Lobby.tsx
+++ b/packages/web/src/islands/Lobby.tsx
@@ -288,7 +288,8 @@ export default function Lobby() {
 				onCreateRoom={async (params) => {
 					const room = await lobbyStore.createRoom({
 						name: params.name,
-						defaultPath: params.defaultPath ?? '',
+						// NewSessionModal always provides defaultPath (selectedPath from the form)
+						defaultPath: params.defaultPath!,
 						...(params.background ? { background: params.background } : {}),
 						...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
 					});

--- a/packages/web/src/islands/Lobby.tsx
+++ b/packages/web/src/islands/Lobby.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useEffect, useState } from 'preact/hooks';
-import type { ModelInfo, Provider, CreateRoomParams } from '@neokai/shared';
+import type { ModelInfo, Provider } from '@neokai/shared';
 import { lobbyStore } from '../lib/lobby-store';
 import { globalStore } from '../lib/global-store';
 import { navigateToRoom, navigateToSession } from '../lib/router';
@@ -266,11 +266,11 @@ export default function Lobby() {
 				isOpen={isCreateRoomModalOpen}
 				onClose={() => (createRoomModalSignal.value = false)}
 				onSubmit={async (params) => {
-					// TODO(Milestone 2, task 2.2): CreateRoomModal does not yet collect a
-					// workspace path. Casting to CreateRoomParams means defaultPath is absent
-					// in the wire payload (undefined), so the server's || workspaceRoot
-					// fallback fires correctly.
-					const room = await lobbyStore.createRoom(params as unknown as CreateRoomParams);
+					const room = await lobbyStore.createRoom({
+						name: params.name,
+						defaultPath: params.defaultPath,
+						...(params.background ? { background: params.background } : {}),
+					});
 					if (room) {
 						createRoomModalSignal.value = false;
 						navigateToRoom(room.id);
@@ -286,11 +286,12 @@ export default function Lobby() {
 				recentPaths={recentPaths}
 				rooms={rooms}
 				onCreateRoom={async (params) => {
-					// TODO(Milestone 2, task 2.2): NewSessionModal already provides
-					// defaultPath when the user selects a workspace path. Casting to
-					// CreateRoomParams passes it through as-is; when absent it arrives as
-					// undefined so the server's || workspaceRoot fallback fires correctly.
-					const room = await lobbyStore.createRoom(params as unknown as CreateRoomParams);
+					const room = await lobbyStore.createRoom({
+						name: params.name,
+						defaultPath: params.defaultPath ?? '',
+						...(params.background ? { background: params.background } : {}),
+						...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
+					});
 					return room;
 				}}
 			/>


### PR DESCRIPTION
Adds a required "Workspace Path" input to `CreateRoomModal`, wiring it end-to-end so `room.create` always receives a `defaultPath`.

- `CreateRoomModal`: new workspace path input pre-populated from daemon `workspaceRoot` (via `systemState`), client-side validation via `validateWorkspacePath()` with inline error display, `onSubmit` type updated to include `defaultPath`
- `Lobby.tsx`: removes TODO cast placeholders for both `CreateRoomModal` and `NewSessionModal` `onCreateRoom` handlers; real form values passed to `lobbyStore.createRoom()`
- 12 new unit tests covering rendering, validation, and submission scenarios