### PR TITLE
feat(ui-demo): add 2 headless-only notification variants

### DIFF
--- a/packages/ui/demo/sections/NotificationDemo.tsx
+++ b/packages/ui/demo/sections/NotificationDemo.tsx
@@ -350,13 +350,14 @@ function NotificationWithAvatar() {
 				Show avatar notification
 			</button>
 
+			{/* Fixed overlay container - note: multiple visible notifications will stack at sm:items-end */}
 			<div
 				aria-live="assertive"
 				class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
 			>
 				<div class="flex w-full flex-col items-center space-y-4 sm:items-end">
 					<Transition show={show}>
-						<div class="pointer-events-auto flex w-full max-w-md rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 dark:bg-gray-800">
+						<div class="pointer-events-auto flex w-full max-w-md rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2">
 							<div class="w-0 flex-1 p-4">
 								<div class="flex items-start">
 									<div class="shrink-0 pt-0.5">
@@ -407,13 +408,14 @@ function NotificationWithSplitButtons() {
 				Show split-button notification
 			</button>
 
+			{/* Fixed overlay container - note: multiple visible notifications will stack at sm:items-end */}
 			<div
 				aria-live="assertive"
 				class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
 			>
 				<div class="flex w-full flex-col items-center space-y-4 sm:items-end">
 					<Transition show={show}>
-						<div class="pointer-events-auto flex w-full max-w-md divide-x divide-surface-border rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 sm:data-[closed]:translate-x-2 dark:bg-gray-800">
+						<div class="pointer-events-auto flex w-full max-w-md divide-x divide-surface-border rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 sm:data-[closed]:translate-x-2">
 							<div class="flex w-0 flex-1 items-center p-4">
 								<div class="w-full">
 									<p class="text-sm font-medium text-text-primary">Receive notifications</p>
@@ -490,4 +492,4 @@ function NotificationDemo() {
 	);
 }
 
-export { NotificationDemo };
+export { NotificationDemo, NotificationWithAvatar, NotificationWithSplitButtons };

--- a/packages/ui/demo/sections/NotificationDemo.tsx
+++ b/packages/ui/demo/sections/NotificationDemo.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
 import type { VNode } from 'preact';
-import { Toaster, useToast } from '../../src/mod.ts';
+import { Transition, Toaster, useToast } from '../../src/mod.ts';
 import type { ToastVariant } from '../../src/mod.ts';
 
 interface NotificationItem {
@@ -337,6 +337,126 @@ function InlineToastExamples() {
 	);
 }
 
+function NotificationWithAvatar() {
+	const [show, setShow] = useState(true);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setShow(true)}
+				class="px-4 py-2 rounded-lg bg-surface-2 border border-surface-border text-sm text-text-primary hover:border-accent-500 transition-colors cursor-pointer"
+			>
+				Show avatar notification
+			</button>
+
+			<div
+				aria-live="assertive"
+				class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
+			>
+				<div class="flex w-full flex-col items-center space-y-4 sm:items-end">
+					<Transition show={show}>
+						<div class="pointer-events-auto flex w-full max-w-md rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 dark:bg-gray-800">
+							<div class="w-0 flex-1 p-4">
+								<div class="flex items-start">
+									<div class="shrink-0 pt-0.5">
+										<img
+											alt=""
+											src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2.2&w=160&h=160&q=80"
+											class="h-10 w-10 rounded-full bg-surface-2"
+										/>
+									</div>
+									<div class="ml-3 w-0 flex-1">
+										<p class="text-sm font-medium text-text-primary">Emilia Gates</p>
+										<p class="mt-1 text-sm text-text-secondary">Sure! 8:30pm works great!</p>
+									</div>
+								</div>
+							</div>
+							<div class="flex border-l border-surface-border">
+								<button
+									type="button"
+									onClick={() => setShow(false)}
+									class="flex w-full items-center justify-center rounded-none rounded-r-lg p-4 text-sm font-medium text-accent-400 hover:text-accent-300 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-inset transition-colors cursor-pointer"
+								>
+									Reply
+								</button>
+							</div>
+						</div>
+					</Transition>
+				</div>
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Notification with avatar using <code class="text-accent-400 font-mono">Transition</code>{' '}
+				component.
+			</p>
+		</div>
+	);
+}
+
+function NotificationWithSplitButtons() {
+	const [show, setShow] = useState(true);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setShow(true)}
+				class="px-4 py-2 rounded-lg bg-surface-2 border border-surface-border text-sm text-text-primary hover:border-accent-500 transition-colors cursor-pointer"
+			>
+				Show split-button notification
+			</button>
+
+			<div
+				aria-live="assertive"
+				class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
+			>
+				<div class="flex w-full flex-col items-center space-y-4 sm:items-end">
+					<Transition show={show}>
+						<div class="pointer-events-auto flex w-full max-w-md divide-x divide-surface-border rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 sm:data-[closed]:translate-x-2 dark:bg-gray-800">
+							<div class="flex w-0 flex-1 items-center p-4">
+								<div class="w-full">
+									<p class="text-sm font-medium text-text-primary">Receive notifications</p>
+									<p class="mt-1 text-sm text-text-secondary">
+										Notifications may include alerts, sounds, and badges.
+									</p>
+								</div>
+							</div>
+							<div class="flex">
+								<div class="flex flex-col divide-y divide-surface-border">
+									<div class="flex h-0 flex-1">
+										<button
+											type="button"
+											onClick={() => setShow(false)}
+											class="flex w-full items-center justify-center rounded-none rounded-tr-lg px-4 py-3 text-sm font-medium text-accent-400 hover:text-accent-300 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-inset transition-colors cursor-pointer"
+										>
+											Reply
+										</button>
+									</div>
+									<div class="flex h-0 flex-1">
+										<button
+											type="button"
+											onClick={() => setShow(false)}
+											class="flex w-full items-center justify-center rounded-none rounded-br-lg px-4 py-3 text-sm font-medium text-text-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-inset transition-colors cursor-pointer"
+										>
+											Don't allow
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</Transition>
+				</div>
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Notification with split action buttons using{' '}
+				<code class="text-accent-400 font-mono">Transition</code> component.
+			</p>
+		</div>
+	);
+}
+
 function NotificationDemo() {
 	return (
 		<div class="space-y-8">
@@ -355,6 +475,16 @@ function NotificationDemo() {
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">Notification group with state</h3>
 				<NotificationGroup />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Notification with avatar</h3>
+				<NotificationWithAvatar />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Notification with split buttons</h3>
+				<NotificationWithSplitButtons />
 			</div>
 		</div>
 	);

--- a/packages/ui/tests/notification-demo.test.tsx
+++ b/packages/ui/tests/notification-demo.test.tsx
@@ -1,0 +1,266 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Transition } from '../src/mod.ts';
+
+describe('Notification with Avatar (Transition-based)', () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('renders notification when show=true', async () => {
+		function NotificationWithAvatar() {
+			const [show, setShow] = [true, () => {}];
+			return (
+				<div aria-live="assertive">
+					<Transition show={show}>
+						<div data-testid="avatar-notification" class="flex">
+							<img alt="" src="https://example.com/avatar.jpg" class="h-10 w-10 rounded-full" />
+							<div>
+								<p class="text-sm font-medium">Emilia Gates</p>
+								<p class="mt-1 text-sm">Sure! 8:30pm works great!</p>
+							</div>
+							<button onClick={() => setShow(false)}>Reply</button>
+						</div>
+					</Transition>
+				</div>
+			);
+		}
+
+		render(<NotificationWithAvatar />);
+		await act(async () => {});
+
+		const notification = screen.queryByTestId('avatar-notification');
+		expect(notification).not.toBeNull();
+	});
+
+	it('renders avatar image with alt text', async () => {
+		function NotificationWithAvatar() {
+			const [show, setShow] = [true, () => {}];
+			return (
+				<Transition show={show}>
+					<div data-testid="avatar-container">
+						<img alt="User avatar" src="https://example.com/avatar.jpg" />
+						<p data-testid="sender-name">Emilia Gates</p>
+					</div>
+				</Transition>
+			);
+		}
+
+		render(<NotificationWithAvatar />);
+		await act(async () => {});
+
+		const img = screen.queryByRole('img', { name: 'User avatar' });
+		expect(img).not.toBeNull();
+	});
+
+	it('has reply button', async () => {
+		function NotificationWithAvatar() {
+			const [show] = [true];
+			return (
+				<Transition show={show}>
+					<div>
+						<img alt="" src="https://example.com/avatar.jpg" />
+						<button data-testid="reply-btn" type="button">
+							Reply
+						</button>
+					</div>
+				</Transition>
+			);
+		}
+
+		render(<NotificationWithAvatar />);
+		await act(async () => {});
+
+		const replyBtn = screen.getByTestId('reply-btn');
+		expect(replyBtn).not.toBeNull();
+		expect(replyBtn.textContent).toBe('Reply');
+	});
+});
+
+describe('Notification with Split Buttons (Transition-based)', () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('renders notification when show=true', async () => {
+		function NotificationWithSplitButtons() {
+			const [show, setShow] = [true, () => {}];
+			return (
+				<div aria-live="assertive">
+					<Transition show={show}>
+						<div data-testid="split-notification" class="flex divide-x">
+							<div class="flex-1 p-4">
+								<p class="text-sm font-medium">Receive notifications</p>
+								<p class="mt-1 text-sm">Notifications may include alerts, sounds, and badges.</p>
+							</div>
+							<div class="flex flex-col divide-y">
+								<button onClick={() => setShow(false)}>Reply</button>
+								<button onClick={() => setShow(false)}>Don't allow</button>
+							</div>
+						</div>
+					</Transition>
+				</div>
+			);
+		}
+
+		render(<NotificationWithSplitButtons />);
+		await act(async () => {});
+
+		const notification = screen.queryByTestId('split-notification');
+		expect(notification).not.toBeNull();
+	});
+
+	it('has two action buttons', async () => {
+		function NotificationWithSplitButtons() {
+			const [show, setShow] = [true, () => {}];
+			return (
+				<Transition show={show}>
+					<div>
+						<div>
+							<p class="text-sm font-medium">Receive notifications</p>
+						</div>
+						<div class="flex flex-col divide-y">
+							<button data-testid="reply-btn" onClick={() => setShow(false)}>
+								Reply
+							</button>
+							<button data-testid="dismiss-btn" onClick={() => setShow(false)}>
+								Don't allow
+							</button>
+						</div>
+					</div>
+				</Transition>
+			);
+		}
+
+		render(<NotificationWithSplitButtons />);
+		await act(async () => {});
+
+		const replyBtn = screen.getByTestId('reply-btn');
+		const dismissBtn = screen.getByTestId('dismiss-btn');
+
+		expect(replyBtn).not.toBeNull();
+		expect(dismissBtn).not.toBeNull();
+		expect(replyBtn.textContent).toBe('Reply');
+		expect(dismissBtn.textContent).toBe("Don't allow");
+	});
+
+	it('reply button is clickable', async () => {
+		const onReply = vi.fn();
+
+		function NotificationWithSplitButtons() {
+			const [show, setShow] = [true, onReply];
+			return (
+				<Transition show={show}>
+					<div>
+						<button data-testid="reply-btn" onClick={() => setShow(false)}>
+							Reply
+						</button>
+					</div>
+				</Transition>
+			);
+		}
+
+		render(<NotificationWithSplitButtons />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByTestId('reply-btn'));
+		});
+
+		expect(onReply).toHaveBeenCalled();
+	});
+
+	it('dismiss button is clickable', async () => {
+		const onDismiss = vi.fn();
+
+		function NotificationWithSplitButtons() {
+			const [show, setShow] = [true, onDismiss];
+			return (
+				<Transition show={show}>
+					<div>
+						<button data-testid="dismiss-btn" onClick={() => setShow(false)}>
+							Don't allow
+						</button>
+					</div>
+				</Transition>
+			);
+		}
+
+		render(<NotificationWithSplitButtons />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByTestId('dismiss-btn'));
+		});
+
+		expect(onDismiss).toHaveBeenCalled();
+	});
+});
+
+describe('Transition component integration with notifications', () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('Transition sets data attributes on enter', async () => {
+		function ControlledNotification() {
+			const [show, setShow] = [true, () => {}];
+			return (
+				<Transition show={show}>
+					<div data-testid="transitioned-content">
+						<p>Notification content</p>
+					</div>
+				</Transition>
+			);
+		}
+
+		render(<ControlledNotification />);
+		await act(async () => {});
+
+		const content = screen.getByTestId('transitioned-content');
+		// Transition should have data-enter attribute during enter phase
+		expect(content).toBeTruthy();
+	});
+
+	it('Transition hides content when show=false', async () => {
+		function ControlledNotification() {
+			const [show] = [false];
+			return (
+				<Transition show={show}>
+					<div data-testid="transitioned-content">
+						<p>Notification content</p>
+					</div>
+				</Transition>
+			);
+		}
+
+		render(<ControlledNotification />);
+		await act(async () => {});
+
+		// When show=false, Transition unmounts content
+		const content = screen.queryByTestId('transitioned-content');
+		expect(content).toBeNull();
+	});
+
+	it('notification uses proper aria-live region', async () => {
+		function NotificationContainer() {
+			const [show] = [true];
+			return (
+				<div aria-live="assertive" data-testid="live-region">
+					<Transition show={show}>
+						<div data-testid="notification">Notification content</div>
+					</Transition>
+				</div>
+			);
+		}
+
+		render(<NotificationContainer />);
+		await act(async () => {});
+
+		const liveRegion = screen.getByTestId('live-region');
+		expect(liveRegion.getAttribute('aria-live')).toBe('assertive');
+	});
+});

--- a/packages/ui/tests/notification-demo.test.tsx
+++ b/packages/ui/tests/notification-demo.test.tsx
@@ -1,266 +1,160 @@
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/preact';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Transition } from '../src/mod.ts';
+import {
+	NotificationWithAvatar,
+	NotificationWithSplitButtons,
+} from '../demo/sections/NotificationDemo.tsx';
 
-describe('Notification with Avatar (Transition-based)', () => {
-	afterEach(() => {
-		cleanup();
-		vi.restoreAllMocks();
-	});
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
 
-	it('renders notification when show=true', async () => {
-		function NotificationWithAvatar() {
-			const [show, setShow] = [true, () => {}];
-			return (
-				<div aria-live="assertive">
-					<Transition show={show}>
-						<div data-testid="avatar-notification" class="flex">
-							<img alt="" src="https://example.com/avatar.jpg" class="h-10 w-10 rounded-full" />
-							<div>
-								<p class="text-sm font-medium">Emilia Gates</p>
-								<p class="mt-1 text-sm">Sure! 8:30pm works great!</p>
-							</div>
-							<button onClick={() => setShow(false)}>Reply</button>
-						</div>
-					</Transition>
-				</div>
-			);
-		}
-
+describe('NotificationWithAvatar', () => {
+	it('renders the notification content when component mounts', async () => {
 		render(<NotificationWithAvatar />);
 		await act(async () => {});
 
-		const notification = screen.queryByTestId('avatar-notification');
-		expect(notification).not.toBeNull();
+		// Check that sender name is visible
+		expect(screen.getByText('Emilia Gates')).toBeTruthy();
+
+		// Check that message is visible
+		expect(screen.getByText('Sure! 8:30pm works great!')).toBeTruthy();
 	});
 
-	it('renders avatar image with alt text', async () => {
-		function NotificationWithAvatar() {
-			const [show, setShow] = [true, () => {}];
-			return (
-				<Transition show={show}>
-					<div data-testid="avatar-container">
-						<img alt="User avatar" src="https://example.com/avatar.jpg" />
-						<p data-testid="sender-name">Emilia Gates</p>
-					</div>
-				</Transition>
-			);
-		}
-
+	it('renders avatar image from correct URL', async () => {
 		render(<NotificationWithAvatar />);
 		await act(async () => {});
 
-		const img = screen.queryByRole('img', { name: 'User avatar' });
-		expect(img).not.toBeNull();
+		const img = screen.getByRole('img');
+		expect(img).toBeTruthy();
+		expect(img.getAttribute('src')).toContain('images.unsplash.com');
 	});
 
-	it('has reply button', async () => {
-		function NotificationWithAvatar() {
-			const [show] = [true];
-			return (
-				<Transition show={show}>
-					<div>
-						<img alt="" src="https://example.com/avatar.jpg" />
-						<button data-testid="reply-btn" type="button">
-							Reply
-						</button>
-					</div>
-				</Transition>
-			);
-		}
-
+	it('has a Reply button', async () => {
 		render(<NotificationWithAvatar />);
 		await act(async () => {});
 
-		const replyBtn = screen.getByTestId('reply-btn');
-		expect(replyBtn).not.toBeNull();
-		expect(replyBtn.textContent).toBe('Reply');
+		const replyBtn = screen.getByRole('button', { name: 'Reply' });
+		expect(replyBtn).toBeTruthy();
+	});
+
+	it('hides notification when Reply button is clicked', async () => {
+		render(<NotificationWithAvatar />);
+		await act(async () => {});
+
+		// Verify notification is visible initially
+		expect(screen.getByText('Emilia Gates')).toBeTruthy();
+
+		// Click Reply button
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+		});
+
+		// Notification should be hidden after clicking Reply
+		expect(screen.queryByText('Emilia Gates')).toBeNull();
+	});
+
+	it('has aria-live="assertive" on overlay container', async () => {
+		render(<NotificationWithAvatar />);
+		await act(async () => {});
+
+		const liveRegion = document.querySelector('[aria-live="assertive"]');
+		expect(liveRegion).toBeTruthy();
 	});
 });
 
-describe('Notification with Split Buttons (Transition-based)', () => {
-	afterEach(() => {
-		cleanup();
-		vi.restoreAllMocks();
-	});
-
-	it('renders notification when show=true', async () => {
-		function NotificationWithSplitButtons() {
-			const [show, setShow] = [true, () => {}];
-			return (
-				<div aria-live="assertive">
-					<Transition show={show}>
-						<div data-testid="split-notification" class="flex divide-x">
-							<div class="flex-1 p-4">
-								<p class="text-sm font-medium">Receive notifications</p>
-								<p class="mt-1 text-sm">Notifications may include alerts, sounds, and badges.</p>
-							</div>
-							<div class="flex flex-col divide-y">
-								<button onClick={() => setShow(false)}>Reply</button>
-								<button onClick={() => setShow(false)}>Don't allow</button>
-							</div>
-						</div>
-					</Transition>
-				</div>
-			);
-		}
-
+describe('NotificationWithSplitButtons', () => {
+	it('renders the notification content when component mounts', async () => {
 		render(<NotificationWithSplitButtons />);
 		await act(async () => {});
 
-		const notification = screen.queryByTestId('split-notification');
-		expect(notification).not.toBeNull();
+		// Check that title is visible
+		expect(screen.getByText('Receive notifications')).toBeTruthy();
+
+		// Check that description is visible
+		expect(screen.getByText('Notifications may include alerts, sounds, and badges.')).toBeTruthy();
 	});
 
-	it('has two action buttons', async () => {
-		function NotificationWithSplitButtons() {
-			const [show, setShow] = [true, () => {}];
-			return (
-				<Transition show={show}>
-					<div>
-						<div>
-							<p class="text-sm font-medium">Receive notifications</p>
-						</div>
-						<div class="flex flex-col divide-y">
-							<button data-testid="reply-btn" onClick={() => setShow(false)}>
-								Reply
-							</button>
-							<button data-testid="dismiss-btn" onClick={() => setShow(false)}>
-								Don't allow
-							</button>
-						</div>
-					</div>
-				</Transition>
-			);
-		}
-
+	it('has a Reply button', async () => {
 		render(<NotificationWithSplitButtons />);
 		await act(async () => {});
 
-		const replyBtn = screen.getByTestId('reply-btn');
-		const dismissBtn = screen.getByTestId('dismiss-btn');
-
-		expect(replyBtn).not.toBeNull();
-		expect(dismissBtn).not.toBeNull();
-		expect(replyBtn.textContent).toBe('Reply');
-		expect(dismissBtn.textContent).toBe("Don't allow");
+		const replyBtn = screen.getByRole('button', { name: 'Reply' });
+		expect(replyBtn).toBeTruthy();
 	});
 
-	it('reply button is clickable', async () => {
-		const onReply = vi.fn();
-
-		function NotificationWithSplitButtons() {
-			const [show, setShow] = [true, onReply];
-			return (
-				<Transition show={show}>
-					<div>
-						<button data-testid="reply-btn" onClick={() => setShow(false)}>
-							Reply
-						</button>
-					</div>
-				</Transition>
-			);
-		}
-
+	it('has a "Don\'t allow" button', async () => {
 		render(<NotificationWithSplitButtons />);
 		await act(async () => {});
 
+		const dismissBtn = screen.getByRole('button', { name: "Don't allow" });
+		expect(dismissBtn).toBeTruthy();
+	});
+
+	it('hides notification when Reply button is clicked', async () => {
+		render(<NotificationWithSplitButtons />);
+		await act(async () => {});
+
+		// Verify notification is visible initially
+		expect(screen.getByText('Receive notifications')).toBeTruthy();
+
+		// Click Reply button
 		await act(async () => {
-			fireEvent.click(screen.getByTestId('reply-btn'));
+			fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
 		});
 
-		expect(onReply).toHaveBeenCalled();
+		// Notification should be hidden after clicking Reply
+		expect(screen.queryByText('Receive notifications')).toBeNull();
 	});
 
-	it('dismiss button is clickable', async () => {
-		const onDismiss = vi.fn();
-
-		function NotificationWithSplitButtons() {
-			const [show, setShow] = [true, onDismiss];
-			return (
-				<Transition show={show}>
-					<div>
-						<button data-testid="dismiss-btn" onClick={() => setShow(false)}>
-							Don't allow
-						</button>
-					</div>
-				</Transition>
-			);
-		}
-
+	it('hides notification when "Don\'t allow" button is clicked', async () => {
 		render(<NotificationWithSplitButtons />);
 		await act(async () => {});
 
+		// Verify notification is visible initially
+		expect(screen.getByText('Receive notifications')).toBeTruthy();
+
+		// Click "Don't allow" button
 		await act(async () => {
-			fireEvent.click(screen.getByTestId('dismiss-btn'));
+			fireEvent.click(screen.getByRole('button', { name: "Don't allow" }));
 		});
 
-		expect(onDismiss).toHaveBeenCalled();
+		// Notification should be hidden after clicking "Don't allow"
+		expect(screen.queryByText('Receive notifications')).toBeNull();
+	});
+
+	it('has aria-live="assertive" on overlay container', async () => {
+		render(<NotificationWithSplitButtons />);
+		await act(async () => {});
+
+		const liveRegion = document.querySelector('[aria-live="assertive"]');
+		expect(liveRegion).toBeTruthy();
 	});
 });
 
-describe('Transition component integration with notifications', () => {
-	afterEach(() => {
-		cleanup();
-		vi.restoreAllMocks();
-	});
-
-	it('Transition sets data attributes on enter', async () => {
-		function ControlledNotification() {
-			const [show, setShow] = [true, () => {}];
-			return (
-				<Transition show={show}>
-					<div data-testid="transitioned-content">
-						<p>Notification content</p>
-					</div>
-				</Transition>
-			);
-		}
-
-		render(<ControlledNotification />);
+describe('Notification dismiss behavior', () => {
+	it('can re-show avatar notification after dismissing', async () => {
+		render(<NotificationWithSplitButtons />);
 		await act(async () => {});
 
-		const content = screen.getByTestId('transitioned-content');
-		// Transition should have data-enter attribute during enter phase
-		expect(content).toBeTruthy();
-	});
+		// Initially visible
+		expect(screen.getByText('Receive notifications')).toBeTruthy();
 
-	it('Transition hides content when show=false', async () => {
-		function ControlledNotification() {
-			const [show] = [false];
-			return (
-				<Transition show={show}>
-					<div data-testid="transitioned-content">
-						<p>Notification content</p>
-					</div>
-				</Transition>
-			);
-		}
+		// Dismiss
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+		});
 
-		render(<ControlledNotification />);
-		await act(async () => {});
+		// Hidden
+		expect(screen.queryByText('Receive notifications')).toBeNull();
 
-		// When show=false, Transition unmounts content
-		const content = screen.queryByTestId('transitioned-content');
-		expect(content).toBeNull();
-	});
+		// Click "Show split-button notification" to re-show
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Show split-button notification' }));
+		});
 
-	it('notification uses proper aria-live region', async () => {
-		function NotificationContainer() {
-			const [show] = [true];
-			return (
-				<div aria-live="assertive" data-testid="live-region">
-					<Transition show={show}>
-						<div data-testid="notification">Notification content</div>
-					</Transition>
-				</div>
-			);
-		}
-
-		render(<NotificationContainer />);
-		await act(async () => {});
-
-		const liveRegion = screen.getByTestId('live-region');
-		expect(liveRegion.getAttribute('aria-live')).toBe('assertive');
+		// Should be visible again
+		expect(screen.getByText('Receive notifications')).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## Summary
- Port 2 notification reference files from Tailwind Application UI v4
- Add notification with avatar component
- Add notification with split action buttons component
- Uses @neokai/ui Transition component with data-[closed]: bracket syntax
- Includes unit tests

## Test plan
- [x] Run `bun run test -- tests/notification-demo.test.tsx` - all tests pass
- [x] Run `bun run dev` - server starts without errors
- [x] Verify no @headlessui imports remain