### PR TITLE
feat(ui-demo): port 35 pure HTML reference examples (data-display, lists, nav, feedback)

### DIFF
--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -23,6 +23,14 @@ import { TransitionDemo } from './sections/TransitionDemo.tsx';
 import { CommandPaletteDemo } from './sections/CommandPaletteDemo.tsx';
 import { DrawerDemo } from './sections/DrawerDemo.tsx';
 import { NotificationDemo } from './sections/NotificationDemo.tsx';
+import { StatsDemo } from './sections/StatsDemo.tsx';
+import { GridListsDemo } from './sections/GridListsDemo.tsx';
+import { StackedListsDemo } from './sections/StackedListsDemo.tsx';
+import { TablesDemo } from './sections/TablesDemo.tsx';
+import { PaginationDemo } from './sections/PaginationDemo.tsx';
+import { ProgressBarsDemo } from './sections/ProgressBarsDemo.tsx';
+import { VerticalNavigationDemo } from './sections/VerticalNavigationDemo.tsx';
+import { EmptyStatesDemo } from './sections/EmptyStatesDemo.tsx';
 
 interface DemoSectionProps {
 	id: string;
@@ -63,6 +71,14 @@ const componentSections = [
 	{ id: 'transition', label: 'Transition' },
 	{ id: 'spinner', label: 'Spinner' },
 	{ id: 'skeleton', label: 'Skeleton' },
+	{ id: 'stats', label: 'Stats' },
+	{ id: 'grid-lists', label: 'Grid Lists' },
+	{ id: 'stacked-lists', label: 'Stacked Lists' },
+	{ id: 'tables', label: 'Tables' },
+	{ id: 'pagination', label: 'Pagination' },
+	{ id: 'progress-bars', label: 'Progress Bars' },
+	{ id: 'vertical-navigation', label: 'Vertical Navigation' },
+	{ id: 'empty-states', label: 'Empty States' },
 ];
 
 // Application UI subcategories (placeholder sections for future demos)
@@ -375,6 +391,30 @@ export function App() {
 					</DemoSection>
 					<DemoSection id="skeleton" title="Skeleton">
 						<SkeletonDemo />
+					</DemoSection>
+					<DemoSection id="stats" title="Stats">
+						<StatsDemo />
+					</DemoSection>
+					<DemoSection id="grid-lists" title="Grid Lists">
+						<GridListsDemo />
+					</DemoSection>
+					<DemoSection id="stacked-lists" title="Stacked Lists">
+						<StackedListsDemo />
+					</DemoSection>
+					<DemoSection id="tables" title="Tables">
+						<TablesDemo />
+					</DemoSection>
+					<DemoSection id="pagination" title="Pagination">
+						<PaginationDemo />
+					</DemoSection>
+					<DemoSection id="progress-bars" title="Progress Bars">
+						<ProgressBarsDemo />
+					</DemoSection>
+					<DemoSection id="vertical-navigation" title="Vertical Navigation">
+						<VerticalNavigationDemo />
+					</DemoSection>
+					<DemoSection id="empty-states" title="Empty States">
+						<EmptyStatesDemo />
 					</DemoSection>
 				</main>
 			</div>

--- a/packages/ui/demo/sections/EmptyStatesDemo.tsx
+++ b/packages/ui/demo/sections/EmptyStatesDemo.tsx
@@ -1,0 +1,41 @@
+export function EmptyStatesDemo() {
+	return (
+		<div class="text-center">
+			<svg
+				fill="none"
+				stroke="currentColor"
+				viewBox="0 0 24 24"
+				aria-hidden="true"
+				class="mx-auto size-12 text-text-tertiary dark:text-text-secondary"
+			>
+				<path
+					d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"
+					strokeWidth={2}
+					vectorEffect="non-scaling-stroke"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+			</svg>
+			<h3 class="mt-2 text-sm font-semibold text-text-primary dark:text-white">No projects</h3>
+			<p class="mt-1 text-sm text-text-secondary dark:text-text-secondary">
+				Get started by creating a new project.
+			</p>
+			<div class="mt-6">
+				<button
+					type="button"
+					class="inline-flex items-center rounded-md bg-accent-500 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-accent-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 dark:bg-accent-500 dark:shadow-none dark:hover:bg-accent-400 dark:focus-visible:outline-accent-400"
+				>
+					<svg
+						aria-hidden="true"
+						class="mr-1.5 -ml-0.5 size-5"
+						fill="currentColor"
+						viewBox="0 0 20 20"
+					>
+						<path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
+					</svg>
+					New Project
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/GridListsDemo.tsx
+++ b/packages/ui/demo/sections/GridListsDemo.tsx
@@ -1,0 +1,290 @@
+const people = [
+	{
+		name: 'Jane Cooper',
+		title: 'Paradigm Representative',
+		role: 'Admin',
+		email: 'janecooper@example.com',
+		telephone: '+1-202-555-0170',
+		imageUrl:
+			'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Cody Fisher',
+		title: 'Lead Security Associate',
+		role: 'Admin',
+		email: 'codyfisher@example.com',
+		telephone: '+1-202-555-0114',
+		imageUrl:
+			'https://images.unsplash.com/photo-1570295999919-56ceb5ecca61?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Esther Howard',
+		title: 'Assurance Administrator',
+		email: 'estherhoward@example.com',
+		telephone: '+1-202-555-0143',
+		role: 'Admin',
+		imageUrl:
+			'https://images.unsplash.com/photo-1520813792240-56fc4a3765a7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Jenny Wilson',
+		title: 'Chief Accountability Analyst',
+		role: 'Admin',
+		email: 'jennywilson@example.com',
+		telephone: '+1-202-555-0184',
+		imageUrl:
+			'https://images.unsplash.com/photo-1498551172505-8ee7ad69f235?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Kristin Watson',
+		title: 'Investor Data Orchestrator',
+		role: 'Admin',
+		email: 'kristinwatson@example.com',
+		telephone: '+1-202-555-0191',
+		imageUrl:
+			'https://images.unsplash.com/photo-1532417344469-368f9ae6d187?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Cameron Williamson',
+		title: 'Product Infrastructure Executive',
+		role: 'Admin',
+		email: 'cameronwilliamson@example.com',
+		telephone: '+1-202-555-0108',
+		imageUrl:
+			'https://images.unsplash.com/photo-1566492031773-4f4e44671857?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Courtney Henry',
+		title: 'Investor Factors Associate',
+		role: 'Admin',
+		email: 'courtneyhenry@example.com',
+		telephone: '+1-202-555-0104',
+		imageUrl:
+			'https://images.unsplash.com/photo-1534751516642-a1af1ef26a56?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Theresa Webb',
+		title: 'Global Division Officer',
+		role: 'Admin',
+		email: 'theresawebb@example.com',
+		telephone: '+1-202-555-0138',
+		imageUrl:
+			'https://images.unsplash.com/photo-1488426862026-3ee34a7d66df?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+];
+
+const people2 = [
+	{
+		name: 'Jane Cooper',
+		title: 'Regional Paradigm Technician',
+		role: 'Admin',
+		email: 'janecooper@example.com',
+		telephone: '+1-202-555-0170',
+		imageUrl:
+			'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Cody Fisher',
+		title: 'Product Directives Officer',
+		role: 'Admin',
+		email: 'codyfisher@example.com',
+		telephone: '+1-202-555-0114',
+		imageUrl:
+			'https://images.unsplash.com/photo-1570295999919-56ceb5ecca61?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Esther Howard',
+		title: 'Forward Response Developer',
+		email: 'estherhoward@example.com',
+		telephone: '+1-202-555-0143',
+		role: 'Admin',
+		imageUrl:
+			'https://images.unsplash.com/photo-1520813792240-56fc4a3765a7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Jenny Wilson',
+		title: 'Central Security Manager',
+		role: 'Admin',
+		email: 'jennywilson@example.com',
+		telephone: '+1-202-555-0184',
+		imageUrl:
+			'https://images.unsplash.com/photo-1498551172505-8ee7ad69f235?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Kristin Watson',
+		title: 'Lead Implementation Liaison',
+		role: 'Admin',
+		email: 'kristinwatson@example.com',
+		telephone: '+1-202-555-0191',
+		imageUrl:
+			'https://images.unsplash.com/photo-1532417344469-368f9ae6d187?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+	{
+		name: 'Cameron Williamson',
+		title: 'Internal Applications Engineer',
+		role: 'Admin',
+		email: 'cameronwilliamson@example.com',
+		telephone: '+1-202-555-0108',
+		imageUrl:
+			'https://images.unsplash.com/photo-1566492031773-4f4e44671857?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=4&w=256&h=256&q=60',
+	},
+];
+
+function MailIcon({ class: className }: { class?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			class={className}
+		>
+			<rect width="20" height="16" x="2" y="4" rx="2" />
+			<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+		</svg>
+	);
+}
+
+function PhoneIcon({ class: className }: { class?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			class={className}
+		>
+			<path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
+		</svg>
+	);
+}
+
+export function GridListsDemo() {
+	return (
+		<div class="space-y-8">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Contact cards with small portrait
+				</h3>
+				<ul role="list" class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+					{people.map((person) => (
+						<li
+							key={person.email}
+							class="col-span-1 flex flex-col divide-y divide-surface-2 rounded-lg bg-surface-0 text-center shadow-sm dark:divide-white/10 dark:bg-surface-0/50 dark:shadow-none dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="flex flex-1 flex-col p-8">
+								<img
+									alt=""
+									src={person.imageUrl}
+									class="mx-auto size-32 shrink-0 rounded-full bg-surface-3 outline -outline-offset-1 outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+								/>
+								<h3 class="mt-6 text-sm font-medium text-text-primary">{person.name}</h3>
+								<dl class="mt-1 flex grow flex-col justify-between">
+									<dt class="sr-only">Title</dt>
+									<dd class="text-sm text-text-secondary">{person.title}</dd>
+									<dt class="sr-only">Role</dt>
+									<dd class="mt-3">
+										<span class="inline-flex items-center rounded-full bg-green-500/10 px-2 py-1 text-xs font-medium text-green-500 inset-ring inset-ring-green-500/10 dark:bg-green-500/10 dark:text-green-500 dark:inset-ring-green-500/10">
+											{person.role}
+										</span>
+									</dd>
+								</dl>
+							</div>
+							<div>
+								<div class="-mt-px flex divide-x divide-surface-2 dark:divide-white/10">
+									<div class="flex w-0 flex-1">
+										<a
+											href={`mailto:${person.email}`}
+											class="relative -mr-px inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-bl-lg border border-transparent py-4 text-sm font-semibold text-text-primary"
+										>
+											<MailIcon
+												aria-hidden="true"
+												class="size-5 text-text-tertiary dark:text-text-secondary"
+											/>
+											Email
+										</a>
+									</div>
+									<div class="-ml-px flex w-0 flex-1">
+										<a
+											href={`tel:${person.telephone}`}
+											class="relative inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-br-lg border border-transparent py-4 text-sm font-semibold text-text-primary"
+										>
+											<PhoneIcon
+												aria-hidden="true"
+												class="size-5 text-text-tertiary dark:text-text-secondary"
+											/>
+											Call
+										</a>
+									</div>
+								</div>
+							</div>
+						</li>
+					))}
+				</ul>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Contact cards</h3>
+				<ul role="list" class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+					{people2.map((person) => (
+						<li
+							key={person.email}
+							class="col-span-1 divide-y divide-surface-2 rounded-lg bg-surface-0 shadow-sm dark:divide-white/10 dark:bg-surface-0/50 dark:shadow-none dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="flex w-full items-center justify-between space-x-6 p-6">
+								<div class="flex-1 truncate">
+									<div class="flex items-center space-x-3">
+										<h3 class="truncate text-sm font-medium text-text-primary">{person.name}</h3>
+										<span class="inline-flex shrink-0 items-center rounded-full bg-green-500/10 px-1.5 py-0.5 text-xs font-medium text-green-500 inset-ring inset-ring-green-500/10 dark:bg-green-500/10 dark:text-green-500 dark:inset-ring-green-500/10">
+											{person.role}
+										</span>
+									</div>
+									<p class="mt-1 truncate text-sm text-text-secondary">{person.title}</p>
+								</div>
+								<img
+									alt=""
+									src={person.imageUrl}
+									class="size-10 shrink-0 rounded-full bg-surface-3 outline -outline-offset-1 outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+								/>
+							</div>
+							<div>
+								<div class="-mt-px flex divide-x divide-surface-2 dark:divide-white/10">
+									<div class="flex w-0 flex-1">
+										<a
+											href={`mailto:${person.email}`}
+											class="relative -mr-px inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-bl-lg border border-transparent py-4 text-sm font-semibold text-text-primary"
+										>
+											<MailIcon
+												aria-hidden="true"
+												class="size-5 text-text-tertiary dark:text-text-secondary"
+											/>
+											Email
+										</a>
+									</div>
+									<div class="-ml-px flex w-0 flex-1">
+										<a
+											href={`tel:${person.telephone}`}
+											class="relative inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-br-lg border border-transparent py-4 text-sm font-semibold text-text-primary"
+										>
+											<PhoneIcon
+												aria-hidden="true"
+												class="size-5 text-text-tertiary dark:text-text-secondary"
+											/>
+											Call
+										</a>
+									</div>
+								</div>
+							</div>
+						</li>
+					))}
+				</ul>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/PaginationDemo.tsx
+++ b/packages/ui/demo/sections/PaginationDemo.tsx
@@ -1,0 +1,113 @@
+export function PaginationDemo() {
+	return (
+		<div class="flex items-center justify-between border-t border-surface-border bg-white px-4 py-3 sm:px-6 dark:border-white/10 dark:bg-transparent">
+			<div class="flex flex-1 justify-between sm:hidden">
+				<a
+					href="#"
+					class="relative inline-flex items-center rounded-md border border-surface-border bg-white px-4 py-2 text-sm font-medium text-text-secondary hover:bg-surface-0 dark:border-white/10 dark:bg-white/5 dark:text-gray-200 dark:hover:bg-white/10"
+				>
+					Previous
+				</a>
+				<a
+					href="#"
+					class="relative ml-3 inline-flex items-center rounded-md border border-surface-border bg-white px-4 py-2 text-sm font-medium text-text-secondary hover:bg-surface-0 dark:border-white/10 dark:bg-white/5 dark:text-gray-200 dark:hover:bg-white/10"
+				>
+					Next
+				</a>
+			</div>
+			<div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
+				<div>
+					<p class="text-sm text-text-secondary dark:text-gray-300">
+						Showing <span class="font-medium">1</span> to <span class="font-medium">10</span> of{' '}
+						<span class="font-medium">97</span> results
+					</p>
+				</div>
+				<div>
+					<nav
+						aria-label="Pagination"
+						class="isolate inline-flex -space-x-px rounded-md shadow-xs dark:shadow-none"
+					>
+						<a
+							href="#"
+							class="relative inline-flex items-center rounded-l-md px-2 py-2 text-text-tertiary inset-ring inset-ring-surface-border hover:bg-surface-0 focus:z-20 focus:outline-offset-0 dark:inset-ring-gray-700 dark:hover:bg-white/5"
+						>
+							<span class="sr-only">Previous</span>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+								aria-hidden="true"
+								class="size-5"
+							>
+								<path
+									fill-rule="evenodd"
+									d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z"
+									clip-rule="evenodd"
+								/>
+							</svg>
+						</a>
+						<a
+							href="#"
+							aria-current="page"
+							class="relative z-10 inline-flex items-center bg-accent-500 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 dark:bg-accent-500 dark:focus-visible:outline-accent-500"
+						>
+							1
+						</a>
+						<a
+							href="#"
+							class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-text-primary inset-ring inset-ring-surface-border hover:bg-surface-0 focus:z-20 focus:outline-offset-0 dark:text-gray-200 dark:inset-ring-gray-700 dark:hover:bg-white/5"
+						>
+							2
+						</a>
+						<a
+							href="#"
+							class="relative hidden items-center px-4 py-2 text-sm font-semibold text-text-primary inset-ring inset-ring-surface-border hover:bg-surface-0 focus:z-20 focus:outline-offset-0 md:inline-flex dark:text-gray-200 dark:inset-ring-gray-700 dark:hover:bg-white/5"
+						>
+							3
+						</a>
+						<span class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-text-secondary inset-ring inset-ring-surface-border focus:outline-offset-0 dark:text-gray-400 dark:inset-ring-gray-700">
+							...
+						</span>
+						<a
+							href="#"
+							class="relative hidden items-center px-4 py-2 text-sm font-semibold text-text-primary inset-ring inset-ring-surface-border hover:bg-surface-0 focus:z-20 focus:outline-offset-0 md:inline-flex dark:text-gray-200 dark:inset-ring-gray-700 dark:hover:bg-white/5"
+						>
+							8
+						</a>
+						<a
+							href="#"
+							class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-text-primary inset-ring inset-ring-surface-border hover:bg-surface-0 focus:z-20 focus:outline-offset-0 dark:text-gray-200 dark:inset-ring-gray-700 dark:hover:bg-white/5"
+						>
+							9
+						</a>
+						<a
+							href="#"
+							class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-text-primary inset-ring inset-ring-surface-border hover:bg-surface-0 focus:z-20 focus:outline-offset-0 dark:text-gray-200 dark:inset-ring-gray-700 dark:hover:bg-white/5"
+						>
+							10
+						</a>
+						<a
+							href="#"
+							class="relative inline-flex items-center rounded-r-md px-2 py-2 text-text-tertiary inset-ring inset-ring-surface-border hover:bg-surface-0 focus:z-20 focus:outline-offset-0 dark:inset-ring-gray-700 dark:hover:bg-white/5"
+						>
+							<span class="sr-only">Next</span>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+								aria-hidden="true"
+								class="size-5"
+							>
+								<path
+									fill-rule="evenodd"
+									d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+									clip-rule="evenodd"
+								/>
+							</svg>
+						</a>
+					</nav>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/ProgressBarsDemo.tsx
+++ b/packages/ui/demo/sections/ProgressBarsDemo.tsx
@@ -1,0 +1,205 @@
+export function SimpleProgressBars() {
+	const steps = [
+		{ id: 'Step 1', name: 'Job details', href: '#', status: 'complete' },
+		{ id: 'Step 2', name: 'Application form', href: '#', status: 'current' },
+		{ id: 'Step 3', name: 'Preview', href: '#', status: 'upcoming' },
+	];
+
+	return (
+		<nav aria-label="Progress">
+			<ol role="list" class="space-y-4 md:flex md:space-y-0 md:space-x-8">
+				{steps.map((step) => (
+					<li key={step.name} class="md:flex-1">
+						{step.status === 'complete' ? (
+							<a
+								href={step.href}
+								class="group flex flex-col border-l-4 border-accent-500 py-2 pl-4 hover:border-accent-600 md:border-t-4 md:border-l-0 md:pt-4 md:pb-0 md:pl-0"
+							>
+								<span class="text-sm font-medium text-accent-500 group-hover:text-accent-600">
+									{step.id}
+								</span>
+								<span class="text-sm font-medium text-text-primary">{step.name}</span>
+							</a>
+						) : step.status === 'current' ? (
+							<a
+								href={step.href}
+								aria-current="step"
+								class="flex flex-col border-l-4 border-accent-500 py-2 pl-4 md:border-t-4 md:border-l-0 md:pt-4 md:pb-0 md:pl-0"
+							>
+								<span class="text-sm font-medium text-accent-500">{step.id}</span>
+								<span class="text-sm font-medium text-text-primary">{step.name}</span>
+							</a>
+						) : (
+							<a
+								href={step.href}
+								class="group flex flex-col border-l-4 border-surface-2 py-2 pl-4 hover:border-surface-border md:border-t-4 md:border-l-0 md:pt-4 md:pb-0 md:pl-0"
+							>
+								<span class="text-sm font-medium text-text-secondary group-hover:text-text-primary">
+									{step.id}
+								</span>
+								<span class="text-sm font-medium text-text-primary">{step.name}</span>
+							</a>
+						)}
+					</li>
+				))}
+			</ol>
+		</nav>
+	);
+}
+
+export function PanelProgressBars() {
+	const steps = [
+		{ id: '01', name: 'Job details', href: '#', status: 'complete' },
+		{ id: '02', name: 'Application form', href: '#', status: 'current' },
+		{ id: '03', name: 'Preview', href: '#', status: 'upcoming' },
+	];
+
+	return (
+		<nav aria-label="Progress">
+			<ol
+				role="list"
+				class="divide-y divide-surface-border rounded-md border border-surface-border md:flex md:divide-y-0"
+			>
+				{steps.map((step, stepIdx) => (
+					<li key={step.name} class="relative md:flex md:flex-1">
+						{step.status === 'complete' ? (
+							<a href={step.href} class="group flex w-full items-center">
+								<span class="flex items-center px-6 py-4 text-sm font-medium">
+									<span class="flex size-10 shrink-0 items-center justify-center rounded-full bg-accent-500 group-hover:bg-accent-600">
+										<svg
+											aria-hidden="true"
+											class="size-6 text-white"
+											fill="currentColor"
+											viewBox="0 0 20 20"
+										>
+											<path
+												fill-rule="evenodd"
+												d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+												clip-rule="evenodd"
+											/>
+										</svg>
+									</span>
+									<span class="ml-4 text-sm font-medium text-text-primary">{step.name}</span>
+								</span>
+							</a>
+						) : step.status === 'current' ? (
+							<a
+								href={step.href}
+								aria-current="step"
+								class="flex items-center px-6 py-4 text-sm font-medium"
+							>
+								<span class="flex size-10 shrink-0 items-center justify-center rounded-full border-2 border-accent-500">
+									<span class="text-accent-500">{step.id}</span>
+								</span>
+								<span class="ml-4 text-sm font-medium text-accent-500">{step.name}</span>
+							</a>
+						) : (
+							<a href={step.href} class="group flex items-center">
+								<span class="flex items-center px-6 py-4 text-sm font-medium">
+									<span class="flex size-10 shrink-0 items-center justify-center rounded-full border-2 border-surface-border group-hover:border-surface-border/80">
+										<span class="text-text-secondary group-hover:text-text-primary">{step.id}</span>
+									</span>
+									<span class="ml-4 text-sm font-medium text-text-secondary group-hover:text-text-primary">
+										{step.name}
+									</span>
+								</span>
+							</a>
+						)}
+
+						{stepIdx !== steps.length - 1 ? (
+							<div aria-hidden="true" class="absolute top-0 right-0 hidden h-full w-5 md:block">
+								<svg
+									fill="none"
+									viewBox="0 0 22 80"
+									preserveAspectRatio="none"
+									class="size-full text-surface-border"
+								>
+									<path
+										d="M0 -2L20 40L0 82"
+										stroke="currentColor"
+										vector-effect="non-scaling-stroke"
+										stroke-linejoin="round"
+									/>
+								</svg>
+							</div>
+						) : null}
+					</li>
+				))}
+			</ol>
+		</nav>
+	);
+}
+
+export function BulletProgressBars() {
+	const steps = [
+		{ name: 'Step 1', href: '#', status: 'complete' },
+		{ name: 'Step 2', href: '#', status: 'current' },
+		{ name: 'Step 3', href: '#', status: 'upcoming' },
+		{ name: 'Step 4', href: '#', status: 'upcoming' },
+	];
+
+	return (
+		<nav aria-label="Progress" class="flex items-center justify-center">
+			<p class="text-sm font-medium text-text-primary">
+				Step {steps.findIndex((step) => step.status === 'current') + 1} of {steps.length}
+			</p>
+			<ol role="list" class="ml-8 flex items-center space-x-5">
+				{steps.map((step) => (
+					<li key={step.name}>
+						{step.status === 'complete' ? (
+							<a
+								href={step.href}
+								class="block size-2.5 rounded-full bg-accent-500 hover:bg-accent-600"
+							>
+								<span class="sr-only">{step.name}</span>
+							</a>
+						) : step.status === 'current' ? (
+							<a
+								href={step.href}
+								aria-current="step"
+								class="relative flex items-center justify-center"
+							>
+								<span aria-hidden="true" class="absolute flex size-5 p-px">
+									<span class="size-full rounded-full bg-accent-900/20" />
+								</span>
+								<span
+									aria-hidden="true"
+									class="relative block size-2.5 rounded-full bg-accent-500"
+								/>
+								<span class="sr-only">{step.name}</span>
+							</a>
+						) : (
+							<a
+								href={step.href}
+								class="block size-2.5 rounded-full bg-surface-2 hover:bg-surface-border"
+							>
+								<span class="sr-only">{step.name}</span>
+							</a>
+						)}
+					</li>
+				))}
+			</ol>
+		</nav>
+	);
+}
+
+export function ProgressBarsDemo() {
+	return (
+		<div class="space-y-12">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple Steps</h3>
+				<SimpleProgressBars />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Panels</h3>
+				<PanelProgressBars />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Bullets</h3>
+				<BulletProgressBars />
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/StackedListsDemo.tsx
+++ b/packages/ui/demo/sections/StackedListsDemo.tsx
@@ -1,0 +1,379 @@
+const people = [
+	{
+		name: 'Leslie Alexander',
+		email: 'leslie.alexander@example.com',
+		role: 'Co-Founder / CEO',
+		imageUrl:
+			'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		href: '#',
+		lastSeen: '3h ago',
+		lastSeenDateTime: '2023-01-23T13:23Z',
+	},
+	{
+		name: 'Michael Foster',
+		email: 'michael.foster@example.com',
+		role: 'Co-Founder / CTO',
+		imageUrl:
+			'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		href: '#',
+		lastSeen: '3h ago',
+		lastSeenDateTime: '2023-01-23T13:23Z',
+	},
+	{
+		name: 'Dries Vincent',
+		email: 'dries.vincent@example.com',
+		role: 'Business Relations',
+		imageUrl:
+			'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		href: '#',
+		lastSeen: null,
+	},
+	{
+		name: 'Lindsay Walton',
+		email: 'lindsay.walton@example.com',
+		role: 'Front-end Developer',
+		imageUrl:
+			'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		href: '#',
+		lastSeen: '3h ago',
+		lastSeenDateTime: '2023-01-23T13:23Z',
+	},
+	{
+		name: 'Courtney Henry',
+		email: 'courtney.henry@example.com',
+		role: 'Designer',
+		imageUrl:
+			'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		href: '#',
+		lastSeen: '3h ago',
+		lastSeenDateTime: '2023-01-23T13:23Z',
+	},
+	{
+		name: 'Tom Cook',
+		email: 'tom.cook@example.com',
+		role: 'Director of Product',
+		imageUrl:
+			'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		href: '#',
+		lastSeen: null,
+	},
+];
+
+function ChevronRightIcon({ class: className }: { class?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			aria-hidden="true"
+			class={className}
+		>
+			<path
+				fill-rule="evenodd"
+				d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function OnlineIndicator() {
+	return (
+		<div class="mt-1 flex items-center gap-x-1.5">
+			<div class="flex-none rounded-full bg-green-500/20 p-1 dark:bg-green-500/30">
+				<div class="size-1.5 rounded-full bg-green-500" />
+			</div>
+			<p class="text-xs/5 text-text-secondary">Online</p>
+		</div>
+	);
+}
+
+function PersonRowSimple({ person }: { person: (typeof people)[0] }) {
+	return (
+		<li class="relative flex justify-between gap-x-6 px-4 py-5 hover:bg-surface-1 sm:px-6 dark:hover:bg-white/2.5">
+			<div class="flex min-w-0 gap-x-4">
+				<img
+					alt=""
+					src={person.imageUrl}
+					class="size-12 flex-none rounded-full bg-surface-1 dark:bg-surface-2 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+				/>
+				<div class="min-w-0 flex-auto">
+					<p class="text-sm/6 font-semibold text-text-primary">
+						<a href={person.href}>
+							<span class="absolute inset-x-0 -top-px bottom-0" />
+							{person.name}
+						</a>
+					</p>
+					<p class="mt-1 flex text-xs/5 text-text-secondary">
+						<a href={`mailto:${person.email}`} class="relative truncate hover:underline">
+							{person.email}
+						</a>
+					</p>
+				</div>
+			</div>
+			<div class="flex shrink-0 items-center gap-x-4">
+				<div class="hidden sm:flex sm:flex-col sm:items-end">
+					<p class="text-sm/6 text-text-primary">{person.role}</p>
+					{person.lastSeen ? (
+						<p class="mt-1 text-xs/5 text-text-secondary">
+							Last seen <time dateTime={person.lastSeenDateTime}>{person.lastSeen}</time>
+						</p>
+					) : (
+						<OnlineIndicator />
+					)}
+				</div>
+				<ChevronRightIcon class="size-5 flex-none text-text-tertiary dark:text-text-secondary" />
+			</div>
+		</li>
+	);
+}
+
+function PersonRowTwoColumns({ person }: { person: (typeof people)[0] }) {
+	return (
+		<li key={person.email} class="relative flex justify-between py-5">
+			<div class="flex gap-x-4 pr-6 sm:w-1/2 sm:flex-none">
+				<img
+					alt=""
+					src={person.imageUrl}
+					class="size-12 flex-none rounded-full bg-surface-1 dark:bg-surface-2 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+				/>
+				<div class="min-w-0 flex-auto">
+					<p class="text-sm/6 font-semibold text-text-primary">
+						<a href={person.href}>
+							<span class="absolute inset-x-0 -top-px bottom-0" />
+							{person.name}
+						</a>
+					</p>
+					<p class="mt-1 flex text-xs/5 text-text-secondary">
+						<a href={`mailto:${person.email}`} class="relative truncate hover:underline">
+							{person.email}
+						</a>
+					</p>
+				</div>
+			</div>
+			<div class="flex items-center justify-between gap-x-4 sm:w-1/2 sm:flex-none">
+				<div class="hidden sm:block">
+					<p class="text-sm/6 text-text-primary">{person.role}</p>
+					{person.lastSeen ? (
+						<p class="mt-1 text-xs/5 text-text-secondary">
+							Last seen <time dateTime={person.lastSeenDateTime}>{person.lastSeen}</time>
+						</p>
+					) : (
+						<OnlineIndicator />
+					)}
+				</div>
+				<ChevronRightIcon class="size-5 flex-none text-text-tertiary dark:text-text-secondary" />
+			</div>
+		</li>
+	);
+}
+
+function PersonRowFullWidth({ person }: { person: (typeof people)[0] }) {
+	return (
+		<li key={person.email} class="relative py-5 hover:bg-surface-1 dark:hover:bg-white/2.5">
+			<div class="px-4 sm:px-6 lg:px-8">
+				<div class="mx-auto flex max-w-4xl justify-between gap-x-6">
+					<div class="flex min-w-0 gap-x-4">
+						<img
+							alt=""
+							src={person.imageUrl}
+							class="size-12 flex-none rounded-full bg-surface-1 dark:bg-surface-2 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						/>
+						<div class="min-w-0 flex-auto">
+							<p class="text-sm/6 font-semibold text-text-primary">
+								<a href={person.href}>
+									<span class="absolute inset-x-0 -top-px bottom-0" />
+									{person.name}
+								</a>
+							</p>
+							<p class="mt-1 flex text-xs/5 text-text-secondary">
+								<a href={`mailto:${person.email}`} class="relative truncate hover:underline">
+									{person.email}
+								</a>
+							</p>
+						</div>
+					</div>
+					<div class="flex shrink-0 items-center gap-x-4">
+						<div class="hidden sm:flex sm:flex-col sm:items-end">
+							<p class="text-sm/6 text-text-primary">{person.role}</p>
+							{person.lastSeen ? (
+								<p class="mt-1 text-xs/5 text-text-secondary">
+									Last seen <time dateTime={person.lastSeenDateTime}>{person.lastSeen}</time>
+								</p>
+							) : (
+								<OnlineIndicator />
+							)}
+						</div>
+						<ChevronRightIcon class="size-5 flex-none text-text-tertiary dark:text-text-secondary" />
+					</div>
+				</div>
+			</div>
+		</li>
+	);
+}
+
+function PersonRowPlain({ person }: { person: (typeof people)[0] }) {
+	return (
+		<li key={person.email} class="flex justify-between gap-x-6 py-5">
+			<div class="flex min-w-0 gap-x-4">
+				<img
+					alt=""
+					src={person.imageUrl}
+					class="size-12 flex-none rounded-full bg-surface-1 dark:bg-surface-2 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+				/>
+				<div class="min-w-0 flex-auto">
+					<p class="text-sm/6 font-semibold text-text-primary">{person.name}</p>
+					<p class="mt-1 truncate text-xs/5 text-text-secondary">{person.email}</p>
+				</div>
+			</div>
+			<div class="hidden shrink-0 sm:flex sm:flex-col sm:items-end">
+				<p class="text-sm/6 text-text-primary">{person.role}</p>
+				{person.lastSeen ? (
+					<p class="mt-1 text-xs/5 text-text-secondary">
+						Last seen <time dateTime={person.lastSeenDateTime}>{person.lastSeen}</time>
+					</p>
+				) : (
+					<OnlineIndicator />
+				)}
+			</div>
+		</li>
+	);
+}
+
+export function StackedListsDemo() {
+	return (
+		<div class="space-y-8">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple stacked list in card</h3>
+				<ul
+					role="list"
+					class="divide-y divide-surface-2 overflow-hidden bg-surface-0 shadow-sm outline outline-1 outline-black/5 sm:rounded-xl dark:divide-white/5 dark:bg-surface-0/50 dark:shadow-none dark:outline-white/10 dark:sm:-outline-offset-1"
+				>
+					{people.map((person) => (
+						<PersonRowSimple person={person} />
+					))}
+				</ul>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Plain stacked list with links</h3>
+				<ul role="list" class="divide-y divide-surface-2 dark:divide-white/5">
+					{people.map((person) => (
+						<li
+							key={person.email}
+							class="relative flex justify-between gap-x-6 px-4 py-5 hover:bg-surface-1 sm:px-6 lg:px-8 dark:hover:bg-white/2.5"
+						>
+							<div class="flex min-w-0 gap-x-4">
+								<img
+									alt=""
+									src={person.imageUrl}
+									class="size-12 flex-none rounded-full bg-surface-1 dark:bg-surface-2 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+								/>
+								<div class="min-w-0 flex-auto">
+									<p class="text-sm/6 font-semibold text-text-primary">
+										<a href={person.href}>
+											<span class="absolute inset-x-0 -top-px bottom-0" />
+											{person.name}
+										</a>
+									</p>
+									<p class="mt-1 flex text-xs/5 text-text-secondary">
+										<a href={`mailto:${person.email}`} class="relative truncate hover:underline">
+											{person.email}
+										</a>
+									</p>
+								</div>
+							</div>
+							<div class="flex shrink-0 items-center gap-x-4">
+								<div class="hidden sm:flex sm:flex-col sm:items-end">
+									<p class="text-sm/6 text-text-primary">{person.role}</p>
+									{person.lastSeen ? (
+										<p class="mt-1 text-xs/5 text-text-secondary">
+											Last seen <time dateTime={person.lastSeenDateTime}>{person.lastSeen}</time>
+										</p>
+									) : (
+										<OnlineIndicator />
+									)}
+								</div>
+								<ChevronRightIcon class="size-5 flex-none text-text-tertiary dark:text-text-secondary" />
+							</div>
+						</li>
+					))}
+				</ul>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Stacked list in card</h3>
+				<div class="overflow-hidden bg-surface-0 shadow-sm outline outline-1 outline-black/5 dark:bg-surface-0/50 dark:shadow-none dark:outline-white/10 sm:rounded-xl">
+					<ul role="list" class="divide-y divide-surface-2 dark:divide-white/5">
+						{people.map((person) => (
+							<PersonRowPlain person={person} />
+						))}
+					</ul>
+				</div>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Two columns with links</h3>
+				<ul role="list" class="divide-y divide-surface-2 dark:divide-white/5">
+					{people.map((person) => (
+						<PersonRowTwoColumns person={person} />
+					))}
+				</ul>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Full width with links</h3>
+				<ul role="list" class="divide-y divide-surface-2 dark:divide-white/5">
+					{people.map((person) => (
+						<PersonRowFullWidth person={person} />
+					))}
+				</ul>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Full width with constrained content
+				</h3>
+				<ul role="list" class="divide-y divide-surface-2 dark:divide-white/5">
+					{people.map((person) => (
+						<li key={person.email} class="relative flex justify-between gap-x-6 py-5">
+							<div class="flex min-w-0 gap-x-4">
+								<img
+									alt=""
+									src={person.imageUrl}
+									class="size-12 flex-none rounded-full bg-surface-1 dark:bg-surface-2 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+								/>
+								<div class="min-w-0 flex-auto">
+									<p class="text-sm/6 font-semibold text-text-primary">
+										<a href={person.href}>
+											<span class="absolute inset-x-0 -top-px bottom-0" />
+											{person.name}
+										</a>
+									</p>
+									<p class="mt-1 flex text-xs/5 text-text-secondary">
+										<a href={`mailto:${person.email}`} class="relative truncate hover:underline">
+											{person.email}
+										</a>
+									</p>
+								</div>
+							</div>
+							<div class="flex shrink-0 items-center gap-x-4">
+								<div class="hidden sm:flex sm:flex-col sm:items-end">
+									<p class="text-sm/6 text-text-primary">{person.role}</p>
+									{person.lastSeen ? (
+										<p class="mt-1 text-xs/5 text-text-secondary">
+											Last seen <time dateTime={person.lastSeenDateTime}>{person.lastSeen}</time>
+										</p>
+									) : (
+										<OnlineIndicator />
+									)}
+								</div>
+								<ChevronRightIcon class="size-5 flex-none text-text-tertiary dark:text-text-secondary" />
+							</div>
+						</li>
+					))}
+				</ul>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/StatsDemo.tsx
+++ b/packages/ui/demo/sections/StatsDemo.tsx
@@ -1,0 +1,117 @@
+function classNames(...classes: (string | boolean | undefined | null)[]) {
+	return classes.filter(Boolean).join(' ');
+}
+
+const stats1 = [
+	{ name: 'Revenue', value: '$405,091.00', change: '+4.75%', changeType: 'positive' },
+	{ name: 'Overdue invoices', value: '$12,787.00', change: '+54.02%', changeType: 'negative' },
+	{ name: 'Outstanding invoices', value: '$245,988.00', change: '-1.39%', changeType: 'positive' },
+	{ name: 'Expenses', value: '$30,156.00', change: '+10.18%', changeType: 'negative' },
+];
+
+const stats2 = [
+	{ name: 'Number of deploys', value: '405' },
+	{ name: 'Average deploy time', value: '3.65', unit: 'mins' },
+	{ name: 'Number of servers', value: '3' },
+	{ name: 'Success rate', value: '98.5%' },
+];
+
+const stats3 = [
+	{ name: 'Total Subscribers', stat: '71,897' },
+	{ name: 'Avg. Open Rate', stat: '58.16%' },
+	{ name: 'Avg. Click Rate', stat: '24.57%' },
+];
+
+function WithTrending() {
+	return (
+		<dl class="mx-auto grid grid-cols-1 gap-px bg-gray-900/5 sm:grid-cols-2 lg:grid-cols-4 dark:bg-white/10">
+			{stats1.map((stat) => (
+				<div
+					key={stat.name}
+					class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8 dark:bg-gray-900"
+				>
+					<dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">{stat.name}</dt>
+					<dd
+						class={classNames(
+							stat.changeType === 'negative'
+								? 'text-rose-600 dark:text-rose-400'
+								: 'text-gray-700 dark:text-gray-300',
+							'text-xs font-medium'
+						)}
+					>
+						{stat.change}
+					</dd>
+					<dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+						{stat.value}
+					</dd>
+				</div>
+			))}
+		</dl>
+	);
+}
+
+function Simple() {
+	return (
+		<div class="bg-white dark:bg-gray-900">
+			<div class="mx-auto max-w-7xl">
+				<div class="grid grid-cols-1 gap-px bg-gray-900/5 sm:grid-cols-2 lg:grid-cols-4 dark:bg-white/10">
+					{stats2.map((stat) => (
+						<div key={stat.name} class="bg-white px-4 py-6 sm:px-6 lg:px-8 dark:bg-gray-900">
+							<p class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">{stat.name}</p>
+							<p class="mt-2 flex items-baseline gap-x-2">
+								<span class="text-4xl font-semibold tracking-tight text-gray-900 dark:text-white">
+									{stat.value}
+								</span>
+								{stat.unit ? (
+									<span class="text-sm text-gray-500 dark:text-gray-400">{stat.unit}</span>
+								) : null}
+							</p>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function SimpleInCards() {
+	return (
+		<div>
+			<h3 class="text-base font-semibold text-gray-900 dark:text-white">Last 30 days</h3>
+			<dl class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-3">
+				{stats3.map((item) => (
+					<div
+						key={item.name}
+						class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow-sm sm:p-6 dark:bg-gray-800/75 dark:inset-ring dark:inset-ring-white/10"
+					>
+						<dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400">
+							{item.name}
+						</dt>
+						<dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900 dark:text-white">
+							{item.stat}
+						</dd>
+					</div>
+				))}
+			</dl>
+		</div>
+	);
+}
+
+export function StatsDemo() {
+	return (
+		<div class="space-y-12">
+			<section>
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">With Trending</h2>
+				<WithTrending />
+			</section>
+			<section>
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Simple</h2>
+				<Simple />
+			</section>
+			<section>
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Simple in Cards</h2>
+				<SimpleInCards />
+			</section>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/StatsDemo.tsx
+++ b/packages/ui/demo/sections/StatsDemo.tsx
@@ -1,6 +1,4 @@
-function classNames(...classes: (string | boolean | undefined | null)[]) {
-	return classes.filter(Boolean).join(' ');
-}
+import { classNames } from '../../src/internal/class-names.ts';
 
 const stats1 = [
 	{ name: 'Revenue', value: '$405,091.00', change: '+4.75%', changeType: 'positive' },

--- a/packages/ui/demo/sections/TablesDemo.tsx
+++ b/packages/ui/demo/sections/TablesDemo.tsx
@@ -1,0 +1,2492 @@
+import { useState, useRef, useLayoutEffect } from 'preact/hooks';
+
+function classNames(...classes: string[]) {
+	return classes.filter(Boolean).join(' ');
+}
+
+// ============================================================
+// 01 - Simple Table
+// ============================================================
+const people1 = [
+	{
+		name: 'Lindsay Walton',
+		title: 'Front-end Developer',
+		email: 'lindsay.walton@example.com',
+		role: 'Member',
+	},
+	{ name: 'Courtney Henry', title: 'Designer', email: 'courtney.henry@example.com', role: 'Admin' },
+	{ name: 'Tom Cook', title: 'Director of Product', email: 'tom.cook@example.com', role: 'Member' },
+	{
+		name: 'Whitney Francis',
+		title: 'Copywriter',
+		email: 'whitney.francis@example.com',
+		role: 'Admin',
+	},
+	{
+		name: 'Leonard Krasner',
+		title: 'Senior Designer',
+		email: 'leonard.krasner@example.com',
+		role: 'Owner',
+	},
+	{
+		name: 'Floyd Miles',
+		title: 'Principal Designer',
+		email: 'floyd.miles@example.com',
+		role: 'Member',
+	},
+];
+
+export function SimpleTable() {
+	return (
+		<div>
+			<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+				<div class="sm:flex sm:items-center">
+					<div class="sm:flex-auto">
+						<h3 class="text-base font-semibold text-text-primary">Users</h3>
+						<p class="mt-2 text-sm text-text-secondary">
+							A list of all the users in your account including their name, title, email and role.
+						</p>
+					</div>
+					<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+						<button
+							type="button"
+							class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+						>
+							Add user
+						</button>
+					</div>
+				</div>
+			</div>
+			<div class="mt-8 flow-root overflow-hidden">
+				<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+					<table class="w-full text-left">
+						<thead class="bg-white dark:bg-gray-900">
+							<tr>
+								<th
+									scope="col"
+									class="relative isolate py-3.5 pr-3 text-left text-sm font-semibold text-text-primary"
+								>
+									Name
+									<div class="absolute inset-y-0 right-full -z-10 w-screen border-b border-surface-border" />
+									<div class="absolute inset-y-0 left-0 -z-10 w-screen border-b border-surface-border" />
+								</th>
+								<th
+									scope="col"
+									class="hidden px-3 py-3.5 text-left text-sm font-semibold text-text-primary sm:table-cell"
+								>
+									Title
+								</th>
+								<th
+									scope="col"
+									class="hidden px-3 py-3.5 text-left text-sm font-semibold text-text-primary md:table-cell"
+								>
+									Email
+								</th>
+								<th
+									scope="col"
+									class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+								>
+									Role
+								</th>
+								<th scope="col" class="py-3.5 pl-3">
+									<span class="sr-only">Edit</span>
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{people1.map((person) => (
+								<tr key={person.email}>
+									<td class="relative py-4 pr-3 text-sm font-medium text-text-primary">
+										{person.name}
+										<div class="absolute right-full bottom-0 h-px w-screen bg-surface-1" />
+										<div class="absolute bottom-0 left-0 h-px w-screen bg-surface-1" />
+									</td>
+									<td class="hidden px-3 py-4 text-sm text-text-secondary sm:table-cell">
+										{person.title}
+									</td>
+									<td class="hidden px-3 py-4 text-sm text-text-secondary md:table-cell">
+										{person.email}
+									</td>
+									<td class="px-3 py-4 text-sm text-text-secondary">{person.role}</td>
+									<td class="py-4 pl-3 text-right text-sm font-medium">
+										<a href="#" class="text-accent-500 hover:text-accent-400">
+											Edit<span class="sr-only">, {person.name}</span>
+										</a>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 03 - Simple Table in Card
+// ============================================================
+export function SimpleInCard() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<table class="relative min-w-full divide-y divide-surface-border">
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-0"
+									>
+										Name
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Title
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Email
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Role
+									</th>
+									<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-0">
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-surface-border">
+								{people1.map((person) => (
+									<tr key={person.email}>
+										<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-0">
+											{person.name}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.title}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.email}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.role}
+										</td>
+										<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-0">
+											<a href="#" class="text-accent-500 hover:text-accent-400">
+												Edit<span class="sr-only">, {person.name}</span>
+											</a>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 04 - Full Width Table
+// ============================================================
+export function FullWidthTable() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<table class="relative min-w-full divide-y divide-surface-border">
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-3"
+									>
+										Name
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Title
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Email
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Role
+									</th>
+									<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-3">
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody class="bg-white dark:bg-gray-900">
+								{people1.map((person, idx) => (
+									<tr key={person.email} class={idx % 2 === 1 ? 'even:bg-surface-0' : ''}>
+										<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-3">
+											{person.name}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.title}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.email}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.role}
+										</td>
+										<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-3">
+											<a href="#" class="text-accent-500 hover:text-accent-400">
+												Edit<span class="sr-only">, {person.name}</span>
+											</a>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 04b - Full Width with Constrained Content
+// ============================================================
+const peopleWithAvatars = [
+	{
+		name: 'Lindsay Walton',
+		title: 'Front-end Developer',
+		department: 'Optimization',
+		email: 'lindsay.walton@example.com',
+		role: 'Member',
+		image:
+			'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Courtney Henry',
+		title: 'Designer',
+		department: 'Intranet',
+		email: 'courtney.henry@example.com',
+		role: 'Admin',
+		image:
+			'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Tom Cook',
+		title: 'Director of Product',
+		department: 'Directives',
+		email: 'tom.cook@example.com',
+		role: 'Member',
+		image:
+			'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Whitney Francis',
+		title: 'Copywriter',
+		department: 'Program',
+		email: 'whitney.francis@example.com',
+		role: 'Admin',
+		image:
+			'https://images.unsplash.com/photo-1517365830460-955ce3ccd263?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Leonard Krasner',
+		title: 'Senior Designer',
+		department: 'Mobility',
+		email: 'leonard.krasner@example.com',
+		role: 'Owner',
+		image:
+			'https://images.unsplash.com/photo-1519345182560-3f2917c472ef?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Floyd Miles',
+		title: 'Principal Designer',
+		department: 'Security',
+		email: 'floyd.miles@example.com',
+		role: 'Member',
+		image:
+			'https://images.unsplash.com/photo-1463453091185-61582044d556?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+];
+
+export function FullWidthConstrained() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<table class="relative min-w-full divide-y divide-surface-border">
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-0"
+									>
+										Name
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Title
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Status
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Role
+									</th>
+									<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-0">
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+								{peopleWithAvatars.map((person) => (
+									<tr key={person.email}>
+										<td class="py-5 pr-3 pl-4 text-sm whitespace-nowrap sm:pl-0">
+											<div class="flex items-center">
+												<div class="size-11 shrink-0">
+													<img alt="" src={person.image} class="size-11 rounded-full" />
+												</div>
+												<div class="ml-4">
+													<div class="font-medium text-text-primary">{person.name}</div>
+													<div class="mt-1 text-text-secondary">{person.email}</div>
+												</div>
+											</div>
+										</td>
+										<td class="px-3 py-5 text-sm whitespace-nowrap text-text-secondary">
+											<div class="text-text-primary">{person.title}</div>
+											<div class="mt-1 text-text-secondary">{person.department}</div>
+										</td>
+										<td class="px-3 py-5 text-sm whitespace-nowrap text-text-secondary">
+											<span class="inline-flex items-center rounded-md bg-green-500/10 px-2 py-1 text-xs font-medium text-green-500 ring-1 ring-green-500/20">
+												Active
+											</span>
+										</td>
+										<td class="px-3 py-5 text-sm whitespace-nowrap text-text-secondary">
+											{person.role}
+										</td>
+										<td class="py-5 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-0">
+											<a href="#" class="text-accent-500 hover:text-accent-400">
+												Edit<span class="sr-only">, {person.name}</span>
+											</a>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 05 - Full Width with Striped Rows
+// ============================================================
+export function StripedRows() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="-mx-4 mt-8 sm:-mx-0">
+				<table class="min-w-full divide-y divide-surface-border">
+					<thead>
+						<tr>
+							<th
+								scope="col"
+								class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-0"
+							>
+								Name
+							</th>
+							<th
+								scope="col"
+								class="hidden px-3 py-3.5 text-left text-sm font-semibold text-text-primary lg:table-cell"
+							>
+								Title
+							</th>
+							<th
+								scope="col"
+								class="hidden px-3 py-3.5 text-left text-sm font-semibold text-text-primary sm:table-cell"
+							>
+								Email
+							</th>
+							<th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary">
+								Role
+							</th>
+							<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-0">
+								<span class="sr-only">Edit</span>
+							</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+						{people1.map((person) => (
+							<tr key={person.email}>
+								<td class="w-full max-w-0 py-4 pr-3 pl-4 text-sm font-medium text-text-primary sm:w-auto sm:max-w-none sm:pl-0">
+									{person.name}
+									<dl class="font-normal lg:hidden">
+										<dt class="sr-only">Title</dt>
+										<dd class="mt-1 truncate text-text-secondary">{person.title}</dd>
+										<dt class="sr-only sm:hidden">Email</dt>
+										<dd class="mt-1 truncate text-text-tertiary sm:hidden">{person.email}</dd>
+									</dl>
+								</td>
+								<td class="hidden px-3 py-4 text-sm text-text-secondary lg:table-cell">
+									{person.title}
+								</td>
+								<td class="hidden px-3 py-4 text-sm text-text-secondary sm:table-cell">
+									{person.email}
+								</td>
+								<td class="px-3 py-4 text-sm text-text-secondary">{person.role}</td>
+								<td class="py-4 pr-4 pl-3 text-right text-sm font-medium sm:pr-0">
+									<a href="#" class="text-accent-500 hover:text-accent-400">
+										Edit<span class="sr-only">, {person.name}</span>
+									</a>
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 06 - With Uppercase Headings
+// ============================================================
+export function UppercaseHeadings() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<table class="relative min-w-full divide-y divide-surface-border">
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										class="py-3 pr-3 pl-4 text-left text-xs font-medium tracking-wide text-text-tertiary uppercase sm:pl-0"
+									>
+										Name
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3 text-left text-xs font-medium tracking-wide text-text-tertiary uppercase"
+									>
+										Title
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3 text-left text-xs font-medium tracking-wide text-text-tertiary uppercase"
+									>
+										Email
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3 text-left text-xs font-medium tracking-wide text-text-tertiary uppercase"
+									>
+										Role
+									</th>
+									<th scope="col" class="py-3 pr-4 pl-3 sm:pr-0">
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+								{people1.map((person) => (
+									<tr key={person.email}>
+										<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-0">
+											{person.name}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.title}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.email}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.role}
+										</td>
+										<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-0">
+											<a href="#" class="text-accent-500 hover:text-accent-400">
+												Edit<span class="sr-only">, {person.name}</span>
+											</a>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 07 - With Stacked Columns on Mobile
+// ============================================================
+export function StackedColumnsMobile() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="-mx-4 mt-8 sm:-mx-0">
+				<table class="min-w-full divide-y divide-surface-border">
+					<thead>
+						<tr>
+							<th
+								scope="col"
+								class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-0"
+							>
+								Name
+							</th>
+							<th
+								scope="col"
+								class="hidden px-3 py-3.5 text-left text-sm font-semibold text-text-primary sm:table-cell"
+							>
+								Title
+							</th>
+							<th
+								scope="col"
+								class="hidden px-3 py-3.5 text-left text-sm font-semibold text-text-primary lg:table-cell"
+							>
+								Email
+							</th>
+							<th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary">
+								Role
+							</th>
+							<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-0">
+								<span class="sr-only">Edit</span>
+							</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+						{people1.map((person) => (
+							<tr key={person.email}>
+								<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-0">
+									{person.name}
+								</td>
+								<td class="hidden px-3 py-4 text-sm whitespace-nowrap text-text-secondary sm:table-cell">
+									{person.title}
+								</td>
+								<td class="hidden px-3 py-4 text-sm whitespace-nowrap text-text-secondary lg:table-cell">
+									{person.email}
+								</td>
+								<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+									{person.role}
+								</td>
+								<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-0">
+									<a href="#" class="text-accent-500 hover:text-accent-400">
+										Edit<span class="sr-only">, {person.name}</span>
+									</a>
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 08 - With Hidden Columns on Mobile
+// ============================================================
+export function HiddenColumnsMobile() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<div class="overflow-hidden shadow-sm outline-1 outline-black/5 sm:rounded-lg">
+							<table class="relative min-w-full divide-y divide-surface-border">
+								<thead class="bg-surface-0">
+									<tr>
+										<th
+											scope="col"
+											class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-6"
+										>
+											Name
+										</th>
+										<th
+											scope="col"
+											class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+										>
+											Title
+										</th>
+										<th
+											scope="col"
+											class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+										>
+											Email
+										</th>
+										<th
+											scope="col"
+											class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+										>
+											Role
+										</th>
+										<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-6">
+											<span class="sr-only">Edit</span>
+										</th>
+									</tr>
+								</thead>
+								<tbody class="divide-y divide-surface-border bg-white">
+									{people1.map((person) => (
+										<tr key={person.email}>
+											<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-6">
+												{person.name}
+											</td>
+											<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+												{person.title}
+											</td>
+											<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+												{person.email}
+											</td>
+											<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+												{person.role}
+											</td>
+											<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-6">
+												<a href="#" class="text-accent-500 hover:text-accent-400">
+													Edit<span class="sr-only">, {person.name}</span>
+												</a>
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 09 - With Avatars and Multiline Content
+// ============================================================
+export function AvatarsMultiline() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle">
+						<table class="relative min-w-full divide-y divide-surface-border">
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-6 lg:pl-8"
+									>
+										Name
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Title
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Email
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Role
+									</th>
+									<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-6 lg:pr-8">
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+								{people1.map((person) => (
+									<tr key={person.email}>
+										<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-6 lg:pl-8">
+											{person.name}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.title}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.email}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.role}
+										</td>
+										<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-6 lg:pr-8">
+											<a href="#" class="text-accent-500 hover:text-accent-400">
+												Edit<span class="sr-only">, {person.name}</span>
+											</a>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 10 - With Sticky Header
+// ============================================================
+const projects = [
+	{
+		id: 1,
+		name: 'Logo redesign',
+		description: 'New logo and digital asset playbook.',
+		hours: '20.0',
+		rate: '$100.00',
+		price: '$2,000.00',
+	},
+	{
+		id: 2,
+		name: 'Website redesign',
+		description: 'Design and program new company website.',
+		hours: '52.0',
+		rate: '$100.00',
+		price: '$5,200.00',
+	},
+	{
+		id: 3,
+		name: 'Business cards',
+		description: 'Design and production of 3.5" x 2.0" business cards.',
+		hours: '12.0',
+		rate: '$100.00',
+		price: '$1,200.00',
+	},
+	{
+		id: 4,
+		name: 'T-shirt design',
+		description: 'Three t-shirt design concepts.',
+		hours: '4.0',
+		rate: '$100.00',
+		price: '$400.00',
+	},
+];
+
+export function StickyHeader() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Invoice</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						For work completed from <time dateTime="2022-08-01">August 1, 2022</time> to{' '}
+						<time dateTime="2022-08-31">August 31, 2022</time>.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Print
+					</button>
+				</div>
+			</div>
+			<div class="-mx-4 mt-8 flow-root sm:mx-0">
+				<table class="min-w-full">
+					<colgroup>
+						<col class="w-full sm:w-1/2" />
+						<col class="sm:w-1/6" />
+						<col class="sm:w-1/6" />
+						<col class="sm:w-1/6" />
+					</colgroup>
+					<thead class="border-b border-surface-border text-text-primary">
+						<tr>
+							<th
+								scope="col"
+								class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-0"
+							>
+								Project
+							</th>
+							<th
+								scope="col"
+								class="hidden px-3 py-3.5 text-right text-sm font-semibold text-text-primary sm:table-cell"
+							>
+								Hours
+							</th>
+							<th
+								scope="col"
+								class="hidden px-3 py-3.5 text-right text-sm font-semibold text-text-primary sm:table-cell"
+							>
+								Rate
+							</th>
+							<th
+								scope="col"
+								class="py-3.5 pr-4 pl-3 text-right text-sm font-semibold text-text-primary sm:pr-0"
+							>
+								Price
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{projects.map((project) => (
+							<tr key={project.id} class="border-b border-surface-border">
+								<td class="max-w-0 py-5 pr-3 pl-4 text-sm sm:pl-0">
+									<div class="font-medium text-text-primary">{project.name}</div>
+									<div class="mt-1 truncate text-text-secondary">{project.description}</div>
+								</td>
+								<td class="hidden px-3 py-5 text-right text-sm text-text-secondary sm:table-cell">
+									{project.hours}
+								</td>
+								<td class="hidden px-3 py-5 text-right text-sm text-text-secondary sm:table-cell">
+									{project.rate}
+								</td>
+								<td class="py-5 pr-4 pl-3 text-right text-sm text-text-secondary sm:pr-0">
+									{project.price}
+								</td>
+							</tr>
+						))}
+					</tbody>
+					<tfoot>
+						<tr>
+							<th
+								scope="row"
+								colSpan={3}
+								class="hidden pt-6 pr-3 pl-4 text-right text-sm font-normal text-text-secondary sm:table-cell sm:pl-0"
+							>
+								Subtotal
+							</th>
+							<th
+								scope="row"
+								class="pt-6 pr-3 pl-4 text-left text-sm font-normal text-text-secondary sm:hidden"
+							>
+								Subtotal
+							</th>
+							<td class="pt-6 pr-4 pl-3 text-right text-sm text-text-secondary sm:pr-0">
+								$8,800.00
+							</td>
+						</tr>
+						<tr>
+							<th
+								scope="row"
+								colSpan={3}
+								class="hidden pt-4 pr-3 pl-4 text-right text-sm font-normal text-text-secondary sm:table-cell sm:pl-0"
+							>
+								Tax
+							</th>
+							<th
+								scope="row"
+								class="pt-4 pr-3 pl-4 text-left text-sm font-normal text-text-secondary sm:hidden"
+							>
+								Tax
+							</th>
+							<td class="pt-4 pr-4 pl-3 text-right text-sm text-text-secondary sm:pr-0">
+								$1,760.00
+							</td>
+						</tr>
+						<tr>
+							<th
+								scope="row"
+								colSpan={3}
+								class="hidden pt-4 pr-3 pl-4 text-right text-sm font-semibold text-text-primary sm:table-cell sm:pl-0"
+							>
+								Total
+							</th>
+							<th
+								scope="row"
+								class="pt-4 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:hidden"
+							>
+								Total
+							</th>
+							<td class="pt-4 pr-4 pl-3 text-right text-sm font-semibold text-text-primary sm:pr-0">
+								$10,560.00
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 11 - With Vertical Lines
+// ============================================================
+const people11 = [
+	{
+		name: 'Lindsay Walton',
+		title: 'Front-end Developer',
+		email: 'lindsay.walton@example.com',
+		role: 'Member',
+	},
+	{ name: 'Courtney Henry', title: 'Designer', email: 'courtney.henry@example.com', role: 'Admin' },
+	{ name: 'Tom Cook', title: 'Director of Product', email: 'tom.cook@example.com', role: 'Member' },
+	{
+		name: 'Whitney Francis',
+		title: 'Copywriter',
+		email: 'whitney.francis@example.com',
+		role: 'Admin',
+	},
+	{
+		name: 'Leonard Krasner',
+		title: 'Senior Designer',
+		email: 'leonard.krasner@example.com',
+		role: 'Owner',
+	},
+	{
+		name: 'Floyd Miles',
+		title: 'Principal Designer',
+		email: 'floyd.miles@example.com',
+		role: 'Member',
+	},
+	{
+		name: 'Emily Selman',
+		title: 'VP, User Experience',
+		email: 'emily.selman@example.com',
+		role: 'Member',
+	},
+	{
+		name: 'Kristin Watson',
+		title: 'VP, Human Resources',
+		email: 'kristin.watson@example.com',
+		role: 'Admin',
+	},
+	{
+		name: 'Emma Dorsey',
+		title: 'Senior Developer',
+		email: 'emma.dorsey@example.com',
+		role: 'Member',
+	},
+	{
+		name: 'Alicia Bell',
+		title: 'Junior Copywriter',
+		email: 'alicia.bell@example.com',
+		role: 'Admin',
+	},
+	{
+		name: 'Jenny Wilson',
+		title: 'Studio Artist',
+		email: 'jenny.wilson@example.com',
+		role: 'Owner',
+	},
+	{
+		name: 'Anna Roberts',
+		title: 'Partner, Creative',
+		email: 'anna.roberts@example.com',
+		role: 'Member',
+	},
+	{
+		name: 'Benjamin Russel',
+		title: 'Director, Print Operations',
+		email: 'benjamin.russel@example.com',
+		role: 'Member',
+	},
+	{
+		name: 'Jeffrey Webb',
+		title: 'Senior Art Director',
+		email: 'jeffrey.webb@example.com',
+		role: 'Admin',
+	},
+	{
+		name: 'Kathryn Murphy',
+		title: 'Associate Creative Director',
+		email: 'kathryn.murphy@example.com',
+		role: 'Member',
+	},
+];
+
+export function VerticalLines() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle">
+						<table class="min-w-full border-separate border-spacing-0">
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										class="sticky top-0 z-10 border-b border-surface-border bg-white/75 py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary backdrop-blur-sm backdrop-filter sm:pl-6 lg:pl-8"
+									>
+										Name
+									</th>
+									<th
+										scope="col"
+										class="sticky top-0 z-10 hidden border-b border-surface-border bg-white/75 px-3 py-3.5 text-left text-sm font-semibold text-text-primary backdrop-blur-sm backdrop-filter sm:table-cell"
+									>
+										Title
+									</th>
+									<th
+										scope="col"
+										class="sticky top-0 z-10 hidden border-b border-surface-border bg-white/75 px-3 py-3.5 text-left text-sm font-semibold text-text-primary backdrop-blur-sm backdrop-filter lg:table-cell"
+									>
+										Email
+									</th>
+									<th
+										scope="col"
+										class="sticky top-0 z-10 border-b border-surface-border bg-white/75 px-3 py-3.5 text-left text-sm font-semibold text-text-primary backdrop-blur-sm backdrop-filter"
+									>
+										Role
+									</th>
+									<th
+										scope="col"
+										class="sticky top-0 z-10 border-b border-surface-border bg-white/75 py-3.5 pr-4 pl-3 backdrop-blur-sm backdrop-filter sm:pr-6 lg:pr-8"
+									>
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								{people11.map((person, personIdx) => (
+									<tr key={person.email}>
+										<td
+											class={classNames(
+												personIdx !== people11.length - 1 ? 'border-b border-surface-border' : '',
+												'py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-6 lg:pl-8'
+											)}
+										>
+											{person.name}
+										</td>
+										<td
+											class={classNames(
+												personIdx !== people11.length - 1 ? 'border-b border-surface-border' : '',
+												'hidden px-3 py-4 text-sm whitespace-nowrap text-text-secondary sm:table-cell'
+											)}
+										>
+											{person.title}
+										</td>
+										<td
+											class={classNames(
+												personIdx !== people11.length - 1 ? 'border-b border-surface-border' : '',
+												'hidden px-3 py-4 text-sm whitespace-nowrap text-text-secondary lg:table-cell'
+											)}
+										>
+											{person.email}
+										</td>
+										<td
+											class={classNames(
+												personIdx !== people11.length - 1 ? 'border-b border-surface-border' : '',
+												'px-3 py-4 text-sm whitespace-nowrap text-text-secondary'
+											)}
+										>
+											{person.role}
+										</td>
+										<td
+											class={classNames(
+												personIdx !== people11.length - 1 ? 'border-b border-surface-border' : '',
+												'py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-8 lg:pr-8'
+											)}
+										>
+											<a href="#" class="text-accent-500 hover:text-accent-400">
+												Edit<span class="sr-only">, {person.name}</span>
+											</a>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 12 - With Condensed Content
+// ============================================================
+const activityItems = [
+	{
+		user: {
+			name: 'Michael Foster',
+			imageUrl:
+				'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		},
+		commit: '2d89f0c8',
+		branch: 'main',
+		status: 'Completed',
+		duration: '25s',
+		date: '45 minutes ago',
+		dateTime: '2023-01-23T11:00',
+	},
+	{
+		user: {
+			name: 'Lindsay Walton',
+			imageUrl:
+				'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		},
+		commit: '249df660',
+		branch: 'main',
+		status: 'Completed',
+		duration: '1m 32s',
+		date: '3 hours ago',
+		dateTime: '2023-01-23T09:00',
+	},
+	{
+		user: {
+			name: 'Courtney Henry',
+			imageUrl:
+				'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		},
+		commit: '11464223',
+		branch: 'main',
+		status: 'Error',
+		duration: '1m 4s',
+		date: '12 hours ago',
+		dateTime: '2023-01-23T00:00',
+	},
+	{
+		user: {
+			name: 'Courtney Henry',
+			imageUrl:
+				'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		},
+		commit: 'dad28e95',
+		branch: 'main',
+		status: 'Completed',
+		duration: '2m 15s',
+		date: '2 days ago',
+		dateTime: '2023-01-21T13:00',
+	},
+	{
+		user: {
+			name: 'Michael Foster',
+			imageUrl:
+				'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		},
+		commit: '624bc94c',
+		branch: 'main',
+		status: 'Completed',
+		duration: '1m 12s',
+		date: '5 days ago',
+		dateTime: '2023-01-18T12:34',
+	},
+	{
+		user: {
+			name: 'Courtney Henry',
+			imageUrl:
+				'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		},
+		commit: 'e111f80e',
+		branch: 'main',
+		status: 'Completed',
+		duration: '1m 56s',
+		date: '1 week ago',
+		dateTime: '2023-01-16T15:54',
+	},
+	{
+		user: {
+			name: 'Michael Foster',
+			imageUrl:
+				'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		},
+		commit: '5e136005',
+		branch: 'main',
+		status: 'Completed',
+		duration: '3m 45s',
+		date: '1 week ago',
+		dateTime: '2023-01-16T11:31',
+	},
+	{
+		user: {
+			name: 'Whitney Francis',
+			imageUrl:
+				'https://images.unsplash.com/photo-1517365830460-955ce3ccd263?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		},
+		commit: '5c1fd07f',
+		branch: 'main',
+		status: 'Completed',
+		duration: '37s',
+		date: '2 weeks ago',
+		dateTime: '2023-01-09T08:45',
+	},
+];
+
+export function CondensedContent() {
+	return (
+		<div class="bg-white py-10 dark:bg-gray-900">
+			<h3 class="px-4 text-base/7 font-semibold text-text-primary sm:px-6 lg:px-8">
+				Latest activity
+			</h3>
+			<table class="mt-6 w-full text-left whitespace-nowrap">
+				<colgroup>
+					<col class="w-full sm:w-4/12" />
+					<col class="lg:w-4/12" />
+					<col class="lg:w-2/12" />
+					<col class="lg:w-1/12" />
+					<col class="lg:w-1/12" />
+				</colgroup>
+				<thead class="border-b border-surface-border text-sm/6 text-text-primary">
+					<tr>
+						<th scope="col" class="py-2 pr-8 pl-4 font-semibold sm:pl-6 lg:pl-8">
+							User
+						</th>
+						<th scope="col" class="hidden py-2 pr-8 pl-0 font-semibold sm:table-cell">
+							Commit
+						</th>
+						<th
+							scope="col"
+							class="py-2 pr-4 pl-0 text-right font-semibold sm:pr-8 sm:text-left lg:pr-20"
+						>
+							Status
+						</th>
+						<th scope="col" class="hidden py-2 pr-8 pl-0 font-semibold md:table-cell lg:pr-20">
+							Duration
+						</th>
+						<th
+							scope="col"
+							class="hidden py-2 pr-4 pl-0 text-right font-semibold sm:table-cell sm:pr-6 lg:pr-8"
+						>
+							Deployed at
+						</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-surface-border">
+					{activityItems.map((item) => (
+						<tr key={item.commit}>
+							<td class="py-4 pr-8 pl-4 sm:pl-6 lg:pl-8">
+								<div class="flex items-center gap-x-4">
+									<img alt="" src={item.user.imageUrl} class="size-8 rounded-full bg-surface-1" />
+									<div class="truncate text-sm/6 font-medium text-text-primary">
+										{item.user.name}
+									</div>
+								</div>
+							</td>
+							<td class="hidden py-4 pr-4 pl-0 sm:table-cell sm:pr-8">
+								<div class="flex gap-x-3">
+									<div class="font-mono text-sm/6 text-text-secondary">{item.commit}</div>
+									<div class="rounded-md bg-surface-1 px-2 py-1 text-xs font-medium text-text-secondary outline-1 outline-surface-border">
+										{item.branch}
+									</div>
+								</div>
+							</td>
+							<td class="py-4 pr-4 pl-0 text-sm/6 sm:pr-8 lg:pr-20">
+								<div class="flex items-center justify-end gap-x-2 sm:justify-start">
+									<time dateTime={item.dateTime} class="text-text-secondary sm:hidden">
+										{item.date}
+									</time>
+									{item.status === 'Completed' ? (
+										<div class="flex-none rounded-full bg-green-500/10 p-1 text-green-500">
+											<div class="size-1.5 rounded-full bg-current" />
+										</div>
+									) : null}
+									{item.status === 'Error' ? (
+										<div class="flex-none rounded-full bg-red-500/10 p-1 text-red-500">
+											<div class="size-1.5 rounded-full bg-current" />
+										</div>
+									) : null}
+									<div class="hidden text-text-primary sm:block">{item.status}</div>
+								</div>
+							</td>
+							<td class="hidden py-4 pr-8 pl-0 text-sm/6 text-text-secondary md:table-cell lg:pr-20">
+								{item.duration}
+							</td>
+							<td class="hidden py-4 pr-4 pl-0 text-right text-sm/6 text-text-secondary sm:table-cell sm:pr-6 lg:pr-8">
+								<time dateTime={item.dateTime}>{item.date}</time>
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+// ============================================================
+// 13 - With Sortable Headings
+// ============================================================
+const ChevronDownIcon = () => (
+	<svg class="size-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+		<path
+			fill-rule="evenodd"
+			d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+);
+
+export function SortableHeadings() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<table class="relative min-w-full divide-y divide-surface-border">
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-0"
+									>
+										<a href="#" class="group inline-flex">
+											Name
+											<span class="invisible ml-2 flex-none rounded-sm text-text-tertiary group-hover:visible group-focus:visible">
+												<ChevronDownIcon />
+											</span>
+										</a>
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										<a href="#" class="group inline-flex">
+											Title
+											<span class="ml-2 flex-none rounded-sm bg-surface-1 text-text-primary group-hover:bg-surface-2">
+												<ChevronDownIcon />
+											</span>
+										</a>
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										<a href="#" class="group inline-flex">
+											Email
+											<span class="invisible ml-2 flex-none rounded-sm text-text-tertiary group-hover:visible group-focus:visible">
+												<ChevronDownIcon />
+											</span>
+										</a>
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										<a href="#" class="group inline-flex">
+											Role
+											<span class="invisible ml-2 flex-none rounded-sm text-text-tertiary group-hover:visible group-focus:visible">
+												<ChevronDownIcon />
+											</span>
+										</a>
+									</th>
+									<th scope="col" class="py-3.5 pr-0 pl-3">
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+								{people1.map((person) => (
+									<tr key={person.email}>
+										<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-0">
+											{person.name}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.title}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.email}
+										</td>
+										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.role}
+										</td>
+										<td class="py-4 pr-4 pl-3 text-right text-sm whitespace-nowrap sm:pr-0">
+											<a href="#" class="text-accent-500 hover:text-accent-400">
+												Edit<span class="sr-only">, {person.name}</span>
+											</a>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 14 - With Grouped Rows
+// ============================================================
+const locations = [
+	{
+		name: 'Edinburgh',
+		people: [
+			{
+				name: 'Lindsay Walton',
+				title: 'Front-end Developer',
+				email: 'lindsay.walton@example.com',
+				role: 'Member',
+			},
+			{
+				name: 'Courtney Henry',
+				title: 'Designer',
+				email: 'courtney.henry@example.com',
+				role: 'Admin',
+			},
+		],
+	},
+	{
+		name: 'London',
+		people: [
+			{
+				name: 'Tom Cook',
+				title: 'Director of Product',
+				email: 'tom.cook@example.com',
+				role: 'Member',
+			},
+			{
+				name: 'Whitney Francis',
+				title: 'Copywriter',
+				email: 'whitney.francis@example.com',
+				role: 'Admin',
+			},
+			{
+				name: 'Leonard Krasner',
+				title: 'Senior Designer',
+				email: 'leonard.krasner@example.com',
+				role: 'Owner',
+			},
+			{
+				name: 'Floyd Miles',
+				title: 'Principal Designer',
+				email: 'floyd.miles@example.com',
+				role: 'Member',
+			},
+		],
+	},
+	{
+		name: 'Leeds',
+		people: [
+			{
+				name: 'Emily Selman',
+				title: 'VP, User Experience',
+				email: 'emily.selman@example.com',
+				role: 'Member',
+			},
+			{
+				name: 'Kristin Watson',
+				title: 'VP, Human Resources',
+				email: 'kristin.watson@example.com',
+				role: 'Admin',
+			},
+			{
+				name: 'Emma Dorsey',
+				title: 'Senior Developer',
+				email: 'emma.dorsey@example.com',
+				role: 'Member',
+			},
+		],
+	},
+];
+
+export function GroupedRows() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<table class="relative min-w-full">
+							<thead class="bg-white dark:bg-gray-900">
+								<tr>
+									<th
+										scope="col"
+										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-3"
+									>
+										Name
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Title
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Email
+									</th>
+									<th
+										scope="col"
+										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Role
+									</th>
+									<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-3">
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody class="bg-white dark:bg-gray-900">
+								{locations.map((location) => (
+									<tbody key={location.name}>
+										<tr class="border-t border-surface-border">
+											<th
+												scope="colgroup"
+												colSpan={5}
+												class="bg-surface-0 py-2 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-3"
+											>
+												{location.name}
+											</th>
+										</tr>
+										{location.people.map((person, personIdx) => (
+											<tr
+												key={person.email}
+												class={classNames(
+													personIdx === 0 ? 'border-surface-border' : 'border-surface-border',
+													'border-t'
+												)}
+											>
+												<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-3">
+													{person.name}
+												</td>
+												<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+													{person.title}
+												</td>
+												<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+													{person.email}
+												</td>
+												<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+													{person.role}
+												</td>
+												<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-3">
+													<a href="#" class="text-accent-500 hover:text-accent-400">
+														Edit<span class="sr-only">, {person.name}</span>
+													</a>
+												</td>
+											</tr>
+										))}
+									</tbody>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 15 - With Summary Rows
+// ============================================================
+const days = [
+	{
+		date: 'Today',
+		dateTime: '2023-03-22',
+		transactions: [
+			{
+				id: 1,
+				invoiceNumber: '00012',
+				href: '#',
+				amount: '$7,600.00 USD',
+				tax: '$500.00',
+				status: 'Paid',
+				client: 'Reform',
+				description: 'Website redesign',
+			},
+			{
+				id: 2,
+				invoiceNumber: '00011',
+				href: '#',
+				amount: '$10,000.00 USD',
+				status: 'Withdraw',
+				client: 'Tom Cook',
+				description: 'Salary',
+			},
+			{
+				id: 3,
+				invoiceNumber: '00009',
+				href: '#',
+				amount: '$2,000.00 USD',
+				tax: '$130.00',
+				status: 'Overdue',
+				client: 'Tuple',
+				description: 'Logo design',
+			},
+		],
+	},
+	{
+		date: 'Yesterday',
+		dateTime: '2023-03-21',
+		transactions: [
+			{
+				id: 4,
+				invoiceNumber: '00010',
+				href: '#',
+				amount: '$14,000.00 USD',
+				tax: '$900.00',
+				status: 'Paid',
+				client: 'SavvyCal',
+				description: 'Website redesign',
+			},
+		],
+	},
+];
+
+const ArrowUpCircleIcon = () => (
+	<svg
+		class="hidden h-6 w-5 flex-none text-text-tertiary sm:block"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+	>
+		<circle cx="10" cy="10" r="10" />
+		<path
+			fill-rule="evenodd"
+			d="M8.75 9a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5a.75.75 0 0 1 .75-.75Zm3.5 1.5a.75.75 0 0 1-1.5 0V9.707l-1.146 1.147a.75.75 0 0 1-1.06-1.06l2.5-2.5a.75.75 0 0 1 1.06 0l2.5 2.5a.75.75 0 0 1-1.06 1.06L13.707 9H14Z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+);
+
+const ArrowDownCircleIcon = () => (
+	<svg
+		class="hidden h-6 w-5 flex-none text-text-tertiary sm:block"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+	>
+		<circle cx="10" cy="10" r="10" />
+		<path
+			fill-rule="evenodd"
+			d="M8.75 11a.75.75 0 0 1 .75-.75h3.5a.75.75 0 0 1 0 1.5h-3.5a.75.75 0 0 1-.75-.75ZM10 8.25a.75.75 0 0 0-.75.75v3.5a.75.75 0 0 0 1.5 0v-3.5A.75.75 0 0 0 10 8.25Z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+);
+
+const ArrowPathIcon = () => (
+	<svg
+		class="hidden h-6 w-5 flex-none text-text-tertiary sm:block"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+	>
+		<path
+			fill-rule="evenodd"
+			d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H3.989a.75.75 0 0 0-.75.75v4.242a.75.75 0 0 0 1.5 0v-2.43l.31.31a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39Zm1.23-3.723a.75.75 0 0 0 .219-.53V2.929a.75.75 0 0 0-1.5 0V5.36l-.31-.31A7 7 0 0 0 3.239 8.188a.75.75 0 1 0 1.448.389A5.5 5.5 0 0 1 13.89 6.11l.311.31h-2.432a.75.75 0 0 0 0 1.5h4.243a.75.75 0 0 0 .53-.219Z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+);
+
+export function SummaryRows() {
+	return (
+		<div>
+			<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+				<h3 class="mx-auto max-w-2xl text-base font-semibold text-text-primary lg:mx-0 lg:max-w-none">
+					Recent activity
+				</h3>
+			</div>
+			<div class="mt-6 overflow-hidden border-t border-surface-border">
+				<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+					<div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
+						<table class="w-full text-left">
+							<thead class="sr-only">
+								<tr>
+									<th>Amount</th>
+									<th class="hidden sm:table-cell">Client</th>
+									<th>More details</th>
+								</tr>
+							</thead>
+							<tbody>
+								{days.map((day) => (
+									<tbody key={day.dateTime}>
+										<tr class="text-sm/6 text-text-primary">
+											<th scope="colgroup" colSpan={3} class="relative isolate py-2 font-semibold">
+												<time dateTime={day.dateTime}>{day.date}</time>
+												<div class="absolute inset-y-0 right-full -z-10 w-screen border-b border-surface-border bg-surface-0" />
+												<div class="absolute inset-y-0 left-0 -z-10 w-screen border-b border-surface-border bg-surface-0" />
+											</th>
+										</tr>
+										{day.transactions.map((transaction) => (
+											<tr key={transaction.id}>
+												<td class="relative py-5 pr-6">
+													<div class="flex gap-x-6">
+														{transaction.status === 'Paid' ? (
+															<ArrowUpCircleIcon />
+														) : transaction.status === 'Withdraw' ? (
+															<ArrowDownCircleIcon />
+														) : (
+															<ArrowPathIcon />
+														)}
+														<div class="flex-auto">
+															<div class="flex items-start gap-x-3">
+																<div class="text-sm/6 font-medium text-text-primary">
+																	{transaction.amount}
+																</div>
+																{transaction.status === 'Paid' ? (
+																	<div class="rounded-md bg-green-500/10 px-2 py-1 text-xs font-medium text-green-500 ring-1 ring-green-500/20">
+																		{transaction.status}
+																	</div>
+																) : null}
+																{transaction.status === 'Withdraw' ? (
+																	<div class="rounded-md bg-surface-1 px-2 py-1 text-xs font-medium text-text-secondary ring-1 ring-surface-border">
+																		{transaction.status}
+																	</div>
+																) : null}
+																{transaction.status === 'Overdue' ? (
+																	<div class="rounded-md bg-red-500/10 px-2 py-1 text-xs font-medium text-red-500 ring-1 ring-red-500/20">
+																		{transaction.status}
+																	</div>
+																) : null}
+															</div>
+															{transaction.tax ? (
+																<div class="mt-1 text-xs/5 text-text-secondary">
+																	{transaction.tax} tax
+																</div>
+															) : null}
+														</div>
+													</div>
+													<div class="absolute right-full bottom-0 h-px w-screen bg-surface-1" />
+													<div class="absolute bottom-0 left-0 h-px w-screen bg-surface-1" />
+												</td>
+												<td class="hidden py-5 pr-6 sm:table-cell">
+													<div class="text-sm/6 text-text-primary">{transaction.client}</div>
+													<div class="mt-1 text-xs/5 text-text-secondary">
+														{transaction.description}
+													</div>
+												</td>
+												<td class="py-5 text-right">
+													<div class="flex justify-end">
+														<a
+															href={transaction.href}
+															class="text-sm/6 font-medium text-accent-500 hover:text-accent-400"
+														>
+															View<span class="hidden sm:inline"> transaction</span>
+															<span class="sr-only">
+																, invoice #{transaction.invoiceNumber}, {transaction.client}
+															</span>
+														</a>
+													</div>
+													<div class="mt-1 text-xs/5 text-text-secondary">
+														Invoice{' '}
+														<span class="text-text-primary">#{transaction.invoiceNumber}</span>
+													</div>
+												</td>
+											</tr>
+										))}
+									</tbody>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 17 - With Checkboxes
+// ============================================================
+
+const people17 = [
+	{
+		name: 'Lindsay Walton',
+		title: 'Front-end Developer',
+		email: 'lindsay.walton@example.com',
+		role: 'Member',
+	},
+	{ name: 'Courtney Henry', title: 'Designer', email: 'courtney.henry@example.com', role: 'Admin' },
+	{ name: 'Tom Cook', title: 'Director of Product', email: 'tom.cook@example.com', role: 'Member' },
+	{
+		name: 'Whitney Francis',
+		title: 'Copywriter',
+		email: 'whitney.francis@example.com',
+		role: 'Admin',
+	},
+	{
+		name: 'Leonard Krasner',
+		title: 'Senior Designer',
+		email: 'leonard.krasner@example.com',
+		role: 'Owner',
+	},
+	{
+		name: 'Floyd Miles',
+		title: 'Principal Designer',
+		email: 'floyd.miles@example.com',
+		role: 'Member',
+	},
+];
+
+export function WithCheckboxes() {
+	const checkbox = useRef<HTMLInputElement | null>(null);
+	const [checked, setChecked] = useState(false);
+	const [indeterminate, setIndeterminate] = useState(false);
+	const [selectedPeople, setSelectedPeople] = useState<typeof people17>([]);
+
+	useLayoutEffect(() => {
+		const isIndeterminate = selectedPeople.length > 0 && selectedPeople.length < people17.length;
+		setChecked(selectedPeople.length === people17.length);
+		setIndeterminate(isIndeterminate);
+		if (checkbox.current) {
+			checkbox.current.indeterminate = isIndeterminate;
+		}
+	}, [selectedPeople]);
+
+	function toggleAll() {
+		setSelectedPeople(checked || indeterminate ? [] : [...people17]);
+		setChecked(!checked && !indeterminate);
+		setIndeterminate(false);
+	}
+
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-1.5 text-center text-sm/6 font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<div class="group/table relative">
+							<div class="absolute top-0 left-14 z-10 hidden h-12 items-center space-x-3 bg-white group-has-checked/table:flex sm:left-12 dark:bg-gray-900">
+								<button
+									type="button"
+									class="inline-flex items-center rounded-sm bg-white px-2 py-1 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-0 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-white dark:bg-white/10 dark:text-white dark:ring-white/10 dark:hover:bg-white/15 dark:disabled:hover:bg-white/10"
+								>
+									Bulk edit
+								</button>
+								<button
+									type="button"
+									class="inline-flex items-center rounded-sm bg-white px-2 py-1 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-0 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-white dark:bg-white/10 dark:text-white dark:ring-white/10 dark:hover:bg-white/15 dark:disabled:hover:bg-white/10"
+								>
+									Delete all
+								</button>
+							</div>
+							<table class="relative min-w-full table-fixed divide-y divide-surface-border">
+								<thead>
+									<tr>
+										<th scope="col" class="relative px-7 sm:w-12 sm:px-6">
+											<div class="group absolute top-1/2 left-4 -mt-2 grid size-4 grid-cols-1">
+												<input
+													type="checkbox"
+													class="col-start-1 row-start-1 appearance-none rounded-sm border border-surface-border bg-white checked:border-accent-500 checked:bg-accent-500 indeterminate:border-accent-500 indeterminate:bg-accent-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 disabled:border-surface-border disabled:bg-surface-1 disabled:checked:bg-surface-1 dark:border-white/20 dark:bg-gray-800/50 dark:checked:border-accent-500 dark:checked:bg-accent-500 dark:indeterminate:border-accent-500 dark:indeterminate:bg-accent-500 dark:focus-visible:outline-accent-500 dark:disabled:border-white/10 dark:disabled:bg-gray-800 dark:disabled:checked:bg-gray-800 forced-colors:appearance-auto"
+													ref={checkbox}
+													checked={checked}
+													onChange={toggleAll}
+												/>
+												<svg
+													class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-text-muted/25 dark:group-has-disabled:stroke-white/25"
+													viewBox="0 0 14 14"
+													fill="none"
+												>
+													<path
+														class="opacity-0 group-has-checked:opacity-100"
+														d="M3 8L6 11L11 3.5"
+														stroke-width="2"
+														stroke-linecap="round"
+														stroke-linejoin="round"
+													/>
+													<path
+														class="opacity-0 group-has-indeterminate:opacity-100"
+														d="M3 7H11"
+														stroke-width="2"
+														stroke-linecap="round"
+														stroke-linejoin="round"
+													/>
+												</svg>
+											</div>
+										</th>
+										<th
+											scope="col"
+											class="min-w-48 py-3.5 pr-3 text-left text-sm font-semibold text-text-primary"
+										>
+											Name
+										</th>
+										<th
+											scope="col"
+											class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+										>
+											Title
+										</th>
+										<th
+											scope="col"
+											class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+										>
+											Email
+										</th>
+										<th
+											scope="col"
+											class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
+										>
+											Role
+										</th>
+										<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-3">
+											<span class="sr-only">Edit</span>
+										</th>
+									</tr>
+								</thead>
+								<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+									{people17.map((person) => (
+										<tr
+											key={person.email}
+											class="group has-checked:bg-surface-0 dark:has-checked:bg-gray-800/50"
+										>
+											<td class="relative px-7 sm:w-12 sm:px-6">
+												<div class="absolute inset-y-0 left-0 hidden w-0.5 bg-accent-500 group-has-checked:block" />
+
+												<div class="absolute top-1/2 left-4 -mt-2 grid size-4 grid-cols-1">
+													<input
+														type="checkbox"
+														class="col-start-1 row-start-1 appearance-none rounded-sm border border-surface-border bg-white checked:border-accent-500 checked:bg-accent-500 indeterminate:border-accent-500 indeterminate:bg-accent-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 disabled:border-surface-border disabled:bg-surface-1 disabled:checked:bg-surface-1 dark:border-white/20 dark:bg-gray-800/50 dark:checked:border-accent-500 dark:checked:bg-accent-500 dark:indeterminate:border-accent-500 dark:indeterminate:bg-accent-500 dark:focus-visible:outline-accent-500 dark:disabled:border-white/10 dark:disabled:bg-gray-800 dark:disabled:checked:bg-gray-800 forced-colors:appearance-auto"
+														value={person.email}
+														checked={selectedPeople.includes(person)}
+														onChange={(e) =>
+															setSelectedPeople(
+																(e.target as HTMLInputElement).checked
+																	? [...selectedPeople, person]
+																	: selectedPeople.filter((p) => p !== person)
+															)
+														}
+													/>
+													<svg
+														class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-text-muted/25 dark:group-has-disabled:stroke-white/25"
+														viewBox="0 0 14 14"
+														fill="none"
+													>
+														<path
+															class="opacity-0 group-has-checked:opacity-100"
+															d="M3 8L6 11L11 3.5"
+															stroke-width="2"
+															stroke-linecap="round"
+															stroke-linejoin="round"
+														/>
+														<path
+															class="opacity-0 group-has-indeterminate:opacity-100"
+															d="M3 7H11"
+															stroke-width="2"
+															stroke-linecap="round"
+															stroke-linejoin="round"
+														/>
+													</svg>
+												</div>
+											</td>
+											<td class="py-4 pr-3 text-sm font-medium whitespace-nowrap text-text-primary group-has-checked:text-accent-500 dark:group-has-checked:text-accent-400">
+												{person.name}
+											</td>
+											<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+												{person.title}
+											</td>
+											<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+												{person.email}
+											</td>
+											<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+												{person.role}
+											</td>
+											<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-3">
+												<a href="#" class="text-accent-500 hover:text-accent-400">
+													Edit<span class="sr-only">, {person.name}</span>
+												</a>
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 18 - With Hidden Headings
+// ============================================================
+const transactions = [
+	{
+		id: 'AAPS0L',
+		company: 'Chase & Co.',
+		share: 'CAC',
+		commission: '+$4.37',
+		price: '$3,509.00',
+		quantity: '12.00',
+		netAmount: '$4,397.00',
+	},
+	{
+		id: 'O2KMND',
+		company: 'Amazon.com Inc.',
+		share: 'AMZN',
+		commission: '+$5.92',
+		price: '$2,900.00',
+		quantity: '8.80',
+		netAmount: '$3,509.00',
+	},
+	{
+		id: '1LP2P4',
+		company: 'Procter & Gamble',
+		share: 'PG',
+		commission: '-$5.65',
+		price: '$7,978.00',
+		quantity: '2.30',
+		netAmount: '$2,652.00',
+	},
+	{
+		id: 'PS9FJGL',
+		company: 'Berkshire Hathaway',
+		share: 'BRK',
+		commission: '+$4.37',
+		price: '$3,116.00',
+		quantity: '48.00',
+		netAmount: '$6,055.00',
+	},
+	{
+		id: 'QYR135',
+		company: 'Apple Inc.',
+		share: 'AAPL',
+		commission: '+$38.00',
+		price: '$8,508.00',
+		quantity: '36.00',
+		netAmount: '$3,496.00',
+	},
+	{
+		id: '99SLSM',
+		company: 'NVIDIA Corporation',
+		share: 'NVDA',
+		commission: '+$1,427.00',
+		price: '$4,425.00',
+		quantity: '18.00',
+		netAmount: '$2,109.00',
+	},
+	{
+		id: 'OSDJLS',
+		company: 'Johnson & Johnson',
+		share: 'JNJ',
+		commission: '+$1,937.23',
+		price: '$4,038.00',
+		quantity: '32.00',
+		netAmount: '$7,210.00',
+	},
+	{
+		id: '4HJK3N',
+		company: 'JPMorgan',
+		share: 'JPM',
+		commission: '-$3.67',
+		price: '$3,966.00',
+		quantity: '80.00',
+		netAmount: '$6,432.00',
+	},
+];
+
+export function HiddenHeadings() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Transactions</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A table of placeholder stock market data that does not make any sense.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Export
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<table class="relative min-w-full divide-y divide-surface-border">
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold whitespace-nowrap text-text-primary sm:pl-0"
+									>
+										Transaction ID
+									</th>
+									<th
+										scope="col"
+										class="px-2 py-3.5 text-left text-sm font-semibold whitespace-nowrap text-text-primary"
+									>
+										Company
+									</th>
+									<th
+										scope="col"
+										class="px-2 py-3.5 text-left text-sm font-semibold whitespace-nowrap text-text-primary"
+									>
+										Share
+									</th>
+									<th
+										scope="col"
+										class="px-2 py-3.5 text-left text-sm font-semibold whitespace-nowrap text-text-primary"
+									>
+										Commission
+									</th>
+									<th
+										scope="col"
+										class="px-2 py-3.5 text-left text-sm font-semibold whitespace-nowrap text-text-primary"
+									>
+										Price
+									</th>
+									<th
+										scope="col"
+										class="px-2 py-3.5 text-left text-sm font-semibold whitespace-nowrap text-text-primary"
+									>
+										Quantity
+									</th>
+									<th
+										scope="col"
+										class="px-2 py-3.5 text-left text-sm font-semibold whitespace-nowrap text-text-primary"
+									>
+										Net amount
+									</th>
+									<th scope="col" class="py-3.5 pr-4 pl-3 whitespace-nowrap sm:pr-0">
+										<span class="sr-only">Edit</span>
+									</th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+								{transactions.map((transaction) => (
+									<tr key={transaction.id}>
+										<td class="py-2 pr-3 pl-4 text-sm whitespace-nowrap text-text-secondary sm:pl-0">
+											{transaction.id}
+										</td>
+										<td class="px-2 py-2 text-sm font-medium whitespace-nowrap text-text-primary">
+											{transaction.company}
+										</td>
+										<td class="px-2 py-2 text-sm whitespace-nowrap text-text-primary">
+											{transaction.share}
+										</td>
+										<td class="px-2 py-2 text-sm whitespace-nowrap text-text-secondary">
+											{transaction.commission}
+										</td>
+										<td class="px-2 py-2 text-sm whitespace-nowrap text-text-secondary">
+											{transaction.price}
+										</td>
+										<td class="px-2 py-2 text-sm whitespace-nowrap text-text-secondary">
+											{transaction.quantity}
+										</td>
+										<td class="px-2 py-2 text-sm whitespace-nowrap text-text-secondary">
+											{transaction.netAmount}
+										</td>
+										<td class="py-2 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-0">
+											<a href="#" class="text-accent-500 hover:text-accent-400">
+												Edit<span class="sr-only">, {transaction.id}</span>
+											</a>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// 19 - Full Width with Avatars
+// ============================================================
+export function FullWidthAvatars() {
+	return (
+		<div class="px-4 sm:px-6 lg:px-8">
+			<div class="sm:flex sm:items-center">
+				<div class="sm:flex-auto">
+					<h3 class="text-base font-semibold text-text-primary">Users</h3>
+					<p class="mt-2 text-sm text-text-secondary">
+						A list of all the users in your account including their name, title, email and role.
+					</p>
+				</div>
+				<div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+					<button
+						type="button"
+						class="block rounded-md bg-accent-500 px-3 py-2 text-center text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+					>
+						Add user
+					</button>
+				</div>
+			</div>
+			<div class="mt-8 flow-root">
+				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+						<table class="min-w-full divide-y divide-surface-border">
+							<thead>
+								<tr class="divide-x divide-surface-border">
+									<th
+										scope="col"
+										class="py-3.5 pr-4 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-0"
+									>
+										Name
+									</th>
+									<th
+										scope="col"
+										class="px-4 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Title
+									</th>
+									<th
+										scope="col"
+										class="px-4 py-3.5 text-left text-sm font-semibold text-text-primary"
+									>
+										Email
+									</th>
+									<th
+										scope="col"
+										class="py-3.5 pr-4 pl-4 text-left text-sm font-semibold text-text-primary sm:pr-0"
+									>
+										Role
+									</th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
+								{people1.map((person) => (
+									<tr key={person.email} class="divide-x divide-surface-border">
+										<td class="py-4 pr-4 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-0">
+											{person.name}
+										</td>
+										<td class="p-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.title}
+										</td>
+										<td class="p-4 text-sm whitespace-nowrap text-text-secondary">
+											{person.email}
+										</td>
+										<td class="py-4 pr-4 pl-4 text-sm whitespace-nowrap text-text-secondary sm:pr-0">
+											{person.role}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ============================================================
+// TablesDemo - Main wrapper
+// ============================================================
+export function TablesDemo() {
+	return (
+		<div class="space-y-12">
+			<SimpleTable />
+			<SimpleInCard />
+			<FullWidthTable />
+			<FullWidthConstrained />
+			<StripedRows />
+			<UppercaseHeadings />
+			<StackedColumnsMobile />
+			<HiddenColumnsMobile />
+			<AvatarsMultiline />
+			<StickyHeader />
+			<VerticalLines />
+			<CondensedContent />
+			<SortableHeadings />
+			<GroupedRows />
+			<SummaryRows />
+			<WithCheckboxes />
+			<HiddenHeadings />
+			<FullWidthAvatars />
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/TablesDemo.tsx
+++ b/packages/ui/demo/sections/TablesDemo.tsx
@@ -1,8 +1,5 @@
 import { useState, useRef, useLayoutEffect } from 'preact/hooks';
-
-function classNames(...classes: string[]) {
-	return classes.filter(Boolean).join(' ');
-}
+import { classNames } from '../../src/internal/class-names.ts';
 
 // ============================================================
 // 01 - Simple Table
@@ -269,8 +266,8 @@ export function FullWidthTable() {
 								</tr>
 							</thead>
 							<tbody class="bg-white dark:bg-gray-900">
-								{people1.map((person, idx) => (
-									<tr key={person.email} class={idx % 2 === 1 ? 'even:bg-surface-0' : ''}>
+								{people1.map((person) => (
+									<tr key={person.email} class="even:bg-surface-0">
 										<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-3">
 											{person.name}
 										</td>
@@ -767,7 +764,7 @@ export function HiddenColumnsMobile() {
 										</th>
 									</tr>
 								</thead>
-								<tbody class="divide-y divide-surface-border bg-white">
+								<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
 									{people1.map((person) => (
 										<tr key={person.email}>
 											<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-6">
@@ -823,13 +820,13 @@ export function AvatarsMultiline() {
 			</div>
 			<div class="mt-8 flow-root">
 				<div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-					<div class="inline-block min-w-full py-2 align-middle">
+					<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
 						<table class="relative min-w-full divide-y divide-surface-border">
 							<thead>
 								<tr>
 									<th
 										scope="col"
-										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-6 lg:pl-8"
+										class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-text-primary sm:pl-0"
 									>
 										Name
 									</th>
@@ -843,7 +840,7 @@ export function AvatarsMultiline() {
 										scope="col"
 										class="px-3 py-3.5 text-left text-sm font-semibold text-text-primary"
 									>
-										Email
+										Status
 									</th>
 									<th
 										scope="col"
@@ -851,27 +848,42 @@ export function AvatarsMultiline() {
 									>
 										Role
 									</th>
-									<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-6 lg:pr-8">
+									<th scope="col" class="py-3.5 pr-4 pl-3 sm:pr-0">
 										<span class="sr-only">Edit</span>
 									</th>
 								</tr>
 							</thead>
 							<tbody class="divide-y divide-surface-border bg-white dark:bg-gray-900">
-								{people1.map((person) => (
+								{peopleWithAvatars.map((person) => (
 									<tr key={person.email}>
-										<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-6 lg:pl-8">
-											{person.name}
+										<td class="py-5 pr-3 pl-4 text-sm whitespace-nowrap sm:pl-0">
+											<div class="flex items-center">
+												<div class="size-11 shrink-0">
+													<img
+														alt=""
+														src={person.image}
+														class="size-11 rounded-full dark:outline dark:outline-white/10"
+													/>
+												</div>
+												<div class="ml-4">
+													<div class="font-medium text-text-primary">{person.name}</div>
+													<div class="mt-1 text-text-secondary">{person.email}</div>
+												</div>
+											</div>
 										</td>
-										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
-											{person.title}
+										<td class="px-3 py-5 text-sm whitespace-nowrap text-text-secondary">
+											<div class="text-text-primary">{person.title}</div>
+											<div class="mt-1 text-text-secondary">{person.department}</div>
 										</td>
-										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
-											{person.email}
+										<td class="px-3 py-5 text-sm whitespace-nowrap text-text-secondary">
+											<span class="inline-flex items-center rounded-md bg-green-500/10 px-2 py-1 text-xs font-medium text-green-400 ring-1 ring-green-500/20 ring-inset">
+												Active
+											</span>
 										</td>
-										<td class="px-3 py-4 text-sm whitespace-nowrap text-text-secondary">
+										<td class="px-3 py-5 text-sm whitespace-nowrap text-text-secondary">
 											{person.role}
 										</td>
-										<td class="py-4 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-6 lg:pr-8">
+										<td class="py-5 pr-4 pl-3 text-right text-sm font-medium whitespace-nowrap sm:pr-0">
 											<a href="#" class="text-accent-500 hover:text-accent-400">
 												Edit<span class="sr-only">, {person.name}</span>
 											</a>
@@ -1720,13 +1732,10 @@ export function GroupedRows() {
 												{location.name}
 											</th>
 										</tr>
-										{location.people.map((person, personIdx) => (
+										{location.people.map((person) => (
 											<tr
 												key={person.email}
-												class={classNames(
-													personIdx === 0 ? 'border-surface-border' : 'border-surface-border',
-													'border-t'
-												)}
+												class={classNames('border-surface-border', 'border-t')}
 											>
 												<td class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-text-primary sm:pl-3">
 													{person.name}

--- a/packages/ui/demo/sections/VerticalNavigationDemo.tsx
+++ b/packages/ui/demo/sections/VerticalNavigationDemo.tsx
@@ -1,6 +1,4 @@
-function classNames(...classes: (string | boolean | undefined | null)[]) {
-	return classes.filter(Boolean).join(' ');
-}
+import { classNames } from '../../src/internal/class-names.ts';
 
 const simpleNavigation = [
 	{ name: 'Dashboard', href: '#', current: true },

--- a/packages/ui/demo/sections/VerticalNavigationDemo.tsx
+++ b/packages/ui/demo/sections/VerticalNavigationDemo.tsx
@@ -1,0 +1,92 @@
+function classNames(...classes: (string | boolean | undefined | null)[]) {
+	return classes.filter(Boolean).join(' ');
+}
+
+const simpleNavigation = [
+	{ name: 'Dashboard', href: '#', current: true },
+	{ name: 'Team', href: '#', current: false },
+	{ name: 'Projects', href: '#', current: false },
+	{ name: 'Calendar', href: '#', current: false },
+	{ name: 'Documents', href: '#', current: false },
+	{ name: 'Reports', href: '#', current: false },
+];
+
+const badgeNavigation = [
+	{ name: 'Dashboard', href: '#', count: '5', current: true },
+	{ name: 'Team', href: '#', current: false },
+	{ name: 'Projects', href: '#', count: '12', current: false },
+	{ name: 'Calendar', href: '#', count: '20+', current: false },
+	{ name: 'Documents', href: '#', current: false },
+	{ name: 'Reports', href: '#', current: false },
+];
+
+export function SimpleVerticalNavigation() {
+	return (
+		<nav aria-label="Sidebar" class="flex flex-1 flex-col">
+			<ul role="list" class="-mx-2 space-y-1">
+				{simpleNavigation.map((item) => (
+					<li key={item.name}>
+						<a
+							href={item.href}
+							class={classNames(
+								item.current
+									? 'bg-surface-0 text-accent-500 dark:bg-white/5 dark:text-white'
+									: 'text-text-secondary hover:bg-surface-0 hover:text-accent-500 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+								'group flex gap-x-3 rounded-md p-2 pl-3 text-sm/6 font-semibold'
+							)}
+						>
+							{item.name}
+						</a>
+					</li>
+				))}
+			</ul>
+		</nav>
+	);
+}
+
+export function BadgeVerticalNavigation() {
+	return (
+		<nav aria-label="Sidebar" class="flex flex-1 flex-col">
+			<ul role="list" class="-mx-2 space-y-1">
+				{badgeNavigation.map((item) => (
+					<li key={item.name}>
+						<a
+							href={item.href}
+							class={classNames(
+								item.current
+									? 'bg-surface-0 text-accent-500 dark:bg-white/5 dark:text-white'
+									: 'text-text-secondary hover:bg-surface-0 hover:text-accent-500 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+								'group flex gap-x-3 rounded-md p-2 pl-3 text-sm/6 font-semibold'
+							)}
+						>
+							{item.name}
+							{item.count ? (
+								<span
+									aria-hidden="true"
+									class="ml-auto w-9 min-w-max rounded-full bg-white px-2.5 py-0.5 text-center text-xs/5 font-medium whitespace-nowrap text-text-secondary outline-1 -outline-offset-1 outline-surface-border dark:bg-surface-1 dark:text-text-tertiary dark:outline-white/10"
+								>
+									{item.count}
+								</span>
+							) : null}
+						</a>
+					</li>
+				))}
+			</ul>
+		</nav>
+	);
+}
+
+export function VerticalNavigationDemo() {
+	return (
+		<div class="flex flex-col gap-8">
+			<div>
+				<h3 class="text-sm font-medium text-text-secondary mb-3">Simple</h3>
+				<SimpleVerticalNavigation />
+			</div>
+			<div>
+				<h3 class="text-sm font-medium text-text-secondary mb-3">With Badges</h3>
+				<BadgeVerticalNavigation />
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Port 35 pure HTML reference examples from Tailwind Application UI v4 across 8 new demo sections:

- **StatsDemo.tsx** (3 files): with-trending, simple, simple-in-cards
- **GridListsDemo.tsx** (2 files): contact cards variants
- **StackedListsDemo.tsx** (6 files): simple, with links, in cards, two-columns, full-width variants
- **TablesDemo.tsx** (17 files): simple, card, full-width, striped, uppercase, stacked columns, hidden columns, avatars, sticky header, vertical lines, condensed, sortable, grouped rows, summary, checkboxes, hidden headings, full-width avatars
- **PaginationDemo.tsx** (1 file): card footer with page buttons
- **ProgressBarsDemo.tsx** (3 files): simple, panels, bullets
- **VerticalNavigationDemo.tsx** (2 files): simple, with badges
- **EmptyStatesDemo.tsx** (1 file): simple empty state

## Technical Details

All examples ported with:
- Preact JSX (`class=` instead of `className=`)
- Inline SVG icons (no external icon dependencies)
- Design system color tokens
- Named exports for each demo section
- App.tsx sidebar updated with 8 new component entries

## Test Plan

- [x] Typecheck passes
- [x] Lint passes  
- [x] Format passes
- [ ] `bun run dev` starts without errors (manual verification)