### PR TITLE
perf: eliminate redundant queries on room entry and parallelize subscriptions

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -27,7 +27,7 @@ import type {
 	RewindResult,
 } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
-import type { Room, NeoTask, TaskSummary } from '@neokai/shared';
+import type { Room, NeoTask } from '@neokai/shared';
 
 /**
  * Compaction trigger type
@@ -207,8 +207,6 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		sessionId: string; // 'room:${roomId}' for channel routing
 		room: Room;
 		sessions: { id: string; title: string; status: string; lastActiveAt: number }[];
-		activeTasks: TaskSummary[];
-		allTasks?: TaskSummary[];
 	};
 	'room.runtime.stateChanged': {
 		sessionId: string; // 'room:${roomId}' for channel routing

--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -58,8 +58,6 @@ export interface NeoQueryRoomManager {
 	getRoomOverview(roomId: string): {
 		room: Room;
 		sessions: { id: string; title: string; status: string; lastActiveAt: number }[];
-		activeTasks: TaskSummary[];
-		allTasks?: TaskSummary[];
 	} | null;
 }
 
@@ -278,7 +276,7 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 				return errorResult(`Room not found: ${args.room_id}`);
 			}
 
-			const { room, sessions, activeTasks, allTasks } = overview;
+			const { room, sessions } = overview;
 			const goals = goalRepository.listGoals(room.id);
 
 			const goalsSummary = goals.map((g) => ({
@@ -292,6 +290,29 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 				linkedTaskCount: g.linkedTaskIds.length,
 			}));
 
+			const toSummary = (task: NeoTask): TaskSummary => ({
+				id: task.id,
+				shortId: task.shortId,
+				title: task.title,
+				status: task.status,
+				priority: task.priority,
+				progress: task.progress,
+				currentStep: task.currentStep,
+				dependsOn: task.dependsOn,
+				error: task.error,
+				activeSession: task.activeSession,
+				prUrl: task.prUrl,
+				prNumber: task.prNumber,
+				updatedAt: task.updatedAt,
+			});
+
+			const allTasks = taskRepository.listTasks(room.id, { includeArchived: true });
+			const nonTerminal = allTasks.filter(
+				(t) =>
+					t.status !== 'completed' && t.status !== 'needs_attention' && t.status !== 'cancelled'
+			);
+			const activeTasks = nonTerminal.map(toSummary);
+
 			return jsonResult({
 				id: room.id,
 				name: room.name,
@@ -303,7 +324,7 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 				sessions,
 				goals: goalsSummary,
 				activeTasks,
-				allTaskCount: allTasks?.length ?? activeTasks.length,
+				allTaskCount: allTasks.length,
 				createdAt: room.createdAt,
 				updatedAt: room.updatedAt,
 			});

--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -35,7 +35,6 @@ import type {
 	AuthStatus,
 	Room,
 	RoomGoal,
-	TaskSummary,
 	AppMcpServer,
 	AppSkill,
 	Space,
@@ -47,6 +46,7 @@ import type {
 	MissionExecution,
 } from '@neokai/shared';
 import { isWorkerSessionId } from '../../room/session-utils';
+import { toTaskSummary } from '../../task-utils';
 
 // ---------------------------------------------------------------------------
 // Minimal interfaces — only the surface used by these tools
@@ -290,28 +290,12 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 				linkedTaskCount: g.linkedTaskIds.length,
 			}));
 
-			const toSummary = (task: NeoTask): TaskSummary => ({
-				id: task.id,
-				shortId: task.shortId,
-				title: task.title,
-				status: task.status,
-				priority: task.priority,
-				progress: task.progress,
-				currentStep: task.currentStep,
-				dependsOn: task.dependsOn,
-				error: task.error,
-				activeSession: task.activeSession,
-				prUrl: task.prUrl,
-				prNumber: task.prNumber,
-				updatedAt: task.updatedAt,
-			});
-
 			const allTasks = taskRepository.listTasks(room.id, { includeArchived: true });
 			const nonTerminal = allTasks.filter(
 				(t) =>
 					t.status !== 'completed' && t.status !== 'needs_attention' && t.status !== 'cancelled'
 			);
-			const activeTasks = nonTerminal.map(toSummary);
+			const activeTasks = nonTerminal.map(toTaskSummary);
 
 			return jsonResult({
 				id: room.id,

--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -17,14 +17,7 @@ import { TaskRepository } from '../../../storage/repositories/task-repository';
 import { SessionRepository } from '../../../storage/repositories/session-repository';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { isWorkerSessionId } from '../session-utils';
-import type {
-	Room,
-	CreateRoomParams,
-	UpdateRoomParams,
-	RoomOverview,
-	TaskSummary,
-	NeoTask,
-} from '@neokai/shared';
+import type { Room, CreateRoomParams, UpdateRoomParams, RoomOverview } from '@neokai/shared';
 
 export class RoomManager {
 	private db: BunDatabase;
@@ -125,32 +118,6 @@ export class RoomManager {
 		const room = this.roomRepo.getRoom(roomId);
 		if (!room) return null;
 
-		// Get non-archived tasks for activeTasks
-		const tasks = this.taskRepo.listTasks(roomId);
-		// Get all tasks including archived for allTasks field
-		const allTasks = this.taskRepo.listTasks(roomId, { includeArchived: true });
-
-		const toSummary = (task: NeoTask): TaskSummary => ({
-			id: task.id,
-			shortId: task.shortId,
-			title: task.title,
-			status: task.status,
-			priority: task.priority,
-			progress: task.progress,
-			currentStep: task.currentStep,
-			dependsOn: task.dependsOn,
-			error: task.error,
-			activeSession: task.activeSession,
-			prUrl: task.prUrl,
-			prNumber: task.prNumber,
-			updatedAt: task.updatedAt,
-		});
-		const nonTerminal = tasks.filter(
-			(t) => t.status !== 'completed' && t.status !== 'needs_attention' && t.status !== 'cancelled'
-		);
-		const taskSummaries = nonTerminal.map(toSummary);
-		const allTaskSummaries = allTasks.map(toSummary);
-
 		// Build session summaries from actual session data (batch query to avoid N+1)
 		// Filter out room-specific sessions (chat, craft, lead) and archived (deleted) sessions
 		const workerIds = room.sessionIds.filter(isWorkerSessionId);
@@ -184,8 +151,6 @@ export class RoomManager {
 		return {
 			room,
 			sessions,
-			activeTasks: taskSummaries,
-			allTasks: allTaskSummaries,
 		};
 	}
 

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -16,9 +16,10 @@
  * - task.updateDraft - Persist human input draft for a task (server-side, debounced by client)
  * - task.group.create - (non-production) Create a synthetic session group for a task
  * - task.group.addMessage - (non-production) Insert a synthetic canonical timeline row
+ * - inbox.reviewTasks - Get all review-status tasks across all active rooms
  */
 
-import type { MessageHub, TaskPriority, TaskStatus } from '@neokai/shared';
+import type { MessageHub, TaskPriority, TaskStatus, TaskSummary } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { ReactiveDatabase } from '../../storage/reactive-database';
@@ -1118,5 +1119,43 @@ export function setupTaskHandlers(
 		// TODO: remove once session LiveQuery covers list
 		emitRoomOverview(params.roomId);
 		return { success: true };
+	});
+
+	// inbox.reviewTasks - Get all review-status tasks across all active rooms.
+	// Replaces the client-side fan-out of room.get calls with a single targeted query
+	// that only reads task rows (no session/overview overhead).
+	messageHub.onRequest('inbox.reviewTasks', async () => {
+		const rooms = roomManager.listRooms(false);
+		const reviewTasks: Array<{ task: TaskSummary; roomId: string; roomTitle: string }> = [];
+
+		for (const room of rooms) {
+			const tasks = makeTaskRepo().listTasks(room.id);
+			for (const task of tasks) {
+				if (task.status === 'review') {
+					reviewTasks.push({
+						task: {
+							id: task.id,
+							shortId: task.shortId,
+							title: task.title,
+							status: task.status,
+							priority: task.priority,
+							progress: task.progress,
+							currentStep: task.currentStep,
+							dependsOn: task.dependsOn,
+							error: task.error,
+							activeSession: task.activeSession,
+							prUrl: task.prUrl,
+							prNumber: task.prNumber,
+							updatedAt: task.updatedAt,
+						},
+						roomId: room.id,
+						roomTitle: room.name,
+					});
+				}
+			}
+		}
+
+		reviewTasks.sort((a, b) => b.task.updatedAt - a.task.updatedAt);
+		return { tasks: reviewTasks };
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -73,8 +73,6 @@ export function setupTaskHandlers(
 					sessionId: `room:${roomId}`,
 					room: overview.room,
 					sessions: overview.sessions,
-					activeTasks: overview.activeTasks,
-					allTasks: overview.allTasks,
 				})
 				.catch((error) => {
 					log.warn(`Failed to emit room.overview for room ${roomId}:`, error);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -28,6 +28,7 @@ import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { TaskManager, VALID_STATUS_TRANSITIONS } from '../room/managers/task-manager';
 import { TaskRepository } from '../../storage/repositories/task-repository';
 import { resolveTaskId } from '../id-resolution';
+import { toTaskSummary } from '../task-utils';
 import { SessionGroupRepository } from '../room/state/session-group-repository';
 import { routeHumanMessageToGroup } from '../room/runtime/human-message-routing';
 import { SDKMessageRepository } from '../../storage/repositories/sdk-message-repository';
@@ -1124,32 +1125,17 @@ export function setupTaskHandlers(
 	// that only reads task rows (no session/overview overhead).
 	messageHub.onRequest('inbox.reviewTasks', async () => {
 		const rooms = roomManager.listRooms(false);
+		const taskRepo = makeTaskRepo();
 		const reviewTasks: Array<{ task: TaskSummary; roomId: string; roomTitle: string }> = [];
 
 		for (const room of rooms) {
-			const tasks = makeTaskRepo().listTasks(room.id);
+			const tasks = taskRepo.listTasks(room.id, { status: 'review' });
 			for (const task of tasks) {
-				if (task.status === 'review') {
-					reviewTasks.push({
-						task: {
-							id: task.id,
-							shortId: task.shortId,
-							title: task.title,
-							status: task.status,
-							priority: task.priority,
-							progress: task.progress,
-							currentStep: task.currentStep,
-							dependsOn: task.dependsOn,
-							error: task.error,
-							activeSession: task.activeSession,
-							prUrl: task.prUrl,
-							prNumber: task.prNumber,
-							updatedAt: task.updatedAt,
-						},
-						roomId: room.id,
-						roomTitle: room.name,
-					});
-				}
+				reviewTasks.push({
+					task: toTaskSummary(task),
+					roomId: room.id,
+					roomTitle: room.name,
+				});
 			}
 		}
 

--- a/packages/daemon/src/lib/task-utils.ts
+++ b/packages/daemon/src/lib/task-utils.ts
@@ -1,0 +1,22 @@
+import type { NeoTask, TaskSummary } from '@neokai/shared';
+
+/**
+ * Convert a full NeoTask to a lightweight TaskSummary for list/overview contexts.
+ */
+export function toTaskSummary(task: NeoTask): TaskSummary {
+	return {
+		id: task.id,
+		shortId: task.shortId,
+		title: task.title,
+		status: task.status,
+		priority: task.priority,
+		progress: task.progress,
+		currentStep: task.currentStep,
+		dependsOn: task.dependsOn,
+		error: task.error,
+		activeSession: task.activeSession,
+		prUrl: task.prUrl,
+		prNumber: task.prNumber,
+		updatedAt: task.updatedAt,
+	};
+}

--- a/packages/daemon/tests/online/room/short-id-flow.test.ts
+++ b/packages/daemon/tests/online/room/short-id-flow.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { createDaemonServer, type DaemonServerContext } from '../../helpers/daemon-server';
-import type { NeoTask, RoomGoal, RoomOverview } from '@neokai/shared';
+import type { NeoTask, RoomGoal } from '@neokai/shared';
 import { createRoom, createGoal } from './room-test-helpers';
 
 describe('Short ID Full Flow Integration', () => {
@@ -122,30 +122,30 @@ describe('Short ID Full Flow Integration', () => {
 			}
 		});
 
-		test('room.overview includes shortId in task summaries', async () => {
-			const roomId = await createRoom(daemon, 'short-id-overview');
+		test('task.list returns tasks with shortId', async () => {
+			const roomId = await createRoom(daemon, 'short-id-list');
 
 			try {
-				const task1 = await createTask(roomId, 'Overview task 1');
-				const task2 = await createTask(roomId, 'Overview task 2');
+				const task1 = await createTask(roomId, 'List task 1');
+				const task2 = await createTask(roomId, 'List task 2');
 
 				expect(task1.shortId).toBe('t-1');
 				expect(task2.shortId).toBe('t-2');
 
-				const overview = await getRoomOverview(roomId);
+				const result = (await daemon.messageHub.request('task.list', {
+					roomId,
+				})) as { tasks: unknown[] };
 
-				// allTasks includes all tasks (activeTasks excludes terminal tasks)
-				const allTasks = overview.allTasks!;
-				expect(allTasks.length).toBeGreaterThanOrEqual(2);
+				expect(result.tasks.length).toBeGreaterThanOrEqual(2);
 
-				const summary1 = allTasks.find((t) => t.id === task1.id);
-				const summary2 = allTasks.find((t) => t.id === task2.id);
+				const found1 = result.tasks.find((t: any) => t.id === task1.id);
+				const found2 = result.tasks.find((t: any) => t.id === task2.id);
 
-				expect(summary1).toBeDefined();
-				expect(summary1?.shortId).toBe('t-1');
+				expect(found1).toBeDefined();
+				expect(found1?.shortId).toBe('t-1');
 
-				expect(summary2).toBeDefined();
-				expect(summary2?.shortId).toBe('t-2');
+				expect(found2).toBeDefined();
+				expect(found2?.shortId).toBe('t-2');
 			} finally {
 				await deleteRoom(roomId);
 			}

--- a/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
+++ b/packages/daemon/tests/unit/neo/neo-query-tools.test.ts
@@ -150,7 +150,7 @@ function makeRoomManager(
 			if (overview && overview.room.id === roomId) return overview;
 			const room = rooms.find((r) => r.id === roomId);
 			if (!room) return null;
-			return { room, sessions: [], activeTasks: [], allTasks: [] };
+			return { room, sessions: [] };
 		},
 	};
 }
@@ -589,14 +589,22 @@ describe('get_room_details', () => {
 			makeGoal({ id: 'g1', title: 'Goal 1', status: 'active', progress: 50 }),
 			makeGoal({ id: 'g2', title: 'Goal 2', status: 'completed', progress: 100 }),
 		];
-		const activeTasks = [{ id: 'task-1', title: 'Task 1', status: 'in_progress' }];
 		const sessions = [{ id: 'session-1', title: 'Session 1', status: 'active', lastActiveAt: NOW }];
-
-		const overview = { room, sessions, activeTasks, allTasks: activeTasks };
+		const overview = { room, sessions };
+		const tasks = [
+			makeTask({
+				id: 'task-1',
+				roomId: 'room-1',
+				title: 'Task 1',
+				status: 'in_progress',
+				priority: 'normal',
+			}),
+		];
 		const handlers = createNeoQueryToolHandlers(
 			makeConfig({
 				roomManager: makeRoomManager([room], overview),
 				goalRepository: makeGoalRepository({ 'room-1': goals }),
+				taskRepository: makeTaskRepository({ 'room-1': tasks }),
 			})
 		);
 

--- a/packages/daemon/tests/unit/room/room-manager.test.ts
+++ b/packages/daemon/tests/unit/room/room-manager.test.ts
@@ -121,7 +121,7 @@ describe('RoomManager', () => {
 	});
 
 	describe('getRoomOverview', () => {
-		it('should return room overview with empty sessions and tasks', () => {
+		it('should return room overview with empty sessions ', () => {
 			const room = roomManager.createRoom({ name: 'Overview Room' });
 			const overview = roomManager.getRoomOverview(room.id);
 
@@ -129,7 +129,6 @@ describe('RoomManager', () => {
 			expect(overview?.room.id).toBe(room.id);
 			expect(overview?.room.name).toBe('Overview Room');
 			expect(overview?.sessions).toEqual([]);
-			expect(overview?.activeTasks).toEqual([]);
 		});
 
 		it('should return null for non-existent room', () => {
@@ -225,134 +224,6 @@ describe('RoomManager', () => {
 			expect(overview?.sessions[0].title).toBe('Session non-exis');
 		});
 
-		it('should include active tasks in overview', () => {
-			const room = roomManager.createRoom({ name: 'Room With Tasks' });
-			const dbRaw = db.getDatabase();
-
-			// Create some tasks directly in the database
-			dbRaw
-				.prepare(
-					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at)
-	           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-				)
-				.run(
-					'task-1',
-					room.id,
-					'Active Task',
-					'Description',
-					'in_progress',
-					'high',
-					'[]',
-					Date.now()
-				);
-			dbRaw
-				.prepare(
-					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at)
-	           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-				)
-				.run(
-					'task-2',
-					room.id,
-					'Completed Task',
-					'Description',
-					'completed',
-					'normal',
-					'[]',
-					Date.now()
-				);
-
-			const overview = roomManager.getRoomOverview(room.id);
-
-			// Only non-completed, non-failed tasks should be included
-			expect(overview?.activeTasks).toHaveLength(1);
-			expect(overview?.activeTasks[0].id).toBe('task-1');
-			expect(overview?.activeTasks[0].title).toBe('Active Task');
-			expect(overview?.activeTasks[0].status).toBe('in_progress');
-			expect(overview?.activeTasks[0].priority).toBe('high');
-		});
-
-		it('should include shortId in task summaries when present', () => {
-			const room = roomManager.createRoom({ name: 'Room With ShortId Tasks' });
-			const dbRaw = db.getDatabase();
-
-			// Insert a task with a short_id
-			dbRaw
-				.prepare(
-					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at, short_id)
-	           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-				)
-				.run(
-					'task-short-1',
-					room.id,
-					'Task With Short ID',
-					'Desc',
-					'pending',
-					'normal',
-					'[]',
-					Date.now(),
-					't-1'
-				);
-
-			// Insert a task without a short_id (legacy task)
-			dbRaw
-				.prepare(
-					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at)
-	           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-				)
-				.run(
-					'task-no-short',
-					room.id,
-					'Task Without Short ID',
-					'Desc',
-					'in_progress',
-					'normal',
-					'[]',
-					Date.now()
-				);
-
-			const overview = roomManager.getRoomOverview(room.id);
-
-			expect(overview?.activeTasks).toHaveLength(2);
-
-			const withShort = overview?.activeTasks.find((t) => t.id === 'task-short-1');
-			expect(withShort?.shortId).toBe('t-1');
-
-			const withoutShort = overview?.activeTasks.find((t) => t.id === 'task-no-short');
-			expect(withoutShort).toBeDefined();
-			// RoomManager creates TaskRepository without a ShortIdAllocator, so lazy backfill
-			// never fires — legacy tasks without short_id in DB always return undefined shortId
-			expect(withoutShort?.shortId).toBeUndefined();
-		});
-
-		it('should include shortId in allTasks summaries', () => {
-			const room = roomManager.createRoom({ name: 'Room allTasks ShortId' });
-			const dbRaw = db.getDatabase();
-
-			dbRaw
-				.prepare(
-					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at, short_id)
-	           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-				)
-				.run(
-					'task-done',
-					room.id,
-					'Completed Task',
-					'Desc',
-					'completed',
-					'normal',
-					'[]',
-					Date.now(),
-					't-2'
-				);
-
-			const overview = roomManager.getRoomOverview(room.id);
-
-			// Completed tasks are excluded from activeTasks but included in allTasks
-			expect(overview?.activeTasks).toHaveLength(0);
-			const inAll = overview?.allTasks?.find((t) => t.id === 'task-done');
-			expect(inAll?.shortId).toBe('t-2');
-		});
-
 		it('should batch-fetch sessions for multiple worker session IDs', () => {
 			const room = roomManager.createRoom({ name: 'Room Multi Worker' });
 			const dbRaw = db.getDatabase();
@@ -403,36 +274,6 @@ describe('RoomManager', () => {
 			// Only the worker session should appear; room:chat: is filtered out
 			expect(overview?.sessions).toHaveLength(1);
 			expect(overview?.sessions[0].id).toBe('worker-abc');
-		});
-
-		it('should not include terminal-status tasks in activeTasks but include in allTasks', () => {
-			const room = roomManager.createRoom({ name: 'Room Terminal Tasks' });
-			const dbRaw = db.getDatabase();
-
-			// Create tasks with terminal statuses
-			const terminalStatuses = ['completed', 'needs_attention', 'cancelled'];
-			for (const status of terminalStatuses) {
-				dbRaw
-					.prepare(
-						`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at)
-	           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-					)
-					.run(
-						`task-${status}`,
-						room.id,
-						`Task ${status}`,
-						'D',
-						status,
-						'normal',
-						'[]',
-						Date.now()
-					);
-			}
-
-			const overview = roomManager.getRoomOverview(room.id);
-
-			expect(overview?.activeTasks).toHaveLength(0);
-			expect(overview?.allTasks).toHaveLength(3);
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/room-manager.test.ts
+++ b/packages/daemon/tests/unit/room/room-manager.test.ts
@@ -121,7 +121,7 @@ describe('RoomManager', () => {
 	});
 
 	describe('getRoomOverview', () => {
-		it('should return room overview with empty sessions ', () => {
+		it('should return room overview with empty sessions', () => {
 			const room = roomManager.createRoom({ name: 'Overview Room' });
 			const overview = roomManager.getRoomOverview(room.id);
 

--- a/packages/daemon/tests/unit/rpc-handlers/inbox-review-tasks.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/inbox-review-tasks.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for inbox.reviewTasks RPC Handler
+ *
+ * Covers:
+ * - Returns only review-status tasks across active rooms
+ * - Skips non-review tasks (in_progress, pending, completed, etc.)
+ * - Sorts results by updatedAt descending
+ * - Returns empty array when no review tasks exist
+ * - Skips archived rooms (via listRooms(false))
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import { setupTaskHandlers } from '../../../src/lib/rpc-handlers/task-handlers';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+import type { RoomManager } from '../../../src/lib/room/managers/room-manager';
+import type { Database } from '../../../src/storage/database';
+
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {
+		emit: mock(async () => {}),
+		on: mock(() => () => {}),
+		off: mock(() => () => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+}
+
+function makeTaskRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		id: '00000000-0000-4000-8000-000000000001',
+		room_id: 'room-1',
+		short_id: null,
+		title: 'Test Task',
+		description: '',
+		status: 'review',
+		priority: 'normal',
+		task_type: 'coding',
+		assigned_agent: 'coder',
+		created_by_task_id: null,
+		progress: null,
+		current_step: null,
+		result: null,
+		error: null,
+		depends_on: '[]',
+		input_draft: null,
+		created_at: 1000,
+		started_at: null,
+		completed_at: null,
+		archived_at: null,
+		active_session: null,
+		pr_url: null,
+		pr_number: null,
+		pr_created_at: null,
+		restrictions: null,
+		updated_at: 2000,
+		...overrides,
+	};
+}
+
+describe('inbox.reviewTasks RPC handler', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+	let mockRoomManager: RoomManager;
+	let taskRowsByRoom: Map<string, Record<string, unknown>[]>;
+
+	beforeEach(() => {
+		const result = createMockMessageHub();
+		hub = result.hub;
+		handlers = result.handlers;
+		taskRowsByRoom = new Map();
+
+		const roomList = [
+			{ id: 'room-a', name: 'Room A' },
+			{ id: 'room-b', name: 'Room B' },
+		];
+
+		mockRoomManager = {
+			listRooms: mock(() => roomList),
+			getRoomOverview: mock(() => null),
+		} as unknown as RoomManager;
+
+		const allFn = mock((...params: unknown[]) => {
+			const roomId = params[0] as string;
+			return taskRowsByRoom.get(roomId) ?? [];
+		});
+
+		const stmt = {
+			get: mock(() => null),
+			run: mock(() => ({ lastInsertRowid: 1 })),
+			all: allFn,
+		};
+		const rawDb = { prepare: mock(() => stmt) };
+		const mockDb = { getDatabase: mock(() => rawDb) } as unknown as Database;
+
+		setupTaskHandlers(hub, mockRoomManager, createMockDaemonHub(), mockDb, {
+			notifyChange: () => {},
+		} as never);
+	});
+
+	it('should return only review-status tasks across all rooms', async () => {
+		taskRowsByRoom.set('room-a', [
+			makeTaskRow({ id: 't1', room_id: 'room-a', status: 'review', updated_at: 3000 }),
+			makeTaskRow({ id: 't2', room_id: 'room-a', status: 'in_progress', updated_at: 4000 }),
+		]);
+		taskRowsByRoom.set('room-b', [
+			makeTaskRow({ id: 't3', room_id: 'room-b', status: 'review', updated_at: 2000 }),
+			makeTaskRow({ id: 't4', room_id: 'room-b', status: 'completed', updated_at: 5000 }),
+		]);
+
+		const handler = handlers.get('inbox.reviewTasks')!;
+		const result = (await handler({}, {})) as { tasks: Array<{ task: { id: string } }> };
+
+		expect(result.tasks).toHaveLength(2);
+		const ids = result.tasks.map((t) => t.task.id);
+		expect(ids).toContain('t1');
+		expect(ids).toContain('t3');
+	});
+
+	it('should sort results by updatedAt descending', async () => {
+		taskRowsByRoom.set('room-a', [
+			makeTaskRow({ id: 'old', room_id: 'room-a', status: 'review', updated_at: 1000 }),
+			makeTaskRow({ id: 'new', room_id: 'room-a', status: 'review', updated_at: 5000 }),
+		]);
+		taskRowsByRoom.set('room-b', [
+			makeTaskRow({ id: 'mid', room_id: 'room-b', status: 'review', updated_at: 3000 }),
+		]);
+
+		const handler = handlers.get('inbox.reviewTasks')!;
+		const result = (await handler({}, {})) as { tasks: Array<{ task: { id: string } }> };
+
+		const ids = result.tasks.map((t) => t.task.id);
+		expect(ids).toEqual(['new', 'mid', 'old']);
+	});
+
+	it('should include room metadata (roomId, roomTitle) with each task', async () => {
+		taskRowsByRoom.set('room-a', [
+			makeTaskRow({ id: 't1', room_id: 'room-a', status: 'review', updated_at: 1000 }),
+		]);
+		taskRowsByRoom.set('room-b', [
+			makeTaskRow({ id: 't2', room_id: 'room-b', status: 'review', updated_at: 2000 }),
+		]);
+
+		const handler = handlers.get('inbox.reviewTasks')!;
+		const result = (await handler({}, {})) as {
+			tasks: Array<{ task: { id: string }; roomId: string; roomTitle: string }>;
+		};
+
+		const task1 = result.tasks.find((t) => t.task.id === 't1');
+		expect(task1?.roomId).toBe('room-a');
+		expect(task1?.roomTitle).toBe('Room A');
+
+		const task2 = result.tasks.find((t) => t.task.id === 't2');
+		expect(task2?.roomId).toBe('room-b');
+		expect(task2?.roomTitle).toBe('Room B');
+	});
+
+	it('should return empty array when no review tasks exist', async () => {
+		taskRowsByRoom.set('room-a', [
+			makeTaskRow({ id: 't1', room_id: 'room-a', status: 'in_progress' }),
+		]);
+		taskRowsByRoom.set('room-b', [makeTaskRow({ id: 't2', room_id: 'room-b', status: 'pending' })]);
+
+		const handler = handlers.get('inbox.reviewTasks')!;
+		const result = (await handler({}, {})) as { tasks: unknown[] };
+
+		expect(result.tasks).toHaveLength(0);
+	});
+
+	it('should return empty array when rooms have no tasks', async () => {
+		taskRowsByRoom.set('room-a', []);
+		taskRowsByRoom.set('room-b', []);
+
+		const handler = handlers.get('inbox.reviewTasks')!;
+		const result = (await handler({}, {})) as { tasks: unknown[] };
+
+		expect(result.tasks).toHaveLength(0);
+	});
+
+	it('should include all TaskSummary fields in the response', async () => {
+		taskRowsByRoom.set('room-a', [
+			makeTaskRow({
+				id: 't1',
+				room_id: 'room-a',
+				status: 'review',
+				title: 'Fix login bug',
+				priority: 'high',
+				progress: 75,
+				current_step: 'Writing tests',
+				depends_on: JSON.stringify(['dep-1']),
+				error: null,
+				active_session: 'worker',
+				pr_url: 'https://github.com/example/pr/1',
+				pr_number: 42,
+				updated_at: 3000,
+			}),
+		]);
+
+		const handler = handlers.get('inbox.reviewTasks')!;
+		const result = (await handler({}, {})) as {
+			tasks: Array<{ task: Record<string, unknown>; roomId: string }>;
+		};
+
+		expect(result.tasks).toHaveLength(1);
+		const task = result.tasks[0].task;
+		expect(task.id).toBe('t1');
+		expect(task.title).toBe('Fix login bug');
+		expect(task.status).toBe('review');
+		expect(task.priority).toBe('high');
+		expect(task.progress).toBe(75);
+		expect(task.currentStep).toBe('Writing tests');
+		expect(task.dependsOn).toEqual(['dep-1']);
+		expect(task.activeSession).toBe('worker');
+		expect(task.prUrl).toBe('https://github.com/example/pr/1');
+		expect(task.prNumber).toBe(42);
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/inbox-review-tasks.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/inbox-review-tasks.test.ts
@@ -111,7 +111,13 @@ describe('inbox.reviewTasks RPC handler', () => {
 
 		const allFn = mock((...params: unknown[]) => {
 			const roomId = params[0] as string;
-			return taskRowsByRoom.get(roomId) ?? [];
+			let rows = taskRowsByRoom.get(roomId) ?? [];
+			// Simulate SQL-level status filtering (mirrors TaskRepository.listTasks)
+			if (params.length > 1 && params[1]) {
+				const status = params[1] as string;
+				rows = rows.filter((r) => r.status === status);
+			}
+			return rows;
 		});
 
 		const stmt = {

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -108,7 +108,6 @@ function createMockRoomManager(): {
 	const mockRoomOverview: RoomOverview = {
 		room: mockRoom,
 		sessions: [],
-		activeTasks: [],
 	};
 
 	const mockRoomStatus: NeoStatus = {

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -142,7 +142,6 @@ function createMockRoomManager(): {
 	const getRoomOverviewMock = mock(() => ({
 		room: { id: 'room-123', name: 'Test Room' },
 		sessions: [],
-		activeTasks: [],
 	}));
 
 	const roomManager = {

--- a/packages/daemon/tests/unit/session/state-manager.test.ts
+++ b/packages/daemon/tests/unit/session/state-manager.test.ts
@@ -669,7 +669,6 @@ describe('StateManager', () => {
 						sessionId: 'room:room-123',
 						room: { id: 'room-123', name: 'Test Room' },
 						sessions: [],
-						activeTasks: [],
 					};
 
 					handler!(data);

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -495,10 +495,6 @@ export interface TaskSummary {
 export interface RoomOverview {
 	room: Room;
 	sessions: SessionSummary[];
-	/** Non-terminal tasks (excludes completed, failed, cancelled) — backward compat */
-	activeTasks: TaskSummary[];
-	/** All tasks including completed, failed, and cancelled */
-	allTasks?: TaskSummary[];
 	/** Current runtime state */
 	runtimeState?: RuntimeState;
 }

--- a/packages/web/src/hooks/__tests__/useRoomSkills.test.ts
+++ b/packages/web/src/hooks/__tests__/useRoomSkills.test.ts
@@ -116,8 +116,7 @@ function makeSkill(id: string, overrides: Partial<EffectiveRoomSkill> = {}): Eff
 
 function setupHubRequests(hub: MockHub): void {
 	hub.request.mockImplementation((method: string) => {
-		if (method === 'room.get')
-			return Promise.resolve({ room: { id: ROOM_ID }, sessions: [], allTasks: [] });
+		if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });
 		if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
 		return Promise.resolve({ ok: true });
 	});

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -33,7 +33,7 @@ function makeMockHub() {
 		onConnection: vi.fn(() => () => {}),
 		request: vi.fn(async (method: string) => {
 			if (method === 'room.get') {
-				return { room: { id: 'room-1' }, sessions: [], allTasks: [] };
+				return { room: { id: 'room-1' }, sessions: [] };
 			}
 			if (method === 'goal.list') return { goals: [] };
 			if (method === 'room.runtime.state') throw new Error('no runtime');

--- a/packages/web/src/lib/__tests__/room-store-create-session.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-create-session.test.ts
@@ -18,7 +18,6 @@ function makeMockHub() {
 			return {
 				room: { id: 'room-1', defaultPath: '/workspace', allowedPaths: [] },
 				sessions: [],
-				allTasks: [],
 			};
 		}
 		if (method === 'goal.list') return { goals: [] };

--- a/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
@@ -110,8 +110,7 @@ function makeGoal(id: string, overrides: Partial<RoomGoal> = {}): RoomGoal {
 
 function setupHubRequests(hub: MockHub): void {
 	hub.request.mockImplementation((method: string) => {
-		if (method === 'room.get')
-			return Promise.resolve({ room: { id: ROOM_ID }, sessions: [], allTasks: [] });
+		if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });
 		if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
 		// liveQuery.subscribe and liveQuery.unsubscribe return { ok: true }
 		return Promise.resolve({ ok: true });

--- a/packages/web/src/lib/__tests__/room-store-review.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-review.test.ts
@@ -38,7 +38,7 @@ function makeMockHub() {
 		onConnection: vi.fn(() => () => {}),
 		request: vi.fn(async (method: string) => {
 			if (method === 'room.get') {
-				return { room: { id: ROOM_ID }, sessions: [], allTasks: [] };
+				return { room: { id: ROOM_ID }, sessions: [] };
 			}
 			if (method === 'room.runtime.state') throw new Error('no runtime');
 			return { ok: true };

--- a/packages/web/src/lib/__tests__/room-store-session-events.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-session-events.test.ts
@@ -115,8 +115,6 @@ function twoSessionOverview(): RoomOverview {
 			{ id: 'session-1', title: 'Session One', status: 'active', lastActiveAt: 1000 },
 			{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
 		] as SessionSummary[],
-		activeTasks: [],
-		allTasks: [],
 	};
 }
 

--- a/packages/web/src/lib/__tests__/room-store-stale-event-guard.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-stale-event-guard.test.ts
@@ -131,8 +131,7 @@ function makeGoal(id: string, overrides: Partial<RoomGoal> = {}): RoomGoal {
 
 function setupHubRequests(hub: MockHub): void {
 	hub.request.mockImplementation((method: string) => {
-		if (method === 'room.get')
-			return Promise.resolve({ room: { id: ROOM_ID }, sessions: [], allTasks: [] });
+		if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });
 		if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
 		return Promise.resolve({ ok: true });
 	});

--- a/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
@@ -109,8 +109,7 @@ function makeTask(id: string, overrides: Partial<NeoTask> = {}): NeoTask {
 
 function setupHubRequests(hub: MockHub): void {
 	hub.request.mockImplementation((method: string) => {
-		if (method === 'room.get')
-			return Promise.resolve({ room: { id: ROOM_ID }, sessions: [], allTasks: [] });
+		if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });
 		if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
 		// liveQuery.subscribe and liveQuery.unsubscribe return { ok: true }
 		return Promise.resolve({ ok: true });

--- a/packages/web/src/lib/inbox-store.test.ts
+++ b/packages/web/src/lib/inbox-store.test.ts
@@ -84,6 +84,14 @@ describe('InboxStore', () => {
 			expect(await inboxStore.approveTask('t1', 'r')).toBe(true);
 			expect(mockHub.request).toHaveBeenCalledWith('inbox.reviewTasks', {});
 		});
+
+		it('should show toast.error and return false when approveTask fails', async () => {
+			const mockHub = { request: vi.fn().mockRejectedValueOnce(new Error('Network error')) };
+			mockGetHub.mockResolvedValue(mockHub);
+			const result = await inboxStore.approveTask('task-1', 'room-1');
+			expect(result).toBe(false);
+			expect(mockToastError).toHaveBeenCalledWith('Network error');
+		});
 	});
 
 	describe('rejectTask()', () => {
@@ -97,6 +105,14 @@ describe('InboxStore', () => {
 			mockGetHub.mockResolvedValue(mockHub);
 			expect(await inboxStore.rejectTask('t1', 'r', 'feedback')).toBe(true);
 			expect(mockHub.request).toHaveBeenCalledWith('inbox.reviewTasks', {});
+		});
+
+		it('should show toast.error and return false when rejectTask fails', async () => {
+			const mockHub = { request: vi.fn().mockRejectedValueOnce(new Error('Network error')) };
+			mockGetHub.mockResolvedValue(mockHub);
+			const result = await inboxStore.rejectTask('task-1', 'room-1', 'needs work');
+			expect(result).toBe(false);
+			expect(mockToastError).toHaveBeenCalledWith('Network error');
 		});
 	});
 

--- a/packages/web/src/lib/inbox-store.test.ts
+++ b/packages/web/src/lib/inbox-store.test.ts
@@ -1,299 +1,85 @@
 /**
  * Tests for InboxStore
- *
- * Tests task aggregation across rooms, filtering to review status,
- * sorting, and computed reviewCount.
  */
-
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { signal } from '@preact/signals';
-import type { Room, RoomOverview, TaskSummary } from '@neokai/shared';
+import type { TaskSummary } from '@neokai/shared';
+import type { InboxTask } from './inbox-store.ts';
 
-// Hoisted mocks
 const { mockGetHub, mockToastError } = vi.hoisted(() => ({
 	mockGetHub: vi.fn(),
 	mockToastError: vi.fn(),
 }));
 
-vi.mock('./connection-manager', () => ({
-	connectionManager: {
-		getHub: mockGetHub,
-	},
-}));
+vi.mock('./connection-manager', () => ({ connectionManager: { getHub: mockGetHub } }));
+vi.mock('./toast', () => ({ toast: { error: mockToastError } }));
 
-vi.mock('./toast', () => ({
-	toast: {
-		error: mockToastError,
-	},
-}));
-
-// Lobby store mock rooms signal
-const mockRoomsSignal = signal<Room[]>([]);
-vi.mock('./lobby-store', () => ({
-	lobbyStore: {
-		get rooms() {
-			return mockRoomsSignal;
-		},
-	},
-}));
-
-// Import after mocks are set up
 const { inboxStore } = await import('./inbox-store.ts');
 
-function makeRoom(id: string, name: string): Room {
-	return {
-		id,
-		name,
-		allowedPaths: [],
-		sessionIds: [],
-		status: 'active',
-		createdAt: Date.now(),
-		updatedAt: Date.now(),
-	};
-}
-
 function makeTask(id: string, status: TaskSummary['status'], updatedAt = Date.now()): TaskSummary {
-	return {
-		id,
-		title: `Task ${id}`,
-		status,
-		priority: 'normal',
-		progress: null,
-		dependsOn: [],
-		updatedAt,
-	};
+	return { id, title: `Task ${id}`, status, priority: 'normal', progress: null, dependsOn: [], updatedAt };
 }
 
-function makeOverview(room: Room, tasks: TaskSummary[]): RoomOverview {
-	return {
-		room,
-		sessions: [],
-		activeTasks: tasks.filter((t) => !['completed', 'cancelled'].includes(t.status)),
-		allTasks: tasks,
-	};
+function makeInboxTask(task: TaskSummary, roomId: string, roomTitle: string): InboxTask {
+	return { task, roomId, roomTitle };
 }
 
 describe('InboxStore', () => {
-	beforeEach(() => {
-		mockRoomsSignal.value = [];
-		inboxStore.items.value = [];
-		inboxStore.isLoading.value = false;
-		vi.clearAllMocks();
-	});
+	beforeEach(() => { inboxStore.items.value = []; inboxStore.isLoading.value = false; vi.clearAllMocks(); });
 
 	describe('refresh()', () => {
-		it('should set items to empty array when no rooms', async () => {
-			mockRoomsSignal.value = [];
-
+		it('should call inbox.reviewTasks RPC and set items from response', async () => {
+			const reviewTasks = [makeInboxTask(makeTask('t1', 'review', 3000), 'room-a', 'Room A')];
+			const mockHub = { request: vi.fn().mockResolvedValue({ tasks: reviewTasks }) };
+			mockGetHub.mockResolvedValue(mockHub);
 			await inboxStore.refresh();
+			expect(mockHub.request).toHaveBeenCalledWith('inbox.reviewTasks', {});
+			expect(inboxStore.items.value).toEqual(reviewTasks);
+		});
 
+		it('should set items to empty array on error', async () => {
+			const mockHub = { request: vi.fn().mockRejectedValue(new Error('Connection lost')) };
+			mockGetHub.mockResolvedValue(mockHub);
+			await inboxStore.refresh();
 			expect(inboxStore.items.value).toEqual([]);
-			expect(mockGetHub).not.toHaveBeenCalled();
-		});
-
-		it('should aggregate review-status tasks across rooms', async () => {
-			const roomA = makeRoom('room-a', 'Room A');
-			const roomB = makeRoom('room-b', 'Room B');
-			mockRoomsSignal.value = [roomA, roomB];
-
-			const tasksA = [makeTask('t1', 'review', 1000), makeTask('t2', 'in_progress', 2000)];
-			const tasksB = [makeTask('t3', 'review', 3000), makeTask('t4', 'completed', 4000)];
-
-			const mockHub = {
-				request: vi
-					.fn()
-					.mockImplementationOnce(() => Promise.resolve(makeOverview(roomA, tasksA)))
-					.mockImplementationOnce(() => Promise.resolve(makeOverview(roomB, tasksB))),
-			};
-			mockGetHub.mockResolvedValue(mockHub);
-
-			await inboxStore.refresh();
-
-			const items = inboxStore.items.value;
-			expect(items).toHaveLength(2);
-
-			// Both should be review tasks
-			expect(items.every((item) => item.task.status === 'review')).toBe(true);
-
-			// Should include correct room metadata
-			const ids = items.map((i) => i.task.id);
-			expect(ids).toContain('t1');
-			expect(ids).toContain('t3');
-
-			const itemA = items.find((i) => i.task.id === 't1');
-			expect(itemA?.roomId).toBe('room-a');
-			expect(itemA?.roomTitle).toBe('Room A');
-		});
-
-		it('should sort items by updatedAt descending', async () => {
-			const room = makeRoom('room-1', 'Room 1');
-			mockRoomsSignal.value = [room];
-
-			const tasks = [
-				makeTask('early', 'review', 1000),
-				makeTask('latest', 'review', 3000),
-				makeTask('middle', 'review', 2000),
-			];
-
-			const mockHub = {
-				request: vi.fn().mockResolvedValue(makeOverview(room, tasks)),
-			};
-			mockGetHub.mockResolvedValue(mockHub);
-
-			await inboxStore.refresh();
-
-			const ids = inboxStore.items.value.map((i) => i.task.id);
-			expect(ids).toEqual(['latest', 'middle', 'early']);
-		});
-
-		it('should skip failed room requests gracefully', async () => {
-			const roomA = makeRoom('room-a', 'Room A');
-			const roomB = makeRoom('room-b', 'Room B');
-			mockRoomsSignal.value = [roomA, roomB];
-
-			const tasksB = [makeTask('t1', 'review')];
-			const mockHub = {
-				request: vi
-					.fn()
-					.mockImplementationOnce(() => Promise.reject(new Error('Network error')))
-					.mockImplementationOnce(() => Promise.resolve(makeOverview(roomB, tasksB))),
-			};
-			mockGetHub.mockResolvedValue(mockHub);
-
-			await inboxStore.refresh();
-
-			// Should still have tasks from the successful room
-			expect(inboxStore.items.value).toHaveLength(1);
-			expect(inboxStore.items.value[0].task.id).toBe('t1');
 		});
 
 		it('should set isLoading to false after completion', async () => {
-			mockRoomsSignal.value = [makeRoom('r', 'R')];
-			const mockHub = {
-				request: vi.fn().mockResolvedValue(makeOverview(makeRoom('r', 'R'), [])),
-			};
+			const mockHub = { request: vi.fn().mockResolvedValue({ tasks: [] }) };
 			mockGetHub.mockResolvedValue(mockHub);
-
-			const refreshPromise = inboxStore.refresh();
-			// Loading should be true while in flight
+			const p = inboxStore.refresh();
 			expect(inboxStore.isLoading.value).toBe(true);
-
-			await refreshPromise;
+			await p;
 			expect(inboxStore.isLoading.value).toBe(false);
 		});
 
-		it('should ignore archived rooms', async () => {
-			const activeRoom = makeRoom('active', 'Active Room');
-			const archivedRoom = {
-				...makeRoom('archived', 'Archived Room'),
-				status: 'archived' as const,
-			};
-			mockRoomsSignal.value = [activeRoom, archivedRoom];
-
-			const mockHub = {
-				request: vi.fn().mockResolvedValue(makeOverview(activeRoom, [])),
-			};
+		it('should set isLoading to false even on error', async () => {
+			const mockHub = { request: vi.fn().mockRejectedValue(new Error('fail')) };
 			mockGetHub.mockResolvedValue(mockHub);
-
 			await inboxStore.refresh();
-
-			// Only one request — for the active room
-			expect(mockHub.request).toHaveBeenCalledTimes(1);
+			expect(inboxStore.isLoading.value).toBe(false);
 		});
 	});
 
 	describe('approveTask()', () => {
-		it('should call task.approve, refresh, and return true on success', async () => {
-			const room = makeRoom('r', 'R');
-			mockRoomsSignal.value = [room];
-
-			const mockHub = {
-				request: vi
-					.fn()
-					.mockImplementationOnce(() => Promise.resolve(undefined)) // approve
-					.mockImplementationOnce(() => Promise.resolve(makeOverview(room, []))), // refresh
-			};
+		it('should call task.approve, refresh, and return true', async () => {
+			const mockHub = { request: vi.fn().mockImplementationOnce(() => Promise.resolve(undefined)).mockImplementationOnce(() => Promise.resolve({ tasks: [] })) };
 			mockGetHub.mockResolvedValue(mockHub);
-
-			const result = await inboxStore.approveTask('task-1', 'r');
-
-			expect(result).toBe(true);
-			expect(mockHub.request).toHaveBeenCalledWith('task.approve', {
-				roomId: 'r',
-				taskId: 'task-1',
-			});
-		});
-
-		it('should show toast.error and return false when approve fails', async () => {
-			const mockHub = {
-				request: vi.fn().mockRejectedValue(new Error('Server error')),
-			};
-			mockGetHub.mockResolvedValue(mockHub);
-
-			const result = await inboxStore.approveTask('task-1', 'r');
-
-			expect(result).toBe(false);
-			expect(mockToastError).toHaveBeenCalledWith('Server error');
+			expect(await inboxStore.approveTask('t1', 'r')).toBe(true);
+			expect(mockHub.request).toHaveBeenCalledWith('inbox.reviewTasks', {});
 		});
 	});
 
 	describe('rejectTask()', () => {
-		it('should call task.reject with feedback, refresh, and return true on success', async () => {
-			const room = makeRoom('r', 'R');
-			mockRoomsSignal.value = [room];
-
-			const mockHub = {
-				request: vi
-					.fn()
-					.mockImplementationOnce(() => Promise.resolve(undefined)) // reject
-					.mockImplementationOnce(() => Promise.resolve(makeOverview(room, []))), // refresh
-			};
+		it('should call task.reject with feedback, refresh, and return true', async () => {
+			const mockHub = { request: vi.fn().mockImplementationOnce(() => Promise.resolve(undefined)).mockImplementationOnce(() => Promise.resolve({ tasks: [] })) };
 			mockGetHub.mockResolvedValue(mockHub);
-
-			const result = await inboxStore.rejectTask('task-1', 'r', 'needs more work');
-
-			expect(result).toBe(true);
-			expect(mockHub.request).toHaveBeenCalledWith('task.reject', {
-				roomId: 'r',
-				taskId: 'task-1',
-				feedback: 'needs more work',
-			});
-		});
-
-		it('should show toast.error and return false when reject fails', async () => {
-			const mockHub = {
-				request: vi.fn().mockRejectedValue(new Error('Reject failed')),
-			};
-			mockGetHub.mockResolvedValue(mockHub);
-
-			const result = await inboxStore.rejectTask('task-1', 'r', 'feedback');
-
-			expect(result).toBe(false);
-			expect(mockToastError).toHaveBeenCalledWith('Reject failed');
+			expect(await inboxStore.rejectTask('t1', 'r', 'feedback')).toBe(true);
+			expect(mockHub.request).toHaveBeenCalledWith('inbox.reviewTasks', {});
 		});
 	});
 
 	describe('reviewCount', () => {
-		it('should return 0 when items is empty', () => {
-			inboxStore.items.value = [];
-			expect(inboxStore.reviewCount.value).toBe(0);
-		});
-
-		it('should return the number of items', () => {
-			const room = makeRoom('r', 'R');
-			inboxStore.items.value = [
-				{ task: makeTask('t1', 'review'), roomId: 'r', roomTitle: 'R' },
-				{ task: makeTask('t2', 'review'), roomId: 'r', roomTitle: 'R' },
-			];
-			expect(inboxStore.reviewCount.value).toBe(2);
-		});
-
-		it('should update reactively when items change', () => {
-			inboxStore.items.value = [];
-			expect(inboxStore.reviewCount.value).toBe(0);
-
-			inboxStore.items.value = [{ task: makeTask('t1', 'review'), roomId: 'r', roomTitle: 'R' }];
-			expect(inboxStore.reviewCount.value).toBe(1);
-		});
+		it('should return 0 when empty', () => { inboxStore.items.value = []; expect(inboxStore.reviewCount.value).toBe(0); });
+		it('should return count', () => { inboxStore.items.value = [makeInboxTask(makeTask('t1', 'review'), 'r', 'R')]; expect(inboxStore.reviewCount.value).toBe(1); });
 	});
 });

--- a/packages/web/src/lib/inbox-store.test.ts
+++ b/packages/web/src/lib/inbox-store.test.ts
@@ -16,7 +16,15 @@ vi.mock('./toast', () => ({ toast: { error: mockToastError } }));
 const { inboxStore } = await import('./inbox-store.ts');
 
 function makeTask(id: string, status: TaskSummary['status'], updatedAt = Date.now()): TaskSummary {
-	return { id, title: `Task ${id}`, status, priority: 'normal', progress: null, dependsOn: [], updatedAt };
+	return {
+		id,
+		title: `Task ${id}`,
+		status,
+		priority: 'normal',
+		progress: null,
+		dependsOn: [],
+		updatedAt,
+	};
 }
 
 function makeInboxTask(task: TaskSummary, roomId: string, roomTitle: string): InboxTask {
@@ -24,7 +32,11 @@ function makeInboxTask(task: TaskSummary, roomId: string, roomTitle: string): In
 }
 
 describe('InboxStore', () => {
-	beforeEach(() => { inboxStore.items.value = []; inboxStore.isLoading.value = false; vi.clearAllMocks(); });
+	beforeEach(() => {
+		inboxStore.items.value = [];
+		inboxStore.isLoading.value = false;
+		vi.clearAllMocks();
+	});
 
 	describe('refresh()', () => {
 		it('should call inbox.reviewTasks RPC and set items from response', async () => {
@@ -62,7 +74,12 @@ describe('InboxStore', () => {
 
 	describe('approveTask()', () => {
 		it('should call task.approve, refresh, and return true', async () => {
-			const mockHub = { request: vi.fn().mockImplementationOnce(() => Promise.resolve(undefined)).mockImplementationOnce(() => Promise.resolve({ tasks: [] })) };
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockImplementationOnce(() => Promise.resolve(undefined))
+					.mockImplementationOnce(() => Promise.resolve({ tasks: [] })),
+			};
 			mockGetHub.mockResolvedValue(mockHub);
 			expect(await inboxStore.approveTask('t1', 'r')).toBe(true);
 			expect(mockHub.request).toHaveBeenCalledWith('inbox.reviewTasks', {});
@@ -71,7 +88,12 @@ describe('InboxStore', () => {
 
 	describe('rejectTask()', () => {
 		it('should call task.reject with feedback, refresh, and return true', async () => {
-			const mockHub = { request: vi.fn().mockImplementationOnce(() => Promise.resolve(undefined)).mockImplementationOnce(() => Promise.resolve({ tasks: [] })) };
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockImplementationOnce(() => Promise.resolve(undefined))
+					.mockImplementationOnce(() => Promise.resolve({ tasks: [] })),
+			};
 			mockGetHub.mockResolvedValue(mockHub);
 			expect(await inboxStore.rejectTask('t1', 'r', 'feedback')).toBe(true);
 			expect(mockHub.request).toHaveBeenCalledWith('inbox.reviewTasks', {});
@@ -79,7 +101,13 @@ describe('InboxStore', () => {
 	});
 
 	describe('reviewCount', () => {
-		it('should return 0 when empty', () => { inboxStore.items.value = []; expect(inboxStore.reviewCount.value).toBe(0); });
-		it('should return count', () => { inboxStore.items.value = [makeInboxTask(makeTask('t1', 'review'), 'r', 'R')]; expect(inboxStore.reviewCount.value).toBe(1); });
+		it('should return 0 when empty', () => {
+			inboxStore.items.value = [];
+			expect(inboxStore.reviewCount.value).toBe(0);
+		});
+		it('should return count', () => {
+			inboxStore.items.value = [makeInboxTask(makeTask('t1', 'review'), 'r', 'R')];
+			expect(inboxStore.reviewCount.value).toBe(1);
+		});
 	});
 });

--- a/packages/web/src/lib/inbox-store.ts
+++ b/packages/web/src/lib/inbox-store.ts
@@ -1,22 +1,16 @@
 /**
  * InboxStore - Aggregates review-status tasks across all rooms
  *
- * Data layer for the Inbox feature. Fans out room.get requests in parallel
- * to collect all tasks with status === 'review', providing a unified inbox view.
- *
- * No dedicated inbox API exists on the backend; this store composes
- * existing room.get RPC calls (same pattern as RoomStore.fetchInitialState).
+ * Data layer for the Inbox feature. Calls the dedicated inbox.reviewTasks RPC
+ * endpoint to fetch all tasks with status === 'review' in a single request,
+ * providing a unified inbox view without the overhead of per-room room.get calls.
  */
 
 import { signal, computed } from '@preact/signals';
-import type { TaskSummary, RoomOverview } from '@neokai/shared';
+import type { TaskSummary } from '@neokai/shared';
 import { connectionManager } from './connection-manager';
-import { lobbyStore } from './lobby-store';
 import { toast } from './toast';
 
-/**
- * A review-status task enriched with room metadata for inbox display
- */
 export interface InboxTask {
 	task: TaskSummary;
 	roomId: string;
@@ -25,52 +19,16 @@ export interface InboxTask {
 
 const items = signal<InboxTask[]>([]);
 const isLoading = signal<boolean>(false);
-
-/**
- * Computed count of tasks awaiting review
- */
 const reviewCount = computed(() => items.value.length);
 
-/**
- * Fan out room.get requests to all rooms in parallel, collect review-status tasks,
- * and update the items signal sorted by updatedAt descending.
- */
 async function refresh(): Promise<void> {
-	const rooms = lobbyStore.rooms.value.filter((r) => r.status === 'active');
-	if (rooms.length === 0) {
-		items.value = [];
-		return;
-	}
-
 	isLoading.value = true;
 	try {
 		const hub = await connectionManager.getHub();
-
-		const results = await Promise.all(
-			rooms.map((room) =>
-				hub
-					.request<RoomOverview>('room.get', { roomId: room.id })
-					.then((overview) => ({ overview, room }))
-					.catch(() => null)
-			)
-		);
-
-		const inbox: InboxTask[] = [];
-		for (const result of results) {
-			if (!result?.overview) continue;
-			const { overview, room } = result;
-			const tasks = overview.allTasks ?? overview.activeTasks;
-			for (const task of tasks) {
-				if (task.status === 'review') {
-					inbox.push({ task, roomId: room.id, roomTitle: room.name });
-				}
-			}
-		}
-
-		// Sort by updatedAt descending (most recently updated first)
-		inbox.sort((a, b) => b.task.updatedAt - a.task.updatedAt);
-
-		items.value = inbox;
+		const result = await hub.request<{ tasks: InboxTask[] }>('inbox.reviewTasks', {});
+		items.value = result.tasks;
+	} catch {
+		items.value = [];
 	} finally {
 		isLoading.value = false;
 	}
@@ -100,11 +58,4 @@ async function rejectTask(taskId: string, roomId: string, feedback: string): Pro
 	}
 }
 
-export const inboxStore = {
-	items,
-	isLoading,
-	refresh,
-	reviewCount,
-	approveTask,
-	rejectTask,
-};
+export const inboxStore = { items, isLoading, refresh, reviewCount, approveTask, rejectTask };

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -463,10 +463,11 @@ class RoomStore {
 			cleanups.push(unsubSkillDelta);
 
 			// --- Fire ALL subscribe calls in parallel ---
+			// Use Promise.allSettled so a single failure doesn't leak the other two.
 			// Mark goals loading before subscribing; the snapshot handler clears it.
 			this.goalStore.loading.value = true;
 
-			await Promise.all([
+			const subResults = await Promise.allSettled([
 				hub.request('liveQuery.subscribe', {
 					queryName: 'tasks.byRoom',
 					params: [roomId],
@@ -498,72 +499,67 @@ class RoomStore {
 				return;
 			}
 
-			// --- Register reconnect and cleanup handlers AFTER all subscribe calls resolve ---
+			const subIds = [tasksSubId, goalsSubId, skillsSubId] as const;
+			const queryNames = ['tasks.byRoom', 'goals.byRoom', 'skills.byRoom'] as const;
 
-			// Tasks reconnect + cleanup
-			const unsubTaskReconnect = hub.onConnection((state) => {
-				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
-				hub
-					.request('liveQuery.subscribe', {
-						queryName: 'tasks.byRoom',
-						params: [roomId],
-						subscriptionId: tasksSubId,
-					})
-					.catch((err) => {
-						logger.warn('Tasks LiveQuery re-subscribe failed:', err);
-					});
-			});
-			cleanups.push(unsubTaskReconnect);
-			cleanups.push(() => {
-				const h = connectionManager.getHubIfConnected();
-				if (h) {
-					h.request('liveQuery.unsubscribe', { subscriptionId: tasksSubId }).catch(() => {});
-				}
-			});
+			for (let i = 0; i < subResults.length; i++) {
+				const result = subResults[i];
+				const subId = subIds[i];
+				const queryName = queryNames[i];
 
-			// Goals reconnect + cleanup
-			const unsubGoalReconnect = hub.onConnection((state) => {
-				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
-				this.goalStore.loading.value = true;
-				hub
-					.request('liveQuery.subscribe', {
-						queryName: 'goals.byRoom',
-						params: [roomId],
-						subscriptionId: goalsSubId,
-					})
-					.catch((err) => {
-						logger.warn('Goals LiveQuery re-subscribe failed:', err);
-						this.goalStore.loading.value = false;
-					});
-			});
-			cleanups.push(unsubGoalReconnect);
-			cleanups.push(() => {
-				const h = connectionManager.getHubIfConnected();
-				if (h) {
-					h.request('liveQuery.unsubscribe', { subscriptionId: goalsSubId }).catch(() => {});
+				if (result.status === 'rejected') {
+					logger.warn(`${queryName} LiveQuery subscribe failed:`, result.reason);
+					// Fire-and-forget unsubscribe in case the server partially registered
+					const h = connectionManager.getHubIfConnected();
+					if (h) {
+						h.request('liveQuery.unsubscribe', { subscriptionId: subId }).catch(() => {});
+					}
+					continue;
 				}
-			});
 
-			// Skills reconnect + cleanup
-			const unsubSkillReconnect = hub.onConnection((state) => {
-				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
-				hub
-					.request('liveQuery.subscribe', {
-						queryName: 'skills.byRoom',
-						params: [roomId],
-						subscriptionId: skillsSubId,
-					})
-					.catch((err) => {
-						logger.warn('Skills LiveQuery re-subscribe failed:', err);
+				// Successful subscription — add reconnect and cleanup handlers
+				const qn = queryName;
+				const sid = subId;
+
+				if (qn === 'goals.byRoom') {
+					const unsubReconnect = hub.onConnection((state) => {
+						if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
+						this.goalStore.loading.value = true;
+						hub
+							.request('liveQuery.subscribe', {
+								queryName: qn,
+								params: [roomId],
+								subscriptionId: sid,
+							})
+							.catch((err) => {
+								logger.warn(`${qn} LiveQuery re-subscribe failed:`, err);
+								this.goalStore.loading.value = false;
+							});
 					});
-			});
-			cleanups.push(unsubSkillReconnect);
-			cleanups.push(() => {
-				const h = connectionManager.getHubIfConnected();
-				if (h) {
-					h.request('liveQuery.unsubscribe', { subscriptionId: skillsSubId }).catch(() => {});
+					cleanups.push(unsubReconnect);
+				} else {
+					const unsubReconnect = hub.onConnection((state) => {
+						if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
+						hub
+							.request('liveQuery.subscribe', {
+								queryName: qn,
+								params: [roomId],
+								subscriptionId: sid,
+							})
+							.catch((err) => {
+								logger.warn(`${qn} LiveQuery re-subscribe failed:`, err);
+							});
+					});
+					cleanups.push(unsubReconnect);
 				}
-			});
+
+				cleanups.push(() => {
+					const h = connectionManager.getHubIfConnected();
+					if (h) {
+						h.request('liveQuery.unsubscribe', { subscriptionId: sid }).catch(() => {});
+					}
+				});
+			}
 		} catch (err) {
 			this.liveQueryActive.delete(roomId);
 			// Run any cleanups that were registered before the error, so that
@@ -750,7 +746,7 @@ class RoomStore {
 			}
 
 			// Process runtime state result
-			if (runtimeStateResult.status === 'fulfilled') {
+			if (runtimeStateResult.status === 'fulfilled' && runtimeStateResult.value?.state) {
 				this.runtimeState.value = runtimeStateResult.value.state;
 			}
 			// Runtime may not exist yet — silently ignore rejection

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -360,15 +360,26 @@ class RoomStore {
 			const cleanups: Array<() => void> = [];
 			this.liveQueryCleanups.set(roomId, cleanups);
 
-			// --- Tasks via LiveQuery ---
+			// Subscription IDs
 			const tasksSubId = `tasks-byRoom-${roomId}`;
+			const goalsSubId = `goals-byRoom-${roomId}`;
+			const skillsSubId = `skills-byRoom-${roomId}`;
 
-			// Stale-event guard: mark this subscriptionId as active before registering
-			// handlers. unsubscribeRoom clears it immediately so any event queued in the
-			// JS event loop after the room switch is discarded.
+			// --- Register ALL snapshot/delta handlers FIRST (synchronous) ---
+			// Handlers must be registered before subscribe calls so we never miss
+			// the initial snapshot that the server pushes synchronously before replying.
+
+			// Stale-event guards: mark subscriptionIds as active before registering
+			// handlers. unsubscribeRoom clears them immediately so any event queued
+			// in the JS event loop after the room switch is discarded.
 			this.activeSubscriptionIds.add(tasksSubId);
+			this.activeSubscriptionIds.add(goalsSubId);
+			this.activeSubscriptionIds.add(skillsSubId);
 			cleanups.push(() => this.activeSubscriptionIds.delete(tasksSubId));
+			cleanups.push(() => this.activeSubscriptionIds.delete(goalsSubId));
+			cleanups.push(() => this.activeSubscriptionIds.delete(skillsSubId));
 
+			// Tasks handlers
 			const unsubTaskSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
 				'liveQuery.snapshot',
 				(event) => {
@@ -407,57 +418,7 @@ class RoomStore {
 			});
 			cleanups.push(unsubTaskDelta);
 
-			await hub.request('liveQuery.subscribe', {
-				queryName: 'tasks.byRoom',
-				params: [roomId],
-				subscriptionId: tasksSubId,
-			});
-
-			// Guard: abort if unsubscribed while awaiting the subscribe request
-			if (!this.liveQueryActive.has(roomId)) {
-				for (const fn of cleanups) {
-					try {
-						fn();
-					} catch {
-						/* ignore */
-					}
-				}
-				this.liveQueryCleanups.delete(roomId);
-				return;
-			}
-
-			// Re-subscribe on reconnect: the server-side subscription is per-connection.
-			const unsubTaskReconnect = hub.onConnection((state) => {
-				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
-				hub
-					.request('liveQuery.subscribe', {
-						queryName: 'tasks.byRoom',
-						params: [roomId],
-						subscriptionId: tasksSubId,
-					})
-					.catch((err) => {
-						logger.warn('Tasks LiveQuery re-subscribe failed:', err);
-					});
-			});
-			cleanups.push(unsubTaskReconnect);
-
-			// Cleanup: tell the server to dispose the subscription when leaving the room.
-			cleanups.push(() => {
-				const h = connectionManager.getHubIfConnected();
-				if (h) {
-					h.request('liveQuery.unsubscribe', { subscriptionId: tasksSubId }).catch(() => {});
-				}
-			});
-
-			// --- Goals via LiveQuery ---
-			// Register snapshot/delta handlers BEFORE subscribing so we never miss the
-			// initial snapshot that the server pushes synchronously before replying.
-			const goalsSubId = `goals-byRoom-${roomId}`;
-
-			// Stale-event guard for goals (same semantics as tasks above).
-			this.activeSubscriptionIds.add(goalsSubId);
-			cleanups.push(() => this.activeSubscriptionIds.delete(goalsSubId));
-
+			// Goals handlers
 			const unsubGoalSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
 				'liveQuery.snapshot',
 				(event) => {
@@ -477,67 +438,7 @@ class RoomStore {
 			});
 			cleanups.push(unsubGoalDelta);
 
-			// Subscribe to the goals.byRoom named query.
-			// Mark loading before subscribing; the snapshot handler clears it.
-			this.goalStore.loading.value = true;
-			await hub.request('liveQuery.subscribe', {
-				queryName: 'goals.byRoom',
-				params: [roomId],
-				subscriptionId: goalsSubId,
-			});
-
-			// Guard: abort if unsubscribed while awaiting the subscribe request
-			if (!this.liveQueryActive.has(roomId)) {
-				for (const fn of cleanups) {
-					try {
-						fn();
-					} catch {
-						/* ignore */
-					}
-				}
-				this.liveQueryCleanups.delete(roomId);
-				// Reset goalsLoading: it was set to true above but the snapshot
-				// handler (which normally clears it) will never fire.
-				this.goalStore.loading.value = false;
-				return;
-			}
-
-			// Re-subscribe on reconnect: the server-side subscription is per-connection
-			// and is gone after a disconnect. Requesting liveQuery.subscribe again with
-			// the same subscriptionId delivers a fresh snapshot to the already-registered
-			// snapshot handler above.
-			const unsubGoalReconnect = hub.onConnection((state) => {
-				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
-				this.goalStore.loading.value = true;
-				hub
-					.request('liveQuery.subscribe', {
-						queryName: 'goals.byRoom',
-						params: [roomId],
-						subscriptionId: goalsSubId,
-					})
-					.catch((err) => {
-						logger.warn('Goals LiveQuery re-subscribe failed:', err);
-						this.goalStore.loading.value = false;
-					});
-			});
-			cleanups.push(unsubGoalReconnect);
-
-			// Cleanup: tell the server to dispose the subscription when leaving the room.
-			cleanups.push(() => {
-				const h = connectionManager.getHubIfConnected();
-				if (h) {
-					h.request('liveQuery.unsubscribe', { subscriptionId: goalsSubId }).catch(() => {});
-				}
-			});
-
-			// --- Room Skills via LiveQuery (skills.byRoom) ---
-			// The server JOINs skills with room_skill_overrides and returns the effective
-			// enabled state + overriddenByRoom flag — no client-side merging needed.
-			const skillsSubId = `skills-byRoom-${roomId}`;
-
-			this.activeSubscriptionIds.add(skillsSubId);
-			cleanups.push(() => this.activeSubscriptionIds.delete(skillsSubId));
-
+			// Skills handlers
 			const unsubSkillSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
 				'liveQuery.snapshot',
 				(event) => {
@@ -561,13 +462,29 @@ class RoomStore {
 			});
 			cleanups.push(unsubSkillDelta);
 
-			await hub.request('liveQuery.subscribe', {
-				queryName: 'skills.byRoom',
-				params: [roomId],
-				subscriptionId: skillsSubId,
-			});
+			// --- Fire ALL subscribe calls in parallel ---
+			// Mark goals loading before subscribing; the snapshot handler clears it.
+			this.goalStore.loading.value = true;
 
-			// Guard: abort if unsubscribed while awaiting the subscribe request
+			await Promise.all([
+				hub.request('liveQuery.subscribe', {
+					queryName: 'tasks.byRoom',
+					params: [roomId],
+					subscriptionId: tasksSubId,
+				}),
+				hub.request('liveQuery.subscribe', {
+					queryName: 'goals.byRoom',
+					params: [roomId],
+					subscriptionId: goalsSubId,
+				}),
+				hub.request('liveQuery.subscribe', {
+					queryName: 'skills.byRoom',
+					params: [roomId],
+					subscriptionId: skillsSubId,
+				}),
+			]);
+
+			// Guard: abort if unsubscribed while awaiting the subscribe requests
 			if (!this.liveQueryActive.has(roomId)) {
 				for (const fn of cleanups) {
 					try {
@@ -577,10 +494,57 @@ class RoomStore {
 					}
 				}
 				this.liveQueryCleanups.delete(roomId);
+				this.goalStore.loading.value = false;
 				return;
 			}
 
-			// Re-subscribe on reconnect: the server-side subscription is per-connection.
+			// --- Register reconnect and cleanup handlers AFTER all subscribe calls resolve ---
+
+			// Tasks reconnect + cleanup
+			const unsubTaskReconnect = hub.onConnection((state) => {
+				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
+				hub
+					.request('liveQuery.subscribe', {
+						queryName: 'tasks.byRoom',
+						params: [roomId],
+						subscriptionId: tasksSubId,
+					})
+					.catch((err) => {
+						logger.warn('Tasks LiveQuery re-subscribe failed:', err);
+					});
+			});
+			cleanups.push(unsubTaskReconnect);
+			cleanups.push(() => {
+				const h = connectionManager.getHubIfConnected();
+				if (h) {
+					h.request('liveQuery.unsubscribe', { subscriptionId: tasksSubId }).catch(() => {});
+				}
+			});
+
+			// Goals reconnect + cleanup
+			const unsubGoalReconnect = hub.onConnection((state) => {
+				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
+				this.goalStore.loading.value = true;
+				hub
+					.request('liveQuery.subscribe', {
+						queryName: 'goals.byRoom',
+						params: [roomId],
+						subscriptionId: goalsSubId,
+					})
+					.catch((err) => {
+						logger.warn('Goals LiveQuery re-subscribe failed:', err);
+						this.goalStore.loading.value = false;
+					});
+			});
+			cleanups.push(unsubGoalReconnect);
+			cleanups.push(() => {
+				const h = connectionManager.getHubIfConnected();
+				if (h) {
+					h.request('liveQuery.unsubscribe', { subscriptionId: goalsSubId }).catch(() => {});
+				}
+			});
+
+			// Skills reconnect + cleanup
 			const unsubSkillReconnect = hub.onConnection((state) => {
 				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
 				hub
@@ -594,8 +558,6 @@ class RoomStore {
 					});
 			});
 			cleanups.push(unsubSkillReconnect);
-
-			// Cleanup: tell the server to dispose the subscription when leaving the room.
 			cleanups.push(() => {
 				const h = connectionManager.getHubIfConnected();
 				if (h) {
@@ -759,36 +721,39 @@ class RoomStore {
 
 	/**
 	 * Fetch initial state via RPC calls (pure WebSocket)
+	 *
+	 * All three RPCs (room.get, room.runtime.state, room.runtime.models) are
+	 * independent and run in parallel via Promise.allSettled so that a failure
+	 * in one does not block the others.
 	 */
 	private async fetchInitialState(
 		hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
 		roomId: string
 	): Promise<void> {
 		try {
-			const overview = await hub.request<RoomOverview>('room.get', { roomId });
+			// Fire all three RPCs in parallel — none depend on each other
+			const [overviewResult, runtimeStateResult] = await Promise.allSettled([
+				hub.request<RoomOverview>('room.get', { roomId }),
+				hub.request<{ state: RuntimeState }>('room.runtime.state', { roomId }),
+				this.fetchRuntimeModels(),
+			]);
 
-			if (overview) {
-				this.room.value = overview.room;
-				this.sessions.value = overview.sessions;
-			} else {
+			// Process room.get result
+			if (overviewResult.status === 'fulfilled' && overviewResult.value) {
+				this.room.value = overviewResult.value.room;
+				this.sessions.value = overviewResult.value.sessions;
+			} else if (overviewResult.status === 'fulfilled' && !overviewResult.value) {
 				this.error.value = 'Room not found';
+			} else if (overviewResult.status === 'rejected') {
+				logger.error('Failed to fetch room overview:', overviewResult.reason);
+				this.error.value = 'Failed to load room';
 			}
 
-			// Tasks and goals are delivered via LiveQuery snapshot pushed
-			// synchronously during liveQuery.subscribe in startSubscriptions.
-
-			// Fetch runtime state
-			try {
-				const { state } = await hub.request<{ state: RuntimeState }>('room.runtime.state', {
-					roomId,
-				});
-				this.runtimeState.value = state;
-			} catch {
-				// Runtime may not exist yet
+			// Process runtime state result
+			if (runtimeStateResult.status === 'fulfilled') {
+				this.runtimeState.value = runtimeStateResult.value.state;
 			}
-
-			// Fetch runtime models (leader/worker)
-			await this.fetchRuntimeModels();
+			// Runtime may not exist yet — silently ignore rejection
 		} catch (err) {
 			logger.error('Failed to fetch room state:', err);
 			this.error.value = err instanceof Error ? err.message : 'Failed to load room';


### PR DESCRIPTION
Eliminates redundant queries on room entry and parallelizes independent RPC/LiveQuery calls.

## Phase 1: Eliminate redundant queries
- **Remove `activeTasks`/`allTasks` from `RoomOverview`** — the frontend already gets tasks via `tasks.byRoom` LiveQuery, making these fields dead weight that caused 2 unnecessary full task DB queries per room entry
- **Add `inbox.reviewTasks` RPC** — replaces the fan-out of N `room.get` calls with a single server-side query that collects review-status tasks using SQL-level filtering

## Phase 3: Parallelize
- **`fetchInitialState()`**: `room.get`, `room.runtime.state`, and `room.runtime.models` run in parallel via `Promise.allSettled` with safe null guards (was 3 sequential awaits)
- **`subscribeRoom()`**: all three LiveQuery subscriptions (tasks, goals, skills) fire in parallel via `Promise.allSettled` — failed subscriptions are cleaned up server-side to prevent leaks

## Review fixes (round 2)
- **P1**: Changed `subscribeRoom` from `Promise.all` to `Promise.allSettled` — on partial failure, successfully-registered subscriptions get reconnect/cleanup handlers while failed ones are unsubscribed server-side
- **P1**: Added `?.state` guard in `fetchInitialState` to prevent TypeError on empty runtime response
- **P2**: `inbox.reviewTasks` now filters at SQL level (`{ status: 'review' }`) and hoists `makeTaskRepo()` outside the loop
- **P2**: Extracted `toTaskSummary()` to `packages/daemon/src/lib/task-utils.ts` — shared by task-handlers and neo-query-tools
- **P2**: Restored error-path tests for `approveTask`/`rejectTask` in inbox-store
- **P3**: Removed stale `allTasks`/`activeTasks` from test mocks across 10 files
- **P3**: Fixed trailing space in test description