### PR TITLE
test(e2e): room creation with workspace path E2E tests

### DIFF
--- a/packages/e2e/tests/features/room-creation-workspace.e2e.ts
+++ b/packages/e2e/tests/features/room-creation-workspace.e2e.ts
@@ -160,9 +160,9 @@ test.describe('Room Creation with Workspace Path', () => {
 		// Use 3000ms timeout — comfortably shorter than the toast's 5000ms auto-dismiss
 		// duration. The default 5000ms assertion timeout would race with dismissal on
 		// slow CI machines, potentially missing the toast entirely.
-		await expect(page.getByRole('alert')).toContainText('defaultPath does not exist', {
-			timeout: 3000,
-		});
+		await expect(
+			page.getByRole('alert').filter({ hasText: 'defaultPath does not exist' })
+		).toBeVisible({ timeout: 3000 });
 	});
 
 	// ─── Successful Room Creation ─────────────────────────────────────────────────

--- a/packages/e2e/tests/features/room-creation-workspace.e2e.ts
+++ b/packages/e2e/tests/features/room-creation-workspace.e2e.ts
@@ -150,8 +150,16 @@ test.describe('Room Creation with Workspace Path', () => {
 		// Submit via the form's submit button
 		await page.locator('button[type="submit"]').click();
 
-		// Server-side error from room-handlers.ts: "defaultPath does not exist: ..."
-		await expect(page.locator('text=does not exist')).toBeVisible({ timeout: 5000 });
+		// Server-side error from room-handlers.ts: "defaultPath does not exist: <path>"
+		// The error flows through setError() in the modal, rendering in the general
+		// red error banner — NOT in the path-specific inline <p> (which is only used
+		// for client-side validateWorkspacePath errors).
+		// Use the full error prefix "defaultPath does not exist" for a specific match
+		// that won't false-positive on any other "does not exist" text.
+		await expect(page.locator('text=defaultPath does not exist')).toBeVisible({ timeout: 5000 });
+		// Confirm the path-specific inline error paragraph is NOT shown, verifying
+		// the error went to the general banner (setError) not the inline field (setPathError).
+		await expect(page.locator('p.text-xs.text-red-400')).not.toBeVisible();
 	});
 
 	// ─── Successful Room Creation ─────────────────────────────────────────────────

--- a/packages/e2e/tests/features/room-creation-workspace.e2e.ts
+++ b/packages/e2e/tests/features/room-creation-workspace.e2e.ts
@@ -151,15 +151,14 @@ test.describe('Room Creation with Workspace Path', () => {
 		await page.locator('button[type="submit"]').click();
 
 		// Server-side error from room-handlers.ts: "defaultPath does not exist: <path>"
-		// The error flows through setError() in the modal, rendering in the general
-		// red error banner — NOT in the path-specific inline <p> (which is only used
-		// for client-side validateWorkspacePath errors).
-		// Use the full error prefix "defaultPath does not exist" for a specific match
-		// that won't false-positive on any other "does not exist" text.
-		await expect(page.locator('text=defaultPath does not exist')).toBeVisible({ timeout: 5000 });
-		// Confirm the path-specific inline error paragraph is NOT shown, verifying
-		// the error went to the general banner (setError) not the inline field (setPathError).
-		await expect(page.locator('p.text-xs.text-red-400')).not.toBeVisible();
+		// The actual error flow: lobbyStore.createRoom() catches the RPC error and calls
+		// toast.error(err.message) — it does NOT re-throw. The onSubmit in Lobby.tsx
+		// resolves without throwing, so CreateRoomModal.handleSubmit's catch block never
+		// fires and neither setError() nor setPathError() is called. The error text is
+		// shown in a toast notification (role="alert"), not in the modal's error banner.
+		await expect(page.getByRole('alert')).toContainText('defaultPath does not exist', {
+			timeout: 5000,
+		});
 	});
 
 	// ─── Successful Room Creation ─────────────────────────────────────────────────

--- a/packages/e2e/tests/features/room-creation-workspace.e2e.ts
+++ b/packages/e2e/tests/features/room-creation-workspace.e2e.ts
@@ -4,7 +4,8 @@
  * Verifies the CreateRoomModal flow:
  * - Opening the modal via "Create Room" button
  * - Workspace path field is visible and pre-populated from daemon workspaceRoot
- * - Validation: empty name, empty path, relative path, non-existent path all show errors
+ * - Validation: empty name, empty path, relative path show inline modal errors;
+ *   non-existent path shows a toast error (lobbyStore catches the RPC error)
  * - Successful creation navigates to /room/:id
  * - Created room appears in the lobby
  *
@@ -156,8 +157,11 @@ test.describe('Room Creation with Workspace Path', () => {
 		// resolves without throwing, so CreateRoomModal.handleSubmit's catch block never
 		// fires and neither setError() nor setPathError() is called. The error text is
 		// shown in a toast notification (role="alert"), not in the modal's error banner.
+		// Use 3000ms timeout — comfortably shorter than the toast's 5000ms auto-dismiss
+		// duration. The default 5000ms assertion timeout would race with dismissal on
+		// slow CI machines, potentially missing the toast entirely.
 		await expect(page.getByRole('alert')).toContainText('defaultPath does not exist', {
-			timeout: 5000,
+			timeout: 3000,
 		});
 	});
 

--- a/packages/e2e/tests/features/room-creation-workspace.e2e.ts
+++ b/packages/e2e/tests/features/room-creation-workspace.e2e.ts
@@ -1,0 +1,241 @@
+/**
+ * Room Creation with Workspace Path E2E Tests
+ *
+ * Verifies the CreateRoomModal flow:
+ * - Opening the modal via "Create Room" button
+ * - Workspace path field is visible and pre-populated from daemon workspaceRoot
+ * - Validation: empty name, empty path, relative path all show errors
+ * - Successful creation navigates to /room/:id
+ * - Created room appears in the lobby
+ *
+ * Setup: navigates to lobby via UI for each test
+ * Cleanup: deletes created room via RPC in afterEach (infrastructure pattern)
+ *
+ * NOTE: The Neo panel sidebar also has role="dialog", so we target the Create Room
+ * modal by its `h2` title heading or via `button[type="submit"]` within the form,
+ * rather than using `page.getByRole('dialog')` which would cause strict-mode violations.
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { deleteRoom } from '../helpers/room-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+
+test.describe('Room Creation with Workspace Path', () => {
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let createdRoomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		// Wait for Lobby to be ready by checking the header title
+		await expect(page.locator('h2:has-text("Neo Lobby")')).toBeVisible({ timeout: 10000 });
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (createdRoomId) {
+			await deleteRoom(page, createdRoomId);
+			createdRoomId = '';
+		}
+	});
+
+	// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+	/**
+	 * Open the Create Room modal.
+	 * Uses .first() to avoid strict-mode violation: both the header button and the
+	 * empty-state RoomGrid button share the accessible name "Create Room".
+	 */
+	async function openCreateRoomModal(page: Parameters<typeof waitForWebSocketConnected>[0]) {
+		await page.getByRole('button', { name: 'Create Room', exact: true }).first().click();
+		// Wait for the modal title to appear (specific to the Create Room modal)
+		await expect(page.locator('h2:has-text("Create Room")')).toBeVisible({ timeout: 5000 });
+	}
+
+	// ─── Modal Opens ─────────────────────────────────────────────────────────────
+
+	test('opens Create Room dialog when button clicked', async ({ page }) => {
+		await openCreateRoomModal(page);
+
+		// Verify modal-specific elements are visible
+		await expect(page.locator('label:has-text("Workspace Path")')).toBeVisible({ timeout: 3000 });
+		await expect(page.locator('label:has-text("Room Name")')).toBeVisible({ timeout: 3000 });
+	});
+
+	// ─── Workspace Path Pre-population ───────────────────────────────────────────
+
+	test('workspace path field is visible and pre-populated from daemon workspaceRoot', async ({
+		page,
+	}) => {
+		const workspaceRoot = await getWorkspaceRoot(page);
+
+		await openCreateRoomModal(page);
+
+		const pathInput = page.locator('input[placeholder="/path/to/workspace"]');
+		await expect(pathInput).toBeVisible({ timeout: 3000 });
+		await expect(pathInput).toHaveValue(workspaceRoot, { timeout: 3000 });
+	});
+
+	// ─── Validation Tests ─────────────────────────────────────────────────────────
+
+	test('shows error when room name is empty on submit', async ({ page }) => {
+		await openCreateRoomModal(page);
+
+		// Name input is autoFocus and should be empty by default
+		const nameInput = page.locator('input[placeholder*="Website Development"]');
+		await nameInput.fill('');
+
+		// Submit via the form's submit button
+		await page.locator('button[type="submit"]').click();
+
+		await expect(page.locator('text=Room name is required')).toBeVisible({ timeout: 3000 });
+	});
+
+	test('shows error when workspace path is empty on submit', async ({ page }) => {
+		await openCreateRoomModal(page);
+
+		// Fill room name but clear workspace path
+		await page.locator('input[placeholder*="Website Development"]').fill('Test Room');
+		await page.locator('input[placeholder="/path/to/workspace"]').fill('');
+
+		// Submit via the form's submit button
+		await page.locator('button[type="submit"]').click();
+
+		await expect(page.locator('text=Workspace path must not be empty')).toBeVisible({
+			timeout: 3000,
+		});
+	});
+
+	test('shows error when workspace path is relative on submit', async ({ page }) => {
+		await openCreateRoomModal(page);
+
+		// Fill room name and a relative (non-absolute) path
+		await page.locator('input[placeholder*="Website Development"]').fill('Test Room');
+		await page.locator('input[placeholder="/path/to/workspace"]').fill('relative/path/here');
+
+		// Submit via the form's submit button
+		await page.locator('button[type="submit"]').click();
+
+		// Error message from validateWorkspacePath: "Workspace path must be an absolute path (start with /)"
+		await expect(page.locator('text=Workspace path must be an absolute path')).toBeVisible({
+			timeout: 3000,
+		});
+	});
+
+	// ─── Successful Room Creation ─────────────────────────────────────────────────
+
+	test('creates room and navigates to /room/:id', async ({ page }) => {
+		const workspaceRoot = await getWorkspaceRoot(page);
+		const roomName = `E2E Workspace Room ${Date.now()}`;
+
+		await openCreateRoomModal(page);
+
+		// Fill room name
+		await page.locator('input[placeholder*="Website Development"]').fill(roomName);
+
+		// Workspace path should already be pre-filled; verify and keep it
+		await expect(page.locator('input[placeholder="/path/to/workspace"]')).toHaveValue(
+			workspaceRoot,
+			{ timeout: 3000 }
+		);
+
+		// Submit via the form's submit button
+		await page.locator('button[type="submit"]').click();
+
+		// Should navigate to /room/:id
+		await page.waitForURL(/\/room\/[a-f0-9-]+/, { timeout: 10000 });
+
+		// Extract room ID for cleanup
+		const url = page.url();
+		const match = url.match(/\/room\/([a-f0-9-]+)/);
+		if (match) {
+			createdRoomId = match[1];
+		}
+
+		// Room page should load (Overview tab in room tab bar)
+		await expect(page.getByRole('button', { name: 'Overview' }).first()).toBeVisible({
+			timeout: 10000,
+		});
+	});
+
+	test('created room appears in the lobby', async ({ page }) => {
+		const workspaceRoot = await getWorkspaceRoot(page);
+		const roomName = `E2E Lobby Check Room ${Date.now()}`;
+
+		await openCreateRoomModal(page);
+
+		await page.locator('input[placeholder*="Website Development"]').fill(roomName);
+		await expect(page.locator('input[placeholder="/path/to/workspace"]')).toHaveValue(
+			workspaceRoot,
+			{ timeout: 3000 }
+		);
+
+		// Submit
+		await page.locator('button[type="submit"]').click();
+
+		// Wait for navigation
+		await page.waitForURL(/\/room\/[a-f0-9-]+/, { timeout: 10000 });
+
+		const url = page.url();
+		const match = url.match(/\/room\/([a-f0-9-]+)/);
+		if (match) {
+			createdRoomId = match[1];
+		}
+
+		// Navigate back to lobby
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		await expect(page.locator('h2:has-text("Neo Lobby")')).toBeVisible({ timeout: 10000 });
+
+		// Room should appear in the lobby grid (use .first() — room name may also
+		// appear in the recent sessions sidebar)
+		await expect(page.locator(`h3:has-text("${roomName}")`).first()).toBeVisible({
+			timeout: 10000,
+		});
+	});
+
+	test('dialog can be closed with Cancel button', async ({ page }) => {
+		await openCreateRoomModal(page);
+
+		await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+
+		// Modal is closed when its title heading is no longer visible
+		await expect(page.locator('h2:has-text("Create Room")')).not.toBeVisible({ timeout: 3000 });
+	});
+
+	// ─── Custom Workspace Path ────────────────────────────────────────────────────
+
+	test('accepts a custom existing workspace path', async ({ page }) => {
+		// Use the daemon workspace root — guaranteed to exist on both dev machines and CI
+		const workspaceRoot = await getWorkspaceRoot(page);
+		const roomName = `E2E Custom Path Room ${Date.now()}`;
+
+		await openCreateRoomModal(page);
+
+		await page.locator('input[placeholder*="Website Development"]').fill(roomName);
+
+		// Override workspace path (clear and re-type the same existing path)
+		const pathInput = page.locator('input[placeholder="/path/to/workspace"]');
+		await pathInput.fill('');
+		await pathInput.fill(workspaceRoot);
+
+		// Submit
+		await page.locator('button[type="submit"]').click();
+
+		// Should navigate to /room/:id without error
+		await page.waitForURL(/\/room\/[a-f0-9-]+/, { timeout: 10000 });
+
+		const url = page.url();
+		const match = url.match(/\/room\/([a-f0-9-]+)/);
+		if (match) {
+			createdRoomId = match[1];
+		}
+
+		// Room page should load
+		await expect(page.getByRole('button', { name: 'Overview' }).first()).toBeVisible({
+			timeout: 10000,
+		});
+	});
+});

--- a/packages/e2e/tests/features/room-creation-workspace.e2e.ts
+++ b/packages/e2e/tests/features/room-creation-workspace.e2e.ts
@@ -4,7 +4,7 @@
  * Verifies the CreateRoomModal flow:
  * - Opening the modal via "Create Room" button
  * - Workspace path field is visible and pre-populated from daemon workspaceRoot
- * - Validation: empty name, empty path, relative path all show errors
+ * - Validation: empty name, empty path, relative path, non-existent path all show errors
  * - Successful creation navigates to /room/:id
  * - Created room appears in the lobby
  *
@@ -16,6 +16,7 @@
  * rather than using `page.getByRole('dialog')` which would cause strict-mode violations.
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
 import { deleteRoom } from '../helpers/room-helpers';
@@ -48,15 +49,26 @@ test.describe('Room Creation with Workspace Path', () => {
 	 * Uses .first() to avoid strict-mode violation: both the header button and the
 	 * empty-state RoomGrid button share the accessible name "Create Room".
 	 */
-	async function openCreateRoomModal(page: Parameters<typeof waitForWebSocketConnected>[0]) {
+	async function openCreateRoomModal(page: Page) {
 		await page.getByRole('button', { name: 'Create Room', exact: true }).first().click();
 		// Wait for the modal title to appear (specific to the Create Room modal)
 		await expect(page.locator('h2:has-text("Create Room")')).toBeVisible({ timeout: 5000 });
 	}
 
+	/**
+	 * Extract the room ID from the current page URL after navigating to /room/:id.
+	 * Stores the ID in `createdRoomId` for afterEach cleanup.
+	 */
+	function captureRoomIdFromUrl(page: Page) {
+		const match = page.url().match(/\/room\/([a-f0-9-]+)/);
+		if (match) {
+			createdRoomId = match[1];
+		}
+	}
+
 	// ─── Modal Opens ─────────────────────────────────────────────────────────────
 
-	test('opens Create Room dialog when button clicked', async ({ page }) => {
+	test('opens Create Room modal when button clicked', async ({ page }) => {
 		await openCreateRoomModal(page);
 
 		// Verify modal-specific elements are visible
@@ -69,9 +81,11 @@ test.describe('Room Creation with Workspace Path', () => {
 	test('workspace path field is visible and pre-populated from daemon workspaceRoot', async ({
 		page,
 	}) => {
-		const workspaceRoot = await getWorkspaceRoot(page);
-
 		await openCreateRoomModal(page);
+
+		// Resolve workspace root after opening the modal so the systemState signal has
+		// had a chance to deliver its value and pre-fill the field.
+		const workspaceRoot = await getWorkspaceRoot(page);
 
 		const pathInput = page.locator('input[placeholder="/path/to/workspace"]');
 		await expect(pathInput).toBeVisible({ timeout: 3000 });
@@ -83,9 +97,9 @@ test.describe('Room Creation with Workspace Path', () => {
 	test('shows error when room name is empty on submit', async ({ page }) => {
 		await openCreateRoomModal(page);
 
-		// Name input is autoFocus and should be empty by default
+		// Name input starts empty (autoFocus). Verify initial state before submitting.
 		const nameInput = page.locator('input[placeholder*="Website Development"]');
-		await nameInput.fill('');
+		await expect(nameInput).toHaveValue('');
 
 		// Submit via the form's submit button
 		await page.locator('button[type="submit"]').click();
@@ -124,6 +138,22 @@ test.describe('Room Creation with Workspace Path', () => {
 		});
 	});
 
+	test('shows error when workspace path does not exist on disk', async ({ page }) => {
+		await openCreateRoomModal(page);
+
+		// Fill room name and an absolute path guaranteed not to exist
+		await page.locator('input[placeholder*="Website Development"]').fill('Test Room');
+		await page
+			.locator('input[placeholder="/path/to/workspace"]')
+			.fill('/nonexistent/e2e-path-xyz123');
+
+		// Submit via the form's submit button
+		await page.locator('button[type="submit"]').click();
+
+		// Server-side error from room-handlers.ts: "defaultPath does not exist: ..."
+		await expect(page.locator('text=does not exist')).toBeVisible({ timeout: 5000 });
+	});
+
 	// ─── Successful Room Creation ─────────────────────────────────────────────────
 
 	test('creates room and navigates to /room/:id', async ({ page }) => {
@@ -146,13 +176,7 @@ test.describe('Room Creation with Workspace Path', () => {
 
 		// Should navigate to /room/:id
 		await page.waitForURL(/\/room\/[a-f0-9-]+/, { timeout: 10000 });
-
-		// Extract room ID for cleanup
-		const url = page.url();
-		const match = url.match(/\/room\/([a-f0-9-]+)/);
-		if (match) {
-			createdRoomId = match[1];
-		}
+		captureRoomIdFromUrl(page);
 
 		// Room page should load (Overview tab in room tab bar)
 		await expect(page.getByRole('button', { name: 'Overview' }).first()).toBeVisible({
@@ -177,12 +201,7 @@ test.describe('Room Creation with Workspace Path', () => {
 
 		// Wait for navigation
 		await page.waitForURL(/\/room\/[a-f0-9-]+/, { timeout: 10000 });
-
-		const url = page.url();
-		const match = url.match(/\/room\/([a-f0-9-]+)/);
-		if (match) {
-			createdRoomId = match[1];
-		}
+		captureRoomIdFromUrl(page);
 
 		// Navigate back to lobby
 		await page.goto('/');
@@ -196,7 +215,7 @@ test.describe('Room Creation with Workspace Path', () => {
 		});
 	});
 
-	test('dialog can be closed with Cancel button', async ({ page }) => {
+	test('modal can be closed with Cancel button', async ({ page }) => {
 		await openCreateRoomModal(page);
 
 		await page.getByRole('button', { name: 'Cancel', exact: true }).click();
@@ -226,12 +245,7 @@ test.describe('Room Creation with Workspace Path', () => {
 
 		// Should navigate to /room/:id without error
 		await page.waitForURL(/\/room\/[a-f0-9-]+/, { timeout: 10000 });
-
-		const url = page.url();
-		const match = url.match(/\/room\/([a-f0-9-]+)/);
-		if (match) {
-			createdRoomId = match[1];
-		}
+		captureRoomIdFromUrl(page);
 
 		// Room page should load
 		await expect(page.getByRole('button', { name: 'Overview' }).first()).toBeVisible({


### PR DESCRIPTION
Add 9 Playwright E2E tests for the CreateRoomModal workspace path flow (Task 6.2).

**Tests cover:**
- Modal opens with workspace path field visible
- Workspace path pre-populated from daemon `workspaceRoot`
- Validation errors: empty name, empty path, relative path
- Successful creation navigates to `/room/:id`
- Created room appears in the lobby
- Cancel button closes the modal
- Custom existing workspace path accepted

**Implementation notes:**
- Uses `h2:has-text("Create Room")` to target the modal (avoids strict-mode collision with the Neo panel sidebar which also has `role="dialog"`)
- Uses `button[type="submit"]` for form submission to avoid ambiguity with the header/empty-state "Create Room" buttons
- Room cleanup via `deleteRoom()` RPC in `afterEach` (infrastructure exception per E2E conventions)
- Workspace path uses `getWorkspaceRoot()` (guaranteed to exist on all environments)