### PR TITLE
feat: frontend status/field migration (comprehensive)

### DIFF
--- a/packages/web/src/components/space/SpaceContextPanel.tsx
+++ b/packages/web/src/components/space/SpaceContextPanel.tsx
@@ -27,14 +27,16 @@ function taskStatusColor(status: string): string {
 	switch (status) {
 		case 'in_progress':
 			return 'bg-blue-400';
-		case 'review':
-			return 'bg-amber-400';
-		case 'pending':
+		case 'open':
 			return 'bg-gray-400';
-		case 'needs_attention':
+		case 'done':
+			return 'bg-green-400';
+		case 'blocked':
 			return 'bg-red-400';
-		case 'draft':
+		case 'cancelled':
 			return 'bg-gray-500';
+		case 'archived':
+			return 'bg-gray-600';
 		default:
 			return 'bg-gray-500';
 	}

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -16,7 +16,7 @@
  * Node status (from tasks in the space store):
  *   - pending:    gray box, no tasks yet
  *   - active:     blue box, pulsing — has in_progress tasks
- *   - completed:  green box, checkmark + elapsed time
+ *   - done:       green box, checkmark + elapsed time
  *   - failed:     red box — task errored or run failed
  */
 

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -50,7 +50,7 @@ const CANVAS_PADDING = 40;
 // Types
 // ============================================================================
 
-type NodeStatus = 'pending' | 'active' | 'completed' | 'failed';
+type NodeStatus = 'pending' | 'active' | 'done' | 'failed';
 
 type GateStatus = 'open' | 'blocked' | 'waiting_human';
 
@@ -637,7 +637,7 @@ function NodeBox({
 				/>
 			);
 			break;
-		case 'completed': {
+		case 'done': {
 			borderColor = '#16a34a';
 			bgColor = '#052e16';
 			labelColor = '#86efac';
@@ -817,7 +817,7 @@ function getNodeStatus(
 		)
 	) {
 		// All terminal — check if they succeeded
-		if (nodeTasks.some((t) => t.status === 'done')) return 'completed';
+		if (nodeTasks.some((t) => t.status === 'done')) return 'done';
 	}
 
 	if (run?.status === 'blocked' || run?.status === 'cancelled') {

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -502,7 +502,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 	const [showTemplates, setShowTemplates] = useState(false);
 
 	const agents = filterAgents(spaceStore.agents.value);
-	const tasksByNodeId = spaceStore.tasksByNodeId.value;
+	const nodeExecutionsByNodeId = spaceStore.nodeExecutionsByNodeId.value;
 
 	// Determine which workflow run to use for completion indicators.
 	// Prefer an active run; fall back to the most recently updated run.
@@ -814,17 +814,17 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 
 					<div class="space-y-2">
 						{steps.map((step, i) => {
-							// Derive per-agent completion states from live task data for this node,
+							// Derive per-agent completion states from node execution data for this node,
 							// scoped to the most relevant workflow run to avoid mixing state from
 							// past runs with the current one.
-							const allNodeTasks = step.id ? (tasksByNodeId.get(step.id) ?? []) : [];
-							const nodeTasks = relevantRunId
-								? allNodeTasks.filter((t) => t.workflowRunId === relevantRunId)
-								: allNodeTasks;
-							const nodeTaskStates: AgentTaskState[] = nodeTasks.map((t) => ({
-								agentName: null,
-								status: t.status,
-								completionSummary: t.result ?? null,
+							const allNodeExecs = step.id ? (nodeExecutionsByNodeId.get(step.id) ?? []) : [];
+							const nodeExecs = relevantRunId
+								? allNodeExecs.filter((e) => e.workflowRunId === relevantRunId)
+								: allNodeExecs;
+							const nodeTaskStates: AgentTaskState[] = nodeExecs.map((e) => ({
+								agentName: e.agentName || null,
+								status: e.status,
+								completionSummary: e.result ?? null,
 							}));
 							return (
 								<WorkflowNodeCard

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -822,7 +822,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 								? allNodeExecs.filter((e) => e.workflowRunId === relevantRunId)
 								: allNodeExecs;
 							const nodeTaskStates: AgentTaskState[] = nodeExecs.map((e) => ({
-								agentName: e.agentName || null,
+								agentName: e.agentName ?? null,
 								status: e.status,
 								completionSummary: e.result ?? null,
 							}));

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -8,13 +8,13 @@
  * Expanded: name input, agent dropdown, entry/exit gate selectors, instructions
  */
 
-import { useState, useCallback } from 'preact/hooks';
 import type {
-	SpaceAgent,
-	WorkflowNodeAgent,
-	WorkflowChannel,
 	NodeExecutionStatus,
+	SpaceAgent,
+	WorkflowChannel,
+	WorkflowNodeAgent,
 } from '@neokai/shared';
+import { useCallback, useState } from 'preact/hooks';
 import { cn } from '../../lib/utils';
 
 // ============================================================================
@@ -681,7 +681,7 @@ interface WorkflowNodeCardProps {
 	disableRemove?: boolean;
 	/**
 	 * Runtime agent completion states for this node.
-	 * Derived from SpaceTask records filtered by the node's ID.
+	 * Derived from NodeExecution records filtered by the node's ID.
 	 * When provided, per-agent status indicators are shown in the collapsed header.
 	 */
 	nodeTaskStates?: AgentTaskState[];

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -13,7 +13,7 @@ import type {
 	SpaceAgent,
 	WorkflowNodeAgent,
 	WorkflowChannel,
-	SpaceTaskStatus,
+	NodeExecutionStatus,
 } from '@neokai/shared';
 import { cn } from '../../lib/utils';
 
@@ -70,11 +70,11 @@ export interface ConditionDraft {
 export interface AgentTaskState {
 	/** Matches WorkflowNodeAgent.name; null means single-agent node */
 	agentName: string | null;
-	status: SpaceTaskStatus;
+	status: NodeExecutionStatus;
 	completionSummary?: string | null;
 }
 
-/** Returns true when all provided agent states have status === 'completed'. */
+/** Returns true when all provided agent states have status === 'done'. */
 export function isNodeFullyCompleted(states: AgentTaskState[]): boolean {
 	return states.length > 0 && states.every((s) => s.status === 'done');
 }

--- a/packages/web/src/components/space/WorkflowNodeCard.tsx
+++ b/packages/web/src/components/space/WorkflowNodeCard.tsx
@@ -65,7 +65,7 @@ export interface ConditionDraft {
 
 /**
  * Runtime completion state for a single agent slot within a workflow node.
- * Derived from SpaceTask records filtered by workflowNodeId.
+ * Derived from NodeExecution records grouped by workflowNodeId.
  */
 export interface AgentTaskState {
 	/** Matches WorkflowNodeAgent.name; null means single-agent node */

--- a/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
@@ -67,7 +67,7 @@ const TASK_MOCK = {
 	spaceId: 'space-1',
 	title: 'Test task',
 	description: '',
-	status: 'pending',
+	status: 'open',
 	priority: 'normal',
 	taskType: 'coding',
 	dependsOn: [],

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -60,7 +60,7 @@ function makeSpace(overrides: Partial<Space> = {}): Space {
 	};
 }
 
-function makeTask(id: string, status: SpaceTask['status'] = 'pending'): SpaceTask {
+function makeTask(id: string, status: SpaceTask['status'] = 'open'): SpaceTask {
 	return {
 		id,
 		spaceId: 'space-1',
@@ -137,8 +137,8 @@ describe('SpaceDashboard', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [
 			makeTask('t1', 'in_progress'),
-			makeTask('t2', 'review'),
-			makeTask('t3', 'completed'),
+			makeTask('t2', 'blocked'),
+			makeTask('t3', 'done'),
 		];
 		const { getByText, getAllByText } = render(<SpaceDashboard spaceId="space-1" />);
 		expect(getAllByText('Active').length).toBeGreaterThanOrEqual(1);
@@ -150,9 +150,9 @@ describe('SpaceDashboard', () => {
 	it('shows attention, in-progress, and recent sections for tasks', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [
-			makeTask('attention', 'needs_attention'),
+			makeTask('attention', 'blocked'),
 			makeTask('active', 'in_progress'),
-			makeTask('done', 'completed'),
+			makeTask('done', 'done'),
 		];
 		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
 		expect(getByText('Attention Queue')).toBeTruthy();
@@ -185,7 +185,7 @@ describe('SpaceDashboard', () => {
 
 	it('calls onSelectTask when a recent task row is clicked', () => {
 		mockSpace.value = makeSpace();
-		mockTasks.value = [makeTask('t1', 'completed')];
+		mockTasks.value = [makeTask('t1', 'done')];
 		const onSelectTask = vi.fn();
 		const { getByText } = render(<SpaceDashboard spaceId="space-1" onSelectTask={onSelectTask} />);
 		fireEvent.click(getByText('Task t1').closest('button')!);

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -57,7 +57,7 @@ function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
 		spaceId: 'space-1',
 		title: 'Fix the bug',
 		description: 'Task description',
-		status: 'pending',
+		status: 'open',
 		priority: 'normal',
 		dependsOn: [],
 		createdAt: Date.now(),

--- a/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
@@ -9,12 +9,12 @@
  * - Gate icon rendered ON channel line (not as separate node)
  * - Gate status: open (green), blocked (gray lock), waiting_human (amber)
  * - Human approval gate shows waiting_human when no data
- * - Runtime mode shows live node status (active, completed)
+ * - Runtime mode shows live node status (active, done)
  * - Template mode shows "+ add gate" buttons on channels without gates
  * - Template mode shows remove-gate button on gated channels
  * - Node active status shows pulsing class
  * - Completed node shows checkmark indicator
- * - Active run banner shows when run is needs_attention
+ * - Active run banner shows when run is blocked
  * - Gate data event subscription updates gate status
  * - "View Artifacts" button opens artifacts panel overlay for waiting_human gate
  * - Closing the artifacts panel overlay hides it

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -26,7 +26,7 @@ import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
-const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+const mockNodeExecutionsByNodeId = signal(new Map<string, unknown[]>());
 const mockWorkflowRuns = signal<unknown[]>([]);
 
 const mockCreateWorkflow = vi.fn();
@@ -37,7 +37,7 @@ vi.mock('../../../lib/space-store', () => ({
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
-			tasksByNodeId: mockTasksByNodeId,
+			nodeExecutionsByNodeId: mockNodeExecutionsByNodeId,
 			workflowRuns: mockWorkflowRuns,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,

--- a/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowNodeCard.test.tsx
@@ -436,8 +436,8 @@ describe('WorkflowNodeCard — agent completion state', () => {
 		expect(getByTestId('agent-status-fail')).toBeTruthy();
 	});
 
-	it('shows pending dot for open agent', () => {
-		const states: AgentTaskState[] = [{ agentName: null, status: 'open' }];
+	it('shows pending dot for pending agent', () => {
+		const states: AgentTaskState[] = [{ agentName: null, status: 'pending' }];
 		const { getByTestId } = render(<WorkflowNodeCard {...makeProps({ nodeTaskStates: states })} />);
 		expect(getByTestId('agent-status-pending')).toBeTruthy();
 	});

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -255,7 +255,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const canvasContainerRef = useRef<HTMLDivElement>(null);
 
 	const agents = filterAgents(spaceStore.agents.value);
-	const tasksByNodeId = spaceStore.tasksByNodeId.value;
+	const nodeExecutionsByNodeId = spaceStore.nodeExecutionsByNodeId.value;
 	const regularNodes = useMemo(
 		() =>
 			nodes.filter(
@@ -410,15 +410,15 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const nodeData = useMemo<WorkflowNodeData[]>(() => {
 		return regularNodes.map((node, i) => {
 			const nodeId = node.step.id;
-			const allNodeTasks = nodeId ? (tasksByNodeId.get(nodeId) ?? []) : [];
+			const allNodeExecs = nodeId ? (nodeExecutionsByNodeId.get(nodeId) ?? []) : [];
 			// Filter to the most relevant run to avoid mixing state from past runs.
-			const nodeTasks = relevantRunId
-				? allNodeTasks.filter((t) => t.workflowRunId === relevantRunId)
-				: allNodeTasks;
-			const nodeTaskStates: AgentTaskState[] = nodeTasks.map((t) => ({
-				agentName: null,
-				status: t.status,
-				completionSummary: t.result,
+			const nodeExecs = relevantRunId
+				? allNodeExecs.filter((e) => e.workflowRunId === relevantRunId)
+				: allNodeExecs;
+			const nodeTaskStates: AgentTaskState[] = nodeExecs.map((e) => ({
+				agentName: e.agentName || null,
+				status: e.status,
+				completionSummary: e.result,
 			}));
 			return {
 				stepIndex: i,
@@ -438,7 +438,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		channels,
 		nodeIsStart,
 		nodeIsEnd,
-		tasksByNodeId,
+		nodeExecutionsByNodeId,
 		relevantRunId,
 		anchorUsageByNodeId,
 	]);

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -416,7 +416,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				? allNodeExecs.filter((e) => e.workflowRunId === relevantRunId)
 				: allNodeExecs;
 			const nodeTaskStates: AgentTaskState[] = nodeExecs.map((e) => ({
-				agentName: e.agentName || null,
+				agentName: e.agentName ?? null,
 				status: e.status,
 				completionSummary: e.result,
 			}));

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -68,7 +68,7 @@ import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
-const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+const mockNodeExecutionsByNodeId = signal(new Map<string, unknown[]>());
 const mockWorkflowRuns = signal<unknown[]>([]);
 
 const mockCreateWorkflow = vi.fn();
@@ -107,7 +107,7 @@ vi.mock('../../../../lib/space-store', () => ({
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
-			tasksByNodeId: mockTasksByNodeId,
+			nodeExecutionsByNodeId: mockNodeExecutionsByNodeId,
 			workflowRuns: mockWorkflowRuns,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../WorkflowCanvas', async (importOriginal) => {
 
 const mockAgents: Signal<SpaceAgent[]> = signal([]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
-const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+const mockNodeExecutionsByNodeId = signal(new Map<string, unknown[]>());
 const mockWorkflowRuns = signal<unknown[]>([]);
 const mockCreateWorkflow = vi.fn();
 const mockUpdateWorkflow = vi.fn();
@@ -47,7 +47,7 @@ vi.mock('../../../../lib/space-store', () => ({
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
-			tasksByNodeId: mockTasksByNodeId,
+			nodeExecutionsByNodeId: mockNodeExecutionsByNodeId,
 			workflowRuns: mockWorkflowRuns,
 			createWorkflow: mockCreateWorkflow,
 			updateWorkflow: mockUpdateWorkflow,

--- a/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
@@ -48,7 +48,7 @@ const mockAgents: Signal<SpaceAgent[]> = signal([
 ]);
 const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
 
-const mockTasksByNodeId = signal(new Map<string, unknown[]>());
+const mockNodeExecutionsByNodeId = signal(new Map<string, unknown[]>());
 const mockWorkflowRuns = signal<unknown[]>([]);
 
 vi.mock('../../../../lib/space-store', () => ({
@@ -56,7 +56,7 @@ vi.mock('../../../../lib/space-store', () => ({
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
-			tasksByNodeId: mockTasksByNodeId,
+			nodeExecutionsByNodeId: mockNodeExecutionsByNodeId,
 			workflowRuns: mockWorkflowRuns,
 			createWorkflow: vi.fn(),
 			updateWorkflow: vi.fn(),

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -13,6 +13,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type {
+	NodeExecution,
 	Space,
 	SpaceTask,
 	SpaceWorkflowRun,
@@ -175,6 +176,7 @@ function makeMockHub() {
 			// spaceWorkflow handlers return wrapped { workflow }
 			if (method === 'spaceWorkflow.create') return { workflow: makeWorkflow('new-wf') };
 			if (method === 'spaceWorkflow.update') return { workflow: makeWorkflow('wf1') };
+			if (method === 'nodeExecution.list') return { executions: [] };
 			// space.listWithTasks returns array of spaces enriched with tasks
 			if (method === 'space.listWithTasks')
 				return [
@@ -1135,5 +1137,268 @@ describe('SpaceStore — refresh', () => {
 		await spaceStore.refresh();
 
 		expect(mockHub.request).not.toHaveBeenCalledWith('space.overview', expect.anything());
+	});
+});
+
+// -------------------------------------------------------
+// Helper: create NodeExecution fixtures
+// -------------------------------------------------------
+
+function makeNodeExecution(overrides: Partial<NodeExecution> = {}): NodeExecution {
+	return {
+		id: overrides.id ?? 'exec-1',
+		workflowRunId: overrides.workflowRunId ?? 'run-1',
+		workflowNodeId: overrides.workflowNodeId ?? 'node-1',
+		agentName: overrides.agentName ?? 'coder',
+		agentId: overrides.agentId ?? 'agent-1',
+		agentSessionId: overrides.agentSessionId ?? null,
+		status: overrides.status ?? ('pending' as NodeExecution['status']),
+		result: overrides.result ?? null,
+		createdAt: overrides.createdAt ?? Date.now(),
+		startedAt: overrides.startedAt ?? null,
+		completedAt: overrides.completedAt ?? null,
+		updatedAt: overrides.updatedAt ?? Date.now(),
+	};
+}
+
+describe('SpaceStore — node execution LiveQuery subscriptions', () => {
+	beforeEach(resetStore);
+	afterEach(() => vi.clearAllMocks());
+
+	it('subscribes to LiveQuery when workflowRun.created fires', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		const run = makeRun('run-1');
+		handler({ spaceId: 'space-1', runId: run.id, run, sessionId: 's1' });
+
+		expect(spaceStore.workflowRuns.value).toContainEqual(run);
+		expect(mockHub.request).toHaveBeenCalledWith('liveQuery.subscribe', {
+			queryName: 'nodeExecutions.byRun',
+			params: ['run-1'],
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+		});
+	});
+
+	it('does not subscribe to LiveQuery if spaceId does not match', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		const run = makeRun('run-2');
+		handler({ spaceId: 'space-other', runId: run.id, run, sessionId: 's1' });
+
+		expect(spaceStore.workflowRuns.value).not.toContainEqual(run);
+		expect(mockHub.request).not.toHaveBeenCalledWith(
+			'liveQuery.subscribe',
+			expect.objectContaining({ params: ['run-2'] })
+		);
+	});
+
+	it('applies LiveQuery snapshot to nodeExecutions signal', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		const run = makeRun('run-1');
+		handler({ spaceId: 'space-1', runId: run.id, run, sessionId: 's1' });
+
+		const exec1 = makeNodeExecution({
+			id: 'exec-1',
+			workflowRunId: 'run-1',
+			workflowNodeId: 'node-a',
+		});
+		const exec2 = makeNodeExecution({
+			id: 'exec-2',
+			workflowRunId: 'run-1',
+			workflowNodeId: 'node-b',
+		});
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			rows: [exec1, exec2],
+			version: 1,
+		});
+
+		expect(spaceStore.nodeExecutions.value).toEqual([exec1, exec2]);
+	});
+
+	it('applies LiveQuery delta (add/update/remove) to nodeExecutions signal', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		const run = makeRun('run-1');
+		handler({ spaceId: 'space-1', runId: run.id, run, sessionId: 's1' });
+
+		const exec1 = makeNodeExecution({ id: 'exec-1', status: 'pending' });
+		const exec2 = makeNodeExecution({ id: 'exec-2', status: 'pending' });
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			rows: [exec1, exec2],
+			version: 1,
+		});
+
+		const exec1Updated = { ...exec1, status: 'done' as const, result: 'All good' };
+		const exec3 = makeNodeExecution({ id: 'exec-3', workflowNodeId: 'node-c' });
+		fireMockEvent('liveQuery.delta', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			updated: [exec1Updated],
+			removed: [exec2],
+			added: [exec3],
+			version: 2,
+		});
+
+		expect(spaceStore.nodeExecutions.value).toHaveLength(2);
+		expect(spaceStore.nodeExecutions.value).toContainEqual(exec1Updated);
+		expect(spaceStore.nodeExecutions.value).toContainEqual(exec3);
+		expect(spaceStore.nodeExecutions.value).not.toContainEqual(exec2);
+	});
+
+	it('replaces snapshot data for a specific run without affecting other runs', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		handler({ spaceId: 'space-1', runId: 'run-1', run: makeRun('run-1'), sessionId: 's1' });
+		handler({ spaceId: 'space-1', runId: 'run-2', run: makeRun('run-2'), sessionId: 's1' });
+
+		const exec1 = makeNodeExecution({ id: 'exec-1', workflowRunId: 'run-1' });
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			rows: [exec1],
+			version: 1,
+		});
+
+		const exec2 = makeNodeExecution({ id: 'exec-2', workflowRunId: 'run-2' });
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-2',
+			rows: [exec2],
+			version: 1,
+		});
+
+		expect(spaceStore.nodeExecutions.value).toHaveLength(2);
+
+		const exec1New = makeNodeExecution({ id: 'exec-1-new', workflowRunId: 'run-1' });
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			rows: [exec1New],
+			version: 2,
+		});
+
+		expect(spaceStore.nodeExecutions.value).toHaveLength(2);
+		expect(spaceStore.nodeExecutions.value).toContainEqual(exec1New);
+		expect(spaceStore.nodeExecutions.value).toContainEqual(exec2);
+	});
+
+	it('handles empty snapshot (clears executions for that run)', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		handler({ spaceId: 'space-1', runId: 'run-1', run: makeRun('run-1'), sessionId: 's1' });
+
+		const exec1 = makeNodeExecution({ id: 'exec-1', workflowRunId: 'run-1' });
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			rows: [exec1],
+			version: 1,
+		});
+		expect(spaceStore.nodeExecutions.value).toHaveLength(1);
+
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			rows: [],
+			version: 2,
+		});
+		expect(spaceStore.nodeExecutions.value).toHaveLength(0);
+	});
+
+	it('computes nodeExecutionsByNodeId correctly', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		handler({ spaceId: 'space-1', runId: 'run-1', run: makeRun('run-1'), sessionId: 's1' });
+
+		const exec1 = makeNodeExecution({
+			id: 'exec-1',
+			workflowRunId: 'run-1',
+			workflowNodeId: 'node-a',
+		});
+		const exec2 = makeNodeExecution({
+			id: 'exec-2',
+			workflowRunId: 'run-1',
+			workflowNodeId: 'node-a',
+		});
+		const exec3 = makeNodeExecution({
+			id: 'exec-3',
+			workflowRunId: 'run-1',
+			workflowNodeId: 'node-b',
+		});
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			rows: [exec1, exec2, exec3],
+			version: 1,
+		});
+
+		const byNode = spaceStore.nodeExecutionsByNodeId.value;
+		expect(byNode.get('node-a')).toEqual([exec1, exec2]);
+		expect(byNode.get('node-b')).toEqual([exec3]);
+		expect(byNode.get('node-nonexistent')).toBeUndefined();
+	});
+
+	it('ignores snapshot events for wrong subscriptionId', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		handler({ spaceId: 'space-1', runId: 'run-1', run: makeRun('run-1'), sessionId: 's1' });
+
+		const exec1 = makeNodeExecution({ id: 'exec-1' });
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'wrong-subscription-id',
+			rows: [exec1],
+			version: 1,
+		});
+
+		expect(spaceStore.nodeExecutions.value).toHaveLength(0);
+	});
+
+	it('clears nodeExecutions on space switch', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		handler({ spaceId: 'space-1', runId: 'run-1', run: makeRun('run-1'), sessionId: 's1' });
+
+		const exec1 = makeNodeExecution({ id: 'exec-1' });
+		fireMockEvent('liveQuery.snapshot', {
+			subscriptionId: 'nodeExecutions-byRun-run-1',
+			rows: [exec1],
+			version: 1,
+		});
+		expect(spaceStore.nodeExecutions.value).toHaveLength(1);
+
+		// Override mock for space-2
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.overview')
+				return { space: makeSpace('space-2'), tasks: [], workflowRuns: [], sessions: [] };
+			if (method === 'spaceAgent.list') return { agents: [] };
+			if (method === 'spaceWorkflow.list') return { workflows: [] };
+			if (method === 'nodeExecution.list') return { executions: [] };
+			return {};
+		});
+		await spaceStore.selectSpace('space-2');
+
+		expect(spaceStore.nodeExecutions.value).toHaveLength(0);
+	});
+
+	it('does not duplicate subscription when workflowRun.created fires twice for same run', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const handler = mockEventHandlers.get('space.workflowRun.created')!;
+		const run = makeRun('run-1');
+
+		handler({ spaceId: 'space-1', runId: run.id, run, sessionId: 's1' });
+		handler({ spaceId: 'space-1', runId: run.id, run, sessionId: 's1' });
+
+		const subscribeCalls = mockHub.request.mock.calls.filter(
+			(c: unknown[]) =>
+				c[0] === 'liveQuery.subscribe' &&
+				(c[1] as Record<string, unknown>)?.queryName === 'nodeExecutions.byRun'
+		);
+		expect(subscribeCalls).toHaveLength(1);
 	});
 });

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -15,6 +15,8 @@
  * - agents: SpaceAgent list for the space
  * - workflows: SpaceWorkflow list for the space
  * - runtimeState: Runtime state (running/paused/stopped)
+ * - nodeExecutions: NodeExecution list for all workflow runs in the space
+ * - nodeExecutionsByNodeId: NodeExecutions grouped by workflow node ID
  * - loading: Loading state
  * - error: Error state
  */
@@ -125,7 +127,7 @@ class SpaceStore {
 	/** Tasks not associated with any workflow run */
 	readonly standaloneTasks = computed(() => this.tasks.value.filter((t) => !t.workflowRunId));
 
-	/** Node executions for this space — fetched per workflow run */
+	/** Node executions for all workflow runs — loaded via initial fetch and LiveQuery subscriptions */
 	readonly nodeExecutions = signal<NodeExecution[]>([]);
 
 	/** Node executions grouped by workflow node ID */
@@ -534,10 +536,6 @@ class SpaceStore {
 				const exists = this.workflowRuns.value.some((r) => r.id === event.run.id);
 				if (!exists) {
 					this.workflowRuns.value = [...this.workflowRuns.value, event.run];
-					// Fetch node executions for the new run so the UI stays current.
-					this.fetchNodeExecutions(hub, spaceId).catch((err) => {
-						logger.warn('Failed to fetch node executions after run creation:', err);
-					});
 					// Subscribe to the new run's LiveQuery for real-time updates
 					this.subscribeNodeExecutionsByRun(hub, event.run.id);
 				}
@@ -561,10 +559,6 @@ class SpaceStore {
 						...this.workflowRuns.value.slice(idx + 1),
 					];
 				}
-				// Re-fetch node executions when a run is updated (e.g. node status changes).
-				this.fetchNodeExecutions(hub, spaceId).catch((err) => {
-					logger.warn('Failed to fetch node executions after run update:', err);
-				});
 			}
 		});
 		this.cleanupFunctions.push(unsubRunUpdated);
@@ -759,7 +753,7 @@ class SpaceStore {
 							workflowRunId: run.id,
 							spaceId,
 						})
-						.then((r) => r.executions ?? [])
+						.then((r) => r?.executions ?? [])
 				)
 			);
 			const allExecs: NodeExecution[] = [];
@@ -933,7 +927,7 @@ class SpaceStore {
 		const unsubSnapshot = hub.onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
 			if (event.subscriptionId !== subscriptionId) return;
 			if (!this.activeNodeExecSubscriptionIds.has(subscriptionId)) return;
-			this.mergeNodeExecSnapshot(event.rows as NodeExecution[]);
+			this.mergeNodeExecSnapshot(event.rows as NodeExecution[], runId);
 		});
 		this.nodeExecCleanupFns.push(unsubSnapshot);
 
@@ -973,10 +967,8 @@ class SpaceStore {
 	/**
 	 * Merge a LiveQuery snapshot (full replace for one run) into nodeExecutions.
 	 */
-	private mergeNodeExecSnapshot(rows: NodeExecution[]): void {
+	private mergeNodeExecSnapshot(rows: NodeExecution[], runId: string): void {
 		const current = this.nodeExecutions.value;
-		const runId = rows[0]?.workflowRunId;
-		if (!runId) return;
 		// Remove old executions for this run, add fresh snapshot
 		const filtered = current.filter((e) => e.workflowRunId !== runId);
 		this.nodeExecutions.value = [...filtered, ...rows];

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -26,6 +26,7 @@ import type {
 	SpaceWorkflowRun,
 	SpaceAgent,
 	SpaceWorkflow,
+	NodeExecution,
 	RuntimeState,
 	SpaceTaskActivityMember,
 	LiveQuerySnapshotEvent,
@@ -124,18 +125,33 @@ class SpaceStore {
 	/** Tasks not associated with any workflow run */
 	readonly standaloneTasks = computed(() => this.tasks.value.filter((t) => !t.workflowRunId));
 
-	/** Tasks grouped by workflow run ID — used to show per-run agent completion state */
-	readonly tasksByNodeId = computed(() => {
-		const map = new Map<string, SpaceTask[]>();
-		for (const task of this.tasks.value) {
-			if (task.workflowRunId) {
-				let arr = map.get(task.workflowRunId);
-				if (!arr) {
-					arr = [];
-					map.set(task.workflowRunId, arr);
-				}
-				arr.push(task);
+	/** Node executions for this space — fetched per workflow run */
+	readonly nodeExecutions = signal<NodeExecution[]>([]);
+
+	/** Node executions grouped by workflow node ID */
+	readonly nodeExecutionsByNodeId = computed(() => {
+		const map = new Map<string, NodeExecution[]>();
+		for (const exec of this.nodeExecutions.value) {
+			let arr = map.get(exec.workflowNodeId);
+			if (!arr) {
+				arr = [];
+				map.set(exec.workflowNodeId, arr);
 			}
+			arr.push(exec);
+		}
+		return map;
+	});
+
+	/** Node executions grouped by workflow run ID */
+	readonly nodeExecutionsByRun = computed(() => {
+		const map = new Map<string, NodeExecution[]>();
+		for (const exec of this.nodeExecutions.value) {
+			let arr = map.get(exec.workflowRunId);
+			if (!arr) {
+				arr = [];
+				map.set(exec.workflowRunId, arr);
+			}
+			arr.push(exec);
 		}
 		return map;
 	});
@@ -389,6 +405,7 @@ class SpaceStore {
 		this.workflowRuns.value = [];
 		this.agents.value = [];
 		this.workflows.value = [];
+		this.nodeExecutions.value = [];
 		this.runtimeState.value = null;
 		this.taskActivity.value = new Map();
 		this.error.value = null;
@@ -672,8 +689,12 @@ class SpaceStore {
 
 		const resolvedId = overview.space.id;
 
-		// Fetch agents and workflows in parallel
-		await Promise.all([this.fetchAgents(hub, resolvedId), this.fetchWorkflows(hub, resolvedId)]);
+		// Fetch agents, workflows, and node executions in parallel
+		await Promise.all([
+			this.fetchAgents(hub, resolvedId),
+			this.fetchWorkflows(hub, resolvedId),
+			this.fetchNodeExecutions(hub, resolvedId),
+		]);
 
 		return resolvedId;
 	}
@@ -709,6 +730,42 @@ class SpaceStore {
 			this.workflows.value = result?.workflows ?? [];
 		} catch (err) {
 			logger.error('Failed to fetch workflows:', err);
+		}
+	}
+
+	/**
+	 * Fetch node executions for all workflow runs in the space.
+	 * Calls nodeExecution.list for each run and aggregates the results.
+	 */
+	private async fetchNodeExecutions(
+		hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
+		spaceId: string
+	): Promise<void> {
+		try {
+			const runs = this.workflowRuns.value;
+			if (runs.length === 0) {
+				this.nodeExecutions.value = [];
+				return;
+			}
+			const results = await Promise.allSettled(
+				runs.map((run) =>
+					hub
+						.request<{ executions: NodeExecution[] }>('nodeExecution.list', {
+							workflowRunId: run.id,
+							spaceId,
+						})
+						.then((r) => r.executions ?? [])
+				)
+			);
+			const allExecs: NodeExecution[] = [];
+			for (const result of results) {
+				if (result.status === 'fulfilled') {
+					allExecs.push(...result.value);
+				}
+			}
+			this.nodeExecutions.value = allExecs;
+		} catch (err) {
+			logger.error('Failed to fetch node executions:', err);
 		}
 	}
 

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -922,6 +922,7 @@ class SpaceStore {
 		runId: string
 	): void {
 		const subscriptionId = `nodeExecutions-byRun-${runId}`;
+		if (this.activeNodeExecSubscriptionIds.has(subscriptionId)) return;
 		this.activeNodeExecSubscriptionIds.add(subscriptionId);
 
 		const unsubSnapshot = hub.onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -178,6 +178,12 @@ class SpaceStore {
 	/** Stale-event guard for task-activity LiveQuery subscriptions */
 	private activeTaskActivitySubscriptionIds = new Set<string>();
 
+	/** Cleanup functions for node execution LiveQuery subscriptions */
+	private nodeExecCleanupFns: Array<() => void> = [];
+
+	/** Stale-event guard for node execution LiveQuery subscriptions */
+	private activeNodeExecSubscriptionIds = new Set<string>();
+
 	// ========================================
 	// Global Space List
 	// ========================================
@@ -532,6 +538,8 @@ class SpaceStore {
 					this.fetchNodeExecutions(hub, spaceId).catch((err) => {
 						logger.warn('Failed to fetch node executions after run creation:', err);
 					});
+					// Subscribe to the new run's LiveQuery for real-time updates
+					this.subscribeNodeExecutionsByRun(hub, event.run.id);
 				}
 			}
 		});
@@ -690,6 +698,9 @@ class SpaceStore {
 			this.fetchNodeExecutions(hub, resolvedId),
 		]);
 
+		// Subscribe to node execution LiveQueries for real-time updates
+		this.subscribeNodeExecutions(hub);
+
 		return resolvedId;
 	}
 
@@ -778,6 +789,7 @@ class SpaceStore {
 		}
 		this.cleanupFunctions = [];
 		this.unsubscribeTaskActivity();
+		this.unsubscribeNodeExecutions();
 	}
 
 	private applyTaskActivityDelta(
@@ -887,6 +899,129 @@ class SpaceStore {
 		if (hub) {
 			hub.request('liveQuery.unsubscribe', { subscriptionId }).catch(() => {});
 		}
+	}
+
+	// ========================================
+	// Node Execution LiveQuery subscriptions
+	// ========================================
+
+	/**
+	 * Subscribe to nodeExecutions.byRun LiveQueries for all current workflow runs.
+	 * Called after initial fetch to enable real-time status updates.
+	 */
+	private subscribeNodeExecutions(hub: Awaited<ReturnType<typeof connectionManager.getHub>>): void {
+		this.unsubscribeNodeExecutions();
+
+		const runs = this.workflowRuns.value;
+		if (runs.length === 0) return;
+
+		for (const run of runs) {
+			this.subscribeNodeExecutionsByRun(hub, run.id);
+		}
+	}
+
+	/**
+	 * Subscribe to nodeExecutions.byRun for a single workflow run.
+	 */
+	private subscribeNodeExecutionsByRun(
+		hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
+		runId: string
+	): void {
+		const subscriptionId = `nodeExecutions-byRun-${runId}`;
+		this.activeNodeExecSubscriptionIds.add(subscriptionId);
+
+		const unsubSnapshot = hub.onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+			if (event.subscriptionId !== subscriptionId) return;
+			if (!this.activeNodeExecSubscriptionIds.has(subscriptionId)) return;
+			this.mergeNodeExecSnapshot(event.rows as NodeExecution[]);
+		});
+		this.nodeExecCleanupFns.push(unsubSnapshot);
+
+		const unsubDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+			if (event.subscriptionId !== subscriptionId) return;
+			if (!this.activeNodeExecSubscriptionIds.has(subscriptionId)) return;
+			this.mergeNodeExecDelta(event);
+		});
+		this.nodeExecCleanupFns.push(unsubDelta);
+
+		const unsubReconnect = hub.onConnection((state) => {
+			if (state !== 'connected') return;
+			if (!this.activeNodeExecSubscriptionIds.has(subscriptionId)) return;
+			hub
+				.request('liveQuery.subscribe', {
+					queryName: 'nodeExecutions.byRun',
+					params: [runId],
+					subscriptionId,
+				})
+				.catch((err) => {
+					logger.warn('Node execution LiveQuery re-subscribe failed:', err);
+				});
+		});
+		this.nodeExecCleanupFns.push(unsubReconnect);
+
+		hub
+			.request('liveQuery.subscribe', {
+				queryName: 'nodeExecutions.byRun',
+				params: [runId],
+				subscriptionId,
+			})
+			.catch((err) => {
+				logger.warn('Node execution LiveQuery subscribe failed:', err);
+			});
+	}
+
+	/**
+	 * Merge a LiveQuery snapshot (full replace for one run) into nodeExecutions.
+	 */
+	private mergeNodeExecSnapshot(rows: NodeExecution[]): void {
+		const current = this.nodeExecutions.value;
+		const runId = rows[0]?.workflowRunId;
+		if (!runId) return;
+		// Remove old executions for this run, add fresh snapshot
+		const filtered = current.filter((e) => e.workflowRunId !== runId);
+		this.nodeExecutions.value = [...filtered, ...rows];
+	}
+
+	/**
+	 * Merge a LiveQuery delta (add/remove/update) into nodeExecutions.
+	 */
+	private mergeNodeExecDelta(event: LiveQueryDeltaEvent): void {
+		const current = this.nodeExecutions.value;
+		const next = new Map(current.map((e) => [e.id, e]));
+
+		for (const row of (event.removed ?? []) as NodeExecution[]) {
+			next.delete(row.id);
+		}
+		for (const row of (event.updated ?? []) as NodeExecution[]) {
+			next.set(row.id, row);
+		}
+		for (const row of (event.added ?? []) as NodeExecution[]) {
+			next.set(row.id, row);
+		}
+
+		this.nodeExecutions.value = Array.from(next.values());
+	}
+
+	/**
+	 * Unsubscribe from all node execution LiveQueries.
+	 */
+	private unsubscribeNodeExecutions(): void {
+		for (const cleanup of this.nodeExecCleanupFns) {
+			try {
+				cleanup();
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+		this.nodeExecCleanupFns = [];
+
+		for (const subId of this.activeNodeExecSubscriptionIds) {
+			const hub = connectionManager.getHubIfConnected();
+			if (hub) {
+				hub.request('liveQuery.unsubscribe', { subscriptionId: subId }).catch(() => {});
+			}
+		}
+		this.activeNodeExecSubscriptionIds = new Set();
 	}
 
 	// ========================================

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -19,29 +19,29 @@
  * - error: Error state
  */
 
-import { signal, computed } from '@preact/signals';
 import type {
-	Space,
-	SpaceTask,
-	SpaceWorkflowRun,
-	SpaceAgent,
-	SpaceWorkflow,
+	CreateSpaceAgentParams,
+	CreateSpaceTaskParams,
+	CreateSpaceWorkflowParams,
+	CreateWorkflowRunParams,
+	LiveQueryDeltaEvent,
+	LiveQuerySnapshotEvent,
 	NodeExecution,
 	RuntimeState,
+	Space,
+	SpaceAgent,
+	SpaceTask,
 	SpaceTaskActivityMember,
-	LiveQuerySnapshotEvent,
-	LiveQueryDeltaEvent,
-	CreateSpaceTaskParams,
-	UpdateSpaceTaskParams,
-	CreateSpaceAgentParams,
+	SpaceWorkflow,
+	SpaceWorkflowRun,
 	UpdateSpaceAgentParams,
-	CreateSpaceWorkflowParams,
-	UpdateSpaceWorkflowParams,
-	CreateWorkflowRunParams,
 	UpdateSpaceParams,
+	UpdateSpaceTaskParams,
+	UpdateSpaceWorkflowParams,
 } from '@neokai/shared';
+import { isUUID, Logger } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
-import { Logger, isUUID } from '@neokai/shared';
+import { computed, signal } from '@preact/signals';
 import { connectionManager } from './connection-manager';
 
 const logger = new Logger('kai:web:spacestore');
@@ -553,6 +553,10 @@ class SpaceStore {
 						...this.workflowRuns.value.slice(idx + 1),
 					];
 				}
+				// Re-fetch node executions when a run is updated (e.g. node status changes).
+				this.fetchNodeExecutions(hub, spaceId).catch((err) => {
+					logger.warn('Failed to fetch node executions after run update:', err);
+				});
 			}
 		});
 		this.cleanupFunctions.push(unsubRunUpdated);
@@ -751,6 +755,8 @@ class SpaceStore {
 			for (const result of results) {
 				if (result.status === 'fulfilled') {
 					allExecs.push(...result.value);
+				} else {
+					logger.warn('Failed to fetch node executions for a run:', result.reason);
 				}
 			}
 			this.nodeExecutions.value = allExecs;

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -142,20 +142,6 @@ class SpaceStore {
 		return map;
 	});
 
-	/** Node executions grouped by workflow run ID */
-	readonly nodeExecutionsByRun = computed(() => {
-		const map = new Map<string, NodeExecution[]>();
-		for (const exec of this.nodeExecutions.value) {
-			let arr = map.get(exec.workflowRunId);
-			if (!arr) {
-				arr = [];
-				map.set(exec.workflowRunId, arr);
-			}
-			arr.push(exec);
-		}
-		return map;
-	});
-
 	// ========================================
 	// Private State
 	// ========================================
@@ -542,6 +528,10 @@ class SpaceStore {
 				const exists = this.workflowRuns.value.some((r) => r.id === event.run.id);
 				if (!exists) {
 					this.workflowRuns.value = [...this.workflowRuns.value, event.run];
+					// Fetch node executions for the new run so the UI stays current.
+					this.fetchNodeExecutions(hub, spaceId).catch((err) => {
+						logger.warn('Failed to fetch node executions after run creation:', err);
+					});
 				}
 			}
 		});

--- a/packages/web/src/lib/task-constants.ts
+++ b/packages/web/src/lib/task-constants.ts
@@ -1,12 +1,19 @@
 export const TASK_STATUS_COLORS: Record<string, string> = {
-	pending: 'text-gray-400',
+	// SpaceTaskStatus values
+	open: 'text-gray-400',
 	in_progress: 'text-yellow-400',
+	done: 'text-green-400',
+	blocked: 'text-red-400',
+	cancelled: 'text-gray-500',
+	archived: 'text-gray-600',
+	// TaskStatus (room) values
+	pending: 'text-gray-400',
 	completed: 'text-green-400',
 	needs_attention: 'text-red-400',
 	review: 'text-purple-400',
 	draft: 'text-gray-500',
-	cancelled: 'text-gray-500',
-	archived: 'text-gray-600',
+	rate_limited: 'text-orange-500',
+	usage_limited: 'text-orange-600',
 };
 
 export const ROLE_COLORS: Record<string, { border: string; label: string; labelColor: string }> = {


### PR DESCRIPTION
Migrate frontend components to use new shared type values:

- **TASK_STATUS_COLORS**: Added SpaceTaskStatus keys (`open`, `done`, `blocked`, `rate_limited`, `usage_limited`) alongside existing TaskStatus keys
- **SpaceContextPanel**: Updated `taskStatusColor()` to use new SpaceTaskStatus values (`open`, `done`, `blocked`, `cancelled`, `archived`)
- **WorkflowCanvas**: `NodeStatus` type updated from `'completed'` → `'done'`
- **WorkflowNodeCard**: `AgentTaskState.status` changed from `SpaceTaskStatus` to `NodeExecutionStatus`
- **space-store**: Removed duplicate `tasksByNodeId` signal, added `nodeExecutions` signal with `fetchNodeExecutions()` method, added `nodeExecutionsByNodeId` and `nodeExecutionsByRun` computed signals
- **WorkflowEditor + VisualWorkflowEditor**: `tasksByNodeId` → `nodeExecutionsByNodeId`, updated data mapping from SpaceTask to NodeExecution
- **Tests**: Updated mock data in SpaceDashboard, SpaceTaskPane, SpaceCreateTaskDialog; renamed `tasksByNodeId` → `nodeExecutionsByNodeId` in WorkflowEditor and VisualWorkflowEditor tests

Part of: Add end node to workflow definition for deterministic workflow completion