### PR TITLE
refactor: agent and utility cleanup

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -14,22 +14,52 @@ import type {
 	SpaceTask,
 	SpaceWorkflow,
 	SpaceWorkflowRun,
+	WorkflowNodeAgentOverride,
 } from '@neokai/shared';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import { inferProviderForModel } from '../../providers/registry';
-import { getFeaturesForRole } from './seed-agents';
+import { SUB_SESSION_FEATURES } from './seed-agents';
 
 const DEFAULT_CUSTOM_AGENT_MODEL = 'claude-sonnet-4-5-20250929';
 
 /**
  * Per-slot overrides from a `WorkflowNodeAgent` entry.
  * Applied on top of the base `SpaceAgent` config when spawning a specific slot.
+ *
+ * Override semantics:
+ * - `mode: 'override'` — replaces the agent's base value entirely.
+ * - `mode: 'expand'`   — appends the value to the agent's base (joined with `\n\n`).
+ * - absent (undefined) — uses the agent's base value unchanged.
  */
 export interface SlotOverrides {
 	/** Override the agent's default model for this slot */
 	model?: string;
 	/** Override the agent's default system prompt for this slot */
-	systemPrompt?: string;
+	systemPrompt?: WorkflowNodeAgentOverride;
+	/** Override the agent's default instructions for this slot */
+	instructions?: WorkflowNodeAgentOverride;
+}
+
+/**
+ * Two-layer composition: applies a slot override on top of a base value.
+ *
+ * - If `override` is absent (undefined), returns the `base` unchanged.
+ * - If `override.mode === 'override'`, returns `override.value` (replaces base).
+ * - If `override.mode === 'expand'`, returns `base + '\n\n' + override.value`.
+ *   When `base` is empty/null/undefined, only `override.value` is returned.
+ */
+export function composePromptLayer(
+	base: string | null | undefined,
+	override: WorkflowNodeAgentOverride | undefined
+): string {
+	if (!override) return base?.trim() ?? '';
+	const trimmedBase = base?.trim() ?? '';
+	const trimmedValue = override.value.trim();
+	if (override.mode === 'override') return trimmedValue;
+	// expand mode — if value is empty after trimming, just return base
+	if (!trimmedValue) return trimmedBase;
+	if (!trimmedBase) return trimmedValue;
+	return `${trimmedBase}\n\n${trimmedValue}`;
 }
 
 export interface CustomAgentConfig {
@@ -56,20 +86,25 @@ export interface CustomAgentConfig {
 /**
  * Build the runtime system prompt text for a custom agent.
  *
- * This function intentionally returns only the visible prompt text configured by
- * the user or workflow. No role-based behavioral instructions are injected.
+ * Applies the slot's `systemPrompt` override (if any) on top of the agent's
+ * base `systemPrompt` using two-layer composition.
  */
-export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
-	return customAgent.systemPrompt?.trim() ?? '';
+export function buildCustomAgentSystemPrompt(
+	customAgent: SpaceAgent,
+	slotOverrides?: SlotOverrides
+): string {
+	return composePromptLayer(customAgent.systemPrompt, slotOverrides?.systemPrompt);
 }
 
 /**
  * Build the initial user message for a custom agent session.
  *
  * This message contains only factual task/workflow/space context.
+ * Slot-level instructions override is composed separately and passed as
+ * part of the initial message when provided.
  */
 export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
-	const { task, workflowRun, workflow, space, previousTaskSummaries } = config;
+	const { task, workflowRun, workflow, space, previousTaskSummaries, slotOverrides } = config;
 
 	const sections: string[] = [];
 
@@ -77,7 +112,6 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 	sections.push(`**Title:** ${task.title}`);
 	sections.push(`**Description:** ${task.description}`);
 	if (task.priority) sections.push(`**Priority:** ${task.priority}`);
-	// taskType removed from SpaceTask
 
 	if (workflowRun) {
 		sections.push(`\n## Workflow Context\n`);
@@ -103,8 +137,6 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 				}
 			}
 		}
-
-		// workflow.rules removed — no rule rendering
 	}
 
 	if (space.backgroundContext) {
@@ -129,7 +161,29 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		}
 	}
 
+	// Compose slot-level instructions override on top of agent's base instructions.
+	// When present, this provides the node-specific HOW for the agent.
+	const composedInstructions = composePromptLayer(
+		customAgentInstructions(config.customAgent, config),
+		slotOverrides?.instructions
+	);
+	if (composedInstructions) {
+		sections.push(`\n## Instructions\n`);
+		sections.push(composedInstructions);
+	}
+
 	return sections.join('\n');
+}
+
+/**
+ * Extract the agent's instructions field for composition.
+ * Used as the base layer for slot-level instruction overrides.
+ */
+function customAgentInstructions(
+	customAgent: SpaceAgent,
+	_config: CustomAgentConfig
+): string | null {
+	return customAgent.instructions;
 }
 
 /**
@@ -138,9 +192,13 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
  * Workflow execution is WYSIWYG:
  * - inside a workflow run, the workflow slot prompt is the only behavioral prompt
  * - outside a workflow run, the agent's own `systemPrompt` is used
+ *
+ * Override/expand composition:
+ * - `slotOverrides.systemPrompt` composes on top of `customAgent.systemPrompt`
+ * - `slotOverrides.instructions` composes on top of `customAgent.instructions`
  */
 export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionInit {
-	const { customAgent, space, sessionId, workspacePath, slotOverrides, workflowRun } = config;
+	const { customAgent, space, sessionId, workspacePath, slotOverrides } = config;
 
 	const customTools =
 		customAgent.tools && customAgent.tools.length > 0 ? customAgent.tools : undefined;
@@ -148,13 +206,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 		slotOverrides?.model ?? customAgent.model ?? space.defaultModel ?? DEFAULT_CUSTOM_AGENT_MODEL;
 	const provider = inferProviderForModel(model);
 
-	const promptAgent: SpaceAgent =
-		workflowRun !== null
-			? { ...customAgent, systemPrompt: slotOverrides?.systemPrompt }
-			: slotOverrides?.systemPrompt !== undefined
-				? { ...customAgent, systemPrompt: slotOverrides.systemPrompt }
-				: customAgent;
-	const visiblePrompt = buildCustomAgentSystemPrompt(promptAgent);
+	const visiblePrompt = buildCustomAgentSystemPrompt(customAgent, slotOverrides);
 
 	if (customTools) {
 		const agentKey = sanitizeAgentKey(customAgent.name);
@@ -172,7 +224,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 				type: 'preset',
 				preset: 'claude_code',
 			},
-			features: getFeaturesForRole('coder'),
+			features: SUB_SESSION_FEATURES,
 			context: { spaceId: space.id },
 			type: 'worker',
 			model,
@@ -191,7 +243,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 			preset: 'claude_code',
 			append: visiblePrompt,
 		},
-		features: getFeaturesForRole('coder'),
+		features: SUB_SESSION_FEATURES,
 		context: { spaceId: space.id },
 		type: 'worker',
 		model,

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -3,71 +3,38 @@
  *
  * Seeds the five default SpaceAgent records when a new Space is created.
  * Preset agents are regular SpaceAgent rows — fully editable by users — that
- * happen to have a well-known role label and sensible defaults for tools and model.
- * SpaceRuntime resolves all agents by ID at
- * runtime; there is no special builtin code path.
+ * have sensible defaults for tools and model.
+ * SpaceRuntime resolves all agents by ID at runtime; there is no special
+ * builtin code path.
  *
  * Preset agents seeded per Space:
- *   - Coder    (role: 'coder')    — implementation worker
- *   - General  (role: 'general')  — general-purpose worker
- *   - Planner  (role: 'planner')  — planning/orchestration worker
- *   - Reviewer (role: 'reviewer') — code review specialist
- *   - QA       (role: 'qa')       — quality assurance specialist
+ *   - Coder    — implementation worker
+ *   - General  — general-purpose worker (Done node agent)
+ *   - Planner  — planning/orchestration worker
+ *   - Reviewer — code review specialist
+ *   - QA       — quality assurance specialist
  */
 
-import type { SpaceAgent, SessionFeatures } from '@neokai/shared';
+import type { SpaceAgent } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentManager, SpaceAgentResult } from '../managers/space-agent-manager';
+
 // ---------------------------------------------------------------------------
-// Feature flag profiles per role
+// Sub-session features
 // ---------------------------------------------------------------------------
 
 /**
- * All sub-session roles disable UI features — sub-sessions are internal
- * and should not expose rewind, worktree, coordinator, archive, or sessionInfo.
+ * Features for all sub-session agents (node agents spawned by the Task Agent).
+ * Sub-sessions are internal and should not expose rewind, worktree, coordinator,
+ * archive, or sessionInfo UI features.
  */
-export const ROLE_FEATURES: Record<string, SessionFeatures> = {
-	coder: { rewind: false, worktree: false, coordinator: false, archive: false, sessionInfo: false },
-	general: {
-		rewind: false,
-		worktree: false,
-		coordinator: false,
-		archive: false,
-		sessionInfo: false,
-	},
-	planner: {
-		rewind: false,
-		worktree: false,
-		coordinator: false,
-		archive: false,
-		sessionInfo: false,
-	},
-	reviewer: {
-		rewind: false,
-		worktree: false,
-		coordinator: false,
-		archive: false,
-		sessionInfo: false,
-	},
-	qa: { rewind: false, worktree: false, coordinator: false, archive: false, sessionInfo: false },
-};
-
-/** Default features for roles not explicitly listed in ROLE_FEATURES */
-export const DEFAULT_ROLE_FEATURES: SessionFeatures = {
+export const SUB_SESSION_FEATURES = {
 	rewind: false,
 	worktree: false,
 	coordinator: false,
 	archive: false,
 	sessionInfo: false,
-};
-
-/**
- * Look up feature flags for a given role.
- * Falls back to DEFAULT_ROLE_FEATURES for unknown roles.
- */
-export function getFeaturesForRole(role: string): SessionFeatures {
-	return ROLE_FEATURES[role] ?? DEFAULT_ROLE_FEATURES;
-}
+} as const;
 
 // ---------------------------------------------------------------------------
 // Tool defaults per role
@@ -91,8 +58,7 @@ const REVIEWER_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'W
 const QA_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
 
 /**
- * Tool profiles per role. Exported for testing and external consumption.
- * Keys match the SpaceAgent.role value.
+ * Tool profiles per preset agent name. Exported for testing and external consumption.
  */
 export const ROLE_TOOLS: Record<string, string[]> = {
 	coder: CODER_TOOLS,

--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -52,7 +52,6 @@ export interface WorkflowSummary {
 export interface AgentSummary {
 	id: string;
 	name: string;
-	role?: string;
 	description?: string;
 }
 
@@ -129,7 +128,7 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
 		sections.push(`\n## Available Agents\n`);
 		for (const agent of context.agents) {
 			const desc = agent.description ? ` — ${agent.description}` : '';
-			sections.push(`- **${agent.name}**${agent.role ? ` (role: ${agent.role})` : ''}${desc}`);
+			sections.push(`- **${agent.name}**${desc}`);
 		}
 	}
 

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -146,10 +146,6 @@ export type ValidationResult<T> = { ok: true; value: T } | { ok: false; error: s
 /**
  * Convert a SpaceAgent to the portable export format.
  * Strips `id`, `spaceId`, `createdAt`, `updatedAt`.
- *
- * `SpaceAgent.toolConfig` (per-tool configuration map) is intentionally **not**
- * exported — it is an implementation detail of the runtime and is not part of the
- * portable format. Only `tools` (the list of tool names) is exported.
  */
 export function exportAgent(agent: SpaceAgent): ExportedSpaceAgent {
 	const exported: ExportedSpaceAgent = {

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -29,7 +29,7 @@ export type {
 	CommandRunner,
 } from './runtime/workflow-executor';
 export { SpaceRuntime } from './runtime/space-runtime';
-export type { SpaceRuntimeConfig, ResolvedTaskType } from './runtime/space-runtime';
+export type { SpaceRuntimeConfig } from './runtime/space-runtime';
 export { NullNotificationSink } from './runtime/notification-sink';
 export type {
 	NotificationSink,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -56,7 +56,7 @@ export interface SpaceRuntimeConfig {
 	db: BunDatabase;
 	/** Space manager for listing spaces and fetching workspace paths */
 	spaceManager: SpaceManager;
-	/** Agent manager for resolving agent roles in resolveTaskTypeForStep() */
+	/** Agent manager for resolving agents */
 	spaceAgentManager: SpaceAgentManager;
 	/** Workflow manager for loading workflow definitions */
 	spaceWorkflowManager: SpaceWorkflowManager;
@@ -96,18 +96,6 @@ export interface SpaceRuntimeConfig {
 	 * Defaults to `new CompletionDetector(taskRepo)` if not provided.
 	 */
 	completionDetector?: CompletionDetector;
-}
-
-// ---------------------------------------------------------------------------
-// Return types
-// ---------------------------------------------------------------------------
-
-/** Result of resolveTaskTypeForAgent(): agentId for the resolved agent */
-export interface ResolvedTaskType {
-	/**
-	 * The agent ID for this task's execution.
-	 */
-	agentId: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -401,29 +389,6 @@ export class SpaceRuntime {
 		this.resolveAndStoreChannels(run.id, space.id, startStep, workflow.channels ?? []);
 
 		return { run, tasks };
-	}
-
-	/**
-	 * Resolve the agent ID for a specific agent entry.
-	 */
-	resolveTaskTypeForAgent(agentId: string): ResolvedTaskType {
-		return { agentId };
-	}
-
-	/**
-	 * Resolve per-agent task types for a workflow step.
-	 * Returns one `ResolvedTaskType` per agent entry in the step (in order).
-	 */
-	resolveTaskTypesForStep(step: WorkflowNode): ResolvedTaskType[] {
-		const nodeAgents = resolveNodeAgents(step);
-		return nodeAgents.map((sa) => this.resolveTaskTypeForAgent(sa.agentId));
-	}
-
-	/**
-	 * Resolve the ResolvedTaskType for a workflow step (first agent).
-	 */
-	resolveTaskTypeForStep(step: WorkflowNode): ResolvedTaskType {
-		return this.resolveTaskTypesForStep(step)[0];
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -90,7 +90,7 @@ export interface SubSessionState {
 export interface SubSessionMemberInfo {
 	/** ID of the SpaceAgent config this sub-session uses */
 	agentId?: string;
-	/** Freeform role string from SpaceAgent.role (e.g. 'coder', 'reviewer') */
+	/** Slot name from WorkflowNodeAgent.name (e.g. 'coder', 'reviewer') */
 	role?: string;
 }
 
@@ -428,6 +428,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					space,
 					sessionId: actualSessionId,
 					workspacePath,
+					slotOverrides,
 				});
 				await messageInjector(actualSessionId, taskMessage);
 			} catch (err) {

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -313,7 +313,8 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			// Extract slot-level overrides (systemPrompt) if present.
 			// model is no longer on WorkflowNodeAgent; systemPrompt is now WorkflowNodeAgentOverride.
 			const slotOverrides: import('../agents/custom-agent').SlotOverrides = {
-				systemPrompt: agentSlot?.systemPrompt?.value,
+				systemPrompt: agentSlot?.systemPrompt,
+				instructions: agentSlot?.instructions,
 			};
 
 			// Generate a new session ID for the sub-session.

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -176,7 +176,7 @@ describe('createCustomAgentInit', () => {
 			makeConfig({
 				customAgent: makeAgent({ systemPrompt: 'Hidden base prompt' }),
 				workflowRun: makeWorkflowRun(),
-				slotOverrides: { systemPrompt: 'Workflow-visible prompt' },
+				slotOverrides: { systemPrompt: { mode: 'override', value: 'Workflow-visible prompt' } },
 			})
 		);
 
@@ -184,15 +184,15 @@ describe('createCustomAgentInit', () => {
 		expect(init.systemPrompt?.append).not.toContain('Hidden base prompt');
 	});
 
-	it('uses an empty prompt when a workflow slot does not define one', () => {
+	it('uses the agent system prompt when no slot override is defined', () => {
 		const init = createCustomAgentInit(
 			makeConfig({
-				customAgent: makeAgent({ systemPrompt: 'Hidden base prompt' }),
+				customAgent: makeAgent({ systemPrompt: 'Agent base prompt' }),
 				workflowRun: makeWorkflowRun(),
 			})
 		);
 
-		expect(init.systemPrompt?.append).toBe('');
+		expect(init.systemPrompt?.append).toBe('Agent base prompt');
 	});
 
 	it('uses tool-restricted agent mode when tools are configured', () => {

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -157,6 +157,48 @@ describe('buildCustomAgentTaskMessage', () => {
 		expect(message).not.toContain('Push your changes to update this PR');
 		expect(message).not.toContain('Focus on the current step first');
 	});
+
+	it('applies instructions override in override mode', () => {
+		const message = buildCustomAgentTaskMessage(
+			makeConfig({
+				customAgent: makeAgent({ instructions: 'Base instructions' }),
+				slotOverrides: {
+					instructions: { mode: 'override', value: 'Override instructions' },
+				},
+			})
+		);
+
+		expect(message).toContain('## Instructions');
+		expect(message).toContain('Override instructions');
+		expect(message).not.toContain('Base instructions');
+	});
+
+	it('applies instructions override in expand mode', () => {
+		const message = buildCustomAgentTaskMessage(
+			makeConfig({
+				customAgent: makeAgent({ instructions: 'Base instructions' }),
+				slotOverrides: {
+					instructions: { mode: 'expand', value: 'Additional context' },
+				},
+			})
+		);
+
+		expect(message).toContain('## Instructions');
+		expect(message).toContain('Base instructions');
+		expect(message).toContain('Additional context');
+		expect(message).toContain('Base instructions\n\nAdditional context');
+	});
+
+	it('uses agent instructions when no slot override is provided', () => {
+		const message = buildCustomAgentTaskMessage(
+			makeConfig({
+				customAgent: makeAgent({ instructions: 'Agent own instructions' }),
+			})
+		);
+
+		expect(message).toContain('## Instructions');
+		expect(message).toContain('Agent own instructions');
+	});
 });
 
 describe('createCustomAgentInit', () => {

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -150,11 +150,9 @@ describe('exportAgent', () => {
 		expect(exported.tools).toEqual(['edit_file', 'bash']);
 	});
 
-	test('exports reviewer role', () => {
+	test('exports reviewer agent', () => {
 		const agent = makeReviewerAgent();
 		const exported = exportAgent(agent);
-		// role field was removed from SpaceAgent in M71; not exported
-		expect((exported as Record<string, unknown>).role).toBeUndefined();
 		expect(exported.name).toBe('Reviewer');
 	});
 

--- a/packages/daemon/tests/unit/space/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/node-agent-tools.test.ts
@@ -1894,12 +1894,10 @@ describe('node-agent-tools: system prompt uses only visible prompt text', () => 
 			id: 'agent-1',
 			spaceId: 'space-1',
 			name: 'Coder',
-			role: 'coder',
 			description: '',
 			model: null,
 			tools: [],
 			systemPrompt: 'Visible workflow prompt',
-			injectWorkflowContext: false,
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 		});

--- a/packages/daemon/tests/unit/space/role-config.test.ts
+++ b/packages/daemon/tests/unit/space/role-config.test.ts
@@ -1,23 +1,19 @@
 /**
- * Role Configuration Unit Tests
+ * Tool Access and Sub-Session Features Unit Tests
  *
- * Verifies feature flag profiles and tool access per role.
- * Ensures reviewers and QA cannot use Write/Edit, while coders and planners
- * have full tool access.
+ * Verifies tool access per preset agent and that sub-session features are
+ * correctly applied to custom agent init configs.
  */
 
 import { describe, it, expect } from 'bun:test';
-import {
-	ROLE_FEATURES,
-	ROLE_TOOLS,
-	DEFAULT_ROLE_FEATURES,
-	getFeaturesForRole,
-} from '../../../src/lib/space/agents/seed-agents';
+import { ROLE_TOOLS, SUB_SESSION_FEATURES } from '../../../src/lib/space/agents/seed-agents';
 import {
 	createCustomAgentInit,
+	composePromptLayer,
+	type SlotOverrides,
 	type CustomAgentConfig,
 } from '../../../src/lib/space/agents/custom-agent';
-import type { SpaceAgent, Space, SpaceTask, SessionFeatures } from '@neokai/shared';
+import type { SpaceAgent, Space, SpaceTask } from '@neokai/shared';
 
 // ============================================================================
 // Test fixtures
@@ -28,7 +24,7 @@ function makeAgent(overrides?: Partial<SpaceAgent>): SpaceAgent {
 		id: 'agent-1',
 		spaceId: 'space-1',
 		name: 'TestAgent',
-		role: 'coder',
+		instructions: null,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		...overrides,
@@ -66,9 +62,9 @@ function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
 	};
 }
 
-function makeConfig(role: string, tools?: string[]): CustomAgentConfig {
+function makeConfig(tools?: string[]): CustomAgentConfig {
 	return {
-		customAgent: makeAgent({ role, tools, name: `Test${role}` }),
+		customAgent: makeAgent({ tools, name: 'TestAgent' }),
 		task: makeTask(),
 		workflowRun: null,
 		space: makeSpace(),
@@ -77,62 +73,8 @@ function makeConfig(role: string, tools?: string[]): CustomAgentConfig {
 	};
 }
 
-const ALL_FEATURES_FALSE: SessionFeatures = {
-	rewind: false,
-	worktree: false,
-	coordinator: false,
-	archive: false,
-	sessionInfo: false,
-};
-
 // ============================================================================
-// Feature flag profiles per role
-// ============================================================================
-
-describe('ROLE_FEATURES', () => {
-	it('defines feature profiles for all known roles', () => {
-		const knownRoles = ['coder', 'general', 'planner', 'reviewer', 'qa'];
-		for (const role of knownRoles) {
-			expect(ROLE_FEATURES[role]).toBeDefined();
-		}
-	});
-
-	it('disables all features for coder role', () => {
-		expect(ROLE_FEATURES.coder).toEqual(ALL_FEATURES_FALSE);
-	});
-
-	it('disables all features for reviewer role', () => {
-		expect(ROLE_FEATURES.reviewer).toEqual(ALL_FEATURES_FALSE);
-	});
-
-	it('disables all features for planner role', () => {
-		expect(ROLE_FEATURES.planner).toEqual(ALL_FEATURES_FALSE);
-	});
-
-	it('disables all features for qa role', () => {
-		expect(ROLE_FEATURES.qa).toEqual(ALL_FEATURES_FALSE);
-	});
-
-	it('disables all features for general role', () => {
-		expect(ROLE_FEATURES.general).toEqual(ALL_FEATURES_FALSE);
-	});
-});
-
-describe('getFeaturesForRole', () => {
-	it('returns correct features for known roles', () => {
-		expect(getFeaturesForRole('coder')).toEqual(ALL_FEATURES_FALSE);
-		expect(getFeaturesForRole('reviewer')).toEqual(ALL_FEATURES_FALSE);
-		expect(getFeaturesForRole('qa')).toEqual(ALL_FEATURES_FALSE);
-	});
-
-	it('falls back to DEFAULT_ROLE_FEATURES for unknown roles', () => {
-		expect(getFeaturesForRole('unknown-role')).toEqual(DEFAULT_ROLE_FEATURES);
-		expect(getFeaturesForRole('')).toEqual(DEFAULT_ROLE_FEATURES);
-	});
-});
-
-// ============================================================================
-// Tool access per role
+// Tool access per preset agent
 // ============================================================================
 
 describe('ROLE_TOOLS', () => {
@@ -203,37 +145,193 @@ describe('ROLE_TOOLS', () => {
 });
 
 // ============================================================================
-// createCustomAgentInit applies role-based configuration
+// Sub-session features
 // ============================================================================
 
-describe('createCustomAgentInit — role-based configuration', () => {
-	it('applies correct features for coder role', () => {
-		const init = createCustomAgentInit(makeConfig('coder', ROLE_TOOLS.coder));
-		expect(init.features).toEqual(ALL_FEATURES_FALSE);
+describe('SUB_SESSION_FEATURES', () => {
+	it('disables all UI features for sub-session agents', () => {
+		expect(SUB_SESSION_FEATURES).toEqual({
+			rewind: false,
+			worktree: false,
+			coordinator: false,
+			archive: false,
+			sessionInfo: false,
+		});
+	});
+});
+
+// ============================================================================
+// composePromptLayer — override/expand composition
+// ============================================================================
+
+describe('composePromptLayer', () => {
+	it('returns base when no override is provided', () => {
+		expect(composePromptLayer('base prompt', undefined)).toBe('base prompt');
 	});
 
-	it('applies correct features for reviewer role', () => {
-		const init = createCustomAgentInit(makeConfig('reviewer', ROLE_TOOLS.reviewer));
-		expect(init.features).toEqual(ALL_FEATURES_FALSE);
+	it('returns empty string when base and override are both absent', () => {
+		expect(composePromptLayer(undefined, undefined)).toBe('');
+		expect(composePromptLayer(null, undefined)).toBe('');
+		expect(composePromptLayer('', undefined)).toBe('');
 	});
 
-	it('applies correct features for planner role', () => {
-		const init = createCustomAgentInit(makeConfig('planner', ROLE_TOOLS.planner));
-		expect(init.features).toEqual(ALL_FEATURES_FALSE);
+	it('override mode replaces base entirely', () => {
+		const override = { mode: 'override' as const, value: 'new prompt' };
+		expect(composePromptLayer('old base', override)).toBe('new prompt');
 	});
 
-	it('applies correct features for qa role', () => {
-		const init = createCustomAgentInit(makeConfig('qa', ROLE_TOOLS.qa));
-		expect(init.features).toEqual(ALL_FEATURES_FALSE);
+	it('override mode uses value when base is absent', () => {
+		const override = { mode: 'override' as const, value: 'new prompt' };
+		expect(composePromptLayer(null, override)).toBe('new prompt');
 	});
 
-	it('applies correct features for unknown role', () => {
-		const init = createCustomAgentInit(makeConfig('custom-role', ['Read', 'Bash']));
-		expect(init.features).toEqual(DEFAULT_ROLE_FEATURES);
+	it('expand mode appends to base with double newline', () => {
+		const override = { mode: 'expand' as const, value: 'additional' };
+		expect(composePromptLayer('base', override)).toBe('base\n\nadditional');
+	});
+
+	it('expand mode returns value only when base is empty', () => {
+		const override = { mode: 'expand' as const, value: 'additional' };
+		expect(composePromptLayer('', override)).toBe('additional');
+		expect(composePromptLayer(null, override)).toBe('additional');
+		expect(composePromptLayer(undefined, override)).toBe('additional');
+	});
+
+	it('trims whitespace from both base and override value', () => {
+		const override = { mode: 'expand' as const, value: '  extra  ' };
+		expect(composePromptLayer('  base  ', override)).toBe('base\n\nextra');
+	});
+
+	it('handles multiline values in expand mode', () => {
+		const override = { mode: 'expand' as const, value: 'line1\nline2\nline3' };
+		const result = composePromptLayer('base', override);
+		expect(result).toBe('base\n\nline1\nline2\nline3');
+	});
+
+	it('handles multiline values in override mode', () => {
+		const override = { mode: 'override' as const, value: 'line1\nline2' };
+		expect(composePromptLayer('old base', override)).toBe('line1\nline2');
+	});
+
+	it('expands on top of non-empty base instructions', () => {
+		const base = 'Follow TDD principles.\nWrite tests first.';
+		const override = { mode: 'expand' as const, value: 'Use bun:test for all tests.' };
+		const result = composePromptLayer(base, override);
+		expect(result).toBe(
+			'Follow TDD principles.\nWrite tests first.\n\nUse bun:test for all tests.'
+		);
+	});
+
+	it('overrides long base instructions with short override', () => {
+		const base = 'Follow TDD principles.\nWrite tests first.\nCommit frequently.';
+		const override = { mode: 'override' as const, value: 'Just write code.' };
+		expect(composePromptLayer(base, override)).toBe('Just write code.');
+	});
+
+	it('preserves empty override value in override mode', () => {
+		const override = { mode: 'override' as const, value: '' };
+		expect(composePromptLayer('base', override)).toBe('');
+	});
+
+	it('preserves empty override value in expand mode', () => {
+		const override = { mode: 'expand' as const, value: '' };
+		expect(composePromptLayer('base', override)).toBe('base');
+	});
+
+	it('works with SlotOverrides interface type', () => {
+		const overrides: SlotOverrides = {
+			systemPrompt: { mode: 'expand', value: 'extra context' },
+			instructions: { mode: 'override', value: 'new instructions' },
+		};
+
+		expect(composePromptLayer('base prompt', overrides.systemPrompt)).toBe(
+			'base prompt\n\nextra context'
+		);
+		expect(composePromptLayer('old instructions', overrides.instructions)).toBe('new instructions');
+	});
+
+	it('returns base when SlotOverrides.systemPrompt is undefined', () => {
+		const overrides: SlotOverrides = {};
+		expect(composePromptLayer('base prompt', overrides.systemPrompt)).toBe('base prompt');
+	});
+
+	it('returns base when SlotOverrides.instructions is undefined', () => {
+		const overrides: SlotOverrides = {};
+		expect(composePromptLayer('base instructions', overrides.instructions)).toBe(
+			'base instructions'
+		);
+	});
+
+	it('handles expand with null base', () => {
+		const override = { mode: 'expand' as const, value: 'some text' };
+		expect(composePromptLayer(null, override)).toBe('some text');
+	});
+
+	it('handles override trimming edge cases', () => {
+		const override = { mode: 'override' as const, value: '\n\n  padded  \n\n' };
+		expect(composePromptLayer('old', override)).toBe('padded');
+	});
+
+	it('handles expand trimming edge cases', () => {
+		const override = { mode: 'expand' as const, value: '\n\n  padded  \n\n' };
+		expect(composePromptLayer('base', override)).toBe('base\n\npadded');
+	});
+
+	it('with only whitespace base and expand mode', () => {
+		const override = { mode: 'expand' as const, value: 'value' };
+		expect(composePromptLayer('   ', override)).toBe('value');
+	});
+
+	it('with only whitespace base and override mode', () => {
+		const override = { mode: 'override' as const, value: 'value' };
+		expect(composePromptLayer('   ', override)).toBe('value');
+	});
+
+	it('with empty override and empty base returns empty', () => {
+		const override = { mode: 'expand' as const, value: '' };
+		expect(composePromptLayer('', override)).toBe('');
+	});
+
+	it('preserves exact base when override is undefined', () => {
+		expect(composePromptLayer('  exact  spacing  ', undefined)).toBe('exact  spacing');
+	});
+
+	it('handles unicode content', () => {
+		const override = { mode: 'expand' as const, value: '日本語の指示' };
+		expect(composePromptLayer('English base', override)).toBe('English base\n\n日本語の指示');
+	});
+
+	it('handles very long values', () => {
+		const longValue = 'x'.repeat(10000);
+		const override = { mode: 'expand' as const, value: longValue };
+		const result = composePromptLayer('base', override);
+		expect(result).toBe(`base\n\n${longValue}`);
+		expect(result.length).toBe(10006);
+	});
+});
+
+// ============================================================================
+// createCustomAgentInit applies sub-session features
+// ============================================================================
+
+describe('createCustomAgentInit — sub-session features', () => {
+	it('applies SUB_SESSION_FEATURES for agent with tools', () => {
+		const init = createCustomAgentInit(makeConfig(ROLE_TOOLS.coder));
+		expect(init.features).toEqual(SUB_SESSION_FEATURES);
+	});
+
+	it('applies SUB_SESSION_FEATURES for agent with restricted tools', () => {
+		const init = createCustomAgentInit(makeConfig(ROLE_TOOLS.reviewer));
+		expect(init.features).toEqual(SUB_SESSION_FEATURES);
+	});
+
+	it('applies SUB_SESSION_FEATURES for agent without tools', () => {
+		const init = createCustomAgentInit(makeConfig(undefined));
+		expect(init.features).toEqual(SUB_SESSION_FEATURES);
 	});
 
 	it('reviewer init uses agents pattern with restricted tools', () => {
-		const config = makeConfig('reviewer', ROLE_TOOLS.reviewer);
+		const config = makeConfig(ROLE_TOOLS.reviewer);
 		const init = createCustomAgentInit(config);
 
 		// When tools are specified, the agents pattern is used
@@ -249,7 +347,7 @@ describe('createCustomAgentInit — role-based configuration', () => {
 	});
 
 	it('qa init uses agents pattern with restricted tools', () => {
-		const config = makeConfig('qa', ROLE_TOOLS.qa);
+		const config = makeConfig(ROLE_TOOLS.qa);
 		const init = createCustomAgentInit(config);
 
 		expect(init.agent).toBeDefined();
@@ -263,7 +361,7 @@ describe('createCustomAgentInit — role-based configuration', () => {
 	});
 
 	it('coder init uses agents pattern with full tools', () => {
-		const config = makeConfig('coder', ROLE_TOOLS.coder);
+		const config = makeConfig(ROLE_TOOLS.coder);
 		const init = createCustomAgentInit(config);
 
 		expect(init.agent).toBeDefined();
@@ -276,10 +374,44 @@ describe('createCustomAgentInit — role-based configuration', () => {
 	});
 
 	it('agent without tools uses simple preset path (no agent key)', () => {
-		const config = makeConfig('coder');
+		const config = makeConfig(undefined);
 		const init = createCustomAgentInit(config);
 
 		expect(init.agent).toBeUndefined();
 		expect(init.agents).toBeUndefined();
+	});
+
+	it('applies systemPrompt override mode in system prompt', () => {
+		const config = makeConfig(ROLE_TOOLS.coder);
+		config.slotOverrides = {
+			systemPrompt: { mode: 'override', value: 'Override prompt' },
+		};
+		const init = createCustomAgentInit(config);
+
+		// Check that the system prompt is set via append (non-tools path)
+		if (init.systemPrompt && 'append' in init.systemPrompt) {
+			expect(init.systemPrompt.append).toBe('Override prompt');
+		} else if (init.systemPrompt && 'type' in init.systemPrompt) {
+			// tools path — check agent prompt
+			const agentKey = init.agent as string;
+			const agentDef = init.agents![agentKey];
+			expect(agentDef.prompt).toBe('Override prompt');
+		}
+	});
+
+	it('applies systemPrompt expand mode in system prompt', () => {
+		const config = makeConfig(undefined);
+		config.customAgent = makeAgent({
+			systemPrompt: 'Base prompt',
+			tools: undefined,
+		});
+		config.slotOverrides = {
+			systemPrompt: { mode: 'expand', value: 'Expanded context' },
+		};
+		const init = createCustomAgentInit(config);
+
+		if (init.systemPrompt && 'append' in init.systemPrompt) {
+			expect(init.systemPrompt.append).toBe('Base prompt\n\nExpanded context');
+		}
 	});
 });

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -132,7 +132,7 @@ describe('seedPresetAgents', () => {
 
 	it('partial collision — seeds succeed for non-conflicting names', async () => {
 		// Pre-create just the 'Coder' agent
-		await manager.create({ spaceId: 'space-1', name: 'Coder', role: 'coder' });
+		await manager.create({ spaceId: 'space-1', name: 'Coder' });
 
 		const result = await seedPresetAgents('space-1', manager);
 
@@ -140,14 +140,6 @@ describe('seedPresetAgents', () => {
 		expect(result.seeded).toHaveLength(4);
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0].name).toBe('Coder');
-	});
-
-	it('preset agents do not seed hidden workflow-context flags', async () => {
-		const { seeded } = await seedPresetAgents('space-1', manager);
-
-		for (const agent of seeded) {
-			expect(agent.injectWorkflowContext).toBeUndefined();
-		}
 	});
 
 	it('General agent has restricted tools (no Write or Edit) — read-only Done node', async () => {

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -1470,7 +1470,7 @@ describe('createSpaceAgentToolHandlers — task creation and planning node activ
 	});
 
 	test('start_workflow_run with planning start node creates task with planning taskType', async () => {
-		// Seed a planner agent so resolveTaskTypeForAgent returns 'planning'
+		// Seed a planner agent for the planning step
 		seedAgentRow(ctx.db, 'agent-planner-1', ctx.spaceId, 'Planner');
 
 		const stepId = 'planning-step-1';

--- a/packages/daemon/tests/unit/space/space-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/space/space-chat-agent.test.ts
@@ -156,11 +156,6 @@ describe('buildSpaceChatSystemPrompt — agent information', () => {
 		expect(prompt).toContain('Coder');
 	});
 
-	test('includes agent role', () => {
-		const prompt = buildSpaceChatSystemPrompt(makeContext());
-		expect(prompt).toContain('coder');
-	});
-
 	test('includes agent description', () => {
 		const prompt = buildSpaceChatSystemPrompt(makeContext());
 		expect(prompt).toContain('Implementation specialist');
@@ -168,10 +163,7 @@ describe('buildSpaceChatSystemPrompt — agent information', () => {
 
 	test('includes multiple agents', () => {
 		const ctx = makeContext({
-			agents: [
-				makeAgent({ name: 'Coder', role: 'coder' }),
-				makeAgent({ id: 'agent-2', name: 'Reviewer', role: 'reviewer' }),
-			],
+			agents: [makeAgent({ name: 'Coder' }), makeAgent({ id: 'agent-2', name: 'Reviewer' })],
 		});
 		const prompt = buildSpaceChatSystemPrompt(ctx);
 		expect(prompt).toContain('Coder');

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -9,7 +9,6 @@
  * - Rule injection: getRulesForStep() filters correctly
  * - Rehydration: executors reconstructed from DB on startup
  * - Executor cleanup: removed from map on run complete/cancel
- * - resolveTaskTypeForStep(): correct mapping for planner, coder, general, custom roles
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -168,118 +167,6 @@ describe('SpaceRuntime', () => {
 		}
 	});
 
-	// -------------------------------------------------------------------------
-	// resolveTaskTypeForStep
-	// -------------------------------------------------------------------------
-
-	describe('resolveTaskTypeForStep()', () => {
-		test('planner role → agentId returned', () => {
-			const step = { id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER };
-			const result = runtime.resolveTaskTypeForStep(step);
-			expect(result.agentId).toBe(AGENT_PLANNER);
-		});
-
-		test('coder role → agentId returned', () => {
-			const step = { id: STEP_A, name: 'Code', agentId: AGENT_CODER };
-			const result = runtime.resolveTaskTypeForStep(step);
-			expect(result.agentId).toBe(AGENT_CODER);
-		});
-
-		test('general role → agentId returned', () => {
-			const step = { id: STEP_A, name: 'Research', agentId: AGENT_GENERAL };
-			const result = runtime.resolveTaskTypeForStep(step);
-			expect(result.agentId).toBe(AGENT_GENERAL);
-		});
-
-		test('custom role → agentId returned', () => {
-			const step = { id: STEP_A, name: 'Custom', agentId: AGENT_CUSTOM };
-			const result = runtime.resolveTaskTypeForStep(step);
-			expect(result.agentId).toBe(AGENT_CUSTOM);
-		});
-
-		test('unknown agentId → agentId returned as-is', () => {
-			const step = { id: STEP_A, name: 'Unknown', agentId: 'non-existent-uuid' };
-			const result = runtime.resolveTaskTypeForStep(step);
-			expect(result.agentId).toBe('non-existent-uuid');
-		});
-	});
-
-	// -------------------------------------------------------------------------
-	// resolveTaskTypesForStep (multi-agent variant)
-	// -------------------------------------------------------------------------
-
-	describe('resolveTaskTypesForStep()', () => {
-		test('single agentId shorthand → one-element array with agentId', () => {
-			const step = { id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER };
-			const results = runtime.resolveTaskTypesForStep(step);
-			expect(results).toHaveLength(1);
-			expect(results[0].agentId).toBe(AGENT_PLANNER);
-		});
-
-		test('multi-agent step → one ResolvedTaskType per agent entry', () => {
-			const step = {
-				id: STEP_A,
-				name: 'Multi',
-				agents: [
-					{ agentId: AGENT_PLANNER, name: 'planner' },
-					{ agentId: AGENT_CODER, name: 'coder' },
-					{ agentId: AGENT_CUSTOM, name: 'my-custom-role' },
-				],
-			};
-			const results = runtime.resolveTaskTypesForStep(step);
-			expect(results).toHaveLength(3);
-			expect(results[0].agentId).toBe(AGENT_PLANNER);
-			expect(results[1].agentId).toBe(AGENT_CODER);
-			expect(results[2].agentId).toBe(AGENT_CUSTOM);
-		});
-
-		test('multi-agent step with general role → agentIds returned', () => {
-			const step = {
-				id: STEP_A,
-				name: 'Multi',
-				agents: [
-					{ agentId: AGENT_GENERAL, name: 'general' },
-					{ agentId: AGENT_CODER, name: 'coder' },
-				],
-			};
-			const results = runtime.resolveTaskTypesForStep(step);
-			expect(results).toHaveLength(2);
-			expect(results[0].agentId).toBe(AGENT_GENERAL);
-			expect(results[1].agentId).toBe(AGENT_CODER);
-		});
-
-		test('multi-agent step with unknown agentId → agentId preserved as-is', () => {
-			const step = {
-				id: STEP_A,
-				name: 'Multi',
-				agents: [
-					{ agentId: AGENT_CODER, name: 'coder' },
-					{ agentId: 'unknown-agent-id', name: 'unknown' },
-				],
-			};
-			const results = runtime.resolveTaskTypesForStep(step);
-			expect(results).toHaveLength(2);
-			expect(results[0].agentId).toBe(AGENT_CODER);
-			expect(results[1].agentId).toBe('unknown-agent-id');
-		});
-
-		test('resolveTaskTypeForStep delegates to first entry of resolveTaskTypesForStep', () => {
-			const step = {
-				id: STEP_A,
-				name: 'Multi',
-				agents: [
-					{ agentId: AGENT_PLANNER, name: 'planner' },
-					{ agentId: AGENT_CODER, name: 'coder' },
-				],
-			};
-			const single = runtime.resolveTaskTypeForStep(step);
-			const multi = runtime.resolveTaskTypesForStep(step);
-			expect(single).toEqual(multi[0]);
-			expect(single.agentId).toBe(AGENT_PLANNER);
-		});
-	});
-
-	// -------------------------------------------------------------------------
 	// getRulesForStep — removed in M71; no tests needed
 	// -------------------------------------------------------------------------
 
@@ -1266,19 +1153,6 @@ describe('SpaceRuntime', () => {
 			// Run should still be in_progress — sibling task is still running
 			const updatedRun = workflowRunRepo.getRun(run.id)!;
 			expect(updatedRun.status).toBe('in_progress');
-		});
-
-		test('resolveTaskTypeForAgent() returns { agentId } for each agent (M71: taskType/customAgentId removed)', () => {
-			// M71: ResolvedTaskType changed from { taskType, customAgentId } to { agentId }
-			expect(runtime.resolveTaskTypeForAgent(AGENT_PLANNER)).toEqual({ agentId: AGENT_PLANNER });
-			expect(runtime.resolveTaskTypeForAgent(AGENT_CODER)).toEqual({ agentId: AGENT_CODER });
-			expect(runtime.resolveTaskTypeForAgent(AGENT_GENERAL)).toEqual({ agentId: AGENT_GENERAL });
-			expect(runtime.resolveTaskTypeForAgent(AGENT_CUSTOM)).toEqual({ agentId: AGENT_CUSTOM });
-		});
-
-		test('resolveTaskTypeForAgent() preserves agentId for unknown agentId', () => {
-			const result = runtime.resolveTaskTypeForAgent('unknown-agent-id');
-			expect(result.agentId).toBe('unknown-agent-id');
 		});
 	});
 

--- a/packages/e2e/tests/features/space-export-import.e2e.ts
+++ b/packages/e2e/tests/features/space-export-import.e2e.ts
@@ -60,7 +60,6 @@ async function createTestSpace(page: Page): Promise<{
 			const agentRes = await hub.request('spaceAgent.create', {
 				spaceId,
 				name: 'Test Coder',
-				role: 'coder',
 				description: 'A test coder agent',
 			});
 			const agentId = (agentRes as { agent: { id: string } }).agent.id;
@@ -205,7 +204,6 @@ test.describe('Space Export/Import', () => {
 					version: 1,
 					type: 'agent',
 					name: 'Imported Reviewer',
-					role: 'reviewer',
 					description: 'A reviewer agent imported from a bundle',
 					tools: [],
 				},
@@ -248,7 +246,6 @@ test.describe('Space Export/Import', () => {
 					version: 1,
 					type: 'agent',
 					name: agentName, // same name → conflict
-					role: 'coder',
 					description: 'Duplicate agent',
 					tools: [],
 				},
@@ -297,7 +294,6 @@ test.describe('Space Export/Import', () => {
 					version: 1,
 					type: 'agent',
 					name: 'Bundle Agent',
-					role: 'general',
 					tools: [],
 				},
 			],

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -290,11 +290,15 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 					if (!hub?.request) throw new Error('Hub not available');
 
 					const agentsRes = await hub.request('spaceAgent.list', { spaceId: sid });
-					const agents = (agentsRes as { agents: Array<{ id: string; role: string }> }).agents;
-					const planner = agents.find((a) => a.role === 'planner') ?? agents[0];
+					const agents = (agentsRes as { agents: Array<{ id: string; name: string }> }).agents;
+					const planner = agents.find((a) => a.name === 'Planner') ?? agents[0];
 					if (!planner) throw new Error('No agents seeded in space');
 
-					const node = { id: crypto.randomUUID(), name: 'Node 1', agentId: planner.id };
+					const node = {
+						id: crypto.randomUUID(),
+						name: 'Node 1',
+						agents: [{ agentId: planner.id, name: 'Planner' }],
+					};
 					await hub.request('spaceWorkflow.create', {
 						spaceId: sid,
 						name: wname,

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -59,9 +59,9 @@ export async function getDefaultAgentId(page: Page, spaceId: string): Promise<st
 		const hub = window.__messageHub || window.appState?.messageHub;
 		if (!hub?.request) throw new Error('Hub not available');
 		const res = (await hub.request('spaceAgent.list', { spaceId: sid })) as {
-			agents: Array<{ id: string; role: string }>;
+			agents: Array<{ id: string; name: string }>;
 		};
-		const agent = res.agents.find((a) => a.role === 'planner') ?? res.agents[0];
+		const agent = res.agents.find((a) => a.name === 'Planner') ?? res.agents[0];
 		if (!agent) throw new Error('No agents found in space');
 		return agent.id;
 	}, spaceId);

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -27,9 +27,15 @@ import type {
  * Wildcard and array `to` declarations are expanded into one entry per resolved pair.
  */
 export interface ResolvedChannel {
-	/** Name of the sending agent (matches WorkflowNodeAgent.name) */
+	/**
+	 * Name of the sending agent (matches WorkflowNodeAgent.name).
+	 * Note: field name is historical — stores agent name, not role.
+	 */
 	fromRole: string;
-	/** Name of the receiving agent (matches WorkflowNodeAgent.name) */
+	/**
+	 * Name of the receiving agent (matches WorkflowNodeAgent.name).
+	 * Note: field name is historical — stores agent name, not role.
+	 */
 	toRole: string;
 	/** Agent ID of the sender */
 	fromAgentId: string;

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -79,9 +79,8 @@ export function resolveNodeAgents(node: WorkflowNode): WorkflowNodeAgent[] {
 
 	// Backward compatibility: if `agentId` shorthand is present on the node object
 	// (legacy test code and call-sites), synthesize a single-agent array.
-	const legacyAgentId = (node as unknown as Record<string, unknown>)['agentId'] as
-		| string
-		| undefined;
+	const legacyRecord = node as unknown as Record<string, unknown>;
+	const legacyAgentId = legacyRecord['agentId'] as string | undefined;
 	if (legacyAgentId) {
 		return [{ agentId: legacyAgentId, name: node.name }];
 	}

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -39,7 +39,7 @@ export interface ResolvedChannel {
 	direction: 'one-way';
 	/**
 	 * True when the `to` side of the source WorkflowChannel resolved to a node name
-	 * (fan-out delivery to all agents in that node), not an individual agent role.
+	 * (fan-out delivery to all agents in that node), not an individual agent name.
 	 *
 	 * Note: `isFanOut` specifically describes **to-side** fan-out. When `from` in the
 	 * source channel is a node name, the resolver creates one `ResolvedChannel` entry
@@ -330,8 +330,8 @@ export function validateNodeChannels(
  *   (which must be unique across all nodes in the workflow for correct routing).
  * - When `to` matches a **node name** (from `WorkflowNode.name`), the channel
  *   fans out to all agents in that node (`isFanOut: true`).
- * - When `to` matches an **agent role**, the channel is a point-to-point DM (`isFanOut: false`).
- * - The wildcard `'*'` for `from` or `to` (as sole element) expands to all agent roles,
+ * - When `to` matches an **agent name**, the channel is a point-to-point DM (`isFanOut: false`).
+ * - The wildcard `'*'` for `from` or `to` (as sole element) expands to all agent names,
  *   preserving backward compatibility with node-level channel declarations.
  * - Bidirectional channels expand to two one-way entries.
  * - Self-loops are skipped.

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -326,7 +326,7 @@ export function validateNodeChannels(
  * cross-node, DM, and fan-out. There is no separate resolveNodeChannels call needed.
  *
  * Addressing semantics:
- * - `from`/`to` values are looked up globally against `WorkflowNodeAgent.role` strings
+ * - `from`/`to` values are looked up globally against `WorkflowNodeAgent.name` strings
  *   (which must be unique across all nodes in the workflow for correct routing).
  * - When `to` matches a **node name** (from `WorkflowNode.name`), the channel
  *   fans out to all agents in that node (`isFanOut: true`).


### PR DESCRIPTION
## Summary

- Remove deprecated `SpaceAgent.role`, `toolConfig`, `injectWorkflowContext` fields from codebase
- Remove `ResolvedTaskType` interface and all `resolveTaskTypeFor*`/`resolveTaskTypesForStep` methods from `SpaceRuntime`
- Replace `ROLE_FEATURES`/`getFeaturesForRole()` with a single `SUB_SESSION_FEATURES` constant
- Update `SlotOverrides` to use structured `WorkflowNodeAgentOverride` for `systemPrompt` and `instructions` (supporting `override` and `expand` composition modes)
- Add exported `composePromptLayer()` function for two-layer prompt composition
- Keep `WorkflowNode.agentId` shorthand as permanent compat shim in `resolveNodeAgents()`
- Remove `role` from `AgentSummary` in space-chat-agent prompt builder
- Wire `instructions` override through `task-agent-tools.ts` alongside `systemPrompt`

## Test plan

- [x] All 67 space-chat-agent tests pass
- [x] All 283 space unit tests pass (role-config, custom-agent, seed-agents, space-runtime, export-format, node-agent-tools)
- [x] TypeScript type checking passes
- [x] Oxlint passes with 0 errors
- [x] Biome format passes
- [x] Knip dead code detection shows only pre-existing findings