### PR TITLE
feat: implement db-query MCP server with scoped read-only SQL access

### DIFF
--- a/packages/daemon/src/lib/db-query/sql-validator.ts
+++ b/packages/daemon/src/lib/db-query/sql-validator.ts
@@ -397,6 +397,26 @@ export function validateSql(sql: string): SqlValidationResult {
 		};
 	}
 
+	// Reject double-quoted identifiers ("table") and backtick-quoted identifiers
+	// (`table`). These bypass table-ref extraction and scope filtering.
+	if (withoutStrings.includes('"') || withoutStrings.includes('`')) {
+		return {
+			valid: false,
+			error: 'Quoted identifiers (double-quoted or backtick) are not allowed',
+			tableRefs: [],
+		};
+	}
+
+	// Reject OFFSET — the subquery wrapper strips LIMIT and would silently
+	// drop OFFSET, breaking pagination without any indication to the caller.
+	if (/\bOFFSET\b/i.test(withoutStrings)) {
+		return {
+			valid: false,
+			error: 'OFFSET is not supported (use LIMIT only)',
+			tableRefs: [],
+		};
+	}
+
 	// Normalize whitespace
 	const cleaned = normalizeWhitespace(withoutStrings);
 

--- a/packages/daemon/src/lib/db-query/sql-validator.ts
+++ b/packages/daemon/src/lib/db-query/sql-validator.ts
@@ -359,22 +359,31 @@ function extractTableRefs(sql: string, exclude: Set<string>): string[] {
 // ============ Public API ============
 
 /**
- * Check whether the SQL contains a UNION or UNION ALL keyword at the top level
- * (depth 0, outside parentheses). This allows UNION ALL inside CTE bodies
- * (e.g. WITH RECURSIVE) while rejecting top-level UNION queries.
+ * Check whether the SQL contains a top-level set operator
+ * (UNION, INTERSECT, or EXCEPT) at depth 0 (outside parentheses).
+ * This allows UNION ALL inside CTE bodies (e.g. WITH RECURSIVE)
+ * while rejecting top-level compound queries.
+ *
+ * Precondition: `sql` must have string literal contents stripped
+ * (via `stripStringContents`) so that parentheses inside strings don't
+ * affect depth tracking.
  */
-function hasTopLevelUnion(sql: string): boolean {
+function hasTopLevelSetOperator(sql: string): boolean {
 	const upper = sql.toUpperCase();
+	const setOperators = ['UNION', 'INTERSECT', 'EXCEPT'];
 	let depth = 0;
 	for (let i = 0; i < sql.length; i++) {
 		if (sql[i] === '(') depth++;
 		else if (sql[i] === ')') depth--;
-		else if (depth === 0 && upper.slice(i, i + 5) === 'UNION') {
-			// Check word boundary before and after
-			const beforeOk = i === 0 || /\s/.test(sql[i - 1]);
-			const afterChar = i + 5 < sql.length ? sql[i + 5] : ' ';
-			const afterOk = /\s/.test(afterChar) || afterChar === '(';
-			if (beforeOk && afterOk) return true;
+		else if (depth === 0) {
+			for (const op of setOperators) {
+				if (upper.slice(i, i + op.length) === op) {
+					const beforeOk = i === 0 || /\s/.test(sql[i - 1]);
+					const afterChar = i + op.length < sql.length ? sql[i + op.length] : ' ';
+					const afterOk = /\s/.test(afterChar);
+					if (beforeOk && afterOk) return true;
+				}
+			}
 		}
 	}
 	return false;
@@ -443,10 +452,11 @@ export function validateSql(sql: string): SqlValidationResult {
 	// WITH RECURSIVE uses UNION ALL inside CTE bodies, which is fine.
 	// Top-level UNION is incompatible with the scope-wrapping subquery because
 	// each arm gets rewritten to SELECT * with different column counts.
-	if (hasTopLevelUnion(withoutStrings)) {
+	if (hasTopLevelSetOperator(withoutStrings)) {
 		return {
 			valid: false,
-			error: 'UNION queries are not supported (use CTEs or subqueries instead)',
+			error:
+				'Compound queries (UNION, INTERSECT, EXCEPT) are not supported (use CTEs or subqueries instead)',
 			tableRefs: [],
 		};
 	}

--- a/packages/daemon/src/lib/db-query/sql-validator.ts
+++ b/packages/daemon/src/lib/db-query/sql-validator.ts
@@ -359,6 +359,28 @@ function extractTableRefs(sql: string, exclude: Set<string>): string[] {
 // ============ Public API ============
 
 /**
+ * Check whether the SQL contains a UNION or UNION ALL keyword at the top level
+ * (depth 0, outside parentheses). This allows UNION ALL inside CTE bodies
+ * (e.g. WITH RECURSIVE) while rejecting top-level UNION queries.
+ */
+function hasTopLevelUnion(sql: string): boolean {
+	const upper = sql.toUpperCase();
+	let depth = 0;
+	for (let i = 0; i < sql.length; i++) {
+		if (sql[i] === '(') depth++;
+		else if (sql[i] === ')') depth--;
+		else if (depth === 0 && upper.slice(i, i + 5) === 'UNION') {
+			// Check word boundary before and after
+			const beforeOk = i === 0 || /\s/.test(sql[i - 1]);
+			const afterChar = i + 5 < sql.length ? sql[i + 5] : ' ';
+			const afterOk = /\s/.test(afterChar) || afterChar === '(';
+			if (beforeOk && afterOk) return true;
+		}
+	}
+	return false;
+}
+
+/**
  * Validate a SQL statement for use with the db-query MCP server.
  *
  * Checks:
@@ -413,6 +435,18 @@ export function validateSql(sql: string): SqlValidationResult {
 		return {
 			valid: false,
 			error: 'OFFSET is not supported (use LIMIT only)',
+			tableRefs: [],
+		};
+	}
+
+	// Reject UNION at the top level only (not inside parentheses/CTE bodies).
+	// WITH RECURSIVE uses UNION ALL inside CTE bodies, which is fine.
+	// Top-level UNION is incompatible with the scope-wrapping subquery because
+	// each arm gets rewritten to SELECT * with different column counts.
+	if (hasTopLevelUnion(withoutStrings)) {
+		return {
+			valid: false,
+			error: 'UNION queries are not supported (use CTEs or subqueries instead)',
 			tableRefs: [],
 		};
 	}

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -100,19 +100,25 @@ function findTopLevelKeyword(sql: string, keyword: string): number {
 
 /**
  * Rewrite ALL SELECT column lists to `*` so that all columns
-/**
- * Rewrite ALL SELECT column lists to `*` so that all columns
  * (including scope columns needed by the outer filter) are available.
  * This handles both the main SELECT and SELECTs inside CTE bodies,
- * subqueries, and nested parentheses.
+ * subqueries, and nested parentheses. Preserves DISTINCT when present.
  *
  * Strategy: collect all (selectPos, fromPos) pairs in a single forward pass
  * (at any depth, respecting string literals), then replace from right to
- * left to preserve string positions.
+ * left to preserve string positions. The outer loop walks left-to-right, so
+ * pairs are in ascending order by selectStart — this invariant is required
+ * for the right-to-left replacement to be correct.
  */
 function rewriteSelectToStar(sql: string): string {
-	// Collect all SELECT→FROM pairs at any depth (except inside string literals)
-	const pairs: Array<{ selectStart: number; selectEnd: number; fromStart: number }> = [];
+	// Collect all SELECT→FROM pairs at any depth (except inside string literals).
+	// Each pair records selectStart (position of S in SELECT), fromStart
+	// (position of F in FROM), and whether DISTINCT follows SELECT.
+	const pairs: Array<{
+		selectStart: number;
+		fromStart: number;
+		hasDistinct: boolean;
+	}> = [];
 	const upper = sql.toUpperCase();
 	let depth = 0;
 	let inString = false;
@@ -154,6 +160,10 @@ function rewriteSelectToStar(sql: string): string {
 				const selectEnd = i + 6;
 				const targetDepth = depth;
 
+				// Check for DISTINCT keyword immediately after SELECT
+				const afterSelect = sql.slice(selectEnd).trimStart();
+				const hasDistinct = /^DISTINCT\b/i.test(afterSelect);
+
 				// Find matching FROM at the same depth as this SELECT
 				let fDepth = depth;
 				let fInString = false;
@@ -185,7 +195,7 @@ function rewriteSelectToStar(sql: string): string {
 					}
 				}
 				if (fromStart !== -1) {
-					pairs.push({ selectStart: i, selectEnd, fromStart });
+					pairs.push({ selectStart: i, fromStart, hasDistinct });
 				}
 			}
 		}
@@ -193,11 +203,14 @@ function rewriteSelectToStar(sql: string): string {
 
 	if (pairs.length === 0) return sql;
 
-	// Replace from right to left to preserve positions
+	// Replace from right to left to preserve positions. Pairs are in ascending
+	// order by selectStart (outer loop walks left-to-right), so processing
+	// right-to-left ensures earlier positions remain valid after each replacement.
 	let result = sql;
 	for (let p = pairs.length - 1; p >= 0; p--) {
-		const { selectStart, fromStart } = pairs[p];
-		result = `${result.slice(0, selectStart)}SELECT * ${result.slice(fromStart)}`;
+		const { selectStart, fromStart, hasDistinct } = pairs[p];
+		const replacement = hasDistinct ? 'SELECT DISTINCT * ' : 'SELECT * ';
+		result = `${result.slice(0, selectStart)}${replacement}${result.slice(fromStart)}`;
 	}
 
 	return result;
@@ -286,7 +299,8 @@ function rewriteScopedQuery(
 	// No scope filters needed (global scope or all tables unscoped)
 	if (scopeFilterSet.size === 0) {
 		const { sql: strippedSql, userLimit: existingLimit } = stripLimit(sql);
-		const effectiveLimit = Math.min(existingLimit ?? DEFAULT_LIMIT, MAX_LIMIT);
+		// Use the stricter of the arg-level limit and the SQL-embedded limit
+		const effectiveLimit = Math.min(cappedLimit, Math.min(existingLimit ?? MAX_LIMIT, MAX_LIMIT));
 		return {
 			sql: `${strippedSql} LIMIT ${effectiveLimit}`,
 			params: userParams,

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -339,18 +339,43 @@ function rewriteSelectToStar(sql: string, options?: { skipOutermost?: boolean })
 		}
 	}
 
+	// Post-processing: skip SELECTs inside column-list subqueries.
+	// A SELECT at depth D is a column-list subquery when its position falls
+	// between another SELECT's selectStart and fromStart at a shallower depth.
+	// Rewriting these would change scalar subqueries to potentially return
+	// multiple columns, breaking the query.
+	const nonSubqueryPairs = pairs.filter((pair) => {
+		for (const other of pairs) {
+			if (other === pair) continue;
+			if (
+				other.depth < pair.depth &&
+				pair.selectStart > other.selectStart &&
+				pair.selectStart < other.fromStart
+			) {
+				return false;
+			}
+		}
+		return true;
+	});
+
 	// Filter out outermost SELECTs when skipOutermost is true (for aggregate/DISTINCT queries)
-	const activePairs = skipOutermost ? pairs.filter((p) => p.depth > 0) : pairs;
+	const activePairs = skipOutermost
+		? nonSubqueryPairs.filter((p) => p.depth > 0)
+		: nonSubqueryPairs;
 	if (activePairs.length === 0) return sql;
 
 	// Replace from right to left to preserve positions. Active pairs are in ascending
 	// order by selectStart (outer loop walks left-to-right), so processing
 	// right-to-left ensures earlier positions remain valid after each replacement.
 	let result = sql;
+	let shift = 0;
 	for (let p = activePairs.length - 1; p >= 0; p--) {
 		const { selectStart, fromStart, hasDistinct } = activePairs[p];
+		const adjFrom = fromStart + shift;
+		const oldLen = adjFrom - selectStart;
 		const replacement = hasDistinct ? 'SELECT DISTINCT * ' : 'SELECT * ';
-		result = `${result.slice(0, selectStart)}${replacement}${result.slice(fromStart)}`;
+		result = `${result.slice(0, selectStart)}${replacement}${result.slice(adjFrom)}`;
+		shift += replacement.length - oldLen;
 	}
 
 	return result;
@@ -409,14 +434,26 @@ function isAggregateOrDistinctQuery(sql: string): boolean {
 		if (/^DISTINCT\b/i.test(afterSelect)) return true;
 	}
 
-	// Check for aggregate functions in the outermost SELECT's column list
-	// (between the top-level SELECT and the top-level FROM)
+	// Find the top-level FROM position (used for subquery and aggregate detection)
 	const fromPos = findTopLevelKeyword(sql, 'FROM');
+
+	// Check for subqueries in the column list. These cannot be handled
+	// by the subquery wrapper (rewriteSelectToStar would destroy them),
+	// so they must go through the direct WHERE injection path.
+	if (selectPos !== -1 && fromPos !== -1) {
+		const columnList = sql.slice(selectPos + 6, fromPos);
+		if (/\(\s*SELECT\b/i.test(columnList)) return true;
+	}
+
+	// Check for aggregate functions in the outermost SELECT's column list
+	// (between the top-level SELECT and the top-level FROM), skipping any
+	// parenthesized subqueries to avoid false positives from correlated
+	// subqueries like: SELECT (SELECT COUNT(*) FROM t) AS cnt FROM ...
 	if (selectPos === -1 || fromPos === -1 || fromPos <= selectPos) return false;
 
-	const columnList = sql.slice(selectPos + 6, fromPos).toUpperCase();
+	const aggColumnList = sql.slice(selectPos + 6, fromPos).toUpperCase();
 	const aggFunctions = ['COUNT(', 'SUM(', 'AVG(', 'MIN(', 'MAX(', 'GROUP_CONCAT(', 'TOTAL('];
-	return aggFunctions.some((fn) => columnList.includes(fn));
+	return aggFunctions.some((fn) => aggColumnList.includes(fn));
 }
 
 /**
@@ -553,6 +590,7 @@ function rewriteScopedQuery(
 
 	// Aggregate/DISTINCT queries: inject scope filter directly into the query.
 	// Rewriting SELECT to * would destroy aggregate/DISTINCT semantics.
+	// ORDER BY is preserved naturally — injectWhereClause inserts before it.
 	if (isAggregateOrDistinctQuery(strippedSql)) {
 		// Rewrite inner SELECTs (CTE bodies, subqueries) to * so scope columns
 		// flow through, but skip the outermost SELECT which contains the aggregate.

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -235,7 +235,7 @@ function getCteColumnListRanges(sql: string): Array<[number, number]> {
  * pairs are in ascending order by selectStart — this invariant is required
  * for the right-to-left replacement to be correct.
  */
-function rewriteSelectToStar(sql: string): string {
+function rewriteSelectToStar(sql: string, options?: { skipOutermost?: boolean }): string {
 	// Pre-compute ranges of CTE bodies that have explicit column lists.
 	// SELECTs inside these ranges must not be rewritten because the column
 	// count must match the declared CTE columns.
@@ -245,10 +245,13 @@ function rewriteSelectToStar(sql: string): string {
 	// and CTE bodies with explicit column lists).
 	// Each pair records selectStart (position of S in SELECT), fromStart
 	// (position of F in FROM), and whether DISTINCT follows SELECT.
+	const { skipOutermost = false } = options ?? {};
+
 	const pairs: Array<{
 		selectStart: number;
 		fromStart: number;
 		hasDistinct: boolean;
+		depth: number;
 	}> = [];
 	const upper = sql.toUpperCase();
 	let depth = 0;
@@ -330,20 +333,22 @@ function rewriteSelectToStar(sql: string): string {
 					}
 				}
 				if (fromStart !== -1 && !isInCteRange(i)) {
-					pairs.push({ selectStart: i, fromStart, hasDistinct });
+					pairs.push({ selectStart: i, fromStart, hasDistinct, depth: targetDepth });
 				}
 			}
 		}
 	}
 
-	if (pairs.length === 0) return sql;
+	// Filter out outermost SELECTs when skipOutermost is true (for aggregate/DISTINCT queries)
+	const activePairs = skipOutermost ? pairs.filter((p) => p.depth > 0) : pairs;
+	if (activePairs.length === 0) return sql;
 
-	// Replace from right to left to preserve positions. Pairs are in ascending
+	// Replace from right to left to preserve positions. Active pairs are in ascending
 	// order by selectStart (outer loop walks left-to-right), so processing
 	// right-to-left ensures earlier positions remain valid after each replacement.
 	let result = sql;
-	for (let p = pairs.length - 1; p >= 0; p--) {
-		const { selectStart, fromStart, hasDistinct } = pairs[p];
+	for (let p = activePairs.length - 1; p >= 0; p--) {
+		const { selectStart, fromStart, hasDistinct } = activePairs[p];
 		const replacement = hasDistinct ? 'SELECT DISTINCT * ' : 'SELECT * ';
 		result = `${result.slice(0, selectStart)}${replacement}${result.slice(fromStart)}`;
 	}
@@ -364,6 +369,97 @@ function stripLimit(sql: string): { sql: string; userLimit?: number } {
 	const userLimit = match ? Number.parseInt(match[1], 10) : undefined;
 
 	return { sql: sql.slice(0, limitPos).trimEnd(), userLimit };
+}
+
+/**
+ * Strip the user's top-level ORDER BY clause from a SQL statement.
+ * Returns the SQL without ORDER BY and the extracted clause (if any).
+ * Only strips ORDER BY at the top level (depth 0), preserving ORDER BY
+ * inside CTE bodies and subqueries.
+ */
+function stripOrderBy(sql: string): { sql: string; orderBy?: string } {
+	const pos = findTopLevelKeyword(sql, 'ORDER BY');
+	if (pos === -1) return { sql };
+
+	const orderBy = sql.slice(pos).trimEnd();
+	return { sql: sql.slice(0, pos).trimEnd(), orderBy };
+}
+
+/**
+ * Detect whether a SQL query is an aggregate or DISTINCT query.
+ * Aggregate queries use GROUP BY, HAVING, or aggregate functions
+ * (COUNT, SUM, AVG, MIN, MAX) in the outermost SELECT's column list.
+ * DISTINCT queries use the DISTINCT keyword in the outermost SELECT.
+ *
+ * These queries cannot use the subquery wrapper approach because
+ * rewriting SELECT columns to * would destroy the aggregate/DISTINCT
+ * semantics. Instead, scope filters are injected directly into the query.
+ */
+function isAggregateOrDistinctQuery(sql: string): boolean {
+	// Check for GROUP BY at top level
+	if (findTopLevelKeyword(sql, 'GROUP BY') !== -1) return true;
+
+	// Check for HAVING at top level
+	if (findTopLevelKeyword(sql, 'HAVING') !== -1) return true;
+
+	// Check for DISTINCT keyword after the top-level SELECT
+	const selectPos = findTopLevelKeyword(sql, 'SELECT');
+	if (selectPos !== -1) {
+		const afterSelect = sql.slice(selectPos + 6).trimStart();
+		if (/^DISTINCT\b/i.test(afterSelect)) return true;
+	}
+
+	// Check for aggregate functions in the outermost SELECT's column list
+	// (between the top-level SELECT and the top-level FROM)
+	const fromPos = findTopLevelKeyword(sql, 'FROM');
+	if (selectPos === -1 || fromPos === -1 || fromPos <= selectPos) return false;
+
+	const columnList = sql.slice(selectPos + 6, fromPos).toUpperCase();
+	const aggFunctions = ['COUNT(', 'SUM(', 'AVG(', 'MIN(', 'MAX(', 'GROUP_CONCAT(', 'TOTAL('];
+	return aggFunctions.some((fn) => columnList.includes(fn));
+}
+
+/**
+ * Find the position of the first top-level clause boundary keyword
+ * (GROUP BY, HAVING, ORDER BY) in the SQL. Returns sql.length if none found.
+ * Used to determine where to insert WHERE clauses.
+ */
+function findTopLevelBoundary(sql: string): number {
+	const keywords = ['GROUP BY', 'HAVING', 'ORDER BY'];
+	let earliest = sql.length;
+
+	for (const kw of keywords) {
+		const pos = findTopLevelKeyword(sql, kw);
+		if (pos !== -1 && pos < earliest) {
+			earliest = pos;
+		}
+	}
+
+	return earliest;
+}
+
+/**
+ * Inject a WHERE clause into a SQL query.
+ * Handles both queries with and without an existing WHERE clause.
+ * The clause is inserted before GROUP BY, HAVING, or ORDER BY (whichever comes first).
+ */
+function injectWhereClause(sql: string, whereClause: string): string {
+	const wherePos = findTopLevelKeyword(sql, 'WHERE');
+
+	if (wherePos !== -1) {
+		// Query has WHERE — append AND before the next boundary keyword
+		const boundary = findTopLevelBoundary(sql);
+		return `${sql.slice(0, boundary)} AND ${whereClause}${sql.slice(boundary)}`;
+	}
+
+	// No WHERE — insert before GROUP BY, HAVING, ORDER BY, or at the end
+	const insertPos = findTopLevelBoundary(sql);
+
+	if (insertPos < sql.length) {
+		return `${sql.slice(0, insertPos)} WHERE ${whereClause} ${sql.slice(insertPos)}`;
+	}
+
+	return `${sql} WHERE ${whereClause}`;
 }
 
 // ============ Scope Filter Builder ============
@@ -402,13 +498,18 @@ function buildPrefixedScopeFilter(
 }
 
 /**
- * Rewrite a validated SELECT query with scope filter injection via subquery wrapping.
+ * Rewrite a validated SELECT query with scope filter injection.
  *
  * Strategy:
  *   - Global scope (no filters): append LIMIT cap to the original SQL.
- *   - Room/Space scope: wrap the user's query as a subquery aliased `_dbq`,
- *     then apply combined scope filters in the outer WHERE clause.
- *     The inner query's SELECT is rewritten to `*` so scope columns are available.
+ *   - Aggregate/DISTINCT queries: inject scope filters directly into the
+ *     query's WHERE clause. Rewriting SELECT to * would destroy aggregate
+ *     or DISTINCT semantics. CTE bodies (without explicit column lists) are
+ *     still rewritten to * so scope columns flow through to the main query.
+ *   - Regular queries in room/space scope: wrap as a subquery aliased `_dbq`,
+ *     then apply combined scope filters in the outer WHERE clause. The inner
+ *     query's SELECT is rewritten to `*` so scope columns are available.
+ *     ORDER BY is moved from the inner query to the outer wrapper.
  */
 function rewriteScopedQuery(
 	sql: string,
@@ -445,21 +546,67 @@ function rewriteScopedQuery(
 		};
 	}
 
-	// Scope-aware wrapping
-	const combinedWhere = [...scopeFilterSet.keys()].join(' AND ');
-	const scopeParams = [...scopeFilterSet.values()].flat();
-
 	// Strip user's LIMIT and honor it alongside the arg-level limit
 	const { sql: strippedSql, userLimit: existingLimit } = stripLimit(sql);
 	const effectiveLimit = Math.min(cappedLimit, existingLimit ?? MAX_LIMIT);
+	const scopeParams = [...scopeFilterSet.values()].flat();
+
+	// Aggregate/DISTINCT queries: inject scope filter directly into the query.
+	// Rewriting SELECT to * would destroy aggregate/DISTINCT semantics.
+	if (isAggregateOrDistinctQuery(strippedSql)) {
+		// Rewrite inner SELECTs (CTE bodies, subqueries) to * so scope columns
+		// flow through, but skip the outermost SELECT which contains the aggregate.
+		const innerRewritten = rewriteSelectToStar(strippedSql, { skipOutermost: true });
+
+		// Build direct scope filters (without _dbq. prefix) using unqualified
+		// column names. Deduplicate identical clauses.
+		const directFilters = new Map<string, unknown[]>();
+		for (const config of tableConfigs.values()) {
+			if (config.scopeColumn) {
+				const clause = `${config.scopeColumn} = ?`;
+				if (!directFilters.has(clause)) {
+					directFilters.set(clause, [scopeValue]);
+				}
+			}
+			if (config.scopeJoin) {
+				const join = config.scopeJoin;
+				const clause = `${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} = ?)`;
+				if (!directFilters.has(clause)) {
+					directFilters.set(clause, [scopeValue]);
+				}
+			}
+		}
+
+		let filteredSql = innerRewritten;
+		const directParams: unknown[] = [];
+		if (directFilters.size > 0) {
+			const combinedClause = [...directFilters.keys()].join(' AND ');
+			filteredSql = injectWhereClause(innerRewritten, combinedClause);
+			directParams.push(...[...directFilters.values()].flat());
+		}
+
+		return {
+			sql: `${filteredSql} LIMIT ${effectiveLimit}`,
+			params: [...userParams, ...directParams],
+			cappedLimit: effectiveLimit,
+		};
+	}
+
+	// Regular queries: subquery wrapping approach
+	const combinedWhere = [...scopeFilterSet.keys()].join(' AND ');
+
+	// Strip ORDER BY from the inner query — SQLite does not guarantee ordering
+	// from subqueries, so ORDER BY must be on the outer wrapper.
+	const { sql: noOrderBy, orderBy } = stripOrderBy(strippedSql);
 
 	// Rewrite all SELECTs (including CTE bodies) to * for the inner query
 	// so scope columns are available. The outer SELECT also uses * because
 	// qualified column names (table.column) and aliases become invalid in
 	// the subquery wrapper context — only _dbq is a valid table reference.
-	const innerSql = rewriteSelectToStar(strippedSql);
+	const innerSql = rewriteSelectToStar(noOrderBy);
 
-	const wrappedSql = `SELECT * FROM (${innerSql}) AS _dbq WHERE ${combinedWhere} LIMIT ${effectiveLimit}`;
+	const orderClause = orderBy ? ` ${orderBy}` : '';
+	const wrappedSql = `SELECT * FROM (${innerSql}) AS _dbq WHERE ${combinedWhere}${orderClause} LIMIT ${effectiveLimit}`;
 
 	return { sql: wrappedSql, params: [...userParams, ...scopeParams], cappedLimit: effectiveLimit };
 }

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -302,7 +302,7 @@ function rewriteScopedQuery(
 	if (scopeFilterSet.size === 0) {
 		const { sql: strippedSql, userLimit: existingLimit } = stripLimit(sql);
 		// Use the stricter of the arg-level limit and the SQL-embedded limit
-		const effectiveLimit = Math.min(cappedLimit, Math.min(existingLimit ?? MAX_LIMIT, MAX_LIMIT));
+		const effectiveLimit = Math.min(cappedLimit, existingLimit ?? MAX_LIMIT);
 		return {
 			sql: `${strippedSql} LIMIT ${effectiveLimit}`,
 			params: userParams,
@@ -467,6 +467,10 @@ export function createDbQueryToolHandlers(config: DbQueryToolsConfig, db: Databa
 			// PRAGMA does not support parameterized bindings, so the table name
 			// is interpolated directly. The table_name has already been validated
 			// against the scope config's accessible table names (alphanumeric + underscore).
+			// Self-contained format guard: table names must be alphanumeric+underscore
+			if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(table_name)) {
+				return errorResult(`Invalid table name: "${table_name}"`);
+			}
 			const columns = db.query(`PRAGMA table_info("${table_name}")`).all() as Array<{
 				cid: number;
 				name: string;

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -1,0 +1,602 @@
+/**
+ * db-query MCP Server — scoped read-only SQL access for agent sessions.
+ *
+ * Provides three tools: db_query, db_list_tables, db_describe_table.
+ * Each instance owns a single read-only SQLite connection created at init
+ * and closed via the returned close() method.
+ *
+ * Scope enforcement is layered:
+ *   1. SQL validation rejects non-SELECT statements (fast feedback)
+ *   2. Table-ref validation rejects queries referencing out-of-scope tables
+ *   3. Subquery wrapping injects WHERE clauses for room/space scopes
+ *   4. Connection-level read-only mode (readonly: true + PRAGMA query_only = ON)
+ *   5. Row limit cap (default 200, max 1000)
+ *   6. Column blacklist removes sensitive columns from results
+ */
+
+import { Database } from 'bun:sqlite';
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import { type DbScopeType, type ScopeTableConfig, getScopeConfig } from './scope-config.ts';
+import { validateSql } from './sql-validator.ts';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface DbQueryToolsConfig {
+	dbPath: string;
+	scopeType: DbScopeType;
+	scopeValue: string;
+}
+
+interface ToolResult {
+	[key: string]: unknown;
+	content: Array<{ type: 'text'; text: string }>;
+}
+
+interface DbQueryMcpServer {
+	type: 'sdk';
+	name: string;
+	version?: string;
+	tools?: unknown[];
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	instance: any;
+	close(): void;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+// ============ SQL Parsing Helpers ============
+
+/**
+ * Find the position of a top-level SQL keyword, respecting parentheses
+ * depth and single-quoted string literals.
+ */
+function findTopLevelKeyword(sql: string, keyword: string): number {
+	const upper = sql.toUpperCase();
+	const kwLen = keyword.length;
+	let depth = 0;
+	let inString = false;
+
+	for (let i = 0; i < sql.length; i++) {
+		const ch = sql[i];
+
+		if (inString) {
+			if (ch === "'" && i + 1 < sql.length && sql[i + 1] === "'") {
+				i++; // skip escaped quote
+				continue;
+			}
+			if (ch === "'") {
+				inString = false;
+			}
+			continue;
+		}
+
+		if (ch === "'") {
+			inString = true;
+			continue;
+		}
+		if (ch === '(') {
+			depth++;
+			continue;
+		}
+		if (ch === ')') {
+			depth--;
+			continue;
+		}
+
+		if (depth === 0 && upper.slice(i, i + kwLen) === keyword) {
+			const beforeOk = i === 0 || /\s/.test(sql[i - 1]);
+			const afterChar = i + kwLen < sql.length ? sql[i + kwLen] : ' ';
+			const afterOk = i + kwLen >= sql.length || /\s/.test(afterChar) || afterChar === '(';
+			if (beforeOk && afterOk) return i;
+		}
+	}
+
+	return -1;
+}
+
+/**
+ * Find the position of the main SELECT keyword (the one after any WITH/CTE block).
+ * Returns the position relative to the start of the input string.
+ */
+function findMainSelectPos(sql: string): number {
+	const trimmed = sql.trimStart();
+	const offset = sql.length - trimmed.length;
+
+	if (!/^[Ww][Ii][Tt][Hh]\b/.test(trimmed)) {
+		// No CTE — main SELECT is at the start (after any leading whitespace)
+		return offset;
+	}
+
+	// Skip past the WITH block
+	let pos = 4; // skip "WITH"
+	const len = trimmed.length;
+
+	while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+	// Skip optional RECURSIVE
+	if (pos + 8 <= len && trimmed.slice(pos, pos + 9).toLowerCase() === 'recursive') {
+		pos += 9;
+		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+	}
+
+	// Skip CTE definitions
+	while (pos < len) {
+		// Skip CTE name
+		while (pos < len && /[\p{L}\p{N}_]/u.test(trimmed[pos])) pos++;
+		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+		// Skip optional column list
+		if (pos < len && trimmed[pos] === '(') {
+			let depth = 1;
+			pos++;
+			while (pos < len && depth > 0) {
+				if (trimmed[pos] === '(') depth++;
+				else if (trimmed[pos] === ')') depth--;
+				pos++;
+			}
+			while (pos < len && /\s/.test(trimmed[pos])) pos++;
+		}
+
+		// Skip AS keyword
+		if (
+			pos + 1 < len &&
+			trimmed[pos].toLowerCase() === 'a' &&
+			trimmed[pos + 1].toLowerCase() === 's'
+		) {
+			pos += 2;
+		} else {
+			break;
+		}
+		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+		// Skip CTE body (parenthesized)
+		if (pos < len && trimmed[pos] === '(') {
+			let depth = 1;
+			pos++;
+			while (pos < len && depth > 0) {
+				if (trimmed[pos] === '(') {
+					depth++;
+					pos++;
+				} else if (trimmed[pos] === ')') {
+					depth--;
+					pos++;
+				} else if (trimmed[pos] === "'") {
+					pos++;
+					while (pos < len) {
+						if (trimmed[pos] === "'" && pos + 1 < len && trimmed[pos + 1] === "'") {
+							pos += 2;
+						} else if (trimmed[pos] === "'") {
+							pos++;
+							break;
+						} else {
+							pos++;
+						}
+					}
+				} else {
+					pos++;
+				}
+			}
+		}
+
+		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+
+		// Comma = more CTEs; anything else = end of WITH block
+		if (pos < len && trimmed[pos] === ',') {
+			pos++;
+			while (pos < len && /\s/.test(trimmed[pos])) pos++;
+		} else {
+			break;
+		}
+	}
+
+	return offset + pos;
+}
+
+/**
+ * Rewrite the main SELECT's column list to `*` so that all columns
+ * (including scope columns) are available in the subquery wrapper.
+ */
+function rewriteSelectToStar(sql: string): string {
+	const mainSelectPos = findMainSelectPos(sql);
+	const remaining = sql.slice(mainSelectPos);
+
+	// Skip "SELECT" keyword and whitespace
+	const selectKwLen = remaining.match(/^[Ss][Ee][Ll][Ee][Cc][Tt]\b/)?.[0].length ?? 6;
+	const afterSelect = remaining.slice(selectKwLen);
+
+	// Find the FROM keyword (top-level only) in the remaining SQL
+	const fromPos = findTopLevelKeyword(afterSelect, 'FROM');
+	if (fromPos === -1) return sql; // no FROM — return as-is
+
+	return `${sql.slice(0, mainSelectPos)}SELECT * ${afterSelect.slice(fromPos)}`;
+}
+
+/**
+ * Strip the user's LIMIT clause from the end of a SQL statement.
+ * Returns the SQL without LIMIT and the user-specified limit value (if any).
+ */
+function stripLimit(sql: string): { sql: string; userLimit?: number } {
+	const limitPos = findTopLevelKeyword(sql, 'LIMIT');
+	if (limitPos === -1) return { sql };
+
+	const afterLimit = sql.slice(limitPos + 5).trim();
+	const match = afterLimit.match(/^(\d+)/);
+	const userLimit = match ? Number.parseInt(match[1], 10) : undefined;
+
+	return { sql: sql.slice(0, limitPos).trimEnd(), userLimit };
+}
+
+// ============ Scope Filter Builder ============
+
+/**
+ * Build a parameterized WHERE clause for a scoped table, using the `_dbq.` prefix
+ * for column references that belong to the outer wrapper table.
+ */
+function buildPrefixedScopeFilter(
+	config: ScopeTableConfig,
+	scopeValue: string
+): { whereClause: string; params: unknown[] } {
+	// No scope column or join — no filter needed (global tables)
+	if (!config.scopeColumn && !config.scopeJoin) {
+		return { whereClause: '', params: [] };
+	}
+
+	// Direct scope filter
+	if (config.scopeColumn) {
+		return {
+			whereClause: `_dbq.${config.scopeColumn} = ?`,
+			params: [scopeValue],
+		};
+	}
+
+	// Indirect scope filter via join table
+	if (config.scopeJoin) {
+		const join = config.scopeJoin;
+		return {
+			whereClause: `_dbq.${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} = ?)`,
+			params: [scopeValue],
+		};
+	}
+
+	return { whereClause: '', params: [] };
+}
+
+/**
+ * Rewrite a validated SELECT query with scope filter injection via subquery wrapping.
+ *
+ * Strategy:
+ *   - Global scope (no filters): append LIMIT cap to the original SQL.
+ *   - Room/Space scope: wrap the user's query as a subquery aliased `_dbq`,
+ *     then apply combined scope filters in the outer WHERE clause.
+ *     The inner query's SELECT is rewritten to `*` so scope columns are available.
+ */
+function rewriteScopedQuery(
+	sql: string,
+	userParams: unknown[],
+	scopeType: DbScopeType,
+	scopeValue: string,
+	tableConfigs: Map<string, ScopeTableConfig>,
+	userLimit?: number
+): { sql: string; params: unknown[] } {
+	const cappedLimit = Math.min(userLimit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+	// Build scope filters for all referenced tables
+	const scopeFilters: Array<{ whereClause: string; params: unknown[] }> = [];
+	for (const config of tableConfigs.values()) {
+		const filter = buildPrefixedScopeFilter(config, scopeValue);
+		if (filter.whereClause) {
+			scopeFilters.push(filter);
+		}
+	}
+
+	// No scope filters needed (global scope or all tables unscoped)
+	if (scopeFilters.length === 0) {
+		const { sql: strippedSql, userLimit: existingLimit } = stripLimit(sql);
+		const effectiveLimit = Math.min(existingLimit ?? DEFAULT_LIMIT, MAX_LIMIT);
+		return { sql: `${strippedSql} LIMIT ${effectiveLimit}`, params: userParams };
+	}
+
+	// Scope-aware wrapping
+	const combinedWhere = scopeFilters.map((f) => f.whereClause).join(' AND ');
+	const scopeParams = scopeFilters.flatMap((f) => f.params);
+
+	// Strip user's LIMIT and rewrite inner SELECT to *
+	const { sql: strippedSql } = stripLimit(sql);
+	const innerSql = rewriteSelectToStar(strippedSql);
+
+	const wrappedSql = `SELECT * FROM (${innerSql}) AS _dbq WHERE ${combinedWhere} LIMIT ${cappedLimit}`;
+
+	return { sql: wrappedSql, params: [...userParams, ...scopeParams] };
+}
+
+/**
+ * Remove blacklisted columns from query result rows.
+ * Collects blacklists from all referenced tables and removes those keys.
+ */
+function removeBlacklistedColumns(
+	rows: Record<string, unknown>[],
+	tableConfigs: Map<string, ScopeTableConfig>
+): Record<string, unknown>[] {
+	// Collect all blacklisted column names across referenced tables
+	const blacklisted = new Set<string>();
+	for (const config of tableConfigs.values()) {
+		for (const col of config.blacklistedColumns) {
+			blacklisted.add(col);
+		}
+	}
+
+	if (blacklisted.size === 0) return rows;
+
+	return rows.map((row) => {
+		const filtered: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(row)) {
+			if (!blacklisted.has(key)) {
+				filtered[key] = value;
+			}
+		}
+		return filtered;
+	});
+}
+
+// ============ JSON helper ============
+
+function jsonResult(data: Record<string, unknown>): ToolResult {
+	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+function errorResult(message: string): ToolResult {
+	return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+// ============ Tool Handlers ============
+
+/**
+ * Create plain handler functions for the three db-query tools.
+ * These can be tested directly without the SDK MCP server wrapper.
+ */
+export function createDbQueryToolHandlers(config: DbQueryToolsConfig, db: Database) {
+	const { scopeType, scopeValue } = config;
+	const scopeConfigs = getScopeConfig(scopeType);
+
+	// Build lookup map for table configs
+	const configMap = new Map<string, ScopeTableConfig>();
+	for (const tc of scopeConfigs) {
+		configMap.set(tc.tableName, tc);
+	}
+
+	return {
+		async db_query(args: { sql: string; params?: unknown[]; limit?: number }): Promise<ToolResult> {
+			const { sql, params = [], limit } = args;
+
+			// Step 1: Validate SQL — reject if not a valid SELECT
+			const validation = validateSql(sql);
+			if (!validation.valid) {
+				return errorResult(validation.error ?? 'Invalid SQL');
+			}
+
+			// Step 2: Check all tableRefs are within the current scope
+			for (const tableRef of validation.tableRefs) {
+				if (!configMap.has(tableRef)) {
+					return errorResult(`Table "${tableRef}" is not accessible in ${scopeType} scope`);
+				}
+			}
+
+			// Step 3: Build per-table scope filter configs
+			const tableConfigs = new Map<string, ScopeTableConfig>();
+			for (const tableRef of validation.tableRefs) {
+				const tc = configMap.get(tableRef);
+				if (tc) tableConfigs.set(tableRef, tc);
+			}
+
+			// Step 4-6: Rewrite query with scope filter wrapping and LIMIT cap
+			const { sql: wrappedSql, params: allParams } = rewriteScopedQuery(
+				sql,
+				params,
+				scopeType,
+				scopeValue,
+				tableConfigs,
+				limit
+			);
+
+			// Step 7: Execute the rewritten query
+			try {
+				const stmt = db.query(wrappedSql);
+				const rows = stmt.all(...(allParams as [])) as Record<string, unknown>[];
+
+				// Step 8: Apply column blacklist
+				const filteredRows = removeBlacklistedColumns(rows, tableConfigs);
+
+				// Step 9: Return result
+				const truncated =
+					rows.length > filteredRows.length ||
+					(limit !== undefined && rows.length >= Math.min(limit, MAX_LIMIT));
+
+				return jsonResult({
+					rows: filteredRows,
+					rowCount: filteredRows.length,
+					truncated,
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return errorResult(`Query execution error: ${message}`);
+			}
+		},
+
+		async db_list_tables(): Promise<ToolResult> {
+			const lines: string[] = ['| Table | Description |', '|-------|-------------|'];
+			for (const tc of scopeConfigs) {
+				const blacklistNote =
+					tc.blacklistedColumns.length > 0
+						? ` (${tc.blacklistedColumns.length} column(s) hidden)`
+						: '';
+				lines.push(`| ${tc.tableName} | ${tc.description}${blacklistNote} |`);
+			}
+			return jsonResult({
+				tables: scopeConfigs.map((tc) => tc.tableName),
+				description: lines.join('\n'),
+			});
+		},
+
+		async db_describe_table(args: { table_name: string }): Promise<ToolResult> {
+			const { table_name } = args;
+
+			// Verify table is in current scope
+			if (!configMap.has(table_name)) {
+				return errorResult(`Table "${table_name}" is not accessible in ${scopeType} scope`);
+			}
+
+			const tableConfig = configMap.get(table_name)!;
+			const blacklisted = new Set(tableConfig.blacklistedColumns);
+
+			// Execute PRAGMA table_info — server-side, not user SQL.
+			// PRAGMA does not support parameterized bindings, so the table name
+			// is interpolated directly. The table_name has already been validated
+			// against the scope config's accessible table names (alphanumeric + underscore).
+			const columns = db.query(`PRAGMA table_info("${table_name}")`).all() as Array<{
+				cid: number;
+				name: string;
+				type: string;
+				notnull: number;
+				dflt_value: unknown;
+				pk: number;
+			}>;
+
+			// Filter out blacklisted columns
+			const visibleColumns = columns.filter((col) => !blacklisted.has(col.name));
+
+			// Execute PRAGMA foreign_key_list
+			const fks = db.query(`PRAGMA foreign_key_list("${table_name}")`).all() as Array<{
+				id: number;
+				seq: number;
+				table: string;
+				from: string;
+				to: string;
+			}>;
+
+			// Format output
+			const parts: string[] = [];
+			parts.push(`## ${table_name}`);
+			parts.push('');
+			parts.push(tableConfig.description);
+			parts.push('');
+
+			if (visibleColumns.length > 0) {
+				parts.push('### Columns');
+				parts.push('');
+				parts.push('| Name | Type | Not Null | Default | PK |');
+				parts.push('|------|------|----------|---------|----|');
+				for (const col of visibleColumns) {
+					const notNull = col.notnull ? 'YES' : 'no';
+					const defaultVal = col.dflt_value !== null ? String(col.dflt_value) : '';
+					const pk = col.pk ? `#${col.pk}` : '';
+					parts.push(`| ${col.name} | ${col.type} | ${notNull} | ${defaultVal} | ${pk} |`);
+				}
+			} else {
+				parts.push('*All columns are hidden by the column blacklist.*');
+			}
+
+			if (blacklisted.size > 0) {
+				parts.push('');
+				parts.push(`**${blacklisted.size} column(s) hidden:** ${[...blacklisted].join(', ')}`);
+			}
+
+			if (fks.length > 0) {
+				parts.push('');
+				parts.push('### Foreign Keys');
+				parts.push('');
+				parts.push('| Column | References |');
+				parts.push('|--------|-----------|');
+				for (const fk of fks) {
+					parts.push(`| ${fk.from} | ${fk.table}.${fk.to} |`);
+				}
+			}
+
+			return jsonResult({ description: parts.join('\n') });
+		},
+	};
+}
+
+// ============ MCP Server Factory ============
+
+/**
+ * Create the db-query MCP server with a dedicated read-only connection.
+ *
+ * The server owns a single SQLite connection that is closed when the
+ * returned close() method is called. This is typically called during
+ * session teardown.
+ *
+ * // TODO: Add query timeout — AbortController-based cancellation or a
+ * // worker thread with sqlite3_interrupt() could handle pathological queries.
+ * // For now, PRAGMA busy_timeout = 5000 handles lock contention only.
+ */
+export function createDbQueryMcpServer(config: DbQueryToolsConfig): DbQueryMcpServer {
+	// Create a dedicated read-only connection
+	const db = new Database(config.dbPath, { readonly: true });
+	db.exec('PRAGMA busy_timeout = 5000');
+	db.exec('PRAGMA query_only = ON');
+
+	const handlers = createDbQueryToolHandlers(config, db);
+
+	const scopeDescription =
+		config.scopeType === 'global'
+			? 'global scope (full read access to all visible tables, no row filtering)'
+			: `${config.scopeType} scope (auto-filters to ${config.scopeType}_id = current entity)`;
+
+	const tools = [
+		tool(
+			'db_query',
+			`Execute a scoped SELECT query against the NeoKai database. ` +
+				`Operating in ${scopeDescription}. ` +
+				`Only SELECT statements are allowed — INSERT/UPDATE/DELETE are rejected. ` +
+				`Results are limited to ${MAX_LIMIT} rows (default ${DEFAULT_LIMIT}). ` +
+				`Sensitive columns are automatically removed from results. ` +
+				`Use db_list_tables to see available tables and db_describe_table for column details.`,
+			{
+				sql: z.string().describe('SELECT SQL statement to execute'),
+				params: z
+					.array(z.unknown())
+					.optional()
+					.describe('Parameterized query parameters (positional ? placeholders)'),
+				limit: z
+					.number()
+					.int()
+					.min(1)
+					.max(MAX_LIMIT)
+					.optional()
+					.describe(`Maximum rows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT})`),
+			},
+			(args) => handlers.db_query(args)
+		),
+		tool(
+			'db_list_tables',
+			`List all tables visible in the current ${config.scopeType} scope with descriptions. ` +
+				`Use this to discover what data you can query with db_query.`,
+			{},
+			() => handlers.db_list_tables()
+		),
+		tool(
+			'db_describe_table',
+			`Show column definitions, types, and foreign keys for a specific table. ` +
+				`Sensitive columns are excluded from the output.`,
+			{
+				table_name: z.string().describe('Name of the table to describe'),
+			},
+			(args) => handlers.db_describe_table(args)
+		),
+	];
+
+	const server = createSdkMcpServer({ name: 'db-query', version: '1.0.0', tools });
+
+	return {
+		...server,
+		close() {
+			db.close();
+		},
+	};
+}
+
+export type { DbQueryMcpServer };

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -367,15 +367,13 @@ function rewriteSelectToStar(sql: string, options?: { skipOutermost?: boolean })
 	// Replace from right to left to preserve positions. Active pairs are in ascending
 	// order by selectStart (outer loop walks left-to-right), so processing
 	// right-to-left ensures earlier positions remain valid after each replacement.
+	// No shift tracking is needed — positions to the LEFT of a replaced range
+	// are unchanged by right-to-left processing.
 	let result = sql;
-	let shift = 0;
 	for (let p = activePairs.length - 1; p >= 0; p--) {
 		const { selectStart, fromStart, hasDistinct } = activePairs[p];
-		const adjFrom = fromStart + shift;
-		const oldLen = adjFrom - selectStart;
 		const replacement = hasDistinct ? 'SELECT DISTINCT * ' : 'SELECT * ';
-		result = `${result.slice(0, selectStart)}${replacement}${result.slice(adjFrom)}`;
-		shift += replacement.length - oldLen;
+		result = `${result.slice(0, selectStart)}${replacement}${result.slice(fromStart)}`;
 	}
 
 	return result;
@@ -446,9 +444,11 @@ function isAggregateOrDistinctQuery(sql: string): boolean {
 	}
 
 	// Check for aggregate functions in the outermost SELECT's column list
-	// (between the top-level SELECT and the top-level FROM), skipping any
-	// parenthesized subqueries to avoid false positives from correlated
-	// subqueries like: SELECT (SELECT COUNT(*) FROM t) AS cnt FROM ...
+	// (between the top-level SELECT and the top-level FROM).
+	// Note: this does NOT skip parenthesized subqueries — the raw column list
+	// text is scanned. False positives from correlated subqueries like
+	// `SELECT (SELECT COUNT(*) FROM t) AS cnt FROM ...` are prevented by the
+	// `/\(\s*SELECT\b/i` guard above, which short-circuits before reaching here.
 	if (selectPos === -1 || fromPos === -1 || fromPos <= selectPos) return false;
 
 	const aggColumnList = sql.slice(selectPos + 6, fromPos).toUpperCase();

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -296,7 +296,9 @@ function rewriteScopedQuery(
 		}
 	}
 
-	// No scope filters needed (global scope or all tables unscoped)
+	// No scope filters needed (global scope, all tables unscoped, or no table refs
+	// e.g. SELECT 1). Table-less queries are safe to pass through — they don't
+	// access any scoped data.
 	if (scopeFilterSet.size === 0) {
 		const { sql: strippedSql, userLimit: existingLimit } = stripLimit(sql);
 		// Use the stricter of the arg-level limit and the SQL-embedded limit

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -99,6 +99,131 @@ function findTopLevelKeyword(sql: string, keyword: string): number {
 }
 
 /**
+ * Find character ranges of CTE bodies that declare explicit column lists.
+ * SELECTs inside these ranges must NOT be rewritten to * because the
+ * column count must match the declared CTE columns.
+ *
+ * Example:
+ *   WITH t(a, b) AS (SELECT x, y FROM ...) SELECT * FROM t
+ *                    ^^^^^^^^^^^^^^^^^^^^^^^  — this range is excluded
+ *
+ * Returns sorted array of [start, end) half-open ranges (start inclusive, end exclusive).
+ */
+function getCteColumnListRanges(sql: string): Array<[number, number]> {
+	const ranges: Array<[number, number]> = [];
+	const upper = sql.toUpperCase();
+	const len = sql.length;
+
+	// Must start with WITH
+	if (!/^\s*WITH\b/i.test(sql)) return ranges;
+
+	let pos = sql.search(/\bWITH\b/i) + 4;
+
+	// Skip whitespace
+	while (pos < len && /\s/.test(sql[pos])) pos++;
+
+	// Skip optional RECURSIVE
+	if (pos + 8 <= len && upper.slice(pos, pos + 9) === 'RECURSIVE') {
+		pos += 9;
+		while (pos < len && /\s/.test(sql[pos])) pos++;
+	}
+
+	while (pos < len) {
+		// Read CTE name (identifier)
+		const nameStart = pos;
+		while (pos < len && /[\p{L}\p{N}_]/u.test(sql[pos])) pos++;
+		if (pos === nameStart) break;
+
+		// Skip whitespace
+		while (pos < len && /\s/.test(sql[pos])) pos++;
+
+		// Check for optional column list: name(c1, c2) AS (body)
+		let hasColumnList = false;
+		if (pos < len && sql[pos] === '(') {
+			const savedPos = pos;
+			let depth = 1;
+			pos++;
+			while (pos < len && depth > 0) {
+				if (sql[pos] === '(') depth++;
+				else if (sql[pos] === ')') depth--;
+				pos++;
+			}
+			// Skip whitespace after closing paren
+			while (pos < len && /\s/.test(sql[pos])) pos++;
+			// If followed by AS, this was a column list
+			if (pos + 1 < len && upper.slice(pos, pos + 2) === 'AS') {
+				hasColumnList = true;
+			} else {
+				// Not a column list — backtrack
+				pos = savedPos;
+			}
+		}
+
+		// Skip whitespace
+		while (pos < len && /\s/.test(sql[pos])) pos++;
+
+		// Expect AS keyword
+		if (pos + 1 < len && upper.slice(pos, pos + 2) === 'AS') {
+			pos += 2;
+		} else {
+			break;
+		}
+
+		// Skip whitespace
+		while (pos < len && /\s/.test(sql[pos])) pos++;
+
+		// Expect ( for CTE body
+		if (pos < len && sql[pos] === '(') {
+			const bodyStart = pos; // include the opening (
+			let depth = 1;
+			pos++;
+			while (pos < len && depth > 0) {
+				if (sql[pos] === "'") {
+					// Skip string literal, handling '' escaped quotes
+					pos++;
+					while (pos < len) {
+						if (sql[pos] === "'" && pos + 1 < len && sql[pos + 1] === "'") {
+							pos += 2;
+						} else if (sql[pos] === "'") {
+							pos++;
+							break;
+						} else {
+							pos++;
+						}
+					}
+				} else if (sql[pos] === '(') {
+					depth++;
+					pos++;
+				} else if (sql[pos] === ')') {
+					depth--;
+					pos++;
+				} else {
+					pos++;
+				}
+			}
+			const bodyEnd = pos; // after the closing )
+
+			if (hasColumnList) {
+				ranges.push([bodyStart, bodyEnd]);
+			}
+		}
+
+		// Skip whitespace
+		while (pos < len && /\s/.test(sql[pos])) pos++;
+
+		// Check for comma (more CTEs)
+		if (pos < len && sql[pos] === ',') {
+			pos++;
+			while (pos < len && /\s/.test(sql[pos])) pos++;
+		} else {
+			break;
+		}
+	}
+
+	return ranges;
+}
+
+/**
  * Rewrite ALL SELECT column lists to `*` so that all columns
  * (including scope columns needed by the outer filter) are available.
  * This handles both the main SELECT and SELECTs inside CTE bodies,
@@ -111,7 +236,13 @@ function findTopLevelKeyword(sql: string, keyword: string): number {
  * for the right-to-left replacement to be correct.
  */
 function rewriteSelectToStar(sql: string): string {
-	// Collect all SELECT→FROM pairs at any depth (except inside string literals).
+	// Pre-compute ranges of CTE bodies that have explicit column lists.
+	// SELECTs inside these ranges must not be rewritten because the column
+	// count must match the declared CTE columns.
+	const cteRanges = getCteColumnListRanges(sql);
+
+	// Collect all SELECT→FROM pairs at any depth (except inside string literals
+	// and CTE bodies with explicit column lists).
 	// Each pair records selectStart (position of S in SELECT), fromStart
 	// (position of F in FROM), and whether DISTINCT follows SELECT.
 	const pairs: Array<{
@@ -122,6 +253,10 @@ function rewriteSelectToStar(sql: string): string {
 	const upper = sql.toUpperCase();
 	let depth = 0;
 	let inString = false;
+
+	function isInCteRange(pos: number): boolean {
+		return cteRanges.some(([start, end]) => pos >= start && pos < end);
+	}
 
 	for (let i = 0; i < sql.length; i++) {
 		const ch = sql[i];
@@ -194,7 +329,7 @@ function rewriteSelectToStar(sql: string): string {
 						break;
 					}
 				}
-				if (fromStart !== -1) {
+				if (fromStart !== -1 && !isInCteRange(i)) {
 					pairs.push({ selectStart: i, fromStart, hasDistinct });
 				}
 			}
@@ -314,8 +449,9 @@ function rewriteScopedQuery(
 	const combinedWhere = [...scopeFilterSet.keys()].join(' AND ');
 	const scopeParams = [...scopeFilterSet.values()].flat();
 
-	// Strip user's LIMIT
-	const { sql: strippedSql } = stripLimit(sql);
+	// Strip user's LIMIT and honor it alongside the arg-level limit
+	const { sql: strippedSql, userLimit: existingLimit } = stripLimit(sql);
+	const effectiveLimit = Math.min(cappedLimit, existingLimit ?? MAX_LIMIT);
 
 	// Rewrite all SELECTs (including CTE bodies) to * for the inner query
 	// so scope columns are available. The outer SELECT also uses * because
@@ -323,9 +459,9 @@ function rewriteScopedQuery(
 	// the subquery wrapper context — only _dbq is a valid table reference.
 	const innerSql = rewriteSelectToStar(strippedSql);
 
-	const wrappedSql = `SELECT * FROM (${innerSql}) AS _dbq WHERE ${combinedWhere} LIMIT ${cappedLimit}`;
+	const wrappedSql = `SELECT * FROM (${innerSql}) AS _dbq WHERE ${combinedWhere} LIMIT ${effectiveLimit}`;
 
-	return { sql: wrappedSql, params: [...userParams, ...scopeParams], cappedLimit };
+	return { sql: wrappedSql, params: [...userParams, ...scopeParams], cappedLimit: effectiveLimit };
 }
 
 /**

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -99,120 +99,108 @@ function findTopLevelKeyword(sql: string, keyword: string): number {
 }
 
 /**
- * Find the position of the main SELECT keyword (the one after any WITH/CTE block).
- * Returns the position relative to the start of the input string.
+ * Rewrite ALL SELECT column lists to `*` so that all columns
+/**
+ * Rewrite ALL SELECT column lists to `*` so that all columns
+ * (including scope columns needed by the outer filter) are available.
+ * This handles both the main SELECT and SELECTs inside CTE bodies,
+ * subqueries, and nested parentheses.
+ *
+ * Strategy: collect all (selectPos, fromPos) pairs in a single forward pass
+ * (at any depth, respecting string literals), then replace from right to
+ * left to preserve string positions.
  */
-function findMainSelectPos(sql: string): number {
-	const trimmed = sql.trimStart();
-	const offset = sql.length - trimmed.length;
+function rewriteSelectToStar(sql: string): string {
+	// Collect all SELECT→FROM pairs at any depth (except inside string literals)
+	const pairs: Array<{ selectStart: number; selectEnd: number; fromStart: number }> = [];
+	const upper = sql.toUpperCase();
+	let depth = 0;
+	let inString = false;
 
-	if (!/^[Ww][Ii][Tt][Hh]\b/.test(trimmed)) {
-		// No CTE — main SELECT is at the start (after any leading whitespace)
-		return offset;
-	}
+	for (let i = 0; i < sql.length; i++) {
+		const ch = sql[i];
 
-	// Skip past the WITH block
-	let pos = 4; // skip "WITH"
-	const len = trimmed.length;
-
-	while (pos < len && /\s/.test(trimmed[pos])) pos++;
-
-	// Skip optional RECURSIVE
-	if (pos + 8 <= len && trimmed.slice(pos, pos + 9).toLowerCase() === 'recursive') {
-		pos += 9;
-		while (pos < len && /\s/.test(trimmed[pos])) pos++;
-	}
-
-	// Skip CTE definitions
-	while (pos < len) {
-		// Skip CTE name
-		while (pos < len && /[\p{L}\p{N}_]/u.test(trimmed[pos])) pos++;
-		while (pos < len && /\s/.test(trimmed[pos])) pos++;
-
-		// Skip optional column list
-		if (pos < len && trimmed[pos] === '(') {
-			let depth = 1;
-			pos++;
-			while (pos < len && depth > 0) {
-				if (trimmed[pos] === '(') depth++;
-				else if (trimmed[pos] === ')') depth--;
-				pos++;
+		if (inString) {
+			if (ch === "'" && i + 1 < sql.length && sql[i + 1] === "'") {
+				i++;
+				continue;
 			}
-			while (pos < len && /\s/.test(trimmed[pos])) pos++;
+			if (ch === "'") {
+				inString = false;
+			}
+			continue;
 		}
 
-		// Skip AS keyword
+		if (ch === "'") {
+			inString = true;
+			continue;
+		}
+		if (ch === '(') {
+			depth++;
+			continue;
+		}
+		if (ch === ')') {
+			depth--;
+			continue;
+		}
+
+		// Check for SELECT keyword at any depth (CTE bodies, subqueries, etc.)
 		if (
-			pos + 1 < len &&
-			trimmed[pos].toLowerCase() === 'a' &&
-			trimmed[pos + 1].toLowerCase() === 's'
+			upper.slice(i, i + 6) === 'SELECT' &&
+			(i === 0 || /\s/.test(sql[i - 1]) || sql[i - 1] === '(')
 		) {
-			pos += 2;
-		} else {
-			break;
-		}
-		while (pos < len && /\s/.test(trimmed[pos])) pos++;
+			const afterChar = i + 6 < sql.length ? sql[i + 6] : ' ';
+			if (/\s/.test(afterChar) || afterChar === '(') {
+				const selectEnd = i + 6;
+				const targetDepth = depth;
 
-		// Skip CTE body (parenthesized)
-		if (pos < len && trimmed[pos] === '(') {
-			let depth = 1;
-			pos++;
-			while (pos < len && depth > 0) {
-				if (trimmed[pos] === '(') {
-					depth++;
-					pos++;
-				} else if (trimmed[pos] === ')') {
-					depth--;
-					pos++;
-				} else if (trimmed[pos] === "'") {
-					pos++;
-					while (pos < len) {
-						if (trimmed[pos] === "'" && pos + 1 < len && trimmed[pos + 1] === "'") {
-							pos += 2;
-						} else if (trimmed[pos] === "'") {
-							pos++;
-							break;
-						} else {
-							pos++;
+				// Find matching FROM at the same depth as this SELECT
+				let fDepth = depth;
+				let fInString = false;
+				let fromStart = -1;
+				for (let j = selectEnd; j < sql.length; j++) {
+					const c = sql[j];
+					if (fInString) {
+						if (c === "'" && j + 1 < sql.length && sql[j + 1] === "'") {
+							j++;
+							continue;
 						}
+						if (c === "'") fInString = false;
+						continue;
 					}
-				} else {
-					pos++;
+					if (c === "'") {
+						fInString = true;
+						continue;
+					}
+					if (c === '(') fDepth++;
+					if (c === ')') fDepth--;
+					if (fDepth !== targetDepth) continue;
+					if (
+						upper.slice(j, j + 4) === 'FROM' &&
+						(j === 0 || /\s/.test(sql[j - 1])) &&
+						(j + 4 >= sql.length || /\s/.test(sql[j + 4]))
+					) {
+						fromStart = j;
+						break;
+					}
+				}
+				if (fromStart !== -1) {
+					pairs.push({ selectStart: i, selectEnd, fromStart });
 				}
 			}
 		}
-
-		while (pos < len && /\s/.test(trimmed[pos])) pos++;
-
-		// Comma = more CTEs; anything else = end of WITH block
-		if (pos < len && trimmed[pos] === ',') {
-			pos++;
-			while (pos < len && /\s/.test(trimmed[pos])) pos++;
-		} else {
-			break;
-		}
 	}
 
-	return offset + pos;
-}
+	if (pairs.length === 0) return sql;
 
-/**
- * Rewrite the main SELECT's column list to `*` so that all columns
- * (including scope columns) are available in the subquery wrapper.
- */
-function rewriteSelectToStar(sql: string): string {
-	const mainSelectPos = findMainSelectPos(sql);
-	const remaining = sql.slice(mainSelectPos);
+	// Replace from right to left to preserve positions
+	let result = sql;
+	for (let p = pairs.length - 1; p >= 0; p--) {
+		const { selectStart, fromStart } = pairs[p];
+		result = `${result.slice(0, selectStart)}SELECT * ${result.slice(fromStart)}`;
+	}
 
-	// Skip "SELECT" keyword and whitespace
-	const selectKwLen = remaining.match(/^[Ss][Ee][Ll][Ee][Cc][Tt]\b/)?.[0].length ?? 6;
-	const afterSelect = remaining.slice(selectKwLen);
-
-	// Find the FROM keyword (top-level only) in the remaining SQL
-	const fromPos = findTopLevelKeyword(afterSelect, 'FROM');
-	if (fromPos === -1) return sql; // no FROM — return as-is
-
-	return `${sql.slice(0, mainSelectPos)}SELECT * ${afterSelect.slice(fromPos)}`;
+	return result;
 }
 
 /**
@@ -281,36 +269,47 @@ function rewriteScopedQuery(
 	scopeValue: string,
 	tableConfigs: Map<string, ScopeTableConfig>,
 	userLimit?: number
-): { sql: string; params: unknown[] } {
+): { sql: string; params: unknown[]; cappedLimit: number } {
 	const cappedLimit = Math.min(userLimit ?? DEFAULT_LIMIT, MAX_LIMIT);
 
-	// Build scope filters for all referenced tables
-	const scopeFilters: Array<{ whereClause: string; params: unknown[] }> = [];
+	// Build scope filters for all referenced tables, deduplicating identical
+	// clauses to avoid ambiguous column references when multiple tables share
+	// the same scope column (e.g. tasks JOIN goals both have room_id).
+	const scopeFilterSet = new Map<string, unknown[]>();
 	for (const config of tableConfigs.values()) {
 		const filter = buildPrefixedScopeFilter(config, scopeValue);
-		if (filter.whereClause) {
-			scopeFilters.push(filter);
+		if (filter.whereClause && !scopeFilterSet.has(filter.whereClause)) {
+			scopeFilterSet.set(filter.whereClause, filter.params);
 		}
 	}
 
 	// No scope filters needed (global scope or all tables unscoped)
-	if (scopeFilters.length === 0) {
+	if (scopeFilterSet.size === 0) {
 		const { sql: strippedSql, userLimit: existingLimit } = stripLimit(sql);
 		const effectiveLimit = Math.min(existingLimit ?? DEFAULT_LIMIT, MAX_LIMIT);
-		return { sql: `${strippedSql} LIMIT ${effectiveLimit}`, params: userParams };
+		return {
+			sql: `${strippedSql} LIMIT ${effectiveLimit}`,
+			params: userParams,
+			cappedLimit: effectiveLimit,
+		};
 	}
 
 	// Scope-aware wrapping
-	const combinedWhere = scopeFilters.map((f) => f.whereClause).join(' AND ');
-	const scopeParams = scopeFilters.flatMap((f) => f.params);
+	const combinedWhere = [...scopeFilterSet.keys()].join(' AND ');
+	const scopeParams = [...scopeFilterSet.values()].flat();
 
-	// Strip user's LIMIT and rewrite inner SELECT to *
+	// Strip user's LIMIT
 	const { sql: strippedSql } = stripLimit(sql);
+
+	// Rewrite all SELECTs (including CTE bodies) to * for the inner query
+	// so scope columns are available. The outer SELECT also uses * because
+	// qualified column names (table.column) and aliases become invalid in
+	// the subquery wrapper context — only _dbq is a valid table reference.
 	const innerSql = rewriteSelectToStar(strippedSql);
 
 	const wrappedSql = `SELECT * FROM (${innerSql}) AS _dbq WHERE ${combinedWhere} LIMIT ${cappedLimit}`;
 
-	return { sql: wrappedSql, params: [...userParams, ...scopeParams] };
+	return { sql: wrappedSql, params: [...userParams, ...scopeParams], cappedLimit };
 }
 
 /**
@@ -393,14 +392,11 @@ export function createDbQueryToolHandlers(config: DbQueryToolsConfig, db: Databa
 			}
 
 			// Step 4-6: Rewrite query with scope filter wrapping and LIMIT cap
-			const { sql: wrappedSql, params: allParams } = rewriteScopedQuery(
-				sql,
-				params,
-				scopeType,
-				scopeValue,
-				tableConfigs,
-				limit
-			);
+			const {
+				sql: wrappedSql,
+				params: allParams,
+				cappedLimit,
+			} = rewriteScopedQuery(sql, params, scopeType, scopeValue, tableConfigs, limit);
 
 			// Step 7: Execute the rewritten query
 			try {
@@ -410,10 +406,9 @@ export function createDbQueryToolHandlers(config: DbQueryToolsConfig, db: Databa
 				// Step 8: Apply column blacklist
 				const filteredRows = removeBlacklistedColumns(rows, tableConfigs);
 
-				// Step 9: Return result
-				const truncated =
-					rows.length > filteredRows.length ||
-					(limit !== undefined && rows.length >= Math.min(limit, MAX_LIMIT));
+				// Step 9: Return result — truncated is true when the result set
+				// hit the applied LIMIT cap, meaning more rows may exist
+				const truncated = rows.length >= cappedLimit;
 
 				return jsonResult({
 					rows: filteredRows,
@@ -532,6 +527,10 @@ export function createDbQueryToolHandlers(config: DbQueryToolsConfig, db: Databa
  * // TODO: Add query timeout — AbortController-based cancellation or a
  * // worker thread with sqlite3_interrupt() could handle pathological queries.
  * // For now, PRAGMA busy_timeout = 5000 handles lock contention only.
+ *
+ * // TODO: Wire into agent sessions — createDbQueryMcpServer is not yet integrated
+ * // into query-options-builder.ts or agent-session.ts. This is intentional
+ * // (follow-up task) but should be connected before the db-query server is usable.
  */
 export function createDbQueryMcpServer(config: DbQueryToolsConfig): DbQueryMcpServer {
 	// Create a dedicated read-only connection

--- a/packages/daemon/tests/unit/db-query/sql-validator.test.ts
+++ b/packages/daemon/tests/unit/db-query/sql-validator.test.ts
@@ -511,8 +511,8 @@ describe('validateSql — edge cases', () => {
 		expect(result.tableRefs).toEqual(['tasks', 'sessions']);
 	});
 
-	test('ORDER BY, LIMIT, OFFSET preserved', () => {
-		const result = validateSql('SELECT * FROM tasks ORDER BY created_at DESC LIMIT 10 OFFSET 20');
+	test('ORDER BY, LIMIT preserved (no OFFSET)', () => {
+		const result = validateSql('SELECT * FROM tasks ORDER BY created_at DESC LIMIT 10');
 		expect(result.valid).toBe(true);
 		expect(result.tableRefs).toEqual(['tasks']);
 	});
@@ -529,5 +529,69 @@ describe('validateSql — edge cases', () => {
 		const result = validateSql('SELECT * FROM tasks UNION SELECT * FROM archived_tasks');
 		expect(result.valid).toBe(true);
 		expect(result.tableRefs).toEqual(['tasks', 'archived_tasks']);
+	});
+});
+
+// ============ Quoted identifiers rejected ============
+
+describe('validateSql — quoted identifiers rejected', () => {
+	test('rejects double-quoted table name', () => {
+		const result = validateSql('SELECT * FROM "tasks"');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('Quoted identifiers');
+	});
+
+	test('rejects backtick-quoted table name', () => {
+		const result = validateSql('SELECT * FROM `tasks`');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('Quoted identifiers');
+	});
+
+	test('rejects double-quoted column in WHERE', () => {
+		const result = validateSql('SELECT * FROM tasks WHERE "status" = ?');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('Quoted identifiers');
+	});
+
+	test('double quotes inside string literals are allowed', () => {
+		const result = validateSql('SELECT * FROM tasks WHERE name = \'say "hello"\'');
+		expect(result.valid).toBe(true);
+	});
+});
+
+// ============ OFFSET rejected ============
+
+describe('validateSql — OFFSET rejected', () => {
+	test('rejects OFFSET clause', () => {
+		const result = validateSql('SELECT * FROM tasks LIMIT 10 OFFSET 20');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('OFFSET');
+	});
+
+	test('rejects OFFSET without LIMIT', () => {
+		const result = validateSql('SELECT * FROM tasks OFFSET 5');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('OFFSET');
+	});
+
+	test('allows OFFSET keyword inside string literal', () => {
+		const result = validateSql("SELECT * FROM tasks WHERE notes = 'see OFFSET clause'");
+		expect(result.valid).toBe(true);
+	});
+});
+
+// ============ DISTINCT preserved ============
+
+describe('validateSql — DISTINCT queries', () => {
+	test('accepts SELECT DISTINCT', () => {
+		const result = validateSql('SELECT DISTINCT status FROM tasks');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
+	});
+
+	test('accepts SELECT DISTINCT with WHERE', () => {
+		const result = validateSql('SELECT DISTINCT room_id FROM tasks WHERE status = ?');
+		expect(result.valid).toBe(true);
+		expect(result.tableRefs).toEqual(['tasks']);
 	});
 });

--- a/packages/daemon/tests/unit/db-query/sql-validator.test.ts
+++ b/packages/daemon/tests/unit/db-query/sql-validator.test.ts
@@ -525,10 +525,16 @@ describe('validateSql — edge cases', () => {
 		expect(result.tableRefs).toEqual(['sessions']);
 	});
 
-	test('UNION queries', () => {
+	test('UNION queries rejected', () => {
 		const result = validateSql('SELECT * FROM tasks UNION SELECT * FROM archived_tasks');
-		expect(result.valid).toBe(true);
-		expect(result.tableRefs).toEqual(['tasks', 'archived_tasks']);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('UNION');
+	});
+
+	test('UNION ALL rejected', () => {
+		const result = validateSql('SELECT * FROM tasks UNION ALL SELECT * FROM tasks');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('UNION');
 	});
 });
 

--- a/packages/daemon/tests/unit/db-query/sql-validator.test.ts
+++ b/packages/daemon/tests/unit/db-query/sql-validator.test.ts
@@ -536,6 +536,18 @@ describe('validateSql — edge cases', () => {
 		expect(result.valid).toBe(false);
 		expect(result.error).toContain('UNION');
 	});
+
+	test('INTERSECT rejected', () => {
+		const result = validateSql('SELECT id FROM tasks INTERSECT SELECT id FROM goals');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('INTERSECT');
+	});
+
+	test('EXCEPT rejected', () => {
+		const result = validateSql('SELECT id FROM tasks EXCEPT SELECT id FROM goals');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('EXCEPT');
+	});
 });
 
 // ============ Quoted identifiers rejected ============

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -584,6 +584,27 @@ describe('db-query tools', () => {
 				expect(result.isError).toBeFalsy();
 				expect(parseResult(result).rowCount).toBe(2);
 			});
+
+			it('CTE with explicit outer column list is rewritten correctly in scoped mode', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// Regression test: outer SELECT has explicit columns (not *),
+				// and the CTE body also has explicit columns. Both should be
+				// rewritten to * without shift corruption.
+				const result = await handlers.db_query({
+					sql: 'WITH active AS (SELECT id, title, status FROM tasks WHERE status = ?) SELECT id, title FROM active',
+					params: ['pending'],
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1 has task-2 with status 'pending'
+				expect(parsed.rowCount).toBe(1);
+				expect(parsed.rows[0].id).toBe('task-2');
+				expect(parsed.rows[0].title).toBe('Task 2');
+			});
 		});
 
 		describe('indirect scope tables filtered correctly', () => {

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -22,7 +22,9 @@ function createTestDb(): Database {
 		CREATE TABLE IF NOT EXISTS rooms (
 			id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,
-			config TEXT
+			config TEXT,
+			parent_id TEXT,
+			FOREIGN KEY (parent_id) REFERENCES rooms(id)
 		)
 	`);
 	db.exec(`
@@ -925,7 +927,60 @@ describe('db-query tools', () => {
 					sql: 'SELECT id FROM tasks UNION SELECT id FROM goals',
 				});
 				expect(result.isError).toBe(true);
-				expect(parseResult(result).raw).toContain('UNION');
+				expect(parseResult(result).raw).toContain('Compound');
+			});
+		});
+
+		describe('INTERSECT and EXCEPT rejected at handler level', () => {
+			it('rejects INTERSECT query', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT id FROM tasks INTERSECT SELECT id FROM goals',
+				});
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('INTERSECT');
+			});
+
+			it('rejects EXCEPT query', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT id FROM tasks EXCEPT SELECT id FROM goals',
+				});
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('EXCEPT');
+			});
+		});
+
+		describe('WITH RECURSIVE in scoped mode', () => {
+			it('single-column WITH RECURSIVE works in scoped mode', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM cnt WHERE n < 5) SELECT * FROM cnt',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(5);
+			});
+
+			it('multi-column WITH RECURSIVE works in global scope', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'WITH RECURSIVE hierarchy(id, name, depth) AS (SELECT id, name, 0 FROM rooms WHERE parent_id IS NULL UNION ALL SELECT r.id, r.name, h.depth + 1 FROM rooms r JOIN hierarchy h ON r.parent_id = h.id) SELECT * FROM hierarchy',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
 			});
 		});
 

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -839,6 +839,115 @@ describe('db-query tools', () => {
 				}
 			});
 		});
+
+		describe('SELECT DISTINCT preserved in scope wrapping', () => {
+			it('DISTINCT is preserved in scoped queries', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT DISTINCT status FROM tasks',
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				// room-1 has tasks with 'in_progress' and 'pending' — 2 distinct statuses
+				expect(parsed.rows).toHaveLength(2);
+				const statuses = parsed.rows.map((r: Record<string, unknown>) => r.status);
+				expect(statuses.sort()).toEqual(['in_progress', 'pending']);
+			});
+		});
+
+		describe('quoted identifiers rejected', () => {
+			it('rejects double-quoted table names', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM "tasks"' });
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('Quoted identifiers');
+			});
+
+			it('rejects backtick-quoted table names', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM `tasks`' });
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('Quoted identifiers');
+			});
+		});
+
+		describe('OFFSET rejected', () => {
+			it('rejects queries with OFFSET clause', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM rooms LIMIT 10 OFFSET 5',
+				});
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('OFFSET');
+			});
+		});
+
+		describe('mixed direct/indirect scope JOIN', () => {
+			it('JOINs direct-scope and indirect-scope tables correctly', async () => {
+				seedMissionExecutions(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// goals (direct scope via room_id) JOIN mission_executions (indirect via goals)
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM goals JOIN mission_executions ON goals.id = mission_executions.goal_id',
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				// room-1 goals: goal-1, goal-2; goal-1 → exec-1, exec-2; goal-2 → exec-3
+				expect(parsed.rows).toHaveLength(3);
+			});
+		});
+
+		describe('global scope limit arg', () => {
+			it('respects explicit limit arg in global scope', async () => {
+				seedRooms(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				// 3 rooms in global scope, limit to 2
+				const result = await handlers.db_query({ sql: 'SELECT * FROM rooms', limit: 2 });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBe(2);
+				expect(parsed.truncated).toBe(true);
+			});
+
+			it('uses stricter of arg limit and SQL LIMIT in global scope', async () => {
+				seedRooms(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				// SQL has LIMIT 10, arg has limit 2 — should use 2 (stricter)
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM rooms LIMIT 10',
+					limit: 2,
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBe(2);
+			});
+		});
 	});
 
 	// ── db_list_tables ─────────────────────────────────────────────────────────

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -513,6 +513,77 @@ describe('db-query tools', () => {
 			});
 		});
 
+		describe('same-scope JOIN queries', () => {
+			it('JOINs two room-scoped tables with deduplicated scope filter', async () => {
+				seedRooms(db);
+				// Insert goals and tasks without re-seeding rooms
+				db.exec(
+					"INSERT INTO goals (id, room_id, title, status, mission_type, created_at) VALUES ('goal-1', 'room-1', 'Goal 1', 'active', 'one_shot', 1000)"
+				);
+				db.exec(
+					"INSERT INTO goals (id, room_id, title, status, mission_type, created_at) VALUES ('goal-2', 'room-1', 'Goal 2', 'completed', 'recurring', 2000)"
+				);
+				db.exec(
+					"INSERT INTO tasks (id, room_id, title, status, restrictions, created_at) VALUES ('task-1', 'room-1', 'Task 1', 'in_progress', NULL, 3000)"
+				);
+				db.exec(
+					"INSERT INTO tasks (id, room_id, title, status, restrictions, created_at) VALUES ('task-2', 'room-1', 'Task 2', 'pending', NULL, 4000)"
+				);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// Both tasks and goals have scopeColumn 'room_id' — the wrapper
+				// should deduplicate the filter to a single _dbq.room_id = ?
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM tasks JOIN goals ON tasks.room_id = goals.room_id',
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				// room-1 has 2 tasks and 2 goals — cross join on room_id = room_id
+				expect(parsed.rows).toHaveLength(4);
+				for (const row of parsed.rows) {
+					// SQLite suffixes duplicate column names with :1
+					expect(['Goal 1', 'Goal 2']).toContain(row['title:1']);
+				}
+			});
+		});
+
+		describe('CTE queries', () => {
+			it('handles CTE with scoped table reference', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'WITH active AS (SELECT * FROM tasks WHERE status = ?) SELECT * FROM active',
+					params: ['in_progress'],
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(1);
+				expect(parsed.rows[0].title).toBe('Task 1');
+			});
+
+			it('CTE name is excluded from table-ref scope validation', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// "active" is a CTE name, not a real table — should not trigger
+				// a "not accessible in scope" error
+				const result = await handlers.db_query({
+					sql: 'WITH active AS (SELECT id, title FROM tasks) SELECT * FROM active',
+				});
+				expect(result.isError).toBeFalsy();
+				expect(parseResult(result).rowCount).toBe(2);
+			});
+		});
+
 		describe('indirect scope tables filtered correctly', () => {
 			it('mission_executions filtered via goals room scope', async () => {
 				seedMissionExecutions(db);
@@ -623,6 +694,44 @@ describe('db-query tools', () => {
 
 				expect(parsed.isError).toBeFalsy();
 				expect(parsed.rowCount).toBeLessThanOrEqual(1000);
+			});
+		});
+
+		describe('truncated flag', () => {
+			it('truncated flag is true when results hit the default limit', async () => {
+				seedRooms(db);
+				// Insert enough rows to exceed the default limit (200)
+				for (let i = 0; i < 250; i++) {
+					db.exec(
+						`INSERT INTO goals (id, room_id, title, status, created_at) VALUES ('trunc-${i}', 'room-1', 'Truncation Test ${i}', 'active', ${i})`
+					);
+				}
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// No explicit limit — default 200 should apply
+				const result = await handlers.db_query({ sql: 'SELECT * FROM goals' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBe(200);
+				expect(parsed.truncated).toBe(true);
+			});
+
+			it('truncated flag is false when results fit within limit', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// Only 2 tasks in room-1, well under the limit
+				const result = await handlers.db_query({ sql: 'SELECT * FROM tasks' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBe(2);
+				expect(parsed.truncated).toBe(false);
 			});
 		});
 

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -1028,6 +1028,130 @@ describe('db-query tools', () => {
 			});
 		});
 
+		describe('aggregate queries in scoped mode', () => {
+			it('COUNT(*) returns correct count for scoped room', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT COUNT(*) AS cnt FROM tasks',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1 has task-1 and task-2
+				expect(parsed.rowCount).toBe(1);
+				expect(parsed.rows[0].cnt).toBe(2);
+			});
+
+			it('GROUP BY with aggregate works in scoped mode', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT status, COUNT(*) AS cnt FROM tasks GROUP BY status',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1: task-1 (in_progress), task-2 (pending)
+				expect(parsed.rowCount).toBe(2);
+			});
+
+			it('aggregate with existing WHERE adds scope filter with AND', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: "SELECT COUNT(*) AS cnt FROM tasks WHERE status = 'in_progress'",
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1 has 1 in_progress task
+				expect(parsed.rows[0].cnt).toBe(1);
+			});
+
+			it('SUM aggregate works in scoped mode', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT SUM(created_at) AS total FROM tasks',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1: task-1 (1000) + task-2 (2000) = 3000
+				expect(parsed.rows[0].total).toBe(3000);
+			});
+		});
+
+		describe('DISTINCT queries in scoped mode', () => {
+			it('DISTINCT deduplicates on selected columns only', async () => {
+				// Create multiple tasks with same status in room-1
+				seedRooms(db);
+				db.exec(
+					"INSERT INTO tasks (id, room_id, title, status, priority, created_at) VALUES ('t1', 'room-1', 'A', 'active', 'high', 1000)"
+				);
+				db.exec(
+					"INSERT INTO tasks (id, room_id, title, status, priority, created_at) VALUES ('t2', 'room-1', 'B', 'active', 'normal', 2000)"
+				);
+				db.exec(
+					"INSERT INTO tasks (id, room_id, title, status, priority, created_at) VALUES ('t3', 'room-1', 'C', 'pending', 'low', 3000)"
+				);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT DISTINCT status FROM tasks',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// 3 tasks: 2 active, 1 pending → DISTINCT gives 2 rows
+				expect(parsed.rowCount).toBe(2);
+			});
+		});
+
+		describe('ORDER BY in scoped mode', () => {
+			it('ORDER BY is preserved in room scope', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT id, title FROM tasks ORDER BY created_at ASC',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1: task-1 (created_at=1000), task-2 (created_at=2000)
+				expect(parsed.rows[0].id).toBe('task-1');
+				expect(parsed.rows[1].id).toBe('task-2');
+			});
+
+			it('ORDER BY DESC is preserved in room scope', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT id, title FROM tasks ORDER BY created_at DESC',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// DESC order: task-2 first, task-1 second
+				expect(parsed.rows[0].id).toBe('task-2');
+				expect(parsed.rows[1].id).toBe('task-1');
+			});
+		});
+
 		describe('table-less queries in scoped mode', () => {
 			it('SELECT 1 returns result without scope filter', async () => {
 				const handlers = createDbQueryToolHandlers(

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -1,0 +1,1008 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	createDbQueryToolHandlers,
+	createDbQueryMcpServer,
+} from '../../../src/lib/db-query/tools.ts';
+
+// ── Test Schema ────────────────────────────────────────────────────────────────
+
+/**
+ * Create a minimal in-memory database with tables that mirror the NeoKai schema
+ * subset used by the db-query scope config.
+ */
+function createTestDb(): Database {
+	const db = new Database(':memory:');
+
+	// Room-scoped tables
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS rooms (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			config TEXT
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS tasks (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending',
+			priority TEXT NOT NULL DEFAULT 'normal',
+			restrictions TEXT,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (room_id) REFERENCES rooms(id)
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS goals (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active',
+			priority TEXT NOT NULL DEFAULT 'normal',
+			mission_type TEXT,
+			structured_metrics TEXT,
+			schedule TEXT,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (room_id) REFERENCES rooms(id)
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS mission_executions (
+			id TEXT PRIMARY KEY,
+			goal_id TEXT NOT NULL,
+			execution_number INTEGER NOT NULL,
+			status TEXT NOT NULL DEFAULT 'running',
+			result_summary TEXT,
+			task_ids TEXT NOT NULL DEFAULT '[]',
+			started_at INTEGER,
+			completed_at INTEGER,
+			FOREIGN KEY (goal_id) REFERENCES goals(id),
+			UNIQUE(goal_id, execution_number)
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS mission_metric_history (
+			id TEXT PRIMARY KEY,
+			goal_id TEXT NOT NULL,
+			metric_name TEXT NOT NULL,
+			value REAL NOT NULL,
+			recorded_at INTEGER NOT NULL,
+			FOREIGN KEY (goal_id) REFERENCES goals(id)
+		)
+	`);
+
+	// Space-scoped tables
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS spaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			workspace_path TEXT NOT NULL,
+			config TEXT,
+			created_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflows (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			config TEXT,
+			gates TEXT,
+			channels TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id)
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_tasks (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending',
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id)
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflow_runs (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			workflow_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending',
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id)
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS gate_data (
+			run_id TEXT NOT NULL,
+			gate_id TEXT NOT NULL,
+			data TEXT NOT NULL DEFAULT '{}',
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY (run_id, gate_id),
+			FOREIGN KEY (run_id) REFERENCES space_workflow_runs(id)
+		)
+	`);
+
+	return db;
+}
+
+// ── Seed helpers ───────────────────────────────────────────────────────────────
+
+function seedRooms(db: Database) {
+	db.exec(
+		"INSERT INTO rooms (id, name, config) VALUES ('room-1', 'Room 1', '{\"model\":\"opus\"}')"
+	);
+	db.exec(
+		"INSERT INTO rooms (id, name, config) VALUES ('room-2', 'Room 2', '{\"model\":\"sonnet\"}')"
+	);
+	db.exec("INSERT INTO rooms (id, name, config) VALUES ('room-3', 'Room 3', NULL)");
+}
+
+function seedTasks(db: Database) {
+	seedRooms(db);
+	db.exec(
+		"INSERT INTO tasks (id, room_id, title, status, priority, restrictions, created_at) VALUES ('task-1', 'room-1', 'Task 1', 'in_progress', 'high', '{\"maxTokens\":100}', 1000)"
+	);
+	db.exec(
+		"INSERT INTO tasks (id, room_id, title, status, priority, restrictions, created_at) VALUES ('task-2', 'room-1', 'Task 2', 'pending', 'normal', NULL, 2000)"
+	);
+	db.exec(
+		"INSERT INTO tasks (id, room_id, title, status, priority, restrictions, created_at) VALUES ('task-3', 'room-2', 'Task 3', 'completed', 'low', NULL, 3000)"
+	);
+}
+
+function seedGoals(db: Database) {
+	seedRooms(db);
+	db.exec(
+		"INSERT INTO goals (id, room_id, title, status, mission_type, created_at) VALUES ('goal-1', 'room-1', 'Goal 1', 'active', 'one_shot', 1000)"
+	);
+	db.exec(
+		"INSERT INTO goals (id, room_id, title, status, mission_type, created_at) VALUES ('goal-2', 'room-1', 'Goal 2', 'completed', 'recurring', 2000)"
+	);
+	db.exec(
+		"INSERT INTO goals (id, room_id, title, status, mission_type, created_at) VALUES ('goal-3', 'room-2', 'Goal 3', 'active', NULL, 3000)"
+	);
+}
+
+function seedMissionExecutions(db: Database) {
+	seedGoals(db);
+	db.exec(
+		"INSERT INTO mission_executions (id, goal_id, execution_number, status, result_summary, started_at) VALUES ('exec-1', 'goal-1', 1, 'completed', 'success', 1000)"
+	);
+	db.exec(
+		"INSERT INTO mission_executions (id, goal_id, execution_number, status, result_summary, started_at) VALUES ('exec-2', 'goal-1', 2, 'running', 'in progress', 2000)"
+	);
+	db.exec(
+		"INSERT INTO mission_executions (id, goal_id, execution_number, status, result_summary, started_at) VALUES ('exec-3', 'goal-2', 1, 'completed', 'done', 3000)"
+	);
+}
+
+function seedSpaces(db: Database) {
+	db.exec(
+		"INSERT INTO spaces (id, name, workspace_path, config, created_at) VALUES ('space-1', 'Space 1', '/path1', '{\"agents\":[]}', 1000)"
+	);
+	db.exec(
+		"INSERT INTO spaces (id, name, workspace_path, config, created_at) VALUES ('space-2', 'Space 2', '/path2', '{\"agents\":[]}', 2000)"
+	);
+}
+
+function seedSpaceWorkflows(db: Database) {
+	seedSpaces(db);
+	db.exec(
+		"INSERT INTO space_workflows (id, space_id, name, config, gates, channels, created_at, updated_at) VALUES ('wf-1', 'space-1', 'WF 1', '{\"key\":\"val\"}', '{\"g1\":{}}', '{\"ch1\":{}}', 1000, 1000)"
+	);
+	db.exec(
+		"INSERT INTO space_workflows (id, space_id, name, config, gates, channels, created_at, updated_at) VALUES ('wf-2', 'space-1', 'WF 2', '{\"key\":\"val2\"}', NULL, NULL, 2000, 2000)"
+	);
+	db.exec(
+		"INSERT INTO space_workflows (id, space_id, name, config, gates, channels, created_at, updated_at) VALUES ('wf-3', 'space-2', 'WF 3', '{\"key\":\"val3\"}', NULL, NULL, 3000, 3000)"
+	);
+}
+
+function seedSpaceWorkflowRuns(db: Database) {
+	seedSpaces(db);
+	db.exec(
+		"INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at) VALUES ('run-1', 'space-1', 'wf-1', 'Run 1', 'in_progress', 1000)"
+	);
+	db.exec(
+		"INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at) VALUES ('run-2', 'space-1', 'wf-1', 'Run 2', 'completed', 2000)"
+	);
+	db.exec(
+		"INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at) VALUES ('run-3', 'space-2', 'wf-2', 'Run 3', 'pending', 3000)"
+	);
+}
+
+function seedGateData(db: Database) {
+	seedSpaceWorkflowRuns(db);
+	db.exec(
+		"INSERT INTO gate_data (run_id, gate_id, data, updated_at) VALUES ('run-1', 'gate-1', '{\"approved\":true}', 1000)"
+	);
+	db.exec(
+		"INSERT INTO gate_data (run_id, gate_id, data, updated_at) VALUES ('run-2', 'gate-1', '{\"approved\":false}', 2000)"
+	);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function parseResult(result: {
+	content: Array<{ type: string; text: string }>;
+	isError?: boolean;
+}) {
+	const text = result.content[0].text;
+	try {
+		return { ...JSON.parse(text), isError: result.isError };
+	} catch {
+		return { raw: text, isError: result.isError };
+	}
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('db-query tools', () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = createTestDb();
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// ── db_query ──────────────────────────────────────────────────────────────
+
+	describe('db_query', () => {
+		describe('valid SELECT returns rows', () => {
+			it('returns rows for a simple SELECT query', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM tasks' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(2);
+				expect(parsed.rowCount).toBe(2);
+				expect(parsed.rows[0].room_id).toBe('room-1');
+			});
+
+			it('returns rows with explicit columns', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT id, title FROM tasks' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(2);
+				expect(parsed.rows[0]).toHaveProperty('id');
+				expect(parsed.rows[0]).toHaveProperty('title');
+			});
+
+			it('returns rows with WHERE clause', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM tasks WHERE status = ?',
+					params: ['pending'],
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(1);
+				expect(parsed.rows[0].title).toBe('Task 2');
+			});
+
+			it('global scope returns all rows without filtering', async () => {
+				seedRooms(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM rooms' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(3);
+			});
+		});
+
+		describe('rejects non-SELECT statements', () => {
+			it('rejects INSERT', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'INSERT INTO rooms (id, name) VALUES (?, ?)',
+					params: ['room-x', 'X'],
+				});
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('Only SELECT');
+			});
+
+			it('rejects UPDATE', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'UPDATE rooms SET name = ? WHERE id = ?',
+					params: ['New Name', 'room-1'],
+				});
+				expect(result.isError).toBe(true);
+			});
+
+			it('rejects DELETE', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'DELETE FROM rooms' });
+				expect(result.isError).toBe(true);
+			});
+
+			it('rejects DROP TABLE', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'DROP TABLE rooms' });
+				expect(result.isError).toBe(true);
+			});
+
+			it('rejects CREATE TABLE', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'CREATE TABLE foo (id TEXT)',
+				});
+				expect(result.isError).toBe(true);
+			});
+		});
+
+		describe('rejects queries referencing tables outside scope', () => {
+			it('room scope rejects global-only tables (rooms)', async () => {
+				seedRooms(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM rooms' });
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('not accessible');
+			});
+
+			it('room scope rejects space-scoped tables (space_tasks)', async () => {
+				seedSpaces(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM space_tasks' });
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('not accessible');
+			});
+
+			it('space scope rejects room-scoped tables (tasks)', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM tasks' });
+				expect(result.isError).toBe(true);
+			});
+
+			it('prevents cross-scope joins', async () => {
+				seedTasks(db);
+				seedSpaces(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM tasks JOIN spaces ON tasks.id = spaces.id',
+				});
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('not accessible');
+			});
+		});
+
+		describe('scope subquery wrapping filters results correctly', () => {
+			it('room scope filters tasks by room_id', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM tasks' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(2);
+				for (const row of parsed.rows) {
+					expect(row.room_id).toBe('room-1');
+				}
+			});
+
+			it('room scope filters goals by room_id', async () => {
+				seedGoals(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM goals' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(2);
+				for (const row of parsed.rows) {
+					expect(row.room_id).toBe('room-1');
+				}
+			});
+
+			it('space scope filters space_workflow_runs by space_id', async () => {
+				seedSpaceWorkflowRuns(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM space_workflow_runs',
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(2);
+				for (const row of parsed.rows) {
+					expect(row.space_id).toBe('space-1');
+				}
+			});
+
+			it('scope filter works alongside user WHERE clause', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM tasks WHERE status = ?',
+					params: ['pending'],
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(1);
+				expect(parsed.rows[0].title).toBe('Task 2');
+				expect(parsed.rows[0].room_id).toBe('room-1');
+			});
+
+			it('scope filter works with user params', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM tasks WHERE priority = ?',
+					params: ['high'],
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(1);
+				expect(parsed.rows[0].title).toBe('Task 1');
+			});
+		});
+
+		describe('indirect scope tables filtered correctly', () => {
+			it('mission_executions filtered via goals room scope', async () => {
+				seedMissionExecutions(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM mission_executions',
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				// goal-1 (room-1) has exec-1, exec-2; goal-2 (room-1) has exec-3
+				expect(parsed.rows).toHaveLength(3);
+				const goalIds = parsed.rows.map((r: Record<string, unknown>) => r.goal_id);
+				expect(goalIds.sort()).toEqual(['goal-1', 'goal-1', 'goal-2']);
+			});
+
+			it('gate_data filtered via space_workflow_runs space scope', async () => {
+				seedGateData(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM gate_data' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				// run-1 (space-1) has gate-1; run-2 (space-1) has gate-1
+				expect(parsed.rows).toHaveLength(2);
+				const runIds = parsed.rows.map((r: Record<string, unknown>) => r.run_id);
+				expect(runIds.sort()).toEqual(['run-1', 'run-2']);
+			});
+
+			it('indirect scope does not leak data from other scopes', async () => {
+				seedMissionExecutions(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-2' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM mission_executions',
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				// room-2 has goal-3 which has no executions
+				expect(parsed.rows).toHaveLength(0);
+			});
+		});
+
+		describe('row limit cap enforced', () => {
+			it('default limit is 200', async () => {
+				// Insert many rows
+				seedRooms(db);
+				for (let i = 0; i < 10; i++) {
+					db.exec(
+						`INSERT INTO tasks (id, room_id, title, status, created_at) VALUES ('bulk-${i}', 'room-1', 'Bulk ${i}', 'pending', ${i})`
+					);
+				}
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM tasks' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBeLessThanOrEqual(200);
+			});
+
+			it('user-specified limit is respected when under max', async () => {
+				seedRooms(db);
+				for (let i = 0; i < 10; i++) {
+					db.exec(
+						`INSERT INTO tasks (id, room_id, title, status, created_at) VALUES ('lim-${i}', 'room-1', 'Limit ${i}', 'pending', ${i})`
+					);
+				}
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM tasks', limit: 3 });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBe(3);
+			});
+
+			it('limit is capped at 1000 even if user requests more', async () => {
+				seedRooms(db);
+				for (let i = 0; i < 10; i++) {
+					db.exec(
+						`INSERT INTO goals (id, room_id, title, status, created_at) VALUES ('glimit-${i}', 'room-1', 'Goal Limit ${i}', 'active', ${i})`
+					);
+				}
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// Request 5000 — should be capped at 1000
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM goals',
+					limit: 5000,
+				});
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBeLessThanOrEqual(1000);
+			});
+		});
+
+		describe('column blacklist removes sensitive columns', () => {
+			it('removes config column from rooms in global scope', async () => {
+				seedRooms(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM rooms' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				for (const row of parsed.rows) {
+					expect(row).not.toHaveProperty('config');
+					expect(row).toHaveProperty('id');
+					expect(row).toHaveProperty('name');
+				}
+			});
+
+			it('removes restrictions column from tasks', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM tasks' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				for (const row of parsed.rows) {
+					expect(row).not.toHaveProperty('restrictions');
+					expect(row).toHaveProperty('id');
+					expect(row).toHaveProperty('title');
+				}
+			});
+
+			it('removes config column from space_workflows in space scope', async () => {
+				seedSpaceWorkflows(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM space_workflows' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				for (const row of parsed.rows) {
+					expect(row).not.toHaveProperty('config');
+					expect(row).not.toHaveProperty('gates');
+					expect(row).not.toHaveProperty('channels');
+					expect(row).toHaveProperty('id');
+					expect(row).toHaveProperty('name');
+				}
+			});
+
+			it('blacklist does not apply to tables with no blacklisted columns', async () => {
+				seedGoals(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT * FROM goals' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(2);
+				// goals has no blacklisted columns — all columns should be present
+				expect(parsed.rows[0]).toHaveProperty('id');
+				expect(parsed.rows[0]).toHaveProperty('title');
+				expect(parsed.rows[0]).toHaveProperty('status');
+				expect(parsed.rows[0]).toHaveProperty('mission_type');
+			});
+		});
+
+		describe('SQL execution errors return isError', () => {
+			it('returns error for reference to nonexistent column', async () => {
+				seedRooms(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT nonexistent_col FROM rooms',
+				});
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('Query execution error');
+			});
+
+			it('returns error for type mismatch in params', async () => {
+				seedRooms(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM rooms WHERE id = ?',
+					params: [123], // wrong type — rooms.id is TEXT
+				});
+				// SQLite is flexible with types, so this may or may not error
+				// The point is that if it errors, isError is set
+				if (result.isError) {
+					expect(parseResult(result).raw).toContain('Query execution error');
+				}
+			});
+		});
+	});
+
+	// ── db_list_tables ─────────────────────────────────────────────────────────
+
+	describe('db_list_tables', () => {
+		it('returns only scope-appropriate tables for room scope', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+				db
+			);
+			const result = await handlers.db_list_tables();
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.tables).toContain('tasks');
+			expect(parsed.tables).toContain('goals');
+			expect(parsed.tables).toContain('mission_executions');
+			expect(parsed.tables).toContain('mission_metric_history');
+			// Should NOT contain global or space tables
+			expect(parsed.tables).not.toContain('rooms');
+			expect(parsed.tables).not.toContain('spaces');
+			expect(parsed.tables).not.toContain('space_tasks');
+		});
+
+		it('returns only scope-appropriate tables for space scope', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-1' },
+				db
+			);
+			const result = await handlers.db_list_tables();
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.tables).toContain('space_tasks');
+			expect(parsed.tables).toContain('space_workflow_runs');
+			expect(parsed.tables).toContain('gate_data');
+			// Should NOT contain room or global tables
+			expect(parsed.tables).not.toContain('tasks');
+			expect(parsed.tables).not.toContain('goals');
+			expect(parsed.tables).not.toContain('rooms');
+		});
+
+		it('returns global tables for global scope', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+				db
+			);
+			const result = await handlers.db_list_tables();
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.tables).toContain('rooms');
+			expect(parsed.tables).toContain('sessions');
+			expect(parsed.tables).toContain('spaces');
+			// Should NOT contain room or space scoped tables
+			expect(parsed.tables).not.toContain('tasks');
+			expect(parsed.tables).not.toContain('goals');
+		});
+
+		it('includes table descriptions', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+				db
+			);
+			const result = await handlers.db_list_tables();
+			const parsed = parseResult(result);
+
+			expect(parsed.description).toContain('tasks');
+			expect(parsed.description).toContain('goals');
+		});
+	});
+
+	// ── db_describe_table ──────────────────────────────────────────────────────
+
+	describe('db_describe_table', () => {
+		it('returns column info for an in-scope table', async () => {
+			seedTasks(db);
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+				db
+			);
+			const result = await handlers.db_describe_table({ table_name: 'tasks' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.description).toContain('tasks');
+			expect(parsed.description).toContain('id');
+			expect(parsed.description).toContain('room_id');
+			expect(parsed.description).toContain('title');
+			expect(parsed.description).toContain('status');
+		});
+
+		it('excludes blacklisted columns from output', async () => {
+			seedTasks(db);
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+				db
+			);
+			const result = await handlers.db_describe_table({ table_name: 'tasks' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			// 'restrictions' is blacklisted for tasks — should appear in the
+			// hidden columns note but NOT as a column in the table definition
+			expect(parsed.description).toContain('hidden');
+			// Verify restrictions does NOT appear as a column row in the table
+			const columnTableMatch = parsed.description.match(
+				/\|[\s\S]*?\|[\s\S]*?\|[\s\S]*?\|[\s\S]*?\|[\s\S]*?\|/g
+			);
+			const columnRows = columnTableMatch?.filter((row: string) => row.includes('TEXT')) ?? [];
+			for (const row of columnRows) {
+				expect(row).not.toContain('restrictions');
+			}
+		});
+
+		it('includes foreign key info', async () => {
+			seedTasks(db);
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+				db
+			);
+			const result = await handlers.db_describe_table({ table_name: 'mission_executions' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.description).toContain('Foreign Keys');
+			expect(parsed.description).toContain('goals');
+		});
+
+		it('rejects tables outside scope', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+				db
+			);
+			const result = await handlers.db_describe_table({ table_name: 'rooms' });
+			expect(result.isError).toBe(true);
+			expect(parseResult(result).raw).toContain('not accessible');
+		});
+
+		it('rejects non-existent tables', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+				db
+			);
+			const result = await handlers.db_describe_table({
+				table_name: 'nonexistent_table',
+			});
+			expect(result.isError).toBe(true);
+			expect(parseResult(result).raw).toContain('not accessible');
+		});
+
+		it('shows hidden column count when columns are blacklisted', async () => {
+			seedRooms(db);
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'global', scopeValue: '' },
+				db
+			);
+			const result = await handlers.db_describe_table({ table_name: 'rooms' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.description).toContain('hidden');
+			expect(parsed.description).toContain('config');
+		});
+	});
+
+	// ── createDbQueryMcpServer ─────────────────────────────────────────────────
+
+	describe('createDbQueryMcpServer', () => {
+		let tmpDir: string;
+
+		beforeEach(() => {
+			tmpDir = mkdtempSync(join(tmpdir(), 'neokai-test-'));
+		});
+
+		afterEach(() => {
+			rmSync(tmpDir, { recursive: true, force: true });
+		});
+
+		it('creates a server with the correct name and tools', () => {
+			const dbPath = join(tmpDir, 'test.db');
+			// Create the database file first
+			const initDb = new Database(dbPath);
+			initDb.exec('CREATE TABLE rooms (id TEXT PRIMARY KEY, name TEXT, config TEXT)');
+			initDb.close();
+
+			const server = createDbQueryMcpServer({
+				dbPath,
+				scopeType: 'global',
+				scopeValue: '',
+			});
+
+			expect(server.name).toBe('db-query');
+			// Note: version is set in the real SDK's createSdkMcpServer call,
+			// but the test mock may not propagate it in all environments
+			expect(server.type).toBe('sdk');
+			expect(server.instance._registeredTools).toHaveProperty('db_query');
+			expect(server.instance._registeredTools).toHaveProperty('db_list_tables');
+			expect(server.instance._registeredTools).toHaveProperty('db_describe_table');
+
+			server.close();
+		});
+
+		it('registers tools with correct descriptions', () => {
+			const dbPath = join(tmpDir, 'test.db');
+			const initDb = new Database(dbPath);
+			initDb.exec(
+				'CREATE TABLE tasks (id TEXT PRIMARY KEY, room_id TEXT, title TEXT, restrictions TEXT)'
+			);
+			initDb.close();
+
+			const server = createDbQueryMcpServer({
+				dbPath,
+				scopeType: 'room',
+				scopeValue: 'room-1',
+			});
+
+			const queryTool = server.instance._registeredTools.db_query as {
+				description: string;
+			};
+			expect(queryTool.description).toContain('room scope');
+			expect(queryTool.description).toContain('SELECT');
+
+			const listTool = server.instance._registeredTools.db_list_tables as {
+				description: string;
+			};
+			expect(listTool.description).toContain('room');
+
+			server.close();
+		});
+
+		it('close() properly closes the connection', () => {
+			const dbPath = join(tmpDir, 'test.db');
+			const initDb = new Database(dbPath);
+			initDb.exec('CREATE TABLE rooms (id TEXT PRIMARY KEY)');
+			initDb.close();
+
+			const server = createDbQueryMcpServer({
+				dbPath,
+				scopeType: 'global',
+				scopeValue: '',
+			});
+
+			// close() should not throw
+			expect(() => server.close()).not.toThrow();
+		});
+
+		it('tools are functional through the MCP server', async () => {
+			const dbPath = join(tmpDir, 'test.db');
+			const initDb = new Database(dbPath);
+			initDb.exec('CREATE TABLE rooms (id TEXT PRIMARY KEY, name TEXT, config TEXT)');
+			initDb.exec("INSERT INTO rooms VALUES ('r1', 'Room 1', '{\"m\":\"o\"}')");
+			initDb.close();
+
+			const server = createDbQueryMcpServer({
+				dbPath,
+				scopeType: 'global',
+				scopeValue: '',
+			});
+
+			expect(server.type).toBe('sdk');
+			// Verify the handler can be invoked
+			const queryHandler = (
+				server.instance._registeredTools.db_query as {
+					handler: (args: { sql: string }) => Promise<{ content: Array<{ text: string }> }>;
+				}
+			).handler;
+			const result = await queryHandler({ sql: 'SELECT * FROM rooms' });
+			const data = JSON.parse(result.content[0].text);
+			expect(data.rows).toHaveLength(1);
+			expect(data.rows[0]).not.toHaveProperty('config');
+
+			server.close();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -1201,6 +1201,87 @@ describe('db-query tools', () => {
 			});
 		});
 
+		describe('aggregate query edge cases', () => {
+			it('correlated subquery with aggregate in SELECT list is not misclassified', async () => {
+				seedGoals(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// This is NOT an aggregate query — the COUNT is in a subquery.
+				// It goes through direct WHERE injection to preserve the subquery.
+				const result = await handlers.db_query({
+					sql: 'SELECT id, title, (SELECT COUNT(*) FROM tasks) AS total FROM goals',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1 has goal-1 and goal-2 — should get 2 rows
+				expect(parsed.rowCount).toBe(2);
+			});
+
+			it('aggregate on indirect-scope table (scopeJoin) works', async () => {
+				seedMissionExecutions(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT COUNT(*) AS n FROM mission_executions',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1: goal-1 → exec-1, exec-2; goal-2 → exec-3 = 3 executions
+				expect(parsed.rows[0].n).toBe(3);
+			});
+
+			it('HAVING clause works in scoped aggregate mode', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT status, COUNT(*) AS cnt FROM tasks GROUP BY status HAVING cnt > 1',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1: in_progress=1, pending=1 — neither > 1, so 0 rows
+				expect(parsed.rowCount).toBe(0);
+			});
+
+			it('aggregate with CTE in scoped mode', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: "WITH pending AS (SELECT * FROM tasks WHERE status = 'pending') SELECT COUNT(*) AS n FROM pending",
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1: task-2 is pending
+				expect(parsed.rows[0].n).toBe(1);
+			});
+
+			it('DISTINCT + ORDER BY combined in scoped mode', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT DISTINCT status FROM tasks ORDER BY status',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1: in_progress, pending — ordered alphabetically
+				expect(parsed.rowCount).toBe(2);
+				expect(parsed.rows[0].status).toBe('in_progress');
+				expect(parsed.rows[1].status).toBe('pending');
+			});
+		});
+
 		describe('SQL LIMIT honored in scoped mode', () => {
 			it('respects SQL LIMIT in room scope', async () => {
 				seedTasks(db);

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -915,6 +915,35 @@ describe('db-query tools', () => {
 			});
 		});
 
+		describe('UNION queries rejected at handler level', () => {
+			it('rejects UNION query with clear error', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'SELECT id FROM tasks UNION SELECT id FROM goals',
+				});
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('UNION');
+			});
+		});
+
+		describe('table-less queries in scoped mode', () => {
+			it('SELECT 1 returns result without scope filter', async () => {
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({ sql: 'SELECT 1' });
+				const parsed = parseResult(result);
+
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rows).toHaveLength(1);
+				expect(parsed.rows[0]).toEqual({ '1': 1 });
+			});
+		});
+
 		describe('global scope limit arg', () => {
 			it('respects explicit limit arg in global scope', async () => {
 				seedRooms(db);

--- a/packages/daemon/tests/unit/db-query/tools.test.ts
+++ b/packages/daemon/tests/unit/db-query/tools.test.ts
@@ -984,6 +984,50 @@ describe('db-query tools', () => {
 			});
 		});
 
+		describe('named-column CTEs in scoped mode', () => {
+			it('preserves CTE column list when scope column is included', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'WITH active(id, title, room_id) AS (SELECT id, title, room_id FROM tasks) SELECT * FROM active',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				// room-1 has task-1 and task-2
+				expect(parsed.rowCount).toBe(2);
+			});
+
+			it('fails with clear error when CTE omits scope column', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'WITH active(id, title) AS (SELECT id, title FROM tasks) SELECT * FROM active',
+				});
+				expect(result.isError).toBe(true);
+				expect(parseResult(result).raw).toContain('room_id');
+			});
+
+			it('rewrites CTE without column list (backward compat)', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				const result = await handlers.db_query({
+					sql: 'WITH active AS (SELECT id, title FROM tasks) SELECT * FROM active',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBe(2);
+			});
+		});
+
 		describe('table-less queries in scoped mode', () => {
 			it('SELECT 1 returns result without scope filter', async () => {
 				const handlers = createDbQueryToolHandlers(
@@ -1030,6 +1074,40 @@ describe('db-query tools', () => {
 
 				expect(parsed.isError).toBeFalsy();
 				expect(parsed.rowCount).toBe(2);
+			});
+		});
+
+		describe('SQL LIMIT honored in scoped mode', () => {
+			it('respects SQL LIMIT in room scope', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// room-1 has 2 tasks, SQL LIMIT 1 should return 1
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM tasks LIMIT 1',
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBe(1);
+				expect(parsed.truncated).toBe(true);
+			});
+
+			it('uses stricter of arg limit and SQL LIMIT in room scope', async () => {
+				seedTasks(db);
+				const handlers = createDbQueryToolHandlers(
+					{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-1' },
+					db
+				);
+				// SQL has LIMIT 10, arg has limit 1 — should use 1 (stricter)
+				const result = await handlers.db_query({
+					sql: 'SELECT * FROM tasks LIMIT 10',
+					limit: 1,
+				});
+				const parsed = parseResult(result);
+				expect(parsed.isError).toBeFalsy();
+				expect(parsed.rowCount).toBe(1);
 			});
 		});
 	});


### PR DESCRIPTION
Implement the core `db-query` MCP server that provides agents with safe, scoped read-only access to the NeoKai SQLite database.

## What's included

**`packages/daemon/src/lib/db-query/tools.ts`** — Three tools:

| Tool | Description |
|------|-------------|
| `db_query` | Execute scoped SELECT with automatic WHERE injection, row limit (max 1000), and column blacklist |
| `db_list_tables` | List tables visible in the current scope with descriptions |
| `db_describe_table` | Show column definitions, types, and FK references (blacklisted columns hidden) |

**`packages/daemon/tests/unit/db-query/tools.test.ts`** — 44 unit tests covering:
- Valid SELECT queries return rows (simple, explicit columns, WHERE, global scope)
- Non-SELECT statements rejected (INSERT, UPDATE, DELETE, DROP, CREATE)
- Out-of-scope table access rejected (including cross-scope joins)
- Scope subquery wrapping filters correctly (room/space/global)
- Indirect scope tables (mission_executions via goals, gate_data via runs)
- Row limit cap enforced (default 200, max 1000)
- Column blacklist removes sensitive columns (config, restrictions, gates, etc.)
- SQL execution errors return `isError: true`
- `db_list_tables` returns scope-appropriate tables
- `db_describe_table` column info, blacklisted column filtering, FK info
- `close()` properly closes the connection

## Safety layers

1. SQL validation rejects non-SELECT statements
2. Table-ref validation rejects out-of-scope table access
3. Subquery wrapping auto-injects WHERE clauses for room/space scopes
4. Connection-level read-only (`readonly: true` + `PRAGMA query_only = ON`)
5. Row limit cap (default 200, max 1000)
6. Column blacklist removes sensitive columns from results