### PR TITLE
fix: update test files to use NodeExecutionRepository for CompletionDetector and SpaceRuntime

### DIFF
--- a/packages/daemon/tests/unit/space/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-completion.test.ts
@@ -29,6 +29,7 @@ import type {
 } from '../../../src/lib/space/runtime/notification-sink.ts';
 import type { SpaceWorkflow, SpaceTask, SpaceWorkflowRun, Space } from '@neokai/shared';
 import type { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager.ts';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 
 // ---------------------------------------------------------------------------
 // MockNotificationSink
@@ -155,6 +156,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	const AGENT_C = 'agent-cd-c';
 
 	function makeRuntimeWithTam(extraConfig?: Partial<SpaceRuntimeConfig>): SpaceRuntime {
+		const nodeExecutionRepo = new NodeExecutionRepository(db);
 		const config: SpaceRuntimeConfig = {
 			db,
 			spaceManager,
@@ -162,6 +164,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			spaceWorkflowManager: workflowManager,
 			workflowRunRepo,
 			taskRepo,
+			nodeExecutionRepo,
 			notificationSink: sink,
 			taskAgentManager: new MockTaskAgentManager() as unknown as TaskAgentManager,
 			...extraConfig,

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -34,6 +34,7 @@ import type {
 } from '../../../src/lib/space/runtime/notification-sink.ts';
 import type { SpaceWorkflow, SpaceTask, SpaceWorkflowRun, Space } from '@neokai/shared';
 import type { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager.ts';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 
 // ---------------------------------------------------------------------------
 // MockNotificationSink
@@ -147,6 +148,7 @@ describe('SpaceRuntime — notification events', () => {
 	const STEP_B = 'step-nb';
 
 	function makeRuntime(extraConfig?: Partial<SpaceRuntimeConfig>): SpaceRuntime {
+		const nodeExecutionRepo = new NodeExecutionRepository(db);
 		const config: SpaceRuntimeConfig = {
 			db,
 			spaceManager,
@@ -154,6 +156,7 @@ describe('SpaceRuntime — notification events', () => {
 			spaceWorkflowManager: workflowManager,
 			workflowRunRepo,
 			taskRepo,
+			nodeExecutionRepo,
 			notificationSink: sink,
 			...extraConfig,
 		};
@@ -1188,6 +1191,7 @@ describe('SpaceRuntime — notification events', () => {
 		const AGENT_PLANNER2 = 'agent-planner-cd';
 
 		function makeRuntimeWithTam(extraConfig?: Partial<SpaceRuntimeConfig>): SpaceRuntime {
+			const nodeExecutionRepo = new NodeExecutionRepository(db);
 			const config: SpaceRuntimeConfig = {
 				db,
 				spaceManager,
@@ -1195,6 +1199,7 @@ describe('SpaceRuntime — notification events', () => {
 				spaceWorkflowManager: workflowManager,
 				workflowRunRepo,
 				taskRepo,
+				nodeExecutionRepo,
 				notificationSink: sink,
 				taskAgentManager: new MockTaskAgentManager() as unknown as TaskAgentManager,
 				...extraConfig,

--- a/packages/daemon/tests/unit/space/task-agent-collaboration.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-collaboration.test.ts
@@ -36,6 +36,7 @@ import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-man
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import { CompletionDetector } from '../../../src/lib/space/runtime/completion-detector.ts';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 import {
 	createTaskAgentToolHandlers,
 	type SubSessionFactory,
@@ -180,6 +181,7 @@ interface TestCtx {
 	workflowManager: SpaceWorkflowManager;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	taskRepo: SpaceTaskRepository;
+	nodeExecutionRepo: NodeExecutionRepository;
 	taskManager: SpaceTaskManager;
 	agentManager: SpaceAgentManager;
 	runtime: SpaceRuntime;
@@ -205,6 +207,7 @@ function makeCtx(): TestCtx {
 
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
 	const taskRepo = new SpaceTaskRepository(db);
+	const nodeExecutionRepo = new NodeExecutionRepository(db);
 	const spaceManager = new SpaceManager(db);
 	const taskManager = new SpaceTaskManager(db, spaceId);
 
@@ -215,6 +218,7 @@ function makeCtx(): TestCtx {
 		spaceWorkflowManager: workflowManager,
 		workflowRunRepo,
 		taskRepo,
+		nodeExecutionRepo,
 	});
 
 	const space = makeSpace(spaceId, workspacePath);
@@ -229,6 +233,7 @@ function makeCtx(): TestCtx {
 		workflowManager,
 		workflowRunRepo,
 		taskRepo,
+		nodeExecutionRepo,
 		taskManager,
 		agentManager,
 		runtime,
@@ -371,7 +376,7 @@ describe('Task Agent — full collaboration flow', () => {
 						completedAt: Date.now(),
 					});
 				},
-				completionDetector: new CompletionDetector(ctx.taskRepo),
+				completionDetector: new CompletionDetector(ctx.nodeExecutionRepo),
 			})
 		);
 
@@ -435,7 +440,7 @@ describe('Task Agent — full collaboration flow', () => {
 		});
 
 		const factory = makeMockSessionFactory();
-		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
 
 		const handlers = createTaskAgentToolHandlers(
 			makeConfig(ctx, mainTask.id, run.id, factory, {
@@ -659,7 +664,7 @@ describe('Task Agent — gate-blocked flow with escalation', () => {
 		expect(stepTasks.length).toBeGreaterThan(0);
 		ctx.taskRepo.updateTask(stepTasks[0].id, { status: 'blocked' });
 
-		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(
 			makeConfig(ctx, mainTask.id, run.id, factory, { completionDetector })
@@ -687,7 +692,7 @@ describe('Task Agent — gate-blocked flow with escalation', () => {
 		const stepTasks = ctx.taskRepo.listByWorkflowRun(run.id).filter((t) => t.id !== mainTask.id);
 		ctx.taskRepo.updateTask(stepTasks[0].id, { status: 'in_progress' });
 
-		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(
 			makeConfig(ctx, mainTask.id, run.id, factory, { completionDetector })
@@ -765,7 +770,7 @@ describe('Task Agent — multi-agent node collaboration', () => {
 		const nodeTasks = ctx.taskRepo.listByWorkflowRun(run.id).filter((t) => t.id !== mainTask.id);
 		expect(nodeTasks).toHaveLength(2);
 
-		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
 		const factory = makeMockSessionFactory();
 		const handlers = createTaskAgentToolHandlers(
 			makeConfig(ctx, mainTask.id, run.id, factory, { completionDetector })

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -81,6 +81,7 @@ import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-man
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import { CompletionDetector } from '../../../src/lib/space/runtime/completion-detector.ts';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 import {
 	createTaskAgentToolHandlers,
 	createTaskAgentMcpServer,
@@ -294,6 +295,7 @@ interface TestCtx {
 	workflowManager: SpaceWorkflowManager;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	taskRepo: SpaceTaskRepository;
+	nodeExecutionRepo: NodeExecutionRepository;
 	taskManager: SpaceTaskManager;
 	agentManager: SpaceAgentManager;
 	runtime: SpaceRuntime;
@@ -317,6 +319,7 @@ function makeCtx(): TestCtx {
 
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
 	const taskRepo = new SpaceTaskRepository(db);
+	const nodeExecutionRepo = new NodeExecutionRepository(db);
 	const spaceManager = new SpaceManager(db);
 	const taskManager = new SpaceTaskManager(db, spaceId);
 
@@ -327,6 +330,7 @@ function makeCtx(): TestCtx {
 		spaceWorkflowManager: workflowManager,
 		workflowRunRepo,
 		taskRepo,
+		nodeExecutionRepo,
 	});
 
 	const space = makeSpace(spaceId, workspacePath);
@@ -340,6 +344,7 @@ function makeCtx(): TestCtx {
 		workflowManager,
 		workflowRunRepo,
 		taskRepo,
+		nodeExecutionRepo,
 		taskManager,
 		agentManager,
 		runtime,
@@ -2019,7 +2024,7 @@ describe('createTaskAgentToolHandlers — report_workflow_done with CompletionDe
 		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
 
 		// The step task is still 'pending' — not terminal
-		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
 		const factory = makeMockSessionFactory();
 		const config = makeConfig(ctx, mainTask.id, run.id, factory);
 		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
@@ -2041,7 +2046,7 @@ describe('createTaskAgentToolHandlers — report_workflow_done with CompletionDe
 		const stepTask = ctx.taskRepo.listByWorkflowRun(run.id)[0];
 		ctx.taskRepo.updateTask(stepTask!.id, { status: 'in_progress' });
 
-		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
 		const factory = makeMockSessionFactory();
 		const config = makeConfig(ctx, mainTask.id, run.id, factory);
 		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
@@ -2071,7 +2076,7 @@ describe('createTaskAgentToolHandlers — report_workflow_done with CompletionDe
 			status: 'in_progress',
 		});
 
-		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
 		const factory = makeMockSessionFactory();
 		const config = makeConfig(ctx, mainTask.id, run.id, factory);
 		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
@@ -2101,7 +2106,7 @@ describe('createTaskAgentToolHandlers — report_workflow_done with CompletionDe
 			status: 'in_progress',
 		});
 
-		const completionDetector = new CompletionDetector(ctx.taskRepo);
+		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
 		const factory = makeMockSessionFactory();
 		const config = makeConfig(ctx, mainTask.id, run.id, factory);
 		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });


### PR DESCRIPTION
## Summary
- Update 4 test files to pass `NodeExecutionRepository` instead of `SpaceTaskRepository` to `CompletionDetector` constructor
- Add required `nodeExecutionRepo` field to all `SpaceRuntimeConfig` objects in test files
- Files changed: `task-agent-tools.test.ts`, `task-agent-collaboration.test.ts`, `space-runtime-completion.test.ts`, `space-runtime-notifications.test.ts`

## Test plan
- [x] TypeScript compilation passes (`tsc --build --noEmit`)
- [ ] Pre-commit hooks pass (lint, format, typecheck, knip)
- [ ] Unit tests pass (blocked by missing SDK modules in worktree environment)