### PR TITLE
feat(ui): add demo examples for composable patterns

### DIFF
--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -19,6 +19,9 @@ import { TabsDemo } from './sections/TabsDemo.tsx';
 import { ToastDemo } from './sections/ToastDemo.tsx';
 import { TooltipDemo } from './sections/TooltipDemo.tsx';
 import { TransitionDemo } from './sections/TransitionDemo.tsx';
+import { CommandPaletteDemo } from './sections/CommandPaletteDemo.tsx';
+import { DrawerDemo } from './sections/DrawerDemo.tsx';
+import { NotificationDemo } from './sections/NotificationDemo.tsx';
 
 interface DemoSectionProps {
 	id: string;
@@ -64,11 +67,14 @@ const sections = [
 	{ id: 'input', label: 'Input' },
 	{ id: 'field', label: 'Field' },
 	{ id: 'dialog', label: 'Dialog' },
+	{ id: 'command-palette', label: 'Command Palette' },
+	{ id: 'drawer', label: 'Drawer' },
 	{ id: 'menu', label: 'Menu' },
 	{ id: 'disclosure', label: 'Disclosure' },
 	{ id: 'popover', label: 'Popover' },
 	{ id: 'tooltip', label: 'Tooltip' },
 	{ id: 'toast', label: 'Toast' },
+	{ id: 'notification', label: 'Notification' },
 	{ id: 'tabs', label: 'Tabs' },
 	{ id: 'listbox', label: 'Listbox' },
 	{ id: 'combobox', label: 'Combobox' },
@@ -157,6 +163,12 @@ export function App() {
 					<DemoSection id="dialog" title="Dialog">
 						<DialogDemo />
 					</DemoSection>
+					<DemoSection id="command-palette" title="Command Palette (Dialog + Combobox)">
+						<CommandPaletteDemo />
+					</DemoSection>
+					<DemoSection id="drawer" title="Drawer">
+						<DrawerDemo />
+					</DemoSection>
 					<DemoSection id="menu" title="Menu">
 						<MenuDemo />
 					</DemoSection>
@@ -171,6 +183,9 @@ export function App() {
 					</DemoSection>
 					<DemoSection id="toast" title="Toast">
 						<ToastDemo />
+					</DemoSection>
+					<DemoSection id="notification" title="Notification (Toast Variants)">
+						<NotificationDemo />
 					</DemoSection>
 					<DemoSection id="tabs" title="Tabs">
 						<TabsDemo />

--- a/packages/ui/demo/sections/CommandPaletteDemo.tsx
+++ b/packages/ui/demo/sections/CommandPaletteDemo.tsx
@@ -173,6 +173,7 @@ function CommandPaletteDemo() {
 									autoFocus
 									class="col-start-1 row-start-1 h-14 w-full pr-4 pl-12 text-base text-text-primary bg-transparent outline-none placeholder:text-text-muted"
 									placeholder="Search projects, actions, or type a command..."
+									// Command palette clears query on close, so no need to display selected item
 									displayValue={() => query}
 									onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
 								/>

--- a/packages/ui/demo/sections/CommandPaletteDemo.tsx
+++ b/packages/ui/demo/sections/CommandPaletteDemo.tsx
@@ -1,0 +1,320 @@
+import { useState } from 'preact/hooks';
+import {
+	Combobox,
+	ComboboxInput,
+	ComboboxOption,
+	ComboboxOptions,
+	Dialog,
+	DialogBackdrop,
+	DialogPanel,
+} from '../../src/mod.ts';
+
+interface CommandItem {
+	id: string;
+	name: string;
+	type: 'project' | 'action' | 'recent';
+	shortcut?: string;
+	description?: string;
+}
+
+const recentItems: CommandItem[] = [
+	{ id: 'recent-1', name: 'Workflow Inc. / Website Redesign', type: 'recent' },
+	{ id: 'recent-2', name: 'Mobile App / iOS Development', type: 'recent' },
+];
+
+const actions: CommandItem[] = [
+	{
+		id: 'action-1',
+		name: 'Create new project...',
+		type: 'action',
+		shortcut: 'N',
+		description: 'Start a fresh project',
+	},
+	{
+		id: 'action-2',
+		name: 'Create new file...',
+		type: 'action',
+		shortcut: 'F',
+		description: 'Add a new file to the workspace',
+	},
+	{
+		id: 'action-3',
+		name: 'Add collaborator...',
+		type: 'action',
+		shortcut: 'C',
+		description: 'Invite a team member',
+	},
+	{
+		id: 'action-4',
+		name: 'Open settings',
+		type: 'action',
+		shortcut: ',',
+		description: 'Configure preferences',
+	},
+];
+
+const projects: CommandItem[] = [
+	{ id: 'project-1', name: 'Workflow Inc. / Website Redesign', type: 'project' },
+	{ id: 'project-2', name: 'Mobile App / iOS Development', type: 'project' },
+	{ id: 'project-3', name: 'Marketing / Q4 Campaign', type: 'project' },
+	{ id: 'project-4', name: 'Infrastructure / Cloud Migration', type: 'project' },
+];
+
+function SearchIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function FolderIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+			<path d="M3.75 3A2.25 2.25 0 001.5 5.25v9.5A2.25 2.25 0 003.75 17h12.5A2.25 2.25 0 0018.5 14.75v-6.5a2.25 2.25 0 00-2.25-2.25H9.227l-1.721-2.153A1.5 1.5 0 006.292 3H3.75z" />
+		</svg>
+	);
+}
+
+function BoltIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M13.3 2.3a.75.75 0 00-1.06-1.06L8.47 4.98a.75.75 0 000 1.06l3.77 3.77a.75.75 0 001.06-1.06l-3.04-3.04 2.76-2.34z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function CommandIcon() {
+	return (
+		<svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+			<path d="M3.5 3A1.5 1.5 0 002 4.5v1A1.5 1.5 0 003.5 7h1A1.5 1.5 0 006 8.5v1A1.5 1.5 0 004.5 11h-1A1.5 1.5 0 002 9.5v-1A1.5 1.5 0 003.5 7H4.5v1h-.5a.5.5 0 000 1h.5v1.5a.5.5 0 001 0V8.5h.5a.5.5 0 000-1H5V6h.5a.5.5 0 000-1H5v-.5A.5.5 0 004.5 4H4a.5.5 0 000-1h-.5z" />
+			<path d="M9.5 3a.5.5 0 01.5.5V4h1a.5.5 0 010 1h-.5v.5a.5.5 0 01-1 0V5H8.5a.5.5 0 010-1h.5v-.5A.5.5 0 019.5 3z" />
+			<path d="M14.5 3a.5.5 0 00-.5.5V4h-1a.5.5 0 000 1h.5v.5a.5.5 0 101 0V5h.5a.5.5 0 000-1H14v-.5A.5.5 0 0014.5 3z" />
+			<path
+				fill-rule="evenodd"
+				d="M16 9.5a.5.5 0 00-.5-.5h-1a.5.5 0 000 1h.5v.5a.5.5 0 001 0v-.5h.5a.5.5 0 000-1h-.5V9.5z"
+				clip-rule="evenodd"
+			/>
+			<path
+				fill-rule="evenodd"
+				d="M3 10a.5.5 0 01.5-.5h1a.5.5 0 010 1H4v.5a.5.5 0 01-1 0V10.5H2.5a.5.5 0 010-1h1v-.5A.5.5 0 013 9.5z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function CommandPaletteDemo() {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState('');
+
+	const filteredProjects =
+		query === '' ? [] : projects.filter((p) => p.name.toLowerCase().includes(query.toLowerCase()));
+
+	const filteredActions =
+		query === ''
+			? actions
+			: actions.filter((a) => a.name.toLowerCase().includes(query.toLowerCase()));
+
+	const showResults = query !== '' || filteredActions.length > 0;
+
+	function handleClose() {
+		setOpen(false);
+		setQuery('');
+	}
+
+	function handleSelect(_item: CommandItem) {
+		// Handle item selection - would navigate or execute action
+		handleClose();
+	}
+
+	return (
+		<div class="space-y-6">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Command Palette — Dialog + Combobox composition
+				</h3>
+				<button
+					type="button"
+					onClick={() => setOpen(true)}
+					class="inline-flex items-center gap-2 bg-surface-2 hover:bg-surface-3 border border-surface-border text-text-primary px-4 py-2 rounded-lg text-sm transition-colors cursor-pointer"
+				>
+					<SearchIcon />
+					<span>Search or jump to...</span>
+					<kbd class="ml-4 px-1.5 py-0.5 text-xs bg-surface-3 border border-surface-border rounded font-mono text-text-tertiary">
+						⌘K
+					</kbd>
+				</button>
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Combines <code class="text-accent-400 font-mono">Dialog</code> as the modal container with{' '}
+				<code class="text-accent-400 font-mono">Combobox</code> for searchable options. Shows recent
+				items, grouped results, keyboard shortcuts, and a footer with tips.
+			</p>
+
+			{/* Command Palette Modal */}
+			<Dialog open={open} onClose={handleClose} class="relative z-50">
+				<DialogBackdrop class="fixed inset-0 bg-black/50 backdrop-blur-sm transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in" />
+
+				<div class="fixed inset-0 z-10 overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel class="mx-auto max-w-2xl transform divide-y divide-surface-border overflow-hidden rounded-xl bg-surface-1 shadow-2xl border border-surface-border outline-1 outline-surface-border transition-all data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in">
+						<Combobox onChange={handleSelect}>
+							<div class="grid grid-cols-1">
+								<ComboboxInput
+									autoFocus
+									class="col-start-1 row-start-1 h-14 w-full pr-4 pl-12 text-base text-text-primary bg-transparent outline-none placeholder:text-text-muted"
+									placeholder="Search projects, actions, or type a command..."
+									displayValue={() => query}
+									onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
+								/>
+								<span class="col-start-1 row-start-1 ml-4 self-center text-text-tertiary pointer-events-none">
+									<SearchIcon />
+								</span>
+							</div>
+
+							{showResults && (
+								<ComboboxOptions static class="max-h-80 scroll-py-2 overflow-y-auto">
+									{/* Recent searches - only when no query */}
+									{query === '' && recentItems.length > 0 && (
+										<li class="p-2">
+											<h2 class="px-3 py-2 text-xs font-semibold text-text-tertiary uppercase tracking-wider">
+												Recent
+											</h2>
+											<ul class="text-sm text-text-secondary">
+												{recentItems.map((item) => (
+													<ComboboxOption
+														key={item.id}
+														value={item}
+														class="group flex cursor-default items-center rounded-lg px-3 py-2.5 select-none data-[focus]:bg-accent-500 data-[focus]:text-white transition-colors"
+													>
+														<span class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-3 group-data-[focus]:bg-accent-600 text-text-tertiary group-data-[focus]:text-white transition-colors">
+															<FolderIcon />
+														</span>
+														<span class="ml-3 flex-auto truncate">{item.name}</span>
+														<span class="ml-3 hidden flex-none text-xs text-text-muted group-data-[focus]:text-accent-200">
+															Jump to
+														</span>
+													</ComboboxOption>
+												))}
+											</ul>
+										</li>
+									)}
+
+									{/* Quick actions */}
+									<li class="p-2">
+										<h2 class="px-3 py-2 text-xs font-semibold text-text-tertiary uppercase tracking-wider">
+											{query === '' ? 'Quick actions' : 'Actions'}
+										</h2>
+										<ul class="text-sm text-text-secondary">
+											{filteredActions.map((item) => (
+												<ComboboxOption
+													key={item.id}
+													value={item}
+													class="group flex cursor-default items-center rounded-lg px-3 py-2.5 select-none data-[focus]:bg-accent-500 data-[focus]:text-white transition-colors"
+												>
+													<span class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-3 group-data-[focus]:bg-accent-600 text-text-tertiary group-data-[focus]:text-white transition-colors">
+														<BoltIcon />
+													</span>
+													<span class="ml-3 flex-auto truncate">{item.name}</span>
+													{item.shortcut && (
+														<span class="ml-3 flex-none">
+															<kbd class="px-1.5 py-0.5 text-xs font-mono rounded bg-surface-3 group-data-[focus]:bg-accent-600 text-text-muted group-data-[focus]:text-accent-200 border border-surface-border group-data-[focus]:border-accent-400">
+																⌘{item.shortcut}
+															</kbd>
+														</span>
+													)}
+												</ComboboxOption>
+											))}
+										</ul>
+									</li>
+
+									{/* Projects - only when searching */}
+									{query !== '' && filteredProjects.length > 0 && (
+										<li class="p-2">
+											<h2 class="px-3 py-2 text-xs font-semibold text-text-tertiary uppercase tracking-wider">
+												Projects
+											</h2>
+											<ul class="text-sm text-text-secondary">
+												{filteredProjects.map((item) => (
+													<ComboboxOption
+														key={item.id}
+														value={item}
+														class="group flex cursor-default items-center rounded-lg px-3 py-2.5 select-none data-[focus]:bg-accent-500 data-[focus]:text-white transition-colors"
+													>
+														<span class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-3 group-data-[focus]:bg-accent-600 text-text-tertiary group-data-[focus]:text-white transition-colors">
+															<FolderIcon />
+														</span>
+														<span class="ml-3 flex-auto truncate">{item.name}</span>
+														<span class="ml-3 hidden flex-none text-xs text-text-muted group-data-[focus]:text-accent-200">
+															Open
+														</span>
+													</ComboboxOption>
+												))}
+											</ul>
+										</li>
+									)}
+
+									{/* Empty state */}
+									{query !== '' &&
+										filteredProjects.length === 0 &&
+										filteredActions.length === 0 && (
+											<li class="px-6 py-14 text-center">
+												<span class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-surface-3 text-text-tertiary">
+													<SearchIcon />
+												</span>
+												<p class="mt-4 text-sm text-text-secondary">
+													No results found for "{query}"
+												</p>
+												<p class="mt-1 text-xs text-text-muted">
+													Try searching for projects or actions
+												</p>
+											</li>
+										)}
+								</ComboboxOptions>
+							)}
+
+							{/* Footer */}
+							<div class="flex items-center justify-between border-t border-surface-border px-4 py-3 text-xs text-text-muted">
+								<div class="flex items-center gap-4">
+									<span class="flex items-center gap-1">
+										<kbd class="px-1 py-0.5 bg-surface-3 border border-surface-border rounded font-mono">
+											↑↓
+										</kbd>
+										<span>Navigate</span>
+									</span>
+									<span class="flex items-center gap-1">
+										<kbd class="px-1 py-0.5 bg-surface-3 border border-surface-border rounded font-mono">
+											↵
+										</kbd>
+										<span>Select</span>
+									</span>
+									<span class="flex items-center gap-1">
+										<kbd class="px-1 py-0.5 bg-surface-3 border border-surface-border rounded font-mono">
+											esc
+										</kbd>
+										<span>Close</span>
+									</span>
+								</div>
+								<div class="flex items-center gap-1">
+									<CommandIcon />
+									<span>Powered by @neokai/ui</span>
+								</div>
+							</div>
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+export { CommandPaletteDemo };

--- a/packages/ui/demo/sections/DrawerDemo.tsx
+++ b/packages/ui/demo/sections/DrawerDemo.tsx
@@ -1,0 +1,291 @@
+import { useState } from 'preact/hooks';
+import {
+	CloseButton,
+	Dialog,
+	DialogBackdrop,
+	DialogDescription,
+	DialogTitle,
+	Transition,
+	TransitionChild,
+} from '../../src/mod.ts';
+
+function DrawerDemo() {
+	const [rightOpen, setRightOpen] = useState(false);
+	const [leftOpen, setLeftOpen] = useState(false);
+	const [inlineOpen, setInlineOpen] = useState(false);
+
+	return (
+		<div class="space-y-8">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Drawer — Slide from right with overlay
+				</h3>
+				<button
+					type="button"
+					onClick={() => setRightOpen(true)}
+					class="bg-accent-500 hover:bg-accent-600 text-white px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer"
+				>
+					Open right drawer
+				</button>
+				<p class="mt-2 text-xs text-text-muted">
+					Uses <code class="text-accent-400 font-mono">Dialog</code> +{' '}
+					<code class="text-accent-400 font-mono">DialogPanel</code> with{' '}
+					<code class="text-accent-400 font-mono">data-closed:translate-x-full</code> transition.
+				</p>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Drawer — Slide from left</h3>
+				<button
+					type="button"
+					onClick={() => setLeftOpen(true)}
+					class="bg-surface-2 hover:bg-surface-3 border border-surface-border text-text-primary px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer"
+				>
+					Open left drawer
+				</button>
+				<p class="mt-2 text-xs text-text-muted">
+					Flip the slide direction with{' '}
+					<code class="text-accent-400 font-mono">-translate-x-full</code> and{' '}
+					<code class="text-accent-400 font-mono">-translate-x-0</code>.
+				</p>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Drawer — Inline (no overlay, full height)
+				</h3>
+				<button
+					type="button"
+					onClick={() => setInlineOpen(true)}
+					class="bg-surface-2 hover:bg-surface-3 border border-surface-border text-text-primary px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer"
+				>
+					Open inline drawer
+				</button>
+				<p class="mt-2 text-xs text-text-muted">
+					Inline variant without backdrop for sidebar-style panels.
+				</p>
+			</div>
+
+			{/* Right Drawer */}
+			<Dialog open={rightOpen} onClose={setRightOpen} class="relative z-10">
+				<Transition show={rightOpen}>
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-black/50 transition-opacity duration-300 ease-out data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in"
+					/>
+
+					<div class="fixed inset-0 overflow-hidden">
+						<div class="absolute inset-0 overflow-hidden">
+							<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10">
+								<TransitionChild
+									show={rightOpen}
+									transition
+									as="div"
+									class="pointer-events-auto w-screen max-w-md transform transition duration-300 ease-in-out data-[closed]:translate-x-full sm:duration-500"
+								>
+									<div class="flex h-full flex-col overflow-y-scroll bg-surface-1 shadow-xl">
+										<div class="px-4 py-6 sm:px-6">
+											<div class="flex items-start justify-between">
+												<DialogTitle class="text-lg font-semibold text-text-primary">
+													Project Settings
+												</DialogTitle>
+												<div class="ml-3 flex h-7 items-center">
+													<CloseButton
+														onClick={() => setRightOpen(false)}
+														class="rounded-lg p-1.5 text-text-tertiary hover:text-text-primary hover:bg-surface-2 transition-colors cursor-pointer"
+													>
+														<span class="sr-only">Close panel</span>
+														<svg class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
+															<path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+														</svg>
+													</CloseButton>
+												</div>
+											</div>
+										</div>
+
+										<div class="relative mt-6 flex-1 px-4 sm:px-6 space-y-6">
+											<DialogDescription class="text-sm text-text-secondary">
+												Configure your project settings and preferences.
+											</DialogDescription>
+
+											<div class="space-y-4">
+												<div>
+													<label class="block text-sm font-medium text-text-primary mb-1.5">
+														Project Name
+													</label>
+													<input
+														type="text"
+														defaultValue="Website Redesign"
+														class="w-full px-3 py-2 rounded-lg bg-surface-2 border border-surface-border text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent"
+													/>
+												</div>
+
+												<div>
+													<label class="block text-sm font-medium text-text-primary mb-1.5">
+														Description
+													</label>
+													<textarea
+														rows={3}
+														defaultValue="Complete redesign of the marketing website"
+														class="w-full px-3 py-2 rounded-lg bg-surface-2 border border-surface-border text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent resize-none"
+													/>
+												</div>
+
+												<div>
+													<label class="block text-sm font-medium text-text-primary mb-1.5">
+														Visibility
+													</label>
+													<select class="w-full px-3 py-2 rounded-lg bg-surface-2 border border-surface-border text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent">
+														<option>Private</option>
+														<option>Team</option>
+														<option>Public</option>
+													</select>
+												</div>
+											</div>
+										</div>
+
+										<div class="flex shrink-0 justify-end gap-3 border-t border-surface-border px-4 py-4 sm:px-6">
+											<button
+												type="button"
+												onClick={() => setRightOpen(false)}
+												class="px-4 py-2 rounded-lg text-sm font-medium border border-surface-border text-text-primary hover:bg-surface-2 transition-colors cursor-pointer"
+											>
+												Cancel
+											</button>
+											<button
+												type="button"
+												onClick={() => setRightOpen(false)}
+												class="px-4 py-2 rounded-lg text-sm font-medium bg-accent-500 hover:bg-accent-600 text-white transition-colors cursor-pointer"
+											>
+												Save changes
+											</button>
+										</div>
+									</div>
+								</TransitionChild>
+							</div>
+						</div>
+					</div>
+				</Transition>
+			</Dialog>
+
+			{/* Left Drawer */}
+			<Dialog open={leftOpen} onClose={setLeftOpen} class="relative z-10">
+				<Transition show={leftOpen}>
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-black/50 transition-opacity duration-300 ease-out data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in"
+					/>
+
+					<div class="fixed inset-0 overflow-hidden">
+						<div class="absolute inset-0 overflow-hidden">
+							<div class="pointer-events-none fixed inset-y-0 left-0 flex max-w-full pr-10">
+								<TransitionChild
+									show={leftOpen}
+									transition
+									as="div"
+									class="pointer-events-auto w-screen max-w-xs transform transition duration-300 ease-in-out data-[closed]:-translate-x-full sm:duration-500"
+								>
+									<div class="flex h-full flex-col bg-surface-1 shadow-xl border-r border-surface-border">
+										<div class="px-4 py-6">
+											<div class="flex items-start justify-between">
+												<DialogTitle class="text-lg font-semibold text-text-primary">
+													Navigation
+												</DialogTitle>
+												<CloseButton
+													onClick={() => setLeftOpen(false)}
+													class="rounded-lg p-1.5 text-text-tertiary hover:text-text-primary hover:bg-surface-2 transition-colors cursor-pointer"
+												>
+													<span class="sr-only">Close panel</span>
+													<svg class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
+														<path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+													</svg>
+												</CloseButton>
+											</div>
+										</div>
+
+										<nav class="flex-1 px-4 space-y-1">
+											<a
+												href="#"
+												class="flex items-center gap-3 px-3 py-2 rounded-lg bg-accent-500 text-white text-sm font-medium"
+											>
+												<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+													<path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+												</svg>
+												Home
+											</a>
+											<a
+												href="#"
+												class="flex items-center gap-3 px-3 py-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-2 text-sm font-medium transition-colors"
+											>
+												<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+													<path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z" />
+												</svg>
+												Projects
+											</a>
+											<a
+												href="#"
+												class="flex items-center gap-3 px-3 py-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-2 text-sm font-medium transition-colors"
+											>
+												<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+													<path
+														fill-rule="evenodd"
+														d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+														clip-rule="evenodd"
+													/>
+												</svg>
+												Team
+											</a>
+											<a
+												href="#"
+												class="flex items-center gap-3 px-3 py-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-2 text-sm font-medium transition-colors"
+											>
+												<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+													<path
+														fill-rule="evenodd"
+														d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
+														clip-rule="evenodd"
+													/>
+												</svg>
+												Settings
+											</a>
+										</nav>
+									</div>
+								</TransitionChild>
+							</div>
+						</div>
+					</div>
+				</Transition>
+			</Dialog>
+
+			{/* Inline Drawer */}
+			<div class="relative overflow-hidden border border-surface-border rounded-xl bg-surface-0">
+				{inlineOpen && (
+					<div class="absolute inset-y-0 left-0 w-64 bg-surface-1 shadow-xl border-r border-surface-border z-10">
+						<div class="flex items-center justify-between p-4 border-b border-surface-border">
+							<span class="font-semibold text-text-primary">Sidebar</span>
+							<CloseButton
+								onClick={() => setInlineOpen(false)}
+								class="rounded-lg p-1 text-text-tertiary hover:text-text-primary hover:bg-surface-2 transition-colors cursor-pointer"
+							>
+								<svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+									<path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+								</svg>
+							</CloseButton>
+						</div>
+						<div class="p-4 text-sm text-text-secondary">
+							This is an inline drawer variant without backdrop overlay. Useful for persistent
+							sidebars.
+						</div>
+					</div>
+				)}
+				<div class="p-8 text-center">
+					<p class="text-text-secondary">
+						Main content area — click "Open inline drawer" to see the sidebar
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export { DrawerDemo };

--- a/packages/ui/demo/sections/DrawerDemo.tsx
+++ b/packages/ui/demo/sections/DrawerDemo.tsx
@@ -29,8 +29,8 @@ function DrawerDemo() {
 				</button>
 				<p class="mt-2 text-xs text-text-muted">
 					Uses <code class="text-accent-400 font-mono">Dialog</code> +{' '}
-					<code class="text-accent-400 font-mono">DialogPanel</code> with{' '}
-					<code class="text-accent-400 font-mono">data-closed:translate-x-full</code> transition.
+					<code class="text-accent-400 font-mono">TransitionChild</code> with{' '}
+					<code class="text-accent-400 font-mono">data-[closed]:translate-x-full</code> transition.
 				</p>
 			</div>
 
@@ -67,18 +67,14 @@ function DrawerDemo() {
 			</div>
 
 			{/* Right Drawer */}
-			<Dialog open={rightOpen} onClose={setRightOpen} class="relative z-10">
+			<Dialog open={rightOpen} onClose={setRightOpen} class="relative z-50">
 				<Transition show={rightOpen}>
-					<DialogBackdrop
-						transition
-						class="fixed inset-0 bg-black/50 transition-opacity duration-300 ease-out data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in"
-					/>
+					<DialogBackdrop class="fixed inset-0 bg-black/50 transition-opacity duration-300 ease-out data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in" />
 
 					<div class="fixed inset-0 overflow-hidden">
 						<div class="absolute inset-0 overflow-hidden">
 							<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10">
 								<TransitionChild
-									show={rightOpen}
 									transition
 									as="div"
 									class="pointer-events-auto w-screen max-w-md transform transition duration-300 ease-in-out data-[closed]:translate-x-full sm:duration-500"
@@ -169,18 +165,14 @@ function DrawerDemo() {
 			</Dialog>
 
 			{/* Left Drawer */}
-			<Dialog open={leftOpen} onClose={setLeftOpen} class="relative z-10">
+			<Dialog open={leftOpen} onClose={setLeftOpen} class="relative z-50">
 				<Transition show={leftOpen}>
-					<DialogBackdrop
-						transition
-						class="fixed inset-0 bg-black/50 transition-opacity duration-300 ease-out data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in"
-					/>
+					<DialogBackdrop class="fixed inset-0 bg-black/50 transition-opacity duration-300 ease-out data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in" />
 
 					<div class="fixed inset-0 overflow-hidden">
 						<div class="absolute inset-0 overflow-hidden">
 							<div class="pointer-events-none fixed inset-y-0 left-0 flex max-w-full pr-10">
 								<TransitionChild
-									show={leftOpen}
 									transition
 									as="div"
 									class="pointer-events-auto w-screen max-w-xs transform transition duration-300 ease-in-out data-[closed]:-translate-x-full sm:duration-500"
@@ -259,8 +251,12 @@ function DrawerDemo() {
 
 			{/* Inline Drawer */}
 			<div class="relative overflow-hidden border border-surface-border rounded-xl bg-surface-0">
-				{inlineOpen && (
-					<div class="absolute inset-y-0 left-0 w-64 bg-surface-1 shadow-xl border-r border-surface-border z-10">
+				<Transition show={inlineOpen}>
+					<TransitionChild
+						transition
+						as="div"
+						class="absolute inset-y-0 left-0 w-64 bg-surface-1 shadow-xl border-r border-surface-border z-10 data-[closed]:-translate-x-full transition-transform duration-300 ease-out"
+					>
 						<div class="flex items-center justify-between p-4 border-b border-surface-border">
 							<span class="font-semibold text-text-primary">Sidebar</span>
 							<CloseButton
@@ -276,8 +272,8 @@ function DrawerDemo() {
 							This is an inline drawer variant without backdrop overlay. Useful for persistent
 							sidebars.
 						</div>
-					</div>
-				)}
+					</TransitionChild>
+				</Transition>
 				<div class="p-8 text-center">
 					<p class="text-text-secondary">
 						Main content area — click "Open inline drawer" to see the sidebar

--- a/packages/ui/demo/sections/NotificationDemo.tsx
+++ b/packages/ui/demo/sections/NotificationDemo.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'preact/hooks';
+import type { VNode } from 'preact';
 import { Toaster, useToast } from '../../src/mod.ts';
 import type { ToastVariant } from '../../src/mod.ts';
 
@@ -94,8 +95,6 @@ const iconMap: Record<ToastVariant, () => VNode> = {
 	info: InfoIcon,
 	warning: ExclamationIcon,
 };
-
-import type { VNode } from 'preact';
 
 function NotificationStack() {
 	const { toast } = useToast();
@@ -278,23 +277,9 @@ function NotificationGroup() {
 					<div
 						key={notification.id}
 						class={`group relative p-4 bg-surface-1 border border-surface-border rounded-lg transition-colors ${
-							notification.read ? 'opacity-60' : 'border-l-4'
-						} ${
-							notification.variant === 'success'
-								? notification.read
-									? ''
-									: 'border-l-green-500'
-								: notification.variant === 'error'
-									? notification.read
-										? ''
-										: 'border-l-red-500'
-									: notification.variant === 'info'
-										? notification.read
-											? ''
-											: 'border-l-accent-500'
-										: notification.read
-											? ''
-											: 'border-l-yellow-500'
+							notification.read
+								? 'opacity-60'
+								: `border-l-4 ${borderColorMap[notification.variant]}`
 						}`}
 					>
 						<NotificationCard
@@ -352,7 +337,7 @@ function InlineToastExamples() {
 	);
 }
 
-export function NotificationDemo() {
+function NotificationDemo() {
 	return (
 		<div class="space-y-8">
 			<div>
@@ -374,3 +359,5 @@ export function NotificationDemo() {
 		</div>
 	);
 }
+
+export { NotificationDemo };

--- a/packages/ui/demo/sections/NotificationDemo.tsx
+++ b/packages/ui/demo/sections/NotificationDemo.tsx
@@ -1,0 +1,376 @@
+import { useState } from 'preact/hooks';
+import { Toaster, useToast } from '../../src/mod.ts';
+import type { ToastVariant } from '../../src/mod.ts';
+
+interface NotificationItem {
+	id: number;
+	variant: ToastVariant;
+	title: string;
+	description: string;
+	timestamp: Date;
+	read: boolean;
+}
+
+const iconColorMap: Record<ToastVariant, string> = {
+	success: 'text-green-400',
+	error: 'text-red-400',
+	info: 'text-accent-400',
+	warning: 'text-yellow-400',
+};
+
+const iconBgMap: Record<ToastVariant, string> = {
+	success: 'bg-green-400/10',
+	error: 'bg-red-400/10',
+	info: 'bg-accent-400/10',
+	warning: 'bg-yellow-400/10',
+};
+
+const borderColorMap: Record<ToastVariant, string> = {
+	success: 'border-l-green-500',
+	error: 'border-l-red-500',
+	info: 'border-l-accent-500',
+	warning: 'border-l-yellow-500',
+};
+
+function CheckCircleIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function XCircleIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function InfoIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function ExclamationIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function BellIcon() {
+	return (
+		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+			<path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
+		</svg>
+	);
+}
+
+const iconMap: Record<ToastVariant, () => VNode> = {
+	success: CheckCircleIcon,
+	error: XCircleIcon,
+	info: InfoIcon,
+	warning: ExclamationIcon,
+};
+
+import type { VNode } from 'preact';
+
+function NotificationStack() {
+	const { toast } = useToast();
+
+	return (
+		<div class="space-y-4">
+			<div class="flex gap-3 flex-wrap">
+				<button
+					onClick={() =>
+						toast({
+							title: 'File uploaded',
+							description: 'image-banner.png has been uploaded to your project.',
+							variant: 'success',
+							duration: 5000,
+						})
+					}
+					class="px-4 py-2 rounded-lg bg-green-900/30 border border-green-700 text-green-300 text-sm font-medium hover:bg-green-900/50 transition-colors cursor-pointer"
+				>
+					Success notification
+				</button>
+				<button
+					onClick={() =>
+						toast({
+							title: 'Build failed',
+							description: '3 errors found in src/components/App.tsx',
+							variant: 'error',
+							duration: 8000,
+						})
+					}
+					class="px-4 py-2 rounded-lg bg-red-900/30 border border-red-700 text-red-300 text-sm font-medium hover:bg-red-900/50 transition-colors cursor-pointer"
+				>
+					Error notification
+				</button>
+				<button
+					onClick={() =>
+						toast({
+							title: 'Deploy complete',
+							description: 'Your changes are now live at example.com',
+							variant: 'info',
+							duration: 5000,
+						})
+					}
+					class="px-4 py-2 rounded-lg bg-surface-2 border border-surface-border text-text-primary text-sm font-medium hover:border-accent-500 transition-colors cursor-pointer"
+				>
+					Info notification
+				</button>
+				<button
+					onClick={() =>
+						toast({
+							title: 'Storage limit warning',
+							description: 'You have used 85% of your storage quota.',
+							variant: 'warning',
+							duration: 0,
+						})
+					}
+					class="px-4 py-2 rounded-lg bg-yellow-900/30 border border-yellow-700 text-yellow-300 text-sm font-medium hover:bg-yellow-900/50 transition-colors cursor-pointer"
+				>
+					Warning notification
+				</button>
+				<button
+					onClick={() =>
+						toast({
+							title: 'Deployment in progress',
+							description: 'This may take a few minutes...',
+							variant: 'info',
+							showProgress: true,
+							duration: 10000,
+						})
+					}
+					class="px-4 py-2 rounded-lg bg-surface-2 border border-surface-border text-text-primary text-sm font-medium hover:border-accent-500 transition-colors cursor-pointer"
+				>
+					With progress bar
+				</button>
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Typed notifications using <code class="text-accent-400 font-mono">ToastVariant</code> with{' '}
+				<code class="text-accent-400 font-mono">data-variant</code> attribute for styling.
+			</p>
+
+			<Toaster
+				position="bottom-right"
+				class="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-80"
+			/>
+		</div>
+	);
+}
+
+function NotificationCard({
+	variant,
+	title,
+	description,
+}: {
+	variant: ToastVariant;
+	title: string;
+	description: string;
+}) {
+	const Icon = iconMap[variant];
+
+	return (
+		<div
+			class={`flex items-start gap-3 p-4 bg-surface-1 border border-surface-border border-l-4 rounded-lg shadow-md ${borderColorMap[variant]}`}
+		>
+			<span
+				class={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${iconBgMap[variant]} ${iconColorMap[variant]}`}
+			>
+				<Icon />
+			</span>
+			<div class="flex-1 min-w-0">
+				<p class="text-sm font-medium text-text-primary">{title}</p>
+				<p class="mt-0.5 text-xs text-text-tertiary">{description}</p>
+			</div>
+		</div>
+	);
+}
+
+function NotificationGroup() {
+	const [notifications, setNotifications] = useState<NotificationItem[]>([
+		{
+			id: 1,
+			variant: 'success',
+			title: 'Deployment successful',
+			description: 'v2.3.1 is now live in production',
+			timestamp: new Date(Date.now() - 5 * 60 * 1000),
+			read: false,
+		},
+		{
+			id: 2,
+			variant: 'info',
+			title: 'New comment',
+			description: 'Sarah mentioned you in "API Design"',
+			timestamp: new Date(Date.now() - 30 * 60 * 1000),
+			read: false,
+		},
+		{
+			id: 3,
+			variant: 'warning',
+			title: 'SSL certificate expiring',
+			description: 'Renew within 7 days to avoid downtime',
+			timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
+			read: true,
+		},
+	]);
+
+	const unreadCount = notifications.filter((n) => !n.read).length;
+
+	function dismiss(id: number) {
+		setNotifications((prev) => prev.filter((n) => n.id !== id));
+	}
+
+	function markAllRead() {
+		setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+	}
+
+	return (
+		<div class="space-y-4">
+			<div class="flex items-center justify-between">
+				<div class="flex items-center gap-2">
+					<BellIcon />
+					<span class="text-sm font-medium text-text-primary">Notifications</span>
+					{unreadCount > 0 && (
+						<span class="px-2 py-0.5 text-xs font-medium bg-accent-500 text-white rounded-full">
+							{unreadCount}
+						</span>
+					)}
+				</div>
+				{unreadCount > 0 && (
+					<button
+						type="button"
+						onClick={markAllRead}
+						class="text-xs text-accent-400 hover:text-accent-300 transition-colors cursor-pointer"
+					>
+						Mark all as read
+					</button>
+				)}
+			</div>
+
+			<div class="space-y-2">
+				{notifications.map((notification) => (
+					<div
+						key={notification.id}
+						class={`group relative p-4 bg-surface-1 border border-surface-border rounded-lg transition-colors ${
+							notification.read ? 'opacity-60' : 'border-l-4'
+						} ${
+							notification.variant === 'success'
+								? notification.read
+									? ''
+									: 'border-l-green-500'
+								: notification.variant === 'error'
+									? notification.read
+										? ''
+										: 'border-l-red-500'
+									: notification.variant === 'info'
+										? notification.read
+											? ''
+											: 'border-l-accent-500'
+										: notification.read
+											? ''
+											: 'border-l-yellow-500'
+						}`}
+					>
+						<NotificationCard
+							variant={notification.variant}
+							title={notification.title}
+							description={notification.description}
+						/>
+						<button
+							type="button"
+							onClick={() => dismiss(notification.id)}
+							class="absolute top-2 right-2 p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-2 transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
+						>
+							<svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+								<path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+							</svg>
+						</button>
+					</div>
+				))}
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Notification groups with unread badges, mark as read, and dismiss functionality.
+			</p>
+		</div>
+	);
+}
+
+function InlineToastExamples() {
+	return (
+		<div class="space-y-4">
+			<h4 class="text-sm font-medium text-text-secondary">Inline variants</h4>
+			<div class="grid gap-3 sm:grid-cols-2">
+				<NotificationCard
+					variant="success"
+					title="Changes saved"
+					description="Your project has been updated successfully."
+				/>
+				<NotificationCard
+					variant="error"
+					title="Payment failed"
+					description="Please check your card details and try again."
+				/>
+				<NotificationCard
+					variant="info"
+					title="Meeting in 10 minutes"
+					description="Standup sync in the #engineering room."
+				/>
+				<NotificationCard
+					variant="warning"
+					title="Low disk space"
+					description="Only 2GB remaining. Consider freeing up space."
+				/>
+			</div>
+		</div>
+	);
+}
+
+export function NotificationDemo() {
+	return (
+		<div class="space-y-8">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Toast notifications — typed with variants
+				</h3>
+				<NotificationStack />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Inline notification cards</h3>
+				<InlineToastExamples />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Notification group with state</h3>
+				<NotificationGroup />
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/src/components/alert/alert.tsx
+++ b/packages/ui/src/components/alert/alert.tsx
@@ -1,0 +1,238 @@
+import { createContext, createElement } from 'preact';
+import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+import { render } from '../../internal/render.ts';
+import type { ElementType } from '../../internal/types.ts';
+import { useId } from '../../internal/use-id.ts';
+
+// --- Alert Context ---
+
+interface AlertContextValue {
+	open: boolean;
+	variant: string;
+	dismissible: boolean;
+	dismiss: () => void;
+	titleId: string | null;
+	setTitleId: (id: string | null) => void;
+	descriptionId: string | null;
+	setDescriptionId: (id: string | null) => void;
+}
+
+const AlertContext = createContext<AlertContextValue | null>(null);
+AlertContext.displayName = 'AlertContext';
+
+function useAlertContext(component: string): AlertContextValue {
+	const ctx = useContext(AlertContext);
+	if (ctx === null) {
+		throw new Error(`<${component}> must be used within an <Alert>`);
+	}
+	return ctx;
+}
+
+// --- Alert (root) ---
+
+type AlertVariant = 'info' | 'success' | 'warning' | 'error';
+
+interface AlertProps {
+	variant?: AlertVariant;
+	dismissible?: boolean;
+	onDismiss?: () => void;
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AlertFn({
+	variant = 'info',
+	dismissible = false,
+	onDismiss,
+	as: Tag = 'div',
+	children,
+	...rest
+}: AlertProps) {
+	const [open, setOpen] = useState(true);
+	const [titleId, setTitleId] = useState<string | null>(null);
+	const [descriptionId, setDescriptionId] = useState<string | null>(null);
+
+	const dismiss = useCallback(() => {
+		setOpen(false);
+		onDismiss?.();
+	}, [onDismiss]);
+
+	const ctx: AlertContextValue = {
+		open,
+		variant,
+		dismissible,
+		dismiss,
+		titleId,
+		setTitleId,
+		descriptionId,
+		setDescriptionId,
+	};
+
+	const slot = { open, variant, dismissible };
+
+	const ourProps: Record<string, unknown> = {
+		role: 'alert',
+		'data-variant': variant,
+		'data-dismissible': dismissible || undefined,
+	};
+
+	const inner = render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'div',
+		name: 'Alert',
+	});
+
+	return createElement(AlertContext.Provider, { value: ctx }, inner);
+}
+
+AlertFn.displayName = 'Alert';
+export const Alert = AlertFn;
+
+// --- AlertIcon ---
+
+interface AlertIconProps {
+	as?: ElementType;
+	icon?: unknown;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AlertIconFn({ as: Tag = 'div', icon, children, ...rest }: AlertIconProps) {
+	const { variant } = useAlertContext('AlertIcon');
+
+	const slot = {};
+
+	// Default icons based on variant
+	const defaultIcons: Record<string, string> = {
+		info: `<svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" /></svg>`,
+		success: `<svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" /></svg>`,
+		warning: `<svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" /></svg>`,
+		error: `<svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" /></svg>`,
+	};
+
+	const iconContent =
+		icon ??
+		createElement('svg', {
+			'aria-hidden': 'true',
+			viewBox: '0 0 20 20',
+			fill: 'currentColor',
+			dangerouslySetInnerHTML: { __html: defaultIcons[variant] || defaultIcons.info },
+		});
+
+	const ourProps: Record<string, unknown> = {
+		'data-slot': 'icon',
+	};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children: children ?? iconContent, ...rest },
+		slot,
+		defaultTag: 'div',
+		name: 'AlertIcon',
+	});
+}
+
+AlertIconFn.displayName = 'AlertIcon';
+export const AlertIcon = AlertIconFn;
+
+// --- AlertTitle ---
+
+interface AlertTitleProps {
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AlertTitleFn({ as: Tag = 'h3', children, ...rest }: AlertTitleProps) {
+	const { open, setTitleId } = useAlertContext('AlertTitle');
+	const id = useId();
+
+	useEffect(() => {
+		setTitleId(id);
+		return () => setTitleId(null);
+	}, [id, setTitleId]);
+
+	const slot = { open };
+
+	const ourProps: Record<string, unknown> = {
+		id,
+	};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'h3',
+		name: 'AlertTitle',
+	});
+}
+
+AlertTitleFn.displayName = 'AlertTitle';
+export const AlertTitle = AlertTitleFn;
+
+// --- AlertDescription ---
+
+interface AlertDescriptionProps {
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AlertDescriptionFn({ as: Tag = 'p', children, ...rest }: AlertDescriptionProps) {
+	const { open, setDescriptionId } = useAlertContext('AlertDescription');
+	const id = useId();
+
+	useEffect(() => {
+		setDescriptionId(id);
+		return () => setDescriptionId(null);
+	}, [id, setDescriptionId]);
+
+	const slot = { open };
+
+	const ourProps: Record<string, unknown> = {
+		id,
+	};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'p',
+		name: 'AlertDescription',
+	});
+}
+
+AlertDescriptionFn.displayName = 'AlertDescription';
+export const AlertDescription = AlertDescriptionFn;
+
+// --- AlertActions ---
+
+interface AlertActionsProps {
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AlertActionsFn({ as: Tag = 'div', children, ...rest }: AlertActionsProps) {
+	const { open } = useAlertContext('AlertActions');
+
+	const slot = { open };
+
+	const ourProps: Record<string, unknown> = {
+		'data-slot': 'actions',
+	};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'div',
+		name: 'AlertActions',
+	});
+}
+
+AlertActionsFn.displayName = 'AlertActions';
+export const AlertActions = AlertActionsFn;

--- a/packages/ui/src/components/alert/alert.tsx
+++ b/packages/ui/src/components/alert/alert.tsx
@@ -73,6 +73,9 @@ function AlertFn({
 
 	const ourProps: Record<string, unknown> = {
 		role: 'alert',
+		'aria-labelledby': titleId ?? undefined,
+		'aria-describedby': descriptionId ?? undefined,
+		hidden: open ? undefined : true,
 		'data-variant': variant,
 		'data-dismissible': dismissible || undefined,
 	};
@@ -105,12 +108,28 @@ function AlertIconFn({ as: Tag = 'div', icon, children, ...rest }: AlertIconProp
 
 	const slot = {};
 
-	// Default icons based on variant
-	const defaultIcons: Record<string, string> = {
-		info: `<svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" /></svg>`,
-		success: `<svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" /></svg>`,
-		warning: `<svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" /></svg>`,
-		error: `<svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" /></svg>`,
+	// Default icon paths for each variant
+	const iconPaths: Record<string, preact.ComponentChildren> = {
+		info: createElement('path', {
+			'fill-rule': 'evenodd',
+			d: 'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z',
+			'clip-rule': 'evenodd',
+		}),
+		success: createElement('path', {
+			'fill-rule': 'evenodd',
+			d: 'M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z',
+			'clip-rule': 'evenodd',
+		}),
+		warning: createElement('path', {
+			'fill-rule': 'evenodd',
+			d: 'M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z',
+			'clip-rule': 'evenodd',
+		}),
+		error: createElement('path', {
+			'fill-rule': 'evenodd',
+			d: 'M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z',
+			'clip-rule': 'evenodd',
+		}),
 	};
 
 	const iconContent =
@@ -119,7 +138,7 @@ function AlertIconFn({ as: Tag = 'div', icon, children, ...rest }: AlertIconProp
 			'aria-hidden': 'true',
 			viewBox: '0 0 20 20',
 			fill: 'currentColor',
-			dangerouslySetInnerHTML: { __html: defaultIcons[variant] || defaultIcons.info },
+			children: iconPaths[variant] || iconPaths.info,
 		});
 
 	const ourProps: Record<string, unknown> = {

--- a/packages/ui/src/components/avatar/avatar.tsx
+++ b/packages/ui/src/components/avatar/avatar.tsx
@@ -1,0 +1,310 @@
+import { createContext, createElement } from 'preact';
+import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+import { render } from '../../internal/render.ts';
+import type { ElementType } from '../../internal/types.ts';
+
+// --- Types ---
+
+type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type AvatarShape = 'circle' | 'rounded';
+type AvatarStatus = 'online' | 'busy' | 'away' | 'offline';
+
+// --- Avatar Context ---
+
+interface AvatarContextValue {
+	size: AvatarSize;
+	shape: AvatarShape;
+	status?: AvatarStatus;
+}
+
+const AvatarContext = createContext<AvatarContextValue | null>(null);
+AvatarContext.displayName = 'AvatarContext';
+
+function useAvatarContext(component: string): AvatarContextValue {
+	const ctx = useContext(AvatarContext);
+	if (ctx === null) {
+		throw new Error(`<${component}> must be used within an <Avatar>`);
+	}
+	return ctx;
+}
+
+// --- Avatar Group Context ---
+
+interface AvatarGroupContextValue {
+	size: AvatarSize;
+	max: number;
+	visible: number;
+	overflow: number;
+	count: number;
+}
+
+const AvatarGroupContext = createContext<AvatarGroupContextValue | null>(null);
+AvatarGroupContext.displayName = 'AvatarGroupContext';
+
+function useAvatarGroupContext(component: string): AvatarGroupContextValue {
+	const ctx = useContext(AvatarGroupContext);
+	if (ctx === null) {
+		throw new Error(`<${component}> must be used within an <AvatarGroup>`);
+	}
+	return ctx;
+}
+
+// --- Avatar (individual) ---
+
+interface AvatarProps {
+	src?: string;
+	alt?: string;
+	fallback?: string;
+	size?: AvatarSize;
+	shape?: AvatarShape;
+	status?: AvatarStatus;
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AvatarFn({
+	size = 'md',
+	shape = 'circle',
+	status,
+	as: Tag = 'span',
+	children,
+	...rest
+}: AvatarProps) {
+	const ctx: AvatarContextValue = { size, shape, status };
+
+	const slot = {};
+
+	const ourProps: Record<string, unknown> = {
+		'data-size': size,
+		'data-shape': shape,
+		'data-status': status,
+	};
+
+	const inner = render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'span',
+		name: 'Avatar',
+	});
+
+	return createElement(AvatarContext.Provider, { value: ctx }, inner);
+}
+
+AvatarFn.displayName = 'Avatar';
+export const Avatar = AvatarFn;
+
+// --- AvatarGroup ---
+
+interface AvatarGroupProps {
+	max?: number;
+	size?: AvatarSize;
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AvatarGroupFn({ max, size = 'md', as: Tag = 'div', children, ...rest }: AvatarGroupProps) {
+	// Count visible children
+	const [count, setCount] = useState(0);
+
+	useEffect(() => {
+		// Count avatar children after mount
+		let visible = 0;
+		const traverse = (node: preact.ComponentChildren) => {
+			if (!node) return;
+			if (Array.isArray(node)) {
+				node.forEach(traverse);
+				return;
+			}
+			const vnode = node as preact.VNode;
+			if (
+				vnode.type === Avatar ||
+				(typeof vnode.type === 'function' && vnode.type.displayName === 'Avatar')
+			) {
+				visible++;
+			} else if (
+				vnode.type === AvatarGroupOverflow ||
+				(typeof vnode.type === 'function' && vnode.type.displayName === 'AvatarGroupOverflow')
+			) {
+				// Don't count overflow
+			} else if (vnode.props?.children) {
+				traverse(vnode.props.children);
+			}
+		};
+		traverse(children as preact.ComponentChildren);
+		setCount(visible);
+	}, [children]);
+
+	const overflow = max !== undefined ? Math.max(0, count - max) : 0;
+	const visible = max !== undefined ? Math.min(count, max) : count;
+
+	const ctx: AvatarGroupContextValue = { size, max: max ?? count, visible, overflow, count };
+
+	const slot = { overflow: overflow > 0, count: overflow };
+
+	const ourProps: Record<string, unknown> = {
+		'data-overflow': overflow > 0 || undefined,
+	};
+
+	const inner = render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'div',
+		name: 'AvatarGroup',
+	});
+
+	return createElement(AvatarGroupContext.Provider, { value: ctx }, inner);
+}
+
+AvatarGroupFn.displayName = 'AvatarGroup';
+export const AvatarGroup = AvatarGroupFn;
+
+// --- AvatarGroupOverflow ---
+
+interface AvatarGroupOverflowProps {
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AvatarGroupOverflowFn({ as: Tag = 'span', children, ...rest }: AvatarGroupOverflowProps) {
+	const { overflow, count } = useAvatarGroupContext('AvatarGroupOverflow');
+
+	const ourProps: Record<string, unknown> = {
+		'data-count': count || undefined,
+	};
+
+	const slot = { overflow, count };
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'span',
+		name: 'AvatarGroupOverflow',
+	});
+}
+
+AvatarGroupOverflowFn.displayName = 'AvatarGroupOverflow';
+export const AvatarGroupOverflow = AvatarGroupOverflowFn;
+
+// --- AvatarImage ---
+
+interface AvatarImageProps {
+	src?: string;
+	alt?: string;
+	onLoad?: () => void;
+	onError?: () => void;
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AvatarImageFn({ src, alt, onLoad, onError, as: Tag = 'img', ...rest }: AvatarImageProps) {
+	const [loaded, setLoaded] = useState(false);
+	const [error, setError] = useState(false);
+
+	const handleLoad = useCallback(() => {
+		setLoaded(true);
+		onLoad?.();
+	}, [onLoad]);
+
+	const handleError = useCallback(() => {
+		setError(true);
+		onError?.();
+	}, [onError]);
+
+	const { size: _size } = useAvatarContext('AvatarImage');
+
+	const ourProps: Record<string, unknown> = {
+		src,
+		alt: alt ?? '',
+		onLoad: handleLoad,
+		onError: handleError,
+		'data-loaded': loaded || undefined,
+		'data-error': error || undefined,
+	};
+
+	const slot = { loaded, error };
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children: undefined, ...rest },
+		slot,
+		defaultTag: 'img',
+		name: 'AvatarImage',
+	});
+}
+
+AvatarImageFn.displayName = 'AvatarImage';
+export const AvatarImage = AvatarImageFn;
+
+// --- AvatarFallback ---
+
+interface AvatarFallbackProps {
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function AvatarFallbackFn({ as: Tag = 'span', children, ...rest }: AvatarFallbackProps) {
+	const { size: _size } = useAvatarContext('AvatarFallback');
+
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		// Show fallback after a tick (allows image to attempt load first)
+		const timer = setTimeout(() => setVisible(true), 0);
+		return () => clearTimeout(timer);
+	}, []);
+
+	const slot = { visible };
+
+	const ourProps: Record<string, unknown> = {};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'span',
+		name: 'AvatarFallback',
+	});
+}
+
+AvatarFallbackFn.displayName = 'AvatarFallback';
+export const AvatarFallback = AvatarFallbackFn;
+
+// --- AvatarStatus ---
+
+interface AvatarStatusProps {
+	status: AvatarStatus;
+	as?: ElementType;
+	[key: string]: unknown;
+}
+
+function AvatarStatusFn({ status, as: Tag = 'span', ...rest }: AvatarStatusProps) {
+	const { size: _size, shape: _shape } = useAvatarContext('AvatarStatus');
+
+	const slot = {};
+
+	const ourProps: Record<string, unknown> = {
+		'aria-label': `Status: ${status}`,
+	};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, ...rest },
+		slot,
+		defaultTag: 'span',
+		name: 'AvatarStatus',
+	});
+}
+
+AvatarStatusFn.displayName = 'AvatarStatus';
+export const AvatarStatus = AvatarStatusFn;
+
+// Needed to suppress unused import warning
+void createElement;

--- a/packages/ui/src/components/avatar/avatar.tsx
+++ b/packages/ui/src/components/avatar/avatar.tsx
@@ -54,7 +54,6 @@ function useAvatarGroupContext(component: string): AvatarGroupContextValue {
 interface AvatarProps {
 	src?: string;
 	alt?: string;
-	fallback?: string;
 	size?: AvatarSize;
 	shape?: AvatarShape;
 	status?: AvatarStatus;
@@ -217,7 +216,7 @@ function AvatarImageFn({ src, alt, onLoad, onError, as: Tag = 'img', ...rest }: 
 		onError?.();
 	}, [onError]);
 
-	const { size: _size } = useAvatarContext('AvatarImage');
+	useAvatarContext('AvatarImage');
 
 	const ourProps: Record<string, unknown> = {
 		src,
@@ -251,7 +250,7 @@ interface AvatarFallbackProps {
 }
 
 function AvatarFallbackFn({ as: Tag = 'span', children, ...rest }: AvatarFallbackProps) {
-	const { size: _size } = useAvatarContext('AvatarFallback');
+	useAvatarContext('AvatarFallback');
 
 	const [visible, setVisible] = useState(false);
 
@@ -286,7 +285,7 @@ interface AvatarStatusProps {
 }
 
 function AvatarStatusFn({ status, as: Tag = 'span', ...rest }: AvatarStatusProps) {
-	const { size: _size, shape: _shape } = useAvatarContext('AvatarStatus');
+	useAvatarContext('AvatarStatus');
 
 	const slot = {};
 
@@ -305,6 +304,3 @@ function AvatarStatusFn({ status, as: Tag = 'span', ...rest }: AvatarStatusProps
 
 AvatarStatusFn.displayName = 'AvatarStatus';
 export const AvatarStatus = AvatarStatusFn;
-
-// Needed to suppress unused import warning
-void createElement;

--- a/packages/ui/src/components/badge/badge.tsx
+++ b/packages/ui/src/components/badge/badge.tsx
@@ -50,8 +50,8 @@ function BadgeFn({
 		'data-color': color,
 		'data-size': size,
 		'data-shape': shape,
-		'data-dot': dot || undefined,
-		'data-removable': removable || undefined,
+		'data-dot': dot ? '' : undefined,
+		'data-removable': removable ? '' : undefined,
 		// Interaction state handlers
 		onMouseEnter: () => setHover(true),
 		onMouseLeave: () => setHover(false),

--- a/packages/ui/src/components/badge/badge.tsx
+++ b/packages/ui/src/components/badge/badge.tsx
@@ -1,0 +1,110 @@
+import { createElement } from 'preact';
+import { useCallback, useState } from 'preact/hooks';
+import { render } from '../../internal/render.ts';
+import type { ElementType } from '../../internal/types.ts';
+
+// --- Badge ---
+
+type BadgeVariant = 'subtle' | 'outline' | 'solid';
+type BadgeColor = 'gray' | 'red' | 'yellow' | 'green' | 'blue' | 'indigo' | 'purple' | 'pink';
+type BadgeSize = 'sm' | 'md';
+type BadgeShape = 'rounded' | 'pill' | 'square';
+
+interface BadgeProps {
+	variant?: BadgeVariant;
+	color?: BadgeColor;
+	size?: BadgeSize;
+	shape?: BadgeShape;
+	dot?: boolean;
+	removable?: boolean;
+	onRemove?: () => void;
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function BadgeFn({
+	variant = 'subtle',
+	color = 'gray',
+	size = 'md',
+	shape = 'rounded',
+	dot = false,
+	removable = false,
+	onRemove,
+	as: Tag = 'span',
+	children,
+	...rest
+}: BadgeProps) {
+	const [hover, setHover] = useState(false);
+	const [focus, setFocus] = useState(false);
+	const [active, setActive] = useState(false);
+
+	const handleRemove = useCallback(() => {
+		onRemove?.();
+	}, [onRemove]);
+
+	const slot = { hover, focus, active };
+
+	const ourProps: Record<string, unknown> = {
+		'data-variant': variant,
+		'data-color': color,
+		'data-size': size,
+		'data-shape': shape,
+		'data-dot': dot || undefined,
+		'data-removable': removable || undefined,
+		// Interaction state handlers
+		onMouseEnter: () => setHover(true),
+		onMouseLeave: () => setHover(false),
+		onFocus: () => setFocus(true),
+		onBlur: () => setFocus(false),
+		onMouseDown: () => setActive(true),
+		onMouseUp: () => setActive(false),
+	};
+
+	// Build children with optional dot and remove button
+	const dotElement = dot
+		? createElement('svg', {
+				'aria-hidden': 'true',
+				viewBox: '0 0 6 6',
+				className: 'badge-dot',
+				children: createElement('circle', {
+					cx: '3',
+					cy: '3',
+					r: '3',
+					fill: 'currentColor',
+				}),
+			})
+		: null;
+
+	const removeButton = removable
+		? createElement('button', {
+				type: 'button',
+				'aria-label': 'Remove',
+				onClick: handleRemove,
+				className: 'badge-remove',
+				children: createElement('svg', {
+					'aria-hidden': 'true',
+					viewBox: '0 0 16 16',
+					fill: 'none',
+					stroke: 'currentColor',
+					'stroke-width': '2',
+					children: createElement('path', {
+						d: 'M4 4l8 8m0-8l-8 8',
+					}),
+				}),
+			})
+		: null;
+
+	const badgeContent = [dotElement, children, removeButton].filter(Boolean);
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children: badgeContent, ...rest },
+		slot,
+		defaultTag: 'span',
+		name: 'Badge',
+	});
+}
+
+BadgeFn.displayName = 'Badge';
+export const Badge = BadgeFn;

--- a/packages/ui/src/components/progress-bar/progress-bar.tsx
+++ b/packages/ui/src/components/progress-bar/progress-bar.tsx
@@ -1,0 +1,80 @@
+import { createElement } from 'preact';
+import { render } from '../../internal/render.ts';
+import type { ElementType } from '../../internal/types.ts';
+
+// --- ProgressBar ---
+
+type ProgressBarSize = 'sm' | 'md' | 'lg';
+
+interface ProgressBarProps {
+	value: number;
+	min?: number;
+	max?: number;
+	label?: string;
+	showValue?: boolean;
+	size?: ProgressBarSize;
+	color?: string;
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function ProgressBarFn({
+	value,
+	min = 0,
+	max = 100,
+	label,
+	showValue = false,
+	size = 'md',
+	color,
+	as: Tag = 'div',
+	children,
+	...rest
+}: ProgressBarProps) {
+	// Calculate percentage, clamped between 0 and 100
+	const percentage = Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
+
+	const isIndeterminate = value === null || value === undefined;
+
+	const slot = { value, percentage, indeterminate: isIndeterminate };
+
+	const ourProps: Record<string, unknown> = {
+		role: 'progressbar',
+		'aria-valuenow': isIndeterminate ? undefined : value,
+		'aria-valuemin': min,
+		'aria-valuemax': max,
+		'aria-valuetext': isIndeterminate ? undefined : `${Math.round(percentage)}%`,
+		'aria-label': label,
+		'data-value': value,
+		'data-min': min,
+		'data-max': max,
+		'data-size': size,
+		'data-indeterminate': isIndeterminate || undefined,
+	};
+
+	const fillStyle = color
+		? { width: `${percentage}%`, backgroundColor: color }
+		: { width: `${percentage}%` };
+
+	const fillElement = createElement('div', {
+		'data-progress-fill': true,
+		style: fillStyle,
+	});
+
+	const labelElement = showValue
+		? createElement('span', { 'data-progress-value': true }, `${Math.round(percentage)}%`)
+		: null;
+
+	const content = [fillElement, labelElement, children].filter(Boolean);
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children: content, ...rest },
+		slot,
+		defaultTag: 'div',
+		name: 'ProgressBar',
+	});
+}
+
+ProgressBarFn.displayName = 'ProgressBar';
+export const ProgressBar = ProgressBarFn;

--- a/packages/ui/src/components/progress-bar/progress-bar.tsx
+++ b/packages/ui/src/components/progress-bar/progress-bar.tsx
@@ -7,7 +7,7 @@ import type { ElementType } from '../../internal/types.ts';
 type ProgressBarSize = 'sm' | 'md' | 'lg';
 
 interface ProgressBarProps {
-	value: number;
+	value: number | null | undefined;
 	min?: number;
 	max?: number;
 	label?: string;
@@ -31,10 +31,12 @@ function ProgressBarFn({
 	children,
 	...rest
 }: ProgressBarProps) {
-	// Calculate percentage, clamped between 0 and 100
-	const percentage = Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
-
 	const isIndeterminate = value === null || value === undefined;
+
+	// Calculate percentage only if not indeterminate, clamped between 0 and 100
+	const percentage = isIndeterminate
+		? 0
+		: Math.min(100, Math.max(0, ((value! - min) / (max - min)) * 100));
 
 	const slot = { value, percentage, indeterminate: isIndeterminate };
 
@@ -45,25 +47,28 @@ function ProgressBarFn({
 		'aria-valuemax': max,
 		'aria-valuetext': isIndeterminate ? undefined : `${Math.round(percentage)}%`,
 		'aria-label': label,
-		'data-value': value,
+		'data-value': value ?? undefined,
 		'data-min': min,
 		'data-max': max,
 		'data-size': size,
-		'data-indeterminate': isIndeterminate || undefined,
+		'data-indeterminate': isIndeterminate ? '' : undefined,
 	};
 
-	const fillStyle = color
-		? { width: `${percentage}%`, backgroundColor: color }
-		: { width: `${percentage}%` };
+	const fillStyle = isIndeterminate
+		? { width: '100%' }
+		: color
+			? { width: `${percentage}%`, backgroundColor: color }
+			: { width: `${percentage}%` };
 
 	const fillElement = createElement('div', {
 		'data-progress-fill': true,
 		style: fillStyle,
 	});
 
-	const labelElement = showValue
-		? createElement('span', { 'data-progress-value': true }, `${Math.round(percentage)}%`)
-		: null;
+	const labelElement =
+		showValue && !isIndeterminate
+			? createElement('span', { 'data-progress-value': true }, `${Math.round(percentage)}%`)
+			: null;
 
 	const content = [fillElement, labelElement, children].filter(Boolean);
 

--- a/packages/ui/src/components/stepper/stepper.tsx
+++ b/packages/ui/src/components/stepper/stepper.tsx
@@ -13,10 +13,10 @@ interface StepperContextValue {
 const StepperContext = createContext<StepperContextValue | null>(null);
 StepperContext.displayName = 'StepperContext';
 
-function useStepperContext(): StepperContextValue {
+function useStepperContext(componentName: string): StepperContextValue {
 	const ctx = useContext(StepperContext);
 	if (ctx === null) {
-		throw new Error('<StepperContext> must be used within a <Stepper>');
+		throw new Error(`<${componentName}> must be used within a <Stepper>`);
 	}
 	return ctx;
 }
@@ -75,7 +75,7 @@ interface StepperStepProps {
 }
 
 function StepperStepFn({ status, as: Tag = 'div', children, ...rest }: StepperStepProps) {
-	const { currentStep, orientation } = useStepperContext();
+	const { currentStep, orientation } = useStepperContext('StepperStep');
 
 	const slot = { status, currentStep, orientation };
 
@@ -101,6 +101,7 @@ export const StepperStep = StepperStepFn;
 // --- StepperIcon ---
 
 interface StepperIconProps {
+	stepIndex: number;
 	status?: StepStatus;
 	as?: ElementType;
 	children?: unknown;
@@ -108,14 +109,13 @@ interface StepperIconProps {
 }
 
 function StepperIconFn({
+	stepIndex,
 	status = 'upcoming',
 	as: Tag = 'span',
 	children,
 	...rest
 }: StepperIconProps) {
-	const { currentStep } = useStepperContext();
-
-	const slot = { status, currentStep };
+	const slot = { status, stepIndex };
 
 	// For complete status, show checkmark
 	const checkmarkSvg = createElement('svg', {
@@ -129,8 +129,8 @@ function StepperIconFn({
 		}),
 	});
 
-	// For current/upcoming, show step number
-	const numberContent = String(currentStep + 1);
+	// Show step number (1-indexed)
+	const numberContent = String(stepIndex + 1);
 
 	const iconContent =
 		children ??
@@ -213,7 +213,7 @@ interface StepperSeparatorProps {
 }
 
 function StepperSeparatorFn({ as: Tag = 'div', children, ...rest }: StepperSeparatorProps) {
-	const { orientation } = useStepperContext();
+	const { orientation } = useStepperContext('StepperSeparator');
 
 	const slot = { orientation };
 

--- a/packages/ui/src/components/stepper/stepper.tsx
+++ b/packages/ui/src/components/stepper/stepper.tsx
@@ -1,0 +1,235 @@
+import { createContext, createElement } from 'preact';
+import { useContext } from 'preact/hooks';
+import { render } from '../../internal/render.ts';
+import type { ElementType } from '../../internal/types.ts';
+
+// --- Stepper Context ---
+
+interface StepperContextValue {
+	currentStep: number;
+	orientation: 'horizontal' | 'vertical';
+}
+
+const StepperContext = createContext<StepperContextValue | null>(null);
+StepperContext.displayName = 'StepperContext';
+
+function useStepperContext(): StepperContextValue {
+	const ctx = useContext(StepperContext);
+	if (ctx === null) {
+		throw new Error('<StepperContext> must be used within a <Stepper>');
+	}
+	return ctx;
+}
+
+// --- Stepper (container) ---
+
+interface StepperProps {
+	currentStep: number;
+	orientation?: 'horizontal' | 'vertical';
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function StepperFn({
+	currentStep,
+	orientation = 'horizontal',
+	as: Tag = 'div',
+	children,
+	...rest
+}: StepperProps) {
+	const ctx: StepperContextValue = { currentStep, orientation };
+
+	const slot = { currentStep, orientation };
+
+	const ourProps: Record<string, unknown> = {
+		role: 'list',
+		'data-orientation': orientation,
+	};
+
+	return createElement(
+		StepperContext.Provider,
+		{ value: ctx },
+		render({
+			ourProps,
+			theirProps: { as: Tag, children, ...rest },
+			slot,
+			defaultTag: 'div',
+			name: 'Stepper',
+		})
+	);
+}
+
+StepperFn.displayName = 'Stepper';
+export const Stepper = StepperFn;
+
+// --- StepperStep ---
+
+type StepStatus = 'complete' | 'current' | 'upcoming';
+
+interface StepperStepProps {
+	status: StepStatus;
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function StepperStepFn({ status, as: Tag = 'div', children, ...rest }: StepperStepProps) {
+	const { currentStep, orientation } = useStepperContext();
+
+	const slot = { status, currentStep, orientation };
+
+	const ourProps: Record<string, unknown> = {
+		role: 'listitem',
+		'aria-current': status === 'current' ? 'step' : undefined,
+		'data-status': status,
+		'data-orientation': orientation,
+	};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'div',
+		name: 'StepperStep',
+	});
+}
+
+StepperStepFn.displayName = 'StepperStep';
+export const StepperStep = StepperStepFn;
+
+// --- StepperIcon ---
+
+interface StepperIconProps {
+	status?: StepStatus;
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function StepperIconFn({
+	status = 'upcoming',
+	as: Tag = 'span',
+	children,
+	...rest
+}: StepperIconProps) {
+	const { currentStep } = useStepperContext();
+
+	const slot = { status, currentStep };
+
+	// For complete status, show checkmark
+	const checkmarkSvg = createElement('svg', {
+		'aria-hidden': 'true',
+		viewBox: '0 0 20 20',
+		fill: 'currentColor',
+		children: createElement('path', {
+			'fill-rule': 'evenodd',
+			d: 'M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z',
+			'clip-rule': 'evenodd',
+		}),
+	});
+
+	// For current/upcoming, show step number
+	const numberContent = String(currentStep + 1);
+
+	const iconContent =
+		children ??
+		(status === 'complete'
+			? checkmarkSvg
+			: createElement('span', { 'data-step-number': true }, numberContent));
+
+	const ourProps: Record<string, unknown> = {
+		'data-status': status,
+	};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children: iconContent, ...rest },
+		slot,
+		defaultTag: 'span',
+		name: 'StepperIcon',
+	});
+}
+
+StepperIconFn.displayName = 'StepperIcon';
+export const StepperIcon = StepperIconFn;
+
+// --- StepperLabel ---
+
+interface StepperLabelProps {
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function StepperLabelFn({ as: Tag = 'span', children, ...rest }: StepperLabelProps) {
+	const slot = {};
+
+	const ourProps: Record<string, unknown> = {};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'span',
+		name: 'StepperLabel',
+	});
+}
+
+StepperLabelFn.displayName = 'StepperLabel';
+export const StepperLabel = StepperLabelFn;
+
+// --- StepperDescription ---
+
+interface StepperDescriptionProps {
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function StepperDescriptionFn({ as: Tag = 'span', children, ...rest }: StepperDescriptionProps) {
+	const slot = {};
+
+	const ourProps: Record<string, unknown> = {};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'span',
+		name: 'StepperDescription',
+	});
+}
+
+StepperDescriptionFn.displayName = 'StepperDescription';
+export const StepperDescription = StepperDescriptionFn;
+
+// --- StepperSeparator ---
+
+interface StepperSeparatorProps {
+	as?: ElementType;
+	children?: unknown;
+	[key: string]: unknown;
+}
+
+function StepperSeparatorFn({ as: Tag = 'div', children, ...rest }: StepperSeparatorProps) {
+	const { orientation } = useStepperContext();
+
+	const slot = { orientation };
+
+	const ourProps: Record<string, unknown> = {
+		'data-orientation': orientation,
+		'data-separator': true,
+	};
+
+	return render({
+		ourProps,
+		theirProps: { as: Tag, children, ...rest },
+		slot,
+		defaultTag: 'div',
+		name: 'StepperSeparator',
+	});
+}
+
+StepperSeparatorFn.displayName = 'StepperSeparator';
+export const StepperSeparator = StepperSeparatorFn;

--- a/packages/ui/src/components/touch-target/touch-target.tsx
+++ b/packages/ui/src/components/touch-target/touch-target.tsx
@@ -1,0 +1,67 @@
+import type { ComponentChildren } from 'preact';
+import type { ElementType } from '../../internal/types.ts';
+
+// --- TouchTarget ---
+
+/**
+ * A utility component that expands the touch target area of its parent element
+ * to meet WCAG 2.2 Success Criterion 2.5.8 (Minimum Target Size).
+ *
+ * This component renders an absolutely positioned `<span>` that covers the
+ * entire area of its parent, expanding the effective touch target without
+ * affecting the visual appearance.
+ *
+ * Usage: Place this component inside an interactive element (Button, IconButton, etc.)
+ * to expand its touch target area. Consumers should apply `pointer-fine:hidden`
+ * to this element (via Tailwind or CSS) to ensure the expanded area only
+ * intercepts touch events, not mouse/trackpad clicks.
+ *
+ * @example
+ * ```tsx
+ * <Button>
+ *   <TouchTarget />
+ *   Click me
+ * </Button>
+ * ```
+ *
+ * With Tailwind:
+ * ```tsx
+ * <Button class="relative">
+ *   <TouchTarget class="pointer-fine:hidden" />
+ *   Click me
+ * </Button>
+ * ```
+ *
+ * @see https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html
+ */
+interface TouchTargetProps {
+	as?: ElementType;
+	children?: ComponentChildren;
+	class?: string;
+	[key: string]: unknown;
+}
+
+function TouchTargetFn({
+	as: Tag = 'span',
+	children,
+	class: className,
+	...rest
+}: TouchTargetProps) {
+	const ourProps: Record<string, unknown> = {
+		'aria-hidden': 'true',
+		className,
+		style: {
+			position: 'absolute',
+			inset: '0',
+		},
+	};
+
+	return (
+		<Tag {...ourProps} {...rest}>
+			{children}
+		</Tag>
+	);
+}
+
+TouchTargetFn.displayName = 'TouchTarget';
+export const TouchTarget = TouchTargetFn;

--- a/packages/ui/src/mod.ts
+++ b/packages/ui/src/mod.ts
@@ -76,6 +76,23 @@ export {
 	AvatarImage,
 	AvatarStatus,
 } from './components/avatar/avatar.tsx';
+export {
+	Alert,
+	AlertActions,
+	AlertDescription,
+	AlertIcon,
+	AlertTitle,
+} from './components/alert/alert.tsx';
+export { Badge } from './components/badge/badge.tsx';
+export { ProgressBar } from './components/progress-bar/progress-bar.tsx';
+export {
+	Stepper,
+	StepperDescription,
+	StepperIcon,
+	StepperLabel,
+	StepperSeparator,
+	StepperStep,
+} from './components/stepper/stepper.tsx';
 export { IconButton } from './components/icon-button/icon-button.tsx';
 export { Skeleton } from './components/skeleton/skeleton.tsx';
 export { Spinner } from './components/spinner/spinner.tsx';

--- a/packages/ui/src/mod.ts
+++ b/packages/ui/src/mod.ts
@@ -68,6 +68,14 @@ export {
 	ToastTitle,
 	useToast,
 } from './components/toast/toast.tsx';
+export {
+	Avatar,
+	AvatarFallback,
+	AvatarGroup,
+	AvatarGroupOverflow,
+	AvatarImage,
+	AvatarStatus,
+} from './components/avatar/avatar.tsx';
 export { IconButton } from './components/icon-button/icon-button.tsx';
 export { Skeleton } from './components/skeleton/skeleton.tsx';
 export { Spinner } from './components/spinner/spinner.tsx';

--- a/packages/ui/src/mod.ts
+++ b/packages/ui/src/mod.ts
@@ -57,17 +57,17 @@ export {
 	TabPanel,
 	TabPanels,
 } from './components/tabs/tabs.tsx';
-export { Transition } from './components/transition/transition.tsx';
+export { Transition, TransitionChild } from './components/transition/transition.tsx';
 export {
 	Toast,
 	ToastAction,
 	ToastDescription,
 	ToastProgress,
-	ToastVariant,
 	Toaster,
 	ToastTitle,
 	useToast,
 } from './components/toast/toast.tsx';
+export type { ToastVariant } from './components/toast/toast.tsx';
 export {
 	Avatar,
 	AvatarFallback,
@@ -96,6 +96,7 @@ export {
 export { IconButton } from './components/icon-button/icon-button.tsx';
 export { Skeleton } from './components/skeleton/skeleton.tsx';
 export { Spinner } from './components/spinner/spinner.tsx';
+export { TouchTarget } from './components/touch-target/touch-target.tsx';
 
 // Hooks
 export { useClose } from './hooks/use-close.ts';

--- a/packages/ui/tests/r2-headless-components.test.tsx
+++ b/packages/ui/tests/r2-headless-components.test.tsx
@@ -1,0 +1,881 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/preact';
+import { createElement } from 'preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	Alert,
+	AlertActions,
+	AlertDescription,
+	AlertIcon,
+	AlertTitle,
+	Badge,
+	ProgressBar,
+	Stepper,
+	StepperDescription,
+	StepperIcon,
+	StepperLabel,
+	StepperSeparator,
+	StepperStep,
+} from '../src/mod.ts';
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+// --- Alert Tests ---
+
+describe('Alert', () => {
+	it('should render with default variant (info)', () => {
+		render(<Alert>Alert content</Alert>);
+		const alert = screen.getByRole('alert');
+		expect(alert).not.toBeNull();
+		expect(alert.getAttribute('data-variant')).toBe('info');
+	});
+
+	it('should render with success variant', () => {
+		render(<Alert variant="success">Success message</Alert>);
+		expect(screen.getByRole('alert').getAttribute('data-variant')).toBe('success');
+	});
+
+	it('should render with warning variant', () => {
+		render(<Alert variant="warning">Warning message</Alert>);
+		expect(screen.getByRole('alert').getAttribute('data-variant')).toBe('warning');
+	});
+
+	it('should render with error variant', () => {
+		render(<Alert variant="error">Error message</Alert>);
+		expect(screen.getByRole('alert').getAttribute('data-variant')).toBe('error');
+	});
+
+	it('should set role="alert"', () => {
+		render(<Alert>Alert</Alert>);
+		expect(screen.getByRole('alert')).not.toBeNull();
+	});
+
+	it('should not have data-dismissible when dismissible is false', () => {
+		render(<Alert dismissible={false}>Alert</Alert>);
+		expect(screen.getByRole('alert').getAttribute('data-dismissible')).toBeNull();
+	});
+
+	it('should have data-dismissible when dismissible is true', () => {
+		render(<Alert dismissible>Alert</Alert>);
+		expect(screen.getByRole('alert').getAttribute('data-dismissible')).toBe('');
+	});
+
+	it('should render children', () => {
+		render(<Alert>Hello World</Alert>);
+		expect(screen.getByText('Hello World')).not.toBeNull();
+	});
+
+	it('should render as custom element when as prop is provided', () => {
+		render(<Alert as="section">Section Alert</Alert>);
+		const section = document.querySelector('section');
+		expect(section).not.toBeNull();
+		expect(section?.getAttribute('role')).toBe('alert');
+	});
+});
+
+describe('AlertTitle', () => {
+	it('should render with default tag (h3)', () => {
+		render(
+			<Alert>
+				<AlertTitle>Title</AlertTitle>
+			</Alert>
+		);
+		const title = screen.getByRole('heading');
+		expect(title).not.toBeNull();
+		expect(title.tagName).toBe('H3');
+	});
+
+	it('should render children', () => {
+		render(
+			<Alert>
+				<AlertTitle>Alert Title</AlertTitle>
+			</Alert>
+		);
+		expect(screen.getByText('Alert Title')).not.toBeNull();
+	});
+
+	it('should render with custom as prop', () => {
+		render(
+			<Alert>
+				<AlertTitle as="h2">Custom Heading</AlertTitle>
+			</Alert>
+		);
+		const title = screen.getByRole('heading');
+		expect(title.tagName).toBe('H2');
+	});
+});
+
+describe('AlertDescription', () => {
+	it('should render with default tag (p)', () => {
+		render(
+			<Alert>
+				<AlertDescription>Description text</AlertDescription>
+			</Alert>
+		);
+		const desc = document.querySelector('p');
+		expect(desc).not.toBeNull();
+		expect(desc?.textContent).toBe('Description text');
+	});
+
+	it('should render children', () => {
+		render(
+			<Alert>
+				<AlertDescription>Description content</AlertDescription>
+			</Alert>
+		);
+		expect(screen.getByText('Description content')).not.toBeNull();
+	});
+});
+
+describe('AlertActions', () => {
+	it('should render with default tag (div)', () => {
+		render(
+			<Alert>
+				<AlertActions>Actions</AlertActions>
+			</Alert>
+		);
+		const actions = document.querySelector('div[data-slot="actions"]');
+		expect(actions).not.toBeNull();
+	});
+
+	it('should render children', () => {
+		render(
+			<Alert>
+				<AlertActions>
+					<button>Action 1</button>
+					<button>Action 2</button>
+				</AlertActions>
+			</Alert>
+		);
+		expect(screen.getByText('Action 1')).not.toBeNull();
+		expect(screen.getByText('Action 2')).not.toBeNull();
+	});
+});
+
+describe('AlertIcon', () => {
+	it('should render with default tag (div)', () => {
+		render(
+			<Alert>
+				<AlertIcon />
+			</Alert>
+		);
+		const icon = document.querySelector('div[data-slot="icon"]');
+		expect(icon).not.toBeNull();
+	});
+
+	it('should render an SVG icon', () => {
+		render(
+			<Alert>
+				<AlertIcon />
+			</Alert>
+		);
+		const svg = document.querySelector('div[data-slot="icon"] svg');
+		expect(svg).not.toBeNull();
+	});
+
+	it('should render custom icon when provided', () => {
+		const customIcon = createElement('span', { 'data-custom-icon': true }, 'Icon');
+		render(
+			<Alert>
+				<AlertIcon icon={customIcon} />
+			</Alert>
+		);
+		const icon = document.querySelector('span[data-custom-icon="true"]');
+		expect(icon).not.toBeNull();
+	});
+});
+
+// --- Badge Tests ---
+
+describe('Badge', () => {
+	it('should render a badge by default', () => {
+		render(<Badge>Badge</Badge>);
+		const badge = document.querySelector('span');
+		expect(badge).not.toBeNull();
+	});
+
+	it('should render children', () => {
+		render(<Badge>Label</Badge>);
+		expect(screen.getByText('Label')).not.toBeNull();
+	});
+
+	// Variant tests
+	it('should render with subtle variant by default', () => {
+		render(<Badge>Subtle</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-variant')).toBe('subtle');
+	});
+
+	it('should render with outline variant', () => {
+		render(<Badge variant="outline">Outline</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-variant')).toBe('outline');
+	});
+
+	it('should render with solid variant', () => {
+		render(<Badge variant="solid">Solid</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-variant')).toBe('solid');
+	});
+
+	// Color tests
+	it('should render with gray color by default', () => {
+		render(<Badge>Gray</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-color')).toBe('gray');
+	});
+
+	it('should render with red color', () => {
+		render(<Badge color="red">Red</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-color')).toBe('red');
+	});
+
+	it('should render with yellow color', () => {
+		render(<Badge color="yellow">Yellow</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-color')).toBe('yellow');
+	});
+
+	it('should render with green color', () => {
+		render(<Badge color="green">Green</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-color')).toBe('green');
+	});
+
+	it('should render with blue color', () => {
+		render(<Badge color="blue">Blue</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-color')).toBe('blue');
+	});
+
+	it('should render with indigo color', () => {
+		render(<Badge color="indigo">Indigo</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-color')).toBe('indigo');
+	});
+
+	it('should render with purple color', () => {
+		render(<Badge color="purple">Purple</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-color')).toBe('purple');
+	});
+
+	it('should render with pink color', () => {
+		render(<Badge color="pink">Pink</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-color')).toBe('pink');
+	});
+
+	// Size tests
+	it('should render with md size by default', () => {
+		render(<Badge>Medium</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-size')).toBe('md');
+	});
+
+	it('should render with sm size', () => {
+		render(<Badge size="sm">Small</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-size')).toBe('sm');
+	});
+
+	// Shape tests
+	it('should render with rounded shape by default', () => {
+		render(<Badge>Rounded</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-shape')).toBe('rounded');
+	});
+
+	it('should render with pill shape', () => {
+		render(<Badge shape="pill">Pill</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-shape')).toBe('pill');
+	});
+
+	it('should render with square shape', () => {
+		render(<Badge shape="square">Square</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-shape')).toBe('square');
+	});
+
+	// Dot indicator
+	it('should not have data-dot when dot is false', () => {
+		render(<Badge dot={false}>No Dot</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-dot')).toBeNull();
+	});
+
+	it('should have data-dot when dot is true', () => {
+		render(<Badge dot>With Dot</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-dot')).toBe('');
+	});
+
+	it('should render dot SVG element when dot is true', () => {
+		render(<Badge dot>Dot</Badge>);
+		const dot = document.querySelector('.badge-dot');
+		expect(dot).not.toBeNull();
+	});
+
+	// Removable state
+	it('should not have data-removable when removable is false', () => {
+		render(<Badge removable={false}>Not Removable</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-removable')).toBeNull();
+	});
+
+	it('should have data-removable when removable is true', () => {
+		render(<Badge removable>Removable</Badge>);
+		expect(document.querySelector('span')?.getAttribute('data-removable')).toBe('');
+	});
+
+	it('should render remove button when removable is true', () => {
+		render(<Badge removable onRemove={() => {}}>Remove</Badge>);
+		const removeBtn = document.querySelector('button[aria-label="Remove"]');
+		expect(removeBtn).not.toBeNull();
+	});
+
+	it('should call onRemove when remove button is clicked', () => {
+		const onRemove = vi.fn();
+		render(<Badge removable onRemove={onRemove}>Remove Me</Badge>);
+		const removeBtn = document.querySelector('button[aria-label="Remove"]');
+		fireEvent.click(removeBtn!);
+		expect(onRemove).toHaveBeenCalledTimes(1);
+	});
+
+	// Interaction states
+	it('should set data-hover on mouse enter', async () => {
+		render(<Badge>Hover</Badge>);
+		const badge = document.querySelector('span') as HTMLElement;
+		await act(async () => {
+			fireEvent.mouseEnter(badge);
+		});
+		expect(badge.getAttribute('data-hover')).toBe('');
+	});
+
+	it('should remove data-hover on mouse leave', async () => {
+		render(<Badge>Hover</Badge>);
+		const badge = document.querySelector('span') as HTMLElement;
+		await act(async () => {
+			fireEvent.mouseEnter(badge);
+		});
+		expect(badge.getAttribute('data-hover')).toBe('');
+		await act(async () => {
+			fireEvent.mouseLeave(badge);
+		});
+		expect(badge.getAttribute('data-hover')).toBeNull();
+	});
+
+	it('should set data-focus on focus', async () => {
+		render(<Badge>Focus</Badge>);
+		const badge = document.querySelector('span') as HTMLElement;
+		await act(async () => {
+			badge.focus();
+		});
+		expect(badge.getAttribute('data-focus')).toBe('');
+	});
+
+	it('should remove data-focus on blur', async () => {
+		render(<Badge>Focus</Badge>);
+		const badge = document.querySelector('span') as HTMLElement;
+		await act(async () => {
+			badge.focus();
+		});
+		expect(badge.getAttribute('data-focus')).toBe('');
+		await act(async () => {
+			badge.blur();
+		});
+		expect(badge.getAttribute('data-focus')).toBeNull();
+	});
+
+	it('should set data-active on mouse down', async () => {
+		render(<Badge>Active</Badge>);
+		const badge = document.querySelector('span') as HTMLElement;
+		await act(async () => {
+			fireEvent.mouseDown(badge);
+		});
+		expect(badge.getAttribute('data-active')).toBe('');
+	});
+
+	it('should remove data-active on mouse up', async () => {
+		render(<Badge>Active</Badge>);
+		const badge = document.querySelector('span') as HTMLElement;
+		await act(async () => {
+			fireEvent.mouseDown(badge);
+		});
+		expect(badge.getAttribute('data-active')).toBe('');
+		await act(async () => {
+			fireEvent.mouseUp(badge);
+		});
+		expect(badge.getAttribute('data-active')).toBeNull();
+	});
+
+	// Custom element
+	it('should render as custom element when as prop is provided', () => {
+		render(<Badge as="div">Div Badge</Badge>);
+		const div = document.querySelector('div[data-variant="subtle"]');
+		expect(div).not.toBeNull();
+	});
+});
+
+// --- ProgressBar Tests ---
+
+describe('ProgressBar', () => {
+	it('should render with role="progressbar"', () => {
+		render(<ProgressBar value={50} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar).not.toBeNull();
+	});
+
+	it('should set aria-valuenow with numeric value', () => {
+		render(<ProgressBar value={75} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuenow')).toBe('75');
+	});
+
+	it('should set aria-valuemin', () => {
+		render(<ProgressBar value={50} min={0} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuemin')).toBe('0');
+	});
+
+	it('should set aria-valuemax', () => {
+		render(<ProgressBar value={50} max={100} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuemax')).toBe('100');
+	});
+
+	it('should set aria-valuetext with percentage', () => {
+		render(<ProgressBar value={50} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuetext')).toBe('50%');
+	});
+
+	it('should set aria-label when label is provided', () => {
+		render(<ProgressBar value={50} label="Upload Progress" />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-label')).toBe('Upload Progress');
+	});
+
+	it('should calculate percentage correctly at 0', () => {
+		render(<ProgressBar value={0} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('data-value')).toBe('0');
+		expect(progressbar.getAttribute('data-min')).toBe('0');
+		expect(progressbar.getAttribute('data-max')).toBe('100');
+	});
+
+	it('should calculate percentage correctly at 50', () => {
+		render(<ProgressBar value={50} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuetext')).toBe('50%');
+	});
+
+	it('should calculate percentage correctly at 100', () => {
+		render(<ProgressBar value={100} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuetext')).toBe('100%');
+	});
+
+	it('should calculate percentage with custom min and max', () => {
+		render(<ProgressBar value={75} min={0} max={200} />);
+		const progressbar = screen.getByRole('progressbar');
+		// 75/200 * 100 = 37.5 -> rounded to 38%
+		expect(progressbar.getAttribute('aria-valuetext')).toBe('38%');
+	});
+
+	it('should clamp percentage to 100 when value exceeds max', () => {
+		render(<ProgressBar value={150} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuetext')).toBe('100%');
+	});
+
+	it('should clamp percentage to 0 when value is below min', () => {
+		render(<ProgressBar value={-50} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuetext')).toBe('0%');
+	});
+
+	it('should have data-size sm', () => {
+		render(<ProgressBar value={50} size="sm" />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('data-size')).toBe('sm');
+	});
+
+	it('should have data-size md by default', () => {
+		render(<ProgressBar value={50} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('data-size')).toBe('md');
+	});
+
+	it('should have data-size lg', () => {
+		render(<ProgressBar value={50} size="lg" />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('data-size')).toBe('lg');
+	});
+
+	// Indeterminate state
+	it('should not have data-indeterminate when value is provided', () => {
+		render(<ProgressBar value={50} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('data-indeterminate')).toBeNull();
+	});
+
+	it('should have data-indeterminate when value is null', () => {
+		render(<ProgressBar value={null as unknown as number} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('data-indeterminate')).toBe('');
+	});
+
+	it('should have data-indeterminate when value is undefined', () => {
+		render(<ProgressBar value={undefined as unknown as number} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('data-indeterminate')).toBe('');
+	});
+
+	it('should not set aria-valuenow when indeterminate', () => {
+		render(<ProgressBar value={undefined as unknown as number} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuenow')).toBeNull();
+	});
+
+	it('should not set aria-valuetext when indeterminate', () => {
+		render(<ProgressBar value={undefined as unknown as number} />);
+		const progressbar = screen.getByRole('progressbar');
+		expect(progressbar.getAttribute('aria-valuetext')).toBeNull();
+	});
+
+	// Show value
+	it('should not render value element when showValue is false', () => {
+		render(<ProgressBar value={50} showValue={false} />);
+		const valueElement = document.querySelector('[data-progress-value]');
+		expect(valueElement).toBeNull();
+	});
+
+	it('should render value element when showValue is true', () => {
+		render(<ProgressBar value={50} showValue />);
+		const valueElement = document.querySelector('[data-progress-value]');
+		expect(valueElement).not.toBeNull();
+		expect(valueElement?.textContent).toBe('50%');
+	});
+
+	// Fill element
+	it('should render fill element with correct width', () => {
+		render(<ProgressBar value={75} />);
+		const fill = document.querySelector('[data-progress-fill]') as HTMLElement;
+		expect(fill).not.toBeNull();
+		expect(fill.style.width).toBe('75%');
+	});
+
+	// Custom element
+	it('should render as custom element when as prop is provided', () => {
+		render(<ProgressBar value={50} as="section" />);
+		const section = document.querySelector('section');
+		expect(section).not.toBeNull();
+		expect(section?.getAttribute('role')).toBe('progressbar');
+	});
+
+	// Color
+	it('should apply color style when color is provided', () => {
+		render(<ProgressBar value={50} color="#ff0000" />);
+		const fill = document.querySelector('[data-progress-fill]') as HTMLElement;
+		expect(fill.style.backgroundColor).toBe('#ff0000');
+	});
+});
+
+// --- Stepper Tests ---
+
+describe('Stepper', () => {
+	it('should render with role="list"', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">Step 1</StepperStep>
+			</Stepper>
+		);
+		const stepper = document.querySelector('[role="list"]');
+		expect(stepper).not.toBeNull();
+	});
+
+	it('should have data-orientation horizontal by default', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">Step 1</StepperStep>
+			</Stepper>
+		);
+		const stepper = document.querySelector('[data-orientation="horizontal"]');
+		expect(stepper).not.toBeNull();
+	});
+
+	it('should have data-orientation vertical when specified', () => {
+		render(
+			<Stepper currentStep={0} orientation="vertical">
+				<StepperStep status="complete">Step 1</StepperStep>
+			</Stepper>
+		);
+		const stepper = document.querySelector('[data-orientation="vertical"]');
+		expect(stepper).not.toBeNull();
+	});
+
+	it('should render children', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">Step 1</StepperStep>
+				<StepperStep status="current">Step 2</StepperStep>
+			</Stepper>
+		);
+		expect(screen.getByText('Step 1')).not.toBeNull();
+		expect(screen.getByText('Step 2')).not.toBeNull();
+	});
+});
+
+describe('StepperStep', () => {
+	it('should have role="listitem"', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">Step 1</StepperStep>
+			</Stepper>
+		);
+		const step = document.querySelector('[role="listitem"]');
+		expect(step).not.toBeNull();
+	});
+
+	it('should have data-status complete', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">Step 1</StepperStep>
+			</Stepper>
+		);
+		const step = document.querySelector('[data-status="complete"]');
+		expect(step).not.toBeNull();
+	});
+
+	it('should have data-status current', () => {
+		render(
+			<Stepper currentStep={1}>
+				<StepperStep status="current">Step 2</StepperStep>
+			</Stepper>
+		);
+		const step = document.querySelector('[data-status="current"]');
+		expect(step).not.toBeNull();
+	});
+
+	it('should have data-status upcoming', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="upcoming">Step 2</StepperStep>
+			</Stepper>
+		);
+		const step = document.querySelector('[data-status="upcoming"]');
+		expect(step).not.toBeNull();
+	});
+
+	it('should have aria-current="step" when status is current', () => {
+		render(
+			<Stepper currentStep={1}>
+				<StepperStep status="current">Step 2</StepperStep>
+			</Stepper>
+		);
+		const step = document.querySelector('[aria-current="step"]');
+		expect(step).not.toBeNull();
+	});
+
+	it('should not have aria-current when status is complete', () => {
+		render(
+			<Stepper currentStep={1}>
+				<StepperStep status="complete">Step 1</StepperStep>
+			</Stepper>
+		);
+		const step = document.querySelector('[role="listitem"]');
+		expect(step?.getAttribute('aria-current')).toBeNull();
+	});
+
+	it('should not have aria-current when status is upcoming', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="upcoming">Step 2</StepperStep>
+			</Stepper>
+		);
+		const step = document.querySelector('[role="listitem"]');
+		expect(step?.getAttribute('aria-current')).toBeNull();
+	});
+
+	it('should have data-orientation from context', () => {
+		render(
+			<Stepper currentStep={0} orientation="vertical">
+				<StepperStep status="complete">Step 1</StepperStep>
+			</Stepper>
+		);
+		const step = document.querySelector('[data-orientation="vertical"]');
+		expect(step).not.toBeNull();
+	});
+});
+
+describe('StepperIcon', () => {
+	it('should render with data-status complete', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">
+					<StepperIcon status="complete" />
+				</StepperStep>
+			</Stepper>
+		);
+		const icon = document.querySelector('[data-status="complete"]');
+		expect(icon).not.toBeNull();
+	});
+
+	it('should render with data-status current', () => {
+		render(
+			<Stepper currentStep={1}>
+				<StepperStep status="current">
+					<StepperIcon status="current" />
+				</StepperStep>
+			</Stepper>
+		);
+		const icon = document.querySelector('[data-status="current"]');
+		expect(icon).not.toBeNull();
+	});
+
+	it('should render with data-status upcoming', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="upcoming">
+					<StepperIcon status="upcoming" />
+				</StepperStep>
+			</Stepper>
+		);
+		const icon = document.querySelector('[data-status="upcoming"]');
+		expect(icon).not.toBeNull();
+	});
+
+	it('should render checkmark SVG for complete status', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">
+					<StepperIcon status="complete" />
+				</StepperStep>
+			</Stepper>
+		);
+		const svg = document.querySelector('[data-status="complete"] svg');
+		expect(svg).not.toBeNull();
+	});
+
+	it('should render step number for current status', () => {
+		render(
+			<Stepper currentStep={1}>
+				<StepperStep status="current">
+					<StepperIcon status="current" />
+				</StepperStep>
+			</Stepper>
+		);
+		const number = document.querySelector('[data-status="current"] [data-step-number]');
+		expect(number).not.toBeNull();
+		expect(number?.textContent).toBe('2'); // currentStep + 1
+	});
+
+	it('should render step number for upcoming status', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="upcoming">
+					<StepperIcon status="upcoming" />
+				</StepperStep>
+			</Stepper>
+		);
+		const number = document.querySelector('[data-status="upcoming"] [data-step-number]');
+		expect(number).not.toBeNull();
+		expect(number?.textContent).toBe('1'); // currentStep + 1
+	});
+
+	it('should render custom children when provided', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">
+					<StepperIcon>Custom Icon</StepperIcon>
+				</StepperStep>
+			</Stepper>
+		);
+		expect(screen.getByText('Custom Icon')).not.toBeNull();
+	});
+});
+
+describe('StepperLabel', () => {
+	it('should render with default tag (span)', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">
+					<StepperLabel>Label</StepperLabel>
+				</StepperStep>
+			</Stepper>
+		);
+		const label = document.querySelector('span');
+		expect(label).not.toBeNull();
+	});
+
+	it('should render children', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">
+					<StepperLabel>Step Label</StepperLabel>
+				</StepperStep>
+			</Stepper>
+		);
+		expect(screen.getByText('Step Label')).not.toBeNull();
+	});
+});
+
+describe('StepperDescription', () => {
+	it('should render with default tag (span)', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">
+					<StepperDescription>Description</StepperDescription>
+				</StepperStep>
+			</Stepper>
+		);
+		const desc = document.querySelector('span');
+		expect(desc).not.toBeNull();
+	});
+
+	it('should render children', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">
+					<StepperDescription>Step Description</StepperDescription>
+				</StepperStep>
+			</Stepper>
+		);
+		expect(screen.getByText('Step Description')).not.toBeNull();
+	});
+});
+
+describe('StepperSeparator', () => {
+	it('should render with data-separator', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">Step 1</StepperStep>
+				<StepperSeparator />
+				<StepperStep status="current">Step 2</StepperStep>
+			</Stepper>
+		);
+		const separator = document.querySelector('[data-separator="true"]');
+		expect(separator).not.toBeNull();
+	});
+
+	it('should have data-orientation horizontal', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">Step 1</StepperStep>
+				<StepperSeparator />
+				<StepperStep status="current">Step 2</StepperStep>
+			</Stepper>
+		);
+		const separator = document.querySelector('[data-orientation="horizontal"]');
+		expect(separator).not.toBeNull();
+	});
+
+	it('should have data-orientation vertical when orientation is vertical', () => {
+		render(
+			<Stepper currentStep={0} orientation="vertical">
+				<StepperStep status="complete">Step 1</StepperStep>
+				<StepperSeparator />
+				<StepperStep status="current">Step 2</StepperStep>
+			</Stepper>
+		);
+		const separator = document.querySelector('[data-orientation="vertical"]');
+		expect(separator).not.toBeNull();
+	});
+
+	it('should render with default tag (div)', () => {
+		render(
+			<Stepper currentStep={0}>
+				<StepperStep status="complete">Step 1</StepperStep>
+				<StepperSeparator />
+			</Stepper>
+		);
+		const separator = document.querySelector('div[data-separator="true"]');
+		expect(separator).not.toBeNull();
+	});
+});

--- a/packages/ui/tests/r2-headless-components.test.tsx
+++ b/packages/ui/tests/r2-headless-components.test.tsx
@@ -314,14 +314,22 @@ describe('Badge', () => {
 	});
 
 	it('should render remove button when removable is true', () => {
-		render(<Badge removable onRemove={() => {}}>Remove</Badge>);
+		render(
+			<Badge removable onRemove={() => {}}>
+				Remove
+			</Badge>
+		);
 		const removeBtn = document.querySelector('button[aria-label="Remove"]');
 		expect(removeBtn).not.toBeNull();
 	});
 
 	it('should call onRemove when remove button is clicked', () => {
 		const onRemove = vi.fn();
-		render(<Badge removable onRemove={onRemove}>Remove Me</Badge>);
+		render(
+			<Badge removable onRemove={onRemove}>
+				Remove Me
+			</Badge>
+		);
 		const removeBtn = document.querySelector('button[aria-label="Remove"]');
 		fireEvent.click(removeBtn!);
 		expect(onRemove).toHaveBeenCalledTimes(1);

--- a/packages/ui/tests/touch-target.test.tsx
+++ b/packages/ui/tests/touch-target.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from '@testing-library/preact';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TouchTarget } from '../src/mod.ts';
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('TouchTarget', () => {
+	it('should render a span by default', () => {
+		render(<TouchTarget />);
+		const element = document.querySelector('span');
+		expect(element).not.toBeNull();
+		expect(element?.tagName.toLowerCase()).toBe('span');
+	});
+
+	it('should be aria-hidden', () => {
+		render(<TouchTarget />);
+		const element = document.querySelector('span');
+		expect(element?.getAttribute('aria-hidden')).toBe('true');
+	});
+
+	it('should render with absolute positioning and inset-0 styles', () => {
+		render(<TouchTarget />);
+		const element = document.querySelector('span');
+		const style = element?.style;
+		expect(style?.position).toBe('absolute');
+		expect(style?.inset).toBe('0');
+	});
+
+	it('should support custom as prop to render as different element', () => {
+		render(<TouchTarget as="div" />);
+		const element = document.querySelector('div');
+		expect(element).not.toBeNull();
+	});
+
+	it('should pass through className', () => {
+		render(<TouchTarget class="pointer-fine:hidden custom-class" />);
+		const element = document.querySelector('span');
+		expect(element?.className).toContain('pointer-fine:hidden');
+		expect(element?.className).toContain('custom-class');
+	});
+
+	it('should render children when provided', () => {
+		render(
+			<TouchTarget>
+				<span data-testid="child-span">Expanded touch area</span>
+			</TouchTarget>
+		);
+		const childElement = document.querySelector('[data-testid="child-span"]');
+		expect(childElement?.textContent).toBe('Expanded touch area');
+	});
+
+	it('should pass through additional props', () => {
+		render(<TouchTarget data-testid="touch-target" />);
+		const element = document.querySelector('[data-testid="touch-target"]');
+		expect(element).not.toBeNull();
+	});
+
+	it('should have displayName set correctly', () => {
+		expect(TouchTarget.displayName).toBe('TouchTarget');
+	});
+});


### PR DESCRIPTION
## Summary

Add demo examples demonstrating composable UI patterns from @neokai/ui components:

- **Command Palette**: Dialog + Combobox composition with search filtering, grouped results (Recent/Actions/Projects), keyboard shortcuts, and footer navigation hints
- **Drawer**: Dialog + TransitionChild with slide transitions, supporting right/left drawers and inline variant without overlay
- **Notification**: Toast-based notification patterns with typed variants (success/error/info/warning), notification cards, and grouped notifications with unread badges

## Test plan

- [ ] Run `make dev` and verify demos appear in the kitchen sink app
- [ ] Test Command Palette: open with button, search filters results, keyboard navigation works
- [ ] Test Drawer: verify right/left slides and inline variants work correctly
- [ ] Test Notifications: verify toast variants render correctly with proper icons and colors

## References

- Plan: docs/plans/audit-neokaiui-against-tailwind-application-ui-v4-reference.md (R6)