### PR TITLE
feat: inject db-query MCP server into all agent session types

### DIFF
--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -25,6 +25,7 @@ import {
 	type NeoToolsConfig,
 	type NeoActionToolsConfig,
 } from './tools/neo-tools-server';
+import { createDbQueryMcpServer, type DbQueryMcpServer } from '../db-query/tools';
 
 export const NEO_SESSION_ID = 'neo:global';
 const NEO_SESSION_TITLE = 'Neo';
@@ -60,6 +61,8 @@ export class NeoAgentManager {
 	private actionToolsConfig: NeoActionToolsConfig | null = null;
 	private appMcpManager: NeoAppMcpManager | null = null;
 	private activityLogger: NeoActivityLogger | null = null;
+	private dbPath: string | null = null;
+	private dbQueryServer: DbQueryMcpServer | null = null;
 
 	constructor(
 		private readonly sessionManager: NeoSessionManager,
@@ -182,6 +185,23 @@ export class NeoAgentManager {
 	}
 
 	/**
+	 * Wire in the database path for the db-query MCP server.
+	 *
+	 * Must be called before `provision()`. When set, `attachTools()` will create a
+	 * read-only db-query MCP server with global scope (all non-sensitive tables, no
+	 * WHERE filter injection) and attach it to the Neo session alongside the neo-query
+	 * and neo-action servers.
+	 *
+	 * Follows the same order-independent wiring pattern as setToolsConfig() and
+	 * setActivityLogger().
+	 *
+	 * @param dbPath  Absolute path to the SQLite database file.
+	 */
+	setDbPath(dbPath: string): void {
+		this.dbPath = dbPath;
+	}
+
+	/**
 	 * Health-check the Neo session.
 	 *
 	 * Detects:
@@ -252,7 +272,8 @@ export class NeoAgentManager {
 	/**
 	 * Gracefully shut down the Neo session.
 	 *
-	 * Called during daemon shutdown. Delegates to AgentSession.cleanup().
+	 * Called during daemon shutdown. Delegates to AgentSession.cleanup() and
+	 * closes the db-query MCP server's read-only SQLite connection.
 	 */
 	async cleanup(): Promise<void> {
 		if (!this.session) return;
@@ -264,6 +285,14 @@ export class NeoAgentManager {
 			this.logger.error('Error during Neo session cleanup:', error);
 		}
 		this.session = null;
+
+		// Close the db-query server's read-only connection.
+		try {
+			this.dbQueryServer?.close();
+		} catch (error) {
+			this.logger.warn('Error closing db-query server during Neo cleanup:', error);
+		}
+		this.dbQueryServer = null;
 	}
 
 	// ============================================================================
@@ -379,6 +408,16 @@ export class NeoAgentManager {
 	private attachTools(): void {
 		if (!this.session || !this.toolsConfig) return;
 
+		// Close any existing db-query server instance before creating a new one.
+		// This prevents connection leaks when attachTools() is called multiple times
+		// during mid-lifecycle resets (e.g., destroyAndRecreate(), clearSession()).
+		try {
+			this.dbQueryServer?.close();
+		} catch (error) {
+			this.logger.warn('Error closing stale db-query server in attachTools():', error);
+		}
+		this.dbQueryServer = null;
+
 		const inProcessServers = createNeoToolsMcpServers(
 			this.toolsConfig,
 			this.actionToolsConfig ?? undefined
@@ -394,9 +433,22 @@ export class NeoAgentManager {
 			}
 		}
 
+		// Create the db-query MCP server with global scope (no WHERE filter injection).
+		// Placed last in the merge map so it wins on key collision.
+		const dbQueryServers: Record<string, McpServerConfig> = {};
+		if (this.dbPath) {
+			this.dbQueryServer = createDbQueryMcpServer({
+				dbPath: this.dbPath,
+				scopeType: 'global',
+				scopeValue: '',
+			});
+			dbQueryServers['db-query'] = this.dbQueryServer as unknown as McpServerConfig;
+		}
+
 		this.session.setRuntimeMcpServers({
 			...registryMcpServers,
 			...inProcessServers,
+			...dbQueryServers,
 		});
 	}
 }

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -37,6 +37,7 @@ import { TaskManager } from '../managers/task-manager';
 import { GoalManager } from '../managers/goal-manager';
 import { AgentSession } from '../../agent/agent-session';
 import { createRoomAgentMcpServer } from '../tools/room-agent-tools';
+import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
 import { buildRoomChatSystemPrompt } from '../agents/room-chat-agent';
 import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-repository';
 import { recoverRuntime, type SessionStateChecker } from './runtime-recovery';
@@ -84,6 +85,9 @@ export interface RoomRuntimeServiceConfig {
 	appMcpServerRepo?: AppMcpServerRepository;
 	/** Room skill override repository for fetching per-room skill enablement overrides. Optional for backwards compatibility. */
 	roomSkillOverrideRepo?: RoomSkillOverrideRepository;
+	/** Absolute path to the SQLite database file. When provided, a db-query MCP server
+	 * with room scope is attached to each room chat session. */
+	dbPath?: string;
 }
 
 export class RoomRuntimeService {
@@ -93,6 +97,8 @@ export class RoomRuntimeService {
 	private unsubscribers: Array<() => void> = [];
 	/** Stores the room-agent-tools McpServerConfig per room for hot-reload on registry changes */
 	private roomAgentMcpServers = new Map<string, McpServerConfig>();
+	/** Stores the db-query server instances per room for cleanup on session teardown */
+	private roomDbQueryServers = new Map<string, DbQueryMcpServer>();
 
 	constructor(private ctx: RoomRuntimeServiceConfig) {}
 
@@ -210,6 +216,16 @@ export class RoomRuntimeService {
 		this.runtimes.delete(roomId);
 		this.observers.delete(roomId);
 		this.roomAgentMcpServers.delete(roomId);
+		// Close db-query server connection for this room.
+		const dbQueryServer = this.roomDbQueryServers.get(roomId);
+		if (dbQueryServer) {
+			try {
+				dbQueryServer.close();
+			} catch (err) {
+				log.warn(`Failed to close db-query server on stopRuntime for room ${roomId}:`, err);
+			}
+			this.roomDbQueryServers.delete(roomId);
+		}
 		this.persistRuntimePreference(roomId, 'stopped');
 		return true;
 	}
@@ -233,6 +249,16 @@ export class RoomRuntimeService {
 			// Clear the cached room-agent-tools server; createOrGetRuntime() →
 			// setupRoomAgentSession() will repopulate it for the fresh runtime.
 			this.roomAgentMcpServers.delete(roomId);
+			// Close old db-query server; setupRoomAgentSession() will create a fresh one.
+			const oldDbQueryServer = this.roomDbQueryServers.get(roomId);
+			if (oldDbQueryServer) {
+				try {
+					oldDbQueryServer.close();
+				} catch (err) {
+					log.warn(`Failed to close old db-query server on startRuntime for room ${roomId}:`, err);
+				}
+				this.roomDbQueryServers.delete(roomId);
+			}
 		}
 
 		// Create a fresh runtime - autoStart=true starts it immediately
@@ -264,6 +290,16 @@ export class RoomRuntimeService {
 		}
 		this.agentSessions.clear();
 		this.roomAgentMcpServers.clear();
+
+		// Close all db-query server connections to release read-only SQLite handles.
+		for (const [roomId, server] of this.roomDbQueryServers) {
+			try {
+				server.close();
+			} catch (error) {
+				log.warn(`Failed to close db-query server for room ${roomId}:`, error);
+			}
+		}
+		this.roomDbQueryServers.clear();
 
 		for (const unsub of this.unsubscribers) {
 			unsub();
@@ -806,11 +842,35 @@ export class RoomRuntimeService {
 				const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
 				const registryMcpServers =
 					this.ctx.appMcpManager?.getEnabledMcpConfigsForRoom(room.id) ?? {};
-				roomChatSession.setRuntimeMcpServers({
+
+				// Create a room-scoped db-query server (auto-injects WHERE room_id = ?).
+				// Only created when dbPath is configured; close any existing instance first to
+				// prevent connection leaks on re-setup.
+				const existingDbQueryServer = this.roomDbQueryServers.get(room.id);
+				if (existingDbQueryServer) {
+					try {
+						existingDbQueryServer.close();
+					} catch (err) {
+						log.warn(`Failed to close stale db-query server for room ${room.id}:`, err);
+					}
+				}
+
+				const roomMcpServers: Record<string, McpServerConfig> = {
 					...fileMcpServers,
 					...registryMcpServers,
 					'room-agent-tools': roomAgentMcpServer,
-				});
+				};
+				if (this.ctx.dbPath) {
+					const dbQueryServer = createDbQueryMcpServer({
+						dbPath: this.ctx.dbPath,
+						scopeType: 'room',
+						scopeValue: room.id,
+					});
+					this.roomDbQueryServers.set(room.id, dbQueryServer);
+					roomMcpServers['db-query'] = dbQueryServer as unknown as McpServerConfig;
+				}
+
+				roomChatSession.setRuntimeMcpServers(roomMcpServers);
 				// Inject the room chat system prompt so the agent knows the proper
 				// goal → plan → approval → task workflow and never creates tasks
 				// prematurely when a goal is created.
@@ -862,6 +922,19 @@ export class RoomRuntimeService {
 							this.runtimes.delete(event.roomId);
 							this.observers.delete(event.roomId);
 							this.roomAgentMcpServers.delete(event.roomId);
+							// Close old db-query server; createOrGetRuntime() → setupRoomAgentSession() creates a fresh one.
+							const oldDbQueryServer = this.roomDbQueryServers.get(event.roomId);
+							if (oldDbQueryServer) {
+								try {
+									oldDbQueryServer.close();
+								} catch (err) {
+									log.warn(
+										`Failed to close db-query server on room.updated for room ${event.roomId}:`,
+										err
+									);
+								}
+								this.roomDbQueryServers.delete(event.roomId);
+							}
 							this.createOrGetRuntime(room);
 							return;
 						}
@@ -928,6 +1001,11 @@ export class RoomRuntimeService {
 							const roomAgentMcpServer = this.roomAgentMcpServers.get(roomId);
 							if (roomAgentMcpServer) {
 								merged['room-agent-tools'] = roomAgentMcpServer;
+							}
+							// Re-include the db-query server so it survives registry refreshes.
+							const dbQueryServer = this.roomDbQueryServers.get(roomId);
+							if (dbQueryServer) {
+								merged['db-query'] = dbQueryServer as unknown as McpServerConfig;
 							}
 							session.setRuntimeMcpServers(merged);
 						})

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -215,6 +215,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		skillsManager: deps.skillsManager,
 		appMcpServerRepo: deps.reactiveDb.db.appMcpServers,
 		roomSkillOverrideRepo: deps.reactiveDb.db.roomSkillOverrides,
+		dbPath: deps.db.getDatabasePath(),
 	});
 
 	// Seed an initial room.tick job for every room after startup, and for each
@@ -388,6 +389,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceTaskRepository: spaceTaskRepo,
 	};
 	deps.neoAgentManager.setToolsConfig(neoToolsConfig, deps.appMcpManager);
+	deps.neoAgentManager.setDbPath(deps.db.getDatabasePath());
 
 	const spaceTaskManagerFactory: SpaceTaskManagerFactory = (spaceId: string) => {
 		return new SpaceTaskManager(deps.db.getDatabase(), spaceId, deps.reactiveDb);
@@ -419,6 +421,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase());
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
+		dbPath: deps.db.getDatabasePath(),
 		spaceManager: deps.spaceManager,
 		spaceAgentManager: deps.spaceAgentManager,
 		spaceWorkflowManager,
@@ -475,6 +478,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		skillsManager: deps.skillsManager,
 		appMcpServerRepo: deps.reactiveDb.db.appMcpServers,
 		nodeExecutionRepo,
+		dbPath: deps.db.getDatabasePath(),
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -30,11 +30,15 @@ import { SpaceTaskManager } from '../managers/space-task-manager';
 import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
 import { buildSpaceChatSystemPrompt } from '../agents/space-chat-agent';
 import { Logger } from '../../logger';
+import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
 
 const log = new Logger('space-runtime-service');
 
 export interface SpaceRuntimeServiceConfig {
 	db: BunDatabase;
+	/** Absolute path to the SQLite database file. When provided, a db-query MCP server
+	 * with space scope is attached to each space chat session. */
+	dbPath?: string;
 	spaceManager: SpaceManager;
 	spaceAgentManager: SpaceAgentManager;
 	spaceWorkflowManager: SpaceWorkflowManager;
@@ -83,6 +87,8 @@ export class SpaceRuntimeService {
 	private taskAgentManager: TaskAgentManager | null = null;
 	/** Resolved nodeExecutionRepo — created from db if not provided in config. */
 	private readonly nodeExecutionRepo: NodeExecutionRepository;
+	/** Stores db-query server instances per space for cleanup on stop. */
+	private readonly spaceDbQueryServers = new Map<string, DbQueryMcpServer>();
 
 	constructor(private readonly config: SpaceRuntimeServiceConfig) {
 		// Ensure nodeExecutionRepo is available — create from db if not provided.
@@ -124,6 +130,17 @@ export class SpaceRuntimeService {
 			unsub();
 		}
 		this.unsubscribers.length = 0;
+
+		// Close all db-query server connections to release read-only SQLite handles.
+		for (const [spaceId, server] of this.spaceDbQueryServers) {
+			try {
+				server.close();
+			} catch (error) {
+				log.warn(`Failed to close db-query server for space ${spaceId}:`, error);
+			}
+		}
+		this.spaceDbQueryServers.clear();
+
 		log.info('SpaceRuntimeService stopped');
 	}
 
@@ -221,9 +238,31 @@ export class SpaceRuntimeService {
 			taskAgentManager: this.taskAgentManager,
 		});
 
-		session.setRuntimeMcpServers({
+		// Create a space-scoped db-query server if dbPath is configured.
+		// Close any existing instance for this space to prevent connection leaks on re-setup.
+		const existingDbQueryServer = this.spaceDbQueryServers.get(space.id);
+		if (existingDbQueryServer) {
+			try {
+				existingDbQueryServer.close();
+			} catch (err) {
+				log.warn(`Failed to close stale db-query server for space ${space.id}:`, err);
+			}
+		}
+
+		const mcpServers: Record<string, McpServerConfig> = {
 			'space-agent-tools': mcpServer as unknown as McpServerConfig,
-		});
+		};
+		if (this.config.dbPath) {
+			const dbQueryServer = createDbQueryMcpServer({
+				dbPath: this.config.dbPath,
+				scopeType: 'space',
+				scopeValue: space.id,
+			});
+			this.spaceDbQueryServers.set(space.id, dbQueryServer);
+			mcpServers['db-query'] = dbQueryServer as unknown as McpServerConfig;
+		}
+
+		session.setRuntimeMcpServers(mcpServers);
 
 		session.setRuntimeSystemPrompt(
 			buildSpaceChatSystemPrompt({

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -74,6 +74,7 @@ import type {
 } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
+import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
 import { CompletionDetector } from './completion-detector';
@@ -190,6 +191,9 @@ export interface TaskAgentManagerConfig {
 	appMcpServerRepo: AppMcpServerRepository;
 	/** Node execution repository — for CompletionDetector to query workflow-internal execution state */
 	nodeExecutionRepo: NodeExecutionRepository;
+	/** Absolute path to the SQLite database file. When provided, a space-scoped db-query MCP
+	 * server is attached to each task agent session. */
+	dbPath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +255,12 @@ export class TaskAgentManager {
 	 * Also populated during rehydrateTaskAgent() from the workflow run config.
 	 */
 	private taskWorktreePaths = new Map<string, string>();
+
+	/**
+	 * Maps taskId → db-query MCP server instance for active Task Agent sessions.
+	 * Closed when the task agent session is cleaned up.
+	 */
+	private taskDbQueryServers = new Map<string, DbQueryMcpServer>();
 
 	constructor(private readonly config: TaskAgentManagerConfig) {}
 
@@ -681,10 +691,22 @@ export class TaskAgentManager {
 					);
 				}
 			}
-			agentSession.setRuntimeMcpServers({
+			const taskMcpServers: Record<string, McpServerConfig> = {
 				...registryMcpServers,
 				'task-agent': mcpServer as unknown as McpServerConfig,
-			});
+			};
+			// Create a space-scoped db-query server when dbPath is configured.
+			if (this.config.dbPath) {
+				const dbQueryServer = createDbQueryMcpServer({
+					dbPath: this.config.dbPath,
+					scopeType: 'space',
+					scopeValue: spaceId,
+				});
+				this.taskDbQueryServers.set(taskId, dbQueryServer);
+				taskMcpServers['db-query'] = dbQueryServer as unknown as McpServerConfig;
+			}
+
+			agentSession.setRuntimeMcpServers(taskMcpServers);
 
 			// --- Persist taskAgentSessionId on the SpaceTask
 			this.config.taskRepo.updateTask(taskId, { taskAgentSessionId: sessionId });
@@ -1021,6 +1043,17 @@ export class TaskAgentManager {
 		}
 		// Always remove from in-memory path map regardless of worktreeManager presence.
 		this.taskWorktreePaths.delete(taskId);
+
+		// Close db-query server connection for this task.
+		const dbQueryServer = this.taskDbQueryServers.get(taskId);
+		if (dbQueryServer) {
+			try {
+				dbQueryServer.close();
+			} catch (err) {
+				log.warn(`TaskAgentManager: failed to close db-query server for task ${taskId}:`, err);
+			}
+			this.taskDbQueryServers.delete(taskId);
+		}
 
 		log.info(`TaskAgentManager: cleaned up all sessions for task ${taskId} (reason: ${reason})`);
 	}
@@ -1491,10 +1524,34 @@ export class TaskAgentManager {
 				);
 			}
 		}
-		agentSession.setRuntimeMcpServers({
+		const rehydrateMcpServers: Record<string, McpServerConfig> = {
 			...rehydrateRegistryMcpServers,
 			'task-agent': mcpServer as unknown as McpServerConfig,
-		});
+		};
+		// Create a space-scoped db-query server when dbPath is configured.
+		if (this.config.dbPath) {
+			const rehydrateDbQueryServer = createDbQueryMcpServer({
+				dbPath: this.config.dbPath,
+				scopeType: 'space',
+				scopeValue: spaceId,
+			});
+			// Close any stale server for this taskId before storing the new one.
+			const staleDbQueryServer = this.taskDbQueryServers.get(taskId);
+			if (staleDbQueryServer) {
+				try {
+					staleDbQueryServer.close();
+				} catch (err) {
+					log.warn(
+						`Failed to close stale db-query server during rehydration for task ${taskId}:`,
+						err
+					);
+				}
+			}
+			this.taskDbQueryServers.set(taskId, rehydrateDbQueryServer);
+			rehydrateMcpServers['db-query'] = rehydrateDbQueryServer as unknown as McpServerConfig;
+		}
+
+		agentSession.setRuntimeMcpServers(rehydrateMcpServers);
 
 		// Re-attach system prompt (runtime-only, not persisted).
 		// Generated fresh from createTaskAgentInit() so it reflects the current task/workflow state.

--- a/packages/daemon/tests/unit/db-query/session-integration.test.ts
+++ b/packages/daemon/tests/unit/db-query/session-integration.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Integration tests: db-query MCP server wired into NeoAgentManager sessions.
+ *
+ * Covers:
+ * - NeoAgentManager with setDbPath() includes 'db-query' key in setRuntimeMcpServers
+ * - NeoAgentManager cleanup() calls close() on the db-query server without error
+ * - createDbQueryMcpServer can be created, queried, and closed end-to-end
+ * - db-query server scoped as 'global' includes correct tool descriptions
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Database } from 'bun:sqlite';
+import { createDbQueryMcpServer } from '../../../src/lib/db-query/tools.ts';
+import { NeoAgentManager, NEO_SESSION_ID } from '../../../src/lib/neo/neo-agent-manager.ts';
+import type {
+	NeoSessionManager,
+	NeoSettingsManager,
+} from '../../../src/lib/neo/neo-agent-manager.ts';
+import type { AgentSession } from '../../../src/lib/agent/agent-session.ts';
+import type { McpServerConfig } from '@neokai/shared';
+import type {
+	NeoToolsConfig,
+	NeoQueryRoomManager,
+	NeoQueryGoalRepository,
+	NeoQueryTaskRepository,
+	NeoQuerySessionManager,
+	NeoQuerySettingsManager,
+	NeoQueryAuthManager,
+	NeoQueryMcpServerRepository,
+	NeoQuerySkillsManager,
+	NeoQuerySpaceManager,
+	NeoQuerySpaceAgentManager,
+	NeoQuerySpaceWorkflowManager,
+	NeoQueryWorkflowRunRepository,
+	NeoQuerySpaceTaskRepository,
+} from '../../../src/lib/neo/tools/neo-query-tools.ts';
+
+// ---------------------------------------------------------------------------
+// Shared temp-db setup
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let dbPath: string;
+
+function setupTempDb(extraSetup?: (db: Database) => void): void {
+	tmpDir = mkdtempSync(join(tmpdir(), 'neokai-db-query-session-'));
+	dbPath = join(tmpDir, 'test.db');
+	const db = new Database(dbPath);
+	db.exec('CREATE TABLE rooms (id TEXT PRIMARY KEY, name TEXT, config TEXT)');
+	db.exec('CREATE TABLE tasks (id TEXT PRIMARY KEY, room_id TEXT, title TEXT, restrictions TEXT)');
+	if (extraSetup) extraSetup(db);
+	db.close();
+}
+
+function teardownTempDb(): void {
+	rmSync(tmpDir, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal stubs mirroring neo-agent-manager-all-tools.test.ts
+// ---------------------------------------------------------------------------
+
+function makeSession(): AgentSession {
+	return {
+		getProcessingState: mock(() => ({ status: 'idle' })),
+		isCleaningUp: mock(() => false),
+		setRuntimeSystemPrompt: mock(() => undefined),
+		setRuntimeModel: mock(() => undefined),
+		setRuntimeMcpServers: mock(() => undefined),
+		cleanup: mock(async () => undefined),
+		queryPromise: null,
+		queryObject: null,
+	} as unknown as AgentSession;
+}
+
+function makeSessionManager(createdSession?: AgentSession): NeoSessionManager {
+	const sessions = new Map<string, AgentSession | null>();
+	let getCallCount = 0;
+
+	return {
+		createSession: mock(async () => {
+			sessions.set(NEO_SESSION_ID, createdSession ?? makeSession());
+			return NEO_SESSION_ID;
+		}),
+		getSessionAsync: mock(async (_id: string): Promise<AgentSession | null> => {
+			if (getCallCount === 0) {
+				getCallCount++;
+				return null; // no pre-existing session — first run
+			}
+			return sessions.get(NEO_SESSION_ID) ?? null;
+		}),
+		deleteSession: mock(async (_id: string) => {
+			sessions.delete(NEO_SESSION_ID);
+		}),
+		unregisterSession: mock((_id: string) => {}),
+	};
+}
+
+function makeSettingsManager(): NeoSettingsManager {
+	return {
+		getGlobalSettings: mock(() => ({ neoSecurityMode: 'balanced', model: 'sonnet' })),
+	};
+}
+
+function makeMinimalQueryConfig(): NeoToolsConfig {
+	const noopRoomManager: NeoQueryRoomManager = {
+		listRooms: () => [],
+		getRoom: () => null,
+		getRoomOverview: () => null,
+	};
+	const noopGoalRepo: NeoQueryGoalRepository = {
+		listGoals: () => [],
+		getGoal: () => null,
+		listExecutions: () => [],
+	};
+	const noopTaskRepo: NeoQueryTaskRepository = {
+		listTasks: () => [],
+		getTask: () => null,
+	};
+	const noopSessionManager: NeoQuerySessionManager = {
+		getActiveSessions: () => 0,
+		listSessions: () => [],
+	};
+	const noopSettingsManager: NeoQuerySettingsManager = {
+		getGlobalSettings: () =>
+			({
+				settingSources: [],
+				model: 'sonnet',
+				permissionMode: 'default',
+				thinkingLevel: 'none',
+				autoScroll: true,
+				coordinatorMode: false,
+				maxConcurrentWorkers: 3,
+				neoSecurityMode: 'balanced',
+				neoModel: null,
+				showArchived: false,
+				fallbackModels: [],
+				disabledMcpServers: [],
+			}) as ReturnType<NeoQuerySettingsManager['getGlobalSettings']>,
+	};
+	const noopAuthManager: NeoQueryAuthManager = {
+		getAuthStatus: async () => ({
+			isAuthenticated: false,
+			method: 'none',
+			source: 'env' as const,
+		}),
+	};
+	const noopMcpRepo: NeoQueryMcpServerRepository = {
+		list: () => [],
+		get: () => null,
+	};
+	const noopSkillsManager: NeoQuerySkillsManager = {
+		listSkills: () => [],
+		getSkill: () => null,
+	};
+	const noopSpaceManager: NeoQuerySpaceManager = {
+		listSpaces: () => [],
+		getSpace: () => null,
+	};
+	const noopSpaceAgentManager: NeoQuerySpaceAgentManager = {
+		listBySpaceId: () => [],
+	};
+	const noopSpaceWorkflowManager: NeoQuerySpaceWorkflowManager = {
+		listWorkflows: () => [],
+	};
+	const noopWorkflowRunRepo: NeoQueryWorkflowRunRepository = {
+		listBySpace: () => [],
+	};
+	const noopSpaceTaskRepo: NeoQuerySpaceTaskRepository = {
+		listBySpace: () => [],
+		listByStatus: () => [],
+	};
+
+	return {
+		roomManager: noopRoomManager,
+		goalRepository: noopGoalRepo,
+		taskRepository: noopTaskRepo,
+		sessionManager: noopSessionManager,
+		settingsManager: noopSettingsManager,
+		authManager: noopAuthManager,
+		mcpServerRepository: noopMcpRepo,
+		skillsManager: noopSkillsManager,
+		workspaceRoot: '/workspace',
+		appVersion: '0.1.1',
+		startedAt: Date.now() - 1_000,
+		spaceManager: noopSpaceManager,
+		spaceAgentManager: noopSpaceAgentManager,
+		spaceWorkflowManager: noopSpaceWorkflowManager,
+		workflowRunRepository: noopWorkflowRunRepo,
+		spaceTaskRepository: noopSpaceTaskRepo,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests: NeoAgentManager + db-query server wiring
+// ---------------------------------------------------------------------------
+
+describe('db-query session integration — NeoAgentManager', () => {
+	beforeEach(() => {
+		setupTempDb();
+	});
+
+	afterEach(() => {
+		teardownTempDb();
+	});
+
+	it('setDbPath() causes db-query key to appear in setRuntimeMcpServers when toolsConfig is set', async () => {
+		const session = makeSession();
+		const mgr = new NeoAgentManager(makeSessionManager(session), makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		mgr.setDbPath(dbPath);
+
+		await mgr.provision();
+
+		const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const servers = calls[0][0] as Record<string, McpServerConfig>;
+		expect('db-query' in servers).toBe(true);
+	});
+
+	it('db-query key is absent from setRuntimeMcpServers when setDbPath() is not called', async () => {
+		const session = makeSession();
+		const mgr = new NeoAgentManager(makeSessionManager(session), makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		// Deliberately omit setDbPath()
+
+		await mgr.provision();
+
+		const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const servers = calls[0][0] as Record<string, McpServerConfig>;
+		expect('db-query' in servers).toBe(false);
+	});
+
+	it('cleanup() closes the db-query server connection without error', async () => {
+		const session = makeSession();
+		const mgr = new NeoAgentManager(makeSessionManager(session), makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		mgr.setDbPath(dbPath);
+
+		await mgr.provision();
+
+		// Should not throw — db-query server's close() is called internally.
+		await expect(mgr.cleanup()).resolves.toBeUndefined();
+		expect(mgr.getSession()).toBeNull();
+	});
+
+	it('cleanup() is safe to call twice (idempotent — db-query server already closed)', async () => {
+		const session = makeSession();
+		const mgr = new NeoAgentManager(makeSessionManager(session), makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		mgr.setDbPath(dbPath);
+
+		await mgr.provision();
+		await mgr.cleanup();
+
+		// Second cleanup is safe (no db-query server to close, session is null).
+		await expect(mgr.cleanup()).resolves.toBeUndefined();
+	});
+
+	it('neo-query server coexists with db-query server in setRuntimeMcpServers', async () => {
+		const session = makeSession();
+		const mgr = new NeoAgentManager(makeSessionManager(session), makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		mgr.setDbPath(dbPath);
+
+		await mgr.provision();
+
+		const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+		const servers = calls[0][0] as Record<string, McpServerConfig>;
+		expect('neo-query' in servers).toBe(true);
+		expect('db-query' in servers).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: createDbQueryMcpServer end-to-end
+// ---------------------------------------------------------------------------
+
+describe('db-query session integration — createDbQueryMcpServer end-to-end', () => {
+	beforeEach(() => {
+		setupTempDb((db) => {
+			db.exec("INSERT INTO rooms VALUES ('r1', 'Main Room', null)");
+		});
+	});
+
+	afterEach(() => {
+		teardownTempDb();
+	});
+
+	it('creates a server with type sdk and name db-query', () => {
+		const server = createDbQueryMcpServer({
+			dbPath,
+			scopeType: 'global',
+			scopeValue: '',
+		});
+
+		expect(server.type).toBe('sdk');
+		expect(server.name).toBe('db-query');
+
+		server.close();
+	});
+
+	it('registers db_query, db_list_tables, and db_describe_table tools', () => {
+		const server = createDbQueryMcpServer({
+			dbPath,
+			scopeType: 'global',
+			scopeValue: '',
+		});
+
+		expect(server.instance._registeredTools).toHaveProperty('db_query');
+		expect(server.instance._registeredTools).toHaveProperty('db_list_tables');
+		expect(server.instance._registeredTools).toHaveProperty('db_describe_table');
+
+		server.close();
+	});
+
+	it('db_query handler returns data from the database', async () => {
+		const server = createDbQueryMcpServer({
+			dbPath,
+			scopeType: 'global',
+			scopeValue: '',
+		});
+
+		const handler = (
+			server.instance._registeredTools.db_query as {
+				handler: (args: { sql: string }) => Promise<{ content: Array<{ text: string }> }>;
+			}
+		).handler;
+
+		const result = await handler({ sql: 'SELECT id, name FROM rooms' });
+		const data = JSON.parse(result.content[0].text);
+		expect(data.rows).toHaveLength(1);
+		expect(data.rows[0].id).toBe('r1');
+		expect(data.rows[0].name).toBe('Main Room');
+
+		server.close();
+	});
+
+	it('db_query handler rejects non-SELECT statements', async () => {
+		const server = createDbQueryMcpServer({
+			dbPath,
+			scopeType: 'global',
+			scopeValue: '',
+		});
+
+		const handler = (
+			server.instance._registeredTools.db_query as {
+				handler: (args: { sql: string }) => Promise<{ content: Array<{ text: string }> }>;
+			}
+		).handler;
+
+		const result = await handler({ sql: "INSERT INTO rooms VALUES ('r2', 'Bad', null)" });
+		// The error response is a text content with error message.
+		expect(result.content[0].text).toContain('SELECT');
+
+		server.close();
+	});
+
+	it('close() releases the database connection without error', () => {
+		const server = createDbQueryMcpServer({
+			dbPath,
+			scopeType: 'global',
+			scopeValue: '',
+		});
+
+		expect(() => server.close()).not.toThrow();
+	});
+
+	it('global scope db_query tool description mentions global scope', () => {
+		const server = createDbQueryMcpServer({
+			dbPath,
+			scopeType: 'global',
+			scopeValue: '',
+		});
+
+		const queryTool = server.instance._registeredTools.db_query as { description: string };
+		expect(queryTool.description).toContain('global scope');
+
+		server.close();
+	});
+});

--- a/packages/daemon/tests/unit/neo-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/neo-agent-manager.test.ts
@@ -12,12 +12,36 @@
  * - cleanup(): delegates to AgentSession.cleanup()
  * - getSecurityMode(): reads from settings, defaults to 'balanced'
  * - getModel(): reads neoModel, falls back to model, then 'sonnet'
+ * - setDbPath(): wires db-query server into setRuntimeMcpServers
+ * - cleanup(): closes db-query server
+ * - destroyAndRecreate(): closes old db-query server and creates new one
  */
 
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, mock, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Database } from 'bun:sqlite';
 import { NeoAgentManager, NEO_SESSION_ID } from '../../src/lib/neo/neo-agent-manager';
 import type { NeoSessionManager, NeoSettingsManager } from '../../src/lib/neo/neo-agent-manager';
 import type { AgentSession } from '../../src/lib/agent/agent-session';
+import type { McpServerConfig } from '@neokai/shared';
+import type {
+	NeoToolsConfig,
+	NeoQueryRoomManager,
+	NeoQueryGoalRepository,
+	NeoQueryTaskRepository,
+	NeoQuerySessionManager,
+	NeoQuerySettingsManager,
+	NeoQueryAuthManager,
+	NeoQueryMcpServerRepository,
+	NeoQuerySkillsManager,
+	NeoQuerySpaceManager,
+	NeoQuerySpaceAgentManager,
+	NeoQuerySpaceWorkflowManager,
+	NeoQueryWorkflowRunRepository,
+	NeoQuerySpaceTaskRepository,
+} from '../../src/lib/neo/tools/neo-query-tools';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -439,5 +463,266 @@ describe('NeoAgentManager', () => {
 			const prompt = calls[0][0] as string;
 			expect(prompt).toContain('Balanced');
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for db-query integration tests
+// ---------------------------------------------------------------------------
+
+function makeMinimalQueryConfig(): NeoToolsConfig {
+	const noopRoomManager: NeoQueryRoomManager = {
+		listRooms: () => [],
+		getRoom: () => null,
+		getRoomOverview: () => null,
+	};
+	const noopGoalRepo: NeoQueryGoalRepository = {
+		listGoals: () => [],
+		getGoal: () => null,
+		listExecutions: () => [],
+	};
+	const noopTaskRepo: NeoQueryTaskRepository = {
+		listTasks: () => [],
+		getTask: () => null,
+	};
+	const noopSessionManager: NeoQuerySessionManager = {
+		getActiveSessions: () => 0,
+		listSessions: () => [],
+	};
+	const noopSettingsManager: NeoQuerySettingsManager = {
+		getGlobalSettings: () =>
+			({
+				settingSources: [],
+				model: 'sonnet',
+				permissionMode: 'default',
+				thinkingLevel: 'none',
+				autoScroll: true,
+				coordinatorMode: false,
+				maxConcurrentWorkers: 3,
+				neoSecurityMode: 'balanced',
+				neoModel: null,
+				showArchived: false,
+				fallbackModels: [],
+				disabledMcpServers: [],
+			}) as ReturnType<NeoQuerySettingsManager['getGlobalSettings']>,
+	};
+	const noopAuthManager: NeoQueryAuthManager = {
+		getAuthStatus: async () => ({
+			isAuthenticated: false,
+			method: 'none',
+			source: 'env' as const,
+		}),
+	};
+	const noopMcpRepo: NeoQueryMcpServerRepository = {
+		list: () => [],
+		get: () => null,
+	};
+	const noopSkillsManager: NeoQuerySkillsManager = {
+		listSkills: () => [],
+		getSkill: () => null,
+	};
+	const noopSpaceManager: NeoQuerySpaceManager = {
+		listSpaces: () => [],
+		getSpace: () => null,
+	};
+	const noopSpaceAgentManager: NeoQuerySpaceAgentManager = {
+		listBySpaceId: () => [],
+	};
+	const noopSpaceWorkflowManager: NeoQuerySpaceWorkflowManager = {
+		listWorkflows: () => [],
+	};
+	const noopWorkflowRunRepo: NeoQueryWorkflowRunRepository = {
+		listBySpace: () => [],
+	};
+	const noopSpaceTaskRepo: NeoQuerySpaceTaskRepository = {
+		listBySpace: () => [],
+		listByStatus: () => [],
+	};
+
+	return {
+		roomManager: noopRoomManager,
+		goalRepository: noopGoalRepo,
+		taskRepository: noopTaskRepo,
+		sessionManager: noopSessionManager,
+		settingsManager: noopSettingsManager,
+		authManager: noopAuthManager,
+		mcpServerRepository: noopMcpRepo,
+		skillsManager: noopSkillsManager,
+		workspaceRoot: '/workspace',
+		appVersion: '0.1.1',
+		startedAt: Date.now() - 1_000,
+		spaceManager: noopSpaceManager,
+		spaceAgentManager: noopSpaceAgentManager,
+		spaceWorkflowManager: noopSpaceWorkflowManager,
+		workflowRunRepository: noopWorkflowRunRepo,
+		spaceTaskRepository: noopSpaceTaskRepo,
+	};
+}
+
+function makeDbSessionManager(
+	opts: { createdSession?: AgentSession | null } = {}
+): NeoSessionManager & { _createCalls: number } {
+	const sessions = new Map<string, AgentSession | null>();
+	let getCallCount = 0;
+	const sessionQueue: Array<AgentSession | null> =
+		opts.createdSession !== undefined ? [opts.createdSession] : [];
+
+	const sm = {
+		_createCalls: 0,
+
+		createSession: mock(async () => {
+			sm._createCalls++;
+			const next = sessionQueue.length > 0 ? sessionQueue.shift()! : makeSession();
+			sessions.set(NEO_SESSION_ID, next);
+			return NEO_SESSION_ID;
+		}),
+
+		getSessionAsync: mock(async (_id: string): Promise<AgentSession | null> => {
+			if (getCallCount === 0) {
+				getCallCount++;
+			}
+			return sessions.get(NEO_SESSION_ID) ?? null;
+		}),
+
+		deleteSession: mock(async (_id: string) => {
+			sessions.delete(NEO_SESSION_ID);
+		}),
+
+		unregisterSession: mock((_id: string) => {}),
+	};
+
+	return sm;
+}
+
+// ---------------------------------------------------------------------------
+// db-query MCP server integration tests
+// ---------------------------------------------------------------------------
+
+describe('NeoAgentManager — setDbPath() / db-query server', () => {
+	let tmpDir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), 'neokai-test-'));
+		dbPath = join(tmpDir, 'test.db');
+		// Create a minimal SQLite database so createDbQueryMcpServer can open it.
+		const initDb = new Database(dbPath);
+		initDb.exec('CREATE TABLE rooms (id TEXT PRIMARY KEY, name TEXT, config TEXT)');
+		initDb.close();
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('when setDbPath() is called and toolsConfig is set, db-query key appears in setRuntimeMcpServers', async () => {
+		const session = makeSession();
+		const sm = makeDbSessionManager({ createdSession: session });
+		const mgr = new NeoAgentManager(sm, makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		mgr.setDbPath(dbPath);
+
+		await mgr.provision();
+
+		const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const servers = calls[0][0] as Record<string, McpServerConfig>;
+		expect('db-query' in servers).toBe(true);
+	});
+
+	test('when setDbPath() is NOT called, db-query key is absent from setRuntimeMcpServers', async () => {
+		const session = makeSession();
+		const sm = makeDbSessionManager({ createdSession: session });
+		const mgr = new NeoAgentManager(sm, makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		// No setDbPath() call
+
+		await mgr.provision();
+
+		const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const servers = calls[0][0] as Record<string, McpServerConfig>;
+		expect('db-query' in servers).toBe(false);
+	});
+
+	test('cleanup() closes the db-query server (no error)', async () => {
+		const session = makeSession();
+		const sm = makeDbSessionManager({ createdSession: session });
+		const mgr = new NeoAgentManager(sm, makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		mgr.setDbPath(dbPath);
+
+		await mgr.provision();
+
+		// cleanup() should not throw even though db-query server holds an open connection.
+		await expect(mgr.cleanup()).resolves.toBeUndefined();
+		// Session should be cleared after cleanup.
+		expect(mgr.getSession()).toBeNull();
+	});
+
+	test('destroyAndRecreate via clearSession() closes old db-query server and creates a new one', async () => {
+		const firstSession = makeSession();
+		const secondSession = makeSession();
+		// Use the makeSessionManager that supports multiple sessions in order.
+		const sessions = new Map<string, AgentSession | null>();
+		let getCallCount = 0;
+		const sessionQueue = [firstSession, secondSession];
+		const sm: NeoSessionManager = {
+			createSession: mock(async () => {
+				const next = sessionQueue.shift() ?? makeSession();
+				sessions.set(NEO_SESSION_ID, next);
+				return NEO_SESSION_ID;
+			}),
+			getSessionAsync: mock(async () => {
+				if (getCallCount === 0) {
+					getCallCount++;
+					return null; // first call → no existing session → create
+				}
+				return sessions.get(NEO_SESSION_ID) ?? null;
+			}),
+			deleteSession: mock(async () => {
+				sessions.delete(NEO_SESSION_ID);
+			}),
+			unregisterSession: mock(() => {}),
+		};
+
+		const mgr = new NeoAgentManager(sm, makeSettingsManager());
+		mgr.setToolsConfig(makeMinimalQueryConfig());
+		mgr.setDbPath(dbPath);
+
+		// Provision creates firstSession with a db-query server.
+		await mgr.provision();
+		expect(mgr.getSession()).toBe(firstSession);
+
+		const firstCalls = (firstSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+		expect(firstCalls.length).toBe(1);
+		const firstServers = firstCalls[0][0] as Record<string, McpServerConfig>;
+		expect('db-query' in firstServers).toBe(true);
+
+		// clearSession() destroys firstSession and provisions secondSession with a fresh db-query server.
+		await mgr.clearSession();
+		expect(mgr.getSession()).toBe(secondSession);
+
+		const secondCalls = (secondSession.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+		expect(secondCalls.length).toBe(1);
+		const secondServers = secondCalls[0][0] as Record<string, McpServerConfig>;
+		expect('db-query' in secondServers).toBe(true);
+
+		// Cleanup should not throw (old server is already closed, new one gets closed now).
+		await expect(mgr.cleanup()).resolves.toBeUndefined();
+	});
+
+	test('when toolsConfig is not set, setDbPath() alone does NOT call setRuntimeMcpServers', async () => {
+		const session = makeSession();
+		const sm = makeDbSessionManager({ createdSession: session });
+		const mgr = new NeoAgentManager(sm, makeSettingsManager());
+		// Only setDbPath(), no setToolsConfig()
+		mgr.setDbPath(dbPath);
+
+		await mgr.provision();
+
+		// attachTools() is a no-op when toolsConfig is null, so setRuntimeMcpServers is never called.
+		const calls = (session.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(0);
 	});
 });


### PR DESCRIPTION
Wire the `db-query` MCP server into Neo, room, task agent, and space chat sessions, giving each agent type scoped read-only SQL access to the daemon's SQLite database.

**Scope assignments:**
- Neo agent → `global` scope (full read access, no WHERE filter)
- Room chat sessions → `room` scope (auto-injects `WHERE room_id = ?`)
- Task agent sessions → `space` scope (auto-injects `WHERE space_id = ?`)
- Space chat sessions → `space` scope

**Changes:**
- `NeoAgentManager`: `setDbPath()` method; db-query server created in `attachTools()`, closed on cleanup/re-provision
- `RoomRuntimeService`: room-scoped db-query in `setupRoomAgentSession()`; cleanup in stop/restart/room.updated; survives `mcp.registry.changed`
- `TaskAgentManager`: space-scoped db-query in `spawnTaskAgent()` and `rehydrateTaskAgent()`; cleanup on task teardown
- `SpaceRuntimeService`: space-scoped db-query in `setupSpaceAgentSession()`; cleanup on stop
- `rpc-handlers/index.ts`: wires `dbPath` via `deps.db.getDatabasePath()` into all four session types

Each service uses an optional `dbPath` config field for backward compatibility with existing unit tests that use mock db objects.