### PR TITLE
feat(room): propagate defaultPath changes to room chat session and runtime

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -847,6 +847,23 @@ export class RoomRuntimeService {
 				if (runtime) {
 					const room = this.ctx.roomManager.getRoom(event.roomId);
 					if (room) {
+						// When defaultPath changes, the runtime's TaskGroupManager.workspacePath
+						// is readonly and cannot be mutated. Stop the old runtime and recreate it
+						// so the new runtime uses the updated workspacePath for future task groups.
+						// Task 4.1's guard ensures no active task groups exist at this point, so
+						// runtime.stop() does not terminate any in-flight agent sessions.
+						if (room.defaultPath && room.defaultPath !== runtime.taskGroupManager.workspacePath) {
+							log.info(
+								`Room ${room.id} defaultPath changed from ` +
+									`"${runtime.taskGroupManager.workspacePath}" to "${room.defaultPath}" — ` +
+									`stopping and recreating runtime.`
+							);
+							runtime.stop();
+							this.runtimes.delete(event.roomId);
+							this.createOrGetRuntime(room);
+							return;
+						}
+
 						runtime.updateRoom(room);
 						// Re-apply the room chat system prompt so it reflects the latest
 						// room background/instructions (e.g. after room.update changes them).

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -860,6 +860,8 @@ export class RoomRuntimeService {
 							);
 							runtime.stop();
 							this.runtimes.delete(event.roomId);
+							this.observers.delete(event.roomId);
+							this.roomAgentMcpServers.delete(event.roomId);
 							this.createOrGetRuntime(room);
 							return;
 						}

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -164,6 +164,7 @@ export function setupRoomHandlers(
 
 		// Guard: validate new defaultPath and check for active task groups
 		let updatedAllowedPaths = params.allowedPaths;
+		let defaultPathChanged = false;
 		if (params.defaultPath !== undefined) {
 			const currentRoom = roomManager.getRoom(params.roomId);
 			if (!currentRoom) {
@@ -171,6 +172,7 @@ export function setupRoomHandlers(
 			}
 
 			if (params.defaultPath !== currentRoom.defaultPath) {
+				defaultPathChanged = true;
 				// Validate the new path (only the incoming path — current path may be a sentinel value)
 				const pathValidation = validateWorkspacePath(params.defaultPath);
 				if (!pathValidation.valid) {
@@ -238,7 +240,7 @@ export function setupRoomHandlers(
 		// both the DB and the in-memory AgentSession metadata via updateSession(), so
 		// resolveSessionContext (which re-fetches from DB on cache miss) is always
 		// consistent — no additional cache invalidation is needed.
-		if (params.defaultPath !== undefined && room.defaultPath && sessionManager) {
+		if (defaultPathChanged && room.defaultPath && sessionManager) {
 			const roomChatSessionId = `room:chat:${room.id}`;
 			try {
 				const existingSession = sessionManager.getSessionFromDB(roomChatSessionId);

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -233,6 +233,25 @@ export function setupRoomHandlers(
 			}
 		}
 
+		// When defaultPath changes, sync the room chat session's workspacePath so the
+		// next SDK invocation uses the updated path. The session record is updated in
+		// both the DB and the in-memory AgentSession metadata via updateSession(), so
+		// resolveSessionContext (which re-fetches from DB on cache miss) is always
+		// consistent — no additional cache invalidation is needed.
+		if (params.defaultPath !== undefined && room.defaultPath && sessionManager) {
+			const roomChatSessionId = `room:chat:${room.id}`;
+			try {
+				const existingSession = sessionManager.getSessionFromDB(roomChatSessionId);
+				if (existingSession) {
+					await sessionManager.updateSession(roomChatSessionId, {
+						workspacePath: room.defaultPath,
+					});
+				}
+			} catch (err) {
+				log.warn(`Could not sync room chat session workspacePath for room ${room.id}:`, err);
+			}
+		}
+
 		// Broadcast room update event
 		daemonHub
 			.emit('room.updated', {

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -756,6 +756,257 @@ describe('SessionFactory.getCurrentModel', () => {
 	});
 });
 
+describe('room.updated — stop and recreate runtime when defaultPath changes', () => {
+	let rawDb: Database;
+
+	afterEach(() => {
+		rawDb?.close();
+	});
+
+	// Minimal DB schema needed for createOrGetRuntime
+	function createMinimalDb() {
+		const db = new Database(':memory:');
+		db.exec(`
+			CREATE TABLE goals (id TEXT PRIMARY KEY, room_id TEXT, title TEXT, description TEXT DEFAULT '',
+				status TEXT DEFAULT 'active', priority TEXT DEFAULT 'normal', progress INTEGER DEFAULT 0,
+				linked_task_ids TEXT DEFAULT '[]', metrics TEXT DEFAULT '{}',
+				created_at INTEGER, updated_at INTEGER, completed_at INTEGER,
+				planning_attempts INTEGER DEFAULT 0, goal_review_attempts INTEGER DEFAULT 0,
+				mission_type TEXT DEFAULT 'one_shot', autonomy_level TEXT DEFAULT 'supervised',
+				schedule TEXT, schedule_paused INTEGER DEFAULT 0, next_run_at INTEGER,
+				structured_metrics TEXT, max_consecutive_failures INTEGER DEFAULT 3,
+				max_planning_attempts INTEGER DEFAULT 5, consecutive_failures INTEGER DEFAULT 0,
+				replan_count INTEGER DEFAULT 0, short_id TEXT);
+			CREATE TABLE tasks (id TEXT PRIMARY KEY, room_id TEXT, title TEXT, description TEXT,
+				status TEXT DEFAULT 'pending', priority TEXT DEFAULT 'normal', progress INTEGER,
+				current_step TEXT, result TEXT, error TEXT, depends_on TEXT DEFAULT '[]',
+				task_type TEXT DEFAULT 'coding', created_by_task_id TEXT, assigned_agent TEXT DEFAULT 'coder',
+				created_at INTEGER, started_at INTEGER, completed_at INTEGER, archived_at INTEGER,
+				active_session TEXT, pr_url TEXT, pr_number INTEGER, pr_created_at INTEGER,
+				short_id TEXT, updated_at INTEGER);
+			CREATE TABLE session_groups (id TEXT PRIMARY KEY, group_type TEXT DEFAULT 'task',
+				ref_id TEXT, state TEXT DEFAULT 'awaiting_worker', version INTEGER DEFAULT 0,
+				metadata TEXT DEFAULT '{}', created_at INTEGER, completed_at INTEGER);
+			CREATE TABLE session_group_members (group_id TEXT, session_id TEXT, role TEXT, joined_at INTEGER,
+				PRIMARY KEY (group_id, session_id));
+			CREATE TABLE task_group_events (id INTEGER PRIMARY KEY AUTOINCREMENT, group_id TEXT,
+				kind TEXT, payload_json TEXT, created_at INTEGER);
+			CREATE TABLE session_group_messages (id INTEGER PRIMARY KEY AUTOINCREMENT, group_id TEXT,
+				session_id TEXT, role TEXT DEFAULT 'system', message_type TEXT DEFAULT 'status',
+				content TEXT DEFAULT '', created_at INTEGER);
+		`);
+		return db;
+	}
+
+	// Simple daemonHub that captures listeners per event:sessionId
+	function makeDaemonHub() {
+		const listeners = new Map<string, Array<(data: unknown) => void>>();
+		return {
+			on(event: string, handler: (data: unknown) => void, options?: { sessionId?: string }) {
+				const key = `${event}:${options?.sessionId ?? '*'}`;
+				const arr = listeners.get(key) ?? [];
+				arr.push(handler);
+				listeners.set(key, arr);
+				return () => {
+					const next = (listeners.get(key) ?? []).filter((fn) => fn !== handler);
+					if (next.length === 0) listeners.delete(key);
+					else listeners.set(key, next);
+				};
+			},
+			emit(event: string, data: Record<string, unknown> & { sessionId?: string }) {
+				for (const key of [`${event}:*`, `${event}:${data.sessionId ?? '*'}`]) {
+					for (const handler of listeners.get(key) ?? []) {
+						handler(data);
+					}
+				}
+			},
+		};
+	}
+
+	function makeRoom(overrides: Partial<Room> = {}): Room {
+		return {
+			id: 'room-1',
+			name: 'Test Room',
+			allowedPaths: [{ path: '/old/workspace' }],
+			defaultPath: '/old/workspace',
+			sessionIds: [],
+			status: 'active',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+			...overrides,
+		};
+	}
+
+	it('stops the old runtime and creates a new one when defaultPath changes', async () => {
+		rawDb = createMinimalDb();
+		const daemonHub = makeDaemonHub();
+
+		const roomUpdatedHandlers: Array<(event: { roomId: string; room: Room }) => void> = [];
+		const roomCreatedHandlers: Array<(event: { room: Room }) => void> = [];
+		const originalOn = daemonHub.on.bind(daemonHub);
+		const capturedOn = (
+			event: string,
+			handler: (data: unknown) => void,
+			options?: { sessionId?: string }
+		) => {
+			if (event === 'room.updated') {
+				roomUpdatedHandlers.push(handler as (event: { roomId: string; room: Room }) => void);
+			}
+			if (event === 'room.created') {
+				roomCreatedHandlers.push(handler as (event: { room: Room }) => void);
+			}
+			return originalOn(event, handler, options);
+		};
+
+		const sessionManager = {
+			getSessionAsync: mock(async () => null),
+			registerSession: () => {},
+			unregisterSession: () => {},
+		};
+
+		const initialRoom = makeRoom();
+		const updatedRoom = makeRoom({ defaultPath: '/new/workspace' });
+
+		const mockRoomManager = {
+			listRooms: () => [],
+			getRoom: mock((id: string) => (id === 'room-1' ? updatedRoom : null)),
+		} as unknown as RoomManager;
+
+		const config: RoomRuntimeServiceConfig = {
+			db: {
+				getDatabase: () => rawDb,
+				getShortIdAllocator: () => undefined,
+				getSession: () => null,
+			} as never,
+			messageHub: { onRequest: () => {} } as never,
+			daemonHub: { ...daemonHub, on: capturedOn } as never,
+			getApiKey: async () => null,
+			roomManager: mockRoomManager,
+			sessionManager: sessionManager as never,
+			defaultWorkspacePath: '/old/workspace',
+			defaultModel: 'test-model',
+			getGlobalSettings: () => ({}) as never,
+			settingsManager: { getEnabledMcpServersConfig: mock(() => ({})) } as never,
+			reactiveDb: { onChange: () => () => {}, emit: async () => {} } as never,
+		};
+
+		const service = new RoomRuntimeService(config);
+		await service.start();
+
+		// Trigger runtime creation for room-1 via room.created
+		expect(roomCreatedHandlers.length).toBeGreaterThan(0);
+		roomCreatedHandlers[0]!({ room: initialRoom });
+		// Allow async setupRoomAgentSession to settle
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Grab the created runtime and spy on stop()
+		const serviceAny = service as unknown as { runtimes: Map<string, RoomRuntime> };
+		const oldRuntime = serviceAny.runtimes.get('room-1');
+		expect(oldRuntime).toBeDefined();
+		expect(oldRuntime!.taskGroupManager.workspacePath).toBe('/old/workspace');
+
+		let stopCalled = false;
+		const originalStop = oldRuntime!.stop.bind(oldRuntime!);
+		oldRuntime!.stop = () => {
+			stopCalled = true;
+			originalStop();
+		};
+
+		// Emit room.updated with new defaultPath
+		expect(roomUpdatedHandlers.length).toBeGreaterThan(0);
+		roomUpdatedHandlers[0]!({ roomId: 'room-1', room: updatedRoom });
+
+		// Old runtime should be stopped
+		expect(stopCalled).toBe(true);
+
+		// A new runtime should be in the map with the new workspacePath
+		const newRuntime = serviceAny.runtimes.get('room-1');
+		expect(newRuntime).toBeDefined();
+		expect(newRuntime).not.toBe(oldRuntime);
+		expect(newRuntime!.taskGroupManager.workspacePath).toBe('/new/workspace');
+	});
+
+	it('does NOT stop/recreate runtime when defaultPath is unchanged', async () => {
+		rawDb = createMinimalDb();
+		const daemonHub = makeDaemonHub();
+
+		const roomUpdatedHandlers: Array<(event: { roomId: string; room: Room }) => void> = [];
+		const roomCreatedHandlers: Array<(event: { room: Room }) => void> = [];
+		const originalOn = daemonHub.on.bind(daemonHub);
+		const capturedOn = (
+			event: string,
+			handler: (data: unknown) => void,
+			options?: { sessionId?: string }
+		) => {
+			if (event === 'room.updated') {
+				roomUpdatedHandlers.push(handler as (event: { roomId: string; room: Room }) => void);
+			}
+			if (event === 'room.created') {
+				roomCreatedHandlers.push(handler as (event: { room: Room }) => void);
+			}
+			return originalOn(event, handler, options);
+		};
+
+		const sessionManager = {
+			getSessionAsync: mock(async () => null),
+			registerSession: () => {},
+			unregisterSession: () => {},
+		};
+
+		const room = makeRoom({ defaultPath: '/same/workspace' });
+
+		const mockRoomManager = {
+			listRooms: () => [],
+			getRoom: mock(() => room),
+		} as unknown as RoomManager;
+
+		const config: RoomRuntimeServiceConfig = {
+			db: {
+				getDatabase: () => rawDb,
+				getShortIdAllocator: () => undefined,
+				getSession: () => null,
+			} as never,
+			messageHub: { onRequest: () => {} } as never,
+			daemonHub: { ...daemonHub, on: capturedOn } as never,
+			getApiKey: async () => null,
+			roomManager: mockRoomManager,
+			sessionManager: sessionManager as never,
+			defaultWorkspacePath: '/same/workspace',
+			defaultModel: 'test-model',
+			getGlobalSettings: () => ({}) as never,
+			settingsManager: { getEnabledMcpServersConfig: mock(() => ({})) } as never,
+			reactiveDb: { onChange: () => () => {}, emit: async () => {} } as never,
+		};
+
+		const service = new RoomRuntimeService(config);
+		await service.start();
+
+		// Create runtime via room.created
+		roomCreatedHandlers[0]!({ room });
+		await new Promise((r) => setTimeout(r, 0));
+
+		const serviceAny = service as unknown as { runtimes: Map<string, RoomRuntime> };
+		const originalRuntime = serviceAny.runtimes.get('room-1');
+		expect(originalRuntime).toBeDefined();
+
+		let stopCalled = false;
+		originalRuntime!.stop = () => {
+			stopCalled = true;
+		};
+
+		// Emit room.updated with same defaultPath (only name changed)
+		const updatedRoom: Room = { ...room, name: 'Updated Name' };
+		(mockRoomManager.getRoom as ReturnType<typeof mock>).mockReturnValue(updatedRoom);
+		roomUpdatedHandlers[0]!({ roomId: 'room-1', room: updatedRoom });
+		await new Promise((r) => setTimeout(r, 0));
+
+		// stop() must NOT have been called
+		expect(stopCalled).toBe(false);
+		// Same runtime instance must still be in the map
+		expect(serviceAny.runtimes.get('room-1')).toBe(originalRuntime);
+	});
+});
+
 describe('SessionFactory.restoreSession — worker MCP injection and skills', () => {
 	type FactoryType = ReturnType<
 		typeof import('../../../src/lib/room/runtime/room-runtime-service').RoomRuntimeService.prototype.createSessionFactory

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -900,10 +900,17 @@ describe('room.updated — stop and recreate runtime when defaultPath changes', 
 		await new Promise((r) => setTimeout(r, 0));
 
 		// Grab the created runtime and spy on stop()
-		const serviceAny = service as unknown as { runtimes: Map<string, RoomRuntime> };
+		const serviceAny = service as unknown as {
+			runtimes: Map<string, RoomRuntime>;
+			observers: Map<string, SessionObserver>;
+		};
 		const oldRuntime = serviceAny.runtimes.get('room-1');
 		expect(oldRuntime).toBeDefined();
 		expect(oldRuntime!.taskGroupManager.workspacePath).toBe('/old/workspace');
+
+		// Capture the observer that was registered for the old runtime
+		const oldObserver = serviceAny.observers.get('room-1');
+		expect(oldObserver).toBeDefined();
 
 		let stopCalled = false;
 		const originalStop = oldRuntime!.stop.bind(oldRuntime!);
@@ -915,6 +922,8 @@ describe('room.updated — stop and recreate runtime when defaultPath changes', 
 		// Emit room.updated with new defaultPath
 		expect(roomUpdatedHandlers.length).toBeGreaterThan(0);
 		roomUpdatedHandlers[0]!({ roomId: 'room-1', room: updatedRoom });
+		// Allow async setupRoomAgentSession in createOrGetRuntime to settle
+		await new Promise((r) => setTimeout(r, 0));
 
 		// Old runtime should be stopped
 		expect(stopCalled).toBe(true);
@@ -924,6 +933,12 @@ describe('room.updated — stop and recreate runtime when defaultPath changes', 
 		expect(newRuntime).toBeDefined();
 		expect(newRuntime).not.toBe(oldRuntime);
 		expect(newRuntime!.taskGroupManager.workspacePath).toBe('/new/workspace');
+
+		// The observer for the old runtime must have been evicted from the map
+		// so DaemonHub subscriptions (from old observer) don't dangle.
+		// The new entry is either absent (no session found) or a fresh observer.
+		const newObserver = serviceAny.observers.get('room-1');
+		expect(newObserver).not.toBe(oldObserver);
 	});
 
 	it('does NOT stop/recreate runtime when defaultPath is unchanged', async () => {

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -675,6 +675,32 @@ describe('Room RPC Handlers', () => {
 			expect(updateSessionMock).not.toHaveBeenCalled();
 		});
 
+		it('does not sync workspacePath when defaultPath is unchanged', async () => {
+			// mockRoom has defaultPath: tempDir — sending the same value should be a no-op
+			const updateSessionMock = mock(async () => {});
+			const existingSession: Partial<Session> = {
+				id: 'room:chat:room-123',
+				workspacePath: tempDir,
+			};
+			const sessionManager = {
+				getSessionFromDB: mock(() => existingSession as Session),
+				updateSession: updateSessionMock,
+			} as unknown as SessionManager;
+
+			const { hub, handlers } = createMockMessageHub();
+			const { roomManager } = createMockRoomManager();
+			setupRoomHandlers(hub, roomManager, daemonHubData.daemonHub, sessionManager);
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			// Send the same defaultPath that the room already has
+			await handler!({ roomId: 'room-123', defaultPath: tempDir }, {});
+
+			// defaultPath did not change — no workspacePath sync needed
+			expect(updateSessionMock).not.toHaveBeenCalled();
+		});
+
 		it('does not sync workspacePath when room chat session does not exist', async () => {
 			const updateSessionMock = mock(async () => {});
 			const sessionManager = {

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -595,6 +595,125 @@ describe('Room RPC Handlers', () => {
 		});
 	});
 
+	describe('room.update defaultPath workspacePath sync', () => {
+		it('syncs room chat session workspacePath when defaultPath changes', async () => {
+			const updateSessionMock = mock(async () => {});
+			const existingSession: Partial<Session> = {
+				id: 'room:chat:room-123',
+				workspacePath: tempDir,
+			};
+			const sessionManager = {
+				getSessionFromDB: mock(() => existingSession as Session),
+				updateSession: updateSessionMock,
+			} as unknown as SessionManager;
+
+			const { hub, handlers } = createMockMessageHub();
+			const { roomManager, mocks } = createMockRoomManager();
+
+			const { mkdtempSync: mktemp } = await import('node:fs');
+			const { tmpdir: getTmpdir } = await import('node:os');
+			const newPath = mktemp(`${getTmpdir()}/room-handlers-wspath-test-`);
+			try {
+				// Make updateRoom return a room with the new defaultPath (simulates DB update)
+				const updatedRoom: Room = {
+					id: 'room-123',
+					name: 'Test Room',
+					allowedPaths: [{ path: newPath }],
+					defaultPath: newPath,
+					sessionIds: [],
+					status: 'active' as const,
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				};
+				mocks.updateRoom.mockReturnValueOnce(updatedRoom);
+
+				setupRoomHandlers(
+					hub,
+					roomManager,
+					daemonHubData.daemonHub,
+					sessionManager,
+					undefined,
+					undefined,
+					{
+						hasActiveTaskGroups: () => false,
+					}
+				);
+
+				const handler = handlers.get('room.update');
+				expect(handler).toBeDefined();
+
+				await handler!({ roomId: 'room-123', defaultPath: newPath }, {});
+
+				expect(updateSessionMock).toHaveBeenCalledWith(
+					'room:chat:room-123',
+					expect.objectContaining({ workspacePath: newPath })
+				);
+			} finally {
+				const { rmSync } = await import('node:fs');
+				rmSync(newPath, { recursive: true, force: true });
+			}
+		});
+
+		it('does not sync workspacePath when defaultPath is not provided', async () => {
+			const updateSessionMock = mock(async () => {});
+			const sessionManager = {
+				getSessionFromDB: mock(() => null),
+				updateSession: updateSessionMock,
+			} as unknown as SessionManager;
+
+			const { hub, handlers } = createMockMessageHub();
+			const { roomManager } = createMockRoomManager();
+			setupRoomHandlers(hub, roomManager, daemonHubData.daemonHub, sessionManager);
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			// Update only the name — no defaultPath
+			await handler!({ roomId: 'room-123', name: 'Updated Name' }, {});
+
+			// workspacePath sync should NOT be called
+			expect(updateSessionMock).not.toHaveBeenCalled();
+		});
+
+		it('does not sync workspacePath when room chat session does not exist', async () => {
+			const updateSessionMock = mock(async () => {});
+			const sessionManager = {
+				// Returns null — session not in DB yet
+				getSessionFromDB: mock(() => null),
+				updateSession: updateSessionMock,
+			} as unknown as SessionManager;
+
+			const { hub, handlers } = createMockMessageHub();
+			const { roomManager } = createMockRoomManager();
+			setupRoomHandlers(
+				hub,
+				roomManager,
+				daemonHubData.daemonHub,
+				sessionManager,
+				undefined,
+				undefined,
+				{
+					hasActiveTaskGroups: () => false,
+				}
+			);
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			const { mkdtempSync: mktemp } = await import('node:fs');
+			const { tmpdir: getTmpdir } = await import('node:os');
+			const newPath = mktemp(`${getTmpdir()}/room-handlers-nosession-test-`);
+			try {
+				await handler!({ roomId: 'room-123', defaultPath: newPath }, {});
+				// updateSession must NOT be called when session does not exist
+				expect(updateSessionMock).not.toHaveBeenCalled();
+			} finally {
+				const { rmSync } = await import('node:fs');
+				rmSync(newPath, { recursive: true, force: true });
+			}
+		});
+	});
+
 	describe('room.archive', () => {
 		it('archives a room', async () => {
 			const handler = messageHubData.handlers.get('room.archive');


### PR DESCRIPTION
Implements Task 4.2: when `room.update` successfully changes `defaultPath`, propagate the new path to (a) the room chat session's `workspacePath` and (b) the `RoomRuntime`'s workspace via stop-and-recreate.

## Changes

**`room-handlers.ts`** — After `defaultModel` sync, add `defaultPath` sync: call `sessionManager.updateSession('room:chat:<id>', { workspacePath: newPath })` when the room chat session exists. `updateSession` updates both the DB row and in-memory `AgentSession` metadata — no cache invalidation needed since `resolveSessionContext` re-fetches from DB on cache miss.

**`room-runtime-service.ts`** — In the `room.updated` handler, detect when `room.defaultPath !== runtime.taskGroupManager.workspacePath`. When they differ: call `runtime.stop()`, delete from `this.runtimes`, then `createOrGetRuntime(room)` to build a fresh runtime. `TaskGroupManager.workspacePath` is `readonly` so mutation is not an option. Task 4.1's guard ensures no active task groups exist, so `stop()` does not terminate in-flight agent sessions.

**Note on room chat session SDK subprocess**: The SDK subprocess is NOT interrupted — any in-flight conversation finishes with the old path. The next invocation uses the updated `workspacePath`. This is acceptable because room chat sessions don't fork worktrees.

## Tests

- Room chat `workspacePath` sync: happy path, skipped when session absent, no-op when `defaultPath` not provided
- Runtime stop-and-recreate: verifies old runtime stopped + new runtime has updated `workspacePath`
- No stop/recreate when `defaultPath` unchanged