### PR TITLE
feat: make Config.workspaceRoot optional (Task 5.1)

### DIFF
--- a/packages/cli/main.ts
+++ b/packages/cli/main.ts
@@ -50,7 +50,7 @@ const serverMode = isDev ? 'Development' : isTest ? 'Test' : 'Production';
 console.log(`\n🚀 NeoKai ${serverMode} Server`);
 console.log(`   Mode: ${config.nodeEnv}`);
 console.log(`   Model: ${config.defaultModel}`);
-console.log(`   Workspace: ${config.workspaceRoot}\n`);
+console.log(`   Workspace: ${config.workspaceRoot ?? '(none)'}\n`);
 
 if (isDev) {
 	// Development mode: Vite dev server + Daemon (for local development with HMR)

--- a/packages/cli/prod-entry.ts
+++ b/packages/cli/prod-entry.ts
@@ -60,7 +60,7 @@ if (!cliOptions.workspace && !process.env.NEOKAI_WORKSPACE_PATH) {
 const config = getConfig(cliOptions);
 
 console.log(`\nNeoKai Server`);
-console.log(`   Workspace: ${config.workspaceRoot}\n`);
+console.log(`   Workspace: ${config.workspaceRoot ?? '(none)'}\n`);
 
 try {
 	await startProdServer(config);

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'bun';
+import { homedir } from 'os';
 import type { Config } from './config';
 import type { WebSocketData } from './types/websocket';
 import { Database } from './storage/database';
@@ -194,8 +195,13 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	const authManager = new AuthManager(db, config);
 	await authManager.initialize();
 
-	// Initialize settings manager
-	const settingsManager = new SettingsManager(db, config.workspaceRoot);
+	// Initialize settings manager.
+	// When no workspace is set, fall back to homedir() so SettingsManager reads global
+	// MCP config from ~/.claude/.mcp.json. This means MCP servers configured in a
+	// project-level .mcp.json won't be discovered for the global instance — but that
+	// is acceptable because room-scoped sessions use their own defaultPath for MCP
+	// resolution, not the global settings manager workspace path.
+	const settingsManager = new SettingsManager(db, config.workspaceRoot ?? homedir());
 
 	// Check authentication status
 	const authStatus = await authManager.getAuthStatus();

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -42,7 +42,7 @@ export interface Config {
 	temperature: number;
 	maxSessions: number;
 	nodeEnv: string;
-	workspaceRoot: string;
+	workspaceRoot?: string;
 	disableWorktrees?: boolean; // For testing - disables git worktree creation
 	// GitHub integration
 	githubWebhookSecret?: string; // Secret for verifying webhook signatures
@@ -63,8 +63,8 @@ export function getConfig(overrides?: ConfigOverrides): Config {
 	// Workspace root priority:
 	// 1. CLI --workspace flag (overrides parameter)
 	// 2. NEOKAI_WORKSPACE_PATH environment variable
-	// Note: No default fallback - caller (CLI package) must provide workspace path
-	let workspaceRoot: string;
+	// 3. undefined — daemon can start without a workspace (e.g. headless/API-only mode)
+	let workspaceRoot: string | undefined;
 	if (overrides?.workspace) {
 		// CLI override has highest priority
 		workspaceRoot = overrides.workspace;
@@ -72,23 +72,28 @@ export function getConfig(overrides?: ConfigOverrides): Config {
 		// Environment variable
 		workspaceRoot = process.env.NEOKAI_WORKSPACE_PATH;
 	} else {
-		// No workspace provided - this is an error
-		throw new Error(
-			'Workspace path must be explicitly provided via --workspace flag or NEOKAI_WORKSPACE_PATH environment variable. ' +
-				'The daemon does not provide default workspace paths.'
-		);
+		// No workspace provided — this is intentionally allowed.
+		// The daemon can operate without a global workspace root; rooms provide
+		// their own defaultPath for all room-scoped operations.
+		workspaceRoot = undefined;
 	}
 
-	// Default database path: ~/.neokai/projects/{encoded-workspace-path}/database/daemon.db
-	// This ensures each workspace/project gets its own isolated database
-	const defaultDbPath = join(
-		homedir(),
-		'.neokai',
-		'projects',
-		encodeRepoPath(workspaceRoot),
-		'database',
-		'daemon.db'
-	);
+	// Default database path:
+	//   - With workspace: ~/.neokai/projects/{encoded-workspace-path}/database/daemon.db
+	//     (each workspace gets its own isolated database)
+	//   - Without workspace: ~/.neokai/data/daemon.db
+	//     (global fallback that does not collide with any workspace-derived path)
+	const defaultDbPath =
+		workspaceRoot !== undefined
+			? join(
+					homedir(),
+					'.neokai',
+					'projects',
+					encodeRepoPath(workspaceRoot),
+					'database',
+					'daemon.db'
+				)
+			: join(homedir(), '.neokai', 'data', 'daemon.db');
 
 	return {
 		port: overrides?.port ?? parseInt(process.env.NEOKAI_PORT || '9283'),

--- a/packages/daemon/src/lib/file-index.ts
+++ b/packages/daemon/src/lib/file-index.ts
@@ -213,7 +213,7 @@ export class FileIndex {
 	private readonly pollInterval: number;
 
 	constructor(
-		private readonly workspacePath: string,
+		private readonly workspacePath: string | undefined,
 		pollIntervalMs?: number
 	) {
 		this.pollInterval =
@@ -222,7 +222,7 @@ export class FileIndex {
 
 	/** Load .gitignore from workspace root if it exists. */
 	private async loadGitignore(): Promise<void> {
-		const gitignorePath = join(this.workspacePath, '.gitignore');
+		const gitignorePath = join(this.workspacePath!, '.gitignore');
 		try {
 			if (!existsSync(gitignorePath)) return;
 			const content = await readFile(gitignorePath, 'utf-8');
@@ -249,9 +249,9 @@ export class FileIndex {
 
 		for (const entry of entries) {
 			const absPath = join(absDir, entry.name);
-			const relPath = relative(this.workspacePath, absPath);
+			const relPath = relative(this.workspacePath!, absPath);
 
-			if (!isSafePath(this.workspacePath, relPath)) continue;
+			if (!isSafePath(this.workspacePath!, relPath)) continue;
 
 			// Resolve symlinks: stat() follows the link to get the target type.
 			// Symlinked directories are NOT recursed into to prevent infinite loops.
@@ -297,9 +297,9 @@ export class FileIndex {
 
 		for (const entry of entries) {
 			const absPath = join(absDir, entry.name);
-			const relPath = relative(this.workspacePath, absPath);
+			const relPath = relative(this.workspacePath!, absPath);
 
-			if (!isSafePath(this.workspacePath, relPath)) continue;
+			if (!isSafePath(this.workspacePath!, relPath)) continue;
 
 			// Resolve symlinks: stat() follows the link; do NOT recurse into symlinked dirs.
 			if (entry.isSymbolicLink()) {
@@ -343,7 +343,7 @@ export class FileIndex {
 
 		try {
 			const seen = new Set<string>();
-			await this.refreshDirectory(this.workspacePath, seen);
+			await this.refreshDirectory(this.workspacePath!, seen);
 
 			// Remove entries that no longer exist on disk
 			for (const key of this.cache.keys()) {
@@ -367,10 +367,18 @@ export class FileIndex {
 	/**
 	 * Perform the initial workspace scan.
 	 * Must be called before search(). Starts the background polling timer.
+	 *
+	 * When no workspace path was provided at construction time, this is a no-op:
+	 * the index remains empty and search() will return no results.
 	 */
 	async init(): Promise<void> {
+		// Guard: no-op when no workspace path is set (daemon started without --workspace).
+		// The index degrades gracefully — search() returns empty results.
+		if (this.workspacePath === undefined) {
+			return;
+		}
 		await this.loadGitignore();
-		await this.scanDirectory(this.workspacePath);
+		await this.scanDirectory(this.workspacePath!);
 		this.ready = true;
 
 		// Start background polling

--- a/packages/daemon/src/lib/file-index.ts
+++ b/packages/daemon/src/lib/file-index.ts
@@ -338,6 +338,10 @@ export class FileIndex {
 
 	/** Run a full incremental refresh scan. */
 	private async runRefresh(): Promise<void> {
+		// Guard: no-op when workspacePath is not set (mirrors the init() guard).
+		// Prevents non-null assertions below from firing if this method is ever
+		// called before init() completes or via an unexpected code path.
+		if (this.workspacePath === undefined) return;
 		if (this.scanning) return; // Skip if previous scan is still running
 		this.scanning = true;
 

--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -150,8 +150,8 @@ export interface NeoToolsConfig {
 	authManager: NeoQueryAuthManager;
 	mcpServerRepository: NeoQueryMcpServerRepository;
 	skillsManager: NeoQuerySkillsManager;
-	/** Absolute path to the workspace root */
-	workspaceRoot: string;
+	/** Absolute path to the workspace root (optional — daemon can run without a global workspace) */
+	workspaceRoot?: string;
 	/** Human-readable app version string, e.g. "0.1.1" */
 	appVersion: string;
 	/** Unix timestamp (ms) when the daemon process started */

--- a/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/reference-handlers.ts
@@ -75,8 +75,8 @@ export interface ReferenceHandlerDeps {
 	taskRepo: TaskRepoForReference;
 	/** Goal repository (not scoped to room — uses global DB access) */
 	goalRepo: GoalRepoForReference;
-	/** Workspace root path — used as fallback when no session is provided */
-	workspaceRoot: string;
+	/** Workspace root path — used as fallback when no session is provided (optional) */
+	workspaceRoot?: string;
 	/** File index for fast file/folder search (reference.search) */
 	fileIndex: FileIndex;
 	/**
@@ -168,9 +168,11 @@ export function setupReferenceHandlers(messageHub: MessageHub, deps: ReferenceHa
 						return { resolved: resolveGoal(params.id, roomId, deps) };
 
 					case 'file':
+						if (!workspacePath) return { resolved: null };
 						return { resolved: await resolveFile(params.id, workspacePath) };
 
 					case 'folder':
+						if (!workspacePath) return { resolved: null };
 						return { resolved: await resolveFolder(params.id, workspacePath) };
 
 					default: {
@@ -330,7 +332,7 @@ export function setupReferenceHandlers(messageHub: MessageHub, deps: ReferenceHa
 async function resolveSessionContext(
 	sessionId: string,
 	deps: ReferenceHandlerDeps
-): Promise<{ workspacePath: string; roomId: string | null }> {
+): Promise<{ workspacePath: string | undefined; roomId: string | null }> {
 	const agentSession = await deps.sessionManager.getSessionAsync(sessionId);
 	if (!agentSession) {
 		// The room agent route uses a synthetic session ID "room:chat:<roomId>"

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -167,7 +167,10 @@ export class SessionLifecycle {
 		let worktreeMetadata: WorktreeMetadata | undefined;
 		// When no workspace is available (daemon started without --workspace and no explicit
 		// workspacePath), fall back to process.cwd() so Session.workspacePath always has a value.
-		// Global sessions (neo, spaces_global) don't use the workspace path for file operations.
+		// Global sessions (neo, spaces_global) don't use the workspace path for file operations,
+		// so the value stored here is benign for those session types.
+		// TODO: make Session.workspacePath optional (string | undefined) as part of the larger
+		// workspace decoupling effort, so this process.cwd() fallback can be removed.
 		let sessionWorkspacePath: string = baseWorkspacePath ?? process.cwd();
 		const initialBranchName = shouldSkipAutoTitle
 			? generateBranchName(providedTitle!, sessionId) // Title is defined when shouldSkipAutoTitle is true

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -25,7 +25,7 @@ export interface SessionLifecycleConfig {
 	defaultModel: string;
 	maxTokens: number;
 	temperature: number;
-	workspaceRoot: string;
+	workspaceRoot?: string;
 	disableWorktrees?: boolean;
 }
 
@@ -122,9 +122,17 @@ export class SessionLifecycle {
 		}
 		const baseWorkspacePath = params.workspacePath || this.config.workspaceRoot;
 
-		// Detect git support before creating worktree
-		const gitSupport = await this.worktreeManager.detectGitSupport(baseWorkspacePath);
-		const isGitRepo = gitSupport.isGitRepo;
+		// Guard: when no workspace path is available (daemon started without --workspace and
+		// session provides no explicit workspacePath), skip git-support detection and worktree
+		// creation. This protects non-room sessions (e.g., spaces_global, neo) that
+		// intentionally omit workspacePath and would otherwise cause detectGitSupport(undefined)
+		// to crash.
+		let gitSupport: Awaited<ReturnType<typeof this.worktreeManager.detectGitSupport>> | undefined;
+		let isGitRepo = false;
+		if (baseWorkspacePath !== undefined) {
+			gitSupport = await this.worktreeManager.detectGitSupport(baseWorkspacePath);
+			isGitRepo = gitSupport.isGitRepo;
+		}
 
 		// Worktree choice is only for worker sessions.
 		const supportsWorktreeChoice = sessionType === 'worker';
@@ -133,9 +141,12 @@ export class SessionLifecycle {
 		const shouldShowChoice = supportsWorktreeChoice && isGitRepo && !this.config.disableWorktrees;
 
 		// Determine if worktree should be created immediately
-		// Only for non-git repos (git repos go through choice flow)
+		// Only for non-git repos (git repos go through choice flow); requires a workspace path.
 		const shouldCreateWorktree =
-			supportsWorktreeChoice && !this.config.disableWorktrees && !isGitRepo;
+			baseWorkspacePath !== undefined &&
+			supportsWorktreeChoice &&
+			!this.config.disableWorktrees &&
+			!isGitRepo;
 
 		// Read global settings for defaults (model, thinkingLevel, autoScroll)
 		const globalSettings = this.db.getGlobalSettings();
@@ -154,7 +165,10 @@ export class SessionLifecycle {
 		// Create worktree with appropriate branch name
 		// If title provided, use meaningful branch name; otherwise use session/{uuid}
 		let worktreeMetadata: WorktreeMetadata | undefined;
-		let sessionWorkspacePath = baseWorkspacePath;
+		// When no workspace is available (daemon started without --workspace and no explicit
+		// workspacePath), fall back to process.cwd() so Session.workspacePath always has a value.
+		// Global sessions (neo, spaces_global) don't use the workspace path for file operations.
+		let sessionWorkspacePath: string = baseWorkspacePath ?? process.cwd();
 		const initialBranchName = shouldSkipAutoTitle
 			? generateBranchName(providedTitle!, sessionId) // Title is defined when shouldSkipAutoTitle is true
 			: `session/${sessionId}`;
@@ -190,9 +204,10 @@ export class SessionLifecycle {
 
 		// Detect current branch for non-worktree git repos
 		let currentBranch: string | undefined = worktreeMetadata?.branch;
-		if (!currentBranch && isGitRepo && gitSupport.gitRoot) {
+		if (!currentBranch && isGitRepo && gitSupport?.gitRoot) {
 			try {
-				const branch = await this.worktreeManager.getCurrentBranch(gitSupport.gitRoot);
+				// gitSupport and gitSupport.gitRoot are guaranteed non-null by the guard above
+				const branch = await this.worktreeManager.getCurrentBranch(gitSupport!.gitRoot!);
 				currentBranch = branch ?? undefined;
 			} catch (error) {
 				this.logger.debug('[SessionLifecycle] Failed to get current branch:', error);

--- a/packages/daemon/tests/unit/core/config.test.ts
+++ b/packages/daemon/tests/unit/core/config.test.ts
@@ -4,9 +4,10 @@
  * Tests for the configuration module.
  */
 
-import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { getConfig, logCredentialDiscovery } from '../../../src/config';
-import type { DiscoveryResult } from '../../../src/lib/credential-discovery';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { getConfig } from '../../../src/config';
+import { homedir } from 'os';
+import { join } from 'path';
 
 describe('getConfig', () => {
 	let originalEnv: NodeJS.ProcessEnv;
@@ -141,13 +142,24 @@ describe('getConfig', () => {
 		expect(config.workspaceRoot).toBe('/env/workspace');
 	});
 
-	test('throws error when no workspace is provided', () => {
+	test('returns workspaceRoot: undefined when no workspace is provided', () => {
 		process.env.NODE_ENV = 'production';
-		// No NEOKAI_WORKSPACE_PATH env var set
+		// No NEOKAI_WORKSPACE_PATH env var set, no --workspace flag
 
-		expect(() => getConfig()).toThrow(
-			'Workspace path must be explicitly provided via --workspace flag or NEOKAI_WORKSPACE_PATH environment variable'
-		);
+		const config = getConfig();
+
+		expect(config.workspaceRoot).toBeUndefined();
+	});
+
+	test('falls back to ~/.neokai/data/daemon.db when no workspace is provided', () => {
+		process.env.NODE_ENV = 'production';
+		delete process.env.DB_PATH;
+		// No NEOKAI_WORKSPACE_PATH env var set, no --workspace flag
+
+		const config = getConfig();
+
+		expect(config.workspaceRoot).toBeUndefined();
+		expect(config.dbPath).toBe(join(homedir(), '.neokai', 'data', 'daemon.db'));
 	});
 
 	test('reads API key from env var', () => {

--- a/packages/daemon/tests/unit/core/daemon-app-cleanup.test.ts
+++ b/packages/daemon/tests/unit/core/daemon-app-cleanup.test.ts
@@ -276,4 +276,82 @@ describe('Daemon App Cleanup', () => {
 			await daemonContext.cleanup();
 		});
 	});
+
+	describe('daemon startup without --workspace (workspaceRoot: undefined)', () => {
+		test('should start successfully without a workspaceRoot', async () => {
+			// Omit workspaceRoot entirely — daemon must start without it
+			const noWorkspaceConfig: Config = {
+				...config,
+				workspaceRoot: undefined,
+			};
+
+			const daemonContext = await createDaemonApp({
+				config: noWorkspaceConfig,
+				verbose: true,
+				standalone: false,
+			});
+
+			// Core context components must be present
+			expect(daemonContext.server).toBeDefined();
+			expect(daemonContext.authManager).toBeDefined();
+			expect(daemonContext.messageHub).toBeDefined();
+			expect(daemonContext.sessionManager).toBeDefined();
+			expect(daemonContext.settingsManager).toBeDefined();
+			expect(daemonContext.fileIndex).toBeDefined();
+
+			// FileIndex should be ready=false (init() was a no-op since no workspace)
+			expect(daemonContext.fileIndex.isReady()).toBe(false);
+
+			// Cleanup
+			await daemonContext.cleanup();
+		});
+
+		test('should warn about sentinel rooms when workspaceRoot is undefined', async () => {
+			// Use a real file-based DB so the pre-seeded sentinel row persists into the daemon.
+			const tmpDir = process.env.TMPDIR || '/tmp';
+			const sentinelDbPath = `${tmpDir}/neokai-sentinel-test-${Date.now()}.db`;
+
+			const noWorkspaceConfig: Config = {
+				...config,
+				dbPath: sentinelDbPath,
+				workspaceRoot: undefined,
+			};
+
+			// Seed the sentinel row before the daemon opens the database.
+			const { Database } = await import('../../../src/storage/database');
+			const db = new Database(sentinelDbPath);
+			const { createReactiveDatabase } = await import('../../../src/storage/reactive-database');
+			const reactiveDb = createReactiveDatabase(db);
+			await db.initialize(reactiveDb);
+			const rawDb = db.getDatabase();
+			rawDb
+				.prepare(
+					`INSERT OR IGNORE INTO rooms
+						(id, name, default_path, allowed_paths, status, created_at, updated_at)
+					VALUES ('test-room-sentinel', 'Test', '__NEEDS_WORKSPACE_PATH__', '[]', 'active', datetime('now'), datetime('now'))`
+				)
+				.run();
+			db.close(); // Close so the daemon can open it
+
+			// Daemon should start (non-fatal warning, not an error)
+			const daemonContext = await createDaemonApp({
+				config: noWorkspaceConfig,
+				verbose: true,
+				standalone: false,
+			});
+
+			// Warning must have been logged
+			const warnLog = logs.find((log) => log.includes('__NEEDS_WORKSPACE_PATH__'));
+			expect(warnLog).toBeTruthy();
+
+			await daemonContext.cleanup();
+
+			// Clean up the temp DB file
+			try {
+				await import('fs/promises').then((fs) => fs.unlink(sentinelDbPath));
+			} catch {
+				// Ignore cleanup errors
+			}
+		});
+	});
 });

--- a/packages/shared/src/state-types.ts
+++ b/packages/shared/src/state-types.ts
@@ -49,8 +49,8 @@ export interface SystemState {
 	maxSessions: number;
 	storageLocation: string;
 
-	// Workspace
-	workspaceRoot: string;
+	// Workspace (optional — daemon can run without a global workspace root)
+	workspaceRoot?: string;
 
 	// Authentication
 	auth: AuthStatus;


### PR DESCRIPTION
Make `Config.workspaceRoot` optional so the daemon can start without `--workspace`.

## Changes

- `Config.workspaceRoot` changed to `string | undefined`; `getConfig()` returns `undefined` instead of throwing when no workspace is set
- Default DB path falls back to `~/.neokai/data/daemon.db` when workspaceRoot is undefined (no collision with workspace-derived paths)
- `SystemState.workspaceRoot` made optional so the frontend can hide the field when absent
- `FileIndex`: accepts `undefined` workspacePath; `init()` is a no-op and searches return empty results
- `SettingsManager` constructed with `config.workspaceRoot ?? homedir()` fallback (reads global `~/.claude/.mcp.json` for MCP config when no workspace is set)
- `SessionLifecycle`: guard for `baseWorkspacePath === undefined` skips `detectGitSupport` and worktree creation for no-workspace sessions (neo, spaces_global)
- `NeoToolsConfig.workspaceRoot` and `ReferenceHandlerDeps.workspaceRoot` made optional
- CLI entry points log `(none)` gracefully when workspaceRoot is undefined
- Config tests updated: "throws error" test replaced with two tests for undefined workspaceRoot and fallback DB path