### PR TITLE
fix(ui): add missing package.json exports and install lucide-preact

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "@types/bun": "1.3.11",
         "@vitest/coverage-v8": "4.1.2",
         "happy-dom": "20.8.9",
+        "lucide-preact": "0.577.0",
         "tailwindcss": "4.2.2",
         "vite": "8.0.3",
         "vitest": "4.1.2",
@@ -909,6 +910,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lucide-preact": ["lucide-preact@0.577.0", "", { "peerDependencies": { "preact": "^10.27.2" } }, "sha512-fCY59YQ2OMYWqE1V7k8HwfXyiBMHAfTI1roCOasdc+Cekya7BIObSJ/cil+tVMSbU6siv4uZlaz5twAGmkYqIQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/knip.json
+++ b/knip.json
@@ -37,6 +37,7 @@
 		"tailwindcss",
 		"@floating-ui/dom",
 		"@vitest/coverage-v8",
-		"use-sync-external-store"
+		"use-sync-external-store",
+		"lucide-preact"
 	]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,14 @@
 		"./toast": "./src/components/toast/toast.tsx",
 		"./spinner": "./src/components/spinner/spinner.tsx",
 		"./skeleton": "./src/components/skeleton/skeleton.tsx",
-		"./icon-button": "./src/components/icon-button/icon-button.tsx"
+		"./icon-button": "./src/components/icon-button/icon-button.tsx",
+		"./alert": "./src/components/alert/alert.tsx",
+		"./avatar": "./src/components/avatar/avatar.tsx",
+		"./badge": "./src/components/badge/badge.tsx",
+		"./input-group": "./src/components/input-group/input-group.tsx",
+		"./progress-bar": "./src/components/progress-bar/progress-bar.tsx",
+		"./stepper": "./src/components/stepper/stepper.tsx",
+		"./touch-target": "./src/components/touch-target/touch-target.tsx"
 	},
 	"dependencies": {
 		"@floating-ui/dom": "1.7.6",
@@ -37,6 +44,7 @@
 		"@types/bun": "1.3.11",
 		"@vitest/coverage-v8": "4.1.2",
 		"happy-dom": "20.8.9",
+		"lucide-preact": "0.577.0",
 		"tailwindcss": "4.2.2",
 		"vite": "8.0.3",
 		"vitest": "4.1.2"


### PR DESCRIPTION
## Summary
- Add 7 missing exports to packages/ui/package.json (alert, avatar, badge, input-group, progress-bar, stepper, touch-target)
- Install lucide-preact@0.577.0 as devDependency for icon support

## Test plan
- [x] Verify dev server starts without errors
- [x] All exports present in package.json
- [x] lucide-preact in devDependencies