### PR TITLE
test: add end-node bypass, composePromptLayer, and orchestration auto-complete integration tests

### DIFF
--- a/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
+++ b/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
@@ -12,12 +12,12 @@
  * - writeGateData          — write arbitrary data to a gate (simulates agent write_gate call)
  * - readGateData           — read current gate data for a (runId, gateId) pair
  * - approveGate            — human-approve a gate (writes approved:true + triggers activation)
- * - rejectGate             — human-reject a gate (writes approved:false, run → needs_attention)
- * - markRunFailed          — mark run as needs_attention with a specific failureReason
+ * - rejectGate             — human-reject a gate (writes approved:false, run → blocked)
+ * - markRunFailed          — mark run as blocked with a specific failureReason
  * - waitForNodeStatus      — poll until at least one task for a node reaches a target status
  * - waitForRunStatus       — poll until the workflow run reaches a target status
  * - getGateArtifacts       — fetch gate artifacts (changed files + diff) for a run
- * - mockAgentDone          — mark a task as completed directly via spaceTask.update
+ * - mockAgentDone          — mark a task as done directly via spaceTask.update
  * - restartDaemon          — kill the daemon and restart it with the same workspace/database
  *
  * ## Usage
@@ -172,7 +172,7 @@ export async function readGateData(
 
 /**
  * Human-approve a gate: writes approved:true and triggers downstream node activation.
- * If the run was previously in needs_attention+humanRejected, it resumes to in_progress.
+ * If the run was previously in blocked+humanRejected, it resumes to in_progress.
  */
 export async function approveGate(
 	daemon: DaemonServerContext,
@@ -189,7 +189,7 @@ export async function approveGate(
 }
 
 /**
- * Human-reject a gate: writes approved:false and transitions run to needs_attention
+ * Human-reject a gate: writes approved:false and transitions run to blocked
  * with failureReason: 'humanRejected'.
  */
 export async function rejectGate(
@@ -315,10 +315,10 @@ export async function getGateArtifacts(
 // ---------------------------------------------------------------------------
 
 /**
- * Mark a task as 'completed' directly via spaceTask.update.
+ * Mark a task as 'done' directly via spaceTask.update.
  *
  * Simulates an agent calling report_result without actually running a session.
- * Handles intermediate transitions: if the task is still 'pending', it is first
+ * Handles intermediate transitions: if the task is still 'open', it is first
  * moved to 'in_progress' before completing.
  */
 export async function mockAgentDone(
@@ -374,8 +374,8 @@ export async function getTasksForNode(
  * (non-terminal) status: pending or in_progress.
  *
  * Use this instead of `waitForNodeActivated` when the node was previously
- * activated (and those tasks are now completed). `waitForNodeActivated` accepts
- * terminal statuses as a match, so it can return the old completed task instead
+ * activated (and those tasks are now done). `waitForNodeActivated` accepts
+ * terminal statuses as a match, so it can return the old done task instead
  * of the freshly created one. This helper avoids that by explicitly excluding
  * known task IDs.
  */
@@ -431,12 +431,12 @@ export async function getTasksForNodeId(
 // ---------------------------------------------------------------------------
 
 /**
- * Mark a workflow run as needs_attention with a specific failure reason.
+ * Mark a workflow run as blocked with a specific failure reason.
  * Simulates what the Space Agent does when it detects an unrecoverable failure
  * (e.g. agentCrash, maxIterationsReached).
  *
  * Uses the spaceWorkflowRun.markFailed RPC which transitions the run to
- * needs_attention and sets the failureReason field atomically.
+ * blocked and sets the failureReason field atomically.
  */
 export async function markRunFailed(
 	daemon: DaemonServerContext,

--- a/packages/daemon/tests/online/space/space-agent-coordination.test.ts
+++ b/packages/daemon/tests/online/space/space-agent-coordination.test.ts
@@ -207,7 +207,7 @@ describe('Space Agent Coordination — Online Tests', () => {
 	}, SETUP_TIMEOUT);
 
 	test(
-		'supervised mode: agent escalates to human when receiving task_needs_attention',
+		'supervised mode: agent escalates to human when receiving task_blocked',
 		async () => {
 			// 1. Create a supervised space and task
 			const space = await createTestSpace(daemon, 'Supervised Test Space', 'supervised');
@@ -263,7 +263,7 @@ describe('Space Agent Coordination — Online Tests', () => {
 	);
 
 	test(
-		'task_needs_attention: agent calls get_task_detail to assess the situation',
+		'task_blocked: agent calls get_task_detail to assess the situation',
 		async () => {
 			// 1. Create a semi_autonomous space and task
 			const space = await createTestSpace(

--- a/packages/daemon/tests/online/space/space-edge-cases.test.ts
+++ b/packages/daemon/tests/online/space/space-edge-cases.test.ts
@@ -10,7 +10,7 @@
  *                              tasks to 'cancelled'; cancellation is idempotent.
  *   c. Agent crash           — spaceWorkflowRun.markFailed (the production RPC the
  *                              Space Agent calls on crash detection) transitions
- *                              run → needs_attention with failureReason: 'agentCrash';
+ *                              run → blocked with failureReason: 'agentCrash';
  *                              the run can then be resumed.
  *   d. Approval gate persistence — gate data written before a daemon restart is
  *                              intact and readable after the daemon restarts.
@@ -225,7 +225,7 @@ describe('Space Workflow — Edge Cases', () => {
 
 	// =========================================================================
 	// c. Agent crash — spaceWorkflowRun.markFailed (production path) sets
-	//    run → needs_attention with failureReason: 'agentCrash'
+	//    run → blocked with failureReason: 'agentCrash'
 	//
 	// The Space Agent calls markFailed when it detects an unrecoverable failure
 	// (e.g. session terminated unexpectedly). These tests exercise that RPC
@@ -233,7 +233,7 @@ describe('Space Workflow — Edge Cases', () => {
 	// =========================================================================
 
 	test(
-		'markFailed RPC transitions run to needs_attention with agentCrash failureReason',
+		'markFailed RPC transitions run to blocked with agentCrash failureReason',
 		async () => {
 			const { space, workflow } = await createTestSpace(daemon);
 			const { runId } = await startWorkflowRun(daemon, space.id, workflow.id, 'Agent Crash Test');
@@ -260,7 +260,7 @@ describe('Space Workflow — Edge Cases', () => {
 	);
 
 	test(
-		'A run in needs_attention (agentCrash) can be resumed to in_progress',
+		'A run in blocked (agentCrash) can be resumed to in_progress',
 		async () => {
 			const { space, workflow } = await createTestSpace(daemon);
 			const { runId } = await startWorkflowRun(

--- a/packages/daemon/tests/online/space/space-happy-path-code-review.test.ts
+++ b/packages/daemon/tests/online/space/space-happy-path-code-review.test.ts
@@ -158,7 +158,7 @@ async function setupToCodePrGate(
  * Complete all three reviewer tasks and write rejection vote to review-reject-gate,
  * then wait for a *new* Coding task to appear (not the one in preCycleTaskIds).
  *
- * Returns the newly activated Coding task and the IDs of the completed reviewer tasks.
+ * Returns the newly activated Coding task and the IDs of the done reviewer tasks.
  */
 async function triggerRejectCycle(
 	daemon: DaemonServerContext,
@@ -184,8 +184,8 @@ async function triggerRejectCycle(
 	});
 
 	// Use waitForNewNodeTask to confirm a *fresh* Coding task was created,
-	// not the old completed one. waitForNodeActivated would match the old task
-	// because it accepts 'completed' as a valid status.
+	// not the old done task. waitForNodeActivated would match the old task
+	// because it accepts terminal statuses (including 'done').
 	return waitForNewNodeTask(
 		daemon,
 		spaceId,
@@ -375,8 +375,8 @@ describe('Space Happy Path — Code Review with Parallel Reviewers', () => {
 				waitForNodeActivated(daemon, spaceId, runId, 'Reviewer 3', NODE_ACTIVATION_TIMEOUT),
 			]);
 
-			// Collect existing Coding task IDs (completed from setup) so we can confirm
-			// the post-cycle Coding task is genuinely new (not the old completed one).
+			// Collect existing Coding task IDs (done from setup) so we can confirm
+			// the post-cycle Coding task is genuinely new (not the old done one).
 			const existingCodingTasks = await getTasksForNode(daemon, spaceId, runId, 'Coding');
 			const preCycleIds = new Set(existingCodingTasks.map((t) => t.id));
 
@@ -396,7 +396,7 @@ describe('Space Happy Path — Code Review with Parallel Reviewers', () => {
 			const qaTasks = await getTasksForNode(daemon, spaceId, runId, 'QA');
 			expect(qaTasks.length).toBe(0);
 
-			// Run must remain in_progress (not needs_attention — rejection is a cycle, not a human-reject)
+			// Run must remain in_progress (not blocked — rejection is a cycle, not a human-reject)
 			const { run } = (await daemon.messageHub.request('spaceWorkflowRun.get', {
 				id: runId,
 			})) as { run: SpaceWorkflowRun };

--- a/packages/daemon/tests/online/space/space-happy-path-full-pipeline.test.ts
+++ b/packages/daemon/tests/online/space/space-happy-path-full-pipeline.test.ts
@@ -18,11 +18,11 @@
  *   QA
  *     └─► qa-result-gate     — QA writes passed
  *   Done
- *     └─► run.status = completed
+ *     └─► run.status = done
  *
  * ## Test scenarios
  *
- *  1. Happy path — full pipeline completes; run.status becomes completed
+ *  1. Happy path — full pipeline completes; run.status becomes done
  *     Verifies every stage in order and confirms the completion summary.
  *
  *  2. Failure-and-recovery — two failure injections:
@@ -309,7 +309,7 @@ describe('Space Happy Path — Full Pipeline End-to-End', () => {
 	//   driveToCodePrGateOpen → QA activates (all approved, round 1)
 	//   → QA fails (qa-fail-gate) → Coding cycles back (cycle 1 via qa-fail channel)
 	//   → Reviewer 1 rejects (review-reject-gate) → Coding cycles back (cycle 1 via reject channel)
-	//   → all 3 approve (round 3) → QA passes → Done → completed
+	//   → all 3 approve (round 3) → QA passes → Done → done
 	// -------------------------------------------------------------------------
 	test(
 		'Failure-and-recovery: QA fail + reviewer rejection → eventual completion',

--- a/packages/daemon/tests/online/space/space-happy-path-plan-to-approve.test.ts
+++ b/packages/daemon/tests/online/space/space-happy-path-plan-to-approve.test.ts
@@ -20,7 +20,7 @@
  * 3. plan-pr-gate is readable and contains the written data
  * 4. plan-approval-gate blocks Coding when no approval exists
  * 5. Approving plan-approval-gate → Coding node activates
- * 6. Rejecting plan-approval-gate → run transitions to needs_attention + humanRejected
+ * 6. Rejecting plan-approval-gate → run transitions to blocked + humanRejected
  *
  * ## Running
  *
@@ -268,10 +268,10 @@ describe('Space Happy Path — Plan-to-Approve Flow', () => {
 	);
 
 	// -------------------------------------------------------------------------
-	// Test 6: Rejection → needs_attention with humanRejected
+	// Test 6: Rejection → blocked with humanRejected
 	// -------------------------------------------------------------------------
 	test(
-		'Rejecting plan-approval-gate transitions run to needs_attention with humanRejected',
+		'Rejecting plan-approval-gate transitions run to blocked with humanRejected',
 		async () => {
 			const { space, workflow } = await createTestSpace(daemon);
 			const { runId } = await startWorkflowRun(

--- a/packages/daemon/tests/online/space/task-agent-lifecycle.test.ts
+++ b/packages/daemon/tests/online/space/task-agent-lifecycle.test.ts
@@ -7,7 +7,7 @@
  * 3. Task Agent processes its initial context message
  * 4. Task Agent can call each workflow tool (spawn_node_agent, check_node_status,
  *    report_result) verified via probe mocks
- * 5. When report_result is called (via full MCP name mock), task status becomes 'completed'
+ * 5. When report_result is called (via full MCP name mock), task status becomes 'done'
  * 6. Space Agent receives the completion notification event
  *
  * Note: advance_workflow was removed in Task 3.5 (agent-driven progression).
@@ -516,7 +516,7 @@ describe('Task Agent Lifecycle — Online Tests', () => {
 			);
 			expect(reportUses.length).toBeGreaterThan(0);
 
-			// The task status must have changed to 'completed' because the tool was executed
+			// The task status must have changed to 'done' because the tool was executed
 			const finalStatus = await waitForTaskStatus(
 				daemon,
 				space.id,

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -4,6 +4,7 @@ import type { SpaceAgentManager } from '../../../src/lib/space/managers/space-ag
 import {
 	buildCustomAgentSystemPrompt,
 	buildCustomAgentTaskMessage,
+	composePromptLayer,
 	createCustomAgentInit,
 	resolveAgentInit,
 	type CustomAgentConfig,
@@ -323,5 +324,69 @@ describe('resolveAgentInit', () => {
 		});
 
 		expect(init.systemPrompt?.append).toBe('Visible prompt');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// composePromptLayer
+// ---------------------------------------------------------------------------
+
+describe('composePromptLayer', () => {
+	describe('override mode', () => {
+		it('replaces non-empty base entirely', () => {
+			expect(composePromptLayer('Base value', { mode: 'override', value: 'X' })).toBe('X');
+		});
+
+		it('replaces null base', () => {
+			expect(composePromptLayer(null, { mode: 'override', value: 'Override only' })).toBe(
+				'Override only'
+			);
+		});
+
+		it('replaces empty string base', () => {
+			expect(composePromptLayer('', { mode: 'override', value: 'Override' })).toBe('Override');
+		});
+
+		it('returns trimmed override value', () => {
+			expect(composePromptLayer('Base', { mode: 'override', value: '  Trimmed  ' })).toBe(
+				'Trimmed'
+			);
+		});
+	});
+
+	describe('expand mode', () => {
+		it('appends override to non-empty base with double newline', () => {
+			expect(composePromptLayer('Base prompt', { mode: 'expand', value: 'Extra' })).toBe(
+				'Base prompt\n\nExtra'
+			);
+		});
+
+		it('returns only override value when base is empty string', () => {
+			expect(composePromptLayer('', { mode: 'expand', value: 'Expand only' })).toBe('Expand only');
+		});
+
+		it('returns only override value when base is null', () => {
+			expect(composePromptLayer(null, { mode: 'expand', value: 'Expand only' })).toBe(
+				'Expand only'
+			);
+		});
+
+		it('returns base only when override value is blank', () => {
+			expect(composePromptLayer('Base value', { mode: 'expand', value: '   ' })).toBe('Base value');
+		});
+	});
+
+	describe('no override (undefined)', () => {
+		it('returns base value unchanged', () => {
+			expect(composePromptLayer('Agent base prompt', undefined)).toBe('Agent base prompt');
+		});
+
+		it('returns empty string when base is null', () => {
+			expect(composePromptLayer(null, undefined)).toBe('');
+		});
+
+		it('returns empty string when base is empty', () => {
+			expect(composePromptLayer('', undefined)).toBe('');
+		});
 	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-completion.test.ts
@@ -30,6 +30,7 @@ import type {
 import type { SpaceWorkflow, SpaceTask, SpaceWorkflowRun, Space } from '@neokai/shared';
 import type { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager.ts';
 import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
+import { composePromptLayer } from '../../../src/lib/space/agents/custom-agent.ts';
 
 // ---------------------------------------------------------------------------
 // MockNotificationSink
@@ -133,6 +134,8 @@ function seedNodeExec(
 // ---------------------------------------------------------------------------
 
 class MockTaskAgentManager {
+	readonly cancelledSessions: string[] = [];
+
 	isTaskAgentAlive(_taskId: string): boolean {
 		return false;
 	}
@@ -151,6 +154,10 @@ class MockTaskAgentManager {
 	}
 
 	async rehydrate(): Promise<void> {}
+
+	cancelBySessionId(agentSessionId: string): void {
+		this.cancelledSessions.push(agentSessionId);
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -961,6 +968,367 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(completedEvents).toHaveLength(1);
 			// Dedup entry was removed when executor was cleaned up
 			expect(rt.getNotifiedTaskSet().has(dedupKey)).toBe(false);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// End-node bypass completion scenarios
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	describe('end-node bypass completion', () => {
+		test('end node execution done → run completes via end-node short-circuit', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `End-Node Bypass ${Date.now()}`,
+				description: '',
+				nodes: [
+					{ id: 'en-start', name: 'Start', agentId: AGENT_A },
+					{ id: 'en-end', name: 'End', agentId: AGENT_B },
+				],
+				startNodeId: 'en-start',
+				endNodeId: 'en-end',
+				tags: [],
+			});
+			expect(workflow.endNodeId).toBe('en-end');
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Complete start node task
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
+
+			// Seed both node executions — end node is done
+			seedNodeExec(db, run.id, 'en-start', 'Start', 'done');
+			seedNodeExec(db, run.id, 'en-end', 'End', 'done');
+
+			await rt.executeTick();
+
+			const completedRun = workflowRunRepo.getRun(run.id);
+			expect(completedRun?.status).toBe('done');
+			expect(completedRun?.completedAt).toBeDefined();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				expect(completedEvents[0].status).toBe('done');
+			}
+		});
+
+		test('non-end node done but end node still in_progress → run stays in_progress', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Non-End Done ${Date.now()}`,
+				description: '',
+				nodes: [
+					{ id: 'ne-start', name: 'Start', agentId: AGENT_A },
+					{ id: 'ne-end', name: 'End', agentId: AGENT_B },
+				],
+				startNodeId: 'ne-start',
+				endNodeId: 'ne-end',
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
+
+			// Start node exec is terminal, but end node exec is still in_progress
+			seedNodeExec(db, run.id, 'ne-start', 'Start', 'done');
+			seedNodeExec(db, run.id, 'ne-end', 'End', 'in_progress');
+
+			await rt.executeTick();
+
+			const runAfter = workflowRunRepo.getRun(run.id);
+			expect(runAfter?.status).toBe('in_progress');
+			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(0);
+		});
+
+		test('end node execution not created AND sibling in_progress → run stays in_progress', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `End Not Created Sibling IP ${Date.now()}`,
+				description: '',
+				nodes: [
+					{ id: 'encip-start', name: 'Start', agentId: AGENT_A },
+					{ id: 'encip-mid', name: 'Middle', agentId: AGENT_B },
+					{ id: 'encip-end', name: 'End', agentId: AGENT_C },
+				],
+				startNodeId: 'encip-start',
+				endNodeId: 'encip-end',
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
+
+			// Start node done, middle node in_progress, end node not created
+			seedNodeExec(db, run.id, 'encip-start', 'Start', 'done');
+			seedNodeExec(db, run.id, 'encip-mid', 'Middle', 'in_progress');
+			// No exec for 'encip-end'
+
+			await rt.executeTick();
+
+			// Middle exec is in_progress → fallback returns false → run stays in_progress
+			const runAfter = workflowRunRepo.getRun(run.id);
+			expect(runAfter?.status).toBe('in_progress');
+			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(0);
+		});
+
+		test('end node done while sibling exec in_progress → run completes, sibling exec cancelled', async () => {
+			const mockTam = new MockTaskAgentManager();
+			const rt = makeRuntimeWithTam({
+				taskAgentManager: mockTam as unknown as TaskAgentManager,
+			});
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `End Bypass Sibling Cancel ${Date.now()}`,
+				description: '',
+				nodes: [
+					{ id: 'ec-sibling', name: 'Sibling', agentId: AGENT_A },
+					{ id: 'ec-end', name: 'End', agentId: AGENT_B },
+				],
+				startNodeId: 'ec-sibling',
+				endNodeId: 'ec-end',
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Set start task to in_progress (sibling)
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+
+			// Seed sibling exec as in_progress with an agentSessionId
+			const siblingExecId = seedNodeExec(db, run.id, 'ec-sibling', 'Sibling', 'in_progress');
+			const siblingSessionId = 'mock-sibling-session-001';
+			db.prepare('UPDATE node_executions SET agent_session_id = ? WHERE id = ?').run(
+				siblingSessionId,
+				siblingExecId
+			);
+
+			// Seed end node exec as done
+			seedNodeExec(db, run.id, 'ec-end', 'End', 'done');
+
+			await rt.executeTick();
+
+			// Run should be done (end-node short-circuit)
+			const completedRun = workflowRunRepo.getRun(run.id);
+			expect(completedRun?.status).toBe('done');
+
+			// Sibling exec should be cancelled
+			const execs = nodeExecutionRepo.listByWorkflowRun(run.id);
+			const siblingExec = execs.find((e) => e.workflowNodeId === 'ec-sibling');
+			expect(siblingExec?.status).toBe('cancelled');
+
+			// TAM should have received cancelBySessionId for the sibling session
+			expect(mockTam.cancelledSessions).toContain(siblingSessionId);
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+		});
+
+		test('workflow without endNodeId → all-executions-done fallback (backward compat)', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `No End Node ${Date.now()}`,
+				description: '',
+				nodes: [
+					{ id: 'no-en-1', name: 'Step 1', agentId: AGENT_A },
+					{ id: 'no-en-2', name: 'Step 2', agentId: AGENT_B },
+				],
+				startNodeId: 'no-en-1',
+				tags: [],
+			});
+			expect(workflow.endNodeId).toBeUndefined();
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
+
+			// Both node execs terminal
+			seedNodeExec(db, run.id, 'no-en-1', 'Step 1', 'done');
+			seedNodeExec(db, run.id, 'no-en-2', 'Step 2', 'done');
+
+			await rt.executeTick();
+
+			const completedRun = workflowRunRepo.getRun(run.id);
+			expect(completedRun?.status).toBe('done');
+			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(1);
+		});
+
+		test('end-node bypass: blocked sibling does not block run when end node is done', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `End Bypass Blocked Sibling ${Date.now()}`,
+				description: '',
+				nodes: [
+					{ id: 'ebs-sibling', name: 'Sibling', agentId: AGENT_A },
+					{ id: 'ebs-end', name: 'End', agentId: AGENT_B },
+				],
+				startNodeId: 'ebs-sibling',
+				endNodeId: 'ebs-end',
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Sibling task is blocked
+			taskRepo.updateTask(tasks[0].id, { status: 'blocked' });
+
+			// Sibling exec blocked, end exec done
+			seedNodeExec(db, run.id, 'ebs-sibling', 'Sibling', 'blocked');
+			seedNodeExec(db, run.id, 'ebs-end', 'End', 'done');
+
+			await rt.executeTick();
+
+			// End-node bypass is active → blocked task notification skipped
+			// CompletionDetector returns true (end node done) → run completes
+			const runAfter = workflowRunRepo.getRun(run.id);
+			expect(runAfter?.status).toBe('done');
+
+			// No spurious task_blocked events (end-node bypass suppressed them)
+			const blockedEvents = sink.events.filter((e) => e.kind === 'task_blocked');
+			expect(blockedEvents).toHaveLength(0);
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// composePromptLayer: slot override composition
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	describe('composePromptLayer: slot override composition', () => {
+		test('systemPrompt override mode → replaces base prompt entirely', () => {
+			const result = composePromptLayer('Base system prompt', { mode: 'override', value: 'X' });
+			expect(result).toBe('X');
+		});
+
+		test('systemPrompt expand mode → appends override value to base with double newline', () => {
+			const result = composePromptLayer('Base system prompt', { mode: 'expand', value: 'X' });
+			expect(result).toBe('Base system prompt\n\nX');
+		});
+
+		test('instructions override mode → replaces base instructions entirely', () => {
+			const base = 'Original instructions for the agent';
+			const result = composePromptLayer(base, { mode: 'override', value: 'Override instructions' });
+			expect(result).toBe('Override instructions');
+		});
+
+		test('instructions expand mode → appends override to base instructions', () => {
+			const base = 'Original instructions for the agent';
+			const result = composePromptLayer(base, { mode: 'expand', value: 'Extra instructions' });
+			expect(result).toBe('Original instructions for the agent\n\nExtra instructions');
+		});
+
+		test('no override → returns base value unchanged', () => {
+			const base = 'Agent base system prompt';
+			expect(composePromptLayer(base, undefined)).toBe(base);
+		});
+
+		test('expand with empty base → returns only override value', () => {
+			const result = composePromptLayer('', { mode: 'expand', value: 'Expand only' });
+			expect(result).toBe('Expand only');
+		});
+
+		test('expand with null base → returns only override value', () => {
+			const result = composePromptLayer(null, { mode: 'expand', value: 'Expand only' });
+			expect(result).toBe('Expand only');
+		});
+
+		test('override with null base → returns override value', () => {
+			const result = composePromptLayer(null, { mode: 'override', value: 'Override only' });
+			expect(result).toBe('Override only');
+		});
+
+		test('no override with null base → returns empty string', () => {
+			expect(composePromptLayer(null, undefined)).toBe('');
+		});
+
+		test('expand with empty override value → returns base only', () => {
+			const result = composePromptLayer('Base value', { mode: 'expand', value: '   ' });
+			expect(result).toBe('Base value');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Orchestration task auto-complete on run completion
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	describe('orchestration task auto-complete on run completion', () => {
+		test('in_progress orchestration task auto-completed when run completes', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'orch-node-1', name: 'Step', agentId: AGENT_A },
+			]);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Orch Run');
+
+			// Create an orchestration task with taskAgentSessionId starting with 'space:'
+			const orchTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Orchestration',
+				description: 'Task agent orchestration task',
+				workflowRunId: run.id,
+				status: 'in_progress',
+				taskAgentSessionId: `space:${SPACE_ID}:task:${tasks[0].id}`,
+			});
+
+			// Complete the workflow node execution
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
+			seedNodeExec(db, run.id, 'orch-node-1', 'agent', 'done');
+
+			await rt.executeTick();
+
+			// Run should be done
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
+
+			// Orchestration task should be auto-completed
+			const orchTaskAfter = taskRepo.getTask(orchTask.id);
+			expect(orchTaskAfter?.status).toBe('done');
+		});
+
+		test('open orchestration task is skipped on run completion (no throw)', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'orch-open-1', name: 'Step', agentId: AGENT_A },
+			]);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Orch Open Run');
+
+			// Create an orchestration task with taskAgentSessionId but in 'open' state
+			const orchTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Orchestration Open',
+				description: 'Task agent orchestration task in open state',
+				workflowRunId: run.id,
+				status: 'open',
+				taskAgentSessionId: `space:${SPACE_ID}:task:${tasks[0].id}`,
+			});
+
+			// Complete the workflow node execution
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
+			seedNodeExec(db, run.id, 'orch-open-1', 'agent', 'done');
+
+			// Should not throw
+			await rt.executeTick();
+
+			// Run should be done
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
+
+			// Orchestration task should remain 'open' — only 'in_progress' tasks are auto-completed
+			const orchTaskAfter = taskRepo.getTask(orchTask.id);
+			expect(orchTaskAfter?.status).toBe('open');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-completion.test.ts
@@ -2,9 +2,9 @@
  * SpaceRuntime Completion Detection & Status Transition Tests
  *
  * Tests the tick loop integration with CompletionDetector:
- *   - Status transition in_progress → completed sets completedAt
+ *   - Status transition in_progress → done sets completedAt
  *   - Multi-node workflows with mixed terminal statuses
- *   - needs_attention / completed / cancelled runs are skipped
+ *   - blocked / done / cancelled runs are skipped
  *   - Pending-but-blocked via workflow channels
  *   - No duplicate notifications across ticks
  */
@@ -30,7 +30,6 @@ import type {
 import type { SpaceWorkflow, SpaceTask, SpaceWorkflowRun, Space } from '@neokai/shared';
 import type { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager.ts';
 import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
-import { composePromptLayer } from '../../../src/lib/space/agents/custom-agent.ts';
 
 // ---------------------------------------------------------------------------
 // MockNotificationSink
@@ -240,7 +239,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	// -------------------------------------------------------------------------
 
 	describe('completedAt timestamp', () => {
-		test('sets completedAt when CompletionDetector marks run as completed', async () => {
+		test('sets completedAt when CompletionDetector marks run as done', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-ts', name: 'Step', agentId: AGENT_A },
@@ -276,7 +275,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	// -------------------------------------------------------------------------
 
 	describe('multi-node workflow completion', () => {
-		test('multi-node with all tasks completed → run completes', async () => {
+		test('multi-node with all tasks done → run completes', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'node-cd-1', name: 'Plan', agentId: AGENT_B },
@@ -320,7 +319,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			}
 		});
 
-		test('multi-node with mixed terminal statuses (completed + cancelled) → run completes', async () => {
+		test('multi-node with mixed terminal statuses (done + cancelled) → run completes', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'node-mix-1', name: 'Plan', agentId: AGENT_B },
@@ -329,7 +328,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// First node completed
+			// First node done
 			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 
 			// Second node cancelled
@@ -366,7 +365,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// First node completed
+			// First node done
 			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 
 			// Second node in progress
@@ -400,23 +399,23 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	// -------------------------------------------------------------------------
 
 	describe('tick loop early returns', () => {
-		test('processRunTick skips run in needs_attention state', async () => {
+		test('processRunTick skips run in blocked state', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-na-skip', name: 'Step', agentId: AGENT_A },
 			]);
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-			// Escalate to needs_attention
+			// Escalate to blocked
 			workflowRunRepo.transitionStatus(run.id, 'blocked');
 
-			// Set task to completed — normally this would trigger completion
+			// Set task to done — normally this would trigger completion
 			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 
 			await rt.executeTick();
 
-			// Run should still be needs_attention (not completed) because
-			// processRunTick returns early for needs_attention runs
+			// Run should still be blocked (not done) because
+			// processRunTick returns early for blocked runs
 			const runAfter = workflowRunRepo.getRun(run.id);
 			expect(runAfter?.status).toBe('blocked');
 
@@ -424,7 +423,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(completedEvents).toHaveLength(0);
 		});
 
-		test('processRunTick skips run in completed state', async () => {
+		test('processRunTick skips run in done state', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-done-skip', name: 'Step', agentId: AGENT_A },
@@ -432,7 +431,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Complete the task and let tick mark run as completed
+			// Complete the task and let tick mark run as done
 			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 			seedNodeExec(db, run.id, 'step-done-skip', 'agent', 'done');
 			await rt.executeTick();
@@ -463,7 +462,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			await rt.executeTick();
 
 			// No notifications for cancelled runs (cleanupTerminalExecutors
-			// does NOT emit for cancelled, only for completed)
+			// does NOT emit for cancelled, only for done)
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
 			expect(completedEvents).toHaveLength(0);
 
@@ -477,7 +476,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	// -------------------------------------------------------------------------
 
 	describe('status transition lifecycle', () => {
-		test('in_progress → completed is a valid transition via CompletionDetector', async () => {
+		test('in_progress → done is a valid transition via CompletionDetector', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-lifecycle', name: 'Step', agentId: AGENT_A },
@@ -494,7 +493,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(runAfter?.status).toBe('done');
 		});
 
-		test('completed run cannot transition again — subsequent ticks are no-ops', async () => {
+		test('done run cannot transition again — subsequent ticks are no-ops', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-Immutable', name: 'Step', agentId: AGENT_A },
@@ -514,11 +513,11 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			await rt.executeTick();
 			await rt.executeTick();
 
-			// Still exactly one completed event
+			// Still exactly one done event
 			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(1);
 		});
 
-		test('needs_attention run does not auto-complete even when all tasks become terminal', async () => {
+		test('blocked run does not auto-complete even when all tasks become terminal', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-na-no-auto', name: 'Step', agentId: AGENT_A },
@@ -526,7 +525,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Move to needs_attention
+			// Move to blocked
 			workflowRunRepo.transitionStatus(run.id, 'blocked');
 
 			// All tasks terminal
@@ -540,7 +539,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(runAfter?.completedAt).toBeNull();
 		});
 
-		test('needs_attention → in_progress → completed lifecycle via resume', async () => {
+		test('blocked → in_progress → done lifecycle via resume', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-resume', name: 'Step', agentId: AGENT_A },
@@ -548,7 +547,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Step 1: escalate to needs_attention
+			// Step 1: escalate to blocked
 			workflowRunRepo.transitionStatus(run.id, 'blocked');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
 
@@ -561,7 +560,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			seedNodeExec(db, run.id, 'step-resume', 'agent', 'done');
 			await rt.executeTick();
 
-			// Step 4: run should now be completed
+			// Step 4: run should now be done
 			const finalRun = workflowRunRepo.getRun(run.id);
 			expect(finalRun?.status).toBe('done');
 			expect(finalRun?.completedAt).toBeDefined();
@@ -859,7 +858,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			db.prepare('UPDATE node_executions SET status = ? WHERE id = ?').run('done', exec2Id);
 			await rt.executeTick();
 
-			// Now the run should be completed
+			// Now the run should be done
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
 			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(1);
 
@@ -912,7 +911,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(coderExec?.status).toBe('done');
 			expect(reviewerExec?.status).toBe('in_progress');
 
-			// Run must NOT be completed — reviewer is still in progress.
+			// Run must NOT be done — reviewer is still in progress.
 			const runAfter = workflowRunRepo.getRun(run.id);
 			expect(runAfter?.status).toBe('in_progress');
 			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(0);
@@ -921,7 +920,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			taskRepo.updateTask(tasks[1].id, { status: 'done', completedAt: Date.now() });
 			await rt.executeTick();
 
-			// Both execs should now be 'done', and the run should be completed.
+			// Both execs should now be 'done', and the run should be done.
 			const execsFinal = nodeExecutionRepo.listByWorkflowRun(run.id);
 			expect(execsFinal.every((e) => e.status === 'done')).toBe(true);
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
@@ -963,7 +962,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			seedNodeExec(db, run.id, 'step-dedup-clean', 'agent', 'done');
 			await rt.executeTick();
 
-			// Run should be completed
+			// Run should be done
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
 			expect(completedEvents).toHaveLength(1);
 			// Dedup entry was removed when executor was cleaned up
@@ -1200,62 +1199,36 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
 			expect(completedEvents).toHaveLength(1);
 		});
-	});
 
-	// ─────────────────────────────────────────────────────────────────────────────
-	// composePromptLayer: slot override composition
-	// ─────────────────────────────────────────────────────────────────────────────
+		test('end node execution cancelled (terminal) also triggers run completion', async () => {
+			const rt = makeRuntimeWithTam();
 
-	describe('composePromptLayer: slot override composition', () => {
-		test('systemPrompt override mode → replaces base prompt entirely', () => {
-			const result = composePromptLayer('Base system prompt', { mode: 'override', value: 'X' });
-			expect(result).toBe('X');
-		});
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `End Node Cancelled ${Date.now()}`,
+				description: '',
+				nodes: [
+					{ id: 'enc-start', name: 'Start', agentId: AGENT_A },
+					{ id: 'enc-end', name: 'End', agentId: AGENT_B },
+				],
+				startNodeId: 'enc-start',
+				endNodeId: 'enc-end',
+				tags: [],
+			});
 
-		test('systemPrompt expand mode → appends override value to base with double newline', () => {
-			const result = composePromptLayer('Base system prompt', { mode: 'expand', value: 'X' });
-			expect(result).toBe('Base system prompt\n\nX');
-		});
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 
-		test('instructions override mode → replaces base instructions entirely', () => {
-			const base = 'Original instructions for the agent';
-			const result = composePromptLayer(base, { mode: 'override', value: 'Override instructions' });
-			expect(result).toBe('Override instructions');
-		});
+			seedNodeExec(db, run.id, 'enc-start', 'Start', 'done');
+			// End node exec is 'cancelled' — still terminal, should trigger completion
+			seedNodeExec(db, run.id, 'enc-end', 'End', 'cancelled');
 
-		test('instructions expand mode → appends override to base instructions', () => {
-			const base = 'Original instructions for the agent';
-			const result = composePromptLayer(base, { mode: 'expand', value: 'Extra instructions' });
-			expect(result).toBe('Original instructions for the agent\n\nExtra instructions');
-		});
+			await rt.executeTick();
 
-		test('no override → returns base value unchanged', () => {
-			const base = 'Agent base system prompt';
-			expect(composePromptLayer(base, undefined)).toBe(base);
-		});
-
-		test('expand with empty base → returns only override value', () => {
-			const result = composePromptLayer('', { mode: 'expand', value: 'Expand only' });
-			expect(result).toBe('Expand only');
-		});
-
-		test('expand with null base → returns only override value', () => {
-			const result = composePromptLayer(null, { mode: 'expand', value: 'Expand only' });
-			expect(result).toBe('Expand only');
-		});
-
-		test('override with null base → returns override value', () => {
-			const result = composePromptLayer(null, { mode: 'override', value: 'Override only' });
-			expect(result).toBe('Override only');
-		});
-
-		test('no override with null base → returns empty string', () => {
-			expect(composePromptLayer(null, undefined)).toBe('');
-		});
-
-		test('expand with empty override value → returns base only', () => {
-			const result = composePromptLayer('Base value', { mode: 'expand', value: '   ' });
-			expect(result).toBe('Base value');
+			// 'cancelled' is a terminal status for end-node short-circuit
+			const completedRun = workflowRunRepo.getRun(run.id);
+			expect(completedRun?.status).toBe('done');
+			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(1);
 		});
 	});
 

--- a/packages/daemon/tests/unit/space/task-agent-collaboration.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-collaboration.test.ts
@@ -7,13 +7,13 @@
  *    - Multi-node workflow with channels between agents
  *    - Task Agent spawns node agents for each node
  *    - All agents reach terminal status
- *    - report_workflow_done succeeds and closes the run
+ *    - End node reports done → SpaceRuntime tick completes the run
  *
  * 2. Gate-blocked flow with escalation:
  *    - Human gate on a channel blocks message delivery
  *    - Task Agent detects blocked state via check_node_status
  *    - Task Agent escalates by calling request_human_input
- *    - Main task transitions to needs_attention
+ *    - Main task transitions to blocked
  *
  * 3. Multi-agent node collaboration:
  *    - Multiple agents on the same node can complete independently
@@ -399,15 +399,15 @@ describe('Task Agent — gate-blocked flow with escalation', () => {
 		expect(spawnParsed.success).toBe(true);
 
 		// The code agent is blocked (waiting for human approval on the gate)
-		// Task Agent simulates detecting this by checking a needs_attention state on the step task
+		// Task Agent simulates detecting this by checking the blocked state on the step task
 		// workflowNodeId was removed in M71 — filter by tasks that are not the main task
 		const stepTasks = ctx.taskRepo.listByWorkflowRun(run.id).filter((t) => t.id !== mainTask.id);
 		expect(stepTasks.length).toBeGreaterThan(0);
 
-		// Simulate the node agent reaching needs_attention (gate blocked)
+		// Simulate the node agent reaching blocked state (gate blocked)
 		ctx.taskRepo.updateTask(stepTasks[0].id, { status: 'blocked' });
 
-		// check_node_status should report needs_attention
+		// check_node_status should report blocked
 		const checkResult = await handlers.check_node_status({ step_id: wf.startNodeId });
 		const checkParsed = JSON.parse(checkResult.content[0].text);
 		expect(checkParsed.success).toBe(true);


### PR DESCRIPTION
Adds new integration test scenarios to the `space-runtime-completion.test.ts` test file covering three areas:

- **End-node bypass completion**: Tests that a workflow run completes via end-node short-circuit when the designated end node execution is done, that blocked siblings don't block completion when the end node is done, and that sibling in-progress executions are cancelled with `cancelBySessionId` when the end node completes.
- **`composePromptLayer` composition**: Unit tests for all combinations of override modes (`override`/`expand`), null/empty base values, and absent overrides.
- **Orchestration task auto-complete**: Verifies that `in_progress` tasks with `space:` session IDs are auto-completed when the run finishes, and that `open` tasks are skipped without throwing.

Also updates `MockTaskAgentManager` with `cancelledSessions` tracking and `cancelBySessionId` method, and adds the `composePromptLayer` import.