### PR TITLE
fix: add ?? [] safety guards for optional gate.fields

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -591,7 +591,7 @@ export class ChannelRouter {
 
 		// Load runtime data from DB; fall back to computed defaults from fields
 		const record = this.config.gateDataRepo?.get(runId, gateId);
-		const runtimeData = record?.data ?? computeGateDefaults(gateDef.fields);
+		const runtimeData = record?.data ?? computeGateDefaults(gateDef.fields ?? []);
 
 		return evaluateGate(gateDef, runtimeData);
 	}
@@ -725,7 +725,7 @@ export class ChannelRouter {
 		if (this.config.db && this.config.gateDataRepo && cyclicGates.length > 0) {
 			const transaction = this.config.db.transaction(() => {
 				for (const gate of cyclicGates) {
-					this.config.gateDataRepo!.reset(runId, gate.id, computeGateDefaults(gate.fields));
+					this.config.gateDataRepo!.reset(runId, gate.id, computeGateDefaults(gate.fields ?? []));
 				}
 				return this.config.channelCycleRepo!.incrementCycleCount(runId, channelIndex, maxCycles);
 			});
@@ -738,7 +738,7 @@ export class ChannelRouter {
 		} else {
 			if (this.config.gateDataRepo) {
 				for (const gate of cyclicGates) {
-					this.config.gateDataRepo.reset(runId, gate.id, computeGateDefaults(gate.fields));
+					this.config.gateDataRepo.reset(runId, gate.id, computeGateDefaults(gate.fields ?? []));
 				}
 			}
 			const incremented = this.config.channelCycleRepo.incrementCycleCount(

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -580,9 +580,9 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				const record = gateDataRepo.get(workflowRunId, gate.id);
 				return {
 					gateId: gate.id,
-					fields: gate.fields,
+					fields: gate.fields ?? [],
 					description: gate.description ?? null,
-					currentData: record?.data ?? computeGateDefaults(gate.fields),
+					currentData: record?.data ?? computeGateDefaults(gate.fields ?? []),
 				};
 			});
 			return jsonResult({
@@ -618,7 +618,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			}
 
 			const record = gateDataRepo.get(workflowRunId, gateId);
-			const currentData = record?.data ?? computeGateDefaults(gateDef.fields);
+			const currentData = record?.data ?? computeGateDefaults(gateDef.fields ?? []);
 
 			// Evaluate current gate status
 			const evalResult = evaluateGate(gateDef, currentData);
@@ -626,7 +626,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			return jsonResult({
 				success: true,
 				gateId,
-				fields: gateDef.fields,
+				fields: gateDef.fields ?? [],
 				data: currentData,
 				gateOpen: evalResult.open,
 				reason: evalResult.reason ?? null,

--- a/packages/daemon/tests/unit/space/channel-router.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router.test.ts
@@ -1547,6 +1547,56 @@ describe('ChannelRouter', () => {
 			expect(channelCycleRepo.get(run.id, 1)!.count).toBe(1);
 		});
 
+		test('resetOnCycle: gate with undefined fields (script-only gate) resets to empty object', async () => {
+			// Gate has no fields — simulates a script-only gate where fields is undefined
+			const gate: Gate = {
+				id: 'script-only-gate',
+				resetOnCycle: true,
+			};
+			const channels: WorkflowChannel[] = [
+				{ from: 'coder', to: 'planner', direction: 'one-way' },
+				{ from: 'planner', to: 'coder', direction: 'one-way', maxCycles: 10 },
+			];
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Coder Node', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{
+						id: NODE_B,
+						name: 'Planner Node',
+						agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+					},
+				],
+				channels,
+				[gate]
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Script-Only Gate Reset Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			// Seed arbitrary data (simulating script output written to gate data)
+			gateDataRepo.set(run.id, 'script-only-gate', {
+				scriptResult: true,
+				timestamp: '2025-01-01T00:00:00Z',
+			});
+
+			// Traverse the cyclic (backward) channel: planner → coder
+			await router.deliverMessage(run.id, 'planner', 'coder', 'iterating');
+
+			// Gate data should have been reset to empty object (no fields to compute defaults from)
+			const afterReset = gateDataRepo.get(run.id, 'script-only-gate');
+			expect(afterReset).not.toBeNull();
+			expect(afterReset!.data).toEqual({});
+
+			// Cycle count should have been incremented
+			expect(channelCycleRepo.get(run.id, 1)!.count).toBe(1);
+		});
+
 		test('resetOnCycle: gates with resetOnCycle=false are preserved on cyclic traversal', async () => {
 			const resetGate: Gate = {
 				id: 'review-reject-gate',

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -121,7 +121,7 @@ function buildTemplateCanvasSignature(
 		.map((gate) => ({
 			id: gate.id,
 			description: gate.description ?? null,
-			fields: gate.fields,
+			fields: gate.fields ?? [],
 			resetOnCycle: gate.resetOnCycle,
 		}))
 		.sort((a, b) => a.id.localeCompare(b.id));


### PR DESCRIPTION
Add `?? []` fallback guards at all remaining bare `gate.fields` and `gateDef.fields` production access sites, following the type change that made `fields` optional on `Gate`.

**Files changed:**
- `channel-router.ts` — 3 `computeGateDefaults(gate.fields)` calls
- `node-agent-tools.ts` — `fields: gate.fields`, `fields: gateDef.fields`, 2 `computeGateDefaults()` calls
- `VisualWorkflowEditor.tsx` — `fields: gate.fields` in normalized gate serialization

All other access sites were already guarded in task 1.1.