### PR TITLE
Refine space dashboard shell and add style explorer

### DIFF
--- a/packages/web/public/space-dashboard-style-options.html
+++ b/packages/web/public/space-dashboard-style-options.html
@@ -1,0 +1,797 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Space Dashboard Style Options</title>
+		<style>
+			:root {
+				color-scheme: dark;
+				--bg: #08090c;
+				--panel: #101217;
+				--panel-2: #151923;
+				--line: #232734;
+				--muted: #9098ab;
+				--text: #f3f5fb;
+				--blue: #5aa2ff;
+				--cyan: #54d2ff;
+				--green: #4fd39a;
+				--amber: #f6b64e;
+				--rose: #ff7d91;
+			}
+
+			* {
+				box-sizing: border-box;
+			}
+
+			body {
+				margin: 0;
+				font-family: "SF Pro Display", "Segoe UI", sans-serif;
+				background:
+					radial-gradient(circle at top, rgba(90, 162, 255, 0.14), transparent 28rem),
+					linear-gradient(180deg, #07080b 0%, #0c0e13 100%);
+				color: var(--text);
+			}
+
+			main {
+				max-width: 1680px;
+				margin: 0 auto;
+				padding: 40px 24px 96px;
+			}
+
+			.page-header {
+				margin-bottom: 36px;
+			}
+
+			.eyebrow {
+				font-size: 12px;
+				letter-spacing: 0.22em;
+				text-transform: uppercase;
+				color: #7f8799;
+				margin: 0 0 12px;
+			}
+
+			h1 {
+				margin: 0;
+				font-size: clamp(32px, 5vw, 56px);
+				line-height: 0.98;
+				letter-spacing: -0.04em;
+			}
+
+			.page-copy {
+				max-width: 780px;
+				margin: 16px 0 0;
+				font-size: 18px;
+				line-height: 1.6;
+				color: var(--muted);
+			}
+
+			.catalog {
+				display: grid;
+				gap: 28px;
+			}
+
+			.option {
+				border: 1px solid rgba(255, 255, 255, 0.08);
+				border-radius: 28px;
+				background: rgba(16, 18, 23, 0.88);
+				overflow: hidden;
+				box-shadow: 0 28px 70px rgba(0, 0, 0, 0.28);
+			}
+
+			.option-meta {
+				display: grid;
+				grid-template-columns: 220px minmax(0, 1fr) 280px;
+				gap: 24px;
+				padding: 22px 24px;
+				border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+				background: rgba(255, 255, 255, 0.02);
+			}
+
+			.option-number {
+				font-size: 13px;
+				letter-spacing: 0.18em;
+				text-transform: uppercase;
+				color: #8990a3;
+			}
+
+			.option-title {
+				margin: 8px 0 0;
+				font-size: 30px;
+				letter-spacing: -0.04em;
+			}
+
+			.option-summary {
+				margin: 6px 0 0;
+				color: var(--muted);
+				line-height: 1.55;
+			}
+
+			.option-fit {
+				margin: 0;
+				padding: 0;
+				list-style: none;
+				display: grid;
+				gap: 8px;
+				align-content: start;
+			}
+
+			.option-fit li {
+				color: #c9cfdb;
+				font-size: 14px;
+				line-height: 1.45;
+			}
+
+			.mock {
+				padding: 22px;
+				background: #090b10;
+			}
+
+			.surface {
+				min-height: 470px;
+				border: 1px solid rgba(255, 255, 255, 0.08);
+				border-radius: 24px;
+				overflow: hidden;
+				background: #0b0d12;
+			}
+
+			.tab-row {
+				display: flex;
+				gap: 28px;
+				padding: 0 24px;
+				border-bottom: 1px solid var(--line);
+			}
+
+			.tab-row span {
+				display: inline-flex;
+				align-items: center;
+				gap: 8px;
+				padding: 18px 0 16px;
+				font-size: 16px;
+				color: #8c93a5;
+				border-bottom: 2px solid transparent;
+			}
+
+			.tab-row .active {
+				color: #f3f5fb;
+				border-bottom-color: var(--blue);
+			}
+
+			.count {
+				min-width: 28px;
+				padding: 2px 8px;
+				border-radius: 999px;
+				font-size: 12px;
+				text-align: center;
+				background: rgba(255, 255, 255, 0.08);
+				color: #d7dcea;
+			}
+
+			.cards-3 {
+				display: grid;
+				grid-template-columns: repeat(3, minmax(0, 1fr));
+				gap: 16px;
+				padding: 20px;
+			}
+
+			.card {
+				border-radius: 20px;
+				border: 1px solid rgba(255, 255, 255, 0.07);
+				background: #11141d;
+				padding: 18px;
+			}
+
+			.card h4,
+			.list-card h4,
+			.section-title {
+				margin: 0;
+				font-size: 16px;
+			}
+
+			.muted {
+				color: var(--muted);
+			}
+
+			.pill-row {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 8px;
+				margin-top: 12px;
+			}
+
+			.pill {
+				padding: 6px 10px;
+				border-radius: 999px;
+				font-size: 12px;
+				background: rgba(255, 255, 255, 0.05);
+				color: #cfd5e0;
+			}
+
+			.grid-2 {
+				display: grid;
+				grid-template-columns: 320px minmax(0, 1fr);
+				min-height: 420px;
+			}
+
+			.sidebar {
+				border-right: 1px solid var(--line);
+				padding: 20px;
+				background: #0d1017;
+			}
+
+			.sidebar h4 {
+				margin: 0 0 14px;
+				font-size: 13px;
+				letter-spacing: 0.14em;
+				text-transform: uppercase;
+				color: #7f8799;
+			}
+
+			.sidebar-list,
+			.timeline,
+			.rank-list {
+				display: grid;
+				gap: 10px;
+			}
+
+			.sidebar-item,
+			.timeline-item,
+			.rank-item,
+			.list-card {
+				border-radius: 16px;
+				border: 1px solid rgba(255, 255, 255, 0.06);
+				background: #121621;
+				padding: 14px 16px;
+			}
+
+			.workspace {
+				padding: 20px;
+				display: grid;
+				gap: 14px;
+			}
+
+			.workspace-header {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				gap: 16px;
+			}
+
+			.button {
+				padding: 10px 14px;
+				border-radius: 14px;
+				background: linear-gradient(135deg, #2b75ff 0%, #2b5cff 100%);
+				color: white;
+				font-weight: 600;
+				font-size: 14px;
+			}
+
+			.metrics-row {
+				display: grid;
+				grid-template-columns: repeat(4, minmax(0, 1fr));
+				gap: 14px;
+			}
+
+			.metric {
+				border-radius: 18px;
+				padding: 16px;
+				background: #10141d;
+				border: 1px solid rgba(255, 255, 255, 0.06);
+			}
+
+			.metric-label {
+				font-size: 12px;
+				letter-spacing: 0.14em;
+				text-transform: uppercase;
+				color: #7f8799;
+			}
+
+			.metric-value {
+				margin-top: 8px;
+				font-size: 28px;
+				font-weight: 700;
+			}
+
+			.option-1 .surface {
+				background:
+					radial-gradient(circle at top right, rgba(84, 210, 255, 0.12), transparent 22rem),
+					#0b0d12;
+			}
+
+			.option-2 .surface {
+				background: #0b0c10;
+			}
+
+			.option-2 .lanes {
+				display: grid;
+				grid-template-columns: repeat(3, minmax(0, 1fr));
+				gap: 16px;
+				padding: 18px;
+			}
+
+			.option-2 .lane {
+				border-radius: 20px;
+				background: #11131a;
+				border: 1px solid rgba(255, 255, 255, 0.06);
+				padding: 14px;
+			}
+
+			.option-2 .lane .section-title {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				margin-bottom: 12px;
+			}
+
+			.option-3 .surface {
+				background: #0d1015;
+			}
+
+			.option-3 .table {
+				padding: 12px 18px 18px;
+			}
+
+			.option-3 table {
+				width: 100%;
+				border-collapse: collapse;
+				font-size: 14px;
+			}
+
+			.option-3 th,
+			.option-3 td {
+				padding: 12px 10px;
+				border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+				text-align: left;
+			}
+
+			.option-3 th {
+				color: #7f8799;
+				font-size: 12px;
+				text-transform: uppercase;
+				letter-spacing: 0.14em;
+			}
+
+			.option-4 .surface {
+				background:
+					linear-gradient(180deg, rgba(90, 162, 255, 0.08), transparent 9rem),
+					#090c11;
+			}
+
+			.option-4 .radar {
+				display: grid;
+				grid-template-columns: 1.1fr 0.9fr;
+				gap: 16px;
+				padding: 18px;
+			}
+
+			.option-4 .hero-panel,
+			.option-4 .signal-panel {
+				border-radius: 22px;
+				border: 1px solid rgba(255, 255, 255, 0.06);
+				background: rgba(17, 22, 31, 0.92);
+				padding: 20px;
+			}
+
+			.option-4 .hero-panel h3 {
+				margin: 0 0 10px;
+				font-size: 38px;
+				letter-spacing: -0.05em;
+			}
+
+			.option-5 .surface {
+				background: #0d0f14;
+			}
+
+			.option-5 .split {
+				display: grid;
+				grid-template-columns: 1.1fr 0.9fr;
+				min-height: 420px;
+			}
+
+			.option-5 .review-column {
+				border-right: 1px solid var(--line);
+				padding: 20px;
+				background: linear-gradient(180deg, rgba(246, 182, 78, 0.08), transparent 9rem);
+			}
+
+			.option-6 .surface {
+				background: #090b10;
+			}
+
+			.option-6 .stream {
+				display: grid;
+				grid-template-columns: 1fr 360px;
+				min-height: 420px;
+			}
+
+			.option-6 .feed {
+				padding: 18px;
+				display: grid;
+				gap: 12px;
+			}
+
+			.timeline-item {
+				display: grid;
+				grid-template-columns: 110px minmax(0, 1fr);
+				gap: 16px;
+				align-items: start;
+			}
+
+			.timeline-time {
+				font-size: 12px;
+				color: #7f8799;
+				letter-spacing: 0.12em;
+				text-transform: uppercase;
+			}
+
+			.rank-item {
+				display: grid;
+				grid-template-columns: 36px minmax(0, 1fr) 48px;
+				gap: 12px;
+				align-items: center;
+			}
+
+			.rank {
+				width: 36px;
+				height: 36px;
+				display: grid;
+				place-items: center;
+				border-radius: 12px;
+				background: rgba(255, 255, 255, 0.06);
+				color: #aeb5c6;
+				font-weight: 700;
+			}
+
+			.note {
+				margin-top: 14px;
+				font-size: 13px;
+				line-height: 1.55;
+				color: #a6adbd;
+			}
+
+			@media (max-width: 1100px) {
+				.option-meta,
+				.grid-2,
+				.option-4 .radar,
+				.option-5 .split,
+				.option-6 .stream {
+					grid-template-columns: 1fr;
+				}
+
+				.cards-3,
+				.option-2 .lanes,
+				.metrics-row {
+					grid-template-columns: 1fr;
+				}
+			}
+
+			@media (max-width: 720px) {
+				main {
+					padding: 24px 14px 72px;
+				}
+
+				.option-meta,
+				.mock {
+					padding: 18px;
+				}
+
+				.tab-row {
+					gap: 18px;
+					padding: 0 16px;
+					overflow-x: auto;
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<main>
+			<header class="page-header">
+				<p class="eyebrow">Space Dashboard Exploration</p>
+				<h1>Six directions. Pick a visual model before we touch the app again.</h1>
+				<p class="page-copy">
+					Each option is intentionally different. The point is to choose a dashboard philosophy, not
+					to bikeshed details on the current screen. All six assume spaces are for managing many tasks
+					in parallel.
+				</p>
+			</header>
+
+			<section class="catalog">
+				<article class="option option-1">
+					<div class="option-meta">
+						<div>
+							<div class="option-number">Option 1</div>
+							<h2 class="option-title">Operator Console</h2>
+						</div>
+						<div>
+							<p class="option-summary">
+								A balanced command surface: clear tabs at the top, compact metrics, grouped task lanes
+								below. Feels controlled and productized.
+							</p>
+						</div>
+						<ul class="option-fit">
+							<li>Choose this if you want the safest modern direction.</li>
+							<li>Strong fit for daily operational use and onboarding.</li>
+							<li>Low risk to implement incrementally.</li>
+						</ul>
+					</div>
+					<div class="mock">
+						<div class="surface">
+							<div class="tab-row">
+								<span class="active">Active <b class="count">14</b></span>
+								<span>Review <b class="count">5</b></span>
+								<span>Done <b class="count">38</b></span>
+							</div>
+							<div class="metrics-row" style="padding: 20px 20px 0">
+								<div class="metric"><div class="metric-label">In Progress</div><div class="metric-value">9</div></div>
+								<div class="metric"><div class="metric-label">Queued</div><div class="metric-value">5</div></div>
+								<div class="metric"><div class="metric-label">Needs Review</div><div class="metric-value">5</div></div>
+								<div class="metric"><div class="metric-label">Done Today</div><div class="metric-value">12</div></div>
+							</div>
+							<div class="cards-3">
+								<div class="card">
+									<h4>In Progress</h4>
+									<p class="note">3 active threads, 2 workflow runs, 4 standalone tasks.</p>
+									<div class="pill-row">
+										<span class="pill">Spec cleanup</span>
+										<span class="pill">UI pass</span>
+										<span class="pill">Eval tuning</span>
+									</div>
+								</div>
+								<div class="card">
+									<h4>Review Queue</h4>
+									<p class="note">Pull the highest-friction items up first. Human waiting time is the main signal.</p>
+									<div class="pill-row">
+										<span class="pill">Blocked on design</span>
+										<span class="pill">Needs approval</span>
+									</div>
+								</div>
+								<div class="card">
+									<h4>Recently Finished</h4>
+									<p class="note">Keep the execution trail visible without letting done work dominate the canvas.</p>
+									<div class="pill-row">
+										<span class="pill">Prompt migration</span>
+										<span class="pill">Regression sweep</span>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</article>
+
+				<article class="option option-2">
+					<div class="option-meta">
+						<div>
+							<div class="option-number">Option 2</div>
+							<h2 class="option-title">Kanban Strip</h2>
+						</div>
+						<div>
+							<p class="option-summary">
+								Lean into the “many tasks in parallel” story. Three permanent status lanes with review
+								centered visually as the choke point.
+							</p>
+						</div>
+						<ul class="option-fit">
+							<li>Choose this if the dashboard should feel like a board, not a report.</li>
+							<li>Best when users scan status distribution constantly.</li>
+							<li>Weakest if you need dense metadata per task.</li>
+						</ul>
+					</div>
+					<div class="mock">
+						<div class="surface">
+							<div class="lanes">
+								<div class="lane">
+									<div class="section-title"><span>Active</span><span class="count">14</span></div>
+									<div class="list-card"><h4>Atlas QA hardening</h4><p class="muted">2 agents executing, 1 blocker cleared</p></div>
+									<div class="list-card"><h4>Prompt schema cleanup</h4><p class="muted">Queued behind codegen test run</p></div>
+									<div class="list-card"><h4>CLI trace export</h4><p class="muted">Owner: Coder</p></div>
+								</div>
+								<div class="lane" style="background: linear-gradient(180deg, rgba(246, 182, 78, 0.08), transparent 8rem), #11131a;">
+									<div class="section-title"><span>Review</span><span class="count">5</span></div>
+									<div class="list-card"><h4>Space shell redesign</h4><p class="muted">Waiting on style direction</p></div>
+									<div class="list-card"><h4>Workflow editor labels</h4><p class="muted">Product signoff required</p></div>
+								</div>
+								<div class="lane">
+									<div class="section-title"><span>Done</span><span class="count">38</span></div>
+									<div class="list-card"><h4>Provider fallback patch</h4><p class="muted">Completed 17 min ago</p></div>
+									<div class="list-card"><h4>Typecheck stabilization</h4><p class="muted">Completed 42 min ago</p></div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</article>
+
+				<article class="option option-3">
+					<div class="option-meta">
+						<div>
+							<div class="option-number">Option 3</div>
+							<h2 class="option-title">Triage Table</h2>
+						</div>
+						<div>
+							<p class="option-summary">
+								Dense and clinical. Optimized for sorting, scanning, and bulk decisions rather than
+								atmosphere. This is the least decorative option.
+							</p>
+						</div>
+						<ul class="option-fit">
+							<li>Choose this if the dashboard is primarily an operations console.</li>
+							<li>Best for dozens of concurrent tasks.</li>
+							<li>Feels utilitarian by design.</li>
+						</ul>
+					</div>
+					<div class="mock">
+						<div class="surface">
+							<div class="tab-row">
+								<span class="active">Active <b class="count">14</b></span>
+								<span>Review <b class="count">5</b></span>
+								<span>Done <b class="count">38</b></span>
+							</div>
+							<div class="table">
+								<table>
+									<thead>
+										<tr>
+											<th>Task</th>
+											<th>Status</th>
+											<th>Owner</th>
+											<th>Priority</th>
+											<th>Updated</th>
+											<th>Blocker</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr><td>Space dashboard direction</td><td>Review</td><td>Planner</td><td>High</td><td>2m ago</td><td>Need visual pick</td></tr>
+										<tr><td>Workflow state cleanup</td><td>In progress</td><td>Coder</td><td>High</td><td>8m ago</td><td>None</td></tr>
+										<tr><td>Prompt bundle export</td><td>Queued</td><td>General</td><td>Med</td><td>11m ago</td><td>Waiting on branch</td></tr>
+										<tr><td>Mobile shell spacing</td><td>Done</td><td>Reviewer</td><td>Low</td><td>21m ago</td><td>Resolved</td></tr>
+										<tr><td>Provider fallback</td><td>Done</td><td>QA</td><td>High</td><td>35m ago</td><td>Resolved</td></tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
+					</div>
+				</article>
+
+				<article class="option option-4">
+					<div class="option-meta">
+						<div>
+							<div class="option-number">Option 4</div>
+							<h2 class="option-title">Mission Control</h2>
+						</div>
+						<div>
+							<p class="option-summary">
+								Big signal, high drama. A central status pulse and side telemetry make the space feel
+								more like a live control room than a project page.
+							</p>
+						</div>
+						<ul class="option-fit">
+							<li>Choose this if you want a stronger identity.</li>
+							<li>Best when “parallel orchestration” should feel explicit.</li>
+							<li>Higher design and implementation complexity.</li>
+						</ul>
+					</div>
+					<div class="mock">
+						<div class="surface">
+							<div class="radar">
+								<div class="hero-panel">
+									<div class="eyebrow">Live Flow</div>
+									<h3>14 tasks moving across 5 agents</h3>
+									<p class="option-summary">Review pressure is building faster than execution capacity. Pull two blocked items forward.</p>
+									<div class="pill-row">
+										<span class="pill">2 waiting on design</span>
+										<span class="pill">1 failed check</span>
+										<span class="pill">12 completed today</span>
+									</div>
+								</div>
+								<div class="signal-panel">
+									<div class="rank-list">
+										<div class="rank-item"><div class="rank">1</div><div><strong>Review queue</strong><div class="muted">5 tasks need human action</div></div><div class="count">5</div></div>
+										<div class="rank-item"><div class="rank">2</div><div><strong>Agent load</strong><div class="muted">Coder + QA saturated</div></div><div class="count">3</div></div>
+										<div class="rank-item"><div class="rank">3</div><div><strong>Finished today</strong><div class="muted">Healthy throughput</div></div><div class="count">12</div></div>
+									</div>
+								</div>
+							</div>
+							<div class="cards-3">
+								<div class="card"><h4>Active Work</h4><p class="note">Cluster by execution stream rather than raw status.</p></div>
+								<div class="card"><h4>Needs Intervention</h4><p class="note">Humans are the scarce resource. Show them first.</p></div>
+								<div class="card"><h4>Completed Trail</h4><p class="note">Compact, but visible enough to prove motion.</p></div>
+							</div>
+						</div>
+					</div>
+				</article>
+
+				<article class="option option-5">
+					<div class="option-meta">
+						<div>
+							<div class="option-number">Option 5</div>
+							<h2 class="option-title">Review-First Split</h2>
+						</div>
+						<div>
+							<p class="option-summary">
+								The page admits the real bottleneck: human review. Left side is urgent intervention,
+								right side is execution and completion context.
+							</p>
+						</div>
+						<ul class="option-fit">
+							<li>Choose this if review and unblock work is the dashboard’s primary job.</li>
+							<li>Best when the user opens the space to decide what to approve next.</li>
+							<li>Less balanced than a general-purpose overview.</li>
+						</ul>
+					</div>
+					<div class="mock">
+						<div class="surface">
+							<div class="split">
+								<div class="review-column">
+									<div class="workspace-header">
+										<h3 class="section-title">Review Now</h3>
+										<span class="count">5</span>
+									</div>
+									<div class="sidebar-list" style="margin-top: 14px;">
+										<div class="sidebar-item"><h4>Space dashboard direction</h4><p class="muted">Choose a style before implementation resumes.</p></div>
+										<div class="sidebar-item"><h4>Workflow editor action labels</h4><p class="muted">Needs product language pass.</p></div>
+										<div class="sidebar-item"><h4>Task grouping names</h4><p class="muted">Need alignment on terminology.</p></div>
+									</div>
+								</div>
+								<div class="workspace">
+									<div class="metrics-row">
+										<div class="metric"><div class="metric-label">Active</div><div class="metric-value">14</div></div>
+										<div class="metric"><div class="metric-label">Done</div><div class="metric-value">38</div></div>
+										<div class="metric"><div class="metric-label">Agents</div><div class="metric-value">5</div></div>
+										<div class="metric"><div class="metric-label">Runs</div><div class="metric-value">3</div></div>
+									</div>
+									<div class="card">
+										<h4>Execution Context</h4>
+										<p class="note">The right side stays secondary. Enough context to make a decision, but not enough to distract from review work.</p>
+									</div>
+									<div class="card">
+										<h4>Recent Completions</h4>
+										<div class="pill-row"><span class="pill">Typecheck pass</span><span class="pill">Configure route move</span><span class="pill">Context panel cleanup</span></div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</article>
+
+				<article class="option option-6">
+					<div class="option-meta">
+						<div>
+							<div class="option-number">Option 6</div>
+							<h2 class="option-title">Activity Feed</h2>
+						</div>
+						<div>
+							<p class="option-summary">
+								A living stream of task motion with a compact ranking rail. This makes the space feel
+								like a timeline of ongoing work rather than a static dashboard.
+							</p>
+						</div>
+						<ul class="option-fit">
+							<li>Choose this if “what changed recently?” matters most.</li>
+							<li>Best for active spaces with continuous movement.</li>
+							<li>Harder to use as a planning surface.</li>
+						</ul>
+					</div>
+					<div class="mock">
+						<div class="surface">
+							<div class="stream">
+								<div class="feed">
+									<div class="timeline-item"><div class="timeline-time">2 min ago</div><div><strong>Dashboard style review task reopened</strong><div class="muted">Blocked until a visual direction is selected.</div></div></div>
+									<div class="timeline-item"><div class="timeline-time">8 min ago</div><div><strong>Workflow cleanup entered code review</strong><div class="muted">Reviewer agent attached comments to latest patch.</div></div></div>
+									<div class="timeline-item"><div class="timeline-time">21 min ago</div><div><strong>Mobile spacing pass completed</strong><div class="muted">Typecheck and focused vitest suite passed.</div></div></div>
+									<div class="timeline-item"><div class="timeline-time">35 min ago</div><div><strong>Configure route extracted</strong><div class="muted">Settings controls moved behind dedicated route.</div></div></div>
+								</div>
+								<div class="sidebar">
+									<h4>Right Now</h4>
+									<div class="rank-list">
+										<div class="rank-item"><div class="rank">A</div><div><strong>Review queue</strong><div class="muted">5 tasks</div></div><div class="count">5</div></div>
+										<div class="rank-item"><div class="rank">B</div><div><strong>Active load</strong><div class="muted">14 tasks</div></div><div class="count">14</div></div>
+										<div class="rank-item"><div class="rank">C</div><div><strong>Finished today</strong><div class="muted">12 tasks</div></div><div class="count">12</div></div>
+									</div>
+									<p class="note">This direction emphasizes motion and recency over strict categorization.</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</article>
+			</section>
+		</main>
+	</body>
+</html>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -19,6 +19,7 @@ import {
 	currentSpaceIdSignal,
 	currentSpaceSessionIdSignal,
 	currentSpaceTaskIdSignal,
+	currentSpaceViewModeSignal,
 	navSectionSignal,
 } from './lib/signals.ts';
 import { initSessionStatusTracking } from './lib/session-status.ts';
@@ -34,6 +35,7 @@ import {
 	navigateToHome,
 	navigateToSpacesPage,
 	navigateToSpace,
+	navigateToSpaceConfigure,
 	navigateToSpaceAgent,
 	navigateToSpaceSession,
 	navigateToSpaceTask,
@@ -43,6 +45,7 @@ import {
 	createRoomSessionPath,
 	createRoomTaskPath,
 	createSpacePath,
+	createSpaceConfigurePath,
 	createSpaceAgentPath,
 	createSpaceSessionPath,
 	createSpaceTaskPath,
@@ -108,6 +111,7 @@ export function App() {
 			const spaceId = currentSpaceIdSignal.value;
 			const spaceSessionId = currentSpaceSessionIdSignal.value;
 			const spaceTaskId = currentSpaceTaskIdSignal.value;
+			const spaceViewMode = currentSpaceViewModeSignal.value;
 			const navSection = navSectionSignal.value;
 			const currentPath = window.location.pathname;
 			// Detect agent routes: synthetic session IDs follow the pattern <type>:chat:<id>
@@ -125,7 +129,9 @@ export function App() {
 						? createSpaceAgentPath(spaceId)
 						: spaceSessionId && spaceId
 							? createSpaceSessionPath(spaceId, spaceSessionId)
-							: spaceId
+							: spaceId && spaceViewMode === 'configure'
+								? createSpaceConfigurePath(spaceId)
+								: spaceId
 								? createSpacePath(spaceId)
 								: roomTaskId && roomId
 									? createRoomTaskPath(roomId, roomTaskId)
@@ -152,6 +158,8 @@ export function App() {
 					navigateToSpaceAgent(spaceId, true);
 				} else if (spaceSessionId && spaceId) {
 					navigateToSpaceSession(spaceId, spaceSessionId, true);
+				} else if (spaceId && spaceViewMode === 'configure') {
+					navigateToSpaceConfigure(spaceId, true);
 				} else if (spaceId) {
 					navigateToSpace(spaceId, true);
 				} else if (roomTaskId && roomId) {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -132,20 +132,20 @@ export function App() {
 							: spaceId && spaceViewMode === 'configure'
 								? createSpaceConfigurePath(spaceId)
 								: spaceId
-								? createSpacePath(spaceId)
-								: roomTaskId && roomId
-									? createRoomTaskPath(roomId, roomTaskId)
-									: isAgentRoute
-										? createRoomAgentPath(roomId)
-										: roomSessionId && roomId
-											? createRoomSessionPath(roomId, roomSessionId)
-											: roomId
-												? createRoomPath(roomId)
-												: navSection === 'spaces'
-													? '/spaces'
-													: navSection === 'chats'
-														? '/sessions'
-														: '/';
+									? createSpacePath(spaceId)
+									: roomTaskId && roomId
+										? createRoomTaskPath(roomId, roomTaskId)
+										: isAgentRoute
+											? createRoomAgentPath(roomId)
+											: roomSessionId && roomId
+												? createRoomSessionPath(roomId, roomSessionId)
+												: roomId
+													? createRoomPath(roomId)
+													: navSection === 'spaces'
+														? '/spaces'
+														: navSection === 'chats'
+															? '/sessions'
+															: '/';
 
 			// Only update URL if it's out of sync
 			// This prevents unnecessary history updates and loops

--- a/packages/web/src/components/space/SpaceConfigurePage.tsx
+++ b/packages/web/src/components/space/SpaceConfigurePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import type { Space, SpaceWorkflow } from '@neokai/shared';
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@neokai/ui';
 import { spaceStore } from '../../lib/space-store';
 import { cn } from '../../lib/utils';
 import { SpaceAgentList } from './SpaceAgentList';
@@ -9,77 +10,18 @@ import { VisualWorkflowEditor } from './visual-editor/VisualWorkflowEditor';
 
 type ConfigureTab = 'agents' | 'workflows' | 'settings';
 
-const CONFIGURE_TABS: Array<{
-	id: ConfigureTab;
-	label: string;
-	description: string;
-}> = [
-	{
-		id: 'agents',
-		label: 'Agents',
-		description: 'Define the specialist roles available in this space.',
-	},
-	{
-		id: 'workflows',
-		label: 'Workflows',
-		description: 'Shape the execution graph that fans work out across agents.',
-	},
-	{
-		id: 'settings',
-		label: 'Settings',
-		description: 'Adjust space metadata, export, and lifecycle controls.',
-	},
+const CONFIGURE_TABS: Array<{ id: ConfigureTab; label: string; count: (args: {
+	agentCount: number;
+	workflowCount: number;
+}) => number }> = [
+	{ id: 'agents', label: 'Agents', count: ({ agentCount }) => agentCount },
+	{ id: 'workflows', label: 'Workflows', count: ({ workflowCount }) => workflowCount },
+	{ id: 'settings', label: 'Settings', count: () => 1 },
 ];
 
 interface SpaceConfigurePageProps {
 	space: Space;
 	workflows: SpaceWorkflow[];
-}
-
-function StatPill({
-	label,
-	value,
-}: {
-	label: string;
-	value: string;
-}) {
-	return (
-		<div class="rounded-xl border border-dark-700 bg-dark-900/70 px-3 py-2">
-			<p class="text-[10px] uppercase tracking-[0.18em] text-gray-500">{label}</p>
-			<p class="mt-1 text-sm font-semibold text-gray-100">{value}</p>
-		</div>
-	);
-}
-
-function ConfigureTabButton({
-	id,
-	label,
-	description,
-	active,
-	onClick,
-}: {
-	id: ConfigureTab;
-	label: string;
-	description: string;
-	active: boolean;
-	onClick: () => void;
-}) {
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			data-testid={`space-configure-tab-${id}`}
-			class={cn(
-				'rounded-2xl border px-4 py-3 text-left transition-colors',
-				active
-					? 'border-blue-500/40 bg-blue-500/10'
-					: 'border-dark-700 bg-dark-900/50 hover:border-dark-600 hover:bg-dark-900'
-			)}
-		>
-			<p class={cn('text-sm font-medium', active ? 'text-blue-50' : 'text-gray-100')}>{label}</p>
-			<p class="mt-1 text-xs leading-5 text-gray-500">{description}</p>
-		</button>
-	);
 }
 
 export function SpaceConfigurePage({ space, workflows }: SpaceConfigurePageProps) {
@@ -94,68 +36,52 @@ export function SpaceConfigurePage({ space, workflows }: SpaceConfigurePageProps
 			: undefined;
 
 	const showWorkflowEditor = activeTab === 'workflows' && workflowEditId !== null;
-	const workspacePath = space.workspacePath ?? '';
-	const workspaceName = workspacePath
-		? workspacePath.split('/').filter(Boolean).at(-1) ?? workspacePath
-		: 'Not set';
+	const selectedIndex = Math.max(
+		0,
+		CONFIGURE_TABS.findIndex((tab) => tab.id === activeTab)
+	);
 
 	return (
-		<div class="flex h-full flex-col overflow-y-auto p-6">
-			<div class="mx-auto flex w-full max-w-7xl flex-1 min-h-0 flex-col gap-6">
+		<div class="flex h-full flex-col overflow-y-auto p-3 sm:p-4 lg:p-6">
+			<div class="mx-auto flex w-full max-w-7xl min-h-0 flex-1 flex-col gap-3 lg:gap-4">
 				{!showWorkflowEditor && (
-					<section class="rounded-[28px] border border-dark-700 bg-dark-900/90 px-6 py-6">
-						<div class="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
-							<div class="min-w-0">
-								<p class="text-[11px] uppercase tracking-[0.22em] text-gray-600">Configure</p>
-								<h1 class="mt-3 text-3xl font-semibold tracking-tight text-gray-100">
-									{space.name} setup
-								</h1>
-								<p class="mt-3 max-w-3xl text-sm leading-6 text-gray-400">
-									Adjust the operator surface behind this space: who can work here, how work
-									fans out, and what controls govern the environment.
-								</p>
-							</div>
-							<div class="grid w-full gap-3 sm:grid-cols-3 xl:w-[32rem]">
-								<StatPill label="Agents" value={String(agents.length)} />
-								<StatPill label="Workflows" value={String(workflows.length)} />
-								<StatPill label="Workspace" value={workspaceName} />
-							</div>
-						</div>
-
-						<div
-							class="mt-6 grid gap-3 lg:grid-cols-3"
+					<TabGroup
+						selectedIndex={selectedIndex}
+						onChange={(index: number) => setActiveTab(CONFIGURE_TABS[index]?.id ?? 'agents')}
+					>
+						<TabList
+							class="flex items-center gap-6 border-b border-dark-700 px-6"
 							data-testid="space-configure-tab-bar"
 						>
 							{CONFIGURE_TABS.map((tab) => (
-								<ConfigureTabButton
+								<Tab
 									key={tab.id}
-									id={tab.id}
-									label={tab.label}
-									description={tab.description}
-									active={activeTab === tab.id}
-									onClick={() => setActiveTab(tab.id)}
-								/>
+									data-testid={`space-configure-tab-${tab.id}`}
+									class={cn(
+										'flex items-center gap-2 border-b-2 px-1 py-3 text-sm font-medium transition-colors',
+										activeTab === tab.id
+											? 'border-blue-400 text-gray-100'
+											: 'border-transparent text-gray-400 hover:text-gray-200'
+									)}
+								>
+									<span>{tab.label}</span>
+									<span class="rounded-full bg-dark-800 px-2 py-0.5 text-xs text-gray-300">
+										{tab.count({
+											agentCount: agents.length,
+											workflowCount: workflows.length,
+										})}
+									</span>
+								</Tab>
 							))}
-						</div>
-					</section>
-				)}
+						</TabList>
 
-				<div class="min-h-0 flex-1 overflow-hidden rounded-[28px] border border-dark-700 bg-dark-950/70">
-					{showWorkflowEditor ? (
-						<VisualWorkflowEditor
-							key={workflowEditId}
-							workflow={editingWorkflow}
-							onSave={() => setWorkflowEditId(null)}
-							onCancel={() => setWorkflowEditId(null)}
-						/>
-					) : (
-						<>
-							{activeTab === 'agents' && (
-								<div class="h-full overflow-y-auto p-6">
+						<TabPanels class="min-h-0 flex-1 overflow-hidden rounded-3xl border border-dark-700 bg-dark-950/70 lg:rounded-[28px]">
+							<TabPanel>
+								<div class="h-full overflow-y-auto p-4 sm:p-5 lg:p-6">
 									<SpaceAgentList />
 								</div>
-							)}
-							{activeTab === 'workflows' && (
+							</TabPanel>
+							<TabPanel>
 								<WorkflowList
 									spaceId={space.id}
 									spaceName={space.name}
@@ -163,11 +89,24 @@ export function SpaceConfigurePage({ space, workflows }: SpaceConfigurePageProps
 									onCreateWorkflow={() => setWorkflowEditId('new')}
 									onEditWorkflow={(id) => setWorkflowEditId(id)}
 								/>
-							)}
-							{activeTab === 'settings' && <SpaceSettings space={space} />}
-						</>
-					)}
-				</div>
+							</TabPanel>
+							<TabPanel>
+								<SpaceSettings space={space} />
+							</TabPanel>
+						</TabPanels>
+					</TabGroup>
+				)}
+
+				{showWorkflowEditor && (
+					<div class="min-h-0 flex-1 overflow-hidden rounded-3xl border border-dark-700 bg-dark-950/70 lg:rounded-[28px]">
+						<VisualWorkflowEditor
+							key={workflowEditId}
+							workflow={editingWorkflow}
+							onSave={() => setWorkflowEditId(null)}
+							onCancel={() => setWorkflowEditId(null)}
+						/>
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/SpaceConfigurePage.tsx
+++ b/packages/web/src/components/space/SpaceConfigurePage.tsx
@@ -1,17 +1,34 @@
 import { useState } from 'preact/hooks';
 import type { Space, SpaceWorkflow } from '@neokai/shared';
+import { spaceStore } from '../../lib/space-store';
+import { cn } from '../../lib/utils';
 import { SpaceAgentList } from './SpaceAgentList';
+import { SpaceSettings } from './SpaceSettings';
 import { WorkflowList } from './WorkflowList';
 import { VisualWorkflowEditor } from './visual-editor/VisualWorkflowEditor';
-import { SpaceSettings } from './SpaceSettings';
-import { cn } from '../../lib/utils';
 
 type ConfigureTab = 'agents' | 'workflows' | 'settings';
 
-const CONFIGURE_TABS: { id: ConfigureTab; label: string }[] = [
-	{ id: 'agents', label: 'Agents' },
-	{ id: 'workflows', label: 'Workflows' },
-	{ id: 'settings', label: 'Settings' },
+const CONFIGURE_TABS: Array<{
+	id: ConfigureTab;
+	label: string;
+	description: string;
+}> = [
+	{
+		id: 'agents',
+		label: 'Agents',
+		description: 'Define the specialist roles available in this space.',
+	},
+	{
+		id: 'workflows',
+		label: 'Workflows',
+		description: 'Shape the execution graph that fans work out across agents.',
+	},
+	{
+		id: 'settings',
+		label: 'Settings',
+		description: 'Adjust space metadata, export, and lifecycle controls.',
+	},
 ];
 
 interface SpaceConfigurePageProps {
@@ -19,7 +36,54 @@ interface SpaceConfigurePageProps {
 	workflows: SpaceWorkflow[];
 }
 
+function StatPill({
+	label,
+	value,
+}: {
+	label: string;
+	value: string;
+}) {
+	return (
+		<div class="rounded-xl border border-dark-700 bg-dark-900/70 px-3 py-2">
+			<p class="text-[10px] uppercase tracking-[0.18em] text-gray-500">{label}</p>
+			<p class="mt-1 text-sm font-semibold text-gray-100">{value}</p>
+		</div>
+	);
+}
+
+function ConfigureTabButton({
+	id,
+	label,
+	description,
+	active,
+	onClick,
+}: {
+	id: ConfigureTab;
+	label: string;
+	description: string;
+	active: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			data-testid={`space-configure-tab-${id}`}
+			class={cn(
+				'rounded-2xl border px-4 py-3 text-left transition-colors',
+				active
+					? 'border-blue-500/40 bg-blue-500/10'
+					: 'border-dark-700 bg-dark-900/50 hover:border-dark-600 hover:bg-dark-900'
+			)}
+		>
+			<p class={cn('text-sm font-medium', active ? 'text-blue-50' : 'text-gray-100')}>{label}</p>
+			<p class="mt-1 text-xs leading-5 text-gray-500">{description}</p>
+		</button>
+	);
+}
+
 export function SpaceConfigurePage({ space, workflows }: SpaceConfigurePageProps) {
+	const agents = spaceStore.agents.value;
 	const [activeTab, setActiveTab] = useState<ConfigureTab>('agents');
 	/** null = list view; 'new' = create editor; <id> = edit editor */
 	const [workflowEditId, setWorkflowEditId] = useState<string | null>(null);
@@ -30,59 +94,80 @@ export function SpaceConfigurePage({ space, workflows }: SpaceConfigurePageProps
 			: undefined;
 
 	const showWorkflowEditor = activeTab === 'workflows' && workflowEditId !== null;
+	const workspacePath = space.workspacePath ?? '';
+	const workspaceName = workspacePath
+		? workspacePath.split('/').filter(Boolean).at(-1) ?? workspacePath
+		: 'Not set';
 
 	return (
-		<div class="flex h-full flex-col overflow-hidden">
-			{!showWorkflowEditor && (
-				<div
-					class="flex items-center gap-2 border-b border-dark-700 px-6 py-3"
-					data-testid="space-configure-tab-bar"
-				>
-					{CONFIGURE_TABS.map((tab) => (
-						<button
-							key={tab.id}
-							type="button"
-							onClick={() => setActiveTab(tab.id)}
-							class={cn(
-								'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
-								activeTab === tab.id
-									? 'bg-dark-700 text-gray-100'
-									: 'text-gray-400 hover:bg-dark-800 hover:text-gray-200'
-							)}
-						>
-							{tab.label}
-						</button>
-					))}
-				</div>
-			)}
-
-			<div class="min-h-0 flex-1 overflow-hidden">
-				{showWorkflowEditor ? (
-					<VisualWorkflowEditor
-						key={workflowEditId}
-						workflow={editingWorkflow}
-						onSave={() => setWorkflowEditId(null)}
-						onCancel={() => setWorkflowEditId(null)}
-					/>
-				) : (
-					<>
-						{activeTab === 'agents' && (
-							<div class="h-full overflow-y-auto p-6">
-								<SpaceAgentList />
+		<div class="flex h-full flex-col overflow-y-auto p-6">
+			<div class="mx-auto flex w-full max-w-7xl flex-1 min-h-0 flex-col gap-6">
+				{!showWorkflowEditor && (
+					<section class="rounded-[28px] border border-dark-700 bg-dark-900/90 px-6 py-6">
+						<div class="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+							<div class="min-w-0">
+								<p class="text-[11px] uppercase tracking-[0.22em] text-gray-600">Configure</p>
+								<h1 class="mt-3 text-3xl font-semibold tracking-tight text-gray-100">
+									{space.name} setup
+								</h1>
+								<p class="mt-3 max-w-3xl text-sm leading-6 text-gray-400">
+									Adjust the operator surface behind this space: who can work here, how work
+									fans out, and what controls govern the environment.
+								</p>
 							</div>
-						)}
-						{activeTab === 'workflows' && (
-							<WorkflowList
-								spaceId={space.id}
-								spaceName={space.name}
-								workflows={workflows}
-								onCreateWorkflow={() => setWorkflowEditId('new')}
-								onEditWorkflow={(id) => setWorkflowEditId(id)}
-							/>
-						)}
-						{activeTab === 'settings' && <SpaceSettings space={space} />}
-					</>
+							<div class="grid w-full gap-3 sm:grid-cols-3 xl:w-[32rem]">
+								<StatPill label="Agents" value={String(agents.length)} />
+								<StatPill label="Workflows" value={String(workflows.length)} />
+								<StatPill label="Workspace" value={workspaceName} />
+							</div>
+						</div>
+
+						<div
+							class="mt-6 grid gap-3 lg:grid-cols-3"
+							data-testid="space-configure-tab-bar"
+						>
+							{CONFIGURE_TABS.map((tab) => (
+								<ConfigureTabButton
+									key={tab.id}
+									id={tab.id}
+									label={tab.label}
+									description={tab.description}
+									active={activeTab === tab.id}
+									onClick={() => setActiveTab(tab.id)}
+								/>
+							))}
+						</div>
+					</section>
 				)}
+
+				<div class="min-h-0 flex-1 overflow-hidden rounded-[28px] border border-dark-700 bg-dark-950/70">
+					{showWorkflowEditor ? (
+						<VisualWorkflowEditor
+							key={workflowEditId}
+							workflow={editingWorkflow}
+							onSave={() => setWorkflowEditId(null)}
+							onCancel={() => setWorkflowEditId(null)}
+						/>
+					) : (
+						<>
+							{activeTab === 'agents' && (
+								<div class="h-full overflow-y-auto p-6">
+									<SpaceAgentList />
+								</div>
+							)}
+							{activeTab === 'workflows' && (
+								<WorkflowList
+									spaceId={space.id}
+									spaceName={space.name}
+									workflows={workflows}
+									onCreateWorkflow={() => setWorkflowEditId('new')}
+									onEditWorkflow={(id) => setWorkflowEditId(id)}
+								/>
+							)}
+							{activeTab === 'settings' && <SpaceSettings space={space} />}
+						</>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/SpaceConfigurePage.tsx
+++ b/packages/web/src/components/space/SpaceConfigurePage.tsx
@@ -10,10 +10,11 @@ import { VisualWorkflowEditor } from './visual-editor/VisualWorkflowEditor';
 
 type ConfigureTab = 'agents' | 'workflows' | 'settings';
 
-const CONFIGURE_TABS: Array<{ id: ConfigureTab; label: string; count: (args: {
-	agentCount: number;
-	workflowCount: number;
-}) => number }> = [
+const CONFIGURE_TABS: Array<{
+	id: ConfigureTab;
+	label: string;
+	count: (args: { agentCount: number; workflowCount: number }) => number;
+}> = [
 	{ id: 'agents', label: 'Agents', count: ({ agentCount }) => agentCount },
 	{ id: 'workflows', label: 'Workflows', count: ({ workflowCount }) => workflowCount },
 	{ id: 'settings', label: 'Settings', count: () => 1 },

--- a/packages/web/src/components/space/SpaceConfigurePage.tsx
+++ b/packages/web/src/components/space/SpaceConfigurePage.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'preact/hooks';
+import type { Space, SpaceWorkflow } from '@neokai/shared';
+import { SpaceAgentList } from './SpaceAgentList';
+import { WorkflowList } from './WorkflowList';
+import { VisualWorkflowEditor } from './visual-editor/VisualWorkflowEditor';
+import { SpaceSettings } from './SpaceSettings';
+import { cn } from '../../lib/utils';
+
+type ConfigureTab = 'agents' | 'workflows' | 'settings';
+
+const CONFIGURE_TABS: { id: ConfigureTab; label: string }[] = [
+	{ id: 'agents', label: 'Agents' },
+	{ id: 'workflows', label: 'Workflows' },
+	{ id: 'settings', label: 'Settings' },
+];
+
+interface SpaceConfigurePageProps {
+	space: Space;
+	workflows: SpaceWorkflow[];
+}
+
+export function SpaceConfigurePage({ space, workflows }: SpaceConfigurePageProps) {
+	const [activeTab, setActiveTab] = useState<ConfigureTab>('agents');
+	/** null = list view; 'new' = create editor; <id> = edit editor */
+	const [workflowEditId, setWorkflowEditId] = useState<string | null>(null);
+
+	const editingWorkflow =
+		workflowEditId && workflowEditId !== 'new'
+			? workflows.find((workflow) => workflow.id === workflowEditId)
+			: undefined;
+
+	const showWorkflowEditor = activeTab === 'workflows' && workflowEditId !== null;
+
+	return (
+		<div class="flex h-full flex-col overflow-hidden">
+			{!showWorkflowEditor && (
+				<div
+					class="flex items-center gap-2 border-b border-dark-700 px-6 py-3"
+					data-testid="space-configure-tab-bar"
+				>
+					{CONFIGURE_TABS.map((tab) => (
+						<button
+							key={tab.id}
+							type="button"
+							onClick={() => setActiveTab(tab.id)}
+							class={cn(
+								'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+								activeTab === tab.id
+									? 'bg-dark-700 text-gray-100'
+									: 'text-gray-400 hover:bg-dark-800 hover:text-gray-200'
+							)}
+						>
+							{tab.label}
+						</button>
+					))}
+				</div>
+			)}
+
+			<div class="min-h-0 flex-1 overflow-hidden">
+				{showWorkflowEditor ? (
+					<VisualWorkflowEditor
+						key={workflowEditId}
+						workflow={editingWorkflow}
+						onSave={() => setWorkflowEditId(null)}
+						onCancel={() => setWorkflowEditId(null)}
+					/>
+				) : (
+					<>
+						{activeTab === 'agents' && (
+							<div class="h-full overflow-y-auto p-6">
+								<SpaceAgentList />
+							</div>
+						)}
+						{activeTab === 'workflows' && (
+							<WorkflowList
+								spaceId={space.id}
+								spaceName={space.name}
+								workflows={workflows}
+								onCreateWorkflow={() => setWorkflowEditId('new')}
+								onEditWorkflow={(id) => setWorkflowEditId(id)}
+							/>
+						)}
+						{activeTab === 'settings' && <SpaceSettings space={space} />}
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -1,12 +1,3 @@
-/**
- * SpaceDashboard
- *
- * Task-first overview for a Space.
- * Spaces are designed for parallel task orchestration, so this view focuses on
- * triage and navigation instead of high-level summary cards.
- */
-
-import type { ComponentType } from 'preact';
 import { useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { cn } from '../../lib/utils';
@@ -26,78 +17,6 @@ interface TaskGroupConfig {
 	description: string;
 	tasks: typeof spaceStore.tasks.value;
 	tone: 'default' | 'review' | 'done';
-}
-
-function truncatePath(path: string, maxLen = 64): string {
-	if (path.length <= maxLen) return path;
-	return '…' + path.slice(-(maxLen - 1));
-}
-
-function SparkIcon() {
-	return (
-		<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-			<path
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				stroke-width={2}
-				d="M12 3l1.9 5.8H20l-4.9 3.6 1.9 5.8-5-3.6-5 3.6 1.9-5.8L4 8.8h6.1L12 3z"
-			/>
-		</svg>
-	);
-}
-
-function ActionButton({
-	title,
-	description,
-	icon: Icon,
-	onClick,
-}: {
-	title: string;
-	description: string;
-	icon: ComponentType;
-	onClick?: () => void;
-}) {
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			class="w-full rounded-2xl border border-blue-500/40 bg-blue-500/10 px-4 py-4 text-left transition-all hover:bg-blue-500/15"
-		>
-			<div class="flex items-start gap-3">
-				<div class="mt-0.5 flex h-10 w-10 items-center justify-center rounded-xl bg-blue-500/15 text-blue-200">
-					<Icon />
-				</div>
-				<div class="min-w-0">
-					<p class="text-sm font-medium text-blue-50">{title}</p>
-					<p class="mt-1 text-xs leading-5 text-gray-400">{description}</p>
-				</div>
-			</div>
-		</button>
-	);
-}
-
-function SummaryChip({
-	label,
-	count,
-	tone = 'default',
-}: {
-	label: string;
-	count: number;
-	tone?: 'default' | 'review' | 'done';
-}) {
-	const toneClass =
-		tone === 'review'
-			? 'border-amber-500/30 bg-amber-500/10 text-amber-100'
-			: tone === 'done'
-				? 'border-green-500/30 bg-green-500/10 text-green-100'
-				: 'border-blue-500/30 bg-blue-500/10 text-blue-100';
-
-	return (
-		<div class={cn('rounded-xl border px-3 py-2', toneClass)}>
-			<p class="text-[11px] uppercase tracking-[0.18em] text-gray-500">{label}</p>
-			<p class="mt-1 text-xl font-semibold">{count}</p>
-		</div>
-	);
 }
 
 function OverviewTabButton({
@@ -331,13 +250,13 @@ function buildGroups(
 
 export function SpaceDashboard({
 	spaceId: _spaceId,
-	onOpenSpaceAgent,
+	onOpenSpaceAgent: _onOpenSpaceAgent,
 	onSelectTask,
 	compact = false,
 }: SpaceDashboardProps) {
 	const [activeTab, setActiveTab] = useState<OverviewTab>('active');
-	const space = spaceStore.space.value;
 	const loading = spaceStore.loading.value;
+	const space = spaceStore.space.value;
 	const tasks = [...spaceStore.tasks.value].sort((a, b) => b.updatedAt - a.updatedAt);
 
 	if (loading) {
@@ -369,78 +288,42 @@ export function SpaceDashboard({
 		activeTab,
 		activeTab === 'active' ? activeTasks : activeTab === 'review' ? reviewTasks : doneTasks
 	);
-	const description =
-		space.description ||
-		'Use this space to coordinate many tasks in parallel, keep review work visible, and let workflows scale the execution load.';
 
 	return (
 		<div class={cn('flex h-full min-h-0 flex-col overflow-y-auto', compact ? 'p-4' : 'p-6')}>
-			<div class="flex w-full flex-1 min-h-0 flex-col gap-6">
-				<section class="rounded-[28px] border border-dark-700 bg-dark-900/90 px-6 py-6">
-					<div class="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
-						<div class="min-w-0">
-							<p class="text-[11px] uppercase tracking-[0.22em] text-gray-600">Overview</p>
-							<h1 class="mt-3 text-3xl font-semibold tracking-tight text-gray-100">{space.name}</h1>
-							<p class="mt-3 max-w-3xl text-sm leading-6 text-gray-400">{description}</p>
-							{space.workspacePath && (
-								<p class="mt-3 font-mono text-[11px] text-gray-600" title={space.workspacePath}>
-									{truncatePath(space.workspacePath)}
-								</p>
-							)}
-						</div>
-						<div class="w-full xl:w-[22rem]">
-							<ActionButton
-								title="Ask Space Agent"
-								description="Use the shared agent thread to reshape scope, create follow-up work, and steer execution across many tasks at once."
-								icon={SparkIcon}
-								onClick={onOpenSpaceAgent}
-							/>
-						</div>
+			<div class="flex w-full flex-1 min-h-0 flex-col">
+				<section class="flex flex-1 min-h-[24rem] flex-col rounded-[28px] border border-dark-700 bg-dark-950/70">
+					<div class="flex items-center gap-6 border-b border-dark-700 px-6">
+						<OverviewTabButton
+							label="Active"
+							count={activeTasks.length}
+							active={activeTab === 'active'}
+							onClick={() => setActiveTab('active')}
+						/>
+						<OverviewTabButton
+							label="Review"
+							count={reviewTasks.length}
+							active={activeTab === 'review'}
+							onClick={() => setActiveTab('review')}
+							tone="review"
+						/>
+						<OverviewTabButton
+							label="Done"
+							count={doneTasks.length}
+							active={activeTab === 'done'}
+							onClick={() => setActiveTab('done')}
+							tone="done"
+						/>
 					</div>
-					<div class="mt-6 grid gap-3 md:grid-cols-3">
-						<SummaryChip label="Active" count={activeTasks.length} />
-						<SummaryChip label="Review" count={reviewTasks.length} tone="review" />
-						<SummaryChip label="Done" count={doneTasks.length} tone="done" />
-					</div>
-				</section>
 
-				{totalTasks === 0 ? (
-					<div class="flex flex-1 min-h-[24rem]">
-						<div class="h-full w-full">
+					<div class="flex-1 overflow-y-auto p-6">
+						{totalTasks === 0 ? (
 							<EmptyState
 								title="This space has no tasks yet."
-								copy="Create the first task or ask the space agent to break the work into parallelizable pieces."
+								copy="Create the first task to start the space."
 								fill
 							/>
-						</div>
-					</div>
-				) : (
-					<section class="flex flex-1 min-h-[24rem] flex-col rounded-[28px] border border-dark-700 bg-dark-950/70">
-						<div class="flex items-center gap-6 border-b border-dark-700 px-6">
-							<OverviewTabButton
-								label="Active"
-								count={activeTasks.length}
-								active={activeTab === 'active'}
-								onClick={() => setActiveTab('active')}
-							/>
-							<OverviewTabButton
-								label="Review"
-								count={reviewTasks.length}
-								active={activeTab === 'review'}
-								onClick={() => setActiveTab('review')}
-								tone="review"
-							/>
-							<OverviewTabButton
-								label="Done"
-								count={doneTasks.length}
-								active={activeTab === 'done'}
-								onClick={() => setActiveTab('done')}
-								tone="done"
-							/>
-						</div>
-
-						<div class="flex-1 overflow-y-auto p-6">
-							{groups.length === 0 ? (
+						) : groups.length === 0 ? (
 								<EmptyTabState tab={activeTab} />
 							) : (
 								<div class="grid gap-4 xl:grid-cols-2">
@@ -449,9 +332,8 @@ export function SpaceDashboard({
 									))}
 								</div>
 							)}
-						</div>
-					</section>
-				)}
+					</div>
+				</section>
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -1,15 +1,13 @@
 /**
  * SpaceDashboard
  *
- * Task-centric overview for a Space.
- * Prioritizes:
- * - What needs attention now
- * - What is actively moving
- * - What finished recently
- * - The next action a human should take
+ * Task-first overview for a Space.
+ * Spaces are designed for parallel task orchestration, so this view focuses on
+ * triage and navigation instead of high-level summary cards.
  */
 
-import type { ComponentChildren, ComponentType } from 'preact';
+import type { ComponentType } from 'preact';
+import { useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { cn } from '../../lib/utils';
 
@@ -20,9 +18,32 @@ interface SpaceDashboardProps {
 	compact?: boolean;
 }
 
+type OverviewTab = 'active' | 'review' | 'done';
+
+interface TaskGroupConfig {
+	id: string;
+	title: string;
+	description: string;
+	tasks: typeof spaceStore.tasks.value;
+	tone: 'default' | 'review' | 'done';
+}
+
 function truncatePath(path: string, maxLen = 64): string {
 	if (path.length <= maxLen) return path;
 	return '…' + path.slice(-(maxLen - 1));
+}
+
+function SparkIcon() {
+	return (
+		<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M12 3l1.9 5.8H20l-4.9 3.6 1.9 5.8-5-3.6-5 3.6 1.9-5.8L4 8.8h6.1L12 3z"
+			/>
+		</svg>
+	);
 }
 
 function ActionButton({
@@ -30,82 +51,116 @@ function ActionButton({
 	description,
 	icon: Icon,
 	onClick,
-	tone = 'secondary',
 }: {
 	title: string;
 	description: string;
 	icon: ComponentType;
 	onClick?: () => void;
-	tone?: 'primary' | 'secondary';
 }) {
 	return (
 		<button
 			type="button"
 			onClick={onClick}
-			class={cn(
-				'w-full rounded-2xl border px-4 py-4 text-left transition-all',
-				tone === 'primary'
-					? 'border-blue-500/40 bg-blue-500/10 hover:bg-blue-500/15'
-					: 'border-dark-700 bg-dark-900/70 hover:border-dark-600 hover:bg-dark-900'
-			)}
+			class="w-full rounded-2xl border border-blue-500/40 bg-blue-500/10 px-4 py-4 text-left transition-all hover:bg-blue-500/15"
 		>
 			<div class="flex items-start gap-3">
-				<div
-					class={cn(
-						'mt-0.5 flex h-10 w-10 items-center justify-center rounded-xl',
-						tone === 'primary' ? 'bg-blue-500/15 text-blue-200' : 'bg-dark-800 text-gray-300'
-					)}
-				>
+				<div class="mt-0.5 flex h-10 w-10 items-center justify-center rounded-xl bg-blue-500/15 text-blue-200">
 					<Icon />
 				</div>
 				<div class="min-w-0">
-					<p
-						class={cn('text-sm font-medium', tone === 'primary' ? 'text-blue-50' : 'text-gray-100')}
-					>
-						{title}
-					</p>
-					<p class="mt-1 text-xs leading-5 text-gray-500">{description}</p>
+					<p class="text-sm font-medium text-blue-50">{title}</p>
+					<p class="mt-1 text-xs leading-5 text-gray-400">{description}</p>
 				</div>
 			</div>
 		</button>
 	);
 }
 
-function StatCard({
+function SummaryChip({
 	label,
-	value,
-	helper,
-	accent,
+	count,
+	tone = 'default',
 }: {
 	label: string;
-	value: string;
-	helper: string;
-	accent: string;
+	count: number;
+	tone?: 'default' | 'review' | 'done';
 }) {
+	const toneClass =
+		tone === 'review'
+			? 'border-amber-500/30 bg-amber-500/10 text-amber-100'
+			: tone === 'done'
+				? 'border-green-500/30 bg-green-500/10 text-green-100'
+				: 'border-blue-500/30 bg-blue-500/10 text-blue-100';
+
 	return (
-		<div class="rounded-2xl border border-dark-700 bg-dark-900/70 px-4 py-4">
-			<div class="flex items-center justify-between gap-3">
-				<p class="text-[11px] uppercase tracking-[0.18em] text-gray-500">{label}</p>
-				<span class={cn('h-2.5 w-2.5 rounded-full flex-shrink-0', accent)} />
-			</div>
-			<p class="mt-2 text-2xl font-semibold text-gray-100">{value}</p>
-			<p class="mt-1 text-xs text-gray-500">{helper}</p>
+		<div class={cn('rounded-xl border px-3 py-2', toneClass)}>
+			<p class="text-[11px] uppercase tracking-[0.18em] text-gray-500">{label}</p>
+			<p class="mt-1 text-xl font-semibold">{count}</p>
 		</div>
 	);
 }
 
-function QueueItem({
+function OverviewTabButton({
+	label,
+	count,
+	active,
+	onClick,
+	tone = 'default',
+}: {
+	label: string;
+	count: number;
+	active: boolean;
+	onClick: () => void;
+	tone?: 'default' | 'review' | 'done';
+}) {
+	const activeClass =
+		tone === 'review'
+			? 'border-amber-400 text-amber-200'
+			: tone === 'done'
+				? 'border-green-400 text-green-200'
+				: 'border-blue-400 text-gray-100';
+
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			class={cn(
+				'flex items-center gap-2 border-b-2 px-1 py-3 text-sm font-medium transition-colors',
+				active ? activeClass : 'border-transparent text-gray-400 hover:text-gray-200'
+			)}
+		>
+			<span>{label}</span>
+			<span class="rounded-full bg-dark-800 px-2 py-0.5 text-xs text-gray-300">{count}</span>
+		</button>
+	);
+}
+
+function TaskRow({
 	task,
 	onClick,
 }: {
 	task: {
 		id: string;
+		taskNumber: number;
 		title: string;
 		status: string;
+		priority: string;
 		workflowRunId?: string | null;
+		updatedAt: number;
 	};
 	onClick?: (taskId: string) => void;
 }) {
+	const statusDotClass =
+		task.status === 'in_progress'
+			? 'bg-blue-400'
+			: task.status === 'blocked'
+				? 'bg-amber-400'
+				: task.status === 'done'
+					? 'bg-green-400'
+					: task.status === 'cancelled' || task.status === 'archived'
+						? 'bg-gray-600'
+						: 'bg-gray-500';
+
 	return (
 		<button
 			type="button"
@@ -118,53 +173,52 @@ function QueueItem({
 		>
 			<div class="flex items-start gap-3">
 				<div class="pt-1">
-					<span
-						class={cn(
-							'block h-2.5 w-2.5 rounded-full',
-							task.status === 'in_progress'
-								? 'bg-blue-400'
-								: task.status === 'blocked'
-									? 'bg-amber-400'
-									: task.status === 'done'
-										? 'bg-green-400'
-										: 'bg-gray-500'
-						)}
-					/>
+					<span class={cn('block h-2.5 w-2.5 rounded-full', statusDotClass)} />
 				</div>
 				<div class="min-w-0 flex-1">
 					<div class="flex items-center gap-2">
 						<p class="min-w-0 flex-1 truncate text-sm font-medium text-gray-100">{task.title}</p>
 						<span class="text-[11px] uppercase tracking-[0.14em] text-gray-500">
-							{task.status.replace('_', ' ')}
+							#{task.taskNumber}
 						</span>
 					</div>
-					<p class="mt-1 text-xs text-gray-500">
-						{task.workflowRunId ? 'Part of a workflow-backed task flow.' : 'Standalone task.'}
-					</p>
+					<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+						<span class="uppercase tracking-[0.14em]">{task.status.replace('_', ' ')}</span>
+						<span>·</span>
+						<span class="capitalize">{task.priority} priority</span>
+						<span>·</span>
+						<span>{task.workflowRunId ? 'Workflow task' : 'Standalone task'}</span>
+					</div>
 				</div>
 			</div>
 		</button>
 	);
 }
 
-function Section({
-	title,
-	eyebrow,
-	children,
-}: {
-	title: string;
-	eyebrow?: string;
-	children: ComponentChildren;
-}) {
+function TaskGroup({ group, onSelectTask }: { group: TaskGroupConfig; onSelectTask?: (taskId: string) => void }) {
+	const headingToneClass =
+		group.tone === 'review'
+			? 'text-amber-200'
+			: group.tone === 'done'
+				? 'text-green-200'
+				: 'text-gray-100';
+
 	return (
 		<section class="rounded-2xl border border-dark-700 bg-dark-950/70 p-4">
-			<div class="mb-3 flex items-center justify-between gap-3">
-				<div>
-					<p class="text-[11px] uppercase tracking-[0.18em] text-gray-600">{eyebrow ?? title}</p>
-					<h2 class="mt-1 text-sm font-medium text-gray-100">{title}</h2>
+			<div class="mb-3">
+				<div class="flex items-center justify-between gap-3">
+					<h2 class={cn('text-sm font-medium', headingToneClass)}>{group.title}</h2>
+					<span class="rounded-full bg-dark-800 px-2 py-0.5 text-xs text-gray-400">
+						{group.tasks.length}
+					</span>
 				</div>
+				<p class="mt-1 text-xs text-gray-500">{group.description}</p>
 			</div>
-			{children}
+			<div class="space-y-2">
+				{group.tasks.map((task) => (
+					<TaskRow key={task.id} task={task} onClick={onSelectTask} />
+				))}
+			</div>
 		</section>
 	);
 }
@@ -193,17 +247,86 @@ function EmptyState({
 	);
 }
 
-function SparkIcon() {
-	return (
-		<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-			<path
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				stroke-width={2}
-				d="M12 3l1.9 5.8H20l-4.9 3.6 1.9 5.8-5-3.6-5 3.6 1.9-5.8L4 8.8h6.1L12 3z"
-			/>
-		</svg>
-	);
+function EmptyTabState({ tab }: { tab: OverviewTab }) {
+	const copy =
+		tab === 'review'
+			? {
+					title: 'No tasks need attention right now.',
+					description: 'Blocked tasks and human follow-ups will collect here first.',
+				}
+			: tab === 'done'
+				? {
+						title: 'No finished tasks yet.',
+						description: 'Completed, cancelled, and archived tasks will build the execution trail here.',
+					}
+				: {
+						title: 'No active tasks yet.',
+						description: 'Queued and in-progress work will appear here once the space starts moving.',
+					};
+
+	return <EmptyState title={copy.title} copy={copy.description} fill />;
+}
+
+function buildGroups(
+	tab: OverviewTab,
+	tasks: typeof spaceStore.tasks.value
+): TaskGroupConfig[] {
+	if (tab === 'active') {
+		const inProgress = tasks.filter((task) => task.status === 'in_progress');
+		const queued = tasks.filter((task) => task.status === 'open');
+		return [
+			{
+				id: 'in-progress',
+				title: 'In Progress',
+				description: 'Tasks currently being worked in parallel.',
+				tasks: inProgress,
+				tone: 'default' as const,
+			},
+			{
+				id: 'queued',
+				title: 'Queued',
+				description: 'Ready tasks waiting for an execution slot.',
+				tasks: queued,
+				tone: 'default' as const,
+			},
+		].filter((group) => group.tasks.length > 0);
+	}
+
+	if (tab === 'review') {
+		return [
+			{
+				id: 'blocked',
+				title: 'Needs Review',
+				description: 'Tasks blocked on human attention, approval, or intervention.',
+				tasks: tasks.filter((task) => task.status === 'blocked'),
+				tone: 'review' as const,
+			},
+		].filter((group) => group.tasks.length > 0);
+	}
+
+	return [
+		{
+			id: 'done',
+			title: 'Completed',
+			description: 'Tasks that finished successfully.',
+			tasks: tasks.filter((task) => task.status === 'done'),
+			tone: 'done' as const,
+		},
+		{
+			id: 'cancelled',
+			title: 'Cancelled',
+			description: 'Tasks intentionally stopped before completion.',
+			tasks: tasks.filter((task) => task.status === 'cancelled'),
+			tone: 'done' as const,
+		},
+		{
+			id: 'archived',
+			title: 'Archived',
+			description: 'Tasks hidden from the active execution flow.',
+			tasks: tasks.filter((task) => task.status === 'archived'),
+			tone: 'done' as const,
+		},
+	].filter((group) => group.tasks.length > 0);
 }
 
 export function SpaceDashboard({
@@ -212,9 +335,10 @@ export function SpaceDashboard({
 	onSelectTask,
 	compact = false,
 }: SpaceDashboardProps) {
+	const [activeTab, setActiveTab] = useState<OverviewTab>('active');
 	const space = spaceStore.space.value;
 	const loading = spaceStore.loading.value;
-	const tasks = spaceStore.tasks.value;
+	const tasks = [...spaceStore.tasks.value].sort((a, b) => b.updatedAt - a.updatedAt);
 
 	if (loading) {
 		return (
@@ -235,21 +359,19 @@ export function SpaceDashboard({
 		);
 	}
 
-	const activeTasks = tasks.filter(
-		(task) => task.status === 'open' || task.status === 'in_progress'
-	);
+	const activeTasks = tasks.filter((task) => task.status === 'open' || task.status === 'in_progress');
 	const reviewTasks = tasks.filter((task) => task.status === 'blocked');
-	const completedTasks = tasks.filter(
+	const doneTasks = tasks.filter(
 		(task) => task.status === 'done' || task.status === 'cancelled' || task.status === 'archived'
 	);
-	const recentCompleted = [...completedTasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 6);
-	const activeQueue = [...activeTasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 6);
-	const attentionQueue = [...reviewTasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 6);
 	const totalTasks = tasks.length;
-	const empty = totalTasks === 0;
+	const groups = buildGroups(
+		activeTab,
+		activeTab === 'active' ? activeTasks : activeTab === 'review' ? reviewTasks : doneTasks
+	);
 	const description =
 		space.description ||
-		'Organize execution through tasks, use workflows when they help, and keep the space agent nearby for coordination.';
+		'Use this space to coordinate many tasks in parallel, keep review work visible, and let workflows scale the execution load.';
 
 	return (
 		<div class={cn('flex h-full min-h-0 flex-col overflow-y-auto', compact ? 'p-4' : 'p-6')}>
@@ -269,105 +391,66 @@ export function SpaceDashboard({
 						<div class="w-full xl:w-[22rem]">
 							<ActionButton
 								title="Ask Space Agent"
-								description="Use the shared agent thread to shape the task, refine the scope, and let the system choose the right workflow behind the scenes."
+								description="Use the shared agent thread to reshape scope, create follow-up work, and steer execution across many tasks at once."
 								icon={SparkIcon}
 								onClick={onOpenSpaceAgent}
-								tone="primary"
 							/>
 						</div>
 					</div>
+					<div class="mt-6 grid gap-3 md:grid-cols-3">
+						<SummaryChip label="Active" count={activeTasks.length} />
+						<SummaryChip label="Review" count={reviewTasks.length} tone="review" />
+						<SummaryChip label="Done" count={doneTasks.length} tone="done" />
+					</div>
 				</section>
 
-				<div class="grid gap-4 md:grid-cols-3">
-					<StatCard
-						label="Active"
-						value={String(activeTasks.length)}
-						helper={
-							activeTasks.length === 0 ? 'Nothing is running right now.' : 'Tasks currently moving.'
-						}
-						accent="bg-blue-400"
-					/>
-					<StatCard
-						label="Needs Attention"
-						value={String(reviewTasks.length)}
-						helper={
-							reviewTasks.length === 0
-								? 'Nothing is waiting on you.'
-								: 'Review or unblock these tasks next.'
-						}
-						accent="bg-amber-400"
-					/>
-					<StatCard
-						label="Completed"
-						value={String(completedTasks.length)}
-						helper={
-							completedTasks.length === 0
-								? 'No finished work yet.'
-								: 'Completed work in this space.'
-						}
-						accent="bg-green-400"
-					/>
-				</div>
-
-				{empty ? (
-					<div class="flex flex-1 min-h-[22rem]">
-						<div class="flex h-full flex-1">
-							<div class="h-full w-full">
-								<EmptyState
-									title="This space has no tasks yet."
-									copy="Create the first task or ask the space agent to help you shape the work before reaching for a workflow."
-									fill
-								/>
-							</div>
+				{totalTasks === 0 ? (
+					<div class="flex flex-1 min-h-[24rem]">
+						<div class="h-full w-full">
+							<EmptyState
+								title="This space has no tasks yet."
+								copy="Create the first task or ask the space agent to break the work into parallelizable pieces."
+								fill
+							/>
 						</div>
 					</div>
 				) : (
-					<div class="grid flex-1 min-h-[24rem] gap-4 xl:grid-cols-[1.1fr_1.1fr_0.9fr]">
-						<Section title="Needs Attention" eyebrow="Attention Queue">
-							{attentionQueue.length === 0 ? (
-								<EmptyState
-									title="Nothing is blocked on you."
-									copy="Reviews, approvals, and escalations will collect here."
-								/>
-							) : (
-								<div class="space-y-2">
-									{attentionQueue.map((task) => (
-										<QueueItem key={task.id} task={task} onClick={onSelectTask} />
-									))}
-								</div>
-							)}
-						</Section>
+					<section class="flex flex-1 min-h-[24rem] flex-col rounded-[28px] border border-dark-700 bg-dark-950/70">
+						<div class="flex items-center gap-6 border-b border-dark-700 px-6">
+							<OverviewTabButton
+								label="Active"
+								count={activeTasks.length}
+								active={activeTab === 'active'}
+								onClick={() => setActiveTab('active')}
+							/>
+							<OverviewTabButton
+								label="Review"
+								count={reviewTasks.length}
+								active={activeTab === 'review'}
+								onClick={() => setActiveTab('review')}
+								tone="review"
+							/>
+							<OverviewTabButton
+								label="Done"
+								count={doneTasks.length}
+								active={activeTab === 'done'}
+								onClick={() => setActiveTab('done')}
+								tone="done"
+							/>
+						</div>
 
-						<Section title="In Progress" eyebrow="Active Queue">
-							{activeQueue.length === 0 ? (
-								<EmptyState
-									title="No tasks are moving right now."
-									copy="New tasks and workflow-backed work will appear here while active."
-								/>
+						<div class="flex-1 overflow-y-auto p-6">
+							{groups.length === 0 ? (
+								<EmptyTabState tab={activeTab} />
 							) : (
-								<div class="space-y-2">
-									{activeQueue.map((task) => (
-										<QueueItem key={task.id} task={task} onClick={onSelectTask} />
+								<div class="grid gap-4 xl:grid-cols-2">
+									{groups.map((group) => (
+										<TaskGroup key={group.id} group={group} onSelectTask={onSelectTask} />
 									))}
 								</div>
 							)}
-						</Section>
-
-						<Section title="Recently Finished" eyebrow="Recent Activity">
-							{recentCompleted.length === 0 ? (
-								<EmptyState
-									title="Nothing finished yet."
-									copy="Completed tasks will form the execution trail for this space."
-								/>
-							) : (
-								<div class="space-y-2">
-									{recentCompleted.map((task) => (
-										<QueueItem key={task.id} task={task} onClick={onSelectTask} />
-									))}
-								</div>
-							)}
-						</Section>
-					</div>
+						</div>
+					</section>
 				)}
 			</div>
 		</div>

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -114,7 +114,13 @@ function TaskRow({
 	);
 }
 
-function TaskGroup({ group, onSelectTask }: { group: TaskGroupConfig; onSelectTask?: (taskId: string) => void }) {
+function TaskGroup({
+	group,
+	onSelectTask,
+}: {
+	group: TaskGroupConfig;
+	onSelectTask?: (taskId: string) => void;
+}) {
 	const headingToneClass =
 		group.tone === 'review'
 			? 'text-amber-200'
@@ -176,20 +182,19 @@ function EmptyTabState({ tab }: { tab: OverviewTab }) {
 			: tab === 'done'
 				? {
 						title: 'No finished tasks yet.',
-						description: 'Completed, cancelled, and archived tasks will build the execution trail here.',
+						description:
+							'Completed, cancelled, and archived tasks will build the execution trail here.',
 					}
 				: {
 						title: 'No active tasks yet.',
-						description: 'Queued and in-progress work will appear here once the space starts moving.',
+						description:
+							'Queued and in-progress work will appear here once the space starts moving.',
 					};
 
 	return <EmptyState title={copy.title} copy={copy.description} fill />;
 }
 
-function buildGroups(
-	tab: OverviewTab,
-	tasks: typeof spaceStore.tasks.value
-): TaskGroupConfig[] {
+function buildGroups(tab: OverviewTab, tasks: typeof spaceStore.tasks.value): TaskGroupConfig[] {
 	if (tab === 'active') {
 		const inProgress = tasks.filter((task) => task.status === 'in_progress');
 		const queued = tasks.filter((task) => task.status === 'open');
@@ -278,7 +283,9 @@ export function SpaceDashboard({
 		);
 	}
 
-	const activeTasks = tasks.filter((task) => task.status === 'open' || task.status === 'in_progress');
+	const activeTasks = tasks.filter(
+		(task) => task.status === 'open' || task.status === 'in_progress'
+	);
 	const reviewTasks = tasks.filter((task) => task.status === 'blocked');
 	const doneTasks = tasks.filter(
 		(task) => task.status === 'done' || task.status === 'cancelled' || task.status === 'archived'
@@ -324,14 +331,14 @@ export function SpaceDashboard({
 								fill
 							/>
 						) : groups.length === 0 ? (
-								<EmptyTabState tab={activeTab} />
-							) : (
-								<div class="grid gap-4 xl:grid-cols-2">
-									{groups.map((group) => (
-										<TaskGroup key={group.id} group={group} onSelectTask={onSelectTask} />
-									))}
-								</div>
-							)}
+							<EmptyTabState tab={activeTab} />
+						) : (
+							<div class="grid gap-4 xl:grid-cols-2">
+								{groups.map((group) => (
+									<TaskGroup key={group.id} group={group} onSelectTask={onSelectTask} />
+								))}
+							</div>
+						)}
 					</div>
 				</section>
 			</div>

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -1,29 +1,16 @@
 // @ts-nocheck
 /**
- * Unit tests for SpaceDashboard
- *
- * Tests:
- * - Loading state renders spinner
- * - No space renders "Space not found"
- * - Space name and workspace path rendered
- * - Description shown when present
- * - Primary dashboard action renders
- * - onOpenSpaceAgent callback fires
- * - Overview stats render for active/review/completed tasks
- * - Attention, in-progress, and recent sections render task rows
- * - Empty state renders when there are no tasks
+ * Unit tests for SpaceDashboard.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
-import { signal, computed } from '@preact/signals';
+import { signal } from '@preact/signals';
 import type { Space, SpaceTask } from '@neokai/shared';
 
-// Mock signals
 let mockSpace: ReturnType<typeof signal<Space | null>>;
 let mockLoading: ReturnType<typeof signal<boolean>>;
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
-let mockActiveRuns: ReturnType<typeof computed<unknown[]>>;
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
@@ -31,16 +18,13 @@ vi.mock('../../../lib/space-store', () => ({
 			space: mockSpace,
 			loading: mockLoading,
 			tasks: mockTasks,
-			activeRuns: mockActiveRuns,
 		};
 	},
 }));
 
-// Initialize signals before component import
 mockSpace = signal<Space | null>(null);
 mockLoading = signal(false);
 mockTasks = signal<SpaceTask[]>([]);
-mockActiveRuns = computed(() => []);
 
 import { SpaceDashboard } from '../SpaceDashboard';
 
@@ -60,17 +44,28 @@ function makeSpace(overrides: Partial<Space> = {}): Space {
 	};
 }
 
-function makeTask(id: string, status: SpaceTask['status'] = 'open'): SpaceTask {
+function makeTask(
+	id: string,
+	status: SpaceTask['status'] = 'open',
+	overrides: Partial<SpaceTask> = {}
+): SpaceTask {
 	return {
 		id,
 		spaceId: 'space-1',
+		taskNumber: Number(id.replace(/\D/g, '')) || 1,
 		title: `Task ${id}`,
 		description: '',
 		status,
 		priority: 'normal',
+		labels: [],
 		dependsOn: [],
+		result: null,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
+		startedAt: null,
+		completedAt: null,
+		archivedAt: null,
+		...overrides,
 	};
 }
 
@@ -97,98 +92,97 @@ describe('SpaceDashboard', () => {
 		expect(getByText('Space not found')).toBeTruthy();
 	});
 
-	it('renders space name', () => {
-		mockSpace.value = makeSpace({ name: 'Awesome Project' });
+	it('renders the space name, description, and workspace path', () => {
+		mockSpace.value = makeSpace({
+			name: 'UI Review Space',
+			description: 'Space created for UI review.',
+			workspacePath: '/tmp/workspace',
+		});
 		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		expect(getByText('Awesome Project')).toBeTruthy();
+		expect(getByText('UI Review Space')).toBeTruthy();
+		expect(getByText('Space created for UI review.')).toBeTruthy();
+		expect(getByText('/tmp/workspace')).toBeTruthy();
 	});
 
-	it('renders workspace path', () => {
-		mockSpace.value = makeSpace({ workspacePath: '/home/user/projects/test' });
-		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		expect(getByText('/home/user/projects/test')).toBeTruthy();
-	});
-
-	it('renders description when provided', () => {
-		mockSpace.value = makeSpace({ description: 'A cool project description' });
-		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		expect(getByText('A cool project description')).toBeTruthy();
-	});
-
-	it('renders the primary dashboard action', () => {
+	it('renders the primary overview action', () => {
 		mockSpace.value = makeSpace();
-		const { getByText, queryByText } = render(<SpaceDashboard spaceId="space-1" />);
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
 		expect(getByText('Ask Space Agent')).toBeTruthy();
-		expect(queryByText('Create Task')).toBeNull();
-		expect(queryByText('Run Workflow')).toBeNull();
 	});
 
-	it('calls onOpenSpaceAgent when "Ask Space Agent" is clicked', () => {
+	it('calls onOpenSpaceAgent when Ask Space Agent is clicked', () => {
 		mockSpace.value = makeSpace();
 		const onOpenSpaceAgent = vi.fn();
 		const { getByText } = render(
 			<SpaceDashboard spaceId="space-1" onOpenSpaceAgent={onOpenSpaceAgent} />
 		);
 		fireEvent.click(getByText('Ask Space Agent').closest('button')!);
-		expect(onOpenSpaceAgent).toHaveBeenCalled();
+		expect(onOpenSpaceAgent).toHaveBeenCalledOnce();
 	});
 
-	it('shows active, attention, and completed stats', () => {
+	it('renders summary chips and grouped active tasks', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [
-			makeTask('t1', 'in_progress'),
-			makeTask('t2', 'blocked'),
-			makeTask('t3', 'done'),
+			makeTask('t1', 'open'),
+			makeTask('t2', 'in_progress'),
+			makeTask('t3', 'blocked'),
+			makeTask('t4', 'done'),
 		];
-		const { getByText, getAllByText } = render(<SpaceDashboard spaceId="space-1" />);
-		expect(getAllByText('Active').length).toBeGreaterThanOrEqual(1);
-		expect(getAllByText('Needs Attention').length).toBeGreaterThanOrEqual(1);
-		expect(getAllByText('Completed').length).toBeGreaterThanOrEqual(1);
-		expect(getAllByText('1').length).toBeGreaterThanOrEqual(3);
+
+		const { getAllByText, getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getAllByText('Active').length).toBeGreaterThanOrEqual(2);
+		expect(getAllByText('Review').length).toBeGreaterThanOrEqual(2);
+		expect(getAllByText('Done').length).toBeGreaterThanOrEqual(2);
+		expect(getByText('In Progress')).toBeTruthy();
+		expect(getByText('Queued')).toBeTruthy();
+		expect(getByText('Task t2')).toBeTruthy();
+		expect(getByText('Task t1')).toBeTruthy();
 	});
 
-	it('shows attention, in-progress, and recent sections for tasks', () => {
+	it('switches to the Review tab and shows blocked tasks', () => {
 		mockSpace.value = makeSpace();
-		mockTasks.value = [
-			makeTask('attention', 'blocked'),
-			makeTask('active', 'in_progress'),
-			makeTask('done', 'done'),
-		];
-		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		expect(getByText('Attention Queue')).toBeTruthy();
-		expect(getByText('Active Queue')).toBeTruthy();
-		expect(getByText('Recent Activity')).toBeTruthy();
-		expect(getByText('Task attention')).toBeTruthy();
-		expect(getByText('Task active')).toBeTruthy();
-		expect(getByText('Task done')).toBeTruthy();
+		mockTasks.value = [makeTask('t1', 'blocked'), makeTask('t2', 'open')];
+
+		const { getAllByText, getByText, queryByText } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getAllByText('Review')[1].closest('button')!);
+		expect(getByText('Needs Review')).toBeTruthy();
+		expect(getByText('Task t1')).toBeTruthy();
+		expect(queryByText('Task t2')).toBeNull();
 	});
 
-	it('shows empty-state guidance when there are no tasks', () => {
+	it('switches to the Done tab and shows terminal tasks', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [makeTask('t1', 'done'), makeTask('t2', 'cancelled')];
+
+		const { getAllByText, getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getAllByText('Done')[1].closest('button')!);
+		expect(getByText('Completed')).toBeTruthy();
+		expect(getByText('Cancelled')).toBeTruthy();
+		expect(getByText('Task t1')).toBeTruthy();
+		expect(getByText('Task t2')).toBeTruthy();
+	});
+
+	it('shows the empty-state guidance when there are no tasks', () => {
 		mockSpace.value = makeSpace();
 		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
 		expect(getByText('This space has no tasks yet.')).toBeTruthy();
-		expect(
-			getByText(
-				'Create the first task or ask the space agent to help you shape the work before reaching for a workflow.'
-			)
-		).toBeTruthy();
 	});
 
-	it('truncates long workspace paths', () => {
-		const longPath = '/very/long/path/to/some/deeply/nested/project/directory/my-project';
-		mockSpace.value = makeSpace({ workspacePath: longPath });
-		const { container } = render(<SpaceDashboard spaceId="space-1" />);
-		const pathEl = container.querySelector('.font-mono');
-		// Path should be truncated (starts with ellipsis)
-		expect(pathEl?.textContent?.startsWith('…')).toBe(true);
+	it('shows the empty state for a tab with no tasks', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [makeTask('t1', 'open')];
+		const { getAllByText, getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getAllByText('Review')[1].closest('button')!);
+		expect(getByText('No tasks need attention right now.')).toBeTruthy();
 	});
 
-	it('calls onSelectTask when a recent task row is clicked', () => {
+	it('calls onSelectTask when a task row is clicked', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [makeTask('t1', 'done')];
 		const onSelectTask = vi.fn();
-		const { getByText } = render(<SpaceDashboard spaceId="space-1" onSelectTask={onSelectTask} />);
-		fireEvent.click(getByText('Task t1').closest('button')!);
+		const { getAllByText } = render(<SpaceDashboard spaceId="space-1" onSelectTask={onSelectTask} />);
+		fireEvent.click(getAllByText('Done')[1].closest('button')!);
+		fireEvent.click(getAllByText('Task t1')[0].closest('button')!);
 		expect(onSelectTask).toHaveBeenCalledWith('t1');
 	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -92,35 +92,23 @@ describe('SpaceDashboard', () => {
 		expect(getByText('Space not found')).toBeTruthy();
 	});
 
-	it('renders the space name, description, and workspace path', () => {
+	it('renders the task tabs without the removed overview hero', () => {
 		mockSpace.value = makeSpace({
 			name: 'UI Review Space',
 			description: 'Space created for UI review.',
 			workspacePath: '/tmp/workspace',
 		});
-		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		expect(getByText('UI Review Space')).toBeTruthy();
-		expect(getByText('Space created for UI review.')).toBeTruthy();
-		expect(getByText('/tmp/workspace')).toBeTruthy();
+		const { getByText, queryByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('Active')).toBeTruthy();
+		expect(getByText('Review')).toBeTruthy();
+		expect(getByText('Done')).toBeTruthy();
+		expect(queryByText('UI Review Space')).toBeNull();
+		expect(queryByText('Space created for UI review.')).toBeNull();
+		expect(queryByText('/tmp/workspace')).toBeNull();
+		expect(queryByText('Ask Space Agent')).toBeNull();
 	});
 
-	it('renders the primary overview action', () => {
-		mockSpace.value = makeSpace();
-		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		expect(getByText('Ask Space Agent')).toBeTruthy();
-	});
-
-	it('calls onOpenSpaceAgent when Ask Space Agent is clicked', () => {
-		mockSpace.value = makeSpace();
-		const onOpenSpaceAgent = vi.fn();
-		const { getByText } = render(
-			<SpaceDashboard spaceId="space-1" onOpenSpaceAgent={onOpenSpaceAgent} />
-		);
-		fireEvent.click(getByText('Ask Space Agent').closest('button')!);
-		expect(onOpenSpaceAgent).toHaveBeenCalledOnce();
-	});
-
-	it('renders summary chips and grouped active tasks', () => {
+	it('renders the task tabs and grouped active tasks', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [
 			makeTask('t1', 'open'),
@@ -129,10 +117,10 @@ describe('SpaceDashboard', () => {
 			makeTask('t4', 'done'),
 		];
 
-		const { getAllByText, getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		expect(getAllByText('Active').length).toBeGreaterThanOrEqual(2);
-		expect(getAllByText('Review').length).toBeGreaterThanOrEqual(2);
-		expect(getAllByText('Done').length).toBeGreaterThanOrEqual(2);
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('Active')).toBeTruthy();
+		expect(getByText('Review')).toBeTruthy();
+		expect(getByText('Done')).toBeTruthy();
 		expect(getByText('In Progress')).toBeTruthy();
 		expect(getByText('Queued')).toBeTruthy();
 		expect(getByText('Task t2')).toBeTruthy();
@@ -143,8 +131,8 @@ describe('SpaceDashboard', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [makeTask('t1', 'blocked'), makeTask('t2', 'open')];
 
-		const { getAllByText, getByText, queryByText } = render(<SpaceDashboard spaceId="space-1" />);
-		fireEvent.click(getAllByText('Review')[1].closest('button')!);
+		const { getByText, queryByText } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getByText('Review').closest('button')!);
 		expect(getByText('Needs Review')).toBeTruthy();
 		expect(getByText('Task t1')).toBeTruthy();
 		expect(queryByText('Task t2')).toBeNull();
@@ -154,8 +142,8 @@ describe('SpaceDashboard', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [makeTask('t1', 'done'), makeTask('t2', 'cancelled')];
 
-		const { getAllByText, getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		fireEvent.click(getAllByText('Done')[1].closest('button')!);
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getByText('Done').closest('button')!);
 		expect(getByText('Completed')).toBeTruthy();
 		expect(getByText('Cancelled')).toBeTruthy();
 		expect(getByText('Task t1')).toBeTruthy();
@@ -166,13 +154,14 @@ describe('SpaceDashboard', () => {
 		mockSpace.value = makeSpace();
 		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
 		expect(getByText('This space has no tasks yet.')).toBeTruthy();
+		expect(getByText('Create the first task to start the space.')).toBeTruthy();
 	});
 
 	it('shows the empty state for a tab with no tasks', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [makeTask('t1', 'open')];
-		const { getAllByText, getByText } = render(<SpaceDashboard spaceId="space-1" />);
-		fireEvent.click(getAllByText('Review')[1].closest('button')!);
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getByText('Review').closest('button')!);
 		expect(getByText('No tasks need attention right now.')).toBeTruthy();
 	});
 
@@ -180,9 +169,9 @@ describe('SpaceDashboard', () => {
 		mockSpace.value = makeSpace();
 		mockTasks.value = [makeTask('t1', 'done')];
 		const onSelectTask = vi.fn();
-		const { getAllByText } = render(<SpaceDashboard spaceId="space-1" onSelectTask={onSelectTask} />);
-		fireEvent.click(getAllByText('Done')[1].closest('button')!);
-		fireEvent.click(getAllByText('Task t1')[0].closest('button')!);
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" onSelectTask={onSelectTask} />);
+		fireEvent.click(getByText('Done').closest('button')!);
+		fireEvent.click(getByText('Task t1').closest('button')!);
 		expect(onSelectTask).toHaveBeenCalledWith('t1');
 	});
 });

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -4,6 +4,7 @@ import {
 	contextPanelOpenSignal,
 	currentRoomIdSignal,
 	currentSpaceIdSignal,
+	currentSpaceViewModeSignal,
 	settingsSectionSignal,
 	createRoomModalSignal,
 	type NavSection,
@@ -20,6 +21,7 @@ import {
 	navigateToRooms,
 	navigateToInbox,
 	navigateToSpaces,
+	navigateToSpaceConfigure,
 } from '../lib/router.ts';
 import { roomStore } from '../lib/room-store.ts';
 import { borderColors } from '../lib/design-tokens.ts';
@@ -187,6 +189,7 @@ export function ContextPanel() {
 	const activeSettingsSection = settingsSectionSignal.value;
 	const currentRoomId = currentRoomIdSignal.value;
 	const currentSpaceId = currentSpaceIdSignal.value;
+	const currentSpaceViewMode = currentSpaceViewModeSignal.value;
 
 	// Inbox takes full content width — no sidebar needed
 	if (navSection === 'inbox') return null;
@@ -410,6 +413,32 @@ export function ContextPanel() {
 									</svg>
 								</button>
 								<h2 class="text-lg font-semibold text-gray-100 truncate">{headerTitle}</h2>
+								<button
+									onClick={() => navigateToSpaceConfigure(currentSpaceId!)}
+									class={cn(
+										'ml-1 p-1.5 rounded-lg transition-colors flex-shrink-0',
+										currentSpaceViewMode === 'configure'
+											? 'bg-dark-800 text-gray-100'
+											: 'text-gray-400 hover:bg-dark-800 hover:text-gray-100'
+									)}
+									title="Configure space"
+									aria-label="Configure space"
+								>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+										/>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+										/>
+									</svg>
+								</button>
 							</div>
 						) : (
 							<h2 class="text-lg font-semibold text-gray-100 truncate mr-2">{headerTitle}</h2>

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -6,6 +6,7 @@ import {
 	currentSpaceIdSignal,
 	currentSpaceSessionIdSignal,
 	currentSpaceTaskIdSignal,
+	currentSpaceViewModeSignal,
 	navSectionSignal,
 	settingsSectionSignal,
 } from '../lib/signals.ts';
@@ -38,6 +39,7 @@ export default function MainContent() {
 	const spaceId = currentSpaceIdSignal.value;
 	const spaceSessionViewId = currentSpaceSessionIdSignal.value;
 	const spaceTaskViewId = currentSpaceTaskIdSignal.value;
+	const spaceViewMode = currentSpaceViewModeSignal.value;
 	const sessionsList = sessions.value;
 	const navSection = navSectionSignal.value;
 	const settingsSection = settingsSectionSignal.value;
@@ -50,7 +52,7 @@ export default function MainContent() {
 	// This drives the animate-fadeIn-200 transition wrapper below.
 	let contentKey: string;
 	if (spaceId) {
-		contentKey = `space-${spaceId}`;
+		contentKey = `space-${spaceId}-${spaceViewMode}`;
 	} else if (navSection === 'spaces') {
 		contentKey = 'spaces';
 	} else if (roomId) {
@@ -74,6 +76,7 @@ export default function MainContent() {
 			return (
 				<SpaceIsland
 					spaceId={spaceId}
+					viewMode={spaceViewMode}
 					sessionViewId={spaceSessionViewId}
 					taskViewId={spaceTaskViewId}
 				/>

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -2,11 +2,7 @@
  * SpaceDetailPanel
  *
  * Space-specific context panel for the three-column layout.
- * Mirrors RoomContextPanel's visual structure for a space:
- * 1. Space activity header (no status counters)
- * 2. Pinned items: Dashboard, Space Agent
- * 3. Tasks section (single task list with active/review filters)
- * 4. Sessions section (collapsible, default collapsed)
+ * Prioritizes fast access to overview, review work, and sessions.
  */
 
 import { useMemo, useState } from 'preact/hooks';
@@ -21,19 +17,15 @@ import {
 import { currentSpaceSessionIdSignal, currentSpaceTaskIdSignal } from '../lib/signals';
 import { cn } from '../lib/utils';
 
-type OrphanTab = 'active' | 'review';
+type TaskTab = 'active' | 'review';
 
 const taskStatusColors: Record<string, string> = {
-	draft: 'bg-gray-500',
-	pending: 'bg-yellow-500',
+	open: 'bg-gray-500',
 	in_progress: 'bg-blue-500',
-	review: 'bg-purple-500',
-	needs_attention: 'bg-orange-500',
-	completed: 'bg-green-500',
+	blocked: 'bg-amber-500',
+	done: 'bg-green-500',
 	cancelled: 'bg-gray-600',
-	archived: 'bg-gray-600',
-	rate_limited: 'bg-orange-500',
-	usage_limited: 'bg-orange-600',
+	archived: 'bg-gray-700',
 };
 
 function TaskStatusDot({ status }: { status: string }) {
@@ -49,16 +41,38 @@ interface SpaceDetailPanelProps {
 	onNavigate?: () => void;
 }
 
+function TaskTabButton({
+	label,
+	count,
+	active,
+	onClick,
+}: {
+	label: string;
+	count: number;
+	active: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			class={cn(
+				'flex items-center gap-1.5 rounded px-2 py-0.5 text-xs transition-colors',
+				active ? 'bg-dark-600 text-gray-200' : 'text-gray-500 hover:text-gray-300'
+			)}
+		>
+			<span>{label}</span>
+			<span class="rounded-full bg-dark-800 px-1.5 py-px text-[10px] text-gray-400">{count}</span>
+		</button>
+	);
+}
+
 export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps) {
-	// Read signal values directly for Preact Signals auto-tracking
 	const isLoading = spaceStore.loading.value;
 	const loadedSpaceId = spaceStore.spaceId.value;
 	const tasks = spaceStore.tasks.value;
 	const space = spaceStore.space.value;
 
-	// Show a loading state when the store hasn't loaded data for this space yet.
-	// spaceStore.selectSpace() is called by SpaceIsland; the ContextPanel may render
-	// before that call completes (e.g. on cold navigation before SpaceIsland mounts).
 	const isReady = !isLoading && loadedSpaceId === spaceId;
 
 	if (!isReady) {
@@ -69,66 +83,63 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 		);
 	}
 
-	const [taskTab, setTaskTab] = useState<OrphanTab>('active');
+	const [taskTab, setTaskTab] = useState<TaskTab>('review');
 
-	// Selection state
 	const selectedSessionId = currentSpaceSessionIdSignal.value;
 	const selectedTaskId = currentSpaceTaskIdSignal.value;
-	const selectedTask = selectedTaskId ? (tasks.find((t) => t.id === selectedTaskId) ?? null) : null;
+	const selectedTask = selectedTaskId ? (tasks.find((task) => task.id === selectedTaskId) ?? null) : null;
 	const spaceAgentSessionId = `space:chat:${spaceId}`;
 
-	const isDashboardSelected = selectedSessionId === null && selectedTaskId === null;
+	const isOverviewSelected = selectedSessionId === null && selectedTaskId === null;
 	const isSpaceAgentSelected = selectedSessionId === spaceAgentSessionId;
 
-	// Tasks filtered by tab.
-	// rate_limited/usage_limited are grouped with active.
+	const activeCount = tasks.filter(
+		(task) => task.status === 'open' || task.status === 'in_progress'
+	).length;
+	const reviewCount = tasks.filter((task) => task.status === 'blocked').length;
+
 	const tasksForTab = useMemo(() => {
 		const sorted = [...tasks].sort((a, b) => b.updatedAt - a.updatedAt);
 		let filtered: typeof sorted;
-		if (taskTab === 'active') {
-			filtered = sorted.filter((t) => t.status === 'open' || t.status === 'in_progress');
+
+		if (taskTab === 'review') {
+			filtered = sorted.filter((task) => task.status === 'blocked');
 		} else {
-			filtered = sorted.filter((t) => t.status === 'blocked');
+			filtered = sorted.filter((task) => task.status === 'open' || task.status === 'in_progress');
 		}
 
-		// Keep the currently open task visible even if the tab filter would hide it.
-		// This avoids "No tasks" in the list while the user is actively viewing a task.
-		if (selectedTaskId && !filtered.some((t) => t.id === selectedTaskId)) {
-			const selected = sorted.find((t) => t.id === selectedTaskId);
+		if (selectedTaskId && !filtered.some((task) => task.id === selectedTaskId)) {
+			const selected = sorted.find((task) => task.id === selectedTaskId);
 			if (selected) {
 				filtered = [selected, ...filtered];
 			}
 		}
+
 		return filtered;
 	}, [tasks, taskTab, selectedTaskId]);
 
-	// Sessions list: only manually created sessions from space.sessionIds.
-	// Excludes built-in Space Agent + task/workflow orchestration sessions.
 	const sessions = useMemo(() => {
 		const list: { id: string; title: string }[] = [];
 		const seen = new Set<string>();
-		const isSystemSpaceSession = (sid: string): boolean =>
-			sid === spaceAgentSessionId ||
-			sid.startsWith(`space:${spaceId}:task:`) ||
-			sid.startsWith(`space:${spaceId}:workflow:`);
+		const isSystemSpaceSession = (sessionId: string): boolean =>
+			sessionId === spaceAgentSessionId ||
+			sessionId.startsWith(`space:${spaceId}:task:`) ||
+			sessionId.startsWith(`space:${spaceId}:workflow:`);
 
 		if (space?.sessionIds) {
-			for (const sid of space.sessionIds) {
-				if (isSystemSpaceSession(sid)) {
+			for (const sessionId of space.sessionIds) {
+				if (isSystemSpaceSession(sessionId) || seen.has(sessionId)) {
 					continue;
 				}
-				if (!seen.has(sid)) {
-					list.push({ id: sid, title: sid.slice(0, 8) });
-					seen.add(sid);
-				}
+				list.push({ id: sessionId, title: sessionId.slice(0, 8) });
+				seen.add(sessionId);
 			}
 		}
 
 		return list;
 	}, [space, spaceAgentSessionId, spaceId]);
 
-	// Navigation handlers
-	const handleDashboardClick = () => {
+	const handleOverviewClick = () => {
 		navigateToSpace(spaceId);
 		onNavigate?.();
 	};
@@ -150,28 +161,13 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 
 	return (
 		<div class="flex-1 flex flex-col overflow-hidden">
-			<div class="px-3 pt-3 pb-2 space-y-3 border-b border-dark-800">
-				<div class="space-y-1 px-1 pb-1">
-					<p class="text-[11px] uppercase tracking-[0.18em] text-gray-600">Space Activity</p>
-					<p class="text-xs text-gray-500">
-						{tasks.length === 0
-							? 'No tasks yet.'
-							: 'Use Tasks and Space Agent to monitor and steer ongoing work.'}
-					</p>
-					{space?.workspacePath && (
-						<p class="truncate font-mono text-[11px] text-gray-600">{space.workspacePath}</p>
-					)}
-				</div>
-			</div>
-
-			{/* Pinned items */}
 			<button
-				onClick={handleDashboardClick}
+				onClick={handleOverviewClick}
 				data-testid="space-detail-dashboard"
-				data-active={isDashboardSelected ? 'true' : 'false'}
+				data-active={isOverviewSelected ? 'true' : 'false'}
 				class={cn(
 					'mx-3 mt-3 w-auto rounded-xl px-3 py-2.5 flex items-center gap-2.5 transition-colors border',
-					isDashboardSelected
+					isOverviewSelected
 						? 'bg-dark-700 border-dark-600'
 						: 'bg-transparent border-transparent hover:bg-dark-800 hover:border-dark-700'
 				)}
@@ -191,7 +187,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 						/>
 					</svg>
 				</div>
-				<span class="flex-1 text-sm text-gray-200 text-left truncate">Dashboard</span>
+				<span class="flex-1 text-sm text-gray-200 text-left truncate">Overview</span>
 			</button>
 
 			<button
@@ -223,29 +219,23 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 				<span class="flex-1 text-sm text-gray-200 text-left truncate">Space Agent</span>
 			</button>
 
-			{/* Visual divider after pinned items */}
 			<div class="border-t border-dark-700 mx-3 my-3" />
 
-			{/* Scrollable sections */}
 			<div class="flex-1 overflow-y-auto">
-				{/* Tasks section */}
 				<CollapsibleSection title="Tasks">
-					{/* Tab bar */}
 					<div class="flex items-center gap-1 px-3 py-1.5">
-						{(['active', 'review'] as const).map((tab) => (
-							<button
-								key={tab}
-								onClick={() => setTaskTab(tab)}
-								class={cn(
-									'px-2 py-0.5 text-xs rounded transition-colors capitalize',
-									taskTab === tab
-										? 'bg-dark-600 text-gray-200'
-										: 'text-gray-500 hover:text-gray-300'
-								)}
-							>
-								{tab}
-							</button>
-						))}
+						<TaskTabButton
+							label="Active"
+							count={activeCount}
+							active={taskTab === 'active'}
+							onClick={() => setTaskTab('active')}
+						/>
+						<TaskTabButton
+							label="Review"
+							count={reviewCount}
+							active={taskTab === 'review'}
+							onClick={() => setTaskTab('review')}
+						/>
 					</div>
 					{tasksForTab.length === 0 ? (
 						<div class="px-4 py-3 text-xs text-gray-600">No tasks</div>
@@ -265,9 +255,9 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 									<span class="block text-[11px] uppercase tracking-[0.14em] text-gray-600">
 										{task.workflowRunId ? 'Workflow task' : 'Standalone task'}
 										{selectedTask?.id === task.id &&
-											selectedTask.status !== 'open' &&
-											selectedTask.status !== 'in_progress' &&
-											` · ${selectedTask.status.replace('_', ' ')}`}
+											task.status !== 'open' &&
+											task.status !== 'in_progress' &&
+											` · ${task.status.replace('_', ' ')}`}
 									</span>
 								</div>
 							</button>
@@ -275,32 +265,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					)}
 				</CollapsibleSection>
 
-				{/* Sessions section */}
-				<CollapsibleSection
-					title="Sessions"
-					count={sessions.length}
-					defaultExpanded={false}
-					headerRight={
-						<button
-							onClick={(e: MouseEvent) => {
-								e.stopPropagation();
-							}}
-							disabled
-							class="text-gray-600 cursor-not-allowed p-0.5"
-							aria-label="Create session"
-							title="Session creation coming soon"
-						>
-							<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width={2}
-									d="M12 4v16m8-8H4"
-								/>
-							</svg>
-						</button>
-					}
-				>
+				<CollapsibleSection title="Sessions" count={sessions.length} defaultExpanded={true}>
 					{sessions.length === 0 ? (
 						<div class="px-4 py-3 text-xs text-gray-600">No sessions</div>
 					) : (

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -87,7 +87,9 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 
 	const selectedSessionId = currentSpaceSessionIdSignal.value;
 	const selectedTaskId = currentSpaceTaskIdSignal.value;
-	const selectedTask = selectedTaskId ? (tasks.find((task) => task.id === selectedTaskId) ?? null) : null;
+	const selectedTask = selectedTaskId
+		? (tasks.find((task) => task.id === selectedTaskId) ?? null)
+		: null;
 	const spaceAgentSessionId = `space:chat:${spaceId}`;
 
 	const isOverviewSelected = selectedSessionId === null && selectedTaskId === null;

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -4,66 +4,43 @@
  * Content priority chain (full-width, each replaces the next):
  * 1. sessionViewId set → ChatContainer (agent/session chat)
  * 2. taskViewId set    → SpaceTaskPane (full-width task detail)
- * 3. default          → tabbed view — Dashboard | Agents | Workflows | Settings
+ * 3. default           → route-driven space view
  *
- * Dashboard tab shows a full-width task-centric overview.
- *
- * Space navigation is handled by the Context Panel sidebar.
+ * The default route renders the task-focused overview.
+ * Configure lives at its own route and reuses the same shell/context panel.
  */
 
-import { useState, useEffect } from 'preact/hooks';
-import { spaceStore } from '../lib/space-store';
-import { navigateToSpace, navigateToSpaceAgent, navigateToSpaceTask } from '../lib/router';
+import { useEffect } from 'preact/hooks';
+import type { SpaceViewMode } from '../lib/signals';
+import { SpaceConfigurePage } from '../components/space/SpaceConfigurePage';
 import { SpaceDashboard } from '../components/space/SpaceDashboard';
 import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
-import { SpaceAgentList } from '../components/space/SpaceAgentList';
-import { WorkflowList } from '../components/space/WorkflowList';
-import { VisualWorkflowEditor } from '../components/space/visual-editor/VisualWorkflowEditor';
-import { SpaceSettings } from '../components/space/SpaceSettings';
+import { spaceStore } from '../lib/space-store';
+import { navigateToSpace, navigateToSpaceAgent, navigateToSpaceTask } from '../lib/router';
 import ChatContainer from './ChatContainer';
-import { cn } from '../lib/utils';
 
 interface SpaceIslandProps {
 	spaceId: string;
-	sessionViewId?: string | null; // When set, show this session content instead of space tabs
-	taskViewId?: string | null; // When set, show SpaceTaskPane for this task
+	viewMode: SpaceViewMode;
+	sessionViewId?: string | null;
+	taskViewId?: string | null;
 }
 
-type SpaceTab = 'dashboard' | 'agents' | 'workflows' | 'settings';
-
-const TABS: { id: SpaceTab; label: string }[] = [
-	{ id: 'dashboard', label: 'Dashboard' },
-	{ id: 'agents', label: 'Agents' },
-	{ id: 'workflows', label: 'Workflows' },
-	{ id: 'settings', label: 'Settings' },
-];
-
-export default function SpaceIsland({ spaceId, sessionViewId, taskViewId }: SpaceIslandProps) {
-	const [activeTab, setActiveTab] = useState<SpaceTab>('dashboard');
-	/** null = list view; 'new' = create editor; <id> = edit editor */
-	const [workflowEditId, setWorkflowEditId] = useState<string | null>(null);
+export default function SpaceIsland({
+	spaceId,
+	viewMode,
+	sessionViewId,
+	taskViewId,
+}: SpaceIslandProps) {
 	const loading = spaceStore.loading.value;
 	const error = spaceStore.error.value;
 	const workflows = spaceStore.workflows.value;
 
-	// Load space data on mount or when spaceId changes
 	useEffect(() => {
 		spaceStore.selectSpace(spaceId).catch(() => {
 			// Error is tracked in spaceStore.error
 		});
-
-		return () => {
-			// Optionally clear when unmounting; leave it for now so
-			// navigating back is instant (store shows stale-then-fresh data).
-		};
 	}, [spaceId]);
-
-	// Reset workflow edit state when switching away from workflows tab
-	useEffect(() => {
-		if (activeTab !== 'workflows') {
-			setWorkflowEditId(null);
-		}
-	}, [activeTab]);
 
 	const handleTaskPaneClose = () => {
 		navigateToSpace(spaceId);
@@ -93,19 +70,10 @@ export default function SpaceIsland({ spaceId, sessionViewId, taskViewId }: Spac
 
 	const space = spaceStore.space.value;
 
-	const editingWorkflow =
-		workflowEditId && workflowEditId !== 'new'
-			? workflows.find((w) => w.id === workflowEditId)
-			: undefined;
-
-	const showWorkflowEditor = activeTab === 'workflows' && workflowEditId !== null;
-
-	// Session view: render ChatContainer instead of tabs
 	if (sessionViewId) {
 		return <ChatContainer key={sessionViewId} sessionId={sessionViewId} />;
 	}
 
-	// Task view: render SpaceTaskPane full-width instead of tabs
 	if (taskViewId) {
 		return (
 			<div class="flex-1 flex flex-col overflow-hidden bg-dark-900" data-testid="space-task-pane">
@@ -114,69 +82,32 @@ export default function SpaceIsland({ spaceId, sessionViewId, taskViewId }: Spac
 		);
 	}
 
-	return (
-		<div class="flex-1 flex overflow-hidden bg-dark-900">
-			{/* Main content — tabbed view */}
-			<div class="flex-1 overflow-hidden flex flex-col min-w-0">
-				{/* Tab bar — hidden when workflow editor is open (editor has its own back button) */}
-				{!showWorkflowEditor && (
-					<div class="flex border-b border-dark-700 px-4 flex-shrink-0" data-testid="space-tab-bar">
-						{TABS.map((tab) => (
-							<button
-								key={tab.id}
-								type="button"
-								onClick={() => setActiveTab(tab.id)}
-								class={cn(
-									'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px',
-									activeTab === tab.id
-										? 'text-gray-100 border-blue-400'
-										: 'text-gray-400 border-transparent hover:text-gray-200'
-								)}
-							>
-								{tab.label}
-							</button>
-						))}
-					</div>
-				)}
-
-				{/* Tab content */}
-				<div class="flex-1 overflow-hidden">
-					{showWorkflowEditor ? (
-						<VisualWorkflowEditor
-							key={workflowEditId}
-							workflow={editingWorkflow}
-							onSave={() => setWorkflowEditId(null)}
-							onCancel={() => setWorkflowEditId(null)}
-						/>
-					) : (
-						<>
-							{activeTab === 'dashboard' && (
-								<div class="flex flex-col h-full min-h-0" data-testid="dashboard-view">
-									<SpaceDashboard
-										spaceId={spaceId}
-										onOpenSpaceAgent={() => navigateToSpaceAgent(spaceId)}
-										onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
-									/>
-								</div>
-							)}
-							{activeTab === 'agents' && (
-								<div class="p-6 h-full overflow-y-auto">
-									<SpaceAgentList />
-								</div>
-							)}
-							{activeTab === 'workflows' && space && (
-								<WorkflowList
-									spaceId={spaceId}
-									spaceName={space.name}
-									workflows={workflows}
-									onCreateWorkflow={() => setWorkflowEditId('new')}
-									onEditWorkflow={(id) => setWorkflowEditId(id)}
-								/>
-							)}
-							{activeTab === 'settings' && space && <SpaceSettings space={space} />}
-						</>
-					)}
+	if (viewMode === 'configure' && space) {
+		return (
+			<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-configure-view">
+				<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
+					<SpaceConfigurePage space={space} workflows={workflows} />
 				</div>
+			</div>
+		);
+	}
+
+	if (viewMode === 'configure' && !space) {
+		return (
+			<div class="flex-1 flex items-center justify-center bg-dark-900">
+				<p class="text-sm text-gray-500">Space not found</p>
+			</div>
+		);
+	}
+
+	return (
+		<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-overview-view">
+			<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
+				<SpaceDashboard
+					spaceId={spaceId}
+					onOpenSpaceAgent={() => navigateToSpaceAgent(spaceId)}
+					onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
+				/>
 			</div>
 		</div>
 	);

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -1,18 +1,13 @@
 /**
- * Tests for SpaceDetailPanel component.
+ * Tests for SpaceDetailPanel.
  *
- * Covers: space activity summary, pinned item highlighting, unified task list filtering,
- * click navigation, sessions section, and empty states.
+ * Covers overview/agent navigation, task tab defaults, counters, and sessions behavior.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, screen } from '@testing-library/preact';
-import { signal, computed, type Signal, type ReadonlySignal } from '@preact/signals';
-import type { SpaceTask, SpaceWorkflowRun, Space } from '@neokai/shared';
-
-// -------------------------------------------------------
-// Hoisted mocks
-// -------------------------------------------------------
+import { signal, type Signal } from '@preact/signals';
+import type { SpaceTask, Space } from '@neokai/shared';
 
 const {
 	mockNavigateToSpace,
@@ -26,48 +21,20 @@ const {
 	mockNavigateToSpaceTask: vi.fn(),
 }));
 
-// -------------------------------------------------------
-// Signals used in mocks
-// -------------------------------------------------------
-
 let mockTasksSignal!: Signal<SpaceTask[]>;
-let mockWorkflowRunsSignal!: Signal<SpaceWorkflowRun[]>;
 let mockSpaceSignal!: Signal<Space | null>;
 let mockLoadingSignal!: Signal<boolean>;
 let mockSpaceIdSignal!: Signal<string | null>;
 let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
 let mockCurrentSpaceTaskIdSignal!: Signal<string | null>;
 
-let mockActiveRuns!: ReadonlySignal<SpaceWorkflowRun[]>;
-let mockTasksByRun!: ReadonlySignal<Map<string, SpaceTask[]>>;
-let mockStandaloneTasks!: ReadonlySignal<SpaceTask[]>;
-
 function initSignals() {
 	mockTasksSignal = signal([]);
-	mockWorkflowRunsSignal = signal([]);
 	mockSpaceSignal = signal(null);
-	// By default simulate loaded state: not loading, spaceId matches
 	mockLoadingSignal = signal(false);
 	mockSpaceIdSignal = signal('space-1');
 	mockCurrentSpaceSessionIdSignal = signal(null);
 	mockCurrentSpaceTaskIdSignal = signal(null);
-
-	mockActiveRuns = computed(() =>
-		mockWorkflowRunsSignal.value.filter((r) => r.status === 'pending' || r.status === 'in_progress')
-	);
-
-	mockTasksByRun = computed(() => {
-		const map = new Map<string, SpaceTask[]>();
-		for (const task of mockTasksSignal.value) {
-			if (task.workflowRunId) {
-				const existing = map.get(task.workflowRunId) ?? [];
-				map.set(task.workflowRunId, [...existing, task]);
-			}
-		}
-		return map;
-	});
-
-	mockStandaloneTasks = computed(() => mockTasksSignal.value.filter((t) => !t.workflowRunId));
 }
 
 initSignals();
@@ -76,13 +43,9 @@ vi.mock('../../lib/space-store.ts', () => ({
 	get spaceStore() {
 		return {
 			tasks: mockTasksSignal,
-			workflowRuns: mockWorkflowRunsSignal,
 			space: mockSpaceSignal,
 			loading: mockLoadingSignal,
 			spaceId: mockSpaceIdSignal,
-			activeRuns: mockActiveRuns,
-			tasksByRun: mockTasksByRun,
-			standaloneTasks: mockStandaloneTasks,
 		};
 	},
 }));
@@ -108,10 +71,6 @@ vi.mock('../../lib/signals.ts', async (importOriginal) => {
 });
 
 import { SpaceDetailPanel } from '../SpaceDetailPanel';
-
-// -------------------------------------------------------
-// Helpers
-// -------------------------------------------------------
 
 function makeTask(
 	id: string,
@@ -139,24 +98,6 @@ function makeTask(
 	} as SpaceTask;
 }
 
-function makeRun(
-	id: string,
-	title: string,
-	status: SpaceWorkflowRun['status'] = 'in_progress'
-): SpaceWorkflowRun {
-	return {
-		id,
-		spaceId: 'space-1',
-		workflowId: 'wf-1',
-		title,
-		status,
-		startedAt: null,
-		completedAt: null,
-		createdAt: 0,
-		updatedAt: 0,
-	} as SpaceWorkflowRun;
-}
-
 function makeSpace(id: string, overrides: Partial<Space> = {}): Space {
 	return {
 		id,
@@ -170,10 +111,6 @@ function makeSpace(id: string, overrides: Partial<Space> = {}): Space {
 	} as unknown as Space;
 }
 
-// -------------------------------------------------------
-// Tests
-// -------------------------------------------------------
-
 describe('SpaceDetailPanel', () => {
 	beforeEach(() => {
 		cleanup();
@@ -185,69 +122,41 @@ describe('SpaceDetailPanel', () => {
 		cleanup();
 	});
 
-	// -- Loading guard --
-
 	it('shows loading state when spaceStore is loading', () => {
 		mockLoadingSignal.value = true;
 		render(<SpaceDetailPanel spaceId="space-1" />);
 		expect(screen.getByText('Loading…')).toBeTruthy();
-		expect(screen.queryByText('Dashboard')).toBeNull();
+		expect(screen.queryByText('Overview')).toBeNull();
 	});
 
 	it('shows loading state when store spaceId does not match prop', () => {
-		mockLoadingSignal.value = false;
 		mockSpaceIdSignal.value = 'other-space';
 		render(<SpaceDetailPanel spaceId="space-1" />);
 		expect(screen.getByText('Loading…')).toBeTruthy();
 	});
 
-	it('renders panel content when store is loaded for this space', () => {
-		mockLoadingSignal.value = false;
-		mockSpaceIdSignal.value = 'space-1';
+	it('renders Overview and Space Agent buttons', () => {
 		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.queryByText('Loading…')).toBeNull();
-		expect(screen.getByText('Dashboard')).toBeTruthy();
-	});
-
-	// -- Space activity summary --
-
-	it('renders the empty activity summary when there are no tasks', () => {
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Space Activity')).toBeTruthy();
-		expect(screen.getByText('No tasks yet.')).toBeTruthy();
-	});
-
-	it('renders the non-empty activity summary when tasks exist', () => {
-		mockTasksSignal.value = [makeTask('t1', 'T1', 'in_progress')];
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(
-			screen.getByText('Use Tasks and Space Agent to monitor and steer ongoing work.')
-		).toBeTruthy();
-	});
-
-	it('shows workspace path in activity summary when available', () => {
-		mockSpaceSignal.value = makeSpace('space-1', { workspacePath: '/tmp/workspace' });
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('/tmp/workspace')).toBeTruthy();
-	});
-
-	// -- Pinned items --
-
-	it('renders Dashboard and Space Agent buttons', () => {
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Dashboard')).toBeTruthy();
+		expect(screen.getByText('Overview')).toBeTruthy();
 		expect(screen.getByText('Space Agent')).toBeTruthy();
 	});
 
-	it('navigates to space dashboard and calls onNavigate', () => {
+	it('removes the old Space Activity header block', () => {
+		mockSpaceSignal.value = makeSpace('space-1', { workspacePath: '/tmp/workspace' });
+		render(<SpaceDetailPanel spaceId="space-1" />);
+		expect(screen.queryByText('Space Activity')).toBeNull();
+		expect(screen.queryByText('/tmp/workspace')).toBeNull();
+	});
+
+	it('navigates to space overview and calls onNavigate', () => {
 		const onNavigate = vi.fn();
 		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
-		fireEvent.click(screen.getByText('Dashboard'));
+		fireEvent.click(screen.getByText('Overview'));
 		expect(mockNavigateToSpace).toHaveBeenCalledWith('space-1');
 		expect(onNavigate).toHaveBeenCalledOnce();
 	});
 
-	it('navigates to space agent route and calls onNavigate', () => {
+	it('navigates to the space agent and calls onNavigate', () => {
 		const onNavigate = vi.fn();
 		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
 		fireEvent.click(screen.getByText('Space Agent'));
@@ -255,176 +164,75 @@ describe('SpaceDetailPanel', () => {
 		expect(onNavigate).toHaveBeenCalledOnce();
 	});
 
-	// -- Dashboard highlighting --
-
-	it('highlights Dashboard when both session and task signals are null', () => {
-		mockCurrentSpaceSessionIdSignal.value = null;
-		mockCurrentSpaceTaskIdSignal.value = null;
+	it('highlights Overview when neither session nor task is selected', () => {
 		render(<SpaceDetailPanel spaceId="space-1" />);
-		const dashboardBtn = screen.getByText('Dashboard').closest('button');
-		expect(dashboardBtn?.className).toContain('bg-dark-700');
+		const button = screen.getByText('Overview').closest('button');
+		expect(button?.className).toContain('bg-dark-700');
 	});
 
-	it('does NOT highlight Dashboard when a task is selected', () => {
-		mockCurrentSpaceSessionIdSignal.value = null;
-		mockCurrentSpaceTaskIdSignal.value = 'task-1';
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		const dashboardBtn = screen.getByText('Dashboard').closest('button');
-		expect(dashboardBtn?.className).not.toContain('bg-dark-700');
-	});
-
-	it('does NOT highlight Dashboard when a session is selected', () => {
-		mockCurrentSpaceSessionIdSignal.value = 'some-session';
-		mockCurrentSpaceTaskIdSignal.value = null;
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		const dashboardBtn = screen.getByText('Dashboard').closest('button');
-		expect(dashboardBtn?.className).not.toContain('bg-dark-700');
-	});
-
-	// -- Space Agent highlighting --
-
-	it('highlights Space Agent when its synthetic session ID is selected', () => {
+	it('highlights Space Agent when its synthetic session is selected', () => {
 		mockCurrentSpaceSessionIdSignal.value = 'space:chat:space-1';
 		render(<SpaceDetailPanel spaceId="space-1" />);
-		const agentBtn = screen.getByText('Space Agent').closest('button');
-		expect(agentBtn?.className).toContain('bg-dark-700');
+		const button = screen.getByText('Space Agent').closest('button');
+		expect(button?.className).toContain('bg-dark-700');
 	});
 
-	it('does NOT highlight Space Agent when a different session is selected', () => {
-		mockCurrentSpaceSessionIdSignal.value = 'some-other-session';
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		const agentBtn = screen.getByText('Space Agent').closest('button');
-		expect(agentBtn?.className).not.toContain('bg-dark-700');
-	});
-
-	// -- Tasks section --
-
-	it('shows active tasks under Active tab by default', () => {
+	it('shows Review tasks by default and includes counters on task tabs', () => {
 		mockTasksSignal.value = [
-			makeTask('t1', 'Active Task', 'in_progress'),
-			makeTask('t2', 'Done Task', 'done'),
+			makeTask('t1', 'Queued Task', 'open'),
+			makeTask('t2', 'In Progress Task', 'in_progress'),
+			makeTask('t3', 'Blocked Task', 'blocked'),
 		];
 		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Active Task')).toBeTruthy();
-		expect(screen.queryByText('Done Task')).toBeNull();
+
+		expect(screen.getByText('Blocked Task')).toBeTruthy();
+		expect(screen.queryByText('Queued Task')).toBeNull();
+		expect(screen.getByText('Active')).toBeTruthy();
+		expect(screen.getByText('Review')).toBeTruthy();
+		expect(screen.getByText('2')).toBeTruthy();
+		expect(screen.getByText('1')).toBeTruthy();
 	});
 
-	it('keeps selected done task visible even when Active tab is selected', () => {
+	it('switches to Active tasks when the Active tab is clicked', () => {
 		mockTasksSignal.value = [
-			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t1', 'Queued Task', 'open'),
+			makeTask('t2', 'Blocked Task', 'blocked'),
+		];
+		render(<SpaceDetailPanel spaceId="space-1" />);
+
+		fireEvent.click(screen.getByRole('button', { name: /Active/i }));
+		expect(screen.getByText('Queued Task')).toBeTruthy();
+		expect(screen.queryByText('Blocked Task')).toBeNull();
+	});
+
+	it('keeps the selected task visible even when it does not match the current tab', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Queued Task', 'open'),
 			makeTask('t2', 'Done Task', 'done'),
 		];
 		mockCurrentSpaceTaskIdSignal.value = 't2';
 		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Active Task')).toBeTruthy();
+
 		expect(screen.getByText('Done Task')).toBeTruthy();
-	});
-
-	it('shows workflow tasks alongside standalone tasks in the unified list', () => {
-		mockWorkflowRunsSignal.value = [makeRun('r1', 'Run')];
-		mockTasksSignal.value = [
-			makeTask('t1', 'Run Task', 'in_progress', { workflowRunId: 'r1' }),
-			makeTask('t2', 'Standalone Task', 'open'),
-		];
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Run Task')).toBeTruthy();
-		expect(screen.getByText('Standalone Task')).toBeTruthy();
-		expect(screen.getByText('Workflow task')).toBeTruthy();
-		expect(screen.getByText('Standalone task')).toBeTruthy();
-	});
-
-	it('shows draft and pending tasks under Active tab', () => {
-		mockTasksSignal.value = [
-			makeTask('t1', 'Draft Task', 'open'),
-			makeTask('t2', 'Pending Task', 'open'),
-			makeTask('t3', 'Done Task', 'done'),
-		];
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Draft Task')).toBeTruthy();
-		expect(screen.getByText('Pending Task')).toBeTruthy();
-		expect(screen.queryByText('Done Task')).toBeNull();
-	});
-
-	it('switches to Review tab to show review tasks', () => {
-		mockTasksSignal.value = [
-			makeTask('t1', 'Active Task', 'in_progress'),
-			makeTask('t2', 'Review Task', 'blocked'),
-			makeTask('t3', 'Attention Task', 'blocked'),
-		];
-		render(<SpaceDetailPanel spaceId="space-1" />);
-
-		const reviewTab = screen.getAllByRole('button').find((b) => b.textContent === 'review');
-		fireEvent.click(reviewTab!);
-
-		expect(screen.getByText('Review Task')).toBeTruthy();
-		expect(screen.getByText('Attention Task')).toBeTruthy();
-		expect(screen.queryByText('Active Task')).toBeNull();
-	});
-
-	it('does not render a Done tab', () => {
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.queryByRole('button', { name: 'done' })).toBeNull();
-	});
-
-	it('shows rate_limited tasks under Active tab', () => {
-		mockTasksSignal.value = [makeTask('t1', 'Throttled Task', 'blocked')];
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Throttled Task')).toBeTruthy();
-	});
-
-	it('shows usage_limited tasks under Active tab', () => {
-		mockTasksSignal.value = [makeTask('t1', 'Limited Task', 'blocked')];
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Limited Task')).toBeTruthy();
-	});
-
-	it('hides archived tasks from the task tabs unless explicitly selected', () => {
-		mockTasksSignal.value = [makeTask('t1', 'Archived Task', 'archived')];
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.queryByText('Archived Task')).toBeNull();
-	});
-
-	it('shows "No tasks" in Tasks section when filtered list is empty', () => {
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getAllByText('No tasks').length).toBeGreaterThanOrEqual(1);
 	});
 
 	it('navigates to a task on click and calls onNavigate', () => {
 		const onNavigate = vi.fn();
-		mockTasksSignal.value = [makeTask('t1', 'Click Me', 'open')];
+		mockTasksSignal.value = [makeTask('t1', 'Blocked Task', 'blocked')];
 		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
 
-		fireEvent.click(screen.getByText('Click Me'));
+		fireEvent.click(screen.getByText('Blocked Task'));
 		expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 't1');
 		expect(onNavigate).toHaveBeenCalledOnce();
 	});
 
-	it('highlights selected task in the task list', () => {
-		mockTasksSignal.value = [makeTask('t1', 'Selected Task', 'open')];
-		mockCurrentSpaceTaskIdSignal.value = 't1';
-		render(<SpaceDetailPanel spaceId="space-1" />);
-
-		const taskBtn = screen.getByText('Selected Task').closest('button');
-		expect(taskBtn?.className).toContain('bg-dark-700');
-	});
-
-	// -- Sessions section --
-
-	it('renders Sessions section collapsed by default', () => {
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('Sessions')).toBeTruthy();
-		expect(screen.queryByText('manual-s')).toBeNull();
-	});
-
-	it('shows manually created sessions from space.sessionIds', () => {
+	it('renders Sessions expanded by default', () => {
 		mockSpaceSignal.value = makeSpace('space-1', { sessionIds: ['manual-session-abc123'] });
 		render(<SpaceDetailPanel spaceId="space-1" />);
-		fireEvent.click(screen.getByLabelText('Sessions section'));
-		// Manually created sessions show first 8 chars of ID
 		expect(screen.getByText('manual-s')).toBeTruthy();
 	});
 
-	it('filters out system space sessions from space.sessionIds', () => {
+	it('filters out system sessions from the Sessions section', () => {
 		mockSpaceSignal.value = makeSpace('space-1', {
 			sessionIds: [
 				'space:chat:space-1',
@@ -434,51 +242,19 @@ describe('SpaceDetailPanel', () => {
 			],
 		});
 		render(<SpaceDetailPanel spaceId="space-1" />);
-		fireEvent.click(screen.getByLabelText('Sessions section'));
 
 		expect(screen.queryByText('space:cha')).toBeNull();
 		expect(screen.queryByText('space:spa')).toBeNull();
 		expect(screen.getByText('manual-s')).toBeTruthy();
 	});
 
-	it('navigates to session on click and calls onNavigate', () => {
+	it('navigates to a session on click and calls onNavigate', () => {
 		const onNavigate = vi.fn();
 		mockSpaceSignal.value = makeSpace('space-1', { sessionIds: ['manual-session-abc123'] });
 		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
 
-		fireEvent.click(screen.getByLabelText('Sessions section'));
 		fireEvent.click(screen.getByText('manual-s'));
-
 		expect(mockNavigateToSpaceSession).toHaveBeenCalledWith('space-1', 'manual-session-abc123');
-		expect(onNavigate).toHaveBeenCalled();
-	});
-
-	it('highlights selected session in the sessions list', () => {
-		mockSpaceSignal.value = makeSpace('space-1', { sessionIds: ['manual-session-abc123'] });
-		mockCurrentSpaceSessionIdSignal.value = 'manual-session-abc123';
-		render(<SpaceDetailPanel spaceId="space-1" />);
-
-		fireEvent.click(screen.getByLabelText('Sessions section'));
-		const sessionBtn = screen.getByText('manual-s').closest('button');
-		expect(sessionBtn?.className).toContain('bg-dark-700');
-	});
-
-	it('deduplicates manual sessions', () => {
-		mockSpaceSignal.value = makeSpace('space-1', {
-			sessionIds: ['manual-session-abc123', 'manual-session-abc123'],
-		});
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		fireEvent.click(screen.getByLabelText('Sessions section'));
-		expect(screen.getAllByText('manual-s')).toHaveLength(1);
-	});
-
-	it('renders session count badge in section header', () => {
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByText('(0)')).toBeTruthy();
-	});
-
-	it('renders "Create session" button in sessions header', () => {
-		render(<SpaceDetailPanel spaceId="space-1" />);
-		expect(screen.getByLabelText('Create session')).toBeTruthy();
+		expect(onNavigate).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -183,16 +183,16 @@ describe('SpaceIsland — configure workflow editor', () => {
 	}
 
 	it('renders configure sub-tabs', () => {
-		const { getByTestId, getByText } = renderConfigure();
+		const { getByTestId } = renderConfigure();
 		expect(getByTestId('space-configure-tab-bar')).toBeTruthy();
-		expect(getByText('Agents')).toBeTruthy();
-		expect(getByText('Workflows')).toBeTruthy();
-		expect(getByText('Settings')).toBeTruthy();
+		expect(getByTestId('space-configure-tab-agents')).toBeTruthy();
+		expect(getByTestId('space-configure-tab-workflows')).toBeTruthy();
+		expect(getByTestId('space-configure-tab-settings')).toBeTruthy();
 	});
 
 	it('opens the visual editor when creating a workflow', () => {
 		const result = renderConfigure();
-		fireEvent.click(result.getByText('Workflows'));
+		fireEvent.click(result.getByTestId('space-configure-tab-workflows'));
 		fireEvent.click(result.getByTestId('create-workflow-btn'));
 		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
 		expect(capturedVisualEditorProps.workflow).toBeUndefined();
@@ -200,7 +200,7 @@ describe('SpaceIsland — configure workflow editor', () => {
 
 	it('opens the visual editor when editing a workflow', () => {
 		const result = renderConfigure();
-		fireEvent.click(result.getByText('Workflows'));
+		fireEvent.click(result.getByTestId('space-configure-tab-workflows'));
 		fireEvent.click(result.getByTestId('edit-workflow-btn'));
 		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
 		expect((capturedVisualEditorProps.workflow as SpaceWorkflow)?.id).toBe('wf-existing');
@@ -208,14 +208,14 @@ describe('SpaceIsland — configure workflow editor', () => {
 
 	it('hides configure sub-tabs while editing a workflow', () => {
 		const result = renderConfigure();
-		fireEvent.click(result.getByText('Workflows'));
+		fireEvent.click(result.getByTestId('space-configure-tab-workflows'));
 		fireEvent.click(result.getByTestId('create-workflow-btn'));
 		expect(result.queryByTestId('space-configure-tab-bar')).toBeNull();
 	});
 
 	it('restores configure sub-tabs after save', () => {
 		const result = renderConfigure();
-		fireEvent.click(result.getByText('Workflows'));
+		fireEvent.click(result.getByTestId('space-configure-tab-workflows'));
 		fireEvent.click(result.getByTestId('create-workflow-btn'));
 		fireEvent.click(result.getByTestId('visual-editor-save'));
 		expect(result.getByTestId('space-configure-tab-bar')).toBeTruthy();

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -1,27 +1,17 @@
 // @ts-nocheck
 /**
- * Tests for SpaceIsland — visual workflow editor and dashboard integration
+ * Tests for SpaceIsland.
  *
- * Visual editor
- * - Opens only the visual editor when creating or editing a workflow
- * - Hides the tab bar while editing
- * - Passes the correct workflow prop to the visual editor
- * - onSave/onCancel close the editor
- *
- * Dashboard integration
- * - Shows the dashboard view on the dashboard tab
- * - Does not render a workflow canvas wrapper on the dashboard
- * - Opens the create-task, start-workflow, and space-agent actions from the overview
+ * Covers:
+ * - route-driven overview vs configure rendering
+ * - workflow editor behavior inside configure
+ * - content priority for session/task routes
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { SpaceWorkflow, SpaceAgent, Space, SpaceWorkflowRun } from '@neokai/shared';
-
-// ============================================================================
-// Mock signals — must be declared before vi.mock calls
-// ============================================================================
 
 let mockLoading = signal(false);
 let mockError = signal<string | null>(null);
@@ -32,11 +22,6 @@ let mockActiveRuns = signal<SpaceWorkflowRun[]>([]);
 
 const mockSelectSpace = vi.fn().mockResolvedValue(undefined);
 
-// ============================================================================
-// Child component mocks
-// ============================================================================
-
-// WorkflowList renders a button to trigger create/edit workflow
 vi.mock('../../components/space/WorkflowList', () => ({
 	WorkflowList: (props: { onCreateWorkflow: () => void; onEditWorkflow: (id: string) => void }) => (
 		<div data-testid="workflow-list">
@@ -50,7 +35,6 @@ vi.mock('../../components/space/WorkflowList', () => ({
 	),
 }));
 
-// Track props passed to VisualWorkflowEditor
 let capturedVisualEditorProps: Record<string, unknown> = {};
 vi.mock('../../components/space/visual-editor/VisualWorkflowEditor', () => ({
 	VisualWorkflowEditor: (props: {
@@ -74,10 +58,7 @@ vi.mock('../../components/space/visual-editor/VisualWorkflowEditor', () => ({
 }));
 
 vi.mock('../../components/space/SpaceDashboard', () => ({
-	SpaceDashboard: (props: {
-		onOpenSpaceAgent?: () => void;
-		onSelectTask?: (id: string) => void;
-	}) => (
+	SpaceDashboard: (props: { onOpenSpaceAgent?: () => void }) => (
 		<div data-testid="space-dashboard">
 			<button data-testid="quick-open-space-agent" onClick={props.onOpenSpaceAgent}>
 				Ask Space Agent
@@ -85,8 +66,9 @@ vi.mock('../../components/space/SpaceDashboard', () => ({
 		</div>
 	),
 }));
+
 vi.mock('../../components/space/SpaceTaskPane', () => ({
-	SpaceTaskPane: (props: { taskId: string | null; spaceId?: string; onClose?: () => void }) => (
+	SpaceTaskPane: (props: { taskId: string | null; spaceId?: string }) => (
 		<div
 			data-testid="space-task-pane-inner"
 			data-task-id={props.taskId ?? ''}
@@ -98,9 +80,11 @@ vi.mock('../../components/space/SpaceTaskPane', () => ({
 vi.mock('../../components/space/SpaceAgentList', () => ({
 	SpaceAgentList: () => <div data-testid="space-agent-list" />,
 }));
+
 vi.mock('../../components/space/SpaceSettings', () => ({
 	SpaceSettings: () => <div data-testid="space-settings" />,
 }));
+
 vi.mock('../ChatContainer', () => ({
 	default: ({ sessionId }: { sessionId: string }) => (
 		<div data-testid="chat-container" data-session-id={sessionId} />
@@ -121,26 +105,13 @@ vi.mock('../../lib/space-store', () => ({
 	},
 }));
 
-vi.mock('../../lib/signals', () => ({
-	currentSessionIdSignal: signal(null),
-	slashCommandsSignal: signal([]),
-}));
-
 vi.mock('../../lib/router', () => ({
 	navigateToSpace: vi.fn(),
 	navigateToSpaceAgent: vi.fn(),
 	navigateToSpaceTask: vi.fn(),
 }));
 
-vi.mock('../../lib/utils', () => ({
-	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
-}));
-
 import SpaceIsland from '../SpaceIsland';
-
-// ============================================================================
-// Fixtures
-// ============================================================================
 
 function makeSpace(overrides: Partial<Space> = {}): Space {
 	return {
@@ -171,47 +142,6 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 	};
 }
 
-function makeWorkflowRun(overrides: Partial<SpaceWorkflowRun> = {}): SpaceWorkflowRun {
-	return {
-		id: 'run-1',
-		spaceId: 'space-1',
-		workflowId: 'wf-existing',
-		title: 'Test Run',
-		status: 'in_progress',
-		iterationCount: 0,
-		maxIterations: 10,
-		createdAt: 0,
-		updatedAt: 0,
-		...overrides,
-	};
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/** Render SpaceIsland in the Workflows tab with a space loaded. */
-function renderOnWorkflowsTab() {
-	const result = render(<SpaceIsland spaceId="space-1" />);
-	const workflowsTab = result.getByText('Workflows');
-	fireEvent.click(workflowsTab);
-	return result;
-}
-
-/** Open the create-new workflow editor. */
-function openCreateEditor(result: { getByTestId: (id: string) => HTMLElement }) {
-	fireEvent.click(result.getByTestId('create-workflow-btn'));
-}
-
-/** Open the edit workflow editor (uses wf-existing). */
-function openEditEditor(result: { getByTestId: (id: string) => HTMLElement }) {
-	fireEvent.click(result.getByTestId('edit-workflow-btn'));
-}
-
-// ============================================================================
-// Setup / Teardown
-// ============================================================================
-
 beforeEach(() => {
 	mockLoading = signal(false);
 	mockError = signal(null);
@@ -226,166 +156,98 @@ afterEach(() => {
 	cleanup();
 });
 
-// ============================================================================
-// Tests
-// ============================================================================
-
-describe('SpaceIsland — visual workflow editor', () => {
-	it('does not show the visual editor when the workflows list is open', () => {
-		const { queryByTestId } = renderOnWorkflowsTab();
-		expect(queryByTestId('visual-workflow-editor')).toBeNull();
-	});
-
-	it('opens the visual editor when creating a workflow', () => {
-		const result = renderOnWorkflowsTab();
-		openCreateEditor(result);
-		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
-	});
-
-	it('opens the visual editor when editing an existing workflow', () => {
-		const result = renderOnWorkflowsTab();
-		openEditEditor(result);
-		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
-	});
-
-	it('passes undefined workflow to the visual editor when creating new', () => {
-		const result = renderOnWorkflowsTab();
-		openCreateEditor(result);
-		expect(capturedVisualEditorProps.workflow).toBeUndefined();
-	});
-
-	it('passes the existing workflow to the visual editor when editing', () => {
-		const result = renderOnWorkflowsTab();
-		openEditEditor(result);
-		expect((capturedVisualEditorProps.workflow as SpaceWorkflow)?.id).toBe('wf-existing');
-	});
-
-	it('hides the tab bar while the visual editor is open', () => {
-		const result = renderOnWorkflowsTab();
-		openCreateEditor(result);
-		expect(result.queryByTestId('space-tab-bar')).toBeNull();
-	});
-
-	it('restores the tab bar after saving the visual editor', () => {
-		const result = renderOnWorkflowsTab();
-		openCreateEditor(result);
-		fireEvent.click(result.getByTestId('visual-editor-save'));
-		expect(result.queryByTestId('visual-workflow-editor')).toBeNull();
-		expect(result.getByTestId('space-tab-bar')).toBeTruthy();
-	});
-
-	it('closes the visual editor on cancel', () => {
-		const result = renderOnWorkflowsTab();
-		openCreateEditor(result);
-		fireEvent.click(result.getByTestId('visual-editor-cancel'));
-		expect(result.queryByTestId('visual-workflow-editor')).toBeNull();
-		expect(result.getByTestId('space-tab-bar')).toBeTruthy();
-	});
-});
-
-describe('SpaceIsland — dashboard integration', () => {
-	it('shows the dashboard view on the dashboard tab', () => {
-		const { getByTestId } = render(<SpaceIsland spaceId="space-1" />);
-		expect(getByTestId('dashboard-view')).toBeTruthy();
+describe('SpaceIsland — route-driven views', () => {
+	it('renders the overview view by default', () => {
+		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="overview" />);
+		expect(getByTestId('space-overview-view')).toBeTruthy();
 		expect(getByTestId('space-dashboard')).toBeTruthy();
 	});
 
-	it('does not render a dashboard canvas wrapper', () => {
-		const { queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
-		expect(queryByTestId('canvas-panel')).toBeNull();
-		expect(queryByTestId('dashboard-fallback')).toBeNull();
+	it('renders the configure view when requested', () => {
+		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="configure" />);
+		expect(getByTestId('space-configure-view')).toBeTruthy();
+		expect(getByTestId('space-agent-list')).toBeTruthy();
 	});
 
-	describe('Agents tab', () => {
-		it('renders SpaceAgentList inside a padded wrapper', () => {
-			const { getByTestId, getByText } = render(<SpaceIsland spaceId="space-1" />);
-			fireEvent.click(getByText('Agents'));
-			const agentList = getByTestId('space-agent-list');
-			const wrapper = agentList.parentElement;
-			expect(wrapper?.className).toContain('p-6');
-		});
-	});
-
-	it('does not show the dashboard view when on agents tab', () => {
-		const { queryByTestId, getByText } = render(<SpaceIsland spaceId="space-1" />);
-		fireEvent.click(getByText('Agents'));
-		expect(queryByTestId('dashboard-view')).toBeNull();
+	it('routes to the space agent when Ask Space Agent is clicked from overview', async () => {
+		const router = await import('../../lib/router');
+		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="overview" />);
+		fireEvent.click(getByTestId('quick-open-space-agent'));
+		expect(router.navigateToSpaceAgent).toHaveBeenCalledWith('space-1');
 	});
 });
 
-describe('SpaceIsland — dashboard actions', () => {
-	describe('Space agent action', () => {
-		it('routes to the space agent when Ask Space Agent is clicked', async () => {
-			const router = await import('../../lib/router');
-			const { getByTestId } = render(<SpaceIsland spaceId="space-1" />);
-			fireEvent.click(getByTestId('quick-open-space-agent'));
-			expect(router.navigateToSpaceAgent).toHaveBeenCalledWith('space-1');
-		});
+describe('SpaceIsland — configure workflow editor', () => {
+	function renderConfigure() {
+		return render(<SpaceIsland spaceId="space-1" viewMode="configure" />);
+	}
+
+	it('renders configure sub-tabs', () => {
+		const { getByTestId, getByText } = renderConfigure();
+		expect(getByTestId('space-configure-tab-bar')).toBeTruthy();
+		expect(getByText('Agents')).toBeTruthy();
+		expect(getByText('Workflows')).toBeTruthy();
+		expect(getByText('Settings')).toBeTruthy();
+	});
+
+	it('opens the visual editor when creating a workflow', () => {
+		const result = renderConfigure();
+		fireEvent.click(result.getByText('Workflows'));
+		fireEvent.click(result.getByTestId('create-workflow-btn'));
+		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
+		expect(capturedVisualEditorProps.workflow).toBeUndefined();
+	});
+
+	it('opens the visual editor when editing a workflow', () => {
+		const result = renderConfigure();
+		fireEvent.click(result.getByText('Workflows'));
+		fireEvent.click(result.getByTestId('edit-workflow-btn'));
+		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
+		expect((capturedVisualEditorProps.workflow as SpaceWorkflow)?.id).toBe('wf-existing');
+	});
+
+	it('hides configure sub-tabs while editing a workflow', () => {
+		const result = renderConfigure();
+		fireEvent.click(result.getByText('Workflows'));
+		fireEvent.click(result.getByTestId('create-workflow-btn'));
+		expect(result.queryByTestId('space-configure-tab-bar')).toBeNull();
+	});
+
+	it('restores configure sub-tabs after save', () => {
+		const result = renderConfigure();
+		fireEvent.click(result.getByText('Workflows'));
+		fireEvent.click(result.getByTestId('create-workflow-btn'));
+		fireEvent.click(result.getByTestId('visual-editor-save'));
+		expect(result.getByTestId('space-configure-tab-bar')).toBeTruthy();
 	});
 });
 
 describe('SpaceIsland — content priority chain', () => {
-	describe('sessionViewId prop', () => {
-		it('renders ChatContainer when sessionViewId is set', () => {
-			const { getByTestId } = render(<SpaceIsland spaceId="space-1" sessionViewId="session-abc" />);
-			expect(getByTestId('chat-container')).toBeTruthy();
-		});
-
-		it('passes sessionId to ChatContainer', () => {
-			const { getByTestId } = render(<SpaceIsland spaceId="space-1" sessionViewId="session-abc" />);
-			expect(getByTestId('chat-container').getAttribute('data-session-id')).toBe('session-abc');
-		});
-
-		it('does not render tab bar when sessionViewId is set', () => {
-			const { queryByText } = render(<SpaceIsland spaceId="space-1" sessionViewId="session-abc" />);
-			expect(queryByText('Dashboard')).toBeNull();
-		});
-
-		it('renders tab view when sessionViewId is null', () => {
-			const { getByText, queryByTestId } = render(
-				<SpaceIsland spaceId="space-1" sessionViewId={null} />
-			);
-			expect(getByText('Dashboard')).toBeTruthy();
-			expect(queryByTestId('chat-container')).toBeNull();
-		});
-
-		it('renders tab view when neither sessionViewId nor taskViewId is set', () => {
-			const { getByText, queryByTestId } = render(<SpaceIsland spaceId="space-1" />);
-			expect(getByText('Dashboard')).toBeTruthy();
-			expect(queryByTestId('chat-container')).toBeNull();
-		});
+	it('renders ChatContainer when sessionViewId is set', () => {
+		const { getByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="overview" sessionViewId="session-abc" />
+		);
+		expect(getByTestId('chat-container')).toBeTruthy();
 	});
 
-	describe('taskViewId prop', () => {
-		it('shows SpaceTaskPane wrapper when taskViewId is set', () => {
-			const { getByTestId } = render(<SpaceIsland spaceId="space-1" taskViewId="task-xyz" />);
-			expect(getByTestId('space-task-pane')).toBeTruthy();
-		});
+	it('renders SpaceTaskPane when taskViewId is set', () => {
+		const { getByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="overview" taskViewId="task-xyz" />
+		);
+		expect(getByTestId('space-task-pane')).toBeTruthy();
+		expect(getByTestId('space-task-pane-inner').getAttribute('data-task-id')).toBe('task-xyz');
+	});
 
-		it('hides tab bar when taskViewId is set (full-width task view)', () => {
-			const { queryByText } = render(<SpaceIsland spaceId="space-1" taskViewId="task-xyz" />);
-			expect(queryByText('Dashboard')).toBeNull();
-			expect(queryByText('Agents')).toBeNull();
-		});
-
-		it('passes spaceId and taskId to SpaceTaskPane', () => {
-			const { getByTestId } = render(<SpaceIsland spaceId="space-1" taskViewId="task-xyz" />);
-			const inner = getByTestId('space-task-pane-inner');
-			expect(inner.getAttribute('data-task-id')).toBe('task-xyz');
-			expect(inner.getAttribute('data-space-id')).toBe('space-1');
-		});
-
-		it('does not show SpaceTaskPane when taskViewId is null', () => {
-			const { queryByTestId } = render(<SpaceIsland spaceId="space-1" taskViewId={null} />);
-			expect(queryByTestId('space-task-pane')).toBeNull();
-		});
-
-		it('sessionViewId takes priority over taskViewId — renders ChatContainer', () => {
-			const { getByTestId, queryByTestId } = render(
-				<SpaceIsland spaceId="space-1" sessionViewId="session-abc" taskViewId="task-xyz" />
-			);
-			expect(getByTestId('chat-container')).toBeTruthy();
-			expect(queryByTestId('space-task-pane')).toBeNull();
-		});
+	it('sessionViewId takes priority over taskViewId', () => {
+		const { getByTestId, queryByTestId } = render(
+			<SpaceIsland
+				spaceId="space-1"
+				viewMode="overview"
+				sessionViewId="session-abc"
+				taskViewId="task-xyz"
+			/>
+		);
+		expect(getByTestId('chat-container')).toBeTruthy();
+		expect(queryByTestId('space-task-pane')).toBeNull();
 	});
 });

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -22,6 +22,7 @@ import {
 	currentSpaceIdSignal,
 	currentSpaceSessionIdSignal,
 	currentSpaceTaskIdSignal,
+	currentSpaceViewModeSignal,
 	navSectionSignal,
 } from './signals.ts';
 
@@ -38,6 +39,7 @@ const SPACES_ROUTE_PATTERN = /^\/spaces$/;
 const ROOM_CHAT_COMPAT_PATTERN = /^\/room\/([a-f0-9-]+)\/chat$/;
 /** Space routes accept both UUIDs (a-f0-9-) and slugs (a-z0-9-) */
 const SPACE_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)$/;
+const SPACE_CONFIGURE_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/configure$/;
 const SPACE_AGENT_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/agent$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/session\/([a-f0-9-]+)$/;
 const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
@@ -125,6 +127,9 @@ export function getRoomAgentFromPath(path: string): string | null {
  * Returns null if not on a space route
  */
 export function getSpaceIdFromPath(path: string): string | null {
+	const configureMatch = path.match(SPACE_CONFIGURE_ROUTE_PATTERN);
+	if (configureMatch) return configureMatch[1];
+
 	const match = path.match(SPACE_ROUTE_PATTERN);
 	if (match) return match[1];
 
@@ -144,6 +149,15 @@ export function getSpaceIdFromPath(path: string): string | null {
  */
 export function getSpaceAgentFromPath(path: string): string | null {
 	const match = path.match(SPACE_AGENT_ROUTE_PATTERN);
+	return match ? match[1] : null;
+}
+
+/**
+ * Extract space ID from configure route path
+ * Returns null if not on a space configure route
+ */
+export function getSpaceConfigureFromPath(path: string): string | null {
+	const match = path.match(SPACE_CONFIGURE_ROUTE_PATTERN);
 	return match ? match[1] : null;
 }
 
@@ -216,6 +230,13 @@ export function createRoomTaskPath(roomId: string, taskId: string): string {
  */
 export function createSpacePath(spaceId: string): string {
 	return `/space/${spaceId}`;
+}
+
+/**
+ * Create space configure URL path
+ */
+export function createSpaceConfigurePath(spaceId: string): string {
+	return `/space/${spaceId}/configure`;
 }
 
 /**
@@ -726,6 +747,7 @@ export function navigateToSpace(spaceId: string, replace = false): void {
 
 	if (currentPath === targetPath) {
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -743,6 +765,54 @@ export function navigateToSpace(spaceId: string, replace = false): void {
 		window.history[historyMethod]({ spaceId, path: targetPath }, '', targetPath);
 
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} finally {
+		setTimeout(() => {
+			routerState.isNavigating = false;
+		}, 0);
+	}
+}
+
+/**
+ * Navigate to the Space configure view
+ * Updates URL to /space/:spaceId/configure and keeps the space context panel active
+ */
+export function navigateToSpaceConfigure(spaceId: string, replace = false): void {
+	if (routerState.isNavigating) {
+		return;
+	}
+
+	const targetPath = createSpaceConfigurePath(spaceId);
+	const currentPath = getCurrentPath();
+
+	if (currentPath === targetPath) {
+		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'configure';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+		return;
+	}
+
+	routerState.isNavigating = true;
+
+	try {
+		const historyMethod = replace ? 'replaceState' : 'pushState';
+		window.history[historyMethod]({ spaceId, path: targetPath }, '', targetPath);
+
+		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'configure';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -770,6 +840,7 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 
 	if (currentPath === targetPath) {
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = sessionId;
 		currentSpaceTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -787,6 +858,7 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 		window.history[historyMethod]({ spaceId, sessionId, path: targetPath }, '', targetPath);
 
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = sessionId;
 		currentSpaceTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -814,6 +886,7 @@ export function navigateToSpaceTask(spaceId: string, taskId: string, replace = f
 
 	if (currentPath === targetPath) {
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceTaskIdSignal.value = taskId;
 		currentSpaceSessionIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -831,6 +904,7 @@ export function navigateToSpaceTask(spaceId: string, taskId: string, replace = f
 		window.history[historyMethod]({ spaceId, taskId, path: targetPath }, '', targetPath);
 
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceTaskIdSignal.value = taskId;
 		currentSpaceSessionIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -862,6 +936,7 @@ export function navigateToSpaceAgent(spaceId: string, replace = false): void {
 
 	if (currentPath === targetPath) {
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = `space:chat:${spaceId}`;
 		currentSpaceTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -879,6 +954,7 @@ export function navigateToSpaceAgent(spaceId: string, replace = false): void {
 		window.history[historyMethod]({ spaceId, path: targetPath }, '', targetPath);
 
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = `space:chat:${spaceId}`;
 		currentSpaceTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -907,6 +983,7 @@ function handlePopState(_event: PopStateEvent): void {
 	const roomAgent = getRoomAgentFromPath(path);
 	const roomSession = getRoomSessionIdFromPath(path);
 	const roomTask = getRoomTaskIdFromPath(path);
+	const spaceConfigure = getSpaceConfigureFromPath(path);
 	const spaceTask = getSpaceTaskIdFromPath(path);
 	const spaceSession = getSpaceSessionIdFromPath(path);
 	const spaceAgent = getSpaceAgentFromPath(path);
@@ -919,6 +996,7 @@ function handlePopState(_event: PopStateEvent): void {
 	// fall through to the plain room handler, losing the synthetic session ID.
 	if (spaceTask) {
 		currentSpaceIdSignal.value = spaceTask.spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceTaskIdSignal.value = spaceTask.taskId;
 		currentSpaceSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -928,6 +1006,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'spaces';
 	} else if (spaceSession) {
 		currentSpaceIdSignal.value = spaceSession.spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = spaceSession.sessionId;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -937,7 +1016,18 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'spaces';
 	} else if (spaceAgent) {
 		currentSpaceIdSignal.value = spaceAgent;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = `space:chat:${spaceAgent}`;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} else if (spaceConfigure) {
+		currentSpaceIdSignal.value = spaceConfigure;
+		currentSpaceViewModeSignal.value = 'configure';
+		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
@@ -946,6 +1036,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'spaces';
 	} else if (spaceId) {
 		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -955,6 +1046,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'spaces';
 	} else if (roomAgent) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = roomAgent;
@@ -964,6 +1056,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'rooms';
 	} else if (roomTask) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = roomTask.roomId;
@@ -973,6 +1066,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'rooms';
 	} else if (roomSession) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = roomSession.roomId;
@@ -982,6 +1076,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'rooms';
 	} else if (roomId) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = roomId;
@@ -996,6 +1091,7 @@ function handlePopState(_event: PopStateEvent): void {
 		}
 	} else if (SESSIONS_ROUTE_PATTERN.test(path)) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1005,6 +1101,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'chats';
 	} else if (INBOX_ROUTE_PATTERN.test(path)) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1014,6 +1111,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'inbox';
 	} else if (SPACES_ROUTE_PATTERN.test(path)) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1023,6 +1121,7 @@ function handlePopState(_event: PopStateEvent): void {
 		navSectionSignal.value = 'spaces';
 	} else {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1055,6 +1154,7 @@ export function initializeRouter(): string | null {
 	const initialRoomAgent = getRoomAgentFromPath(initialPath);
 	const initialRoomSession = getRoomSessionIdFromPath(initialPath);
 	const initialRoomTask = getRoomTaskIdFromPath(initialPath);
+	const initialSpaceConfigure = getSpaceConfigureFromPath(initialPath);
 	const initialSpaceTask = getSpaceTaskIdFromPath(initialPath);
 	const initialSpaceSession = getSpaceSessionIdFromPath(initialPath);
 	const initialSpaceAgent = getSpaceAgentFromPath(initialPath);
@@ -1064,6 +1164,7 @@ export function initializeRouter(): string | null {
 	// IMPORTANT: Order is load-bearing — see comment in handlePopState
 	if (initialSpaceTask) {
 		currentSpaceIdSignal.value = initialSpaceTask.spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceTaskIdSignal.value = initialSpaceTask.taskId;
 		currentSpaceSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1073,6 +1174,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'spaces';
 	} else if (initialSpaceSession) {
 		currentSpaceIdSignal.value = initialSpaceSession.spaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = initialSpaceSession.sessionId;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1082,7 +1184,18 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'spaces';
 	} else if (initialSpaceAgent) {
 		currentSpaceIdSignal.value = initialSpaceAgent;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = `space:chat:${initialSpaceAgent}`;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} else if (initialSpaceConfigure) {
+		currentSpaceIdSignal.value = initialSpaceConfigure;
+		currentSpaceViewModeSignal.value = 'configure';
+		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
@@ -1091,6 +1204,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'spaces';
 	} else if (initialSpaceId) {
 		currentSpaceIdSignal.value = initialSpaceId;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1100,6 +1214,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'spaces';
 	} else if (initialRoomAgent) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = initialRoomAgent;
@@ -1109,6 +1224,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomTask) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = initialRoomTask.roomId;
@@ -1118,6 +1234,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomSession) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = initialRoomSession.roomId;
@@ -1127,6 +1244,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomId) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = initialRoomId;
@@ -1136,6 +1254,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'rooms';
 	} else if (SESSIONS_ROUTE_PATTERN.test(initialPath)) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1145,6 +1264,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'chats';
 	} else if (INBOX_ROUTE_PATTERN.test(initialPath)) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1154,6 +1274,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'inbox';
 	} else if (SPACES_ROUTE_PATTERN.test(initialPath)) {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1163,6 +1284,7 @@ export function initializeRouter(): string | null {
 		navSectionSignal.value = 'spaces';
 	} else {
 		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -39,6 +39,8 @@ export const navSectionSignal = signal<NavSection>('home');
 export const currentSpaceIdSignal = signal<string | null>(null);
 export const currentSpaceSessionIdSignal = signal<string | null>(null);
 export const currentSpaceTaskIdSignal = signal<string | null>(null);
+export type SpaceViewMode = 'overview' | 'configure';
+export const currentSpaceViewModeSignal = signal<SpaceViewMode>('overview');
 
 // Mobile drawer signals
 export const contextPanelOpenSignal = signal<boolean>(false);

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -14,9 +14,11 @@
 		"paths": {
 			"@/*": ["./*"],
 			"@neokai/shared": ["../shared/src/mod.ts"],
-			"@neokai/shared/*": ["../shared/src/*"]
+			"@neokai/shared/*": ["../shared/src/*"],
+			"@neokai/ui": ["../ui/src/mod.ts"],
+			"@neokai/ui/*": ["../ui/src/*"]
 		}
 	},
-	"include": ["src/**/*", "build.ts", "../shared/src/**/*"],
+	"include": ["src/**/*", "build.ts", "../shared/src/**/*", "../ui/src/**/*"],
 	"exclude": ["node_modules", "dist", "tests/**/*", "../shared/src/sdk/**/*"]
 }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -83,6 +83,14 @@ export default defineConfig({
 				find: '@neokai/shared',
 				replacement: resolve(__dirname, '../shared/src/mod.ts'),
 			},
+			{
+				find: /^@neokai\/ui\/(.+)$/,
+				replacement: resolve(__dirname, '../ui/src/$1'),
+			},
+			{
+				find: '@neokai/ui',
+				replacement: resolve(__dirname, '../ui/src/mod.ts'),
+			},
 		],
 		extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
 	},

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -36,6 +36,14 @@ export default defineConfig({
 				find: '@neokai/shared',
 				replacement: resolve(__dirname, '../shared/src/mod.ts'),
 			},
+			{
+				find: /^@neokai\/ui\/(.+)$/,
+				replacement: resolve(__dirname, '../ui/src/$1'),
+			},
+			{
+				find: '@neokai/ui',
+				replacement: resolve(__dirname, '../ui/src/mod.ts'),
+			},
 		],
 	},
 });


### PR DESCRIPTION
## Summary
- simplify the space overview so it starts directly with task tabs and content
- move configure to a cleaner tab shell powered by `@neokai/ui` headless tabs
- add a standalone dashboard style exploration page at `/space-dashboard-style-options.html`

## Validation
- `bunx vitest run src/islands/__tests__/SpaceIsland.test.tsx src/islands/__tests__/SpaceDetailPanel.test.tsx src/components/space/__tests__/SpaceDashboard.test.tsx`
- `bun run typecheck`