### PR TITLE
feat(room-handlers): guard defaultPath changes against active task groups

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -241,6 +241,18 @@ export class RoomRuntimeService {
 		return true;
 	}
 
+	/**
+	 * Returns true if there are any active (non-completed) task groups for the given room.
+	 * Queries the DB directly — does NOT rely on the in-memory runtimes map — so it works
+	 * correctly after a daemon restart when the in-memory map may be empty but DB-persisted
+	 * active groups still exist.
+	 */
+	hasActiveTaskGroups(roomId: string): boolean {
+		const rawDb = this.ctx.db.getDatabase();
+		const groupRepo = new SessionGroupRepository(rawDb, this.ctx.reactiveDb);
+		return groupRepo.getActiveGroups(roomId).length > 0;
+	}
+
 	stop(): void {
 		for (const runtime of this.runtimes.values()) {
 			runtime.stop();

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -191,17 +191,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	setupTestHandlers(deps.messageHub, deps.reactiveDb.db);
 	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 
-	// Room handlers
-	setupRoomHandlers(
-		deps.messageHub,
-		roomManager,
-		deps.daemonHub,
-		deps.sessionManager,
-		deps.jobQueue,
-		deps.db
-	);
-
 	// Room Runtime Service (must be created before task/goal handlers — messaging + task approval need it)
+	// Also created before setupRoomHandlers so the hasActiveTaskGroups callback can reference it.
 	const roomRuntimeService = new RoomRuntimeService({
 		// Use reactiveDb.db (proxied Database facade) so sdk_messages writes from
 		// room worker/leader sessions trigger LiveQuery invalidation immediately.
@@ -247,6 +238,18 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			seedRoomTick(event.room.id);
 		},
 		{ sessionId: 'global' }
+	);
+
+	// Room handlers — registered after roomRuntimeService so hasActiveTaskGroups callback
+	// can reference the service (which queries the DB for active groups, not in-memory state).
+	setupRoomHandlers(
+		deps.messageHub,
+		roomManager,
+		deps.daemonHub,
+		deps.sessionManager,
+		deps.jobQueue,
+		deps.db,
+		{ hasActiveTaskGroups: (roomId) => roomRuntimeService.hasActiveTaskGroups(roomId) }
 	);
 
 	// Wire question handlers now that roomRuntimeService is available.

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -29,13 +29,23 @@ import { validateWorkspacePath } from '@neokai/shared';
 
 const log = new Logger('room-handlers');
 
+export interface RoomHandlerOpts {
+	/**
+	 * Callback that returns true if the given room has active (non-completed) task groups.
+	 * Used to guard defaultPath changes — if tasks are running, the change is rejected.
+	 * Implementations MUST query the DB, not only in-memory state, to handle daemon restarts.
+	 */
+	hasActiveTaskGroups?: (roomId: string) => boolean;
+}
+
 export function setupRoomHandlers(
 	messageHub: MessageHub,
 	roomManager: RoomManager,
 	daemonHub: DaemonHub,
 	sessionManager?: SessionManager,
 	jobQueue?: JobQueueRepository,
-	db?: Database
+	db?: Database,
+	opts?: RoomHandlerOpts
 ): void {
 	// room.create - Create a new room
 	messageHub.onRequest('room.create', async (data) => {
@@ -152,9 +162,43 @@ export function setupRoomHandlers(
 			throw new Error('Room ID is required');
 		}
 
+		// Guard: validate new defaultPath and check for active task groups
+		let updatedAllowedPaths = params.allowedPaths;
+		if (params.defaultPath !== undefined) {
+			const currentRoom = roomManager.getRoom(params.roomId);
+			if (!currentRoom) {
+				throw new Error(`Room not found: ${params.roomId}`);
+			}
+
+			if (params.defaultPath !== currentRoom.defaultPath) {
+				// Validate the new path (only the incoming path — current path may be a sentinel value)
+				const pathValidation = validateWorkspacePath(params.defaultPath);
+				if (!pathValidation.valid) {
+					throw new Error(`Invalid defaultPath: ${pathValidation.error}`);
+				}
+				if (!existsSync(params.defaultPath)) {
+					throw new Error(`defaultPath does not exist: ${params.defaultPath}`);
+				}
+
+				// Reject if tasks are still running — workers hold worktrees based on the old path
+				if (opts?.hasActiveTaskGroups?.(params.roomId)) {
+					throw new Error(
+						'Cannot change defaultPath while tasks are active. Stop or complete all tasks first.'
+					);
+				}
+
+				// Auto-add the new defaultPath to allowedPaths if it is not already present
+				const existingAllowedPaths = updatedAllowedPaths ?? currentRoom.allowedPaths ?? [];
+				const alreadyAllowed = existingAllowedPaths.some((wp) => wp.path === params.defaultPath);
+				if (!alreadyAllowed) {
+					updatedAllowedPaths = [...existingAllowedPaths, { path: params.defaultPath }];
+				}
+			}
+		}
+
 		const room = roomManager.updateRoom(params.roomId, {
 			name: params.name,
-			allowedPaths: params.allowedPaths,
+			allowedPaths: updatedAllowedPaths,
 			defaultPath: params.defaultPath,
 			defaultModel: params.defaultModel,
 			allowedModels: params.allowedModels,

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -97,7 +97,8 @@ function createMockRoomManager(): {
 		id: 'room-123',
 		name: 'Test Room',
 		background: 'A test room',
-		allowedPaths: [],
+		allowedPaths: [{ path: tempDir }],
+		defaultPath: tempDir,
 		sessionIds: [],
 		status: 'active',
 		createdAt: Date.now(),
@@ -352,7 +353,7 @@ describe('Room RPC Handlers', () => {
 	});
 
 	describe('room.update', () => {
-		it('updates room with all parameters', async () => {
+		it('updates room with all parameters (no defaultPath change)', async () => {
 			const handler = messageHubData.handlers.get('room.update');
 			expect(handler).toBeDefined();
 
@@ -361,20 +362,21 @@ describe('Room RPC Handlers', () => {
 					roomId: 'room-123',
 					name: 'Updated Name',
 					background: 'Updated background',
-					allowedPaths: [{ path: '/new-path' }],
-					defaultPath: '/new-default',
+					allowedPaths: [{ path: tempDir }],
 					defaultModel: 'claude-opus',
 				},
 				{}
 			);
 
-			expect(roomManagerData.mocks.updateRoom).toHaveBeenCalledWith('room-123', {
-				name: 'Updated Name',
-				background: 'Updated background',
-				allowedPaths: [{ path: '/new-path' }],
-				defaultPath: '/new-default',
-				defaultModel: 'claude-opus',
-			});
+			expect(roomManagerData.mocks.updateRoom).toHaveBeenCalledWith(
+				'room-123',
+				expect.objectContaining({
+					name: 'Updated Name',
+					background: 'Updated background',
+					allowedPaths: [{ path: tempDir }],
+					defaultModel: 'claude-opus',
+				})
+			);
 		});
 
 		it('throws error when roomId is missing', async () => {
@@ -443,6 +445,153 @@ describe('Room RPC Handlers', () => {
 					}),
 				})
 			);
+		});
+	});
+
+	describe('room.update defaultPath guard', () => {
+		it('rejects defaultPath change when active task groups exist', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const { daemonHub } = createMockDaemonHub();
+			const { roomManager } = createMockRoomManager();
+
+			// hasActiveTaskGroups returns true → tasks are running
+			const hasActiveTaskGroups = mock(() => true);
+			setupRoomHandlers(hub, roomManager, daemonHub, undefined, undefined, undefined, {
+				hasActiveTaskGroups,
+			});
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			// Create a second tempDir to represent the new path
+			const { mkdtempSync: mktemp } = await import('node:fs');
+			const { tmpdir } = await import('node:os');
+			const newPath = mktemp(`${tmpdir()}/room-handlers-guard-test-`);
+			try {
+				await expect(handler!({ roomId: 'room-123', defaultPath: newPath }, {})).rejects.toThrow(
+					'Cannot change defaultPath while tasks are active. Stop or complete all tasks first.'
+				);
+				expect(hasActiveTaskGroups).toHaveBeenCalledWith('room-123');
+			} finally {
+				const { rmSync } = await import('node:fs');
+				rmSync(newPath, { recursive: true, force: true });
+			}
+		});
+
+		it('allows defaultPath change when no active task groups exist', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const { daemonHub } = createMockDaemonHub();
+			const { roomManager, mocks } = createMockRoomManager();
+
+			// hasActiveTaskGroups returns false → no tasks running
+			const hasActiveTaskGroups = mock(() => false);
+			setupRoomHandlers(hub, roomManager, daemonHub, undefined, undefined, undefined, {
+				hasActiveTaskGroups,
+			});
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			const { mkdtempSync: mktemp } = await import('node:fs');
+			const { tmpdir } = await import('node:os');
+			const newPath = mktemp(`${tmpdir()}/room-handlers-allow-test-`);
+			try {
+				await handler!({ roomId: 'room-123', defaultPath: newPath }, {});
+				expect(hasActiveTaskGroups).toHaveBeenCalledWith('room-123');
+				expect(mocks.updateRoom).toHaveBeenCalledWith(
+					'room-123',
+					expect.objectContaining({ defaultPath: newPath })
+				);
+			} finally {
+				const { rmSync } = await import('node:fs');
+				rmSync(newPath, { recursive: true, force: true });
+			}
+		});
+
+		it('rejects defaultPath change when new path does not exist on disk', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const { daemonHub } = createMockDaemonHub();
+			const { roomManager } = createMockRoomManager();
+
+			setupRoomHandlers(hub, roomManager, daemonHub, undefined, undefined, undefined, {
+				hasActiveTaskGroups: () => false,
+			});
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ roomId: 'room-123', defaultPath: '/does/not/exist/ever' }, {})
+			).rejects.toThrow('defaultPath does not exist: /does/not/exist/ever');
+		});
+
+		it('rejects defaultPath change when new path is not absolute', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const { daemonHub } = createMockDaemonHub();
+			const { roomManager } = createMockRoomManager();
+
+			setupRoomHandlers(hub, roomManager, daemonHub, undefined, undefined, undefined, {
+				hasActiveTaskGroups: () => false,
+			});
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ roomId: 'room-123', defaultPath: 'relative/path' }, {})
+			).rejects.toThrow('Invalid defaultPath');
+		});
+
+		it('auto-adds new defaultPath to allowedPaths when not already present', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const { daemonHub } = createMockDaemonHub();
+			const { roomManager, mocks } = createMockRoomManager();
+
+			setupRoomHandlers(hub, roomManager, daemonHub, undefined, undefined, undefined, {
+				hasActiveTaskGroups: () => false,
+			});
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			const { mkdtempSync: mktemp } = await import('node:fs');
+			const { tmpdir } = await import('node:os');
+			const newPath = mktemp(`${tmpdir()}/room-handlers-autopaths-test-`);
+			try {
+				await handler!({ roomId: 'room-123', defaultPath: newPath }, {});
+				// newPath was not in the room's original allowedPaths — should be auto-added
+				expect(mocks.updateRoom).toHaveBeenCalledWith(
+					'room-123',
+					expect.objectContaining({
+						defaultPath: newPath,
+						allowedPaths: expect.arrayContaining([{ path: newPath }]),
+					})
+				);
+			} finally {
+				const { rmSync } = await import('node:fs');
+				rmSync(newPath, { recursive: true, force: true });
+			}
+		});
+
+		it('does not trigger guard when defaultPath is unchanged', async () => {
+			const { hub, handlers } = createMockMessageHub();
+			const { daemonHub } = createMockDaemonHub();
+			const { roomManager, mocks } = createMockRoomManager();
+
+			const hasActiveTaskGroups = mock(() => true); // would throw if called
+			setupRoomHandlers(hub, roomManager, daemonHub, undefined, undefined, undefined, {
+				hasActiveTaskGroups,
+			});
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			// mockRoom.defaultPath = tempDir, so passing the same tempDir is "no change"
+			await handler!({ roomId: 'room-123', name: 'New Name', defaultPath: tempDir }, {});
+
+			// guard callback must NOT be called when path is unchanged
+			expect(hasActiveTaskGroups).not.toHaveBeenCalled();
+			expect(mocks.updateRoom).toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
Guard `room.update` defaultPath changes against running workers.

- New `hasActiveTaskGroups(roomId)` method on `RoomRuntimeService` queries the DB via `SessionGroupRepository` (not in-memory map) — works correctly after daemon restarts
- `RoomHandlerOpts` callback approach avoids adding an 8th positional param to `setupRoomHandlers`
- `room.update` now validates new `defaultPath` (absolute + exists), rejects if tasks are active, auto-adds path to `allowedPaths`
- `setupRoomHandlers` moved after `roomRuntimeService` creation in `index.ts` so callback is available
- 6 unit tests: reject with active tasks, allow with no tasks, non-existent/relative path rejection, auto-add allowedPaths, no guard on unchanged path