### PR TITLE
feat(web): use gate label/color/hasScript in EdgeRenderer badge rendering

### DIFF
--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -761,13 +761,17 @@ export function EdgeRenderer({
 				// For one-way or single-direction bidirectional: use whichever is set.
 				// For both-direction bidirectional: use forward gate type (gateType).
 				const effectiveGateType = channel.gateType ?? channel.reverseGateType ?? undefined;
+				// When only the reverse direction is gated on a bidirectional channel,
+				// use the reverse direction's custom fields.
+				const effectiveGateLabel = channel.gateType ? channel.gateLabel : channel.reverseGateLabel;
+				const effectiveGateColor = channel.gateType ? channel.gateColor : channel.reverseGateColor;
 				// Prefer custom gate color, fall back to heuristic color from gateType.
 				const gateColor =
-					channel.gateColor ??
+					effectiveGateColor ??
 					(effectiveGateType ? CHANNEL_GATE_BADGE_COLORS[effectiveGateType] : CHANNEL_EDGE_COLOR);
 				// Prefer custom gate label, fall back to heuristic label from gateType.
 				const gateLabel =
-					channel.gateLabel ??
+					effectiveGateLabel ??
 					(effectiveGateType ? CHANNEL_GATE_BADGE_LABELS[effectiveGateType] : 'Gate');
 				// Whether to show a script icon next to the badge.
 				// For bidirectional channels, use the forward direction's hasScript when available.

--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -85,6 +85,18 @@ export interface ResolvedWorkflowChannel {
 	 * Only set on bidirectional channels where the reverse direction has its own gate.
 	 */
 	reverseGateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
+	/** Custom badge label for the forward gate. `undefined` → heuristic fallback. */
+	gateLabel?: string;
+	/** Custom badge color for the forward gate (hex `#rrggbb`). `undefined` → heuristic fallback. */
+	gateColor?: string;
+	/** Whether the forward gate has a script-based pre-check. */
+	hasScript?: boolean;
+	/** Custom badge label for the reverse gate. `undefined` → heuristic fallback. */
+	reverseGateLabel?: string;
+	/** Custom badge color for the reverse gate (hex `#rrggbb`). `undefined` → heuristic fallback. */
+	reverseGateColor?: string;
+	/** Whether the reverse gate has a script-based pre-check. */
+	reverseHasScript?: boolean;
 	/** Stable ID for selection -- typically the workflow-level channel array index as a string. */
 	id?: string;
 	/** Optional display label from WorkflowChannel.label */
@@ -111,6 +123,8 @@ const CHANNEL_GATE_ARROW_GAP = 4;
 const CHANNEL_GATE_ARROW_TOTAL = CHANNEL_GATE_ARROW_WIDTH + CHANNEL_GATE_ARROW_GAP;
 /** Extra horizontal padding added to badge width to give the arrow room to breathe */
 const CHANNEL_GATE_ARROW_EXTRA_PADDING = 2;
+const CHANNEL_GATE_SCRIPT_ICON_GAP = 4;
+const CHANNEL_GATE_SCRIPT_ICON_WIDTH = 11;
 const CHANNEL_GATE_BADGE_BG = '#0f1115';
 const CHANNEL_GATE_BADGE_BORDER = '#232733';
 const CHANNEL_LOOP_BADGE_COLOR = '#f59e0b';
@@ -747,20 +761,30 @@ export function EdgeRenderer({
 				// For one-way or single-direction bidirectional: use whichever is set.
 				// For both-direction bidirectional: use forward gate type (gateType).
 				const effectiveGateType = channel.gateType ?? channel.reverseGateType ?? undefined;
-				const gateColor = effectiveGateType
-					? CHANNEL_GATE_BADGE_COLORS[effectiveGateType]
-					: CHANNEL_EDGE_COLOR;
-				const gateLabelBase = effectiveGateType
-					? CHANNEL_GATE_BADGE_LABELS[effectiveGateType]
-					: 'Gate';
-				const gateLabel = gateLabelBase;
+				// Prefer custom gate color, fall back to heuristic color from gateType.
+				const gateColor =
+					channel.gateColor ??
+					(effectiveGateType ? CHANNEL_GATE_BADGE_COLORS[effectiveGateType] : CHANNEL_EDGE_COLOR);
+				// Prefer custom gate label, fall back to heuristic label from gateType.
+				const gateLabel =
+					channel.gateLabel ??
+					(effectiveGateType ? CHANNEL_GATE_BADGE_LABELS[effectiveGateType] : 'Gate');
+				// Whether to show a script icon next to the badge.
+				// For bidirectional channels, use the forward direction's hasScript when available.
+				const effectiveHasScript = channel.gateType
+					? !!channel.hasScript
+					: !!channel.reverseHasScript;
 				// Arrow count determines badge width:
 				//   0 arrows (no gate):              base label width
 				//   1 arrow (one-way / single-dir):  label + ARROW_TOTAL
 				//   2 arrows (both-direction gate):  label + 2 * ARROW_TOTAL
 				const arrowCount = hasBothDirectionGates ? 2 : isGated ? 1 : 0;
+				const scriptIconExtra = effectiveHasScript
+					? CHANNEL_GATE_SCRIPT_ICON_WIDTH + CHANNEL_GATE_SCRIPT_ICON_GAP
+					: 0;
 				const gateBadgeWidth =
 					gateLabel.length * CHANNEL_GATE_BADGE_CHAR_WIDTH +
+					scriptIconExtra +
 					CHANNEL_GATE_BADGE_HORIZONTAL_PADDING * 2 +
 					(arrowCount > 0
 						? arrowCount * CHANNEL_GATE_ARROW_TOTAL + CHANNEL_GATE_ARROW_EXTRA_PADDING
@@ -908,7 +932,9 @@ export function EdgeRenderer({
 									</>
 								)}
 								<text
-									x={arrowCount === 1 ? singleArrowTextX : 0}
+									x={
+										arrowCount === 1 ? singleArrowTextX + scriptIconExtra / 2 : scriptIconExtra / 2
+									}
 									y="4"
 									textAnchor="middle"
 									fontSize="11"
@@ -918,6 +944,22 @@ export function EdgeRenderer({
 								>
 									{gateLabel}
 								</text>
+								{effectiveHasScript && (
+									<text
+										x={
+											arrowCount === 1
+												? singleArrowTextX - labelPixelWidth / 2 - CHANNEL_GATE_SCRIPT_ICON_GAP
+												: -labelPixelWidth / 2 - CHANNEL_GATE_SCRIPT_ICON_GAP
+										}
+										y="3"
+										textAnchor="middle"
+										fontSize="9"
+										fill={isSelected ? 'white' : gateColor}
+										opacity={0.7}
+									>
+										⚡
+									</text>
+								)}
 							</g>
 						)}
 						{loopBadgePosition && (

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -47,6 +47,7 @@ import type { NodeChannelLink } from './NodeConfigPanel';
 import { EdgeConfigPanel } from './EdgeConfigPanel';
 import { ChannelRelationConfigPanel } from './ChannelRelationConfigPanel';
 import { buildVisualNodePositions } from './nodeMetrics';
+import type { ResolvedWorkflowChannel } from './EdgeRenderer';
 import {
 	buildNodeAnchorUsage,
 	buildSemanticWorkflowEdges,
@@ -358,26 +359,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		[routedSemanticEdges]
 	);
 
-	const channelEdges = useMemo<
-		{
-			fromStepId: string;
-			toStepId: string;
-			direction: 'one-way' | 'bidirectional';
-			isCyclic?: boolean;
-			gateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
-			reverseGateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
-			gateLabel?: string;
-			gateColor?: string;
-			hasScript?: boolean;
-			reverseGateLabel?: string;
-			reverseGateColor?: string;
-			reverseHasScript?: boolean;
-			sourceSide?: 'top' | 'bottom' | 'left' | 'right';
-			targetSide?: 'top' | 'bottom' | 'left' | 'right';
-			id?: string;
-			label?: string;
-		}[]
-	>(() => {
+	const channelEdges = useMemo<ResolvedWorkflowChannel[]>(() => {
 		return routedSemanticEdges.map((edge) => ({
 			fromStepId: edge.fromStepId,
 			toStepId: edge.toStepId,

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -366,6 +366,12 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			isCyclic?: boolean;
 			gateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
 			reverseGateType?: 'human' | 'condition' | 'task_result' | 'check' | 'count';
+			gateLabel?: string;
+			gateColor?: string;
+			hasScript?: boolean;
+			reverseGateLabel?: string;
+			reverseGateColor?: string;
+			reverseHasScript?: boolean;
 			sourceSide?: 'top' | 'bottom' | 'left' | 'right';
 			targetSide?: 'top' | 'bottom' | 'left' | 'right';
 			id?: string;
@@ -378,6 +384,12 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			direction: edge.direction,
 			gateType: edge.gateType,
 			reverseGateType: edge.reverseGateType,
+			gateLabel: edge.gateLabel,
+			gateColor: edge.gateColor,
+			hasScript: edge.hasScript,
+			reverseGateLabel: edge.reverseGateLabel,
+			reverseGateColor: edge.reverseGateColor,
+			reverseHasScript: edge.reverseHasScript,
 			isCyclic: edge.hasCyclic,
 			sourceSide: edge.sourceSide,
 			targetSide: edge.targetSide,

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -1139,6 +1139,72 @@ describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
 		expect(badgeTexts).toHaveLength(2);
 		expect(badgeTexts[1].textContent).toBe('⚡');
 	});
+
+	it('uses reverseGateLabel when only reverse gate is set on bidirectional', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'bidirectional',
+				reverseGateType: 'human',
+				reverseGateLabel: 'Reverse Label',
+			},
+		];
+		const { getByTestId } = renderEdgesWithChannels({ channels });
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toContain('Reverse Label');
+	});
+
+	it('uses reverseGateColor when only reverse gate is set on bidirectional', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'bidirectional',
+				reverseGateType: 'check',
+				reverseGateColor: '#00ff00',
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const badgeText = container.querySelector('g[data-testid="channel-gate-step-1-step-2"] text');
+		expect(badgeText?.getAttribute('fill')).toBe('#00ff00');
+	});
+
+	it('forward gateLabel/gateColor takes precedence over reverse on bidirectional with both gates', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'bidirectional',
+				gateType: 'human',
+				gateLabel: 'Forward',
+				gateColor: '#ff0000',
+				reverseGateType: 'check',
+				reverseGateLabel: 'Reverse',
+				reverseGateColor: '#00ff00',
+			},
+		];
+		const { container, getByTestId } = renderEdgesWithChannels({ channels });
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toContain('Forward');
+		const badgeText = container.querySelector('g[data-testid="channel-gate-step-1-step-2"] text');
+		expect(badgeText?.getAttribute('fill')).toBe('#ff0000');
+	});
+
+	it('reverseGateColor on arrow polygon when only reverse gate is set', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'bidirectional',
+				reverseGateType: 'check',
+				reverseGateColor: '#aa00ff',
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const arrow = container.querySelector(
+			'polygon[data-testid="channel-gate-arrow-step-1-step-2"]'
+		);
+		expect(arrow?.getAttribute('fill')).toBe('#aa00ff');
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -861,6 +861,287 @@ describe('EdgeRenderer — channel edge rendering', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Gate badge: custom label, color, and hasScript
+// ---------------------------------------------------------------------------
+
+describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
+	it('renders custom gateLabel when set on one-way channel', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				gateLabel: 'Custom Gate',
+			},
+		];
+		const { getByTestId } = renderEdgesWithChannels({ channels });
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toContain('Custom Gate');
+	});
+
+	it('falls back to heuristic label when gateLabel is not set', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'human',
+			},
+		];
+		const { getByTestId } = renderEdgesWithChannels({ channels });
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toContain('Human');
+	});
+
+	it('renders custom gateColor on badge text when set', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				gateColor: '#ff6600',
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const badgeText = container.querySelector('g[data-testid="channel-gate-step-1-step-2"] text');
+		expect(badgeText?.getAttribute('fill')).toBe('#ff6600');
+	});
+
+	it('falls back to heuristic color when gateColor is not set', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const badgeText = container.querySelector('g[data-testid="channel-gate-step-1-step-2"] text');
+		// check gate type heuristic color is #60a5fa
+		expect(badgeText?.getAttribute('fill')).toBe('#60a5fa');
+	});
+
+	it('applies custom gateColor to arrow polygon fills', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'condition',
+				gateColor: '#00ff88',
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const arrow = container.querySelector(
+			'polygon[data-testid="channel-gate-arrow-step-1-step-2"]'
+		);
+		expect(arrow?.getAttribute('fill')).toBe('#00ff88');
+	});
+
+	it('selected state overrides custom gateColor with white on text', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				id: 'custom:gate',
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				gateColor: '#ff6600',
+			},
+		];
+		const { container } = renderEdgesWithChannels({ selectedChannelId: 'custom:gate', channels });
+		const badgeText = container.querySelector('g[data-testid="channel-gate-step-1-step-2"] text');
+		expect(badgeText?.getAttribute('fill')).toBe('white');
+	});
+
+	it('selected state overrides custom gateColor with white on arrow polygon', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				id: 'custom:gate',
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				gateColor: '#ff6600',
+			},
+		];
+		const { container } = renderEdgesWithChannels({ selectedChannelId: 'custom:gate', channels });
+		const arrow = container.querySelector(
+			'polygon[data-testid="channel-gate-arrow-step-1-step-2"]'
+		);
+		expect(arrow?.getAttribute('fill')).toBe('white');
+	});
+
+	it('renders script icon (⚡) when hasScript is true', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				hasScript: true,
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const badgeTexts = container.querySelectorAll(
+			'g[data-testid="channel-gate-step-1-step-2"] text'
+		);
+		// Should have two text elements: label + script icon
+		expect(badgeTexts).toHaveLength(2);
+		const scriptIconText = badgeTexts[1];
+		expect(scriptIconText.textContent).toBe('⚡');
+		expect(scriptIconText.getAttribute('opacity')).toBe('0.7');
+	});
+
+	it('does not render script icon when hasScript is false', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				hasScript: false,
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const badgeTexts = container.querySelectorAll(
+			'g[data-testid="channel-gate-step-1-step-2"] text'
+		);
+		// Should only have the label text element
+		expect(badgeTexts).toHaveLength(1);
+	});
+
+	it('does not render script icon when hasScript is undefined', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				// hasScript not set
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const badgeTexts = container.querySelectorAll(
+			'g[data-testid="channel-gate-step-1-step-2"] text'
+		);
+		expect(badgeTexts).toHaveLength(1);
+	});
+
+	it('script icon uses gateColor when hasScript is true', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				gateColor: '#ff6600',
+				hasScript: true,
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const badgeTexts = container.querySelectorAll(
+			'g[data-testid="channel-gate-step-1-step-2"] text'
+		);
+		const scriptIconText = badgeTexts[1];
+		expect(scriptIconText.getAttribute('fill')).toBe('#ff6600');
+	});
+
+	it('script icon becomes white when selected', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				id: 'script:gate',
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'one-way',
+				gateType: 'check',
+				hasScript: true,
+			},
+		];
+		const { container } = renderEdgesWithChannels({ selectedChannelId: 'script:gate', channels });
+		const badgeTexts = container.querySelectorAll(
+			'g[data-testid="channel-gate-step-1-step-2"] text'
+		);
+		const scriptIconText = badgeTexts[1];
+		expect(scriptIconText.getAttribute('fill')).toBe('white');
+	});
+
+	it('custom gateLabel on bidirectional forward gate renders correctly', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'bidirectional',
+				gateType: 'human',
+				gateLabel: 'Approve',
+				reverseGateType: 'check',
+			},
+		];
+		const { getByTestId } = renderEdgesWithChannels({ channels });
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toContain('Approve');
+	});
+
+	it('custom gateColor on bidirectional both-direction gates applies to both arrows', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'bidirectional',
+				gateType: 'check',
+				gateColor: '#00ccff',
+				reverseGateType: 'check',
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const forwardArrow = container.querySelector(
+			'polygon[data-testid="channel-gate-arrow-step-1-step-2"]'
+		);
+		const reverseArrow = container.querySelector(
+			'polygon[data-testid="channel-gate-reverse-arrow-step-1-step-2"]'
+		);
+		expect(forwardArrow?.getAttribute('fill')).toBe('#00ccff');
+		expect(reverseArrow?.getAttribute('fill')).toBe('#00ccff');
+	});
+
+	it('loop badge is unaffected by gateLabel/gateColor', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-2',
+				toStepId: 'step-1',
+				direction: 'one-way',
+				isCyclic: true,
+				gateType: 'check',
+				gateLabel: 'Custom',
+				gateColor: '#ff0000',
+			},
+		];
+		const { getByTestId } = renderEdgesWithChannels({ channels });
+		// Loop badge should still show "Loop"
+		expect(getByTestId('channel-loop-step-2-step-1').textContent).toBe('Loop');
+	});
+
+	it('uses reverseHasScript when only reverse gate is set on bidirectional', () => {
+		const channels: ResolvedWorkflowChannel[] = [
+			{
+				fromStepId: 'step-1',
+				toStepId: 'step-2',
+				direction: 'bidirectional',
+				reverseGateType: 'check',
+				reverseHasScript: true,
+			},
+		];
+		const { container } = renderEdgesWithChannels({ channels });
+		const badgeTexts = container.querySelectorAll(
+			'g[data-testid="channel-gate-step-1-step-2"] text'
+		);
+		// Should have label + script icon
+		expect(badgeTexts).toHaveLength(2);
+		expect(badgeTexts[1].textContent).toBe('⚡');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // getOrthogonalPathMidpointWithAngle
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Extend `ResolvedWorkflowChannel` with `gateLabel`, `gateColor`, `hasScript` (and reverse variants)
- Propagate gate metadata from `SemanticWorkflowEdge` through `VisualWorkflowEditor.channelEdges`
- EdgeRenderer badge now prefers custom label/color, falls back to heuristic lookup tables
- Arrow polygon fills match badge color (custom or heuristic)
- ⚡ script icon appears next to badge when `hasScript` is true
- Selected state (white) still overrides all colors correctly
- Loop badge is unaffected by gate customization
- 17 new unit tests covering all acceptance criteria

Part of: enhance gate system with customizable badges and script-based checks