### PR TITLE
fix: close queryObject before auto-retry to prevent MCP transport crash

### DIFF
--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -359,6 +359,20 @@ export class QueryRunner {
 					'Session startup timed out. Retrying automatically...'
 				);
 				await stateManager.setIdle();
+
+				// Close the current queryObject BEFORE retrying to prevent the
+				// "Already connected to a transport" crash. The finally{} block has not
+				// yet run (we are still in the catch block), so MCP transports are still
+				// open. Explicitly closing here ensures a clean slate for the retry.
+				if (this.ctx.queryObject) {
+					try {
+						this.ctx.queryObject.close();
+					} catch {
+						// Ignore close errors — transport may already be in a broken state
+					}
+					this.ctx.queryObject = null;
+				}
+
 				return this.runQuery(queryGeneration, true);
 			}
 

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -832,6 +832,36 @@ describe('QueryRunner', () => {
 			const metadata = handleErrorSpy.mock.calls[0][5] as Record<string, unknown>;
 			expect(metadata.startupMaxRetries).toBeUndefined();
 		});
+
+		it('should close queryObject before retrying to prevent MCP "Already connected to a transport" crash', async () => {
+			// Regression test for the race condition where auto-retry after startup timeout
+			// would call runQuery() while the previous query's finally{} block had not yet
+			// run, leaving MCP transports open and causing "Already connected" crashes.
+			//
+			// The fix explicitly closes ctx.queryObject in the catch block BEFORE the
+			// recursive retry call, ensuring MCP transports are released first.
+			let closeCalled = false;
+			const mockQueryObject = {
+				close: () => {
+					closeCalled = true;
+				},
+				[Symbol.asyncIterator]: function* () {},
+			} as unknown as import('@anthropic-ai/claude-agent-sdk').Query;
+
+			// Pre-populate queryObject to simulate a lingering open query (e.g. with open
+			// MCP transports) that existed when the startup timeout fired.
+			const ctx = createContext({ queryObject: mockQueryObject });
+			runner = new QueryRunner(ctx);
+
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			// close() must have been called on the pre-existing queryObject before the retry.
+			expect(closeCalled).toBe(true);
+			// After the close, queryObject should be null (cleaned up by the fix).
+			// The finally block may re-check it, but it will see null and skip redundant close.
+			expect(ctx.queryObject).toBeNull();
+		});
 	});
 
 	describe('auto-recovery removal regression guards (Task 2.3)', () => {


### PR DESCRIPTION
Close the active `queryObject` (and its MCP transports) before the auto-retry recursive call on startup timeout.

## Problem

On startup timeout, `runQuery()` called `this.runQuery(queryGeneration, true)` from within the `catch` block — before the `finally{}` block ran. The previous query's MCP transports were still open, so when the retry tried to create new connections the SDK threw `"Already connected to a transport"`.

## Fix

In the catch block's retry path, explicitly call `ctx.queryObject.close()` and null it before the recursive call. This matches what the `finally` block would do, but does it synchronously before the retry starts.

## Tests

Added a regression test in `query-runner.test.ts` that pre-populates `ctx.queryObject` with a mock, triggers a startup timeout error, and asserts `close()` is called and `queryObject` is null before the retry proceeds.