### PR TITLE
feat: extend Gate interface with label, color, script fields

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -135,7 +135,7 @@ function formatChannel(ch: WorkflowChannel, gates: Gate[]): string {
 
 function formatGate(gate: Gate): string {
 	const desc = gate.description ? ` — ${gate.description}` : '';
-	const fieldSummaries = gate.fields.map((f) => {
+	const fieldSummaries = (gate.fields ?? []).map((f) => {
 		const writers = f.writers.length > 0 ? f.writers.join(', ') : '(none)';
 		const checkDesc =
 			f.check.op === 'count'

--- a/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
@@ -168,7 +168,7 @@ export function isChannelOpen(
  * @param data Runtime data from the `gate_data` table.
  */
 export function evaluateGate(gate: Gate, data: Record<string, unknown>): GateEvalResult {
-	for (const field of gate.fields) {
+	for (const field of gate.fields ?? []) {
 		const result = evaluateFieldCheck(field, data);
 		if (!result.open) return result;
 	}

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -495,7 +495,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					const gateId = channelGateMap.get(`${ch.fromRole}→${ch.toRole}`);
 					const gateEntity = gateId ? gatesById.get(gateId) : undefined;
 					const gateType = gateEntity
-						? gateEntity.fields.some((f) => f.type === 'map' && f.check.op === 'count')
+						? (gateEntity.fields ?? []).some((f) => f.type === 'map' && f.check.op === 'count')
 							? 'count'
 							: 'check'
 						: 'none';
@@ -667,7 +667,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			}
 
 			// Field-level authorization: check each key in data against field declarations
-			const fieldMap = new Map(gateDef.fields.map((f) => [f.name, f]));
+			const fieldMap = new Map((gateDef.fields ?? []).map((f) => [f.name, f]));
 			for (const key of Object.keys(data)) {
 				const fieldDef = fieldMap.get(key);
 				if (!fieldDef) {
@@ -675,7 +675,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 						success: false,
 						error:
 							`Field "${key}" is not declared in gate "${gateId}". ` +
-							`Declared fields: ${gateDef.fields.map((f) => f.name).join(', ') || '(none)'}.`,
+							`Declared fields: ${(gateDef.fields ?? []).map((f) => f.name).join(', ') || '(none)'}.`,
 					});
 				}
 				const writers = fieldDef.writers;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -666,7 +666,10 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				});
 			}
 
-			// Field-level authorization: check each key in data against field declarations
+			// Field-level authorization: check each key in data against field declarations.
+			// For script-only gates (no fields), any data write is rejected since there are
+			// no declared fields to validate against. Script execution populates gate data
+			// internally; agents should not write to script-only gates directly.
 			const fieldMap = new Map((gateDef.fields ?? []).map((f) => [f.name, f]));
 			for (const key of Object.keys(data)) {
 				const fieldDef = fieldMap.get(key);

--- a/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
+++ b/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
@@ -635,6 +635,9 @@ describe('evaluateGate with optional fields', () => {
 	});
 
 	test('Gate with script-only (no fields) evaluates as open', () => {
+		// Note: evaluateGate does not execute gate.script — it only checks field-based
+		// conditions. A script-only gate opens trivially because there are no fields to
+		// fail. Script execution will be implemented in a follow-up task.
 		const gate: Gate = {
 			id: 'gate-script-only',
 			script: {

--- a/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
+++ b/packages/daemon/tests/unit/space/gate-types-and-schema.test.ts
@@ -17,7 +17,16 @@ import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { GateDataRepository } from '../../../src/storage/repositories/gate-data-repository.ts';
 import { SendMessageSchema } from '../../../src/lib/space/tools/node-agent-tool-schemas.ts';
-import type { Gate, Channel, WorkflowRunFailureReason, SpaceWorkflowRun } from '@neokai/shared';
+import type {
+	Gate,
+	Channel,
+	WorkflowRunFailureReason,
+	SpaceWorkflowRun,
+	GateScript,
+	GateField,
+} from '@neokai/shared';
+import { computeGateDefaults } from '@neokai/shared';
+import { evaluateGate } from '../../../src/lib/space/runtime/gate-evaluator.ts';
 
 // ---------------------------------------------------------------------------
 // DB setup
@@ -414,5 +423,246 @@ describe('SendMessageSchema — data field', () => {
 			data: 'not an object',
 		});
 		expect(result.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Extended Gate interface: label, color, script, optional fields
+// ---------------------------------------------------------------------------
+
+describe('Gate extended interface (label, color, script, optional fields)', () => {
+	test('Gate accepts label and color', () => {
+		const gate: Gate = {
+			id: 'gate-label-color',
+			label: 'Code Review',
+			color: '#22c55e',
+			fields: [
+				{
+					name: 'approved',
+					type: 'boolean',
+					writers: ['reviewer'],
+					check: { op: '==', value: true },
+				},
+			],
+			resetOnCycle: false,
+		};
+		expect(gate.label).toBe('Code Review');
+		expect(gate.color).toBe('#22c55e');
+	});
+
+	test('Gate accepts GateScript', () => {
+		const script: GateScript = {
+			interpreter: 'bash',
+			source: 'echo "check passed"',
+			timeoutMs: 5000,
+		};
+		const gate: Gate = {
+			id: 'gate-script',
+			script,
+			resetOnCycle: false,
+		};
+		expect(gate.script).toBeDefined();
+		expect(gate.script!.interpreter).toBe('bash');
+		expect(gate.script!.source).toBe('echo "check passed"');
+		expect(gate.script!.timeoutMs).toBe(5000);
+	});
+
+	test('GateScript accepts all interpreter types', () => {
+		const interpreters: GateScript['interpreter'][] = ['bash', 'node', 'python3'];
+		for (const interpreter of interpreters) {
+			const script: GateScript = { interpreter, source: 'test' };
+			expect(script.interpreter).toBe(interpreter);
+		}
+	});
+
+	test('GateScript timeoutMs is optional', () => {
+		const script: GateScript = {
+			interpreter: 'node',
+			source: 'console.log("ok")',
+		};
+		expect(script.timeoutMs).toBeUndefined();
+	});
+
+	test('Gate without fields compiles and fields is undefined', () => {
+		const gate: Gate = {
+			id: 'gate-no-fields',
+			script: {
+				interpreter: 'bash',
+				source: 'exit 0',
+			},
+			resetOnCycle: false,
+		};
+		expect(gate.fields).toBeUndefined();
+	});
+
+	test('Gate with all new fields together', () => {
+		const gate: Gate = {
+			id: 'gate-full',
+			description: 'Full gate',
+			label: 'Build Check',
+			color: '#ef4444',
+			fields: [
+				{
+					name: 'build_passed',
+					type: 'boolean',
+					writers: ['builder'],
+					check: { op: '==', value: true },
+				},
+			],
+			script: {
+				interpreter: 'bash',
+				source: 'make test',
+				timeoutMs: 60000,
+			},
+			resetOnCycle: false,
+		};
+		expect(gate.label).toBe('Build Check');
+		expect(gate.color).toBe('#ef4444');
+		expect(gate.fields).toHaveLength(1);
+		expect(gate.script!.interpreter).toBe('bash');
+	});
+
+	test('Gate with only label and no fields or script', () => {
+		const gate: Gate = {
+			id: 'gate-label-only',
+			label: 'Manual Gate',
+			resetOnCycle: false,
+		};
+		expect(gate.label).toBe('Manual Gate');
+		expect(gate.fields).toBeUndefined();
+		expect(gate.script).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// computeGateDefaults with optional fields
+// ---------------------------------------------------------------------------
+
+describe('computeGateDefaults with optional fields', () => {
+	test('computeGateDefaults(undefined) returns empty object', () => {
+		const result = computeGateDefaults(undefined);
+		expect(result).toEqual({});
+	});
+
+	test('computeGateDefaults([]) returns empty object', () => {
+		const result = computeGateDefaults([]);
+		expect(result).toEqual({});
+	});
+
+	test('computeGateDefaults with map fields returns map defaults', () => {
+		const fields: GateField[] = [
+			{
+				name: 'reviews',
+				type: 'map',
+				writers: ['reviewer-1', 'reviewer-2'],
+				check: { op: 'count', match: 'approved', min: 2 },
+			},
+		];
+		const result = computeGateDefaults(fields);
+		expect(result).toEqual({ reviews: {} });
+	});
+
+	test('computeGateDefaults with boolean fields returns empty (no key)', () => {
+		const fields: GateField[] = [
+			{
+				name: 'approved',
+				type: 'boolean',
+				writers: ['reviewer'],
+				check: { op: '==', value: true },
+			},
+		];
+		const result = computeGateDefaults(fields);
+		expect(result).toEqual({});
+	});
+
+	test('computeGateDefaults with mixed fields returns only map defaults', () => {
+		const fields: GateField[] = [
+			{
+				name: 'approved',
+				type: 'boolean',
+				writers: ['reviewer'],
+				check: { op: '==', value: true },
+			},
+			{
+				name: 'votes',
+				type: 'map',
+				writers: ['*'],
+				check: { op: 'count', match: 'yes', min: 2 },
+			},
+			{
+				name: 'comment',
+				type: 'string',
+				writers: ['human'],
+				check: { op: 'exists' },
+			},
+		];
+		const result = computeGateDefaults(fields);
+		expect(result).toEqual({ votes: {} });
+	});
+
+	test('computeGateDefaults with multiple map fields returns all map defaults', () => {
+		const fields: GateField[] = [
+			{
+				name: 'reviewer_votes',
+				type: 'map',
+				writers: ['reviewer'],
+				check: { op: 'count', match: 'approved', min: 1 },
+			},
+			{
+				name: 'tester_votes',
+				type: 'map',
+				writers: ['tester'],
+				check: { op: 'count', match: 'passed', min: 1 },
+			},
+		];
+		const result = computeGateDefaults(fields);
+		expect(result).toEqual({ reviewer_votes: {}, tester_votes: {} });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// evaluateGate with optional fields
+// ---------------------------------------------------------------------------
+
+describe('evaluateGate with optional fields', () => {
+	test('Gate with no fields evaluates as open', () => {
+		const gate: Gate = {
+			id: 'gate-empty',
+			resetOnCycle: false,
+		};
+		const result = evaluateGate(gate, {});
+		expect(result.open).toBe(true);
+	});
+
+	test('Gate with script-only (no fields) evaluates as open', () => {
+		const gate: Gate = {
+			id: 'gate-script-only',
+			script: {
+				interpreter: 'bash',
+				source: 'echo "ok"',
+			},
+			resetOnCycle: false,
+		};
+		const result = evaluateGate(gate, {});
+		expect(result.open).toBe(true);
+	});
+
+	test('Gate with fields still evaluates normally', () => {
+		const gate: Gate = {
+			id: 'gate-with-fields',
+			fields: [
+				{
+					name: 'approved',
+					type: 'boolean',
+					writers: ['reviewer'],
+					check: { op: '==', value: true },
+				},
+			],
+			resetOnCycle: false,
+		};
+		const result = evaluateGate(gate, { approved: false });
+		expect(result.open).toBe(false);
+		const result2 = evaluateGate(gate, { approved: true });
+		expect(result2.open).toBe(true);
 	});
 });

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -1589,6 +1589,39 @@ describe('node-agent-tools: write_gate', () => {
 		const data = JSON.parse(result.content[0].text);
 		expect(data.success).toBe(true);
 	});
+
+	test('rejects write_gate on script-only gate (no declared fields)', async () => {
+		// Script-only gates have no declared fields, so any data write is rejected
+		// at the field authorization layer. This is intentional — script execution
+		// populates gate data internally; agents should not write directly.
+		const gate: Gate = {
+			id: 'gate-script-only',
+			script: {
+				interpreter: 'bash',
+				source: 'echo "ok"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-script-only', data: { x: 1 } });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('not declared');
+	});
 });
 
 describe('node-agent-tools: list_reachable_agents', () => {

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -577,13 +577,28 @@ export interface GateField {
  * write to gate data via `write_gate`; the runtime evaluates field checks
  * against current data to decide passage.
  */
+export interface GateScript {
+	/** Script interpreter: 'bash', 'node', or 'python3' */
+	interpreter: 'bash' | 'node' | 'python3';
+	/** Script source code to execute */
+	source: string;
+	/** Timeout in milliseconds (default: 30000) */
+	timeoutMs?: number;
+}
+
 export interface Gate {
 	/** Unique identifier */
 	id: string;
 	/** Human-readable description of what this gate checks. */
 	description?: string;
+	/** Custom label displayed on the gate badge in the workflow editor. */
+	label?: string;
+	/** Custom badge color (CSS color value). */
+	color?: string;
 	/** Declared fields with schema, permissions, and checks. */
-	fields: GateField[];
+	fields?: GateField[];
+	/** Optional script-based pre-check executed before field evaluation. */
+	script?: GateScript;
 	/**
 	 * When true, gate data is reset to defaults on cyclic channel traversal.
 	 * Used for cyclic workflows where gate state should be cleared each loop.
@@ -595,9 +610,9 @@ export interface Gate {
  * Compute default data for a gate from its field declarations.
  * Map fields get `{}`, others get nothing (no key in defaults).
  */
-export function computeGateDefaults(fields: GateField[]): Record<string, unknown> {
+export function computeGateDefaults(fields?: GateField[]): Record<string, unknown> {
 	const defaults: Record<string, unknown> = {};
-	for (const field of fields) {
+	for (const field of fields ?? []) {
 		if (field.type === 'map') {
 			defaults[field.name] = {};
 		}

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -121,14 +121,14 @@ function computeVoteCount(
  *   - All fields must pass their checks for the gate to be open.
  */
 function evaluateGateStatus(gate: Gate, data: Record<string, unknown>): GateStatus {
-	if (gate.fields.length === 0) return 'open';
+	if ((gate.fields ?? []).length === 0) return 'open';
 
 	// Check for human approval field first
-	if (isHumanApprovalGate(gate.fields)) {
+	if (isHumanApprovalGate(gate.fields ?? [])) {
 		const val = data['approved'];
 		if (val === true) {
 			// Check remaining fields too
-			const othersPassed = gate.fields.every((f) => {
+			const othersPassed = (gate.fields ?? []).every((f) => {
 				if (f.name === 'approved') return true;
 				return evalFieldStatus(f, data) === 'open';
 			});
@@ -139,7 +139,7 @@ function evaluateGateStatus(gate: Gate, data: Record<string, unknown>): GateStat
 	}
 
 	// All fields must pass
-	for (const field of gate.fields) {
+	for (const field of gate.fields ?? []) {
 		const status = evalFieldStatus(field, data);
 		if (status !== 'open') return status;
 	}
@@ -1207,9 +1207,9 @@ export function WorkflowCanvas({
 					}
 
 					// Channels without gates are always available (plain arrows)
-					const isHumanGate = gate ? isHumanApprovalGate(gate.fields) : false;
+					const isHumanGate = gate ? isHumanApprovalGate(gate.fields ?? []) : false;
 					const voteCount =
-						gate && isRuntimeMode ? computeVoteCount(gate.fields, gateData) : undefined;
+						gate && isRuntimeMode ? computeVoteCount(gate.fields ?? [], gateData) : undefined;
 
 					return (
 						<g key={`ch-${ch.id}-${ch.toId}`} data-testid={`channel-${ch.id}`}>

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -603,7 +603,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 		setGates(
 			(template.gates ?? []).map((gate) => ({
 				...gate,
-				fields: [...gate.fields],
+				fields: [...(gate.fields ?? [])],
 			}))
 		);
 		if (template.tags) {

--- a/packages/web/src/components/space/visual-editor/ChannelEdgeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/ChannelEdgeConfigPanel.tsx
@@ -170,11 +170,11 @@ export function ChannelEdgeConfigPanel({
 				) : (
 					<div class="space-y-2">
 						{/* Field summary rows */}
-						{currentGate.fields.length === 0 ? (
+						{(currentGate.fields ?? []).length === 0 ? (
 							<p class="text-xs text-gray-600 italic">No fields defined yet</p>
 						) : (
 							<div class="space-y-1">
-								{currentGate.fields.map((field) => (
+								{(currentGate.fields ?? []).map((field) => (
 									<div
 										key={field.name}
 										class="flex items-center gap-2 text-xs bg-dark-800 rounded px-2 py-1.5 border border-dark-700"

--- a/packages/web/src/components/space/visual-editor/GateEditorPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/GateEditorPanel.tsx
@@ -38,7 +38,7 @@ export function GateEditorPanel({
 	}
 
 	function updateField(index: number, updated: GateField) {
-		const next = [...gate.fields];
+		const next = [...(gate.fields ?? [])];
 		next[index] = updated;
 		updateGate({ fields: next });
 	}
@@ -50,12 +50,12 @@ export function GateEditorPanel({
 			writers: ['*'],
 			check: { op: 'exists' },
 		};
-		updateGate({ fields: [...gate.fields, newField] });
-		setExpandedField(gate.fields.length);
+		updateGate({ fields: [...(gate.fields ?? []), newField] });
+		setExpandedField((gate.fields ?? []).length);
 	}
 
 	function deleteField(index: number) {
-		const next = gate.fields.filter((_, i) => i !== index);
+		const next = (gate.fields ?? []).filter((_, i) => i !== index);
 		updateGate({ fields: next });
 		if (expandedField === index) setExpandedField(null);
 		else if (expandedField !== null && expandedField > index) setExpandedField(expandedField - 1);
@@ -68,7 +68,7 @@ export function GateEditorPanel({
 			writers: ['human'],
 			check: { op: '==', value: true },
 		};
-		updateGate({ fields: [...gate.fields, preset] });
+		updateGate({ fields: [...(gate.fields ?? []), preset] });
 	}
 
 	function addTaskResultPreset() {
@@ -78,7 +78,7 @@ export function GateEditorPanel({
 			writers: ['*'],
 			check: { op: '==', value: 'passed' },
 		};
-		updateGate({ fields: [...gate.fields, preset] });
+		updateGate({ fields: [...(gate.fields ?? []), preset] });
 	}
 
 	return (
@@ -146,10 +146,10 @@ export function GateEditorPanel({
 			{/* Fields */}
 			<div class="space-y-2">
 				<label class="text-[11px] uppercase tracking-[0.12em] text-gray-500">Fields</label>
-				{gate.fields.length === 0 && (
+				{(gate.fields ?? []).length === 0 && (
 					<p class="text-xs text-gray-600 italic">No fields — gate always opens</p>
 				)}
-				{gate.fields.map((field, i) => (
+				{(gate.fields ?? []).map((field, i) => (
 					<FieldCard
 						key={i}
 						field={field}

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -1010,7 +1010,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		}));
 		const nextGates = (template.gates ?? []).map((gate) => ({
 			...gate,
-			fields: [...gate.fields],
+			fields: [...(gate.fields ?? [])],
 		}));
 
 		setNodes(nextNodes);

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -211,8 +211,8 @@ describe('workflowToVisualState', () => {
 		const state = workflowToVisualState(wf);
 		expect(state.gates).toHaveLength(1);
 		expect(state.gates[0].id).toBe('review-votes-gate');
-		expect(state.gates[0].fields[0].name).toBe('votes');
-		expect(state.gates[0].fields[0].check).toMatchObject({
+		expect(state.gates[0].fields![0].name).toBe('votes');
+		expect(state.gates[0].fields![0].check).toMatchObject({
 			op: 'count',
 			match: 'approved',
 			min: 3,

--- a/packages/web/src/components/space/visual-editor/semanticWorkflowGraph.ts
+++ b/packages/web/src/components/space/visual-editor/semanticWorkflowGraph.ts
@@ -56,7 +56,7 @@ function resolveSemanticGateType(
 		if (!gate) return 'check';
 
 		// Derive gate type from field declarations
-		const fields = gate.fields;
+		const fields = gate.fields ?? [];
 		if (fields.length === 0) return 'check';
 
 		// If any field is a map with count check -> 'count' (votes)


### PR DESCRIPTION
Extend the `Gate` interface in `packages/shared/src/types/space.ts` with:

- **`GateScript` interface** — `interpreter` ('bash' | 'node' | 'python3'), `source`, optional `timeoutMs`
- **`Gate.label?`** — custom badge label for the workflow editor
- **`Gate.color?`** — custom badge color (CSS value)
- **`Gate.script?`** — optional script-based pre-check
- **`Gate.fields`** changed from required to optional (backward compatible)

`computeGateDefaults()` now accepts `fields?: GateField[]` — treats `undefined` as `[]`.

All production code sites that iterate `gate.fields` updated with `?? []` safety guards.

16 new unit tests covering the extended interface, optional fields behavior, and `evaluateGate` with empty/script-only gates.