### PR TITLE
feat: add workflow manager validation and node execution RPC handlers

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -1116,7 +1116,7 @@ export function createNeoQueryMcpServer(config: NeoToolsConfig) {
 			{
 				space_id: z.string().describe('ID of the space to query'),
 				status: z
-					.enum(['pending', 'in_progress', 'completed', 'cancelled', 'needs_attention'])
+					.enum(['pending', 'in_progress', 'done', 'blocked', 'cancelled'])
 					.optional()
 					.describe('Filter runs by status'),
 			},

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -59,6 +59,7 @@ import { SpaceTaskRepository } from '../../storage/repositories/space-task-repos
 import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import { GateDataRepository } from '../../storage/repositories/gate-data-repository';
 import { ChannelCycleRepository } from '../../storage/repositories/channel-cycle-repository';
+import { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
 import { setupSpaceAgentHandlers } from './space-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
@@ -69,6 +70,7 @@ import { enqueueRoomTick } from '../job-handlers/room-tick.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
 import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
+import { setupNodeExecutionHandlers } from './space-node-execution-handlers';
 import { setupSpaceExportImportHandlers } from './space-export-import-handlers';
 import { provisionGlobalSpacesAgent } from '../space/provision-global-agent';
 import { setupGlobalSpacesHandlers } from './global-spaces-handlers';
@@ -351,6 +353,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(deps.db.getDatabase());
 	const gateDataRepo = new GateDataRepository(deps.db.getDatabase());
 	const channelCycleRepo = new ChannelCycleRepository(deps.db.getDatabase());
+	const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase());
 
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
@@ -424,6 +427,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		reactiveDb: deps.reactiveDb,
 		gateDataRepo,
 		channelCycleRepo,
+		nodeExecutionRepo,
 		sessionManager: deps.sessionManager,
 		daemonHub: deps.daemonHub,
 	});
@@ -514,6 +518,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 				workflowManager: spaceWorkflowManager,
 				taskRepo: spaceTaskRepo,
 				workflowRunRepo: spaceWorkflowRunRepo,
+				nodeExecutionRepo,
 				db: deps.db.getDatabase(),
 			},
 			neoSpacesState
@@ -602,7 +607,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.db.getDatabase(),
 		deps.daemonHub
 	);
-
 	// Space workflow run handlers — reuse the same factory pattern as spaceTask handlers
 	const spaceWorkflowRunTaskManagerFactory: SpaceWorkflowRunTaskManagerFactory = (spaceId) => {
 		return new SpaceTaskManager(deps.db.getDatabase(), spaceId, deps.reactiveDb);
@@ -617,6 +621,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceWorkflowRunTaskManagerFactory,
 		deps.daemonHub
 	);
+
+	// Node execution handlers
+	setupNodeExecutionHandlers(deps.messageHub, nodeExecutionRepo);
 
 	// Provision the Global Spaces Agent session (spaces:global)
 	// Create shared state synchronously so the RPC handler is available immediately.
@@ -663,6 +670,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			sessionFactory: globalSessionFactory,
 			taskRepo: spaceTaskRepo,
 			workflowRunRepo: spaceWorkflowRunRepo,
+			nodeExecutionRepo,
 			db: deps.db.getDatabase(),
 			state: globalSpacesState,
 			daemonHub: deps.daemonHub,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -607,6 +607,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.db.getDatabase(),
 		deps.daemonHub
 	);
+
 	// Space workflow run handlers — reuse the same factory pattern as spaceTask handlers
 	const spaceWorkflowRunTaskManagerFactory: SpaceWorkflowRunTaskManagerFactory = (spaceId) => {
 		return new SpaceTaskManager(deps.db.getDatabase(), spaceId, deps.reactiveDb);
@@ -623,7 +624,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	);
 
 	// Node execution handlers
-	setupNodeExecutionHandlers(deps.messageHub, nodeExecutionRepo);
+	setupNodeExecutionHandlers(deps.messageHub, nodeExecutionRepo, spaceWorkflowRunRepo);
 
 	// Provision the Global Spaces Agent session (spaces:global)
 	// Create shared state synchronously so the RPC handler is available immediately.

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -694,6 +694,25 @@ WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('co
 ORDER BY createdAt ASC, id ASC
 `.trim();
 
+const NODE_EXECUTIONS_BY_RUN_SQL = `
+SELECT
+  id,
+  workflow_run_id  AS workflowRunId,
+  workflow_node_id AS workflowNodeId,
+  agent_name       AS agentName,
+  agent_id         AS agentId,
+  agent_session_id AS agentSessionId,
+  status,
+  result,
+  created_at       AS createdAt,
+  started_at       AS startedAt,
+  completed_at     AS completedAt,
+  updated_at       AS updatedAt
+FROM node_executions
+WHERE workflow_run_id = ?
+ORDER BY created_at ASC, id ASC
+`.trim();
+
 // ============================================================================
 // Registry
 // ============================================================================
@@ -802,6 +821,13 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			sql: NEO_ACTIVITY_SQL,
 			paramCount: 2,
 			mapRow: mapNeoActivityRow,
+		},
+	],
+	[
+		'nodeExecutions.byRun',
+		{
+			sql: NODE_EXECUTIONS_BY_RUN_SQL,
+			paramCount: 1,
 		},
 	],
 ]);

--- a/packages/daemon/src/lib/rpc-handlers/space-node-execution-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-node-execution-handlers.ts
@@ -2,7 +2,7 @@
  * Space Node Execution RPC Handlers
  *
  * RPC handlers for NodeExecution queries:
- * - nodeExecution.list - Lists node executions for a workflow run
+ * - nodeExecution.list - Lists node executions for a workflow run (requires spaceId)
  */
 
 import type { MessageHub } from '@neokai/shared';
@@ -19,18 +19,19 @@ export function setupNodeExecutionHandlers(
 ): void {
 	// ─── nodeExecution.list ─────────────────────────────────────────────────
 	messageHub.onRequest('nodeExecution.list', async (data) => {
-		const params = data as { workflowRunId: string; spaceId?: string };
+		const params = data as { workflowRunId: string; spaceId: string };
 
 		if (!params.workflowRunId) {
 			throw new Error('workflowRunId is required');
 		}
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
 
-		// Ownership check — if spaceId is provided, reject cross-space access
-		if (params.spaceId) {
-			const run = workflowRunRepo.getRun(params.workflowRunId);
-			if (!run || run.spaceId !== params.spaceId) {
-				throw new Error(`WorkflowRun not found: ${params.workflowRunId}`);
-			}
+		// Ownership check — reject cross-space access
+		const run = workflowRunRepo.getRun(params.workflowRunId);
+		if (!run || run.spaceId !== params.spaceId) {
+			throw new Error(`WorkflowRun not found: ${params.workflowRunId}`);
 		}
 
 		const executions = nodeExecutionRepo.listByWorkflowRun(params.workflowRunId);

--- a/packages/daemon/src/lib/rpc-handlers/space-node-execution-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-node-execution-handlers.ts
@@ -1,0 +1,30 @@
+/**
+ * Space Node Execution RPC Handlers
+ *
+ * RPC handlers for NodeExecution queries:
+ * - nodeExecution.list - Lists node executions for a workflow run
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
+
+/**
+ * Register RPC handlers for NodeExecution queries.
+ */
+export function setupNodeExecutionHandlers(
+	messageHub: MessageHub,
+	nodeExecutionRepo: NodeExecutionRepository
+): void {
+	// ─── nodeExecution.list ─────────────────────────────────────────────────
+	messageHub.onRequest('nodeExecution.list', async (data) => {
+		const params = data as { workflowRunId: string };
+
+		if (!params.workflowRunId) {
+			throw new Error('workflowRunId is required');
+		}
+
+		const executions = nodeExecutionRepo.listByWorkflowRun(params.workflowRunId);
+
+		return { executions };
+	});
+}

--- a/packages/daemon/src/lib/rpc-handlers/space-node-execution-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-node-execution-handlers.ts
@@ -7,20 +7,30 @@
 
 import type { MessageHub } from '@neokai/shared';
 import type { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
+import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 
 /**
  * Register RPC handlers for NodeExecution queries.
  */
 export function setupNodeExecutionHandlers(
 	messageHub: MessageHub,
-	nodeExecutionRepo: NodeExecutionRepository
+	nodeExecutionRepo: NodeExecutionRepository,
+	workflowRunRepo: SpaceWorkflowRunRepository
 ): void {
 	// ─── nodeExecution.list ─────────────────────────────────────────────────
 	messageHub.onRequest('nodeExecution.list', async (data) => {
-		const params = data as { workflowRunId: string };
+		const params = data as { workflowRunId: string; spaceId?: string };
 
 		if (!params.workflowRunId) {
 			throw new Error('workflowRunId is required');
+		}
+
+		// Ownership check — if spaceId is provided, reject cross-space access
+		if (params.spaceId) {
+			const run = workflowRunRepo.getRun(params.workflowRunId);
+			if (!run || run.spaceId !== params.spaceId) {
+				throw new Error(`WorkflowRun not found: ${params.workflowRunId}`);
+			}
 		}
 
 		const executions = nodeExecutionRepo.listByWorkflowRun(params.workflowRunId);

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -127,7 +127,6 @@ export function setupSpaceWorkflowRunHandlers(
 			workflowId?: string;
 			title: string;
 			description?: string;
-			goalId?: string;
 		};
 
 		if (!params.spaceId) throw new Error('spaceId is required');
@@ -162,8 +161,7 @@ export function setupSpaceWorkflowRunHandlers(
 			params.spaceId,
 			workflowId,
 			params.title,
-			params.description,
-			params.goalId
+			params.description
 		);
 
 		daemonHub

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -107,6 +107,17 @@ export class SpaceWorkflowManager {
 			);
 			this.validateNodes(existing.spaceId, inputs);
 			this.validateEndNodeId(params.endNodeId, inputs);
+		} else if (params.endNodeId !== undefined) {
+			// endNodeId changed but nodes didn't — validate against existing nodes
+			const existingNodes: WorkflowNodeInput[] = (existing.nodes ?? []).map(
+				(n): WorkflowNodeInput => ({
+					id: n.id,
+					name: n.name,
+					agents: n.agents,
+					instructions: n.instructions,
+				})
+			);
+			this.validateEndNodeId(params.endNodeId, existingNodes);
 		}
 
 		if (params.channels && params.channels.length > 0) {

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -64,6 +64,7 @@ export class SpaceWorkflowManager {
 		this.validateName(params.spaceId, trimmedName, null);
 		const nodes = params.nodes ?? [];
 		this.validateNodes(params.spaceId, nodes);
+		this.validateEndNodeId(params.endNodeId, nodes);
 		if (params.channels && params.channels.length > 0) {
 			this.validateChannels(params.channels);
 		}
@@ -105,6 +106,7 @@ export class SpaceWorkflowManager {
 				})
 			);
 			this.validateNodes(existing.spaceId, inputs);
+			this.validateEndNodeId(params.endNodeId, inputs);
 		}
 
 		if (params.channels && params.channels.length > 0) {
@@ -254,6 +256,22 @@ export class SpaceWorkflowManager {
 					throw new WorkflowValidationError(`${loc}: 'to' must be a non-empty agent name string`);
 				}
 			}
+		}
+	}
+
+	private validateEndNodeId(
+		endNodeId: string | null | undefined,
+		nodes: WorkflowNodeInput[]
+	): void {
+		if (endNodeId === undefined || endNodeId === null) return;
+		if (!endNodeId.trim()) {
+			throw new WorkflowValidationError('endNodeId must be a non-empty string or null');
+		}
+		const nodeIds = new Set(nodes.map((n) => n.id));
+		if (!nodeIds.has(endNodeId)) {
+			throw new WorkflowValidationError(
+				`endNodeId "${endNodeId}" does not match any node in this workflow`
+			);
 		}
 	}
 }

--- a/packages/daemon/src/lib/space/provision-global-agent.ts
+++ b/packages/daemon/src/lib/space/provision-global-agent.ts
@@ -17,6 +17,7 @@ import type { SpaceAgentManager } from './managers/space-agent-manager';
 import type { SpaceWorkflowManager } from './managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import type { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
 import type { SpaceRuntimeService } from './runtime/space-runtime-service';
 import type { DaemonHub } from '../daemon-hub';
 import { Logger } from '../logger';
@@ -53,6 +54,8 @@ export interface ProvisionGlobalSpacesAgentDeps {
 	sessionFactory: SessionFactory;
 	taskRepo: SpaceTaskRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Node execution repository for querying node execution records. */
+	nodeExecutionRepo: NodeExecutionRepository;
 	/** Database instance passed through to GlobalSpacesToolsConfig for SpaceTaskManager creation. */
 	db: BunDatabase;
 	/** Shared mutable state for the active space context. Created externally so RPC handlers can use the same reference. */
@@ -95,6 +98,7 @@ export async function provisionGlobalSpacesAgent(
 		sessionFactory,
 		taskRepo,
 		workflowRunRepo,
+		nodeExecutionRepo,
 		db,
 		state,
 		daemonHub,
@@ -147,6 +151,7 @@ export async function provisionGlobalSpacesAgent(
 			workflowManager: spaceWorkflowManager,
 			taskRepo,
 			workflowRunRepo,
+			nodeExecutionRepo,
 			db,
 		},
 		state

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -59,7 +59,7 @@ export interface SpaceRuntimeServiceConfig {
 	gateDataRepo?: GateDataRepository;
 	channelCycleRepo?: ChannelCycleRepository;
 	/** Node execution repository for querying node execution records. */
-	nodeExecutionRepo?: NodeExecutionRepository;
+	nodeExecutionRepo: NodeExecutionRepository;
 	/**
 	 * Optional SessionManager for provisioning space:chat:${spaceId} sessions.
 	 * When provided, setupSpaceAgentSession() attaches MCP tools and system prompts
@@ -213,7 +213,7 @@ export class SpaceRuntimeService {
 			taskManager: new SpaceTaskManager(db, space.id, this.config.reactiveDb),
 			spaceAgentManager,
 			taskAgentManager: this.taskAgentManager,
-			nodeExecutionRepo: this.config.nodeExecutionRepo!,
+			nodeExecutionRepo: this.config.nodeExecutionRepo,
 		});
 
 		session.setRuntimeMcpServers({

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -18,6 +18,7 @@ import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/s
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
+import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type { NotificationSink } from './notification-sink';
 import type { TaskAgentManager } from './task-agent-manager';
@@ -57,6 +58,8 @@ export interface SpaceRuntimeServiceConfig {
 	 */
 	gateDataRepo?: GateDataRepository;
 	channelCycleRepo?: ChannelCycleRepository;
+	/** Node execution repository for querying node execution records. */
+	nodeExecutionRepo?: NodeExecutionRepository;
 	/**
 	 * Optional SessionManager for provisioning space:chat:${spaceId} sessions.
 	 * When provided, setupSpaceAgentSession() attaches MCP tools and system prompts
@@ -210,6 +213,7 @@ export class SpaceRuntimeService {
 			taskManager: new SpaceTaskManager(db, space.id, this.config.reactiveDb),
 			spaceAgentManager,
 			taskAgentManager: this.taskAgentManager,
+			nodeExecutionRepo: this.config.nodeExecutionRepo!,
 		});
 
 		session.setRuntimeMcpServers({

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -329,8 +329,7 @@ export class SpaceRuntime {
 		spaceId: string,
 		workflowId: string,
 		title: string,
-		description?: string,
-		_goalId?: string
+		description?: string
 	): Promise<{ run: SpaceWorkflowRun; tasks: SpaceTask[] }> {
 		const workflow = this.config.spaceWorkflowManager.getWorkflow(workflowId);
 		if (!workflow) {

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -27,6 +27,7 @@ import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { jsonResult, SUGGEST_WORKFLOW_STOP_WORDS } from './tool-result';
 import type { ToolResult } from './tool-result';
@@ -43,6 +44,8 @@ export interface GlobalSpacesToolsConfig {
 	workflowManager: SpaceWorkflowManager;
 	taskRepo: SpaceTaskRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Node execution repository for querying node execution records. */
+	nodeExecutionRepo: NodeExecutionRepository;
 	/** Database instance used to create SpaceTaskManager instances on demand. */
 	db: BunDatabase;
 }
@@ -85,6 +88,7 @@ export function createGlobalSpacesToolHandlers(
 		workflowManager,
 		taskRepo,
 		workflowRunRepo,
+		nodeExecutionRepo,
 		db,
 	} = config;
 
@@ -251,8 +255,8 @@ export function createGlobalSpacesToolHandlers(
 			if (!run) {
 				return jsonResult({ success: false, error: `Workflow run not found: ${args.run_id}` });
 			}
-			const tasks = taskRepo.listByWorkflowRun(run.id);
-			return jsonResult({ success: true, run, tasks });
+			const executions = nodeExecutionRepo.listByWorkflowRun(run.id);
+			return jsonResult({ success: true, run, executions });
 		},
 
 		async list_tasks(args?: {
@@ -716,7 +720,7 @@ export function createGlobalSpacesMcpServer(
 		),
 		tool(
 			'retry_task',
-			'Reset a failed (needs_attention) or cancelled task back to pending so it can be picked up again. Optionally update the description before retry.',
+			'Reset a failed (blocked) or cancelled task back to pending so it can be picked up again. Optionally update the description before retry.',
 			{
 				task_id: z.string().describe('ID of the task to retry'),
 				space_id: z
@@ -747,7 +751,7 @@ export function createGlobalSpacesMcpServer(
 		),
 		tool(
 			'reassign_task',
-			'Change the agent assigned to a task. Only allowed for tasks in pending, needs_attention, or cancelled status.',
+			'Change the agent assigned to a task. Only allowed for tasks in open, blocked, or cancelled status.',
 			{
 				task_id: z.string().describe('ID of the task to reassign'),
 				space_id: z

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -231,7 +231,6 @@ export function createGlobalSpacesToolHandlers(
 			workflow_id: string;
 			title: string;
 			description?: string;
-			goal_id?: string;
 		}): Promise<ToolResult> {
 			const resolved = resolveSpaceId(args.space_id);
 			if ('error' in resolved) return jsonResult({ success: false, error: resolved.error });

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -240,8 +240,7 @@ export function createGlobalSpacesToolHandlers(
 					resolved.spaceId,
 					args.workflow_id,
 					args.title,
-					args.description,
-					args.goal_id
+					args.description
 				);
 				return jsonResult({ success: true, space_id: resolved.spaceId, run, tasks });
 			} catch (err) {
@@ -605,7 +604,6 @@ export function createGlobalSpacesMcpServer(
 				workflow_id: z.string().describe('ID of the workflow to run'),
 				title: z.string().describe('Short title for this workflow run'),
 				description: z.string().optional().describe('Description of the work'),
-				goal_id: z.string().optional().describe('Goal/mission ID to associate with this run'),
 			},
 			(args) => handlers.start_workflow_run(args)
 		),
@@ -685,14 +683,6 @@ export function createGlobalSpacesMcpServer(
 					.enum(['low', 'normal', 'high', 'urgent'])
 					.optional()
 					.describe('Task priority (default: normal)'),
-				task_type: z
-					.enum(['planning', 'coding', 'research', 'design', 'review'])
-					.optional()
-					.describe('Task type for routing and display'),
-				assigned_agent: z
-					.enum(['coder', 'general'])
-					.optional()
-					.describe('Built-in agent type to assign (default: coder)'),
 				custom_agent_id: z
 					.string()
 					.optional()

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -102,15 +102,13 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			workflow_id: string;
 			title: string;
 			description?: string;
-			goal_id?: string;
 		}): Promise<ToolResult> {
 			try {
 				const { run, tasks } = await runtime.startWorkflowRun(
 					spaceId,
 					args.workflow_id,
 					args.title,
-					args.description,
-					args.goal_id
+					args.description
 				);
 
 				// Event-driven kickoff:
@@ -533,7 +531,6 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.describe('ID of the workflow to run (required — choose from list_workflows)'),
 				title: z.string().describe('Short title for this workflow run'),
 				description: z.string().optional().describe('Detailed description of the work to be done'),
-				goal_id: z.string().optional().describe('Goal/mission ID to associate with this run'),
 			},
 			(args) => handlers.start_workflow_run(args)
 		),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -27,6 +27,7 @@ import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { TaskAgentManager } from '../runtime/task-agent-manager';
@@ -58,6 +59,8 @@ export interface SpaceAgentToolsConfig {
 	 * Optional — when not provided, send_message_to_task returns an error.
 	 */
 	taskAgentManager?: TaskAgentManager | null;
+	/** Node execution repository for querying node execution records. */
+	nodeExecutionRepo: NodeExecutionRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +81,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		taskManager,
 		spaceAgentManager,
 		taskAgentManager,
+		nodeExecutionRepo,
 	} = config;
 
 	return {
@@ -138,10 +142,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				return jsonResult({ success: false, error: `Workflow run not found: ${args.run_id}` });
 			}
 
-			// Include tasks for this run
-			const tasks = taskRepo.listByWorkflowRun(run.id);
+			// Include node executions for this run
+			const executions = nodeExecutionRepo.listByWorkflowRun(run.id);
 
-			return jsonResult({ success: true, run, tasks });
+			return jsonResult({ success: true, run, executions });
 		},
 
 		/**
@@ -621,14 +625,6 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.enum(['low', 'normal', 'high', 'urgent'])
 					.optional()
 					.describe('Task priority (default: normal)'),
-				task_type: z
-					.enum(['planning', 'coding', 'research', 'design', 'review'])
-					.optional()
-					.describe('Task type — determines default execution approach'),
-				assigned_agent: z
-					.enum(['coder', 'general'])
-					.optional()
-					.describe('Agent type to execute this task (default: coder)'),
 				custom_agent_id: z
 					.string()
 					.optional()
@@ -638,7 +634,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'get_task_detail',
-			'Get the full detail of a task by its numeric ID (e.g. task #5) or UUID. Includes error, result, PR URL, PR number, progress, and current step.',
+			'Get the full detail of a task by its numeric ID (e.g. task #5) or UUID. Includes error, result, PR URL, PR number, and current step.',
 			{
 				task_id: z.string().optional().describe('UUID of the task to retrieve'),
 				task_number: z
@@ -650,7 +646,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'retry_task',
-			'Retry a failed (needs_attention) or cancelled task by resetting it to pending. Optionally provide an updated description.',
+			'Retry a failed (blocked) or cancelled task by resetting it to pending. Optionally provide an updated description.',
 			{
 				task_id: z.string().describe('ID of the task to retry'),
 				description: z
@@ -676,7 +672,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'reassign_task',
-			'Change the agent assignment for a task. Only allowed for tasks in pending, needs_attention, or cancelled status.',
+			'Change the agent assignment for a task. Only allowed for tasks in open, blocked, or cancelled status.',
 			{
 				task_id: z.string().describe('ID of the task to reassign'),
 				custom_agent_id: z

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -76,7 +76,9 @@ export class NodeExecutionRepository {
 	 */
 	listByWorkflowRun(workflowRunId: string): NodeExecution[] {
 		const rows = this.db
-			.prepare(`SELECT * FROM node_executions WHERE workflow_run_id = ? ORDER BY created_at ASC`)
+			.prepare(
+				`SELECT * FROM node_executions WHERE workflow_run_id = ? ORDER BY created_at ASC, id ASC`
+			)
 			.all(workflowRunId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToNodeExecution(r));
 	}
@@ -89,7 +91,7 @@ export class NodeExecutionRepository {
 			.prepare(
 				`SELECT * FROM node_executions
 				        WHERE workflow_run_id = ? AND workflow_node_id = ?
-				        ORDER BY created_at ASC`
+				        ORDER BY created_at ASC, id ASC`
 			)
 			.all(workflowRunId, workflowNodeId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToNodeExecution(r));

--- a/packages/daemon/tests/unit/lib/space-workflow-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-workflow-manager.test.ts
@@ -155,7 +155,7 @@ describe('SpaceWorkflowManager', () => {
 			);
 		});
 
-		it('accepts valid endNodeId referencing existing node when nodes and endNodeId updated together', () => {
+		it('accepts valid endNodeId referencing existing node on update (no nodes change)', () => {
 			const created = manager.createWorkflow({
 				spaceId: 'space-1',
 				name: 'Test Workflow',

--- a/packages/daemon/tests/unit/lib/space-workflow-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-workflow-manager.test.ts
@@ -1,0 +1,225 @@
+/**
+ * SpaceWorkflowManager Unit Tests
+ *
+ * Tests for endNodeId validation on create and update operations.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager';
+import { createSpaceAgentSchema, insertSpace } from '../helpers/space-agent-schema';
+
+describe('SpaceWorkflowManager', () => {
+	let db: Database;
+	let repo: SpaceWorkflowRepository;
+	let manager: SpaceWorkflowManager;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceAgentSchema(db);
+		insertSpace(db);
+		repo = new SpaceWorkflowRepository(db as any);
+		manager = new SpaceWorkflowManager(repo, null);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('endNodeId validation on create', () => {
+		it('accepts null endNodeId (no end node constraint)', () => {
+			const result = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+				endNodeId: null,
+			});
+			// SpaceWorkflow type uses optional string — null in DB maps to undefined
+			expect(result.endNodeId).toBeUndefined();
+		});
+
+		it('accepts undefined endNodeId (defaults to no end node)', () => {
+			const result = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+			});
+			expect(result.endNodeId).toBeUndefined();
+		});
+
+		it('accepts valid endNodeId referencing an existing node', () => {
+			const result = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+				endNodeId: 'node-2',
+			});
+			expect(result.endNodeId).toBe('node-2');
+		});
+
+		it('rejects empty string endNodeId', () => {
+			expect(() =>
+				manager.createWorkflow({
+					spaceId: 'space-1',
+					name: 'Test Workflow',
+					nodes: [
+						{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					],
+					endNodeId: '   ',
+				})
+			).toThrow('endNodeId must be a non-empty string or null');
+		});
+
+		it('rejects endNodeId that does not match any node', () => {
+			expect(() =>
+				manager.createWorkflow({
+					spaceId: 'space-1',
+					name: 'Test Workflow',
+					nodes: [
+						{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					],
+					endNodeId: 'nonexistent-node',
+				})
+			).toThrow('endNodeId "nonexistent-node" does not match any node in this workflow');
+		});
+	});
+
+	describe('endNodeId validation on update', () => {
+		it('accepts null endNodeId to remove end node constraint', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+				endNodeId: 'node-2',
+			});
+			expect(created.endNodeId).toBe('node-2');
+
+			const updated = manager.updateWorkflow(created.id, { endNodeId: null });
+			// null clears the end node — stored as NULL in DB, returned as undefined
+			expect(updated?.endNodeId).toBeUndefined();
+		});
+
+		it('accepts undefined endNodeId (no change)', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+				endNodeId: 'node-2',
+			});
+
+			const updated = manager.updateWorkflow(created.id, {});
+			expect(updated?.endNodeId).toBe('node-2');
+		});
+
+		it('accepts valid endNodeId referencing existing node on update (no nodes change)', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+			});
+
+			// Update only endNodeId, not nodes — should validate against existing nodes
+			const updated = manager.updateWorkflow(created.id, { endNodeId: 'node-1' });
+			expect(updated?.endNodeId).toBe('node-1');
+		});
+
+		it('rejects endNodeId that does not match any existing node on update (no nodes change)', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+			});
+
+			// Update only endNodeId, not nodes — should validate against existing nodes
+			expect(() => manager.updateWorkflow(created.id, { endNodeId: 'nonexistent' })).toThrow(
+				'endNodeId "nonexistent" does not match any node in this workflow'
+			);
+		});
+
+		it('accepts valid endNodeId referencing existing node when nodes and endNodeId updated together', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+			});
+
+			const updated = manager.updateWorkflow(created.id, { endNodeId: 'node-1' });
+			expect(updated?.endNodeId).toBe('node-1');
+		});
+
+		it('validates endNodeId against effective nodes when updating nodes and endNodeId together', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+			});
+
+			// endNodeId 'node-2' references a node in the NEW nodes list
+			const updated = manager.updateWorkflow(created.id, {
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+				endNodeId: 'node-2',
+			});
+			expect(updated?.endNodeId).toBe('node-2');
+		});
+
+		it('rejects endNodeId referencing old node when nodes are replaced', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-old', name: 'Old Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+			});
+
+			expect(() =>
+				manager.updateWorkflow(created.id, {
+					nodes: [
+						{ id: 'node-new', name: 'New Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					],
+					endNodeId: 'node-old',
+				})
+			).toThrow('endNodeId "node-old" does not match any node in this workflow');
+		});
+
+		it('rejects empty string endNodeId on update', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+			});
+
+			expect(() => manager.updateWorkflow(created.id, { endNodeId: '  ' })).toThrow(
+				'endNodeId must be a non-empty string or null'
+			);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/space-node-execution-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-node-execution-handlers.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for Space Node Execution RPC Handlers
+ *
+ * Covers:
+ * - nodeExecution.list: throws if workflowRunId missing; returns executions list;
+ *   ownership check (spaceId filter)
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { NodeExecution } from '@neokai/shared';
+import { setupNodeExecutionHandlers } from '../../../src/lib/rpc-handlers/space-node-execution-handlers.ts';
+import type { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
+import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockExecutions: NodeExecution[] = [
+	{
+		id: 'exec-1',
+		workflowRunId: 'run-1',
+		workflowNodeId: 'node-1',
+		agentName: 'coder',
+		agentId: 'agent-1',
+		agentSessionId: null,
+		status: 'done',
+		result: null,
+		createdAt: NOW,
+		startedAt: NOW,
+		completedAt: NOW + 5000,
+		updatedAt: NOW + 5000,
+	},
+	{
+		id: 'exec-2',
+		workflowRunId: 'run-1',
+		workflowNodeId: 'node-2',
+		agentName: 'reviewer',
+		agentId: 'agent-2',
+		agentSessionId: null,
+		status: 'in_progress',
+		result: null,
+		createdAt: NOW + 6000,
+		startedAt: NOW + 6000,
+		completedAt: null,
+		updatedAt: NOW + 6000,
+	},
+];
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockNodeExecutionRepo(executions: NodeExecution[] = []): NodeExecutionRepository {
+	return {
+		listByWorkflowRun: mock((workflowRunId: string) =>
+			executions.filter((e) => e.workflowRunId === workflowRunId)
+		),
+	} as unknown as NodeExecutionRepository;
+}
+
+function createMockWorkflowRunRepo(
+	runs: Record<string, { spaceId: string }> = {}
+): SpaceWorkflowRunRepository {
+	return {
+		getRun: mock((id: string) => {
+			const run = runs[id];
+			return run ? ({ spaceId: run.spaceId } as any) : null;
+		}),
+	} as unknown as SpaceWorkflowRunRepository;
+}
+
+// ─── Test Suite ───────────────────────────────────────────────────────────────
+
+describe('space-node-execution-handlers', () => {
+	let handlers: Map<string, RequestHandler>;
+
+	function setup(
+		opts: { executions?: NodeExecution[]; runs?: Record<string, { spaceId: string }> } = {}
+	) {
+		const { hub, handlers: h } = createMockMessageHub();
+		handlers = h;
+		const nodeExecRepo = createMockNodeExecutionRepo(opts.executions ?? mockExecutions);
+		const runRepo = createMockWorkflowRunRepo(opts.runs ?? { 'run-1': { spaceId: 'space-1' } });
+		setupNodeExecutionHandlers(hub, nodeExecRepo, runRepo);
+	}
+
+	const call = (method: string, data: unknown) => {
+		const handler = handlers.get(method);
+		if (!handler) throw new Error(`No handler registered for ${method}`);
+		return handler(data);
+	};
+
+	describe('nodeExecution.list', () => {
+		it('throws if workflowRunId is missing', async () => {
+			setup();
+			await expect(call('nodeExecution.list', {})).rejects.toThrow('workflowRunId is required');
+		});
+
+		it('returns empty array when no executions exist for the run', async () => {
+			setup({ executions: [] });
+			const result = (await call('nodeExecution.list', {
+				workflowRunId: 'run-nonexistent',
+			})) as { executions: NodeExecution[] };
+
+			expect(result.executions).toEqual([]);
+		});
+
+		it('returns executions filtered by workflowRunId', async () => {
+			setup();
+			const result = (await call('nodeExecution.list', {
+				workflowRunId: 'run-1',
+			})) as { executions: NodeExecution[] };
+
+			expect(result.executions).toHaveLength(2);
+			expect(result.executions[0].id).toBe('exec-1');
+			expect(result.executions[1].id).toBe('exec-2');
+		});
+
+		it('returns only executions matching the given workflowRunId', async () => {
+			const mixedExecutions: NodeExecution[] = [
+				...mockExecutions,
+				{
+					...mockExecutions[0],
+					id: 'exec-3',
+					workflowRunId: 'run-2',
+				},
+			];
+			setup({ executions: mixedExecutions });
+
+			const result = (await call('nodeExecution.list', {
+				workflowRunId: 'run-1',
+			})) as { executions: NodeExecution[] };
+
+			expect(result.executions).toHaveLength(2);
+			expect(result.executions.every((e) => e.workflowRunId === 'run-1')).toBe(true);
+		});
+
+		it('passes through when spaceId is not provided (no ownership check)', async () => {
+			setup();
+			// No spaceId — should return results without ownership check
+			const result = (await call('nodeExecution.list', {
+				workflowRunId: 'run-1',
+			})) as { executions: NodeExecution[] };
+
+			expect(result.executions).toHaveLength(2);
+		});
+
+		it('succeeds when spaceId matches the run spaceId', async () => {
+			setup({ runs: { 'run-1': { spaceId: 'space-1' } } });
+			const result = (await call('nodeExecution.list', {
+				workflowRunId: 'run-1',
+				spaceId: 'space-1',
+			})) as { executions: NodeExecution[] };
+
+			expect(result.executions).toHaveLength(2);
+		});
+
+		it('throws when spaceId does not match the run spaceId (ownership check)', async () => {
+			setup({ runs: { 'run-1': { spaceId: 'space-1' } } });
+			await expect(
+				call('nodeExecution.list', {
+					workflowRunId: 'run-1',
+					spaceId: 'space-other',
+				})
+			).rejects.toThrow('WorkflowRun not found: run-1');
+		});
+
+		it('throws when spaceId is provided but run not found', async () => {
+			setup({ runs: {} });
+			await expect(
+				call('nodeExecution.list', {
+					workflowRunId: 'run-missing',
+					spaceId: 'space-1',
+				})
+			).rejects.toThrow('WorkflowRun not found: run-missing');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/space-node-execution-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-node-execution-handlers.test.ts
@@ -2,8 +2,8 @@
  * Tests for Space Node Execution RPC Handlers
  *
  * Covers:
- * - nodeExecution.list: throws if workflowRunId missing; returns executions list;
- *   ownership check (spaceId filter)
+ * - nodeExecution.list: throws if workflowRunId/spaceId missing; returns executions list;
+ *   ownership check (spaceId enforcement)
  */
 
 import { describe, expect, it, mock } from 'bun:test';
@@ -123,13 +123,26 @@ describe('space-node-execution-handlers', () => {
 	describe('nodeExecution.list', () => {
 		it('throws if workflowRunId is missing', async () => {
 			setup();
-			await expect(call('nodeExecution.list', {})).rejects.toThrow('workflowRunId is required');
+			await expect(call('nodeExecution.list', { spaceId: 'space-1' })).rejects.toThrow(
+				'workflowRunId is required'
+			);
+		});
+
+		it('throws if spaceId is missing', async () => {
+			setup();
+			await expect(call('nodeExecution.list', { workflowRunId: 'run-1' })).rejects.toThrow(
+				'spaceId is required'
+			);
 		});
 
 		it('returns empty array when no executions exist for the run', async () => {
-			setup({ executions: [] });
+			setup({
+				executions: [],
+				runs: { 'run-1': { spaceId: 'space-1' } },
+			});
 			const result = (await call('nodeExecution.list', {
-				workflowRunId: 'run-nonexistent',
+				workflowRunId: 'run-1',
+				spaceId: 'space-1',
 			})) as { executions: NodeExecution[] };
 
 			expect(result.executions).toEqual([]);
@@ -139,6 +152,7 @@ describe('space-node-execution-handlers', () => {
 			setup();
 			const result = (await call('nodeExecution.list', {
 				workflowRunId: 'run-1',
+				spaceId: 'space-1',
 			})) as { executions: NodeExecution[] };
 
 			expect(result.executions).toHaveLength(2);
@@ -159,20 +173,11 @@ describe('space-node-execution-handlers', () => {
 
 			const result = (await call('nodeExecution.list', {
 				workflowRunId: 'run-1',
+				spaceId: 'space-1',
 			})) as { executions: NodeExecution[] };
 
 			expect(result.executions).toHaveLength(2);
 			expect(result.executions.every((e) => e.workflowRunId === 'run-1')).toBe(true);
-		});
-
-		it('passes through when spaceId is not provided (no ownership check)', async () => {
-			setup();
-			// No spaceId — should return results without ownership check
-			const result = (await call('nodeExecution.list', {
-				workflowRunId: 'run-1',
-			})) as { executions: NodeExecution[] };
-
-			expect(result.executions).toHaveLength(2);
 		});
 
 		it('succeeds when spaceId matches the run spaceId', async () => {
@@ -195,7 +200,7 @@ describe('space-node-execution-handlers', () => {
 			).rejects.toThrow('WorkflowRun not found: run-1');
 		});
 
-		it('throws when spaceId is provided but run not found', async () => {
+		it('throws when run not found', async () => {
 			setup({ runs: {} });
 			await expect(
 				call('nodeExecution.list', {

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
@@ -52,11 +52,10 @@ const mockWorkflow: SpaceWorkflow = {
 		{
 			id: 'step-1',
 			name: 'Code',
-			agentId: 'agent-uuid-1',
-			order: 0,
+			agents: [{ agentId: 'agent-uuid-1', name: 'coder' }],
 		},
 	],
-	rules: [],
+	startNodeId: 'step-1',
 	tags: [],
 	createdAt: NOW,
 	updatedAt: NOW,

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -50,10 +50,8 @@ const mockWorkflow: SpaceWorkflow = {
 	id: 'workflow-1',
 	spaceId: 'space-1',
 	name: 'Test Workflow',
-	nodes: [{ id: 'step-1', name: 'Step One', agentId: 'agent-1' }],
-	transitions: [],
+	nodes: [{ id: 'step-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] }],
 	startNodeId: 'step-1',
-	rules: [],
 	tags: [],
 	createdAt: NOW,
 	updatedAt: NOW,
@@ -347,8 +345,7 @@ describe('space-workflow-run-handlers', () => {
 				'space-1',
 				'workflow-1',
 				'My Run',
-				'Some context',
-				undefined
+				'Some context'
 			);
 			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflowRun.created', {
 				sessionId: 'global',
@@ -364,7 +361,6 @@ describe('space-workflow-run-handlers', () => {
 				'space-1',
 				'workflow-1',
 				'Auto',
-				undefined,
 				undefined
 			);
 		});
@@ -379,12 +375,11 @@ describe('space-workflow-run-handlers', () => {
 				'space-1',
 				'workflow-1',
 				'Explicit WF',
-				undefined,
 				undefined
 			);
 		});
 
-		it('passes goalId through to startWorkflowRun', async () => {
+		it('does not pass goalId to startWorkflowRun (removed)', async () => {
 			await call('spaceWorkflowRun.start', {
 				spaceId: 'space-1',
 				title: 'Goal Run',
@@ -394,8 +389,7 @@ describe('space-workflow-run-handlers', () => {
 				'space-1',
 				'workflow-1',
 				'Goal Run',
-				undefined,
-				'goal-rpc-123'
+				undefined
 			);
 		});
 	});

--- a/packages/daemon/tests/unit/space/provision-global-agent-mcp.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent-mcp.test.ts
@@ -24,6 +24,7 @@ import { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtim
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -126,6 +127,7 @@ function buildDeps(
 	const stub = opts.stub ?? makeSessionStub();
 
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const nodeExecutionRepo = new NodeExecutionRepository(db);
 	const taskRepo = new SpaceTaskRepository(db);
 	const agentRepo = new SpaceAgentRepository(db);
 	const agentManager = new SpaceAgentManager(agentRepo);
@@ -158,6 +160,7 @@ function buildDeps(
 		sessionFactory: makeSessionFactory(),
 		taskRepo,
 		workflowRunRepo,
+		nodeExecutionRepo,
 		db,
 		state,
 		appMcpManager: appMcpManager as never,

--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -26,6 +26,7 @@ import { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtim
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -209,6 +210,7 @@ function buildDeps(
 	spyService: SpySpaceRuntimeService;
 } {
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const nodeExecutionRepo = new NodeExecutionRepository(db);
 	const taskRepo = new SpaceTaskRepository(db);
 	const agentRepo = new SpaceAgentRepository(db);
 	const agentManager = new SpaceAgentManager(agentRepo);
@@ -249,6 +251,7 @@ function buildDeps(
 		sessionFactory,
 		taskRepo,
 		workflowRunRepo,
+		nodeExecutionRepo,
 		db,
 		state,
 		spyService,
@@ -277,6 +280,7 @@ function makeMinimalToolConfig(db: BunDatabase): GlobalSpacesToolsConfig {
 		} as unknown as ISpaceWorkflowManager,
 		taskRepo: new SpaceTaskRepository(db),
 		workflowRunRepo: new SpaceWorkflowRunRepository(db),
+		nodeExecutionRepo: new NodeExecutionRepository(db),
 		db,
 	};
 }

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -4,7 +4,7 @@
  * Covers (per M7 spec tools):
  * - list_workflows: returns space workflows
  * - start_workflow_run: explicit workflowId required; creates run + tasks
- * - get_workflow_run: returns run status, current step, and tasks
+ * - get_workflow_run: returns run status, current step, and node executions
  * - change_plan: description update; workflow switch (cancel + restart)
  * - list_tasks: filter by status, workflowRunId
  */

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -17,6 +17,7 @@ import { runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -99,6 +100,7 @@ interface TestCtx {
 	taskManager: SpaceTaskManager;
 	agentManager: SpaceAgentManager;
 	runtime: SpaceRuntime;
+	nodeExecutionRepo: NodeExecutionRepository;
 }
 
 function makeCtx(): TestCtx {
@@ -118,6 +120,7 @@ function makeCtx(): TestCtx {
 	const workflowManager = new SpaceWorkflowManager(workflowRepo);
 
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const nodeExecutionRepo = new NodeExecutionRepository(db);
 	const taskRepo = new SpaceTaskRepository(db);
 	const spaceManager = new SpaceManager(db);
 
@@ -143,6 +146,7 @@ function makeCtx(): TestCtx {
 		taskManager,
 		agentManager,
 		runtime,
+		nodeExecutionRepo,
 	};
 }
 
@@ -155,6 +159,7 @@ function makeHandlers(ctx: TestCtx) {
 		workflowRunRepo: ctx.workflowRunRepo,
 		taskManager: ctx.taskManager,
 		spaceAgentManager: ctx.agentManager,
+		nodeExecutionRepo: ctx.nodeExecutionRepo,
 	});
 }
 
@@ -257,7 +262,7 @@ describe('createSpaceAgentToolHandlers — get_workflow_run', () => {
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('returns run with tasks', async () => {
+	test('returns run with executions', async () => {
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Get WF');
 
 		const startResult = await makeHandlers(ctx).start_workflow_run({
@@ -272,7 +277,7 @@ describe('createSpaceAgentToolHandlers — get_workflow_run', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.run.id).toBe(runId);
 		expect(parsed.run.status).toBe('in_progress');
-		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.executions).toHaveLength(0);
 	});
 
 	test('returns error when run not found', async () => {
@@ -293,7 +298,7 @@ describe('createSpaceAgentToolHandlers — get_workflow_run', () => {
 		const result = await makeHandlers(ctx).get_workflow_run({ run_id: rawRun.id });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
-		expect(parsed.tasks).toHaveLength(0);
+		expect(parsed.executions).toHaveLength(0);
 	});
 });
 

--- a/packages/daemon/tests/unit/storage/node-execution-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/node-execution-repository.test.ts
@@ -74,6 +74,38 @@ describe('NodeExecutionRepository', () => {
 		});
 	}
 
+	// Helper to create a node execution with an explicit created_at timestamp
+	function createExecutionWithTimestamp(
+		overrides: Partial<import('@neokai/shared').CreateNodeExecutionParams> & { createdAt: number }
+	) {
+		const { createdAt, ...rest } = overrides;
+		const id = crypto.randomUUID();
+		const now = Date.now();
+		(db as any)
+			.prepare(
+				`INSERT INTO node_executions
+				    (id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				     agent_session_id, status, result, created_at, started_at,
+				     completed_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				workflowRunId,
+				'node-1',
+				rest.agentName ?? 'coder',
+				agentId,
+				null,
+				'pending',
+				null,
+				createdAt,
+				null,
+				null,
+				now
+			);
+		return repo.getById(id)!;
+	}
+
 	describe('create', () => {
 		it('creates a node execution with required fields', () => {
 			const exec = createExecution();
@@ -177,11 +209,13 @@ describe('NodeExecutionRepository', () => {
 
 		it('orders by created_at ASC', () => {
 			const e1 = createExecution({ agentName: 'first' });
-			const e2 = createExecution({ agentName: 'second' });
-			const e3 = createExecution({ agentName: 'third' });
+			// Advance time to ensure distinct created_at values across inserts
+			const base = Date.now();
+			const e2 = createExecutionWithTimestamp({ agentName: 'second', createdAt: base + 1 });
+			const e3 = createExecutionWithTimestamp({ agentName: 'third', createdAt: base + 2 });
 
 			const executions = repo.listByWorkflowRun(workflowRunId);
-			expect(executions.map((e) => e.id)).toEqual([e1.id, e2.id, e3.id]);
+			expect(executions.map((e) => e.agentName)).toEqual(['first', 'second', 'third']);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add `validateEndNodeId()` to `SpaceWorkflowManager` for end node ID validation on create/update
- Remove deprecated `goalId` param from `spaceWorkflowRun.start` RPC handler
- Add `nodeExecution.list` RPC handler for querying node executions by workflow run
- Add `nodeExecutions.byRun` LiveQuery for reactive frontend subscriptions
- Wire `NodeExecutionRepository` through `SpaceRuntimeService`, `provision-global-agent`, and MCP tools
- Switch `get_workflow_run` tools to return `executions` instead of `tasks`
- Update status enums: `needs_attention` -> `blocked`, `completed` -> `done`
- Remove deprecated `task_type` and `assigned_agent` zod params from standalone task tools
- Fix ORDER BY in `nodeExecutionRepo.listByWorkflowRun` for stable ordering

## Test plan
- [x] All existing unit tests pass (2078 tests across 55 files)
- [x] TypeScript type checking passes
- [x] Oxlint, Biome format, Knip all pass
- [x] Updated test fixtures for `SpaceWorkflow` type changes (agents array, removed transitions/rules)
- [x] Updated test assertions for goalId removal (4 args instead of 5)
- [x] Updated test configs for `nodeExecutionRepo` in provision-global-agent tests