### PR TITLE
feat(ui-demo): add Command Palettes and Navbars demos

### DIFF
--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -32,6 +32,8 @@ import { ProgressBarsDemo } from './sections/ProgressBarsDemo.tsx';
 import { VerticalNavigationDemo } from './sections/VerticalNavigationDemo.tsx';
 import { BreadcrumbsDemo } from './sections/BreadcrumbsDemo.tsx';
 import { SidebarNavigationDemo } from './sections/SidebarNavigationDemo.tsx';
+import { CommandPalettesDemo } from './sections/navigation/CommandPalettesDemo.tsx';
+import { NavbarsDemo } from './sections/navigation/NavbarsDemo.tsx';
 import { EmptyStatesDemo } from './sections/EmptyStatesDemo.tsx';
 import { FeedsDemo } from './sections/FeedsDemo.tsx';
 import { CalendarsDemo } from './sections/CalendarsDemo.tsx';
@@ -545,6 +547,14 @@ export function App() {
 						title="Multi-column (Application Shell)"
 					>
 						<MultiColumnDemo />
+					</DemoSection>
+
+					{/* Application UI - Navigation */}
+					<DemoSection id="navigation-command-palettes" title="Command Palettes (Navigation)">
+						<CommandPalettesDemo />
+					</DemoSection>
+					<DemoSection id="navigation-navbars" title="Navbars (Navigation)">
+						<NavbarsDemo />
 					</DemoSection>
 
 					{/* Application UI - Data Display */}

--- a/packages/ui/demo/sections/SidebarNavigationDemo.tsx
+++ b/packages/ui/demo/sections/SidebarNavigationDemo.tsx
@@ -1,4 +1,14 @@
-import { ChevronRight, Home, Users, Folder, Calendar, Copy, PieChart } from 'lucide-preact';
+import {
+	ChevronRight,
+	Home,
+	Users,
+	Folder,
+	Calendar,
+	Copy,
+	PieChart,
+	Settings,
+	Cog,
+} from 'lucide-preact';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '../../src/mod.ts';
 import { classNames } from '../../src/internal/class-names.ts';
 
@@ -322,6 +332,297 @@ export function ExpandableSectionsSidebarNavigation() {
 	);
 }
 
+export function ExpandableSectionsWithIconsSidebarNavigation() {
+	const expandableNavWithIcons = [
+		{ name: 'Dashboard', href: '#', icon: Home, current: true },
+		{
+			name: 'Teams',
+			icon: Users,
+			current: false,
+			children: [
+				{ name: 'Engineering', href: '#' },
+				{ name: 'Human Resources', href: '#' },
+				{ name: 'Customer Success', href: '#' },
+			],
+		},
+		{
+			name: 'Projects',
+			icon: Folder,
+			current: false,
+			children: [
+				{ name: 'GraphQL API', href: '#' },
+				{ name: 'iOS App', href: '#' },
+				{ name: 'Android App', href: '#' },
+				{ name: 'New Customer Portal', href: '#' },
+			],
+		},
+		{ name: 'Calendar', href: '#', icon: Calendar, current: false },
+		{ name: 'Documents', href: '#', icon: Copy, current: false },
+		{ name: 'Reports', href: '#', icon: PieChart, current: false },
+	];
+
+	return (
+		<div class="relative flex grow flex-col gap-y-5 overflow-y-auto border-r border-surface-border bg-surface-0 px-6 dark:border-white/10 dark:bg-surface-2 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+			<div class="relative flex h-16 shrink-0 items-center">
+				<img
+					alt="Your Company"
+					src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+					class="h-8 w-auto dark:hidden"
+				/>
+				<img
+					alt="Your Company"
+					src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+					class="h-8 w-auto hidden dark:block"
+				/>
+			</div>
+			<nav class="relative flex flex-1 flex-col">
+				<ul role="list" class="flex flex-1 flex-col gap-y-7">
+					<li>
+						<ul role="list" class="-mx-2 space-y-1">
+							{expandableNavWithIcons.map((item) => (
+								<li key={item.name}>
+									{!item.children ? (
+										<a
+											href={item.href}
+											class={classNames(
+												item.current
+													? 'bg-surface-1 dark:bg-white/5 dark:text-white'
+													: 'hover:bg-surface-1 dark:hover:bg-white/5 dark:hover:text-white',
+												'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold text-text-secondary dark:text-text-tertiary'
+											)}
+										>
+											<item.icon
+												aria-hidden="true"
+												class={classNames(
+													item.current
+														? 'text-accent-500 dark:text-white'
+														: 'text-text-tertiary group-hover:text-accent-500 dark:text-text-tertiary dark:group-hover:text-white',
+													'size-6 shrink-0'
+												)}
+											/>
+											{item.name}
+										</a>
+									) : (
+										<Disclosure as="div">
+											<DisclosureButton
+												class={classNames(
+													item.current
+														? 'bg-surface-1 dark:bg-white/5 dark:text-white'
+														: 'hover:bg-surface-1 dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex w-full items-center gap-x-3 rounded-md p-2 text-left text-sm/6 font-semibold text-text-secondary dark:text-text-tertiary'
+												)}
+											>
+												<item.icon
+													aria-hidden="true"
+													class={classNames(
+														item.current
+															? 'text-accent-500 dark:text-white'
+															: 'text-text-tertiary group-hover:text-accent-500 dark:text-text-tertiary dark:group-hover:text-white',
+														'size-6 shrink-0'
+													)}
+												/>
+												{item.name}
+												<ChevronRight
+													aria-hidden="true"
+													class="ml-auto size-5 shrink-0 text-text-tertiary transition-transform group-data-open:rotate-90 group-data-open:text-text-secondary dark:text-text-tertiary dark:group-data-open:text-text-tertiary"
+												/>
+											</DisclosureButton>
+											<DisclosurePanel as="ul" class="mt-1 px-2">
+												{item.children.map((subItem) => (
+													<li key={subItem.name}>
+														<DisclosureButton
+															as="a"
+															href={subItem.href}
+															class={classNames(
+																'hover:bg-surface-1 dark:hover:bg-white/5',
+																'block rounded-md py-2 pr-2 pl-9 text-sm/6 text-text-secondary dark:text-text-tertiary'
+															)}
+														>
+															{subItem.name}
+														</DisclosureButton>
+													</li>
+												))}
+											</DisclosurePanel>
+										</Disclosure>
+									)}
+								</li>
+							))}
+						</ul>
+					</li>
+					<li class="-mx-6 mt-auto">
+						<a
+							href="#"
+							class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-text-primary hover:bg-surface-1 dark:text-white dark:hover:bg-white/5"
+						>
+							<img
+								alt=""
+								src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+								class="size-8 rounded-full bg-surface-1 outline -outline-offset-1 outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+							/>
+							<span class="sr-only">Your profile</span>
+							<span aria-hidden="true">Tom Cook</span>
+						</a>
+					</li>
+				</ul>
+			</nav>
+		</div>
+	);
+}
+
+export function WithSecondaryNavigationSidebarNavigation() {
+	const navigation = [
+		{ name: 'Dashboard', href: '#', icon: Home, current: true },
+		{ name: 'Team', href: '#', icon: Users, current: false },
+		{ name: 'Projects', href: '#', icon: Folder, current: false },
+		{ name: 'Calendar', href: '#', icon: Calendar, current: false },
+	];
+	const _secondaryNavigation = [
+		{ name: 'Support', href: '#' },
+		{ name: 'License', href: '#' },
+	];
+
+	return (
+		<div class="relative flex grow flex-col gap-y-5 overflow-y-auto border-r border-surface-border bg-surface-0 px-6 dark:border-white/10 dark:bg-surface-2 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+			<div class="relative flex h-16 shrink-0 items-center">
+				<img
+					alt="Your Company"
+					src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+					class="h-8 w-auto dark:hidden"
+				/>
+				<img
+					alt="Your Company"
+					src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+					class="h-8 w-auto hidden dark:block"
+				/>
+			</div>
+			<nav class="relative flex flex-1 flex-col">
+				<ul role="list" class="flex flex-1 flex-col gap-y-7">
+					<li>
+						<ul role="list" class="-mx-2 space-y-1">
+							{navigation.map((item) => (
+								<li key={item.name}>
+									<a
+										href={item.href}
+										class={classNames(
+											item.current
+												? 'bg-surface-1 text-accent-500 dark:bg-white/5 dark:text-white'
+												: 'text-text-secondary hover:bg-surface-1 hover:text-accent-500 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+											'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+										)}
+									>
+										<item.icon
+											aria-hidden="true"
+											class={classNames(
+												item.current
+													? 'text-accent-500 dark:text-white'
+													: 'text-text-tertiary group-hover:text-accent-500 dark:text-text-tertiary dark:group-hover:text-white',
+												'size-6 shrink-0'
+											)}
+										/>
+										{item.name}
+									</a>
+								</li>
+							))}
+						</ul>
+					</li>
+					<li>
+						<div class="text-xs/6 font-semibold text-text-tertiary">Your teams</div>
+						<ul role="list" class="-mx-2 mt-2 space-y-1">
+							{teams.map((team) => (
+								<li key={team.name}>
+									<a
+										href={team.href}
+										class={classNames(
+											team.current
+												? 'bg-surface-1 text-accent-500 dark:bg-white/5 dark:text-white'
+												: 'text-text-secondary hover:bg-surface-1 hover:text-accent-500 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+											'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+										)}
+									>
+										<span
+											class={classNames(
+												team.current
+													? 'border-accent-500 text-accent-500 dark:border-white/10 dark:text-white'
+													: 'border-surface-border text-text-tertiary group-hover:border-accent-500 group-hover:text-accent-500 dark:border-white/15 dark:group-hover:border-white/20 dark:group-hover:text-white',
+												'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5'
+											)}
+										>
+											{team.initial}
+										</span>
+										<span class="truncate">{team.name}</span>
+									</a>
+								</li>
+							))}
+						</ul>
+					</li>
+					<li class="-mx-6 mt-auto">
+						<div class="space-y-1 border-t border-surface-border pt-4 dark:border-white/10">
+							<ul role="list" class="-mx-2 space-y-1">
+								<li>
+									<a
+										href="#"
+										class="group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold text-text-secondary hover:bg-surface-1 hover:text-accent-500 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white"
+									>
+										<Settings
+											aria-hidden="true"
+											class="size-6 shrink-0 text-text-tertiary group-hover:text-accent-500 dark:text-text-tertiary dark:group-hover:text-white"
+										/>
+										Settings
+									</a>
+								</li>
+								<li>
+									<a
+										href="#"
+										class="group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold text-text-secondary hover:bg-surface-1 hover:text-accent-500 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white"
+									>
+										<Cog
+											aria-hidden="true"
+											class="size-6 shrink-0 text-text-tertiary group-hover:text-accent-500 dark:text-text-tertiary dark:group-hover:text-white"
+										/>
+										Integrations
+									</a>
+								</li>
+							</ul>
+							<ul role="list" class="mt-4 space-y-1">
+								<li>
+									<a
+										href="#"
+										class="block rounded-md px-3 py-2 text-sm font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white"
+									>
+										Support
+									</a>
+								</li>
+								<li>
+									<a
+										href="#"
+										class="block rounded-md px-3 py-2 text-sm font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white"
+									>
+										License
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+					<li class="-mx-6">
+						<a
+							href="#"
+							class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-text-primary hover:bg-surface-1 dark:text-white dark:hover:bg-white/5"
+						>
+							<img
+								alt=""
+								src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+								class="size-8 rounded-full bg-surface-1 outline -outline-offset-1 outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+							/>
+							<span class="sr-only">Your profile</span>
+							<span aria-hidden="true">Tom Cook</span>
+						</a>
+					</li>
+				</ul>
+			</nav>
+		</div>
+	);
+}
+
 export function SidebarNavigationDemo() {
 	return (
 		<div class="flex flex-col gap-8">
@@ -341,6 +642,20 @@ export function SidebarNavigationDemo() {
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">With expandable sections</h3>
 				<div class="h-96 w-64 rounded-lg border border-surface-border">
 					<ExpandableSectionsSidebarNavigation />
+				</div>
+			</div>
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					With expandable sections and icons
+				</h3>
+				<div class="h-96 w-64 rounded-lg border border-surface-border">
+					<ExpandableSectionsWithIconsSidebarNavigation />
+				</div>
+			</div>
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With secondary navigation</h3>
+				<div class="h-96 w-64 rounded-lg border border-surface-border">
+					<WithSecondaryNavigationSidebarNavigation />
 				</div>
 			</div>
 		</div>

--- a/packages/ui/demo/sections/SidebarNavigationDemo.tsx
+++ b/packages/ui/demo/sections/SidebarNavigationDemo.tsx
@@ -476,10 +476,6 @@ export function WithSecondaryNavigationSidebarNavigation() {
 		{ name: 'Projects', href: '#', icon: Folder, current: false },
 		{ name: 'Calendar', href: '#', icon: Calendar, current: false },
 	];
-	const _secondaryNavigation = [
-		{ name: 'Support', href: '#' },
-		{ name: 'License', href: '#' },
-	];
 
 	return (
 		<div class="relative flex grow flex-col gap-y-5 overflow-y-auto border-r border-surface-border bg-surface-0 px-6 dark:border-white/10 dark:bg-surface-2 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">

--- a/packages/ui/demo/sections/navigation/CommandPalettesDemo.tsx
+++ b/packages/ui/demo/sections/navigation/CommandPalettesDemo.tsx
@@ -1223,7 +1223,6 @@ function WithFooterCommandPalette() {
 										<ComboboxOptions
 											as="div"
 											static
-											hold
 											class="flex transform-gpu divide-x divide-surface-border dark:divide-white/10"
 										>
 											<div

--- a/packages/ui/demo/sections/navigation/CommandPalettesDemo.tsx
+++ b/packages/ui/demo/sections/navigation/CommandPalettesDemo.tsx
@@ -1,0 +1,1399 @@
+import { useState } from 'preact/hooks';
+import {
+	Combobox,
+	ComboboxInput,
+	ComboboxOption,
+	ComboboxOptions,
+	Dialog,
+	DialogBackdrop,
+	DialogPanel,
+} from '../../../src/mod.ts';
+import { classNames } from '../../../src/internal/class-names.ts';
+import {
+	ChevronRight,
+	Columns3,
+	FilePlus,
+	Folder,
+	FolderPlus,
+	Globe,
+	Hash,
+	HelpCircle,
+	Image,
+	Link,
+	MessageSquare,
+	PencilLine,
+	Plus,
+	Search,
+	Table,
+	Tag,
+	User,
+	Users,
+	Video,
+	X,
+} from 'lucide-preact';
+
+// ============================================================================
+// DATA
+// ============================================================================
+
+interface Person {
+	id: number;
+	name: string;
+	url: string;
+}
+
+interface Project {
+	id: number;
+	name: string;
+	category: string;
+	url: string;
+}
+
+interface QuickAction {
+	name: string;
+	icon: typeof FilePlus;
+	shortcut: string;
+	url: string;
+}
+
+interface InsertItem {
+	id: number;
+	name: string;
+	description: string;
+	url: string;
+	color: string;
+	icon: typeof PencilLine;
+}
+
+interface User {
+	id: number;
+	name: string;
+	url: string;
+	imageUrl: string;
+}
+
+interface Contact {
+	id: number;
+	name: string;
+	phone: string;
+	email: string;
+	role: string;
+	url: string;
+	profileUrl: string;
+	imageUrl: string;
+}
+
+interface GroupedItem {
+	id: number;
+	name: string;
+	category: string;
+	url: string;
+}
+
+type SearchResult = Project | User;
+
+const people: Person[] = [
+	{ id: 1, name: 'Leslie Alexander', url: '#' },
+	{ id: 2, name: 'Michael Foster', url: '#' },
+	{ id: 3, name: 'Dries Vincent', url: '#' },
+	{ id: 4, name: 'Lindsay Walton', url: '#' },
+	{ id: 5, name: 'Courtney Henry', url: '#' },
+	{ id: 6, name: 'Tom Cook', url: '#' },
+	{ id: 7, name: 'Whitney Francis', url: '#' },
+	{ id: 8, name: 'Leonard Krasner', url: '#' },
+	{ id: 9, name: 'Flo Fox', url: '#' },
+	{ id: 10, name: 'Quinn Hatter', url: '#' },
+];
+
+const projects: Project[] = [
+	{ id: 1, name: 'Workflow Inc. / Website Redesign', category: 'Projects', url: '#' },
+	{ id: 2, name: 'GraphQL API Integration', category: 'Projects', url: '#' },
+	{ id: 3, name: 'iOS App Development', category: 'Projects', url: '#' },
+	{ id: 4, name: 'Customer Portal Redesign', category: 'Projects', url: '#' },
+];
+
+const recent: Project[] = [projects[0]];
+const quickActions: QuickAction[] = [
+	{ name: 'Add new file...', icon: FilePlus, shortcut: 'N', url: '#' },
+	{ name: 'Add new folder...', icon: FolderPlus, shortcut: 'F', url: '#' },
+	{ name: 'Add hashtag...', icon: Hash, shortcut: 'H', url: '#' },
+	{ name: 'Add label...', icon: Tag, shortcut: 'L', url: '#' },
+];
+
+const insertItems: InsertItem[] = [
+	{
+		id: 1,
+		name: 'Text',
+		description: 'Add freeform text with basic formatting options.',
+		url: '#',
+		color: 'bg-accent-500',
+		icon: PencilLine,
+	},
+	{
+		id: 2,
+		name: 'Image',
+		description: 'Upload or embed an image from your files.',
+		url: '#',
+		color: 'bg-pink-500',
+		icon: Image,
+	},
+	{
+		id: 3,
+		name: 'Video',
+		description: 'Embed a video from YouTube, Vimeo, or upload.',
+		url: '#',
+		color: 'bg-orange-500',
+		icon: Video,
+	},
+	{
+		id: 4,
+		name: 'Table',
+		description: 'Add a table with custom rows and columns.',
+		url: '#',
+		color: 'bg-green-500',
+		icon: Table,
+	},
+	{
+		id: 5,
+		name: 'Code',
+		description: 'Add a code snippet with syntax highlighting.',
+		url: '#',
+		color: 'bg-cyan-500',
+		icon: Link,
+	},
+	{
+		id: 6,
+		name: 'Columns',
+		description: 'Divide content into multi-column layouts.',
+		url: '#',
+		color: 'bg-violet-500',
+		icon: Columns3,
+	},
+	{
+		id: 7,
+		name: 'Link',
+		description: 'Embed a link with a preview card.',
+		url: '#',
+		color: 'bg-blue-500',
+		icon: Link,
+	},
+	{
+		id: 8,
+		name: 'Quote',
+		description: 'Add a blockquote with styling options.',
+		url: '#',
+		color: 'bg-yellow-500',
+		icon: MessageSquare,
+	},
+];
+
+const users: User[] = [
+	{
+		id: 1,
+		name: 'Leslie Alexander',
+		url: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 2,
+		name: 'Michael Foster',
+		url: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 3,
+		name: 'Dries Vincent',
+		url: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+];
+
+const contacts: Contact[] = [
+	{
+		id: 1,
+		name: 'Leslie Alexander',
+		phone: '1-493-747-9031',
+		email: 'lesliealexander@example.com',
+		role: 'Co-Founder / CEO',
+		url: 'https://example.com',
+		profileUrl: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 2,
+		name: 'Michael Foster',
+		phone: '1-493-747-9032',
+		email: 'michaelfoster@example.com',
+		role: 'Co-Founder / CTO',
+		url: 'https://example.com',
+		profileUrl: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 3,
+		name: 'Dries Vincent',
+		phone: '1-493-747-9033',
+		email: 'driesvincent@example.com',
+		role: 'Manager, Partnerships',
+		url: 'https://example.com',
+		profileUrl: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+];
+
+const recentSearches: Contact[] = [contacts[0], contacts[0], contacts[0], contacts[0], contacts[0]];
+
+const items: GroupedItem[] = [
+	{ id: 1, name: 'Workflow Inc.', category: 'Clients', url: '#' },
+	{ id: 2, name: 'Workcation', category: 'Clients', url: '#' },
+	{ id: 3, name: 'Tailwind Labs', category: 'Clients', url: '#' },
+	{ id: 4, name: 'Phobia', category: 'Clients', url: '#' },
+	{ id: 5, name: 'Website Redesign', category: 'Projects', url: '#' },
+	{ id: 6, name: 'GraphQL API', category: 'Projects', url: '#' },
+	{ id: 7, name: 'iOS App', category: 'Projects', url: '#' },
+	{ id: 8, name: 'Customer Portal', category: 'Projects', url: '#' },
+];
+
+// ============================================================================
+// EXAMPLE 1: Simple Command Palette
+// ============================================================================
+
+function SimpleCommandPalette() {
+	const [query, setQuery] = useState('');
+	const [open, setOpen] = useState(false);
+
+	const filteredPeople =
+		query === ''
+			? []
+			: people.filter((person) => person.name.toLowerCase().includes(query.toLowerCase()));
+
+	return (
+		<div class="relative">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="mx-auto flex items-center gap-x-2 rounded-md bg-surface-1 px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 dark:bg-surface-2 dark:hover:bg-white/5"
+			>
+				<Search class="size-4" />
+				Search people...
+				<kbd class="ml-4 rounded border border-surface-border px-1.5 text-xs">⌘K</kbd>
+			</button>
+
+			<Dialog
+				open={open}
+				onClose={() => {
+					setOpen(false);
+					setQuery('');
+				}}
+				class="relative z-10"
+			>
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/25 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-black/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel
+						transition
+						class="mx-auto max-w-xl transform divide-y divide-surface-border overflow-hidden rounded-xl bg-surface-0 shadow-2xl outline outline-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-surface-2 dark:outline-white/10"
+					>
+						<Combobox
+							onChange={(person: Person) => {
+								if (person) {
+									window.location.href = person.url;
+								}
+							}}
+						>
+							<div class="grid grid-cols-1">
+								<ComboboxInput
+									autoFocus
+									class="col-start-1 row-start-1 h-12 w-full pr-4 pl-11 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm dark:bg-surface-2 dark:text-white"
+									placeholder="Search..."
+									onChange={(event) => setQuery((event.target as HTMLInputElement).value)}
+									onBlur={() => setQuery('')}
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 ml-4 size-5 self-center text-text-tertiary"
+								/>
+							</div>
+
+							{filteredPeople.length > 0 && (
+								<ComboboxOptions
+									static
+									class="max-h-72 scroll-py-2 overflow-y-auto py-2 text-sm text-text-secondary"
+								>
+									{filteredPeople.map((person) => (
+										<ComboboxOption
+											key={person.id}
+											value={person}
+											class="cursor-default px-4 py-2 select-none data-focus:bg-accent-500 data-focus:text-white data-focus:outline-hidden dark:data-focus:bg-accent-500"
+										>
+											{person.name}
+										</ComboboxOption>
+									))}
+								</ComboboxOptions>
+							)}
+
+							{query !== '' && filteredPeople.length === 0 && (
+								<p class="p-4 text-sm text-text-tertiary">No people found.</p>
+							)}
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 2: Simple with Padding
+// ============================================================================
+
+function SimpleWithPaddingCommandPalette() {
+	const [query, setQuery] = useState('');
+	const [open, setOpen] = useState(false);
+
+	const filteredPeople =
+		query === ''
+			? []
+			: people.filter((person) => person.name.toLowerCase().includes(query.toLowerCase()));
+
+	return (
+		<div class="relative">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="mx-auto flex items-center gap-x-2 rounded-md bg-surface-1 px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 dark:bg-surface-2 dark:hover:bg-white/5"
+			>
+				<Search class="size-4" />
+				Search...
+			</button>
+
+			<Dialog
+				open={open}
+				onClose={() => {
+					setOpen(false);
+					setQuery('');
+				}}
+				class="relative z-10"
+			>
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/25 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-black/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel
+						transition
+						class="mx-auto max-w-xl transform rounded-xl bg-surface-0 p-2 shadow-2xl outline outline-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-surface-2 dark:outline-white/10"
+					>
+						<Combobox
+							onChange={(person: Person) => {
+								if (person) {
+									window.location.href = person.url;
+								}
+							}}
+						>
+							<ComboboxInput
+								autoFocus
+								class="w-full rounded-md bg-surface-1 px-4 py-2.5 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm dark:bg-white/5 dark:text-white dark:placeholder:text-text-tertiary"
+								placeholder="Search..."
+								onChange={(event) => setQuery((event.target as HTMLInputElement).value)}
+								onBlur={() => setQuery('')}
+							/>
+
+							{filteredPeople.length > 0 && (
+								<ComboboxOptions
+									static
+									class="-mb-2 max-h-72 scroll-py-2 overflow-y-auto py-2 text-sm text-text-secondary dark:text-gray-200"
+								>
+									{filteredPeople.map((person) => (
+										<ComboboxOption
+											key={person.id}
+											value={person}
+											class="cursor-default rounded-md px-4 py-2 select-none data-focus:bg-accent-500 data-focus:text-white data-focus:outline-hidden dark:data-focus:bg-accent-500"
+										>
+											{person.name}
+										</ComboboxOption>
+									))}
+								</ComboboxOptions>
+							)}
+
+							{query !== '' && filteredPeople.length === 0 && (
+								<div class="px-4 py-14 text-center sm:px-14">
+									<Users class="mx-auto size-6 text-text-tertiary" aria-hidden="true" />
+									<p class="mt-4 text-sm text-text-primary dark:text-gray-200">
+										No people found using that search term.
+									</p>
+								</div>
+							)}
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 3: With Preview
+// ============================================================================
+
+function WithPreviewCommandPalette() {
+	const [open, setOpen] = useState(false);
+	const [rawQuery, setRawQuery] = useState('');
+
+	const query = rawQuery.toLowerCase().replace(/^[#>]/, '');
+
+	const filteredProjects =
+		rawQuery === '#'
+			? projects
+			: query === '' || rawQuery.startsWith('>')
+				? []
+				: projects.filter((project) => project.name.toLowerCase().includes(query));
+
+	const filteredUsers =
+		rawQuery === '>'
+			? users
+			: query === '' || rawQuery.startsWith('#')
+				? []
+				: users.filter((user) => user.name.toLowerCase().includes(query));
+
+	return (
+		<div class="relative">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="mx-auto flex items-center gap-x-2 rounded-md bg-surface-1 px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 dark:bg-surface-2 dark:hover:bg-white/5"
+			>
+				<Search class="size-4" />
+				Search...
+			</button>
+
+			<Dialog
+				open={open}
+				onClose={() => {
+					setOpen(false);
+					setRawQuery('');
+				}}
+				class="relative z-10"
+			>
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/25 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-black/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel
+						transition
+						class="mx-auto max-w-xl transform divide-y divide-surface-border overflow-hidden rounded-xl bg-surface-0 shadow-2xl outline outline-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-surface-2 dark:outline-white/10"
+					>
+						<Combobox
+							onChange={(item: SearchResult) => {
+								if (item) {
+									window.location.href = item.url;
+								}
+							}}
+						>
+							<div class="grid grid-cols-1">
+								<ComboboxInput
+									autoFocus
+									class="col-start-1 row-start-1 h-12 w-full pr-4 pl-11 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm dark:bg-surface-2 dark:text-white dark:placeholder:text-text-tertiary"
+									placeholder="Search..."
+									onChange={(event) => setRawQuery((event.target as HTMLInputElement).value)}
+									onBlur={() => setRawQuery('')}
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 ml-4 size-5 self-center text-text-tertiary"
+								/>
+							</div>
+
+							{(filteredProjects.length > 0 || filteredUsers.length > 0) && (
+								<ComboboxOptions
+									static
+									as="ul"
+									class="max-h-80 transform-gpu scroll-py-10 scroll-pb-2 space-y-4 overflow-y-auto p-4 pb-2"
+								>
+									{filteredProjects.length > 0 && (
+										<li>
+											<h2 class="text-xs font-semibold text-text-primary">Projects</h2>
+											<ul class="-mx-4 mt-2 text-sm text-text-secondary">
+												{filteredProjects.map((project) => (
+													<ComboboxOption
+														as="li"
+														key={project.id}
+														value={project}
+														class="group flex cursor-default items-center px-4 py-2 select-none data-focus:bg-accent-500 data-focus:text-white data-focus:outline-hidden dark:data-focus:bg-accent-500"
+													>
+														<Folder
+															class="size-6 flex-none text-text-tertiary group-data-focus:text-white"
+															aria-hidden="true"
+														/>
+														<span class="ml-3 flex-auto truncate">{project.name}</span>
+													</ComboboxOption>
+												))}
+											</ul>
+										</li>
+									)}
+									{filteredUsers.length > 0 && (
+										<li>
+											<h2 class="text-xs font-semibold text-text-primary">Users</h2>
+											<ul class="-mx-4 mt-2 text-sm text-text-secondary">
+												{filteredUsers.map((user) => (
+													<ComboboxOption
+														as="li"
+														key={user.id}
+														value={user}
+														class="flex cursor-default items-center px-4 py-2 select-none data-focus:bg-accent-500 data-focus:text-white dark:data-focus:bg-accent-500"
+													>
+														<img
+															src={user.imageUrl}
+															alt=""
+															class="size-6 flex-none rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+														/>
+														<span class="ml-3 flex-auto truncate">{user.name}</span>
+													</ComboboxOption>
+												))}
+											</ul>
+										</li>
+									)}
+								</ComboboxOptions>
+							)}
+
+							{rawQuery === '?' && (
+								<div class="px-6 py-14 text-center text-sm sm:px-14">
+									<HelpCircle class="mx-auto size-6 text-text-tertiary" aria-hidden="true" />
+									<p class="mt-4 font-semibold text-text-primary">Help with searching</p>
+									<p class="mt-2 text-text-tertiary">
+										Use this tool to quickly search for users and projects across our entire
+										platform. You can also use the search modifiers found in the footer below to
+										limit the results to just users or projects.
+									</p>
+								</div>
+							)}
+
+							{query !== '' &&
+								rawQuery !== '?' &&
+								filteredProjects.length === 0 &&
+								filteredUsers.length === 0 && (
+									<div class="px-6 py-14 text-center text-sm sm:px-14">
+										<X class="mx-auto size-6 text-text-tertiary" aria-hidden="true" />
+										<p class="mt-4 font-semibold text-text-primary">No results found</p>
+										<p class="mt-2 text-text-tertiary">
+											We couldn't find anything with that term. Please try again.
+										</p>
+									</div>
+								)}
+
+							<div class="flex flex-wrap items-center bg-surface-1 px-4 py-2.5 text-xs text-text-tertiary dark:bg-surface-2/50 dark:text-gray-300">
+								Type{' '}
+								<kbd
+									class={classNames(
+										'mx-1 flex size-5 items-center justify-center rounded-sm border bg-surface-0 font-semibold sm:mx-2 dark:bg-surface-2',
+										rawQuery.startsWith('#')
+											? 'border-accent-500 text-accent-500'
+											: 'border-surface-border text-text-primary'
+									)}
+								>
+									#
+								</kbd>{' '}
+								<span class="hidden sm:inline">to access projects,</span>
+								<span class="sm:hidden">for projects,</span>
+								<kbd
+									class={classNames(
+										'mx-1 flex size-5 items-center justify-center rounded-sm border bg-surface-0 font-semibold sm:mx-2 dark:bg-surface-2',
+										rawQuery.startsWith('>')
+											? 'border-accent-500 text-accent-500'
+											: 'border-surface-border text-text-primary'
+									)}
+								>
+									&gt;
+								</kbd>{' '}
+								for users, and{' '}
+								<kbd
+									class={classNames(
+										'mx-1 flex size-5 items-center justify-center rounded-sm border bg-surface-0 font-semibold sm:mx-2 dark:bg-surface-2',
+										rawQuery === '?'
+											? 'border-accent-500 text-accent-500'
+											: 'border-surface-border text-text-primary'
+									)}
+								>
+									?
+								</kbd>{' '}
+								for help.
+							</div>
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 4: With Images and Descriptions
+// ============================================================================
+
+function WithImagesAndDescriptionsCommandPalette() {
+	const [query, setQuery] = useState('');
+	const [open, setOpen] = useState(false);
+
+	const filteredItems =
+		query === ''
+			? []
+			: insertItems.filter((item) => item.name.toLowerCase().includes(query.toLowerCase()));
+
+	return (
+		<div class="relative">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="mx-auto flex items-center gap-x-2 rounded-md bg-surface-1 px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 dark:bg-surface-2 dark:hover:bg-white/5"
+			>
+				<Plus class="size-4" />
+				Insert content...
+			</button>
+
+			<Dialog
+				open={open}
+				onClose={() => {
+					setOpen(false);
+					setQuery('');
+				}}
+				class="relative z-10"
+			>
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/25 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-black/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel
+						transition
+						class="mx-auto max-w-xl transform divide-y divide-surface-border overflow-hidden rounded-xl bg-surface-0 shadow-2xl outline outline-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-surface-2 dark:outline-white/10"
+					>
+						<Combobox
+							onChange={(item: InsertItem) => {
+								if (item) {
+									window.location.href = item.url;
+								}
+							}}
+						>
+							<div class="grid grid-cols-1">
+								<ComboboxInput
+									autoFocus
+									class="col-start-1 row-start-1 h-12 w-full pr-4 pl-11 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm dark:bg-surface-2 dark:text-white dark:placeholder:text-text-tertiary"
+									placeholder="Search..."
+									onChange={(event) => setQuery((event.target as HTMLInputElement).value)}
+									onBlur={() => setQuery('')}
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 ml-4 size-5 self-center text-text-tertiary"
+								/>
+							</div>
+
+							{filteredItems.length > 0 && (
+								<ComboboxOptions
+									static
+									class="max-h-96 transform-gpu scroll-py-3 overflow-y-auto p-3"
+								>
+									{filteredItems.map((item) => (
+										<ComboboxOption
+											key={item.id}
+											value={item}
+											class="group flex cursor-default rounded-xl p-3 select-none data-focus:bg-surface-1 data-focus:outline-hidden dark:data-focus:bg-white/5"
+										>
+											<div
+												class={classNames(
+													'flex size-10 flex-none items-center justify-center rounded-lg',
+													item.color
+												)}
+											>
+												<item.icon class="size-6 text-white" aria-hidden="true" />
+											</div>
+											<div class="ml-4 flex-auto">
+												<p class="text-sm font-medium text-text-secondary group-data-focus:text-text-primary dark:text-gray-300 dark:group-data-focus:text-white">
+													{item.name}
+												</p>
+												<p class="text-sm text-text-tertiary group-data-focus:text-text-secondary dark:text-gray-400 dark:group-data-focus:text-gray-300">
+													{item.description}
+												</p>
+											</div>
+										</ComboboxOption>
+									))}
+								</ComboboxOptions>
+							)}
+
+							{query !== '' && filteredItems.length === 0 && (
+								<div class="px-6 py-14 text-center text-sm sm:px-14">
+									<X class="mx-auto size-6 text-text-tertiary" />
+									<p class="mt-4 font-semibold text-text-primary">No results found</p>
+									<p class="mt-2 text-text-tertiary">
+										No components found for this search term. Please try again.
+									</p>
+								</div>
+							)}
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 5: With Icons
+// ============================================================================
+
+function WithIconsCommandPalette() {
+	const [query, setQuery] = useState('');
+	const [open, setOpen] = useState(false);
+
+	const filteredProjects =
+		query === ''
+			? []
+			: projects.filter((project) => project.name.toLowerCase().includes(query.toLowerCase()));
+
+	return (
+		<div class="relative">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="mx-auto flex items-center gap-x-2 rounded-md bg-surface-1 px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 dark:bg-surface-2 dark:hover:bg-white/5"
+			>
+				<Search class="size-4" />
+				Search projects...
+			</button>
+
+			<Dialog
+				open={open}
+				onClose={() => {
+					setOpen(false);
+					setQuery('');
+				}}
+				class="relative z-10"
+			>
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/25 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-black/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel
+						transition
+						class="mx-auto max-w-2xl transform divide-y divide-surface-border overflow-hidden rounded-xl bg-surface-0 shadow-2xl outline outline-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-surface-2 dark:outline-white/10"
+					>
+						<Combobox
+							onChange={(item: Project) => {
+								if (item) {
+									window.location.href = item.url;
+								}
+							}}
+						>
+							<div class="grid grid-cols-1">
+								<ComboboxInput
+									autoFocus
+									class="col-start-1 row-start-1 h-12 w-full pr-4 pl-11 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm dark:bg-surface-2 dark:text-white dark:placeholder:text-text-tertiary"
+									placeholder="Search..."
+									onChange={(event) => setQuery((event.target as HTMLInputElement).value)}
+									onBlur={() => setQuery('')}
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 ml-4 size-5 self-center text-text-tertiary"
+								/>
+							</div>
+
+							{(query === '' || filteredProjects.length > 0) && (
+								<ComboboxOptions
+									static
+									as="ul"
+									class="max-h-80 scroll-py-2 divide-y divide-surface-border overflow-y-auto dark:divide-white/10"
+								>
+									<li class="p-2">
+										{query === '' && (
+											<h2 class="mt-4 mb-2 px-3 text-xs font-semibold text-text-tertiary">
+												Recent searches
+											</h2>
+										)}
+										<ul class="text-sm text-text-secondary">
+											{(query === '' ? recent : filteredProjects).map((project) => (
+												<ComboboxOption
+													as="li"
+													key={project.id}
+													value={project}
+													class="group flex cursor-default items-center rounded-md px-3 py-2 select-none data-focus:bg-accent-500 data-focus:text-white data-focus:outline-hidden dark:data-focus:bg-accent-500"
+												>
+													<Folder
+														class="size-6 flex-none text-text-tertiary group-data-focus:text-white"
+														aria-hidden="true"
+													/>
+													<span class="ml-3 flex-auto truncate">{project.name}</span>
+													<span class="ml-3 hidden flex-none text-accent-500 group-data-focus:inline">
+														Jump to...
+													</span>
+												</ComboboxOption>
+											))}
+										</ul>
+									</li>
+									{query === '' && (
+										<li class="p-2">
+											<h2 class="sr-only">Quick actions</h2>
+											<ul class="text-sm text-text-secondary">
+												{quickActions.map((action) => (
+													<ComboboxOption
+														as="li"
+														key={action.shortcut}
+														value={action}
+														class="group flex cursor-default items-center rounded-md px-3 py-2 select-none data-focus:bg-accent-500 data-focus:text-white data-focus:outline-hidden dark:data-focus:bg-accent-500"
+													>
+														<action.icon
+															class="size-6 flex-none text-text-tertiary group-data-focus:text-white"
+															aria-hidden="true"
+														/>
+														<span class="ml-3 flex-auto truncate">{action.name}</span>
+														<span class="ml-3 flex-none text-xs font-semibold text-text-tertiary group-data-focus:text-white">
+															<kbd class="font-sans">⌘</kbd>
+															<kbd class="font-sans">{action.shortcut}</kbd>
+														</span>
+													</ComboboxOption>
+												))}
+											</ul>
+										</li>
+									)}
+								</ComboboxOptions>
+							)}
+
+							{query !== '' && filteredProjects.length === 0 && (
+								<div class="px-6 py-14 text-center sm:px-14">
+									<Folder class="mx-auto size-6 text-text-tertiary" aria-hidden="true" />
+									<p class="mt-4 text-sm text-text-primary">
+										We couldn't find any projects with that term. Please try again.
+									</p>
+								</div>
+							)}
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 6: Semi-Transparent with Icons
+// ============================================================================
+
+function SemiTransparentWithIconsCommandPalette() {
+	const [query, setQuery] = useState('');
+	const [open, setOpen] = useState(false);
+
+	const filteredProjects =
+		query === ''
+			? []
+			: projects.filter((project) => project.name.toLowerCase().includes(query.toLowerCase()));
+
+	return (
+		<div class="relative">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="mx-auto flex items-center gap-x-2 rounded-md bg-surface-1 px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 dark:bg-surface-2 dark:hover:bg-white/5"
+			>
+				<Search class="size-4" />
+				Search...
+			</button>
+
+			<Dialog
+				open={open}
+				onClose={() => {
+					setOpen(false);
+					setQuery('');
+				}}
+				class="relative z-10"
+			>
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/25 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-black/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel
+						transition
+						class="mx-auto max-w-2xl transform divide-y divide-surface-border overflow-hidden rounded-xl bg-surface-0/80 shadow-2xl outline outline-black/5 backdrop-blur-sm transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:divide-white/10 dark:bg-surface-2/80 dark:outline-white/10"
+					>
+						<Combobox
+							onChange={(item: Project) => {
+								if (item) {
+									window.location.href = item.url;
+								}
+							}}
+						>
+							<div class="grid grid-cols-1">
+								<ComboboxInput
+									autoFocus
+									class="col-start-1 row-start-1 h-12 w-full bg-transparent pr-4 pl-11 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm dark:text-white dark:placeholder:text-text-tertiary"
+									placeholder="Search..."
+									onChange={(event) => setQuery((event.target as HTMLInputElement).value)}
+									onBlur={() => setQuery('')}
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 ml-4 size-5 self-center text-text-tertiary"
+								/>
+							</div>
+
+							{(query === '' || filteredProjects.length > 0) && (
+								<ComboboxOptions
+									static
+									as="ul"
+									class="max-h-80 scroll-py-2 divide-y divide-surface-border overflow-y-auto dark:divide-white/10"
+								>
+									<li class="p-2">
+										{query === '' && (
+											<h2 class="mt-4 mb-2 px-3 text-xs font-semibold text-text-primary">
+												Recent searches
+											</h2>
+										)}
+										<ul class="text-sm text-text-secondary">
+											{(query === '' ? recent : filteredProjects).map((project) => (
+												<ComboboxOption
+													as="li"
+													key={project.id}
+													value={project}
+													class="group flex cursor-default items-center rounded-md px-3 py-2 select-none data-focus:bg-black/5 data-focus:text-text-primary data-focus:outline-hidden dark:data-focus:bg-white/5 dark:data-focus:text-white"
+												>
+													<Folder
+														class="size-6 flex-none text-text-tertiary group-data-focus:text-text-primary dark:text-gray-500 dark:group-data-focus:text-white"
+														aria-hidden="true"
+													/>
+													<span class="ml-3 flex-auto truncate">{project.name}</span>
+													<span class="ml-3 hidden flex-none text-text-tertiary group-data-focus:inline dark:text-gray-400">
+														Jump to...
+													</span>
+												</ComboboxOption>
+											))}
+										</ul>
+									</li>
+									{query === '' && (
+										<li class="p-2">
+											<h2 class="sr-only">Quick actions</h2>
+											<ul class="text-sm text-text-secondary">
+												{quickActions.map((action) => (
+													<ComboboxOption
+														as="li"
+														key={action.shortcut}
+														value={action}
+														class="group flex cursor-default items-center rounded-md px-3 py-2 select-none data-focus:bg-black/5 data-focus:text-text-primary data-focus:outline-hidden dark:data-focus:bg-white/5 dark:data-focus:text-white"
+													>
+														<action.icon
+															class="size-6 flex-none text-text-tertiary group-data-focus:text-text-primary dark:text-gray-500 dark:group-data-focus:text-white"
+															aria-hidden="true"
+														/>
+														<span class="ml-3 flex-auto truncate">{action.name}</span>
+														<span class="ml-3 flex-none text-xs font-semibold text-text-tertiary group-data-focus:text-text-primary dark:text-gray-400 dark:group-data-focus:text-white">
+															<kbd class="font-sans">⌘</kbd>
+															<kbd class="font-sans">{action.shortcut}</kbd>
+														</span>
+													</ComboboxOption>
+												))}
+											</ul>
+										</li>
+									)}
+								</ComboboxOptions>
+							)}
+
+							{query !== '' && filteredProjects.length === 0 && (
+								<div class="px-6 py-14 text-center sm:px-14">
+									<Folder class="mx-auto size-6 text-text-tertiary" aria-hidden="true" />
+									<p class="mt-4 text-sm text-text-primary">
+										We couldn't find any projects with that term. Please try again.
+									</p>
+								</div>
+							)}
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 7: With Groups
+// ============================================================================
+
+function WithGroupsCommandPalette() {
+	const [query, setQuery] = useState('');
+	const [open, setOpen] = useState(false);
+
+	const filteredItems =
+		query === ''
+			? []
+			: items.filter((item) => item.name.toLowerCase().includes(query.toLowerCase()));
+
+	const groups = filteredItems.reduce(
+		(groups, item) => {
+			return { ...groups, [item.category]: [...(groups[item.category] || []), item] };
+		},
+		{} as Record<string, typeof items>
+	);
+
+	return (
+		<div class="relative">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="mx-auto flex items-center gap-x-2 rounded-md bg-surface-1 px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 dark:bg-surface-2 dark:hover:bg-white/5"
+			>
+				<Search class="size-4" />
+				Search...
+			</button>
+
+			<Dialog
+				open={open}
+				onClose={() => {
+					setOpen(false);
+					setQuery('');
+				}}
+				class="relative z-10"
+			>
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/25 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-black/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel
+						transition
+						class="mx-auto max-w-xl transform overflow-hidden rounded-xl bg-surface-0 shadow-2xl outline outline-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-surface-2 dark:outline-white/10"
+					>
+						<Combobox
+							onChange={(item: GroupedItem) => {
+								if (item) {
+									window.location.href = item.url;
+								}
+							}}
+						>
+							<div class="grid grid-cols-1">
+								<ComboboxInput
+									autoFocus
+									class="col-start-1 row-start-1 h-12 w-full pr-4 pl-11 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm dark:bg-surface-2 dark:text-white dark:placeholder:text-text-tertiary"
+									placeholder="Search..."
+									onChange={(event) => setQuery((event.target as HTMLInputElement).value)}
+									onBlur={() => setQuery('')}
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 ml-4 size-5 self-center text-text-tertiary"
+								/>
+							</div>
+
+							{query === '' && (
+								<div class="border-t border-surface-border px-6 py-14 text-center text-sm dark:border-white/10">
+									<Globe class="mx-auto size-6 text-text-tertiary" aria-hidden="true" />
+									<p class="mt-4 font-semibold text-text-primary">
+										Search for clients and projects
+									</p>
+									<p class="mt-2 text-text-tertiary">
+										Quickly access clients and projects by running a global search.
+									</p>
+								</div>
+							)}
+
+							{filteredItems.length > 0 && (
+								<ComboboxOptions
+									static
+									as="ul"
+									class="max-h-80 scroll-pt-11 scroll-pb-2 space-y-2 overflow-y-auto pb-2"
+								>
+									{Object.entries(groups).map(([category, categoryItems]) => (
+										<li key={category}>
+											<h2 class="bg-surface-1 px-4 py-2.5 text-xs font-semibold text-text-primary dark:bg-white/5 dark:text-white">
+												{category}
+											</h2>
+											<ul class="mt-2 text-sm text-text-secondary">
+												{categoryItems.map((item) => (
+													<ComboboxOption
+														key={item.id}
+														value={item}
+														class="cursor-default px-4 py-2 select-none data-focus:bg-accent-500 data-focus:text-white data-focus:outline-hidden dark:data-focus:bg-accent-500"
+													>
+														{item.name}
+													</ComboboxOption>
+												))}
+											</ul>
+										</li>
+									))}
+								</ComboboxOptions>
+							)}
+
+							{query !== '' && filteredItems.length === 0 && (
+								<div class="border-t border-surface-border px-6 py-14 text-center text-sm dark:border-white/10">
+									<X class="mx-auto size-6 text-text-tertiary" aria-hidden="true" />
+									<p class="mt-4 font-semibold text-text-primary">No results found</p>
+									<p class="mt-2 text-text-tertiary">
+										We couldn't find anything with that term. Please try again.
+									</p>
+								</div>
+							)}
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 8: With Footer
+// ============================================================================
+
+function WithFooterCommandPalette() {
+	const [query, setQuery] = useState('');
+	const [open, setOpen] = useState(false);
+
+	const filteredPeople =
+		query === ''
+			? []
+			: contacts.filter((person) => person.name.toLowerCase().includes(query.toLowerCase()));
+
+	return (
+		<div class="relative">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="mx-auto flex items-center gap-x-2 rounded-md bg-surface-1 px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 dark:bg-surface-2 dark:hover:bg-white/5"
+			>
+				<Search class="size-4" />
+				Find contacts...
+			</button>
+
+			<Dialog
+				open={open}
+				onClose={() => {
+					setOpen(false);
+					setQuery('');
+				}}
+				class="relative z-10"
+			>
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/25 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-black/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+					<DialogPanel
+						transition
+						class="mx-auto max-w-3xl transform divide-y divide-surface-border overflow-hidden rounded-xl bg-surface-0 shadow-2xl outline outline-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:bg-surface-2 dark:outline-white/10"
+					>
+						<Combobox
+							onChange={(person: Person) => {
+								if (person) {
+									window.location.href = person.url;
+								}
+							}}
+						>
+							{({ activeOption }: { activeOption?: (typeof contacts)[0] }) => (
+								<>
+									<div class="grid grid-cols-1">
+										<ComboboxInput
+											autoFocus
+											class="col-start-1 row-start-1 h-12 w-full pr-4 pl-11 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm dark:bg-surface-2 dark:text-white dark:placeholder:text-text-tertiary"
+											placeholder="Search..."
+											onChange={(event) => setQuery((event.target as HTMLInputElement).value)}
+											onBlur={() => setQuery('')}
+										/>
+										<Search
+											aria-hidden="true"
+											class="pointer-events-none col-start-1 row-start-1 ml-4 size-5 self-center text-text-tertiary"
+										/>
+									</div>
+
+									{(query === '' || filteredPeople.length > 0) && (
+										<ComboboxOptions
+											as="div"
+											static
+											hold
+											class="flex transform-gpu divide-x divide-surface-border dark:divide-white/10"
+										>
+											<div
+												class={classNames(
+													'max-h-96 min-w-0 flex-auto scroll-py-4 overflow-y-auto px-6 py-4',
+													activeOption && 'sm:h-96'
+												)}
+											>
+												{query === '' && (
+													<h2 class="mt-2 mb-4 text-xs font-semibold text-text-tertiary">
+														Recent searches
+													</h2>
+												)}
+												<div class="-mx-2 text-sm text-text-secondary">
+													{(query === '' ? recentSearches : filteredPeople).map((person) => (
+														<ComboboxOption
+															as="div"
+															key={person.id}
+															value={person}
+															class="group flex cursor-default items-center rounded-md p-2 select-none data-focus:bg-surface-1 data-focus:text-text-primary data-focus:outline-hidden dark:data-focus:bg-white/5 dark:data-focus:text-white"
+														>
+															<img
+																src={person.imageUrl}
+																alt=""
+																class="size-6 flex-none rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+															/>
+															<span class="ml-3 flex-auto truncate">{person.name}</span>
+															<ChevronRight
+																class="ml-3 hidden size-5 flex-none text-text-tertiary group-data-focus:block dark:text-gray-500"
+																aria-hidden="true"
+															/>
+														</ComboboxOption>
+													))}
+												</div>
+											</div>
+
+											{activeOption && (
+												<div class="hidden h-96 w-1/2 flex-none flex-col divide-y divide-surface-border overflow-y-auto sm:flex dark:divide-white/10">
+													<div class="flex-none p-6 text-center">
+														<img
+															src={activeOption.imageUrl}
+															alt=""
+															class="mx-auto size-16 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+														/>
+														<h2 class="mt-3 font-semibold text-text-primary">
+															{activeOption.name}
+														</h2>
+														<p class="text-sm/6 text-text-tertiary">{activeOption.role}</p>
+													</div>
+													<div class="flex flex-auto flex-col justify-between p-6">
+														<dl class="grid grid-cols-1 gap-x-6 gap-y-3 text-sm text-text-secondary">
+															<dt class="col-end-1 font-semibold text-text-primary">Phone</dt>
+															<dd>{activeOption.phone}</dd>
+															<dt class="col-end-1 font-semibold text-text-primary">URL</dt>
+															<dd class="truncate">
+																<a href={activeOption.url} class="text-accent-500 underline">
+																	{activeOption.url}
+																</a>
+															</dd>
+															<dt class="col-end-1 font-semibold text-text-primary">Email</dt>
+															<dd class="truncate">
+																<a
+																	href={`mailto:${activeOption.email}`}
+																	class="text-accent-500 underline"
+																>
+																	{activeOption.email}
+																</a>
+															</dd>
+														</dl>
+														<button
+															type="button"
+															class="mt-6 w-full rounded-md bg-accent-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-accent-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+														>
+															Send message
+														</button>
+													</div>
+												</div>
+											)}
+										</ComboboxOptions>
+									)}
+
+									{query !== '' && filteredPeople.length === 0 && (
+										<div class="px-6 py-14 text-center text-sm sm:px-14">
+											<Users class="mx-auto size-6 text-text-tertiary" aria-hidden="true" />
+											<p class="mt-4 font-semibold text-text-primary">No people found</p>
+											<p class="mt-2 text-text-tertiary">
+												We couldn't find anything with that term. Please try again.
+											</p>
+										</div>
+									)}
+								</>
+							)}
+						</Combobox>
+					</DialogPanel>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// ============================================================================
+// MAIN EXPORT
+// ============================================================================
+
+export function CommandPalettesDemo() {
+	return (
+		<div class="flex flex-col gap-12">
+			{/* Example 1: Simple */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple</h3>
+				<div class="flex justify-center rounded-lg border border-surface-border bg-surface-0 p-8 dark:bg-surface-2">
+					<SimpleCommandPalette />
+				</div>
+			</div>
+
+			{/* Example 2: Simple with Padding */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple with padding</h3>
+				<div class="flex justify-center rounded-lg border border-surface-border bg-surface-0 p-8 dark:bg-surface-2">
+					<SimpleWithPaddingCommandPalette />
+				</div>
+			</div>
+
+			{/* Example 3: With Preview */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With preview</h3>
+				<div class="flex justify-center rounded-lg border border-surface-border bg-surface-0 p-8 dark:bg-surface-2">
+					<WithPreviewCommandPalette />
+				</div>
+			</div>
+
+			{/* Example 4: With Images and Descriptions */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With images and descriptions</h3>
+				<div class="flex justify-center rounded-lg border border-surface-border bg-surface-0 p-8 dark:bg-surface-2">
+					<WithImagesAndDescriptionsCommandPalette />
+				</div>
+			</div>
+
+			{/* Example 5: With Icons */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With icons</h3>
+				<div class="flex justify-center rounded-lg border border-surface-border bg-surface-0 p-8 dark:bg-surface-2">
+					<WithIconsCommandPalette />
+				</div>
+			</div>
+
+			{/* Example 6: Semi-Transparent with Icons */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Semi-transparent with icons</h3>
+				<div class="flex justify-center rounded-lg border border-surface-border bg-surface-1/50 p-8 dark:bg-surface-2/50">
+					<SemiTransparentWithIconsCommandPalette />
+				</div>
+			</div>
+
+			{/* Example 7: With Groups */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With groups</h3>
+				<div class="flex justify-center rounded-lg border border-surface-border bg-surface-0 p-8 dark:bg-surface-2">
+					<WithGroupsCommandPalette />
+				</div>
+			</div>
+
+			{/* Example 8: With Footer */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With footer</h3>
+				<div class="flex justify-center rounded-lg border border-surface-border bg-surface-0 p-8 dark:bg-surface-2">
+					<WithFooterCommandPalette />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/navigation/NavbarsDemo.tsx
+++ b/packages/ui/demo/sections/navigation/NavbarsDemo.tsx
@@ -1,0 +1,2100 @@
+import {
+	Disclosure,
+	DisclosureButton,
+	DisclosurePanel,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuItems,
+	Popover,
+	PopoverButton,
+	PopoverPanel,
+} from '../../../src/mod.ts';
+import { classNames } from '../../../src/internal/class-names.ts';
+import { Bell, Menu as MenuIcon, Plus, Search, X } from 'lucide-preact';
+
+// ============================================================================
+// DATA
+// ============================================================================
+
+const user = {
+	name: 'Tom Cook',
+	email: 'tom@example.com',
+	imageUrl:
+		'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+};
+
+const userImageAlt =
+	'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80';
+
+const navigation = [
+	{ name: 'Dashboard', href: '#', current: true },
+	{ name: 'Team', href: '#', current: false },
+	{ name: 'Projects', href: '#', current: false },
+	{ name: 'Calendar', href: '#', current: false },
+];
+
+const userNavigation = [
+	{ name: 'Your profile', href: '#' },
+	{ name: 'Settings', href: '#' },
+	{ name: 'Sign out', href: '#' },
+];
+
+// ============================================================================
+// EXAMPLE 1: Simple Dark with Menu Button on Left
+// ============================================================================
+
+function SimpleDarkWithMenuButtonOnLeft() {
+	return (
+		<Disclosure
+			as="nav"
+			class="relative bg-surface-2 dark:bg-surface-2/50 dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+				<div class="flex h-16 items-center justify-between">
+					<div class="flex items-center">
+						<div class="shrink-0">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto"
+							/>
+						</div>
+						<div class="hidden sm:ml-6 sm:block">
+							<div class="flex space-x-4">
+								{navigation.map((item) => (
+									<a
+										key={item.name}
+										href={item.href}
+										aria-current={item.current ? 'page' : undefined}
+										class={classNames(
+											item.current
+												? 'bg-gray-900 text-white dark:bg-gray-950/50'
+												: 'text-gray-300 hover:bg-white/5 hover:text-white',
+											'rounded-md px-3 py-2 text-sm font-medium'
+										)}
+									>
+										{item.name}
+									</a>
+								))}
+							</div>
+						</div>
+					</div>
+					<div class="hidden sm:ml-6 sm:block">
+						<div class="flex items-center">
+							<button
+								type="button"
+								class="relative rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+
+							{/* Profile dropdown */}
+							<Menu as="div" class="relative ml-3">
+								<MenuButton class="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">Open user menu</span>
+									<img
+										alt=""
+										src={userImageAlt}
+										class="size-8 rounded-full bg-surface-2 outline outline-white/10"
+									/>
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+								>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+										>
+											Your profile
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+										>
+											Settings
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+										>
+											Sign out
+										</a>
+									</MenuItem>
+								</MenuItems>
+							</Menu>
+						</div>
+					</div>
+					<div class="-mr-2 flex sm:hidden">
+						{/* Mobile menu button */}
+						<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-white/5 hover:text-white focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500">
+							<span class="absolute -inset-0.5" />
+							<span class="sr-only">Open main menu</span>
+							<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+							<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+						</DisclosureButton>
+					</div>
+				</div>
+			</div>
+
+			<DisclosurePanel class="sm:hidden">
+				<div class="space-y-1 px-2 pt-2 pb-3">
+					{navigation.map((item) => (
+						<DisclosureButton
+							key={item.name}
+							as="a"
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-gray-900 text-white dark:bg-gray-950/50'
+									: 'text-gray-300 hover:bg-white/5 hover:text-white',
+								'block rounded-md px-3 py-2 text-base font-medium'
+							)}
+						>
+							{item.name}
+						</DisclosureButton>
+					))}
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 2: Dark with Quick Action
+// ============================================================================
+
+function DarkWithQuickAction() {
+	return (
+		<Disclosure
+			as="nav"
+			class="relative bg-surface-2 dark:bg-surface-2/50 dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+				<div class="flex h-16 justify-between">
+					<div class="flex">
+						<div class="mr-2 -ml-2 flex items-center md:hidden">
+							{/* Mobile menu button */}
+							<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-white/5 hover:text-white focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500">
+								<span class="absolute -inset-0.5" />
+								<span class="sr-only">Open main menu</span>
+								<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+								<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+							</DisclosureButton>
+						</div>
+						<div class="flex shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto"
+							/>
+						</div>
+						<div class="hidden md:ml-6 md:flex md:items-center md:space-x-4">
+							{navigation.map((item) => (
+								<a
+									key={item.name}
+									href={item.href}
+									aria-current={item.current ? 'page' : undefined}
+									class={classNames(
+										item.current
+											? 'bg-gray-900 text-white dark:bg-gray-950/50'
+											: 'text-gray-300 hover:bg-white/5 hover:text-white',
+										'rounded-md px-3 py-2 text-sm font-medium'
+									)}
+								>
+									{item.name}
+								</a>
+							))}
+						</div>
+					</div>
+					<div class="flex items-center">
+						<div class="shrink-0">
+							<button
+								type="button"
+								class="relative inline-flex items-center gap-x-1.5 rounded-md bg-accent-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-accent-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 dark:shadow-none"
+							>
+								<Plus aria-hidden="true" class="-ml-0.5 size-5" />
+								New Job
+							</button>
+						</div>
+						<div class="hidden md:ml-4 md:flex md:shrink-0 md:items-center">
+							<button
+								type="button"
+								class="relative rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:text-gray-400"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+
+							{/* Profile dropdown */}
+							<Menu as="div" class="relative ml-3">
+								<MenuButton class="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">Open user menu</span>
+									<img
+										alt=""
+										src={userImageAlt}
+										class="size-8 rounded-full bg-surface-2 outline outline-white/10"
+									/>
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-200 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+								>
+									{userNavigation.map((item) => (
+										<MenuItem key={item.name}>
+											<a
+												href={item.href}
+												class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-200 dark:data-focus:bg-white/5"
+											>
+												{item.name}
+											</a>
+										</MenuItem>
+									))}
+								</MenuItems>
+							</Menu>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<DisclosurePanel class="md:hidden">
+				<div class="space-y-1 px-2 pt-2 pb-3 sm:px-3">
+					{navigation.map((item) => (
+						<DisclosureButton
+							key={item.name}
+							as="a"
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-gray-900 text-white dark:bg-gray-950/50'
+									: 'text-gray-300 hover:bg-white/5 hover:text-white',
+								'block rounded-md px-3 py-2 text-base font-medium'
+							)}
+						>
+							{item.name}
+						</DisclosureButton>
+					))}
+				</div>
+				<div class="border-t border-white/10 pt-4 pb-3">
+					<div class="flex items-center px-5 sm:px-6">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-2 outline outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-white">{user.name}</div>
+							<div class="text-sm font-medium text-gray-400">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1 px-2 sm:px-3">
+						{userNavigation.map((item) => (
+							<DisclosureButton
+								key={item.name}
+								as="a"
+								href={item.href}
+								class="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-white/5 hover:text-white"
+							>
+								{item.name}
+							</DisclosureButton>
+						))}
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 3: Simple Dark
+// ============================================================================
+
+function SimpleDark() {
+	return (
+		<Disclosure
+			as="nav"
+			class="relative bg-surface-2 dark:bg-surface-2/50 dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+				<div class="flex h-16 items-center justify-between">
+					<div class="flex items-center px-2 lg:px-0">
+						<div class="shrink-0">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto"
+							/>
+						</div>
+						<div class="hidden lg:ml-6 lg:block">
+							<div class="flex space-x-4">
+								<a
+									href="#"
+									class="rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white dark:bg-gray-950/50"
+								>
+									Dashboard
+								</a>
+								<a
+									href="#"
+									class="rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-white/5 hover:text-white"
+								>
+									Team
+								</a>
+								<a
+									href="#"
+									class="rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-white/5 hover:text-white"
+								>
+									Projects
+								</a>
+								<a
+									href="#"
+									class="rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-white/5 hover:text-white"
+								>
+									Calendar
+								</a>
+							</div>
+						</div>
+					</div>
+					<div class="flex flex-1 justify-center px-2 lg:ml-6 lg:justify-end">
+						<div class="grid w-full max-w-lg grid-cols-1 lg:max-w-xs">
+							<input
+								name="search"
+								placeholder="Search"
+								aria-label="Search"
+								class="col-start-1 row-start-1 block w-full rounded-md bg-white/5 py-1.5 pr-3 pl-10 text-base text-white outline outline-white/10 placeholder:text-gray-500 focus:text-white focus:outline-2 focus:outline-accent-500 sm:text-sm/6"
+							/>
+							<Search
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-gray-400"
+							/>
+						</div>
+					</div>
+					<div class="flex lg:hidden">
+						{/* Mobile menu button */}
+						<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-white/5 hover:text-white focus:outline-2 focus:outline-accent-500">
+							<span class="absolute -inset-0.5" />
+							<span class="sr-only">Open main menu</span>
+							<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+							<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+						</DisclosureButton>
+					</div>
+					<div class="hidden lg:ml-4 lg:block">
+						<div class="flex items-center">
+							<button
+								type="button"
+								class="relative shrink-0 rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+
+							{/* Profile dropdown */}
+							<Menu as="div" class="relative ml-4 shrink-0">
+								<MenuButton class="relative flex rounded-full text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">Open user menu</span>
+									<img
+										alt=""
+										src={userImageAlt}
+										class="size-8 rounded-full bg-surface-2 outline outline-white/10"
+									/>
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+								>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-gray-700"
+										>
+											Your profile
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-gray-700"
+										>
+											Settings
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-gray-700"
+										>
+											Sign out
+										</a>
+									</MenuItem>
+								</MenuItems>
+							</Menu>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<DisclosurePanel class="lg:hidden">
+				<div class="space-y-1 px-2 pt-2 pb-3">
+					<a
+						href="#"
+						class="block rounded-md bg-gray-900 px-3 py-2 text-base font-medium text-white dark:bg-gray-950/50"
+					>
+						Dashboard
+					</a>
+					<a
+						href="#"
+						class="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-white/5 hover:text-white"
+					>
+						Team
+					</a>
+					<a
+						href="#"
+						class="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-white/5 hover:text-white"
+					>
+						Projects
+					</a>
+					<a
+						href="#"
+						class="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-white/5 hover:text-white"
+					>
+						Calendar
+					</a>
+				</div>
+				<div class="border-t border-white/10 pt-4 pb-3">
+					<div class="flex items-center px-5">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-2 outline outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-white">{user.name}</div>
+							<div class="text-sm font-medium text-gray-400">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1 px-2">
+						<a
+							href="#"
+							class="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-white/5 hover:text-white"
+						>
+							Your profile
+						</a>
+						<a
+							href="#"
+							class="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-white/5 hover:text-white"
+						>
+							Settings
+						</a>
+						<a
+							href="#"
+							class="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-white/5 hover:text-white"
+						>
+							Sign out
+						</a>
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 4: Simple with Menu Button on Left
+// ============================================================================
+
+function SimpleWithMenuButtonOnLeft() {
+	return (
+		<Disclosure
+			as="nav"
+			class="relative bg-surface-0 shadow-sm dark:bg-surface-2/50 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+				<div class="flex h-16 items-center justify-between">
+					<div class="flex">
+						<div class="flex shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+								class="h-8 w-auto dark:hidden"
+							/>
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto hidden dark:block"
+							/>
+						</div>
+						<div class="hidden sm:ml-6 sm:block">
+							<div class="flex space-x-8">
+								<a
+									href="#"
+									class="inline-flex items-center border-b-2 border-accent-500 px-1 pt-1 text-sm font-medium text-text-primary dark:text-white"
+								>
+									Dashboard
+								</a>
+								<a
+									href="#"
+									class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:text-white"
+								>
+									Team
+								</a>
+								<a
+									href="#"
+									class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:text-white"
+								>
+									Projects
+								</a>
+								<a
+									href="#"
+									class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:text-white"
+								>
+									Calendar
+								</a>
+							</div>
+						</div>
+					</div>
+					<div class="hidden sm:ml-6 sm:flex sm:items-center">
+						<button
+							type="button"
+							class="relative rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:hover:text-white dark:focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+
+						{/* Profile dropdown */}
+						<Menu as="div" class="relative ml-3">
+							<MenuButton class="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">Open user menu</span>
+								<img
+									alt=""
+									src={userImageAlt}
+									class="size-8 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+								/>
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-200 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+							>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+									>
+										Your profile
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+									>
+										Settings
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+									>
+										Sign out
+									</a>
+								</MenuItem>
+							</MenuItems>
+						</Menu>
+					</div>
+					<div class="-mr-2 flex items-center sm:hidden">
+						{/* Mobile menu button */}
+						<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-text-tertiary hover:bg-surface-1 hover:text-text-secondary focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500 dark:hover:bg-white/5 dark:hover:text-white dark:focus:outline-accent-500">
+							<span class="absolute -inset-0.5" />
+							<span class="sr-only">Open main menu</span>
+							<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+							<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+						</DisclosureButton>
+					</div>
+				</div>
+			</div>
+
+			<DisclosurePanel class="sm:hidden">
+				<div class="space-y-1 pt-2 pb-3">
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-accent-500 bg-accent-500/10 py-2 pr-4 pl-3 text-base font-medium text-accent-700 dark:border-accent-500 dark:bg-accent-500/10 dark:text-accent-400"
+					>
+						Dashboard
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Team
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Projects
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Calendar
+					</DisclosureButton>
+				</div>
+				<div class="border-t border-surface-border pt-4 pb-3 dark:border-white/10">
+					<div class="flex items-center px-4">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-text-primary dark:text-gray-200">
+								{user.name}
+							</div>
+							<div class="text-sm font-medium text-text-tertiary">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:hover:text-white"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1">
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Your profile
+						</DisclosureButton>
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Settings
+						</DisclosureButton>
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Sign out
+						</DisclosureButton>
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 5: Simple
+// ============================================================================
+
+function SimpleNavbar() {
+	return (
+		<Disclosure
+			as="nav"
+			class="relative bg-surface-0 shadow-sm dark:bg-surface-2/50 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-2 sm:px-4 lg:px-8">
+				<div class="flex h-16 justify-between">
+					<div class="flex px-2 lg:px-0">
+						<div class="flex shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+								class="h-8 w-auto dark:hidden"
+							/>
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto hidden dark:block"
+							/>
+						</div>
+						<div class="hidden lg:ml-6 lg:flex lg:space-x-8">
+							<a
+								href="#"
+								class="inline-flex items-center border-b-2 border-accent-500 px-1 pt-1 text-sm font-medium text-text-primary dark:border-accent-500 dark:text-white"
+							>
+								Dashboard
+							</a>
+							<a
+								href="#"
+								class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-white"
+							>
+								Team
+							</a>
+							<a
+								href="#"
+								class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-white"
+							>
+								Projects
+							</a>
+							<a
+								href="#"
+								class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-white"
+							>
+								Calendar
+							</a>
+						</div>
+					</div>
+					<div class="flex flex-1 items-center justify-center px-2 lg:ml-6 lg:justify-end">
+						<div class="grid w-full max-w-lg grid-cols-1 lg:max-w-xs">
+							<input
+								name="search"
+								type="search"
+								placeholder="Search"
+								class="col-start-1 row-start-1 block w-full rounded-md bg-surface-0 py-1.5 pr-3 pl-10 text-base text-text-primary outline outline-surface-border placeholder:text-text-tertiary focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-accent-500"
+							/>
+							<Search
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-text-tertiary"
+							/>
+						</div>
+					</div>
+					<div class="flex items-center lg:hidden">
+						{/* Mobile menu button */}
+						<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-text-tertiary hover:bg-surface-1 hover:text-text-secondary focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500 dark:hover:bg-white/5 dark:hover:text-white dark:focus:outline-accent-500">
+							<span class="absolute -inset-0.5" />
+							<span class="sr-only">Open main menu</span>
+							<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+							<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+						</DisclosureButton>
+					</div>
+					<div class="hidden lg:ml-4 lg:flex lg:items-center">
+						<button
+							type="button"
+							class="relative shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:hover:text-white dark:focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+
+						{/* Profile dropdown */}
+						<Menu as="div" class="relative ml-4 shrink-0">
+							<MenuButton class="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">Open user menu</span>
+								<img
+									alt=""
+									src={userImageAlt}
+									class="size-8 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+								/>
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+							>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+									>
+										Your profile
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+									>
+										Settings
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+									>
+										Sign out
+									</a>
+								</MenuItem>
+							</MenuItems>
+						</Menu>
+					</div>
+				</div>
+			</div>
+
+			<DisclosurePanel class="lg:hidden">
+				<div class="space-y-1 pt-2 pb-3">
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-accent-500 bg-accent-500/10 py-2 pr-4 pl-3 text-base font-medium text-accent-700 dark:border-accent-500 dark:bg-accent-500/10 dark:text-accent-400"
+					>
+						Dashboard
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Team
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Projects
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Calendar
+					</DisclosureButton>
+				</div>
+				<div class="border-t border-surface-border pt-4 pb-3 dark:border-white/10">
+					<div class="flex items-center px-4">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-text-primary dark:text-gray-200">
+								{user.name}
+							</div>
+							<div class="text-sm font-medium text-text-tertiary">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:hover:text-white"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1">
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Your profile
+						</DisclosureButton>
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Settings
+						</DisclosureButton>
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Sign out
+						</DisclosureButton>
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 6: With Quick Action
+// ============================================================================
+
+function WithQuickAction() {
+	return (
+		<Disclosure
+			as="nav"
+			class="relative bg-surface-0 shadow-sm dark:bg-surface-2/50 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+				<div class="flex h-16 justify-between">
+					<div class="flex">
+						<div class="mr-2 -ml-2 flex items-center md:hidden">
+							{/* Mobile menu button */}
+							<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-text-tertiary hover:bg-surface-1 hover:text-text-secondary focus:ring-2 focus:ring-accent-500 focus:outline-hidden focus:ring-inset dark:hover:bg-white/5 dark:hover:text-white dark:focus:ring-white">
+								<span class="absolute -inset-0.5" />
+								<span class="sr-only">Open main menu</span>
+								<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+								<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+							</DisclosureButton>
+						</div>
+						<div class="flex shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+								class="h-8 w-auto dark:hidden"
+							/>
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto hidden dark:block"
+							/>
+						</div>
+						<div class="hidden md:ml-6 md:flex md:space-x-8">
+							<a
+								href="#"
+								class="inline-flex items-center border-b-2 border-accent-500 px-1 pt-1 text-sm font-medium text-text-primary dark:border-accent-500 dark:text-white"
+							>
+								Dashboard
+							</a>
+							<a
+								href="#"
+								class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:text-white"
+							>
+								Team
+							</a>
+							<a
+								href="#"
+								class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:text-white"
+							>
+								Projects
+							</a>
+							<a
+								href="#"
+								class="inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-300 dark:hover:border-white/20 dark:hover:text-white"
+							>
+								Calendar
+							</a>
+						</div>
+					</div>
+					<div class="flex items-center">
+						<div class="shrink-0">
+							<button
+								type="button"
+								class="relative inline-flex items-center gap-x-1.5 rounded-md bg-accent-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-accent-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 dark:shadow-none dark:hover:bg-accent-400 dark:focus-visible:outline-accent-500"
+							>
+								<Plus aria-hidden="true" class="-ml-0.5 size-5" />
+								New Job
+							</button>
+						</div>
+						<div class="hidden md:ml-4 md:flex md:shrink-0 md:items-center">
+							<button
+								type="button"
+								class="relative rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:hover:text-white dark:focus:outline-accent-500"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+
+							{/* Profile dropdown */}
+							<Menu as="div" class="relative ml-3">
+								<MenuButton class="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">Open user menu</span>
+									<img
+										alt=""
+										src={userImageAlt}
+										class="size-8 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+									/>
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-200 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+								>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+										>
+											Your profile
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+										>
+											Settings
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+										>
+											Sign out
+										</a>
+									</MenuItem>
+								</MenuItems>
+							</Menu>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<DisclosurePanel class="md:hidden">
+				<div class="space-y-1 pt-2 pb-3">
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-accent-500 bg-accent-500/10 py-2 pr-4 pl-3 text-base font-medium text-accent-700 sm:pr-6 sm:pl-5 dark:border-accent-500 dark:bg-accent-500/10 dark:text-accent-400"
+					>
+						Dashboard
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary sm:pr-6 sm:pl-5 dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Team
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary sm:pr-6 sm:pl-5 dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Projects
+					</DisclosureButton>
+					<DisclosureButton
+						as="a"
+						href="#"
+						class="block border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-text-secondary hover:border-surface-border hover:bg-surface-1 hover:text-text-primary sm:pr-6 sm:pl-5 dark:text-gray-300 dark:hover:border-white/20 dark:hover:bg-white/5 dark:hover:text-white"
+					>
+						Calendar
+					</DisclosureButton>
+				</div>
+				<div class="border-t border-surface-border pt-4 pb-3 dark:border-white/10">
+					<div class="flex items-center px-4 sm:px-6">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-text-primary dark:text-white">{user.name}</div>
+							<div class="text-sm font-medium text-text-tertiary">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:hover:text-white dark:focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1">
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Your profile
+						</DisclosureButton>
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Settings
+						</DisclosureButton>
+						<DisclosureButton
+							as="a"
+							href="#"
+							class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Sign out
+						</DisclosureButton>
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 7: Dark with Search
+// ============================================================================
+
+function DarkWithSearch() {
+	return (
+		<Disclosure
+			as="header"
+			class="relative bg-surface-2 dark:bg-surface-2/50 dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-2 sm:px-4 lg:divide-y lg:divide-white/10 lg:px-8">
+				<div class="relative flex h-16 justify-between">
+					<div class="relative z-10 flex px-2 lg:px-0">
+						<div class="flex shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto"
+							/>
+						</div>
+					</div>
+					<div class="relative z-0 flex flex-1 items-center justify-center px-2 sm:absolute sm:inset-0">
+						<div class="grid w-full grid-cols-1 sm:max-w-xs">
+							<input
+								name="search"
+								placeholder="Search"
+								aria-label="Search"
+								class="col-start-1 row-start-1 block w-full rounded-md border-0 bg-white/5 py-1.5 pr-3 pl-10 text-white outline outline-white/10 placeholder:text-gray-500 focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6"
+							/>
+							<Search
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-gray-400"
+							/>
+						</div>
+					</div>
+					<div class="relative z-10 flex items-center lg:hidden">
+						{/* Mobile menu button */}
+						<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-white/5 hover:text-gray-300 focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500">
+							<span class="absolute -inset-0.5" />
+							<span class="sr-only">Open menu</span>
+							<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+							<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+						</DisclosureButton>
+					</div>
+					<div class="hidden lg:relative lg:z-10 lg:ml-4 lg:flex lg:items-center">
+						<button
+							type="button"
+							class="relative shrink-0 rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+
+						{/* Profile dropdown */}
+						<Menu as="div" class="relative ml-4 shrink-0">
+							<MenuButton class="relative flex rounded-full focus-visible:ring-offset-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">Open user menu</span>
+								<img
+									alt=""
+									src={userImageAlt}
+									class="size-8 rounded-full bg-surface-2 outline outline-white/10"
+								/>
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+							>
+								{userNavigation.map((item) => (
+									<MenuItem key={item.name}>
+										<a
+											href={item.href}
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-200 dark:data-focus:bg-white/5"
+										>
+											{item.name}
+										</a>
+									</MenuItem>
+								))}
+							</MenuItems>
+						</Menu>
+					</div>
+				</div>
+				<nav aria-label="Global" class="hidden lg:flex lg:space-x-8 lg:py-2">
+					{navigation.map((item) => (
+						<a
+							key={item.name}
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-gray-900 text-white dark:bg-gray-950/50'
+									: 'text-gray-300 hover:bg-white/5 hover:text-white',
+								'inline-flex items-center rounded-md px-3 py-2 text-sm font-medium'
+							)}
+						>
+							{item.name}
+						</a>
+					))}
+				</nav>
+			</div>
+
+			<DisclosurePanel as="nav" aria-label="Global" class="lg:hidden">
+				<div class="space-y-1 px-2 pt-2 pb-3">
+					{navigation.map((item) => (
+						<DisclosureButton
+							key={item.name}
+							as="a"
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-gray-900 text-white dark:bg-gray-950/50'
+									: 'text-gray-300 hover:bg-white/5 hover:text-white',
+								'block rounded-md px-3 py-2 text-base font-medium'
+							)}
+						>
+							{item.name}
+						</DisclosureButton>
+					))}
+				</div>
+				<div class="border-t border-white/10 pt-4 pb-3">
+					<div class="flex items-center px-4">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-2 outline outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-white">{user.name}</div>
+							<div class="text-sm font-medium text-gray-400">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1 px-2">
+						{userNavigation.map((item) => (
+							<DisclosureButton
+								key={item.name}
+								as="a"
+								href={item.href}
+								class="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-white/5 hover:text-white"
+							>
+								{item.name}
+							</DisclosureButton>
+						))}
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 8: With Search
+// ============================================================================
+
+function WithSearch() {
+	return (
+		<Disclosure
+			as="header"
+			class="relative bg-surface-0 shadow-sm dark:bg-surface-2/50 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-2 sm:px-4 lg:divide-y lg:divide-surface-border lg:px-8 dark:lg:divide-white/10">
+				<div class="relative flex h-16 justify-between">
+					<div class="relative z-10 flex px-2 lg:px-0">
+						<div class="flex shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+								class="h-8 w-auto dark:hidden"
+							/>
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto hidden dark:block"
+							/>
+						</div>
+					</div>
+					<div class="relative z-0 flex flex-1 items-center justify-center px-2 sm:absolute sm:inset-0">
+						<div class="grid w-full grid-cols-1 sm:max-w-xs">
+							<input
+								name="search"
+								placeholder="Search"
+								class="col-start-1 row-start-1 block w-full rounded-md bg-surface-0 py-1.5 pr-3 pl-10 text-base text-text-primary outline outline-surface-border placeholder:text-text-tertiary focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-accent-500"
+							/>
+							<Search
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-text-tertiary"
+							/>
+						</div>
+					</div>
+					<div class="relative z-10 flex items-center lg:hidden">
+						{/* Mobile menu button */}
+						<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-text-tertiary hover:bg-surface-1 hover:text-text-secondary focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white dark:focus:outline-accent-500">
+							<span class="absolute -inset-0.5" />
+							<span class="sr-only">Open menu</span>
+							<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+							<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+						</DisclosureButton>
+					</div>
+					<div class="hidden lg:relative lg:z-10 lg:ml-4 lg:flex lg:items-center">
+						<button
+							type="button"
+							class="relative shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:text-gray-400 dark:hover:text-white dark:focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+
+						{/* Profile dropdown */}
+						<Menu as="div" class="relative ml-4 shrink-0">
+							<MenuButton class="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">Open user menu</span>
+								<img
+									alt=""
+									src={userImageAlt}
+									class="size-8 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+								/>
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+							>
+								{userNavigation.map((item) => (
+									<MenuItem key={item.name}>
+										<a
+											href={item.href}
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+										>
+											{item.name}
+										</a>
+									</MenuItem>
+								))}
+							</MenuItems>
+						</Menu>
+					</div>
+				</div>
+				<nav aria-label="Global" class="hidden lg:flex lg:space-x-8 lg:py-2">
+					{navigation.map((item) => (
+						<a
+							key={item.name}
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-surface-1 text-text-primary dark:bg-gray-950/50 dark:text-white'
+									: 'text-text-primary hover:bg-surface-1 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white',
+								'inline-flex items-center rounded-md px-3 py-2 text-sm font-medium'
+							)}
+						>
+							{item.name}
+						</a>
+					))}
+				</nav>
+			</div>
+
+			<DisclosurePanel as="nav" aria-label="Global" class="lg:hidden">
+				<div class="space-y-1 px-2 pt-2 pb-3">
+					{navigation.map((item) => (
+						<DisclosureButton
+							key={item.name}
+							as="a"
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-surface-1 text-text-primary dark:bg-white/5 dark:text-white'
+									: 'text-text-primary hover:bg-surface-1 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white',
+								'block rounded-md px-3 py-2 text-base font-medium'
+							)}
+						>
+							{item.name}
+						</DisclosureButton>
+					))}
+				</div>
+				<div class="border-t border-surface-border pt-4 pb-3 dark:border-white/10">
+					<div class="flex items-center px-4">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-text-primary dark:text-white">{user.name}</div>
+							<div class="text-sm font-medium text-text-tertiary">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:text-gray-400 dark:hover:text-white dark:focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1 px-2">
+						{userNavigation.map((item) => (
+							<DisclosureButton
+								key={item.name}
+								as="a"
+								href={item.href}
+								class="block rounded-md px-3 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+							>
+								{item.name}
+							</DisclosureButton>
+						))}
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 9: Dark with Centered Search and Secondary Links
+// ============================================================================
+
+function DarkWithCenteredSearchAndSecondaryLinks() {
+	return (
+		<Disclosure
+			as="header"
+			class="relative bg-surface-2 dark:bg-surface-2/50 dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-2 sm:px-4 lg:divide-y lg:divide-white/10 lg:px-8">
+				<div class="relative flex h-16 justify-between">
+					<div class="relative z-10 flex px-2 lg:px-0">
+						<div class="flex shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto"
+							/>
+						</div>
+					</div>
+					<div class="relative z-0 flex flex-1 items-center justify-center px-2 sm:absolute sm:inset-0">
+						<div class="grid w-full grid-cols-1 sm:max-w-xs">
+							<input
+								name="search"
+								placeholder="Search"
+								aria-label="Search"
+								class="col-start-1 row-start-1 block w-full rounded-md border-0 bg-white/5 py-1.5 pr-3 pl-10 text-white outline outline-white/10 placeholder:text-gray-500 focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6"
+							/>
+							<Search
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-gray-400"
+							/>
+						</div>
+					</div>
+					<div class="relative z-10 flex items-center lg:hidden">
+						{/* Mobile menu button */}
+						<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-white/5 hover:text-gray-300 focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500">
+							<span class="absolute -inset-0.5" />
+							<span class="sr-only">Open menu</span>
+							<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+							<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+						</DisclosureButton>
+					</div>
+					<div class="hidden lg:relative lg:z-10 lg:ml-4 lg:flex lg:items-center">
+						<button
+							type="button"
+							class="relative shrink-0 rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+
+						{/* Profile dropdown */}
+						<Menu as="div" class="relative ml-4 shrink-0">
+							<MenuButton class="relative flex rounded-full focus-visible:ring-offset-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">Open user menu</span>
+								<img
+									alt=""
+									src={userImageAlt}
+									class="size-8 rounded-full bg-surface-2 outline outline-white/10"
+								/>
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+							>
+								{userNavigation.map((item) => (
+									<MenuItem key={item.name}>
+										<a
+											href={item.href}
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-200 dark:data-focus:bg-white/5"
+										>
+											{item.name}
+										</a>
+									</MenuItem>
+								))}
+							</MenuItems>
+						</Menu>
+					</div>
+				</div>
+				<nav aria-label="Global" class="hidden lg:flex lg:space-x-8 lg:py-2">
+					{navigation.map((item) => (
+						<a
+							key={item.name}
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-gray-900 text-white dark:bg-gray-950/50'
+									: 'text-gray-300 hover:bg-white/5 hover:text-white',
+								'inline-flex items-center rounded-md px-3 py-2 text-sm font-medium'
+							)}
+						>
+							{item.name}
+						</a>
+					))}
+				</nav>
+			</div>
+
+			<DisclosurePanel as="nav" aria-label="Global" class="lg:hidden">
+				<div class="space-y-1 px-2 pt-2 pb-3">
+					{navigation.map((item) => (
+						<DisclosureButton
+							key={item.name}
+							as="a"
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-gray-900 text-white dark:bg-gray-950/50'
+									: 'text-gray-300 hover:bg-white/5 hover:text-white',
+								'block rounded-md px-3 py-2 text-base font-medium'
+							)}
+						>
+							{item.name}
+						</DisclosureButton>
+					))}
+				</div>
+				<div class="border-t border-white/10 pt-4 pb-3">
+					<div class="flex items-center px-4">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-2 outline outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-white">{user.name}</div>
+							<div class="text-sm font-medium text-gray-400">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1 px-2">
+						{userNavigation.map((item) => (
+							<DisclosureButton
+								key={item.name}
+								as="a"
+								href={item.href}
+								class="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-white/5 hover:text-white"
+							>
+								{item.name}
+							</DisclosureButton>
+						))}
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 10: With Centered Search and Secondary Links
+// ============================================================================
+
+function WithCenteredSearchAndSecondaryLinks() {
+	return (
+		<Disclosure
+			as="header"
+			class="relative bg-surface-0 shadow-sm dark:bg-surface-2/50 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10"
+		>
+			<div class="mx-auto max-w-7xl px-2 sm:px-4 lg:divide-y lg:divide-surface-border lg:px-8 dark:lg:divide-white/10">
+				<div class="relative flex h-16 justify-between">
+					<div class="relative z-10 flex px-2 lg:px-0">
+						<div class="flex shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+								class="h-8 w-auto dark:hidden"
+							/>
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+								class="h-8 w-auto hidden dark:block"
+							/>
+						</div>
+					</div>
+					<div class="relative z-0 flex flex-1 items-center justify-center px-2 sm:absolute sm:inset-0">
+						<div class="grid w-full grid-cols-1 sm:max-w-xs">
+							<input
+								name="search"
+								placeholder="Search"
+								class="col-start-1 row-start-1 block w-full rounded-md bg-surface-0 py-1.5 pr-3 pl-10 text-base text-text-primary outline outline-surface-border placeholder:text-text-tertiary focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-accent-500"
+							/>
+							<Search
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-text-tertiary"
+							/>
+						</div>
+					</div>
+					<div class="relative z-10 flex items-center lg:hidden">
+						{/* Mobile menu button */}
+						<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-text-tertiary hover:bg-surface-1 hover:text-text-secondary focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white dark:focus:outline-accent-500">
+							<span class="absolute -inset-0.5" />
+							<span class="sr-only">Open menu</span>
+							<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+							<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+						</DisclosureButton>
+					</div>
+					<div class="hidden lg:relative lg:z-10 lg:ml-4 lg:flex lg:items-center">
+						<button
+							type="button"
+							class="relative shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:text-gray-400 dark:hover:text-white dark:focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+
+						{/* Profile dropdown */}
+						<Menu as="div" class="relative ml-4 shrink-0">
+							<MenuButton class="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">Open user menu</span>
+								<img
+									alt=""
+									src={userImageAlt}
+									class="size-8 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+								/>
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+							>
+								{userNavigation.map((item) => (
+									<MenuItem key={item.name}>
+										<a
+											href={item.href}
+											class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+										>
+											{item.name}
+										</a>
+									</MenuItem>
+								))}
+							</MenuItems>
+						</Menu>
+					</div>
+				</div>
+				<nav aria-label="Global" class="hidden lg:flex lg:space-x-8 lg:py-2">
+					{navigation.map((item) => (
+						<a
+							key={item.name}
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-surface-1 text-text-primary dark:bg-gray-950/50 dark:text-white'
+									: 'text-text-primary hover:bg-surface-1 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white',
+								'inline-flex items-center rounded-md px-3 py-2 text-sm font-medium'
+							)}
+						>
+							{item.name}
+						</a>
+					))}
+				</nav>
+			</div>
+
+			<DisclosurePanel as="nav" aria-label="Global" class="lg:hidden">
+				<div class="space-y-1 px-2 pt-2 pb-3">
+					{navigation.map((item) => (
+						<DisclosureButton
+							key={item.name}
+							as="a"
+							href={item.href}
+							aria-current={item.current ? 'page' : undefined}
+							class={classNames(
+								item.current
+									? 'bg-surface-1 text-text-primary dark:bg-white/5 dark:text-white'
+									: 'text-text-primary hover:bg-surface-1 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white',
+								'block rounded-md px-3 py-2 text-base font-medium'
+							)}
+						>
+							{item.name}
+						</DisclosureButton>
+					))}
+				</div>
+				<div class="border-t border-surface-border pt-4 pb-3 dark:border-white/10">
+					<div class="flex items-center px-4">
+						<div class="shrink-0">
+							<img
+								alt=""
+								src={userImageAlt}
+								class="size-10 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+							/>
+						</div>
+						<div class="ml-3">
+							<div class="text-base font-medium text-text-primary dark:text-white">{user.name}</div>
+							<div class="text-sm font-medium text-text-tertiary">{user.email}</div>
+						</div>
+						<button
+							type="button"
+							class="relative ml-auto shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:text-gray-400 dark:hover:text-white dark:focus:outline-accent-500"
+						>
+							<span class="absolute -inset-1.5" />
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+					</div>
+					<div class="mt-3 space-y-1 px-2">
+						{userNavigation.map((item) => (
+							<DisclosureButton
+								key={item.name}
+								as="a"
+								href={item.href}
+								class="block rounded-md px-3 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+							>
+								{item.name}
+							</DisclosureButton>
+						))}
+					</div>
+				</div>
+			</DisclosurePanel>
+		</Disclosure>
+	);
+}
+
+// ============================================================================
+// EXAMPLE 11: With Search in Column Layout
+// ============================================================================
+
+function WithSearchInColumnLayout() {
+	return (
+		<>
+			{/* When the mobile menu is open, add `overflow-hidden` to the `body` element to prevent double scrollbars */}
+			<Popover
+				as="header"
+				class="relative bg-surface-0 shadow-xs data-open:fixed data-open:inset-0 data-open:z-40 data-open:overflow-y-auto lg:overflow-y-visible data-open:lg:overflow-y-visible dark:bg-surface-2/50 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10 dark:data-open:after:absolute dark:data-open:after:inset-x-0 dark:data-open:after:bottom-0"
+			>
+				<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+					<div class="relative flex justify-between lg:gap-8 xl:grid xl:grid-cols-12">
+						<div class="flex md:absolute md:inset-y-0 md:left-0 lg:static xl:col-span-2">
+							<div class="flex shrink-0 items-center">
+								<a href="#">
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto dark:hidden"
+									/>
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+										class="h-8 w-auto hidden dark:block"
+									/>
+								</a>
+							</div>
+						</div>
+						<div class="min-w-0 flex-1 md:px-8 lg:px-0 xl:col-span-6">
+							<div class="flex items-center px-6 py-3.5 md:mx-auto md:max-w-3xl lg:mx-0 lg:max-w-none xl:px-0">
+								<div class="grid w-full grid-cols-1">
+									<input
+										name="search"
+										placeholder="Search"
+										class="col-start-1 row-start-1 block w-full rounded-md bg-surface-0 py-1.5 pr-3 pl-10 text-base text-text-primary outline outline-surface-border placeholder:text-text-tertiary focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-accent-500"
+									/>
+									<Search
+										aria-hidden="true"
+										class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-text-tertiary"
+									/>
+								</div>
+							</div>
+						</div>
+						<div class="flex items-center md:absolute md:inset-y-0 md:right-0 lg:hidden">
+							{/* Mobile menu button */}
+							<PopoverButton class="group relative -mx-2 inline-flex items-center justify-center rounded-md p-2 text-text-tertiary hover:bg-surface-1 hover:text-text-secondary focus:outline-2 focus:-outline-offset-1 focus:outline-accent-500 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white dark:focus:outline-accent-500">
+								<span class="absolute -inset-0.5" />
+								<span class="sr-only">Open menu</span>
+								<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+								<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+							</PopoverButton>
+						</div>
+						<div class="hidden lg:flex lg:items-center lg:justify-end xl:col-span-4">
+							<button
+								type="button"
+								class="relative ml-5 shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:text-gray-400 dark:hover:text-white dark:focus:outline-accent-500"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+
+							{/* Profile dropdown */}
+							<Menu as="div" class="relative ml-5 shrink-0">
+								<MenuButton class="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">Open user menu</span>
+									<img
+										alt=""
+										src={userImageAlt}
+										class="size-8 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+									/>
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-0 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:outline-white/10"
+								>
+									{userNavigation.map((item) => (
+										<MenuItem key={item.name}>
+											<a
+												href={item.href}
+												class="block px-4 py-2 text-sm text-text-secondary data-focus:bg-surface-1 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+											>
+												{item.name}
+											</a>
+										</MenuItem>
+									))}
+								</MenuItems>
+							</Menu>
+
+							<a
+								href="#"
+								class="ml-6 inline-flex items-center rounded-md bg-accent-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-accent-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 dark:shadow-none dark:hover:bg-accent-400 dark:focus-visible:outline-accent-500"
+							>
+								New Project
+							</a>
+						</div>
+					</div>
+				</div>
+
+				<PopoverPanel
+					as="nav"
+					aria-label="Global"
+					class="absolute relative left-1/2 z-10 mt-2 w-full -translate-x-1/2 lg:hidden dark:bg-surface-2 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-surface-2/50"
+				>
+					<div class="relative mx-auto max-w-3xl space-y-1 px-2 pt-2 pb-3 sm:px-4">
+						<a
+							href="#"
+							class="block rounded-md bg-surface-1 px-3 py-2 text-base font-medium text-text-primary dark:bg-white/5 dark:text-white"
+						>
+							Dashboard
+						</a>
+						<a
+							href="#"
+							class="block rounded-md px-3 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Calendar
+						</a>
+						<a
+							href="#"
+							class="block rounded-md px-3 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Teams
+						</a>
+						<a
+							href="#"
+							class="block rounded-md px-3 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white"
+						>
+							Directory
+						</a>
+					</div>
+					<div class="relative border-t border-surface-border pt-4 pb-3 dark:border-white/10">
+						<div class="mx-auto flex max-w-3xl items-center px-4 sm:px-6">
+							<div class="shrink-0">
+								<img
+									alt=""
+									src={userImageAlt}
+									class="size-10 rounded-full bg-surface-1 outline outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+								/>
+							</div>
+							<div class="ml-3">
+								<div class="text-base font-medium text-text-primary dark:text-white">
+									{user.name}
+								</div>
+								<div class="text-sm font-medium text-text-tertiary">{user.email}</div>
+							</div>
+							<button
+								type="button"
+								class="relative ml-auto shrink-0 rounded-full p-1 text-text-tertiary hover:text-text-secondary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:text-gray-400 dark:hover:text-white dark:focus:outline-accent-500"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+						</div>
+						<div class="mx-auto mt-3 max-w-3xl space-y-1 px-2 sm:px-4">
+							{userNavigation.map((item) => (
+								<a
+									key={item.name}
+									href={item.href}
+									class="block rounded-md px-3 py-2 text-base font-medium text-text-secondary hover:bg-surface-1 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+								>
+									{item.name}
+								</a>
+							))}
+						</div>
+					</div>
+				</PopoverPanel>
+			</Popover>
+		</>
+	);
+}
+
+// ============================================================================
+// MAIN EXPORT
+// ============================================================================
+
+export function NavbarsDemo() {
+	return (
+		<div class="flex flex-col gap-12">
+			{/* Example 1: Simple Dark with Menu Button on Left */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Simple dark with menu button on left
+				</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-2 dark:bg-surface-2/50">
+					<SimpleDarkWithMenuButtonOnLeft />
+				</div>
+			</div>
+
+			{/* Example 2: Dark with Quick Action */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Dark with quick action</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-2 dark:bg-surface-2/50">
+					<DarkWithQuickAction />
+				</div>
+			</div>
+
+			{/* Example 3: Simple Dark */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple dark</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-2 dark:bg-surface-2/50">
+					<SimpleDark />
+				</div>
+			</div>
+
+			{/* Example 4: Simple with Menu Button on Left */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple with menu button on left</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-0 dark:bg-surface-2/50">
+					<SimpleWithMenuButtonOnLeft />
+				</div>
+			</div>
+
+			{/* Example 5: Simple */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-0 dark:bg-surface-2/50">
+					<SimpleNavbar />
+				</div>
+			</div>
+
+			{/* Example 6: With Quick Action */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With quick action</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-0 dark:bg-surface-2/50">
+					<WithQuickAction />
+				</div>
+			</div>
+
+			{/* Example 7: Dark with Search */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Dark with search</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-2 dark:bg-surface-2/50">
+					<DarkWithSearch />
+				</div>
+			</div>
+
+			{/* Example 8: With Search */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With search</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-0 dark:bg-surface-2/50">
+					<WithSearch />
+				</div>
+			</div>
+
+			{/* Example 9: Dark with Centered Search and Secondary Links */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Dark with centered search and secondary links
+				</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-2 dark:bg-surface-2/50">
+					<DarkWithCenteredSearchAndSecondaryLinks />
+				</div>
+			</div>
+
+			{/* Example 10: With Centered Search and Secondary Links */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					With centered search and secondary links
+				</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-0 dark:bg-surface-2/50">
+					<WithCenteredSearchAndSecondaryLinks />
+				</div>
+			</div>
+
+			{/* Example 11: With Search in Column Layout */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With search in column layout</h3>
+				<div class="rounded-lg border border-surface-border bg-surface-0 dark:bg-surface-2/50">
+					<WithSearchInColumnLayout />
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Add `CommandPalettesDemo.tsx` with 8 Dialog + Combobox examples (Simple, With Padding, With Preview, With Images & Descriptions, With Icons, Semi-Transparent, With Groups, With Footer)
- Add `NavbarsDemo.tsx` with 11 Dialog + Popover examples (Simple, Dark, with Menu on Left, with Border, Full Width, with Centered Search, with Notifications, with User Profile, Mobile Menu, Dark Mobile Menu, Dark with Centered Search)
- Extend `SidebarNavigationDemo.tsx` with 2 headless+icon variants (expandable sections with icons, secondary navigation)
- Register new navigation sections in App.tsx

Ported 21 headless+icon reference examples from Tailwind Application UI v4.