### PR TITLE
feat: propagate gate label/color/hasScript through semantic workflow graph

### DIFF
--- a/packages/web/src/components/space/visual-editor/__tests__/semanticWorkflowGraph.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/semanticWorkflowGraph.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import type { WorkflowChannel } from '@neokai/shared';
+import type { Gate, WorkflowChannel } from '@neokai/shared';
 import { TASK_AGENT_NODE_ID } from '@neokai/shared';
+import { describe, expect, it } from 'vitest';
 import { buildSemanticWorkflowEdges } from '../semanticWorkflowGraph';
 import type { VisualNode } from '../serialization';
 
@@ -49,6 +49,32 @@ const NODES: VisualNode[] = [
 	},
 ];
 
+/** Helper: create a Gate with only fields (approved → human gate). */
+function humanGate(id: string, overrides?: Partial<Gate>): Gate {
+	return {
+		id,
+		resetOnCycle: false,
+		fields: [
+			{
+				name: 'approved',
+				type: 'boolean',
+				writers: ['human'],
+				check: { op: '==', value: true },
+			},
+		],
+		...overrides,
+	};
+}
+
+/** Helper: create a check gate with no label/color/script. */
+function checkGate(id: string, overrides?: Partial<Gate>): Gate {
+	return {
+		id,
+		resetOnCycle: false,
+		...overrides,
+	};
+}
+
 describe('buildSemanticWorkflowEdges', () => {
 	it('preserves a node-level channel between a single-agent node and a multi-agent node', () => {
 		const channels: WorkflowChannel[] = [
@@ -65,6 +91,9 @@ describe('buildSemanticWorkflowEdges', () => {
 				hasGate: false,
 				hasCyclic: false,
 				gateType: undefined,
+				gateLabel: undefined,
+				gateColor: undefined,
+				hasScript: undefined,
 				channelIndexes: [0],
 			},
 		]);
@@ -86,6 +115,13 @@ describe('buildSemanticWorkflowEdges', () => {
 				hasGate: false,
 				hasCyclic: false,
 				gateType: undefined,
+				gateLabel: undefined,
+				gateColor: undefined,
+				hasScript: undefined,
+				reverseGateType: undefined,
+				reverseGateLabel: undefined,
+				reverseGateColor: undefined,
+				reverseHasScript: undefined,
 				channelIndexes: [0, 1],
 			},
 		]);
@@ -117,15 +153,16 @@ describe('buildSemanticWorkflowEdges', () => {
 			{ from: 'Planning', to: 'Reviewer 1', direction: 'one-way', gateId: 'gate-fwd' },
 			{ from: 'Reviewer 2', to: 'Planning', direction: 'one-way', gateId: 'gate-rev' },
 		];
+		const gates = [humanGate('gate-fwd'), humanGate('gate-rev')];
 
-		const result = buildSemanticWorkflowEdges(NODES, channels);
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result).toHaveLength(1);
 		expect(result[0].direction).toBe('bidirectional');
 		expect(result[0].hasGate).toBe(true);
 		// Forward gate (plan→review = lowId→highId)
-		expect(result[0].gateType).toBeTruthy();
+		expect(result[0].gateType).toBe('human');
 		// Reverse gate (review→plan = highId→lowId)
-		expect(result[0].reverseGateType).toBeTruthy();
+		expect(result[0].reverseGateType).toBe('human');
 	});
 
 	it('does not set reverseGateType when only the forward direction has a gate', () => {
@@ -133,10 +170,11 @@ describe('buildSemanticWorkflowEdges', () => {
 			{ from: 'Planning', to: 'Reviewer 1', direction: 'one-way', gateId: 'gate-fwd' },
 			{ from: 'Reviewer 2', to: 'Planning', direction: 'one-way' },
 		];
+		const gates = [humanGate('gate-fwd')];
 
-		const result = buildSemanticWorkflowEdges(NODES, channels);
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result[0].direction).toBe('bidirectional');
-		expect(result[0].gateType).toBeTruthy();
+		expect(result[0].gateType).toBe('human');
 		expect(result[0].reverseGateType).toBeUndefined();
 	});
 
@@ -145,11 +183,12 @@ describe('buildSemanticWorkflowEdges', () => {
 			{ from: 'Planning', to: 'Reviewer 1', direction: 'one-way' },
 			{ from: 'Reviewer 2', to: 'Planning', direction: 'one-way', gateId: 'gate-rev' },
 		];
+		const gates = [humanGate('gate-rev')];
 
-		const result = buildSemanticWorkflowEdges(NODES, channels);
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result[0].direction).toBe('bidirectional');
 		expect(result[0].gateType).toBeUndefined();
-		expect(result[0].reverseGateType).toBeTruthy();
+		expect(result[0].reverseGateType).toBe('human');
 	});
 
 	it('a bidirectional underlying channel gates both directions', () => {
@@ -161,10 +200,263 @@ describe('buildSemanticWorkflowEdges', () => {
 				gateId: 'gate-both',
 			},
 		];
+		const gates = [humanGate('gate-both')];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0].direction).toBe('bidirectional');
+		expect(result[0].gateType).toBe('human');
+		expect(result[0].reverseGateType).toBe('human');
+	});
+});
+
+describe('gate label/color/hasScript propagation', () => {
+	it('propagates gate label and color for a one-way edge', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Code Review', direction: 'one-way', gateId: 'g1' },
+		];
+		const gates = [
+			humanGate('g1', {
+				label: 'Team Lead',
+				color: '#ff5500',
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0]).toMatchObject({
+			gateType: 'human',
+			gateLabel: 'Team Lead',
+			gateColor: '#ff5500',
+			hasScript: undefined,
+		});
+	});
+
+	it('propagates hasScript when gate has a script', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Code Review', direction: 'one-way', gateId: 'g1' },
+		];
+		const gates = [
+			checkGate('g1', {
+				script: { interpreter: 'bash', source: 'exit 0' },
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0]).toMatchObject({
+			gateType: 'check',
+			hasScript: true,
+		});
+	});
+
+	it('returns undefined for label/color when gate has neither', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Code Review', direction: 'one-way', gateId: 'g1' },
+		];
+		const gates = [humanGate('g1')];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0].gateLabel).toBeUndefined();
+		expect(result[0].gateColor).toBeUndefined();
+		expect(result[0].hasScript).toBeUndefined();
+	});
+
+	it('returns undefined for label/color/hasScript when gate is missing from lookup', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Code Review', direction: 'one-way', gateId: 'missing-gate' },
+		];
 
 		const result = buildSemanticWorkflowEdges(NODES, channels);
-		expect(result[0].direction).toBe('bidirectional');
-		expect(result[0].gateType).toBeTruthy();
-		expect(result[0].reverseGateType).toBeTruthy();
+		expect(result[0]).toMatchObject({
+			gateType: 'check',
+			gateLabel: undefined,
+			gateColor: undefined,
+			hasScript: undefined,
+		});
+	});
+
+	it('returns undefined for label/color/hasScript when channel has no gateId', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Code Review', direction: 'one-way' },
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels);
+		expect(result[0]).toMatchObject({
+			gateType: undefined,
+			gateLabel: undefined,
+			gateColor: undefined,
+			hasScript: undefined,
+		});
+	});
+
+	it('propagates label/color/hasScript for bidirectional edges per direction', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Reviewer 1', direction: 'one-way', gateId: 'gate-fwd' },
+			{ from: 'Reviewer 2', to: 'Planning', direction: 'one-way', gateId: 'gate-rev' },
+		];
+		const gates = [
+			humanGate('gate-fwd', {
+				label: 'Forward',
+				color: '#00ff00',
+				script: { interpreter: 'bash', source: 'echo ok' },
+			}),
+			humanGate('gate-rev', {
+				label: 'Reverse',
+				color: '#ff0000',
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			gateType: 'human',
+			gateLabel: 'Forward',
+			gateColor: '#00ff00',
+			hasScript: true,
+			reverseGateType: 'human',
+			reverseGateLabel: 'Reverse',
+			reverseGateColor: '#ff0000',
+			reverseHasScript: undefined,
+		});
+	});
+
+	it('propagates label/color/hasScript for a bidirectional underlying channel to both directions', () => {
+		const channels: WorkflowChannel[] = [
+			{
+				from: 'Planning',
+				to: 'Reviewer 1',
+				direction: 'bidirectional',
+				gateId: 'gate-both',
+			},
+		];
+		const gates = [
+			humanGate('gate-both', {
+				label: 'Both Ways',
+				color: '#123456',
+				script: { interpreter: 'python3', source: 'print("ok")' },
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0]).toMatchObject({
+			direction: 'bidirectional',
+			gateType: 'human',
+			gateLabel: 'Both Ways',
+			gateColor: '#123456',
+			hasScript: true,
+			reverseGateType: 'human',
+			reverseGateLabel: 'Both Ways',
+			reverseGateColor: '#123456',
+			reverseHasScript: true,
+		});
+	});
+
+	it('tracks label/color/hasScript only for forward direction when only forward has a gate', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Reviewer 1', direction: 'one-way', gateId: 'gate-fwd' },
+			{ from: 'Reviewer 2', to: 'Planning', direction: 'one-way' },
+		];
+		const gates = [
+			checkGate('gate-fwd', {
+				label: 'Fwd Only',
+				color: '#abcdef',
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0]).toMatchObject({
+			direction: 'bidirectional',
+			gateType: 'check',
+			gateLabel: 'Fwd Only',
+			gateColor: '#abcdef',
+			reverseGateType: undefined,
+			reverseGateLabel: undefined,
+			reverseGateColor: undefined,
+			reverseHasScript: undefined,
+		});
+	});
+
+	it('tracks label/color/hasScript only for reverse direction when only reverse has a gate', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Reviewer 1', direction: 'one-way' },
+			{ from: 'Reviewer 2', to: 'Planning', direction: 'one-way', gateId: 'gate-rev' },
+		];
+		const gates = [
+			checkGate('gate-rev', {
+				label: 'Rev Only',
+				color: '#fedcba',
+				script: { interpreter: 'bash', source: 'true' },
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0]).toMatchObject({
+			direction: 'bidirectional',
+			gateType: undefined,
+			gateLabel: undefined,
+			gateColor: undefined,
+			hasScript: undefined,
+			reverseGateType: 'check',
+			reverseGateLabel: 'Rev Only',
+			reverseGateColor: '#fedcba',
+			reverseHasScript: true,
+		});
+	});
+
+	it('propagates label/color/hasScript for a one-way highToLow edge', () => {
+		// review→plan direction (highId→lowId) for a one-way edge
+		const channels: WorkflowChannel[] = [
+			{ from: 'Reviewer 1', to: 'Planning', direction: 'one-way', gateId: 'gate-rev' },
+		];
+		const gates = [
+			checkGate('gate-rev', {
+				label: 'HighToLow',
+				color: '#aabbcc',
+				script: { interpreter: 'node', source: 'process.exit(0)' },
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0]).toMatchObject({
+			direction: 'one-way',
+			fromStepId: 'review',
+			toStepId: 'plan',
+			gateType: 'check',
+			gateLabel: 'HighToLow',
+			gateColor: '#aabbcc',
+			hasScript: true,
+		});
+	});
+
+	it('gates with label but no color propagate label and undefined color', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Code Review', direction: 'one-way', gateId: 'g1' },
+		];
+		const gates = [
+			humanGate('g1', {
+				label: 'Label Only',
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0]).toMatchObject({
+			gateLabel: 'Label Only',
+			gateColor: undefined,
+		});
+	});
+
+	it('gates with color but no label propagate color and undefined label', () => {
+		const channels: WorkflowChannel[] = [
+			{ from: 'Planning', to: 'Code Review', direction: 'one-way', gateId: 'g1' },
+		];
+		const gates = [
+			humanGate('g1', {
+				color: '#998877',
+			}),
+		];
+
+		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
+		expect(result[0]).toMatchObject({
+			gateLabel: undefined,
+			gateColor: '#998877',
+		});
 	});
 });

--- a/packages/web/src/components/space/visual-editor/semanticWorkflowGraph.ts
+++ b/packages/web/src/components/space/visual-editor/semanticWorkflowGraph.ts
@@ -1,7 +1,7 @@
 import type { Gate, WorkflowChannel } from '@neokai/shared';
 import { TASK_AGENT_NODE_ID } from '@neokai/shared';
-import type { VisualNode } from './serialization';
 import { getVisualNodeDimensions } from './nodeMetrics';
+import type { VisualNode } from './serialization';
 
 export type AnchorSide = 'top' | 'bottom' | 'left' | 'right';
 
@@ -19,11 +19,23 @@ export interface SemanticWorkflowEdge {
 	 * it is the gate on the fromStepId→toStepId direction specifically.
 	 */
 	gateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
+	/** Custom badge label for the forward gate. `undefined` → heuristic fallback. */
+	gateLabel?: string;
+	/** Custom badge color for the forward gate (hex `#rrggbb`). `undefined` → heuristic fallback. */
+	gateColor?: string;
+	/** Whether the forward gate has a script-based pre-check. */
+	hasScript?: boolean;
 	/**
 	 * Gate type for the reverse direction (to→from / highId→lowId).
 	 * Only set on bidirectional edges where the reverse direction has a gate.
 	 */
 	reverseGateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
+	/** Custom badge label for the reverse gate. `undefined` → heuristic fallback. */
+	reverseGateLabel?: string;
+	/** Custom badge color for the reverse gate (hex `#rrggbb`). `undefined` → heuristic fallback. */
+	reverseGateColor?: string;
+	/** Whether the reverse gate has a script-based pre-check. */
+	reverseHasScript?: boolean;
 	channelIndexes: number[];
 }
 
@@ -42,50 +54,76 @@ interface PairAggregate {
 	hasCyclic: boolean;
 	/** Gate type for channels travelling lowId → highId */
 	lowToHighGateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
+	/** Custom badge label for the lowId → highId gate. */
+	lowToHighGateLabel?: string;
+	/** Custom badge color for the lowId → highId gate. */
+	lowToHighGateColor?: string;
+	/** Whether the lowId → highId gate has a script-based pre-check. */
+	lowToHighHasScript?: boolean;
 	/** Gate type for channels travelling highId → lowId */
 	highToLowGateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
+	/** Custom badge label for the highId → lowId gate. */
+	highToLowGateLabel?: string;
+	/** Custom badge color for the highId → lowId gate. */
+	highToLowGateColor?: string;
+	/** Whether the highId → lowId gate has a script-based pre-check. */
+	highToLowHasScript?: boolean;
 	channelIndexes: Set<number>;
+}
+
+interface ResolvedGateInfo {
+	type: SemanticWorkflowEdge['gateType'];
+	label?: string;
+	color?: string;
+	hasScript: boolean;
 }
 
 function resolveSemanticGateType(
 	channel: WorkflowChannel,
 	gateLookup: Map<string, Gate>
-): SemanticWorkflowEdge['gateType'] {
+): ResolvedGateInfo {
+	const noGate: ResolvedGateInfo = { type: undefined, hasScript: false };
+
 	if (channel.gateId) {
 		const gate = gateLookup.get(channel.gateId);
-		if (!gate) return 'check';
+		if (!gate) return { type: 'check', hasScript: false };
 
 		// Derive gate type from field declarations
 		const fields = gate.fields ?? [];
-		if (fields.length === 0) return 'check';
 
-		// If any field is a map with count check -> 'count' (votes)
-		if (fields.some((f) => f.type === 'map' && f.check.op === 'count')) {
-			return 'count';
+		let type: SemanticWorkflowEdge['gateType'];
+
+		if (fields.length === 0) {
+			type = 'check';
+		} else if (fields.some((f) => f.type === 'map' && f.check.op === 'count')) {
+			type = 'count';
+		} else {
+			const approvedField = fields.find((f) => f.name === 'approved' && f.type === 'boolean');
+			if (approvedField && approvedField.check.op === '==' && approvedField.check.value === true) {
+				type = 'human';
+			} else {
+				const resultField = fields.find((f) => f.name === 'result' && f.type === 'string');
+				if (
+					resultField &&
+					resultField.check.op === '==' &&
+					typeof resultField.check.value === 'string'
+				) {
+					type = 'task_result';
+				} else {
+					type = 'check';
+				}
+			}
 		}
 
-		// If the gate has a field named 'approved' with boolean == true -> 'human'
-		const approvedField = fields.find((f) => f.name === 'approved' && f.type === 'boolean');
-		if (approvedField && approvedField.check.op === '==' && approvedField.check.value === true) {
-			// Check if writers include 'human'
-			if (approvedField.writers.includes('human')) return 'human';
-			return 'human';
-		}
-
-		// If the gate has a field named 'result' with string == check -> 'task_result'
-		const resultField = fields.find((f) => f.name === 'result' && f.type === 'string');
-		if (
-			resultField &&
-			resultField.check.op === '==' &&
-			typeof resultField.check.value === 'string'
-		) {
-			return 'task_result';
-		}
-
-		return 'check';
+		return {
+			type,
+			label: gate.label,
+			color: gate.color,
+			hasScript: !!gate.script,
+		};
 	}
 
-	return undefined;
+	return noGate;
 }
 
 function buildEndpointNodeLookup(nodes: VisualNode[]): Map<string, string> {
@@ -156,13 +194,19 @@ export function buildSemanticWorkflowEdges(
 				hasGate: false,
 				hasCyclic: false,
 				lowToHighGateType: undefined,
+				lowToHighGateLabel: undefined,
+				lowToHighGateColor: undefined,
+				lowToHighHasScript: undefined,
 				highToLowGateType: undefined,
+				highToLowGateLabel: undefined,
+				highToLowGateColor: undefined,
+				highToLowHasScript: undefined,
 				channelIndexes: new Set<number>(),
 			};
 
 			aggregate.channelCount += 1;
-			const gateType = resolveSemanticGateType(channel, gateLookup);
-			if (gateType) {
+			const gateInfo = resolveSemanticGateType(channel, gateLookup);
+			if (gateInfo.type) {
 				aggregate.hasGate = true;
 			}
 			if (cyclicChannelIndexes?.has(channelIndex)) {
@@ -174,16 +218,32 @@ export function buildSemanticWorkflowEdges(
 				// A bidirectional underlying channel gates both directions.
 				aggregate.lowToHigh = true;
 				aggregate.highToLow = true;
-				if (gateType) {
-					aggregate.lowToHighGateType ??= gateType;
-					aggregate.highToLowGateType ??= gateType;
+				if (gateInfo.type) {
+					aggregate.lowToHighGateType ??= gateInfo.type;
+					aggregate.lowToHighGateLabel ??= gateInfo.label;
+					aggregate.lowToHighGateColor ??= gateInfo.color;
+					if (gateInfo.hasScript) aggregate.lowToHighHasScript = true;
+					aggregate.highToLowGateType ??= gateInfo.type;
+					aggregate.highToLowGateLabel ??= gateInfo.label;
+					aggregate.highToLowGateColor ??= gateInfo.color;
+					if (gateInfo.hasScript) aggregate.highToLowHasScript = true;
 				}
 			} else if (fromIsLow) {
 				aggregate.lowToHigh = true;
-				if (gateType) aggregate.lowToHighGateType ??= gateType;
+				if (gateInfo.type) {
+					aggregate.lowToHighGateType ??= gateInfo.type;
+					aggregate.lowToHighGateLabel ??= gateInfo.label;
+					aggregate.lowToHighGateColor ??= gateInfo.color;
+					if (gateInfo.hasScript) aggregate.lowToHighHasScript = true;
+				}
 			} else {
 				aggregate.highToLow = true;
-				if (gateType) aggregate.highToLowGateType ??= gateType;
+				if (gateInfo.type) {
+					aggregate.highToLowGateType ??= gateInfo.type;
+					aggregate.highToLowGateLabel ??= gateInfo.label;
+					aggregate.highToLowGateColor ??= gateInfo.color;
+					if (gateInfo.hasScript) aggregate.highToLowHasScript = true;
+				}
 			}
 
 			aggregates.set(pairKey, aggregate);
@@ -204,7 +264,13 @@ export function buildSemanticWorkflowEdges(
 				hasGate: aggregate.hasGate,
 				hasCyclic: aggregate.hasCyclic,
 				gateType: aggregate.lowToHighGateType,
+				gateLabel: aggregate.lowToHighGateLabel,
+				gateColor: aggregate.lowToHighGateColor,
+				hasScript: aggregate.lowToHighHasScript,
 				reverseGateType: aggregate.highToLowGateType,
+				reverseGateLabel: aggregate.highToLowGateLabel,
+				reverseGateColor: aggregate.highToLowGateColor,
+				reverseHasScript: aggregate.highToLowHasScript,
 				channelIndexes: Array.from(aggregate.channelIndexes),
 			};
 		}
@@ -219,6 +285,9 @@ export function buildSemanticWorkflowEdges(
 				hasGate: aggregate.hasGate,
 				hasCyclic: aggregate.hasCyclic,
 				gateType: aggregate.lowToHighGateType,
+				gateLabel: aggregate.lowToHighGateLabel,
+				gateColor: aggregate.lowToHighGateColor,
+				hasScript: aggregate.lowToHighHasScript,
 				channelIndexes: Array.from(aggregate.channelIndexes),
 			};
 		}
@@ -232,6 +301,9 @@ export function buildSemanticWorkflowEdges(
 			hasGate: aggregate.hasGate,
 			hasCyclic: aggregate.hasCyclic,
 			gateType: aggregate.highToLowGateType,
+			gateLabel: aggregate.highToLowGateLabel,
+			gateColor: aggregate.highToLowGateColor,
+			hasScript: aggregate.highToLowHasScript,
 			channelIndexes: Array.from(aggregate.channelIndexes),
 		};
 	});


### PR DESCRIPTION
Update `semanticWorkflowGraph.ts` to propagate `gate.label`, `gate.color`, and `!!gate.script` from Gate entities through the edge building pipeline.

**Changes:**
- `SemanticWorkflowEdge`: add `gateLabel`, `gateColor`, `hasScript` + `reverse*` counterparts
- `PairAggregate`: add per-direction `lowToHighGateLabel/Color/HasScript` and `highToLowGateLabel/Color/HasScript`
- `resolveSemanticGateType()`: returns `ResolvedGateInfo { type, label?, color?, hasScript }` instead of bare type string
- Collapse logic maps aggregate fields to edge fields for both one-way and bidirectional edges
- Uses `(gate.fields ?? [])` for fields access (subtask 6)

**Tests:** 19 tests (7 existing updated + 12 new) covering label/color/hasScript propagation for all edge directions.