### PR TITLE
[codex] Make startup-timeout retry transparent

### DIFF
--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -355,9 +355,6 @@ export class QueryRunner {
 			// Skip messageQueue.clear() so the user's pending message is preserved for the retry.
 			if (isStartupTimeout && !isRetry && !this.ctx.isCleaningUp()) {
 				logger.warn('Auto-retrying query after startup timeout (1 retry).');
-				await this.displayErrorAsAssistantMessage(
-					'Session startup timed out. Retrying automatically...'
-				);
 				await stateManager.setIdle();
 
 				// Close the current queryObject BEFORE retrying to prevent the
@@ -373,7 +370,10 @@ export class QueryRunner {
 					this.ctx.queryObject = null;
 				}
 
-				return this.runQuery(queryGeneration, true);
+				// Use `return await` so this call's finally{} runs only after the retry
+				// completes. Otherwise finally{} would race the retry and can tear down
+				// shared state (queue/controller/queryObject) while it is still running.
+				return await this.runQuery(queryGeneration, true);
 			}
 
 			// Clear the queue on non-retryable errors so stale messages don't bleed into the next session.

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -822,6 +822,27 @@ describe('QueryRunner', () => {
 			expect(setIdleSpy).toHaveBeenCalled();
 		});
 
+		it('should not emit an assistant retry notice for startup-timeout auto-retry', async () => {
+			const ctx = createContext();
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(saveSDKMessageSpy).not.toHaveBeenCalledWith(
+				'test-session-id',
+				expect.objectContaining({
+					type: 'assistant',
+					message: expect.objectContaining({
+						content: expect.arrayContaining([
+							expect.objectContaining({
+								text: expect.stringContaining('Retrying automatically'),
+							}),
+						]),
+					}),
+				})
+			);
+		});
+
 		it('should NOT pass startupMaxRetries in handleError metadata', async () => {
 			const ctx = createContext();
 			runner = new QueryRunner(ctx);


### PR DESCRIPTION
## Summary
- remove the visible assistant message (`"Session startup timed out. Retrying automatically..."`) from the startup-timeout auto-retry path
- keep startup-timeout recovery automatic and transparent to users
- change retry control flow to `return await this.runQuery(...)` so outer `finally` does not race and tear down shared query state while retry is active
- add a unit test asserting no assistant retry notice is emitted during startup-timeout auto-retry

## Root Cause
The retry path surfaced an assistant-level status message to users and used `return this.runQuery(...)` inside `catch`, which allows `finally` to run before the recursive retry promise settles. That can race cleanup against the retry lifecycle.

## Validation
- `bun test --preload=./tests/unit/setup.ts ./tests/unit/agent/query-runner.test.ts -t "should not emit an assistant retry notice for startup-timeout auto-retry"`
- `bun test --preload=./tests/unit/setup.ts ./tests/unit/agent/query-runner.test.ts` (contains 2 unrelated pre-existing failures in this environment due missing `@github/copilot-sdk` mock path during provider loading)

## Impact
After model switch startup timeout, the retry remains automatic without asking users to resend or showing a retry assistant message; if retry succeeds, the UX is silent and seamless.