### PR TITLE
fix: prevent black gap between keyboard and app bottom on iPad/mobile

### DIFF
--- a/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
+++ b/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { renderHook } from '@testing-library/preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useViewportSafety } from '../useViewportSafety.ts';
 
 // ---------------------------------------------------------------------------
@@ -441,7 +442,7 @@ describe('useViewportSafety — keyboard detection', () => {
 		mockVV._trigger('resize');
 
 		// Should dispatch a resize event for BottomTabBar to re-measure
-		expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Event));
+		expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'resize' }));
 
 		dispatchSpy.mockRestore();
 	});
@@ -458,5 +459,35 @@ describe('useViewportSafety — keyboard detection', () => {
 		unmount();
 
 		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
+		// --safe-height should be removed on unmount
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+	});
+
+	it('restores --bottom-bar-height even when it was empty string (desktop)', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
+		setVisualViewport(mockVV);
+
+		// No inline --bottom-bar-height set (desktop: BottomTabBar is md:hidden)
+		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('');
+
+		renderHook(() => useViewportSafety());
+
+		// Open keyboard
+		mockVV.height = WINDOW_INNER_HEIGHT - 300;
+		mockVV._trigger('resize');
+
+		// Keyboard open — override set
+		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('0px');
+
+		// Close keyboard — saved value was '' (empty string, falsy)
+		mockVV.height = WINDOW_INNER_HEIGHT;
+		mockVV._trigger('resize');
+
+		// The inline override should be restored (even though value is '')
+		// so the CSS cascade can fall through to the :root rule
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
+		// The saved '' is restored, removing the inline override
+		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('');
 	});
 });

--- a/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
+++ b/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
@@ -2,7 +2,7 @@
  * Tests for useViewportSafety Hook
  *
  * Tests iPad Safari detection logic, --safe-height CSS property management,
- * and event listener cleanup.
+ * virtual keyboard detection, and event listener cleanup.
  */
 
 import { renderHook } from '@testing-library/preact';
@@ -80,6 +80,9 @@ function restoreVisualViewport(): void {
 	});
 }
 
+/** jsdom default window.innerHeight is 768 */
+const WINDOW_INNER_HEIGHT = 768;
+
 // ---------------------------------------------------------------------------
 // UA fixtures
 // ---------------------------------------------------------------------------
@@ -102,7 +105,7 @@ const CRIOS_UA =
 
 /** Firefox on iOS */
 const FXIOS_UA =
-	'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/605.1.15';
+	'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/604.1';
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -112,6 +115,8 @@ afterEach(() => {
 	restoreNavigator();
 	restoreVisualViewport();
 	document.documentElement.style.removeProperty('--safe-height');
+	document.documentElement.style.removeProperty('--bottom-bar-height');
+	document.documentElement.classList.remove('keyboard-open');
 });
 
 // ---------------------------------------------------------------------------
@@ -121,34 +126,38 @@ afterEach(() => {
 describe('useViewportSafety — iPad Safari detection', () => {
 	it('detects iPad Safari: maxTouchPoints > 1 + Safari UA without Chrome/CriOS/FxiOS', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
-		setVisualViewport(createMockVisualViewport(900));
+		setVisualViewport(createMockVisualViewport(WINDOW_INNER_HEIGHT));
 
 		renderHook(() => useViewportSafety());
 
-		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('900px');
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
+			`${WINDOW_INNER_HEIGHT}px`
+		);
 	});
 
 	it('does NOT detect iPad Safari when maxTouchPoints is 0 (desktop Mac)', () => {
 		setNavigator(0, DESKTOP_SAFARI_UA);
-		setVisualViewport(createMockVisualViewport(900));
+		setVisualViewport(createMockVisualViewport(WINDOW_INNER_HEIGHT));
 
 		renderHook(() => useViewportSafety());
 
+		// --safe-height should NOT be set on desktop Safari when keyboard is not open
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
 	});
 
 	it('does NOT detect iPad Safari for desktop Chrome (UA contains Chrome)', () => {
 		setNavigator(5, DESKTOP_CHROME_UA);
-		setVisualViewport(createMockVisualViewport(900));
+		setVisualViewport(createMockVisualViewport(WINDOW_INNER_HEIGHT));
 
 		renderHook(() => useViewportSafety());
 
+		// Desktop Chrome: no --safe-height when no keyboard
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
 	});
 
 	it('does NOT detect iPad Safari for CriOS (Chrome on iOS)', () => {
 		setNavigator(5, CRIOS_UA);
-		setVisualViewport(createMockVisualViewport(900));
+		setVisualViewport(createMockVisualViewport(WINDOW_INNER_HEIGHT));
 
 		renderHook(() => useViewportSafety());
 
@@ -157,7 +166,7 @@ describe('useViewportSafety — iPad Safari detection', () => {
 
 	it('does NOT detect iPad Safari for FxiOS (Firefox on iOS)', () => {
 		setNavigator(5, FXIOS_UA);
-		setVisualViewport(createMockVisualViewport(900));
+		setVisualViewport(createMockVisualViewport(WINDOW_INNER_HEIGHT));
 
 		renderHook(() => useViewportSafety());
 
@@ -166,7 +175,7 @@ describe('useViewportSafety — iPad Safari detection', () => {
 });
 
 // ---------------------------------------------------------------------------
-// --safe-height property
+// --safe-height property (iPad Safari always-on behavior)
 // ---------------------------------------------------------------------------
 
 describe('useViewportSafety — --safe-height property', () => {
@@ -179,16 +188,16 @@ describe('useViewportSafety — --safe-height property', () => {
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('768px');
 	});
 
-	it('does NOT set --safe-height on non-iPad-Safari (CSS 100svh fallback applies)', () => {
+	it('does NOT set --safe-height on non-iPad-Safari when no keyboard is open', () => {
 		setNavigator(0, DESKTOP_SAFARI_UA);
-		setVisualViewport(createMockVisualViewport(900));
+		setVisualViewport(createMockVisualViewport(WINDOW_INNER_HEIGHT));
 
 		renderHook(() => useViewportSafety());
 
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
 	});
 
-	it('does nothing when visualViewport is unavailable on iPad Safari', () => {
+	it('does nothing when visualViewport is unavailable', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
 		setVisualViewport(null);
 
@@ -204,7 +213,7 @@ describe('useViewportSafety — --safe-height property', () => {
 describe('useViewportSafety — event listeners', () => {
 	it('attaches resize listeners on iPad Safari', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
-		const mockVV = createMockVisualViewport(900);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
 		setVisualViewport(mockVV);
 		const windowAddSpy = vi.spyOn(window, 'addEventListener');
 
@@ -216,19 +225,23 @@ describe('useViewportSafety — event listeners', () => {
 		windowAddSpy.mockRestore();
 	});
 
-	it('does NOT attach listeners on non-iPad-Safari', () => {
+	it('attaches resize listeners on non-iPad-Safari (for keyboard detection)', () => {
 		setNavigator(0, DESKTOP_SAFARI_UA);
-		const mockVV = createMockVisualViewport(900);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
 		setVisualViewport(mockVV);
+		const windowAddSpy = vi.spyOn(window, 'addEventListener');
 
 		renderHook(() => useViewportSafety());
 
-		expect(mockVV.addEventListener).not.toHaveBeenCalled();
+		expect(mockVV.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+		expect(windowAddSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+
+		windowAddSpy.mockRestore();
 	});
 
 	it('removes event listeners on unmount', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
-		const mockVV = createMockVisualViewport(900);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
 		setVisualViewport(mockVV);
 		const windowRemoveSpy = vi.spyOn(window, 'removeEventListener');
 
@@ -241,9 +254,9 @@ describe('useViewportSafety — event listeners', () => {
 		windowRemoveSpy.mockRestore();
 	});
 
-	it('updates --safe-height when visualViewport resize fires', () => {
+	it('updates --safe-height when visualViewport resize fires (iPad Safari)', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
-		const mockVV = createMockVisualViewport(900);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
 		setVisualViewport(mockVV);
 
 		renderHook(() => useViewportSafety());
@@ -254,9 +267,9 @@ describe('useViewportSafety — event listeners', () => {
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('700px');
 	});
 
-	it('updates --safe-height when window resize fires', () => {
+	it('updates --safe-height when window resize fires (iPad Safari)', () => {
 		setNavigator(5, IPAD_SAFARI_UA);
-		const mockVV = createMockVisualViewport(900);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
 		setVisualViewport(mockVV);
 
 		renderHook(() => useViewportSafety());
@@ -265,5 +278,185 @@ describe('useViewportSafety — event listeners', () => {
 		window.dispatchEvent(new Event('resize'));
 
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('600px');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard detection (all platforms)
+// ---------------------------------------------------------------------------
+
+describe('useViewportSafety — keyboard detection', () => {
+	it('detects keyboard open: adds keyboard-open class and adjusts CSS vars', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
+		setVisualViewport(mockVV);
+
+		renderHook(() => useViewportSafety());
+
+		// No keyboard yet
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
+
+		// Simulate keyboard opening (viewport shrinks by more than 50px threshold)
+		mockVV.height = WINDOW_INNER_HEIGHT - 300; // 300px keyboard
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(true);
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
+			`${WINDOW_INNER_HEIGHT - 300}px`
+		);
+		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('0px');
+	});
+
+	it('detects keyboard close: removes keyboard-open class and restores CSS vars', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
+		setVisualViewport(mockVV);
+
+		// Pre-set --bottom-bar-height to simulate BottomTabBar measurement
+		document.documentElement.style.setProperty('--bottom-bar-height', '56px');
+
+		renderHook(() => useViewportSafety());
+
+		// Open keyboard
+		mockVV.height = WINDOW_INNER_HEIGHT - 300;
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(true);
+		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('0px');
+
+		// Close keyboard
+		mockVV.height = WINDOW_INNER_HEIGHT;
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
+		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('56px');
+		// --safe-height should be removed on non-iPad
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+	});
+
+	it('does NOT trigger keyboard detection for small viewport changes (below 50px threshold)', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
+		setVisualViewport(mockVV);
+
+		renderHook(() => useViewportSafety());
+
+		// Small shrinkage (30px) — should not trigger keyboard
+		mockVV.height = WINDOW_INNER_HEIGHT - 30;
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
+	});
+
+	it('detects keyboard at exactly the threshold boundary (51px)', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
+		setVisualViewport(mockVV);
+
+		renderHook(() => useViewportSafety());
+
+		// Exactly at threshold boundary — should trigger (innerHeight - height > 50)
+		mockVV.height = WINDOW_INNER_HEIGHT - 51;
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(true);
+	});
+
+	it('does NOT trigger at threshold boundary (50px exactly)', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
+		setVisualViewport(mockVV);
+
+		renderHook(() => useViewportSafety());
+
+		// Exactly at threshold — should NOT trigger (innerHeight - height === 50 is not > 50)
+		mockVV.height = WINDOW_INNER_HEIGHT - 50;
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
+	});
+
+	it('works on iPad Safari: keyboard detection plus always-on --safe-height', () => {
+		setNavigator(5, IPAD_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
+		setVisualViewport(mockVV);
+
+		renderHook(() => useViewportSafety());
+
+		// iPad Safari: --safe-height is always set
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
+			`${WINDOW_INNER_HEIGHT}px`
+		);
+
+		// Open keyboard
+		mockVV.height = WINDOW_INNER_HEIGHT - 300;
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(true);
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
+			`${WINDOW_INNER_HEIGHT - 300}px`
+		);
+		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('0px');
+
+		// Close keyboard
+		mockVV.height = WINDOW_INNER_HEIGHT;
+		mockVV._trigger('resize');
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
+		// --safe-height is restored to visualViewport.height (still set because iPad Safari)
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
+			`${WINDOW_INNER_HEIGHT}px`
+		);
+	});
+
+	it('detects initial keyboard state on mount', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		// Simulate keyboard already open when hook mounts
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT - 300);
+		setVisualViewport(mockVV);
+
+		renderHook(() => useViewportSafety());
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(true);
+		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
+			`${WINDOW_INNER_HEIGHT - 300}px`
+		);
+		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('0px');
+	});
+
+	it('dispatches window resize when keyboard closes (for BottomTabBar re-measurement)', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT);
+		setVisualViewport(mockVV);
+		const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+		renderHook(() => useViewportSafety());
+
+		// Open keyboard
+		mockVV.height = WINDOW_INNER_HEIGHT - 300;
+		mockVV._trigger('resize');
+
+		// Close keyboard
+		mockVV.height = WINDOW_INNER_HEIGHT;
+		mockVV._trigger('resize');
+
+		// Should dispatch a resize event for BottomTabBar to re-measure
+		expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Event));
+
+		dispatchSpy.mockRestore();
+	});
+
+	it('cleans up keyboard state on unmount', () => {
+		setNavigator(0, DESKTOP_SAFARI_UA);
+		const mockVV = createMockVisualViewport(WINDOW_INNER_HEIGHT - 300);
+		setVisualViewport(mockVV);
+
+		const { unmount } = renderHook(() => useViewportSafety());
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(true);
+
+		unmount();
+
+		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
 	});
 });

--- a/packages/web/src/hooks/useViewportSafety.ts
+++ b/packages/web/src/hooks/useViewportSafety.ts
@@ -13,7 +13,7 @@
  *    Safari's tab bar overlay.
  *
  * 2. **Virtual keyboard detection (all platforms)**: When a virtual keyboard appears
- *    (detected via `visualViewport.height < window.innerHeight`), the hook:
+ *    (detected via `window.innerHeight - visualViewport.height > 50px`), the hook:
  *    - Adds `keyboard-open` class to `<html>` for CSS targeting
  *    - Sets `--safe-height` to `visualViewport.height` (on all platforms, not just
  *      iPad Safari) so the app container shrinks to match the visible area
@@ -23,6 +23,12 @@
  *
  *    When the keyboard closes, these overrides are removed and a `resize` event is
  *    dispatched so the BottomTabBar's ResizeObserver re-measures its height.
+ *
+ * **Known limitation**: On iOS Safari, `window.innerHeight` itself changes when the
+ * address bar shows/hides. This can cause the keyboard detection delta to undercount
+ * the keyboard size in edge cases (e.g. small split-screen on iPad). The 50px
+ * threshold provides a reasonable buffer. A more robust approach would use the
+ * `navigator.virtualKeyboard` API, but it is not broadly supported yet.
  *
  * **IMPORTANT**: This hook must only be called **once globally** in `App.tsx`.
  * Downstream components must NOT call it themselves — doing so would create
@@ -68,7 +74,13 @@ function updateSafeHeight(vv: VisualViewport): void {
 
 /**
  * Check whether the virtual keyboard is currently visible by comparing
- * `visualViewport.height` with `window.innerHeight`.
+ * `visualViewport.height` with `window.innerHeight`. Returns true when the
+ * difference exceeds {@link KEYBOARD_THRESHOLD} to avoid false positives from
+ * browser chrome changes (address bar, etc.).
+ *
+ * **Known limitation**: On iOS Safari, `window.innerHeight` itself fluctuates
+ * when the address bar shows/hides, so the delta may undercount the keyboard
+ * size. The 50px threshold mitigates this.
  */
 function isKeyboardVisible(vv: VisualViewport): boolean {
 	return window.innerHeight - vv.height > KEYBOARD_THRESHOLD;
@@ -136,13 +148,24 @@ export function useViewportSafety(): void {
 				}
 				// On iPad, --safe-height is already updated above via updateSafeHeight()
 
-				// Restore bottom bar height from saved value
-				if (savedBottomBarHeight) {
+				// Restore bottom bar height from saved value.
+				// NOTE: We use !== null instead of truthiness because
+				// getPropertyValue returns '' when the property is not set
+				// inline (e.g. on desktop where BottomTabBar is md:hidden and
+				// never measures itself). null is the correct sentinel.
+				if (savedBottomBarHeight !== null) {
 					document.documentElement.style.setProperty('--bottom-bar-height', savedBottomBarHeight);
 					savedBottomBarHeight = null;
 				}
 
-				// Dispatch resize so BottomTabBar's ResizeObserver re-measures
+				// Dispatch resize so BottomTabBar's ResizeObserver re-measures.
+				// NOTE: This is synchronous and will re-enter handleResize.
+				// This is safe: keyboardOpen is already false and the keyboard
+				// is not visible, so neither branch of the keyboard detection
+				// logic executes. The only redundant work is an extra
+				// updateSafeHeight() call on iPad Safari (a harmless DOM write).
+				// BottomTabBar's listener uses requestAnimationFrame so it
+				// won't interfere with this handler's execution.
 				window.dispatchEvent(new Event('resize'));
 			}
 		};
@@ -173,7 +196,8 @@ export function useViewportSafety(): void {
 
 			// Cleanup: restore original state
 			document.documentElement.classList.remove('keyboard-open');
-			if (savedBottomBarHeight) {
+			document.documentElement.style.removeProperty('--safe-height');
+			if (savedBottomBarHeight !== null) {
 				document.documentElement.style.setProperty('--bottom-bar-height', savedBottomBarHeight);
 			}
 		};

--- a/packages/web/src/hooks/useViewportSafety.ts
+++ b/packages/web/src/hooks/useViewportSafety.ts
@@ -1,15 +1,28 @@
 /**
  * useViewportSafety Hook
  *
- * Manages CSS custom properties for safe layout dimensions on iPad Safari.
+ * Manages CSS custom properties for safe layout dimensions and virtual keyboard
+ * handling across all platforms.
  *
- * On iPad Safari, `window.visualViewport.height` is the actual visible content
- * area after all browser chrome (tab bar, address bar) is subtracted. This hook
- * sets `--safe-height` on `document.documentElement` so layout components can
- * use it instead of `100svh` which does not account for Safari's tab bar overlay.
+ * Two concerns:
  *
- * On all other browsers, `--safe-height` is NOT set — the CSS fallback (`100svh`)
- * takes effect automatically.
+ * 1. **iPad Safari `--safe-height`**: On iPad Safari, `window.visualViewport.height`
+ *    is the actual visible content area after all browser chrome (tab bar, address
+ *    bar) is subtracted. This hook sets `--safe-height` on `document.documentElement`
+ *    so layout components can use it instead of `100svh` which does not account for
+ *    Safari's tab bar overlay.
+ *
+ * 2. **Virtual keyboard detection (all platforms)**: When a virtual keyboard appears
+ *    (detected via `visualViewport.height < window.innerHeight`), the hook:
+ *    - Adds `keyboard-open` class to `<html>` for CSS targeting
+ *    - Sets `--safe-height` to `visualViewport.height` (on all platforms, not just
+ *      iPad Safari) so the app container shrinks to match the visible area
+ *    - Sets `--bottom-bar-height` to `0px` to remove padding reserved for the
+ *      BottomTabBar (which is `position: fixed; bottom: 0` and hidden behind the
+ *      keyboard on mobile)
+ *
+ *    When the keyboard closes, these overrides are removed and a `resize` event is
+ *    dispatched so the BottomTabBar's ResizeObserver re-measures its height.
  *
  * **IMPORTANT**: This hook must only be called **once globally** in `App.tsx`.
  * Downstream components must NOT call it themselves — doing so would create
@@ -17,6 +30,9 @@
  */
 
 import { useEffect } from 'preact/hooks';
+
+/** Minimum visual viewport shrinkage (px) to consider the keyboard visible. */
+const KEYBOARD_THRESHOLD = 50;
 
 /**
  * Detect iPad Safari.
@@ -51,44 +67,115 @@ function updateSafeHeight(vv: VisualViewport): void {
 }
 
 /**
- * Hook that detects iPad Safari and sets `--safe-height` CSS custom property
- * from `window.visualViewport.height`. Listens to `visualViewport.resize` and
- * `window.resize` to keep the value current (e.g. when the address bar shows
- * or hides, or the device rotates).
+ * Check whether the virtual keyboard is currently visible by comparing
+ * `visualViewport.height` with `window.innerHeight`.
+ */
+function isKeyboardVisible(vv: VisualViewport): boolean {
+	return window.innerHeight - vv.height > KEYBOARD_THRESHOLD;
+}
+
+/**
+ * Hook that manages viewport-related CSS custom properties:
  *
- * On non-iPad-Safari browsers this hook is a no-op — the CSS fallback (`100svh`)
- * handles those environments.
+ * - On **iPad Safari**: always sets `--safe-height` from `visualViewport.height`
+ *   to handle Safari's tab bar overlay.
+ *
+ * - On **all platforms with visualViewport**: detects virtual keyboard open/close
+ *   and adjusts `--safe-height` and `--bottom-bar-height` to prevent the
+ *   black gap between the keyboard and app bottom.
  *
  * Must be called **once globally** in `App.tsx` only.
  */
 export function useViewportSafety(): void {
 	useEffect(() => {
-		if (!isIpadSafari()) {
-			return;
-		}
-
 		const vv = window.visualViewport;
 		if (!vv) {
 			// No VisualViewport API — CSS fallback handles it.
 			return;
 		}
 
-		// Set initial value immediately.
-		updateSafeHeight(vv);
+		const ipadSafari = isIpadSafari();
+		let keyboardOpen = false;
+		let savedBottomBarHeight: string | null = null;
 
-		const handleResize = () => updateSafeHeight(vv);
+		/**
+		 * Core resize handler. Runs on every `visualViewport.resize` and
+		 * `window.resize` event to keep layout in sync.
+		 */
+		const handleResize = () => {
+			// Part 1: iPad Safari — always keep --safe-height in sync
+			if (ipadSafari) {
+				updateSafeHeight(vv);
+			}
+
+			// Part 2: Keyboard detection (all platforms)
+			const kbVisible = isKeyboardVisible(vv);
+
+			if (kbVisible && !keyboardOpen) {
+				// Keyboard just appeared
+				keyboardOpen = true;
+				document.documentElement.classList.add('keyboard-open');
+
+				// Shrink the app container to the visible viewport height
+				document.documentElement.style.setProperty('--safe-height', `${vv.height}px`);
+
+				// Remove bottom bar padding — the BottomTabBar is fixed at bottom:0
+				// and hidden behind the keyboard, so reserving space for it creates a gap
+				savedBottomBarHeight =
+					document.documentElement.style.getPropertyValue('--bottom-bar-height');
+				document.documentElement.style.setProperty('--bottom-bar-height', '0px');
+			} else if (!kbVisible && keyboardOpen) {
+				// Keyboard just closed
+				keyboardOpen = false;
+				document.documentElement.classList.remove('keyboard-open');
+
+				// On non-iPad browsers, remove the --safe-height override so the
+				// CSS fallback (100svh) takes effect again
+				if (!ipadSafari) {
+					document.documentElement.style.removeProperty('--safe-height');
+				}
+				// On iPad, --safe-height is already updated above via updateSafeHeight()
+
+				// Restore bottom bar height from saved value
+				if (savedBottomBarHeight) {
+					document.documentElement.style.setProperty('--bottom-bar-height', savedBottomBarHeight);
+					savedBottomBarHeight = null;
+				}
+
+				// Dispatch resize so BottomTabBar's ResizeObserver re-measures
+				window.dispatchEvent(new Event('resize'));
+			}
+		};
+
+		// Set initial --safe-height for iPad Safari
+		if (ipadSafari) {
+			updateSafeHeight(vv);
+		}
+
+		// Check initial keyboard state (e.g. if keyboard was already open)
+		if (isKeyboardVisible(vv)) {
+			keyboardOpen = true;
+			document.documentElement.classList.add('keyboard-open');
+			document.documentElement.style.setProperty('--safe-height', `${vv.height}px`);
+			savedBottomBarHeight = document.documentElement.style.getPropertyValue('--bottom-bar-height');
+			document.documentElement.style.setProperty('--bottom-bar-height', '0px');
+		}
 
 		// `visualViewport.resize` fires whenever the visible area changes
 		// (address bar show/hide, keyboard appearance, etc.).
-		// `window.resize` fires on device rotation — iPadOS also fires
-		// `orientationchange`, but `resize` subsumes it so no separate
-		// `orientationchange` listener is needed.
+		// `window.resize` fires on device rotation.
 		vv.addEventListener('resize', handleResize);
 		window.addEventListener('resize', handleResize);
 
 		return () => {
 			vv.removeEventListener('resize', handleResize);
 			window.removeEventListener('resize', handleResize);
+
+			// Cleanup: restore original state
+			document.documentElement.classList.remove('keyboard-open');
+			if (savedBottomBarHeight) {
+				document.documentElement.style.setProperty('--bottom-bar-height', savedBottomBarHeight);
+			}
 		};
 	}, []);
 }

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -225,6 +225,7 @@ export function BottomTabBar() {
 	return (
 		<div
 			ref={rootRef}
+			data-testid="bottom-tab-bar"
 			class="flex md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark-900/90 backdrop-blur-md border-t border-dark-700 pb-safe"
 			role="tablist"
 			aria-label="Main navigation"

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -593,13 +593,14 @@ a:focus-visible {
  * Virtual keyboard open state.
  *
  * The `keyboard-open` class is toggled on `<html>` by the useViewportSafety hook
- * when it detects a virtual keyboard (via visualViewport.height < window.innerHeight).
+ * when it detects a virtual keyboard (via window.innerHeight - visualViewport.height
+ * exceeding a 50px threshold).
  *
- * When the keyboard is open:
- * - The BottomTabBar (position: fixed; bottom: 0) is hidden behind the keyboard
- *   on mobile — translate it offscreen for clean visual behavior
- * - The ContextPanel sidebar (position: fixed on mobile) should also stay hidden
+ * When the keyboard is open, the BottomTabBar (position: fixed; bottom: 0) is
+ * hidden behind the keyboard on mobile — translate it offscreen with a smooth
+ * transition for clean visual behavior.
  */
 html.keyboard-open [data-testid="bottom-tab-bar"] {
 	transform: translateY(100%);
+	transition: transform 0.2s ease;
 }

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -588,3 +588,18 @@ a:focus-visible {
 .pb-bottom-bar {
 	padding-bottom: var(--bottom-bar-height, 0px);
 }
+
+/*
+ * Virtual keyboard open state.
+ *
+ * The `keyboard-open` class is toggled on `<html>` by the useViewportSafety hook
+ * when it detects a virtual keyboard (via visualViewport.height < window.innerHeight).
+ *
+ * When the keyboard is open:
+ * - The BottomTabBar (position: fixed; bottom: 0) is hidden behind the keyboard
+ *   on mobile — translate it offscreen for clean visual behavior
+ * - The ContextPanel sidebar (position: fixed on mobile) should also stay hidden
+ */
+html.keyboard-open [data-testid="bottom-tab-bar"] {
+	transform: translateY(100%);
+}

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -599,8 +599,14 @@ a:focus-visible {
  * When the keyboard is open, the BottomTabBar (position: fixed; bottom: 0) is
  * hidden behind the keyboard on mobile — translate it offscreen with a smooth
  * transition for clean visual behavior.
+ *
+ * The transition is declared on the base element so it applies bidirectionally:
+ * smooth slide-off when keyboard opens, smooth slide-back when keyboard closes.
  */
+[data-testid="bottom-tab-bar"] {
+	transition: transform 0.2s ease;
+}
+
 html.keyboard-open [data-testid="bottom-tab-bar"] {
 	transform: translateY(100%);
-	transition: transform 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- Extend `useViewportSafety` hook to detect virtual keyboard visibility on all platforms (not just iPad Safari) by comparing `visualViewport.height` with `window.innerHeight`
- When keyboard is open: add `keyboard-open` class to `<html>`, set `--safe-height` to `visualViewport.height`, set `--bottom-bar-height` to `0px` — this eliminates the black gap by shrinking the app container and removing padding for the hidden BottomTabBar
- When keyboard closes: restore original state and dispatch `resize` event so BottomTabBar's ResizeObserver re-measures
- Add CSS rule to translate BottomTabBar offscreen when keyboard is open, with `data-testid` for CSS targeting

## Test plan
- [x] 22 unit tests for useViewportSafety hook (13 existing + 9 new keyboard detection tests)
- [x] All web tests pass (pre-existing failures in visual-editor are unrelated)
- [x] Lint, format, typecheck, knip all pass
- [ ] Manual testing on iPad Safari: focus input → no black gap between keyboard and app bottom
- [ ] Manual testing on iPhone Safari: same verification