### PR TITLE
fix(e2e): initialize git repo for E2E workspace in global-setup

### DIFF
--- a/packages/e2e/global-setup.ts
+++ b/packages/e2e/global-setup.ts
@@ -7,8 +7,10 @@ import { execSync } from 'child_process';
 import { join, dirname } from 'path';
 import { existsSync, rmSync, readdirSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { tmpdir } from 'os';
-import { randomUUID } from 'crypto';
+
+// Shared test environment - Node.js caches this module, so the workspace path
+// is computed once and shared between playwright.config.ts and global-setup.ts.
+import { e2eWorkspaceDir } from './test-env';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -43,29 +45,22 @@ Or set PLAYWRIGHT_BASE_URL explicitly:
 		}
 	}
 
-	// Compute the E2E workspace path using the same logic as playwright.config.ts.
-	// NOTE: process.env.NEOKAI_WORKSPACE_PATH is NOT available here because
-	// webServer.env only sets variables for the child web server process.
-	// global-setup.ts runs in the Playwright test runner process.
-	const testRunId = `e2e-${Date.now()}-${randomUUID().slice(0, 8)}`;
-	const e2eTempDir = join(tmpdir(), 'neokai-e2e', testRunId);
-	const workspacePath = join(e2eTempDir, 'workspace');
-
 	// Initialize the E2E workspace as a git repo so that task planning worktrees can
 	// be created. Without a .git directory, WorktreeManager.findGitRoot() returns null,
 	// causing "task requires isolation" errors and daemon log spam during tests.
-	if (workspacePath && existsSync(workspacePath)) {
-		console.log(`\n🔧 Initializing workspace as git repo: ${workspacePath}`);
+	// The workspace path is shared from test-env.ts (same module instance).
+	if (e2eWorkspaceDir && existsSync(e2eWorkspaceDir)) {
+		console.log(`\n🔧 Initializing workspace as git repo: ${e2eWorkspaceDir}`);
 		try {
-			execSync('git init', { cwd: workspacePath, stdio: 'inherit' });
+			execSync('git init', { cwd: e2eWorkspaceDir, stdio: 'inherit' });
 			execSync('git config user.email "e2e@neokai.test"', {
-				cwd: workspacePath,
+				cwd: e2eWorkspaceDir,
 				stdio: 'inherit',
 			});
-			execSync('git config user.name "NeoKai E2E"', { cwd: workspacePath, stdio: 'inherit' });
+			execSync('git config user.name "NeoKai E2E"', { cwd: e2eWorkspaceDir, stdio: 'inherit' });
 			// Create initial commit so the repo is valid
 			execSync('git commit --allow-empty -m "Initial commit for E2E testing"', {
-				cwd: workspacePath,
+				cwd: e2eWorkspaceDir,
 				stdio: 'inherit',
 			});
 			console.log('✅ Workspace initialized as git repo\n');

--- a/packages/e2e/global-setup.ts
+++ b/packages/e2e/global-setup.ts
@@ -7,6 +7,8 @@ import { execSync } from 'child_process';
 import { join, dirname } from 'path';
 import { existsSync, rmSync, readdirSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -38,6 +40,38 @@ Or set PLAYWRIGHT_BASE_URL explicitly:
 			const parentDir = dirname(currentDir);
 			if (parentDir === currentDir) break;
 			currentDir = parentDir;
+		}
+	}
+
+	// Compute the E2E workspace path using the same logic as playwright.config.ts.
+	// NOTE: process.env.NEOKAI_WORKSPACE_PATH is NOT available here because
+	// webServer.env only sets variables for the child web server process.
+	// global-setup.ts runs in the Playwright test runner process.
+	const testRunId = `e2e-${Date.now()}-${randomUUID().slice(0, 8)}`;
+	const e2eTempDir = join(tmpdir(), 'neokai-e2e', testRunId);
+	const workspacePath = join(e2eTempDir, 'workspace');
+
+	// Initialize the E2E workspace as a git repo so that task planning worktrees can
+	// be created. Without a .git directory, WorktreeManager.findGitRoot() returns null,
+	// causing "task requires isolation" errors and daemon log spam during tests.
+	if (workspacePath && existsSync(workspacePath)) {
+		console.log(`\n🔧 Initializing workspace as git repo: ${workspacePath}`);
+		try {
+			execSync('git init', { cwd: workspacePath, stdio: 'inherit' });
+			execSync('git config user.email "e2e@neokai.test"', {
+				cwd: workspacePath,
+				stdio: 'inherit',
+			});
+			execSync('git config user.name "NeoKai E2E"', { cwd: workspacePath, stdio: 'inherit' });
+			// Create initial commit so the repo is valid
+			execSync('git commit --allow-empty -m "Initial commit for E2E testing"', {
+				cwd: workspacePath,
+				stdio: 'inherit',
+			});
+			console.log('✅ Workspace initialized as git repo\n');
+		} catch (error) {
+			// Log but don't fail — some tests may not need git functionality
+			console.warn('⚠️  Failed to initialize git repo in workspace (continuing):', error);
 		}
 	}
 

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -1,26 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 import type { CoverageReportOptions } from 'monocart-reporter';
-import { tmpdir } from 'os';
-import { join } from 'path';
-import { mkdirSync } from 'fs';
-import { randomUUID } from 'crypto';
-
-// Create isolated temp directories for this test run
-// This ensures e2e tests NEVER affect production databases or workspaces
-const testRunId = `e2e-${Date.now()}-${randomUUID().slice(0, 8)}`;
-const e2eTempDir = join(tmpdir(), 'neokai-e2e', testRunId);
-const e2eWorkspaceDir = join(e2eTempDir, 'workspace');
-const e2eDatabaseDir = join(e2eTempDir, 'database');
-
-// Ensure directories exist
-mkdirSync(e2eWorkspaceDir, { recursive: true });
-mkdirSync(e2eDatabaseDir, { recursive: true });
-
-console.log(`\n📁 E2E Test Isolation:
-   Temp Dir: ${e2eTempDir}
-   Workspace: ${e2eWorkspaceDir}
-   Database: ${e2eDatabaseDir}/daemon.db
-\n`);
+import { e2eTempDir, e2eWorkspaceDir, e2eDatabaseDir, e2eDatabasePath } from './test-env';
 
 // E2E_PORT: when set, tests start their own server on this specific port (random port mode).
 // PLAYWRIGHT_BASE_URL: when set, reuse an external already-running server.
@@ -29,6 +9,12 @@ const e2ePort = process.env.E2E_PORT;
 const baseURL = e2ePort
 	? `http://localhost:${e2ePort}`
 	: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:9283';
+
+console.log(`\n📁 E2E Test Isolation:
+   Temp Dir: ${e2eTempDir}
+   Workspace: ${e2eWorkspaceDir}
+   Database: ${e2eDatabasePath}
+\n`);
 
 /**
  * Monocart Coverage Reporter Configuration
@@ -252,7 +238,7 @@ export default defineConfig({
 			DEFAULT_MODEL: 'sonnet', // Maps to GLM-4.7 for E2E tests
 			// Isolated paths for this test run
 			NEOKAI_WORKSPACE_PATH: e2eWorkspaceDir,
-			DB_PATH: join(e2eDatabaseDir, 'daemon.db'),
+			DB_PATH: e2eDatabasePath,
 			// Enable Neo agent for E2E tests (bypasses test-mode guard in app.ts)
 			NEOKAI_ENABLE_NEO_AGENT: '1',
 			// Pass random port to CLI when in E2E_PORT mode

--- a/packages/e2e/test-env.ts
+++ b/packages/e2e/test-env.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared test environment configuration for E2E tests.
+ *
+ * This module is imported by both playwright.config.ts and global-setup.ts.
+ * Node.js caches modules, so this is only evaluated ONCE — both files
+ * get the same exported values.
+ *
+ * NOTE: This module has side effects (creates temp directories).
+ * It should only be imported by setup/teardown/config files.
+ */
+
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { mkdirSync, existsSync } from 'fs';
+import { randomUUID } from 'crypto';
+
+// Compute workspace path once (Node.js caches this module)
+const testRunId = `e2e-${Date.now()}-${randomUUID().slice(0, 8)}`;
+export const e2eTempDir = join(tmpdir(), 'neokai-e2e', testRunId);
+export const e2eWorkspaceDir = join(e2eTempDir, 'workspace');
+export const e2eDatabaseDir = join(e2eTempDir, 'database');
+export const e2eDatabasePath = join(e2eDatabaseDir, 'daemon.db');
+
+// Ensure directories exist (only created once due to module caching)
+if (!existsSync(e2eWorkspaceDir)) {
+	mkdirSync(e2eWorkspaceDir, { recursive: true });
+}
+if (!existsSync(e2eDatabaseDir)) {
+	mkdirSync(e2eDatabaseDir, { recursive: true });
+}


### PR DESCRIPTION
## Summary

Fix E2E test failures caused by daemon worktree spam when the E2E workspace is not a git repository.

## Problem

The E2E test workspace was not initialized as a git repository, causing:
- `WorktreeManager.findGitRoot()` to return null
- "Worktree creation failed — task requires isolation" errors in daemon logs
- Planning group spawn failures and daemon log spam

## Solution

Create a shared `test-env.ts` module that both `playwright.config.ts` and `global-setup.ts` import. Node.js caches modules, so the workspace path is computed once and shared between both files.

**Why this works:** `playwright.config.ts` and `global-setup.ts` both run in the same Node.js process. When `test-env.ts` is imported by both, Node.js evaluates it only once and caches the result.

## Changes

- **packages/e2e/test-env.ts**: New shared module for workspace path computation and directory creation
- **packages/e2e/playwright.config.ts**: Use shared test-env module
- **packages/e2e/global-setup.ts**: Use shared test-env module for git initialization

## Test plan

- [x] Verify workspace is initialized as git repo
- [x] Verify no worktree creation errors in daemon logs
- [x] Lint, typecheck, and knip pass