### PR TITLE
fix(ci): add ANTHROPIC_API_KEY to No-LLM E2E tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -988,6 +988,12 @@ jobs:
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
             bunx playwright test "tests/${{ matrix.test.path }}.e2e.ts"
         env:
+          # Set a dummy API key so provider availability check passes.
+          # No-LLM tests don't need real API calls; the key just satisfies isAvailable().
+          ANTHROPIC_API_KEY: "sk-devproxy-test-key"
+          # Clear other auth tokens to avoid credential conflicts
+          ANTHROPIC_AUTH_TOKEN: ""
+          CLAUDE_CODE_OAUTH_TOKEN: ""
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           DEFAULT_MODEL: sonnet
           CI: true


### PR DESCRIPTION
## Summary

No-LLM E2E tests were failing with "Provider Anthropic is not available" error because the provider availability check (`isAvailable()`) requires at least one auth token to be configured.

## Fix

Add a dummy API key (`sk-devproxy-test-key`) to No-LLM tests so the provider availability check passes. This satisfies `isAvailable()` without making real API calls — No-LLM tests don't send messages to the AI.

Also clear `ANTHROPIC_AUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` to ensure the dummy key is the only auth credential used.

## Test Plan

- [ ] Verify No-LLM E2E tests no longer fail with "Provider Anthropic is not available"
- [ ] Verify no regression in LLM E2E tests