### PR TITLE
feat: manually trigger and schedule recurring missions

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -3505,8 +3505,9 @@ export class RoomRuntime {
 	 * Sets `nextRunAt` to now and starts a new execution (if no active execution exists),
 	 * bypassing the normal tick schedule check. Respects overlap prevention guards.
 	 *
-	 * Returns the updated goal with the new nextRunAt.
-	 * Throws if the goal is not recurring, is paused, or already has an active execution.
+	 * Returns the updated goal (fetched fresh from DB after execution starts).
+	 * Throws if the goal is not recurring, is paused, is not active, has no schedule,
+	 * or already has an active execution.
 	 */
 	async triggerNow(goalId: string): Promise<RoomGoal> {
 		const goal = await this.goalManager.getGoal(goalId);
@@ -3535,9 +3536,8 @@ export class RoomRuntime {
 			);
 		}
 
-		// Set nextRunAt to now so the next tick sees it as due (as a fallback),
-		// then immediately trigger the execution.
-		const nowSec = Math.floor(Date.now() / 1000);
+		// Calculate next cron-scheduled time. startExecution writes this atomically
+		// in the same transaction as the execution row insert — no separate update needed.
 		const tz = goal.schedule.timezone ?? 'UTC';
 		const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
 
@@ -3587,8 +3587,10 @@ export class RoomRuntime {
 			await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
 		}
 
-		// Update nextRunAt to now for display purposes (so the UI shows "due now")
-		const updatedGoal = await this.goalManager.updateNextRunAt(goal.id, nowSec);
+		// Return the goal fresh from DB — startExecution already wrote the correct
+		// nextRunAt atomically, so no separate update is needed.
+		const updatedGoal = await this.goalManager.getGoal(goal.id);
+		if (!updatedGoal) throw new Error(`Goal ${goalId} disappeared after execution start`);
 		return updatedGoal;
 	}
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -3500,6 +3500,99 @@ export class RoomRuntime {
 	}
 
 	/**
+	 * Manually trigger a recurring mission execution immediately.
+	 *
+	 * Sets `nextRunAt` to now and starts a new execution (if no active execution exists),
+	 * bypassing the normal tick schedule check. Respects overlap prevention guards.
+	 *
+	 * Returns the updated goal with the new nextRunAt.
+	 * Throws if the goal is not recurring, is paused, or already has an active execution.
+	 */
+	async triggerNow(goalId: string): Promise<RoomGoal> {
+		const goal = await this.goalManager.getGoal(goalId);
+		if (!goal) throw new Error(`Goal not found: ${goalId}`);
+		if (goal.missionType !== 'recurring') {
+			throw new Error(
+				`Goal ${goalId} is not a recurring mission (missionType=${goal.missionType ?? 'one_shot'})`
+			);
+		}
+		if (goal.status !== 'active') {
+			throw new Error(`Goal ${goalId} is not active (status=${goal.status})`);
+		}
+		if (goal.schedulePaused) {
+			throw new Error(`Goal ${goalId} schedule is paused. Resume the schedule first.`);
+		}
+		if (!goal.schedule) {
+			throw new Error(`Goal ${goalId} has no schedule configured.`);
+		}
+
+		// Overlap prevention: check for active execution
+		const activeExecution = this.goalManager.getActiveExecution(goal.id);
+		if (activeExecution) {
+			throw new Error(
+				`Goal ${goalId} already has an active execution (${activeExecution.id}). ` +
+					`Wait for it to complete before triggering again.`
+			);
+		}
+
+		// Set nextRunAt to now so the next tick sees it as due (as a fallback),
+		// then immediately trigger the execution.
+		const nowSec = Math.floor(Date.now() / 1000);
+		const tz = goal.schedule.timezone ?? 'UTC';
+		const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
+
+		let execution;
+		try {
+			execution = this.goalManager.startExecution(goal.id, nextRunAt ?? undefined);
+			log.info(
+				`Recurring mission ${goal.id} (${goal.title}) manually triggered execution ${execution.executionNumber}`
+			);
+		} catch (err) {
+			log.warn(`Recurring mission ${goal.id}: failed to start execution (possible race) — ${err}`);
+			throw new Error(
+				`Failed to start execution for goal ${goalId}. An execution may already be in progress.`
+			);
+		}
+
+		// Fetch previous execution result for context
+		const prevExecutions = this.goalManager.listExecutions(goal.id, 2);
+		const prevCompleted = prevExecutions.find(
+			(e) => e.id !== execution.id && e.status === 'completed'
+		);
+		const previousResultSummary = prevCompleted?.resultSummary;
+
+		// Plan reuse or planning — same logic as _doTickRecurringMissions Phase 2
+		if (execution.executionNumber > 1 && prevCompleted) {
+			try {
+				const clonedCount = await this.reuseExecutionPlan(
+					goal,
+					execution.id,
+					prevCompleted.taskIds
+				);
+				if (clonedCount > 0) {
+					log.info(
+						`Recurring mission ${goal.id}: manual trigger execution ${execution.executionNumber} started with ${clonedCount} reused tasks`
+					);
+				} else {
+					log.warn(
+						`Recurring mission ${goal.id}: no tasks to reuse from previous execution — falling back to planning`
+					);
+					await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
+				}
+			} catch (err) {
+				log.warn(`Recurring mission ${goal.id}: plan reuse failed — falling back to planning`, err);
+				await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
+			}
+		} else {
+			await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
+		}
+
+		// Update nextRunAt to now for display purposes (so the UI shows "due now")
+		const updatedGoal = await this.goalManager.updateNextRunAt(goal.id, nowSec);
+		return updatedGoal;
+	}
+
+	/**
 	 * Find the highest-priority active goal that needs planning.
 	 *
 	 * A goal needs planning when:

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -13,6 +13,8 @@
  * - goal.listExecutions - List execution history for a recurring mission
  * - goal.recordMetric - Record a metric value for a measurable mission
  * - goal.getMetrics - Get current metric state for a goal
+ * - goal.triggerNow - Manually trigger a recurring mission execution immediately
+ * - goal.scheduleNext - Set nextRunAt to a specific datetime for a recurring mission
  * - task.approve - Human approves a task PR (resumes worker for phase 2)
  */
 
@@ -581,4 +583,58 @@ export function setupGoalHandlers(
 
 	// task.approve - Task-scoped RPC name
 	messageHub.onRequest('task.approve', approveTaskHandler);
+
+	// goal.triggerNow - Manually trigger a recurring mission execution immediately
+	messageHub.onRequest('goal.triggerNow', async (data) => {
+		const params = data as { roomId: string; goalId: string };
+
+		if (!params.roomId) throw new Error('Room ID is required');
+		if (!params.goalId) throw new Error('Goal ID is required');
+		if (!runtimeService) {
+			throw new Error('Runtime service is required for goal.triggerNow');
+		}
+
+		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
+
+		const runtime = runtimeService.getRuntime(params.roomId);
+		if (!runtime) {
+			throw new Error(`No runtime found for room: ${params.roomId}`);
+		}
+
+		const goal = await runtime.triggerNow(goalId);
+		log.info(`Manually triggered recurring mission ${goalId} in room ${params.roomId}`);
+		return { goal };
+	});
+
+	// goal.scheduleNext - Set nextRunAt to a specific datetime for a recurring mission
+	messageHub.onRequest('goal.scheduleNext', async (data) => {
+		const params = data as {
+			roomId: string;
+			goalId: string;
+			nextRunAt: number; // Unix timestamp in seconds
+		};
+
+		if (!params.roomId) throw new Error('Room ID is required');
+		if (!params.goalId) throw new Error('Goal ID is required');
+		if (typeof params.nextRunAt !== 'number' || params.nextRunAt <= 0) {
+			throw new Error('nextRunAt must be a positive Unix timestamp in seconds');
+		}
+
+		const goalManager = goalManagerFactory(params.roomId);
+		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
+		const goal = await goalManager.getGoal(goalId);
+		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
+		if (goal.missionType !== 'recurring') {
+			throw new Error(
+				`Goal ${params.goalId} is not a recurring mission (missionType=${goal.missionType ?? 'one_shot'})`
+			);
+		}
+
+		const updatedGoal = await goalManager.updateNextRunAt(goalId, params.nextRunAt);
+		log.info(
+			`Scheduled next run for recurring mission ${goalId} at ${new Date(params.nextRunAt * 1000).toISOString()}`
+		);
+		return { goal: updatedGoal };
+	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -621,6 +621,11 @@ export function setupGoalHandlers(
 			throw new Error('nextRunAt must be a positive Unix timestamp in seconds');
 		}
 
+		const nowSec = Math.floor(Date.now() / 1000);
+		if (params.nextRunAt <= nowSec) {
+			throw new Error('nextRunAt must be in the future');
+		}
+
 		const goalManager = goalManagerFactory(params.roomId);
 		const goalId = resolveGoalId(params.goalId, params.roomId, goalManager);
 		const goal = await goalManager.getGoal(goalId);
@@ -628,6 +633,11 @@ export function setupGoalHandlers(
 		if (goal.missionType !== 'recurring') {
 			throw new Error(
 				`Goal ${params.goalId} is not a recurring mission (missionType=${goal.missionType ?? 'one_shot'})`
+			);
+		}
+		if (goal.status !== 'active') {
+			throw new Error(
+				`Goal ${params.goalId} is not active (status=${goal.status}). Only active missions can be scheduled.`
 			);
 		}
 

--- a/packages/daemon/tests/unit/room/room-runtime-trigger-now.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-trigger-now.test.ts
@@ -1,0 +1,152 @@
+/**
+ * RoomRuntime — triggerNow() Integration Tests
+ *
+ * Tests for the runtime-level triggerNow method for recurring missions:
+ * - Validation: rejects non-recurring, non-active, paused, no-schedule goals
+ * - Overlap prevention: rejects when an active execution exists
+ * - Successful trigger: creates execution, advances nextRunAt to next cron time
+ * - Does NOT clobber nextRunAt with current time (P0 regression test)
+ * - Spawns a planner session for first execution
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { createRuntimeTestContext, type RuntimeTestContext } from './room-runtime-test-helpers';
+
+describe('RoomRuntime — triggerNow', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('throws when goal is not found', async () => {
+		await expect(ctx.runtime.triggerNow('nonexistent')).rejects.toThrow('Goal not found');
+	});
+
+	it('throws when goal is not recurring', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'One-shot goal',
+			missionType: 'one_shot',
+		});
+		await expect(ctx.runtime.triggerNow(goal.id)).rejects.toThrow('not a recurring mission');
+	});
+
+	it('throws when goal is not active', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Inactive recurring',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+		// patchGoal to set status without going through state machine
+		await ctx.goalManager.patchGoal(goal.id, { status: 'completed' });
+		await expect(ctx.runtime.triggerNow(goal.id)).rejects.toThrow('not active');
+	});
+
+	it('throws when schedule is paused', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Paused recurring',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			schedulePaused: true,
+		});
+		await expect(ctx.runtime.triggerNow(goal.id)).rejects.toThrow('schedule is paused');
+	});
+
+	it('throws when goal has no schedule configured', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'No schedule recurring',
+			missionType: 'recurring',
+		});
+		await expect(ctx.runtime.triggerNow(goal.id)).rejects.toThrow('no schedule configured');
+	});
+
+	it('throws when an active execution already exists', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Already running',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+
+		// Manually insert a running execution into the DB to simulate an active execution
+		ctx.db.exec(
+			`INSERT INTO mission_executions (id, goal_id, execution_number, status, started_at, task_ids)
+			 VALUES ('exec-fake', '${goal.id}', 1, 'running', strftime('%s', 'now'), '[]')`
+		);
+
+		await expect(ctx.runtime.triggerNow(goal.id)).rejects.toThrow(
+			'already has an active execution'
+		);
+	});
+
+	it('creates execution and advances nextRunAt to next cron time (not now)', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Daily runner',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+
+		ctx.runtime.start();
+
+		const result = await ctx.runtime.triggerNow(goal.id);
+
+		// Execution should have been created
+		const executions = ctx.goalManager.listExecutions(goal.id, 10);
+		expect(executions).toHaveLength(1);
+		expect(executions[0].status).toBe('running');
+
+		// nextRunAt should be the NEXT cron time (tomorrow for @daily),
+		// NOT the current time — this is the P0 regression check.
+		const nowSec = Math.floor(Date.now() / 1000);
+		expect(result.nextRunAt).toBeGreaterThan(nowSec);
+
+		// Verify nextRunAt is in the future by at least 1 hour (not "now")
+		// and at most 25 hours (next daily slot from any timezone).
+		// We use a wide tolerance because @daily from UTC depends on current time.
+		const secondsUntilNext = result.nextRunAt! - nowSec;
+		expect(secondsUntilNext).toBeGreaterThan(3600);
+		expect(secondsUntilNext).toBeLessThan(25 * 3600);
+
+		// A planner session should have been spawned for execution #1
+		const plannerCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession' && c.args[1] === 'planner'
+		);
+		expect(plannerCalls).toHaveLength(1);
+	});
+
+	it('does not call updateNextRunAt separately (P0: no double-write)', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Hourly runner',
+			missionType: 'recurring',
+			schedule: { expression: '@hourly', timezone: 'UTC' },
+		});
+
+		// Spy on updateNextRunAt by wrapping it
+		let updateNextRunAtCalls = 0;
+		const original = ctx.goalManager.updateNextRunAt.bind(ctx.goalManager);
+		ctx.goalManager.updateNextRunAt = async (...args) => {
+			updateNextRunAtCalls++;
+			return original(...args);
+		};
+
+		ctx.runtime.start();
+
+		await ctx.runtime.triggerNow(goal.id);
+
+		// updateNextRunAt should NOT be called by triggerNow —
+		// startExecution handles it atomically.
+		// (It may be called by other paths, but triggerNow itself should not call it.)
+		// We check by counting calls before vs after — but since we can't
+		// easily isolate, the key assertion is that nextRunAt is correct
+		// (tested in the previous test), not that updateNextRunAt was called
+		// with the wrong value.
+
+		const result = await ctx.goalManager.getGoal(goal.id);
+		expect(result?.nextRunAt).toBeDefined();
+		expect(result!.nextRunAt!).toBeGreaterThan(Math.floor(Date.now() / 1000));
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-trigger-now.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-trigger-now.test.ts
@@ -85,9 +85,9 @@ describe('RoomRuntime — triggerNow', () => {
 
 	it('creates execution and advances nextRunAt to next cron time (not now)', async () => {
 		const goal = await ctx.goalManager.createGoal({
-			title: 'Daily runner',
+			title: 'Hourly runner',
 			missionType: 'recurring',
-			schedule: { expression: '@daily', timezone: 'UTC' },
+			schedule: { expression: '@hourly', timezone: 'UTC' },
 		});
 
 		ctx.runtime.start();
@@ -99,17 +99,16 @@ describe('RoomRuntime — triggerNow', () => {
 		expect(executions).toHaveLength(1);
 		expect(executions[0].status).toBe('running');
 
-		// nextRunAt should be the NEXT cron time (tomorrow for @daily),
+		// nextRunAt should be the NEXT cron time (next hourly slot),
 		// NOT the current time — this is the P0 regression check.
+		// @hourly from UTC: next slot is always 0–3600s away, so nextRunAt
+		// must be strictly greater than now (not "now" or in the past).
 		const nowSec = Math.floor(Date.now() / 1000);
 		expect(result.nextRunAt).toBeGreaterThan(nowSec);
 
-		// Verify nextRunAt is in the future by at least 1 hour (not "now")
-		// and at most 25 hours (next daily slot from any timezone).
-		// We use a wide tolerance because @daily from UTC depends on current time.
+		// Upper bound: next hourly slot plus a few seconds of grace
 		const secondsUntilNext = result.nextRunAt! - nowSec;
-		expect(secondsUntilNext).toBeGreaterThan(3600);
-		expect(secondsUntilNext).toBeLessThan(25 * 3600);
+		expect(secondsUntilNext).toBeLessThan(3700);
 
 		// A planner session should have been spawned for execution #1
 		const plannerCalls = ctx.sessionFactory.calls.filter(
@@ -137,16 +136,9 @@ describe('RoomRuntime — triggerNow', () => {
 
 		await ctx.runtime.triggerNow(goal.id);
 
-		// updateNextRunAt should NOT be called by triggerNow —
-		// startExecution handles it atomically.
-		// (It may be called by other paths, but triggerNow itself should not call it.)
-		// We check by counting calls before vs after — but since we can't
-		// easily isolate, the key assertion is that nextRunAt is correct
-		// (tested in the previous test), not that updateNextRunAt was called
-		// with the wrong value.
-
-		const result = await ctx.goalManager.getGoal(goal.id);
-		expect(result?.nextRunAt).toBeDefined();
-		expect(result!.nextRunAt!).toBeGreaterThan(Math.floor(Date.now() / 1000));
+		// triggerNow must NOT call updateNextRunAt — startExecution handles
+		// nextRunAt atomically in its transaction. This catches regressions
+		// where someone re-adds the separate updateNextRunAt call.
+		expect(updateNextRunAtCalls).toBe(0);
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -1851,6 +1851,25 @@ describe('Goal RPC Handlers', () => {
 				handler!({ roomId: 'room-123', goalId: 'goal-123', nextRunAt: 9999999999 }, {})
 			).rejects.toThrow('not a recurring mission');
 		});
+
+		it('throws when nextRunAt is in the past', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			const pastTimestamp = Math.floor(Date.now() / 1000) - 60;
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123', nextRunAt: pastTimestamp }, {})
+			).rejects.toThrow('nextRunAt must be in the future');
+		});
+
+		it('throws when goal is not active', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce({
+				...recurringGoal,
+				status: 'completed' as const,
+			});
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123', nextRunAt: 9999999999 }, {})
+			).rejects.toThrow('not active');
+		});
 	});
 
 	describe('short ID support', () => {

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -1684,6 +1684,175 @@ describe('Goal RPC Handlers', () => {
 		});
 	});
 
+	// ---- goal.triggerNow and goal.scheduleNext ----
+
+	describe('goal.triggerNow', () => {
+		function setupTriggerNowHandler() {
+			const triggerNowMock = mock(
+				async (): Promise<RoomGoal> => ({
+					...recurringGoal,
+					nextRunAt: Math.floor(Date.now() / 1000),
+				})
+			);
+			const runtime = {
+				triggerNow: triggerNowMock,
+			};
+			const runtimeService = {
+				getRuntime: mock(() => runtime),
+			} as unknown as RoomRuntimeService;
+
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager,
+				undefined,
+				runtimeService
+			);
+
+			return { runtime, runtimeService, triggerNowMock };
+		}
+
+		it('registers the handler', () => {
+			setupTriggerNowHandler();
+			expect(messageHubData.handlers.get('goal.triggerNow')).toBeDefined();
+		});
+
+		it('triggers a recurring mission and returns updated goal', async () => {
+			const { triggerNowMock } = setupTriggerNowHandler();
+			const handler = messageHubData.handlers.get('goal.triggerNow')!;
+
+			const result = (await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})) as {
+				goal: RoomGoal;
+			};
+
+			expect(triggerNowMock).toHaveBeenCalledWith('goal-123');
+			expect(result.goal).toBeDefined();
+		});
+
+		it('throws when roomId is missing', async () => {
+			setupTriggerNowHandler();
+			const handler = messageHubData.handlers.get('goal.triggerNow')!;
+			await expect(handler!({ goalId: 'goal-123' }, {})).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws when goalId is missing', async () => {
+			setupTriggerNowHandler();
+			const handler = messageHubData.handlers.get('goal.triggerNow')!;
+			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Goal ID is required');
+		});
+
+		it('throws when runtime service is not provided', async () => {
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager,
+				undefined,
+				undefined
+			);
+			const handler = messageHubData.handlers.get('goal.triggerNow')!;
+			await expect(handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})).rejects.toThrow(
+				'Runtime service is required'
+			);
+		});
+
+		it('throws when runtime is not found for room', async () => {
+			const runtimeService = {
+				getRuntime: mock(() => null),
+			} as unknown as RoomRuntimeService;
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager,
+				undefined,
+				runtimeService
+			);
+			const handler = messageHubData.handlers.get('goal.triggerNow')!;
+			await expect(handler!({ roomId: 'room-missing', goalId: 'goal-123' }, {})).rejects.toThrow(
+				'No runtime found for room'
+			);
+		});
+
+		it('resolves short ID before calling runtime.triggerNow', async () => {
+			const { triggerNowMock } = setupTriggerNowHandler();
+			mockGoalManager.getGoalByShortId.mockReturnValueOnce({ id: 'goal-uuid-123' });
+			const handler = messageHubData.handlers.get('goal.triggerNow')!;
+
+			await handler!({ roomId: 'room-123', goalId: 'g-42' }, {});
+
+			expect(triggerNowMock).toHaveBeenCalledWith('goal-uuid-123');
+		});
+	});
+
+	describe('goal.scheduleNext', () => {
+		it('registers the handler', () => {
+			expect(messageHubData.handlers.get('goal.scheduleNext')).toBeDefined();
+		});
+
+		it('sets nextRunAt and returns updated goal', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
+			mockGoalManager.updateNextRunAt.mockResolvedValueOnce({
+				...recurringGoal,
+				nextRunAt: 9999999999,
+			});
+
+			const result = (await handler!(
+				{ roomId: 'room-123', goalId: 'goal-123', nextRunAt: 9999999999 },
+				{}
+			)) as { goal: RoomGoal };
+
+			expect(mockGoalManager.updateNextRunAt).toHaveBeenCalledWith('goal-123', 9999999999);
+			expect(result.goal).toBeDefined();
+		});
+
+		it('throws when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			await expect(handler!({ goalId: 'goal-123', nextRunAt: 9999999999 }, {})).rejects.toThrow(
+				'Room ID is required'
+			);
+		});
+
+		it('throws when goalId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			await expect(handler!({ roomId: 'room-123', nextRunAt: 9999999999 }, {})).rejects.toThrow(
+				'Goal ID is required'
+			);
+		});
+
+		it('throws when nextRunAt is not a number', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123', nextRunAt: 'invalid' }, {})
+			).rejects.toThrow('nextRunAt must be a positive Unix timestamp');
+		});
+
+		it('throws when nextRunAt is zero or negative', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123', nextRunAt: -1 }, {})
+			).rejects.toThrow('nextRunAt must be a positive Unix timestamp');
+		});
+
+		it('throws when goal is not found', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(null);
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'no-such', nextRunAt: 9999999999 }, {})
+			).rejects.toThrow('Goal not found');
+		});
+
+		it('throws when goal is not a recurring mission', async () => {
+			const handler = messageHubData.handlers.get('goal.scheduleNext')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce({
+				...recurringGoal,
+				missionType: 'one_shot',
+			});
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123', nextRunAt: 9999999999 }, {})
+			).rejects.toThrow('not a recurring mission');
+		});
+	});
+
 	describe('short ID support', () => {
 		const GOAL_UUID = 'f1e2d3c4-b5a6-4789-a123-456789abcdef';
 		const ROOM_UUID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -34,6 +34,7 @@ import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { Skeleton } from '../ui/Skeleton';
+import { toast } from '../../lib/toast';
 
 // ─── Create Form Types ────────────────────────────────────────────────────────
 
@@ -1240,6 +1241,8 @@ function GoalItem({
 		setIsTriggering(true);
 		try {
 			await onTriggerNow(goal.id);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to trigger mission');
 		} finally {
 			setIsTriggering(false);
 		}
@@ -1254,6 +1257,8 @@ function GoalItem({
 			await onScheduleNext(goal.id, timestamp);
 			setShowSchedulePicker(false);
 			setScheduleDateTime('');
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to schedule mission');
 		} finally {
 			setIsUpdating(false);
 		}

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -1206,6 +1206,8 @@ function GoalItem({
 		}
 	}, [isExpanded, missionType, onListExecutions, goal.id, executions]);
 
+	const hasActiveExecution = executions?.some((e) => e.status === 'running') ?? false;
+
 	const handleStatusChange = async (newStatus: GoalStatus) => {
 		setIsUpdating(true);
 		try {
@@ -1502,7 +1504,12 @@ function GoalItem({
 											variant="primary"
 											size="sm"
 											onClick={handleTriggerNow}
-											disabled={isTriggering || goal.schedulePaused}
+											disabled={isTriggering || goal.schedulePaused || hasActiveExecution}
+											title={
+												hasActiveExecution
+													? 'An execution is already running — wait for it to complete'
+													: undefined
+											}
 											loading={isTriggering}
 											data-testid="run-now-btn"
 										>

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -80,6 +80,10 @@ export interface GoalsEditorProps {
 	onDismissNotification?: (taskId: string) => void;
 	/** Fetch execution history for a recurring mission (optional) */
 	onListExecutions?: (goalId: string) => Promise<MissionExecution[]>;
+	/** Manually trigger a recurring mission execution immediately (optional) */
+	onTriggerNow?: (goalId: string) => Promise<void>;
+	/** Set nextRunAt to a specific datetime for a recurring mission (optional) */
+	onScheduleNext?: (goalId: string, nextRunAt: number) => Promise<void>;
 }
 
 // ─── Common Schedule Presets ──────────────────────────────────────────────────
@@ -1164,6 +1168,8 @@ interface GoalItemProps {
 	isExpanded: boolean;
 	onToggleExpand: () => void;
 	onListExecutions?: (goalId: string) => Promise<MissionExecution[]>;
+	onTriggerNow?: (goalId: string) => Promise<void>;
+	onScheduleNext?: (goalId: string, nextRunAt: number) => Promise<void>;
 }
 
 function GoalItem({
@@ -1176,12 +1182,17 @@ function GoalItem({
 	isExpanded,
 	onToggleExpand,
 	onListExecutions,
+	onTriggerNow,
+	onScheduleNext,
 }: GoalItemProps) {
 	const [isEditing, setIsEditing] = useState(false);
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 	const [linkTaskId, setLinkTaskId] = useState('');
 	const [isUpdating, setIsUpdating] = useState(false);
 	const [executions, setExecutions] = useState<MissionExecution[] | null>(null);
+	const [isTriggering, setIsTriggering] = useState(false);
+	const [showSchedulePicker, setShowSchedulePicker] = useState(false);
+	const [scheduleDateTime, setScheduleDateTime] = useState('');
 
 	const missionType: MissionType = goal.missionType ?? 'one_shot';
 
@@ -1219,6 +1230,30 @@ function GoalItem({
 		try {
 			await onDelete();
 			setShowDeleteConfirm(false);
+		} finally {
+			setIsUpdating(false);
+		}
+	};
+
+	const handleTriggerNow = async () => {
+		if (!onTriggerNow) return;
+		setIsTriggering(true);
+		try {
+			await onTriggerNow(goal.id);
+		} finally {
+			setIsTriggering(false);
+		}
+	};
+
+	const handleScheduleNext = async () => {
+		if (!onScheduleNext || !scheduleDateTime) return;
+		const timestamp = Math.floor(new Date(scheduleDateTime).getTime() / 1000);
+		if (timestamp <= Math.floor(Date.now() / 1000)) return;
+		setIsUpdating(true);
+		try {
+			await onScheduleNext(goal.id, timestamp);
+			setShowSchedulePicker(false);
+			setScheduleDateTime('');
 		} finally {
 			setIsUpdating(false);
 		}
@@ -1455,6 +1490,110 @@ function GoalItem({
 							<div>
 								<h5 class="text-xs font-medium text-gray-400 uppercase mb-2">Schedule</h5>
 								<RecurringScheduleInfo goal={goal} />
+								{/* Manual trigger controls for active, non-paused recurring missions */}
+								{goal.status === 'active' && onTriggerNow && (
+									<div class="mt-3 flex flex-wrap gap-2" data-testid="recurring-controls">
+										<Button
+											variant="primary"
+											size="sm"
+											onClick={handleTriggerNow}
+											disabled={isTriggering || goal.schedulePaused}
+											loading={isTriggering}
+											data-testid="run-now-btn"
+										>
+											<span class="flex items-center gap-1.5">
+												<svg
+													class="w-3.5 h-3.5"
+													fill="none"
+													viewBox="0 0 24 24"
+													stroke="currentColor"
+												>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														stroke-width={2}
+														d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+													/>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														stroke-width={2}
+														d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+													/>
+												</svg>
+												{isTriggering ? 'Starting...' : 'Run Now'}
+											</span>
+										</Button>
+										{onScheduleNext && (
+											<>
+												{!showSchedulePicker ? (
+													<Button
+														variant="secondary"
+														size="sm"
+														onClick={() => setShowSchedulePicker(true)}
+														disabled={isUpdating}
+														data-testid="schedule-next-btn"
+													>
+														<span class="flex items-center gap-1.5">
+															<svg
+																class="w-3.5 h-3.5"
+																fill="none"
+																viewBox="0 0 24 24"
+																stroke="currentColor"
+															>
+																<path
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																	stroke-width={2}
+																	d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+																/>
+															</svg>
+															Schedule
+														</span>
+													</Button>
+												) : (
+													<div class="flex items-center gap-2">
+														<input
+															type="datetime-local"
+															value={scheduleDateTime}
+															onInput={(e) =>
+																setScheduleDateTime((e.target as HTMLInputElement).value)
+															}
+															min={new Date().toISOString().slice(0, 16)}
+															class="px-2 py-1 bg-dark-700 border border-dark-600 rounded text-xs text-gray-100 focus:outline-none focus:ring-1 focus:ring-blue-500"
+															data-testid="schedule-datetime-input"
+														/>
+														<Button
+															variant="primary"
+															size="sm"
+															onClick={handleScheduleNext}
+															disabled={
+																!scheduleDateTime ||
+																isUpdating ||
+																new Date(scheduleDateTime).getTime() <= Date.now()
+															}
+															loading={isUpdating}
+															data-testid="schedule-confirm-btn"
+														>
+															Set
+														</Button>
+														<Button
+															variant="ghost"
+															size="sm"
+															onClick={() => {
+																setShowSchedulePicker(false);
+																setScheduleDateTime('');
+															}}
+															disabled={isUpdating}
+														>
+															Cancel
+														</Button>
+													</div>
+												)}
+											</>
+										)}
+									</div>
+								)}
 							</div>
 						)}
 
@@ -1786,6 +1925,8 @@ export function GoalsEditor({
 	autoCompletedNotifications = [],
 	onDismissNotification,
 	onListExecutions,
+	onTriggerNow,
+	onScheduleNext,
 }: GoalsEditorProps) {
 	const [showCreateModal, setShowCreateModal] = useState(false);
 	const [expandedGoalId, setExpandedGoalId] = useState<string | null>(null);
@@ -1880,6 +2021,8 @@ export function GoalsEditor({
 							isExpanded={expandedGoalId === goal.id}
 							onToggleExpand={() => toggleExpand(goal.id)}
 							onListExecutions={onListExecutions}
+							onTriggerNow={onTriggerNow}
+							onScheduleNext={onScheduleNext}
 						/>
 					))}
 				</div>

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -253,6 +253,12 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 										autoCompletedNotifications={roomStore.autoCompletedNotifications.value}
 										onDismissNotification={(taskId) => roomStore.dismissAutoCompleted(taskId)}
 										onListExecutions={(goalId) => roomStore.listExecutions(goalId)}
+										onTriggerNow={async (goalId) => {
+											await roomStore.triggerNow(goalId);
+										}}
+										onScheduleNext={async (goalId, nextRunAt) => {
+											await roomStore.scheduleNext(goalId, nextRunAt);
+										}}
 									/>
 								</div>
 							)}

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -1073,6 +1073,39 @@ class RoomStore {
 	}
 
 	/**
+	 * Manually trigger a recurring mission execution immediately.
+	 */
+	async triggerNow(goalId: string): Promise<RoomGoal> {
+		const roomId = this.roomId.value;
+		if (!roomId) throw new Error('No room selected');
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+		const result = await hub.request<{ goal: RoomGoal }>('goal.triggerNow', {
+			roomId,
+			goalId,
+		});
+		return result.goal;
+	}
+
+	/**
+	 * Set nextRunAt to a specific datetime for a recurring mission.
+	 * @param goalId The goal to update
+	 * @param nextRunAt Unix timestamp in seconds
+	 */
+	async scheduleNext(goalId: string, nextRunAt: number): Promise<RoomGoal> {
+		const roomId = this.roomId.value;
+		if (!roomId) throw new Error('No room selected');
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+		const result = await hub.request<{ goal: RoomGoal }>('goal.scheduleNext', {
+			roomId,
+			goalId,
+			nextRunAt,
+		});
+		return result.goal;
+	}
+
+	/**
 	 * Dismiss an auto-completed task notification
 	 */
 	dismissAutoCompleted(taskId: string): void {


### PR DESCRIPTION
Add UI controls and backend support for manually triggering recurring missions.

**Backend:**
- `RoomRuntime.triggerNow(goalId)` — bypasses tick schedule, respects overlap guards
- `goal.triggerNow` RPC handler — immediate execution trigger
- `goal.scheduleNext` RPC handler — set nextRunAt to a specific Unix timestamp

**Frontend:**
- "Run Now" button in the expanded recurring mission schedule section
- "Schedule" button with datetime-local picker for custom next-run time
- Both wired through RoomStore → GoalsEditor → Room.tsx

**Tests:** 16 new unit tests covering validation, guards, and short ID resolution.