### PR TITLE
feat: wire node-agent-tools for async gate evaluation

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -77,6 +77,7 @@ import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
 import { CompletionDetector } from './completion-detector';
+import { executeGateScript } from './gate-script-executor';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
 import { Logger } from '../../logger';
 import { SpaceTaskManager } from '../managers/space-task-manager';
@@ -1776,6 +1777,8 @@ export class TaskAgentManager {
 			workflow,
 			gateDataRepo: this.config.gateDataRepo,
 			onGateDataChanged: (runId, gateId) => nodeAgentChannelRouter.onGateDataChanged(runId, gateId),
+			scriptExecutor: executeGateScript,
+			scriptContext: { workspacePath, runId: workflowRunId, gateId: '' },
 		});
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1778,6 +1778,7 @@ export class TaskAgentManager {
 			gateDataRepo: this.config.gateDataRepo,
 			onGateDataChanged: (runId, gateId) => nodeAgentChannelRouter.onGateDataChanged(runId, gateId),
 			scriptExecutor: executeGateScript,
+			// gateId is overridden per-gate by the handler ({ ...scriptContext, gateId })
 			scriptContext: { workspacePath, runId: workflowRunId, gateId: '' },
 		});
 	}

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -709,7 +709,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			}
 
 			// Merge data into gate_data table
-			const updated = gateDataRepo.merge(workflowRunId, gateId, data);
+			let updated = gateDataRepo.merge(workflowRunId, gateId, data);
 
 			// Re-evaluate gate with updated data. Uses scriptExecutor when available for
 			// async script-based gates; otherwise falls back to field-only evaluation.
@@ -720,11 +720,24 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				scriptContext ? { ...scriptContext, gateId } : undefined
 			);
 
-			// Store script evaluation failure reason in gate data for frontend transport.
-			// This flows through the space.gateData.updated event to the UI (Task 4.6).
-			if (evalResult.reason && gateDef.script && !evalResult.open) {
-				updated.data._scriptResult = { success: false, reason: evalResult.reason };
+			// Persist script evaluation result to gate data for frontend transport.
+			// Only set _scriptResult when a scriptExecutor actually ran (not when a
+			// field-only check fails on a script-annotated gate without an executor).
+			// Persisted to DB so re-fetches include the result.
+			if (scriptExecutor && gateDef.script && !evalResult.open && evalResult.reason) {
+				updated = gateDataRepo.merge(workflowRunId, gateId, {
+					_scriptResult: { success: false, reason: evalResult.reason },
+				});
+			} else if (updated.data._scriptResult) {
+				// Clean up stale _scriptResult from a previous failed script evaluation
+				const { _scriptResult, ...rest } = updated.data;
+				updated = gateDataRepo.set(workflowRunId, gateId, rest);
 			}
+
+			// TODO (P2): evaluateGate deep-merges script output into a local copy of
+			// gateData, but the merged data is not returned to the caller. The event
+			// below emits pre-script data. To fix, evaluateGate should return
+			// { open, reason, mergedData? } so callers can persist/emit the merged state.
 
 			// Trigger re-evaluation and lazy node activation for channels referencing
 			// this gate (fire-and-forget — response is not delayed waiting for activation).

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -31,7 +31,11 @@ import { Logger } from '../../logger';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import { ChannelResolver } from '../runtime/channel-resolver';
-import { evaluateGate } from '../runtime/gate-evaluator';
+import {
+	evaluateGate,
+	type GateScriptExecutorFn,
+	type GateScriptExecutorContext,
+} from '../runtime/gate-evaluator';
 import type { AgentMessageRouter } from '../runtime/agent-message-router';
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { SpaceWorkflow } from '@neokai/shared';
@@ -135,6 +139,18 @@ export interface NodeAgentToolsConfig {
 	 * When absent, nodes are activated at the next `deliverMessage` call instead.
 	 */
 	onGateDataChanged?: (runId: string, gateId: string) => Promise<unknown>;
+	/**
+	 * Optional script executor for async gate evaluation.
+	 * When provided, `write_gate` and `read_gate` run gate scripts before
+	 * field evaluation. When absent, script-based gates report as open
+	 * (sync-only path — documented limitation for `list_gates`).
+	 */
+	scriptExecutor?: GateScriptExecutorFn;
+	/**
+	 * Context for gate script execution (workspace path, gate/run IDs).
+	 * Required when `scriptExecutor` is provided.
+	 */
+	scriptContext?: GateScriptExecutorContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -163,6 +179,8 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		workflow,
 		gateDataRepo,
 		onGateDataChanged,
+		scriptExecutor,
+		scriptContext,
 	} = config;
 
 	return {
@@ -609,8 +627,14 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			const record = gateDataRepo.get(workflowRunId, gateId);
 			const currentData = record?.data ?? computeGateDefaults(gateDef.fields ?? []);
 
-			// Evaluate current gate status (no scriptExecutor — script-based gates report as open)
-			const evalResult = await evaluateGate(gateDef, currentData);
+			// Evaluate current gate status. Uses scriptExecutor when available for
+			// async script-based gates; otherwise falls back to field-only evaluation.
+			const evalResult = await evaluateGate(
+				gateDef,
+				currentData,
+				scriptExecutor,
+				scriptContext ? { ...scriptContext, gateId } : undefined
+			);
 
 			return jsonResult({
 				success: true,
@@ -687,8 +711,20 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			// Merge data into gate_data table
 			const updated = gateDataRepo.merge(workflowRunId, gateId, data);
 
-			// Re-evaluate gate with updated data (no scriptExecutor — script-based gates report as open)
-			const evalResult = await evaluateGate(gateDef, updated.data);
+			// Re-evaluate gate with updated data. Uses scriptExecutor when available for
+			// async script-based gates; otherwise falls back to field-only evaluation.
+			const evalResult = await evaluateGate(
+				gateDef,
+				updated.data,
+				scriptExecutor,
+				scriptContext ? { ...scriptContext, gateId } : undefined
+			);
+
+			// Store script evaluation failure reason in gate data for frontend transport.
+			// This flows through the space.gateData.updated event to the UI (Task 4.6).
+			if (evalResult.reason && gateDef.script && !evalResult.open) {
+				updated.data._scriptResult = { success: false, reason: evalResult.reason };
+			}
 
 			// Trigger re-evaluation and lazy node activation for channels referencing
 			// this gate (fire-and-forget — response is not delayed waiting for activation).

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -2128,7 +2128,7 @@ describe('node-agent-tools: async gate evaluation', () => {
 		expect(data.reason).toContain('Script check failed');
 	});
 
-	test('write_gate stores _scriptResult in gate data when script fails', async () => {
+	test('write_gate persists _scriptResult to DB when script fails', async () => {
 		const gate: Gate = {
 			id: 'gate-script-result',
 			fields: [{ name: 'x', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
@@ -2146,8 +2146,10 @@ describe('node-agent-tools: async gate evaluation', () => {
 			error: 'some reason',
 		});
 
+		const gateDataRepo = new GateDataRepository(ctx.db);
 		const config = makeConfig(ctx, {
 			workflow,
+			gateDataRepo,
 			scriptExecutor: mockExecutor,
 			scriptContext: {
 				workspacePath: '/tmp',
@@ -2161,11 +2163,16 @@ describe('node-agent-tools: async gate evaluation', () => {
 
 		expect(data.success).toBe(true);
 		expect(data.gateOpen).toBe(false);
-		// _scriptResult should be in updatedData — reason is the evalResult.reason
-		// which includes "Script check failed: " prefix from evaluateGate
 		const scriptResult = data.updatedData._scriptResult as { success: boolean; reason: string };
 		expect(scriptResult.success).toBe(false);
 		expect(scriptResult.reason).toContain('some reason');
+
+		// P0: _scriptResult should survive a DB re-fetch
+		const dbRecord = gateDataRepo.get(ctx.workflowRunId, 'gate-script-result');
+		expect(dbRecord).not.toBeNull();
+		const dbScriptResult = dbRecord!.data._scriptResult as { success: boolean; reason: string };
+		expect(dbScriptResult.success).toBe(false);
+		expect(dbScriptResult.reason).toContain('some reason');
 	});
 
 	test('write_gate emits space.gateData.updated with _scriptResult when script fails', async () => {
@@ -2369,6 +2376,95 @@ describe('node-agent-tools: async gate evaluation', () => {
 		expect(receivedContext!.runId).toBe('run-123');
 		// gateId should be overridden per-gate from the handler
 		expect(receivedContext!.gateId).toBe('gate-context-check');
+	});
+
+	test('write_gate does not store _scriptResult on field failure without executor (P1)', async () => {
+		// Gate has both script and fields, but no scriptExecutor is wired.
+		// A field-check failure should NOT produce a _scriptResult because
+		// the script was never actually executed.
+		const gate: Gate = {
+			id: 'gate-p1-bug',
+			fields: [
+				{ name: 'ready', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			script: {
+				interpreter: 'bash',
+				source: 'echo "never runs"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		const gateDataRepo = new GateDataRepository(ctx.db);
+		// No scriptExecutor provided — falls back to field-only evaluation
+		const config = makeConfig(ctx, { workflow, gateDataRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-p1-bug', data: { ready: false } });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(false);
+		expect(data.reason).toContain('ready');
+		// _scriptResult should NOT be present — it's a field failure, not a script failure
+		expect(data.updatedData._scriptResult).toBeUndefined();
+
+		// Verify it's not in the DB either
+		const dbRecord = gateDataRepo.get(ctx.workflowRunId, 'gate-p1-bug');
+		expect(dbRecord).not.toBeNull();
+		expect(dbRecord!.data._scriptResult).toBeUndefined();
+	});
+
+	test('write_gate cleans up stale _scriptResult on subsequent success', async () => {
+		const gate: Gate = {
+			id: 'gate-cleanup',
+			fields: [
+				{ name: 'ready', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			script: {
+				interpreter: 'bash',
+				source: 'echo "ok"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		const gateDataRepo = new GateDataRepository(ctx.db);
+		let callCount = 0;
+		const mockExecutor = async () => {
+			callCount++;
+			if (callCount === 1) {
+				return { success: false, data: {}, error: 'first run fails' };
+			}
+			return { success: true, data: { ready: true }, error: undefined };
+		};
+
+		const config = makeConfig(ctx, {
+			workflow,
+			gateDataRepo,
+			scriptExecutor: mockExecutor,
+			scriptContext: {
+				workspacePath: '/tmp',
+				runId: ctx.workflowRunId,
+				gateId: 'gate-cleanup',
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// First write: script fails, _scriptResult should be persisted
+		const result1 = await handlers.write_gate({ gateId: 'gate-cleanup', data: {} });
+		const data1 = JSON.parse(result1.content[0].text);
+		expect(data1.gateOpen).toBe(false);
+		expect(data1.updatedData._scriptResult).toBeDefined();
+		let dbRecord = gateDataRepo.get(ctx.workflowRunId, 'gate-cleanup');
+		expect(dbRecord!.data._scriptResult).toBeDefined();
+
+		// Second write: script succeeds, _scriptResult should be cleaned up
+		const result2 = await handlers.write_gate({ gateId: 'gate-cleanup', data: {} });
+		const data2 = JSON.parse(result2.content[0].text);
+		expect(data2.gateOpen).toBe(true);
+		expect(data2.updatedData._scriptResult).toBeUndefined();
+		dbRecord = gateDataRepo.get(ctx.workflowRunId, 'gate-cleanup');
+		expect(dbRecord!.data._scriptResult).toBeUndefined();
 	});
 
 	test('script-only gate does not crash at field authorization (no fields)', async () => {

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -2022,3 +2022,391 @@ describe('list_peers — completion state', () => {
 		}
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Tests: async gate evaluation (scriptExecutor + scriptContext)
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: async gate evaluation', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	function makeWorkflowWithGate(gate: Gate, spaceId: string): SpaceWorkflow {
+		return {
+			id: 'wf-1',
+			spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [gate],
+		};
+	}
+
+	test('write_gate uses scriptExecutor when provided (script passes)', async () => {
+		const gate: Gate = {
+			id: 'gate-script-pass',
+			fields: [
+				{ name: 'ready', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			script: {
+				interpreter: 'bash',
+				source: 'echo "ok"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		// Script executor that returns success with merged data
+		const mockExecutor = async () => ({
+			success: true,
+			data: { ready: true },
+			error: undefined,
+		});
+
+		const config = makeConfig(ctx, {
+			workflow,
+			scriptExecutor: mockExecutor,
+			scriptContext: {
+				workspacePath: '/tmp',
+				runId: ctx.workflowRunId,
+				gateId: 'gate-script-pass',
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-script-pass', data: {} });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(true);
+	});
+
+	test('write_gate uses scriptExecutor when provided (script fails)', async () => {
+		const gate: Gate = {
+			id: 'gate-script-fail',
+			fields: [{ name: 'x', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			script: {
+				interpreter: 'bash',
+				source: 'exit 1',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		const mockExecutor = async () => ({
+			success: false,
+			data: {},
+			error: 'Script check failed: exit code 1',
+		});
+
+		const config = makeConfig(ctx, {
+			workflow,
+			scriptExecutor: mockExecutor,
+			scriptContext: {
+				workspacePath: '/tmp',
+				runId: ctx.workflowRunId,
+				gateId: 'gate-script-fail',
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-script-fail', data: {} });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(false);
+		expect(data.reason).toContain('Script check failed');
+	});
+
+	test('write_gate stores _scriptResult in gate data when script fails', async () => {
+		const gate: Gate = {
+			id: 'gate-script-result',
+			fields: [{ name: 'x', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			script: {
+				interpreter: 'bash',
+				source: 'echo "fail"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		const mockExecutor = async () => ({
+			success: false,
+			data: {},
+			error: 'some reason',
+		});
+
+		const config = makeConfig(ctx, {
+			workflow,
+			scriptExecutor: mockExecutor,
+			scriptContext: {
+				workspacePath: '/tmp',
+				runId: ctx.workflowRunId,
+				gateId: 'gate-script-result',
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-script-result', data: {} });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(false);
+		// _scriptResult should be in updatedData — reason is the evalResult.reason
+		// which includes "Script check failed: " prefix from evaluateGate
+		const scriptResult = data.updatedData._scriptResult as { success: boolean; reason: string };
+		expect(scriptResult.success).toBe(false);
+		expect(scriptResult.reason).toContain('some reason');
+	});
+
+	test('write_gate emits space.gateData.updated with _scriptResult when script fails', async () => {
+		const gate: Gate = {
+			id: 'gate-event',
+			fields: [{ name: 'x', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			script: {
+				interpreter: 'bash',
+				source: 'exit 1',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		const mockExecutor = async () => ({
+			success: false,
+			data: {},
+			error: 'Script failed',
+		});
+
+		const emitted: Array<{ name: string; payload: Record<string, unknown> }> = [];
+		const fakeDaemonHub = {
+			emit: async (name: string, payload: unknown) => {
+				emitted.push({ name, payload: payload as Record<string, unknown> });
+			},
+		};
+
+		const config = makeConfig(ctx, {
+			workflow,
+			scriptExecutor: mockExecutor,
+			scriptContext: { workspacePath: '/tmp', runId: ctx.workflowRunId, gateId: 'gate-event' },
+			daemonHub: fakeDaemonHub as unknown as NodeAgentToolsConfig['daemonHub'],
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		await handlers.write_gate({ gateId: 'gate-event', data: {} });
+
+		// Allow microtasks to flush
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(emitted).toHaveLength(1);
+		expect(emitted[0].name).toBe('space.gateData.updated');
+		const payload = emitted[0].payload;
+		expect(payload.gateId).toBe('gate-event');
+		// _scriptResult should be in the emitted data
+		expect(payload.data).toBeDefined();
+		const gateData = payload.data as Record<string, unknown>;
+		expect(gateData._scriptResult).toEqual({
+			success: false,
+			reason: expect.stringContaining('Script failed'),
+		});
+	});
+
+	test('write_gate does not store _scriptResult when script passes', async () => {
+		const gate: Gate = {
+			id: 'gate-no-result',
+			fields: [
+				{ name: 'ready', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			script: {
+				interpreter: 'bash',
+				source: 'echo "ok"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		const mockExecutor = async () => ({
+			success: true,
+			data: { ready: true },
+			error: undefined,
+		});
+
+		const config = makeConfig(ctx, {
+			workflow,
+			scriptExecutor: mockExecutor,
+			scriptContext: { workspacePath: '/tmp', runId: ctx.workflowRunId, gateId: 'gate-no-result' },
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-no-result', data: {} });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(true);
+		expect(data.updatedData._scriptResult).toBeUndefined();
+	});
+
+	test('read_gate uses scriptExecutor when provided', async () => {
+		const gate: Gate = {
+			id: 'gate-read-script',
+			fields: [],
+			script: {
+				interpreter: 'bash',
+				source: 'exit 1',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		const mockExecutor = async () => ({
+			success: false,
+			data: {},
+			error: 'Script failed',
+		});
+
+		const config = makeConfig(ctx, {
+			workflow,
+			scriptExecutor: mockExecutor,
+			scriptContext: {
+				workspacePath: '/tmp',
+				runId: ctx.workflowRunId,
+				gateId: 'gate-read-script',
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.read_gate({ gateId: 'gate-read-script' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(false);
+		expect(data.reason).toContain('Script check failed');
+	});
+
+	test('read_gate without scriptExecutor reports script-only gate as open', async () => {
+		const gate: Gate = {
+			id: 'gate-read-no-exec',
+			fields: [],
+			script: {
+				interpreter: 'bash',
+				source: 'echo "should not run"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		// No scriptExecutor provided — script-only gates report as open (documented limitation)
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.read_gate({ gateId: 'gate-read-no-exec' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateOpen).toBe(true);
+	});
+
+	test('write_gate without scriptExecutor reports script-only gate as open', async () => {
+		const gate: Gate = {
+			id: 'gate-write-no-exec',
+			fields: [{ name: 'x', type: 'boolean', writers: ['*'], check: { op: 'exists' } }],
+			script: {
+				interpreter: 'bash',
+				source: 'echo "should not run"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		// No scriptExecutor provided — script check is skipped
+		const config = makeConfig(ctx, { workflow });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({ gateId: 'gate-write-no-exec', data: { x: true } });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		// Gate should be open because script is skipped and field check passes
+		expect(data.gateOpen).toBe(true);
+	});
+
+	test('scriptExecutor receives correct context with gateId', async () => {
+		const gate: Gate = {
+			id: 'gate-context-check',
+			fields: [
+				{ name: 'ready', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+			],
+			script: {
+				interpreter: 'bash',
+				source: 'echo "ok"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		let receivedContext: { workspacePath: string; runId: string; gateId: string } | null = null;
+		const mockExecutor = async (
+			_script: import('@neokai/shared').GateScript,
+			context: { workspacePath: string; runId: string; gateId: string }
+		) => {
+			receivedContext = context;
+			return { success: true, data: { ready: true }, error: undefined };
+		};
+
+		const config = makeConfig(ctx, {
+			workflow,
+			scriptExecutor: mockExecutor,
+			scriptContext: { workspacePath: '/my-workspace', runId: 'run-123', gateId: '' },
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		await handlers.write_gate({ gateId: 'gate-context-check', data: {} });
+
+		expect(receivedContext).not.toBeNull();
+		expect(receivedContext!.workspacePath).toBe('/my-workspace');
+		expect(receivedContext!.runId).toBe('run-123');
+		// gateId should be overridden per-gate from the handler
+		expect(receivedContext!.gateId).toBe('gate-context-check');
+	});
+
+	test('script-only gate does not crash at field authorization (no fields)', async () => {
+		// Script-only gate (no fields) — any write attempt should be rejected at
+		// the field authorization layer (fieldMap will be empty), not crash.
+		const gate: Gate = {
+			id: 'gate-script-only-no-crash',
+			script: {
+				interpreter: 'bash',
+				source: 'echo "ok"',
+			},
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGate(gate, ctx.spaceId);
+
+		const mockExecutor = async () => ({
+			success: true,
+			data: {},
+			error: undefined,
+		});
+
+		const config = makeConfig(ctx, {
+			workflow,
+			scriptExecutor: mockExecutor,
+			scriptContext: {
+				workspacePath: '/tmp',
+				runId: ctx.workflowRunId,
+				gateId: 'gate-script-only-no-crash',
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.write_gate({
+			gateId: 'gate-script-only-no-crash',
+			data: { anyKey: 'val' },
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('not declared');
+	});
+});


### PR DESCRIPTION
## Summary
- Add `scriptExecutor` and `scriptContext` to `NodeAgentToolsConfig` so `write_gate` and `read_gate` can run gate scripts before field evaluation
- Store script failure reason under `_scriptResult` key in gate data for frontend transport via `space.gateData.updated` event
- Wire `executeGateScript` in `buildNodeAgentMcpServerForSession` to enable async gate evaluation from node agent sub-sessions

## Test plan
- [x] 10 new unit tests covering: script pass/fail, `_scriptResult` storage, event emission with `_scriptResult`, `read_gate` with scriptExecutor, no-executor fallback, context propagation, script-only gate safety
- [x] All 78 existing node-agent-tools tests still pass
- [x] TypeScript type check, lint, format, knip all clean