### PR TITLE
fix: resolve room:chat sessions to room defaultPath in reference handlers

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -303,6 +303,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		goalRepo: deps.db.getGoalRepo(),
 		workspaceRoot: deps.config.workspaceRoot,
 		fileIndex,
+		getRoomDefaultPath: (roomId: string) => roomManager.getRoom(roomId)?.defaultPath ?? undefined,
 	});
 
 	// LiveQuery subscribe/unsubscribe handlers

--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -79,6 +79,12 @@ export interface ReferenceHandlerDeps {
 	workspaceRoot: string;
 	/** File index for fast file/folder search (reference.search) */
 	fileIndex: FileIndex;
+	/**
+	 * Callback to resolve a room's defaultPath by room ID.
+	 * Used to resolve workspace path for `room:chat:*` synthetic session IDs,
+	 * which have no DB entry and thus no stored workspacePath.
+	 */
+	getRoomDefaultPath?: (roomId: string) => string | undefined;
 }
 
 // ============================================================================
@@ -328,9 +334,19 @@ async function resolveSessionContext(
 	const agentSession = await deps.sessionManager.getSessionAsync(sessionId);
 	if (!agentSession) {
 		// The room agent route uses a synthetic session ID "room:chat:<roomId>"
-		// which has no DB entry — extract the roomId from it.
+		// which has no DB entry — extract the roomId from it and look up the
+		// room's defaultPath rather than falling back to the global workspaceRoot.
 		if (sessionId.startsWith('room:chat:')) {
-			return { workspacePath: deps.workspaceRoot, roomId: sessionId.slice('room:chat:'.length) };
+			const roomId = sessionId.slice('room:chat:'.length);
+			if (deps.getRoomDefaultPath) {
+				const roomPath = deps.getRoomDefaultPath(roomId);
+				if (roomPath) {
+					return { workspacePath: roomPath, roomId };
+				}
+				// Room not found (e.g. deleted while a reference request was in-flight) — warn and fall back.
+				log.warn(`resolveSessionContext: room ${roomId} not found, falling back to workspaceRoot`);
+			}
+			return { workspacePath: deps.workspaceRoot, roomId };
 		}
 		return { workspacePath: deps.workspaceRoot, roomId: null };
 	}

--- a/packages/daemon/tests/unit/rpc-handlers/reference-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/reference-handlers.test.ts
@@ -729,4 +729,136 @@ describe('reference.resolve handler', () => {
 			expect(result.resolved!.data.content).toBe('fallback content');
 		});
 	});
+
+	// -------------------------------------------------------------------------
+	// room:chat:* session resolution
+	// -------------------------------------------------------------------------
+
+	describe('room:chat session resolution', () => {
+		it('resolves workspace from room defaultPath for room:chat:<roomId> sessions', async () => {
+			const roomWorkspace = join(
+				tmpdir(),
+				`room-ws-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			await mkdir(roomWorkspace, { recursive: true });
+			await writeFile(join(roomWorkspace, 'room-file.txt'), 'room content');
+
+			try {
+				const { hub, handlers } = createMockMessageHub();
+				const deps: ReferenceHandlerDeps = {
+					sessionManager: makeSessionManager({
+						workspacePath: testWorkspace,
+						exists: false,
+					}) as never,
+					taskRepo: makeTaskRepo(),
+					goalRepo: makeGoalRepo(),
+					workspaceRoot: testWorkspace,
+					getRoomDefaultPath: (roomId: string) =>
+						roomId === 'room-42' ? roomWorkspace : undefined,
+				};
+				setupReferenceHandlers(hub, deps);
+				const handler = handlers.get('reference.resolve')!;
+
+				const result = (await handler({
+					sessionId: 'room:chat:room-42',
+					type: 'file',
+					id: 'room-file.txt',
+				})) as {
+					resolved: { data: { content: string } } | null;
+				};
+
+				expect(result.resolved).not.toBeNull();
+				expect(result.resolved!.data.content).toBe('room content');
+			} finally {
+				await rm(roomWorkspace, { recursive: true, force: true });
+			}
+		});
+
+		it('falls back to workspaceRoot when room is not found (deleted room)', async () => {
+			await writeFile(join(testWorkspace, 'fallback.txt'), 'fallback content');
+
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					exists: false,
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+				getRoomDefaultPath: (_roomId: string) => undefined, // room not found
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'room:chat:deleted-room',
+				type: 'file',
+				id: 'fallback.txt',
+			})) as {
+				resolved: { data: { content: string } } | null;
+			};
+
+			expect(result.resolved).not.toBeNull();
+			expect(result.resolved!.data.content).toBe('fallback content');
+		});
+
+		it('falls back to workspaceRoot when getRoomDefaultPath is not provided', async () => {
+			await writeFile(join(testWorkspace, 'fallback.txt'), 'fallback content');
+
+			const { hub, handlers } = createMockMessageHub();
+			// No getRoomDefaultPath in deps (omitted)
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					exists: false,
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'room:chat:some-room',
+				type: 'file',
+				id: 'fallback.txt',
+			})) as {
+				resolved: { data: { content: string } } | null;
+			};
+
+			expect(result.resolved).not.toBeNull();
+			expect(result.resolved!.data.content).toBe('fallback content');
+		});
+
+		it('extracts correct roomId from room:chat:<roomId> for task resolution', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const deps: ReferenceHandlerDeps = {
+				sessionManager: makeSessionManager({
+					workspacePath: testWorkspace,
+					exists: false,
+				}) as never,
+				taskRepo: makeTaskRepo(),
+				goalRepo: makeGoalRepo(),
+				workspaceRoot: testWorkspace,
+				getRoomDefaultPath: (roomId: string) => (roomId === 'room-1' ? testWorkspace : undefined),
+			};
+			setupReferenceHandlers(hub, deps);
+			const handler = handlers.get('reference.resolve')!;
+
+			const result = (await handler({
+				sessionId: 'room:chat:room-1',
+				type: 'task',
+				id: 'task-uuid-1',
+			})) as { resolved: unknown };
+
+			// Task belongs to room-1 — should resolve successfully
+			expect(result.resolved).toMatchObject({
+				type: 'task',
+				id: 'task-uuid-1',
+				data: { id: 'task-uuid-1', title: 'Fix bug' },
+			});
+		});
+	});
 });


### PR DESCRIPTION
Fixes `resolveSessionContext` in `reference-handlers.ts` to look up the room's `defaultPath` instead of falling back to `deps.workspaceRoot` for `room:chat:*` synthetic session IDs.

**Changes:**
- Added `getRoomDefaultPath?: (roomId: string) => string | undefined` to `ReferenceHandlerDeps`
- `resolveSessionContext` now calls this callback for `room:chat:<roomId>` sessions and returns the room's `defaultPath`
- Graceful fallback to `workspaceRoot` when room is not found (deleted mid-request), with a warning log — no uncaught throws
- `index.ts` wires `roomManager.getRoom(roomId)?.defaultPath` as the callback
- 4 new unit tests covering: happy path, deleted-room fallback, missing-callback fallback, task resolution via room context