### PR TITLE
fix(e2e): clean up archived spaces to prevent UNIQUE constraint errors

### DIFF
--- a/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
+++ b/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
@@ -51,10 +51,10 @@ async function createSpaceWithRun(
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
-			// Clean up any leftover space at this workspace path.
+			// Clean up any leftover space at this workspace path (including archived).
 			const norm = (p: string) => p.replace(/^\/private/, '');
 			try {
-				const list = (await hub.request('space.list', {})) as Array<{
+				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
 					id: string;
 					workspacePath: string;
 				}>;

--- a/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
+++ b/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
@@ -52,10 +52,10 @@ async function createSpaceWithRun(
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
-			// Clean up any leftover space at this workspace path.
+			// Clean up any leftover space at this workspace path (including archived).
 			const norm = (p: string) => p.replace(/^\/private/, '');
 			try {
-				const list = (await hub.request('space.list', {})) as Array<{
+				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
 					id: string;
 					workspacePath: string;
 				}>;

--- a/packages/e2e/tests/features/space-export-import.e2e.ts
+++ b/packages/e2e/tests/features/space-export-import.e2e.ts
@@ -34,9 +34,9 @@ async function createTestSpace(page: Page): Promise<{
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
-			// Delete any leftover space from a previous failed run
+			// Delete any leftover space from a previous failed run (including archived).
 			try {
-				const list = (await hub.request('space.list', {})) as Array<{
+				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
 					id: string;
 					workspacePath: string;
 				}>;

--- a/packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts
+++ b/packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts
@@ -29,7 +29,7 @@ async function createSpaceWithRun(
 
 			const norm = (p: string) => p.replace(/^\/private/, '');
 			try {
-				const list = (await hub.request('space.list', {})) as Array<{
+				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
 					id: string;
 					workspacePath: string;
 				}>;

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -32,11 +32,11 @@ async function createTestSpace(page: Page): Promise<string> {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
-			// Clean up any leftover space at this workspace path.
+			// Clean up any leftover space at this workspace path (including archived).
 			// Normalize paths to handle macOS symlink resolution (/var/ vs /private/var/).
 			const norm = (p: string) => p.replace(/^\/private/, '');
 			try {
-				const list = (await hub.request('space.list', {})) as Array<{
+				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
 					id: string;
 					workspacePath: string;
 				}>;

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -20,10 +20,10 @@ export async function createSpace(page: Page, name: string): Promise<string> {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
-			// Clean up any leftover space at this workspace path.
+			// Clean up any leftover space at this workspace path (including archived).
 			const norm = (p: string) => p.replace(/^\/private/, '');
 			try {
-				const list = (await hub.request('space.list', {})) as Array<{
+				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
 					id: string;
 					workspacePath: string;
 				}>;


### PR DESCRIPTION
## Summary

Fixes `UNIQUE constraint failed: spaces.workspace_path` errors in E2E tests by ensuring archived spaces are properly cleaned up during test setup.

## Problem

Tests that archive spaces (e.g., via Settings UI) were not cleaning up archived spaces in their `beforeEach` cleanup. When tests retry or run again, they try to create a space at the same workspace path, but `getSpaceByPath` finds the archived space and throws "A space already exists for workspace path" error.

The `workspace_path` column has a UNIQUE constraint, so archived spaces permanently claim their path until deleted.

## Fix

Changed all `space.list({})` calls in test cleanup to use `space.list({ includeArchived: true })` to ensure archived spaces are deleted before creating new spaces.

## Files Changed

- `packages/e2e/tests/helpers/workflow-editor-helpers.ts` - shared helper used by multiple test files
- `packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts`
- `packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts`
- `packages/e2e/tests/features/space-export-import.e2e.ts`
- `packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts`
- `packages/e2e/tests/features/space-workflow-rules.e2e.ts`

## Test Plan

- [x] Run linting on changed files (0 errors)
- [ ] Verify E2E tests pass in CI