### PR TITLE
feat: require defaultPath in room.create handler (task 2.1)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -196,7 +196,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.messageHub,
 		roomManager,
 		deps.daemonHub,
-		deps.config.workspaceRoot,
 		deps.sessionManager,
 		deps.jobQueue,
 		deps.db

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -20,10 +20,12 @@ import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import type { SessionManager } from '../session-manager';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { Database } from '../../storage/database';
+import { existsSync } from 'node:fs';
 import { getCliAgents, refresh as refreshCliAgents } from '../room/agents/cli-agent-registry';
 import { inferProviderForModel } from '../providers/registry';
 import { Logger } from '../logger';
 import { cancelPendingTickJobs, enqueueRoomTick } from '../job-handlers/room-tick.handler';
+import { validateWorkspacePath } from '@neokai/shared';
 
 const log = new Logger('room-handlers');
 
@@ -38,29 +40,38 @@ export function setupRoomHandlers(
 ): void {
 	// room.create - Create a new room
 	messageHub.onRequest('room.create', async (data) => {
-		// Wire type: defaultPath is still optional at the RPC boundary for backward
-		// compatibility until Milestone 2 (task 2.1) enforces it from the client.
 		const params = data as Omit<CreateRoomParams, 'defaultPath'> & { defaultPath?: string };
 
 		if (!params.name) {
 			throw new Error('Room name is required');
 		}
 
-		// Auto-populate workspace paths from workspaceRoot if not provided
-		const allowedPaths = params.allowedPaths ?? (workspaceRoot ? [{ path: workspaceRoot }] : []);
+		// Require defaultPath from the client (Milestone 2, task 2.1)
+		if (!params.defaultPath) {
+			throw new Error('defaultPath is required when creating a room');
+		}
 
-		// TODO(Milestone 2, task 2.1): Remove workspaceRoot fallback; require defaultPath
-		// from the client. Using || (not ??) also catches empty-string placeholders sent
-		// by callers that have not yet been updated. When both are absent, defaultPath is
-		// omitted from the params object so downstream `room.defaultPath ?? fallback`
-		// chains in room-runtime-service still work correctly.
-		const defaultPath = params.defaultPath || workspaceRoot;
+		// Validate path format (non-empty, absolute POSIX path)
+		const pathValidation = validateWorkspacePath(params.defaultPath);
+		if (!pathValidation.valid) {
+			throw new Error(`Invalid defaultPath: ${pathValidation.error}`);
+		}
+
+		// Validate path exists on filesystem
+		if (!existsSync(params.defaultPath)) {
+			throw new Error(`defaultPath does not exist: ${params.defaultPath}`);
+		}
+
+		const defaultPath = params.defaultPath;
+
+		// Derive allowedPaths from defaultPath if not explicitly provided
+		const allowedPaths = params.allowedPaths ?? [{ path: defaultPath }];
 
 		const room = roomManager.createRoom({
 			name: params.name,
 			background: params.background,
 			allowedPaths,
-			...(defaultPath ? { defaultPath } : {}),
+			defaultPath,
 		} as CreateRoomParams);
 
 		// Create the room's user-facing chat session
@@ -71,7 +82,7 @@ export function setupRoomHandlers(
 				await sessionManager.createSession({
 					sessionId: roomChatSessionId,
 					title: room.name,
-					workspacePath: defaultPath ?? allowedPaths[0]?.path,
+					workspacePath: defaultPath,
 					config: {
 						model: room.defaultModel,
 						provider: room.defaultModel ? inferProviderForModel(room.defaultModel) : undefined,

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -33,14 +33,13 @@ export function setupRoomHandlers(
 	messageHub: MessageHub,
 	roomManager: RoomManager,
 	daemonHub: DaemonHub,
-	workspaceRoot?: string,
 	sessionManager?: SessionManager,
 	jobQueue?: JobQueueRepository,
 	db?: Database
 ): void {
 	// room.create - Create a new room
 	messageHub.onRequest('room.create', async (data) => {
-		const params = data as Omit<CreateRoomParams, 'defaultPath'> & { defaultPath?: string };
+		const params = data as CreateRoomParams;
 
 		if (!params.name) {
 			throw new Error('Room name is required');
@@ -72,7 +71,7 @@ export function setupRoomHandlers(
 			background: params.background,
 			allowedPaths,
 			defaultPath,
-		} as CreateRoomParams);
+		});
 
 		// Create the room's user-facing chat session
 		// Session ID format: room:chat:${roomId}

--- a/packages/daemon/tests/online/room/room-chat-constraints.test.ts
+++ b/packages/daemon/tests/online/room/room-chat-constraints.test.ts
@@ -76,6 +76,7 @@ describe('Room Chat Constraints', () => {
 		async () => {
 			const createRoomResult = (await daemon.messageHub.request('room.create', {
 				name: `Room Chat Constraints ${Date.now()}`,
+				defaultPath: daemon.workspacePath ?? process.env.NEOKAI_WORKSPACE_PATH,
 			})) as { room: { id: string } };
 
 			const roomChatSessionId = `room:chat:${createRoomResult.room.id}`;

--- a/packages/daemon/tests/online/room/room-multi-agent-flow.test.ts
+++ b/packages/daemon/tests/online/room/room-multi-agent-flow.test.ts
@@ -39,6 +39,7 @@ describe('Room Multi-Agent Flow (API-dependent)', () => {
 
 		const result = (await daemon.messageHub.request('room.create', {
 			name: `Multi-Agent Flow ${Date.now()}`,
+			defaultPath: daemon.workspacePath ?? process.env.NEOKAI_WORKSPACE_PATH,
 		})) as { room: { id: string } };
 		roomId = result.room.id;
 	}, 30_000);

--- a/packages/daemon/tests/online/room/room-test-helpers.ts
+++ b/packages/daemon/tests/online/room/room-test-helpers.ts
@@ -248,6 +248,7 @@ export async function waitForGroupState(
 export async function createRoom(daemon: DaemonServerContext, name: string): Promise<string> {
 	const result = (await daemon.messageHub.request('room.create', {
 		name: `${name} ${Date.now()}`,
+		defaultPath: daemon.workspacePath ?? process.env.NEOKAI_WORKSPACE_PATH,
 	})) as { room: { id: string } };
 	return result.room.id;
 }

--- a/packages/daemon/tests/online/room/room-tick-job.test.ts
+++ b/packages/daemon/tests/online/room/room-tick-job.test.ts
@@ -112,7 +112,10 @@ function acceleratePendingTick(daemonCtx: DaemonAppContext, roomId: string): voi
 
 /** Create a room and return its ID. */
 async function createRoom(daemon: DaemonServerContext, name: string): Promise<string> {
-	const result = (await daemon.messageHub.request('room.create', { name })) as {
+	const result = (await daemon.messageHub.request('room.create', {
+		name,
+		defaultPath: daemon.workspacePath ?? process.env.NEOKAI_WORKSPACE_PATH,
+	})) as {
 		room: { id: string };
 	};
 	return result.room.id;

--- a/packages/daemon/tests/online/rpc/rpc-live-query.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-live-query.test.ts
@@ -61,6 +61,7 @@ describe('LiveQuery — end-to-end reactive pipeline', () => {
 	async function createRoom(label: string): Promise<string> {
 		const result = (await daemon.messageHub.request('room.create', {
 			name: `lq-${label}-${Date.now()}`,
+			defaultPath: daemon.workspacePath ?? process.env.NEOKAI_WORKSPACE_PATH,
 		})) as { room: { id: string } };
 		return result.room.id;
 	}

--- a/packages/daemon/tests/online/rpc/rpc-task-draft-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-task-draft-handlers.test.ts
@@ -26,6 +26,7 @@ describe('Task Draft RPC Handlers', () => {
 	async function createRoom(name: string): Promise<string> {
 		const result = (await daemon.messageHub.request('room.create', {
 			name: `${name} ${Date.now()}`,
+			defaultPath: daemon.workspacePath ?? process.env.NEOKAI_WORKSPACE_PATH,
 		})) as { room: { id: string } };
 		return result.room.id;
 	}

--- a/packages/daemon/tests/online/rpc/rpc-task-lifecycle.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-task-lifecycle.test.ts
@@ -52,6 +52,7 @@ describe('Task Lifecycle RPC Integration', () => {
 	async function createRoom(label: string): Promise<string> {
 		const result = (await daemon.messageHub.request('room.create', {
 			name: `${label}-${Date.now()}`,
+			defaultPath: daemon.workspacePath ?? process.env.NEOKAI_WORKSPACE_PATH,
 		})) as { room: { id: string } };
 		return result.room.id;
 	}

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -16,6 +16,8 @@
  */
 
 import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { MessageHub } from '@neokai/shared';
 import { setupRoomHandlers } from '../../../src/lib/rpc-handlers/room-handlers';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
@@ -136,6 +138,9 @@ function createMockRoomManager(): {
 	};
 }
 
+// A real temporary directory used for tests that need a valid defaultPath on disk
+const tempDir = mkdtempSync(`${tmpdir()}/room-handlers-test-`);
+
 describe('Room RPC Handlers', () => {
 	let messageHubData: ReturnType<typeof createMockMessageHub>;
 	let daemonHubData: ReturnType<typeof createMockDaemonHub>;
@@ -155,19 +160,21 @@ describe('Room RPC Handlers', () => {
 	});
 
 	describe('room.create', () => {
-		it('creates a room with required name', async () => {
+		it('creates a room with required name and defaultPath', async () => {
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();
 
-			const result = (await handler!({ name: 'New Room' }, {})) as { room: Room };
+			const result = (await handler!({ name: 'New Room', defaultPath: tempDir }, {})) as {
+				room: Room;
+			};
 
 			expect(result.room).toBeDefined();
 			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
-				expect.objectContaining({ name: 'New Room' })
+				expect.objectContaining({ name: 'New Room', defaultPath: tempDir })
 			);
 		});
 
-		it('creates a room with background (no defaultPath — omitted when absent)', async () => {
+		it('creates a room with background and defaultPath', async () => {
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();
 
@@ -175,56 +182,46 @@ describe('Room RPC Handlers', () => {
 				{
 					name: 'Full Room',
 					background: 'A full featured room',
+					defaultPath: tempDir,
 				},
 				{}
 			);
 
-			// No workspaceRoot in this test setup and no defaultPath from the client, so
-			// defaultPath is omitted from the createRoom call entirely. Downstream ??
-			// chains in room-runtime-service then fall through to their own fallbacks.
-			// TODO(Milestone 2, task 2.1): Once the server enforces defaultPath from the
-			// client, this test should pass an explicit path.
-			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
-				expect.not.objectContaining({ defaultPath: expect.anything() })
-			);
 			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
 				expect.objectContaining({
 					name: 'Full Room',
 					background: 'A full featured room',
-					allowedPaths: [],
+					defaultPath: tempDir,
 				})
 			);
 		});
 
-		it('omits defaultPath key when client sends empty string', async () => {
-			// '' should be treated the same as absent because we use || not ??
+		it('derives allowedPaths from defaultPath when not explicitly provided', async () => {
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();
 
-			await handler!({ name: 'Empty Path Room', defaultPath: '' }, {});
+			await handler!({ name: 'Path Room', defaultPath: tempDir }, {});
 
-			// No workspaceRoot in this test setup so defaultPath is still omitted
 			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
-				expect.not.objectContaining({ defaultPath: expect.anything() })
+				expect.objectContaining({
+					allowedPaths: [{ path: tempDir }],
+				})
 			);
 		});
 
-		it('creates a room with an explicit defaultPath', async () => {
+		it('uses explicit allowedPaths when provided', async () => {
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();
 
+			const customPaths = [{ path: tempDir }, { path: '/other/path' }];
 			await handler!(
-				{
-					name: 'Path Room',
-					defaultPath: '/workspace/my-project',
-				},
+				{ name: 'Custom Paths Room', defaultPath: tempDir, allowedPaths: customPaths },
 				{}
 			);
 
 			expect(roomManagerData.mocks.createRoom).toHaveBeenCalledWith(
 				expect.objectContaining({
-					name: 'Path Room',
-					defaultPath: '/workspace/my-project',
+					allowedPaths: customPaths,
 				})
 			);
 		});
@@ -233,16 +230,52 @@ describe('Room RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();
 
-			await expect(handler!({ description: 'No name' }, {})).rejects.toThrow(
+			await expect(handler!({ description: 'No name', defaultPath: tempDir }, {})).rejects.toThrow(
 				'Room name is required'
 			);
+		});
+
+		it('throws error when defaultPath is missing', async () => {
+			const handler = messageHubData.handlers.get('room.create');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ name: 'No Path Room' }, {})).rejects.toThrow(
+				'defaultPath is required when creating a room'
+			);
+		});
+
+		it('throws error when defaultPath is empty string', async () => {
+			const handler = messageHubData.handlers.get('room.create');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ name: 'Empty Path Room', defaultPath: '' }, {})).rejects.toThrow(
+				'defaultPath is required when creating a room'
+			);
+		});
+
+		it('throws error when defaultPath is not an absolute path', async () => {
+			const handler = messageHubData.handlers.get('room.create');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ name: 'Relative Path Room', defaultPath: 'relative/path' }, {})
+			).rejects.toThrow('Invalid defaultPath');
+		});
+
+		it('throws error when defaultPath does not exist on disk', async () => {
+			const handler = messageHubData.handlers.get('room.create');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ name: 'Bad Path Room', defaultPath: '/nonexistent/path/xyz-12345' }, {})
+			).rejects.toThrow('defaultPath does not exist: /nonexistent/path/xyz-12345');
 		});
 
 		it('broadcasts room.created event', async () => {
 			const handler = messageHubData.handlers.get('room.create');
 			expect(handler).toBeDefined();
 
-			await handler!({ name: 'New Room' }, {});
+			await handler!({ name: 'New Room', defaultPath: tempDir }, {});
 
 			expect(daemonHubData.emitMock).toHaveBeenCalledWith(
 				'room.created',

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -15,8 +15,8 @@
  * - room.removePath - Remove an allowed path from a room
  */
 
-import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
-import { mkdtempSync } from 'node:fs';
+import { describe, expect, it, beforeEach, mock, afterEach, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { MessageHub } from '@neokai/shared';
 import { setupRoomHandlers } from '../../../src/lib/rpc-handlers/room-handlers';
@@ -140,6 +140,10 @@ function createMockRoomManager(): {
 
 // A real temporary directory used for tests that need a valid defaultPath on disk
 const tempDir = mkdtempSync(`${tmpdir()}/room-handlers-test-`);
+
+afterAll(() => {
+	rmSync(tempDir, { recursive: true, force: true });
+});
 
 describe('Room RPC Handlers', () => {
 	let messageHubData: ReturnType<typeof createMockMessageHub>;
@@ -423,13 +427,7 @@ describe('Room RPC Handlers', () => {
 			} as unknown as SessionManager;
 
 			const { hub, handlers } = createMockMessageHub();
-			setupRoomHandlers(
-				hub,
-				roomManagerData.roomManager,
-				daemonHubData.daemonHub,
-				undefined,
-				sessionManager
-			);
+			setupRoomHandlers(hub, roomManagerData.roomManager, daemonHubData.daemonHub, sessionManager);
 
 			const handler = handlers.get('room.update');
 			expect(handler).toBeDefined();

--- a/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
+++ b/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
@@ -16,22 +16,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-import { deleteRoom } from '../helpers/room-helpers';
+import { createRoom, deleteRoom } from '../helpers/room-helpers';
 
 // ─── Infrastructure Helpers ───────────────────────────────────────────────────
-
-async function createRoom(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	name: string
-): Promise<string> {
-	await waitForWebSocketConnected(page);
-	return page.evaluate(async (roomName) => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('MessageHub not available');
-		const res = await hub.request('room.create', { name: roomName });
-		return (res as { room: { id: string } }).room.id;
-	}, name);
-}
 
 async function createTask(
 	page: Parameters<typeof waitForWebSocketConnected>[0],

--- a/packages/e2e/tests/features/mission-creation.e2e.ts
+++ b/packages/e2e/tests/features/mission-creation.e2e.ts
@@ -12,21 +12,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-import { deleteRoom, openMissionsTab } from '../helpers/room-helpers';
+import { createRoom, deleteRoom, openMissionsTab } from '../helpers/room-helpers';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0]): Promise<string> {
-	await waitForWebSocketConnected(page);
-	return page.evaluate(async () => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('MessageHub not available');
-		const res = await hub.request('room.create', {
-			name: 'E2E Mission Creation Test Room',
-		});
-		return (res as { room: { id: string } }).room.id;
-	});
-}
 
 async function openCreateMissionModal(
 	page: Parameters<typeof waitForWebSocketConnected>[0]
@@ -62,7 +50,7 @@ test.describe('Mission Creation', () => {
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
-		roomId = await createRoom(page);
+		roomId = await createRoom(page, 'E2E Mission Creation Test Room');
 	});
 
 	test.afterEach(async ({ page }) => {

--- a/packages/e2e/tests/features/mission-detail.e2e.ts
+++ b/packages/e2e/tests/features/mission-detail.e2e.ts
@@ -11,21 +11,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-import { deleteRoom, openMissionsTab } from '../helpers/room-helpers';
+import { createRoom, deleteRoom, openMissionsTab } from '../helpers/room-helpers';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0]): Promise<string> {
-	await waitForWebSocketConnected(page);
-	return page.evaluate(async () => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('MessageHub not available');
-		const res = await hub.request('room.create', {
-			name: 'E2E Mission Detail Test Room',
-		});
-		return (res as { room: { id: string } }).room.id;
-	});
-}
 
 async function openCreateMissionModal(
 	page: Parameters<typeof waitForWebSocketConnected>[0]
@@ -105,7 +93,7 @@ test.describe('Mission Detail Views', () => {
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
-		roomId = await createRoom(page);
+		roomId = await createRoom(page, 'E2E Mission Detail Test Room');
 	});
 
 	test.afterEach(async ({ page }) => {

--- a/packages/e2e/tests/features/mission-terminology.e2e.ts
+++ b/packages/e2e/tests/features/mission-terminology.e2e.ts
@@ -14,21 +14,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-import { deleteRoom } from '../helpers/room-helpers';
+import { createRoom, deleteRoom } from '../helpers/room-helpers';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0]): Promise<string> {
-	await waitForWebSocketConnected(page);
-	return page.evaluate(async () => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('MessageHub not available');
-		const res = await hub.request('room.create', {
-			name: 'E2E Mission Terminology Test Room',
-		});
-		return (res as { room: { id: string } }).room.id;
-	});
-}
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -37,7 +25,7 @@ test.describe('Mission Terminology', () => {
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
-		roomId = await createRoom(page);
+		roomId = await createRoom(page, 'E2E Mission Terminology Test Room');
 	});
 
 	test.afterEach(async ({ page }) => {

--- a/packages/e2e/tests/features/neo-conversation.e2e.ts
+++ b/packages/e2e/tests/features/neo-conversation.e2e.ts
@@ -157,8 +157,13 @@ async function createTestRoom(page: Page, name: string): Promise<string> {
 	const roomId = await page.evaluate(async (roomName) => {
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
-		const response = await hub.request('room.create', { name: roomName });
-		return (response as { id: string }).id;
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+		const response = await hub.request('room.create', {
+			name: roomName,
+			defaultPath: workspaceRoot,
+		});
+		return (response as { room: { id: string } }).room.id;
 	}, name);
 	return roomId;
 }

--- a/packages/e2e/tests/features/room-sidebar-navigation.e2e.ts
+++ b/packages/e2e/tests/features/room-sidebar-navigation.e2e.ts
@@ -11,20 +11,7 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-import { deleteRoom } from '../helpers/room-helpers';
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0]): Promise<string> {
-	return page.evaluate(async () => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('MessageHub not available');
-		const res = await hub.request('room.create', {
-			name: 'E2E Navigation Test Room',
-		});
-		return (res as { room: { id: string } }).room.id;
-	});
-}
+import { createRoom, deleteRoom } from '../helpers/room-helpers';
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -38,7 +25,7 @@ test.describe('Room Sidebar Navigation: URL persistence', () => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
 
-		roomId = await createRoom(page);
+		roomId = await createRoom(page, 'E2E Navigation Test Room');
 
 		// Create a task for the Task URL test (infrastructure — not a UI action)
 		orphanTaskId = await page.evaluate(async (rId) => {

--- a/packages/e2e/tests/features/room-sidebar-sections.e2e.ts
+++ b/packages/e2e/tests/features/room-sidebar-sections.e2e.ts
@@ -100,8 +100,14 @@ async function setupRoomWithData(page: Page): Promise<SetupResult> {
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
 
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+
 		// Create room
-		const roomRes = await hub.request('room.create', { name: 'E2E Sidebar Test Room' });
+		const roomRes = await hub.request('room.create', {
+			name: 'E2E Sidebar Test Room',
+			defaultPath: workspaceRoot,
+		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 
 		// Stop the runtime and wait until it is actually stopped before creating goals.
@@ -483,8 +489,12 @@ test.describe('Room Sidebar Sections', () => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
+			const systemState2 = await hub.request('state.system', {});
+			const workspaceRoot2 = (systemState2 as { workspaceRoot: string }).workspaceRoot;
+
 			const roomRes = await hub.request('room.create', {
 				name: 'E2E Completed Tasks Toggle Room',
+				defaultPath: workspaceRoot2,
 			});
 			const roomId = (roomRes as { room: { id: string } }).room.id;
 
@@ -551,8 +561,12 @@ test.describe('Room Sidebar Sections', () => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
+			const systemState3 = await hub.request('state.system', {});
+			const workspaceRoot3 = (systemState3 as { workspaceRoot: string }).workspaceRoot;
+
 			const roomRes = await hub.request('room.create', {
 				name: 'E2E Show Completed Toggle Room',
+				defaultPath: workspaceRoot3,
 			});
 			const roomId = (roomRes as { room: { id: string } }).room.id;
 
@@ -616,8 +630,12 @@ test.describe('Room Sidebar Sections', () => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
+			const systemState4 = await hub.request('state.system', {});
+			const workspaceRoot4 = (systemState4 as { workspaceRoot: string }).workspaceRoot;
+
 			const roomRes = await hub.request('room.create', {
 				name: 'E2E Persistence Room',
+				defaultPath: workspaceRoot4,
 			});
 			const roomId = (roomRes as { room: { id: string } }).room.id;
 

--- a/packages/e2e/tests/features/short-id-display.e2e.ts
+++ b/packages/e2e/tests/features/short-id-display.e2e.ts
@@ -16,22 +16,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-import { deleteRoom } from '../helpers/room-helpers';
+import { createRoom, deleteRoom } from '../helpers/room-helpers';
 
 // ─── RPC Infrastructure Helpers ───────────────────────────────────────────────
-
-/**
- * Create a room via RPC. For use in beforeEach setup only.
- */
-async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0]): Promise<string> {
-	await waitForWebSocketConnected(page);
-	return page.evaluate(async () => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('MessageHub not available');
-		const res = await hub.request('room.create', { name: 'E2E Short ID Display Test Room' });
-		return (res as { room: { id: string } }).room.id;
-	});
-}
 
 /**
  * Create a task via RPC and return both the UUID and the short ID.
@@ -75,7 +62,7 @@ test.describe('Short ID Display and Copy', () => {
 			.getByRole('button', { name: 'New Session', exact: true })
 			.waitFor({ timeout: 10000 });
 
-		roomId = await createRoom(page);
+		roomId = await createRoom(page, 'E2E Short ID Display Test Room');
 		({ taskId, shortId } = await createTask(page, roomId));
 	});
 

--- a/packages/e2e/tests/features/task-actions-dropdown.e2e.ts
+++ b/packages/e2e/tests/features/task-actions-dropdown.e2e.ts
@@ -28,9 +28,13 @@ async function createRoomAndTask(
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
 
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+
 		// Create room
 		const roomRes = await hub.request('room.create', {
 			name: 'E2E Test Room — Task Actions',
+			defaultPath: workspaceRoot,
 		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 

--- a/packages/e2e/tests/features/task-goal-indicator.e2e.ts
+++ b/packages/e2e/tests/features/task-goal-indicator.e2e.ts
@@ -28,9 +28,13 @@ async function createRoomWithLinkedGoalAndTask(
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
 
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+
 		// Create room
 		const roomRes = await hub.request('room.create', {
 			name: 'E2E Goal Indicator Test Room',
+			defaultPath: workspaceRoot,
 		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 
@@ -70,8 +74,12 @@ async function createRoomWithUnlinkedTask(
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
 
+		const systemState2 = await hub.request('state.system', {});
+		const workspaceRoot2 = (systemState2 as { workspaceRoot: string }).workspaceRoot;
+
 		const roomRes = await hub.request('room.create', {
 			name: 'E2E Goal Indicator Unlinked Test Room',
+			defaultPath: workspaceRoot2,
 		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 

--- a/packages/e2e/tests/features/task-lifecycle.e2e.ts
+++ b/packages/e2e/tests/features/task-lifecycle.e2e.ts
@@ -33,9 +33,13 @@ async function createRoomAndTaskInStatus(
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
 
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+
 		// Create room
 		const roomRes = await hub.request('room.create', {
 			name: 'E2E Lifecycle Test Room',
+			defaultPath: workspaceRoot,
 		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 

--- a/packages/e2e/tests/features/task-message-pagination.e2e.ts
+++ b/packages/e2e/tests/features/task-message-pagination.e2e.ts
@@ -37,7 +37,13 @@ async function createRoomWithTask(
 		};
 		if (!hub?.request) throw new Error('MessageHub not available');
 
-		const roomRes = await hub.request('room.create', { name: 'E2E Pagination Test Room' });
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+
+		const roomRes = await hub.request('room.create', {
+			name: 'E2E Pagination Test Room',
+			defaultPath: workspaceRoot,
+		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 
 		const taskRes = await hub.request('task.create', {

--- a/packages/e2e/tests/features/task-message-streaming.e2e.ts
+++ b/packages/e2e/tests/features/task-message-streaming.e2e.ts
@@ -68,7 +68,13 @@ async function createRoomWithTask(
 		};
 		if (!hub?.request) throw new Error('MessageHub not available');
 
-		const roomRes = await hub.request('room.create', { name: 'E2E Streaming Test Room' });
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+
+		const roomRes = await hub.request('room.create', {
+			name: 'E2E Streaming Test Room',
+			defaultPath: workspaceRoot,
+		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 
 		const taskRes = await hub.request('task.create', {

--- a/packages/e2e/tests/features/task-view-action-dropdown.e2e.ts
+++ b/packages/e2e/tests/features/task-view-action-dropdown.e2e.ts
@@ -28,9 +28,13 @@ async function createRoomAndTask(
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
 
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+
 		// Create room
 		const roomRes = await hub.request('room.create', {
 			name: 'E2E Test Room — Action Dropdown',
+			defaultPath: workspaceRoot,
 		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 

--- a/packages/e2e/tests/features/task-view-v2.e2e.ts
+++ b/packages/e2e/tests/features/task-view-v2.e2e.ts
@@ -43,8 +43,12 @@ async function createRoomAndTask(
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
 
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
+
 		const roomRes = await hub.request('room.create', {
 			name: 'E2E TaskViewV2 Test Room',
+			defaultPath: workspaceRoot,
 		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 
@@ -75,8 +79,12 @@ async function createRoomTaskAndGroup(
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
 
+		const systemState2 = await hub.request('state.system', {});
+		const workspaceRoot2 = (systemState2 as { workspaceRoot: string }).workspaceRoot;
+
 		const roomRes = await hub.request('room.create', {
 			name: 'E2E TaskViewV2 Group Test Room',
+			defaultPath: workspaceRoot2,
 		});
 		const roomId = (roomRes as { room: { id: string } }).room.id;
 

--- a/packages/e2e/tests/helpers/room-helpers.ts
+++ b/packages/e2e/tests/helpers/room-helpers.ts
@@ -18,11 +18,13 @@ export async function createRoom(page: Page, name: string): Promise<string> {
 	return page.evaluate(async (roomName) => {
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('MessageHub not available');
-		// TODO(Milestone 2, task 2.1): Replace '/tmp/test-workspace' with the actual
-		// E2E workspace path once defaultPath is enforced server-side.
+		// Resolve the actual workspace root from the server-side system state so the
+		// path is guaranteed to exist on disk regardless of the test environment.
+		const systemState = await hub.request('state.system', {});
+		const workspaceRoot = (systemState as { workspaceRoot: string }).workspaceRoot;
 		const res = await hub.request('room.create', {
 			name: roomName,
-			defaultPath: '/tmp/test-workspace',
+			defaultPath: workspaceRoot,
 		});
 		return (res as { room: { id: string } }).room.id;
 	}, name);


### PR DESCRIPTION
Enforces `defaultPath` as a required field on `room.create` — removes the silent `workspaceRoot` fallback introduced as a temporary backward-compat shim.

- Throws `'defaultPath is required when creating a room'` when absent or empty string
- Validates path format via `validateWorkspacePath()` (must be non-empty absolute POSIX path)
- Validates path exists on disk via `existsSync()`
- Derives `allowedPaths` as `[{ path: defaultPath }]` when not explicitly provided by the caller

Tests updated: replaced the old optional-defaultPath backward-compat cases with strict enforcement tests using a real temp directory. Added new cases covering missing, empty-string, relative, and non-existent paths.

Part of milestone 2 (task 2.1) of the decouple-daemon-from-workspaceRoot plan.