### PR TITLE
feat: add scope config for db-query MCP server

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -1,0 +1,382 @@
+import type { SessionContext } from '@neokai/shared';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+/** The three scope levels that determine table access and filter injection. */
+export type DbScopeType = 'global' | 'room' | 'space';
+
+/** Configuration for indirect scope resolution via a join table. */
+export interface ScopeJoinConfig {
+	/** Column on the target table that references the join table (e.g., 'goal_id'). */
+	localColumn: string;
+	/** The intermediate table used for scope resolution (e.g., 'goals'). */
+	joinTable: string;
+	/** Primary key column on the join table (e.g., 'id'). */
+	joinPkColumn: string;
+	/** The scope column on the join table (e.g., 'room_id' or 'space_id'). */
+	scopeColumn: string;
+}
+
+/** Full configuration for a table within a given scope. */
+export interface ScopeTableConfig {
+	/** Must match the actual table name in the SQLite schema. */
+	tableName: string;
+	/** Direct scope column on this table (e.g., 'room_id', 'space_id'). */
+	scopeColumn?: string;
+	/** Indirect scope resolution via a join table. */
+	scopeJoin?: ScopeJoinConfig;
+	/** Columns to exclude from `db_describe_table` and `SELECT *`. */
+	blacklistedColumns: string[];
+	/** Human-readable description for the agent. */
+	description: string;
+}
+
+/** Resolved scope information for a given session context. */
+export interface ResolvedScope {
+	scopeType: DbScopeType;
+	scopeValue: string;
+}
+
+/** Parameterized WHERE clause result from `buildScopeFilter`. */
+export interface ScopeFilterResult {
+	whereClause: string;
+	params: unknown[];
+}
+
+// ── Global column blacklist (applied regardless of scope) ─────────────────────
+
+/**
+ * Per-table column blacklists. These columns are excluded from
+ * `db_describe_table` output and `SELECT *` expansion.
+ *
+ * Blacklists are global per-table, not scope-dependent.
+ */
+const COLUMN_BLACKLISTS: Record<string, string[]> = {
+	sessions: ['config', 'session_context'],
+	rooms: ['config'],
+	spaces: ['config'],
+	app_mcp_servers: ['env'],
+	inbox_items: ['raw_event', 'security_check'],
+	neo_activity_log: ['undo_data'],
+	job_queue: ['payload'],
+	space_agents: ['system_prompt'],
+	space_workflows: ['config', 'gates', 'channels'],
+	space_workflow_nodes: ['config'],
+};
+
+// ── Scope configurations ──────────────────────────────────────────────────────
+
+/**
+ * Tables visible in the **global** scope (Neo agent / no entity filter).
+ * No WHERE clause injection — the agent can read all rows.
+ */
+const GLOBAL_SCOPE_TABLES: ScopeTableConfig[] = [
+	{
+		tableName: 'sessions',
+		blacklistedColumns: COLUMN_BLACKLISTS.sessions,
+		description:
+			'Agent sessions with metadata such as title, status, workspace path, type, and timestamps.',
+	},
+	{
+		tableName: 'rooms',
+		blacklistedColumns: COLUMN_BLACKLISTS.rooms,
+		description:
+			'Room definitions with name, instructions, allowed paths, model config, and status.',
+	},
+	{
+		tableName: 'spaces',
+		blacklistedColumns: COLUMN_BLACKLISTS.spaces,
+		description:
+			'Space definitions for multi-agent environments with workspace path, slug, and config.',
+	},
+	{
+		tableName: 'app_mcp_servers',
+		blacklistedColumns: COLUMN_BLACKLISTS.app_mcp_servers,
+		description:
+			'Globally-configured MCP servers with connection details (command, args, URL, headers).',
+	},
+	{
+		tableName: 'skills',
+		blacklistedColumns: [],
+		description:
+			'Available skills (plugins, MCP servers, built-ins) with config, enablement, and validation status.',
+	},
+	{
+		tableName: 'inbox_items',
+		blacklistedColumns: COLUMN_BLACKLISTS.inbox_items,
+		description: 'Incoming GitHub events (issues, comments, PRs) routed through the inbox system.',
+	},
+	{
+		tableName: 'neo_activity_log',
+		blacklistedColumns: COLUMN_BLACKLISTS.neo_activity_log,
+		description:
+			'Audit log of Neo agent tool invocations including status, targets, and undo data.',
+	},
+	{
+		tableName: 'job_queue',
+		blacklistedColumns: COLUMN_BLACKLISTS.job_queue,
+		description:
+			'Background job queue entries with status, priority, retry tracking, and scheduling.',
+	},
+	{
+		tableName: 'short_id_counters',
+		blacklistedColumns: [],
+		description: 'Auto-incrementing short-ID counters keyed by entity type and scope.',
+	},
+];
+
+/**
+ * Tables visible in the **room** scope (room agent).
+ * Auto-injects `WHERE room_id = ?` (or indirect equivalent) on all queries.
+ */
+const ROOM_SCOPE_TABLES: ScopeTableConfig[] = [
+	{
+		tableName: 'tasks',
+		scopeColumn: 'room_id',
+		blacklistedColumns: [],
+		description:
+			'Room tasks with title, status, priority, dependencies, PR tracking, and agent assignments.',
+	},
+	{
+		tableName: 'goals',
+		scopeColumn: 'room_id',
+		blacklistedColumns: [],
+		description:
+			'Room missions/goals with mission type, autonomy level, schedule, structured metrics, and execution tracking.',
+	},
+	{
+		tableName: 'mission_executions',
+		scopeJoin: {
+			localColumn: 'goal_id',
+			joinTable: 'goals',
+			joinPkColumn: 'id',
+			scopeColumn: 'room_id',
+		},
+		blacklistedColumns: [],
+		description:
+			'Individual execution runs of recurring missions with status, task IDs, and planning attempts.',
+	},
+	{
+		tableName: 'mission_metric_history',
+		scopeJoin: {
+			localColumn: 'goal_id',
+			joinTable: 'goals',
+			joinPkColumn: 'id',
+			scopeColumn: 'room_id',
+		},
+		blacklistedColumns: [],
+		description: 'Time-series snapshots of measurable mission metrics recorded over time.',
+	},
+	{
+		tableName: 'room_github_mappings',
+		scopeColumn: 'room_id',
+		blacklistedColumns: [],
+		description: 'GitHub repository mappings for rooms with priority ordering.',
+	},
+	{
+		tableName: 'room_mcp_enablement',
+		scopeColumn: 'room_id',
+		blacklistedColumns: [],
+		description: 'Per-room MCP server enablement overrides.',
+	},
+	{
+		tableName: 'room_skill_overrides',
+		scopeColumn: 'room_id',
+		blacklistedColumns: [],
+		description: 'Per-room skill enablement overrides.',
+	},
+];
+
+/**
+ * Tables visible in the **space** scope (space agent).
+ * Auto-injects `WHERE space_id = ?` (or indirect equivalent) on all queries.
+ */
+const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
+	{
+		tableName: 'space_agents',
+		scopeColumn: 'space_id',
+		blacklistedColumns: COLUMN_BLACKLISTS.space_agents,
+		description: 'Space agent definitions with name, model, tools, provider, and instructions.',
+	},
+	{
+		tableName: 'space_workflows',
+		scopeColumn: 'space_id',
+		blacklistedColumns: COLUMN_BLACKLISTS.space_workflows,
+		description:
+			'Space workflow definitions with graph layout, channel routing, and gate configurations.',
+	},
+	{
+		tableName: 'space_workflow_nodes',
+		scopeJoin: {
+			localColumn: 'workflow_id',
+			joinTable: 'space_workflows',
+			joinPkColumn: 'id',
+			scopeColumn: 'space_id',
+		},
+		blacklistedColumns: COLUMN_BLACKLISTS.space_workflow_nodes,
+		description:
+			'Individual nodes/steps within a space workflow with name, description, and config.',
+	},
+	{
+		tableName: 'space_workflow_runs',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description: 'Executions of space workflows with status, timestamps, and failure tracking.',
+	},
+	{
+		tableName: 'space_tasks',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description:
+			'Tasks within a space with numbering, status, PR tracking, and workflow run associations.',
+	},
+	{
+		tableName: 'space_worktrees',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description: 'Git worktree mappings for space tasks with slug and path tracking.',
+	},
+	{
+		tableName: 'gate_data',
+		scopeJoin: {
+			localColumn: 'run_id',
+			joinTable: 'space_workflow_runs',
+			joinPkColumn: 'id',
+			scopeColumn: 'space_id',
+		},
+		blacklistedColumns: [],
+		description: 'Gate evaluation data for human-in-the-loop approval checkpoints in workflows.',
+	},
+	{
+		tableName: 'channel_cycles',
+		scopeJoin: {
+			localColumn: 'run_id',
+			joinTable: 'space_workflow_runs',
+			joinPkColumn: 'id',
+			scopeColumn: 'space_id',
+		},
+		blacklistedColumns: [],
+		description: 'Cycle counters for workflow channels to prevent infinite loop execution.',
+	},
+];
+
+/**
+ * Tables that are intentionally excluded from ALL scopes.
+ * These include sensitive config tables, raw message stores, and internal infrastructure.
+ */
+const EXCLUDED_TABLE_NAMES: string[] = [
+	// Sensitive configuration (contains auth tokens, API keys)
+	'auth_config',
+	'global_tools_config',
+	'global_settings',
+	// Raw SDK message store (too large, not useful for ad-hoc queries)
+	'sdk_messages',
+	// Internal session group infrastructure
+	'session_groups',
+	'session_group_members',
+	'task_group_events',
+	// Node execution tracking (internal infrastructure)
+	'node_executions',
+	// Dropped tables (no longer exist in schema)
+	'space_session_groups',
+	'space_session_group_members',
+	'space_workflow_transitions',
+	// Legacy dropped tables
+	'messages',
+	'tool_calls',
+];
+
+// ── Scope config registry ─────────────────────────────────────────────────────
+
+const SCOPE_CONFIGS: Record<DbScopeType, ScopeTableConfig[]> = {
+	global: GLOBAL_SCOPE_TABLES,
+	room: ROOM_SCOPE_TABLES,
+	space: SPACE_SCOPE_TABLES,
+};
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the full table configurations for a given scope type.
+ */
+export function getScopeConfig(scopeType: DbScopeType): ScopeTableConfig[] {
+	return SCOPE_CONFIGS[scopeType];
+}
+
+/**
+ * Resolves the scope type and value from a session context.
+ *
+ * - roomId present → room scope
+ * - spaceId present (no roomId) → space scope
+ * - Neither → global scope
+ */
+export function getScopeForSession(context: SessionContext): ResolvedScope {
+	if (context.roomId) {
+		return { scopeType: 'room', scopeValue: context.roomId };
+	}
+	if (context.spaceId) {
+		return { scopeType: 'space', scopeValue: context.spaceId };
+	}
+	return { scopeType: 'global', scopeValue: '' };
+}
+
+/**
+ * Returns the list of table names accessible within a given scope.
+ */
+export function getAccessibleTableNames(scopeType: DbScopeType): string[] {
+	return SCOPE_CONFIGS[scopeType].map((cfg) => cfg.tableName);
+}
+
+/**
+ * Returns column blacklists for a given table.
+ * Blacklists are global per-table (not scope-dependent).
+ * Returns an empty array for tables with no blacklisted columns.
+ */
+export function getBlacklistedColumns(tableName: string): string[] {
+	return COLUMN_BLACKLISTS[tableName] ?? [];
+}
+
+/**
+ * Returns the list of tables that are excluded from all scopes.
+ * Used for schema evolution validation to ensure sensitive/infrastructure
+ * tables are never accidentally exposed.
+ */
+export function getExcludedTableNames(): string[] {
+	return [...EXCLUDED_TABLE_NAMES];
+}
+
+/**
+ * Builds a parameterized WHERE clause for a scoped table configuration.
+ *
+ * Direct scope:  `room_id = ?`  (one param)
+ * Indirect scope: `goal_id IN (SELECT id FROM goals WHERE room_id = ?)`  (one param)
+ * Global scope:  returns empty clause (no filtering)
+ */
+export function buildScopeFilter(
+	tableConfig: ScopeTableConfig,
+	scopeValue: string
+): ScopeFilterResult {
+	// Global tables have no scope column or join — no filter needed
+	if (!tableConfig.scopeColumn && !tableConfig.scopeJoin) {
+		return { whereClause: '', params: [] };
+	}
+
+	// Direct scope filter
+	if (tableConfig.scopeColumn) {
+		return {
+			whereClause: `${tableConfig.scopeColumn} = ?`,
+			params: [scopeValue],
+		};
+	}
+
+	// Indirect scope filter via join table
+	if (tableConfig.scopeJoin) {
+		const join = tableConfig.scopeJoin;
+		return {
+			whereClause: `${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} = ?)`,
+			params: [scopeValue],
+		};
+	}
+
+	return { whereClause: '', params: [] };
+}

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -61,6 +61,7 @@ const COLUMN_BLACKLISTS: Record<string, string[]> = {
 	job_queue: ['payload'],
 	space_agents: ['system_prompt'],
 	space_workflows: ['config', 'gates', 'channels'],
+	tasks: ['restrictions'], // internal use — agent-imposed task constraints
 	space_workflow_nodes: ['config'],
 };
 
@@ -98,6 +99,9 @@ const GLOBAL_SCOPE_TABLES: ScopeTableConfig[] = [
 	{
 		tableName: 'skills',
 		blacklistedColumns: [],
+		// Note: skills.config stores structured config (McpServerSkillConfig with appMcpServerId UUID,
+		// PluginSkillConfig with local path) — no raw credentials. If credential-bearing config is
+		// ever added to skill configs, it must be blacklisted here and in COLUMN_BLACKLISTS.
 		description:
 			'Available skills (plugins, MCP servers, built-ins) with config, enablement, and validation status.',
 	},
@@ -133,7 +137,7 @@ const ROOM_SCOPE_TABLES: ScopeTableConfig[] = [
 	{
 		tableName: 'tasks',
 		scopeColumn: 'room_id',
-		blacklistedColumns: [],
+		blacklistedColumns: COLUMN_BLACKLISTS.tasks,
 		description:
 			'Room tasks with title, status, priority, dependencies, PR tracking, and agent assignments.',
 	},
@@ -275,8 +279,10 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	'session_groups',
 	'session_group_members',
 	'task_group_events',
-	// Node execution tracking (internal infrastructure)
+	// Node execution tracking — transient per-run agent state, not useful for ad-hoc queries
 	'node_executions',
+	// Dynamically created tables (managed by FilterConfigManager, not part of static schema)
+	'github_filter_configs',
 	// Dropped tables (no longer exist in schema)
 	'space_session_groups',
 	'space_session_group_members',

--- a/packages/daemon/tests/unit/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/db-query/scope-config.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	buildScopeFilter,
+	getAccessibleTableNames,
+	getBlacklistedColumns,
+	getExcludedTableNames,
+	getScopeConfig,
+	getScopeForSession,
+	type ScopeTableConfig,
+} from '@/lib/db-query/scope-config';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function tableNames(configs: ScopeTableConfig[]): string[] {
+	return configs.map((c) => c.tableName);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('scope-config', () => {
+	// ── getScopeConfig ────────────────────────────────────────────────────────
+
+	describe('getScopeConfig', () => {
+		it('global scope returns the correct set of tables', () => {
+			const config = getScopeConfig('global');
+			const names = tableNames(config);
+			expect(names).toEqual([
+				'sessions',
+				'rooms',
+				'spaces',
+				'app_mcp_servers',
+				'skills',
+				'inbox_items',
+				'neo_activity_log',
+				'job_queue',
+				'short_id_counters',
+			]);
+			expect(names).toHaveLength(9);
+		});
+
+		it('room scope returns the correct set of tables', () => {
+			const config = getScopeConfig('room');
+			const names = tableNames(config);
+			expect(names).toEqual([
+				'tasks',
+				'goals',
+				'mission_executions',
+				'mission_metric_history',
+				'room_github_mappings',
+				'room_mcp_enablement',
+				'room_skill_overrides',
+			]);
+			expect(names).toHaveLength(7);
+		});
+
+		it('space scope returns the correct set of tables', () => {
+			const config = getScopeConfig('space');
+			const names = tableNames(config);
+			expect(names).toEqual([
+				'space_agents',
+				'space_workflows',
+				'space_workflow_nodes',
+				'space_workflow_runs',
+				'space_tasks',
+				'space_worktrees',
+				'gate_data',
+				'channel_cycles',
+			]);
+			expect(names).toHaveLength(8);
+		});
+
+		it('all table configs have a description', () => {
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				for (const table of getScopeConfig(scopeType)) {
+					expect(table.description.length).toBeGreaterThan(0);
+				}
+			}
+		});
+	});
+
+	// ── Column blacklists ─────────────────────────────────────────────────────
+
+	describe('column blacklists', () => {
+		it('sessions blacklist excludes config and session_context', () => {
+			const sessions = getScopeConfig('global').find((t) => t.tableName === 'sessions')!;
+			expect(sessions.blacklistedColumns).toContain('config');
+			expect(sessions.blacklistedColumns).toContain('session_context');
+		});
+
+		it('rooms blacklist excludes config', () => {
+			const rooms = getScopeConfig('global').find((t) => t.tableName === 'rooms')!;
+			expect(rooms.blacklistedColumns).toEqual(['config']);
+		});
+
+		it('app_mcp_servers blacklist excludes env', () => {
+			const mcp = getScopeConfig('global').find((t) => t.tableName === 'app_mcp_servers')!;
+			expect(mcp.blacklistedColumns).toEqual(['env']);
+		});
+
+		it('inbox_items blacklist excludes raw_event and security_check', () => {
+			const inbox = getScopeConfig('global').find((t) => t.tableName === 'inbox_items')!;
+			expect(inbox.blacklistedColumns).toContain('raw_event');
+			expect(inbox.blacklistedColumns).toContain('security_check');
+		});
+
+		it('space_workflows blacklist excludes config, gates, and channels', () => {
+			const wf = getScopeConfig('space').find((t) => t.tableName === 'space_workflows')!;
+			expect(wf.blacklistedColumns).toContain('config');
+			expect(wf.blacklistedColumns).toContain('gates');
+			expect(wf.blacklistedColumns).toContain('channels');
+		});
+
+		it('space_workflow_nodes blacklist excludes config', () => {
+			const nodes = getScopeConfig('space').find((t) => t.tableName === 'space_workflow_nodes')!;
+			expect(nodes.blacklistedColumns).toEqual(['config']);
+		});
+
+		it('getBlacklistedColumns returns empty array for tables with no blacklist', () => {
+			expect(getBlacklistedColumns('skills')).toEqual([]);
+			expect(getBlacklistedColumns('tasks')).toEqual([]);
+			expect(getBlacklistedColumns('nonexistent_table')).toEqual([]);
+		});
+
+		it('getBlacklistedColumns returns correct blacklist for known tables', () => {
+			expect(getBlacklistedColumns('sessions')).toContain('config');
+			expect(getBlacklistedColumns('app_mcp_servers')).toContain('env');
+			expect(getBlacklistedColumns('space_agents')).toContain('system_prompt');
+			expect(getBlacklistedColumns('neo_activity_log')).toContain('undo_data');
+			expect(getBlacklistedColumns('job_queue')).toContain('payload');
+		});
+	});
+
+	// ── getScopeForSession ────────────────────────────────────────────────────
+
+	describe('getScopeForSession', () => {
+		it('maps roomId to room scope', () => {
+			const result = getScopeForSession({ roomId: 'room-123' });
+			expect(result).toEqual({ scopeType: 'room', scopeValue: 'room-123' });
+		});
+
+		it('maps spaceId to space scope when no roomId', () => {
+			const result = getScopeForSession({ spaceId: 'space-456' });
+			expect(result).toEqual({ scopeType: 'space', scopeValue: 'space-456' });
+		});
+
+		it('prefers roomId over spaceId when both are present', () => {
+			const result = getScopeForSession({ roomId: 'room-1', spaceId: 'space-2' });
+			expect(result).toEqual({ scopeType: 'room', scopeValue: 'room-1' });
+		});
+
+		it('returns global scope when neither roomId nor spaceId', () => {
+			const result = getScopeForSession({});
+			expect(result).toEqual({ scopeType: 'global', scopeValue: '' });
+		});
+
+		it('returns global scope when only other fields are present', () => {
+			const result = getScopeForSession({ lobbyId: 'lobby-1', taskId: 'task-1' });
+			expect(result).toEqual({ scopeType: 'global', scopeValue: '' });
+		});
+	});
+
+	// ── Sensitive tables never in any scope ───────────────────────────────────
+
+	describe('sensitive table exclusion', () => {
+		it('auth_config is not in any scope', () => {
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				const names = getAccessibleTableNames(scopeType);
+				expect(names).not.toContain('auth_config');
+			}
+		});
+
+		it('global_tools_config is not in any scope', () => {
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				expect(getAccessibleTableNames(scopeType)).not.toContain('global_tools_config');
+			}
+		});
+
+		it('global_settings is not in any scope', () => {
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				expect(getAccessibleTableNames(scopeType)).not.toContain('global_settings');
+			}
+		});
+
+		it('sdk_messages is not in any scope', () => {
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				expect(getAccessibleTableNames(scopeType)).not.toContain('sdk_messages');
+			}
+		});
+
+		it('internal infrastructure tables are not in any scope', () => {
+			const internalTables = ['session_groups', 'session_group_members', 'task_group_events'];
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				const names = getAccessibleTableNames(scopeType);
+				for (const table of internalTables) {
+					expect(names).not.toContain(table);
+				}
+			}
+		});
+
+		it('node_executions is not in any scope', () => {
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				expect(getAccessibleTableNames(scopeType)).not.toContain('node_executions');
+			}
+		});
+	});
+
+	// ── Dropped tables ────────────────────────────────────────────────────────
+
+	describe('dropped tables', () => {
+		const droppedTables = [
+			'space_session_groups',
+			'space_session_group_members',
+			'space_workflow_transitions',
+		];
+
+		it('dropped tables are not in any scope config', () => {
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				const names = getAccessibleTableNames(scopeType);
+				for (const table of droppedTables) {
+					expect(names).not.toContain(table);
+				}
+			}
+		});
+
+		it('dropped tables are in getExcludedTableNames', () => {
+			const excluded = getExcludedTableNames();
+			for (const table of droppedTables) {
+				expect(excluded).toContain(table);
+			}
+		});
+	});
+
+	// ── getExcludedTableNames ─────────────────────────────────────────────────
+
+	describe('getExcludedTableNames', () => {
+		it('includes all sensitive tables', () => {
+			const excluded = getExcludedTableNames();
+			expect(excluded).toContain('auth_config');
+			expect(excluded).toContain('global_tools_config');
+			expect(excluded).toContain('global_settings');
+		});
+
+		it('includes sdk_messages', () => {
+			expect(getExcludedTableNames()).toContain('sdk_messages');
+		});
+
+		it('includes internal infrastructure tables', () => {
+			const excluded = getExcludedTableNames();
+			expect(excluded).toContain('session_groups');
+			expect(excluded).toContain('session_group_members');
+			expect(excluded).toContain('task_group_events');
+			expect(excluded).toContain('node_executions');
+		});
+
+		it('includes all dropped tables', () => {
+			const excluded = getExcludedTableNames();
+			expect(excluded).toContain('space_session_groups');
+			expect(excluded).toContain('space_session_group_members');
+			expect(excluded).toContain('space_workflow_transitions');
+			expect(excluded).toContain('messages');
+			expect(excluded).toContain('tool_calls');
+		});
+
+		it('returns a non-empty array', () => {
+			expect(getExcludedTableNames().length).toBeGreaterThan(0);
+		});
+
+		it('excluded tables do not overlap with any accessible tables', () => {
+			const excluded = new Set(getExcludedTableNames());
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				const accessible = getAccessibleTableNames(scopeType);
+				for (const name of accessible) {
+					expect(excluded.has(name)).toBe(false);
+				}
+			}
+		});
+	});
+
+	// ── buildScopeFilter ──────────────────────────────────────────────────────
+
+	describe('buildScopeFilter', () => {
+		it('returns empty filter for global scope tables (no scopeColumn or scopeJoin)', () => {
+			const sessions = getScopeConfig('global').find((t) => t.tableName === 'sessions')!;
+			const result = buildScopeFilter(sessions, 'unused');
+			expect(result).toEqual({ whereClause: '', params: [] });
+		});
+
+		it('produces direct scope filter for room-scoped tables with scopeColumn', () => {
+			const tasks = getScopeConfig('room').find((t) => t.tableName === 'tasks')!;
+			expect(tasks.scopeColumn).toBe('room_id');
+			const result = buildScopeFilter(tasks, 'room-abc');
+			expect(result.whereClause).toBe('room_id = ?');
+			expect(result.params).toEqual(['room-abc']);
+		});
+
+		it('produces direct scope filter for goals', () => {
+			const goals = getScopeConfig('room').find((t) => t.tableName === 'goals')!;
+			const result = buildScopeFilter(goals, 'room-xyz');
+			expect(result.whereClause).toBe('room_id = ?');
+			expect(result.params).toEqual(['room-xyz']);
+		});
+
+		it('produces direct scope filter for space-scoped tables', () => {
+			const agents = getScopeConfig('space').find((t) => t.tableName === 'space_agents')!;
+			expect(agents.scopeColumn).toBe('space_id');
+			const result = buildScopeFilter(agents, 'space-123');
+			expect(result.whereClause).toBe('space_id = ?');
+			expect(result.params).toEqual(['space-123']);
+		});
+
+		it('produces indirect scope filter for mission_executions via goals', () => {
+			const execs = getScopeConfig('room').find((t) => t.tableName === 'mission_executions')!;
+			expect(execs.scopeJoin).toBeDefined();
+			expect(execs.scopeJoin!.localColumn).toBe('goal_id');
+			expect(execs.scopeJoin!.joinTable).toBe('goals');
+			expect(execs.scopeJoin!.joinPkColumn).toBe('id');
+			expect(execs.scopeJoin!.scopeColumn).toBe('room_id');
+
+			const result = buildScopeFilter(execs, 'room-42');
+			expect(result.whereClause).toBe('goal_id IN (SELECT id FROM goals WHERE room_id = ?)');
+			expect(result.params).toEqual(['room-42']);
+		});
+
+		it('produces indirect scope filter for mission_metric_history via goals', () => {
+			const history = getScopeConfig('room').find((t) => t.tableName === 'mission_metric_history')!;
+			const result = buildScopeFilter(history, 'room-99');
+			expect(result.whereClause).toBe('goal_id IN (SELECT id FROM goals WHERE room_id = ?)');
+			expect(result.params).toEqual(['room-99']);
+		});
+
+		it('produces indirect scope filter for space_workflow_nodes via space_workflows', () => {
+			const nodes = getScopeConfig('space').find((t) => t.tableName === 'space_workflow_nodes')!;
+			expect(nodes.scopeJoin).toBeDefined();
+			expect(nodes.scopeJoin!.localColumn).toBe('workflow_id');
+			expect(nodes.scopeJoin!.joinTable).toBe('space_workflows');
+			expect(nodes.scopeJoin!.joinPkColumn).toBe('id');
+			expect(nodes.scopeJoin!.scopeColumn).toBe('space_id');
+
+			const result = buildScopeFilter(nodes, 'space-alpha');
+			expect(result.whereClause).toBe(
+				'workflow_id IN (SELECT id FROM space_workflows WHERE space_id = ?)'
+			);
+			expect(result.params).toEqual(['space-alpha']);
+		});
+
+		it('produces indirect scope filter for gate_data via space_workflow_runs', () => {
+			const gateData = getScopeConfig('space').find((t) => t.tableName === 'gate_data')!;
+			expect(gateData.scopeJoin).toBeDefined();
+			expect(gateData.scopeJoin!.localColumn).toBe('run_id');
+			expect(gateData.scopeJoin!.joinTable).toBe('space_workflow_runs');
+			expect(gateData.scopeJoin!.joinPkColumn).toBe('id');
+			expect(gateData.scopeJoin!.scopeColumn).toBe('space_id');
+
+			const result = buildScopeFilter(gateData, 'space-beta');
+			expect(result.whereClause).toBe(
+				'run_id IN (SELECT id FROM space_workflow_runs WHERE space_id = ?)'
+			);
+			expect(result.params).toEqual(['space-beta']);
+		});
+
+		it('produces indirect scope filter for channel_cycles via space_workflow_runs', () => {
+			const cycles = getScopeConfig('space').find((t) => t.tableName === 'channel_cycles')!;
+			expect(cycles.scopeJoin).toBeDefined();
+			expect(cycles.scopeJoin!.localColumn).toBe('run_id');
+
+			const result = buildScopeFilter(cycles, 'space-gamma');
+			expect(result.whereClause).toBe(
+				'run_id IN (SELECT id FROM space_workflow_runs WHERE space_id = ?)'
+			);
+			expect(result.params).toEqual(['space-gamma']);
+		});
+
+		it('all indirect scope filters produce valid SQL with one parameter', () => {
+			// Collect all indirect configs across all scopes
+			const indirectConfigs: ScopeTableConfig[] = [];
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				for (const cfg of getScopeConfig(scopeType)) {
+					if (cfg.scopeJoin) {
+						indirectConfigs.push(cfg);
+					}
+				}
+			}
+
+			expect(indirectConfigs.length).toBeGreaterThan(0);
+
+			for (const cfg of indirectConfigs) {
+				const result = buildScopeFilter(cfg, 'test-scope-value');
+				// Should contain IN subquery pattern
+				expect(result.whereClause).toContain('IN (SELECT');
+				expect(result.whereClause).toContain('FROM');
+				expect(result.whereClause).toContain('WHERE');
+				expect(result.whereClause).toContain('?');
+				// Exactly one parameter
+				expect(result.params).toHaveLength(1);
+				expect(result.params[0]).toBe('test-scope-value');
+			}
+		});
+
+		it('all direct scope filters produce equality clause with one parameter', () => {
+			const directConfigs: ScopeTableConfig[] = [];
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				for (const cfg of getScopeConfig(scopeType)) {
+					if (cfg.scopeColumn) {
+						directConfigs.push(cfg);
+					}
+				}
+			}
+
+			expect(directConfigs.length).toBeGreaterThan(0);
+
+			for (const cfg of directConfigs) {
+				const result = buildScopeFilter(cfg, 'test-scope-value');
+				expect(result.whereClause).toBe(`${cfg.scopeColumn} = ?`);
+				expect(result.params).toHaveLength(1);
+				expect(result.params[0]).toBe('test-scope-value');
+			}
+		});
+	});
+
+	// ── Cross-cutting: no duplicate table names across scopes ─────────────────
+
+	describe('table name uniqueness', () => {
+		it('no table appears in more than one scope', () => {
+			const allTables = new Map<string, string[]>();
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				for (const name of getAccessibleTableNames(scopeType)) {
+					const existing = allTables.get(name) ?? [];
+					existing.push(scopeType);
+					allTables.set(name, existing);
+				}
+			}
+
+			const duplicates: string[] = [];
+			for (const [name, scopes] of allTables) {
+				if (scopes.length > 1) {
+					duplicates.push(`${name}: ${scopes.join(', ')}`);
+				}
+			}
+			expect(duplicates).toEqual([]);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/db-query/scope-config.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createTables, runMigrations } from '../../../src/storage/schema/index.ts';
 import {
 	buildScopeFilter,
 	getAccessibleTableNames,
@@ -92,6 +94,11 @@ describe('scope-config', () => {
 			expect(rooms.blacklistedColumns).toEqual(['config']);
 		});
 
+		it('tasks blacklist excludes restrictions (internal use)', () => {
+			const tasks = getScopeConfig('room').find((t) => t.tableName === 'tasks')!;
+			expect(tasks.blacklistedColumns).toContain('restrictions');
+		});
+
 		it('app_mcp_servers blacklist excludes env', () => {
 			const mcp = getScopeConfig('global').find((t) => t.tableName === 'app_mcp_servers')!;
 			expect(mcp.blacklistedColumns).toEqual(['env']);
@@ -117,7 +124,7 @@ describe('scope-config', () => {
 
 		it('getBlacklistedColumns returns empty array for tables with no blacklist', () => {
 			expect(getBlacklistedColumns('skills')).toEqual([]);
-			expect(getBlacklistedColumns('tasks')).toEqual([]);
+			expect(getBlacklistedColumns('goals')).toEqual([]);
 			expect(getBlacklistedColumns('nonexistent_table')).toEqual([]);
 		});
 
@@ -127,6 +134,7 @@ describe('scope-config', () => {
 			expect(getBlacklistedColumns('space_agents')).toContain('system_prompt');
 			expect(getBlacklistedColumns('neo_activity_log')).toContain('undo_data');
 			expect(getBlacklistedColumns('job_queue')).toContain('payload');
+			expect(getBlacklistedColumns('tasks')).toContain('restrictions');
 		});
 	});
 
@@ -259,6 +267,11 @@ describe('scope-config', () => {
 			expect(excluded).toContain('space_workflow_transitions');
 			expect(excluded).toContain('messages');
 			expect(excluded).toContain('tool_calls');
+		});
+
+		it('includes dynamically created tables', () => {
+			const excluded = getExcludedTableNames();
+			expect(excluded).toContain('github_filter_configs');
 		});
 
 		it('returns a non-empty array', () => {
@@ -417,6 +430,30 @@ describe('scope-config', () => {
 		});
 	});
 
+	// ── Scope filter enforcement ──────────────────────────────────────────────
+
+	describe('scope filter enforcement', () => {
+		it('every room-scoped table has scopeColumn or scopeJoin', () => {
+			const unfiltered: string[] = [];
+			for (const table of getScopeConfig('room')) {
+				if (!table.scopeColumn && !table.scopeJoin) {
+					unfiltered.push(table.tableName);
+				}
+			}
+			expect(unfiltered).toEqual([]);
+		});
+
+		it('every space-scoped table has scopeColumn or scopeJoin', () => {
+			const unfiltered: string[] = [];
+			for (const table of getScopeConfig('space')) {
+				if (!table.scopeColumn && !table.scopeJoin) {
+					unfiltered.push(table.tableName);
+				}
+			}
+			expect(unfiltered).toEqual([]);
+		});
+	});
+
 	// ── Cross-cutting: no duplicate table names across scopes ─────────────────
 
 	describe('table name uniqueness', () => {
@@ -437,6 +474,50 @@ describe('scope-config', () => {
 				}
 			}
 			expect(duplicates).toEqual([]);
+		});
+	});
+
+	// ── Schema evolution: every actual DB table is accounted for ──────────────
+
+	describe('schema evolution', () => {
+		it('every table in the actual schema is either in a scope config or in the excluded list', () => {
+			// Create a fresh in-memory database with the full schema
+			const db = new Database(':memory:');
+			runMigrations(db, () => {});
+			createTables(db);
+
+			// Query sqlite_master for all actual table names
+			const rows = db
+				.query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+				.all() as {
+				name: string;
+			}[];
+			const actualTables = new Set(
+				rows
+					.map((r) => r.name)
+					// Filter out internal SQLite tables (sqlite_sequence is auto-created for AUTOINCREMENT)
+					.filter((name) => !name.startsWith('sqlite_'))
+			);
+
+			// Collect all tables that are either in a scope config or excluded
+			const accountedFor = new Set<string>();
+			for (const scopeType of ['global', 'room', 'space'] as const) {
+				for (const name of getAccessibleTableNames(scopeType)) {
+					accountedFor.add(name);
+				}
+			}
+			for (const name of getExcludedTableNames()) {
+				accountedFor.add(name);
+			}
+
+			// Every actual table must be accounted for
+			const unaccounted: string[] = [];
+			for (const tableName of actualTables) {
+				if (!accountedFor.has(tableName)) {
+					unaccounted.push(tableName);
+				}
+			}
+			expect(unaccounted).toEqual([]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Add `packages/daemon/src/lib/db-query/scope-config.ts` defining `DbScopeType`, `ScopeTableConfig`, and `ScopeJoinConfig` types
- Implement table access lists for global (9 tables), room (7 tables), and space (8 tables) scopes
- Add column blacklists for sensitive columns (`config`, `env`, `session_context`, `raw_event`, `system_prompt`, `gates`, `channels`, etc.)
- Implement `getScopeConfig`, `getScopeForSession`, `getAccessibleTableNames`, `getBlacklistedColumns`, `getExcludedTableNames`, and `buildScopeFilter` functions
- Support both direct scope filtering (`room_id = ?`) and indirect join-based filtering (`goal_id IN (SELECT id FROM goals WHERE room_id = ?)`)
- 43 unit tests covering all acceptance criteria

## Test plan
- [x] Each scope returns correct table set
- [x] Column blacklists applied correctly
- [x] `getScopeForSession` maps roomId/spaceId/neither
- [x] Sensitive tables (`auth_config`, `global_tools_config`, `global_settings`) not in any scope
- [x] `sdk_messages` excluded from all scopes
- [x] Internal infrastructure tables excluded
- [x] Dropped tables not in any scope config
- [x] `buildScopeFilter` produces correct parameterized SQL for direct and indirect configs
- [x] No table name overlaps across scopes