### PR TITLE
fix: defensive JSON parsing for schedule/structuredMetrics in goals

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -9,7 +9,7 @@
 
 import { Database as BunDatabase } from 'bun:sqlite';
 import type { MessageHub } from '@neokai/shared';
-import { createEventMessage } from '@neokai/shared';
+import { createEventMessage, parseJson, parseJsonOptional } from '@neokai/shared';
 import type {
 	LiveQuerySubscribeRequest,
 	LiveQuerySubscribeResponse,
@@ -76,13 +76,10 @@ function mapTaskRow(row: Record<string, unknown>): Record<string, unknown> {
 function mapGoalRow(row: Record<string, unknown>): Record<string, unknown> {
 	return {
 		...row,
-		linkedTaskIds: JSON.parse((row.linkedTaskIds as string | null) ?? '[]') as string[],
-		metrics: JSON.parse((row.metrics as string | null) ?? '{}') as Record<string, number>,
-		structuredMetrics:
-			row.structuredMetrics != null
-				? (JSON.parse(row.structuredMetrics as string) as unknown[])
-				: undefined,
-		schedule: row.schedule != null ? (JSON.parse(row.schedule as string) as unknown) : undefined,
+		linkedTaskIds: parseJson<string[]>((row.linkedTaskIds as string | null) ?? '[]', []),
+		metrics: parseJson<Record<string, number>>((row.metrics as string | null) ?? '{}', {}),
+		structuredMetrics: parseJsonOptional(row.structuredMetrics as string | null),
+		schedule: parseJsonOptional(row.schedule as string | null),
 		schedulePaused: row.schedulePaused === 1,
 	};
 }

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
-import { generateUUID, parseJsonOptional } from '@neokai/shared';
+import { generateUUID, parseJson, parseJsonOptional } from '@neokai/shared';
 import type {
 	RoomGoal,
 	GoalStatus,
@@ -654,8 +654,8 @@ export class GoalRepository {
 			status: row.status as GoalStatus,
 			priority: row.priority as GoalPriority,
 			progress: row.progress as number,
-			linkedTaskIds: JSON.parse(row.linked_task_ids as string) as string[],
-			metrics: JSON.parse(row.metrics as string) as Record<string, number>,
+			linkedTaskIds: parseJson<string[]>((row.linked_task_ids as string | null) ?? '[]', []),
+			metrics: parseJson<Record<string, number>>((row.metrics as string | null) ?? '{}', {}),
 			planning_attempts: (row.planning_attempts as number | null) ?? 0,
 			goal_review_attempts: (row.goal_review_attempts as number | null) ?? 0,
 			createdAt: row.created_at as number,

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
-import { generateUUID } from '@neokai/shared';
+import { generateUUID, parseJsonOptional } from '@neokai/shared';
 import type {
 	RoomGoal,
 	GoalStatus,
@@ -664,12 +664,10 @@ export class GoalRepository {
 			// Mission V2 fields
 			missionType: (row.mission_type as MissionType | null) ?? 'one_shot',
 			autonomyLevel: (row.autonomy_level as AutonomyLevel | null) ?? 'supervised',
-			structuredMetrics:
-				row.structured_metrics != null
-					? (JSON.parse(row.structured_metrics as string) as MissionMetric[])
-					: undefined,
-			schedule:
-				row.schedule != null ? (JSON.parse(row.schedule as string) as CronSchedule) : undefined,
+			structuredMetrics: parseJsonOptional<MissionMetric[]>(
+				row.structured_metrics as string | null
+			),
+			schedule: parseJsonOptional<CronSchedule>(row.schedule as string | null),
 			schedulePaused: row.schedule_paused === 1,
 			nextRunAt: (row.next_run_at as number | null) ?? undefined,
 			maxConsecutiveFailures: (row.max_consecutive_failures as number | null) ?? 3,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -287,6 +287,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Sets default_path from allowed_paths[0].path, or '__NEEDS_WORKSPACE_PATH__' sentinel
 	// when allowed_paths is also empty. Sentinel is replaced at startup with config.workspaceRoot.
 	runMigration70(db);
+	// Migration 71: Fix corrupted schedule values in goals table.
+	// Some rows may contain raw cron strings (e.g. "@daily") instead of the expected
+	// JSON object {"expression":"@daily","timezone":"UTC"}. This wraps bare strings
+	// into the proper CronSchedule shape.
+	runMigration71(db);
 }
 
 /**
@@ -4561,5 +4566,51 @@ export function runMigration70(db: BunDatabase): void {
 			// JSON parse failed — fall through to sentinel
 		}
 		update.run(newPath, row.id);
+	}
+}
+
+/**
+ * Migration 71: Fix corrupted schedule values in goals table.
+ *
+ * Some rows may contain raw cron strings (e.g. "@daily", "0 9 * * *") instead
+ * of the expected JSON object {"expression":"@daily","timezone":"UTC"}.
+ * This migration detects such rows and wraps bare strings into the proper
+ * CronSchedule shape.
+ *
+ * Idempotency: if no rows have non-JSON schedule values, the function returns early.
+ */
+export function runMigration71(db: BunDatabase): void {
+	if (!tableExists(db, 'goals')) return;
+
+	// Check if the schedule column exists (older DBs may not have it)
+	const goalColumns = db.prepare(`PRAGMA table_info(goals)`).all() as Array<{ name: string }>;
+	const hasSchedule = goalColumns.some((col) => col.name === 'schedule');
+	if (!hasSchedule) return;
+
+	const rows = db
+		.prepare(`SELECT id, schedule FROM goals WHERE schedule IS NOT NULL`)
+		.all() as Array<{ id: string; schedule: string }>;
+
+	if (rows.length === 0) return;
+
+	const update = db.prepare(`UPDATE goals SET schedule = ? WHERE id = ?`);
+
+	for (const row of rows) {
+		try {
+			const parsed = JSON.parse(row.schedule);
+			// If it parses and is an object with expression field, it's already correct
+			if (typeof parsed === 'object' && parsed !== null && typeof parsed.expression === 'string') {
+				continue;
+			}
+			// If it parses but is a bare string (somehow valid JSON string), wrap it
+			if (typeof parsed === 'string') {
+				const fixedVal = JSON.stringify({ expression: parsed, timezone: 'UTC' });
+				update.run(fixedVal, row.id);
+			}
+		} catch {
+			// JSON parse failed — this is a raw cron string like "@daily"
+			const fixedVal = JSON.stringify({ expression: row.schedule, timezone: 'UTC' });
+			update.run(fixedVal, row.id);
+		}
 	}
 }

--- a/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
+++ b/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
@@ -220,4 +220,49 @@ describe('GoalRepository — V2 Mission fields', () => {
 			expect(goals[0].schedule?.expression).toBe('0 9 * * *');
 		});
 	});
+
+	describe('defensive JSON parsing for corrupted schedule and structuredMetrics', () => {
+		it('should not crash when schedule column contains a raw cron string', () => {
+			// Create a goal normally, then corrupt the schedule column via direct SQL
+			const goal = repo.createGoal({ roomId, title: 'Corrupted Schedule' });
+			const goalId = goal.id;
+			db.exec(`UPDATE goals SET schedule = '@daily' WHERE id = '${goalId}'`);
+
+			const fetched = repo.getGoal(goalId);
+			expect(fetched).not.toBeNull();
+			expect(fetched!.schedule).toBeUndefined();
+		});
+
+		it('should not crash when structuredMetrics column contains corrupted JSON', () => {
+			const goal = repo.createGoal({ roomId, title: 'Corrupted Metrics' });
+			const goalId = goal.id;
+			db.exec(`UPDATE goals SET structured_metrics = 'corrupted{json' WHERE id = '${goalId}'`);
+
+			const fetched = repo.getGoal(goalId);
+			expect(fetched).not.toBeNull();
+			expect(fetched!.structuredMetrics).toBeUndefined();
+		});
+
+		it('should not crash when both schedule and structuredMetrics are corrupted', () => {
+			const goal = repo.createGoal({ roomId, title: 'Both Corrupted' });
+			const goalId = goal.id;
+			db.exec(
+				`UPDATE goals SET schedule = '0 9 * * *', structured_metrics = 'broken' WHERE id = '${goalId}'`
+			);
+
+			const fetched = repo.getGoal(goalId);
+			expect(fetched).not.toBeNull();
+			expect(fetched!.schedule).toBeUndefined();
+			expect(fetched!.structuredMetrics).toBeUndefined();
+		});
+
+		it('should handle corrupted schedule via listGoals without crashing', () => {
+			const goal = repo.createGoal({ roomId, title: 'List Corrupted' });
+			db.exec(`UPDATE goals SET schedule = '@weekly' WHERE id = '${goal.id}'`);
+
+			const goals = repo.listGoals(roomId);
+			expect(goals).toHaveLength(1);
+			expect(goals[0].schedule).toBeUndefined();
+		});
+	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
@@ -425,6 +425,61 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			const sql = NAMED_QUERY_REGISTRY.get('goals.byRoom')!.sql;
 			expect(sql).toContain('ORDER BY priority DESC, created_at ASC, id ASC');
 		});
+
+		describe('defensive JSON parsing for schedule and structuredMetrics', () => {
+			function insertGoalRaw(overrides: Record<string, unknown> = {}): string {
+				const id = `goal-${Date.now()}-${Math.random()}`;
+				const linkedTaskIds = JSON.stringify(overrides.linkedTaskIds ?? []);
+				const metrics = JSON.stringify(overrides.metrics ?? {});
+				const schedule = overrides.schedule != null ? `'${String(overrides.schedule)}'` : 'NULL';
+				const structuredMetrics =
+					overrides.structuredMetrics != null ? `'${String(overrides.structuredMetrics)}'` : 'NULL';
+				db.exec(`
+					INSERT INTO goals (
+						id, room_id, title, description, status, priority, progress,
+						linked_task_ids, metrics, created_at, updated_at,
+						schedule, structured_metrics
+					) VALUES (
+						'${id}', '${roomId}', 'Test Goal', 'Desc', 'active', 'normal', 0,
+						'${linkedTaskIds}', '${metrics}', ${now}, ${now},
+						${schedule}, ${structuredMetrics}
+					)
+				`);
+				return id;
+			}
+
+			test('raw cron string in schedule column does not crash — returns undefined', () => {
+				insertGoalRaw({ schedule: '@daily' });
+				const [row] = queryAndMap();
+				expect(row.schedule).toBeUndefined();
+			});
+
+			test('valid JSON schedule parses correctly', () => {
+				const scheduleJson = JSON.stringify({ expression: '@daily', timezone: 'UTC' });
+				insertGoalRaw({ schedule: scheduleJson });
+				const [row] = queryAndMap();
+				expect(row.schedule).toEqual({ expression: '@daily', timezone: 'UTC' });
+			});
+
+			test('corrupted JSON in structuredMetrics column does not crash', () => {
+				insertGoalRaw({ structuredMetrics: 'corrupted{json' });
+				const [row] = queryAndMap();
+				expect(row.structuredMetrics).toBeUndefined();
+			});
+
+			test('valid JSON structuredMetrics parses correctly', () => {
+				const metricsJson = JSON.stringify([{ name: 'coverage', target: 80, current: 60 }]);
+				insertGoalRaw({ structuredMetrics: metricsJson });
+				const [row] = queryAndMap();
+				expect(row.structuredMetrics).toEqual([{ name: 'coverage', target: 80, current: 60 }]);
+			});
+
+			test('corrupted JSON in schedule column does not crash', () => {
+				insertGoalRaw({ schedule: 'not-valid-json{' });
+				const [row] = queryAndMap();
+				expect(row.schedule).toBeUndefined();
+			});
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/storage/migrations/migration-71_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-71_test.ts
@@ -10,8 +10,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigration71 } from '../../../../src/storage/schema/migrations';
 
@@ -40,33 +38,20 @@ function insertGoal(db: BunDatabase, id: string, schedule: string | null): void 
 	const now = Date.now();
 	db.prepare(
 		`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids, metrics, created_at, updated_at, schedule)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	).run(id, 'room-1', 'Test Goal', 'Desc', 'active', 'normal', 0, '[]', '{}', now, now, schedule);
 }
 
 describe('Migration 71: Fix corrupted schedule values in goals table', () => {
-	let testDir: string;
 	let db: BunDatabase;
 
 	beforeEach(() => {
-		testDir = join(process.cwd(), 'tmp', 'test-migration-71', `test-${Date.now()}`);
-		mkdirSync(testDir, { recursive: true });
-		const dbPath = join(testDir, 'test.db');
-		db = new BunDatabase(dbPath);
+		db = new BunDatabase(':memory:');
 		db.exec('PRAGMA foreign_keys = OFF');
 	});
 
 	afterEach(() => {
-		try {
-			db.close();
-		} catch {
-			// ignore
-		}
-		try {
-			rmSync(testDir, { recursive: true, force: true });
-		} catch {
-			// ignore
-		}
+		db.close();
 	});
 
 	test('wraps a bare cron string like @daily into proper JSON', () => {

--- a/packages/daemon/tests/unit/storage/migrations/migration-71_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-71_test.ts
@@ -1,0 +1,199 @@
+/**
+ * Migration 71 Tests
+ *
+ * Migration 71: Fix corrupted schedule values in the goals table.
+ * - Wraps bare cron strings (e.g. "@daily") into {"expression":"@daily","timezone":"UTC"}
+ * - Leaves already-valid JSON schedule objects unchanged
+ * - Handles null schedule correctly (no-op)
+ * - Is idempotent (running twice doesn't change anything)
+ * - Handles JSON-quoted strings (valid JSON but wrong shape) by wrapping them
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigration71 } from '../../../../src/storage/schema/migrations';
+
+function createGoalsTable(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS goals (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active',
+			priority TEXT NOT NULL DEFAULT 'normal',
+			progress INTEGER NOT NULL DEFAULT 0,
+			linked_task_ids TEXT NOT NULL DEFAULT '[]',
+			metrics TEXT NOT NULL DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			schedule TEXT,
+			schedule_paused INTEGER NOT NULL DEFAULT 0,
+			next_run_at INTEGER
+		)
+	`);
+}
+
+function insertGoal(db: BunDatabase, id: string, schedule: string | null): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids, metrics, created_at, updated_at, schedule)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(id, 'room-1', 'Test Goal', 'Desc', 'active', 'normal', 0, '[]', '{}', now, now, schedule);
+}
+
+describe('Migration 71: Fix corrupted schedule values in goals table', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-71', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = OFF');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('wraps a bare cron string like @daily into proper JSON', () => {
+		createGoalsTable(db);
+		insertGoal(db, 'goal-1', '@daily');
+
+		runMigration71(db);
+
+		const row = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-1'`).get() as {
+			schedule: string;
+		};
+		const parsed = JSON.parse(row.schedule) as { expression: string; timezone: string };
+		expect(parsed.expression).toBe('@daily');
+		expect(parsed.timezone).toBe('UTC');
+	});
+
+	test('wraps a 5-field cron string into proper JSON', () => {
+		createGoalsTable(db);
+		insertGoal(db, 'goal-2', '0 9 * * 1');
+
+		runMigration71(db);
+
+		const row = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-2'`).get() as {
+			schedule: string;
+		};
+		const parsed = JSON.parse(row.schedule) as { expression: string; timezone: string };
+		expect(parsed.expression).toBe('0 9 * * 1');
+		expect(parsed.timezone).toBe('UTC');
+	});
+
+	test('leaves already-valid JSON schedule unchanged', () => {
+		createGoalsTable(db);
+		const validSchedule = JSON.stringify({ expression: '0 9 * * *', timezone: 'UTC' });
+		insertGoal(db, 'goal-3', validSchedule);
+
+		runMigration71(db);
+
+		const row = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-3'`).get() as {
+			schedule: string;
+		};
+		expect(row.schedule).toBe(validSchedule);
+	});
+
+	test('handles null schedule correctly (no-op)', () => {
+		createGoalsTable(db);
+		insertGoal(db, 'goal-4', null);
+
+		runMigration71(db);
+
+		const row = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-4'`).get() as {
+			schedule: string | null;
+		};
+		expect(row.schedule).toBeNull();
+	});
+
+	test('is idempotent — running twice does not change anything', () => {
+		createGoalsTable(db);
+		insertGoal(db, 'goal-5', '@weekly');
+
+		runMigration71(db);
+		const afterFirst = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-5'`).get() as {
+			schedule: string;
+		};
+
+		runMigration71(db);
+		const afterSecond = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-5'`).get() as {
+			schedule: string;
+		};
+
+		expect(afterSecond.schedule).toBe(afterFirst.schedule);
+	});
+
+	test('handles a JSON-quoted string like "@daily" by wrapping it', () => {
+		createGoalsTable(db);
+		// This is valid JSON (a string), but not the expected object shape
+		insertGoal(db, 'goal-6', '"@daily"');
+
+		runMigration71(db);
+
+		const row = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-6'`).get() as {
+			schedule: string;
+		};
+		const parsed = JSON.parse(row.schedule) as { expression: string; timezone: string };
+		expect(parsed.expression).toBe('@daily');
+		expect(parsed.timezone).toBe('UTC');
+	});
+
+	test('is no-op when goals table does not exist', () => {
+		expect(() => runMigration71(db)).not.toThrow();
+	});
+
+	test('is no-op when goals table has no schedule column', () => {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS goals (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL
+			)
+		`);
+		expect(() => runMigration71(db)).not.toThrow();
+	});
+
+	test('handles multiple goals with mixed schedule states', () => {
+		createGoalsTable(db);
+		insertGoal(db, 'goal-a', '@daily');
+		insertGoal(db, 'goal-b', JSON.stringify({ expression: '0 9 * * *', timezone: 'UTC' }));
+		insertGoal(db, 'goal-c', null);
+		insertGoal(db, 'goal-d', 'not-valid-cron');
+
+		runMigration71(db);
+
+		const a = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-a'`).get() as {
+			schedule: string;
+		};
+		const b = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-b'`).get() as {
+			schedule: string;
+		};
+		const c = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-c'`).get() as {
+			schedule: string | null;
+		};
+		const d = db.prepare(`SELECT schedule FROM goals WHERE id = 'goal-d'`).get() as {
+			schedule: string;
+		};
+
+		expect(JSON.parse(a.schedule)).toEqual({ expression: '@daily', timezone: 'UTC' });
+		expect(JSON.parse(b.schedule)).toEqual({ expression: '0 9 * * *', timezone: 'UTC' });
+		expect(c.schedule).toBeNull();
+		expect(JSON.parse(d.schedule)).toEqual({ expression: 'not-valid-cron', timezone: 'UTC' });
+	});
+});

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -20,10 +20,6 @@ export function isUUID(value: string): boolean {
 }
 
 /**
- * Generate a UUID v4 (browser and Node.js compatible)
- * Uses crypto.randomUUID() if available, otherwise falls back to a polyfill
- */
-/**
  * Safely parse a JSON string, returning a fallback value on failure.
  * Use this for reading DB columns that should be JSON but may be corrupted.
  */
@@ -49,6 +45,10 @@ export function parseJsonOptional<T>(raw: string | null | undefined): T | undefi
 	}
 }
 
+/**
+ * Generate a UUID v4 (browser and Node.js compatible)
+ * Uses crypto.randomUUID() if available, otherwise falls back to a polyfill
+ */
 export function generateUUID(): string {
 	// Try to use the native crypto.randomUUID() if available
 	if (typeof globalThis.crypto?.randomUUID === 'function') {

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -23,6 +23,32 @@ export function isUUID(value: string): boolean {
  * Generate a UUID v4 (browser and Node.js compatible)
  * Uses crypto.randomUUID() if available, otherwise falls back to a polyfill
  */
+/**
+ * Safely parse a JSON string, returning a fallback value on failure.
+ * Use this for reading DB columns that should be JSON but may be corrupted.
+ */
+export function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+	if (raw == null) return fallback;
+	try {
+		return JSON.parse(raw) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+/**
+ * Safely parse a JSON string, returning undefined on failure or null input.
+ * Use this for reading optional DB columns that should be JSON but may be corrupted.
+ */
+export function parseJsonOptional<T>(raw: string | null | undefined): T | undefined {
+	if (raw == null) return undefined;
+	try {
+		return JSON.parse(raw) as T;
+	} catch {
+		return undefined;
+	}
+}
+
 export function generateUUID(): string {
 	// Try to use the native crypto.randomUUID() if available
 	if (typeof globalThis.crypto?.randomUUID === 'function') {

--- a/packages/shared/tests/utils.test.ts
+++ b/packages/shared/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { generateUUID } from '../src/utils.ts';
+import { generateUUID, parseJson, parseJsonOptional } from '../src/utils.ts';
 
 describe('generateUUID', () => {
 	test('generates valid UUID format', () => {
@@ -77,5 +77,95 @@ describe('generateUUID', () => {
 		if (globalThis.crypto && original) {
 			globalThis.crypto.randomUUID = original;
 		}
+	});
+});
+
+describe('parseJson', () => {
+	test('returns parsed value for valid JSON string', () => {
+		const result1 = parseJson<Record<string, number>>('{"a":1}', {});
+		expect(result1).toEqual({ a: 1 });
+
+		const result2 = parseJson<number[]>('[1,2,3]', []);
+		expect(result2).toEqual([1, 2, 3]);
+
+		const result3 = parseJson<string>('"hello"', 'fallback');
+		expect(result3).toBe('hello');
+
+		const result4 = parseJson<number>('42', 0);
+		expect(result4).toBe(42);
+
+		const result5 = parseJson<boolean>('true', false);
+		expect(result5).toBe(true);
+	});
+
+	test('returns fallback for null input', () => {
+		const result1 = parseJson<string>(null, 'default');
+		expect(result1).toBe('default');
+
+		const result2 = parseJson<Record<string, number>>(null, { key: 1 });
+		expect(result2).toEqual({ key: 1 });
+	});
+
+	test('returns fallback for undefined input', () => {
+		const result1 = parseJson<string>(undefined, 'default');
+		expect(result1).toBe('default');
+
+		const result2 = parseJson<number[]>(undefined, [1, 2]);
+		expect(result2).toEqual([1, 2]);
+	});
+
+	test('returns fallback for invalid JSON string', () => {
+		const result1 = parseJson<string>('{not json}', 'fallback');
+		expect(result1).toBe('fallback');
+
+		const result2 = parseJson<Record<string, unknown>>('trailing comma,', {});
+		expect(result2).toEqual({});
+
+		const result3 = parseJson<Record<string, unknown>>('', {});
+		expect(result3).toEqual({});
+	});
+
+	test('returns fallback for empty string', () => {
+		const result1 = parseJson<string>('', 'default');
+		expect(result1).toBe('default');
+
+		const result2 = parseJson<number[]>('', []);
+		expect(result2).toEqual([]);
+	});
+});
+
+describe('parseJsonOptional', () => {
+	test('returns parsed value for valid JSON string', () => {
+		const result1 = parseJsonOptional<Record<string, number>>('{"a":1}');
+		expect(result1).toEqual({ a: 1 });
+
+		const result2 = parseJsonOptional<number[]>('[1,2,3]');
+		expect(result2).toEqual([1, 2, 3]);
+
+		const result3 = parseJsonOptional<string>('"hello"');
+		expect(result3).toBe('hello');
+
+		const result4 = parseJsonOptional<number>('42');
+		expect(result4).toBe(42);
+
+		const result5 = parseJsonOptional<boolean>('true');
+		expect(result5).toBe(true);
+	});
+
+	test('returns undefined for null input', () => {
+		expect(parseJsonOptional(null)).toBeUndefined();
+	});
+
+	test('returns undefined for undefined input', () => {
+		expect(parseJsonOptional(undefined)).toBeUndefined();
+	});
+
+	test('returns undefined for invalid JSON string', () => {
+		expect(parseJsonOptional('{not json}')).toBeUndefined();
+		expect(parseJsonOptional('trailing comma,')).toBeUndefined();
+	});
+
+	test('returns undefined for empty string', () => {
+		expect(parseJsonOptional('')).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Fix daemon crash when `schedule` column in goals table contains a raw cron
string (e.g. `@daily`) instead of the expected JSON object.

## Changes

- **`shared/src/utils.ts`**: Add `parseJson`/`parseJsonOptional` safe parsing utilities
- **`daemon/src/lib/rpc-handlers/live-query-handlers.ts`**: Use `parseJson`/`parseJsonOptional` in `mapGoalRow` for `linkedTaskIds`, `metrics`, `structuredMetrics`, `schedule`
- **`daemon/src/storage/repositories/goal-repository.ts`**: Use `parseJsonOptional` in `rowToGoal` for `structuredMetrics`, `schedule`
- **`daemon/src/storage/schema/migrations.ts`**: Add migration 71 to fix corrupted schedule values at startup (wraps bare cron strings into proper `CronSchedule` shape)

## Tests

- `shared/tests/utils.test.ts` — 10 tests for `parseJson`/`parseJsonOptional`
- `daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts` — 5 tests for `mapGoalRow` corrupted data
- `daemon/tests/unit/room/goal-repository-v2.test.ts` — 4 tests for `rowToGoal` corrupted data
- `daemon/tests/unit/storage/migrations/migration-71_test.ts` — 9 tests for schedule migration