### PR TITLE
test: update tests for report_workflow_done removal and space.task.done rename

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -449,8 +449,8 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 	};
 
 	// Space Task Agent completion events (use 'global' as sessionId)
-	/** Emitted by report_result when a Task Agent marks a task as completed. */
-	'space.task.completed': {
+	/** Emitted by report_result when a Task Agent marks a task as done. */
+	'space.task.done': {
 		sessionId: string;
 		taskId: string;
 		spaceId: string;

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -202,15 +202,9 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push(
 		`- **report_result** — Mark the task as completed or failed and record a result summary. ` +
-			`Pass \`status\` (\`completed\`, \`needs_attention\`, or \`cancelled\`) and a \`summary\` string. ` +
-			`Call this when the workflow reaches a terminal step or an unrecoverable error occurs.`
-	);
-	sections.push(
-		`- **report_workflow_done** — Explicitly mark the entire workflow run as completed and close the main task. ` +
-			`Pass a \`summary\` string describing what the workflow accomplished — use the Done node agent's ` +
-			`result summary (collected via \`check_node_status\`) as the summary when available. ` +
-			`Call this when all node agents have finished and you are certain the workflow is done. ` +
-			`This immediately marks the run completed without waiting for the automatic detector.`
+			`Pass \`status\` (\`done\`, \`blocked\`, or \`cancelled\`) and a \`summary\` string. ` +
+			`Call this when the workflow reaches an unrecoverable error or you need to cancel. ` +
+			`Workflow completion is automatic — the end node's \`report_done\` call triggers it.`
 	);
 	sections.push(
 		`- **request_human_input** — Surface a human gate and block until the human responds. ` +
@@ -221,7 +215,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	sections.push(
 		`- **list_group_members** — List all members of the current task's session group. ` +
 			`Returns each member's \`sessionId\`, \`agentName\`, \`status\`, \`completionState\`, and ` +
-			`\`permittedTargets\`. Completion state is read from \`space_tasks\` — use this to monitor ` +
+			`\`permittedTargets\`. Completion state is read from node execution records — use this to monitor ` +
 			`when all agents have called \`report_done\`. Use it after event messages and before finalizing.`
 	);
 	sections.push(
@@ -234,9 +228,9 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push(
 		`**Node agent tools (for reference):** Each spawned node agent also has access to: ` +
-			`\`list_peers\` (discover peers with completion state from space_tasks), ` +
+			`\`list_peers\` (discover peers with completion state from node executions), ` +
 			`\`send_message\` (same string-based targeting), ` +
-			`\`report_done\` (signal task completion), and ` +
+			`\`report_done\` (signal task completion — the end node's call triggers automatic workflow completion), and ` +
 			`\`list_reachable_agents\` (discover reachable agents and cross-node gate status). ` +
 			`Node agents drive their own progression — you do not need to manually route messages between them.`
 	);
@@ -265,10 +259,11 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`a \`human\` gate requires explicit approval (call \`request_human_input\`); ` +
 			`\`condition\` and \`task_result\` gates are evaluated automatically by the system. ` +
 			`If a node agent reports that a message was blocked by a gate, surface the gate to the user.\n` +
-			`6. **Detect completion** — When \`list_group_members\` shows all members have completed, ` +
-			`collect the Done node agent's result summary (via \`check_node_status\` only if needed). Then call \`report_workflow_done\` with that ` +
-			`summary to mark the workflow run and task as completed. ` +
-			`You may also use \`report_result\` directly for finer-grained status control.\n` +
+			`6. **Automatic workflow completion** — When the end node agent calls \`report_done\`, the ` +
+			`system automatically marks the workflow run and main task as completed. You do not need to ` +
+			`call any completion tool — just wait for the \`[STEP_COMPLETE]\` event from the end node. ` +
+			`Use \`list_group_members\` to verify all agents have finished if needed. ` +
+			`Only call \`report_result\` if you need to cancel or signal an unrecoverable error.\n` +
 			`7. **Handle errors** — If a node agent errors, call \`report_result\` with ` +
 			`\`status: "cancelled"\` and the error details.`
 	);

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -255,16 +255,16 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`5. **Agents drive their own progression** — When a node agent sends a message to another ` +
 			`agent via \`send_message\` (using an agent name for DM or a node name for fan-out), ` +
 			`the target node is activated automatically. New pending tasks will appear — spawn their agents (return to step 1).\n` +
-			`5. **Handle gate-blocked messages** — Channels may have gate conditions that block delivery: ` +
+			`6. **Handle gate-blocked messages** — Channels may have gate conditions that block delivery: ` +
 			`a \`human\` gate requires explicit approval (call \`request_human_input\`); ` +
 			`\`condition\` and \`task_result\` gates are evaluated automatically by the system. ` +
 			`If a node agent reports that a message was blocked by a gate, surface the gate to the user.\n` +
-			`6. **Automatic workflow completion** — When the end node agent calls \`report_done\`, the ` +
+			`7. **Automatic workflow completion** — When the end node agent calls \`report_done\`, the ` +
 			`system automatically marks the workflow run and main task as completed. You do not need to ` +
 			`call any completion tool — just wait for the \`[STEP_COMPLETE]\` event from the end node. ` +
 			`Use \`list_group_members\` to verify all agents have finished if needed. ` +
 			`Only call \`report_result\` if you need to cancel or signal an unrecoverable error.\n` +
-			`7. **Handle errors** — If a node agent errors, call \`report_result\` with ` +
+			`8. **Handle errors** — If a node agent errors, call \`report_result\` with ` +
 			`\`status: "cancelled"\` and the error details.`
 	);
 

--- a/packages/daemon/src/lib/space/provision-global-agent.ts
+++ b/packages/daemon/src/lib/space/provision-global-agent.ts
@@ -62,7 +62,7 @@ export interface ProvisionGlobalSpacesAgentDeps {
 	/**
 	 * DaemonHub for subscribing to task completion/failure events emitted by Task Agents.
 	 * When provided, the global Space Agent session receives notification messages when tasks
-	 * complete or fail via `space.task.completed` / `space.task.failed` events.
+	 * complete or fail via `space.task.done` / `space.task.failed` events.
 	 *
 	 * The subscription routes all space task events to the single `spaces:global` session,
 	 * which is intentional: the global agent manages tasks across all spaces. The notification
@@ -194,7 +194,10 @@ export async function provisionGlobalSpacesAgent(
 		_taskEventUnsubs.forEach((unsub) => unsub());
 		_taskEventUnsubs = [];
 
-		const unsubCompleted = daemonHub.on('space.task.completed', (event) => {
+		// space.task.done: emitted by report_result when status === 'done'.
+		// The 'blocked' status is handled by space.task.failed — it is recoverable
+		// (the Task Agent will surface a human gate and resume after human responds).
+		const unsubDone = daemonHub.on('space.task.done', (event) => {
 			const summaryPart = event.summary ? ` Summary: ${event.summary}` : '';
 			const message =
 				`Task '${event.taskTitle}' (taskId: ${event.taskId}, spaceId: ${event.spaceId}) ` +
@@ -203,7 +206,7 @@ export async function provisionGlobalSpacesAgent(
 				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'defer' })
 				.catch((err) => {
 					log.warn(
-						`Failed to inject task.completed notification into ${GLOBAL_SESSION_ID}: ${err instanceof Error ? err.message : String(err)}`
+						`Failed to inject task.done notification into ${GLOBAL_SESSION_ID}: ${err instanceof Error ? err.message : String(err)}`
 					);
 				});
 		});
@@ -223,8 +226,8 @@ export async function provisionGlobalSpacesAgent(
 				});
 		});
 
-		_taskEventUnsubs = [unsubCompleted, unsubFailed];
-		log.info('Subscribed to space.task.completed and space.task.failed events');
+		_taskEventUnsubs = [unsubDone, unsubFailed];
+		log.info('Subscribed to space.task.done and space.task.failed events');
 	}
 
 	log.info('Global spaces agent session provisioned');

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -76,7 +76,6 @@ import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
-import { CompletionDetector } from './completion-detector';
 import { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import { executeGateScript } from './gate-script-executor';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
@@ -621,8 +620,7 @@ export class TaskAgentManager {
 
 			const workflowRunId = workflowRun?.id ?? '';
 
-			// Build shared channel routing and completion detection instances.
-			// Both use the same underlying repositories as the task agent tools.
+			// Build shared channel routing instance.
 			const channelRouter = new ChannelRouter({
 				taskRepo: this.config.taskRepo,
 				workflowRunRepo: this.config.workflowRunRepo,
@@ -633,7 +631,6 @@ export class TaskAgentManager {
 				db: this.config.db.getDatabase(),
 				workspacePath,
 			});
-			const completionDetector = new CompletionDetector(this.config.nodeExecutionRepo);
 
 			const mcpServer = createTaskAgentMcpServer({
 				taskId,
@@ -643,6 +640,7 @@ export class TaskAgentManager {
 				workflowManager: this.config.spaceWorkflowManager,
 				taskRepo: this.config.taskRepo,
 				workflowRunRepo: this.config.workflowRunRepo,
+				nodeExecutionRepo: this.config.nodeExecutionRepo,
 				agentManager: this.config.spaceAgentManager,
 				taskManager,
 				sessionFactory: subSessionFactory,
@@ -652,7 +650,6 @@ export class TaskAgentManager {
 					this.handleSubSessionComplete(taskId, stepId, subSessionId),
 				daemonHub: this.config.daemonHub,
 				channelRouter,
-				completionDetector,
 				buildNodeAgentMcpServer: (subSessionId, role, stepTaskId) =>
 					this.buildNodeAgentMcpServerForSession(
 						taskId,
@@ -1496,7 +1493,7 @@ export class TaskAgentManager {
 
 		const rehydrateWorkflowRunId = workflowRun?.id ?? '';
 
-		// Build shared channel routing and completion detection instances for rehydration.
+		// Build shared channel routing instance for rehydration.
 		const rehydrateChannelRouter = new ChannelRouter({
 			taskRepo: this.config.taskRepo,
 			workflowRunRepo: this.config.workflowRunRepo,
@@ -1508,7 +1505,6 @@ export class TaskAgentManager {
 			db: this.config.db.getDatabase(),
 			workspacePath: rehydrateWorkspacePath,
 		});
-		const rehydrateCompletionDetector = new CompletionDetector(this.config.nodeExecutionRepo);
 
 		const mcpServer = createTaskAgentMcpServer({
 			taskId,
@@ -1518,6 +1514,7 @@ export class TaskAgentManager {
 			workflowManager: this.config.spaceWorkflowManager,
 			taskRepo: this.config.taskRepo,
 			workflowRunRepo: this.config.workflowRunRepo,
+			nodeExecutionRepo: this.config.nodeExecutionRepo,
 			agentManager: this.config.spaceAgentManager,
 			taskManager,
 			sessionFactory: subSessionFactory,
@@ -1527,7 +1524,6 @@ export class TaskAgentManager {
 				this.handleSubSessionComplete(taskId, stepId, subSessionId),
 			daemonHub: this.config.daemonHub,
 			channelRouter: rehydrateChannelRouter,
-			completionDetector: rehydrateCompletionDetector,
 			buildNodeAgentMcpServer: (subSessionId, role, stepTaskId) =>
 				this.buildNodeAgentMcpServerForSession(
 					taskId,
@@ -1855,6 +1851,7 @@ export class TaskAgentManager {
 			workflowRunId,
 			spaceTaskRepo: this.config.taskRepo,
 			workflowNodeId,
+			nodeExecutionRepo: this.config.nodeExecutionRepo,
 			messageInjector: (targetSessionId, message) =>
 				this.injectSubSessionMessage(targetSessionId, message),
 			taskManager,

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -30,6 +30,7 @@ import type { DaemonHub } from '../../daemon-hub';
 import { Logger } from '../../logger';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import { ChannelResolver } from '../runtime/channel-resolver';
 import {
 	evaluateGate,
@@ -93,18 +94,24 @@ export interface NodeAgentToolsConfig {
 	 * An empty resolver (no channels) means send_message is unavailable for this session.
 	 */
 	channelResolver: ChannelResolver;
-	/** Workflow run ID — used with spaceTaskRepo to query node completion state. */
+	/** Workflow run ID — used to query node execution state. */
 	workflowRunId: string;
-	/** Space task repository for querying completion state. */
+	/** Space task repository for querying completion state (fallback when nodeExecutionRepo unavailable). */
 	spaceTaskRepo: SpaceTaskRepository;
-	/** Workflow node ID — used to query peer tasks on the same node. */
+	/** Workflow node ID — used to query peer executions on the same node. */
 	workflowNodeId: string;
+	/**
+	 * Node execution repository for report_done, list_peers, and send_message peer resolution.
+	 * When provided, these tools use NodeExecution records instead of SpaceTask records.
+	 * Optional — falls back to SpaceTask-based lookups when absent.
+	 */
+	nodeExecutionRepo?: NodeExecutionRepository;
 	/**
 	 * Injects a message into a peer sub-session as a user turn.
 	 * Used by `send_message` to deliver messages to target sessions.
 	 */
 	messageInjector: (sessionId: string, message: string) => Promise<void>;
-	/** Task manager for validated status transitions. Used by report_done. */
+	/** Task manager for validated status transitions. Used by report_done fallback. */
 	taskManager: SpaceTaskManager;
 	/**
 	 * DaemonHub instance for emitting task update events.
@@ -172,6 +179,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		workflowRunId,
 		spaceTaskRepo,
 		workflowNodeId,
+		nodeExecutionRepo,
 		messageInjector,
 		taskManager,
 		daemonHub,
@@ -186,20 +194,82 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 	return {
 		/**
 		 * List all peers (other group members) with their roles, statuses, session IDs,
-		 * permitted channel connections, and completion state from space_tasks.
+		 * permitted channel connections, and completion state.
 		 *
 		 * Does NOT include self (filtered by `mySessionId`).
 		 * Does NOT include the Task Agent (filtered by role 'task-agent').
 		 *
 		 * Returns permittedTargets: roles this agent can directly send to via send_message.
-		 * Returns completionState per peer: task status, completion summary, and completedAt.
-		 * Returns nodeCompletionState: all tasks on this workflow node with their completion state.
+		 * Returns completionState per peer: execution status, completion summary, and completedAt.
+		 * Returns nodeCompletionState: all executions on this workflow node with their completion state.
+		 *
+		 * Queries NodeExecutionRepository when available; falls back to SpaceTask-based lookup.
 		 */
 		async list_peers(_args: ListPeersInput): Promise<ToolResult> {
-			// Load all tasks on this workflow node from the DB
-			const nodeTasks = workflowRunId ? spaceTaskRepo.listByWorkflowRun(workflowRunId) : [];
-
 			const resolver = channelResolver;
+
+			if (nodeExecutionRepo) {
+				// Preferred path: query NodeExecution records for this node
+				const nodeExecs = workflowRunId
+					? nodeExecutionRepo.listByNode(workflowRunId, workflowNodeId)
+					: [];
+
+				// Exclude self (by agentSessionId) and include peers with a session or completed state
+				const peers = nodeExecs
+					.filter(
+						(ne) =>
+							ne.agentSessionId !== mySessionId &&
+							(ne.agentSessionId != null || ne.status === 'done')
+					)
+					.map((ne) => {
+						const execStatus = ne.status;
+						const memberStatus =
+							execStatus === 'done'
+								? ('completed' as const)
+								: execStatus === 'blocked' || execStatus === 'cancelled'
+									? ('failed' as const)
+									: ('active' as const);
+						return {
+							sessionId: ne.agentSessionId ?? null,
+							role: ne.agentName,
+							agentId: ne.agentId ?? null,
+							status: memberStatus,
+							completionState: {
+								agentName: ne.agentName,
+								taskStatus: ne.status,
+								completionSummary: ne.result ?? null,
+								completedAt: ne.completedAt ?? null,
+							},
+						};
+					});
+
+				const nodeCompletionState = nodeExecs.map((ne) => ({
+					agentName: ne.agentName,
+					taskStatus: ne.status,
+					completionSummary: ne.result ?? null,
+					completedAt: ne.completedAt ?? null,
+				}));
+
+				const permittedTargets = resolver.getPermittedTargets(myRole);
+				const channelTopologyDeclared = !resolver.isEmpty();
+
+				return jsonResult({
+					success: true,
+					myRole,
+					peers,
+					nodeCompletionState,
+					permittedTargets,
+					channelTopologyDeclared,
+					message:
+						`Found ${peers.length} peer(s). ` +
+						(channelTopologyDeclared
+							? `Permitted direct targets via send_message: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`
+							: 'No channel topology declared.'),
+				});
+			}
+
+			// Fallback path: query SpaceTask records
+			const nodeTasks = workflowRunId ? spaceTaskRepo.listByWorkflowRun(workflowRunId) : [];
 
 			// Build peers from all node tasks, excluding self and task-agent.
 			// Includes completed tasks (taskAgentSessionId may be null) so callers
@@ -362,13 +432,17 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				});
 			}
 
-			// Find peer sessions via task repo
-			const legacyNodeTasks = workflowRunId
-				? spaceTaskRepo.listByWorkflowRun(workflowRunId).filter((t) => t.taskAgentSessionId)
-				: [];
-			const peers = legacyNodeTasks
-				.filter((t) => t.taskAgentSessionId !== mySessionId)
-				.map((t) => ({ sessionId: t.taskAgentSessionId!, role: t.title ?? 'agent' }));
+			// Find peer sessions — prefer NodeExecution, fall back to SpaceTask
+			const peers: Array<{ sessionId: string; role: string }> = nodeExecutionRepo
+				? (workflowRunId ? nodeExecutionRepo.listByWorkflowRun(workflowRunId) : [])
+						.filter((ne) => ne.agentSessionId && ne.agentSessionId !== mySessionId)
+						.map((ne) => ({ sessionId: ne.agentSessionId!, role: ne.agentName }))
+				: (workflowRunId
+						? spaceTaskRepo.listByWorkflowRun(workflowRunId).filter((t) => t.taskAgentSessionId)
+						: []
+					)
+						.filter((t) => t.taskAgentSessionId !== mySessionId)
+						.map((t) => ({ sessionId: t.taskAgentSessionId!, role: t.title ?? 'agent' }));
 			const delivered: Array<{ role: string; sessionId: string }> = [];
 			const notFound: string[] = [];
 			const failed: Array<{ role: string; sessionId: string; error: string }> = [];
@@ -781,8 +855,14 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		/**
 		 * Signal that this node agent has completed its work.
 		 *
-		 * Marks the step's SpaceTask as 'done', persists the optional summary
-		 * as the task result, and emits a `space.task.updated` event for real-time UI.
+		 * When nodeExecutionRepo is available: updates the NodeExecution record for
+		 * this agent (identified by workflowNodeId + myRole) to status 'done' and
+		 * persists the optional summary. SpaceRuntime detects the state change and
+		 * triggers workflow completion checks (end-node short-circuit or
+		 * CompletionDetector safety net).
+		 *
+		 * When nodeExecutionRepo is absent (test/compat fallback): updates the step's
+		 * SpaceTask via taskManager.setTaskStatus().
 		 *
 		 * After calling this tool, the node agent should stop and not perform
 		 * further work — the task lifecycle is closed.
@@ -791,6 +871,39 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			const { summary } = args;
 
 			try {
+				if (nodeExecutionRepo) {
+					// Preferred path: update NodeExecution status to 'done'
+					const nodeExecs = workflowRunId
+						? nodeExecutionRepo.listByNode(workflowRunId, workflowNodeId)
+						: [];
+					const myExec = nodeExecs.find((e) => e.agentName === myRole);
+
+					if (!myExec) {
+						return jsonResult({
+							success: false,
+							error:
+								`NodeExecution not found for agent "${myRole}" in node "${workflowNodeId}" ` +
+								`(run: ${workflowRunId}). Cannot mark as done.`,
+						});
+					}
+
+					nodeExecutionRepo.update(myExec.id, {
+						status: 'done',
+						result: summary ?? null,
+					});
+
+					return jsonResult({
+						success: true,
+						executionId: myExec.id,
+						agentName: myRole,
+						summary,
+						message:
+							'Step execution has been marked as completed. ' +
+							'Your work is done — stop here and do not continue.',
+					});
+				}
+
+				// Fallback path: update SpaceTask via taskManager
 				const updatedTask = await taskManager.setTaskStatus(stepTaskId, 'done', {
 					result: summary,
 				});

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -1,13 +1,12 @@
 /**
- * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 6
+ * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 5
  * tools available to the Task Agent session (send_message schema is shared
- * from node-agent-tool-schemas.ts, making 7 tools total in the MCP server).
+ * from node-agent-tool-schemas.ts, making 6 tools total in the MCP server).
  *
  * Tools (defined in this file):
  *   spawn_node_agent      — spawn a sub-session for a specific workflow node
  *   check_node_status     — check the status of the current or a specific node's sub-session
  *   report_result         — report the final task result (terminal tool)
- *   report_workflow_done  — explicitly mark the entire workflow run as completed
  *   request_human_input   — pause execution and surface a question to the human user
  *   list_group_members    — list all members of the current task's session group
  *
@@ -126,27 +125,7 @@ export const ListGroupMembersSchema = z.object({});
 export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
 
 // ---------------------------------------------------------------------------
-// report_workflow_done
-// ---------------------------------------------------------------------------
-
-/**
- * Schema for `report_workflow_done` input.
- * Explicitly marks the entire workflow run as completed, bypassing the
- * automatic all-agents-done detector. Use this when all node agents have
- * finished and you are certain the run is complete.
- */
-export const ReportWorkflowDoneSchema = z.object({
-	/** Optional summary of what the workflow accomplished overall. */
-	summary: z
-		.string()
-		.describe('Optional human-readable summary of what the workflow accomplished')
-		.optional(),
-});
-
-export type ReportWorkflowDoneInput = z.infer<typeof ReportWorkflowDoneSchema>;
-
-// ---------------------------------------------------------------------------
-// Aggregate export for MCP server factory (Milestone 3)
+// Aggregate export for MCP server factory
 // ---------------------------------------------------------------------------
 
 /**
@@ -157,7 +136,6 @@ export const TASK_AGENT_TOOL_SCHEMAS = {
 	spawn_node_agent: SpawnNodeAgentSchema,
 	check_node_status: CheckNodeStatusSchema,
 	report_result: ReportResultSchema,
-	report_workflow_done: ReportWorkflowDoneSchema,
 	request_human_input: RequestHumanInputSchema,
 	list_group_members: ListGroupMembersSchema,
 } as const;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -1,11 +1,10 @@
 /**
  * Task Agent Tools — MCP tool handlers for the Task Agent session.
  *
- * These handlers implement the business logic for the 7 Task Agent tools:
+ * These handlers implement the business logic for the 6 Task Agent tools:
  *   spawn_node_agent      — Spawn a sub-session for a workflow node's assigned agent
  *   check_node_status     — Poll the status of a running node agent sub-session
  *   report_result         — Mark the task as completed/failed and record the result
- *   report_workflow_done  — Explicitly mark the workflow run as completed
  *   request_human_input   — Pause execution and surface a question to the human user
  *   list_group_members    — List all members of the current task's session group
  *   send_message          — Send a message to peer node agents via channel topology
@@ -31,18 +30,17 @@ import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import { resolveAgentInit, buildCustomAgentTaskMessage } from '../agents/custom-agent';
 import { ChannelResolver } from '../runtime/channel-resolver';
 import type { ChannelRouter } from '../runtime/channel-router';
-import type { CompletionDetector } from '../runtime/completion-detector';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
 	SpawnNodeAgentSchema,
 	CheckNodeStatusSchema,
 	ReportResultSchema,
-	ReportWorkflowDoneSchema,
 	RequestHumanInputSchema,
 	ListGroupMembersSchema,
 } from './task-agent-tool-schemas';
@@ -52,7 +50,6 @@ import type {
 	SpawnNodeAgentInput,
 	CheckNodeStatusInput,
 	ReportResultInput,
-	ReportWorkflowDoneInput,
 	RequestHumanInputInput,
 	ListGroupMembersInput,
 } from './task-agent-tool-schemas';
@@ -148,6 +145,12 @@ export interface TaskAgentToolsConfig {
 	taskRepo: SpaceTaskRepository;
 	/** Workflow run repository for reading and updating runs. */
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	/**
+	 * Node execution repository for idempotency checks in spawn_node_agent and
+	 * querying execution state in list_group_members.
+	 * Optional — if omitted, falls back to SpaceTask-based lookups.
+	 */
+	nodeExecutionRepo?: NodeExecutionRepository;
 	/** Agent manager for resolving node agents. */
 	agentManager: SpaceAgentManager;
 	/** Task manager for validated status transitions. */
@@ -192,13 +195,6 @@ export interface TaskAgentToolsConfig {
 	 * Optional — existing ChannelResolver-based routing is used as fallback.
 	 */
 	channelRouter?: ChannelRouter;
-	/**
-	 * Completion detector for validating all-agents-done state.
-	 * When provided, report_workflow_done checks that all node agent tasks have
-	 * reached a terminal status before marking the workflow run as completed.
-	 * Optional — if omitted, no completion pre-check is performed.
-	 */
-	completionDetector?: CompletionDetector;
 }
 
 // ---------------------------------------------------------------------------
@@ -218,6 +214,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		workflowManager,
 		taskRepo,
 		workflowRunRepo,
+		nodeExecutionRepo,
 		agentManager,
 		taskManager,
 		sessionFactory,
@@ -225,7 +222,6 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		onSubSessionComplete,
 		daemonHub,
 		buildNodeAgentMcpServer,
-		completionDetector,
 	} = config;
 
 	return {
@@ -269,6 +265,38 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				});
 			}
 
+			// Resolve agent slots and member role early — needed for NodeExecution idempotency check.
+			// Use resolveNodeAgents to get the agent list for this step.
+			const nodeAgents = resolveNodeAgents(step);
+			const primaryAgentId = nodeAgents[0]?.agentId;
+
+			// Find the WorkflowNodeAgent slot for this step.
+			// Use the first slot as the primary agent.
+			const agentSlot = nodeAgents[0];
+
+			// Use the slot's name (WorkflowNodeAgent.name) for channel routing and group membership.
+			// Falls back to 'agent' if not available.
+			const agentForMemberEarly = primaryAgentId ? agentManager.getById(primaryAgentId) : null;
+			const memberRole = agentSlot?.name ?? agentForMemberEarly?.name ?? 'agent';
+
+			// Idempotency guard: if a NodeExecution for this agent already has an agentSessionId,
+			// return it without creating a duplicate. Prevents double-spawning from orphaning
+			// the first session when the Task Agent retries a spawn_node_agent call.
+			if (nodeExecutionRepo) {
+				const existingExec = nodeExecutionRepo
+					.listByNode(workflowRunId, step_id)
+					.find((e) => e.agentName === memberRole);
+				if (existingExec?.agentSessionId) {
+					return jsonResult({
+						success: true,
+						sessionId: existingExec.agentSessionId,
+						stepId: step_id,
+						stepName: step.name,
+						alreadySpawned: true,
+					});
+				}
+			}
+
 			// Find the pending task for this step (created when the workflow node was activated).
 			// Task-to-node mapping uses title matching since workflowNodeId is no longer on SpaceTask.
 			// Build the set of expected task titles from the node definition:
@@ -293,10 +321,8 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			// Use the most recently created task for this step.
 			const stepTask = stepTasks[stepTasks.length - 1];
 
-			// Idempotency guard: if this step already has a tracked sub-session, return it
-			// without creating a duplicate. Prevents double-spawning from orphaning the first
-			// session when the Task Agent retries a spawn_node_agent call.
-			if (stepTask.taskAgentSessionId) {
+			// Fallback idempotency guard via SpaceTask (when nodeExecutionRepo is unavailable).
+			if (!nodeExecutionRepo && stepTask.taskAgentSessionId) {
 				return jsonResult({
 					success: true,
 					sessionId: stepTask.taskAgentSessionId,
@@ -307,16 +333,8 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				});
 			}
 
-			// Use resolveNodeAgents to get the agent list for this step.
-			const nodeAgents = resolveNodeAgents(step);
-			const primaryAgentId = nodeAgents[0]?.agentId;
-
 			// Build effectiveTask with optional instruction override
 			const effectiveTask = instructions ? { ...stepTask, description: instructions } : stepTask;
-
-			// Find the WorkflowNodeAgent slot for this step.
-			// Use the first slot as the primary agent.
-			const agentSlot = nodeAgents[0];
 
 			// Extract slot-level overrides (systemPrompt) if present.
 			// model is no longer on WorkflowNodeAgent; systemPrompt is now WorkflowNodeAgentOverride.
@@ -352,13 +370,6 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: `Failed to resolve agent init: ${message}` });
 			}
-
-			// Resolve agent identity for group membership tracking.
-			const agentForMember = agentManager.getById(primaryAgentId);
-
-			// Use the slot's name (WorkflowNodeAgent.name) for channel routing and group membership.
-			// Falls back to agent name, then 'agent' if neither is available.
-			const memberRole = agentSlot?.name ?? agentForMember?.name ?? 'agent';
 
 			// Attach node agent peer communication MCP server if a factory is provided.
 			// The server is built with the slot role so it can validate channels using the
@@ -615,7 +626,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 						workflowRunId,
 						taskTitle: mainTask.title,
 					};
-					const eventName = status === 'done' ? 'space.task.completed' : 'space.task.failed';
+					const eventName = status === 'done' ? 'space.task.done' : 'space.task.failed';
 					void daemonHub.emit(eventName, eventPayload).catch((err) => {
 						log.warn(
 							`Failed to emit ${eventName} for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
@@ -637,126 +648,71 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		},
 
 		/**
-		 * Explicitly mark the workflow run as completed.
-		 *
-		 * Use this tool when all node agents have finished and you are certain the
-		 * overall workflow is done. It:
-		 *   1. Validates the workflow run exists and is still in_progress
-		 *   2. Marks the workflow run as completed (sets completedAt)
-		 *   3. Marks the main task as completed via report_result logic
-		 *   4. Emits a space.task.completed event so listeners are notified
-		 *
-		 * The SpaceRuntime tick loop will detect the completed run status on the next
-		 * tick and emit a workflow_run_completed notification to the Space Agent.
-		 */
-		async report_workflow_done(args: ReportWorkflowDoneInput): Promise<ToolResult> {
-			const { summary } = args;
-
-			const run = workflowRunRepo.getRun(workflowRunId);
-			if (!run) {
-				return jsonResult({
-					success: false,
-					error: `Workflow run not found: ${workflowRunId}`,
-				});
-			}
-
-			if (run.status !== 'in_progress') {
-				return jsonResult({
-					success: false,
-					error:
-						`Cannot mark workflow run as completed when status is "${run.status}". ` +
-						`Workflow run must be in_progress.`,
-					currentStatus: run.status,
-				});
-			}
-
-			// Validate that all node agents have reached terminal status before
-			// allowing an explicit workflow completion. This guards against the Task
-			// Agent calling report_workflow_done prematurely while agents are still
-			// running.
-			if (completionDetector) {
-				if (!completionDetector.isComplete({ workflowRunId })) {
-					return jsonResult({
-						success: false,
-						error:
-							'Not all node agents have reached a terminal state yet. ' +
-							'Wait for all agents to complete (check via check_node_status) ' +
-							'before calling report_workflow_done.',
-					});
-				}
-			}
-
-			const mainTask = taskRepo.getTask(taskId);
-			if (!mainTask) {
-				return jsonResult({ success: false, error: `Task not found: ${taskId}` });
-			}
-
-			try {
-				// Mark the workflow run as done — SpaceRuntime tick will detect this
-				// and emit workflow_run_completed via the notification sink.
-				workflowRunRepo.transitionStatus(workflowRunId, 'done');
-
-				// Mark the main task as done (mirrors report_result logic).
-				await taskManager.setTaskStatus(taskId, 'done', {
-					result: summary,
-				});
-
-				// Emit DaemonHub event so the Space Agent is notified.
-				if (daemonHub) {
-					void daemonHub
-						.emit('space.task.completed', {
-							sessionId: 'global',
-							taskId,
-							spaceId: space.id,
-							status: 'done',
-							summary: summary ?? '',
-							workflowRunId,
-							taskTitle: mainTask.title,
-						})
-						.catch((err) => {
-							log.warn(
-								`Failed to emit space.task.completed for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
-							);
-						});
-				}
-
-				return jsonResult({
-					success: true,
-					workflowRunId,
-					taskId,
-					summary,
-					message:
-						'Workflow run has been marked as completed. ' +
-						'The main task has also been closed. Stop here — do not call any further tools.',
-				});
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				return jsonResult({ success: false, error: message });
-			}
-		},
-
-		/**
 		 * List all members of the current task's session group.
 		 *
-		 * Returns every member (including the Task Agent itself) with:
-		 *   - sessionId, role, agentId, status
+		 * Returns every member with:
+		 *   - sessionId, role (agentName), agentId, status
 		 *   - permittedTargets: roles this member can send to per channel topology
-		 *   - completionState: task status and completion summary for this member's slot task
+		 *   - completionState: execution status and result summary
 		 *
-		 * Also returns nodeCompletionState — all tasks on the current node with their completion state.
+		 * Also returns nodeCompletionState — all executions in the run with their completion state.
 		 *
-		 * The channel topology is read from the active workflow run's config
-		 * (`run.config._resolvedChannels` — stored by SpaceRuntime at step-start).
-		 * If no channels are declared, `permittedTargets` is empty for all members.
-		 *
-		 * The Task Agent itself is listed as a member (role: 'task-agent').
+		 * Queries NodeExecutionRepository when available; falls back to SpaceTask-based lookup.
 		 */
 		async list_group_members(_args: ListGroupMembersInput): Promise<ToolResult> {
 			// Build ChannelResolver — run.config is no longer stored on SpaceWorkflowRun,
 			// so channel topology is not available here; resolver will be empty.
 			const resolver = ChannelResolver.fromRunConfig(undefined);
 
-			// Get all tasks for this workflow run with active sub-sessions
+			if (nodeExecutionRepo) {
+				// Preferred path: query NodeExecution records
+				const allExecs = nodeExecutionRepo.listByWorkflowRun(workflowRunId);
+				const activeExecs = allExecs.filter((ne) => ne.agentSessionId);
+
+				const members = activeExecs.map((ne) => {
+					const execStatus = ne.status;
+					const memberStatus =
+						execStatus === 'done'
+							? 'completed'
+							: execStatus === 'blocked' || execStatus === 'cancelled'
+								? 'failed'
+								: 'active';
+					return {
+						sessionId: ne.agentSessionId!,
+						role: ne.agentName,
+						agentId: ne.agentId ?? (null as string | null),
+						status: memberStatus,
+						permittedTargets: resolver.getPermittedTargets(ne.agentName),
+						completionState: {
+							agentName: ne.agentName,
+							taskStatus: ne.status,
+							completionSummary: ne.result ?? null,
+							completedAt: ne.completedAt ?? null,
+						},
+					};
+				});
+
+				const nodeCompletionState = allExecs.map((ne) => ({
+					agentName: ne.agentName,
+					taskStatus: ne.status,
+					completionSummary: ne.result ?? null,
+					completedAt: ne.completedAt ?? null,
+				}));
+
+				return jsonResult({
+					success: true,
+					members,
+					nodeCompletionState,
+					channelTopologyDeclared: !resolver.isEmpty(),
+					message:
+						`Run has ${members.length} active member(s). ` +
+						(resolver.isEmpty()
+							? 'No channel topology declared.'
+							: `Channel topology is active and enforced.`),
+				});
+			}
+
+			// Fallback path: query SpaceTask records (when nodeExecutionRepo is unavailable)
 			const allRunTasks = taskRepo.listByWorkflowRun(workflowRunId);
 			const activeTasks = allRunTasks.filter((t) => t.taskAgentSessionId);
 
@@ -770,12 +726,12 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 							: 'active';
 				return {
 					sessionId: t.taskAgentSessionId!,
-					role: 'agent',
+					role: t.title ?? 'agent',
 					agentId: null as string | null,
 					status: memberStatus,
-					permittedTargets: resolver.getPermittedTargets('agent'),
+					permittedTargets: resolver.getPermittedTargets(t.title ?? 'agent'),
 					completionState: {
-						agentName: null as string | null,
+						agentName: t.title ?? null,
 						taskStatus: t.status,
 						completionSummary: t.result ?? null,
 						completedAt: t.completedAt ?? null,
@@ -784,7 +740,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			});
 
 			const nodeCompletionState = allRunTasks.map((t) => ({
-				agentName: null as string | null,
+				agentName: t.title ?? null,
 				taskStatus: t.status,
 				completionSummary: t.result ?? null,
 				completedAt: t.completedAt ?? null,
@@ -1025,14 +981,6 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 				'Call this when the workflow reaches a terminal step or an unrecoverable error occurs.',
 			ReportResultSchema.shape,
 			(args) => handlers.report_result(args)
-		),
-		tool(
-			'report_workflow_done',
-			'Explicitly mark the entire workflow run as completed and close the main task. ' +
-				'Call this when all node agents have finished and the workflow is fully done. ' +
-				'This bypasses the automatic all-agents-done detector and immediately marks the run completed.',
-			ReportWorkflowDoneSchema.shape,
-			(args) => handlers.report_workflow_done(args)
 		),
 		tool(
 			'request_human_input',

--- a/packages/daemon/tests/online/space/task-agent-lifecycle.test.ts
+++ b/packages/daemon/tests/online/space/task-agent-lifecycle.test.ts
@@ -29,7 +29,7 @@
  *
  * The report_result test uses the full MCP name "mcp__task-agent__report_result" with
  * stop_reason "tool_use" so the SDK dispatches the tool, which updates the task status
- * to 'completed' and emits the DaemonHub space.task.completed event.
+ * to 'done' and emits the DaemonHub space.task.done event.
  *
  * ## Running
  *
@@ -474,7 +474,7 @@ describe('Task Agent Lifecycle — Online Tests', () => {
 		async () => {
 			// This test uses the FULL MCP tool name "mcp__task-agent__report_result" with
 			// stop_reason "tool_use" so the SDK dispatches the tool. The handler updates the
-			// task status to 'completed' and emits the DaemonHub space.task.completed event.
+			// task status to 'done' and emits the DaemonHub space.task.done event.
 			// See probe mock "probe_task_agent_report_complete_001" in .devproxy/mocks.json.
 			const { space, workflow } = await createTestFixtures(daemon);
 
@@ -601,7 +601,7 @@ describe('Task Agent Lifecycle — Online Tests', () => {
 			expect(finalStatus).toBe('done');
 
 			// Wait for the Space Agent to receive and process the completion notification.
-			// provision-global-agent.ts subscribes to space.task.completed and injects
+			// provision-global-agent.ts subscribes to space.task.done and injects
 			// a notification message into the spaces:global session.
 			await waitForIdle(daemon, GLOBAL_SPACES_SESSION_ID, IDLE_TIMEOUT);
 

--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -697,14 +697,14 @@ describe('createGlobalSpacesMcpServer — MCP instance tool registration', () =>
 });
 
 // ===========================================================================
-// Task 6.2 — space.task.completed / space.task.failed subscription tests
+// Task 6.2 — space.task.done / space.task.failed subscription tests
 // ===========================================================================
 
 /** Build a controllable mock DaemonHub that records subscriptions and allows triggering them. */
 function makeMockDaemonHubForProvision(): {
 	hub: DaemonHub;
 	trigger: (
-		event: 'space.task.completed' | 'space.task.failed',
+		event: 'space.task.done' | 'space.task.failed',
 		payload: Record<string, unknown>
 	) => Promise<void>;
 } {
@@ -727,7 +727,7 @@ function makeMockDaemonHubForProvision(): {
 	} as unknown as DaemonHub;
 
 	async function trigger(
-		event: 'space.task.completed' | 'space.task.failed',
+		event: 'space.task.done' | 'space.task.failed',
 		payload: Record<string, unknown>
 	): Promise<void> {
 		const eventHandlers = handlers.get(event) ?? [];
@@ -739,7 +739,7 @@ function makeMockDaemonHubForProvision(): {
 	return { hub, trigger };
 }
 
-describe('provisionGlobalSpacesAgent — task completion event subscriptions', () => {
+describe('provisionGlobalSpacesAgent — task done/failed event subscriptions', () => {
 	let db: BunDatabase;
 	let dir: string;
 
@@ -760,7 +760,7 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 		}
 	});
 
-	test('subscribes to space.task.completed and space.task.failed when daemonHub is provided', async () => {
+	test('subscribes to space.task.done and space.task.failed when daemonHub is provided', async () => {
 		const { hub } = makeMockDaemonHubForProvision();
 		const deps = buildDeps(db);
 
@@ -768,7 +768,7 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 
 		const onMock = hub.on as ReturnType<typeof mock>;
 		const subscribedEvents = onMock.mock.calls.map((call: unknown[]) => call[0] as string);
-		expect(subscribedEvents).toContain('space.task.completed');
+		expect(subscribedEvents).toContain('space.task.done');
 		expect(subscribedEvents).toContain('space.task.failed');
 	});
 
@@ -778,14 +778,14 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 		await expect(provisionGlobalSpacesAgent(deps)).resolves.toBeUndefined();
 	});
 
-	test('injects completed notification into global session when space.task.completed fires', async () => {
+	test('injects completed notification into global session when space.task.done fires', async () => {
 		const sessionFactory = makeMockSessionFactory();
 		const { hub, trigger } = makeMockDaemonHubForProvision();
 		const deps = buildDeps(db, { sessionFactory });
 
 		await provisionGlobalSpacesAgent({ ...deps, daemonHub: hub });
 
-		await trigger('space.task.completed', {
+		await trigger('space.task.done', {
 			sessionId: 'global',
 			taskId: 'task-001',
 			spaceId: 'space-001',
@@ -867,7 +867,7 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 
 		// Should not throw even when injection fails
 		await expect(
-			trigger('space.task.completed', {
+			trigger('space.task.done', {
 				sessionId: 'global',
 				taskId: 'task-004',
 				spaceId: 'space-001',

--- a/packages/daemon/tests/unit/space/task-agent-collaboration.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-collaboration.test.ts
@@ -17,11 +17,10 @@
  *
  * 3. Multi-agent node collaboration:
  *    - Multiple agents on the same node can complete independently
- *    - CompletionDetector correctly tracks all-done state
- *    - report_workflow_done only allowed after all agents are terminal
+ *    - Channels are persisted and accessible
  */
 
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
@@ -35,7 +34,6 @@ import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-work
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
-import { CompletionDetector } from '../../../src/lib/space/runtime/completion-detector.ts';
 import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 import {
 	createTaskAgentToolHandlers,
@@ -78,35 +76,6 @@ function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, name: s
 		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
      VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
 	).run(agentId, spaceId, name, Date.now(), Date.now());
-}
-
-/**
- * Ensure a node_execution record exists with the given status.
- * If a record with the same (runId, nodeId, agentName) already exists,
- * update its status. Otherwise, create a new record.
- */
-function ensureNodeExec(
-	repo: NodeExecutionRepository,
-	runId: string,
-	nodeId: string,
-	agentName: string,
-	agentId: string | null,
-	status: string
-): void {
-	const existing = repo
-		.listByWorkflowRun(runId)
-		.find((e) => e.workflowNodeId === nodeId && e.agentName === agentName);
-	if (existing) {
-		repo.updateStatus(existing.id, status as import('@neokai/shared').NodeExecutionStatus);
-	} else {
-		repo.createOrIgnore({
-			workflowRunId: runId,
-			workflowNodeId: nodeId,
-			agentName,
-			agentId: agentId ?? null,
-			status: status as import('@neokai/shared').NodeExecutionStatus,
-		});
-	}
 }
 
 function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {
@@ -171,29 +140,6 @@ function makeMockSessionFactory(overrides?: {
 		_completionCallbacks: Map<string, () => Promise<void>>;
 		_triggerComplete: (sessionId: string) => Promise<void>;
 	};
-}
-
-// ---------------------------------------------------------------------------
-// Mock DaemonHub helper
-// ---------------------------------------------------------------------------
-
-interface MockDaemonHub {
-	hub: DaemonHub;
-	emittedEvents: Array<{ name: string; payload: Record<string, unknown> }>;
-}
-
-function makeMockDaemonHub(): MockDaemonHub {
-	const emittedEvents: Array<{ name: string; payload: Record<string, unknown> }> = [];
-	const hub = {
-		emit: mock((name: string, payload: Record<string, unknown>) => {
-			emittedEvents.push({ name, payload });
-			return Promise.resolve();
-		}),
-		on: mock(() => () => {}),
-		off: mock(() => {}),
-		once: mock(async () => {}),
-	} as unknown as DaemonHub;
-	return { hub, emittedEvents };
 }
 
 // ---------------------------------------------------------------------------
@@ -277,7 +223,6 @@ function makeConfig(
 	options?: {
 		messageInjector?: (sessionId: string, message: string) => Promise<void>;
 		onSubSessionComplete?: (stepId: string, sessionId: string) => Promise<void>;
-		completionDetector?: CompletionDetector;
 		daemonHub?: DaemonHub;
 	}
 ): TaskAgentToolsConfig {
@@ -294,7 +239,6 @@ function makeConfig(
 		sessionFactory,
 		messageInjector: options?.messageInjector ?? (async () => {}),
 		onSubSessionComplete: options?.onSubSessionComplete ?? (async () => {}),
-		completionDetector: options?.completionDetector,
 		daemonHub: options?.daemonHub,
 	};
 }
@@ -379,247 +323,6 @@ describe('Task Agent — full collaboration flow', () => {
 	afterEach(() => {
 		ctx.db.close();
 		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('single-node workflow: spawn → complete → report_workflow_done succeeds', async () => {
-		const wf = ctx.workflowManager.createWorkflow({
-			spaceId: ctx.spaceId,
-			name: 'Single Node WF',
-			nodes: [{ id: 'code-node', name: 'Code', agentId: ctx.coderAgentId }],
-			transitions: [],
-			startNodeId: 'code-node',
-			rules: [],
-			channels: [],
-		});
-
-		const { run, mainTask, stepTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, {
-				onSubSessionComplete: async (_stepId) => {
-					// workflowNodeId was removed in M71; use stepTask directly since it's in scope
-					ctx.taskRepo.updateTask(stepTask.id, {
-						status: 'done',
-						completedAt: Date.now(),
-					});
-					// Update node_execution record to 'done' for CompletionDetector.
-					// startWorkflowRun() creates the record with 'pending', so we
-					// must update it here.
-					ensureNodeExec(
-						ctx.nodeExecutionRepo,
-						run.id,
-						wf.nodes[0].id,
-						'Code',
-						ctx.coderAgentId,
-						'done'
-					);
-				},
-				completionDetector: new CompletionDetector(ctx.nodeExecutionRepo),
-			})
-		);
-
-		// 1. Spawn the node agent
-		const spawnResult = await handlers.spawn_node_agent({ step_id: 'code-node' });
-		const spawnParsed = JSON.parse(spawnResult.content[0].text);
-		expect(spawnParsed.success).toBe(true);
-
-		// 2. Trigger completion
-		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(
-			spawnParsed.sessionId
-		);
-
-		// Step task should now be completed
-		const updatedStepTask = ctx.taskRepo.getTask(stepTask.id);
-		expect(updatedStepTask?.status).toBe('done');
-
-		// 3. report_workflow_done should succeed
-		const doneResult = await handlers.report_workflow_done({
-			summary: 'All nodes completed successfully.',
-		});
-		const doneParsed = JSON.parse(doneResult.content[0].text);
-		expect(doneParsed.success).toBe(true);
-
-		// Workflow run should be marked completed
-		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
-		expect(updatedRun?.status).toBe('done');
-
-		// Main task should be closed
-		const finalTask = ctx.taskRepo.getTask(mainTask.id);
-		expect(finalTask?.status).toBe('done');
-	});
-
-	test('multi-node workflow: spawn both agents → both complete → report_workflow_done succeeds', async () => {
-		const node1Id = 'node-code';
-		const node2Id = 'node-review';
-		const wf = ctx.workflowManager.createWorkflow({
-			spaceId: ctx.spaceId,
-			name: 'Multi-Node WF',
-			nodes: [
-				{ id: node1Id, name: 'Code', agentId: ctx.coderAgentId },
-				{ id: node2Id, name: 'Review', agentId: ctx.reviewerAgentId },
-			],
-			transitions: [],
-			startNodeId: node1Id,
-			rules: [],
-			channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
-		});
-
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		// Manually create a task for node2 (normally done by WorkflowExecutor / lazy activation)
-		// Note: workflowNodeId and customAgentId were removed in M71
-		const reviewTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Review task',
-			description: '',
-			status: 'open',
-			workflowRunId: run.id,
-		});
-
-		const factory = makeMockSessionFactory();
-		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
-
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, {
-				onSubSessionComplete: async (_stepId, sessionId) => {
-					// workflowNodeId was removed in M71; find the task by taskAgentSessionId
-					const tasks = ctx.taskRepo.listByWorkflowRun(run.id);
-					const task = tasks.find((t) => t.taskAgentSessionId === sessionId);
-					if (task) {
-						ctx.taskRepo.updateTask(task.id, {
-							status: 'done',
-							completedAt: Date.now(),
-						});
-						// Update existing node_execution record to 'done' for CompletionDetector
-						const nodeExec = wf.nodes.find(
-							(n) => task.title.includes(n.name) || task.title.includes(n.id)
-						);
-						if (nodeExec) {
-							const executions = ctx.nodeExecutionRepo.listByNode(run.id, nodeExec.id);
-							const execution = executions.find(
-								(e) => e.status !== 'done' && e.status !== 'cancelled'
-							);
-							if (execution) {
-								ctx.nodeExecutionRepo.updateStatus(execution.id, 'done');
-							}
-						}
-					}
-				},
-				completionDetector,
-			})
-		);
-
-		// Spawn both agents
-		const spawn1 = await handlers.spawn_node_agent({ step_id: node1Id });
-		const spawn1Parsed = JSON.parse(spawn1.content[0].text);
-		expect(spawn1Parsed.success).toBe(true);
-
-		const spawn2 = await handlers.spawn_node_agent({ step_id: node2Id });
-		const spawn2Parsed = JSON.parse(spawn2.content[0].text);
-		expect(spawn2Parsed.success).toBe(true);
-
-		// Ensure node_execution records exist for both nodes (pending status)
-		// so CompletionDetector sees all nodes and checks their status
-		ensureNodeExec(
-			ctx.nodeExecutionRepo,
-			run.id,
-			node1Id,
-			wf.nodes[0].name,
-			wf.nodes[0].agents[0].agentId,
-			'pending'
-		);
-		ensureNodeExec(
-			ctx.nodeExecutionRepo,
-			run.id,
-			node2Id,
-			wf.nodes[1].name,
-			wf.nodes[1].agents[0].agentId,
-			'pending'
-		);
-
-		// Complete only node1 — report_workflow_done should be blocked
-		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(
-			spawn1Parsed.sessionId
-		);
-
-		const earlyDone = await handlers.report_workflow_done({ summary: 'Too early' });
-		const earlyParsed = JSON.parse(earlyDone.content[0].text);
-		expect(earlyParsed.success).toBe(false);
-		expect(earlyParsed.error).toContain('Not all node agents');
-
-		// Complete node2 — now report_workflow_done should succeed
-		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(
-			spawn2Parsed.sessionId
-		);
-
-		// Both step tasks should be completed
-		// workflowNodeId was removed in M71 — find the first step task (not main task) in the run
-		const runTasks = ctx.taskRepo.listByWorkflowRun(run.id);
-		const stepTasks = runTasks.filter((t) => t.id !== mainTask.id);
-		const reviewTaskUpdated = ctx.taskRepo.getTask(reviewTask.id);
-		expect(stepTasks.every((t) => t.status === 'done')).toBe(true);
-		expect(reviewTaskUpdated?.status).toBe('done');
-
-		const doneFinal = await handlers.report_workflow_done({ summary: 'All done!' });
-		const doneParsed = JSON.parse(doneFinal.content[0].text);
-		expect(doneParsed.success).toBe(true);
-
-		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
-		expect(updatedRun?.status).toBe('done');
-	});
-
-	test('report_workflow_done emits space.task.completed event after full flow', async () => {
-		const wf = ctx.workflowManager.createWorkflow({
-			spaceId: ctx.spaceId,
-			name: 'Event Test WF',
-			nodes: [{ id: 'node-1', name: 'Work', agentId: ctx.coderAgentId }],
-			transitions: [],
-			startNodeId: 'node-1',
-			rules: [],
-			channels: [],
-		});
-
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		const factory = makeMockSessionFactory();
-		const { hub, emittedEvents } = makeMockDaemonHub();
-
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, {
-				onSubSessionComplete: async (_stepId) => {
-					// workflowNodeId was removed in M71; mark the first active task as done
-					const tasks = ctx.taskRepo
-						.listByWorkflowRun(run.id)
-						.filter((t) => t.status === 'in_progress' || t.status === 'open');
-					if (tasks.length > 0) {
-						ctx.taskRepo.updateTask(tasks[0].id, {
-							status: 'done',
-							completedAt: Date.now(),
-						});
-					}
-				},
-				daemonHub: hub,
-			})
-		);
-
-		const spawn = await handlers.spawn_node_agent({ step_id: 'node-1' });
-		const spawnParsed = JSON.parse(spawn.content[0].text);
-		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(
-			spawnParsed.sessionId
-		);
-
-		await handlers.report_workflow_done({ summary: 'Completed!' });
-
-		const completedEvent = emittedEvents.find((e) => e.name === 'space.task.completed');
-		expect(completedEvent).toBeDefined();
-		expect(completedEvent?.payload.taskId).toBe(mainTask.id);
-		expect(completedEvent?.payload.workflowRunId).toBe(run.id);
-		expect(completedEvent?.payload.status).toBe('done');
-		expect(completedEvent?.payload.summary).toBe('Completed!');
 	});
 
 	test('check_node_status reflects completion after agent finishes', async () => {
@@ -725,66 +428,6 @@ describe('Task Agent — gate-blocked flow with escalation', () => {
 		expect(updatedTask?.status).toBe('blocked');
 	});
 
-	test('gate-blocked: report_workflow_done blocked while agent is in needs_attention', async () => {
-		const wf = buildHumanGateWorkflow(ctx);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		// Set the step task to done (terminal) with a matching node_execution record
-		// so CompletionDetector considers the workflow complete.
-		const stepTasks = ctx.taskRepo.listByWorkflowRun(run.id).filter((t) => t.id !== mainTask.id);
-		expect(stepTasks.length).toBeGreaterThan(0);
-		ctx.taskRepo.updateTask(stepTasks[0].id, { status: 'done', completedAt: Date.now() });
-
-		// Ensure node_execution record is 'done' — terminal status for CompletionDetector
-		ensureNodeExec(
-			ctx.nodeExecutionRepo,
-			run.id,
-			wf.nodes[0].id,
-			wf.nodes[0].name,
-			wf.nodes[0].agents[0].agentId,
-			'done'
-		);
-
-		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, { completionDetector })
-		);
-
-		// report_workflow_done should succeed — node execution has terminal status
-		const result = await handlers.report_workflow_done({ summary: 'Should complete' });
-		const parsed = JSON.parse(result.content[0].text);
-		// 'done' is a terminal status — CompletionDetector allows it
-		expect(parsed.success).toBe(true);
-		// Confirm run was marked completed
-		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
-		expect(updatedRun?.status).toBe('done');
-	});
-
-	test('gate-blocked: report_workflow_done blocked while agent is still in_progress', async () => {
-		const wf = buildHumanGateWorkflow(ctx);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		// Set step task to in_progress (not terminal)
-		// workflowNodeId was removed in M71 — filter by tasks that are not the main task
-		const stepTasks = ctx.taskRepo.listByWorkflowRun(run.id).filter((t) => t.id !== mainTask.id);
-		ctx.taskRepo.updateTask(stepTasks[0].id, { status: 'in_progress' });
-
-		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, { completionDetector })
-		);
-
-		// Task Agent tries to complete before node agent is done — must be blocked
-		const result = await handlers.report_workflow_done({ summary: 'Too early' });
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('Not all node agents have reached a terminal state');
-	});
-
 	test('escalation context is recorded on task error field', async () => {
 		const wf = buildHumanGateWorkflow(ctx);
 		const { run, mainTask } = await startRun(ctx, wf);
@@ -819,81 +462,6 @@ describe('Task Agent — multi-agent node collaboration', () => {
 	afterEach(() => {
 		ctx.db.close();
 		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('two agents on same node: both must complete before report_workflow_done', async () => {
-		const nodeId = 'multi-agent-node';
-		const wf = ctx.workflowManager.createWorkflow({
-			spaceId: ctx.spaceId,
-			name: 'Multi-Agent Node WF',
-			nodes: [
-				{
-					id: nodeId,
-					name: 'Parallel Work',
-					agents: [
-						{ agentId: ctx.coderAgentId, name: 'coder-a' },
-						{ agentId: ctx.reviewerAgentId, name: 'reviewer-a' },
-					],
-				},
-			],
-			transitions: [],
-			startNodeId: nodeId,
-			rules: [],
-			channels: [],
-		});
-
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		// startRun creates tasks via runtime.startWorkflowRun; expect 2 tasks for multi-agent node
-		// workflowNodeId was removed in M71 — filter all tasks except the main orchestration task
-		const nodeTasks = ctx.taskRepo.listByWorkflowRun(run.id).filter((t) => t.id !== mainTask.id);
-		expect(nodeTasks).toHaveLength(2);
-
-		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, { completionDetector })
-		);
-
-		// Spawn both agents (one spawn_node_agent per task)
-		const spawn1 = await handlers.spawn_node_agent({ step_id: nodeId });
-		const spawn1Parsed = JSON.parse(spawn1.content[0].text);
-		expect(spawn1Parsed.success).toBe(true);
-		// Second spawn for same node returns existing session (idempotent)
-		const spawn2 = await handlers.spawn_node_agent({ step_id: nodeId });
-		const spawn2Parsed = JSON.parse(spawn2.content[0].text);
-		expect(spawn2Parsed.success).toBe(true);
-		// Idempotency: second spawn returns the same session (the last-created task)
-		expect(spawn2Parsed.alreadySpawned).toBe(true);
-
-		// Node_execution records are created by startWorkflowRun() with per-agent names.
-
-		// Mark one task completed, one still pending — detector should block
-		ctx.taskRepo.updateTask(nodeTasks[0].id, { status: 'done', completedAt: Date.now() });
-		// Update first agent's node_execution to 'done'
-		const exec1 = ctx.nodeExecutionRepo.listByNode(run.id, nodeId).find((e) => e.status !== 'done');
-		if (exec1) ctx.nodeExecutionRepo.updateStatus(exec1.id, 'done');
-
-		const earlyResult = await handlers.report_workflow_done({ summary: 'Too early' });
-		const earlyParsed = JSON.parse(earlyResult.content[0].text);
-		expect(earlyParsed.success).toBe(false);
-		expect(earlyParsed.error).toContain('Not all node agents');
-
-		// Mark second task completed
-		ctx.taskRepo.updateTask(nodeTasks[1].id, { status: 'done', completedAt: Date.now() });
-		// Update second agent's node_execution to 'done'
-		const exec2 = ctx.nodeExecutionRepo.listByNode(run.id, nodeId).find((e) => e.status !== 'done');
-		if (exec2) ctx.nodeExecutionRepo.updateStatus(exec2.id, 'done');
-
-		const finalResult = await handlers.report_workflow_done({
-			summary: 'All parallel agents done',
-		});
-		const finalParsed = JSON.parse(finalResult.content[0].text);
-		expect(finalParsed.success).toBe(true);
-
-		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
-		expect(updatedRun?.status).toBe('done');
 	});
 
 	test('collaboration workflow with channels: channel map in workflow is persisted and accessible', async () => {

--- a/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
@@ -11,7 +11,6 @@ import {
 	SpawnNodeAgentSchema,
 	CheckNodeStatusSchema,
 	ReportResultSchema,
-	ReportWorkflowDoneSchema,
 	RequestHumanInputSchema,
 	TaskResultStatusSchema,
 	TASK_AGENT_TOOL_SCHEMAS,
@@ -244,53 +243,18 @@ describe('RequestHumanInputSchema', () => {
 });
 
 // ---------------------------------------------------------------------------
-// report_workflow_done
-// ---------------------------------------------------------------------------
-
-describe('ReportWorkflowDoneSchema', () => {
-	test('accepts empty object (summary is optional)', () => {
-		const result = ReportWorkflowDoneSchema.safeParse({});
-		expect(result.success).toBe(true);
-		if (result.success) {
-			expect(result.data.summary).toBeUndefined();
-		}
-	});
-
-	test('accepts valid input with summary', () => {
-		const result = ReportWorkflowDoneSchema.safeParse({
-			summary: 'All agents completed successfully. PR #42 merged.',
-		});
-		expect(result.success).toBe(true);
-		if (result.success) {
-			expect(result.data.summary).toBe('All agents completed successfully. PR #42 merged.');
-		}
-	});
-
-	test('rejects non-string summary', () => {
-		const result = ReportWorkflowDoneSchema.safeParse({ summary: 123 });
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects null summary', () => {
-		const result = ReportWorkflowDoneSchema.safeParse({ summary: null });
-		expect(result.success).toBe(false);
-	});
-});
-
-// ---------------------------------------------------------------------------
 // TASK_AGENT_TOOL_SCHEMAS aggregate
 // ---------------------------------------------------------------------------
 
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
-	test('contains all 6 tool schemas', () => {
+	test('contains all 5 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
 		expect(keys).toContain('spawn_node_agent');
 		expect(keys).toContain('check_node_status');
 		expect(keys).toContain('report_result');
-		expect(keys).toContain('report_workflow_done');
 		expect(keys).toContain('request_human_input');
 		expect(keys).toContain('list_group_members');
-		expect(keys).toHaveLength(6);
+		expect(keys).toHaveLength(5);
 	});
 
 	test('each schema value is a valid Zod schema with safeParse', () => {

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -80,7 +80,6 @@ import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-work
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
-import { CompletionDetector } from '../../../src/lib/space/runtime/completion-detector.ts';
 import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
 import {
 	createTaskAgentToolHandlers,
@@ -1000,7 +999,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('emits space.task.completed event when status is completed', async () => {
+	test('emits space.task.done event when status is done', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Test Task',
@@ -1020,7 +1019,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 		// The mock emit is synchronous (records events before returning Promise.resolve()),
 		// so no async flush is needed — assertions can run immediately.
 		expect(emittedEvents).toHaveLength(1);
-		expect(emittedEvents[0].name).toBe('space.task.completed');
+		expect(emittedEvents[0].name).toBe('space.task.done');
 		expect(emittedEvents[0].payload.taskId).toBe(mainTask.id);
 		expect(emittedEvents[0].payload.spaceId).toBe(ctx.spaceId);
 		expect(emittedEvents[0].payload.status).toBe('done');
@@ -1363,14 +1362,13 @@ describe('createTaskAgentMcpServer', () => {
 		expect(server.name).toBe('task-agent');
 	});
 
-	test('registers all 7 expected tools', async () => {
+	test('registers all 6 expected tools', async () => {
 		const { server } = await makeServerCtx();
 		const registered = Object.keys(server.instance._registeredTools).sort();
 		expect(registered).toEqual([
 			'check_node_status',
 			'list_group_members',
 			'report_result',
-			'report_workflow_done',
 			'request_human_input',
 			'send_message',
 			'spawn_node_agent',
@@ -1475,9 +1473,9 @@ describe('createTaskAgentMcpServer', () => {
 
 		// Each call returns a distinct server instance
 		expect(server1.instance).not.toBe(server2.instance);
-		// Both register all 7 tools
-		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(7);
-		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(7);
+		// Both register all 6 tools
+		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(6);
+		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(6);
 	});
 });
 
@@ -1853,296 +1851,5 @@ describe('createTaskAgentToolHandlers — spawn_node_agent slot role and overrid
 		expect(parsed.success).toBe(true);
 		// model is provided from base agent config
 		expect(capturedInit?.model).toBeString();
-	});
-});
-
-// ===========================================================================
-// report_workflow_done tests
-// ===========================================================================
-
-describe('createTaskAgentToolHandlers — report_workflow_done', () => {
-	let ctx: TestCtx;
-	beforeEach(() => {
-		ctx = makeCtx();
-	});
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('marks workflow run as completed when run is in_progress', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		// Task agent would have called spawn_node_agent before report_workflow_done,
-		// which transitions the main task to in_progress.
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-		const factory = makeMockSessionFactory();
-
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-
-		const result = await handlers.report_workflow_done({ summary: 'All done' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.workflowRunId).toBe(run.id);
-
-		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
-		expect(updatedRun?.status).toBe('done');
-		expect(updatedRun?.completedAt).toBeDefined();
-	});
-
-	test('marks main task as completed', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		// Transition main task to in_progress so report_workflow_done can close it
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-
-		await handlers.report_workflow_done({ summary: 'Workflow complete' });
-
-		const updatedTask = ctx.taskRepo.getTask(mainTask.id);
-		expect(updatedTask?.status).toBe('done');
-	});
-
-	test('stores summary on the main task result', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-
-		await handlers.report_workflow_done({ summary: 'The PR was merged successfully.' });
-
-		const updatedTask = ctx.taskRepo.getTask(mainTask.id);
-		expect(updatedTask?.result).toBe('The PR was merged successfully.');
-	});
-
-	test('succeeds without a summary (summary is optional)', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-
-		const result = await handlers.report_workflow_done({});
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
-		expect(updatedRun?.status).toBe('done');
-	});
-
-	test('rejects when workflow run is not in_progress', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		// Manually mark the run as already completed
-		ctx.workflowRunRepo.transitionStatus(run.id, 'done');
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-
-		const result = await handlers.report_workflow_done({ summary: 'Duplicate' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.currentStatus).toBe('done');
-	});
-
-	test('rejects when workflow run does not exist', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { mainTask } = await startRun(ctx, wf);
-		const factory = makeMockSessionFactory();
-
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, 'nonexistent-run-id', factory)
-		);
-
-		const result = await handlers.report_workflow_done({ summary: 'Should fail' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('nonexistent-run-id');
-	});
-
-	test('emits space.task.completed event via daemonHub', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		const { hub, emittedEvents } = makeMockDaemonHub();
-		const factory = makeMockSessionFactory();
-		const config = makeConfig(ctx, mainTask.id, run.id, factory);
-		const handlers = createTaskAgentToolHandlers({ ...config, daemonHub: hub });
-
-		await handlers.report_workflow_done({ summary: 'Done!' });
-
-		const completedEvent = emittedEvents.find((e) => e.name === 'space.task.completed');
-		expect(completedEvent).toBeDefined();
-		expect(completedEvent?.payload.taskId).toBe(mainTask.id);
-		expect(completedEvent?.payload.workflowRunId).toBe(run.id);
-		expect(completedEvent?.payload.status).toBe('done');
-	});
-
-	test('does not emit event when daemonHub is not provided', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		const factory = makeMockSessionFactory();
-		// No daemonHub in config
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-
-		// Should succeed without throwing
-		const result = await handlers.report_workflow_done({ summary: 'No hub' });
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-	});
-});
-
-// ===========================================================================
-// report_workflow_done with CompletionDetector
-// ===========================================================================
-
-describe('createTaskAgentToolHandlers — report_workflow_done with CompletionDetector', () => {
-	let ctx: TestCtx;
-	beforeEach(() => {
-		ctx = makeCtx();
-	});
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('blocks when node agents have not all completed', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		// The step task is still 'pending' — not terminal
-		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
-		const factory = makeMockSessionFactory();
-		const config = makeConfig(ctx, mainTask.id, run.id, factory);
-		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
-
-		const result = await handlers.report_workflow_done({ summary: 'Premature' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('Not all node agents have reached a terminal state');
-	});
-
-	test('blocks when a step task is still in_progress', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		// Set the step task to in_progress (non-terminal) — CompletionDetector should block
-		// workflowNodeId was removed in M71; get the first task in the run as the step task
-		const stepTask = ctx.taskRepo.listByWorkflowRun(run.id)[0];
-		ctx.taskRepo.updateTask(stepTask!.id, { status: 'in_progress' });
-
-		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
-		const factory = makeMockSessionFactory();
-		const config = makeConfig(ctx, mainTask.id, run.id, factory);
-		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
-
-		const result = await handlers.report_workflow_done({ summary: 'Too soon' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('Not all node agents');
-	});
-
-	test('allows completion when all step tasks have reached a terminal status', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		// Use the raw runtime to start the run (creates step tasks with workflowRunId set)
-		const { run, tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Test run');
-		const stepTask = tasks[0];
-
-		// Mark the step task as terminal (bypass state machine)
-		ctx.taskRepo.updateTask(stepTask.id, { status: 'done' });
-
-		// Update the existing node_execution record (created by startWorkflowRun)
-		// to terminal status so CompletionDetector sees it as complete.
-		const executions = ctx.nodeExecutionRepo.listByWorkflowRun(run.id);
-		expect(executions).toHaveLength(1);
-		ctx.nodeExecutionRepo.updateStatus(executions[0].id, 'done');
-
-		// Create the orchestration (main) task WITHOUT workflowRunId so the
-		// CompletionDetector does not see it and only checks step tasks.
-		const mainTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Main orchestration task',
-			description: '',
-			status: 'in_progress',
-		});
-
-		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
-		const factory = makeMockSessionFactory();
-		const config = makeConfig(ctx, mainTask.id, run.id, factory);
-		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
-
-		const result = await handlers.report_workflow_done({ summary: 'All done' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		// Confirm the workflow run was actually marked completed
-		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
-		expect(updatedRun?.status).toBe('done');
-	});
-
-	test('allows completion when step task has cancelled status (terminal for NodeExecution)', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Test run');
-		const stepTask = tasks[0];
-
-		// cancelled is a terminal status for NodeExecution (done + cancelled)
-		ctx.taskRepo.updateTask(stepTask.id, { status: 'cancelled' });
-
-		// Update the existing node_execution record to terminal status.
-		// 'cancelled' is a terminal status for NodeExecution.
-		const executions = ctx.nodeExecutionRepo.listByWorkflowRun(run.id);
-		expect(executions).toHaveLength(1);
-		ctx.nodeExecutionRepo.updateStatus(executions[0].id, 'cancelled');
-
-		// Create orchestration task WITHOUT workflowRunId (excluded from detector)
-		const mainTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Main orchestration task',
-			description: '',
-			status: 'in_progress',
-		});
-
-		const completionDetector = new CompletionDetector(ctx.nodeExecutionRepo);
-		const factory = makeMockSessionFactory();
-		const config = makeConfig(ctx, mainTask.id, run.id, factory);
-		const handlers = createTaskAgentToolHandlers({ ...config, completionDetector });
-
-		const result = await handlers.report_workflow_done({ summary: 'Agent cancelled but done' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-	});
-
-	test('skips completion check when completionDetector is not provided', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
-
-		// Step task is still pending — without a detector this should still succeed
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-
-		const result = await handlers.report_workflow_done({ summary: 'No detector' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		// No completionDetector → existing behaviour: no pre-check, should succeed
-		expect(parsed.success).toBe(true);
 	});
 });


### PR DESCRIPTION
Updates test files to match source code changes:

- Remove `ReportWorkflowDoneSchema` tests and `report_workflow_done` handler describe blocks
- Update `TASK_AGENT_TOOL_SCHEMAS` count assertions from 6 to 5
- Update `createTaskAgentMcpServer` tool count assertions from 7 to 6
- Rename `space.task.completed` event references to `space.task.done` across test files
- Remove `CompletionDetector` import and related test blocks from task-agent-tools.test.ts