### PR TITLE
feat(web): handle optional workspaceRoot in CreateRoomModal (Task 5.2)

### DIFF
--- a/packages/web/src/components/lobby/CreateRoomModal.tsx
+++ b/packages/web/src/components/lobby/CreateRoomModal.tsx
@@ -3,7 +3,7 @@
  *
  * Modal form for creating a new room with:
  * - Room name (required)
- * - Workspace path (required, pre-filled from daemon workspaceRoot)
+ * - Workspace path (required, pre-filled from daemon workspaceRoot when set; empty otherwise)
  * - Background context (optional)
  * - Form validation and error handling
  */

--- a/packages/web/src/components/lobby/__tests__/CreateRoomModal.test.tsx
+++ b/packages/web/src/components/lobby/__tests__/CreateRoomModal.test.tsx
@@ -64,8 +64,15 @@ describe('CreateRoomModal', () => {
 			expect(getPathInput().value).toBe('/home/user/projects');
 		});
 
-		it('pre-fills empty string when systemState has no workspaceRoot', () => {
+		it('pre-fills empty string when systemState is null', () => {
 			mockSystemStateSignal.value = null;
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			expect(getPathInput().value).toBe('');
+		});
+
+		it('pre-fills empty string when systemState.workspaceRoot is undefined', () => {
+			// workspaceRoot is optional on SystemState — daemon may omit it
+			mockSystemStateSignal.value = {} as SystemState;
 			render(<CreateRoomModal {...DEFAULT_PROPS} />);
 			expect(getPathInput().value).toBe('');
 		});
@@ -97,6 +104,19 @@ describe('CreateRoomModal', () => {
 			});
 
 			expect(getPathInput().value).toBe('/late/arrival');
+		});
+
+		it('leaves path empty when late-arriving systemState has no workspaceRoot', async () => {
+			mockSystemStateSignal.value = null;
+			render(<CreateRoomModal {...DEFAULT_PROPS} />);
+			expect(getPathInput().value).toBe('');
+
+			// State arrives but without workspaceRoot
+			await act(async () => {
+				mockSystemStateSignal.value = {} as SystemState;
+			});
+
+			expect(getPathInput().value).toBe('');
 		});
 
 		it('does not overwrite user-edited path when systemState changes', async () => {


### PR DESCRIPTION
Handles `SystemState.workspaceRoot` being optional in the frontend (follow-up to Task 5.1 which made daemon `workspaceRoot` optional).

## Changes

- Updated JSDoc in `CreateRoomModal.tsx` to clarify workspaceRoot is only pre-filled when set
- Added 2 new tests covering the `workspaceRoot: undefined` case explicitly:
  - Field renders empty when `state.workspaceRoot` is `undefined` (state object present but field absent)
  - Late-arriving state without `workspaceRoot` leaves the field empty
- Confirmed no other web components reference `workspaceRoot` — only `CreateRoomModal` used it, and its existing `?? ''` guards already handle the optional case correctly