### PR TITLE
docs: plan for @neokai/ui missing components + full 364-example demo

### DIFF
--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/00-overview.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/00-overview.md
@@ -75,12 +75,12 @@ M6 can start once enough of M2-M5 are done (it reuses patterns from all prior mi
 
 ## Dependency Breakdown by Reference File
 
-| Dependency type | File count | Subcategories |
+| Dependency type | File count | Subcategories (with per-subcategory counts) |
 |----------------|------------|---------------|
-| Pure HTML (no deps) | 162 | avatars, badges, buttons, button-groups, headings, cards, containers, dividers, list-containers, media-objects, tables, stacked-lists, stats, toggles, checkboxes, radio-groups, input-groups (most), sign-in-forms, textareas (most), action-panels, empty-states (1), form-layouts (0) |
-| Icon-only (heroicons) | 94 | alerts, empty-states (5), description-lists, calendars (1), stats (2), form-layouts (4), input-groups (7), radio-groups (1), select-menus (1), dividers (5), feeds, grid-lists (5), stacked-lists (8), tables (2), breadcrumbs, pagination (2), progress-bars (5), sidebar-navigation (3), tabs (9), vertical-navigation (4), button-groups (3), buttons (4), headings (5) |
+| Pure HTML (no deps) | 162 | avatars (11), badges (16), buttons (5), button-groups (1), card-headings (4), page-headings (3), section-headings (6), cards (10), containers (5), dividers (4), list-containers (7), media-objects (8), tables (17), stacked-lists (6), stats (3), toggles (5), checkboxes (4), radio-groups (11), input-groups (14), sign-in-forms (4), textareas (1), action-panels (8), empty-states (1), pagination (1), progress-bars (3), vertical-navigation (2) |
+| Icon-only (heroicons) | 94 | alerts (6), empty-states (5), description-lists (6), calendars (1), stats (2), form-layouts (4), input-groups (7), radio-groups (1), select-menus (1), dividers (4), feeds (2), grid-lists (4), stacked-lists (7), tables (2), breadcrumbs (4), pagination (2), progress-bars (5), sidebar-navigation (3), tabs (9), vertical-navigation (4), button-groups (3), buttons (3), card-headings (1), page-headings (3), section-headings (3), multi-column (2) |
 | Headless-only (headlessui) | 2 | notifications (2) |
-| Both (headlessui + heroicons) | 106 | command-palettes (9), navbars (11), drawers (12), modal-dialogs (6), notifications (4), comboboxes (5), select-menus (6), textareas (3), dropdowns (5), button-groups (1), application-shells (23), calendars (7), stacked-lists (2), feeds (1), grid-lists (1), headings (4), sidebar-navigation (2), page-examples (6) — of these, 100 are in M5, 6 page-examples are in M6 |
+| Both (headlessui + heroicons) | 106 | command-palettes (8), navbars (11), drawers (12), modal-dialogs (6), notifications (4), comboboxes (4), select-menus (6), textareas (4), dropdowns (5), button-groups (1), multi-column (4), sidebar (8), stacked (9), calendars (7), stacked-lists (2), feeds (1), grid-lists (1), card-headings (1), page-headings (3), section-headings (1), sidebar-navigation (2), page-examples (6) — of these, 100 are in M5, 6 page-examples are in M6 |
 
 ## Milestone File Index
 

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/00-overview.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/00-overview.md
@@ -1,0 +1,95 @@
+# Plan: Complete @neokai/ui -- Missing Components + Full 364-Example Demo
+
+## Goal Summary
+
+Port all 364 Tailwind Application UI v4 reference examples as live demo sections in `packages/ui/demo/`, add missing headless component wrappers, and integrate an icon library. The result is a comprehensive visual reference ("kitchen sink") showcasing every @neokai/ui component with real-world layout patterns.
+
+## High-Level Approach
+
+1. **Foundation** -- Fix package.json exports gap, add `lucide-preact` icon library, refactor demo App.tsx to support a categorized sidebar (48+ sections across 11 categories).
+2. **Pure HTML demos** -- Port the 162 reference files that have zero external dependencies first (no headlessui, no heroicons). These are pure Tailwind markup and are the fastest to port.
+3. **Icon-only demos** -- Port the 93 reference files that use heroicons but not headlessui. Depends on lucide-preact being available and icon name mapping being established.
+4. **Headless-only demos** -- Port the 2 reference files that use headlessui but not heroicons. These map directly to existing @neokai/ui component APIs. (Very small batch; only notification variants.)
+5. **Combined headless+icon demos** -- Port the 106 reference files that use both headlessui and heroicons. The most complex batch requiring both component API knowledge and icon mapping.
+6. **Page-example compositions** -- Port the 6 full-page reference examples (detail-screens, home-screens, settings-screens) that combine multiple categories into cohesive layouts.
+7. **Integration and QA** -- Visual QA pass, sidebar navigation polish, dark/light theme verification, ensure all 364 examples render correctly.
+
+## Data Attribute Syntax Decision
+
+Reference files use `data-closed:` (unbracketed Tailwind v4 syntax). Existing @neokai/ui demos use `data-[closed]:` (bracketed). Both work because the render utility sets `data-closed=""`. **Decision: keep the bracketed form (`data-[closed]:`)** for consistency with existing demos. All ported examples must convert unbracketed to bracketed data attribute variants.
+
+## Reference Location
+
+All 364 reference JSX files are at: `/Users/lsm/focus/tmp/tailwind/application-ui-v4/react/`
+- 11 categories, 48 subcategories
+- Each subcategory has 2-21 JSX files
+
+## Demo Output Location
+
+All new demo files go to: `packages/ui/demo/sections/`
+- One file per subcategory (48 new demo files)
+- Each file exports a single Preact function component
+
+## Component Source Location
+
+@neokai/ui component source: `packages/ui/src/components/`
+Package barrel export: `packages/ui/src/mod.ts`
+
+## Cross-Milestone Dependencies
+
+```
+M1 (Foundation) -- no dependencies
+M2 (Pure HTML demos) -- depends on M1 (App.tsx categorized sidebar)
+M3 (Icon-only demos) -- depends on M1 (lucide-preact setup, icon name mapping)
+M4 (Headless-only demos) -- depends on M1 (App.tsx sidebar)
+M5 (Headless+icon demos) -- depends on M3 (icon mapping), M4 (headless patterns)
+M6 (Page compositions) -- depends on M2-M5 (reuses patterns)
+M7 (Integration & QA) -- depends on M2-M6 (all demos complete)
+```
+
+M2, M3, M4 can run in parallel after M1 completes.
+M5 depends on M3 completing (for icon mapping). M4 is so small (2 files) it can be folded into M5 or done in parallel.
+M6 can start once enough of M2-M5 are done (it reuses patterns from all prior milestones).
+
+## Icon Library: lucide-preact
+
+- **Package**: `lucide-preact` (v0.577.0, official Preact support, tree-shakable)
+- **Install as**: devDependency in `packages/ui/package.json`
+- **Heroicons-to-lucide mapping**: A lookup table mapping 68 heroicon names to their lucide equivalents will be created in M1. Most heroicons have direct lucide counterparts; a few may need `ChevronDown` -> `ChevronDown`, `XMarkIcon` -> `X`, etc.
+- **Usage pattern**: `import { Search, Folder } from 'lucide-preact'` then `<Search class="w-5 h-5" />`
+
+## Total Estimated Task Count
+
+**7 milestones, 16 tasks total**
+
+| Milestone | Tasks | Reference Files |
+|-----------|-------|-----------------|
+| M1: Foundation | 2 | 0 (infrastructure) |
+| M2: Pure HTML demos | 3 | ~162 |
+| M3: Icon-only demos | 2 | ~93 |
+| M4: Headless-only demos | 1 | 2 |
+| M5: Headless+icon demos | 3 | ~106 |
+| M6: Page compositions | 1 | 6 |
+| M7: Integration & QA | 2 | 0 (verification) |
+| **Total** | **16** | **364** |
+
+## Dependency Breakdown by Reference File
+
+| Dependency type | File count | Subcategories |
+|----------------|------------|---------------|
+| Pure HTML (no deps) | ~163 | avatars, badges, buttons, button-groups, headings, cards, containers, dividers, list-containers, media-objects, tables, stacked-lists, stats, toggles, checkboxes, radio-groups, input-groups (most), sign-in-forms, textareas (most), action-panels, empty-states (1), form-layouts (0) |
+| Icon-only (heroicons) | ~93 | alerts, empty-states (5), description-lists, calendars (1), stats (2), form-layouts (5), input-groups (7), radio-groups (1), select-menus (1), dividers (5), feeds, grid-lists (5), stacked-lists (8), tables (2), breadcrumbs, pagination (2), progress-bars (5), sidebar-navigation (3), tabs (9), vertical-navigation (4), button-groups (3), buttons (4), headings (5) |
+| Headless-only (headlessui) | 2 | notifications (2) |
+| Both (headlessui + heroicons) | ~106 | command-palettes (9), navbars (11), drawers (12), modal-dialogs (6), notifications (4), comboboxes (5), select-menus (6), textareas (3), dropdowns (5), button-groups (1), application-shells (23), calendars (7), stacked-lists (2), feeds (1), grid-lists (1), headings (4), sidebar-navigation (2), page-examples (6) |
+
+## Milestone File Index
+
+| File | Milestone |
+|------|-----------|
+| `01-foundation.md` | Foundation: exports, icon library, App.tsx refactor |
+| `02-pure-html-demos.md` | Pure HTML demos: layout, headings, forms (no deps) |
+| `03-icon-only-demos.md` | Icon-only demos: elements, feedback, navigation (heroicons only) |
+| `04-headless-only-demos.md` | Headless-only demos: notification overlays (headlessui only, 2 files) |
+| `05-headless-icon-demos.md` | Combined headless+icon demos: forms, navigation, overlays |
+| `06-page-compositions.md` | Page compositions: full-screen layouts combining patterns |
+| `07-integration-qa.md` | Integration, visual QA, sidebar polish, final verification |

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/00-overview.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/00-overview.md
@@ -6,11 +6,11 @@ Port all 364 Tailwind Application UI v4 reference examples as live demo sections
 
 ## High-Level Approach
 
-1. **Foundation** -- Fix package.json exports gap, add `lucide-preact` icon library, refactor demo App.tsx to support a categorized sidebar (48+ sections across 11 categories).
-2. **Pure HTML demos** -- Port the 162 reference files that have zero external dependencies first (no headlessui, no heroicons). These are pure Tailwind markup and are the fastest to port.
-3. **Icon-only demos** -- Port the 93 reference files that use heroicons but not headlessui. Depends on lucide-preact being available and icon name mapping being established.
+1. **Foundation** -- Fix package.json exports gap, add `lucide-preact` icon library, refactor demo App.tsx to support a categorized sidebar (49 sections across 11 categories).
+2. **Pure HTML demos** -- Port 162 reference files that have zero external dependencies first (no headlessui, no heroicons). These are pure Tailwind markup and are the fastest to port.
+3. **Icon-only demos** -- Port 94 reference files that use heroicons but not headlessui. Depends on lucide-preact being available and icon name mapping being established.
 4. **Headless-only demos** -- Port the 2 reference files that use headlessui but not heroicons. These map directly to existing @neokai/ui component APIs. (Very small batch; only notification variants.)
-5. **Combined headless+icon demos** -- Port the 106 reference files that use both headlessui and heroicons. The most complex batch requiring both component API knowledge and icon mapping.
+5. **Combined headless+icon demos** -- Port 106 reference files that use both headlessui and heroicons. 100 are covered by M5 tasks; the remaining 6 page-examples are in M6. The most complex batch requiring both component API knowledge and icon mapping.
 6. **Page-example compositions** -- Port the 6 full-page reference examples (detail-screens, home-screens, settings-screens) that combine multiple categories into cohesive layouts.
 7. **Integration and QA** -- Visual QA pass, sidebar navigation polish, dark/light theme verification, ensure all 364 examples render correctly.
 
@@ -21,13 +21,13 @@ Reference files use `data-closed:` (unbracketed Tailwind v4 syntax). Existing @n
 ## Reference Location
 
 All 364 reference JSX files are at: `/Users/lsm/focus/tmp/tailwind/application-ui-v4/react/`
-- 11 categories, 48 subcategories
+- 11 categories, 49 subcategories
 - Each subcategory has 2-21 JSX files
 
 ## Demo Output Location
 
 All new demo files go to: `packages/ui/demo/sections/`
-- One file per subcategory (48 new demo files)
+- One file per subcategory (49 new demo files)
 - Each file exports a single Preact function component
 
 ## Component Source Location
@@ -55,7 +55,7 @@ M6 can start once enough of M2-M5 are done (it reuses patterns from all prior mi
 
 - **Package**: `lucide-preact` (v0.577.0, official Preact support, tree-shakable)
 - **Install as**: devDependency in `packages/ui/package.json`
-- **Heroicons-to-lucide mapping**: A lookup table mapping 68 heroicon names to their lucide equivalents will be created in M1. Most heroicons have direct lucide counterparts; a few may need `ChevronDown` -> `ChevronDown`, `XMarkIcon` -> `X`, etc.
+- **Heroicons-to-lucide mapping**: A lookup table mapping 66 unique heroicon names (plus any aliases) to their lucide equivalents will be created in M1. Most heroicons have direct lucide counterparts; a few may need `ChevronDown` -> `ChevronDown`, `XMarkIcon` -> `X`, etc.
 - **Usage pattern**: `import { Search, Folder } from 'lucide-preact'` then `<Search class="w-5 h-5" />`
 
 ## Total Estimated Task Count
@@ -65,10 +65,10 @@ M6 can start once enough of M2-M5 are done (it reuses patterns from all prior mi
 | Milestone | Tasks | Reference Files |
 |-----------|-------|-----------------|
 | M1: Foundation | 2 | 0 (infrastructure) |
-| M2: Pure HTML demos | 3 | ~162 |
-| M3: Icon-only demos | 2 | ~93 |
+| M2: Pure HTML demos | 3 | 162 |
+| M3: Icon-only demos | 2 | 94 |
 | M4: Headless-only demos | 1 | 2 |
-| M5: Headless+icon demos | 3 | ~106 |
+| M5: Headless+icon demos | 3 | 100 |
 | M6: Page compositions | 1 | 6 |
 | M7: Integration & QA | 2 | 0 (verification) |
 | **Total** | **16** | **364** |
@@ -77,10 +77,10 @@ M6 can start once enough of M2-M5 are done (it reuses patterns from all prior mi
 
 | Dependency type | File count | Subcategories |
 |----------------|------------|---------------|
-| Pure HTML (no deps) | ~163 | avatars, badges, buttons, button-groups, headings, cards, containers, dividers, list-containers, media-objects, tables, stacked-lists, stats, toggles, checkboxes, radio-groups, input-groups (most), sign-in-forms, textareas (most), action-panels, empty-states (1), form-layouts (0) |
-| Icon-only (heroicons) | ~93 | alerts, empty-states (5), description-lists, calendars (1), stats (2), form-layouts (5), input-groups (7), radio-groups (1), select-menus (1), dividers (5), feeds, grid-lists (5), stacked-lists (8), tables (2), breadcrumbs, pagination (2), progress-bars (5), sidebar-navigation (3), tabs (9), vertical-navigation (4), button-groups (3), buttons (4), headings (5) |
+| Pure HTML (no deps) | 162 | avatars, badges, buttons, button-groups, headings, cards, containers, dividers, list-containers, media-objects, tables, stacked-lists, stats, toggles, checkboxes, radio-groups, input-groups (most), sign-in-forms, textareas (most), action-panels, empty-states (1), form-layouts (0) |
+| Icon-only (heroicons) | 94 | alerts, empty-states (5), description-lists, calendars (1), stats (2), form-layouts (4), input-groups (7), radio-groups (1), select-menus (1), dividers (5), feeds, grid-lists (5), stacked-lists (8), tables (2), breadcrumbs, pagination (2), progress-bars (5), sidebar-navigation (3), tabs (9), vertical-navigation (4), button-groups (3), buttons (4), headings (5) |
 | Headless-only (headlessui) | 2 | notifications (2) |
-| Both (headlessui + heroicons) | ~106 | command-palettes (9), navbars (11), drawers (12), modal-dialogs (6), notifications (4), comboboxes (5), select-menus (6), textareas (3), dropdowns (5), button-groups (1), application-shells (23), calendars (7), stacked-lists (2), feeds (1), grid-lists (1), headings (4), sidebar-navigation (2), page-examples (6) |
+| Both (headlessui + heroicons) | 106 | command-palettes (9), navbars (11), drawers (12), modal-dialogs (6), notifications (4), comboboxes (5), select-menus (6), textareas (3), dropdowns (5), button-groups (1), application-shells (23), calendars (7), stacked-lists (2), feeds (1), grid-lists (1), headings (4), sidebar-navigation (2), page-examples (6) — of these, 100 are in M5, 6 page-examples are in M6 |
 
 ## Milestone File Index
 

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/01-foundation.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/01-foundation.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Set up the infrastructure needed for all subsequent demo porting work: fix missing package exports, install the icon library, create the heroicons-to-lucide name mapping, and refactor the demo App.tsx to support a categorized sidebar with 48+ sections.
+Set up the infrastructure needed for all subsequent demo porting work: fix missing package exports, install the icon library, create the heroicons-to-lucide name mapping, and refactor the demo App.tsx to support a categorized sidebar with 49 sections.
 
 ## Scope
 
@@ -45,13 +45,13 @@ Set up the infrastructure needed for all subsequent demo porting work: fix missi
 
 ### Task 1.2: Create heroicons-to-lucide icon name mapping and refactor demo App.tsx sidebar
 
-**Description**: Create a mapping utility that translates heroicon component names to lucide-preact icon names. Then refactor `packages/ui/demo/App.tsx` to support a categorized sidebar with 11 categories and 48+ sections, replacing the current flat list.
+**Description**: Create a mapping utility that translates heroicon component names to lucide-preact icon names. Then refactor `packages/ui/demo/App.tsx` to support a categorized sidebar with 11 categories and 49 sections, replacing the current flat list.
 
 **Subtasks**:
 
 1. **Create icon mapping file** at `packages/ui/demo/icon-map.ts`:
    - Export a `Record<string, string>` mapping heroicon names to lucide names
-   - Map all 68 unique heroicon names found in the 364 reference files
+   - Map all 66 unique heroicon names found in the 364 reference files (plus any aliases)
    - Key naming convention: heroicon `ChevronDownIcon` maps to lucide `ChevronDown`, `XMarkIcon` maps to `X`, `Bars3Icon` maps to `Menu`, `MagnifyingGlassIcon` maps to `Search`
    - Size variants (16/solid, 20/solid, 24/outline, 24/solid) are NOT needed in the mapping -- lucide icons are size-agnostic via `class="w-N h-N"` and always use the same stroke style
 
@@ -71,7 +71,7 @@ Set up the infrastructure needed for all subsequent demo porting work: fix missi
      Page Examples (detail-screens, home-screens, settings-screens)
      ```
    - Keep the existing 22 "Component" sections in a top-level category
-   - Add a new "Application UI" category with the 48 subcategories (initially empty/placeholder)
+   - Add a new "Application UI" category with the 49 subcategories (initially empty/placeholder)
    - Implement collapsible category headers in the sidebar
    - Use the lucide-preact `ChevronDown` / `ChevronRight` icons for collapse/expand toggles
    - Replace the inline `SunIcon` / `MoonIcon` SVGs with lucide `Sun` / `Moon` icons
@@ -82,7 +82,7 @@ Set up the infrastructure needed for all subsequent demo porting work: fix missi
    - Consider widening the sidebar from `w-56` to `w-64` to accommodate category nesting
 
 **Acceptance criteria**:
-- `packages/ui/demo/icon-map.ts` exports a mapping for all 68 heroicon names
+- `packages/ui/demo/icon-map.ts` exports a mapping for all 66 heroicon names (plus any aliases)
 - App.tsx sidebar shows categories with collapsible sections
 - All 22 existing demo sections still render correctly
 - Theme toggle (dark/light) still works

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/01-foundation.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/01-foundation.md
@@ -1,0 +1,96 @@
+# Milestone 1: Foundation
+
+## Goal
+
+Set up the infrastructure needed for all subsequent demo porting work: fix missing package exports, install the icon library, create the heroicons-to-lucide name mapping, and refactor the demo App.tsx to support a categorized sidebar with 48+ sections.
+
+## Scope
+
+- Fix `packages/ui/package.json` exports for 7 components missing from the exports map
+- Install `lucide-preact` as a devDependency
+- Create heroicons-to-lucide icon name mapping utility
+- Refactor `packages/ui/demo/App.tsx` to support categorized sidebar navigation
+
+## Tasks
+
+### Task 1.1: Fix package.json exports and install lucide-preact
+
+**Description**: Update `packages/ui/package.json` to add missing exports for components that exist in `src/mod.ts` but are not in the `exports` map. Install `lucide-preact` as a devDependency.
+
+**Subtasks**:
+1. Compare `src/mod.ts` exports with `package.json` exports field. Missing entries:
+   - `"./alert"` -> `./src/components/alert/alert.tsx`
+   - `"./avatar"` -> `./src/components/avatar/avatar.tsx`
+   - `"./badge"` -> `./src/components/badge/badge.tsx`
+   - `"./input-group"` -> `./src/components/input-group/input-group.tsx`
+   - `"./progress-bar"` -> `./src/components/progress-bar/progress-bar.tsx`
+   - `"./stepper"` -> `./src/components/stepper/stepper.tsx`
+   - `"./touch-target"` -> `./src/components/touch-target/touch-target.tsx`
+2. Run `bun add -D lucide-preact@0.577.0` in the `packages/ui` directory
+3. Verify the demo dev server still starts (`bun run dev`)
+
+**Acceptance criteria**:
+- All 26 component groups from `src/mod.ts` have corresponding entries in `package.json` exports
+- `lucide-preact` is listed in devDependencies
+- `bun run dev` starts without errors
+- `bun run test` still passes
+
+**Depends on**: Nothing
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 1.2: Create heroicons-to-lucide icon name mapping and refactor demo App.tsx sidebar
+
+**Description**: Create a mapping utility that translates heroicon component names to lucide-preact icon names. Then refactor `packages/ui/demo/App.tsx` to support a categorized sidebar with 11 categories and 48+ sections, replacing the current flat list.
+
+**Subtasks**:
+
+1. **Create icon mapping file** at `packages/ui/demo/icon-map.ts`:
+   - Export a `Record<string, string>` mapping heroicon names to lucide names
+   - Map all 68 unique heroicon names found in the 364 reference files
+   - Key naming convention: heroicon `ChevronDownIcon` maps to lucide `ChevronDown`, `XMarkIcon` maps to `X`, `Bars3Icon` maps to `Menu`, `MagnifyingGlassIcon` maps to `Search`
+   - Size variants (16/solid, 20/solid, 24/outline, 24/solid) are NOT needed in the mapping -- lucide icons are size-agnostic via `class="w-N h-N"` and always use the same stroke style
+
+2. **Refactor demo App.tsx sidebar**:
+   - Define a categorized section structure with 11 categories matching the reference taxonomy:
+     ```
+     Application Shells (multi-column, sidebar, stacked)
+     Data Display (calendars, description-lists, stats)
+     Elements (avatars, badges, button-groups, buttons, dropdowns)
+     Feedback (alerts, empty-states)
+     Forms (action-panels, checkboxes, comboboxes, form-layouts, input-groups, radio-groups, select-menus, sign-in-forms, textareas, toggles)
+     Headings (card-headings, page-headings, section-headings)
+     Layout (cards, containers, dividers, list-containers, media-objects)
+     Lists (feeds, grid-lists, stacked-lists, tables)
+     Navigation (breadcrumbs, command-palettes, navbars, pagination, progress-bars, sidebar-navigation, tabs, vertical-navigation)
+     Overlays (drawers, modal-dialogs, notifications)
+     Page Examples (detail-screens, home-screens, settings-screens)
+     ```
+   - Keep the existing 22 "Component" sections in a top-level category
+   - Add a new "Application UI" category with the 48 subcategories (initially empty/placeholder)
+   - Implement collapsible category headers in the sidebar
+   - Use the lucide-preact `ChevronDown` / `ChevronRight` icons for collapse/expand toggles
+   - Replace the inline `SunIcon` / `MoonIcon` SVGs with lucide `Sun` / `Moon` icons
+   - Keep all existing demo sections functional (no regressions)
+
+3. **Update demo/styles.css** if needed:
+   - Add any CSS custom properties needed for the expanded sidebar
+   - Consider widening the sidebar from `w-56` to `w-64` to accommodate category nesting
+
+**Acceptance criteria**:
+- `packages/ui/demo/icon-map.ts` exports a mapping for all 68 heroicon names
+- App.tsx sidebar shows categories with collapsible sections
+- All 22 existing demo sections still render correctly
+- Theme toggle (dark/light) still works
+- Inline SVGs for Sun/Moon replaced with lucide imports
+- `bun run dev` starts and sidebar navigation works
+
+**Depends on**: Task 1.1 (lucide-preact must be installed)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/02-pure-html-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/02-pure-html-demos.md
@@ -2,12 +2,12 @@
 
 ## Goal
 
-Port all ~163 reference files that have zero external dependencies (no headlessui, no heroicons) into demo section files. These are pure Tailwind CSS markup -- the fastest and least complex batch.
+Port all 162 reference files that have zero external dependencies (no headlessui, no heroicons) into demo section files. These are pure Tailwind CSS markup -- the fastest and least complex batch.
 
 ## Scope
 
 - 20 subcategories across 7 top-level categories
-- ~163 reference JSX files total
+- 162 reference JSX files total
 - Each subcategory becomes one demo section file
 
 ## Porting Checklist (per file)
@@ -16,13 +16,13 @@ For every reference file, the coder must:
 1. Convert `className` to `class`
 2. Remove `'use client'` directive (React-specific)
 3. Convert `import { useState } from 'react'` to `import { useState } from 'preact/hooks'` (if present)
-4. Convert unbracketed data attribute variants (`data-closed:`, `data-focus:`, etc.) to bracketed form (`data-[closed]:`, `data-[focus]:`, etc.)
+4. Convert unbracketed data attribute variants (`data-closed:`, `data-focus:`, etc.) to bracketed form (`data-[closed]:`, `data-[focus]:`, etc.). **Exception**: calendar files use custom rendering attributes (`data-is-today:`, `data-is-selected:`, `data-is-current-month:`, `data-first-line:`) that are NOT Tailwind variants -- these should NOT be converted to bracketed form.
 5. Wrap each example in a `<div class="space-y-4">` or similar container with a label/title
 6. Ensure all examples in a subcategory are rendered within the single demo component
 
 ## Tasks
 
-### Task 2.1: Pure HTML demos -- Elements, Headings, Layout (75 files)
+### Task 2.1: Pure HTML demos -- Elements, Headings, Layout (80 files)
 
 **Description**: Port all pure-HTML reference files from the elements, headings, and layout categories.
 
@@ -56,7 +56,7 @@ For every reference file, the coder must:
 
 **Acceptance criteria**:
 - 12 new demo section files created
-- All 75 reference examples render in the demo app
+- All 80 reference examples render in the demo app
 - No `className`, no `'use client'`, no `from 'react'` in any file
 - All data attribute variants use bracketed form
 - Sidebar navigation shows new sections under correct categories
@@ -70,9 +70,9 @@ For every reference file, the coder must:
 
 ---
 
-### Task 2.2: Pure HTML demos -- Forms (67 files)
+### Task 2.2: Pure HTML demos -- Forms (47 files)
 
-**Description**: Port all pure-HTML reference files from the forms category. This is the largest pure-HTML batch.
+**Description**: Port all pure-HTML reference files from the forms category.
 
 **Subtasks**:
 
@@ -108,7 +108,7 @@ For every reference file, the coder must:
 
 ---
 
-### Task 2.3: Pure HTML demos -- Data Display, Lists, Navigation, Feedback (41 files)
+### Task 2.3: Pure HTML demos -- Data Display, Lists, Navigation, Feedback (35 files)
 
 **Description**: Port all remaining pure-HTML reference files from data-display, lists, navigation, and feedback categories.
 
@@ -134,7 +134,7 @@ For every reference file, the coder must:
 
 **Acceptance criteria**:
 - 8 new demo section files created
-- All ~37 reference examples render in the demo app
+- All 35 reference examples render in the demo app
 - No `className`, no `'use client'`, no `from 'react'` in any file
 - All data attribute variants use bracketed form
 - Sidebar navigation shows new sections under correct categories

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/02-pure-html-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/02-pure-html-demos.md
@@ -1,0 +1,147 @@
+# Milestone 2: Pure HTML Demos
+
+## Goal
+
+Port all ~163 reference files that have zero external dependencies (no headlessui, no heroicons) into demo section files. These are pure Tailwind CSS markup -- the fastest and least complex batch.
+
+## Scope
+
+- 20 subcategories across 7 top-level categories
+- ~163 reference JSX files total
+- Each subcategory becomes one demo section file
+
+## Porting Checklist (per file)
+
+For every reference file, the coder must:
+1. Convert `className` to `class`
+2. Remove `'use client'` directive (React-specific)
+3. Convert `import { useState } from 'react'` to `import { useState } from 'preact/hooks'` (if present)
+4. Convert unbracketed data attribute variants (`data-closed:`, `data-focus:`, etc.) to bracketed form (`data-[closed]:`, `data-[focus]:`, etc.)
+5. Wrap each example in a `<div class="space-y-4">` or similar container with a label/title
+6. Ensure all examples in a subcategory are rendered within the single demo component
+
+## Tasks
+
+### Task 2.1: Pure HTML demos -- Elements, Headings, Layout (75 files)
+
+**Description**: Port all pure-HTML reference files from the elements, headings, and layout categories.
+
+**Subtasks**:
+
+1. **Create `elements/avatars/AvatarsDemo.tsx`** (11 files): Circular/rounded avatars, with notifications (top/bottom), with placeholder icon/initials, avatar groups, with text.
+
+2. **Create `elements/badges/BadgesDemo.tsx`** (18 files): With border, with dot, pill variants, flat variants, with remove button, small variants.
+
+3. **Create `elements/buttons/ButtonsDemo.tsx`** (5 files): Primary, secondary, soft, rounded primary, rounded secondary. Note: some button files are in the icon-only or headless batches; only port the 5 pure-HTML ones.
+
+4. **Create `elements/button-groups/ButtonGroupsDemo.tsx`** (1 file): Basic button group. Note: only 1 of 5 button-group files is pure HTML.
+
+5. **Create `headings/card-headings/CardHeadingsDemo.tsx`** (4 files): Simple, with action, with description and action, with description.
+
+6. **Create `headings/page-headings/PageHeadingsDemo.tsx`** (3 files): With actions, with avatar and actions, card with avatar and stats.
+
+7. **Create `headings/section-headings/SectionHeadingsDemo.tsx`** (5 files): Simple, with description, with actions, with action, with inline tabs, with label.
+
+8. **Create `layout/cards/CardsDemo.tsx`** (10 files): Basic card, edge-to-edge on mobile, with header, with footer, with header and footer, gray footer, gray body, well variants.
+
+9. **Create `layout/containers/ContainersDemo.tsx`** (5 files): Full-width on mobile constrained, constrained with padded content, narrow constrained.
+
+10. **Create `layout/dividers/DividersDemo.tsx`** (3 files): With label, with label on left, with title, with title on left. Note: some divider files are in the icon-only batch.
+
+11. **Create `layout/list-containers/ListContainersDemo.tsx`** (7 files): Simple with dividers, card with dividers, separate cards, flat card, full-width on mobile variants.
+
+12. **Create `layout/media-objects/MediaObjectsDemo.tsx`** (8 files): Basic, aligned to center/bottom, stretched, media on right, responsive variants, nested.
+
+13. **Update `packages/ui/demo/App.tsx`** to import and render all new demo sections in the "Application UI > Elements", "Application UI > Headings", and "Application UI > Layout" sidebar categories.
+
+**Acceptance criteria**:
+- 12 new demo section files created
+- All 75 reference examples render in the demo app
+- No `className`, no `'use client'`, no `from 'react'` in any file
+- All data attribute variants use bracketed form
+- Sidebar navigation shows new sections under correct categories
+- `bun run dev` starts without errors
+
+**Depends on**: Task 1.2 (categorized sidebar must exist)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2.2: Pure HTML demos -- Forms (67 files)
+
+**Description**: Port all pure-HTML reference files from the forms category. This is the largest pure-HTML batch.
+
+**Subtasks**:
+
+1. **Create `forms/action-panels/ActionPanelsDemo.tsx`** (8 files): Simple, with link, with button on right, with button at top right, with toggle, with input, simple well, with well.
+
+2. **Create `forms/checkboxes/CheckboxesDemo.tsx`** (4 files): List with description, inline description, checkbox on right, simple list with heading.
+
+3. **Create `forms/input-groups/InputGroupsDemo.tsx`** (13 files): Input with label, with label and help text, disabled state, hidden label, corner hint, with add-on, inline add-on, inline leading and trailing add-ons, inset label, overlapping label, pill shape, gray background, keyboard shortcut. Note: some input-group files are in icon-only or headless batches.
+
+4. **Create `forms/radio-groups/RadioGroupsDemo.tsx`** (12 files): Simple list, inline list, with description, inline description, radio on right, simple table, descriptions in panel, color picker, small cards, stacked cards.
+
+5. **Create `forms/sign-in-forms/SignInFormsDemo.tsx`** (4 files): Simple, simple no labels, split screen, simple card.
+
+6. **Create `forms/textareas/TextareasDemo.tsx`** (1 file): Simple. Note: most textarea files are in icon/headless batches.
+
+7. **Create `forms/toggles/TogglesDemo.tsx`** (5 files): Simple toggle, short toggle, with icon, with left label and description, with right label.
+
+8. **Update `packages/ui/demo/App.tsx`** to import and render all new demo sections in the "Application UI > Forms" sidebar category.
+
+**Acceptance criteria**:
+- 7 new demo section files created
+- All 47 reference examples render in the demo app (some input-group files deferred to icon-only batch)
+- No `className`, no `'use client'`, no `from 'react'` in any file
+- All data attribute variants use bracketed form
+- Sidebar navigation shows new sections under Forms category
+- `bun run dev` starts without errors
+
+**Depends on**: Task 1.2 (categorized sidebar must exist)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2.3: Pure HTML demos -- Data Display, Lists, Navigation, Feedback (41 files)
+
+**Description**: Port all remaining pure-HTML reference files from data-display, lists, navigation, and feedback categories.
+
+**Subtasks**:
+
+1. **Create `data-display/stats/StatsDemo.tsx`** (3 files): With trending, simple, simple in cards. Note: 2 stats files are in the icon-only batch.
+
+2. **Create `lists/grid-lists/GridListsDemo.tsx`** (2 files): Horizontal link cards, images with details. Note: most grid-list files are in icon/headless batches.
+
+3. **Create `lists/stacked-lists/StackedListsDemo.tsx`** (6 files): Simple, narrow, narrow with sticky headings, narrow with actions, narrow with truncated content, narrow with small avatars. Note: many stacked-list files are in icon/headless batches.
+
+4. **Create `lists/tables/TablesDemo.tsx`** (18 files): Simple, simple in card, full-width, striped rows, uppercase headings, stacked columns on mobile, hidden columns, avatars with multiline content, sticky header, vertical lines, condensed, grouped rows, summary rows, with border, with checkboxes, full-width with avatars. Note: 2 table files are in icon-only batch.
+
+5. **Create `navigation/pagination/PaginationDemo.tsx`** (1 file): Simple card footer. Note: 2 pagination files are in icon-only batch.
+
+6. **Create `navigation/progress-bars/ProgressBarsDemo.tsx`** (4 files): Simple, bullets, progress bar. Note: 5 progress-bar files are in icon-only batch.
+
+7. **Create `navigation/vertical-navigation/VerticalNavigationDemo.tsx`** (2 files): Simple, with badges. Note: 4 vertical-navigation files are in icon-only batch.
+
+8. **Create `feedback/empty-states/EmptyStatesDemo.tsx`** (1 file): With dashed border. Note: 5 empty-state files are in icon-only batch.
+
+9. **Update `packages/ui/demo/App.tsx`** to import and render all new demo sections.
+
+**Acceptance criteria**:
+- 8 new demo section files created
+- All ~37 reference examples render in the demo app
+- No `className`, no `'use client'`, no `from 'react'` in any file
+- All data attribute variants use bracketed form
+- Sidebar navigation shows new sections under correct categories
+- `bun run dev` starts without errors
+
+**Depends on**: Task 1.2 (categorized sidebar must exist)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/02-pure-html-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/02-pure-html-demos.md
@@ -30,7 +30,7 @@ For every reference file, the coder must:
 
 1. **Create `elements/avatars/AvatarsDemo.tsx`** (11 files): Circular/rounded avatars, with notifications (top/bottom), with placeholder icon/initials, avatar groups, with text.
 
-2. **Create `elements/badges/BadgesDemo.tsx`** (18 files): With border, with dot, pill variants, flat variants, with remove button, small variants.
+2. **Create `elements/badges/BadgesDemo.tsx`** (16 files): With border, with dot, pill variants, flat variants, with remove button, small variants.
 
 3. **Create `elements/buttons/ButtonsDemo.tsx`** (5 files): Primary, secondary, soft, rounded primary, rounded secondary. Note: some button files are in the icon-only or headless batches; only port the 5 pure-HTML ones.
 
@@ -40,13 +40,13 @@ For every reference file, the coder must:
 
 6. **Create `headings/page-headings/PageHeadingsDemo.tsx`** (3 files): With actions, with avatar and actions, card with avatar and stats.
 
-7. **Create `headings/section-headings/SectionHeadingsDemo.tsx`** (5 files): Simple, with description, with actions, with action, with inline tabs, with label.
+7. **Create `headings/section-headings/SectionHeadingsDemo.tsx`** (6 files): Simple, with description, with actions, with action, with inline tabs, with label.
 
 8. **Create `layout/cards/CardsDemo.tsx`** (10 files): Basic card, edge-to-edge on mobile, with header, with footer, with header and footer, gray footer, gray body, well variants.
 
 9. **Create `layout/containers/ContainersDemo.tsx`** (5 files): Full-width on mobile constrained, constrained with padded content, narrow constrained.
 
-10. **Create `layout/dividers/DividersDemo.tsx`** (3 files): With label, with label on left, with title, with title on left. Note: some divider files are in the icon-only batch.
+10. **Create `layout/dividers/DividersDemo.tsx`** (4 files): With label, with label on left, with title, with title on left. Note: some divider files are in the icon-only batch.
 
 11. **Create `layout/list-containers/ListContainersDemo.tsx`** (7 files): Simple with dividers, card with dividers, separate cards, flat card, full-width on mobile variants.
 
@@ -80,9 +80,9 @@ For every reference file, the coder must:
 
 2. **Create `forms/checkboxes/CheckboxesDemo.tsx`** (4 files): List with description, inline description, checkbox on right, simple list with heading.
 
-3. **Create `forms/input-groups/InputGroupsDemo.tsx`** (13 files): Input with label, with label and help text, disabled state, hidden label, corner hint, with add-on, inline add-on, inline leading and trailing add-ons, inset label, overlapping label, pill shape, gray background, keyboard shortcut. Note: some input-group files are in icon-only or headless batches.
+3. **Create `forms/input-groups/InputGroupsDemo.tsx`** (14 files): Input with label, with label and help text, disabled state, hidden label, corner hint, with add-on, inline add-on, inline leading and trailing add-ons, inset label, inputs with inset labels and shared borders, overlapping label, pill shape, gray background, keyboard shortcut. Note: some input-group files are in icon-only or headless batches.
 
-4. **Create `forms/radio-groups/RadioGroupsDemo.tsx`** (12 files): Simple list, inline list, with description, inline description, radio on right, simple table, descriptions in panel, color picker, small cards, stacked cards.
+4. **Create `forms/radio-groups/RadioGroupsDemo.tsx`** (11 files): Simple list, inline list, with description, inline description, radio on right, simple list with radio on right, simple table, descriptions in panel, color picker, small cards, stacked cards.
 
 5. **Create `forms/sign-in-forms/SignInFormsDemo.tsx`** (4 files): Simple, simple no labels, split screen, simple card.
 
@@ -120,11 +120,11 @@ For every reference file, the coder must:
 
 3. **Create `lists/stacked-lists/StackedListsDemo.tsx`** (6 files): Simple, narrow, narrow with sticky headings, narrow with actions, narrow with truncated content, narrow with small avatars. Note: many stacked-list files are in icon/headless batches.
 
-4. **Create `lists/tables/TablesDemo.tsx`** (18 files): Simple, simple in card, full-width, striped rows, uppercase headings, stacked columns on mobile, hidden columns, avatars with multiline content, sticky header, vertical lines, condensed, grouped rows, summary rows, with border, with checkboxes, full-width with avatars. Note: 2 table files are in icon-only batch.
+4. **Create `lists/tables/TablesDemo.tsx`** (17 files): Simple, simple in card, full-width, striped rows, uppercase headings, stacked columns on mobile, hidden columns, avatars with multiline content, sticky header, vertical lines, condensed, grouped rows, summary rows, with border, with checkboxes, full-width with avatars. Note: 2 table files are in icon-only batch.
 
 5. **Create `navigation/pagination/PaginationDemo.tsx`** (1 file): Simple card footer. Note: 2 pagination files are in icon-only batch.
 
-6. **Create `navigation/progress-bars/ProgressBarsDemo.tsx`** (4 files): Simple, bullets, progress bar. Note: 5 progress-bar files are in icon-only batch.
+6. **Create `navigation/progress-bars/ProgressBarsDemo.tsx`** (3 files): Simple, bullets, progress bar. Note: 5 progress-bar files are in icon-only batch.
 
 7. **Create `navigation/vertical-navigation/VerticalNavigationDemo.tsx`** (2 files): Simple, with badges. Note: 4 vertical-navigation files are in icon-only batch.
 

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/03-icon-only-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/03-icon-only-demos.md
@@ -1,0 +1,117 @@
+# Milestone 3: Icon-Only Demos
+
+## Goal
+
+Port all ~93 reference files that use heroicons but NOT headlessui. These require the lucide-preact icon library and the heroicons-to-lucide name mapping from M1.
+
+## Scope
+
+- ~30 subcategories across 8 top-level categories
+- ~93 reference JSX files
+- Depends on `lucide-preact` being installed and `icon-map.ts` being available
+
+## Porting Checklist (per file)
+
+Everything from M2 checklist PLUS:
+1. Replace `import { SomeIcon } from '@heroicons/react/24/outline'` with `import { SomeLucideIcon } from 'lucide-preact'`
+2. Use the `icon-map.ts` mapping to translate heroicon names to lucide names
+3. Adjust icon props: heroicons use `className` and sometimes `aria-hidden`, lucide uses `class` and passes through other SVG attributes. Use `class="w-5 h-5"` etc. for sizing.
+4. Remove any `aria-hidden="true"` from icon usage (lucide handles this internally) or keep it if preferred for explicitness
+
+## Tasks
+
+### Task 3.1: Icon-only demos -- Elements, Feedback, Headings, Layout, Forms (41 files)
+
+**Description**: Port icon-only reference files from elements, feedback, headings, layout, and forms categories.
+
+**Subtasks**:
+
+1. **Update `elements/buttons/ButtonsDemo.tsx`** -- add 4 icon-only button examples: buttons with leading icon, with trailing icon, circular buttons. (Already created in M2 with pure-HTML examples; extend it.)
+
+2. **Update `elements/button-groups/ButtonGroupsDemo.tsx`** -- add 3 icon-only examples: icon-only button group, with stat, with checkbox and dropdown.
+
+3. **Create `feedback/alerts/AlertsDemo.tsx`** (6 files): With description, with list, with actions, with link on right, with accent border, with dismiss button. Uses `ExclamationCircleIcon`, `ExclamationTriangleIcon`, `CheckCircleIcon`, `InformationCircleIcon`, `XMarkIcon`.
+
+4. **Update `feedback/empty-states/EmptyStatesDemo.tsx`** -- add 5 icon-only examples: simple, with starting points, with recommendations, with templates, with recommendations grid. Uses various heroicons.
+
+5. **Create `headings/card-headings/CardHeadingsWithIconsDemo.tsx`** or extend existing -- add 1 icon-only example: with avatar and actions.
+
+6. **Create `headings/page-headings/PageHeadingsWithIconsDemo.tsx`** or extend existing -- add 3 icon-only examples: with actions and breadcrumbs, with banner image, with filters and action.
+
+7. **Create `headings/section-headings/SectionHeadingsWithIconsDemo.tsx`** or extend existing -- add 3 icon-only examples: with input group, with tabs, with actions and tabs.
+
+8. **Create `layout/dividers/DividersWithIconsDemo.tsx`** or extend existing -- add 4 icon-only examples: with icon, with button, with title and button, with toolbar.
+
+9. **Create `forms/form-layouts/FormLayoutsDemo.tsx`** (5 files): Stacked, two-column, two-column with cards, labels on left. Uses `EnvelopeIcon`, `PhoneIcon`, `UserCircleIcon`.
+
+10. **Update `forms/input-groups/InputGroupsDemo.tsx`** -- add 7 icon-only examples: with validation error, with leading icon, with trailing icon, with inline leading dropdown, with inline leading add-on and trailing dropdown, with leading icon and trailing button, inputs with shared borders. Uses `ExclamationCircleIcon`, `MagnifyingGlassIcon`, `CreditCardIcon`, `ChevronDownIcon`, `PlusIcon`.
+
+11. **Update `forms/radio-groups/RadioGroupsDemo.tsx`** -- add 1 icon-only example: cards with icons.
+
+12. **Create `forms/select-menus/SelectMenusDemo.tsx`** (1 file): Simple native select. Note: most select-menu files are in headless batches.
+
+13. **Update `packages/ui/demo/App.tsx`** to register any new demo sections.
+
+**Acceptance criteria**:
+- All ~40 icon-only reference examples render correctly
+- All heroicon imports replaced with lucide-preact imports
+- Icon sizing preserved via `class="w-N h-N"` attributes
+- No `@heroicons` imports remain in any file
+- `bun run dev` starts without errors
+
+**Depends on**: Task 1.2 (lucide-preact + icon-map.ts), Task 2.1 (existing demo files to extend)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 3.2: Icon-only demos -- Lists, Navigation, Data Display, Application Shells (52 files)
+
+**Description**: Port icon-only reference files from lists, navigation, data-display, and application-shells categories.
+
+**Subtasks**:
+
+1. **Create `lists/feeds/FeedsDemo.tsx`** (2 files): Simple with icons, with multiple item types.
+
+2. **Update `lists/grid-lists/GridListsDemo.tsx`** -- add 4 icon-only examples: contact cards with small portrait, contact cards, simple cards, actions with shared borders.
+
+3. **Update `lists/stacked-lists/StackedListsDemo.tsx`** -- add 7 icon-only examples: with links, with inline links and avatar group, in card with links, two columns with links, full-width with links, full-width with constrained content, narrow with badges.
+
+4. **Update `lists/tables/TablesDemo.tsx`** -- add 2 icon-only examples: with sortable headings, with hidden headings.
+
+5. **Create `navigation/breadcrumbs/BreadcrumbsDemo.tsx`** (4 files): Contained, full-width bar, simple with chevrons, simple with slashes. Uses `ChevronRightIcon`, `HomeIcon`.
+
+6. **Update `navigation/pagination/PaginationDemo.tsx`** -- add 2 icon-only examples: card footer with page buttons, centered page numbers. Uses `ChevronLeftIcon`, `ChevronRightIcon`.
+
+7. **Update `navigation/progress-bars/ProgressBarsDemo.tsx`** -- add 5 icon-only examples: panels, panels with border, circles, bullets and text, circles with text.
+
+8. **Create `navigation/sidebar-navigation/SidebarNavigationDemo.tsx`** (3 files): Light, dark, brand. Uses various heroicons.
+
+9. **Create `navigation/tabs/TabsDemo.tsx`** (9 files): Tabs with underline, with underline and icons, in pills, in pills on gray, in pills with brand color, full-width with underline, bar with underline, with underline and badges, simple. Uses `UserCircleIcon`, `UserGroupIcon`, `FolderIcon`, `CalendarDaysIcon`, `DocumentDuplicateIcon`, `Cog6ToothIcon`.
+
+10. **Update `navigation/vertical-navigation/VerticalNavigationDemo.tsx`** -- add 4 icon-only examples: with icons and badges, with icons, with secondary navigation, on gray.
+
+11. **Create `data-display/calendars/CalendarsDemo.tsx`** (1 icon-only file): Double calendar. Note: most calendar files are in the headless batch.
+
+12. **Create `data-display/description-lists/DescriptionListsDemo.tsx`** (6 files): Left aligned, left aligned in card, left aligned striped, two-column, left aligned with inline actions, narrow with hidden labels.
+
+13. **Update `data-display/stats/StatsDemo.tsx`** -- add 2 icon-only examples: with brand icon, with shared borders.
+
+14. **Create `application-shells/multi-column/MultiColumnDemo.tsx`** (2 icon-only files): Constrained three column, constrained with sticky columns.
+
+15. **Update `packages/ui/demo/App.tsx`** to register all new demo sections.
+
+**Acceptance criteria**:
+- All ~52 icon-only reference examples render correctly
+- All heroicon imports replaced with lucide-preact imports
+- Icon sizing preserved via `class="w-N h-N"` attributes
+- No `@heroicons` imports remain in any file
+- `bun run dev` starts without errors
+
+**Depends on**: Task 1.2 (lucide-preact + icon-map.ts), Task 2.3 (existing demo files to extend)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/03-icon-only-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/03-icon-only-demos.md
@@ -26,7 +26,7 @@ Everything from M2 checklist PLUS:
 
 **Subtasks**:
 
-1. **Update `elements/buttons/ButtonsDemo.tsx`** -- add 4 icon-only button examples: buttons with leading icon, with trailing icon, circular buttons. (Already created in M2 with pure-HTML examples; extend it.)
+1. **Update `elements/buttons/ButtonsDemo.tsx`** -- add 3 icon-only button examples: buttons with leading icon, with trailing icon, circular buttons. (Already created in M2 with pure-HTML examples; extend it.)
 
 2. **Update `elements/button-groups/ButtonGroupsDemo.tsx`** -- add 3 icon-only examples: icon-only button group, with stat, with checkbox and dropdown.
 
@@ -34,13 +34,13 @@ Everything from M2 checklist PLUS:
 
 4. **Update `feedback/empty-states/EmptyStatesDemo.tsx`** -- add 5 icon-only examples: simple, with starting points, with recommendations, with templates, with recommendations grid. Uses various heroicons.
 
-5. **Create `headings/card-headings/CardHeadingsWithIconsDemo.tsx`** or extend existing -- add 1 icon-only example: with avatar and actions.
+5. **Extend `headings/card-headings/CardHeadingsDemo.tsx`** -- add 1 icon-only example: with avatar and actions. (Already created in M2 with pure-HTML examples.)
 
-6. **Create `headings/page-headings/PageHeadingsWithIconsDemo.tsx`** or extend existing -- add 3 icon-only examples: with actions and breadcrumbs, with banner image, with filters and action.
+6. **Extend `headings/page-headings/PageHeadingsDemo.tsx`** -- add 3 icon-only examples: with actions and breadcrumbs, with banner image, with filters and action. (Already created in M2 with pure-HTML examples.)
 
-7. **Create `headings/section-headings/SectionHeadingsWithIconsDemo.tsx`** or extend existing -- add 3 icon-only examples: with input group, with tabs, with actions and tabs.
+7. **Extend `headings/section-headings/SectionHeadingsDemo.tsx`** -- add 3 icon-only examples: with input group, with tabs, with actions and tabs. (Already created in M2 with pure-HTML examples.)
 
-8. **Create `layout/dividers/DividersWithIconsDemo.tsx`** or extend existing -- add 4 icon-only examples: with icon, with button, with title and button, with toolbar.
+8. **Extend `layout/dividers/DividersDemo.tsx`** -- add 4 icon-only examples: with icon, with button, with title and button, with toolbar. (Already created in M2 with pure-HTML examples.)
 
 9. **Create `forms/form-layouts/FormLayoutsDemo.tsx`** (4 files): Stacked, two-column, two-column with cards, labels on left. Uses `EnvelopeIcon`, `PhoneIcon`, `UserCircleIcon`.
 
@@ -53,7 +53,7 @@ Everything from M2 checklist PLUS:
 13. **Update `packages/ui/demo/App.tsx`** to register any new demo sections.
 
 **Acceptance criteria**:
-- All ~40 icon-only reference examples render correctly
+- All 41 icon-only reference examples render correctly
 - All heroicon imports replaced with lucide-preact imports
 - Icon sizing preserved via `class="w-N h-N"` attributes
 - No `@heroicons` imports remain in any file
@@ -67,7 +67,7 @@ Everything from M2 checklist PLUS:
 
 ---
 
-### Task 3.2: Icon-only demos -- Lists, Navigation, Data Display, Application Shells (52 files)
+### Task 3.2: Icon-only demos -- Lists, Navigation, Data Display, Application Shells (53 files)
 
 **Description**: Port icon-only reference files from lists, navigation, data-display, and application-shells categories.
 
@@ -104,7 +104,7 @@ Everything from M2 checklist PLUS:
 15. **Update `packages/ui/demo/App.tsx`** to register all new demo sections.
 
 **Acceptance criteria**:
-- All ~52 icon-only reference examples render correctly
+- All 53 icon-only reference examples render correctly
 - All heroicon imports replaced with lucide-preact imports
 - Icon sizing preserved via `class="w-N h-N"` attributes
 - No `@heroicons` imports remain in any file

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/03-icon-only-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/03-icon-only-demos.md
@@ -2,12 +2,12 @@
 
 ## Goal
 
-Port all ~93 reference files that use heroicons but NOT headlessui. These require the lucide-preact icon library and the heroicons-to-lucide name mapping from M1.
+Port all 94 reference files that use heroicons but NOT headlessui. These require the lucide-preact icon library and the heroicons-to-lucide name mapping from M1.
 
 ## Scope
 
 - ~30 subcategories across 8 top-level categories
-- ~93 reference JSX files
+- 94 reference JSX files
 - Depends on `lucide-preact` being installed and `icon-map.ts` being available
 
 ## Porting Checklist (per file)
@@ -42,7 +42,7 @@ Everything from M2 checklist PLUS:
 
 8. **Create `layout/dividers/DividersWithIconsDemo.tsx`** or extend existing -- add 4 icon-only examples: with icon, with button, with title and button, with toolbar.
 
-9. **Create `forms/form-layouts/FormLayoutsDemo.tsx`** (5 files): Stacked, two-column, two-column with cards, labels on left. Uses `EnvelopeIcon`, `PhoneIcon`, `UserCircleIcon`.
+9. **Create `forms/form-layouts/FormLayoutsDemo.tsx`** (4 files): Stacked, two-column, two-column with cards, labels on left. Uses `EnvelopeIcon`, `PhoneIcon`, `UserCircleIcon`.
 
 10. **Update `forms/input-groups/InputGroupsDemo.tsx`** -- add 7 icon-only examples: with validation error, with leading icon, with trailing icon, with inline leading dropdown, with inline leading add-on and trailing dropdown, with leading icon and trailing button, inputs with shared borders. Uses `ExclamationCircleIcon`, `MagnifyingGlassIcon`, `CreditCardIcon`, `ChevronDownIcon`, `PlusIcon`.
 

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/04-headless-only-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/04-headless-only-demos.md
@@ -1,0 +1,52 @@
+# Milestone 4: Headless-Only Demos
+
+## Goal
+
+Port the 2 reference files that use headlessui but NOT heroicons. These are notification overlay variants that use the Toast/Toaster API.
+
+## Scope
+
+- 1 subcategory (overlays/notifications)
+- 2 reference JSX files
+- Very small batch; can be combined with M5 or done independently
+
+## Porting Checklist (per file)
+
+Everything from M2 checklist PLUS:
+1. Convert headlessui imports to @neokai/ui equivalents:
+   - Reference uses headlessui Dialog, DialogPanel, DialogBackdrop, DialogTitle, Transition, TransitionChild, etc.
+   - Map to @neokai/ui component imports from `../../src/mod.ts` (or relative path from demo sections)
+2. Convert headlessui component APIs:
+   - `open` / `onClose` props map directly
+   - Data attribute variants (`data-closed:`, `data-open:`, etc.) convert to bracketed form
+   - `Transition` and `TransitionChild` usage is identical between headlessui and @neokai/ui
+3. Handle any headlessui-specific patterns (e.g., `Transition.Child` -> `TransitionChild` in @neokai/ui)
+
+## Tasks
+
+### Task 4.1: Headless-only notification demos (2 files)
+
+**Description**: Port the 2 headless-only notification reference files into the existing NotificationDemo.
+
+**Subtasks**:
+
+1. **Update `packages/ui/demo/sections/NotificationDemo.tsx`** to add 2 new notification variants:
+   - `overlays/notifications/04-with-avatar.jsx`: Notification toast with avatar. Uses Dialog/Transition from headlessui.
+   - `overlays/notifications/05-with-split-buttons.jsx`: Notification toast with split action buttons. Uses Dialog/Transition from headlessui.
+
+2. Convert headlessui imports to @neokai/ui imports. The existing NotificationDemo already imports from `../../src/mod.ts`, so follow the same pattern.
+
+3. Verify the new notification examples integrate well with the existing toast system (Toaster + useToast).
+
+**Acceptance criteria**:
+- 2 new notification variants render correctly in the NotificationDemo section
+- All headlessui imports replaced with @neokai/ui imports
+- No `@headlessui` imports remain
+- Toast system still works for all notification variants
+- `bun run dev` starts without errors
+
+**Depends on**: Task 1.2 (categorized sidebar)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/05-headless-icon-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/05-headless-icon-demos.md
@@ -84,7 +84,7 @@ Everything from M2 + M3 checklists PLUS:
 
 **Subtasks**:
 
-1. **Create `navigation/command-palettes/CommandPalettesDemo.tsx`** (9 files): Simple, simple with padding, with preview, with images and descriptions, with icons, semi-transparent with icons, with groups, with footer. Uses Dialog + Combobox composition. Icons: `MagnifyingGlassIcon`, `FaceFrownIcon`, `CodeBracketIcon`, `CommandLineIcon`, etc.
+1. **Create `navigation/command-palettes/CommandPalettesDemo.tsx`** (8 files): Simple, simple with padding, with preview, with images and descriptions, with icons, semi-transparent with icons, with groups, with footer. Uses Dialog + Combobox composition. Icons: `MagnifyingGlassIcon`, `FaceFrownIcon`, `CodeBracketIcon`, `CommandLineIcon`, etc.
 
 2. **Create `navigation/navbars/NavbarsDemo.tsx`** (11 files): Simple dark with menu button on left, dark with quick action, simple dark, simple with menu button on left, simple, with quick action, dark with search, with search, dark with centered search, with centered search, with search in column layout. Uses Dialog + Transition for mobile menu, Popover for dropdowns. Icons: `Bars3Icon`, `MagnifyingGlassIcon`, `XMarkIcon`, `BellIcon`, `PlusIcon`.
 
@@ -121,7 +121,7 @@ Everything from M2 + M3 checklists PLUS:
 
 3. **Create `application-shells/stacked/StackedShellsDemo.tsx`** (9 files): With bottom border, on subtle background, with lighter page header, branded nav with compact lighter page header, with overlap, brand nav with overlap, brand nav with lighter page header, with compact lighter page header, two-row navigation with overlap. Uses Popover, Disclosure. Icons: various.
 
-4. **Create `forms/comboboxes/ComboboxesDemo.tsx`** (5 files): Simple, with status indicator, with avatar, with secondary text. Uses Combobox from @neokai/ui. Icons: `CheckIcon`, `ChevronUpDownIcon`.
+4. **Create `forms/comboboxes/ComboboxesDemo.tsx`** (4 files): Simple, with status indicator, with avatar, with secondary text. Uses Combobox from @neokai/ui. Icons: `CheckIcon`, `ChevronUpDownIcon`.
 
 5. **Create `forms/select-menus/CustomSelectMenusDemo.tsx`** (6 files): Simple custom, custom with check on left, custom with status indicator, custom with avatar, with secondary text, branded with supporting text. Uses Listbox from @neokai/ui. Icons: `CheckIcon`, `ChevronUpDownIcon`.
 

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/05-headless-icon-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/05-headless-icon-demos.md
@@ -2,12 +2,13 @@
 
 ## Goal
 
-Port all ~106 reference files that use BOTH headlessui AND heroicons. This is the most complex batch requiring component API mapping AND icon library usage.
+Port all 106 reference files that use BOTH headlessui AND heroicons. This is the most complex batch requiring component API mapping AND icon library usage.
 
 ## Scope
 
 - ~25 subcategories across 9 top-level categories
-- ~106 reference JSX files
+- 100 reference JSX files covered by M5 tasks (22 + 21 + 57)
+- The remaining 6 "both" files are page-examples covered by M6 (detail-screens, home-screens, settings-screens)
 - Largest and most complex milestone
 
 ## Porting Checklist (per file)
@@ -45,7 +46,7 @@ Everything from M2 + M3 checklists PLUS:
 
 ## Tasks
 
-### Task 5.1: Headless+icon demos -- Overlays (drawers, modal-dialogs, notifications) (28 files)
+### Task 5.1: Headless+icon demos -- Overlays (drawers, modal-dialogs, notifications) (22 files)
 
 **Description**: Port all combined headless+icon reference files from the overlays category. This includes drawers, modal dialogs, and notifications.
 
@@ -55,13 +56,13 @@ Everything from M2 + M3 checklists PLUS:
 
 2. **Create `overlays/modal-dialogs/ModalDialogsDemo.tsx`** (6 files): Centered with single action, centered with wide buttons, simple alert, simple with dismiss button, simple with gray footer, simple with left-aligned buttons. Uses Dialog + Transition. Icons: `ExclamationTriangleIcon`, `XMarkIcon`.
 
-3. **Update `overlays/notifications/NotificationsDemo.tsx`** -- add 4 headless+icon notification variants: simple, condensed, with actions below, with buttons below. These use Dialog/Transition with icons.
+3. **Update `overlays/notifications/NotificationsDemo.tsx`** -- add 4 headless+icon notification variants: simple, condensed, with actions below, with buttons below. These use Dialog/Transition with icons. **Note**: This extends the same file that M4.1 (Task 4.1) creates. M4.1 must complete first so the base notification demos exist before adding icon variants.
 
 4. **Update `packages/ui/demo/App.tsx`** to register new demo sections.
 
 **Acceptance criteria**:
 - 2 new demo section files created (DrawersDemo, ModalDialogsDemo)
-- Existing NotificationDemo extended with 4 more variants
+- Existing NotificationDemo extended with 4 more variants (M4.1 must be merged first)
 - All 22 overlay reference examples render correctly
 - All headlessui imports replaced with @neokai/ui
 - All heroicon imports replaced with lucide-preact
@@ -69,7 +70,7 @@ Everything from M2 + M3 checklists PLUS:
 - Modal dialogs open/close with backdrop
 - `bun run dev` starts without errors
 
-**Depends on**: Task 1.2 (icon-map.ts, sidebar), Task 3.1 (lucide patterns established)
+**Depends on**: Task 1.2 (icon-map.ts, sidebar), Task 3.1 (lucide patterns established), Task 4.1 (base NotificationDemo.tsx must exist before extending with icon variants)
 
 **Agent type**: coder
 
@@ -77,7 +78,7 @@ Everything from M2 + M3 checklists PLUS:
 
 ---
 
-### Task 5.2: Headless+icon demos -- Navigation (command-palettes, navbars, sidebar-navigation) (24 files)
+### Task 5.2: Headless+icon demos -- Navigation (command-palettes, navbars, sidebar-navigation) (21 files)
 
 **Description**: Port all combined headless+icon reference files from the navigation category.
 
@@ -94,7 +95,7 @@ Everything from M2 + M3 checklists PLUS:
 **Acceptance criteria**:
 - 2 new demo section files created (CommandPalettesDemo, NavbarsDemo)
 - Existing SidebarNavigationDemo extended with 2 more variants
-- All 22 navigation reference examples render correctly
+- All 21 navigation reference examples render correctly
 - Command palettes open/close with search functionality
 - Navbar mobile menus toggle correctly
 - Sidebar expandable sections work with Disclosure
@@ -108,7 +109,7 @@ Everything from M2 + M3 checklists PLUS:
 
 ---
 
-### Task 5.3: Headless+icon demos -- Application Shells, Forms, Lists, Data Display, Headings (54 files)
+### Task 5.3: Headless+icon demos -- Application Shells, Forms, Lists, Data Display, Headings (57 files)
 
 **Description**: Port all remaining combined headless+icon reference files from application-shells, forms, lists, data-display, and headings categories.
 
@@ -149,7 +150,7 @@ Everything from M2 + M3 checklists PLUS:
 **Acceptance criteria**:
 - 7 new demo section files created
 - Multiple existing demo files extended
-- All ~54 reference examples render correctly
+- All 57 reference examples render correctly
 - All interactive elements (comboboxes, listboxes, menus, popovers, disclosures) function correctly
 - `bun run dev` starts without errors
 

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/05-headless-icon-demos.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/05-headless-icon-demos.md
@@ -1,0 +1,160 @@
+# Milestone 5: Combined Headless+Icon Demos
+
+## Goal
+
+Port all ~106 reference files that use BOTH headlessui AND heroicons. This is the most complex batch requiring component API mapping AND icon library usage.
+
+## Scope
+
+- ~25 subcategories across 9 top-level categories
+- ~106 reference JSX files
+- Largest and most complex milestone
+
+## Porting Checklist (per file)
+
+Everything from M2 + M3 checklists PLUS:
+1. Convert headlessui imports to @neokai/ui equivalents (see mapping table below)
+2. Convert headlessui component names and APIs:
+   - `Dialog` -> `Dialog`, `DialogBackdrop` -> `DialogBackdrop`, `DialogPanel` -> `DialogPanel`, `DialogTitle` -> `DialogTitle`, `DialogDescription` -> `DialogDescription`
+   - `Transition` -> `Transition`, `Transition.Child` -> `TransitionChild`
+   - `Combobox`, `ComboboxInput`, `ComboboxOptions`, `ComboboxOption`, `ComboboxButton` -> same names from @neokai/ui
+   - `Listbox`, `ListboxButton`, `ListboxOptions`, `ListboxOption` -> same names
+   - `Menu`, `MenuButton`, `MenuItems`, `MenuItem` -> same names (note: reference uses `MenuItems`, @neokai/ui uses same)
+   - `Popover`, `PopoverButton`, `PopoverPanel`, `PopoverGroup` -> same names
+   - `Disclosure`, `DisclosureButton`, `DisclosurePanel` -> same names
+   - `Tab`, `TabGroup`, `TabList`, `TabPanel`, `TabPanels` -> same names
+   - `CloseButton` -> `CloseButton` (from @neokai/ui Dialog)
+   - `Label`, `Field`, `Description`, `FieldError` -> from @neokai/ui
+3. Convert heroicon imports to lucide-preact using `icon-map.ts`
+4. Handle any headlessui-specific patterns not present in @neokai/ui:
+   - If a component is missing, note it and use a workaround (HTML element with appropriate data attributes)
+   - `Description` in headlessui maps to `DialogDescription` or `Description` from @neokai/ui (verify which is correct for the context)
+
+## headlessui-to-neokai Import Mapping
+
+| headlessui import | @neokai/ui import |
+|-------------------|-------------------|
+| `@headlessui/react` Dialog components | `../../src/mod.ts` or `@neokai/ui` |
+| `@headlessui/react` Transition | Same pattern |
+| `@headlessui/react` Combobox* | Same pattern |
+| `@headlessui/react` Listbox* | Same pattern |
+| `@headlessui/react` Menu* | Same pattern |
+| `@headlessui/react` Popover* | Same pattern |
+| `@headlessui/react` Disclosure* | Same pattern |
+| `@headlessui/react` Tab* | Same pattern |
+
+## Tasks
+
+### Task 5.1: Headless+icon demos -- Overlays (drawers, modal-dialogs, notifications) (28 files)
+
+**Description**: Port all combined headless+icon reference files from the overlays category. This includes drawers, modal dialogs, and notifications.
+
+**Subtasks**:
+
+1. **Create `overlays/drawers/DrawersDemo.tsx`** (12 files): Empty, empty wide, with background overlay, with close button on outside, with branded header, with sticky footer, create project form, wide create project form, user profile, wide user profile, contact list, file details. Uses Dialog + TransitionChild pattern (same as existing DrawerDemo). Icons: `XMarkIcon`, `PlusIcon`, `PhotoIcon`, `PaperClipIcon`, `FolderIcon`, etc.
+
+2. **Create `overlays/modal-dialogs/ModalDialogsDemo.tsx`** (6 files): Centered with single action, centered with wide buttons, simple alert, simple with dismiss button, simple with gray footer, simple with left-aligned buttons. Uses Dialog + Transition. Icons: `ExclamationTriangleIcon`, `XMarkIcon`.
+
+3. **Update `overlays/notifications/NotificationsDemo.tsx`** -- add 4 headless+icon notification variants: simple, condensed, with actions below, with buttons below. These use Dialog/Transition with icons.
+
+4. **Update `packages/ui/demo/App.tsx`** to register new demo sections.
+
+**Acceptance criteria**:
+- 2 new demo section files created (DrawersDemo, ModalDialogsDemo)
+- Existing NotificationDemo extended with 4 more variants
+- All 22 overlay reference examples render correctly
+- All headlessui imports replaced with @neokai/ui
+- All heroicon imports replaced with lucide-preact
+- Drawer panels open/close with transition animations
+- Modal dialogs open/close with backdrop
+- `bun run dev` starts without errors
+
+**Depends on**: Task 1.2 (icon-map.ts, sidebar), Task 3.1 (lucide patterns established)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 5.2: Headless+icon demos -- Navigation (command-palettes, navbars, sidebar-navigation) (24 files)
+
+**Description**: Port all combined headless+icon reference files from the navigation category.
+
+**Subtasks**:
+
+1. **Create `navigation/command-palettes/CommandPalettesDemo.tsx`** (9 files): Simple, simple with padding, with preview, with images and descriptions, with icons, semi-transparent with icons, with groups, with footer. Uses Dialog + Combobox composition. Icons: `MagnifyingGlassIcon`, `FaceFrownIcon`, `CodeBracketIcon`, `CommandLineIcon`, etc.
+
+2. **Create `navigation/navbars/NavbarsDemo.tsx`** (11 files): Simple dark with menu button on left, dark with quick action, simple dark, simple with menu button on left, simple, with quick action, dark with search, with search, dark with centered search, with centered search, with search in column layout. Uses Dialog + Transition for mobile menu, Popover for dropdowns. Icons: `Bars3Icon`, `MagnifyingGlassIcon`, `XMarkIcon`, `BellIcon`, `PlusIcon`.
+
+3. **Update `navigation/sidebar-navigation/SidebarNavigationDemo.tsx`** -- add 2 headless+icon examples: with expandable sections, with secondary navigation. Uses Disclosure for expandable sections.
+
+4. **Update `packages/ui/demo/App.tsx`** to register new demo sections.
+
+**Acceptance criteria**:
+- 2 new demo section files created (CommandPalettesDemo, NavbarsDemo)
+- Existing SidebarNavigationDemo extended with 2 more variants
+- All 22 navigation reference examples render correctly
+- Command palettes open/close with search functionality
+- Navbar mobile menus toggle correctly
+- Sidebar expandable sections work with Disclosure
+- `bun run dev` starts without errors
+
+**Depends on**: Task 1.2 (icon-map.ts, sidebar), Task 3.2 (lucide patterns established)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 5.3: Headless+icon demos -- Application Shells, Forms, Lists, Data Display, Headings (54 files)
+
+**Description**: Port all remaining combined headless+icon reference files from application-shells, forms, lists, data-display, and headings categories.
+
+**Subtasks**:
+
+1. **Create `application-shells/multi-column/MultiColumnShellsDemo.tsx`** (4 files): Full-width three column, full-width secondary column on right, full-width with narrow sidebar, full-width with narrow sidebar and header. Uses Popover for navigation menus. Icons: various.
+
+2. **Create `application-shells/sidebar/SidebarShellsDemo.tsx`** (8 files): Simple sidebar, simple dark sidebar, sidebar with header, dark sidebar with header, with constrained content area, with off-white background, simple brand sidebar, brand sidebar with header. Uses Popover, Disclosure for mobile menus. Icons: `Bars3Icon`, `XMarkIcon`, `BellIcon`, `PlusIcon`, `MagnifyingGlassIcon`.
+
+3. **Create `application-shells/stacked/StackedShellsDemo.tsx`** (9 files): With bottom border, on subtle background, with lighter page header, branded nav with compact lighter page header, with overlap, brand nav with overlap, brand nav with lighter page header, with compact lighter page header, two-row navigation with overlap. Uses Popover, Disclosure. Icons: various.
+
+4. **Create `forms/comboboxes/ComboboxesDemo.tsx`** (5 files): Simple, with status indicator, with avatar, with secondary text. Uses Combobox from @neokai/ui. Icons: `CheckIcon`, `ChevronUpDownIcon`.
+
+5. **Create `forms/select-menus/CustomSelectMenusDemo.tsx`** (6 files): Simple custom, custom with check on left, custom with status indicator, custom with avatar, with secondary text, branded with supporting text. Uses Listbox from @neokai/ui. Icons: `CheckIcon`, `ChevronUpDownIcon`.
+
+6. **Update `forms/textareas/TextareasDemo.tsx`** -- add 4 headless+icon examples: with avatar and actions, with underline and actions, with title and pill actions, with preview button. Uses Popover for menus.
+
+7. **Create `elements/dropdowns/DropdownsDemo.tsx`** (5 files): Simple, with dividers, with icons, with minimal menu icon, with simple header. Uses Menu from @neokai/ui. Icons: `EllipsisVerticalIcon`, `PencilIcon`, `TrashIcon`, `ArchiveBoxIcon`, etc.
+
+8. **Update `elements/button-groups/ButtonGroupsDemo.tsx`** -- add 1 headless+icon example: with dropdown. Uses Menu.
+
+9. **Create `data-display/calendars/CalendarsHeadlessDemo.tsx`** (7 files): Small with meetings, month view, week view, day view, year view, borderless stacked, borderless side-by-side. Uses Dialog for event popups. Icons: `ChevronLeftIcon`, `ChevronRightIcon`, `PlusIcon`, `XMarkIcon`.
+
+10. **Update `lists/feeds/FeedsDemo.tsx`** -- add 1 headless+icon example: with comments. Uses Menu.
+
+11. **Update `lists/grid-lists/GridListsDemo.tsx`** -- add 1 headless+icon example: logos cards with description list.
+
+12. **Update `lists/stacked-lists/StackedListsDemo.tsx`** -- add 2 headless+icon examples: with inline links and actions menu, with badges button and actions menu. Uses Menu.
+
+13. **Update `headings/card-headings/CardHeadingsDemo.tsx`** -- add 1 headless+icon example: with avatar meta and dropdown. Uses Menu, Popover.
+
+14. **Update `headings/page-headings/PageHeadingsDemo.tsx`** -- add 3 headless+icon examples: with meta and actions, with meta actions and breadcrumbs, with logo meta and actions. Uses Menu, Popover.
+
+15. **Update `headings/section-headings/SectionHeadingsDemo.tsx`** -- add 1 headless+icon example: with badge and dropdown. Uses Menu.
+
+16. **Update `packages/ui/demo/App.tsx`** to register all new demo sections.
+
+**Acceptance criteria**:
+- 7 new demo section files created
+- Multiple existing demo files extended
+- All ~54 reference examples render correctly
+- All interactive elements (comboboxes, listboxes, menus, popovers, disclosures) function correctly
+- `bun run dev` starts without errors
+
+**Depends on**: Task 3.1 (lucide patterns), Task 3.2 (existing demos to extend)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/06-page-compositions.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/06-page-compositions.md
@@ -1,0 +1,60 @@
+# Milestone 6: Page Compositions
+
+## Goal
+
+Port the 6 full-page reference examples from `page-examples/`. These are complete page layouts that combine patterns from multiple categories (application shells, navigation, headings, lists, forms) into cohesive compositions.
+
+## Scope
+
+- 3 subcategories: detail-screens, home-screens, settings-screens
+- 6 reference JSX files (2 per subcategory)
+- Each combines application shell layout + navigation + content sections
+
+## Porting Notes
+
+- These are the most complex reference files. Each one renders a full page layout including sidebar navigation, header, breadcrumbs, and content area.
+- All 6 files use both headlessui AND heroicons (Disclosure, Popover, Menu for navigation menus; various icons for UI elements).
+- The sidebar/header patterns may duplicate patterns from the application-shells demos. That is acceptable -- these are full-page compositions meant to showcase how components work together.
+- Consider whether these should render as standalone full-viewport sections or as contained "page preview" cards. Given the existing demo layout (scrollable single-page), rendering them as contained sections with a fixed-height scrollable preview area is likely best.
+
+## Tasks
+
+### Task 6.1: Page composition demos (6 files)
+
+**Description**: Port all 6 page-example reference files as full-page composition demos.
+
+**Subtasks**:
+
+1. **Create `page-examples/detail-screens/DetailScreensDemo.tsx`** (2 files):
+   - `01-sidebar.jsx`: Detail screen with sidebar navigation layout. Uses Disclosure for sidebar sections, Popover for menus. Icons: various.
+   - `02-stacked.jsx`: Detail screen with stacked navigation layout. Uses Popover, Menu. Icons: various.
+
+2. **Create `page-examples/home-screens/HomeScreensDemo.tsx`** (2 files):
+   - `01-sidebar.jsx`: Home/dashboard screen with sidebar. Uses Disclosure, Popover, Menu. Icons: `HomeIcon`, `UsersIcon`, `FolderIcon`, `CalendarDaysIcon`, `DocumentDuplicateIcon`, `Cog6ToothIcon`.
+   - `02-stacked.jsx`: Home/dashboard screen with stacked layout. Uses Popover, Menu.
+
+3. **Create `page-examples/settings-screens/SettingsScreensDemo.tsx`** (2 files):
+   - `01-sidebar.jsx`: Settings screen with sidebar navigation. Uses Disclosure for sidebar sections. Icons: `UserCircleIcon`, `BellIcon`, `GlobeAmericasIcon`, `CommandLineIcon`, `LifebuoyIcon`.
+   - `02-stacked.jsx`: Settings screen with stacked navigation. Uses Menu, Popover.
+
+4. **Update `packages/ui/demo/App.tsx`** to register the 3 new page-example demo sections under "Application UI > Page Examples".
+
+5. **Add CSS for page preview containers** in `demo/styles.css` if needed:
+   - Consider adding a `.page-preview` class that constrains the height and adds overflow scrolling
+   - These full-page layouts may need a fixed-height container to avoid making the demo page extremely long
+
+**Acceptance criteria**:
+- 3 new demo section files created
+- All 6 page composition examples render correctly
+- Sidebar navigation sections expand/collapse
+- Popover menus open/close
+- All heroicon imports replaced with lucide-preact
+- All headlessui imports replaced with @neokai/ui
+- Page compositions are visually contained (not infinitely tall)
+- `bun run dev` starts without errors
+
+**Depends on**: Task 5.1 (overlay patterns), Task 5.2 (navigation patterns), Task 5.3 (application shell patterns)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/07-integration-qa.md
+++ b/docs/plans/complete-neokaiui-missing-components-full-364-example-demo/07-integration-qa.md
@@ -1,0 +1,111 @@
+# Milestone 7: Integration and QA
+
+## Goal
+
+Final integration pass: verify all 364 reference examples are ported and rendering correctly, fix any remaining issues, polish the sidebar navigation, and ensure dark/light theme works across all demos.
+
+## Scope
+
+- Visual QA of all demo sections
+- Sidebar navigation polish
+- Dark/light theme verification
+- Fix any rendering issues discovered during QA
+- Update demo header/description
+- Ensure build works
+
+## Tasks
+
+### Task 7.1: Visual QA and bug fixes
+
+**Description**: Systematically verify all 364 reference examples are ported and rendering correctly. Fix any issues found.
+
+**Subtasks**:
+
+1. **Audit completeness**: Compare the reference file listing against the demo sections. Create a checklist:
+   - For each of the 48 subcategories, verify the demo file exists
+   - For each of the 364 reference files, verify it has a corresponding rendered example in the demo
+   - Count total examples rendered vs. 364 target
+
+2. **Visual QA pass**: Run `bun run dev` and scroll through every section:
+   - Verify layout matches the reference screenshots (if available)
+   - Check that all interactive elements work (buttons, menus, popovers, drawers, dialogs, comboboxes, etc.)
+   - Verify data attribute transitions work (open/close animations)
+   - Check for any console errors
+
+3. **Dark/light theme verification**:
+   - Toggle between dark and light themes
+   - Verify all demos look correct in both modes
+   - Check that semantic color tokens are used consistently (no hardcoded colors that break in one theme)
+
+4. **Fix any issues found**:
+   - Missing examples: port them
+   - Broken layouts: fix CSS class issues
+   - Non-functional interactive elements: debug component API mismatches
+   - Theme issues: replace hardcoded colors with semantic tokens
+   - Import errors: fix component or icon import paths
+
+5. **Lint and type check**:
+   - Run `bun run lint` from repo root and fix any issues
+   - Run `bun run typecheck` from repo root and fix any issues
+   - Run `bun run check` (lint + typecheck + knip) from repo root
+
+**Acceptance criteria**:
+- All 364 reference examples have corresponding rendered demos
+- No console errors when browsing the demo app
+- All interactive elements function correctly
+- Dark and light themes both look correct across all sections
+- `bun run lint` passes
+- `bun run typecheck` passes
+- `bun run check` passes (or only pre-existing failures remain)
+
+**Depends on**: Task 2.1, Task 2.2, Task 2.3, Task 3.1, Task 3.2, Task 4.1, Task 5.1, Task 5.2, Task 5.3, Task 6.1
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 7.2: Sidebar polish, demo header update, and final build verification
+
+**Description**: Polish the demo app's sidebar navigation, update the header/description, and verify the production build works.
+
+**Subtasks**:
+
+1. **Sidebar navigation polish**:
+   - Ensure all categories are collapsed by default except "Components" (existing headless demos)
+   - Add a "scroll to top" link or button at the bottom of the sidebar
+   - Highlight the currently visible section in the sidebar (using Intersection Observer or similar)
+   - Consider adding a search/filter for sections (stretch goal -- only if time permits)
+
+2. **Update demo header**:
+   - Update the demo title from "@neokai/ui -- Kitchen Sink" to something more descriptive like "@neokai/ui -- Component Library & Application UI Reference"
+   - Update the subtitle to mention the count: "Visual demo of all headless UI components and 364+ Tailwind Application UI examples"
+   - Add a link to the GitHub repository or documentation
+
+3. **Update demo/styles.css**:
+   - Review and clean up any temporary CSS added during development
+   - Ensure the page-preview container styles (from M6) are clean
+
+4. **Production build verification**:
+   - Run `bun run build:demo` and verify it completes without errors
+   - Verify the built output can be served (e.g., `npx serve packages/ui/demo/dist` or similar)
+   - Check that the built demo loads correctly in a browser
+
+5. **Run existing tests**:
+   - Run `bun run test` in `packages/ui` to verify no regressions
+   - All existing component tests should still pass
+
+**Acceptance criteria**:
+- Sidebar highlights currently visible section
+- Demo header accurately describes the content
+- `bun run build:demo` completes successfully
+- Built demo loads correctly in browser
+- `bun run test` passes with no regressions
+- No dead CSS or unused imports in demo files
+
+**Depends on**: Task 7.1 (all demos complete and verified)
+
+**Agent type**: coder
+
+**Note**: Changes must be on a feature branch with a GitHub PR created via `gh pr create`.


### PR DESCRIPTION
## Summary

Multi-milestone plan to complete the @neokai/ui demo by:

1. **Foundation**: Fix 7 missing package.json exports, install lucide-preact icon library, refactor demo sidebar to support 48+ categorized sections
2. **Port 364 Tailwind Application UI v4 reference examples** organized by dependency complexity:
   - ~163 pure HTML (no deps) - elements, headings, layout, forms, lists
   - ~93 icon-only (heroicons -> lucide-preact) - feedback, navigation, data display
   - ~106 combined (headlessui + heroicons) - overlays, navigation, application shells
3. **Integration QA**: Visual verification, dark/light theme, sidebar polish, build verification

## Plan files

- `docs/plans/complete-neokaiui-missing-components-full-364-example-demo/00-overview.md` - Full overview with dependency graph
- `docs/plans/complete-neokaiui-missing-components-full-364-example-demo/01-foundation.md` through `07-integration-qa.md` - Per-milestone detail

## Approach

Batch by dependency type (pure HTML first, then icon-only, then headless, then combined) to maximize parallelism. Each task produces one PR with focused changes.