### PR TITLE
plan: scoped read-only db-query MCP server for agent data access (v2)

### DIFF
--- a/docs/plans/add-scoped-read-only-db-query-mcp-server-for-agent-data-acce.md
+++ b/docs/plans/add-scoped-read-only-db-query-mcp-server-for-agent-data-acce.md
@@ -126,6 +126,8 @@ db.exec('PRAGMA query_only = ON');
 
 Use a **column blacklist** per table instead of a whitelist. Blacklisted columns are excluded from `db_describe_table` output and from `SELECT *` expansion. New columns added by future migrations are automatically visible unless explicitly blacklisted.
 
+Blacklists are **global per-table**, not scope-dependent — a column blacklisted on `sessions` (e.g., `session_context`) is excluded regardless of whether the query runs under global, room, or space scope. The `getBlacklistedColumns(tableName)` function takes only the table name, not the scope type.
+
 **Blacklisted columns (all scopes):**
 - `session_context` (on `sessions`) -- JSON with IDs that could enable cross-session access
 - `config` (on `rooms`, `spaces`) -- may contain sensitive JSON blobs
@@ -232,7 +234,7 @@ Create `packages/daemon/src/lib/db-query/scope-config.ts` that defines which tab
    - `context.spaceId` -> `{ scopeType: 'space', scopeValue: spaceId }`
    - Neither -> `{ scopeType: 'global', scopeValue: '' }`
 6. Implement `getAccessibleTableNames(scopeType: DbScopeType): string[]`
-7. Implement `getBlacklistedColumns(tableName: string, scopeType: DbScopeType): string[]`
+7. Implement `getBlacklistedColumns(tableName: string): string[]` (blacklists are global per-table, not scope-dependent)
 8. Implement `buildScopeFilter(tableConfig: ScopeTableConfig, scopeValue: string): { whereClause: string; params: unknown[] }` that returns the WHERE clause for a given table's scope config:
    - Direct: `room_id = ?` or `space_id = ?` (with scopeValue as param)
    - Indirect: `goal_id IN (SELECT id FROM goals WHERE room_id = ?)` (with scopeValue as param)
@@ -359,7 +361,7 @@ Wire the `db-query` MCP server into all agent session types. Each session gets i
 1. Modify `packages/daemon/src/lib/neo/neo-agent-manager.ts`:
    - Add a private `dbPath: string | null = null` field and a public `setDbPath(dbPath: string): void` setter method (follows the same order-independent wiring pattern as `setToolsConfig`, `setActionToolsConfig`, `setActivityLogger`)
    - Call `deps.neoAgentManager.setDbPath(deps.db.getDatabasePath())` in `packages/daemon/src/lib/rpc-handlers/index.ts` alongside the existing `setToolsConfig()` call (lines 388 area) — `deps.db.getDatabasePath()` is already available in that scope
-   - In `attachTools()`: if `this.dbPath` is set, create `createDbQueryMcpServer({ dbPath: this.dbPath, scopeType: 'global', scopeValue: '' })` and merge it into the `setRuntimeMcpServers()` call alongside the existing `inProcessServers` and `registryMcpServers` under the key `'db-query'`
+   - In `attachTools()`: at the top, close any existing db-query server instance (`this.dbQueryServer?.close(); this.dbQueryServer = null;`) before creating a new one — this prevents connection leaks when `attachTools()` is called multiple times during mid-lifecycle resets (e.g., `destroyAndRecreate()`, `clearSession()`). Then if `this.dbPath` is set, create `createDbQueryMcpServer({ dbPath: this.dbPath, scopeType: 'global', scopeValue: '' })` and merge it into the `setRuntimeMcpServers()` call alongside the existing `inProcessServers` and `registryMcpServers` under the key `'db-query'`
    - Store a reference to the created server instance for cleanup (call `close()` on session teardown)
    - The Neo agent's session context has no `roomId` or `spaceId`, so it receives `global` scope (all non-sensitive tables, no WHERE filter injection)
 2. Modify `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`:

--- a/docs/plans/add-scoped-read-only-db-query-mcp-server-for-agent-data-acce.md
+++ b/docs/plans/add-scoped-read-only-db-query-mcp-server-for-agent-data-acce.md
@@ -152,6 +152,7 @@ For the initial implementation, rely on `PRAGMA busy_timeout = 5000` for lock co
 
 ## Files to Modify
 
+- `packages/daemon/src/lib/neo/neo-agent-manager.ts` -- Inject `db-query` MCP server into Neo agent session (global scope)
 - `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` -- Inject `db-query` MCP server into room chat, worker, and leader sessions
 - `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` -- Inject `db-query` MCP server into task agent sessions
 - `packages/daemon/src/lib/space/runtime/space-runtime-service.ts` -- Inject `db-query` MCP server into space chat sessions
@@ -348,24 +349,29 @@ Create the core `db-query` MCP server. Each instance owns one read-only SQLite c
 
 ## Task 4: Integration into Agent Sessions
 
-**Title:** Inject db-query MCP server into room, task agent, space, and leader sessions
+**Title:** Inject db-query MCP server into Neo, room, task agent, space, and leader sessions
 
 **Description:**
 Wire the `db-query` MCP server into all agent session types. Each session gets its own MCP server instance with a single read-only connection.
 
 **Subtasks:**
-1. Modify `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`:
+1. Modify `packages/daemon/src/lib/neo/neo-agent-manager.ts`:
+   - In `attachTools()`: create `createDbQueryMcpServer({ dbPath, scopeType: 'global', scopeValue: '' })` and merge it into the `setRuntimeMcpServers()` call alongside the existing `inProcessServers` and `registryMcpServers` under the key `'db-query'`
+   - Store a reference to the created server instance for cleanup (call `close()` on session teardown)
+   - The Neo agent's session context has no `roomId` or `spaceId`, so it receives `global` scope (all non-sensitive tables, no WHERE filter injection)
+2. Modify `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`:
    - Import `createDbQueryMcpServer` and `getScopeForSession`
    - In `setupRoomAgentSession()`: create `createDbQueryMcpServer({ dbPath: ctx.db.getDatabasePath(), scopeType: 'room', scopeValue: room.id })` and merge into `setRuntimeMcpServers()` under the key `'db-query'`
    - In worker/leader session setup paths: same pattern with room scope
    - Store a reference to the created server instance for cleanup (call `close()` when session ends)
-2. Modify `packages/daemon/src/lib/space/runtime/task-agent-manager.ts`:
+3. Modify `packages/daemon/src/lib/space/runtime/task-agent-manager.ts`:
    - In task agent session creation: create `createDbQueryMcpServer({ dbPath, scopeType: 'space', scopeValue: space.id })` and merge into the task agent's MCP servers
-3. Modify `packages/daemon/src/lib/space/runtime/space-runtime-service.ts`:
+4. Modify `packages/daemon/src/lib/space/runtime/space-runtime-service.ts`:
    - In space chat session setup: create `createDbQueryMcpServer({ dbPath, scopeType: 'space', scopeValue: space.id })` and merge into the space chat session's MCP servers
-4. Add connection cleanup to session teardown paths:
+5. Add connection cleanup to session teardown paths:
    - When a session ends, call the db-query server's `close()` method to release the read-only connection
    - In `RoomRuntime.stop()`: close all db-query server instances for sessions in that room
+   - In Neo agent session teardown: close the db-query server instance
    - In space runtime cleanup: close db-query server instances for space sessions
 
 **Integration details:**
@@ -377,10 +383,10 @@ Wire the `db-query` MCP server into all agent session types. Each session gets i
 **Out of scope for initial implementation (can be added in follow-ups):**
 - **Node agent sub-sessions**: spawned by `TaskAgentManager` for individual workflow steps. Deferred because node agents already inherit MCP tools from their parent task agent session.
 - **Planner agent sessions**: used for planning phases in room missions. Deferred because planner sessions have access to the same room-scoped MCP tools as the leader/worker.
-- **Neo agent sessions**: the global scope is defined but wiring into `neo-agent-manager.ts` is deferred to a follow-up PR.
 - **`readOnlyHint: true`**: the `tool()` helper from `@anthropic-ai/claude-agent-sdk` may or may not support this field in the version currently used (v0.2.86). The implementer should verify against the SDK's `tool()` type signature and omit the field if it causes a type error.
 
 **Acceptance criteria:**
+- Neo agent session has a `db-query` MCP server with `global` scope (no WHERE filter, all non-sensitive tables)
 - Room chat sessions have a `db-query` MCP server with `room` scope
 - Worker/leader sessions have a `db-query` MCP server with `room` scope
 - Space chat sessions have a `db-query` MCP server with `space` scope

--- a/docs/plans/add-scoped-read-only-db-query-mcp-server-for-agent-data-acce.md
+++ b/docs/plans/add-scoped-read-only-db-query-mcp-server-for-agent-data-acce.md
@@ -67,15 +67,19 @@ Tables are categorized by scope with their filtering mechanism:
 | `channel_cycles` | `run_id` -> `space_workflow_runs.space_id` | Indirect join |
 
 **Global tables (no scope filter):**
-`sessions`, `rooms`, `spaces`, `app_mcp_servers`, `skills`, `inbox_items`, `neo_activity_log`, `job_queue`, `short_id_counters`, `github_mapping`
+`sessions`, `rooms`, `spaces`, `app_mcp_servers`, `skills`, `inbox_items`, `neo_activity_log`, `job_queue`, `short_id_counters`
 
 **Always excluded (all scopes):**
 - `auth_config`, `global_tools_config`, `global_settings` -- contain credentials/API keys
 - `sdk_messages` -- excluded due to size (millions of rows) and limited analytical value; agents have other tools for message history
+- `session_groups`, `session_group_members`, `task_group_events` -- internal session lifecycle infrastructure tables, not useful for agent data analysis
 
 **Dropped tables (not in current schema, do not include):**
 - `space_session_groups`, `space_session_group_members` -- dropped in migration 60
 - `space_workflow_transitions` -- dropped in migration 59
+
+**Not classified -- intentionally deferred:**
+- `spaces` table is in global scope, meaning space-scoped agents cannot directly query their own space record. This is intentional: space agents have other MCP tools for space metadata access, and adding `spaces` to space scope would be misleading since it has no per-row space_id filter (every space-scoped agent can only see one space).
 
 ### Scope Filter Injection Strategy
 
@@ -97,7 +101,15 @@ The wrapping approach handles all SQL edge cases (CTEs, subqueries, UNION, ORDER
 
 **Cross-scope join prevention:** The regex validator extracts table references from FROM/JOIN clauses. If any referenced table is outside the current scope's table list, the query is rejected before execution. This prevents a room-scoped agent from joining to space tables.
 
-**Multi-table queries:** If a query references multiple tables (e.g., `tasks JOIN goals`), each table's scope filter is combined with AND. All referenced tables must be in the same scope.
+**Multi-table queries:** If a query references multiple tables (e.g., `tasks JOIN goals`), the inner subquery uses `SELECT *` (not the user's column selection) to ensure all scope columns are available in the outer `_dbq`. The user's column selection is applied after scope filtering. When multiple tables share a scope column name (e.g., both `tasks` and `goals` have `room_id`), the outer WHERE clause qualifies with the `_dbq` alias to avoid ambiguity: `_dbq.room_id = ?`. If different tables in the same query require different scope filters (e.g., one direct, one indirect), each filter is combined with AND and column names are qualified. All referenced tables must be in the same scope.
+
+```sql
+-- Agent provides:  SELECT me.status, g.title FROM mission_executions me JOIN goals g ON me.goal_id = g.id
+-- System wraps:    SELECT me.status, g.title FROM (
+--                     SELECT * FROM mission_executions me JOIN goals g ON me.goal_id = g.id
+--                   ) AS _dbq
+--                   WHERE _dbq.goal_id IN (SELECT id FROM goals WHERE room_id = ?)
+```
 
 ### Connection Management
 
@@ -209,7 +221,7 @@ Create `packages/daemon/src/lib/db-query/scope-config.ts` that defines which tab
    - `blacklistedColumns: string[]` -- columns to exclude from `db_describe_table` and `SELECT *`
    - `description: string` -- human-readable description for the agent
 3. Define scope configurations matching the "Table Access by Scope" table in the Approach section above:
-   - **`global` scope**: sessions, rooms, spaces, app_mcp_servers, skills, inbox_items, neo_activity_log, job_queue, short_id_counters, github_mapping -- no filter, column blacklists applied
+   - **`global` scope**: sessions, rooms, spaces, app_mcp_servers, skills, inbox_items, neo_activity_log, job_queue, short_id_counters -- no filter, column blacklists applied
    - **`room` scope**: tasks, goals, mission_executions (indirect via goals), mission_metric_history (indirect via goals), room_github_mappings, room_mcp_enablement, room_skill_overrides
    - **`space` scope**: space_agents, space_workflows, space_workflow_steps (indirect via space_workflows), space_workflow_runs, space_tasks, space_worktrees, gate_data (indirect via space_workflow_runs), channel_cycles (indirect via space_workflow_runs)
 4. Implement `getScopeConfig(scopeType: DbScopeType): ScopeTableConfig[]`
@@ -236,6 +248,7 @@ Create `packages/daemon/src/lib/db-query/scope-config.ts` that defines which tab
 - All scope configuration tests pass
 - No sensitive tables (`auth_config`, `global_tools_config`, `global_settings`) are in any scope
 - `sdk_messages` is excluded from all scopes
+- Internal infrastructure tables (`session_groups`, `session_group_members`, `task_group_events`) are excluded from all scopes
 - Dropped tables (`space_session_groups`, `space_session_group_members`, `space_workflow_transitions`) are not in any scope config
 - `buildScopeFilter` produces correct parameterized SQL for both direct and indirect scope configs
 - Column blacklists exclude known-sensitive columns
@@ -272,8 +285,8 @@ Create the core `db-query` MCP server. Each instance owns one read-only SQLite c
      1. Call `validateSql(sql)` -- reject if invalid (return `{ isError: true }`)
      2. Check all extracted `tableRefs` are in the current scope's accessible tables -- reject if any table is out-of-scope (prevents cross-scope joins)
      3. For each referenced table, look up its `ScopeTableConfig` and `buildScopeFilter()`
-     4. Combine all scope filters with AND
-     5. Wrap the query: `SELECT * FROM (<original_query>) AS _dbq WHERE <combined_scope_filter>`
+     4. Combine all scope filters with AND, qualifying column names with `_dbq.` prefix to avoid ambiguity when multiple tables share column names
+     5. Rewrite the inner query to use `SELECT *` (ensuring scope columns are available), then wrap: `SELECT <user_columns> FROM (SELECT * FROM <user_tables_and_joins>) AS _dbq WHERE <combined_scope_filter>`. For single-table queries without explicit column selection, the outer SELECT defaults to `*`.
      6. Append LIMIT cap: `Math.min(limit ?? 200, 1000)`
      7. Execute via `db.query(wrappedSql, [...userParams, ...scopeParams])`
      8. Apply column blacklist: remove blacklisted columns from each row before returning
@@ -360,6 +373,12 @@ Wire the `db-query` MCP server into all agent session types. Each session gets i
 - The `dbPath` is obtained from `ctx.db.getDatabasePath()` (verified to exist at `packages/daemon/src/storage/index.ts`)
 - The `createSdkMcpServer` return type is cast to `McpServerConfig` via `as unknown as McpServerConfig` (same pattern as `room-agent-tools`)
 - Each MCP server instance owns its own connection (no pool). The `close()` method is called on session teardown.
+
+**Out of scope for initial implementation (can be added in follow-ups):**
+- **Node agent sub-sessions**: spawned by `TaskAgentManager` for individual workflow steps. Deferred because node agents already inherit MCP tools from their parent task agent session.
+- **Planner agent sessions**: used for planning phases in room missions. Deferred because planner sessions have access to the same room-scoped MCP tools as the leader/worker.
+- **Neo agent sessions**: the global scope is defined but wiring into `neo-agent-manager.ts` is deferred to a follow-up PR.
+- **`readOnlyHint: true`**: the `tool()` helper from `@anthropic-ai/claude-agent-sdk` may or may not support this field in the version currently used (v0.2.86). The implementer should verify against the SDK's `tool()` type signature and omit the field if it causes a type error.
 
 **Acceptance criteria:**
 - Room chat sessions have a `db-query` MCP server with `room` scope

--- a/docs/plans/add-scoped-read-only-db-query-mcp-server-for-agent-data-acce.md
+++ b/docs/plans/add-scoped-read-only-db-query-mcp-server-for-agent-data-acce.md
@@ -153,6 +153,7 @@ For the initial implementation, rely on `PRAGMA busy_timeout = 5000` for lock co
 ## Files to Modify
 
 - `packages/daemon/src/lib/neo/neo-agent-manager.ts` -- Inject `db-query` MCP server into Neo agent session (global scope)
+- `packages/daemon/src/lib/rpc-handlers/index.ts` -- Wire `dbPath` into NeoAgentManager via `setDbPath()`
 - `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` -- Inject `db-query` MCP server into room chat, worker, and leader sessions
 - `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` -- Inject `db-query` MCP server into task agent sessions
 - `packages/daemon/src/lib/space/runtime/space-runtime-service.ts` -- Inject `db-query` MCP server into space chat sessions
@@ -356,7 +357,9 @@ Wire the `db-query` MCP server into all agent session types. Each session gets i
 
 **Subtasks:**
 1. Modify `packages/daemon/src/lib/neo/neo-agent-manager.ts`:
-   - In `attachTools()`: create `createDbQueryMcpServer({ dbPath, scopeType: 'global', scopeValue: '' })` and merge it into the `setRuntimeMcpServers()` call alongside the existing `inProcessServers` and `registryMcpServers` under the key `'db-query'`
+   - Add a private `dbPath: string | null = null` field and a public `setDbPath(dbPath: string): void` setter method (follows the same order-independent wiring pattern as `setToolsConfig`, `setActionToolsConfig`, `setActivityLogger`)
+   - Call `deps.neoAgentManager.setDbPath(deps.db.getDatabasePath())` in `packages/daemon/src/lib/rpc-handlers/index.ts` alongside the existing `setToolsConfig()` call (lines 388 area) — `deps.db.getDatabasePath()` is already available in that scope
+   - In `attachTools()`: if `this.dbPath` is set, create `createDbQueryMcpServer({ dbPath: this.dbPath, scopeType: 'global', scopeValue: '' })` and merge it into the `setRuntimeMcpServers()` call alongside the existing `inProcessServers` and `registryMcpServers` under the key `'db-query'`
    - Store a reference to the created server instance for cleanup (call `close()` on session teardown)
    - The Neo agent's session context has no `roomId` or `spaceId`, so it receives `global` scope (all non-sensitive tables, no WHERE filter injection)
 2. Modify `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`:


### PR DESCRIPTION
## Summary
- Addressed all review feedback from 2 reviewers (14 issues total)
- Simplified to 3 scope types (global/room/space), removed task scope
- Switched from WHERE-clause string manipulation to subquery wrapping approach
- Switched from column whitelist to column blacklist (more maintainable)
- Replaced connection pool with single connection per MCP server instance
- Fixed stale table references (dropped tables removed: space_session_groups, space_session_group_members, space_workflow_transitions)
- Fixed incorrect scope mappings for indirect join tables (mission_executions, mission_metric_history, gate_data, channel_cycles, space_workflow_steps)
- Added schema evolution validation test
- Clarified security model hierarchy (regex is optimization, readonly+PRAGMA are primary boundary)
- Added query timeout TODO for follow-up