### PR TITLE
feat: support legacy plain-string overrides and endNode in export/import

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -58,7 +58,7 @@ import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import type { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
-import { exportBundle, validateExportBundle } from '../space/export-format';
+import { exportBundle, validateExportBundle, normalizeOverride } from '../space/export-format';
 import { Logger } from '../logger';
 
 const log = new Logger('space-export-import-handlers');
@@ -191,8 +191,9 @@ export function buildWorkflowCreateParams(
 				agentId: agentId ?? '',
 				name: a.name,
 			};
-			if (a.systemPrompt !== undefined) entry.systemPrompt = a.systemPrompt;
-			if (a.instructions !== undefined) entry.instructions = a.instructions;
+			// Normalize overrides: plain strings (legacy) → { mode: 'override', value }
+			entry.systemPrompt = normalizeOverride(a.systemPrompt);
+			entry.instructions = normalizeOverride(a.instructions);
 			return entry;
 		});
 

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -192,8 +192,10 @@ export function buildWorkflowCreateParams(
 				name: a.name,
 			};
 			// Normalize overrides: plain strings (legacy) → { mode: 'override', value }
-			entry.systemPrompt = normalizeOverride(a.systemPrompt);
-			entry.instructions = normalizeOverride(a.instructions);
+			const normalizedSP = normalizeOverride(a.systemPrompt);
+			if (normalizedSP !== undefined) entry.systemPrompt = normalizedSP;
+			const normalizedInst = normalizeOverride(a.instructions);
+			if (normalizedInst !== undefined) entry.instructions = normalizedInst;
 			return entry;
 		});
 

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -369,6 +369,17 @@ export function validateExportedWorkflow(data: unknown): ValidationResult<Export
 			error: `invalid: startNode "${result.data.startNode}" does not reference a known node name`,
 		};
 	}
+	// endNode must reference a known node name when present (skip check when nodes is empty)
+	if (
+		result.data.endNode !== undefined &&
+		result.data.nodes.length > 0 &&
+		!nodeNameSet.has(result.data.endNode)
+	) {
+		return {
+			ok: false,
+			error: `invalid: endNode "${result.data.endNode}" does not reference a known node name`,
+		};
+	}
 
 	// Channel from/to must reference known node names, agent slot names, or '*' wildcard.
 	// Build valid name set: '*' + all node names + all agent slot names (agents[].name).

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -63,11 +63,19 @@ const workflowNodeAgentOverrideSchema = z.object({
 	value: z.string(),
 });
 
+/**
+ * Union schema accepting both legacy plain-string overrides and new `{ mode, value }` objects.
+ * Legacy exports stored systemPrompt/instructions as plain strings; the new format uses
+ * `WorkflowNodeAgentOverride { mode, value }`. Both are accepted on import for backward
+ * compatibility — plain strings are normalized to `{ mode: 'override', value }` during import.
+ */
+const overrideOrStringSchema = z.union([workflowNodeAgentOverrideSchema, z.string().min(1)]);
+
 const exportedWorkflowNodeAgentSchema = z.object({
 	agentRef: z.string().min(1),
 	name: z.string().min(1),
-	systemPrompt: workflowNodeAgentOverrideSchema.optional(),
-	instructions: workflowNodeAgentOverrideSchema.optional(),
+	systemPrompt: overrideOrStringSchema.optional(),
+	instructions: overrideOrStringSchema.optional(),
 });
 
 /**
@@ -138,6 +146,27 @@ const exportBundleBaseSchema = z.object({
 // ============================================================================
 
 export type ValidationResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+// ============================================================================
+// Normalization helpers
+// ============================================================================
+
+/**
+ * Normalize a systemPrompt or instructions override value from the exported format.
+ *
+ * The Zod schema accepts both plain strings (legacy) and `{ mode, value }` objects (new).
+ * This helper converts the union to the canonical `WorkflowNodeAgentOverride` format:
+ * - Plain string → `{ mode: 'override', value: <string> }`
+ * - `{ mode, value }` object → passed through as-is
+ * - `undefined` → `undefined`
+ */
+export function normalizeOverride(
+	value: import('@neokai/shared').WorkflowNodeAgentOverride | string | undefined
+): import('@neokai/shared').WorkflowNodeAgentOverride | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === 'string') return { mode: 'override', value };
+	return value;
+}
 
 // ============================================================================
 // Export functions

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -22,6 +22,7 @@ import {
 	validateExportedAgent,
 	validateExportedWorkflow,
 	validateExportBundle,
+	normalizeOverride,
 } from '../../../src/lib/space/export-format.ts';
 import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 
@@ -1876,6 +1877,225 @@ describe('ExportedWorkflowChannel — export and validation', () => {
 			expect(ch.from).toBe('coder');
 			expect(ch.to).toBe('reviewer');
 			expect(ch.direction).toBe('bidirectional');
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// normalizeOverride
+// ---------------------------------------------------------------------------
+
+describe('normalizeOverride', () => {
+	test('returns undefined for undefined input', () => {
+		expect(normalizeOverride(undefined)).toBeUndefined();
+	});
+
+	test('converts plain string to { mode: "override", value }', () => {
+		const result = normalizeOverride('Be helpful.');
+		expect(result).toEqual({ mode: 'override', value: 'Be helpful.' });
+	});
+
+	test('passes through { mode: "override", value } as-is', () => {
+		const override = { mode: 'override' as const, value: 'You are strict.' };
+		const result = normalizeOverride(override);
+		expect(result).toBe(override);
+	});
+
+	test('passes through { mode: "expand", value } as-is', () => {
+		const override = { mode: 'expand' as const, value: 'Append this.' };
+		const result = normalizeOverride(override);
+		expect(result).toBe(override);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// validateExportedWorkflow — legacy plain-string overrides
+// ---------------------------------------------------------------------------
+
+describe('validateExportedWorkflow — legacy plain-string overrides', () => {
+	test('accepts node agent with plain string systemPrompt', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [{ agentRef: 'Coder', name: 'coder', systemPrompt: 'You are helpful' }],
+					name: 'Step',
+				},
+			],
+			startNode: 'Step',
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.nodes[0].agents[0].systemPrompt).toBe('You are helpful');
+		}
+	});
+
+	test('accepts node agent with plain string instructions', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [{ agentRef: 'Coder', name: 'coder', instructions: 'Focus on tests.' }],
+					name: 'Step',
+				},
+			],
+			startNode: 'Step',
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.nodes[0].agents[0].instructions).toBe('Focus on tests.');
+		}
+	});
+
+	test('accepts both plain strings and { mode, value } objects in the same node', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [
+						{
+							agentRef: 'Coder',
+							name: 'coder',
+							systemPrompt: 'You are a coder',
+							instructions: { mode: 'override', value: 'Write tests' },
+						},
+						{
+							agentRef: 'Reviewer',
+							name: 'reviewer',
+							systemPrompt: { mode: 'expand', value: 'Extra context' },
+							instructions: 'Review thoroughly',
+						},
+					],
+					name: 'Step',
+				},
+			],
+			startNode: 'Step',
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const agents = result.value.nodes[0].agents;
+			expect(agents[0].systemPrompt).toBe('You are a coder');
+			expect(agents[0].instructions).toEqual({ mode: 'override', value: 'Write tests' });
+			expect(agents[1].systemPrompt).toEqual({ mode: 'expand', value: 'Extra context' });
+			expect(agents[1].instructions).toBe('Review thoroughly');
+		}
+	});
+
+	test('rejects empty string for systemPrompt (min 1)', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [{ agentRef: 'Coder', name: 'coder', systemPrompt: '' }],
+					name: 'Step',
+				},
+			],
+			startNode: 'Step',
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects empty string for instructions (min 1)', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [
+				{
+					agents: [{ agentRef: 'Coder', name: 'coder', instructions: '' }],
+					name: 'Step',
+				},
+			],
+			startNode: 'Step',
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('plain string overrides survive export → JSON → validate round-trip', () => {
+		// Export produces { mode, value } — but validate should also accept the result
+		const workflow = makeWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			// Exported workflow has no per-slot overrides, so all should be absent
+			for (const node of result.value.nodes) {
+				for (const agent of node.agents) {
+					expect(agent.systemPrompt).toBeUndefined();
+					expect(agent.instructions).toBeUndefined();
+				}
+			}
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// exportWorkflow — endNode
+// ---------------------------------------------------------------------------
+
+describe('exportWorkflow — endNode', () => {
+	test('exports endNode when endNodeId is set (map UUID to node name)', () => {
+		const workflow = makeWorkflow({
+			endNodeId: 'node-uuid-3', // 'Plan step'
+		});
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		expect(exported.endNode).toBe('Plan step');
+	});
+
+	test('omits endNode when endNodeId is not set', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		expect(exported.endNode).toBeUndefined();
+	});
+
+	test('falls back to UUID when endNode name not found', () => {
+		const workflow = makeWorkflow({
+			endNodeId: 'node-uuid-missing',
+		});
+		const exported = exportWorkflow(workflow, []);
+
+		expect(exported.endNode).toBe('node-uuid-missing');
+	});
+
+	test('endNode round-trip: export → JSON → validate → verify endNode matches node name', () => {
+		const workflow = makeWorkflow({
+			endNodeId: 'node-uuid-3', // 'Plan step'
+		});
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.endNode).toBe('Plan step');
 		}
 	});
 });

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -2029,8 +2029,8 @@ describe('validateExportedWorkflow — legacy plain-string overrides', () => {
 		expect(result.ok).toBe(false);
 	});
 
-	test('plain string overrides survive export → JSON → validate round-trip', () => {
-		// Export produces { mode, value } — but validate should also accept the result
+	test('workflow without per-slot overrides round-trips cleanly', () => {
+		// No per-slot overrides — all should be absent after round-trip
 		const workflow = makeWorkflow();
 		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
@@ -2097,5 +2097,37 @@ describe('exportWorkflow — endNode', () => {
 		if (result.ok) {
 			expect(result.value.endNode).toBe('Plan step');
 		}
+	});
+
+	test('rejects endNode that does not reference a known node name', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [{ agents: [{ agentRef: 'A', name: 'a' }], name: 'Step' }],
+			startNode: 'Step',
+			endNode: 'NonExistentNode',
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('endNode');
+			expect(result.error).toContain('NonExistentNode');
+		}
+	});
+
+	test('accepts endNode when nodes array is empty', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			nodes: [],
+			startNode: 'first',
+			endNode: 'NonExistentNode',
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
 	});
 });

--- a/packages/daemon/tests/unit/space/export-import-round-trip.test.ts
+++ b/packages/daemon/tests/unit/space/export-import-round-trip.test.ts
@@ -24,7 +24,7 @@ import {
 	validateExportBundle,
 } from '../../../src/lib/space/export-format.ts';
 import { buildWorkflowCreateParams } from '../../../src/lib/rpc-handlers/space-export-import-handlers.ts';
-import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
+import type { SpaceAgent, SpaceWorkflow, ExportedSpaceWorkflow } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // DB setup helpers
@@ -344,7 +344,8 @@ describe('buildWorkflowCreateParams — per-slot overrides', () => {
 		const nodeAgents = params.nodes[0].agents!;
 
 		const coder = nodeAgents.find((a) => a.name === 'coder');
-		expect(coder!.instructions).toBe('Focus on auth module only.');
+		// Legacy plain-string instructions are normalized to { mode: 'override', value }
+		expect(coder!.instructions).toEqual({ mode: 'override', value: 'Focus on auth module only.' });
 
 		const reviewer = nodeAgents.find((a) => a.name === 'reviewer');
 		expect(reviewer!.instructions).toBeUndefined();
@@ -369,6 +370,169 @@ describe('buildWorkflowCreateParams — per-slot overrides', () => {
 		expect(warnings.length).toBeGreaterThan(0);
 		expect(warnings[0]).toContain('Reviewer Agent');
 	});
+});
+
+// -------------------------------------------------------------------------
+// legacy plain-string overrides — import normalization
+// -------------------------------------------------------------------------
+
+test('normalizes legacy plain-string systemPrompt to { mode: "override", value } on import', () => {
+	const legacyExported: ExportedSpaceWorkflow = {
+		version: 1,
+		type: 'workflow',
+		name: 'Legacy Workflow',
+		nodes: [
+			{
+				name: 'Step',
+				agents: [{ agentRef: 'Coder Agent', name: 'coder', systemPrompt: 'Be strict.' }],
+			},
+		],
+		startNode: 'Step',
+		tags: [],
+	};
+
+	const importedNameToId = new Map([['Coder Agent', 'new-agent-1']]);
+	const existingNameToId = new Map<string, string>();
+
+	const { params, warnings } = buildWorkflowCreateParams(
+		'space-import',
+		'Legacy Workflow',
+		legacyExported,
+		importedNameToId,
+		existingNameToId
+	);
+
+	expect(warnings).toHaveLength(0);
+	const nodeAgents = params.nodes[0].agents!;
+	expect(nodeAgents[0].systemPrompt).toEqual({ mode: 'override', value: 'Be strict.' });
+});
+
+test('normalizes legacy plain-string instructions to { mode: "override", value } on import', () => {
+	const legacyExported: ExportedSpaceWorkflow = {
+		version: 1,
+		type: 'workflow',
+		name: 'Legacy Workflow',
+		nodes: [
+			{
+				name: 'Step',
+				agents: [
+					{ agentRef: 'Reviewer Agent', name: 'reviewer', instructions: 'Review carefully.' },
+				],
+			},
+		],
+		startNode: 'Step',
+		tags: [],
+	};
+
+	const importedNameToId = new Map([['Reviewer Agent', 'new-agent-2']]);
+	const existingNameToId = new Map<string, string>();
+
+	const { params, warnings } = buildWorkflowCreateParams(
+		'space-import',
+		'Legacy Workflow',
+		legacyExported,
+		importedNameToId,
+		existingNameToId
+	);
+
+	expect(warnings).toHaveLength(0);
+	const nodeAgents = params.nodes[0].agents!;
+	expect(nodeAgents[0].instructions).toEqual({ mode: 'override', value: 'Review carefully.' });
+});
+
+test('{ mode: "expand", value } objects pass through unchanged', () => {
+	const legacyExported: ExportedSpaceWorkflow = {
+		version: 1,
+		type: 'workflow',
+		name: 'Modern Workflow',
+		nodes: [
+			{
+				name: 'Step',
+				agents: [
+					{
+						agentRef: 'Coder Agent',
+						name: 'coder',
+						systemPrompt: { mode: 'expand', value: 'Extra context.' },
+						instructions: { mode: 'override', value: 'Follow these rules.' },
+					},
+				],
+			},
+		],
+		startNode: 'Step',
+		tags: [],
+	};
+
+	const importedNameToId = new Map([['Coder Agent', 'new-agent-1']]);
+	const existingNameToId = new Map<string, string>();
+
+	const { params, warnings } = buildWorkflowCreateParams(
+		'space-import',
+		'Modern Workflow',
+		legacyExported,
+		importedNameToId,
+		existingNameToId
+	);
+
+	expect(warnings).toHaveLength(0);
+	const nodeAgents = params.nodes[0].agents!;
+	expect(nodeAgents[0].systemPrompt).toEqual({ mode: 'expand', value: 'Extra context.' });
+	expect(nodeAgents[0].instructions).toEqual({ mode: 'override', value: 'Follow these rules.' });
+});
+
+test('mix of plain strings and { mode, value } objects in the same node normalize correctly', () => {
+	const legacyExported: ExportedSpaceWorkflow = {
+		version: 1,
+		type: 'workflow',
+		name: 'Mixed Workflow',
+		nodes: [
+			{
+				name: 'Step',
+				agents: [
+					{
+						agentRef: 'Coder Agent',
+						name: 'coder',
+						systemPrompt: 'Plain string prompt',
+						instructions: { mode: 'expand', value: 'Modern instructions' },
+					},
+					{
+						agentRef: 'Reviewer Agent',
+						name: 'reviewer',
+						systemPrompt: { mode: 'override', value: 'Modern prompt' },
+						instructions: 'Plain string instructions',
+					},
+				],
+			},
+		],
+		startNode: 'Step',
+		tags: [],
+	};
+
+	const importedNameToId = new Map([
+		['Coder Agent', 'new-agent-1'],
+		['Reviewer Agent', 'new-agent-2'],
+	]);
+	const existingNameToId = new Map<string, string>();
+
+	const { params, warnings } = buildWorkflowCreateParams(
+		'space-import',
+		'Mixed Workflow',
+		legacyExported,
+		importedNameToId,
+		existingNameToId
+	);
+
+	expect(warnings).toHaveLength(0);
+	const nodeAgents = params.nodes[0].agents!;
+
+	// coder: plain string systemPrompt normalized, { mode, value } instructions passed through
+	const coder = nodeAgents.find((a) => a.name === 'coder')!;
+	expect(coder.systemPrompt).toEqual({ mode: 'override', value: 'Plain string prompt' });
+	expect(coder.instructions).toEqual({ mode: 'expand', value: 'Modern instructions' });
+
+	// reviewer: { mode, value } systemPrompt passed through, plain string instructions normalized
+	const reviewer = nodeAgents.find((a) => a.name === 'reviewer')!;
+	expect(reviewer.systemPrompt).toEqual({ mode: 'override', value: 'Modern prompt' });
+	expect(reviewer.instructions).toEqual({ mode: 'override', value: 'Plain string instructions' });
 });
 
 // ---------------------------------------------------------------------------
@@ -640,7 +804,8 @@ describe('full round-trip: export → import → DB read-back', () => {
 
 		const nodeAgents = readBack!.nodes[0].agents!;
 		const coder = nodeAgents.find((a) => a.name === 'coder');
-		expect(coder!.instructions).toBe('Focus on auth module only.');
+		// Legacy plain-string instructions are normalized to { mode: 'override', value }
+		expect(coder!.instructions).toEqual({ mode: 'override', value: 'Focus on auth module only.' });
 
 		const reviewer = nodeAgents.find((a) => a.name === 'reviewer');
 		expect(reviewer!.instructions).toBeUndefined();

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1008,14 +1008,16 @@ export interface ExportedWorkflowNodeAgent {
 	name: string;
 	/**
 	 * Optional system-prompt override for this agent slot.
-	 * `mode: 'override'` replaces; `mode: 'expand'` appends.
+	 * Accepts both plain strings (legacy export format) and `{ mode, value }` objects.
+	 * Plain strings are normalized to `{ mode: 'override', value }` during import.
 	 */
-	systemPrompt?: WorkflowNodeAgentOverride;
+	systemPrompt?: WorkflowNodeAgentOverride | string;
 	/**
 	 * Optional instructions override for this agent slot.
-	 * `mode: 'override'` replaces; `mode: 'expand'` appends.
+	 * Accepts both plain strings (legacy export format) and `{ mode, value }` objects.
+	 * Plain strings are normalized to `{ mode: 'override', value }` during import.
 	 */
-	instructions?: WorkflowNodeAgentOverride;
+	instructions?: WorkflowNodeAgentOverride | string;
 }
 
 /**


### PR DESCRIPTION
Update export/import format for backward compatibility with legacy overrides and endNode support.

- Zod schema accepts both plain strings (legacy) and `{ mode, value }` objects for `systemPrompt`/`instructions` on node agents
- `normalizeOverride()` converts legacy strings to `{ mode: 'override', value }` during import
- `endNode` exported/imported when `endNodeId` is set (UUID → name mapping)
- Updated `ExportedWorkflowNodeAgent` shared type to reflect union

16 new tests: normalizeOverride helper, legacy string schema acceptance, endNode export round-trip, import normalization