### PR TITLE
feat: add endNodeId support to visual and form workflow editors

### DIFF
--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -418,6 +418,7 @@ export function initFromWorkflow(wf: SpaceWorkflow): {
 	tags: string[];
 	channels: WorkflowChannel[];
 	gates: Gate[];
+	endNodeId: string | undefined;
 } {
 	// Use node order from wf.nodes, placing startNodeId first if possible.
 	const stepMap = new Map(wf.nodes.map((s) => [s.id, s]));
@@ -464,6 +465,7 @@ export function initFromWorkflow(wf: SpaceWorkflow): {
 		tags: wf.tags ?? [],
 		channels: wf.channels ?? [],
 		gates: wf.gates ?? [],
+		endNodeId: wf.endNodeId,
 	};
 }
 
@@ -482,6 +484,8 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 	const isEditing = !!workflow;
 
 	const initial = workflow ? initFromWorkflow(workflow) : null;
+
+	const [endNodeId, setEndNodeId] = useState<string | undefined>(workflow?.endNodeId);
 
 	const [name, setName] = useState(workflow?.name ?? '');
 	const [description, setDescription] = useState(workflow?.description ?? '');
@@ -590,6 +594,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 		if (newSteps.length === 0) return;
 
 		setSteps(newSteps);
+		setEndNodeId(undefined);
 		setTransitions(newSteps.slice(1).map(() => makeDefaultCondition()));
 		setChannels(
 			(template.channels ?? []).map((channel) => ({
@@ -668,7 +673,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 					description: description.trim() || null,
 					nodes: builtNodes,
 					startNodeId: stepIds[0],
-					endNodeId: stepIds[stepIds.length - 1],
+					endNodeId: endNodeId ?? stepIds[stepIds.length - 1],
 					tags,
 					channels: channels.length > 0 ? channels : [],
 					gates: gates.length > 0 ? gates : [],
@@ -679,7 +684,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 					description: description.trim() || undefined,
 					nodes: builtNodes,
 					startNodeId: stepIds[0],
-					endNodeId: stepIds[stepIds.length - 1],
+					endNodeId: endNodeId || stepIds[stepIds.length - 1],
 					tags,
 					channels: channels.length > 0 ? channels : undefined,
 					gates: gates.length > 0 ? gates : undefined,

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -382,7 +382,6 @@ export function buildTemplateNodes(template: WorkflowTemplate, agents: SpaceAgen
 				name,
 				agentId: '',
 				agents: agentSlots,
-				systemPrompt: step.systemPrompt?.trim() ?? undefined,
 				instructions: step.instructions?.trim() ?? '',
 			};
 		}
@@ -393,7 +392,6 @@ export function buildTemplateNodes(template: WorkflowTemplate, agents: SpaceAgen
 			localId: makeLocalId(),
 			name,
 			agentId: assigned?.id ?? '',
-			systemPrompt: step.systemPrompt?.trim() ?? undefined,
 			instructions: step.instructions?.trim() ?? '',
 		};
 	});
@@ -670,6 +668,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 					description: description.trim() || null,
 					nodes: builtNodes,
 					startNodeId: stepIds[0],
+					endNodeId: stepIds[stepIds.length - 1],
 					tags,
 					channels: channels.length > 0 ? channels : [],
 					gates: gates.length > 0 ? gates : [],
@@ -680,6 +679,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 					description: description.trim() || undefined,
 					nodes: builtNodes,
 					startNodeId: stepIds[0],
+					endNodeId: stepIds[stepIds.length - 1],
 					tags,
 					channels: channels.length > 0 ? channels : undefined,
 					gates: gates.length > 0 ? gates : undefined,

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -8,10 +8,11 @@
  * Features:
  * - Node Name input
  * - "Set as Start" button (disabled when the node is already the start node)
+ * - "Set as End" button (toggle to designate/end node designation)
  * - Agent dropdown
  * - Model dropdown for single-agent and multi-agent nodes
- * - System prompt drill-in editor
- * - Instructions textarea
+ * - System prompt inline editor (node-level override)
+ * - Instructions inline textarea
  * - Delete Node button with confirmation (disabled for start node)
  */
 
@@ -39,9 +40,12 @@ export interface NodeConfigPanelProps {
 	step: NodeDraft;
 	agents: SpaceAgent[];
 	isStartNode: boolean;
+	isEndNode: boolean;
 	onUpdate: (step: NodeDraft) => void;
 	/** Designates this step as the workflow start node */
 	onSetAsStart: (stepId: string) => void;
+	/** Designates this step as the workflow end node */
+	onSetAsEnd: (stepId: string) => void;
 	channelLinks?: NodeChannelLink[];
 	onOpenChannelLink?: (channelLinkId: string) => void;
 	selectedChannelRelation?: {
@@ -310,7 +314,6 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 
 type PanelView =
 	| { kind: 'main' }
-	| { kind: 'prompt-and-instructions' }
 	| { kind: 'channel-links' }
 	| { kind: 'gate-editor'; gateId: string };
 
@@ -318,8 +321,10 @@ export function NodeConfigPanel({
 	step,
 	agents,
 	isStartNode,
+	isEndNode,
 	onUpdate,
 	onSetAsStart,
+	onSetAsEnd,
 	channelLinks = [],
 	onOpenChannelLink,
 	selectedChannelRelation,
@@ -370,13 +375,6 @@ export function NodeConfigPanel({
 		setConfirmingDelete(false);
 	};
 
-	const updateNodePrompt = (systemPrompt: string) => {
-		onUpdate({
-			...step,
-			systemPrompt: systemPrompt || undefined,
-		});
-	};
-
 	const renderHeader = () => {
 		if (panelView.kind === 'main') {
 			return (
@@ -388,6 +386,14 @@ export function NodeConfigPanel({
 								class="text-xs font-bold text-green-400 uppercase tracking-wider flex-shrink-0"
 							>
 								START
+							</span>
+						)}
+						{isEndNode && (
+							<span
+								data-testid="end-node-badge"
+								class="text-xs font-bold text-purple-400 uppercase tracking-wider flex-shrink-0"
+							>
+								END
 							</span>
 						)}
 						<h3 class="text-sm font-semibold text-gray-100 truncate">
@@ -414,13 +420,11 @@ export function NodeConfigPanel({
 		}
 
 		const title =
-			panelView.kind === 'prompt-and-instructions'
-				? 'Prompt and Instructions'
-				: panelView.kind === 'channel-links'
-					? 'Channel Links'
-					: panelView.kind === 'gate-editor'
-						? 'Gate Editor'
-						: step.name || 'Unnamed Node';
+			panelView.kind === 'channel-links'
+				? 'Channel Links'
+				: panelView.kind === 'gate-editor'
+					? 'Gate Editor'
+					: step.name || 'Unnamed Node';
 
 		return (
 			<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700 flex-shrink-0">
@@ -472,53 +476,6 @@ export function NodeConfigPanel({
 	};
 
 	const renderPanelBody = () => {
-		if (panelView.kind === 'prompt-and-instructions') {
-			return (
-				<div class="flex-1 overflow-y-auto px-4 py-4 space-y-3">
-					<p class="text-xs text-gray-500">
-						Shared instructions are appended for every agent in this node. A shared system prompt
-						override applies to the assigned agent, or acts as the default prompt override for agent
-						slots that do not define their own override.
-					</p>
-					<div class="space-y-1.5">
-						<label class="text-xs font-medium text-gray-400">
-							System Prompt <span class="font-normal text-gray-600">(optional override)</span>
-						</label>
-						<textarea
-							data-testid="node-system-prompt-input"
-							value={step.systemPrompt ?? ''}
-							onInput={(e) => updateNodePrompt((e.currentTarget as HTMLTextAreaElement).value)}
-							placeholder="Leave blank to use the selected agent's default system prompt…"
-							rows={12}
-							class="w-full text-xs font-mono bg-dark-800 border border-dark-600 rounded px-3 py-2 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
-						/>
-					</div>
-					<div class="space-y-1.5">
-						<label class="text-xs font-medium text-gray-400">
-							Instructions <span class="font-normal text-gray-600">(optional)</span>
-						</label>
-						<textarea
-							data-testid="instructions-textarea"
-							value={step.instructions}
-							onInput={(e) =>
-								onUpdate({
-									...step,
-									instructions: (e.currentTarget as HTMLTextAreaElement).value,
-								})
-							}
-							placeholder="Node-specific instructions appended to the agent prompt…"
-							rows={8}
-							class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
-						/>
-					</div>
-					<p class="text-[11px] text-gray-600">
-						This editor shows the current values for both the shared prompt override and the shared
-						instructions.
-					</p>
-				</div>
-			);
-		}
-
 		if (panelView.kind === 'gate-editor') {
 			const editingGate = channelRelationGates.find((g) => g.id === panelView.gateId);
 			if (!editingGate) return null;
@@ -581,30 +538,68 @@ export function NodeConfigPanel({
 						Set as Start Node
 					</button>
 				)}
+				{!isEndNode && (
+					<button
+						data-testid="set-as-end-button"
+						onClick={() => onSetAsEnd(step.localId)}
+						class="w-full text-xs font-medium py-1.5 px-3 rounded border border-purple-700 text-purple-400 hover:bg-purple-900/30 transition-colors"
+					>
+						Set as End Node
+					</button>
+				)}
+				{isEndNode && (
+					<button
+						data-testid="unset-as-end-button"
+						onClick={() => onSetAsEnd(step.localId)}
+						class="w-full text-xs font-medium py-1.5 px-3 rounded border border-purple-700/50 text-purple-500/60 hover:bg-purple-900/20 transition-colors"
+					>
+						Unset End Node
+					</button>
+				)}
 
 				<AgentsSection step={step} agents={agents} onUpdate={onUpdate} />
 
-				<button
-					type="button"
-					data-testid="prompt-instructions-button"
-					onClick={() => setPanelView({ kind: 'prompt-and-instructions' })}
-					class="w-full rounded border border-dark-700 bg-dark-800 px-2.5 py-2 text-left hover:border-amber-500/40 hover:bg-dark-750 transition-colors"
-				>
-					<div class="flex items-center justify-between gap-2">
-						<span class="text-xs font-medium text-gray-200">Prompt and Instructions</span>
-						<div class="flex items-center gap-2 text-[11px] flex-shrink-0">
-							<span class={step.systemPrompt?.trim() ? 'text-amber-300' : 'text-gray-500'}>
-								{step.systemPrompt?.trim() ? 'Prompt set' : 'Prompt default'}
-							</span>
-							<span class={step.instructions?.trim() ? 'text-blue-300' : 'text-gray-500'}>
-								{step.instructions?.trim() ? 'Instructions set' : 'No instructions'}
-							</span>
-						</div>
+				{/* System Prompt (node-level override) */}
+				<div class="space-y-1.5">
+					<div class="flex items-center justify-between">
+						<label class="text-xs font-medium text-gray-400">
+							System Prompt <span class="font-normal text-gray-600">(node override)</span>
+						</label>
 					</div>
-					<p class="mt-1 text-[11px] text-gray-500">
-						Open the dedicated editor to review the shared prompt override and shared instructions.
-					</p>
-				</button>
+					<textarea
+						data-testid="node-system-prompt-input"
+						value={step.systemPrompt ?? ''}
+						onInput={(e) =>
+							onUpdate({
+								...step,
+								systemPrompt: (e.currentTarget as HTMLTextAreaElement).value || undefined,
+							})
+						}
+						placeholder="Leave blank to use agent defaults..."
+						rows={4}
+						class="w-full text-xs font-mono bg-dark-800 border border-dark-600 rounded px-3 py-2 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
+					/>
+				</div>
+
+				{/* Instructions */}
+				<div class="space-y-1.5">
+					<label class="text-xs font-medium text-gray-400">
+						Instructions <span class="font-normal text-gray-600">(optional)</span>
+					</label>
+					<textarea
+						data-testid="instructions-textarea"
+						value={step.instructions}
+						onInput={(e) =>
+							onUpdate({
+								...step,
+								instructions: (e.currentTarget as HTMLTextAreaElement).value,
+							})
+						}
+						placeholder="Node-specific instructions appended to the agent prompt..."
+						rows={4}
+						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
+					/>
+				</div>
 
 				<div class="space-y-1.5">
 					<div class="flex items-center justify-between">

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -66,7 +66,7 @@ function buildTemplateCanvasSignature(
 	channels: WorkflowChannel[],
 	startNodeId: string,
 	gates: Gate[],
-	endNodeId: string
+	endNodeId: string | undefined
 ): string {
 	const regularNodes = nodes
 		.filter(
@@ -227,7 +227,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const [rules, setRules] = useState<RuleDraft[]>(() => initState?.rules ?? []);
 	const [tags, setTags] = useState<string[]>(() => initState?.tags ?? []);
 	const [startNodeId, setStartStepId] = useState<string>(() => initState?.startNodeId ?? '');
-	const [endNodeId, setEndNodeId] = useState<string>(() => initState?.endNodeId ?? '');
+	const [endNodeId, setEndNodeId] = useState<string | undefined>(() => initState?.endNodeId);
 	const [channels, setChannels] = useState<WorkflowChannel[]>(() => initState?.channels ?? []);
 	const [gates, setGates] = useState<Gate[]>(() => initState?.gates ?? []);
 	const [viewportState, setViewportState] = useState<ViewportState>({
@@ -398,7 +398,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	/** True when the given node is the current end node. */
 	const nodeIsEnd = useCallback(
 		(node: VisualNode): boolean => {
-			return node.step.localId === endNodeId || node.step.id === endNodeId;
+			return !!endNodeId && (node.step.localId === endNodeId || node.step.id === endNodeId);
 		},
 		[endNodeId]
 	);
@@ -427,6 +427,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				agents,
 				workflowChannels: channels,
 				isStartNode: nodeIsStart(node),
+				isEndNode: nodeIsEnd(node),
 				activeAnchorSides: anchorUsageByNodeId.get(node.step.localId) ?? [],
 				nodeTaskStates: nodeTaskStates.length > 0 ? nodeTaskStates : undefined,
 			};
@@ -436,6 +437,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		agents,
 		channels,
 		nodeIsStart,
+		nodeIsEnd,
 		tasksByNodeId,
 		relevantRunId,
 		anchorUsageByNodeId,
@@ -704,7 +706,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			}
 
 			if (wasEnd) {
-				setEndNodeId('');
+				setEndNodeId(undefined);
 			}
 
 			setSelectedNodeId(null);
@@ -730,7 +732,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	 * Toggle this node as the end node. Clicking again clears the designation.
 	 */
 	const handleSetAsEnd = useCallback((localId: string) => {
-		setEndNodeId((prev) => (prev === localId ? '' : localId));
+		setEndNodeId((prev) => (prev === localId ? undefined : localId));
 	}, []);
 
 	// ------------------------------------------------------------------
@@ -1035,6 +1037,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			setTags([...template.tags]);
 		}
 		setStartStepId(firstLocalId);
+		setEndNodeId(undefined);
 		setSelectedNodeId(null);
 		setSelectedEdgeId(null);
 		setShowTemplates(false);

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -684,8 +684,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			const remaining = nodes.filter((n) => n.step.localId !== localId);
 			const wasStart =
 				nodeToDelete.step.localId === startNodeId || nodeToDelete.step.id === startNodeId;
-			const wasEnd =
-				nodeToDelete.step.localId === endNodeId || nodeToDelete.step.id === endNodeId;
+			const wasEnd = nodeToDelete.step.localId === endNodeId || nodeToDelete.step.id === endNodeId;
 
 			// Update all state in flat calls — no nested setter inside another updater.
 			setNodes(remaining);
@@ -1041,7 +1040,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		setShowTemplates(false);
 		setPendingTemplate(null);
 		setTemplateBaselineSignature(
-			buildTemplateCanvasSignature(nextNodes, newEdges, nextChannels, firstLocalId, nextGates)
+			buildTemplateCanvasSignature(nextNodes, newEdges, nextChannels, firstLocalId, nextGates, '')
 		);
 		if (!name) setName(template.label);
 
@@ -1111,6 +1110,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			nodes,
 			edges,
 			startNodeId,
+			endNodeId: endNodeId || undefined,
 			rules,
 			tags,
 			channels,
@@ -1358,6 +1358,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 						isStartNode={nodeIsStart(selectedNode)}
 						onUpdate={handleUpdateNode}
 						onSetAsStart={handleSetAsStart}
+						isEndNode={nodeIsEnd(selectedNode)}
+						onSetAsEnd={handleSetAsEnd}
 						channelLinks={nodeChannelLinksByNodeId.get(selectedNode.step.localId) ?? []}
 						onOpenChannelLink={handleChannelSelectFromNodePanel}
 						selectedChannelRelation={

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -65,7 +65,8 @@ function buildTemplateCanvasSignature(
 	edges: VisualEdge[],
 	channels: WorkflowChannel[],
 	startNodeId: string,
-	gates: Gate[]
+	gates: Gate[],
+	endNodeId: string
 ): string {
 	const regularNodes = nodes
 		.filter(
@@ -131,6 +132,7 @@ function buildTemplateCanvasSignature(
 		edges: normalizedEdges,
 		channels: normalizedChannels,
 		startNodeId,
+		endNodeId,
 		gates: normalizedGates,
 	});
 }
@@ -225,6 +227,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const [rules, setRules] = useState<RuleDraft[]>(() => initState?.rules ?? []);
 	const [tags, setTags] = useState<string[]>(() => initState?.tags ?? []);
 	const [startNodeId, setStartStepId] = useState<string>(() => initState?.startNodeId ?? '');
+	const [endNodeId, setEndNodeId] = useState<string>(() => initState?.endNodeId ?? '');
 	const [channels, setChannels] = useState<WorkflowChannel[]>(() => initState?.channels ?? []);
 	const [gates, setGates] = useState<Gate[]>(() => initState?.gates ?? []);
 	const [viewportState, setViewportState] = useState<ViewportState>({
@@ -261,8 +264,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		[nodes]
 	);
 	const currentTemplateCanvasSignature = useMemo(
-		() => buildTemplateCanvasSignature(nodes, edges, channels, startNodeId, gates),
-		[nodes, edges, channels, startNodeId, gates]
+		() => buildTemplateCanvasSignature(nodes, edges, channels, startNodeId, gates, endNodeId),
+		[nodes, edges, channels, startNodeId, gates, endNodeId]
 	);
 	const [templateBaselineSignature, setTemplateBaselineSignature] = useState(() =>
 		buildTemplateCanvasSignature(
@@ -281,7 +284,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			initState?.edges ?? [],
 			initState?.channels ?? [],
 			initState?.startNodeId ?? '',
-			initState?.gates ?? []
+			initState?.gates ?? [],
+			initState?.endNodeId ?? ''
 		)
 	);
 
@@ -389,6 +393,14 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			return node.step.localId === startNodeId || node.step.id === startNodeId;
 		},
 		[startNodeId]
+	);
+
+	/** True when the given node is the current end node. */
+	const nodeIsEnd = useCallback(
+		(node: VisualNode): boolean => {
+			return node.step.localId === endNodeId || node.step.id === endNodeId;
+		},
+		[endNodeId]
 	);
 
 	// ------------------------------------------------------------------
@@ -672,6 +684,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			const remaining = nodes.filter((n) => n.step.localId !== localId);
 			const wasStart =
 				nodeToDelete.step.localId === startNodeId || nodeToDelete.step.id === startNodeId;
+			const wasEnd =
+				nodeToDelete.step.localId === endNodeId || nodeToDelete.step.id === endNodeId;
 
 			// Update all state in flat calls — no nested setter inside another updater.
 			setNodes(remaining);
@@ -690,9 +704,13 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				setStartStepId('');
 			}
 
+			if (wasEnd) {
+				setEndNodeId('');
+			}
+
 			setSelectedNodeId(null);
 		},
-		[nodes, startNodeId]
+		[nodes, startNodeId, endNodeId]
 	);
 
 	const handleUpdateNode = useCallback((step: NodeDraft) => {
@@ -707,6 +725,13 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	 */
 	const handleSetAsStart = useCallback((localId: string) => {
 		setStartStepId(localId);
+	}, []);
+
+	/**
+	 * Toggle this node as the end node. Clicking again clears the designation.
+	 */
+	const handleSetAsEnd = useCallback((localId: string) => {
+		setEndNodeId((prev) => (prev === localId ? '' : localId));
 	}, []);
 
 	// ------------------------------------------------------------------

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -285,7 +285,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			initState?.channels ?? [],
 			initState?.startNodeId ?? '',
 			initState?.gates ?? [],
-			initState?.endNodeId ?? ''
+			initState?.endNodeId
 		)
 	);
 
@@ -1043,7 +1043,14 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		setShowTemplates(false);
 		setPendingTemplate(null);
 		setTemplateBaselineSignature(
-			buildTemplateCanvasSignature(nextNodes, newEdges, nextChannels, firstLocalId, nextGates, '')
+			buildTemplateCanvasSignature(
+				nextNodes,
+				newEdges,
+				nextChannels,
+				firstLocalId,
+				nextGates,
+				undefined
+			)
 		);
 		if (!name) setName(template.label);
 

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -42,6 +42,8 @@ export interface WorkflowNodeProps {
 	isSelected?: boolean;
 	/** First step in the workflow — hides input port, adds green border + START badge */
 	isStartNode?: boolean;
+	/** Last step in the workflow — adds purple END badge */
+	isEndNode?: boolean;
 	/** Current viewport scale — used to convert screen-space drag deltas to canvas-space */
 	scale: number;
 	/** Called continuously while the node is being dragged */
@@ -149,6 +151,7 @@ export function WorkflowNode({
 	workflowChannels: _workflowChannels = [],
 	isSelected = false,
 	isStartNode = false,
+	isEndNode = false,
 	isDropTarget = false,
 	scale,
 	onPositionChange,
@@ -442,6 +445,14 @@ export function WorkflowNode({
 							class="text-xs font-bold text-green-400 uppercase tracking-wider"
 						>
 							START
+						</span>
+					)}
+					{isEndNode && (
+						<span
+							data-testid="end-badge"
+							class="text-xs font-bold text-purple-400 uppercase tracking-wider"
+						>
+							END
 						</span>
 					)}
 				</div>

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -6,13 +6,16 @@
  * - Header shows step name and close button
  * - Step name in header updates when step changes
  * - "Set as Start" button visible for non-start nodes, hidden for start node
+ * - "Set as End" button visible for non-end nodes, "Unset End Node" for end node
  * - "Set as Start" calls onSetAsStart with the step localId
+ * - "Set as End" calls onSetAsEnd with the step localId
  * - onClose fires when close button clicked
  * - onUpdate fires with updated step when fields change
  * - Delete button is disabled for start node with tooltip hint
  * - Delete button shows confirmation dialog when clicked
  * - Confirming delete calls onDelete; cancelling dismisses dialog
  * - Start node badge shown in header when isStartNode=true
+ * - End node badge shown in header when isEndNode=true
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -89,8 +92,10 @@ function makeProps(overrides: Partial<NodeConfigPanelProps> = {}): NodeConfigPan
 		step: makeStep(),
 		agents: defaultAgents,
 		isStartNode: false,
+		isEndNode: false,
 		onUpdate: vi.fn(),
 		onSetAsStart: vi.fn(),
+		onSetAsEnd: vi.fn(),
 		onClose: vi.fn(),
 		onDelete: vi.fn(),
 		...overrides,
@@ -144,9 +149,8 @@ describe('NodeConfigPanel', () => {
 			expect(select.value).toBe('agent-2');
 		});
 
-		it('renders the instructions textarea with current value', () => {
+		it('renders the inline instructions textarea with current value', () => {
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
-			fireEvent.click(getByTestId('prompt-instructions-button'));
 			const textarea = getByTestId('instructions-textarea') as HTMLTextAreaElement;
 			expect(textarea.value).toBe('Do stuff.');
 		});
@@ -181,6 +185,18 @@ describe('NodeConfigPanel', () => {
 		});
 	});
 
+	describe('end node badge', () => {
+		it('shows END badge in header when isEndNode=true', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ isEndNode: true })} />);
+			expect(getByTestId('end-node-badge')).toBeTruthy();
+		});
+
+		it('does not show END badge when isEndNode=false', () => {
+			const { queryByTestId } = render(<NodeConfigPanel {...makeProps({ isEndNode: false })} />);
+			expect(queryByTestId('end-node-badge')).toBeNull();
+		});
+	});
+
 	describe('"Set as Start" button', () => {
 		it('is visible when node is not the start node', () => {
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ isStartNode: false })} />);
@@ -199,6 +215,43 @@ describe('NodeConfigPanel', () => {
 			);
 			fireEvent.click(getByTestId('set-as-start-button'));
 			expect(onSetAsStart).toHaveBeenCalledWith('my-step');
+		});
+	});
+
+	describe('"Set as End" button', () => {
+		it('is visible when node is not the end node', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ isEndNode: false })} />);
+			expect(getByTestId('set-as-end-button')).toBeTruthy();
+		});
+
+		it('is hidden when node is already the end node', () => {
+			const { queryByTestId } = render(<NodeConfigPanel {...makeProps({ isEndNode: true })} />);
+			expect(queryByTestId('set-as-end-button')).toBeNull();
+		});
+
+		it('shows "Unset End Node" button when node is the end node', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ isEndNode: true })} />);
+			expect(getByTestId('unset-as-end-button')).toBeTruthy();
+		});
+
+		it('calls onSetAsEnd with the step localId when clicked', () => {
+			const onSetAsEnd = vi.fn();
+			const { getByTestId } = render(
+				<NodeConfigPanel {...makeProps({ onSetAsEnd, step: makeStep({ localId: 'my-step' }) })} />
+			);
+			fireEvent.click(getByTestId('set-as-end-button'));
+			expect(onSetAsEnd).toHaveBeenCalledWith('my-step');
+		});
+
+		it('"Unset End Node" button calls onSetAsEnd with the step localId', () => {
+			const onSetAsEnd = vi.fn();
+			const { getByTestId } = render(
+				<NodeConfigPanel
+					{...makeProps({ onSetAsEnd, isEndNode: true, step: makeStep({ localId: 'my-step' }) })}
+				/>
+			);
+			fireEvent.click(getByTestId('unset-as-end-button'));
+			expect(onSetAsEnd).toHaveBeenCalledWith('my-step');
 		});
 	});
 
@@ -229,12 +282,22 @@ describe('NodeConfigPanel', () => {
 		it('calls onUpdate with new instructions when textarea changes', () => {
 			const onUpdate = vi.fn();
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onUpdate })} />);
-			fireEvent.click(getByTestId('prompt-instructions-button'));
 			fireEvent.input(getByTestId('instructions-textarea'), {
 				target: { value: 'New instructions.' },
 			});
 			expect(onUpdate).toHaveBeenCalledWith(
 				expect.objectContaining({ instructions: 'New instructions.' })
+			);
+		});
+
+		it('calls onUpdate with new system prompt when textarea changes', () => {
+			const onUpdate = vi.fn();
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onUpdate })} />);
+			fireEvent.input(getByTestId('node-system-prompt-input'), {
+				target: { value: 'Custom system prompt.' },
+			});
+			expect(onUpdate).toHaveBeenCalledWith(
+				expect.objectContaining({ systemPrompt: 'Custom system prompt.' })
 			);
 		});
 
@@ -268,24 +331,14 @@ describe('NodeConfigPanel', () => {
 			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
 		});
 
-		it('opens the dedicated prompt and instructions editor', () => {
-			const { getByTestId, queryByTestId } = render(<NodeConfigPanel {...makeProps()} />);
-			expect(queryByTestId('node-system-prompt-input')).toBeNull();
-			fireEvent.click(getByTestId('prompt-instructions-button'));
+		it('renders the inline system prompt input', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
 			expect(getByTestId('node-system-prompt-input')).toBeTruthy();
-			expect(getByTestId('node-panel-back-button')).toBeTruthy();
 		});
-	});
 
-	describe('instructions copy', () => {
-		it('explains that instructions are appended guidance, not the base system prompt', () => {
-			const { getByTestId, getByText } = render(<NodeConfigPanel {...makeProps()} />);
-			fireEvent.click(getByTestId('prompt-instructions-button'));
-			expect(
-				getByText(
-					'This editor shows the current values for both the shared prompt override and the shared instructions.'
-				)
-			).toBeTruthy();
+		it('renders the inline instructions textarea', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			expect(getByTestId('instructions-textarea')).toBeTruthy();
 		});
 	});
 
@@ -660,20 +713,18 @@ describe('NodeConfigPanel', () => {
 			expect(true).toBeTruthy();
 		});
 
-		it('shared prompt and instructions editor is used for multi-agent nodes too', () => {
+		it('inline system prompt editor is used for multi-agent nodes too', () => {
 			const step = makeStep({
 				agentId: '',
 				agents: [{ agentId: 'agent-1', name: 'planner' }],
 			});
 			const onUpdate = vi.fn();
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
-			fireEvent.click(getByTestId('prompt-instructions-button'));
 			fireEvent.input(getByTestId('node-system-prompt-input'), {
 				target: { value: 'Be very strict.' },
 			});
 			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
 			expect(updatedStep.systemPrompt).toBe('Be very strict.');
-			expect(getByTestId('node-panel-back-button')).toBeTruthy();
 		});
 
 		it('adding same agent twice with different roles: both slots shown', () => {
@@ -716,7 +767,7 @@ describe('NodeConfigPanel', () => {
 			expect(queryAllByTestId('override-badge')).toHaveLength(1);
 		});
 
-		it('shared prompt and instructions view stays addressable after a slot role is renamed', async () => {
+		it('inline system prompt input stays addressable after a slot role is renamed', async () => {
 			// Use a controlled wrapper so onUpdate actually updates the step prop,
 			// matching how the real parent (VisualWorkflowEditor) behaves.
 			function Wrapper() {
@@ -731,7 +782,6 @@ describe('NodeConfigPanel', () => {
 				fireEvent.input(getByTestId('agent-role-input'), { target: { value: 'lead-planner' } });
 			});
 
-			fireEvent.click(getByTestId('prompt-instructions-button'));
 			expect(queryByTestId('node-system-prompt-input')).toBeTruthy();
 		});
 	});

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -23,31 +23,36 @@ import { render, fireEvent, cleanup, act, waitFor } from '@testing-library/preac
 import { useState } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
 
+const mockModelsResponse = {
+	models: [
+		{
+			id: 'claude-sonnet-4-6',
+			display_name: 'Claude Sonnet 4.6',
+			description: '',
+			provider: 'anthropic',
+		},
+		{
+			id: 'gpt-5.4',
+			display_name: 'GPT-5.4',
+			description: '',
+			provider: 'openai',
+		},
+	],
+};
+
+const mockHub = {
+	request: vi.fn(async (method: string) => {
+		if (method === 'models.list') {
+			return mockModelsResponse;
+		}
+		return {};
+	}),
+};
+
 vi.mock('../../../../lib/connection-manager', () => ({
 	connectionManager: {
-		getHubIfConnected: () => ({
-			request: vi.fn(async (method: string) => {
-				if (method === 'models.list') {
-					return {
-						models: [
-							{
-								id: 'claude-sonnet-4-6',
-								display_name: 'Claude Sonnet 4.6',
-								description: '',
-								provider: 'anthropic',
-							},
-							{
-								id: 'gpt-5.4',
-								display_name: 'GPT-5.4',
-								description: '',
-								provider: 'openai',
-							},
-						],
-					};
-				}
-				return {};
-			}),
-		}),
+		getHub: () => Promise.resolve(mockHub),
+		getHubIfConnected: () => mockHub,
 	},
 }));
 
@@ -137,8 +142,8 @@ describe('NodeConfigPanel', () => {
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
 			const select = getByTestId('agent-select') as HTMLSelectElement;
 			const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
-			expect(options).toContain('Planner (planner)');
-			expect(options).toContain('Coder (coder)');
+			expect(options).toContain('Planner');
+			expect(options).toContain('Coder');
 		});
 
 		it('shows currently selected agent in dropdown', () => {
@@ -563,34 +568,36 @@ describe('NodeConfigPanel', () => {
 
 		it('adding the same agent twice generates a unique slot role with numeric suffix', () => {
 			const onUpdate = vi.fn();
+			// Use the agent's actual name 'Coder' as the initial role so baseRole matches
+			// and the suffix logic activates (case-sensitive comparison in addAgent).
 			const step = makeStep({
 				agentId: '',
-				agents: [{ agentId: 'agent-2', name: 'coder' }],
+				agents: [{ agentId: 'agent-2', name: 'Coder' }],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
 			// Add agent-2 (Coder) a second time
 			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
 			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
 			expect(updatedStep.agents).toHaveLength(2);
-			expect(updatedStep.agents[0].name).toBe('coder');
+			expect(updatedStep.agents[0].name).toBe('Coder');
 			// Second slot must get a unique suffix to avoid duplicate-role validation error
-			expect(updatedStep.agents[1].name).toBe('coder-2');
+			expect(updatedStep.agents[1].name).toBe('Coder-2');
 		});
 
-		it('adding the same agent three times produces coder, coder-2, coder-3', () => {
+		it('adding the same agent three times produces Coder, Coder-2, Coder-3', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
 				agents: [
-					{ agentId: 'agent-2', name: 'coder' },
-					{ agentId: 'agent-2', name: 'coder-2' },
+					{ agentId: 'agent-2', name: 'Coder' },
+					{ agentId: 'agent-2', name: 'Coder-2' },
 				],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
 			fireEvent.change(getByTestId('add-agent-select'), { target: { value: 'agent-2' } });
 			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
 			expect(updatedStep.agents).toHaveLength(3);
-			expect(updatedStep.agents[2].name).toBe('coder-3');
+			expect(updatedStep.agents[2].name).toBe('Coder-3');
 		});
 	});
 
@@ -650,18 +657,14 @@ describe('NodeConfigPanel', () => {
 			expect(queryByTestId('override-badge')).toBeNull();
 		});
 
-		it('shows model selector for each slot without extra expansion', async () => {
+		it('does not render per-slot model selector in multi-agent mode (model is node-level)', () => {
 			const step = makeStep({
 				agentId: '',
 				agents: [{ agentId: 'agent-1', name: 'planner' }],
 			});
-			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
-			await waitFor(() =>
-				expect(
-					(getByTestId('agent-model-select') as HTMLSelectElement).options.length
-				).toBeGreaterThan(1)
-			);
-			expect(getByTestId('agent-model-select')).toBeTruthy();
+			const { queryByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			// Per-slot model selector was removed; model override is at the node level only
+			expect(queryByTestId('agent-model-select')).toBeNull();
 		});
 
 		it('editing agent selection calls onUpdate with updated agentId', () => {
@@ -674,43 +677,6 @@ describe('NodeConfigPanel', () => {
 			fireEvent.change(getByTestId('agent-slot-select'), { target: { value: 'agent-2' } });
 			const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
 			expect(updatedStep.agents[0].agentId).toBe('agent-2');
-		});
-
-		it('editing model selector is a no-op for agent slots (model removed from WorkflowNodeAgent)', async () => {
-			const onUpdate = vi.fn();
-			const step = makeStep({
-				agentId: '',
-				agents: [{ agentId: 'agent-1', name: 'planner' }],
-			});
-			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
-			await waitFor(() =>
-				expect(
-					(getByTestId('agent-model-select') as HTMLSelectElement).options.length
-				).toBeGreaterThan(1)
-			);
-			fireEvent.change(getByTestId('agent-model-select'), { target: { value: 'gpt-5.4' } });
-			// model is no longer on WorkflowNodeAgent; the selector is a no-op
-			if (onUpdate.mock.calls.length > 0) {
-				const updatedStep = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
-				expect((updatedStep.agents[0] as Record<string, unknown>)['model']).toBeUndefined();
-			}
-		});
-
-		it('clearing agent model selector is a no-op (model removed from WorkflowNodeAgent)', async () => {
-			const onUpdate = vi.fn();
-			const step = makeStep({
-				agentId: '',
-				agents: [{ agentId: 'agent-1', name: 'planner' }],
-			});
-			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
-			await waitFor(() =>
-				expect(
-					(getByTestId('agent-model-select') as HTMLSelectElement).options.length
-				).toBeGreaterThan(1)
-			);
-			fireEvent.change(getByTestId('agent-model-select'), { target: { value: '' } });
-			// no-op — model not on WorkflowNodeAgent
-			expect(true).toBeTruthy();
 		});
 
 		it('inline system prompt editor is used for multi-agent nodes too', () => {
@@ -742,7 +708,7 @@ describe('NodeConfigPanel', () => {
 			expect(roleInputs[1].value).toBe('coder-2');
 		});
 
-		it('each slot can independently have overrides — override-badge appears only on overridden slot', () => {
+		it('each slot can independently have overrides -- override-badge appears only on overridden slot', () => {
 			const step = makeStep({
 				agentId: '',
 				agents: [
@@ -757,7 +723,7 @@ describe('NodeConfigPanel', () => {
 			const { getAllByTestId, queryAllByTestId } = render(
 				<NodeConfigPanel {...makeProps({ step })} />
 			);
-			// One badge for the slot with model override
+			// One badge for the slot with instructions override
 			expect(getAllByTestId('override-badge')).toHaveLength(1);
 			// Confirm the overridden slot's entry has amber styling via data attribute
 			const entries = getAllByTestId('agent-entry');

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -3,9 +3,9 @@
  *
  * Coverage:
  * - workflowToVisualState: position restoration from layout, auto-layout fallback,
- *   empty edge initialization, startNodeId pass-through
+ *   empty edge initialization, startNodeId pass-through, endNodeId pass-through
  * - visualStateToCreateParams / visualStateToUpdateParams: round-trip,
- *   layout output, rules remapping
+ *   layout output, rules remapping, endNodeId pass-through
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -225,6 +225,35 @@ describe('workflowToVisualState', () => {
 		// Task Agent + 2 regular nodes = 3 unique localIds
 		expect(new Set(localIds).size).toBe(3);
 	});
+
+	it('passes endNodeId through when set', () => {
+		const wf = makeWorkflow({
+			nodes: [makeStep('s1'), makeStep('s2')],
+			startNodeId: 's1',
+			endNodeId: 's2',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.endNodeId).toBe('s2');
+	});
+
+	it('endNodeId is undefined when not set on workflow', () => {
+		const wf = makeWorkflow({
+			nodes: [makeStep('s1'), makeStep('s2')],
+			startNodeId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.endNodeId).toBeUndefined();
+	});
+
+	it('endNodeId falls back to undefined when referencing nonexistent node', () => {
+		const wf = makeWorkflow({
+			nodes: [makeStep('s1'), makeStep('s2')],
+			startNodeId: 's1',
+			endNodeId: 'nonexistent',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.endNodeId).toBeUndefined();
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -405,6 +434,18 @@ describe('visualStateToCreateParams', () => {
 		expect(params.nodes).toHaveLength(0);
 		expect(params.startNodeId).toBeUndefined();
 	});
+
+	it('passes endNodeId through to create params', () => {
+		const state = makeState({ endNodeId: 's2' });
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.endNodeId).toBe('s2');
+	});
+
+	it('endNodeId is undefined when not set on state', () => {
+		const state = makeState();
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.endNodeId).toBeUndefined();
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -424,8 +465,12 @@ describe('round-trip serialization', () => {
 		const params = visualStateToUpdateParams(visualState);
 
 		expect(params.nodes).toHaveLength(2);
-		expect(params.nodes![0]).toMatchObject({ id: 's1', name: 'Plan', agentId: 'agent-p' });
-		expect(params.nodes![1]).toMatchObject({ id: 's2', name: 'Code', agentId: 'agent-c' });
+		expect(params.nodes![0]).toMatchObject({ id: 's1', name: 'Plan' });
+		expect(params.nodes![0].agents).toHaveLength(1);
+		expect(params.nodes![0].agents[0].agentId).toBe('agent-p');
+		expect(params.nodes![1]).toMatchObject({ id: 's2', name: 'Code' });
+		expect(params.nodes![1].agents).toHaveLength(1);
+		expect(params.nodes![1].agents[0].agentId).toBe('agent-c');
 	});
 
 	it('preserves startNodeId after round-trip', () => {
@@ -525,6 +570,25 @@ describe('round-trip serialization', () => {
 		// Tags
 		expect(params.tags).toEqual(['coding']);
 	});
+
+	it('preserves endNodeId after round-trip', () => {
+		const original = makeWorkflow({
+			nodes: [makeStep('s1'), makeStep('s2')],
+			startNodeId: 's1',
+			endNodeId: 's2',
+		});
+		const params = visualStateToUpdateParams(workflowToVisualState(original));
+		expect(params.endNodeId).toBe('s2');
+	});
+
+	it('round-trip preserves endNodeId as null when not set', () => {
+		const original = makeWorkflow({
+			nodes: [makeStep('s1'), makeStep('s2')],
+			startNodeId: 's1',
+		});
+		const params = visualStateToUpdateParams(workflowToVisualState(original));
+		expect(params.endNodeId).toBeNull();
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -575,6 +639,49 @@ describe('visualStateToUpdateParams', () => {
 		const params = visualStateToUpdateParams(state);
 		// rules no longer part of UpdateSpaceWorkflowParams
 		expect((params as Record<string, unknown>)['rules']).toBeUndefined();
+	});
+
+	it('passes endNodeId through to update params', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a', instructions: '' },
+					position: { x: 0, y: 0 },
+				},
+				{
+					step: { localId: 'l2', id: 's2', name: 'S2', agentId: 'a', instructions: '' },
+					position: { x: 200, y: 0 },
+				},
+			],
+			edges: [],
+			startNodeId: 's1',
+			endNodeId: 's2',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [],
+		};
+		const params = visualStateToUpdateParams(state);
+		expect(params.endNodeId).toBe('s2');
+	});
+
+	it('endNodeId is null when not set on state', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a', instructions: '' },
+					position: { x: 0, y: 0 },
+				},
+			],
+			edges: [],
+			startNodeId: 's1',
+			rules: [],
+			tags: [],
+			channels: [],
+			gates: [],
+		};
+		const params = visualStateToUpdateParams(state);
+		expect(params.endNodeId).toBeNull();
 	});
 });
 
@@ -765,22 +872,24 @@ describe('multi-agent step serialization', () => {
 		expect(params.gates![0].id).toBe('review-votes-gate');
 	});
 
-	it('single-agent step round-trip: agentId set in NodeDraft, agents output in serialized params', () => {
+	it('single-agent step round-trip: agents preserved through workflowToVisualState and serialized output', () => {
 		const workflow = makeWorkflow({
 			nodes: [makeStep('s1', 'Code', 'agent-coder')],
 		});
 		const state = workflowToVisualState(workflow);
 		// Use find() — Task Agent virtual node is injected at index 0
 		const s1Node = state.nodes.find((n) => n.step.id === 's1')!;
-		expect(s1Node.step.agentId).toBe('agent-coder');
+		// workflowToVisualState sets agentId to '' and stores the agent in agents array
+		expect(s1Node.step.agents).toHaveLength(1);
+		expect(s1Node.step.agents![0].agentId).toBe('agent-coder');
 
 		const params = visualStateToCreateParams(state, 'space-1', 'WF');
-		// serialization builds agents array from agentId for single-agent steps
+		// serialization builds agents array from agents for single-agent steps
 		expect(params.nodes![0].agents).toHaveLength(1);
 		expect(params.nodes![0].agents[0].agentId).toBe('agent-coder');
 	});
 
-	it('full round-trip workflowToVisualState → visualStateToUpdateParams preserves multi-agent data', () => {
+	it('full round-trip workflowToVisualState -> visualStateToUpdateParams preserves multi-agent data', () => {
 		const workflow = makeWorkflow({
 			channels: [
 				{ from: 'coder', to: 'reviewer', direction: 'one-way' as const },
@@ -1024,7 +1133,7 @@ describe('per-slot agent overrides round-trip', () => {
 		expect(node.agents![1].systemPrompt).toBeUndefined();
 	});
 
-	it('full round-trip: workflow→visualState→createParams preserves all override fields', () => {
+	it('full round-trip: workflow->visualState->createParams preserves all override fields', () => {
 		const wf = makeWorkflow({
 			nodes: [
 				{
@@ -1105,7 +1214,7 @@ describe('per-slot agent overrides round-trip', () => {
 		});
 		const state = workflowToVisualState(wf);
 
-		// Simulate the user renaming 'coder' → 'lead-coder' via the role input
+		// Simulate the user renaming 'coder' -> 'lead-coder' via the role input
 		const nodeIdx = state.nodes.findIndex((n) => n.step.id === 's1');
 		state.nodes[nodeIdx].step.agents = [{ agentId: 'a1', name: 'lead-coder' }];
 

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -81,6 +81,12 @@ export interface VisualEditorState {
 	 * start node. Managed explicitly by the user.
 	 */
 	startNodeId: string;
+	/**
+	 * The step key (step.id for existing, step.localId for new) of the
+	 * end node. Managed explicitly by the user. When set, the workflow
+	 * run auto-completes when the end node's execution calls `report_done`.
+	 */
+	endNodeId?: string;
 	rules: RuleDraft[];
 	tags: string[];
 	/** Directed messaging channels at the workflow level. */
@@ -152,11 +158,18 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 	const startKey =
 		workflow.nodes.find((s) => s.id === workflow.startNodeId)?.id ?? workflow.nodes[0]?.id ?? '';
 
+	// endNodeId: use the step.id directly (matches the edge keys).
+	// Undefined when the workflow has no endNodeId set.
+	const endKey = workflow.endNodeId
+		? (workflow.nodes.find((s) => s.id === workflow.endNodeId)?.id ?? undefined)
+		: undefined;
+
 	return {
 		// Task Agent node is always first — pinned to the top of the canvas.
 		nodes: [taskAgentNode, ...nodes],
 		edges,
 		startNodeId: startKey,
+		endNodeId: endKey,
 		rules: [],
 		tags: workflow.tags ?? [],
 		channels: workflow.channels ?? [],
@@ -179,6 +192,7 @@ interface BuiltWorkflowFields {
 		instructions?: string;
 	}>;
 	startNodeId: string;
+	endNodeId?: string;
 	layout: Record<string, { x: number; y: number }>;
 	tags: string[];
 	channels?: WorkflowChannel[];
@@ -283,6 +297,13 @@ function buildWorkflowFields(state: VisualEditorState): {
 			: null);
 	const startNodeId = startEntry?.persistedId ?? '';
 
+	// Resolve endNodeId — prefer exact key match, then localId match. Undefined when not set.
+	let endNodeId: string | undefined;
+	if (state.endNodeId) {
+		const endEntry = nodeMap.get(state.endNodeId) ?? localIdMap.get(state.endNodeId);
+		endNodeId = endEntry?.persistedId;
+	}
+
 	const referencedGateIds = new Set(
 		state.channels.map((channel) => channel.gateId).filter((gateId): gateId is string => !!gateId)
 	);
@@ -292,6 +313,7 @@ function buildWorkflowFields(state: VisualEditorState): {
 		fields: {
 			nodes,
 			startNodeId,
+			endNodeId,
 			layout,
 			tags: state.tags,
 			channels: state.channels,
@@ -323,6 +345,7 @@ export function visualStateToCreateParams(
 		description,
 		nodes: fields.nodes,
 		startNodeId: fields.startNodeId || undefined,
+		endNodeId: fields.endNodeId || undefined,
 		layout: fields.layout,
 		tags: fields.tags,
 		channels: fields.channels && fields.channels.length > 0 ? fields.channels : undefined,
@@ -346,6 +369,7 @@ export function visualStateToUpdateParams(
 		...overrides,
 		nodes: fields.nodes,
 		startNodeId: fields.startNodeId || null,
+		endNodeId: fields.endNodeId ?? null,
 		layout: fields.layout,
 		tags: fields.tags,
 		channels: fields.channels && fields.channels.length > 0 ? fields.channels : null,


### PR DESCRIPTION
## Summary
- Add `endNodeId` to `VisualEditorState` with full round-trip serialization (create/update params)
- Add "Set as End Node" / "Unset End Node" toggle button and "END" badge in NodeConfigPanel
- Wire `endNodeId` through VisualWorkflowEditor save, delete, and template application
- Default `endNodeId` to last node in form-based WorkflowEditor create/update
- Replace "Prompt and Instructions" drill-in panel with inline textarea fields in NodeConfigPanel
- Remove `systemPrompt` from `buildTemplateNodes()` NodeDraft output (now only on agent slots)

## Test plan
- [x] 9 new endNodeId serialization round-trip tests (pass-through, undefined fallback, round-trip preservation)
- [x] NodeConfigPanel end node badge and set/unset button tests
- [x] All 129 visual editor tests pass (serialization + NodeConfigPanel)
- [ ] 3 pre-existing test failures (performance, WorkflowCanvas, vote-count gate) confirmed unrelated