### PR TITLE
fix: guard room-scoped sessions against missing workspacePath in session-lifecycle

### DIFF
--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -90,6 +90,36 @@ export class SessionLifecycle {
 		const sessionId = params.sessionId || generateUUID();
 		const sessionType = params.sessionType ?? 'worker';
 
+		// Room-scoped session types must always provide an explicit workspacePath.
+		// These sessions are bound to a specific room/space and must not silently fall back
+		// to the daemon's global workspaceRoot. Guard by sessionType (not sessionId prefix)
+		// because worker/leader/planner/coder IDs don't start with 'room:'.
+		//
+		// Non-room sessions (worker, lobby, spaces_global, neo, and the default 'worker')
+		// fall back to this.config.workspaceRoot with a warning.
+		const ROOM_SCOPED_SESSION_TYPES = [
+			'room_chat',
+			'planner',
+			'coder',
+			'leader',
+			'general',
+			'space_chat',
+		] as const;
+		if (
+			(ROOM_SCOPED_SESSION_TYPES as readonly string[]).includes(sessionType) &&
+			!params.workspacePath
+		) {
+			throw new Error(
+				`Room-scoped session (type: '${sessionType}') must have explicit workspacePath`
+			);
+		}
+
+		// For non-room sessions, fall back to daemon workspaceRoot with a warning.
+		if (!params.workspacePath) {
+			this.logger.warn(
+				`No workspacePath provided for session type '${sessionType}'; falling back to workspaceRoot: ${this.config.workspaceRoot}`
+			);
+		}
 		const baseWorkspacePath = params.workspacePath || this.config.workspaceRoot;
 
 		// Detect git support before creating worktree

--- a/packages/daemon/tests/unit/session/session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/session/session-lifecycle.test.ts
@@ -208,6 +208,82 @@ describe('SessionLifecycle', () => {
 			);
 		});
 
+		// --- Workspace path guard tests ---
+
+		it('explicit workspacePath is used as-is and does NOT fall back to config.workspaceRoot', async () => {
+			await lifecycle.create({ workspacePath: '/explicit/path' });
+
+			expect(mockDb.createSession).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workspacePath: '/explicit/path',
+				})
+			);
+		});
+
+		it('room_chat session without workspacePath throws', async () => {
+			await expect(lifecycle.create({ sessionType: 'room_chat' })).rejects.toThrow(
+				"Room-scoped session (type: 'room_chat') must have explicit workspacePath"
+			);
+		});
+
+		it('planner session without workspacePath throws', async () => {
+			await expect(lifecycle.create({ sessionType: 'planner' })).rejects.toThrow(
+				"Room-scoped session (type: 'planner') must have explicit workspacePath"
+			);
+		});
+
+		it('coder session without workspacePath throws', async () => {
+			await expect(lifecycle.create({ sessionType: 'coder' })).rejects.toThrow(
+				"Room-scoped session (type: 'coder') must have explicit workspacePath"
+			);
+		});
+
+		it('leader session without workspacePath throws', async () => {
+			await expect(lifecycle.create({ sessionType: 'leader' })).rejects.toThrow(
+				"Room-scoped session (type: 'leader') must have explicit workspacePath"
+			);
+		});
+
+		it('general session without workspacePath throws', async () => {
+			await expect(lifecycle.create({ sessionType: 'general' })).rejects.toThrow(
+				"Room-scoped session (type: 'general') must have explicit workspacePath"
+			);
+		});
+
+		it('space_chat session without workspacePath throws', async () => {
+			await expect(lifecycle.create({ sessionType: 'space_chat' })).rejects.toThrow(
+				"Room-scoped session (type: 'space_chat') must have explicit workspacePath"
+			);
+		});
+
+		it('worker session without workspacePath falls back to config.workspaceRoot with warning', async () => {
+			const warnSpy = mock(() => {});
+			// Patch the logger on the lifecycle instance
+			(lifecycle as unknown as { logger: { warn: typeof warnSpy } }).logger.warn = warnSpy;
+
+			await lifecycle.create({ sessionType: 'worker' });
+
+			expect(mockDb.createSession).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workspacePath: '/default/workspace',
+				})
+			);
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('falling back to workspaceRoot')
+			);
+		});
+
+		it('default (undefined sessionType) session without workspacePath falls back to config.workspaceRoot', async () => {
+			// sessionType defaults to 'worker' per line 91 — should NOT throw
+			await lifecycle.create({});
+
+			expect(mockDb.createSession).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workspacePath: '/default/workspace',
+				})
+			);
+		});
+
 		it('should create session with pending_worktree_choice status for git repos', async () => {
 			(mockWorktreeManager.detectGitSupport as ReturnType<typeof mock>).mockResolvedValue({
 				isGitRepo: true,
@@ -247,7 +323,7 @@ describe('SessionLifecycle', () => {
 				gitRoot: '/test/repo',
 			});
 
-			await lifecycle.create({ sessionType: 'room_chat' });
+			await lifecycle.create({ sessionType: 'room_chat', workspacePath: '/room/workspace' });
 
 			expect(mockDb.createSession).toHaveBeenCalledWith(
 				expect.objectContaining({


### PR DESCRIPTION
## Summary

- `session-lifecycle.ts`: add `ROOM_SCOPED_SESSION_TYPES` guard — `room_chat`, `planner`, `coder`, `leader`, `general`, `space_chat` sessions now **throw** immediately if `workspacePath` is absent, preventing silent fallback to `config.workspaceRoot`
- Non-room sessions (`worker`, `lobby`, `spaces_global`, `neo`, default) continue to fall back to `workspaceRoot` but now emit a `logger.warn`
- 9 new unit tests cover: explicit path used as-is, all 6 room-scoped types throw with a clear message, `worker` type falls back with warning, `undefined` sessionType (defaults to `worker`) falls back

## Code path verification

All existing room-scoped session creation paths already pass `workspacePath` explicitly:
- **`room-handlers.ts`** (`room.create`): sets `workspacePath: defaultPath` (from `CreateRoomParams`, which is now required — Task 2.1)
- **`task-group-manager.ts`** / **`room-runtime.ts`**: `planner`/`coder`/`leader`/`worker` sessions go through `SessionFactory.createAndStartSession()` which calls `sessionFactory.createWorktree()` first and passes the worktree path — `workspacePath` is always set

Guard uses `sessionType` (not `sessionId` prefix) because worker/planner/coder/leader IDs do not start with `room:`.