### PR TITLE
feat: add NodeExecutionRepository for workflow node execution tracking

### DIFF
--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -1,0 +1,198 @@
+/**
+ * NodeExecutionRepository
+ *
+ * Repository for NodeExecution CRUD operations.
+ *
+ * Records the execution of a single agent slot within a workflow run's node.
+ * One row is created per (workflowRunId, workflowNodeId, agentName) triple.
+ * This separates workflow-internal state from the user-facing SpaceTask.
+ *
+ * Table: node_executions
+ *   - FK to space_workflow_runs ON DELETE CASCADE
+ *   - FK to space_agents ON DELETE SET NULL
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	NodeExecution,
+	NodeExecutionStatus,
+	CreateNodeExecutionParams,
+	UpdateNodeExecutionParams,
+} from '@neokai/shared';
+import type { SQLiteValue } from '../types';
+
+export class NodeExecutionRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Create a new node execution record
+	 */
+	create(params: CreateNodeExecutionParams): NodeExecution {
+		const id = generateUUID();
+		const now = Date.now();
+
+		this.db
+			.prepare(
+				`INSERT INTO node_executions
+				    (id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				     agent_session_id, status, result, created_at, started_at,
+				     completed_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.workflowRunId,
+				params.workflowNodeId,
+				params.agentName,
+				params.agentId,
+				params.agentSessionId ?? null,
+				params.status ?? 'pending',
+				null,
+				now,
+				null,
+				null,
+				now
+			);
+
+		return this.getById(id)!;
+	}
+
+	/**
+	 * Get a node execution by ID
+	 */
+	getById(id: string): NodeExecution | null {
+		const row = this.db.prepare(`SELECT * FROM node_executions WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+
+		if (!row) return null;
+		return this.rowToNodeExecution(row);
+	}
+
+	/**
+	 * List all node executions for a workflow run
+	 */
+	listByWorkflowRun(workflowRunId: string): NodeExecution[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM node_executions WHERE workflow_run_id = ? ORDER BY created_at ASC`)
+			.all(workflowRunId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToNodeExecution(r));
+	}
+
+	/**
+	 * List node executions for a specific node within a workflow run
+	 */
+	listByNode(workflowRunId: string, workflowNodeId: string): NodeExecution[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM node_executions
+				        WHERE workflow_run_id = ? AND workflow_node_id = ?
+				        ORDER BY created_at ASC`
+			)
+			.all(workflowRunId, workflowNodeId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToNodeExecution(r));
+	}
+
+	/**
+	 * Update a node execution with partial updates
+	 */
+	update(id: string, params: UpdateNodeExecutionParams): NodeExecution | null {
+		const fields: string[] = [];
+		const values: SQLiteValue[] = [];
+
+		if (params.status !== undefined) {
+			fields.push('status = ?');
+			values.push(params.status);
+
+			if (params.status === 'in_progress') {
+				fields.push('started_at = ?');
+				values.push(Date.now());
+			} else if (
+				params.status === 'done' ||
+				params.status === 'blocked' ||
+				params.status === 'cancelled'
+			) {
+				fields.push('completed_at = ?');
+				values.push(Date.now());
+			}
+		}
+		if (params.agentSessionId !== undefined) {
+			fields.push('agent_session_id = ?');
+			values.push(params.agentSessionId ?? null);
+		}
+		if (params.result !== undefined) {
+			fields.push('result = ?');
+			values.push(params.result ?? null);
+		}
+		if (params.startedAt !== undefined) {
+			fields.push('started_at = ?');
+			values.push(params.startedAt ?? null);
+		}
+		if (params.completedAt !== undefined) {
+			fields.push('completed_at = ?');
+			values.push(params.completedAt ?? null);
+		}
+
+		if (fields.length > 0) {
+			fields.push('updated_at = ?');
+			values.push(Date.now());
+			values.push(id);
+			this.db
+				.prepare(`UPDATE node_executions SET ${fields.join(', ')} WHERE id = ?`)
+				.run(...values);
+		}
+
+		return this.getById(id);
+	}
+
+	/**
+	 * Update only the status of a node execution, with automatic timestamp stamping.
+	 */
+	updateStatus(id: string, status: NodeExecutionStatus): NodeExecution | null {
+		return this.update(id, { status });
+	}
+
+	/**
+	 * Update the agent session ID for a node execution.
+	 * Used when an agent sub-session is created or cleared.
+	 */
+	updateSessionId(id: string, agentSessionId: string | null): NodeExecution | null {
+		return this.update(id, { agentSessionId });
+	}
+
+	/**
+	 * Delete a node execution by ID
+	 */
+	delete(id: string): boolean {
+		const result = this.db.prepare(`DELETE FROM node_executions WHERE id = ?`).run(id);
+		return result.changes > 0;
+	}
+
+	/**
+	 * Delete all node executions for a workflow run
+	 */
+	deleteByWorkflowRun(workflowRunId: string): void {
+		this.db.prepare(`DELETE FROM node_executions WHERE workflow_run_id = ?`).run(workflowRunId);
+	}
+
+	/**
+	 * Convert a database row to a NodeExecution object
+	 */
+	private rowToNodeExecution(row: Record<string, unknown>): NodeExecution {
+		return {
+			id: row.id as string,
+			workflowRunId: row.workflow_run_id as string,
+			workflowNodeId: row.workflow_node_id as string,
+			agentName: row.agent_name as string,
+			agentId: (row.agent_id as string | null) ?? '',
+			agentSessionId: (row.agent_session_id as string | null) ?? null,
+			status: row.status as NodeExecutionStatus,
+			result: (row.result as string | null) ?? null,
+			createdAt: row.created_at as number,
+			startedAt: (row.started_at as number | null) ?? null,
+			completedAt: (row.completed_at as number | null) ?? null,
+			updatedAt: row.updated_at as number,
+		};
+	}
+}

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -48,6 +48,7 @@ export class NodeExecutionRepository {
 				params.agentId,
 				params.agentSessionId ?? null,
 				params.status ?? 'pending',
+				// result is only set via update() after the agent calls report_done
 				null,
 				now,
 				null,
@@ -105,13 +106,16 @@ export class NodeExecutionRepository {
 			fields.push('status = ?');
 			values.push(params.status);
 
-			if (params.status === 'in_progress') {
+			// Auto-stamp timestamps only when the caller does NOT provide
+			// an explicit value — avoids duplicate SET entries in the SQL.
+			if (params.status === 'in_progress' && params.startedAt === undefined) {
 				fields.push('started_at = ?');
 				values.push(Date.now());
 			} else if (
-				params.status === 'done' ||
-				params.status === 'blocked' ||
-				params.status === 'cancelled'
+				(params.status === 'done' ||
+					params.status === 'blocked' ||
+					params.status === 'cancelled') &&
+				params.completedAt === undefined
 			) {
 				fields.push('completed_at = ?');
 				values.push(Date.now());
@@ -185,7 +189,7 @@ export class NodeExecutionRepository {
 			workflowRunId: row.workflow_run_id as string,
 			workflowNodeId: row.workflow_node_id as string,
 			agentName: row.agent_name as string,
-			agentId: (row.agent_id as string | null) ?? '',
+			agentId: (row.agent_id as string | null) ?? null,
 			agentSessionId: (row.agent_session_id as string | null) ?? null,
 			status: row.status as NodeExecutionStatus,
 			result: (row.result as string | null) ?? null,

--- a/packages/daemon/tests/unit/storage/node-execution-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/node-execution-repository.test.ts
@@ -1,0 +1,499 @@
+/**
+ * NodeExecutionRepository Tests
+ *
+ * Tests CRUD operations, status transitions with automatic timestamp stamping,
+ * query by workflow run and node, session ID management, and FK cascade behavior.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('NodeExecutionRepository', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let runRepo: SpaceWorkflowRunRepository;
+	let repo: NodeExecutionRepository;
+	let spaceId: string;
+	let workflowId: string;
+	let workflowRunId: string;
+	let agentId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		spaceRepo = new SpaceRepository(db as any);
+		runRepo = new SpaceWorkflowRunRepository(db as any);
+		repo = new NodeExecutionRepository(db as any);
+
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/test',
+			slug: 'test',
+			name: 'Test Space',
+		});
+		spaceId = space.id;
+
+		// Insert workflow + run + agent for FK constraints
+		workflowId = 'wf-1';
+		agentId = 'agent-1';
+		const now = Date.now();
+
+		(db as any)
+			.prepare(
+				`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+			)
+			.run(workflowId, spaceId, 'My Workflow', now, now);
+
+		const run = runRepo.createRun({ spaceId, workflowId, title: 'Run #1' });
+		workflowRunId = run.id;
+
+		(db as any)
+			.prepare(
+				`INSERT INTO space_agents (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+			)
+			.run(agentId, spaceId, 'Coder', now, now);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// Helper to create a node execution with defaults
+	function createExecution(
+		overrides: Partial<import('@neokai/shared').CreateNodeExecutionParams> = {}
+	) {
+		return repo.create({
+			workflowRunId,
+			workflowNodeId: 'node-1',
+			agentName: 'coder',
+			agentId,
+			...overrides,
+		});
+	}
+
+	describe('create', () => {
+		it('creates a node execution with required fields', () => {
+			const exec = createExecution();
+
+			expect(exec.id).toBeDefined();
+			expect(exec.workflowRunId).toBe(workflowRunId);
+			expect(exec.workflowNodeId).toBe('node-1');
+			expect(exec.agentName).toBe('coder');
+			expect(exec.agentId).toBe(agentId);
+			expect(exec.status).toBe('pending');
+			expect(exec.agentSessionId).toBeNull();
+			expect(exec.result).toBeNull();
+			expect(exec.createdAt).toBeGreaterThan(0);
+			expect(exec.startedAt).toBeNull();
+			expect(exec.completedAt).toBeNull();
+			expect(exec.updatedAt).toBeGreaterThan(0);
+		});
+
+		it('creates with a custom initial status', () => {
+			const exec = createExecution({ status: 'in_progress' });
+			expect(exec.status).toBe('in_progress');
+		});
+
+		it('creates with an agent session ID', () => {
+			const exec = createExecution({ agentSessionId: 'session-abc' });
+			expect(exec.agentSessionId).toBe('session-abc');
+		});
+
+		it('creates with a different agent', () => {
+			const exec = createExecution({ agentName: 'reviewer', agentId });
+			expect(exec.agentName).toBe('reviewer');
+		});
+
+		it('creates with a different workflow run', () => {
+			const run2 = runRepo.createRun({ spaceId, workflowId, title: 'Run #2' });
+			const exec = createExecution({ workflowRunId: run2.id });
+			expect(exec.workflowRunId).toBe(run2.id);
+		});
+
+		it('creates with a different node', () => {
+			const exec = createExecution({ workflowNodeId: 'node-2' });
+			expect(exec.workflowNodeId).toBe('node-2');
+		});
+	});
+
+	describe('getById', () => {
+		it('returns a node execution by ID', () => {
+			const created = createExecution();
+			const found = repo.getById(created.id);
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(created.id);
+		});
+
+		it('returns null for unknown ID', () => {
+			expect(repo.getById('nonexistent')).toBeNull();
+		});
+
+		it('round-trips all fields correctly', () => {
+			const exec = createExecution({
+				workflowNodeId: 'node-review',
+				agentName: 'reviewer',
+				agentId,
+			});
+			const fetched = repo.getById(exec.id)!;
+			expect(fetched.workflowRunId).toBe(workflowRunId);
+			expect(fetched.workflowNodeId).toBe('node-review');
+			expect(fetched.agentName).toBe('reviewer');
+			expect(fetched.agentId).toBe(agentId);
+		});
+	});
+
+	describe('listByWorkflowRun', () => {
+		it('lists all node executions for a workflow run', () => {
+			createExecution({ workflowNodeId: 'node-1', agentName: 'coder' });
+			createExecution({ workflowNodeId: 'node-1', agentName: 'reviewer' });
+			createExecution({ workflowNodeId: 'node-2', agentName: 'qa' });
+
+			const executions = repo.listByWorkflowRun(workflowRunId);
+			expect(executions).toHaveLength(3);
+		});
+
+		it('returns empty for a run with no executions', () => {
+			const run2 = runRepo.createRun({ spaceId, workflowId, title: 'Run #2' });
+			expect(repo.listByWorkflowRun(run2.id)).toHaveLength(0);
+		});
+
+		it('does not include executions from other runs', () => {
+			createExecution({ workflowNodeId: 'node-1', agentName: 'coder' });
+
+			const run2 = runRepo.createRun({ spaceId, workflowId, title: 'Run #2' });
+			createExecution({
+				workflowRunId: run2.id,
+				workflowNodeId: 'node-1',
+				agentName: 'reviewer',
+			});
+
+			const run1Execs = repo.listByWorkflowRun(workflowRunId);
+			expect(run1Execs).toHaveLength(1);
+			expect(run1Execs[0].agentName).toBe('coder');
+		});
+
+		it('orders by created_at ASC', () => {
+			const e1 = createExecution({ agentName: 'first' });
+			const e2 = createExecution({ agentName: 'second' });
+			const e3 = createExecution({ agentName: 'third' });
+
+			const executions = repo.listByWorkflowRun(workflowRunId);
+			expect(executions.map((e) => e.id)).toEqual([e1.id, e2.id, e3.id]);
+		});
+	});
+
+	describe('listByNode', () => {
+		it('lists node executions for a specific node within a run', () => {
+			createExecution({ workflowNodeId: 'node-A', agentName: 'coder' });
+			createExecution({ workflowNodeId: 'node-A', agentName: 'reviewer' });
+			createExecution({ workflowNodeId: 'node-B', agentName: 'qa' });
+
+			const nodeAExecs = repo.listByNode(workflowRunId, 'node-A');
+			expect(nodeAExecs).toHaveLength(2);
+			expect(nodeAExecs.every((e) => e.workflowNodeId === 'node-A')).toBe(true);
+		});
+
+		it('returns empty for a node with no executions', () => {
+			const execs = repo.listByNode(workflowRunId, 'nonexistent-node');
+			expect(execs).toHaveLength(0);
+		});
+
+		it('does not include executions from other runs for the same node ID', () => {
+			createExecution({ workflowNodeId: 'node-1', agentName: 'coder' });
+
+			const run2 = runRepo.createRun({ spaceId, workflowId, title: 'Run #2' });
+			createExecution({
+				workflowRunId: run2.id,
+				workflowNodeId: 'node-1',
+				agentName: 'reviewer',
+			});
+
+			const node1Execs = repo.listByNode(workflowRunId, 'node-1');
+			expect(node1Execs).toHaveLength(1);
+			expect(node1Execs[0].agentName).toBe('coder');
+		});
+	});
+
+	describe('update', () => {
+		it('updates status and stamps startedAt for in_progress', () => {
+			const exec = createExecution();
+			const updated = repo.update(exec.id, { status: 'in_progress' });
+
+			expect(updated!.status).toBe('in_progress');
+			expect(updated!.startedAt).not.toBeNull();
+			expect(updated!.startedAt).toBeGreaterThan(0);
+		});
+
+		it('updates status and stamps completedAt for done', () => {
+			const exec = createExecution();
+			repo.update(exec.id, { status: 'in_progress' });
+			const updated = repo.update(exec.id, { status: 'done' });
+
+			expect(updated!.status).toBe('done');
+			expect(updated!.completedAt).not.toBeNull();
+			expect(updated!.completedAt).toBeGreaterThan(0);
+		});
+
+		it('updates status and stamps completedAt for blocked', () => {
+			const exec = createExecution();
+			const updated = repo.update(exec.id, { status: 'blocked' });
+
+			expect(updated!.status).toBe('blocked');
+			expect(updated!.completedAt).not.toBeNull();
+		});
+
+		it('updates status and stamps completedAt for cancelled', () => {
+			const exec = createExecution();
+			const updated = repo.update(exec.id, { status: 'cancelled' });
+
+			expect(updated!.status).toBe('cancelled');
+			expect(updated!.completedAt).not.toBeNull();
+		});
+
+		it('updates agentSessionId', () => {
+			const exec = createExecution();
+			const updated = repo.update(exec.id, { agentSessionId: 'session-xyz' });
+			expect(updated!.agentSessionId).toBe('session-xyz');
+		});
+
+		it('clears agentSessionId with null', () => {
+			const exec = createExecution({ agentSessionId: 'session-abc' });
+			const updated = repo.update(exec.id, { agentSessionId: null });
+			expect(updated!.agentSessionId).toBeNull();
+		});
+
+		it('updates result', () => {
+			const exec = createExecution();
+			const updated = repo.update(exec.id, { result: 'All tests passed' });
+			expect(updated!.result).toBe('All tests passed');
+		});
+
+		it('clears result with null', () => {
+			const exec = createExecution();
+			repo.update(exec.id, { result: 'Some result' });
+			const updated = repo.update(exec.id, { result: null });
+			expect(updated!.result).toBeNull();
+		});
+
+		it('updates multiple fields at once', () => {
+			const exec = createExecution();
+			const updated = repo.update(exec.id, {
+				status: 'done',
+				agentSessionId: 'session-final',
+				result: 'Completed successfully',
+			});
+
+			expect(updated!.status).toBe('done');
+			expect(updated!.agentSessionId).toBe('session-final');
+			expect(updated!.result).toBe('Completed successfully');
+			expect(updated!.completedAt).not.toBeNull();
+		});
+
+		it('no-op update returns unchanged execution', () => {
+			const exec = createExecution();
+			const updated = repo.update(exec.id, {});
+			expect(updated!.id).toBe(exec.id);
+			expect(updated!.status).toBe(exec.status);
+		});
+
+		it('returns null for unknown ID', () => {
+			const updated = repo.update('nonexistent', { status: 'done' });
+			expect(updated).toBeNull();
+		});
+
+		it('updates updatedAt timestamp on every change', () => {
+			const exec = createExecution();
+			const originalUpdatedAt = exec.updatedAt;
+
+			// Small delay to ensure timestamp difference
+			const updated = repo.update(exec.id, { status: 'in_progress' });
+			expect(updated!.updatedAt).toBeGreaterThanOrEqual(originalUpdatedAt);
+		});
+	});
+
+	describe('updateStatus', () => {
+		it('transitions pending → in_progress', () => {
+			const exec = createExecution();
+			const updated = repo.updateStatus(exec.id, 'in_progress');
+			expect(updated!.status).toBe('in_progress');
+			expect(updated!.startedAt).not.toBeNull();
+		});
+
+		it('transitions in_progress → done', () => {
+			const exec = createExecution();
+			repo.updateStatus(exec.id, 'in_progress');
+			const updated = repo.updateStatus(exec.id, 'done');
+			expect(updated!.status).toBe('done');
+			expect(updated!.completedAt).not.toBeNull();
+		});
+
+		it('transitions pending → blocked directly', () => {
+			const exec = createExecution();
+			const updated = repo.updateStatus(exec.id, 'blocked');
+			expect(updated!.status).toBe('blocked');
+			expect(updated!.completedAt).not.toBeNull();
+		});
+
+		it('transitions pending → cancelled directly', () => {
+			const exec = createExecution();
+			const updated = repo.updateStatus(exec.id, 'cancelled');
+			expect(updated!.status).toBe('cancelled');
+			expect(updated!.completedAt).not.toBeNull();
+		});
+	});
+
+	describe('updateSessionId', () => {
+		it('sets the session ID', () => {
+			const exec = createExecution();
+			const updated = repo.updateSessionId(exec.id, 'session-abc');
+			expect(updated!.agentSessionId).toBe('session-abc');
+		});
+
+		it('clears the session ID', () => {
+			const exec = createExecution({ agentSessionId: 'session-abc' });
+			const updated = repo.updateSessionId(exec.id, null);
+			expect(updated!.agentSessionId).toBeNull();
+		});
+	});
+
+	describe('delete', () => {
+		it('deletes a node execution', () => {
+			const exec = createExecution();
+			expect(repo.delete(exec.id)).toBe(true);
+			expect(repo.getById(exec.id)).toBeNull();
+		});
+
+		it('returns false for unknown ID', () => {
+			expect(repo.delete('nonexistent')).toBe(false);
+		});
+
+		it('removes the execution from listByWorkflowRun', () => {
+			const exec = createExecution();
+			expect(repo.listByWorkflowRun(workflowRunId)).toHaveLength(1);
+			repo.delete(exec.id);
+			expect(repo.listByWorkflowRun(workflowRunId)).toHaveLength(0);
+		});
+
+		it('removes the execution from listByNode', () => {
+			const exec = createExecution({ workflowNodeId: 'node-X' });
+			expect(repo.listByNode(workflowRunId, 'node-X')).toHaveLength(1);
+			repo.delete(exec.id);
+			expect(repo.listByNode(workflowRunId, 'node-X')).toHaveLength(0);
+		});
+	});
+
+	describe('deleteByWorkflowRun', () => {
+		it('deletes all node executions for a workflow run', () => {
+			createExecution({ workflowNodeId: 'node-1', agentName: 'coder' });
+			createExecution({ workflowNodeId: 'node-1', agentName: 'reviewer' });
+			createExecution({ workflowNodeId: 'node-2', agentName: 'qa' });
+
+			expect(repo.listByWorkflowRun(workflowRunId)).toHaveLength(3);
+			repo.deleteByWorkflowRun(workflowRunId);
+			expect(repo.listByWorkflowRun(workflowRunId)).toHaveLength(0);
+		});
+
+		it('does not affect executions from other runs', () => {
+			createExecution({ workflowNodeId: 'node-1', agentName: 'coder' });
+
+			const run2 = runRepo.createRun({ spaceId, workflowId, title: 'Run #2' });
+			createExecution({
+				workflowRunId: run2.id,
+				workflowNodeId: 'node-1',
+				agentName: 'reviewer',
+			});
+
+			repo.deleteByWorkflowRun(workflowRunId);
+			expect(repo.listByWorkflowRun(workflowRunId)).toHaveLength(0);
+			expect(repo.listByWorkflowRun(run2.id)).toHaveLength(1);
+		});
+
+		it('is idempotent for runs with no executions', () => {
+			const run2 = runRepo.createRun({ spaceId, workflowId, title: 'Run #2' });
+			expect(() => repo.deleteByWorkflowRun(run2.id)).not.toThrow();
+		});
+	});
+
+	describe('FK cascade behavior', () => {
+		it('cascades delete when workflow run is deleted', () => {
+			const exec = createExecution();
+			expect(repo.getById(exec.id)).not.toBeNull();
+
+			// Delete the workflow run — node executions should cascade
+			runRepo.deleteRun(workflowRunId);
+			expect(repo.getById(exec.id)).toBeNull();
+			expect(repo.listByWorkflowRun(workflowRunId)).toHaveLength(0);
+		});
+
+		it('sets agent_id to empty string when agent is deleted (FK SET NULL)', () => {
+			const exec = createExecution({ agentId });
+			expect(exec.agentId).toBe(agentId);
+
+			// Delete the agent — FK ON DELETE SET NULL maps null to ''
+			(db as any).prepare(`DELETE FROM space_agents WHERE id = ?`).run(agentId);
+
+			const updated = repo.getById(exec.id)!;
+			expect(updated.agentId).toBe('');
+		});
+	});
+
+	describe('status transitions and timestamp stamping', () => {
+		it('full lifecycle: pending → in_progress → done', () => {
+			const exec = createExecution();
+			expect(exec.status).toBe('pending');
+			expect(exec.startedAt).toBeNull();
+			expect(exec.completedAt).toBeNull();
+
+			// Start
+			const started = repo.updateStatus(exec.id, 'in_progress')!;
+			expect(started.status).toBe('in_progress');
+			expect(started.startedAt).not.toBeNull();
+			expect(started.completedAt).toBeNull();
+
+			// Complete
+			const completed = repo.updateStatus(started.id, 'done')!;
+			expect(completed.status).toBe('done');
+			expect(completed.startedAt).toBe(started.startedAt);
+			expect(completed.completedAt).not.toBeNull();
+		});
+
+		it('re-entry to in_progress re-stamps startedAt', () => {
+			const exec = createExecution();
+			const first = repo.updateStatus(exec.id, 'in_progress')!;
+			const firstStartedAt = first.startedAt;
+
+			// Simulate going to blocked then back to in_progress
+			repo.updateStatus(exec.id, 'blocked');
+			const reentry = repo.updateStatus(exec.id, 'in_progress')!;
+
+			expect(reentry.status).toBe('in_progress');
+			expect(reentry.startedAt).not.toBeNull();
+			// startedAt is re-stamped (may be same ms on fast machines)
+			expect(reentry.startedAt).toBeGreaterThanOrEqual(firstStartedAt!);
+		});
+	});
+
+	describe('multi-agent node support', () => {
+		it('supports multiple agent slots on the same node', () => {
+			const e1 = createExecution({ workflowNodeId: 'review-node', agentName: 'strict-reviewer' });
+			const e2 = createExecution({ workflowNodeId: 'review-node', agentName: 'quick-reviewer' });
+
+			const nodeExecs = repo.listByNode(workflowRunId, 'review-node');
+			expect(nodeExecs).toHaveLength(2);
+			const names = nodeExecs.map((e) => e.agentName).sort();
+			expect(names).toEqual(['quick-reviewer', 'strict-reviewer']);
+		});
+
+		it('allows same agent on different nodes', () => {
+			const e1 = createExecution({ workflowNodeId: 'node-A', agentName: 'coder' });
+			const e2 = createExecution({ workflowNodeId: 'node-B', agentName: 'coder' });
+
+			expect(e1.id).not.toBe(e2.id);
+			expect(e1.workflowNodeId).toBe('node-A');
+			expect(e2.workflowNodeId).toBe('node-B');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/node-execution-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/node-execution-repository.test.ts
@@ -253,6 +253,31 @@ describe('NodeExecutionRepository', () => {
 			expect(updated!.completedAt).not.toBeNull();
 		});
 
+		it('explicit startedAt overrides auto-stamp when status is in_progress', () => {
+			const exec = createExecution();
+			const explicitTime = 1000000;
+			const updated = repo.update(exec.id, {
+				status: 'in_progress',
+				startedAt: explicitTime,
+			});
+
+			expect(updated!.status).toBe('in_progress');
+			// Explicit value should win, not auto-stamped Date.now()
+			expect(updated!.startedAt).toBe(explicitTime);
+		});
+
+		it('explicit completedAt overrides auto-stamp when status is done', () => {
+			const exec = createExecution();
+			const explicitTime = 2000000;
+			const updated = repo.update(exec.id, {
+				status: 'done',
+				completedAt: explicitTime,
+			});
+
+			expect(updated!.status).toBe('done');
+			expect(updated!.completedAt).toBe(explicitTime);
+		});
+
 		it('updates agentSessionId', () => {
 			const exec = createExecution();
 			const updated = repo.update(exec.id, { agentSessionId: 'session-xyz' });
@@ -428,15 +453,15 @@ describe('NodeExecutionRepository', () => {
 			expect(repo.listByWorkflowRun(workflowRunId)).toHaveLength(0);
 		});
 
-		it('sets agent_id to empty string when agent is deleted (FK SET NULL)', () => {
+		it('sets agentId to null when agent is deleted (FK SET NULL)', () => {
 			const exec = createExecution({ agentId });
 			expect(exec.agentId).toBe(agentId);
 
-			// Delete the agent — FK ON DELETE SET NULL maps null to ''
+			// Delete the agent — FK ON DELETE SET NULL
 			(db as any).prepare(`DELETE FROM space_agents WHERE id = ?`).run(agentId);
 
 			const updated = repo.getById(exec.id)!;
-			expect(updated.agentId).toBe('');
+			expect(updated.agentId).toBeNull();
 		});
 	});
 
@@ -478,8 +503,8 @@ describe('NodeExecutionRepository', () => {
 
 	describe('multi-agent node support', () => {
 		it('supports multiple agent slots on the same node', () => {
-			const e1 = createExecution({ workflowNodeId: 'review-node', agentName: 'strict-reviewer' });
-			const e2 = createExecution({ workflowNodeId: 'review-node', agentName: 'quick-reviewer' });
+			createExecution({ workflowNodeId: 'review-node', agentName: 'strict-reviewer' });
+			createExecution({ workflowNodeId: 'review-node', agentName: 'quick-reviewer' });
 
 			const nodeExecs = repo.listByNode(workflowRunId, 'review-node');
 			expect(nodeExecs).toHaveLength(2);
@@ -488,12 +513,12 @@ describe('NodeExecutionRepository', () => {
 		});
 
 		it('allows same agent on different nodes', () => {
-			const e1 = createExecution({ workflowNodeId: 'node-A', agentName: 'coder' });
-			const e2 = createExecution({ workflowNodeId: 'node-B', agentName: 'coder' });
+			const nodeA = createExecution({ workflowNodeId: 'node-A', agentName: 'coder' });
+			const nodeB = createExecution({ workflowNodeId: 'node-B', agentName: 'coder' });
 
-			expect(e1.id).not.toBe(e2.id);
-			expect(e1.workflowNodeId).toBe('node-A');
-			expect(e2.workflowNodeId).toBe('node-B');
+			expect(nodeA.id).not.toBe(nodeB.id);
+			expect(nodeA.workflowNodeId).toBe('node-A');
+			expect(nodeB.workflowNodeId).toBe('node-B');
 		});
 	});
 });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -345,8 +345,8 @@ export interface NodeExecution {
 	workflowNodeId: string;
 	/** Agent slot name (`WorkflowNodeAgent.name`) — channel routing address */
 	agentName: string;
-	/** ID of the SpaceAgent assigned to this slot */
-	agentId: string;
+	/** ID of the SpaceAgent assigned to this slot; null when the agent has been deleted */
+	agentId: string | null;
 	/** Agent sub-session ID for liveness tracking; null until session is created */
 	agentSessionId: string | null;
 	/** Current execution status */


### PR DESCRIPTION
## Summary
- Add `NodeExecutionRepository` with full CRUD for the `node_executions` table created by M74 migration
- Existing repositories (SpaceTask, SpaceWorkflow, SpaceWorkflowRun, SpaceAgent) were already updated to the new schema by previous tasks (schema type definitions PR #1189)

## New: `NodeExecutionRepository`
- `create()` / `getById()` / `listByWorkflowRun()` / `listByNode()` — standard queries
- `update()` — partial updates with automatic timestamp stamping on status transitions (`startedAt` for `in_progress`, `completedAt` for `done`/`blocked`/`cancelled`)
- `updateStatus()` / `updateSessionId()` — convenience wrappers
- `delete()` / `deleteByWorkflowRun()` — removal with FK cascade awareness

## Verification
- 47 unit tests covering CRUD, status transitions, FK cascade behavior, multi-agent nodes, and query filtering
- All 1018 existing storage tests still pass
- `bun run typecheck` passes
- Lint and format clean