### PR TITLE
feat: add SQL validation layer for db-query MCP server

### DIFF
--- a/packages/daemon/src/lib/db-query/sql-validator.ts
+++ b/packages/daemon/src/lib/db-query/sql-validator.ts
@@ -1,0 +1,217 @@
+/**
+ * SQL validation layer for the db-query MCP server.
+ *
+ * Provides fast, helpful error messages for obviously invalid queries before
+ * they reach SQLite. This is NOT a security boundary — write prevention is
+ * handled by the read-only connection. The goal is to fail fast with clear
+ * messages for common mistakes.
+ */
+
+/** Result of SQL validation, including extracted table references. */
+export interface SqlValidationResult {
+	/** Whether the statement passed all checks. */
+	valid: boolean;
+	/** Human-readable error message when validation fails. */
+	error?: string;
+	/** Table names referenced in FROM / JOIN clauses (CTE names excluded). */
+	tableRefs: string[];
+}
+
+// ============ Internal helpers ============
+
+/**
+ * Strip line comments (--) and block comments (/* *​/) from SQL.
+ * Does NOT handle nested block comments (SQL doesn't support them).
+ */
+function stripComments(sql: string): string {
+	let result = sql;
+
+	// Block comments first (so we don't match inside them with line-comment regex)
+	result = result.replace(/\/\*[\s\S]*?\*\//g, ' ');
+
+	// Line comments
+	result = result.replace(/--[^\n]*/g, ' ');
+
+	return result;
+}
+
+/**
+ * Collapse runs of whitespace into single spaces and trim.
+ */
+function normalizeWhitespace(sql: string): string {
+	return sql.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Extract CTE names from a WITH ... AS (...) preamble.
+ * Returns an object with cteNames (a set of CTE names)
+ * and remaining (the SQL after the WITH block).
+ *
+ * Handles both single and multiple CTEs:
+ *   WITH x AS (...), y AS (...) SELECT ...
+ */
+function extractCtes(sql: string): { cteNames: Set<string>; remaining: string } {
+	const trimmed = sql.trimStart();
+
+	// Must start with WITH (case-insensitive)
+	if (!/^[Ww][Ii][Tt][Hh]\b/.test(trimmed)) {
+		return { cteNames: new Set(), remaining: sql };
+	}
+
+	const cteNames = new Set<string>();
+	let pos = 4; // skip "WITH"
+	const len = trimmed.length;
+
+	// Skip whitespace after WITH
+	while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+	while (pos < len) {
+		// Extract CTE name (identifier)
+		const nameStart = pos;
+		while (pos < len && /[\p{L}\p{N}_]/u.test(trimmed[pos])) pos++;
+		if (pos === nameStart) break; // no name found
+		const cteName = trimmed.slice(nameStart, pos).toLowerCase();
+		cteNames.add(cteName);
+
+		// Skip whitespace
+		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+		// Expect "AS" keyword
+		if (
+			pos + 1 < len &&
+			trimmed[pos].toLowerCase() === 'a' &&
+			trimmed[pos + 1].toLowerCase() === 's'
+		) {
+			pos += 2;
+		} else {
+			break;
+		}
+
+		// Skip whitespace
+		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+		// Skip parenthesised CTE body — track nesting depth
+		if (pos < len && trimmed[pos] === '(') {
+			let depth = 1;
+			pos++;
+			while (pos < len && depth > 0) {
+				if (trimmed[pos] === '(') depth++;
+				else if (trimmed[pos] === ')') depth--;
+				// Skip string literals so parens inside strings aren't counted
+				else if (trimmed[pos] === "'") {
+					pos++;
+					while (pos < len && trimmed[pos] !== "'") {
+						if (trimmed[pos] === "'") pos++; // escaped quote
+						pos++;
+					}
+				}
+				pos++;
+			}
+		}
+
+		// Skip whitespace
+		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+		// Check for trailing comma (more CTEs) or end of WITH block
+		if (pos < len && trimmed[pos] === ',') {
+			pos++;
+			// Skip whitespace after comma
+			while (pos < len && /\s/.test(trimmed[pos])) pos++;
+		} else {
+			break;
+		}
+	}
+
+	return { cteNames, remaining: trimmed.slice(pos) };
+}
+
+/**
+ * Extract table name candidates from FROM and JOIN clauses.
+ * Matches FROM <name> and JOIN <name> (any JOIN variant).
+ * Skips names that appear in the exclude set (e.g., CTE names).
+ */
+function extractTableRefs(sql: string, exclude: Set<string>): string[] {
+	const refs: string[] = [];
+
+	// FROM clause — match FROM <identifier> (not followed by '(' which would be a function)
+	const identRe = '[\\p{L}\\p{N}_]+';
+	const fromRe = new RegExp(`\\b[Ff][Rr][Oo][Mm]\\s+(${identRe})`, 'gu');
+	let m: RegExpExecArray | null;
+	while ((m = fromRe.exec(sql)) !== null) {
+		const name = m[1].toLowerCase();
+		if (!exclude.has(name) && !refs.includes(name)) {
+			refs.push(name);
+		}
+	}
+
+	// JOIN clause — LEFT/RIGHT/INNER/OUTER/CROSS/NATURAL JOIN <identifier>
+	const joinRe = new RegExp(
+		`\\b(?:LEFT|RIGHT|INNER|OUTER|CROSS|NATURAL)?\\s*[Jj][Oo][Ii][Nn]\\s+(${identRe})`,
+		'gu'
+	);
+	while ((m = joinRe.exec(sql)) !== null) {
+		const name = m[1].toLowerCase();
+		if (!exclude.has(name) && !refs.includes(name)) {
+			refs.push(name);
+		}
+	}
+
+	return refs;
+}
+
+// ============ Public API ============
+
+/**
+ * Validate a SQL statement for use with the db-query MCP server.
+ *
+ * Checks:
+ * 1. Rejects NULL bytes
+ * 2. Rejects semicolons (multi-statement injection)
+ * 3. Strips comments and normalizes whitespace
+ * 4. Requires the statement to start with SELECT (or WITH followed by SELECT)
+ * 5. Extracts table references from FROM / JOIN clauses (excluding CTE names)
+ *
+ * @param sql - The raw SQL string to validate.
+ * @returns Validation result with valid flag, optional error, and extracted tableRefs.
+ */
+export function validateSql(sql: string): SqlValidationResult {
+	// Reject NULL bytes
+	if (sql.includes('\0')) {
+		return { valid: false, error: 'NULL byte in SQL is not allowed', tableRefs: [] };
+	}
+
+	// Reject semicolons (multi-statement injection)
+	if (sql.includes(';')) {
+		return {
+			valid: false,
+			error: 'Semicolons are not allowed (single statement only)',
+			tableRefs: [],
+		};
+	}
+
+	// Strip comments and normalize
+	const cleaned = normalizeWhitespace(stripComments(sql));
+
+	if (!cleaned) {
+		return { valid: false, error: 'Empty SQL statement', tableRefs: [] };
+	}
+
+	// Handle CTEs — extract CTE names and get the remaining query
+	const { cteNames, remaining } = extractCtes(cleaned);
+
+	// The remaining (or full cleaned) statement must start with SELECT
+	const checkSql = remaining.trimStart();
+	if (!/^[Ss][Ee][Ll][Ee][Cc][Tt]\b/.test(checkSql)) {
+		return {
+			valid: false,
+			error: 'Only SELECT statements are allowed',
+			tableRefs: [],
+		};
+	}
+
+	// Extract table refs from both the CTE bodies and the main query,
+	// excluding CTE names themselves.
+	const allRefs = extractTableRefs(cleaned, cteNames);
+
+	return { valid: true, tableRefs: allRefs };
+}

--- a/packages/daemon/src/lib/db-query/sql-validator.ts
+++ b/packages/daemon/src/lib/db-query/sql-validator.ts
@@ -43,12 +43,56 @@ function normalizeWhitespace(sql: string): string {
 }
 
 /**
+ * Replace contents of single-quoted string literals with spaces.
+ * Handles SQL-standard escaped quotes ('') correctly.
+ * Preserves the outer quote characters so string boundaries are maintained.
+ *
+ * This allows subsequent checks (semicolons, NULL bytes, FROM/JOIN extraction)
+ * to ignore content inside string literals.
+ */
+function stripStringContents(sql: string): string {
+	let result = '';
+	let i = 0;
+	const len = sql.length;
+
+	while (i < len) {
+		if (sql[i] === "'") {
+			result += "'";
+			i++;
+			// Scan string body, handling '' escaped quotes
+			while (i < len) {
+				if (sql[i] === "'" && i + 1 < len && sql[i + 1] === "'") {
+					// Escaped quote — replace both quotes with spaces
+					result += '  ';
+					i += 2;
+				} else if (sql[i] === "'") {
+					// Closing quote
+					result += "'";
+					i++;
+					break;
+				} else {
+					// Regular character inside string — replace with space
+					result += ' ';
+					i++;
+				}
+			}
+		} else {
+			result += sql[i];
+			i++;
+		}
+	}
+
+	return result;
+}
+
+/**
  * Extract CTE names from a WITH ... AS (...) preamble.
  * Returns an object with cteNames (a set of CTE names)
  * and remaining (the SQL after the WITH block).
  *
- * Handles both single and multiple CTEs:
+ * Handles both single and multiple CTEs, as well as WITH RECURSIVE:
  *   WITH x AS (...), y AS (...) SELECT ...
+ *   WITH RECURSIVE x AS (...) SELECT ...
  */
 function extractCtes(sql: string): { cteNames: Set<string>; remaining: string } {
 	const trimmed = sql.trimStart();
@@ -65,6 +109,13 @@ function extractCtes(sql: string): { cteNames: Set<string>; remaining: string } 
 	// Skip whitespace after WITH
 	while (pos < len && /\s/.test(trimmed[pos])) pos++;
 
+	// Check for optional RECURSIVE keyword
+	if (pos + 8 <= len && trimmed.slice(pos, pos + 9).toLowerCase() === 'recursive') {
+		pos += 9;
+		// Skip whitespace after RECURSIVE
+		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+	}
+
 	while (pos < len) {
 		// Extract CTE name (identifier)
 		const nameStart = pos;
@@ -75,6 +126,19 @@ function extractCtes(sql: string): { cteNames: Set<string>; remaining: string } 
 
 		// Skip whitespace
 		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+		// Skip optional CTE column list: cnt(col1, col2, ...)
+		if (pos < len && trimmed[pos] === '(') {
+			let depth = 1;
+			pos++;
+			while (pos < len && depth > 0) {
+				if (trimmed[pos] === '(') depth++;
+				else if (trimmed[pos] === ')') depth--;
+				pos++;
+			}
+			// Skip whitespace after column list
+			while (pos < len && /\s/.test(trimmed[pos])) pos++;
+		}
 
 		// Expect "AS" keyword
 		if (
@@ -95,17 +159,28 @@ function extractCtes(sql: string): { cteNames: Set<string>; remaining: string } 
 			let depth = 1;
 			pos++;
 			while (pos < len && depth > 0) {
-				if (trimmed[pos] === '(') depth++;
-				else if (trimmed[pos] === ')') depth--;
-				// Skip string literals so parens inside strings aren't counted
-				else if (trimmed[pos] === "'") {
+				if (trimmed[pos] === '(') {
+					depth++;
 					pos++;
-					while (pos < len && trimmed[pos] !== "'") {
-						if (trimmed[pos] === "'") pos++; // escaped quote
-						pos++;
+				} else if (trimmed[pos] === ')') {
+					depth--;
+					pos++;
+				} else if (trimmed[pos] === "'") {
+					// Skip string literal, handling '' escaped quotes
+					pos++; // skip opening quote
+					while (pos < len) {
+						if (trimmed[pos] === "'" && pos + 1 < len && trimmed[pos + 1] === "'") {
+							pos += 2; // skip escaped ''
+						} else if (trimmed[pos] === "'") {
+							pos++; // skip closing quote
+							break;
+						} else {
+							pos++;
+						}
 					}
+				} else {
+					pos++;
 				}
-				pos++;
 			}
 		}
 
@@ -126,34 +201,156 @@ function extractCtes(sql: string): { cteNames: Set<string>; remaining: string } 
 }
 
 /**
+ * Match a SQL identifier (letters, digits, underscores, Unicode letters/digits)
+ * starting at the given position. Returns the matched string in lowercase,
+ * or null if no identifier is found. Advances the position past the match.
+ */
+function matchIdentifier(sql: string, pos: number): { ident: string; end: number } | null {
+	const start = pos;
+	const len = sql.length;
+	while (pos < len && /[\p{L}\p{N}_]/u.test(sql[pos])) pos++;
+	if (pos === start) return null;
+	return { ident: sql.slice(start, pos).toLowerCase(), end: pos };
+}
+
+/**
  * Extract table name candidates from FROM and JOIN clauses.
  * Matches FROM <name> and JOIN <name> (any JOIN variant).
  * Skips names that appear in the exclude set (e.g., CTE names).
+ * Handles schema-qualified names (e.g., main.tasks) by taking the
+ * table name after the dot.
+ *
+ * Expects string literal contents to already be stripped (use stripStringContents first).
  */
 function extractTableRefs(sql: string, exclude: Set<string>): string[] {
 	const refs: string[] = [];
 
-	// FROM clause — match FROM <identifier> (not followed by '(' which would be a function)
-	const identRe = '[\\p{L}\\p{N}_]+';
-	const fromRe = new RegExp(`\\b[Ff][Rr][Oo][Mm]\\s+(${identRe})`, 'gu');
-	let m: RegExpExecArray | null;
-	while ((m = fromRe.exec(sql)) !== null) {
-		const name = m[1].toLowerCase();
-		if (!exclude.has(name) && !refs.includes(name)) {
-			refs.push(name);
-		}
+	// Case-insensitive keyword match helpers
+	function atKeyword(pos: number, keyword: string): boolean {
+		return sql.slice(pos, pos + keyword.length).toUpperCase() === keyword;
 	}
 
-	// JOIN clause — LEFT/RIGHT/INNER/OUTER/CROSS/NATURAL JOIN <identifier>
-	const joinRe = new RegExp(
-		`\\b(?:LEFT|RIGHT|INNER|OUTER|CROSS|NATURAL)?\\s*[Jj][Oo][Ii][Nn]\\s+(${identRe})`,
-		'gu'
-	);
-	while ((m = joinRe.exec(sql)) !== null) {
-		const name = m[1].toLowerCase();
-		if (!exclude.has(name) && !refs.includes(name)) {
-			refs.push(name);
+	function isWordBoundary(pos: number): boolean {
+		if (pos >= sql.length) return true;
+		if (/[\s]/.test(sql[pos])) return true;
+		// Common punctuation that terminates keywords
+		return sql[pos] === '(' || sql[pos] === ')' || sql[pos] === ',';
+	}
+
+	let i = 0;
+	const len = sql.length;
+
+	while (i < len) {
+		// Try matching FROM keyword
+		if (atKeyword(i, 'FROM') && (i === 0 || isWordBoundary(i - 1)) && isWordBoundary(i + 4)) {
+			let pos = i + 4;
+			// Skip whitespace
+			while (pos < len && /\s/.test(sql[pos])) pos++;
+			// Match identifier (potentially schema-qualified)
+			const first = matchIdentifier(sql, pos);
+			if (first) {
+				pos = first.end;
+				// Check for schema.name pattern
+				if (pos < len && sql[pos] === '.') {
+					const second = matchIdentifier(sql, pos + 1);
+					if (second) {
+						const tableName = second.ident;
+						if (!exclude.has(tableName) && !refs.includes(tableName)) {
+							refs.push(tableName);
+						}
+						i = second.end;
+						continue;
+					}
+				}
+				// No dot — first ident is the table name
+				if (!exclude.has(first.ident) && !refs.includes(first.ident)) {
+					refs.push(first.ident);
+				}
+				i = first.end;
+				continue;
+			}
 		}
+
+		// Try matching JOIN keyword with optional prefix
+		let joinMatched = false;
+		// Check for optional prefix keywords (case-insensitive)
+		const prefixes = ['LEFT', 'RIGHT', 'INNER', 'OUTER', 'FULL', 'CROSS', 'NATURAL'];
+		for (const prefix of prefixes) {
+			if (atKeyword(i, prefix) && isWordBoundary(i + prefix.length)) {
+				let pos = i + prefix.length;
+				// Skip whitespace between prefix and optional OUTER
+				while (pos < len && /\s/.test(sql[pos])) pos++;
+				// Check for OUTER after LEFT/RIGHT/FULL
+				if (
+					(prefix === 'LEFT' || prefix === 'RIGHT' || prefix === 'FULL') &&
+					atKeyword(pos, 'OUTER') &&
+					isWordBoundary(pos + 5)
+				) {
+					pos += 5;
+					// Skip whitespace between OUTER and JOIN
+					while (pos < len && /\s/.test(sql[pos])) pos++;
+				}
+				// Now expect JOIN
+				if (atKeyword(pos, 'JOIN') && isWordBoundary(pos + 4)) {
+					let jpos = pos + 4;
+					// Skip whitespace
+					while (jpos < len && /\s/.test(sql[jpos])) jpos++;
+					// Match identifier (potentially schema-qualified)
+					const first = matchIdentifier(sql, jpos);
+					if (first) {
+						jpos = first.end;
+						if (jpos < len && sql[jpos] === '.') {
+							const second = matchIdentifier(sql, jpos + 1);
+							if (second) {
+								const tableName = second.ident;
+								if (!exclude.has(tableName) && !refs.includes(tableName)) {
+									refs.push(tableName);
+								}
+								i = second.end;
+								joinMatched = true;
+								break;
+							}
+						}
+						if (!exclude.has(first.ident) && !refs.includes(first.ident)) {
+							refs.push(first.ident);
+						}
+						i = first.end;
+						joinMatched = true;
+						break;
+					}
+				}
+				break;
+			}
+		}
+
+		// Plain JOIN (no prefix)
+		if (!joinMatched && atKeyword(i, 'JOIN') && isWordBoundary(i + 4)) {
+			let jpos = i + 4;
+			// Skip whitespace
+			while (jpos < len && /\s/.test(sql[jpos])) jpos++;
+			const first = matchIdentifier(sql, jpos);
+			if (first) {
+				jpos = first.end;
+				if (jpos < len && sql[jpos] === '.') {
+					const second = matchIdentifier(sql, jpos + 1);
+					if (second) {
+						const tableName = second.ident;
+						if (!exclude.has(tableName) && !refs.includes(tableName)) {
+							refs.push(tableName);
+						}
+						i = second.end;
+						continue;
+					}
+				}
+				if (!exclude.has(first.ident) && !refs.includes(first.ident)) {
+					refs.push(first.ident);
+				}
+				i = first.end;
+				continue;
+			}
+		}
+
+		i++;
 	}
 
 	return refs;
@@ -165,23 +362,34 @@ function extractTableRefs(sql: string, exclude: Set<string>): string[] {
  * Validate a SQL statement for use with the db-query MCP server.
  *
  * Checks:
- * 1. Rejects NULL bytes
- * 2. Rejects semicolons (multi-statement injection)
+ * 1. Rejects NULL bytes (outside string literals)
+ * 2. Rejects semicolons (outside string literals)
  * 3. Strips comments and normalizes whitespace
  * 4. Requires the statement to start with SELECT (or WITH followed by SELECT)
  * 5. Extracts table references from FROM / JOIN clauses (excluding CTE names)
+ *
+ * String literal contents are stripped before dangerous-character checks and
+ * table-ref extraction, so legitimate queries containing semicolons or SQL
+ * keywords inside string values are handled correctly.
  *
  * @param sql - The raw SQL string to validate.
  * @returns Validation result with valid flag, optional error, and extracted tableRefs.
  */
 export function validateSql(sql: string): SqlValidationResult {
-	// Reject NULL bytes
-	if (sql.includes('\0')) {
+	// Strip comments first (so we can safely check for dangerous chars)
+	const withoutComments = stripComments(sql);
+
+	// Strip string literal contents so keywords/delimiters inside strings
+	// don't trigger false positives.
+	const withoutStrings = stripStringContents(withoutComments);
+
+	// Reject NULL bytes (now only outside string literals)
+	if (withoutStrings.includes('\0')) {
 		return { valid: false, error: 'NULL byte in SQL is not allowed', tableRefs: [] };
 	}
 
-	// Reject semicolons (multi-statement injection)
-	if (sql.includes(';')) {
+	// Reject semicolons (now only outside string literals)
+	if (withoutStrings.includes(';')) {
 		return {
 			valid: false,
 			error: 'Semicolons are not allowed (single statement only)',
@@ -189,8 +397,8 @@ export function validateSql(sql: string): SqlValidationResult {
 		};
 	}
 
-	// Strip comments and normalize
-	const cleaned = normalizeWhitespace(stripComments(sql));
+	// Normalize whitespace
+	const cleaned = normalizeWhitespace(withoutStrings);
 
 	if (!cleaned) {
 		return { valid: false, error: 'Empty SQL statement', tableRefs: [] };

--- a/packages/daemon/tests/unit/db-query/sql-validator.test.ts
+++ b/packages/daemon/tests/unit/db-query/sql-validator.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, test } from 'bun:test';
+import { validateSql } from '../../../src/lib/db-query/sql-validator';
+
+// ============ Valid SELECT queries ============
+
+describe('validateSql — valid SELECT queries', () => {
+	test('simple SELECT', () => {
+		const result = validateSql('SELECT * FROM tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('SELECT with explicit columns', () => {
+		const result = validateSql('SELECT id, name, status FROM tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('SELECT with WHERE clause', () => {
+		const result = validateSql('SELECT * FROM tasks WHERE status = ?', ['active']);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('SELECT with JOIN', () => {
+		const result = validateSql(
+			'SELECT t.id, s.name FROM tasks t JOIN sessions s ON t.session_id = s.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('SELECT with LEFT JOIN', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks LEFT JOIN sessions ON tasks.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('SELECT with multiple JOINs', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks t INNER JOIN sessions s ON t.session_id = s.id LEFT JOIN rooms r ON s.room_id = r.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions', 'rooms']);
+	});
+
+	test('SELECT * FROM with no WHERE', () => {
+		const result = validateSql('SELECT * FROM tasks');
+		expect(result.valid).toBe(true);
+	});
+
+	test('SELECT 1 (no table ref)', () => {
+		const result = validateSql('SELECT 1');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual([]);
+	});
+
+	test('mixed case', () => {
+		const result = validateSql('select * FROM Tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('UPPERCASE SELECT', () => {
+		const result = validateSql('SELECT * FROM TASKS');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('leading whitespace', () => {
+		const result = validateSql('   SELECT * FROM tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('tabs and newlines', () => {
+		const result = validateSql('\t\n  SELECT *\n  FROM tasks\n');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('unicode table name', () => {
+		const result = validateSql('SELECT * FROM задачи');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['задачи']);
+	});
+
+	test('unicode column names', () => {
+		const result = validateSql('SELECT имя, статус FROM tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('very long SQL string', () => {
+		const columns = Array.from({ length: 500 }, (_, i) => `col${i}`).join(', ');
+		const sql = `SELECT ${columns} FROM tasks WHERE id = ?`;
+		const result = validateSql(sql);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+});
+
+// ============ Rejected non-SELECT statements ============
+
+describe('validateSql — rejected statements', () => {
+	const rejectedStatements = [
+		'INSERT INTO tasks VALUES (1)',
+		'UPDATE tasks SET status = ?',
+		'DELETE FROM tasks WHERE id = ?',
+		'DROP TABLE tasks',
+		'ALTER TABLE tasks ADD COLUMN foo TEXT',
+		'CREATE TABLE foo (id INTEGER)',
+		'REPLACE INTO tasks VALUES (1)',
+		'ATTACH DATABASE ? AS other',
+		'PRAGMA journal_mode=WAL',
+	];
+
+	for (const sql of rejectedStatements) {
+		test(`rejects: ${sql.split(' ')[0]}`, () => {
+			const result = validateSql(sql);
+			expect(result.valid).toBe(false);
+			expect(result.error).toBe('Only SELECT statements are allowed');
+			expect(result.tableRefs).toEqual([]);
+		});
+	}
+
+	test('rejects empty string', () => {
+		const result = validateSql('');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Empty SQL statement');
+	});
+
+	test('rejects whitespace-only string', () => {
+		const result = validateSql('   \t\n  ');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Empty SQL statement');
+	});
+
+	test('rejects comments-only string', () => {
+		const result = validateSql('-- just a comment');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Empty SQL statement');
+	});
+
+	test('rejects block-comment-only string', () => {
+		const result = validateSql('/* just a comment */');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Empty SQL statement');
+	});
+});
+
+// ============ Semicolons ============
+
+describe('validateSql — semicolons rejected', () => {
+	test('rejects semicolon at end', () => {
+		const result = validateSql('SELECT * FROM tasks;');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Semicolons are not allowed (single statement only)');
+	});
+
+	test('rejects semicolon in middle', () => {
+		const result = validateSql('SELECT * FROM tasks; DROP TABLE tasks');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Semicolons are not allowed (single statement only)');
+	});
+});
+
+// ============ NULL bytes ============
+
+describe('validateSql — NULL byte rejection', () => {
+	test('rejects NULL byte in SELECT', () => {
+		const result = validateSql('SELECT * FROM tasks\0; DROP TABLE tasks');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('NULL byte in SQL is not allowed');
+	});
+
+	test('rejects NULL byte at start', () => {
+		const result = validateSql('\0SELECT * FROM tasks');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('NULL byte in SQL is not allowed');
+	});
+});
+
+// ============ Comments ============
+
+describe('validateSql — comment stripping', () => {
+	test('strips line comments', () => {
+		const result = validateSql('SELECT * -- comment\nFROM tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('strips block comments', () => {
+		const result = validateSql('SELECT/* comment */ * FROM tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('strips multi-line block comments', () => {
+		const result = validateSql('SELECT * /*\n multi-line\n comment\n */FROM tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('strips comments before rejection check', () => {
+		// A comment disguising a non-SELECT keyword
+		const result = validateSql('-- INSERT INTO\nSELECT * FROM tasks');
+		expect(result.valid).toBe(true);
+	});
+});
+
+// ============ CTEs ============
+
+describe('validateSql — CTE handling', () => {
+	test('simple CTE — CTE name excluded from tableRefs', () => {
+		const result = validateSql(
+			'WITH counts AS (SELECT room_id, COUNT(*) AS n FROM sessions GROUP BY room_id) SELECT * FROM counts'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['sessions']);
+		expect(result.tableRefs).not.toContain('counts');
+	});
+
+	test('CTE with JOIN — both CTE name excluded, real table included', () => {
+		const result = validateSql(
+			'WITH active AS (SELECT * FROM sessions WHERE status = ?) SELECT a.*, r.name FROM active a JOIN rooms r ON a.room_id = r.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['sessions', 'rooms']);
+		expect(result.tableRefs).not.toContain('active');
+	});
+
+	test('multiple CTEs', () => {
+		const result = validateSql(
+			'WITH s AS (SELECT * FROM sessions), r AS (SELECT * FROM rooms) SELECT * FROM s JOIN r ON s.room_id = r.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['sessions', 'rooms']);
+		expect(result.tableRefs).not.toContain('s');
+		expect(result.tableRefs).not.toContain('r');
+	});
+
+	test('nested CTE references other CTE — only real tables extracted', () => {
+		const result = validateSql(
+			'WITH s AS (SELECT * FROM sessions), filtered AS (SELECT * FROM s WHERE status = ?) SELECT * FROM filtered'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['sessions']);
+		expect(result.tableRefs).not.toContain('s');
+		expect(result.tableRefs).not.toContain('filtered');
+	});
+
+	test('CTE with mixed case', () => {
+		const result = validateSql('with MyCte As (select * from tasks) Select * from MyCte');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+		expect(result.tableRefs).not.toContain('mycte');
+	});
+
+	test('CTE with string literals containing parens', () => {
+		const result = validateSql(
+			`WITH parsed AS (SELECT substr(data, 1, instr(data, ')')) AS val FROM logs) SELECT * FROM parsed`
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['logs']);
+		expect(result.tableRefs).not.toContain('parsed');
+	});
+
+	test('non-SELECT after WITH is rejected', () => {
+		const result = validateSql('WITH x AS (SELECT 1) INSERT INTO tasks VALUES (1)');
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Only SELECT statements are allowed');
+	});
+});
+
+// ============ Subqueries ============
+
+describe('validateSql — subqueries', () => {
+	test('subquery in WHERE — table refs extracted', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks WHERE session_id IN (SELECT id FROM sessions WHERE status = ?)'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('subquery in FROM — table refs extracted', () => {
+		const result = validateSql('SELECT sub.* FROM (SELECT * FROM tasks WHERE status = ?) AS sub');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('nested subqueries — all table refs extracted', () => {
+		const result = validateSql(
+			`SELECT * FROM rooms WHERE id IN (SELECT room_id FROM sessions WHERE id IN (SELECT session_id FROM tasks WHERE status = ?))`
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['rooms', 'sessions', 'tasks']);
+	});
+});
+
+// ============ Edge cases ============
+
+describe('validateSql — edge cases', () => {
+	test('duplicate table refs — deduplicated', () => {
+		const result = validateSql('SELECT * FROM tasks t1 JOIN tasks t2 ON t1.id = t2.parent_id');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('table alias does not appear in tableRefs', () => {
+		const result = validateSql('SELECT t.* FROM tasks t');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('CROSS JOIN', () => {
+		const result = validateSql('SELECT * FROM tasks CROSS JOIN sessions');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('NATURAL JOIN', () => {
+		const result = validateSql('SELECT * FROM tasks NATURAL JOIN sessions');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('subquery alias excluded from tableRefs', () => {
+		const result = validateSql(
+			'SELECT sub.id FROM (SELECT * FROM tasks) AS sub JOIN sessions ON sub.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('ORDER BY, LIMIT, OFFSET preserved', () => {
+		const result = validateSql('SELECT * FROM tasks ORDER BY created_at DESC LIMIT 10 OFFSET 20');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('GROUP BY with HAVING', () => {
+		const result = validateSql(
+			'SELECT room_id, COUNT(*) AS n FROM sessions GROUP BY room_id HAVING n > 5'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['sessions']);
+	});
+
+	test('UNION queries', () => {
+		const result = validateSql('SELECT * FROM tasks UNION SELECT * FROM archived_tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'archived_tasks']);
+	});
+});

--- a/packages/daemon/tests/unit/db-query/sql-validator.test.ts
+++ b/packages/daemon/tests/unit/db-query/sql-validator.test.ts
@@ -17,7 +17,7 @@ describe('validateSql — valid SELECT queries', () => {
 	});
 
 	test('SELECT with WHERE clause', () => {
-		const result = validateSql('SELECT * FROM tasks WHERE status = ?', ['active']);
+		const result = validateSql('SELECT * FROM tasks WHERE status = ?');
 		expect(result.valid).toBe(true);
 		expect(result.tableRefs).toEqual(['tasks']);
 	});
@@ -33,6 +33,38 @@ describe('validateSql — valid SELECT queries', () => {
 	test('SELECT with LEFT JOIN', () => {
 		const result = validateSql(
 			'SELECT * FROM tasks LEFT JOIN sessions ON tasks.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('SELECT with RIGHT JOIN', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks RIGHT JOIN sessions ON tasks.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('SELECT with FULL JOIN', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks FULL JOIN sessions ON tasks.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('SELECT with FULL OUTER JOIN', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks FULL OUTER JOIN sessions ON tasks.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('SELECT with LEFT OUTER JOIN', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks LEFT OUTER JOIN sessions ON tasks.session_id = sessions.id'
 		);
 		expect(result.valid).toBe(true);
 		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
@@ -100,6 +132,60 @@ describe('validateSql — valid SELECT queries', () => {
 		expect(result.valid).toBe(true);
 		expect(result.tableRefs).toEqual(['tasks']);
 	});
+
+	test('lowercase join keywords', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks left join sessions on tasks.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('lowercase join prefix keywords', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks inner join sessions on tasks.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('lowercase full join', () => {
+		const result = validateSql(
+			'SELECT * FROM tasks full outer join sessions on tasks.session_id = sessions.id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+});
+
+// ============ Schema-qualified table names ============
+
+describe('validateSql — schema-qualified table names', () => {
+	test('main.tasks extracts tasks as table ref', () => {
+		const result = validateSql('SELECT * FROM main.tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('temp.tasks extracts tasks as table ref', () => {
+		const result = validateSql('SELECT * FROM temp.tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('schema-qualified in JOIN', () => {
+		const result = validateSql(
+			'SELECT * FROM main.tasks JOIN temp.sessions ON tasks.id = sessions.task_id'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
+	});
+
+	test('mix of qualified and unqualified', () => {
+		const result = validateSql('SELECT * FROM main.tasks JOIN rooms ON tasks.room_id = rooms.id');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks', 'rooms']);
+	});
 });
 
 // ============ Rejected non-SELECT statements ============
@@ -164,6 +250,12 @@ describe('validateSql — semicolons rejected', () => {
 		const result = validateSql('SELECT * FROM tasks; DROP TABLE tasks');
 		expect(result.valid).toBe(false);
 		expect(result.error).toBe('Semicolons are not allowed (single statement only)');
+	});
+
+	test('allows semicolon inside string literal', () => {
+		const result = validateSql("SELECT * FROM tasks WHERE description = 'step 1; step 2'");
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
 	});
 });
 
@@ -268,10 +360,57 @@ describe('validateSql — CTE handling', () => {
 		expect(result.tableRefs).not.toContain('parsed');
 	});
 
+	test('CTE with escaped quotes in string literal', () => {
+		const result = validateSql(
+			"WITH escaped AS (SELECT * FROM tasks WHERE name = 'O''Brien''s task') SELECT * FROM escaped"
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+		expect(result.tableRefs).not.toContain('escaped');
+	});
+
 	test('non-SELECT after WITH is rejected', () => {
 		const result = validateSql('WITH x AS (SELECT 1) INSERT INTO tasks VALUES (1)');
 		expect(result.valid).toBe(false);
 		expect(result.error).toBe('Only SELECT statements are allowed');
+	});
+});
+
+// ============ WITH RECURSIVE ============
+
+describe('validateSql — WITH RECURSIVE', () => {
+	test('simple WITH RECURSIVE is accepted', () => {
+		const result = validateSql(
+			'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM cnt WHERE n < 5) SELECT * FROM cnt'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual([]);
+		expect(result.tableRefs).not.toContain('cnt');
+	});
+
+	test('WITH RECURSIVE with real table reference', () => {
+		const result = validateSql(
+			'WITH RECURSIVE hierarchy(id, name, depth) AS (SELECT id, name, 0 FROM rooms WHERE parent_id IS NULL UNION ALL SELECT r.id, r.name, h.depth + 1 FROM rooms r JOIN hierarchy h ON r.parent_id = h.id) SELECT * FROM hierarchy'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['rooms']);
+		expect(result.tableRefs).not.toContain('hierarchy');
+	});
+
+	test('WITH RECURSIVE lowercase', () => {
+		const result = validateSql('with recursive x as (select 1) select * from x');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual([]);
+	});
+
+	test('WITH RECURSIVE with multiple CTEs', () => {
+		const result = validateSql(
+			'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM cnt WHERE n < 5), doubled AS (SELECT n * 2 AS val FROM cnt) SELECT * FROM doubled'
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual([]);
+		expect(result.tableRefs).not.toContain('cnt');
+		expect(result.tableRefs).not.toContain('doubled');
 	});
 });
 
@@ -298,6 +437,42 @@ describe('validateSql — subqueries', () => {
 		);
 		expect(result.valid).toBe(true);
 		expect(result.tableRefs).toEqual(['rooms', 'sessions', 'tasks']);
+	});
+});
+
+// ============ String literal edge cases ============
+
+describe('validateSql — string literal handling', () => {
+	test('FROM/JOIN inside string literal not extracted as table ref', () => {
+		const result = validateSql(
+			"SELECT * FROM tasks WHERE description = 'results FROM other_table'"
+		);
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('JOIN keyword inside string literal not extracted', () => {
+		const result = validateSql("SELECT * FROM tasks WHERE notes = '%LEFT JOIN sessions%'");
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('escaped quotes in string literals handled correctly', () => {
+		const result = validateSql("SELECT * FROM tasks WHERE name = 'it''s a test'");
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('semicolon inside string literal allowed', () => {
+		const result = validateSql("SELECT * FROM tasks WHERE description = 'step 1; step 2; step 3'");
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('FROM keyword in block comment not extracted', () => {
+		const result = validateSql('SELECT * FROM tasks /* FROM other_table */');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Implement `validateSql()` in `packages/daemon/src/lib/db-query/sql-validator.ts` for early rejection of non-SELECT statements before they reach SQLite
- Rejects INSERT/UPDATE/DELETE/DROP/ALTER/CREATE/REPLACE/ATTACH with clear error messages
- Rejects semicolons (multi-statement injection) and NULL bytes
- Extracts table references from FROM/JOIN clauses for downstream scope checking
- Handles CTEs — strips WITH wrapper, tracks CTE names, and excludes them from tableRefs
- Strips SQL comments (line and block) before validation

## Test plan
- 54 unit tests covering: valid SELECTs, rejected write statements, semicolons, NULL bytes, comment stripping, CTE handling, subqueries, mixed case, Unicode, long SQL strings