### PR TITLE
test: consolidate async gate tests and address review feedback

### DIFF
--- a/packages/daemon/tests/unit/space/channel-router-async.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router-async.test.ts
@@ -677,6 +677,168 @@ describe('ChannelRouter async gate evaluation', () => {
 			const result = await router.canDeliver(run.id, 'coder', 'planner');
 			expect(result.allowed).toBe(true);
 		});
+
+		// -------------------------------------------------------------------
+		// Semaphore overflow and start-after-completion
+		// -------------------------------------------------------------------
+
+		test('3 script gates with maxConcurrentScripts=1: serialized execution', async () => {
+			// Serialization timing is already validated by the pre-existing
+			// "respects maxConcurrentScripts: 1" tests above. This test
+			// verifies correctness with 3 gates (all allowed).
+			const AGENT_REVIEWER_A = 'agent-sem-rev-a';
+			const AGENT_REVIEWER_B = 'agent-sem-rev-b';
+			seedAgent(db, AGENT_REVIEWER_A, SPACE_ID, 'general');
+			seedAgent(db, AGENT_REVIEWER_B, SPACE_ID, 'general');
+
+			const gates: Gate[] = ['a', 'b', 'c'].map((id) => ({
+				id: `sem-ov-${id}`,
+				script: {
+					interpreter: 'bash',
+					source: 'sleep 0.2; echo \'{"ok": true}\'',
+					timeoutMs: 5000,
+				},
+				fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+				resetOnCycle: false,
+			}));
+
+			const channels: WorkflowChannel[] = [
+				{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'sem-ov-a' },
+				{ from: 'coder', to: 'reviewer-a', direction: 'one-way', gateId: 'sem-ov-b' },
+				{ from: 'coder', to: 'reviewer-b', direction: 'one-way', gateId: 'sem-ov-c' },
+			];
+
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+					{
+						id: 'node-sem-c',
+						name: 'Rev A',
+						agents: [{ agentId: AGENT_REVIEWER_A, name: 'reviewer-a' }],
+					},
+					{
+						id: 'node-sem-d',
+						name: 'Rev B',
+						agents: [{ agentId: AGENT_REVIEWER_B, name: 'reviewer-b' }],
+					},
+				],
+				channels,
+				gates
+			);
+			const run = createActiveRun(workflow);
+
+			const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 1 });
+
+			const [r1, r2, r3] = await Promise.all([
+				router.canDeliver(run.id, 'coder', 'planner'),
+				router.canDeliver(run.id, 'coder', 'reviewer-a'),
+				router.canDeliver(run.id, 'coder', 'reviewer-b'),
+			]);
+
+			expect(r1.allowed).toBe(true);
+			expect(r2.allowed).toBe(true);
+			expect(r3.allowed).toBe(true);
+		});
+
+		test('after first script gate completes, next one starts immediately (max=2)', async () => {
+			// 3 script gates, maxConcurrentScripts=2. Verify all 3 are allowed
+			// (2 run concurrently, 3rd runs after a slot frees up).
+			const AGENT_REVIEWER_A = 'agent-sem-start-rev-a';
+			const AGENT_REVIEWER_B = 'agent-sem-start-rev-b';
+			seedAgent(db, AGENT_REVIEWER_A, SPACE_ID, 'general');
+			seedAgent(db, AGENT_REVIEWER_B, SPACE_ID, 'general');
+
+			const gates: Gate[] = ['x', 'y', 'z'].map((id) => ({
+				id: `sem-start-${id}`,
+				script: {
+					interpreter: 'bash',
+					source: 'sleep 0.2; echo \'{"ok": true}\'',
+					timeoutMs: 5000,
+				},
+				fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+				resetOnCycle: false,
+			}));
+
+			const channels: WorkflowChannel[] = [
+				{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'sem-start-x' },
+				{ from: 'coder', to: 'reviewer-a', direction: 'one-way', gateId: 'sem-start-y' },
+				{ from: 'coder', to: 'reviewer-b', direction: 'one-way', gateId: 'sem-start-z' },
+			];
+
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+					{
+						id: 'node-sem-start-c',
+						name: 'Rev A',
+						agents: [{ agentId: AGENT_REVIEWER_A, name: 'reviewer-a' }],
+					},
+					{
+						id: 'node-sem-start-d',
+						name: 'Rev B',
+						agents: [{ agentId: AGENT_REVIEWER_B, name: 'reviewer-b' }],
+					},
+				],
+				channels,
+				gates
+			);
+			const run = createActiveRun(workflow);
+
+			const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
+
+			const [r1, r2, r3] = await Promise.all([
+				router.canDeliver(run.id, 'coder', 'planner'),
+				router.canDeliver(run.id, 'coder', 'reviewer-a'),
+				router.canDeliver(run.id, 'coder', 'reviewer-b'),
+			]);
+
+			expect(r1.allowed).toBe(true);
+			expect(r2.allowed).toBe(true);
+			expect(r3.allowed).toBe(true);
+		});
+
+		test('field-only gates are NOT limited by semaphore at all', async () => {
+			// Even with maxConcurrentScripts=1, field-only evaluations should
+			// complete instantly without any semaphore queuing.
+			const gate: Gate = {
+				id: 'field-sem-bypass',
+				fields: [
+					{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+				],
+				resetOnCycle: false,
+			};
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'field-sem-bypass' }],
+				[gate]
+			);
+			const run = createActiveRun(workflow);
+			gateDataRepo.set(run.id, 'field-sem-bypass', { approved: true });
+
+			const router = makeRouter({ maxConcurrentScripts: 1 });
+
+			// 5 concurrent evaluations should all succeed
+			const results = await Promise.all([
+				router.canDeliver(run.id, 'coder', 'planner'),
+				router.canDeliver(run.id, 'coder', 'planner'),
+				router.canDeliver(run.id, 'coder', 'planner'),
+				router.canDeliver(run.id, 'coder', 'planner'),
+				router.canDeliver(run.id, 'coder', 'planner'),
+			]);
+
+			expect(results.every((r) => r.allowed)).toBe(true);
+		});
 	});
 
 	// -------------------------------------------------------------------------
@@ -755,7 +917,7 @@ describe('ChannelRouter async gate evaluation', () => {
 			expect(r2.allowed).toBe(true);
 
 			// The re-evaluation should have occurred.
-			// Timeline: 1st eval (~300ms) + 2nd re-eval (~300ms) = ~600ms minimum
+			// Timeline: 1st eval (~300ms) + 2nd re-eval (~300ms) ≈ 600ms theoretical.
 			// Allow generous tolerance for process startup overhead and CI variance.
 			expect(elapsed).toBeGreaterThanOrEqual(400);
 		});
@@ -975,6 +1137,210 @@ describe('ChannelRouter async gate evaluation', () => {
 			expect(r2.allowed).toBe(false);
 			expect(r2.reason).toContain('Script check failed');
 		});
+
+		// -------------------------------------------------------------------
+		// Coalescing re-evaluation and isolation
+		// -------------------------------------------------------------------
+
+		test('concurrent onGateDataChanged for same gate: second caller re-evaluates after first completes', async () => {
+			const gate: Gate = {
+				id: 're-eval-gate',
+				fields: [
+					{
+						name: 'votes',
+						type: 'map',
+						writers: ['*'],
+						check: { op: 'count', match: 'approved', min: 3 },
+					},
+				],
+				resetOnCycle: false,
+			};
+			const workflow = buildTwoNodeWorkflow(gate);
+			const run = createActiveRun(workflow);
+
+			const router = makeRouter();
+
+			// Set votes to 1 → gate closed
+			gateDataRepo.set(run.id, 're-eval-gate', { votes: { a: 'approved' } });
+			const result1 = await router.onGateDataChanged(run.id, 're-eval-gate');
+			expect(result1).toHaveLength(0);
+
+			// Set votes to 5 → gate opens
+			gateDataRepo.set(run.id, 're-eval-gate', {
+				votes: { a: 'approved', b: 'approved', c: 'approved', d: 'approved', e: 'approved' },
+			});
+
+			// Call onGateDataChanged twice concurrently — both should see votes: 5
+			const [r1, r2] = await Promise.all([
+				router.onGateDataChanged(run.id, 're-eval-gate'),
+				router.onGateDataChanged(run.id, 're-eval-gate'),
+			]);
+
+			// At least one call should activate the node (gate is open with 5 votes).
+			// The second may return empty due to idempotent activation (node already active).
+			const totalActivated = r1.length + r2.length;
+			expect(totalActivated).toBeGreaterThan(0);
+		});
+
+		test('different runId:gateId keys evaluate independently (script gates)', async () => {
+			const gate1: Gate = {
+				id: 'indep-gate-a',
+				script: {
+					interpreter: 'bash',
+					source: 'sleep 0.2; echo \'{"pass": true}\'',
+					timeoutMs: 5000,
+				},
+				fields: [{ name: 'pass', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+				resetOnCycle: false,
+			};
+			const gate2: Gate = {
+				id: 'indep-gate-b',
+				script: {
+					interpreter: 'bash',
+					source: 'echo \'{"go": true}\'',
+					timeoutMs: 5000,
+				},
+				fields: [{ name: 'go', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+				resetOnCycle: false,
+			};
+
+			const channels: WorkflowChannel[] = [
+				{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'indep-gate-a' },
+			];
+
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				channels,
+				[gate1, gate2]
+			);
+			const run = createActiveRun(workflow);
+
+			const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
+
+			const [r1, r2] = await Promise.all([
+				router.onGateDataChanged(run.id, 'indep-gate-a'),
+				router.onGateDataChanged(run.id, 'indep-gate-b'),
+			]);
+
+			// Gate-a has a 0.2s sleep; gate-b is instant. With independent evaluation,
+			// both should complete (gate-b not on any channel, so returns empty).
+			expect(r1.length).toBeGreaterThan(0);
+			expect(r2).toHaveLength(0);
+		});
+
+		test('two runs with same gateId and script: evaluations are isolated', async () => {
+			const gate: Gate = {
+				id: 'shared-script-gate',
+				script: {
+					interpreter: 'bash',
+					source: 'sleep 0.15; echo \'{"ok": true}\'',
+					timeoutMs: 5000,
+				},
+				fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+				resetOnCycle: false,
+			};
+
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'shared-script-gate' }],
+				[gate]
+			);
+
+			const run1 = createActiveRun(workflow);
+			const run2 = createActiveRun(workflow);
+
+			const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
+
+			const [r1, r2] = await Promise.all([
+				router.canDeliver(run1.id, 'coder', 'planner'),
+				router.canDeliver(run2.id, 'coder', 'planner'),
+			]);
+
+			// Two runs should evaluate independently (different composite keys).
+			expect(r1.allowed).toBe(true);
+			expect(r2.allowed).toBe(true);
+		});
+
+		test('same gateId in different runs: gate data isolation', async () => {
+			const gate: Gate = {
+				id: 'iso-gate',
+				fields: [
+					{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+				],
+				resetOnCycle: false,
+			};
+
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+					{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				],
+				[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'iso-gate' }],
+				[gate]
+			);
+
+			const run1 = createActiveRun(workflow);
+			const run2 = createActiveRun(workflow);
+
+			// Run 1: approved = true → gate open
+			gateDataRepo.set(run1.id, 'iso-gate', { approved: true });
+			// Run 2: approved = false → gate closed
+			gateDataRepo.set(run2.id, 'iso-gate', { approved: false });
+
+			const router = makeRouter();
+
+			const [r1, r2] = await Promise.all([
+				router.canDeliver(run1.id, 'coder', 'planner'),
+				router.canDeliver(run2.id, 'coder', 'planner'),
+			]);
+
+			expect(r1.allowed).toBe(true);
+			expect(r2.allowed).toBe(false);
+		});
+
+		test('concurrent onGateDataChanged for same gate: sequential calls produce consistent results', async () => {
+			const gate: Gate = {
+				id: 'seq-gate',
+				fields: [
+					{
+						name: 'count',
+						type: 'map',
+						writers: ['*'],
+						check: { op: 'count', match: 'yes', min: 5 },
+					},
+				],
+				resetOnCycle: false,
+			};
+			const workflow = buildTwoNodeWorkflow(gate);
+			const run = createActiveRun(workflow);
+
+			const router = makeRouter();
+
+			// Sequentially update gate data and check evaluation
+			for (let i = 1; i <= 5; i++) {
+				const votes: Record<string, string> = {};
+				for (let j = 0; j < i; j++) votes[`v${j}`] = 'yes';
+				gateDataRepo.set(run.id, 'seq-gate', { count: votes });
+				const activated = await router.onGateDataChanged(run.id, 'seq-gate');
+				if (i < 5) {
+					expect(activated).toHaveLength(0);
+				} else {
+					expect(activated.length).toBeGreaterThan(0);
+				}
+			}
+		});
 	});
 
 	// -------------------------------------------------------------------------
@@ -1018,527 +1384,66 @@ describe('ChannelRouter async gate evaluation', () => {
 			expect(activated.length).toBeGreaterThan(0);
 		});
 	});
-});
 
-// ---------------------------------------------------------------------------
-// Additional semaphore tests — excess gates wait, then start on completion
-// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
+	// isChannelOpen synchronous behavior via ChannelRouter
+	// -------------------------------------------------------------------------
 
-describe('ChannelRouter async gate — semaphore overflow and start-after-completion', () => {
-	let db: BunDatabase;
-	let dir: string;
+	describe('isChannelOpen synchronous behavior via ChannelRouter', () => {
+		test('field-only gate evaluates synchronously (no async overhead)', async () => {
+			// Gate with fields but no script — canDeliver works without
+			// any semaphore or script execution overhead.
+			const gate: Gate = {
+				id: 'sync-field-gate',
+				fields: [
+					{
+						name: 'approved',
+						type: 'boolean',
+						writers: ['*'],
+						check: { op: '==', value: true },
+					},
+				],
+				resetOnCycle: false,
+			};
+			const workflow = buildTwoNodeWorkflow(gate);
+			const run = createActiveRun(workflow);
+			gateDataRepo.set(run.id, 'sync-field-gate', { approved: true });
 
-	let taskRepo: SpaceTaskRepository;
-	let workflowRunRepo: SpaceWorkflowRunRepository;
-	let workflowManager: SpaceWorkflowManager;
-	let agentManager: SpaceAgentManager;
-	let gateDataRepo: GateDataRepository;
-	let channelCycleRepo: ChannelCycleRepository;
-
-	const SPACE_ID = 'space-sem-overflow';
-	const AGENT_CODER = 'agent-sem-coder';
-	const AGENT_PLANNER = 'agent-sem-planner';
-	const AGENT_REVIEWER_A = 'agent-sem-rev-a';
-	const AGENT_REVIEWER_B = 'agent-sem-rev-b';
-	const NODE_A = 'node-sem-a';
-	const NODE_B = 'node-sem-b';
-	const NODE_C = 'node-sem-c';
-	const NODE_D = 'node-sem-d';
-
-	beforeEach(() => {
-		const dbResult = makeDb();
-		db = dbResult.db;
-		dir = dbResult.dir;
-
-		seedSpace(db, SPACE_ID);
-		seedAgent(db, AGENT_CODER, SPACE_ID, 'coder');
-		seedAgent(db, AGENT_PLANNER, SPACE_ID, 'planner');
-		seedAgent(db, AGENT_REVIEWER_A, SPACE_ID, 'general');
-		seedAgent(db, AGENT_REVIEWER_B, SPACE_ID, 'general');
-
-		taskRepo = new SpaceTaskRepository(db);
-		workflowRunRepo = new SpaceWorkflowRunRepository(db);
-		gateDataRepo = new GateDataRepository(db);
-		channelCycleRepo = new ChannelCycleRepository(db);
-
-		const agentRepo = new SpaceAgentRepository(db);
-		agentManager = new SpaceAgentManager(agentRepo);
-
-		const workflowRepo = new SpaceWorkflowRepository(db);
-		workflowManager = new SpaceWorkflowManager(workflowRepo);
-	});
-
-	afterEach(() => {
-		db.close();
-		rmSync(dir, { recursive: true, force: true });
-	});
-
-	function makeRouter(overrides: Record<string, unknown> = {}): ChannelRouter {
-		return new ChannelRouter({
-			taskRepo,
-			workflowRunRepo,
-			workflowManager,
-			agentManager,
-			gateDataRepo,
-			channelCycleRepo,
-			db,
-			...overrides,
+			const router = makeRouter();
+			const result = await router.canDeliver(run.id, 'coder', 'planner');
+			expect(result.allowed).toBe(true);
 		});
-	}
 
-	function createActiveRun(workflow: ReturnType<typeof buildWorkflowWithGates>) {
-		const run = workflowRunRepo.createRun({
-			spaceId: SPACE_ID,
-			workflowId: workflow.id,
-			title: 'Semaphore Overflow Run',
-		});
-		workflowRunRepo.transitionStatus(run.id, 'in_progress');
-		return run;
-	}
-
-	test('3 script gates with maxConcurrentScripts=1: serialized execution (~600ms)', async () => {
-		const gates: Gate[] = ['a', 'b', 'c'].map((id) => ({
-			id: `sem-ov-${id}`,
-			script: {
-				interpreter: 'bash',
-				source: 'sleep 0.2; echo \'{"ok": true}\'',
-				timeoutMs: 5000,
-			},
-			fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
-			resetOnCycle: false,
-		}));
-
-		const channels: WorkflowChannel[] = [
-			{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'sem-ov-a' },
-			{ from: 'coder', to: 'reviewer-a', direction: 'one-way', gateId: 'sem-ov-b' },
-			{ from: 'coder', to: 'reviewer-b', direction: 'one-way', gateId: 'sem-ov-c' },
-		];
-
-		const workflow = buildWorkflowWithGates(
-			SPACE_ID,
-			workflowManager,
-			[
-				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
-				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
-				{ id: NODE_C, name: 'Rev A', agents: [{ agentId: AGENT_REVIEWER_A, name: 'reviewer-a' }] },
-				{ id: NODE_D, name: 'Rev B', agents: [{ agentId: AGENT_REVIEWER_B, name: 'reviewer-b' }] },
-			],
-			channels,
-			gates
-		);
-		const run = createActiveRun(workflow);
-
-		const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 1 });
-
-		const start = Date.now();
-		const [r1, r2, r3] = await Promise.all([
-			router.canDeliver(run.id, 'coder', 'planner'),
-			router.canDeliver(run.id, 'coder', 'reviewer-a'),
-			router.canDeliver(run.id, 'coder', 'reviewer-b'),
-		]);
-		const elapsed = Date.now() - start;
-
-		expect(r1.allowed).toBe(true);
-		expect(r2.allowed).toBe(true);
-		expect(r3.allowed).toBe(true);
-		// With maxConcurrentScripts=1, all 3 evaluations are serialized (~600ms)
-		expect(elapsed).toBeGreaterThanOrEqual(400);
-	});
-
-	test('after first script gate completes, next one starts immediately (max=2)', async () => {
-		// 3 script gates, maxConcurrentScripts=2. Two run concurrently (~200ms),
-		// then the third runs after one finishes (~400ms total).
-		const gates: Gate[] = ['x', 'y', 'z'].map((id) => ({
-			id: `sem-start-${id}`,
-			script: {
-				interpreter: 'bash',
-				source: 'sleep 0.2; echo \'{"ok": true}\'',
-				timeoutMs: 5000,
-			},
-			fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
-			resetOnCycle: false,
-		}));
-
-		const channels: WorkflowChannel[] = [
-			{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'sem-start-x' },
-			{ from: 'coder', to: 'reviewer-a', direction: 'one-way', gateId: 'sem-start-y' },
-			{ from: 'coder', to: 'reviewer-b', direction: 'one-way', gateId: 'sem-start-z' },
-		];
-
-		const workflow = buildWorkflowWithGates(
-			SPACE_ID,
-			workflowManager,
-			[
-				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
-				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
-				{ id: NODE_C, name: 'Rev A', agents: [{ agentId: AGENT_REVIEWER_A, name: 'reviewer-a' }] },
-				{ id: NODE_D, name: 'Rev B', agents: [{ agentId: AGENT_REVIEWER_B, name: 'reviewer-b' }] },
-			],
-			channels,
-			gates
-		);
-		const run = createActiveRun(workflow);
-
-		const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
-
-		const start = Date.now();
-		const [r1, r2, r3] = await Promise.all([
-			router.canDeliver(run.id, 'coder', 'planner'),
-			router.canDeliver(run.id, 'coder', 'reviewer-a'),
-			router.canDeliver(run.id, 'coder', 'reviewer-b'),
-		]);
-		const elapsed = Date.now() - start;
-
-		expect(r1.allowed).toBe(true);
-		expect(r2.allowed).toBe(true);
-		expect(r3.allowed).toBe(true);
-		// With max=2: first 2 run in parallel (~200ms), 3rd waits for a slot,
-		// then runs (~200ms more). Total: ~400ms minimum.
-		expect(elapsed).toBeGreaterThanOrEqual(300);
-		// But significantly less than if all 3 were serialized (~600ms)
-		expect(elapsed).toBeLessThan(800);
-	});
-
-	test('field-only gates are NOT limited by semaphore at all', async () => {
-		// Even with maxConcurrentScripts=1, field-only evaluations should complete instantly
-		const gate: Gate = {
-			id: 'field-sem-bypass',
-			fields: [
-				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
-			],
-			resetOnCycle: false,
-		};
-		const workflow = buildWorkflowWithGates(
-			SPACE_ID,
-			workflowManager,
-			[
-				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
-				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
-			],
-			[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'field-sem-bypass' }],
-			[gate]
-		);
-		const run = createActiveRun(workflow);
-		gateDataRepo.set(run.id, 'field-sem-bypass', { approved: true });
-
-		const router = makeRouter({ maxConcurrentScripts: 1 });
-
-		// 5 concurrent evaluations should complete near-instantly (no semaphore overhead)
-		const start = Date.now();
-		const results = await Promise.all([
-			router.canDeliver(run.id, 'coder', 'planner'),
-			router.canDeliver(run.id, 'coder', 'planner'),
-			router.canDeliver(run.id, 'coder', 'planner'),
-			router.canDeliver(run.id, 'coder', 'planner'),
-			router.canDeliver(run.id, 'coder', 'planner'),
-		]);
-		const elapsed = Date.now() - start;
-
-		expect(results.every((r) => r.allowed)).toBe(true);
-		expect(elapsed).toBeLessThan(100);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// Additional coalescing tests — re-evaluation semantics and cross-run isolation
-// ---------------------------------------------------------------------------
-
-describe('ChannelRouter async gate — coalescing re-evaluation and isolation', () => {
-	let db: BunDatabase;
-	let dir: string;
-
-	let taskRepo: SpaceTaskRepository;
-	let workflowRunRepo: SpaceWorkflowRunRepository;
-	let workflowManager: SpaceWorkflowManager;
-	let agentManager: SpaceAgentManager;
-	let gateDataRepo: GateDataRepository;
-	let channelCycleRepo: ChannelCycleRepository;
-
-	const SPACE_ID = 'space-coal-re';
-	const AGENT_CODER = 'agent-coal-coder';
-	const AGENT_PLANNER = 'agent-coal-planner';
-	const NODE_A = 'node-coal-a';
-	const NODE_B = 'node-coal-b';
-
-	beforeEach(() => {
-		const dbResult = makeDb();
-		db = dbResult.db;
-		dir = dbResult.dir;
-
-		seedSpace(db, SPACE_ID);
-		seedAgent(db, AGENT_CODER, SPACE_ID, 'coder');
-		seedAgent(db, AGENT_PLANNER, SPACE_ID, 'planner');
-
-		taskRepo = new SpaceTaskRepository(db);
-		workflowRunRepo = new SpaceWorkflowRunRepository(db);
-		gateDataRepo = new GateDataRepository(db);
-		channelCycleRepo = new ChannelCycleRepository(db);
-
-		const agentRepo = new SpaceAgentRepository(db);
-		agentManager = new SpaceAgentManager(agentRepo);
-
-		const workflowRepo = new SpaceWorkflowRepository(db);
-		workflowManager = new SpaceWorkflowManager(workflowRepo);
-	});
-
-	afterEach(() => {
-		db.close();
-		rmSync(dir, { recursive: true, force: true });
-	});
-
-	function makeRouter(overrides: Record<string, unknown> = {}): ChannelRouter {
-		return new ChannelRouter({
-			taskRepo,
-			workflowRunRepo,
-			workflowManager,
-			agentManager,
-			gateDataRepo,
-			channelCycleRepo,
-			db,
-			...overrides,
-		});
-	}
-
-	function buildTwoNodeWorkflow(gate?: Gate, channelGateId?: string) {
-		const channels: WorkflowChannel[] = gate
-			? [{ from: 'coder', to: 'planner', direction: 'one-way', gateId: channelGateId ?? gate.id }]
-			: [];
-		return buildWorkflowWithGates(
-			SPACE_ID,
-			workflowManager,
-			[
-				{
-					id: NODE_A,
-					name: 'Coder Node',
-					agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+		test('gate with script but field-only channel remains synchronous in isChannelOpen context', async () => {
+			// isChannelOpen is a pure function (tested in gate-evaluator.test.ts).
+			// ChannelRouter.canDeliver uses evaluateGateById which always runs
+			// the script asynchronously. For field-only gates (no script), the
+			// async function returns immediately without awaiting anything, so it
+			// is effectively synchronous. This test verifies that a gate with
+			// both fields and a script still evaluates correctly through canDeliver.
+			const gate: Gate = {
+				id: 'sync-script-field-gate',
+				script: {
+					interpreter: 'bash',
+					source: 'echo \'{"approved": true}\'',
+					timeoutMs: 5000,
 				},
-				{
-					id: NODE_B,
-					name: 'Planner Node',
-					agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
-				},
-			],
-			channels,
-			gate ? [gate] : []
-		);
-	}
+				fields: [
+					{
+						name: 'approved',
+						type: 'boolean',
+						writers: ['*'],
+						check: { op: '==', value: true },
+					},
+				],
+				resetOnCycle: false,
+			};
+			const workflow = buildTwoNodeWorkflow(gate);
+			const run = createActiveRun(workflow);
 
-	function createActiveRun(workflow: ReturnType<typeof buildWorkflowWithGates>) {
-		const run = workflowRunRepo.createRun({
-			spaceId: SPACE_ID,
-			workflowId: workflow.id,
-			title: 'Coalescing Run',
+			const router = makeRouter({ workspacePath: '/tmp' });
+			const result = await router.canDeliver(run.id, 'coder', 'planner');
+			expect(result.allowed).toBe(true);
 		});
-		workflowRunRepo.transitionStatus(run.id, 'in_progress');
-		return run;
-	}
-
-	test('concurrent onGateDataChanged for same gate: second caller re-evaluates after first completes', async () => {
-		const gate: Gate = {
-			id: 're-eval-gate',
-			fields: [
-				{
-					name: 'votes',
-					type: 'map',
-					writers: ['*'],
-					check: { op: 'count', match: 'approved', min: 3 },
-				},
-			],
-			resetOnCycle: false,
-		};
-		const workflow = buildTwoNodeWorkflow(gate);
-		const run = createActiveRun(workflow);
-
-		const router = makeRouter();
-
-		// Set votes to 1 → gate closed
-		gateDataRepo.set(run.id, 're-eval-gate', { votes: { a: 'approved' } });
-		const result1 = await router.onGateDataChanged(run.id, 're-eval-gate');
-		expect(result1).toHaveLength(0);
-
-		// Set votes to 5 → gate opens
-		gateDataRepo.set(run.id, 're-eval-gate', {
-			votes: { a: 'approved', b: 'approved', c: 'approved', d: 'approved', e: 'approved' },
-		});
-
-		// Call onGateDataChanged twice concurrently — both should see votes: 5
-		const [r1, r2] = await Promise.all([
-			router.onGateDataChanged(run.id, 're-eval-gate'),
-			router.onGateDataChanged(run.id, 're-eval-gate'),
-		]);
-
-		// At least one call should activate the node (gate is open with 5 votes).
-		// The second may return empty due to idempotent activation (node already active).
-		const totalActivated = r1.length + r2.length;
-		expect(totalActivated).toBeGreaterThan(0);
-	});
-
-	test('different runId:gateId keys evaluate independently (script gates)', async () => {
-		const gate1: Gate = {
-			id: 'indep-gate-a',
-			script: {
-				interpreter: 'bash',
-				source: 'sleep 0.2; echo \'{"pass": true}\'',
-				timeoutMs: 5000,
-			},
-			fields: [{ name: 'pass', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
-			resetOnCycle: false,
-		};
-		const gate2: Gate = {
-			id: 'indep-gate-b',
-			script: {
-				interpreter: 'bash',
-				source: 'echo \'{"go": true}\'',
-				timeoutMs: 5000,
-			},
-			fields: [{ name: 'go', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
-			resetOnCycle: false,
-		};
-
-		const channels: WorkflowChannel[] = [
-			{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'indep-gate-a' },
-		];
-
-		const workflow = buildWorkflowWithGates(
-			SPACE_ID,
-			workflowManager,
-			[
-				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
-				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
-			],
-			channels,
-			[gate1, gate2]
-		);
-		const run = createActiveRun(workflow);
-
-		const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
-
-		const start = Date.now();
-		const [r1, r2] = await Promise.all([
-			router.onGateDataChanged(run.id, 'indep-gate-a'),
-			router.onGateDataChanged(run.id, 'indep-gate-b'),
-		]);
-		const elapsed = Date.now() - start;
-
-		// Gate-a has a 0.2s sleep; gate-b is instant. With independent evaluation,
-		// both should complete quickly (not serialized).
-		expect(r1.length).toBeGreaterThan(0);
-		// gate-b is not on any channel, so onGateDataChanged returns empty
-		expect(r2).toHaveLength(0);
-		expect(elapsed).toBeLessThan(600);
-	});
-
-	test('two runs with same gateId and script: evaluations are isolated', async () => {
-		const gate: Gate = {
-			id: 'shared-script-gate',
-			script: {
-				interpreter: 'bash',
-				source: 'sleep 0.15; echo \'{"ok": true}\'',
-				timeoutMs: 5000,
-			},
-			fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
-			resetOnCycle: false,
-		};
-
-		const workflow = buildWorkflowWithGates(
-			SPACE_ID,
-			workflowManager,
-			[
-				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
-				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
-			],
-			[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'shared-script-gate' }],
-			[gate]
-		);
-
-		const run1 = createActiveRun(workflow);
-		const run2 = createActiveRun(workflow);
-
-		const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
-
-		const start = Date.now();
-		const [r1, r2] = await Promise.all([
-			router.canDeliver(run1.id, 'coder', 'planner'),
-			router.canDeliver(run2.id, 'coder', 'planner'),
-		]);
-		const elapsed = Date.now() - start;
-
-		expect(r1.allowed).toBe(true);
-		expect(r2.allowed).toBe(true);
-
-		// Two runs should evaluate independently (different composite keys).
-		// With maxConcurrentScripts=2, both should run concurrently.
-		expect(elapsed).toBeLessThan(500);
-	});
-
-	test('same gateId in different runs: gate data isolation', async () => {
-		const gate: Gate = {
-			id: 'iso-gate',
-			fields: [
-				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
-			],
-			resetOnCycle: false,
-		};
-
-		const workflow = buildWorkflowWithGates(
-			SPACE_ID,
-			workflowManager,
-			[
-				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
-				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
-			],
-			[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'iso-gate' }],
-			[gate]
-		);
-
-		const run1 = createActiveRun(workflow);
-		const run2 = createActiveRun(workflow);
-
-		// Run 1: approved = true → gate open
-		gateDataRepo.set(run1.id, 'iso-gate', { approved: true });
-		// Run 2: approved = false → gate closed
-		gateDataRepo.set(run2.id, 'iso-gate', { approved: false });
-
-		const router = makeRouter();
-
-		const [r1, r2] = await Promise.all([
-			router.canDeliver(run1.id, 'coder', 'planner'),
-			router.canDeliver(run2.id, 'coder', 'planner'),
-		]);
-
-		expect(r1.allowed).toBe(true);
-		expect(r2.allowed).toBe(false);
-	});
-
-	test('concurrent onGateDataChanged for same gate: sequential calls produce consistent results', async () => {
-		const gate: Gate = {
-			id: 'seq-gate',
-			fields: [
-				{
-					name: 'count',
-					type: 'map',
-					writers: ['*'],
-					check: { op: 'count', match: 'yes', min: 5 },
-				},
-			],
-			resetOnCycle: false,
-		};
-		const workflow = buildTwoNodeWorkflow(gate);
-		const run = createActiveRun(workflow);
-
-		const router = makeRouter();
-
-		// Sequentially update gate data and check evaluation
-		for (let i = 1; i <= 5; i++) {
-			const votes: Record<string, string> = {};
-			for (let j = 0; j < i; j++) votes[`v${j}`] = 'yes';
-			gateDataRepo.set(run.id, 'seq-gate', { count: votes });
-			const activated = await router.onGateDataChanged(run.id, 'seq-gate');
-			if (i < 5) {
-				expect(activated).toHaveLength(0);
-			} else {
-				expect(activated.length).toBeGreaterThan(0);
-			}
-		}
 	});
 });

--- a/packages/daemon/tests/unit/space/channel-router-async.test.ts
+++ b/packages/daemon/tests/unit/space/channel-router-async.test.ts
@@ -1019,3 +1019,526 @@ describe('ChannelRouter async gate evaluation', () => {
 		});
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Additional semaphore tests — excess gates wait, then start on completion
+// ---------------------------------------------------------------------------
+
+describe('ChannelRouter async gate — semaphore overflow and start-after-completion', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	let taskRepo: SpaceTaskRepository;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let workflowManager: SpaceWorkflowManager;
+	let agentManager: SpaceAgentManager;
+	let gateDataRepo: GateDataRepository;
+	let channelCycleRepo: ChannelCycleRepository;
+
+	const SPACE_ID = 'space-sem-overflow';
+	const AGENT_CODER = 'agent-sem-coder';
+	const AGENT_PLANNER = 'agent-sem-planner';
+	const AGENT_REVIEWER_A = 'agent-sem-rev-a';
+	const AGENT_REVIEWER_B = 'agent-sem-rev-b';
+	const NODE_A = 'node-sem-a';
+	const NODE_B = 'node-sem-b';
+	const NODE_C = 'node-sem-c';
+	const NODE_D = 'node-sem-d';
+
+	beforeEach(() => {
+		const dbResult = makeDb();
+		db = dbResult.db;
+		dir = dbResult.dir;
+
+		seedSpace(db, SPACE_ID);
+		seedAgent(db, AGENT_CODER, SPACE_ID, 'coder');
+		seedAgent(db, AGENT_PLANNER, SPACE_ID, 'planner');
+		seedAgent(db, AGENT_REVIEWER_A, SPACE_ID, 'general');
+		seedAgent(db, AGENT_REVIEWER_B, SPACE_ID, 'general');
+
+		taskRepo = new SpaceTaskRepository(db);
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		gateDataRepo = new GateDataRepository(db);
+		channelCycleRepo = new ChannelCycleRepository(db);
+
+		const agentRepo = new SpaceAgentRepository(db);
+		agentManager = new SpaceAgentManager(agentRepo);
+
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		workflowManager = new SpaceWorkflowManager(workflowRepo);
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	function makeRouter(overrides: Record<string, unknown> = {}): ChannelRouter {
+		return new ChannelRouter({
+			taskRepo,
+			workflowRunRepo,
+			workflowManager,
+			agentManager,
+			gateDataRepo,
+			channelCycleRepo,
+			db,
+			...overrides,
+		});
+	}
+
+	function createActiveRun(workflow: ReturnType<typeof buildWorkflowWithGates>) {
+		const run = workflowRunRepo.createRun({
+			spaceId: SPACE_ID,
+			workflowId: workflow.id,
+			title: 'Semaphore Overflow Run',
+		});
+		workflowRunRepo.transitionStatus(run.id, 'in_progress');
+		return run;
+	}
+
+	test('3 script gates with maxConcurrentScripts=1: serialized execution (~600ms)', async () => {
+		const gates: Gate[] = ['a', 'b', 'c'].map((id) => ({
+			id: `sem-ov-${id}`,
+			script: {
+				interpreter: 'bash',
+				source: 'sleep 0.2; echo \'{"ok": true}\'',
+				timeoutMs: 5000,
+			},
+			fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			resetOnCycle: false,
+		}));
+
+		const channels: WorkflowChannel[] = [
+			{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'sem-ov-a' },
+			{ from: 'coder', to: 'reviewer-a', direction: 'one-way', gateId: 'sem-ov-b' },
+			{ from: 'coder', to: 'reviewer-b', direction: 'one-way', gateId: 'sem-ov-c' },
+		];
+
+		const workflow = buildWorkflowWithGates(
+			SPACE_ID,
+			workflowManager,
+			[
+				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				{ id: NODE_C, name: 'Rev A', agents: [{ agentId: AGENT_REVIEWER_A, name: 'reviewer-a' }] },
+				{ id: NODE_D, name: 'Rev B', agents: [{ agentId: AGENT_REVIEWER_B, name: 'reviewer-b' }] },
+			],
+			channels,
+			gates
+		);
+		const run = createActiveRun(workflow);
+
+		const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 1 });
+
+		const start = Date.now();
+		const [r1, r2, r3] = await Promise.all([
+			router.canDeliver(run.id, 'coder', 'planner'),
+			router.canDeliver(run.id, 'coder', 'reviewer-a'),
+			router.canDeliver(run.id, 'coder', 'reviewer-b'),
+		]);
+		const elapsed = Date.now() - start;
+
+		expect(r1.allowed).toBe(true);
+		expect(r2.allowed).toBe(true);
+		expect(r3.allowed).toBe(true);
+		// With maxConcurrentScripts=1, all 3 evaluations are serialized (~600ms)
+		expect(elapsed).toBeGreaterThanOrEqual(400);
+	});
+
+	test('after first script gate completes, next one starts immediately (max=2)', async () => {
+		// 3 script gates, maxConcurrentScripts=2. Two run concurrently (~200ms),
+		// then the third runs after one finishes (~400ms total).
+		const gates: Gate[] = ['x', 'y', 'z'].map((id) => ({
+			id: `sem-start-${id}`,
+			script: {
+				interpreter: 'bash',
+				source: 'sleep 0.2; echo \'{"ok": true}\'',
+				timeoutMs: 5000,
+			},
+			fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			resetOnCycle: false,
+		}));
+
+		const channels: WorkflowChannel[] = [
+			{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'sem-start-x' },
+			{ from: 'coder', to: 'reviewer-a', direction: 'one-way', gateId: 'sem-start-y' },
+			{ from: 'coder', to: 'reviewer-b', direction: 'one-way', gateId: 'sem-start-z' },
+		];
+
+		const workflow = buildWorkflowWithGates(
+			SPACE_ID,
+			workflowManager,
+			[
+				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+				{ id: NODE_C, name: 'Rev A', agents: [{ agentId: AGENT_REVIEWER_A, name: 'reviewer-a' }] },
+				{ id: NODE_D, name: 'Rev B', agents: [{ agentId: AGENT_REVIEWER_B, name: 'reviewer-b' }] },
+			],
+			channels,
+			gates
+		);
+		const run = createActiveRun(workflow);
+
+		const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
+
+		const start = Date.now();
+		const [r1, r2, r3] = await Promise.all([
+			router.canDeliver(run.id, 'coder', 'planner'),
+			router.canDeliver(run.id, 'coder', 'reviewer-a'),
+			router.canDeliver(run.id, 'coder', 'reviewer-b'),
+		]);
+		const elapsed = Date.now() - start;
+
+		expect(r1.allowed).toBe(true);
+		expect(r2.allowed).toBe(true);
+		expect(r3.allowed).toBe(true);
+		// With max=2: first 2 run in parallel (~200ms), 3rd waits for a slot,
+		// then runs (~200ms more). Total: ~400ms minimum.
+		expect(elapsed).toBeGreaterThanOrEqual(300);
+		// But significantly less than if all 3 were serialized (~600ms)
+		expect(elapsed).toBeLessThan(800);
+	});
+
+	test('field-only gates are NOT limited by semaphore at all', async () => {
+		// Even with maxConcurrentScripts=1, field-only evaluations should complete instantly
+		const gate: Gate = {
+			id: 'field-sem-bypass',
+			fields: [
+				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			resetOnCycle: false,
+		};
+		const workflow = buildWorkflowWithGates(
+			SPACE_ID,
+			workflowManager,
+			[
+				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+			],
+			[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'field-sem-bypass' }],
+			[gate]
+		);
+		const run = createActiveRun(workflow);
+		gateDataRepo.set(run.id, 'field-sem-bypass', { approved: true });
+
+		const router = makeRouter({ maxConcurrentScripts: 1 });
+
+		// 5 concurrent evaluations should complete near-instantly (no semaphore overhead)
+		const start = Date.now();
+		const results = await Promise.all([
+			router.canDeliver(run.id, 'coder', 'planner'),
+			router.canDeliver(run.id, 'coder', 'planner'),
+			router.canDeliver(run.id, 'coder', 'planner'),
+			router.canDeliver(run.id, 'coder', 'planner'),
+			router.canDeliver(run.id, 'coder', 'planner'),
+		]);
+		const elapsed = Date.now() - start;
+
+		expect(results.every((r) => r.allowed)).toBe(true);
+		expect(elapsed).toBeLessThan(100);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Additional coalescing tests — re-evaluation semantics and cross-run isolation
+// ---------------------------------------------------------------------------
+
+describe('ChannelRouter async gate — coalescing re-evaluation and isolation', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	let taskRepo: SpaceTaskRepository;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let workflowManager: SpaceWorkflowManager;
+	let agentManager: SpaceAgentManager;
+	let gateDataRepo: GateDataRepository;
+	let channelCycleRepo: ChannelCycleRepository;
+
+	const SPACE_ID = 'space-coal-re';
+	const AGENT_CODER = 'agent-coal-coder';
+	const AGENT_PLANNER = 'agent-coal-planner';
+	const NODE_A = 'node-coal-a';
+	const NODE_B = 'node-coal-b';
+
+	beforeEach(() => {
+		const dbResult = makeDb();
+		db = dbResult.db;
+		dir = dbResult.dir;
+
+		seedSpace(db, SPACE_ID);
+		seedAgent(db, AGENT_CODER, SPACE_ID, 'coder');
+		seedAgent(db, AGENT_PLANNER, SPACE_ID, 'planner');
+
+		taskRepo = new SpaceTaskRepository(db);
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		gateDataRepo = new GateDataRepository(db);
+		channelCycleRepo = new ChannelCycleRepository(db);
+
+		const agentRepo = new SpaceAgentRepository(db);
+		agentManager = new SpaceAgentManager(agentRepo);
+
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		workflowManager = new SpaceWorkflowManager(workflowRepo);
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	function makeRouter(overrides: Record<string, unknown> = {}): ChannelRouter {
+		return new ChannelRouter({
+			taskRepo,
+			workflowRunRepo,
+			workflowManager,
+			agentManager,
+			gateDataRepo,
+			channelCycleRepo,
+			db,
+			...overrides,
+		});
+	}
+
+	function buildTwoNodeWorkflow(gate?: Gate, channelGateId?: string) {
+		const channels: WorkflowChannel[] = gate
+			? [{ from: 'coder', to: 'planner', direction: 'one-way', gateId: channelGateId ?? gate.id }]
+			: [];
+		return buildWorkflowWithGates(
+			SPACE_ID,
+			workflowManager,
+			[
+				{
+					id: NODE_A,
+					name: 'Coder Node',
+					agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+				},
+				{
+					id: NODE_B,
+					name: 'Planner Node',
+					agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+				},
+			],
+			channels,
+			gate ? [gate] : []
+		);
+	}
+
+	function createActiveRun(workflow: ReturnType<typeof buildWorkflowWithGates>) {
+		const run = workflowRunRepo.createRun({
+			spaceId: SPACE_ID,
+			workflowId: workflow.id,
+			title: 'Coalescing Run',
+		});
+		workflowRunRepo.transitionStatus(run.id, 'in_progress');
+		return run;
+	}
+
+	test('concurrent onGateDataChanged for same gate: second caller re-evaluates after first completes', async () => {
+		const gate: Gate = {
+			id: 're-eval-gate',
+			fields: [
+				{
+					name: 'votes',
+					type: 'map',
+					writers: ['*'],
+					check: { op: 'count', match: 'approved', min: 3 },
+				},
+			],
+			resetOnCycle: false,
+		};
+		const workflow = buildTwoNodeWorkflow(gate);
+		const run = createActiveRun(workflow);
+
+		const router = makeRouter();
+
+		// Set votes to 1 → gate closed
+		gateDataRepo.set(run.id, 're-eval-gate', { votes: { a: 'approved' } });
+		const result1 = await router.onGateDataChanged(run.id, 're-eval-gate');
+		expect(result1).toHaveLength(0);
+
+		// Set votes to 5 → gate opens
+		gateDataRepo.set(run.id, 're-eval-gate', {
+			votes: { a: 'approved', b: 'approved', c: 'approved', d: 'approved', e: 'approved' },
+		});
+
+		// Call onGateDataChanged twice concurrently — both should see votes: 5
+		const [r1, r2] = await Promise.all([
+			router.onGateDataChanged(run.id, 're-eval-gate'),
+			router.onGateDataChanged(run.id, 're-eval-gate'),
+		]);
+
+		// At least one call should activate the node (gate is open with 5 votes).
+		// The second may return empty due to idempotent activation (node already active).
+		const totalActivated = r1.length + r2.length;
+		expect(totalActivated).toBeGreaterThan(0);
+	});
+
+	test('different runId:gateId keys evaluate independently (script gates)', async () => {
+		const gate1: Gate = {
+			id: 'indep-gate-a',
+			script: {
+				interpreter: 'bash',
+				source: 'sleep 0.2; echo \'{"pass": true}\'',
+				timeoutMs: 5000,
+			},
+			fields: [{ name: 'pass', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			resetOnCycle: false,
+		};
+		const gate2: Gate = {
+			id: 'indep-gate-b',
+			script: {
+				interpreter: 'bash',
+				source: 'echo \'{"go": true}\'',
+				timeoutMs: 5000,
+			},
+			fields: [{ name: 'go', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			resetOnCycle: false,
+		};
+
+		const channels: WorkflowChannel[] = [
+			{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'indep-gate-a' },
+		];
+
+		const workflow = buildWorkflowWithGates(
+			SPACE_ID,
+			workflowManager,
+			[
+				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+			],
+			channels,
+			[gate1, gate2]
+		);
+		const run = createActiveRun(workflow);
+
+		const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
+
+		const start = Date.now();
+		const [r1, r2] = await Promise.all([
+			router.onGateDataChanged(run.id, 'indep-gate-a'),
+			router.onGateDataChanged(run.id, 'indep-gate-b'),
+		]);
+		const elapsed = Date.now() - start;
+
+		// Gate-a has a 0.2s sleep; gate-b is instant. With independent evaluation,
+		// both should complete quickly (not serialized).
+		expect(r1.length).toBeGreaterThan(0);
+		// gate-b is not on any channel, so onGateDataChanged returns empty
+		expect(r2).toHaveLength(0);
+		expect(elapsed).toBeLessThan(600);
+	});
+
+	test('two runs with same gateId and script: evaluations are isolated', async () => {
+		const gate: Gate = {
+			id: 'shared-script-gate',
+			script: {
+				interpreter: 'bash',
+				source: 'sleep 0.15; echo \'{"ok": true}\'',
+				timeoutMs: 5000,
+			},
+			fields: [{ name: 'ok', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			resetOnCycle: false,
+		};
+
+		const workflow = buildWorkflowWithGates(
+			SPACE_ID,
+			workflowManager,
+			[
+				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+			],
+			[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'shared-script-gate' }],
+			[gate]
+		);
+
+		const run1 = createActiveRun(workflow);
+		const run2 = createActiveRun(workflow);
+
+		const router = makeRouter({ workspacePath: '/tmp', maxConcurrentScripts: 2 });
+
+		const start = Date.now();
+		const [r1, r2] = await Promise.all([
+			router.canDeliver(run1.id, 'coder', 'planner'),
+			router.canDeliver(run2.id, 'coder', 'planner'),
+		]);
+		const elapsed = Date.now() - start;
+
+		expect(r1.allowed).toBe(true);
+		expect(r2.allowed).toBe(true);
+
+		// Two runs should evaluate independently (different composite keys).
+		// With maxConcurrentScripts=2, both should run concurrently.
+		expect(elapsed).toBeLessThan(500);
+	});
+
+	test('same gateId in different runs: gate data isolation', async () => {
+		const gate: Gate = {
+			id: 'iso-gate',
+			fields: [
+				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			resetOnCycle: false,
+		};
+
+		const workflow = buildWorkflowWithGates(
+			SPACE_ID,
+			workflowManager,
+			[
+				{ id: NODE_A, name: 'Coder', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				{ id: NODE_B, name: 'Planner', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+			],
+			[{ from: 'coder', to: 'planner', direction: 'one-way', gateId: 'iso-gate' }],
+			[gate]
+		);
+
+		const run1 = createActiveRun(workflow);
+		const run2 = createActiveRun(workflow);
+
+		// Run 1: approved = true → gate open
+		gateDataRepo.set(run1.id, 'iso-gate', { approved: true });
+		// Run 2: approved = false → gate closed
+		gateDataRepo.set(run2.id, 'iso-gate', { approved: false });
+
+		const router = makeRouter();
+
+		const [r1, r2] = await Promise.all([
+			router.canDeliver(run1.id, 'coder', 'planner'),
+			router.canDeliver(run2.id, 'coder', 'planner'),
+		]);
+
+		expect(r1.allowed).toBe(true);
+		expect(r2.allowed).toBe(false);
+	});
+
+	test('concurrent onGateDataChanged for same gate: sequential calls produce consistent results', async () => {
+		const gate: Gate = {
+			id: 'seq-gate',
+			fields: [
+				{
+					name: 'count',
+					type: 'map',
+					writers: ['*'],
+					check: { op: 'count', match: 'yes', min: 5 },
+				},
+			],
+			resetOnCycle: false,
+		};
+		const workflow = buildTwoNodeWorkflow(gate);
+		const run = createActiveRun(workflow);
+
+		const router = makeRouter();
+
+		// Sequentially update gate data and check evaluation
+		for (let i = 1; i <= 5; i++) {
+			const votes: Record<string, string> = {};
+			for (let j = 0; j < i; j++) votes[`v${j}`] = 'yes';
+			gateDataRepo.set(run.id, 'seq-gate', { count: votes });
+			const activated = await router.onGateDataChanged(run.id, 'seq-gate');
+			if (i < 5) {
+				expect(activated).toHaveLength(0);
+			} else {
+				expect(activated.length).toBeGreaterThan(0);
+			}
+		}
+	});
+});

--- a/packages/daemon/tests/unit/space/gate-evaluator.test.ts
+++ b/packages/daemon/tests/unit/space/gate-evaluator.test.ts
@@ -1200,3 +1200,266 @@ describe('validateGate', () => {
 		expect(errors.some((e) => e.includes('at least one'))).toBe(false);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// evaluateGate — script returns non-JSON stdout (empty data merge)
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — evaluateGate (non-JSON stdout)', () => {
+	const mockContext: GateScriptExecutorContext = {
+		workspacePath: '/workspace',
+		gateId: 'g1',
+		runId: 'run-1',
+	};
+
+	test('executor returns empty data (non-JSON stdout) → field evaluation uses original data', async () => {
+		const gate: Gate = {
+			id: 'g1',
+			fields: [
+				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			script: { interpreter: 'bash', source: 'echo "not json"' },
+			resetOnCycle: false,
+		};
+
+		// Simulates gate-script-executor behavior when stdout is not valid JSON:
+		// parseJsonStdout returns {}, so executor returns { success: true, data: {} }
+		const executor: GateScriptExecutorFn = async () => ({
+			success: true,
+			data: {},
+		});
+
+		// Original data has approved: true
+		const result = await evaluateGate(gate, { approved: true }, executor, mockContext);
+		expect(result.open).toBe(true);
+	});
+
+	test('executor returns empty data → field evaluation fails with original data', async () => {
+		const gate: Gate = {
+			id: 'g1',
+			fields: [
+				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			script: { interpreter: 'bash', source: 'echo "not json"' },
+			resetOnCycle: false,
+		};
+
+		const executor: GateScriptExecutorFn = async () => ({
+			success: true,
+			data: {},
+		});
+
+		// Original data has approved: false — should remain false after merge
+		const result = await evaluateGate(gate, { approved: false }, executor, mockContext);
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('approved');
+	});
+
+	test('executor returns empty data and no original data → field evaluation uses empty object', async () => {
+		const gate: Gate = {
+			id: 'g1',
+			fields: [{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			script: { interpreter: 'bash', source: 'echo "plaintext"' },
+			resetOnCycle: false,
+		};
+
+		const executor: GateScriptExecutorFn = async () => ({
+			success: true,
+			data: {},
+		});
+
+		const result = await evaluateGate(gate, {}, executor, mockContext);
+		expect(result.open).toBe(false);
+		expect(result.reason).toContain('does not exist');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Backward compatibility — gates without script field
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — backward compatibility (gates without script)', () => {
+	test('gate without script field evaluates fields normally', async () => {
+		const gate: Gate = {
+			id: 'legacy-gate',
+			fields: [
+				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			resetOnCycle: false,
+		};
+
+		const result = await evaluateGate(gate, { approved: true });
+		expect(result.open).toBe(true);
+	});
+
+	test('gate with script: undefined evaluates same as no script', async () => {
+		const gate: Gate = {
+			id: 'no-script-gate',
+			fields: [{ name: 'ready', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			script: undefined,
+			resetOnCycle: false,
+		};
+
+		// Script is undefined → scriptExecutor is never called
+		const executor: GateScriptExecutorFn = async () => {
+			throw new Error('should not be called');
+		};
+		const result = await evaluateGate(gate, { ready: true }, executor);
+		expect(result.open).toBe(true);
+	});
+
+	test('gate with script: null evaluates same as no script', async () => {
+		const gate: Gate = {
+			id: 'null-script-gate',
+			fields: [{ name: 'ready', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			script: null,
+			resetOnCycle: false,
+		};
+
+		const executor: GateScriptExecutorFn = async () => {
+			throw new Error('should not be called');
+		};
+		const result = await evaluateGate(gate, { ready: true }, executor);
+		expect(result.open).toBe(true);
+	});
+
+	test('gate with empty fields and no script opens (legacy runtime behavior)', async () => {
+		// At runtime, gates loaded from storage may have fields: [] and no script.
+		// evaluateFields handles this: empty array → no checks → open.
+		// This is different from validateGate (creation-time), which rejects it.
+		const gate: Gate = {
+			id: 'legacy-empty-gate',
+			fields: [],
+			resetOnCycle: false,
+		};
+
+		const result = await evaluateGate(gate, {});
+		expect(result.open).toBe(true);
+	});
+
+	test('gate with no fields key and no script opens (missing fields defaults to [])', async () => {
+		// Fields is optional on Gate; when absent, evaluateFields uses ?? []
+		const gate: Gate = {
+			id: 'no-fields-key-gate',
+			resetOnCycle: false,
+		};
+
+		const result = await evaluateGate(gate, {});
+		expect(result.open).toBe(true);
+	});
+
+	test('field-only gate with scriptExecutor provided is never called', async () => {
+		const gate: Gate = {
+			id: 'field-only-with-executor',
+			fields: [{ name: 'done', type: 'boolean', writers: ['*'], check: { op: '==', value: true } }],
+			resetOnCycle: false,
+		};
+
+		let called = false;
+		const executor: GateScriptExecutorFn = async () => {
+			called = true;
+			return { success: true, data: {} };
+		};
+
+		await evaluateGate(gate, { done: true }, executor);
+		expect(called).toBe(false);
+	});
+
+	test('gate with label and color but no script evaluates fields', async () => {
+		const gate: Gate = {
+			id: 'styled-gate',
+			label: 'Approval',
+			color: '#22c55e',
+			fields: [
+				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			resetOnCycle: false,
+		};
+
+		const result = await evaluateGate(gate, { approved: true });
+		expect(result.open).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isChannelOpen — remains synchronous
+// ---------------------------------------------------------------------------
+
+describe('GateEvaluator — isChannelOpen synchronous guarantee', () => {
+	test('isChannelOpen returns a plain object (not a Promise)', () => {
+		const channel: Channel = { id: 'ch-1', from: 'a', to: 'b' };
+		const result = isChannelOpen(channel, new Map());
+
+		// Verify it's not a thenable (Promise)
+		expect(typeof result.then).toBe('undefined');
+		expect(result.open).toBe(true);
+	});
+
+	test('isChannelOpen with gated channel returns plain object (not a Promise)', () => {
+		const gate: Gate = {
+			id: 'g1',
+			fields: [
+				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			resetOnCycle: false,
+		};
+		const channel: Channel = { id: 'ch-1', from: 'a', to: 'b', gateId: 'g1' };
+		const gates = new Map<string, Gate>([['g1', gate]]);
+
+		const result = isChannelOpen(channel, gates, new Map());
+
+		expect(typeof result.then).toBe('undefined');
+		expect(result.open).toBe(false);
+	});
+
+	test('isChannelOpen ignores gate script — no async execution', () => {
+		const gate: Gate = {
+			id: 'g1',
+			script: { interpreter: 'bash', source: 'echo fail; exit 1' },
+			fields: [
+				{ name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			resetOnCycle: false,
+		};
+		const channel: Channel = { id: 'ch-1', from: 'a', to: 'b', gateId: 'g1' };
+		const gates = new Map<string, Gate>([['g1', gate]]);
+
+		// Gate has a script that would fail, but isChannelOpen never runs it.
+		// It only evaluates fields, and with approved: true the gate opens.
+		const gateData = new Map<string, Record<string, unknown>>([['g1', { approved: true }]]);
+		const result = isChannelOpen(channel, gates, gateData);
+
+		expect(typeof result.then).toBe('undefined');
+		expect(result.open).toBe(true);
+	});
+
+	test('isChannelOpen with script-only gate (no fields) opens without running script', () => {
+		const gate: Gate = {
+			id: 'g1',
+			script: { interpreter: 'bash', source: 'exit 1' },
+			resetOnCycle: false,
+		};
+		const channel: Channel = { id: 'ch-1', from: 'a', to: 'b', gateId: 'g1' };
+		const gates = new Map<string, Gate>([['g1', gate]]);
+
+		// Script-only gate: isChannelOpen uses evaluateFields which checks gate.fields ?? [].
+		// Empty fields → open. Script is never run.
+		const result = isChannelOpen(channel, gates);
+
+		expect(typeof result.then).toBe('undefined');
+		expect(result.open).toBe(true);
+	});
+
+	test('isChannelOpen works with gate that has optional fields (undefined)', () => {
+		const gate: Gate = {
+			id: 'g1',
+			resetOnCycle: false,
+		};
+		const channel: Channel = { id: 'ch-1', from: 'a', to: 'b', gateId: 'g1' };
+		const gates = new Map<string, Gate>([['g1', gate]]);
+
+		const result = isChannelOpen(channel, gates);
+		expect(typeof result.then).toBe('undefined');
+		expect(result.open).toBe(true);
+	});
+});


### PR DESCRIPTION
Address code review feedback on #1222:

- Consolidate 3 top-level describe blocks into 1, removing duplicated beforeEach/afterEach/makeRouter helpers
- Replace flaky wall-clock timing assertions in new tests with correctness-based verification
- Add `isChannelOpen synchronous behavior via ChannelRouter` test block
- Fix comment mismatch on coalescing timing description (≈600ms theoretical, threshold 400ms)