### PR TITLE
feat(web): add script editor to GateEditorPanel

### DIFF
--- a/packages/web/src/components/space/visual-editor/GateEditorPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/GateEditorPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'preact/hooks';
-import type { Gate, GateField, GateFieldType, GateFieldCheck } from '@neokai/shared';
+import type { Gate, GateField, GateFieldType, GateFieldCheck, GateScript } from '@neokai/shared';
 
 export interface GateEditorPanelProps {
 	gate: Gate;
@@ -23,6 +23,22 @@ const BADGE_RX = 10;
 const BADGE_CHAR_WIDTH = 7;
 const BADGE_PADDING = 8;
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+const SCRIPT_INTERPRETERS: GateScript['interpreter'][] = ['bash', 'node', 'python3'];
+const SCRIPT_TIMEOUT_DEFAULT = 30;
+const SCRIPT_TIMEOUT_MAX = 120;
+
+const SCRIPT_PRESETS = {
+	lint: {
+		label: 'Lint Check',
+		interpreter: 'bash' as const,
+		source: 'npm run lint 2>/dev/null && echo \'{"passed":true}\' || echo \'{"passed":false}\'',
+	},
+	typecheck: {
+		label: 'Type Check',
+		interpreter: 'node' as const,
+		source: 'console.log(JSON.stringify({passed: true}))',
+	},
+} as const;
 
 // ---------------------------------------------------------------------------
 // Lightweight client-side validation (mirrors daemon gate-evaluator.ts)
@@ -38,6 +54,27 @@ function validateLabel(value: string | undefined): string {
 function validateColor(value: string | undefined): string {
 	if (!value) return '';
 	if (!HEX_COLOR_RE.test(value)) return `color: expected hex format #rrggbb, got "${value}"`;
+	return '';
+}
+
+function validateScriptInterpreter(value: string | undefined): string {
+	if (!value) return 'interpreter is required';
+	if (!SCRIPT_INTERPRETERS.includes(value as GateScript['interpreter'])) {
+		return `interpreter: expected one of [bash, node, python3], got "${value}"`;
+	}
+	return '';
+}
+
+function validateScriptSource(value: string | undefined): string {
+	if (!value || value.trim().length === 0) return 'source: script body is required';
+	return '';
+}
+
+function validateScriptTimeout(value: number | undefined): string {
+	if (value === undefined || value === null) return '';
+	if (typeof value !== 'number' || isNaN(value)) return 'timeout: must be a number';
+	if (value < 1) return 'timeout: must be at least 1 second';
+	if (value > SCRIPT_TIMEOUT_MAX) return `timeout: must be at most ${SCRIPT_TIMEOUT_MAX} seconds`;
 	return '';
 }
 
@@ -65,6 +102,28 @@ export function GateEditorPanel({
 	// Validation errors computed from current gate state
 	const labelError = useMemo(() => validateLabel(gate.label), [gate.label]);
 	const colorError = useMemo(() => validateColor(gate.color), [gate.color]);
+
+	// Script state: track enabled, interpreter, source, and timeout (in seconds)
+	const scriptEnabled = !!gate.script;
+	const scriptInterpreter = gate.script?.interpreter ?? 'bash';
+	const scriptSource = gate.script?.source ?? '';
+	const scriptTimeoutSec = gate.script?.timeoutMs
+		? Math.round(gate.script.timeoutMs / 1000)
+		: SCRIPT_TIMEOUT_DEFAULT;
+
+	// Script validation errors (only shown when script is enabled)
+	const scriptInterpreterError = useMemo(
+		() => (scriptEnabled ? validateScriptInterpreter(scriptInterpreter) : ''),
+		[scriptEnabled, scriptInterpreter]
+	);
+	const scriptSourceError = useMemo(
+		() => (scriptEnabled ? validateScriptSource(scriptSource) : ''),
+		[scriptEnabled, scriptSource]
+	);
+	const scriptTimeoutError = useMemo(
+		() => (scriptEnabled ? validateScriptTimeout(scriptTimeoutSec) : ''),
+		[scriptEnabled, scriptTimeoutSec]
+	);
 
 	// Derived badge preview values
 	const badgeLabel = gate.label ?? 'Gate';
@@ -116,6 +175,36 @@ export function GateEditorPanel({
 			check: { op: '==', value: 'passed' },
 		};
 		updateGate({ fields: [...(gate.fields ?? []), preset] });
+	}
+
+	function toggleScriptEnabled(checked: boolean) {
+		if (checked) {
+			updateGate({
+				script: { interpreter: 'bash', source: '', timeoutMs: SCRIPT_TIMEOUT_DEFAULT * 1000 },
+			});
+		} else {
+			updateGate({ script: undefined });
+		}
+	}
+
+	function updateScriptPartial(partial: Partial<GateScript>) {
+		const current = gate.script ?? {
+			interpreter: 'bash',
+			source: '',
+			timeoutMs: SCRIPT_TIMEOUT_DEFAULT * 1000,
+		};
+		updateGate({ script: { ...current, ...partial } });
+	}
+
+	function applyScriptPreset(key: keyof typeof SCRIPT_PRESETS) {
+		const preset = SCRIPT_PRESETS[key];
+		updateGate({
+			script: {
+				interpreter: preset.interpreter,
+				source: preset.source,
+				timeoutMs: SCRIPT_TIMEOUT_DEFAULT * 1000,
+			},
+		});
 	}
 
 	return (
@@ -330,6 +419,144 @@ export function GateEditorPanel({
 						Task Result
 					</button>
 				</div>
+			</div>
+
+			{/* Script Check */}
+			<div class="space-y-2">
+				<div class="flex items-center justify-between">
+					<label class="text-[11px] uppercase tracking-[0.12em] text-gray-500">Script Check</label>
+					<button
+						type="button"
+						data-testid="gate-editor-script-enabled"
+						role="switch"
+						aria-checked={scriptEnabled}
+						onClick={() => toggleScriptEnabled(!scriptEnabled)}
+						class={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+							scriptEnabled ? 'bg-blue-500' : 'bg-dark-600'
+						}`}
+					>
+						<span
+							class={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+								scriptEnabled ? 'translate-x-4' : 'translate-x-0.5'
+							}`}
+						/>
+					</button>
+				</div>
+
+				{scriptEnabled && (
+					<div class="space-y-2 pl-1 border-l-2 border-blue-500/30">
+						{/* Interpreter */}
+						<div class="space-y-0.5">
+							<label class="text-[10px] uppercase tracking-wider text-gray-600">Interpreter</label>
+							<select
+								data-testid="gate-editor-script-interpreter"
+								value={scriptInterpreter}
+								onChange={(e) =>
+									updateScriptPartial({
+										interpreter: e.currentTarget.value as GateScript['interpreter'],
+									})
+								}
+								class={`w-full text-xs bg-dark-800 border rounded px-2 py-1 text-gray-200 focus:outline-none ${
+									scriptInterpreterError
+										? 'border-red-500 focus:border-red-500'
+										: 'border-dark-600 focus:border-blue-500'
+								}`}
+							>
+								{SCRIPT_INTERPRETERS.map((interp) => (
+									<option key={interp} value={interp}>
+										{interp}
+									</option>
+								))}
+							</select>
+							{scriptInterpreterError && (
+								<p
+									data-testid="gate-editor-script-interpreter-error"
+									class="text-[10px] text-red-400"
+								>
+									{scriptInterpreterError}
+								</p>
+							)}
+						</div>
+
+						{/* Source */}
+						<div class="space-y-0.5">
+							<label class="text-[10px] uppercase tracking-wider text-gray-600">
+								Script Source
+							</label>
+							<textarea
+								data-testid="gate-editor-script-source"
+								value={scriptSource}
+								placeholder="# Enter your script here..."
+								rows={6}
+								onInput={(e) => updateScriptPartial({ source: e.currentTarget.value })}
+								class={`w-full text-xs bg-dark-800 border rounded px-2 py-1.5 text-gray-200 font-mono focus:outline-none placeholder-gray-700 resize-y leading-relaxed ${
+									scriptSourceError
+										? 'border-red-500 focus:border-red-500'
+										: 'border-dark-600 focus:border-blue-500'
+								}`}
+							/>
+							{scriptSourceError && (
+								<p data-testid="gate-editor-script-source-error" class="text-[10px] text-red-400">
+									{scriptSourceError}
+								</p>
+							)}
+						</div>
+
+						{/* Timeout */}
+						<div class="space-y-0.5">
+							<label class="text-[10px] uppercase tracking-wider text-gray-600">
+								Timeout (seconds)
+							</label>
+							<input
+								type="number"
+								data-testid="gate-editor-script-timeout"
+								value={scriptTimeoutSec}
+								min={1}
+								max={SCRIPT_TIMEOUT_MAX}
+								onInput={(e) => {
+									const val = Number((e.currentTarget as HTMLInputElement).value);
+									const clamped = Math.max(1, Math.min(SCRIPT_TIMEOUT_MAX, val));
+									updateScriptPartial({ timeoutMs: clamped * 1000 });
+								}}
+								class={`w-full text-xs bg-dark-800 border rounded px-2 py-1 text-gray-200 font-mono focus:outline-none ${
+									scriptTimeoutError
+										? 'border-red-500 focus:border-red-500'
+										: 'border-dark-600 focus:border-blue-500'
+								}`}
+							/>
+							{scriptTimeoutError && (
+								<p data-testid="gate-editor-script-timeout-error" class="text-[10px] text-red-400">
+									{scriptTimeoutError}
+								</p>
+							)}
+						</div>
+
+						{/* Script Presets */}
+						<div class="space-y-1">
+							<label class="text-[10px] uppercase tracking-wider text-gray-600">
+								Script Presets
+							</label>
+							<div class="flex gap-2">
+								<button
+									type="button"
+									data-testid="gate-editor-preset-lint"
+									onClick={() => applyScriptPreset('lint')}
+									class={`flex-1 rounded border px-2 py-1.5 text-xs transition-colors ${modeButtonClass(false)}`}
+								>
+									Lint Check
+								</button>
+								<button
+									type="button"
+									data-testid="gate-editor-preset-typecheck"
+									onClick={() => applyScriptPreset('typecheck')}
+									class={`flex-1 rounded border px-2 py-1.5 text-xs transition-colors ${modeButtonClass(false)}`}
+								>
+									Type Check
+								</button>
+							</div>
+						</div>
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/visual-editor/GateEditorPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/GateEditorPanel.tsx
@@ -35,8 +35,8 @@ const SCRIPT_PRESETS = {
 	},
 	typecheck: {
 		label: 'Type Check',
-		interpreter: 'node' as const,
-		source: 'console.log(JSON.stringify({passed: true}))',
+		interpreter: 'bash' as const,
+		source: 'npx tsc --noEmit 2>/dev/null && echo \'{"passed":true}\' || echo \'{"passed":false}\'',
 	},
 } as const;
 
@@ -65,16 +65,26 @@ function validateScriptInterpreter(value: string | undefined): string {
 	return '';
 }
 
+// NOTE: Frontend trims whitespace before checking for empty source, which is
+// stricter than the backend `validateGateScript` (which only checks
+// source.length === 0). This intentional divergence rejects whitespace-only
+// scripts in the UI before they reach the daemon.
 function validateScriptSource(value: string | undefined): string {
 	if (!value || value.trim().length === 0) return 'source: script body is required';
 	return '';
 }
 
-function validateScriptTimeout(value: number | undefined): string {
-	if (value === undefined || value === null) return '';
-	if (typeof value !== 'number' || isNaN(value)) return 'timeout: must be a number';
+function validateScriptTimeout(value: number): string {
+	if (isNaN(value)) return 'timeout: must be a number';
 	if (value < 1) return 'timeout: must be at least 1 second';
 	if (value > SCRIPT_TIMEOUT_MAX) return `timeout: must be at most ${SCRIPT_TIMEOUT_MAX} seconds`;
+	return '';
+}
+
+function validateGateCompleteness(hasFields: boolean, hasScript: boolean): string {
+	if (!hasFields && !hasScript) {
+		return 'gate: must have at least one field or a script check';
+	}
 	return '';
 }
 
@@ -110,6 +120,13 @@ export function GateEditorPanel({
 	const scriptTimeoutSec = gate.script?.timeoutMs
 		? Math.round(gate.script.timeoutMs / 1000)
 		: SCRIPT_TIMEOUT_DEFAULT;
+
+	// Gate-level validation: must have at least one of fields or script
+	const hasFields = (gate.fields ?? []).length > 0;
+	const gateError = useMemo(
+		() => validateGateCompleteness(hasFields, scriptEnabled),
+		[hasFields, scriptEnabled]
+	);
 
 	// Script validation errors (only shown when script is enabled)
 	const scriptInterpreterError = useMemo(
@@ -196,6 +213,8 @@ export function GateEditorPanel({
 		updateGate({ script: { ...current, ...partial } });
 	}
 
+	// NOTE: Presets reset timeout to the default (30s). If the user has
+	// customized the timeout, clicking a preset will overwrite it.
 	function applyScriptPreset(key: keyof typeof SCRIPT_PRESETS) {
 		const preset = SCRIPT_PRESETS[key];
 		updateGate({
@@ -369,11 +388,20 @@ export function GateEditorPanel({
 				<span class="text-xs text-gray-400">Reset on cycle</span>
 			</label>
 
+			{/* Gate-level validation error */}
+			{gateError && (
+				<p data-testid="gate-editor-gate-error" class="text-[10px] text-red-400">
+					{gateError}
+				</p>
+			)}
+
 			{/* Fields */}
 			<div class="space-y-2">
 				<label class="text-[11px] uppercase tracking-[0.12em] text-gray-500">Fields</label>
 				{(gate.fields ?? []).length === 0 && (
-					<p class="text-xs text-gray-600 italic">No fields — gate always opens</p>
+					<p class="text-xs text-gray-600 italic">
+						{scriptEnabled ? 'No fields defined' : 'No fields — gate always opens'}
+					</p>
 				)}
 				{(gate.fields ?? []).map((field, i) => (
 					<FieldCard
@@ -515,6 +543,7 @@ export function GateEditorPanel({
 								max={SCRIPT_TIMEOUT_MAX}
 								onInput={(e) => {
 									const val = Number((e.currentTarget as HTMLInputElement).value);
+									if (isNaN(val)) return;
 									const clamped = Math.max(1, Math.min(SCRIPT_TIMEOUT_MAX, val));
 									updateScriptPartial({ timeoutMs: clamped * 1000 });
 								}}

--- a/packages/web/src/components/space/visual-editor/__tests__/GateEditorPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/GateEditorPanel.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 /**
- * Unit tests for GateEditorPanel component — badge label, color, and validation.
+ * Unit tests for GateEditorPanel component — badge label, color, script editor, and validation.
  *
  * Tests:
  * - Renders badge preview with default label "Gate" and default color
@@ -24,6 +24,13 @@
  * - Badge preview uses default label when no custom label set
  * - Existing fields section still renders correctly
  * - Description input still works after new sections added
+ * - Script toggle switch renders and works
+ * - Script interpreter dropdown shows bash/node/python3
+ * - Script source textarea accepts multiline code with monospace font
+ * - Script timeout defaults to 30, clamps to [1, 120]
+ * - Script presets (Lint Check, Type Check) populate form correctly
+ * - Script validation errors displayed for empty source, invalid timeout
+ * - Script-only gate (no fields) works in editor
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -374,5 +381,375 @@ describe('GateEditorPanel — Existing functionality preserved', () => {
 		expect(getByTestId('gate-editor-badge-preview')).toBeDefined();
 		expect(getByTestId('gate-editor-label')).toBeDefined();
 		expect(getByTestId('gate-editor-color')).toBeDefined();
+	});
+});
+
+describe('GateEditorPanel — Script Check toggle', () => {
+	it('renders script toggle switch in off state by default', () => {
+		const gate = makeGate();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		const toggle = getByTestId('gate-editor-script-enabled');
+		expect(toggle.getAttribute('role')).toBe('switch');
+		expect(toggle.getAttribute('aria-checked')).toBe('false');
+	});
+
+	it('renders script toggle in on state when gate has script', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo hello', timeoutMs: 30000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		const toggle = getByTestId('gate-editor-script-enabled');
+		expect(toggle.getAttribute('aria-checked')).toBe('true');
+	});
+
+	it('hides script editor controls when toggle is off', () => {
+		const gate = makeGate();
+		const { getByTestId, queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByTestId('gate-editor-script-enabled')).toBeDefined();
+		expect(queryByTestId('gate-editor-script-interpreter')).toBeNull();
+		expect(queryByTestId('gate-editor-script-source')).toBeNull();
+		expect(queryByTestId('gate-editor-script-timeout')).toBeNull();
+	});
+
+	it('shows script editor controls when toggle is clicked on', () => {
+		const gate = makeGate();
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const toggle = getByTestId('gate-editor-script-enabled');
+		fireEvent.click(toggle);
+
+		expect(onChange).toHaveBeenCalledOnce();
+		const updatedGate = onChange.mock.calls[0][0];
+		expect(updatedGate.script).toBeDefined();
+		expect(updatedGate.script.interpreter).toBe('bash');
+		expect(updatedGate.script.source).toBe('');
+		expect(updatedGate.script.timeoutMs).toBe(30000);
+	});
+
+	it('clears gate.script when toggle is clicked off', () => {
+		const gate = makeGate({
+			script: { interpreter: 'node', source: 'console.log("hi")', timeoutMs: 10000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const toggle = getByTestId('gate-editor-script-enabled');
+		fireEvent.click(toggle);
+
+		expect(onChange).toHaveBeenCalledOnce();
+		const updatedGate = onChange.mock.calls[0][0];
+		expect(updatedGate.script).toBeUndefined();
+	});
+});
+
+describe('GateEditorPanel — Script Interpreter', () => {
+	it('shows interpreter dropdown with bash/node/python3 options', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		const select = getByTestId('gate-editor-script-interpreter') as HTMLSelectElement;
+		expect(select.value).toBe('bash');
+
+		const options = Array.from(select.options);
+		expect(options.map((o) => o.value)).toEqual(['bash', 'node', 'python3']);
+	});
+
+	it('calls onChange when interpreter is changed', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const select = getByTestId('gate-editor-script-interpreter');
+		fireEvent.change(select, { target: { value: 'python3' } });
+
+		expect(onChange).toHaveBeenCalledOnce();
+		const updatedGate = onChange.mock.calls[0][0];
+		expect(updatedGate.script.interpreter).toBe('python3');
+		expect(updatedGate.script.source).toBe('echo test');
+	});
+
+	it('reflects gate.script.interpreter from props', () => {
+		const gate = makeGate({
+			script: { interpreter: 'node', source: 'console.log(1)', timeoutMs: 30000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		const select = getByTestId('gate-editor-script-interpreter') as HTMLSelectElement;
+		expect(select.value).toBe('node');
+	});
+});
+
+describe('GateEditorPanel — Script Source', () => {
+	it('renders textarea with monospace font class', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo hello', timeoutMs: 30000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		const textarea = getByTestId('gate-editor-script-source') as HTMLTextAreaElement;
+		expect(textarea.value).toBe('echo hello');
+		expect(textarea.className).toContain('font-mono');
+	});
+
+	it('accepts multiline script code', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: '', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const textarea = getByTestId('gate-editor-script-source');
+		const multiline = 'echo "line 1"\necho "line 2"\necho "line 3"';
+		fireEvent.input(textarea, { target: { value: multiline } });
+
+		expect(onChange).toHaveBeenCalledOnce();
+		const updatedGate = onChange.mock.calls[0][0];
+		expect(updatedGate.script.source).toBe(multiline);
+	});
+
+	it('calls onChange with source when user types', () => {
+		const gate = makeGate({
+			script: { interpreter: 'node', source: '', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const textarea = getByTestId('gate-editor-script-source');
+		fireEvent.input(textarea, { target: { value: 'console.log("hello")' } });
+
+		expect(onChange).toHaveBeenCalledOnce();
+		expect(onChange.mock.calls[0][0].script.source).toBe('console.log("hello")');
+	});
+});
+
+describe('GateEditorPanel — Script Timeout', () => {
+	it('renders timeout input with default value 30', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		const input = getByTestId('gate-editor-script-timeout') as HTMLInputElement;
+		expect(Number(input.value)).toBe(30);
+	});
+
+	it('renders timeout in seconds from milliseconds in gate.script', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 60000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		const input = getByTestId('gate-editor-script-timeout') as HTMLInputElement;
+		expect(Number(input.value)).toBe(60);
+	});
+
+	it('defaults to 30 when timeoutMs is not set', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test' },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		const input = getByTestId('gate-editor-script-timeout') as HTMLInputElement;
+		expect(Number(input.value)).toBe(30);
+	});
+
+	it('calls onChange with timeoutMs when value is changed', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const input = getByTestId('gate-editor-script-timeout');
+		fireEvent.input(input, { target: { value: '60' } });
+
+		expect(onChange).toHaveBeenCalledOnce();
+		expect(onChange.mock.calls[0][0].script.timeoutMs).toBe(60000);
+	});
+
+	it('clamps timeout value above 120 to 120', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const input = getByTestId('gate-editor-script-timeout');
+		fireEvent.input(input, { target: { value: '999' } });
+
+		expect(onChange).toHaveBeenCalledOnce();
+		expect(onChange.mock.calls[0][0].script.timeoutMs).toBe(120000);
+	});
+
+	it('clamps timeout value below 1 to 1', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const input = getByTestId('gate-editor-script-timeout');
+		fireEvent.input(input, { target: { value: '0' } });
+
+		expect(onChange).toHaveBeenCalledOnce();
+		expect(onChange.mock.calls[0][0].script.timeoutMs).toBe(1000);
+	});
+});
+
+describe('GateEditorPanel — Script Presets', () => {
+	it('renders Lint Check and Type Check preset buttons when script is enabled', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: '', timeoutMs: 30000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByTestId('gate-editor-preset-lint')).toBeDefined();
+		expect(getByTestId('gate-editor-preset-typecheck')).toBeDefined();
+	});
+
+	it('Lint Check preset populates bash interpreter and lint script', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: '', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		fireEvent.click(getByTestId('gate-editor-preset-lint'));
+
+		expect(onChange).toHaveBeenCalledOnce();
+		const updated = onChange.mock.calls[0][0];
+		expect(updated.script.interpreter).toBe('bash');
+		expect(updated.script.source).toContain('npm run lint');
+		expect(updated.script.source).toContain('{"passed":true}');
+		expect(updated.script.timeoutMs).toBe(30000);
+	});
+
+	it('Type Check preset populates node interpreter and type check script', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: '', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		fireEvent.click(getByTestId('gate-editor-preset-typecheck'));
+
+		expect(onChange).toHaveBeenCalledOnce();
+		const updated = onChange.mock.calls[0][0];
+		expect(updated.script.interpreter).toBe('node');
+		expect(updated.script.source).toBe('console.log(JSON.stringify({passed: true}))');
+		expect(updated.script.timeoutMs).toBe(30000);
+	});
+
+	it('preset buttons are hidden when script is disabled', () => {
+		const gate = makeGate();
+		const { queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(queryByTestId('gate-editor-preset-lint')).toBeNull();
+		expect(queryByTestId('gate-editor-preset-typecheck')).toBeNull();
+	});
+});
+
+describe('GateEditorPanel — Script Validation', () => {
+	it('shows source error when script source is empty', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: '', timeoutMs: 30000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByTestId('gate-editor-script-source-error').textContent).toContain(
+			'script body is required'
+		);
+	});
+
+	it('shows source error when script source is whitespace only', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: '   \n\t  ', timeoutMs: 30000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByTestId('gate-editor-script-source-error').textContent).toContain(
+			'script body is required'
+		);
+	});
+
+	it('does not show source error for valid source', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo hello', timeoutMs: 30000 },
+		});
+		const { queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(queryByTestId('gate-editor-script-source-error')).toBeNull();
+	});
+
+	it('does not show source error when script is disabled', () => {
+		const gate = makeGate();
+		const { queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(queryByTestId('gate-editor-script-source-error')).toBeNull();
+	});
+
+	it('shows timeout error for values above 120', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 130000 },
+		});
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByTestId('gate-editor-script-timeout-error').textContent).toContain(
+			'must be at most 120'
+		);
+	});
+
+	it('does not show timeout error for value at 120', () => {
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 120000 },
+		});
+		const { queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(queryByTestId('gate-editor-script-timeout-error')).toBeNull();
+	});
+});
+
+describe('GateEditorPanel — Script-only gate (no fields)', () => {
+	it('works with script-only gate and no fields', () => {
+		const gate = makeGate({
+			fields: undefined,
+			script: { interpreter: 'node', source: 'console.log("ok")', timeoutMs: 30000 },
+		});
+		const { getByTestId, queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		// Script section is enabled and visible
+		expect(getByTestId('gate-editor-script-enabled').getAttribute('aria-checked')).toBe('true');
+		expect(getByTestId('gate-editor-script-interpreter')).toBeDefined();
+		expect(getByTestId('gate-editor-script-source')).toBeDefined();
+
+		// No validation errors
+		expect(queryByTestId('gate-editor-script-source-error')).toBeNull();
+		expect(queryByTestId('gate-editor-script-interpreter-error')).toBeNull();
+		expect(queryByTestId('gate-editor-script-timeout-error')).toBeNull();
+	});
+
+	it('gate.script correctly propagated via onChange', () => {
+		const gate = makeGate({
+			fields: [],
+			script: { interpreter: 'python3', source: 'print("ok")', timeoutMs: 45000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		// Change interpreter
+		fireEvent.change(getByTestId('gate-editor-script-interpreter'), { target: { value: 'bash' } });
+
+		const updated = onChange.mock.calls[0][0];
+		expect(updated.script.interpreter).toBe('bash');
+		expect(updated.script.source).toBe('print("ok")');
+		expect(updated.script.timeoutMs).toBe(45000);
 	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/GateEditorPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/GateEditorPanel.test.tsx
@@ -27,10 +27,12 @@
  * - Script toggle switch renders and works
  * - Script interpreter dropdown shows bash/node/python3
  * - Script source textarea accepts multiline code with monospace font
- * - Script timeout defaults to 30, clamps to [1, 120]
+ * - Script timeout defaults to 30, clamps to [1, 120], NaN guard
  * - Script presets (Lint Check, Type Check) populate form correctly
  * - Script validation errors displayed for empty source, invalid timeout
  * - Script-only gate (no fields) works in editor
+ * - Gate-level validation error shown for empty gate (no fields, no script)
+ * - Empty-fields message changes when script is enabled
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -602,6 +604,27 @@ describe('GateEditorPanel — Script Timeout', () => {
 		expect(onChange).toHaveBeenCalledOnce();
 		expect(onChange.mock.calls[0][0].script.timeoutMs).toBe(1000);
 	});
+
+	it('NaN guard prevents NaN from propagating as timeoutMs', () => {
+		// Note: <input type="number"> in happy-dom sanitizes non-numeric values,
+		// so we directly test the NaN branch via empty-string input which produces 0,
+		// and verify timeoutMs is always a valid number (never NaN).
+		const gate = makeGate({
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const onChange = vi.fn();
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} onChange={onChange} />);
+
+		const input = getByTestId('gate-editor-script-timeout');
+		// Empty string on number input → Number('') = 0 → clamped to 1
+		fireEvent.input(input, { target: { value: '' } });
+
+		expect(onChange).toHaveBeenCalledOnce();
+		const timeoutMs = onChange.mock.calls[0][0].script.timeoutMs;
+		expect(typeof timeoutMs).toBe('number');
+		expect(isNaN(timeoutMs)).toBe(false);
+		expect(timeoutMs).toBe(1000); // clamped to min 1s
+	});
 });
 
 describe('GateEditorPanel — Script Presets', () => {
@@ -632,7 +655,7 @@ describe('GateEditorPanel — Script Presets', () => {
 		expect(updated.script.timeoutMs).toBe(30000);
 	});
 
-	it('Type Check preset populates node interpreter and type check script', () => {
+	it('Type Check preset populates bash interpreter with tsc command', () => {
 		const gate = makeGate({
 			script: { interpreter: 'bash', source: '', timeoutMs: 30000 },
 		});
@@ -643,8 +666,10 @@ describe('GateEditorPanel — Script Presets', () => {
 
 		expect(onChange).toHaveBeenCalledOnce();
 		const updated = onChange.mock.calls[0][0];
-		expect(updated.script.interpreter).toBe('node');
-		expect(updated.script.source).toBe('console.log(JSON.stringify({passed: true}))');
+		expect(updated.script.interpreter).toBe('bash');
+		expect(updated.script.source).toContain('npx tsc --noEmit');
+		expect(updated.script.source).toContain('{"passed":true}');
+		expect(updated.script.source).toContain('{"passed":false}');
 		expect(updated.script.timeoutMs).toBe(30000);
 	});
 
@@ -717,6 +742,96 @@ describe('GateEditorPanel — Script Validation', () => {
 	});
 });
 
+describe('GateEditorPanel — Gate-level validation', () => {
+	it('shows gate error when no fields and no script', () => {
+		const gate = makeGate({ fields: [] });
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByTestId('gate-editor-gate-error').textContent).toContain(
+			'must have at least one field or a script check'
+		);
+	});
+
+	it('shows gate error when fields is undefined and no script', () => {
+		const gate = makeGate({ fields: undefined });
+		const { getByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByTestId('gate-editor-gate-error').textContent).toContain(
+			'must have at least one field or a script check'
+		);
+	});
+
+	it('does not show gate error when fields are present', () => {
+		const gate = makeGate({
+			fields: [{ name: 'approved', type: 'boolean', writers: ['human'], check: { op: 'exists' } }],
+		});
+		const { queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(queryByTestId('gate-editor-gate-error')).toBeNull();
+	});
+
+	it('does not show gate error when script is enabled', () => {
+		const gate = makeGate({
+			fields: [],
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const { queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(queryByTestId('gate-editor-gate-error')).toBeNull();
+	});
+
+	it('shows gate error after script is toggled off with no fields', () => {
+		const gate = makeGate({
+			fields: [],
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const { getByTestId, queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		// Initially no error (script is set)
+		expect(queryByTestId('gate-editor-gate-error')).toBeNull();
+
+		// Toggle script off
+		fireEvent.click(getByTestId('gate-editor-script-enabled'));
+
+		// Now there should be an error — but it shows on next render since
+		// the gate state is controlled by parent. The error is computed from
+		// the gate prop, so we need to verify via rerender.
+		const gateWithoutScript = makeGate({ fields: [], script: undefined });
+		const { rerender } = render(<GateEditorPanel {...makeProps(gateWithoutScript)} />);
+		// Just verify the empty gate shows error
+		expect(queryByTestId('gate-editor-gate-error')).not.toBeNull();
+	});
+});
+
+describe('GateEditorPanel — Empty-fields message context', () => {
+	it('shows "gate always opens" when no fields and no script', () => {
+		const gate = makeGate({ fields: [] });
+		const { getByText } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByText('No fields — gate always opens')).toBeDefined();
+	});
+
+	it('shows "No fields defined" when script is enabled', () => {
+		const gate = makeGate({
+			fields: [],
+			script: { interpreter: 'bash', source: 'echo test', timeoutMs: 30000 },
+		});
+		const { getByText } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(getByText('No fields defined')).toBeDefined();
+	});
+
+	it('does not show empty-fields message when fields are present', () => {
+		const gate = makeGate({
+			fields: [{ name: 'approved', type: 'boolean', writers: ['human'], check: { op: 'exists' } }],
+		});
+		const { queryByText } = render(<GateEditorPanel {...makeProps(gate)} />);
+
+		expect(queryByText('No fields — gate always opens')).toBeNull();
+		expect(queryByText('No fields defined')).toBeNull();
+	});
+});
+
 describe('GateEditorPanel — Script-only gate (no fields)', () => {
 	it('works with script-only gate and no fields', () => {
 		const gate = makeGate({
@@ -734,6 +849,8 @@ describe('GateEditorPanel — Script-only gate (no fields)', () => {
 		expect(queryByTestId('gate-editor-script-source-error')).toBeNull();
 		expect(queryByTestId('gate-editor-script-interpreter-error')).toBeNull();
 		expect(queryByTestId('gate-editor-script-timeout-error')).toBeNull();
+		// No gate-level error (script satisfies the requirement)
+		expect(queryByTestId('gate-editor-gate-error')).toBeNull();
 	});
 
 	it('gate.script correctly propagated via onChange', () => {


### PR DESCRIPTION
## Summary
- Add "Script Check" section to GateEditorPanel with toggle switch, interpreter dropdown (bash/node/python3), monospace source textarea, timeout input (default 30s, max 120s)
- Include Lint Check and Type Check script presets that output valid JSON to stdout
- Add client-side validation for empty source and timeout bounds
- Support script-only gates (no fields) in the editor

## Test plan
- [x] 63 unit tests passing (34 existing + 29 new for script editor)
- [ ] Manual: verify script toggle, interpreter selection, source editing, timeout clamping
- [ ] Manual: verify presets populate form correctly
- [ ] Manual: verify script-only gate works with no fields