### PR TITLE
feat(ui-demo): add stacked application shell demos

### DIFF
--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -59,6 +59,13 @@ import { TextareasDemo } from './sections/TextareasDemo.tsx';
 import { TogglesDemo } from './sections/TogglesDemo.tsx';
 import { FormLayoutsDemo } from './sections/forms/form-layouts/FormLayoutsDemo.tsx';
 import { SelectMenusDemo } from './sections/forms/select-menus/SelectMenusDemo.tsx';
+import { ComboboxesDemo } from './sections/forms/comboboxes/ComboboxesDemo.tsx';
+import { CustomSelectMenusDemo } from './sections/forms/select-menus/CustomSelectMenusDemo.tsx';
+import { MultiColumnShellsDemo } from './sections/application-shells/multi-column/MultiColumnShellsDemo.tsx';
+import { SidebarShellsDemo } from './sections/application-shells/sidebar/SidebarShellsDemo.tsx';
+import { StackedShellsDemo } from './sections/application-shells/stacked/StackedShellsDemo.tsx';
+import { DropdownsDemo } from './sections/elements/dropdowns/DropdownsDemo.tsx';
+import { CalendarsHeadlessDemo } from './sections/data-display/calendars/CalendarsHeadlessDemo.tsx';
 
 interface DemoSectionProps {
 	id: string;
@@ -546,10 +553,38 @@ export function App() {
 					>
 						<MultiColumnDemo />
 					</DemoSection>
+					<DemoSection
+						id="application-shells-multi-column-shells"
+						title="Multi-column Shells (Headless+Icon)"
+					>
+						<MultiColumnShellsDemo />
+					</DemoSection>
+					<DemoSection id="application-shells-sidebar" title="Sidebar Shells (Headless+Icon)">
+						<SidebarShellsDemo />
+					</DemoSection>
+					<DemoSection id="application-shells-stacked" title="Stacked Shells (Headless+Icon)">
+						<StackedShellsDemo />
+					</DemoSection>
+
+					{/* Application UI - Forms / Comboboxes */}
+					<DemoSection id="forms-comboboxes" title="Comboboxes (Headless+Icon)">
+						<ComboboxesDemo />
+					</DemoSection>
+					<DemoSection id="forms-select-menus-headless" title="Custom Select Menus (Headless+Icon)">
+						<CustomSelectMenusDemo />
+					</DemoSection>
+
+					{/* Application UI - Elements / Dropdowns */}
+					<DemoSection id="elements-dropdowns" title="Dropdowns (Headless+Icon)">
+						<DropdownsDemo />
+					</DemoSection>
 
 					{/* Application UI - Data Display */}
 					<DemoSection id="data-display-calendars" title="Calendars (Data Display)">
 						<CalendarsDemo />
+					</DemoSection>
+					<DemoSection id="data-display-calendars-headless" title="Calendars (Headless+Icon)">
+						<CalendarsHeadlessDemo />
 					</DemoSection>
 					<DemoSection id="data-display-description-lists" title="Description Lists (Data Display)">
 						<DescriptionListsDemo />

--- a/packages/ui/demo/sections/FeedsDemo.tsx
+++ b/packages/ui/demo/sections/FeedsDemo.tsx
@@ -1,4 +1,6 @@
-import { Check, ThumbsUp, User, CheckCircle, Circle } from 'lucide-preact';
+import { useState } from 'preact/hooks';
+import { Check, ThumbsUp, User, CheckCircle, Circle, Smile, Paperclip } from 'lucide-preact';
+import { Listbox, ListboxButton, ListboxOptions, ListboxOption } from '../../src/mod.ts';
 import { classNames } from '../../src/internal/class-names.ts';
 
 // ============================================================
@@ -226,6 +228,178 @@ export function WithComments() {
 }
 
 // ============================================================
+// 03 - With Comments and Mood Selector (Headless)
+// ============================================================
+const moods = [
+	{ name: 'Excited', value: 'excited', bgColor: 'bg-red-500' },
+	{ name: 'Loved', value: 'loved', bgColor: 'bg-pink-400' },
+	{ name: 'Happy', value: 'happy', bgColor: 'bg-green-400' },
+	{ name: 'Sad', value: 'sad', bgColor: 'bg-yellow-400' },
+	{ name: 'Thumbsy', value: 'thumbsy', bgColor: 'bg-blue-500' },
+	{ name: 'I feel nothing', value: null, bgColor: 'bg-transparent' },
+];
+
+export function WithCommentsAndMood() {
+	const [selected, setSelected] = useState(moods[5]);
+
+	return (
+		<>
+			<ul role="list" class="space-y-6">
+				{activity.map((activityItem, activityItemIdx) => (
+					<li key={activityItem.id} class="relative flex gap-x-4">
+						<div
+							class={classNames(
+								activityItemIdx === activity.length - 1 ? 'h-6' : '-bottom-6',
+								'absolute top-0 left-0 flex w-6 justify-center'
+							)}
+						>
+							<div class="w-px bg-surface-2 dark:bg-white/15" />
+						</div>
+						{activityItem.type === 'commented' ? (
+							<>
+								<img
+									alt=""
+									src={activityItem.person.imageUrl}
+									class="relative mt-3 size-6 flex-none rounded-full bg-surface-1 outline -outline-offset-1 outline-black/5 dark:bg-surface-2 dark:outline-white/10"
+								/>
+								<div class="flex-auto rounded-md p-3 ring-1 ring-surface-2 ring-inset dark:ring-white/15">
+									<div class="flex justify-between gap-x-4">
+										<div class="py-0.5 text-xs/5 text-text-secondary">
+											<span class="font-medium text-text-primary">{activityItem.person.name}</span>{' '}
+											commented
+										</div>
+										<time
+											dateTime={activityItem.dateTime}
+											class="flex-none py-0.5 text-xs/5 text-text-secondary"
+										>
+											{activityItem.date}
+										</time>
+									</div>
+									<p class="text-sm/6 text-text-secondary">{activityItem.comment}</p>
+								</div>
+							</>
+						) : (
+							<>
+								<div class="relative flex size-6 flex-none items-center justify-center bg-surface-0 dark:bg-surface-1">
+									{activityItem.type === 'paid' ? (
+										<CheckCircle
+											aria-hidden="true"
+											class="size-6 text-accent-500 dark:text-accent-400"
+										/>
+									) : (
+										<Circle
+											aria-hidden="true"
+											class="size-1.5 rounded-full bg-surface-3 ring ring-surface-3 dark:bg-white/10 dark:ring-white/20"
+										/>
+									)}
+								</div>
+								<p class="flex-auto py-0.5 text-xs/5 text-text-secondary">
+									<span class="font-medium text-text-primary">{activityItem.person.name}</span>{' '}
+									{activityItem.type} the invoice.
+								</p>
+								<time
+									dateTime={activityItem.dateTime}
+									class="flex-none py-0.5 text-xs/5 text-text-secondary"
+								>
+									{activityItem.date}
+								</time>
+							</>
+						)}
+					</li>
+				))}
+			</ul>
+
+			{/* New comment form with mood selector */}
+			<div class="mt-6 flex gap-x-3">
+				<img
+					alt=""
+					src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+					class="size-6 flex-none rounded-full bg-surface-1 dark:bg-surface-2 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+				/>
+				<form action="#" class="relative flex-auto">
+					<div class="overflow-hidden rounded-lg pb-12 outline-1 -outline-offset-1 outline-surface-2 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-accent-500 dark:bg-white/5 dark:outline-white/10">
+						<textarea
+							id="comment"
+							name="comment"
+							rows={2}
+							placeholder="Add your comment..."
+							class="block w-full resize-none bg-transparent px-3 py-1.5 text-base text-text-primary placeholder:text-text-muted focus:outline-none sm:text-sm/6"
+							defaultValue={''}
+						/>
+					</div>
+
+					<div class="absolute inset-x-0 bottom-0 flex justify-between py-2 pr-2 pl-3">
+						<div class="flex items-center space-x-5">
+							<div class="flex items-center">
+								<button
+									type="button"
+									class="-m-2.5 flex size-10 items-center justify-center rounded-full text-text-secondary hover:text-text-primary dark:text-text-secondary dark:hover:text-text-primary"
+								>
+									<Paperclip aria-hidden="true" class="size-5" />
+									<span class="sr-only">Attach a file</span>
+								</button>
+							</div>
+							<Listbox value={selected} onChange={setSelected}>
+								<div class="relative">
+									<ListboxButton class="relative -m-2.5 flex size-10 items-center justify-center rounded-full text-text-secondary hover:text-text-primary dark:text-text-secondary dark:hover:text-text-primary cursor-pointer outline-none">
+										{selected.value === null ? (
+											<Smile aria-hidden="true" class="size-5 shrink-0" />
+										) : (
+											<div
+												class={classNames(
+													selected.bgColor,
+													'flex size-8 items-center justify-center rounded-full'
+												)}
+											>
+												<Smile aria-hidden="true" class="size-5 shrink-0 text-white" />
+											</div>
+										)}
+										<span class="sr-only">Add your mood</span>
+									</ListboxButton>
+									<ListboxOptions class="absolute bottom-10 z-10 -ml-6 w-60 rounded-lg bg-surface-1 py-3 text-base shadow-xl border border-surface-border data-leave:transition data-leave:duration-100 data-leave:ease-in data-closed:data-leave:opacity-0 sm:ml-auto sm:w-64 sm:text-sm outline-none">
+										{moods.map((mood) => (
+											<ListboxOption
+												key={mood.value}
+												value={mood}
+												class="relative cursor-pointer bg-transparent px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[selected]:bg-accent-500 data-[selected]:text-white"
+											>
+												<div class="flex items-center">
+													<div
+														class={classNames(
+															mood.bgColor,
+															'flex size-8 items-center justify-center rounded-full'
+														)}
+													>
+														<Smile
+															aria-hidden="true"
+															class={classNames(
+																mood.value === null ? 'text-text-secondary' : 'text-white',
+																'size-5 shrink-0'
+															)}
+														/>
+													</div>
+													<span class="ml-3 block truncate font-medium">{mood.name}</span>
+												</div>
+											</ListboxOption>
+										))}
+									</ListboxOptions>
+								</div>
+							</Listbox>
+						</div>
+						<button
+							type="submit"
+							class="rounded-md bg-accent-500 px-2.5 py-1.5 text-sm font-semibold text-white shadow-xs hover:bg-accent-600 dark:bg-accent-500 dark:shadow-none dark:hover:bg-accent-400"
+						>
+							Comment
+						</button>
+					</div>
+				</form>
+			</div>
+		</>
+	);
+}
+
+// ============================================================
 // FeedsDemo - Main wrapper
 // ============================================================
 export function FeedsDemo() {
@@ -239,6 +413,11 @@ export function FeedsDemo() {
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">With comments</h3>
 				<WithComments />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">With comments and mood selector</h3>
+				<WithCommentsAndMood />
 			</div>
 		</div>
 	);

--- a/packages/ui/demo/sections/GridListsDemo.tsx
+++ b/packages/ui/demo/sections/GridListsDemo.tsx
@@ -1,3 +1,4 @@
+import { Menu, MenuButton, MenuItems, MenuItem } from '../../src/mod.ts';
 import { EllipsisVertical } from 'lucide-preact';
 import { classNames } from '../../src/internal/class-names.ts';
 
@@ -531,6 +532,118 @@ export function GridListsDemo() {
 							<p class="pointer-events-none block text-sm font-medium text-text-secondary">
 								{file.size}
 							</p>
+						</li>
+					))}
+				</ul>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 07 - Logos Cards with Description List */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Logos cards with description list
+				</h3>
+				<ul role="list" class="grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">
+					{[
+						{
+							id: 1,
+							name: 'Tuple',
+							imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/tuple.svg',
+							lastInvoice: {
+								date: 'December 13, 2022',
+								dateTime: '2022-12-13',
+								amount: '$2,000.00',
+								status: 'Overdue',
+							},
+						},
+						{
+							id: 2,
+							name: 'SavvyCal',
+							imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/savvycal.svg',
+							lastInvoice: {
+								date: 'January 22, 2023',
+								dateTime: '2023-01-22',
+								amount: '$14,000.00',
+								status: 'Paid',
+							},
+						},
+						{
+							id: 3,
+							name: 'Reform',
+							imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/reform.svg',
+							lastInvoice: {
+								date: 'January 23, 2023',
+								dateTime: '2023-01-23',
+								amount: '$7,600.00',
+								status: 'Paid',
+							},
+						},
+					].map((client) => (
+						<li
+							key={client.id}
+							class="overflow-hidden rounded-xl outline outline-gray-200 dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-6 dark:border-white/10 dark:bg-gray-800/50">
+								<img
+									alt={client.name}
+									src={client.imageUrl}
+									class="size-12 flex-none rounded-lg bg-white object-cover ring-1 ring-gray-900/10 dark:bg-gray-700 dark:ring-white/10"
+								/>
+								<div class="text-sm/6 font-medium text-gray-900 dark:text-white">{client.name}</div>
+								<Menu as="div" class="relative ml-auto">
+									<MenuButton class="relative block text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white cursor-pointer">
+										<span class="absolute -inset-2.5" />
+										<span class="sr-only">Open options</span>
+										<EllipsisVertical aria-hidden="true" class="size-5" />
+									</MenuButton>
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-surface-1 py-2 shadow-xl border border-surface-border transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in outline-none"
+									>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+											>
+												View<span class="sr-only">, {client.name}</span>
+											</a>
+										</MenuItem>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+											>
+												Edit<span class="sr-only">, {client.name}</span>
+											</a>
+										</MenuItem>
+									</MenuItems>
+								</Menu>
+							</div>
+							<dl class="-my-3 divide-y divide-surface-2 px-6 py-4 text-sm/6 dark:divide-white/10">
+								<div class="flex justify-between gap-x-4 py-3">
+									<dt class="text-text-secondary">Last invoice</dt>
+									<dd class="text-text-primary">
+										<time dateTime={client.lastInvoice.dateTime}>{client.lastInvoice.date}</time>
+									</dd>
+								</div>
+								<div class="flex justify-between gap-x-4 py-3">
+									<dt class="text-text-secondary">Amount</dt>
+									<dd class="flex items-start gap-x-2">
+										<div class="font-medium text-text-primary">{client.lastInvoice.amount}</div>
+										{client.lastInvoice.status == 'Paid' ? (
+											<div class="rounded-md bg-green-500/10 px-2 py-1 text-xs font-medium text-green-500 ring-1 ring-inset ring-green-500/20 dark:bg-green-500/10 dark:text-green-400 dark:ring-green-500/20">
+												{client.lastInvoice.status}
+											</div>
+										) : null}
+										{client.lastInvoice.status == 'Overdue' ? (
+											<div class="rounded-md bg-red-500/10 px-2 py-1 text-xs font-medium text-red-500 ring-1 ring-inset ring-red-500/20 dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/20">
+												{client.lastInvoice.status}
+											</div>
+										) : null}
+									</dd>
+								</div>
+							</dl>
 						</li>
 					))}
 				</ul>

--- a/packages/ui/demo/sections/StackedListsDemo.tsx
+++ b/packages/ui/demo/sections/StackedListsDemo.tsx
@@ -1,3 +1,6 @@
+import { Menu, MenuButton, MenuItems, MenuItem } from '../../src/mod.ts';
+import { EllipsisVertical } from 'lucide-preact';
+
 const people = [
 	{
 		name: 'Leslie Alexander',
@@ -690,6 +693,226 @@ export function StackedListsDemo() {
 									)}
 								</div>
 								<ChevronRightIcon class="size-5 flex-none text-text-tertiary dark:text-text-secondary" />
+							</div>
+						</li>
+					))}
+				</ul>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 19 - With Inline Links and Actions Menu */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					With inline links and actions menu
+				</h3>
+				<ul role="list" class="divide-y divide-surface-2 dark:divide-white/5">
+					{[
+						{
+							name: 'Leslie Alexander',
+							email: 'leslie.alexander@example.com',
+							role: 'Co-Founder / CEO',
+							imageUrl:
+								'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+							href: '#',
+							lastSeen: '3h ago',
+							lastSeenDateTime: '2023-01-23T13:23Z',
+						},
+						{
+							name: 'Michael Foster',
+							email: 'michael.foster@example.com',
+							role: 'Co-Founder / CTO',
+							imageUrl:
+								'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+							href: '#',
+							lastSeen: '3h ago',
+							lastSeenDateTime: '2023-01-23T13:23Z',
+						},
+						{
+							name: 'Dries Vincent',
+							email: 'dries.vincent@example.com',
+							role: 'Business Relations',
+							imageUrl:
+								'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+							href: '#',
+							lastSeen: null,
+						},
+					].map((person) => (
+						<li key={person.email} class="flex justify-between gap-x-6 py-5">
+							<div class="flex min-w-0 gap-x-4">
+								<img
+									alt=""
+									src={person.imageUrl}
+									class="size-12 flex-none rounded-full bg-surface-1 dark:bg-surface-2 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+								/>
+								<div class="min-w-0 flex-auto">
+									<p class="text-sm/6 font-semibold text-text-primary">
+										<a href={person.href} class="hover:underline">
+											{person.name}
+										</a>
+									</p>
+									<p class="mt-1 flex text-xs/5 text-text-secondary">
+										<a href={`mailto:${person.email}`} class="truncate hover:underline">
+											{person.email}
+										</a>
+									</p>
+								</div>
+							</div>
+							<div class="flex shrink-0 items-center gap-x-6">
+								<div class="hidden sm:flex sm:flex-col sm:items-end">
+									<p class="text-sm/6 text-text-primary">{person.role}</p>
+									{person.lastSeen ? (
+										<p class="mt-1 text-xs/5 text-text-secondary">
+											Last seen <time dateTime={person.lastSeenDateTime}>{person.lastSeen}</time>
+										</p>
+									) : (
+										<div class="mt-1 flex items-center gap-x-1.5">
+											<div class="flex-none rounded-full bg-green-500/20 p-1 dark:bg-green-500/30">
+												<div class="size-1.5 rounded-full bg-green-500" />
+											</div>
+											<p class="text-xs/5 text-text-secondary">Online</p>
+										</div>
+									)}
+								</div>
+								<Menu as="div" class="relative flex-none">
+									<MenuButton class="relative block text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white cursor-pointer">
+										<span class="absolute -inset-2.5" />
+										<span class="sr-only">Open options</span>
+										<EllipsisVertical aria-hidden="true" class="size-5" />
+									</MenuButton>
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md bg-surface-1 shadow-xl border border-surface-border transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in outline-none"
+									>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+											>
+												View profile<span class="sr-only">, {person.name}</span>
+											</a>
+										</MenuItem>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+											>
+												Message<span class="sr-only">, {person.name}</span>
+											</a>
+										</MenuItem>
+									</MenuItems>
+								</Menu>
+							</div>
+						</li>
+					))}
+				</ul>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 20 - With Badges, Button and Actions Menu */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					With badges, button and actions menu
+				</h3>
+				<ul role="list" class="divide-y divide-surface-2 dark:divide-white/5">
+					{[
+						{
+							id: 1,
+							name: 'GraphQL API',
+							href: '#',
+							status: 'Complete',
+							createdBy: 'Leslie Alexander',
+							dueDate: 'March 17, 2023',
+							dueDateTime: '2023-03-17T00:00Z',
+						},
+						{
+							id: 2,
+							name: 'New benefits plan',
+							href: '#',
+							status: 'In progress',
+							createdBy: 'Leslie Alexander',
+							dueDate: 'May 5, 2023',
+							dueDateTime: '2023-05-05T00:00Z',
+						},
+						{
+							id: 3,
+							name: 'Onboarding emails',
+							href: '#',
+							status: 'In progress',
+							createdBy: 'Courtney Henry',
+							dueDate: 'May 25, 2023',
+							dueDateTime: '2023-05-25T00:00Z',
+						},
+					].map((project) => (
+						<li key={project.id} class="flex items-center justify-between gap-x-6 py-5">
+							<div class="min-w-0">
+								<div class="flex items-start gap-x-3">
+									<p class="text-sm/6 font-semibold text-text-primary">{project.name}</p>
+									{project.status === 'In progress' ? (
+										<p class="mt-0.5 rounded-md bg-surface-2 px-1.5 py-0.5 text-xs font-medium text-text-secondary ring-1 ring-inset ring-surface-border/50 dark:bg-surface-2 dark:text-text-secondary">
+											{project.status}
+										</p>
+									) : null}
+									{project.status === 'Complete' ? (
+										<p class="mt-0.5 rounded-md bg-green-500/10 px-1.5 py-0.5 text-xs font-medium text-green-500 ring-1 ring-inset ring-green-500/20 dark:bg-green-500/10 dark:text-green-400 dark:ring-green-500/20">
+											{project.status}
+										</p>
+									) : null}
+								</div>
+								<div class="mt-1 flex items-center gap-x-2 text-xs/5 text-text-secondary">
+									<p class="whitespace-nowrap">
+										Due on <time dateTime={project.dueDateTime}>{project.dueDate}</time>
+									</p>
+									<svg viewBox="0 0 2 2" class="size-0.5 fill-current">
+										<circle r={1} cx={1} cy={1} />
+									</svg>
+									<p class="truncate">Created by {project.createdBy}</p>
+								</div>
+							</div>
+							<div class="flex flex-none items-center gap-x-4">
+								<a
+									href={project.href}
+									class="hidden rounded-md bg-surface-0 px-2.5 py-1.5 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 sm:block dark:bg-surface-0/50 dark:text-text-primary dark:shadow-none dark:hover:bg-surface-1"
+								>
+									View project<span class="sr-only">, {project.name}</span>
+								</a>
+								<Menu as="div" class="relative flex-none">
+									<MenuButton class="relative block text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white cursor-pointer">
+										<span class="absolute -inset-2.5" />
+										<span class="sr-only">Open options</span>
+										<EllipsisVertical aria-hidden="true" class="size-5" />
+									</MenuButton>
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md bg-surface-1 shadow-xl border border-surface-border transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in outline-none"
+									>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+											>
+												Edit<span class="sr-only">, {project.name}</span>
+											</a>
+										</MenuItem>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+											>
+												Move<span class="sr-only">, {project.name}</span>
+											</a>
+										</MenuItem>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-3 py-1 text-sm/6 text-red-400 data-[focus]:bg-red-500 data-[focus]:text-white cursor-pointer"
+											>
+												Delete<span class="sr-only">, {project.name}</span>
+											</a>
+										</MenuItem>
+									</MenuItems>
+								</Menu>
 							</div>
 						</li>
 					))}

--- a/packages/ui/demo/sections/application-shells/multi-column/MultiColumnShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/multi-column/MultiColumnShellsDemo.tsx
@@ -1,0 +1,850 @@
+import { useState } from 'preact/hooks';
+import {
+	Dialog,
+	DialogBackdrop,
+	DialogPanel,
+	Menu,
+	MenuButton,
+	MenuItems,
+	MenuItem,
+	Popover,
+	PopoverPanel,
+} from '../../../../src/mod.ts';
+import {
+	X,
+	Home,
+	Users,
+	Folder,
+	Calendar,
+	FileText,
+	PieChart,
+	Bell,
+	Search,
+	ChevronDown,
+} from 'lucide-preact';
+
+const navigation = [
+	{ name: 'Dashboard', href: '#', icon: Home, current: true },
+	{ name: 'Team', href: '#', icon: Users, current: false },
+	{ name: 'Projects', href: '#', icon: Folder, current: false },
+	{ name: 'Calendar', href: '#', icon: Calendar, current: false },
+	{ name: 'Documents', href: '#', icon: FileText, current: false },
+	{ name: 'Reports', href: '#', icon: PieChart, current: false },
+];
+
+function classNames(...classes: (string | boolean | undefined)[]): string {
+	return classes.filter(Boolean).join(' ');
+}
+
+// Demo 1: Full-width three column layout
+function Demo1() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	return (
+		<section>
+			<h3 class="text-lg font-semibold text-text-primary mb-4">Full-width Three Column Layout</h3>
+			<div class="relative">
+				<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 lg:hidden">
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-black/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+					/>
+
+					<div class="fixed inset-0 flex">
+						<DialogPanel
+							transition
+							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+						>
+							<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+								<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+									<span class="sr-only">Close sidebar</span>
+									<X aria-hidden="true" class="size-6 text-white" />
+								</button>
+							</div>
+
+							<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-surface-inverted px-6 pb-2 ring-1 ring-white/10">
+								<div class="flex h-16 shrink-0 items-center">
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto"
+									/>
+								</div>
+								<nav class="flex flex-1 flex-col">
+									<ul role="list" class="-mx-2 flex-1 space-y-1">
+										{navigation.map((item) => (
+											<li key={item.name}>
+												<a
+													href={item.href}
+													class={classNames(
+														item.current
+															? 'bg-white/5 text-white'
+															: 'text-gray-400 hover:bg-white/5 hover:text-white',
+														'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+													)}
+												>
+													<item.icon aria-hidden="true" class="size-6 shrink-0" />
+													{item.name}
+												</a>
+											</li>
+										))}
+									</ul>
+								</nav>
+							</div>
+						</DialogPanel>
+					</div>
+				</Dialog>
+
+				{/* Static sidebar for desktop */}
+				<div class="hidden lg:fixed lg:inset-y-0 lg:left-0 lg:z-50 lg:block lg:w-20 lg:overflow-y-auto lg:bg-surface-inverted lg:pb-4 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:border-r dark:before:border-white/10 dark:before:bg-black/10">
+					<div class="relative flex h-16 shrink-0 items-center justify-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto"
+						/>
+					</div>
+					<nav class="relative mt-8">
+						<ul role="list" class="flex flex-col items-center space-y-1">
+							{navigation.map((item) => (
+								<li key={item.name}>
+									<a
+										href={item.href}
+										class={classNames(
+											item.current
+												? 'bg-white/5 text-white'
+												: 'text-gray-400 hover:bg-white/5 hover:text-white',
+											'group flex gap-x-3 rounded-md p-3 text-sm/6 font-semibold'
+										)}
+									>
+										<item.icon aria-hidden="true" class="size-6 shrink-0" />
+										<span class="sr-only">{item.name}</span>
+									</a>
+								</li>
+							))}
+						</ul>
+					</nav>
+				</div>
+
+				<div class="sticky top-0 z-40 flex items-center gap-x-6 bg-surface-inverted px-4 py-4 shadow-xs sm:px-6 lg:hidden dark:shadow-none dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:border-b dark:before:border-white/10 dark:before:bg-black/10">
+					<button
+						type="button"
+						onClick={() => setSidebarOpen(true)}
+						class="relative -m-2.5 p-2.5 text-gray-400 lg:hidden"
+					>
+						<span class="sr-only">Open sidebar</span>
+						<Menu aria-hidden="true" class="size-6" />
+					</button>
+					<div class="relative flex-1 text-sm/6 font-semibold text-white">Dashboard</div>
+				</div>
+
+				<main class="lg:pl-20">
+					<div class="xl:pl-96">
+						<div class="px-4 py-10 sm:px-6 lg:px-8 lg:py-6">
+							<div class="bg-surface-primary rounded-lg border border-surface-border p-8 text-center text-text-secondary">
+								Main Content Area
+							</div>
+						</div>
+					</div>
+				</main>
+
+				<aside class="fixed inset-y-0 left-20 hidden w-96 overflow-y-auto border-r border-surface-border px-4 py-6 sm:px-6 lg:px-8 xl:block">
+					<div class="bg-surface-primary rounded-lg border border-surface-border p-8 text-center text-text-secondary h-full">
+						Secondary Column
+					</div>
+				</aside>
+			</div>
+		</section>
+	);
+}
+
+// Demo 2: Full-width with secondary column on right (includes header with search and profile)
+const userNavigation = [
+	{ name: 'Your profile', href: '#' },
+	{ name: 'Sign out', href: '#' },
+];
+
+function Demo2() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	return (
+		<section>
+			<h3 class="text-lg font-semibold text-text-primary mb-4">
+				Full-width with Header and Right Column
+			</h3>
+			<div class="relative">
+				<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 lg:hidden">
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-black/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+					/>
+
+					<div class="fixed inset-0 flex">
+						<DialogPanel
+							transition
+							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+						>
+							<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+								<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+									<span class="sr-only">Close sidebar</span>
+									<X aria-hidden="true" class="size-6 text-white" />
+								</button>
+							</div>
+
+							<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-surface-inverted px-6 pb-2 ring-1 ring-white/10">
+								<div class="flex h-16 shrink-0 items-center">
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+										class="h-8 w-auto"
+									/>
+								</div>
+								<nav class="flex flex-1 flex-col">
+									<ul role="list" class="-mx-2 flex-1 space-y-1">
+										{navigation.map((item) => (
+											<li key={item.name}>
+												<a
+													href={item.href}
+													class={classNames(
+														item.current
+															? 'bg-white/5 text-white'
+															: 'text-gray-400 hover:bg-white/5 hover:text-white',
+														'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+													)}
+												>
+													<item.icon aria-hidden="true" class="size-6 shrink-0" />
+													{item.name}
+												</a>
+											</li>
+										))}
+									</ul>
+								</nav>
+							</div>
+						</DialogPanel>
+					</div>
+				</Dialog>
+
+				{/* Static sidebar for desktop */}
+				<div class="hidden lg:fixed lg:inset-y-0 lg:left-0 lg:z-50 lg:block lg:w-20 lg:overflow-y-auto lg:bg-surface-inverted lg:pb-4 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:border-r dark:before:border-white/10 dark:before:bg-black/10">
+					<div class="relative flex h-16 shrink-0 items-center justify-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto"
+						/>
+					</div>
+					<nav class="relative mt-8">
+						<ul role="list" class="flex flex-col items-center space-y-1">
+							{navigation.map((item) => (
+								<li key={item.name}>
+									<a
+										href={item.href}
+										class={classNames(
+											item.current
+												? 'bg-white/5 text-white'
+												: 'text-gray-400 hover:bg-white/5 hover:text-white',
+											'group flex gap-x-3 rounded-md p-3 text-sm/6 font-semibold'
+										)}
+									>
+										<item.icon aria-hidden="true" class="size-6 shrink-0" />
+										<span class="sr-only">{item.name}</span>
+									</a>
+								</li>
+							))}
+						</ul>
+					</nav>
+				</div>
+
+				<div class="lg:pl-20">
+					<div class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-surface-border bg-surface-primary px-4 shadow-xs sm:gap-x-6 sm:px-6 lg:px-8 dark:shadow-none dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+						<button
+							type="button"
+							onClick={() => setSidebarOpen(true)}
+							class="-m-2.5 p-2.5 text-text-secondary lg:hidden"
+						>
+							<span class="sr-only">Open sidebar</span>
+							<Menu aria-hidden="true" class="size-6" />
+						</button>
+
+						<div aria-hidden="true" class="h-6 w-px bg-surface-border lg:hidden" />
+
+						<div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
+							<form action="#" method="GET" class="grid flex-1 grid-cols-1">
+								<input
+									name="search"
+									placeholder="Search"
+									aria-label="Search"
+									class="col-start-1 row-start-1 block size-full bg-surface-primary pl-8 text-base text-text-primary outline-hidden placeholder:text-text-tertiary sm:text-sm/6"
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 size-5 self-center text-text-tertiary"
+								/>
+							</form>
+							<div class="flex items-center gap-x-4 lg:gap-x-6">
+								<button
+									type="button"
+									class="-m-2.5 p-2.5 text-text-tertiary hover:text-text-secondary"
+								>
+									<span class="sr-only">View notifications</span>
+									<Bell aria-hidden="true" class="size-6" />
+								</button>
+
+								<div
+									aria-hidden="true"
+									class="hidden lg:block lg:h-6 lg:w-px lg:bg-surface-border"
+								/>
+
+								<Popover class="relative">
+									<PopoverPanel
+										static
+										class="absolute right-0 z-10 mt-2.5 w-32 origin-top-right rounded-md bg-surface-primary py-2 shadow-lg outline outline-surface-border transition data-[closed]:scale-95 data-[closed]:transform data-[closed]:opacity-0"
+									>
+										{userNavigation.map((item) => (
+											<a
+												key={item.name}
+												href={item.href}
+												class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-surface-secondary"
+											>
+												{item.name}
+											</a>
+										))}
+									</PopoverPanel>
+								</Popover>
+
+								<Menu as="div" class="relative">
+									<MenuButton class="relative flex items-center">
+										<span class="absolute -inset-1.5" />
+										<span class="sr-only">Open user menu</span>
+										<img
+											alt=""
+											src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+											class="size-8 rounded-full bg-surface-secondary outline -outline-offset-1 outline-surface-border"
+										/>
+										<span class="hidden lg:flex lg:items-center">
+											<span
+												aria-hidden="true"
+												class="ml-4 text-sm/6 font-semibold text-text-primary"
+											>
+												Tom Cook
+											</span>
+											<ChevronDown aria-hidden="true" class="ml-2 size-5 text-text-tertiary" />
+										</span>
+									</MenuButton>
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-2.5 w-32 origin-top-right rounded-md bg-surface-primary py-2 shadow-lg outline outline-surface-border transition data-[closed]:scale-95 data-[closed]:transform data-[closed]:opacity-0"
+									>
+										{userNavigation.map((item) => (
+											<MenuItem key={item.name}>
+												<a
+													href={item.href}
+													class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-surface-secondary data-[focus]:outline-hidden"
+												>
+													{item.name}
+												</a>
+											</MenuItem>
+										))}
+									</MenuItems>
+								</Menu>
+							</div>
+						</div>
+					</div>
+
+					<main class="xl:pl-96">
+						<div class="px-4 py-10 sm:px-6 lg:px-8 lg:py-6">
+							<div class="bg-surface-primary rounded-lg border border-surface-border p-8 text-center text-text-secondary">
+								Main Content Area
+							</div>
+						</div>
+					</main>
+				</div>
+
+				<aside class="fixed top-16 bottom-0 left-20 hidden w-96 overflow-y-auto border-r border-surface-border px-4 py-6 sm:px-6 lg:px-8 xl:block">
+					<div class="bg-surface-primary rounded-lg border border-surface-border p-8 text-center text-text-secondary h-full">
+						Secondary Column
+					</div>
+				</aside>
+			</div>
+		</section>
+	);
+}
+
+// Demo 3: Full-width with narrow sidebar
+const teams = [
+	{ id: 1, name: 'Heroicons', href: '#', initial: 'H', current: false },
+	{ id: 2, name: 'Tailwind Labs', href: '#', initial: 'T', current: false },
+	{ id: 3, name: 'Workcation', href: '#', initial: 'W', current: false },
+];
+
+function Demo3() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	return (
+		<section>
+			<h3 class="text-lg font-semibold text-text-primary mb-4">Full-width with Narrow Sidebar</h3>
+			<div class="relative">
+				<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 lg:hidden">
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-black/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+					/>
+
+					<div class="fixed inset-0 flex">
+						<DialogPanel
+							transition
+							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+						>
+							<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+								<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+									<span class="sr-only">Close sidebar</span>
+									<X aria-hidden="true" class="size-6 text-white" />
+								</button>
+							</div>
+
+							<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-surface-primary px-6 pb-2 dark:bg-surface-inverted dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:border-r dark:before:border-white/10 dark:before:bg-black/10">
+								<div class="relative flex h-16 shrink-0 items-center">
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto"
+									/>
+								</div>
+								<nav class="relative flex flex-1 flex-col">
+									<ul role="list" class="flex flex-1 flex-col gap-y-7">
+										<li>
+											<ul role="list" class="-mx-2 space-y-1">
+												{navigation.map((item) => (
+													<li key={item.name}>
+														<a
+															href={item.href}
+															class={classNames(
+																item.current
+																	? 'bg-surface-secondary text-accent-primary dark:bg-white/5 dark:text-white'
+																	: 'text-text-secondary hover:bg-surface-secondary hover:text-accent-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+															)}
+														>
+															<item.icon
+																aria-hidden="true"
+																class={classNames(
+																	item.current
+																		? 'text-accent-primary dark:text-white'
+																		: 'text-text-tertiary group-hover:text-accent-primary dark:text-text-tertiary dark:group-hover:text-white',
+																	'size-6 shrink-0'
+																)}
+															/>
+															{item.name}
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+										<li>
+											<div class="text-xs/6 font-semibold text-text-tertiary">Your teams</div>
+											<ul role="list" class="-mx-2 mt-2 space-y-1">
+												{teams.map((team) => (
+													<li key={team.name}>
+														<a
+															href={team.href}
+															class={classNames(
+																team.current
+																	? 'bg-surface-secondary text-accent-primary dark:bg-white/5 dark:text-white'
+																	: 'text-text-secondary hover:bg-surface-secondary hover:text-accent-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+															)}
+														>
+															<span
+																class={classNames(
+																	team.current
+																		? 'border-accent-primary text-accent-primary dark:border-white/20 dark:text-white'
+																		: 'border-surface-border text-text-tertiary group-hover:border-accent-primary group-hover:text-accent-primary dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+																	'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-surface-primary text-[0.625rem] font-medium dark:bg-white/5'
+																)}
+															>
+																{team.initial}
+															</span>
+															<span class="truncate">{team.name}</span>
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+									</ul>
+								</nav>
+							</div>
+						</DialogPanel>
+					</div>
+				</Dialog>
+
+				{/* Static sidebar for desktop */}
+				<div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+					<div class="relative flex grow flex-col gap-y-5 overflow-y-auto border-r border-surface-border bg-surface-primary px-6 dark:border-white/10 dark:bg-surface-inverted dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+						<div class="relative flex h-16 shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+								class="h-8 w-auto"
+							/>
+						</div>
+						<nav class="relative flex flex-1 flex-col">
+							<ul role="list" class="flex flex-1 flex-col gap-y-7">
+								<li>
+									<ul role="list" class="-mx-2 space-y-1">
+										{navigation.map((item) => (
+											<li key={item.name}>
+												<a
+													href={item.href}
+													class={classNames(
+														item.current
+															? 'bg-surface-secondary text-accent-primary dark:bg-white/5 dark:text-white'
+															: 'text-text-secondary hover:bg-surface-secondary hover:text-accent-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+														'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+													)}
+												>
+													<item.icon
+														aria-hidden="true"
+														class={classNames(
+															item.current
+																? 'text-accent-primary dark:text-white'
+																: 'text-text-tertiary group-hover:text-accent-primary dark:text-text-tertiary dark:group-hover:text-white',
+															'size-6 shrink-0'
+														)}
+													/>
+													{item.name}
+												</a>
+											</li>
+										))}
+									</ul>
+								</li>
+								<li>
+									<div class="text-xs/6 font-semibold text-text-tertiary">Your teams</div>
+									<ul role="list" class="-mx-2 mt-2 space-y-1">
+										{teams.map((team) => (
+											<li key={team.name}>
+												<a
+													href={team.href}
+													class={classNames(
+														team.current
+															? 'bg-surface-secondary text-accent-primary dark:bg-white/5 dark:text-white'
+															: 'text-text-secondary hover:bg-surface-secondary hover:text-accent-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+														'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+													)}
+												>
+													<span
+														class={classNames(
+															team.current
+																? 'border-accent-primary text-accent-primary dark:border-white/20 dark:text-white'
+																: 'border-surface-border text-text-tertiary group-hover:border-accent-primary group-hover:text-accent-primary dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+															'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-surface-primary text-[0.625rem] font-medium dark:bg-white/5'
+														)}
+													>
+														{team.initial}
+													</span>
+													<span class="truncate">{team.name}</span>
+												</a>
+											</li>
+										))}
+									</ul>
+								</li>
+								<li class="-mx-6 mt-auto">
+									<a
+										href="#"
+										class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-text-primary hover:bg-surface-secondary dark:text-white dark:hover:bg-white/5"
+									>
+										<img
+											alt=""
+											src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+											class="size-8 rounded-full bg-surface-secondary outline -outline-offset-1 outline-surface-border dark:bg-surface-inverted dark:outline-white/10"
+										/>
+										<span class="sr-only">Your profile</span>
+										<span aria-hidden="true">Tom Cook</span>
+									</a>
+								</li>
+							</ul>
+						</nav>
+					</div>
+				</div>
+
+				<div class="sticky top-0 z-40 flex items-center gap-x-6 bg-surface-primary px-4 py-4 shadow-xs sm:px-6 lg:hidden dark:bg-surface-inverted dark:shadow-none dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:border-b dark:before:border-white/10 dark:before:bg-black/10">
+					<button
+						type="button"
+						onClick={() => setSidebarOpen(true)}
+						class="relative -m-2.5 p-2.5 text-text-secondary lg:hidden"
+					>
+						<span class="sr-only">Open sidebar</span>
+						<Menu aria-hidden="true" class="size-6" />
+					</button>
+					<div class="relative flex-1 text-sm/6 font-semibold text-text-primary">Dashboard</div>
+					<a href="#" class="relative">
+						<span class="sr-only">Your profile</span>
+						<img
+							alt=""
+							src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+							class="size-8 rounded-full bg-surface-secondary outline -outline-offset-1 outline-surface-border dark:bg-surface-inverted dark:outline-white/10"
+						/>
+					</a>
+				</div>
+
+				<main class="lg:pl-72">
+					<div class="xl:pl-96">
+						<div class="px-4 py-10 sm:px-6 lg:px-8 lg:py-6">
+							<div class="bg-surface-primary rounded-lg border border-surface-border p-8 text-center text-text-secondary">
+								Main Content Area
+							</div>
+						</div>
+					</div>
+				</main>
+
+				<aside class="fixed inset-y-0 left-72 hidden w-96 overflow-y-auto border-r border-surface-border px-4 py-6 sm:px-6 lg:px-8 xl:block">
+					<div class="bg-surface-primary rounded-lg border border-surface-border p-8 text-center text-text-secondary h-full">
+						Secondary Column
+					</div>
+				</aside>
+			</div>
+		</section>
+	);
+}
+
+// Demo 4: Full-width with narrow sidebar and header
+function Demo4() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	return (
+		<section>
+			<h3 class="text-lg font-semibold text-text-primary mb-4">
+				Full-width with Narrow Sidebar and Header
+			</h3>
+			<div class="relative">
+				<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 lg:hidden">
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-black/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+					/>
+
+					<div class="fixed inset-0 flex">
+						<DialogPanel
+							transition
+							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+						>
+							<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+								<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+									<span class="sr-only">Close sidebar</span>
+									<X aria-hidden="true" class="size-6 text-white" />
+								</button>
+							</div>
+
+							<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-surface-primary px-6 pb-2 dark:bg-surface-inverted dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:border-r dark:before:border-white/10 dark:before:bg-black/10">
+								<div class="relative flex h-16 shrink-0 items-center">
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto"
+									/>
+								</div>
+								<nav class="relative flex flex-1 flex-col">
+									<ul role="list" class="flex flex-1 flex-col gap-y-7">
+										<li>
+											<ul role="list" class="-mx-2 space-y-1">
+												{navigation.map((item) => (
+													<li key={item.name}>
+														<a
+															href={item.href}
+															class={classNames(
+																item.current
+																	? 'bg-surface-secondary text-accent-primary dark:bg-white/5 dark:text-white'
+																	: 'text-text-secondary hover:bg-surface-secondary hover:text-accent-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+															)}
+														>
+															<item.icon
+																aria-hidden="true"
+																class={classNames(
+																	item.current
+																		? 'text-accent-primary dark:text-white'
+																		: 'text-text-tertiary group-hover:text-accent-primary dark:text-text-tertiary dark:group-hover:text-white',
+																	'size-6 shrink-0'
+																)}
+															/>
+															{item.name}
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+										<li>
+											<div class="text-xs/6 font-semibold text-text-tertiary">Your teams</div>
+											<ul role="list" class="-mx-2 mt-2 space-y-1">
+												{teams.map((team) => (
+													<li key={team.name}>
+														<a
+															href={team.href}
+															class={classNames(
+																team.current
+																	? 'bg-surface-secondary text-accent-primary dark:bg-white/5 dark:text-white'
+																	: 'text-text-secondary hover:bg-surface-secondary hover:text-accent-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+															)}
+														>
+															<span
+																class={classNames(
+																	team.current
+																		? 'border-accent-primary text-accent-primary dark:border-white/20 dark:text-white'
+																		: 'border-surface-border text-text-tertiary group-hover:border-accent-primary group-hover:text-accent-primary dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+																	'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-surface-primary text-[0.625rem] font-medium dark:bg-white/5'
+																)}
+															>
+																{team.initial}
+															</span>
+															<span class="truncate">{team.name}</span>
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+									</ul>
+								</nav>
+							</div>
+						</DialogPanel>
+					</div>
+				</Dialog>
+
+				{/* Static sidebar for desktop */}
+				<div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+					<div class="relative flex grow flex-col gap-y-5 overflow-y-auto border-r border-surface-border bg-surface-primary px-6 dark:border-white/10 dark:bg-surface-inverted dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+						<div class="relative flex h-16 shrink-0 items-center">
+							<img
+								alt="Your Company"
+								src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+								class="h-8 w-auto"
+							/>
+						</div>
+						<nav class="relative flex flex-1 flex-col">
+							<ul role="list" class="flex flex-1 flex-col gap-y-7">
+								<li>
+									<ul role="list" class="-mx-2 space-y-1">
+										{navigation.map((item) => (
+											<li key={item.name}>
+												<a
+													href={item.href}
+													class={classNames(
+														item.current
+															? 'bg-surface-secondary text-accent-primary dark:bg-white/5 dark:text-white'
+															: 'text-text-secondary hover:bg-surface-secondary hover:text-accent-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+														'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+													)}
+												>
+													<item.icon
+														aria-hidden="true"
+														class={classNames(
+															item.current
+																? 'text-accent-primary dark:text-white'
+																: 'text-text-tertiary group-hover:text-accent-primary dark:text-text-tertiary dark:group-hover:text-white',
+															'size-6 shrink-0'
+														)}
+													/>
+													{item.name}
+												</a>
+											</li>
+										))}
+									</ul>
+								</li>
+								<li>
+									<div class="text-xs/6 font-semibold text-text-tertiary">Your teams</div>
+									<ul role="list" class="-mx-2 mt-2 space-y-1">
+										{teams.map((team) => (
+											<li key={team.name}>
+												<a
+													href={team.href}
+													class={classNames(
+														team.current
+															? 'bg-surface-secondary text-accent-primary dark:bg-white/5 dark:text-white'
+															: 'text-text-secondary hover:bg-surface-secondary hover:text-accent-primary dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+														'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+													)}
+												>
+													<span
+														class={classNames(
+															team.current
+																? 'border-accent-primary text-accent-primary dark:border-white/20 dark:text-white'
+																: 'border-surface-border text-text-tertiary group-hover:border-accent-primary group-hover:text-accent-primary dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+															'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-surface-primary text-[0.625rem] font-medium dark:bg-white/5'
+														)}
+													>
+														{team.initial}
+													</span>
+													<span class="truncate">{team.name}</span>
+												</a>
+											</li>
+										))}
+									</ul>
+								</li>
+								<li class="-mx-6 mt-auto">
+									<a
+										href="#"
+										class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-text-primary hover:bg-surface-secondary dark:text-white dark:hover:bg-white/5"
+									>
+										<img
+											alt=""
+											src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+											class="size-8 rounded-full bg-surface-secondary outline -outline-offset-1 outline-surface-border dark:bg-surface-inverted dark:outline-white/10"
+										/>
+										<span class="sr-only">Your profile</span>
+										<span aria-hidden="true">Tom Cook</span>
+									</a>
+								</li>
+							</ul>
+						</nav>
+					</div>
+				</div>
+
+				<div class="sticky top-0 z-40 flex items-center gap-x-6 bg-surface-primary px-4 py-4 shadow-xs sm:px-6 lg:hidden dark:bg-surface-inverted dark:shadow-none dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:border-b dark:before:border-white/10 dark:before:bg-black/10">
+					<button
+						type="button"
+						onClick={() => setSidebarOpen(true)}
+						class="relative -m-2.5 p-2.5 text-text-secondary lg:hidden"
+					>
+						<span class="sr-only">Open sidebar</span>
+						<Menu aria-hidden="true" class="size-6" />
+					</button>
+					<div class="relative flex-1 text-sm/6 font-semibold text-text-primary">Dashboard</div>
+					<a href="#" class="relative">
+						<span class="sr-only">Your profile</span>
+						<img
+							alt=""
+							src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+							class="size-8 rounded-full bg-surface-secondary outline -outline-offset-1 outline-surface-border dark:bg-surface-inverted dark:outline-white/10"
+						/>
+					</a>
+				</div>
+
+				<main class="lg:pl-72">
+					<div class="xl:pr-96">
+						<div class="px-4 py-10 sm:px-6 lg:px-8 lg:py-6">
+							<div class="bg-surface-primary rounded-lg border border-surface-border p-8 text-center text-text-secondary">
+								Main Content Area
+							</div>
+						</div>
+					</div>
+				</main>
+
+				<aside class="fixed inset-y-0 right-0 hidden w-96 overflow-y-auto border-l border-surface-border px-4 py-6 sm:px-6 lg:px-8 xl:block">
+					<div class="bg-surface-primary rounded-lg border border-surface-border p-8 text-center text-text-secondary h-full">
+						Secondary Column (Right)
+					</div>
+				</aside>
+			</div>
+		</section>
+	);
+}
+
+export function MultiColumnShellsDemo() {
+	return (
+		<div class="space-y-12">
+			<Demo1 />
+			<Demo2 />
+			<Demo3 />
+			<Demo4 />
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/application-shells/multi-column/MultiColumnShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/multi-column/MultiColumnShellsDemo.tsx
@@ -10,6 +10,7 @@ import {
 	Popover,
 	PopoverPanel,
 } from '../../../../src/mod.ts';
+import { classNames } from '../../../../src/internal/class-names.ts';
 import {
 	X,
 	Home,
@@ -31,10 +32,6 @@ const navigation = [
 	{ name: 'Documents', href: '#', icon: FileText, current: false },
 	{ name: 'Reports', href: '#', icon: PieChart, current: false },
 ];
-
-function classNames(...classes: (string | boolean | undefined)[]): string {
-	return classes.filter(Boolean).join(' ');
-}
 
 // Demo 1: Full-width three column layout
 function Demo1() {

--- a/packages/ui/demo/sections/application-shells/sidebar/SidebarShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/sidebar/SidebarShellsDemo.tsx
@@ -1,0 +1,997 @@
+import { useState } from 'preact/hooks';
+import {
+	Dialog,
+	DialogBackdrop,
+	DialogPanel,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuItems,
+} from '../../../../src/mod.ts';
+import {
+	Bell,
+	Calendar,
+	ChartPie,
+	ChevronDown,
+	Files,
+	Folder,
+	Home,
+	Menu as MenuIcon,
+	Search,
+	Settings,
+	Users,
+	X,
+} from 'lucide-preact';
+import { classNames } from '../../../../src/internal/class-names.ts';
+
+const navigation = [
+	{ name: 'Dashboard', href: '#', icon: Home, current: true },
+	{ name: 'Team', href: '#', icon: Users, current: false },
+	{ name: 'Projects', href: '#', icon: Folder, current: false },
+	{ name: 'Calendar', href: '#', icon: Calendar, current: false },
+	{ name: 'Documents', href: '#', icon: Files, current: false },
+	{ name: 'Reports', href: '#', icon: ChartPie, current: false },
+];
+const teams = [
+	{ id: 1, name: 'Heroicons', href: '#', initial: 'H', current: false },
+	{ id: 2, name: 'Tailwind Labs', href: '#', initial: 'T', current: false },
+	{ id: 3, name: 'Workcation', href: '#', initial: 'W', current: false },
+];
+const userNavigation = [
+	{ name: 'Your profile', href: '#' },
+	{ name: 'Sign out', href: '#' },
+];
+
+// Demo 1: Simple Sidebar with Indigo Background
+function SimpleSidebar() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	return (
+		<div>
+			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 lg:hidden">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+				/>
+
+				<div class="fixed inset-0 flex">
+					<DialogPanel
+						transition
+						class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+					>
+						<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+							<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+								<span class="sr-only">Close sidebar</span>
+								<X aria-hidden="true" class="size-6 text-white" />
+							</button>
+						</div>
+
+						<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-accent-600 px-6 pb-2 dark:bg-accent-800 dark:ring-1 dark:ring-white/10">
+							<div class="flex h-16 shrink-0 items-center">
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=white"
+									class="h-8 w-auto dark:hidden"
+								/>
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=white"
+									class="h-8 w-auto hidden dark:block"
+								/>
+							</div>
+							<nav class="flex flex-1 flex-col">
+								<ul role="list" class="flex flex-1 flex-col gap-y-7">
+									<li>
+										<ul role="list" class="-mx-2 space-y-1">
+											{navigation.map((item) => (
+												<li key={item.name}>
+													<a
+														href={item.href}
+														class={classNames(
+															item.current
+																? 'bg-accent-700 text-white dark:bg-accent-950/25'
+																: 'text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25',
+															'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+														)}
+													>
+														<item.icon
+															aria-hidden="true"
+															class={classNames(
+																item.current
+																	? 'text-white'
+																	: 'text-accent-200 group-hover:text-white dark:text-accent-100',
+																'size-6 shrink-0'
+															)}
+														/>
+														{item.name}
+													</a>
+												</li>
+											))}
+										</ul>
+									</li>
+									<li>
+										<div class="text-xs/6 font-semibold text-accent-200 dark:text-accent-100">
+											Your teams
+										</div>
+										<ul role="list" class="-mx-2 mt-2 space-y-1">
+											{teams.map((team) => (
+												<li key={team.name}>
+													<a
+														href={team.href}
+														class={classNames(
+															team.current
+																? 'bg-accent-700 text-white dark:bg-accent-950/25'
+																: 'text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25',
+															'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+														)}
+													>
+														<span class="flex size-6 shrink-0 items-center justify-center rounded-lg border border-accent-400 bg-accent-500 text-[0.625rem] font-medium text-white dark:border-accent-500/50 dark:bg-accent-700">
+															{team.initial}
+														</span>
+														<span class="truncate">{team.name}</span>
+													</a>
+												</li>
+											))}
+										</ul>
+									</li>
+								</ul>
+							</nav>
+						</div>
+					</DialogPanel>
+				</div>
+			</Dialog>
+
+			{/* Static sidebar for desktop */}
+			<div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+				<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-accent-600 px-6 dark:bg-accent-800 dark:after:pointer-events-none dark:after:absolute dark:after:inset-y-0 dark:after:right-0 dark:after:w-px dark:after:bg-white/10">
+					<div class="flex h-16 shrink-0 items-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=white"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=white"
+							class="h-8 w-auto hidden dark:block"
+						/>
+					</div>
+					<nav class="flex flex-1 flex-col">
+						<ul role="list" class="flex flex-1 flex-col gap-y-7">
+							<li>
+								<ul role="list" class="-mx-2 space-y-1">
+									{navigation.map((item) => (
+										<li key={item.name}>
+											<a
+												href={item.href}
+												class={classNames(
+													item.current
+														? 'bg-accent-700 text-white dark:bg-accent-950/25'
+														: 'text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<item.icon
+													aria-hidden="true"
+													class={classNames(
+														item.current
+															? 'text-white'
+															: 'text-accent-200 group-hover:text-white dark:text-accent-100',
+														'size-6 shrink-0'
+													)}
+												/>
+												{item.name}
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li>
+								<div class="text-xs/6 font-semibold text-accent-200 dark:text-accent-100">
+									Your teams
+								</div>
+								<ul role="list" class="-mx-2 mt-2 space-y-1">
+									{teams.map((team) => (
+										<li key={team.name}>
+											<a
+												href={team.href}
+												class={classNames(
+													team.current
+														? 'bg-accent-700 text-white dark:bg-accent-950/25'
+														: 'text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<span class="flex size-6 shrink-0 items-center justify-center rounded-lg border border-accent-400 bg-accent-500 text-[0.625rem] font-medium text-white dark:border-accent-500/50 dark:bg-accent-700">
+													{team.initial}
+												</span>
+												<span class="truncate">{team.name}</span>
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li class="-mx-6 mt-auto">
+								<a
+									href="#"
+									class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-white hover:bg-accent-700 dark:hover:bg-accent-950/25"
+								>
+									<img
+										alt=""
+										src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+										class="size-8 rounded-full bg-accent-700 outline -outline-offset-1 outline-white/10 dark:bg-accent-800"
+									/>
+									<span class="sr-only">Your profile</span>
+									<span aria-hidden="true">Tom Cook</span>
+								</a>
+							</li>
+						</ul>
+					</nav>
+				</div>
+			</div>
+
+			<div class="sticky top-0 z-40 flex items-center gap-x-6 bg-accent-600 px-4 py-4 shadow-xs sm:px-6 lg:hidden dark:bg-accent-800 dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10">
+				<button
+					type="button"
+					onClick={() => setSidebarOpen(true)}
+					class="-m-2.5 p-2.5 text-accent-200 hover:text-white lg:hidden"
+				>
+					<span class="sr-only">Open sidebar</span>
+					<MenuIcon aria-hidden="true" class="size-6" />
+				</button>
+				<div class="flex-1 text-sm/6 font-semibold text-white">Dashboard</div>
+				<a href="#">
+					<span class="sr-only">Your profile</span>
+					<img
+						alt=""
+						src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+						class="size-8 rounded-full bg-accent-700 outline -outline-offset-1 outline-white/10 dark:bg-accent-800"
+					/>
+				</a>
+			</div>
+
+			<main class="py-10 lg:pl-72">
+				<div class="px-4 sm:px-6 lg:px-8">{/* Your content */}</div>
+			</main>
+		</div>
+	);
+}
+
+// Demo 2: Dark Sidebar with Header, Search, and User Menu
+function DarkSidebarWithHeader() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	return (
+		<div>
+			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 lg:hidden">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+				/>
+
+				<div class="fixed inset-0 flex">
+					<DialogPanel
+						transition
+						class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+					>
+						<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+							<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+								<span class="sr-only">Close sidebar</span>
+								<X aria-hidden="true" class="size-6 text-white" />
+							</button>
+						</div>
+
+						<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-accent-600 px-6 pb-4 dark:bg-accent-800 dark:ring-1 dark:ring-white/10">
+							<div class="flex h-16 shrink-0 items-center">
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=white"
+									class="h-8 w-auto"
+								/>
+							</div>
+							<nav class="flex flex-1 flex-col">
+								<ul role="list" class="flex flex-1 flex-col gap-y-7">
+									<li>
+										<ul role="list" class="-mx-2 space-y-1">
+											{navigation.map((item) => (
+												<li key={item.name}>
+													<a
+														href={item.href}
+														class={classNames(
+															item.current
+																? 'bg-accent-700 text-white dark:bg-accent-950/25'
+																: 'text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25',
+															'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+														)}
+													>
+														<item.icon
+															aria-hidden="true"
+															class={classNames(
+																item.current
+																	? 'text-white'
+																	: 'text-accent-200 group-hover:text-white dark:text-accent-100',
+																'size-6 shrink-0'
+															)}
+														/>
+														{item.name}
+													</a>
+												</li>
+											))}
+										</ul>
+									</li>
+									<li>
+										<div class="text-xs/6 font-semibold text-accent-200 dark:text-accent-100">
+											Your teams
+										</div>
+										<ul role="list" class="-mx-2 mt-2 space-y-1">
+											{teams.map((team) => (
+												<li key={team.name}>
+													<a
+														href={team.href}
+														class={classNames(
+															team.current
+																? 'bg-accent-700 text-white dark:bg-accent-950/25'
+																: 'text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25',
+															'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+														)}
+													>
+														<span class="flex size-6 shrink-0 items-center justify-center rounded-lg border border-accent-400 bg-accent-500 text-[0.625rem] font-medium text-white dark:border-accent-500/50 dark:bg-accent-700">
+															{team.initial}
+														</span>
+														<span class="truncate">{team.name}</span>
+													</a>
+												</li>
+											))}
+										</ul>
+									</li>
+									<li class="mt-auto">
+										<a
+											href="#"
+											class="group -mx-2 flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25"
+										>
+											<Settings
+												aria-hidden="true"
+												class="size-6 shrink-0 text-accent-200 group-hover:text-white dark:text-accent-100"
+											/>
+											Settings
+										</a>
+									</li>
+								</ul>
+							</nav>
+						</div>
+					</DialogPanel>
+				</div>
+			</Dialog>
+
+			{/* Static sidebar for desktop */}
+			<div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+				<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-accent-600 px-6 pb-4 dark:bg-accent-800 dark:after:pointer-events-none dark:after:absolute dark:after:inset-y-0 dark:after:right-0 dark:after:w-px dark:after:bg-white/10">
+					<div class="flex h-16 shrink-0 items-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=white"
+							class="h-8 w-auto"
+						/>
+					</div>
+					<nav class="flex flex-1 flex-col">
+						<ul role="list" class="flex flex-1 flex-col gap-y-7">
+							<li>
+								<ul role="list" class="-mx-2 space-y-1">
+									{navigation.map((item) => (
+										<li key={item.name}>
+											<a
+												href={item.href}
+												class={classNames(
+													item.current
+														? 'bg-accent-700 text-white dark:bg-accent-950/25'
+														: 'text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<item.icon
+													aria-hidden="true"
+													class={classNames(
+														item.current
+															? 'text-white'
+															: 'text-accent-200 group-hover:text-white dark:text-accent-100',
+														'size-6 shrink-0'
+													)}
+												/>
+												{item.name}
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li>
+								<div class="text-xs/6 font-semibold text-accent-200 dark:text-accent-100">
+									Your teams
+								</div>
+								<ul role="list" class="-mx-2 mt-2 space-y-1">
+									{teams.map((team) => (
+										<li key={team.name}>
+											<a
+												href={team.href}
+												class={classNames(
+													team.current
+														? 'bg-accent-700 text-white dark:bg-accent-950/25'
+														: 'text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<span class="flex size-6 shrink-0 items-center justify-center rounded-lg border border-accent-400 bg-accent-500 text-[0.625rem] font-medium text-white dark:border-accent-500/50 dark:bg-accent-700">
+													{team.initial}
+												</span>
+												<span class="truncate">{team.name}</span>
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li class="mt-auto">
+								<a
+									href="#"
+									class="group -mx-2 flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold text-accent-200 hover:bg-accent-700 hover:text-white dark:text-accent-100 dark:hover:bg-accent-950/25"
+								>
+									<Settings
+										aria-hidden="true"
+										class="size-6 shrink-0 text-accent-200 group-hover:text-white dark:text-accent-100"
+									/>
+									Settings
+								</a>
+							</li>
+						</ul>
+					</nav>
+				</div>
+			</div>
+
+			<div class="lg:pl-72">
+				<div class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-surface-border bg-surface-0 px-4 shadow-xs sm:gap-x-6 sm:px-6 lg:px-8 dark:border-white/10 dark:bg-surface-2 dark:shadow-none">
+					<button
+						type="button"
+						onClick={() => setSidebarOpen(true)}
+						class="-m-2.5 p-2.5 text-text-secondary hover:text-text-primary lg:hidden dark:text-text-tertiary dark:hover:text-white"
+					>
+						<span class="sr-only">Open sidebar</span>
+						<MenuIcon aria-hidden="true" class="size-6" />
+					</button>
+
+					{/* Separator */}
+					<div aria-hidden="true" class="h-6 w-px bg-black/10 lg:hidden dark:bg-white/10" />
+
+					<div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
+						<form action="#" method="GET" class="grid flex-1 grid-cols-1">
+							<input
+								name="search"
+								placeholder="Search"
+								aria-label="Search"
+								class="col-start-1 row-start-1 block size-full bg-surface-0 pl-8 text-base text-text-primary outline-hidden placeholder:text-text-muted sm:text-sm/6 dark:bg-surface-2 dark:text-white dark:placeholder:text-text-muted"
+							/>
+							<Search
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 size-5 self-center text-text-muted"
+							/>
+						</form>
+						<div class="flex items-center gap-x-4 lg:gap-x-6">
+							<button
+								type="button"
+								class="-m-2.5 p-2.5 text-text-muted hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+							>
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+
+							{/* Separator */}
+							<div
+								aria-hidden="true"
+								class="hidden lg:block lg:h-6 lg:w-px lg:bg-black/10 dark:lg:bg-white/10"
+							/>
+
+							{/* Profile dropdown */}
+							<Menu as="div" class="relative">
+								<MenuButton class="relative flex items-center">
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">Open user menu</span>
+									<img
+										alt=""
+										src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+										class="size-8 rounded-full bg-surface-1 outline -outline-offset-1 outline-black/5 dark:bg-surface-3 dark:outline-white/10"
+									/>
+									<span class="hidden lg:flex lg:items-center">
+										<span
+											aria-hidden="true"
+											class="ml-4 text-sm/6 font-semibold text-text-primary dark:text-white"
+										>
+											Tom Cook
+										</span>
+										<ChevronDown
+											aria-hidden="true"
+											class="ml-2 size-5 text-text-muted dark:text-text-tertiary"
+										/>
+									</span>
+								</MenuButton>
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2.5 w-32 origin-top-right rounded-md bg-surface-1 py-2 shadow-lg outline outline-surface-border transition data-[closed]:scale-95 data-[closed]:transform data-[closed]:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-3 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+								>
+									{userNavigation.map((item) => (
+										<MenuItem key={item.name}>
+											<a
+												href={item.href}
+												class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-surface-2 data-[focus]:outline-hidden dark:text-white dark:data-[focus]:bg-white/5"
+											>
+												{item.name}
+											</a>
+										</MenuItem>
+									))}
+								</MenuItems>
+							</Menu>
+						</div>
+					</div>
+				</div>
+
+				<main class="py-10">
+					<div class="px-4 sm:px-6 lg:px-8">{/* Your content */}</div>
+				</main>
+			</div>
+		</div>
+	);
+}
+
+// Demo 3: Light Brand Sidebar
+function LightBrandSidebar() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	return (
+		<div>
+			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 lg:hidden">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+				/>
+
+				<div class="fixed inset-0 flex">
+					<DialogPanel
+						transition
+						class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+					>
+						<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+							<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+								<span class="sr-only">Close sidebar</span>
+								<X aria-hidden="true" class="size-6 text-white" />
+							</button>
+						</div>
+
+						<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-surface-0 px-6 pb-2 dark:bg-surface-2 dark:ring dark:ring-white/10 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+							<div class="relative flex h-16 shrink-0 items-center">
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+									class="h-8 w-auto dark:hidden"
+								/>
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+									class="h-8 w-auto hidden dark:block"
+								/>
+							</div>
+							<nav class="relative flex flex-1 flex-col">
+								<ul role="list" class="flex flex-1 flex-col gap-y-7">
+									<li>
+										<ul role="list" class="-mx-2 space-y-1">
+											{navigation.map((item) => (
+												<li key={item.name}>
+													<a
+														href={item.href}
+														class={classNames(
+															item.current
+																? 'bg-surface-1 text-accent-600 dark:bg-white/5 dark:text-white'
+																: 'text-text-secondary hover:bg-surface-1 hover:text-accent-600 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+															'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+														)}
+													>
+														<item.icon
+															aria-hidden="true"
+															class={classNames(
+																item.current
+																	? 'text-accent-600 dark:text-white'
+																	: 'text-text-muted group-hover:text-accent-600 dark:group-hover:text-white',
+																'size-6 shrink-0'
+															)}
+														/>
+														{item.name}
+													</a>
+												</li>
+											))}
+										</ul>
+									</li>
+									<li>
+										<div class="text-xs/6 font-semibold text-text-muted">Your teams</div>
+										<ul role="list" class="-mx-2 mt-2 space-y-1">
+											{teams.map((team) => (
+												<li key={team.name}>
+													<a
+														href={team.href}
+														class={classNames(
+															team.current
+																? 'bg-surface-1 text-accent-600 dark:bg-white/5 dark:text-white'
+																: 'text-text-secondary hover:bg-surface-1 hover:text-accent-600 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+															'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+														)}
+													>
+														<span
+															class={classNames(
+																team.current
+																	? 'border-accent-600 text-accent-600 dark:border-white/20 dark:text-white'
+																	: 'border-surface-border text-text-muted group-hover:border-accent-600 group-hover:text-accent-600 dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+																'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5'
+															)}
+														>
+															{team.initial}
+														</span>
+														<span class="truncate">{team.name}</span>
+													</a>
+												</li>
+											))}
+										</ul>
+									</li>
+								</ul>
+							</nav>
+						</div>
+					</DialogPanel>
+				</div>
+			</Dialog>
+
+			{/* Static sidebar for desktop */}
+			<div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col dark:bg-surface-2">
+				<div class="flex grow flex-col gap-y-5 overflow-y-auto border-r border-surface-border bg-surface-0 px-6 dark:border-white/10 dark:bg-black/10">
+					<div class="flex h-16 shrink-0 items-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto hidden dark:block"
+						/>
+					</div>
+					<nav class="flex flex-1 flex-col">
+						<ul role="list" class="flex flex-1 flex-col gap-y-7">
+							<li>
+								<ul role="list" class="-mx-2 space-y-1">
+									{navigation.map((item) => (
+										<li key={item.name}>
+											<a
+												href={item.href}
+												class={classNames(
+													item.current
+														? 'bg-surface-1 text-accent-600 dark:bg-white/5 dark:text-white'
+														: 'text-text-secondary hover:bg-surface-1 hover:text-accent-600 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<item.icon
+													aria-hidden="true"
+													class={classNames(
+														item.current
+															? 'text-accent-600 dark:text-white'
+															: 'text-text-muted group-hover:text-accent-600 dark:group-hover:text-white',
+														'size-6 shrink-0'
+													)}
+												/>
+												{item.name}
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li>
+								<div class="text-xs/6 font-semibold text-text-muted">Your teams</div>
+								<ul role="list" class="-mx-2 mt-2 space-y-1">
+									{teams.map((team) => (
+										<li key={team.name}>
+											<a
+												href={team.href}
+												class={classNames(
+													team.current
+														? 'bg-surface-1 text-accent-600 dark:bg-white/5 dark:text-white'
+														: 'text-text-secondary hover:bg-surface-1 hover:text-accent-600 dark:text-text-tertiary dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<span
+													class={classNames(
+														team.current
+															? 'border-accent-600 text-accent-600 dark:border-white/20 dark:text-white'
+															: 'border-surface-border text-text-muted group-hover:border-accent-600 group-hover:text-accent-600 dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+														'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5'
+													)}
+												>
+													{team.initial}
+												</span>
+												<span class="truncate">{team.name}</span>
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li class="-mx-6 mt-auto">
+								<a
+									href="#"
+									class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-text-primary hover:bg-surface-1 dark:text-white dark:hover:bg-white/5"
+								>
+									<img
+										alt=""
+										src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+										class="size-8 rounded-full bg-surface-1 outline -outline-offset-1 outline-black/5 dark:bg-surface-3 dark:outline-white/10"
+									/>
+									<span class="sr-only">Your profile</span>
+									<span aria-hidden="true">Tom Cook</span>
+								</a>
+							</li>
+						</ul>
+					</nav>
+				</div>
+			</div>
+
+			<div class="sticky top-0 z-40 flex items-center gap-x-6 bg-surface-0 px-4 py-4 shadow-xs sm:px-6 lg:hidden dark:bg-surface-2 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-0 dark:after:border-b dark:after:border-white/10 dark:after:bg-black/10">
+				<button
+					type="button"
+					onClick={() => setSidebarOpen(true)}
+					class="-m-2.5 p-2.5 text-text-secondary hover:text-text-primary lg:hidden dark:text-text-tertiary dark:hover:text-white"
+				>
+					<span class="sr-only">Open sidebar</span>
+					<MenuIcon aria-hidden="true" class="size-6" />
+				</button>
+				<div class="flex-1 text-sm/6 font-semibold text-text-primary dark:text-white">
+					Dashboard
+				</div>
+				<a href="#">
+					<span class="sr-only">Your profile</span>
+					<img
+						alt=""
+						src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+						class="size-8 rounded-full bg-surface-1 outline -outline-offset-1 outline-black/5 dark:bg-surface-3 dark:outline-white/10"
+					/>
+				</a>
+			</div>
+
+			<main class="py-10 lg:pl-72">
+				<div class="px-4 sm:px-6 lg:px-8">{/* Your content */}</div>
+			</main>
+		</div>
+	);
+}
+
+// Demo 4: Dark Brand Sidebar with Header
+function DarkBrandSidebarWithHeader() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	return (
+		<div>
+			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 lg:hidden">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-black/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+				/>
+
+				<div class="fixed inset-0 flex">
+					<DialogPanel
+						transition
+						class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+					>
+						<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+							<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+								<span class="sr-only">Close sidebar</span>
+								<X aria-hidden="true" class="size-6 text-white" />
+							</button>
+						</div>
+
+						<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-surface-2 px-6 pb-2 ring-1 ring-white/10 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+							<div class="relative flex h-16 shrink-0 items-center">
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+									class="h-8 w-auto dark:hidden"
+								/>
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+									class="relative h-8 w-auto hidden dark:block"
+								/>
+							</div>
+							<nav class="flex flex-1 flex-col">
+								<ul role="list" class="flex flex-1 flex-col gap-y-7">
+									<li>
+										<ul role="list" class="-mx-2 space-y-1">
+											{navigation.map((item) => (
+												<li key={item.name}>
+													<a
+														href={item.href}
+														class={classNames(
+															item.current
+																? 'bg-white/5 text-white'
+																: 'text-text-muted hover:bg-white/5 hover:text-white',
+															'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+														)}
+													>
+														<item.icon aria-hidden="true" class="size-6 shrink-0" />
+														{item.name}
+													</a>
+												</li>
+											))}
+										</ul>
+									</li>
+									<li>
+										<div class="text-xs/6 font-semibold text-text-muted">Your teams</div>
+										<ul role="list" class="-mx-2 mt-2 space-y-1">
+											{teams.map((team) => (
+												<li key={team.name}>
+													<a
+														href={team.href}
+														class={classNames(
+															team.current
+																? 'bg-surface-3 text-white'
+																: 'text-text-muted hover:bg-white/5 hover:text-white',
+															'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+														)}
+													>
+														<span class="flex size-6 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-surface-3 text-[0.625rem] font-medium text-text-muted group-hover:border-white/20 group-hover:text-white">
+															{team.initial}
+														</span>
+														<span class="truncate">{team.name}</span>
+													</a>
+												</li>
+											))}
+										</ul>
+									</li>
+								</ul>
+							</nav>
+						</div>
+					</DialogPanel>
+				</div>
+			</Dialog>
+
+			{/* Static sidebar for desktop */}
+			<div class="hidden bg-surface-2 lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+				<div class="flex grow flex-col gap-y-5 overflow-y-auto border-r border-surface-border px-6 dark:border-white/10 dark:bg-black/10">
+					<div class="flex h-16 shrink-0 items-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto hidden dark:block"
+						/>
+					</div>
+					<nav class="flex flex-1 flex-col">
+						<ul role="list" class="flex flex-1 flex-col gap-y-7">
+							<li>
+								<ul role="list" class="-mx-2 space-y-1">
+									{navigation.map((item) => (
+										<li key={item.name}>
+											<a
+												href={item.href}
+												class={classNames(
+													item.current
+														? 'bg-white/5 text-white'
+														: 'text-text-muted hover:bg-white/5 hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<item.icon aria-hidden="true" class="size-6 shrink-0" />
+												{item.name}
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li>
+								<div class="text-xs/6 font-semibold text-text-muted">Your teams</div>
+								<ul role="list" class="-mx-2 mt-2 space-y-1">
+									{teams.map((team) => (
+										<li key={team.name}>
+											<a
+												href={team.href}
+												class={classNames(
+													team.current
+														? 'bg-surface-3 text-white'
+														: 'text-text-muted hover:bg-white/5 hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<span class="flex size-6 shrink-0 items-center justify-center rounded-lg border border-surface-border bg-surface-3 text-[0.625rem] font-medium text-text-muted group-hover:text-white">
+													{team.initial}
+												</span>
+												<span class="truncate">{team.name}</span>
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li class="-mx-6 mt-auto">
+								<a
+									href="#"
+									class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-white hover:bg-white/5"
+								>
+									<img
+										alt=""
+										src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+										class="size-8 rounded-full bg-surface-3 outline -outline-offset-1 outline-white/10"
+									/>
+									<span class="sr-only">Your profile</span>
+									<span aria-hidden="true">Tom Cook</span>
+								</a>
+							</li>
+						</ul>
+					</nav>
+				</div>
+			</div>
+
+			<div class="sticky top-0 z-40 flex items-center gap-x-6 bg-surface-2 px-4 py-4 shadow-sm sm:px-6 lg:hidden dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-0 dark:after:border-b dark:after:border-white/10 dark:after:bg-black/10">
+				<button
+					type="button"
+					onClick={() => setSidebarOpen(true)}
+					class="-m-2.5 p-2.5 text-text-muted hover:text-white lg:hidden"
+				>
+					<span class="sr-only">Open sidebar</span>
+					<MenuIcon aria-hidden="true" class="size-6" />
+				</button>
+				<div class="flex-1 text-sm/6 font-semibold text-white">Dashboard</div>
+				<a href="#">
+					<span class="sr-only">Your profile</span>
+					<img
+						alt=""
+						src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+						class="size-8 rounded-full bg-surface-3 outline -outline-offset-1 outline-white/10"
+					/>
+				</a>
+			</div>
+
+			<main class="py-10 lg:pl-72">
+				<div class="px-4 sm:px-6 lg:px-8">{/* Your content */}</div>
+			</main>
+		</div>
+	);
+}
+
+export function SidebarShellsDemo() {
+	return (
+		<div class="flex flex-col gap-12">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple sidebar (indigo)</h3>
+				<div class="h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+					<SimpleSidebar />
+				</div>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Dark sidebar with header, search, and user menu
+				</h3>
+				<div class="h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+					<DarkSidebarWithHeader />
+				</div>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Light brand sidebar</h3>
+				<div class="h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+					<LightBrandSidebar />
+				</div>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Dark brand sidebar with header</h3>
+				<div class="h-[32rem] rounded-lg border border-surface-border overflow-hidden dark">
+					<DarkBrandSidebarWithHeader />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/application-shells/stacked/StackedShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/stacked/StackedShellsDemo.tsx
@@ -1,0 +1,810 @@
+import { useState } from 'preact/hooks';
+import {
+	Disclosure,
+	DisclosureButton,
+	DisclosurePanel,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuItems,
+} from '../../../../../src/mod.ts';
+import { Menu as MenuIcon, X, Bell, Search } from 'lucide-preact';
+
+const user = {
+	name: 'Tom Cook',
+	email: 'tom@example.com',
+	imageUrl:
+		'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+};
+const navigation = [
+	{ name: 'Home', href: '#', current: true },
+	{ name: 'Profile', href: '#', current: false },
+	{ name: 'Resources', href: '#', current: false },
+	{ name: 'Company Directory', href: '#', current: false },
+	{ name: 'Openings', href: '#', current: false },
+];
+const userNavigation = [
+	{ name: 'Your profile', href: '#' },
+	{ name: 'Settings', href: '#' },
+	{ name: 'Sign out', href: '#' },
+];
+
+function classNames(...classes: (string | boolean | undefined)[]): string {
+	return classes.filter(Boolean).join(' ');
+}
+
+/* -----------------------------------------------
+   Demo 1: Stacked nav with bottom border
+   ----------------------------------------------- */
+function StackedWithBottomBorder() {
+	const [_open, setOpen] = useState(false);
+
+	return (
+		<div class="min-h-full">
+			<header class="bg-accent-600 pb-24 dark:bg-accent-800">
+				<div class="mx-auto max-w-3xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+					<div class="relative flex items-center justify-center py-5 lg:justify-between">
+						{/* Logo */}
+						<div class="absolute left-0 shrink-0 lg:static">
+							<a href="#">
+								<span class="sr-only">Your Company</span>
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=300"
+									class="h-8 w-auto"
+								/>
+							</a>
+						</div>
+
+						{/* Right section on desktop */}
+						<div class="hidden lg:ml-4 lg:flex lg:items-center lg:pr-0.5">
+							<button
+								type="button"
+								class="relative shrink-0 rounded-full p-1 text-accent-200 hover:text-white focus:outline-2 focus:outline-white"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+
+							{/* Profile dropdown */}
+							<Menu as="div" class="relative ml-4 shrink-0">
+								<MenuButton class="relative flex max-w-xs items-center rounded-full bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">Open user menu</span>
+									<img
+										alt=""
+										src={user.imageUrl}
+										class="size-8 rounded-full outline -outline-offset-1 outline-white/10"
+									/>
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 -mr-2 w-48 origin-top-right rounded-md bg-surface-1 py-1 shadow-lg outline outline-black/5 data-leave:transition data-leave:duration-75 data-leave:ease-in data-closed:data-leave:scale-95 data-closed:data-leave:transform data-closed:data-leave:opacity-0 dark:bg-gray-800 dark:-outline-offset-1 dark:outline-white/10"
+								>
+									{userNavigation.map((item) => (
+										<MenuItem key={item.name}>
+											<a
+												href={item.href}
+												class="block px-4 py-2 text-sm text-text-primary data-focus:bg-surface-2 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+											>
+												{item.name}
+											</a>
+										</MenuItem>
+									))}
+								</MenuItems>
+							</Menu>
+						</div>
+
+						{/* Search */}
+						<div class="min-w-0 flex-1 px-12 lg:hidden">
+							<div class="mx-auto grid w-full max-w-xs grid-cols-1">
+								<input
+									name="search"
+									placeholder="Search"
+									aria-label="Search"
+									class="col-start-1 row-start-1 block w-full rounded-md bg-accent-500/75 py-1.5 pr-3 pl-10 text-base text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white/75 focus:outline-2 focus:-outline-offset-2 focus:outline-white sm:text-sm/6 dark:bg-accent-700/50 dark:outline-accent-400/25 dark:placeholder:text-white/50"
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-white/75 dark:text-white/50"
+								/>
+							</div>
+						</div>
+
+						{/* Menu button */}
+						<div class="absolute right-0 shrink-0 lg:hidden">
+							<button
+								type="button"
+								onClick={() => setOpen(true)}
+								class="relative inline-flex items-center justify-center rounded-md bg-transparent p-2 text-accent-200 hover:bg-white/5 hover:text-white focus-visible:outline-2 focus-visible:outline-white"
+							>
+								<span class="absolute -inset-0.5" />
+								<span class="sr-only">Open main menu</span>
+								<MenuIcon aria-hidden="true" class="size-6" />
+							</button>
+						</div>
+					</div>
+					<div class="hidden border-t border-white/20 py-5 lg:block dark:border-white/10">
+						<div class="grid grid-cols-3 items-center gap-8">
+							<div class="col-span-2">
+								<nav class="flex space-x-4">
+									{navigation.map((item) => (
+										<a
+											key={item.name}
+											href={item.href}
+											aria-current={item.current ? 'page' : undefined}
+											class={classNames(
+												item.current ? 'text-white' : 'text-accent-100',
+												'rounded-md px-3 py-2 text-sm font-medium hover:bg-accent-500/75 dark:hover:bg-accent-700/75',
+											)}
+										>
+											{item.name}
+										</a>
+									))}
+								</nav>
+							</div>
+							<div class="mx-auto grid w-full max-w-md grid-cols-1">
+								<input
+									name="search"
+									placeholder="Search"
+									aria-label="Search"
+									class="col-start-1 row-start-1 block w-full rounded-md bg-accent-500/75 py-1.5 pr-3 pl-10 text-base text-white outline-1 -outline-offset-1 outline-white/10 placeholder:text-white/75 focus:outline-2 focus:-outline-offset-2 focus:outline-white sm:text-sm/6 dark:bg-accent-700/50 dark:outline-accent-400/25 dark:placeholder:text-white/50"
+								/>
+								<Search
+									aria-hidden="true"
+									class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-white/75 dark:text-white/50"
+								/>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<Disclosure as="nav" class="lg:hidden">
+					{() => (
+						<>
+							<DisclosurePanel
+								transition
+								class="fixed inset-0 z-20 bg-black/25 duration-150 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in"
+							>
+								<div class="absolute inset-x-0 top-0 z-30 mx-auto w-full max-w-3xl origin-top transform p-2 transition duration-150 data-closed:scale-95 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in">
+									<div class="divide-y divide-gray-200 rounded-lg bg-surface-1 shadow-lg outline outline-black/5 dark:divide-white/10 dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10">
+										<div class="pt-3 pb-2">
+											<div class="flex items-center justify-between px-4">
+												<div>
+													<img
+														alt="Your Company"
+														src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+														class="h-8 w-auto dark:hidden"
+													/>
+													<img
+														alt="Your Company"
+														src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+														class="h-8 w-auto not-dark:hidden"
+													/>
+												</div>
+												<div class="-mr-2">
+													<DisclosureButton class="relative inline-flex items-center justify-center rounded-md bg-surface-1 p-2 text-gray-400 hover:bg-surface-2 hover:text-gray-500 focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-white dark:bg-gray-800 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:outline-white">
+														<span class="absolute -inset-0.5" />
+														<span class="sr-only">Close menu</span>
+														<X aria-hidden="true" class="size-6" />
+													</DisclosureButton>
+												</div>
+											</div>
+											<div class="mt-3 space-y-1 px-2">
+												{navigation.map((item) => (
+													<DisclosureButton
+														key={item.name}
+														as="a"
+														href={item.href}
+														class="block rounded-md px-3 py-2 text-base font-medium text-text-primary hover:bg-surface-2 hover:text-text-secondary dark:text-gray-100 dark:hover:bg-white/5 dark:hover:text-white"
+													>
+														{item.name}
+													</DisclosureButton>
+												))}
+											</div>
+										</div>
+										<div class="pt-4 pb-2">
+											<div class="flex items-center px-5">
+												<div class="shrink-0">
+													<img
+														alt=""
+														src={user.imageUrl}
+														class="size-10 rounded-full outline -outline-offset-1 outline-black/5 dark:outline-white/10"
+													/>
+												</div>
+												<div class="ml-3 min-w-0 flex-1">
+													<div class="truncate text-base font-medium text-text-primary dark:text-gray-200">
+														{user.name}
+													</div>
+													<div class="truncate text-sm font-medium text-text-muted dark:text-gray-400">
+														{user.email}
+													</div>
+												</div>
+												<button
+													type="button"
+													class="relative ml-auto shrink-0 rounded-full p-1 text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:text-gray-400 dark:hover:text-white dark:focus:outline-white"
+												>
+													<span class="absolute -inset-1.5" />
+													<span class="sr-only">View notifications</span>
+													<Bell aria-hidden="true" class="size-6" />
+												</button>
+											</div>
+											<div class="mt-3 space-y-1 px-2">
+												{userNavigation.map((item) => (
+													<DisclosureButton
+														key={item.name}
+														as="a"
+														href={item.href}
+														class="block rounded-md px-3 py-2 text-base font-medium text-text-primary hover:bg-surface-2 hover:text-text-secondary dark:text-gray-100 dark:hover:bg-white/5 dark:hover:text-white"
+													>
+														{item.name}
+													</DisclosureButton>
+												))}
+											</div>
+										</div>
+									</div>
+								</div>
+							</DisclosurePanel>
+						</>
+					)}
+				</Disclosure>
+			</header>
+			<main class="-mt-24 pb-8">
+				<div class="mx-auto max-w-3xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+					<h1 class="sr-only">Page title</h1>
+					<div class="grid grid-cols-1 items-start gap-4 lg:grid-cols-3 lg:gap-8">
+						<div class="grid grid-cols-1 gap-4 lg:col-span-2">
+							<section aria-labelledby="section-1-title">
+								<h2 id="section-1-title" class="sr-only">
+									Section title
+								</h2>
+								<div class="overflow-hidden rounded-lg bg-surface-1 shadow-sm dark:bg-gray-800 dark:shadow-none dark:outline dark:-outline-offset-1 dark:outline-white/10">
+									<div class="p-6" />
+								</div>
+							</section>
+						</div>
+						<div class="grid grid-cols-1 gap-4">
+							<section aria-labelledby="section-2-title">
+								<h2 id="section-2-title" class="sr-only">
+									Section title
+								</h2>
+								<div class="overflow-hidden rounded-lg bg-surface-1 shadow-sm dark:bg-gray-800 dark:shadow-none dark:inset-ring dark:inset-ring-white/10">
+									<div class="p-6" />
+								</div>
+							</section>
+						</div>
+					</div>
+				</div>
+			</main>
+			<footer>
+				<div class="mx-auto max-w-3xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+					<div class="border-t border-surface-border py-8 text-center text-sm text-text-muted sm:text-left">
+						<span class="block sm:inline">2021 Your Company, Inc.</span>{' '}
+						<span class="block sm:inline">All rights reserved.</span>
+					</div>
+				</div>
+			</footer>
+		</div>
+	);
+}
+
+/* -----------------------------------------------
+   Demo 2: Stacked with lighter page header
+   ----------------------------------------------- */
+function StackedWithLighterPageHeader() {
+	return (
+		<div class="min-h-full">
+			<Disclosure as="nav" class="border-b border-surface-border bg-surface-1 dark:border-white/10 dark:bg-gray-900">
+				<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+					<div class="flex h-16 justify-between">
+						<div class="flex">
+							<div class="flex shrink-0 items-center">
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+									class="h-8 w-auto dark:hidden"
+								/>
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+									class="h-8 w-auto not-dark:hidden"
+								/>
+							</div>
+							<div class="hidden sm:-my-px sm:ml-6 sm:flex sm:space-x-8">
+								{navigation.map((item) => (
+									<a
+										key={item.name}
+										href={item.href}
+										aria-current={item.current ? 'page' : undefined}
+										class={classNames(
+											item.current
+												? 'border-accent-500 text-text-primary dark:border-accent-500 dark:text-white'
+												: 'border-transparent text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-gray-200',
+											'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium',
+										)}
+									>
+										{item.name}
+									</a>
+								))}
+							</div>
+						</div>
+						<div class="hidden sm:ml-6 sm:flex sm:items-center">
+							<button
+								type="button"
+								class="relative rounded-full p-1 text-text-secondary hover:text-text-primary focus:outline-2 focus:outline-offset-2 focus:outline-accent-600 dark:text-gray-400 dark:hover:text-white dark:focus:outline-accent-500"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+
+							<Menu as="div" class="relative ml-3">
+								<MenuButton class="relative flex max-w-xs items-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-500">
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">Open user menu</span>
+									<img
+										alt=""
+										src={user.imageUrl}
+										class="size-8 rounded-full outline -outline-offset-1 outline-black/5 dark:outline-white/10"
+									/>
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-1 py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-200 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+								>
+									{userNavigation.map((item) => (
+										<MenuItem key={item.name}>
+											<a
+												href={item.href}
+												class="block px-4 py-2 text-sm text-text-primary data-focus:bg-surface-2 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+											>
+												{item.name}
+											</a>
+										</MenuItem>
+									))}
+								</MenuItems>
+							</Menu>
+						</div>
+						<div class="-mr-2 flex items-center sm:hidden">
+							<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md bg-surface-1 p-2 text-text-secondary hover:bg-surface-2 hover:text-text-primary focus:outline-2 focus:outline-offset-2 focus:outline-accent-600 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white dark:focus:outline-accent-500">
+								<span class="absolute -inset-0.5" />
+								<span class="sr-only">Open main menu</span>
+								<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+								<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+							</DisclosureButton>
+						</div>
+					</div>
+				</div>
+
+				<DisclosurePanel class="sm:hidden">
+					<div class="space-y-1 pt-2 pb-3">
+						{navigation.map((item) => (
+							<DisclosureButton
+								key={item.name}
+								as="a"
+								href={item.href}
+								aria-current={item.current ? 'page' : undefined}
+								class={classNames(
+									item.current
+										? 'border-accent-500 bg-accent-500/10 text-accent-700 dark:border-accent-500 dark:bg-accent-600/10 dark:text-accent-300'
+										: 'border-transparent text-text-secondary hover:border-surface-border hover:bg-surface-2 hover:text-text-primary dark:text-gray-400 dark:hover:border-gray-500 dark:hover:bg-white/5 dark:hover:text-gray-200',
+									'block border-l-4 py-2 pr-4 pl-3 text-base font-medium',
+								)}
+							>
+								{item.name}
+							</DisclosureButton>
+						))}
+					</div>
+					<div class="border-t border-surface-border pt-4 pb-3 dark:border-gray-700">
+						<div class="flex items-center px-4">
+							<div class="shrink-0">
+								<img
+									alt=""
+									src={user.imageUrl}
+									class="size-10 rounded-full outline -outline-offset-1 outline-black/5 dark:outline-white/10"
+								/>
+							</div>
+							<div class="ml-3">
+								<div class="text-base font-medium text-text-primary dark:text-white">{user.name}</div>
+								<div class="text-sm font-medium text-text-muted dark:text-gray-400">{user.email}</div>
+							</div>
+							<button
+								type="button"
+								class="relative ml-auto shrink-0 rounded-full p-1 text-text-secondary hover:text-text-primary focus:outline-2 focus:outline-offset-2 focus:outline-accent-600 dark:text-gray-400 dark:hover:text-white dark:focus:outline-accent-500"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+						</div>
+						<div class="mt-3 space-y-1">
+							{userNavigation.map((item) => (
+								<DisclosureButton
+									key={item.name}
+									as="a"
+									href={item.href}
+									class="block px-4 py-2 text-base font-medium text-text-secondary hover:bg-surface-2 hover:text-text-primary dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-200"
+								>
+									{item.name}
+								</DisclosureButton>
+							))}
+						</div>
+					</div>
+				</DisclosurePanel>
+			</Disclosure>
+
+			<div class="py-10">
+				<header>
+					<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+						<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">Dashboard</h1>
+					</div>
+				</header>
+				<main>
+					<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8" />
+				</main>
+			</div>
+		</div>
+	);
+}
+
+/* -----------------------------------------------
+   Demo 3: Branded nav with lighter page header
+   ----------------------------------------------- */
+const brandedNav = [
+	{ name: 'Dashboard', href: '#', current: true },
+	{ name: 'Team', href: '#', current: false },
+	{ name: 'Projects', href: '#', current: false },
+	{ name: 'Calendar', href: '#', current: false },
+	{ name: 'Reports', href: '#', current: false },
+];
+
+function BrandedNavWithLighterPageHeader() {
+	return (
+		<div class="min-h-full">
+			<Disclosure as="nav" class="bg-gray-800 dark:bg-gray-800/50">
+				<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+					<div class="flex h-16 items-center justify-between">
+						<div class="flex items-center">
+							<div class="shrink-0">
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+									class="size-8"
+								/>
+							</div>
+							<div class="hidden md:block">
+								<div class="ml-10 flex items-baseline space-x-4">
+									{brandedNav.map((item) => (
+										<a
+											key={item.name}
+											href={item.href}
+											aria-current={item.current ? 'page' : undefined}
+											class={classNames(
+												item.current
+													? 'bg-gray-900 text-white dark:bg-gray-950/50'
+													: 'text-gray-300 hover:bg-white/5 hover:text-white',
+												'rounded-md px-3 py-2 text-sm font-medium',
+											)}
+										>
+											{item.name}
+										</a>
+									))}
+								</div>
+							</div>
+						</div>
+						<div class="hidden md:block">
+							<div class="ml-4 flex items-center md:ml-6">
+								<button
+									type="button"
+									class="relative rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+								>
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">View notifications</span>
+									<Bell aria-hidden="true" class="size-6" />
+								</button>
+
+								<Menu as="div" class="relative ml-3">
+									<MenuButton class="relative flex max-w-xs items-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500">
+										<span class="absolute -inset-1.5" />
+										<span class="sr-only">Open user menu</span>
+										<img
+											alt=""
+											src={user.imageUrl}
+											class="size-8 rounded-full outline -outline-offset-1 outline-white/10"
+										/>
+									</MenuButton>
+
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-1 py-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+									>
+										{userNavigation.map((item) => (
+											<MenuItem key={item.name}>
+												<a
+													href={item.href}
+													class="block px-4 py-2 text-sm text-text-primary data-focus:bg-surface-2 data-focus:outline-hidden dark:text-gray-300 dark:data-focus:bg-white/5"
+												>
+													{item.name}
+												</a>
+											</MenuItem>
+										))}
+									</MenuItems>
+								</Menu>
+							</div>
+						</div>
+						<div class="-mr-2 flex md:hidden">
+							<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-white/5 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500">
+								<span class="absolute -inset-0.5" />
+								<span class="sr-only">Open main menu</span>
+								<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+								<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+							</DisclosureButton>
+						</div>
+					</div>
+				</div>
+
+				<DisclosurePanel class="md:hidden">
+					<div class="space-y-1 px-2 pt-2 pb-3 sm:px-3">
+						{brandedNav.map((item) => (
+							<DisclosureButton
+								key={item.name}
+								as="a"
+								href={item.href}
+								aria-current={item.current ? 'page' : undefined}
+								class={classNames(
+									item.current
+										? 'bg-gray-900 text-white dark:bg-gray-950/50'
+										: 'text-gray-300 hover:bg-white/5 hover:text-white',
+									'block rounded-md px-3 py-2 text-base font-medium',
+								)}
+							>
+								{item.name}
+							</DisclosureButton>
+						))}
+					</div>
+					<div class="border-t border-white/10 pt-4 pb-3">
+						<div class="flex items-center px-5">
+							<div class="shrink-0">
+								<img
+									alt=""
+									src={user.imageUrl}
+									class="size-10 rounded-full outline -outline-offset-1 outline-white/10"
+								/>
+							</div>
+							<div class="ml-3">
+								<div class="text-base/5 font-medium text-white">{user.name}</div>
+								<div class="text-sm font-medium text-gray-400">{user.email}</div>
+							</div>
+							<button
+								type="button"
+								class="relative ml-auto shrink-0 rounded-full p-1 text-gray-400 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-accent-500"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+						</div>
+						<div class="mt-3 space-y-1 px-2">
+							{userNavigation.map((item) => (
+								<DisclosureButton
+									key={item.name}
+									as="a"
+									href={item.href}
+									class="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-white/5 hover:text-white"
+								>
+									{item.name}
+								</DisclosureButton>
+							))}
+						</div>
+					</div>
+				</DisclosurePanel>
+			</Disclosure>
+
+			<header class="relative bg-surface-1 shadow-sm dark:bg-gray-800 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:inset-y-0 dark:after:border-y dark:after:border-white/10">
+				<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+					<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">Dashboard</h1>
+				</div>
+			</header>
+			<main>
+				<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8" />
+			</main>
+		</div>
+	);
+}
+
+/* -----------------------------------------------
+   Demo 4: Two row navigation with overlap
+   ----------------------------------------------- */
+function TwoRowNavigationWithOverlap() {
+	return (
+		<div class="min-h-full">
+			<Disclosure as="nav" class="bg-accent-600 dark:bg-accent-800">
+				<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+					<div class="flex h-16 items-center justify-between">
+						<div class="flex items-center">
+							<div class="shrink-0">
+								<img
+									alt="Your Company"
+									src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=300"
+									class="size-8"
+								/>
+							</div>
+							<div class="hidden md:block">
+								<div class="ml-10 flex items-baseline space-x-4">
+									{brandedNav.map((item) => (
+										<a
+											key={item.name}
+											href={item.href}
+											aria-current={item.current ? 'page' : undefined}
+											class={classNames(
+												item.current
+													? 'bg-accent-700 text-white dark:bg-accent-950/40'
+													: 'text-white hover:bg-accent-500/75 dark:hover:bg-accent-700/75',
+												'rounded-md px-3 py-2 text-sm font-medium',
+											)}
+										>
+											{item.name}
+										</a>
+									))}
+								</div>
+							</div>
+						</div>
+						<div class="hidden md:block">
+							<div class="ml-4 flex items-center md:ml-6">
+								<button
+									type="button"
+									class="relative rounded-full p-1 text-accent-200 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white"
+								>
+									<span class="absolute -inset-1.5" />
+									<span class="sr-only">View notifications</span>
+									<Bell aria-hidden="true" class="size-6" />
+								</button>
+
+								<Menu as="div" class="relative ml-3">
+									<MenuButton class="relative flex max-w-xs items-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">
+										<span class="absolute -inset-1.5" />
+										<span class="sr-only">Open user menu</span>
+										<img
+											alt=""
+											src={user.imageUrl}
+											class="size-8 rounded-full outline -outline-offset-1 outline-white/10"
+										/>
+									</MenuButton>
+
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-1 py-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+									>
+										{userNavigation.map((item) => (
+											<MenuItem key={item.name}>
+												<a
+													href={item.href}
+													class="block px-4 py-2 text-sm text-text-primary data-focus:bg-surface-2 data-focus:outline-hidden dark:text-gray-200 dark:data-focus:bg-white/5"
+												>
+													{item.name}
+												</a>
+											</MenuItem>
+										))}
+									</MenuItems>
+								</Menu>
+							</div>
+						</div>
+						<div class="-mr-2 flex md:hidden">
+							<DisclosureButton class="group relative inline-flex items-center justify-center rounded-md bg-accent-600 p-2 text-accent-200 hover:bg-accent-500/75 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white dark:bg-accent-800 dark:hover:bg-accent-700/75">
+								<span class="absolute -inset-0.5" />
+								<span class="sr-only">Open main menu</span>
+								<MenuIcon aria-hidden="true" class="block size-6 group-data-open:hidden" />
+								<X aria-hidden="true" class="hidden size-6 group-data-open:block" />
+							</DisclosureButton>
+						</div>
+					</div>
+				</div>
+
+				<DisclosurePanel class="md:hidden">
+					<div class="space-y-1 px-2 pt-2 pb-3 sm:px-3">
+						{brandedNav.map((item) => (
+							<DisclosureButton
+								key={item.name}
+								as="a"
+								href={item.href}
+								aria-current={item.current ? 'page' : undefined}
+								class={classNames(
+									item.current
+										? 'bg-accent-700 text-white dark:bg-accent-950/40'
+										: 'text-white hover:bg-accent-500/75 dark:hover:bg-accent-700/75',
+									'block rounded-md px-3 py-2 text-base font-medium',
+								)}
+							>
+								{item.name}
+							</DisclosureButton>
+						))}
+					</div>
+					<div class="border-t border-accent-700 pt-4 pb-3 dark:border-accent-800">
+						<div class="flex items-center px-5">
+							<div class="shrink-0">
+								<img
+									alt=""
+									src={user.imageUrl}
+									class="size-10 rounded-full outline -outline-offset-1 outline-white/10"
+								/>
+							</div>
+							<div class="ml-3">
+								<div class="text-base font-medium text-white">{user.name}</div>
+								<div class="text-sm font-medium text-accent-300">{user.email}</div>
+							</div>
+							<button
+								type="button"
+								class="relative ml-auto shrink-0 rounded-full p-1 text-accent-200 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white"
+							>
+								<span class="absolute -inset-1.5" />
+								<span class="sr-only">View notifications</span>
+								<Bell aria-hidden="true" class="size-6" />
+							</button>
+						</div>
+						<div class="mt-3 space-y-1 px-2">
+							{userNavigation.map((item) => (
+								<DisclosureButton
+									key={item.name}
+									as="a"
+									href={item.href}
+									class="block rounded-md px-3 py-2 text-base font-medium text-white hover:bg-accent-500/75 dark:hover:bg-accent-700/75"
+								>
+									{item.name}
+								</DisclosureButton>
+							))}
+						</div>
+					</div>
+				</DisclosurePanel>
+			</Disclosure>
+
+			<header class="relative bg-surface-1 shadow-sm dark:bg-gray-800 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10">
+				<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+					<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">Dashboard</h1>
+				</div>
+			</header>
+			<main>
+				<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8" />
+			</main>
+		</div>
+	);
+}
+
+/* -----------------------------------------------
+   Main export
+   ----------------------------------------------- */
+export function StackedShellsDemo() {
+	return (
+		<div class="flex flex-col gap-8">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Stacked with bottom border</h3>
+				<div class="rounded-lg border border-surface-border overflow-hidden">
+					<StackedWithBottomBorder />
+				</div>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Stacked with lighter page header</h3>
+				<div class="rounded-lg border border-surface-border overflow-hidden">
+					<StackedWithLighterPageHeader />
+				</div>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Branded nav with lighter page header</h3>
+				<div class="rounded-lg border border-surface-border overflow-hidden">
+					<BrandedNavWithLighterPageHeader />
+				</div>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Two row navigation with overlap</h3>
+				<div class="rounded-lg border border-surface-border overflow-hidden">
+					<TwoRowNavigationWithOverlap />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/application-shells/stacked/StackedShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/stacked/StackedShellsDemo.tsx
@@ -8,6 +8,7 @@ import {
 	MenuItem,
 	MenuItems,
 } from '../../../../src/mod.ts';
+import { classNames } from '../../../../src/internal/class-names.ts';
 import { Menu as MenuIcon, X, Bell, Search } from 'lucide-preact';
 
 const user = {
@@ -28,10 +29,6 @@ const userNavigation = [
 	{ name: 'Settings', href: '#' },
 	{ name: 'Sign out', href: '#' },
 ];
-
-function classNames(...classes: (string | boolean | undefined)[]): string {
-	return classes.filter(Boolean).join(' ');
-}
 
 /* -----------------------------------------------
    Demo 1: Stacked nav with bottom border

--- a/packages/ui/demo/sections/application-shells/stacked/StackedShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/stacked/StackedShellsDemo.tsx
@@ -7,7 +7,7 @@ import {
 	MenuButton,
 	MenuItem,
 	MenuItems,
-} from '../../../../../src/mod.ts';
+} from '../../../../src/mod.ts';
 import { Menu as MenuIcon, X, Bell, Search } from 'lucide-preact';
 
 const user = {
@@ -137,7 +137,7 @@ function StackedWithBottomBorder() {
 											aria-current={item.current ? 'page' : undefined}
 											class={classNames(
 												item.current ? 'text-white' : 'text-accent-100',
-												'rounded-md px-3 py-2 text-sm font-medium hover:bg-accent-500/75 dark:hover:bg-accent-700/75',
+												'rounded-md px-3 py-2 text-sm font-medium hover:bg-accent-500/75 dark:hover:bg-accent-700/75'
 											)}
 										>
 											{item.name}
@@ -296,7 +296,10 @@ function StackedWithBottomBorder() {
 function StackedWithLighterPageHeader() {
 	return (
 		<div class="min-h-full">
-			<Disclosure as="nav" class="border-b border-surface-border bg-surface-1 dark:border-white/10 dark:bg-gray-900">
+			<Disclosure
+				as="nav"
+				class="border-b border-surface-border bg-surface-1 dark:border-white/10 dark:bg-gray-900"
+			>
 				<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
 					<div class="flex h-16 justify-between">
 						<div class="flex">
@@ -322,7 +325,7 @@ function StackedWithLighterPageHeader() {
 											item.current
 												? 'border-accent-500 text-text-primary dark:border-accent-500 dark:text-white'
 												: 'border-transparent text-text-secondary hover:border-surface-border hover:text-text-primary dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-gray-200',
-											'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium',
+											'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium'
 										)}
 									>
 										{item.name}
@@ -391,7 +394,7 @@ function StackedWithLighterPageHeader() {
 									item.current
 										? 'border-accent-500 bg-accent-500/10 text-accent-700 dark:border-accent-500 dark:bg-accent-600/10 dark:text-accent-300'
 										: 'border-transparent text-text-secondary hover:border-surface-border hover:bg-surface-2 hover:text-text-primary dark:text-gray-400 dark:hover:border-gray-500 dark:hover:bg-white/5 dark:hover:text-gray-200',
-									'block border-l-4 py-2 pr-4 pl-3 text-base font-medium',
+									'block border-l-4 py-2 pr-4 pl-3 text-base font-medium'
 								)}
 							>
 								{item.name}
@@ -408,8 +411,12 @@ function StackedWithLighterPageHeader() {
 								/>
 							</div>
 							<div class="ml-3">
-								<div class="text-base font-medium text-text-primary dark:text-white">{user.name}</div>
-								<div class="text-sm font-medium text-text-muted dark:text-gray-400">{user.email}</div>
+								<div class="text-base font-medium text-text-primary dark:text-white">
+									{user.name}
+								</div>
+								<div class="text-sm font-medium text-text-muted dark:text-gray-400">
+									{user.email}
+								</div>
 							</div>
 							<button
 								type="button"
@@ -439,7 +446,9 @@ function StackedWithLighterPageHeader() {
 			<div class="py-10">
 				<header>
 					<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-						<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">Dashboard</h1>
+						<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">
+							Dashboard
+						</h1>
 					</div>
 				</header>
 				<main>
@@ -486,7 +495,7 @@ function BrandedNavWithLighterPageHeader() {
 												item.current
 													? 'bg-gray-900 text-white dark:bg-gray-950/50'
 													: 'text-gray-300 hover:bg-white/5 hover:text-white',
-												'rounded-md px-3 py-2 text-sm font-medium',
+												'rounded-md px-3 py-2 text-sm font-medium'
 											)}
 										>
 											{item.name}
@@ -558,7 +567,7 @@ function BrandedNavWithLighterPageHeader() {
 									item.current
 										? 'bg-gray-900 text-white dark:bg-gray-950/50'
 										: 'text-gray-300 hover:bg-white/5 hover:text-white',
-									'block rounded-md px-3 py-2 text-base font-medium',
+									'block rounded-md px-3 py-2 text-base font-medium'
 								)}
 							>
 								{item.name}
@@ -605,7 +614,9 @@ function BrandedNavWithLighterPageHeader() {
 
 			<header class="relative bg-surface-1 shadow-sm dark:bg-gray-800 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:inset-y-0 dark:after:border-y dark:after:border-white/10">
 				<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-					<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">Dashboard</h1>
+					<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">
+						Dashboard
+					</h1>
 				</div>
 			</header>
 			<main>
@@ -643,7 +654,7 @@ function TwoRowNavigationWithOverlap() {
 												item.current
 													? 'bg-accent-700 text-white dark:bg-accent-950/40'
 													: 'text-white hover:bg-accent-500/75 dark:hover:bg-accent-700/75',
-												'rounded-md px-3 py-2 text-sm font-medium',
+												'rounded-md px-3 py-2 text-sm font-medium'
 											)}
 										>
 											{item.name}
@@ -715,7 +726,7 @@ function TwoRowNavigationWithOverlap() {
 									item.current
 										? 'bg-accent-700 text-white dark:bg-accent-950/40'
 										: 'text-white hover:bg-accent-500/75 dark:hover:bg-accent-700/75',
-									'block rounded-md px-3 py-2 text-base font-medium',
+									'block rounded-md px-3 py-2 text-base font-medium'
 								)}
 							>
 								{item.name}
@@ -762,7 +773,9 @@ function TwoRowNavigationWithOverlap() {
 
 			<header class="relative bg-surface-1 shadow-sm dark:bg-gray-800 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:bottom-0 dark:after:h-px dark:after:bg-white/10">
 				<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-					<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">Dashboard</h1>
+					<h1 class="text-3xl font-bold tracking-tight text-text-primary dark:text-white">
+						Dashboard
+					</h1>
 				</div>
 			</header>
 			<main>
@@ -786,14 +799,18 @@ export function StackedShellsDemo() {
 			</div>
 
 			<div>
-				<h3 class="text-sm font-medium text-text-tertiary mb-3">Stacked with lighter page header</h3>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Stacked with lighter page header
+				</h3>
 				<div class="rounded-lg border border-surface-border overflow-hidden">
 					<StackedWithLighterPageHeader />
 				</div>
 			</div>
 
 			<div>
-				<h3 class="text-sm font-medium text-text-tertiary mb-3">Branded nav with lighter page header</h3>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Branded nav with lighter page header
+				</h3>
 				<div class="rounded-lg border border-surface-border overflow-hidden">
 					<BrandedNavWithLighterPageHeader />
 				</div>

--- a/packages/ui/demo/sections/data-display/calendars/CalendarsHeadlessDemo.tsx
+++ b/packages/ui/demo/sections/data-display/calendars/CalendarsHeadlessDemo.tsx
@@ -1,0 +1,2130 @@
+import { useState } from 'preact/hooks';
+import { Menu, MenuButton, MenuItem, MenuItems } from '../../../../src/mod.ts';
+import {
+	ChevronLeft,
+	ChevronRight,
+	EllipsisVertical,
+	CalendarIcon,
+	MapPin,
+	ChevronDown,
+	Clock,
+} from 'lucide-preact';
+
+// Demo 1: Small Calendar with Meetings
+function SmallWithMeetings() {
+	const meetings = [
+		{
+			id: 1,
+			date: 'January 10th, 2022',
+			time: '5:00 PM',
+			datetime: '2022-01-10T17:00',
+			name: 'Leslie Alexander',
+			imageUrl:
+				'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			location: 'Starbucks',
+		},
+		{
+			id: 2,
+			date: 'January 12th, 2022',
+			time: '3:00 PM',
+			datetime: '2022-01-12T15:00',
+			name: 'Michael Foster',
+			imageUrl:
+				'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			location: 'Tim Hortons',
+		},
+		{
+			id: 3,
+			date: 'January 12th, 2022',
+			time: '5:00 PM',
+			datetime: '2022-01-12T17:00',
+			name: 'Dries Vincent',
+			imageUrl:
+				'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			location: 'Costa Coffee at Braehead',
+		},
+		{
+			id: 4,
+			date: 'January 14th, 2022',
+			time: '10:00 AM',
+			datetime: '2022-01-14T10:00',
+			name: 'Lindsay Walton',
+			imageUrl:
+				'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			location: 'Silverburn',
+		},
+		{
+			id: 5,
+			date: 'January 14th, 2022',
+			time: '12:00 PM',
+			datetime: '2022-01-14T12:00',
+			name: 'Courtney Henry',
+			imageUrl:
+				'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			location: 'The Glasgow Green',
+		},
+	];
+	const days = [
+		{ date: '2021-12-27' },
+		{ date: '2021-12-28' },
+		{ date: '2021-12-29' },
+		{ date: '2021-12-30' },
+		{ date: '2021-12-31' },
+		{ date: '2022-01-01', isCurrentMonth: true },
+		{ date: '2022-01-02', isCurrentMonth: true },
+		{ date: '2022-01-03', isCurrentMonth: true },
+		{ date: '2022-01-04', isCurrentMonth: true },
+		{ date: '2022-01-05', isCurrentMonth: true },
+		{ date: '2022-01-06', isCurrentMonth: true },
+		{ date: '2022-01-07', isCurrentMonth: true },
+		{ date: '2022-01-08', isCurrentMonth: true },
+		{ date: '2022-01-09', isCurrentMonth: true },
+		{ date: '2022-01-10', isCurrentMonth: true },
+		{ date: '2022-01-11', isCurrentMonth: true },
+		{ date: '2022-01-12', isCurrentMonth: true, isToday: true },
+		{ date: '2022-01-13', isCurrentMonth: true },
+		{ date: '2022-01-14', isCurrentMonth: true },
+		{ date: '2022-01-15', isCurrentMonth: true },
+		{ date: '2022-01-16', isCurrentMonth: true },
+		{ date: '2022-01-17', isCurrentMonth: true },
+		{ date: '2022-01-18', isCurrentMonth: true },
+		{ date: '2022-01-19', isCurrentMonth: true },
+		{ date: '2022-01-20', isCurrentMonth: true },
+		{ date: '2022-01-21', isCurrentMonth: true },
+		{ date: '2022-01-22', isCurrentMonth: true, isSelected: true },
+		{ date: '2022-01-23', isCurrentMonth: true },
+		{ date: '2022-01-24', isCurrentMonth: true },
+		{ date: '2022-01-25', isCurrentMonth: true },
+		{ date: '2022-01-26', isCurrentMonth: true },
+		{ date: '2022-01-27', isCurrentMonth: true },
+		{ date: '2022-01-28', isCurrentMonth: true },
+		{ date: '2022-01-29', isCurrentMonth: true },
+		{ date: '2022-01-30', isCurrentMonth: true },
+		{ date: '2022-01-31', isCurrentMonth: true },
+		{ date: '2022-02-01' },
+		{ date: '2022-02-02' },
+		{ date: '2022-02-03' },
+		{ date: '2022-02-04' },
+		{ date: '2022-02-05' },
+		{ date: '2022-02-06' },
+	];
+
+	return (
+		<div>
+			<div class="lg:grid lg:grid-cols-12 lg:gap-x-16">
+				<div class="mt-10 text-center lg:col-start-8 lg:col-end-13 lg:row-start-1 lg:mt-9 xl:col-start-9">
+					<div class="flex items-center text-text-primary">
+						<button
+							type="button"
+							class="-m-1.5 flex flex-none items-center justify-center p-1.5 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+						>
+							<span class="sr-only">Previous month</span>
+							<ChevronLeft aria-hidden="true" class="size-5" />
+						</button>
+						<div class="flex-auto text-sm font-semibold">January</div>
+						<button
+							type="button"
+							class="-m-1.5 flex flex-none items-center justify-center p-1.5 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+						>
+							<span class="sr-only">Next month</span>
+							<ChevronRight aria-hidden="true" class="size-5" />
+						</button>
+					</div>
+					<div class="mt-6 grid grid-cols-7 text-xs/6 text-text-secondary dark:text-text-tertiary">
+						<div>M</div>
+						<div>T</div>
+						<div>W</div>
+						<div>T</div>
+						<div>F</div>
+						<div>S</div>
+						<div>S</div>
+					</div>
+					<div class="isolate mt-2 grid grid-cols-7 gap-px rounded-lg bg-surface-border text-sm shadow-sm ring-1 ring-surface-border dark:bg-white/15 dark:shadow-none dark:ring-white/15">
+						{days.map((day) => (
+							<button
+								key={day.date}
+								type="button"
+								data-is-today={day.isToday ? '' : undefined}
+								data-is-selected={day.isSelected ? '' : undefined}
+								data-is-current-month={day.isCurrentMonth ? '' : undefined}
+								class="py-1.5 not-data-is-current-month:bg-surface-1 not-data-is-selected:not-data-is-current-month:not-data-is-today:text-text-tertiary first:rounded-tl-lg last:rounded-br-lg hover:bg-surface-2 focus:z-10 data-is-current-month:bg-surface-0 not-data-is-selected:data-is-current-month:not-data-is-today:text-text-primary data-is-current-month:hover:bg-surface-1 data-is-selected:font-semibold data-is-selected:text-white data-is-today:font-semibold data-is-today:not-data-is-selected:text-accent-600 nth-36:rounded-bl-lg nth-7:rounded-tr-lg dark:not-data-is-current-month:bg-surface-2/75 dark:not-data-is-selected:not-data-is-current-month:not-data-is-today:text-text-tertiary dark:hover:bg-surface-2/25 dark:data-is-current-month:bg-surface-2/90 dark:not-data-is-selected:data-is-current-month:not-data-is-today:text-white dark:data-is-current-month:hover:bg-surface-2/50 dark:data-is-selected:text-text-primary dark:data-is-today:not-data-is-selected:text-accent-400"
+							>
+								<time
+									dateTime={day.date}
+									class="mx-auto flex size-7 items-center justify-center rounded-full in-data-is-selected:not-in-data-is-today:bg-text-primary in-data-is-selected:in-data-is-today:bg-accent-600 dark:in-data-is-selected:not-in-data-is-today:bg-white dark:in-data-is-selected:in-data-is-today:bg-accent-500"
+								>
+									{day.date.split('-').pop()?.replace(/^0/, '') ?? ''}
+								</time>
+							</button>
+						))}
+					</div>
+					<button
+						type="button"
+						class="mt-8 w-full rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-accent-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:bg-accent-500 dark:shadow-none dark:hover:bg-accent-400 dark:focus-visible:outline-accent-500"
+					>
+						Add event
+					</button>
+				</div>
+				<ol class="mt-4 divide-y divide-surface-border text-sm/6 lg:col-span-7 xl:col-span-8 dark:divide-white/10">
+					{meetings.map((meeting) => (
+						<li key={meeting.id} class="relative flex gap-x-6 py-6 xl:static">
+							<img
+								alt=""
+								src={meeting.imageUrl}
+								class="size-14 flex-none rounded-full dark:outline dark:-outline-offset-1 dark:outline-white/10"
+							/>
+							<div class="flex-auto">
+								<h3 class="pr-10 font-semibold text-text-primary xl:pr-0 dark:text-white">
+									{meeting.name}
+								</h3>
+								<dl class="mt-2 flex flex-col text-text-secondary xl:flex-row dark:text-text-tertiary">
+									<div class="flex items-start gap-x-3">
+										<dt class="mt-0.5">
+											<span class="sr-only">Date</span>
+											<CalendarIcon
+												aria-hidden="true"
+												class="size-5 text-text-tertiary dark:text-text-tertiary"
+											/>
+										</dt>
+										<dd>
+											<time dateTime={meeting.datetime}>
+												{meeting.date} at {meeting.time}
+											</time>
+										</dd>
+									</div>
+									<div class="mt-2 flex items-start gap-x-3 xl:mt-0 xl:ml-3.5 xl:border-l xl:border-surface-border xl:pl-3.5 dark:xl:border-white/50">
+										<dt class="mt-0.5">
+											<span class="sr-only">Location</span>
+											<MapPin
+												aria-hidden="true"
+												class="size-5 text-text-tertiary dark:text-text-tertiary"
+											/>
+										</dt>
+										<dd>{meeting.location}</dd>
+									</div>
+								</dl>
+							</div>
+							<Menu
+								as="div"
+								class="absolute top-6 right-0 xl:relative xl:top-auto xl:right-auto xl:self-center"
+							>
+								<MenuButton class="relative flex items-center rounded-full text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white">
+									<span class="absolute -inset-2" />
+									<span class="sr-only">Open options</span>
+									<EllipsisVertical aria-hidden="true" class="size-5" />
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-36 origin-top-right rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+								>
+									<div class="py-1">
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+											>
+												Edit
+											</a>
+										</MenuItem>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+											>
+												Cancel
+											</a>
+										</MenuItem>
+									</div>
+								</MenuItems>
+							</Menu>
+						</li>
+					))}
+				</ol>
+			</div>
+		</div>
+	);
+}
+
+// Demo 2: Month View Calendar
+function MonthView() {
+	const meetings = [
+		{
+			id: 1,
+			name: 'Leslie Alexander',
+			imageUrl:
+				'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			start: '1:00 PM',
+			startDatetime: '2022-01-21T13:00',
+			end: '2:30 PM',
+			endDatetime: '2022-01-21T14:30',
+		},
+		{
+			id: 2,
+			name: 'Michael Foster',
+			imageUrl:
+				'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			start: '3:00 PM',
+			startDatetime: '2022-01-21T15:00',
+			end: '4:30 PM',
+			endDatetime: '2022-01-21T16:30',
+		},
+		{
+			id: 3,
+			name: 'Dries Vincent',
+			imageUrl:
+				'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			start: '5:00 PM',
+			startDatetime: '2022-01-21T17:00',
+			end: '6:30 PM',
+			endDatetime: '2022-01-21T18:30',
+		},
+		{
+			id: 4,
+			name: 'Lindsay Walton',
+			imageUrl:
+				'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			start: '7:00 PM',
+			startDatetime: '2022-01-21T19:00',
+			end: '8:30 PM',
+			endDatetime: '2022-01-21T20:30',
+		},
+		{
+			id: 5,
+			name: 'Courtney Henry',
+			imageUrl:
+				'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			start: '9:00 PM',
+			startDatetime: '2022-01-21T21:00',
+			end: '10:30 PM',
+			endDatetime: '2022-01-21T22:30',
+		},
+	];
+	const days = [
+		{ date: '2021-12-27' },
+		{ date: '2021-12-28' },
+		{ date: '2021-12-29' },
+		{ date: '2021-12-30' },
+		{ date: '2021-12-31' },
+		{ date: '2022-01-01', isCurrentMonth: true },
+		{ date: '2022-01-02', isCurrentMonth: true },
+		{ date: '2022-01-03', isCurrentMonth: true },
+		{ date: '2022-01-04', isCurrentMonth: true },
+		{ date: '2022-01-05', isCurrentMonth: true },
+		{ date: '2022-01-06', isCurrentMonth: true },
+		{ date: '2022-01-07', isCurrentMonth: true },
+		{ date: '2022-01-08', isCurrentMonth: true },
+		{ date: '2022-01-09', isCurrentMonth: true },
+		{ date: '2022-01-10', isCurrentMonth: true },
+		{ date: '2022-01-11', isCurrentMonth: true },
+		{ date: '2022-01-12', isCurrentMonth: true, isToday: true },
+		{ date: '2022-01-13', isCurrentMonth: true },
+		{ date: '2022-01-14', isCurrentMonth: true },
+		{ date: '2022-01-15', isCurrentMonth: true },
+		{ date: '2022-01-16', isCurrentMonth: true },
+		{ date: '2022-01-17', isCurrentMonth: true },
+		{ date: '2022-01-18', isCurrentMonth: true },
+		{ date: '2022-01-19', isCurrentMonth: true },
+		{ date: '2022-01-20', isCurrentMonth: true },
+		{ date: '2022-01-21', isCurrentMonth: true, isSelected: true },
+		{ date: '2022-01-22', isCurrentMonth: true },
+		{ date: '2022-01-23', isCurrentMonth: true },
+		{ date: '2022-01-24', isCurrentMonth: true },
+		{ date: '2022-01-25', isCurrentMonth: true },
+		{ date: '2022-01-26', isCurrentMonth: true },
+		{ date: '2022-01-27', isCurrentMonth: true },
+		{ date: '2022-01-28', isCurrentMonth: true },
+		{ date: '2022-01-29', isCurrentMonth: true },
+		{ date: '2022-01-30', isCurrentMonth: true },
+		{ date: '2022-01-31', isCurrentMonth: true },
+		{ date: '2022-02-01' },
+		{ date: '2022-02-02' },
+		{ date: '2022-02-03' },
+		{ date: '2022-02-04' },
+		{ date: '2022-02-05' },
+		{ date: '2022-02-06' },
+	];
+
+	return (
+		<div class="md:grid md:grid-cols-2 md:divide-x md:divide-surface-border dark:md:divide-white/10">
+			<div class="md:pr-14">
+				<div class="flex items-center">
+					<h2 class="flex-auto text-sm font-semibold text-text-primary dark:text-white">
+						January 2022
+					</h2>
+					<button
+						type="button"
+						class="-my-1.5 flex flex-none items-center justify-center p-1.5 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+					>
+						<span class="sr-only">Previous month</span>
+						<ChevronLeft aria-hidden="true" class="size-5" />
+					</button>
+					<button
+						type="button"
+						class="-my-1.5 -mr-1.5 ml-2 flex flex-none items-center justify-center p-1.5 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+					>
+						<span class="sr-only">Next month</span>
+						<ChevronRight aria-hidden="true" class="size-5" />
+					</button>
+				</div>
+				<div class="mt-10 grid grid-cols-7 text-center text-xs/6 text-text-secondary dark:text-text-tertiary">
+					<div>M</div>
+					<div>T</div>
+					<div>W</div>
+					<div>T</div>
+					<div>F</div>
+					<div>S</div>
+					<div>S</div>
+				</div>
+				<div class="mt-2 grid grid-cols-7 text-sm">
+					{days.map((day, dayIdx) => (
+						<div
+							key={day.date}
+							data-first-line={dayIdx <= 6 ? '' : undefined}
+							class="py-2 not-data-first-line:border-t not-data-first-line:border-surface-border dark:not-data-first-line:border-white/10"
+						>
+							<button
+								type="button"
+								data-is-today={day.isToday ? '' : undefined}
+								data-is-selected={day.isSelected ? '' : undefined}
+								data-is-current-month={day.isCurrentMonth ? '' : undefined}
+								class="mx-auto flex size-8 items-center justify-center rounded-full not-data-is-selected:not-data-is-today:not-data-is-current-month:text-text-tertiary not-data-is-selected:hover:bg-surface-2 not-data-is-selected:not-data-is-today:data-is-current-month:text-text-primary data-is-selected:font-semibold data-is-selected:text-white data-is-selected:not-data-is-today:bg-text-primary data-is-today:font-semibold not-data-is-selected:data-is-today:text-accent-600 data-is-selected:data-is-today:bg-accent-600 dark:not-data-is-selected:not-data-is-today:not-data-is-current-month:text-text-tertiary dark:not-data-is-selected:hover:bg-white/10 dark:not-data-is-selected:not-data-is-today:data-is-current-month:text-white dark:data-is-selected:not-data-is-today:bg-white dark:data-is-selected:not-data-is-today:text-text-primary dark:not-data-is-selected:data-is-today:text-accent-400 dark:data-is-selected:data-is-today:bg-accent-500"
+							>
+								<time dateTime={day.date}>
+									{day.date.split('-').pop()?.replace(/^0/, '') ?? ''}
+								</time>
+							</button>
+						</div>
+					))}
+				</div>
+			</div>
+			<section class="mt-12 md:mt-0 md:pl-14">
+				<h2 class="text-base font-semibold text-text-primary dark:text-white">
+					Schedule for <time dateTime="2022-01-21">January 21, 2022</time>
+				</h2>
+				<ol class="mt-4 flex flex-col gap-y-1 text-sm/6 text-text-secondary dark:text-text-tertiary">
+					{meetings.map((meeting) => (
+						<li
+							key={meeting.id}
+							class="group flex items-center gap-x-4 rounded-xl px-4 py-2 focus-within:bg-surface-2 hover:bg-surface-2 dark:focus-within:bg-white/5 dark:hover:bg-white/5"
+						>
+							<img
+								alt=""
+								src={meeting.imageUrl}
+								class="size-10 flex-none rounded-full dark:outline dark:-outline-offset-1 dark:outline-white/10"
+							/>
+							<div class="flex-auto">
+								<p class="text-text-primary dark:text-white">{meeting.name}</p>
+								<p class="mt-0.5">
+									<time dateTime={meeting.startDatetime}>{meeting.start}</time> -{' '}
+									<time dateTime={meeting.endDatetime}>{meeting.end}</time>
+								</p>
+							</div>
+							<Menu
+								as="div"
+								class="relative opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+							>
+								<MenuButton class="relative flex items-center rounded-full text-text-tertiary outline-offset-6 hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white">
+									<span class="absolute -inset-2" />
+									<span class="sr-only">Open options</span>
+									<EllipsisVertical aria-hidden="true" class="size-6" />
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-36 origin-top-right rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+								>
+									<div class="py-1">
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+											>
+												Edit
+											</a>
+										</MenuItem>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+											>
+												Cancel
+											</a>
+										</MenuItem>
+									</div>
+								</MenuItems>
+							</Menu>
+						</li>
+					))}
+				</ol>
+			</section>
+		</div>
+	);
+}
+
+// Demo 3: Week View Calendar
+function WeekView() {
+	const events = [
+		{ id: 1, name: 'Maple syrup museum', time: '3PM', datetime: '2022-01-15T09:00', href: '#' },
+		{ id: 2, name: 'Hockey game', time: '7PM', datetime: '2022-01-22T19:00', href: '#' },
+	];
+	const days = [
+		{ date: '2021-12-27', events: [] },
+		{ date: '2021-12-28', events: [] },
+		{ date: '2021-12-29', events: [] },
+		{ date: '2021-12-30', events: [] },
+		{ date: '2021-12-31', events: [] },
+		{ date: '2022-01-01', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-02', isCurrentMonth: true, events: [] },
+		{
+			date: '2022-01-03',
+			isCurrentMonth: true,
+			events: [
+				{ id: 1, name: 'Design review', time: '10AM', datetime: '2022-01-03T10:00', href: '#' },
+				{ id: 2, name: 'Sales meeting', time: '2PM', datetime: '2022-01-03T14:00', href: '#' },
+			],
+		},
+		{ date: '2022-01-04', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-05', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-06', isCurrentMonth: true, events: [] },
+		{
+			date: '2022-01-07',
+			isCurrentMonth: true,
+			events: [{ id: 3, name: 'Date night', time: '6PM', datetime: '2022-01-08T18:00', href: '#' }],
+		},
+		{ date: '2022-01-08', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-09', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-10', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-11', isCurrentMonth: true, events: [] },
+		{
+			date: '2022-01-12',
+			isCurrentMonth: true,
+			isToday: true,
+			events: [
+				{
+					id: 6,
+					name: "Sam's birthday party",
+					time: '2PM',
+					datetime: '2022-01-25T14:00',
+					href: '#',
+				},
+			],
+		},
+		{ date: '2022-01-13', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-14', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-15', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-16', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-17', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-18', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-19', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-20', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-21', isCurrentMonth: true, events: [] },
+		{
+			date: '2022-01-22',
+			isCurrentMonth: true,
+			isSelected: true,
+			events: [
+				{ id: 4, name: 'Maple syrup museum', time: '3PM', datetime: '2022-01-22T15:00', href: '#' },
+				{ id: 5, name: 'Hockey game', time: '7PM', datetime: '2022-01-22T19:00', href: '#' },
+			],
+		},
+		{ date: '2022-01-23', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-24', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-25', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-26', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-27', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-28', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-29', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-30', isCurrentMonth: true, events: [] },
+		{ date: '2022-01-31', isCurrentMonth: true, events: [] },
+		{ date: '2022-02-01', events: [] },
+		{ date: '2022-02-02', events: [] },
+		{ date: '2022-02-03', events: [] },
+		{
+			date: '2022-02-04',
+			events: [
+				{
+					id: 7,
+					name: 'Cinema with friends',
+					time: '9PM',
+					datetime: '2022-02-04T21:00',
+					href: '#',
+				},
+			],
+		},
+		{ date: '2022-02-05', events: [] },
+		{ date: '2022-02-06', events: [] },
+	];
+
+	return (
+		<div class="lg:flex lg:h-full lg:flex-col">
+			<header class="flex items-center justify-between border-b border-surface-border px-6 py-4 lg:flex-none dark:border-white/10 dark:bg-surface-2/50">
+				<h1 class="text-base font-semibold text-text-primary dark:text-white">
+					<time dateTime="2022-01">January 2022</time>
+				</h1>
+				<div class="flex items-center">
+					<div class="relative flex items-center rounded-lg bg-surface-0 shadow-xs outline outline-surface-border md:items-stretch dark:bg-white/10 dark:shadow-none dark:outline-white/5">
+						<button
+							type="button"
+							class="flex h-9 w-12 items-center justify-center rounded-l-lg pr-1 text-text-tertiary hover:text-text-secondary focus:relative md:w-9 md:pr-0 md:hover:bg-surface-1 dark:hover:text-white dark:md:hover:bg-white/10"
+						>
+							<span class="sr-only">Previous month</span>
+							<ChevronLeft aria-hidden="true" class="size-5" />
+						</button>
+						<button
+							type="button"
+							class="hidden px-3.5 text-sm font-semibold text-text-primary hover:bg-surface-1 focus:relative md:block dark:text-white dark:hover:bg-white/10"
+						>
+							Today
+						</button>
+						<span class="relative -mx-px h-5 w-px bg-surface-border md:hidden dark:bg-white/10" />
+						<button
+							type="button"
+							class="flex h-9 w-12 items-center justify-center rounded-r-lg pl-1 text-text-tertiary hover:text-text-secondary focus:relative md:w-9 md:pl-0 md:hover:bg-surface-1 dark:hover:text-white dark:md:hover:bg-white/10"
+						>
+							<span class="sr-only">Next month</span>
+							<ChevronRight aria-hidden="true" class="size-5" />
+						</button>
+					</div>
+					<div class="hidden md:ml-4 md:flex md:items-center">
+						<Menu as="div" class="relative">
+							<MenuButton
+								type="button"
+								class="flex items-center gap-x-1.5 rounded-lg bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20"
+							>
+								Month view
+								<ChevronDown
+									aria-hidden="true"
+									class="-mr-1 size-5 text-text-tertiary dark:text-text-tertiary"
+								/>
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-3 w-36 origin-top-right overflow-hidden rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:-outline-offset-1 dark:outline-white/10"
+							>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Day view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Week view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Month view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Year view
+										</a>
+									</MenuItem>
+								</div>
+							</MenuItems>
+						</Menu>
+						<div class="ml-6 h-6 w-px bg-surface-border dark:bg-white/10" />
+						<button
+							type="button"
+							class="ml-6 rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-accent-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:bg-accent-500 dark:shadow-none dark:hover:bg-accent-400 dark:focus-visible:outline-accent-500"
+						>
+							Add event
+						</button>
+					</div>
+					<Menu as="div" class="relative ml-6 md:hidden">
+						<MenuButton class="-mx-2 flex items-center rounded-full border border-transparent p-2 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white">
+							<span class="sr-only">Open menu</span>
+							<EllipsisVertical aria-hidden="true" class="size-5" />
+						</MenuButton>
+
+						<MenuItems
+							transition
+							class="absolute right-0 z-10 mt-3 w-36 origin-top-right divide-y divide-surface-border overflow-hidden rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:divide-white/10 dark:bg-surface-2 dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="py-1">
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Create event
+									</a>
+								</MenuItem>
+							</div>
+							<div class="py-1">
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Go to today
+									</a>
+								</MenuItem>
+							</div>
+							<div class="py-1">
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Day view
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Week view
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Month view
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Year view
+									</a>
+								</MenuItem>
+							</div>
+						</MenuItems>
+					</Menu>
+				</div>
+			</header>
+			<div class="shadow-sm ring-1 ring-black/5 lg:flex lg:flex-auto lg:flex-col dark:shadow-none dark:ring-white/5">
+				<div class="grid grid-cols-7 gap-px border-b border-surface-border bg-surface-border text-center text-xs/6 font-semibold text-text-secondary lg:flex-none dark:border-white/5 dark:bg-white/15 dark:text-text-tertiary">
+					<div class="flex justify-center bg-surface-0 py-2 dark:bg-surface-2">
+						<span>M</span>
+						<span class="sr-only sm:not-sr-only">on</span>
+					</div>
+					<div class="flex justify-center bg-surface-0 py-2 dark:bg-surface-2">
+						<span>T</span>
+						<span class="sr-only sm:not-sr-only">ue</span>
+					</div>
+					<div class="flex justify-center bg-surface-0 py-2 dark:bg-surface-2">
+						<span>W</span>
+						<span class="sr-only sm:not-sr-only">ed</span>
+					</div>
+					<div class="flex justify-center bg-surface-0 py-2 dark:bg-surface-2">
+						<span>T</span>
+						<span class="sr-only sm:not-sr-only">hu</span>
+					</div>
+					<div class="flex justify-center bg-surface-0 py-2 dark:bg-surface-2">
+						<span>F</span>
+						<span class="sr-only sm:not-sr-only">ri</span>
+					</div>
+					<div class="flex justify-center bg-surface-0 py-2 dark:bg-surface-2">
+						<span>S</span>
+						<span class="sr-only sm:not-sr-only">at</span>
+					</div>
+					<div class="flex justify-center bg-surface-0 py-2 dark:bg-surface-2">
+						<span>S</span>
+						<span class="sr-only sm:not-sr-only">un</span>
+					</div>
+				</div>
+				<div class="flex bg-surface-border text-xs/6 text-text-secondary lg:flex-auto dark:bg-white/10 dark:text-text-tertiary">
+					<div class="hidden w-full lg:grid lg:grid-cols-7 lg:grid-rows-6 lg:gap-px">
+						{days.map((day) => (
+							<div
+								key={day.date}
+								data-is-today={day.isToday ? '' : undefined}
+								data-is-current-month={day.isCurrentMonth ? '' : undefined}
+								class="group relative bg-surface-0 px-3 py-2 text-text-tertiary data-is-current-month:bg-surface-0 dark:bg-surface-2 dark:text-text-tertiary dark:not-data-is-current-month:before:pointer-events-none dark:not-data-is-current-month:before:absolute dark:not-data-is-current-month:before:inset-0 dark:not-data-is-current-month:before:bg-surface-1/50 dark:data-is-current-month:bg-surface-2"
+							>
+								<time
+									dateTime={day.date}
+									class="relative group-not-data-is-current-month:opacity-75 in-data-is-today:flex in-data-is-today:size-6 in-data-is-today:items-center in-data-is-today:justify-center in-data-is-today:rounded-full in-data-is-today:bg-accent-600 in-data-is-today:font-semibold in-data-is-today:text-white dark:in-data-is-today:bg-accent-500"
+								>
+									{day.date.split('-').pop()?.replace(/^0/, '') ?? ''}
+								</time>
+								{day.events.length > 0 ? (
+									<ol class="mt-2">
+										{day.events.slice(0, 2).map((event) => (
+											<li key={event.id}>
+												<a href={event.href} class="group flex">
+													<p class="flex-auto truncate font-medium text-text-primary group-hover:text-accent-600 dark:text-white dark:group-hover:text-accent-400">
+														{event.name}
+													</p>
+													<time
+														dateTime={event.datetime}
+														class="ml-3 hidden flex-none text-text-tertiary group-hover:text-accent-600 xl:block dark:text-text-tertiary dark:group-hover:text-accent-400"
+													>
+														{event.time}
+													</time>
+												</a>
+											</li>
+										))}
+										{day.events.length > 2 ? (
+											<li class="text-text-tertiary dark:text-text-tertiary">
+												+ {day.events.length - 2} more
+											</li>
+										) : null}
+									</ol>
+								) : null}
+							</div>
+						))}
+					</div>
+					<div class="isolate grid w-full grid-cols-7 grid-rows-6 gap-px lg:hidden">
+						{days.map((day) => (
+							<button
+								key={day.date}
+								type="button"
+								data-is-today={day.isToday ? '' : undefined}
+								data-is-selected={day.isSelected ? '' : undefined}
+								data-is-current-month={day.isCurrentMonth ? '' : undefined}
+								class="group relative flex h-14 flex-col px-3 py-2 not-data-is-current-month:bg-surface-1 not-data-is-selected:not-data-is-current-month:not-data-is-today:text-text-tertiary hover:bg-surface-2 focus:z-10 data-is-current-month:bg-surface-0 not-data-is-selected:data-is-current-month:not-data-is-today:text-text-primary data-is-current-month:hover:bg-surface-1 data-is-selected:font-semibold data-is-selected:text-white data-is-today:font-semibold not-data-is-selected:data-is-today:text-accent-600 dark:not-data-is-current-month:bg-surface-2 dark:not-data-is-selected:not-data-is-current-month:not-data-is-today:text-text-tertiary dark:not-data-is-current-month:before:pointer-events-none dark:not-data-is-current-month:before:absolute dark:not-data-is-current-month:before:inset-0 dark:not-data-is-current-month:before:bg-surface-1/50 dark:hover:bg-surface-2/50 dark:data-is-current-month:bg-surface-2 dark:not-data-is-selected:data-is-current-month:not-data-is-today:text-white dark:data-is-current-month:hover:bg-surface-2/50 dark:not-data-is-selected:data-is-today:text-accent-400"
+							>
+								<time
+									dateTime={day.date}
+									class="ml-auto group-not-data-is-current-month:opacity-75 in-data-is-selected:flex in-data-is-selected:size-6 in-data-is-selected:items-center in-data-is-selected:justify-center in-data-is-selected:rounded-full in-data-is-selected:not-in-data-is-today:bg-text-primary in-data-is-selected:in-data-is-today:bg-accent-600 dark:in-data-is-selected:not-in-data-is-today:bg-white dark:in-data-is-selected:not-in-data-is-today:text-text-primary dark:in-data-is-selected:in-data-is-today:bg-accent-500"
+								>
+									{day.date.split('-').pop()?.replace(/^0/, '') ?? ''}
+								</time>
+								<span class="sr-only">{day.events.length} events</span>
+								{day.events.length > 0 ? (
+									<span class="-mx-0.5 mt-auto flex flex-wrap-reverse">
+										{day.events.map((event) => (
+											<span
+												key={event.id}
+												class="mx-0.5 mb-1 size-1.5 rounded-full bg-text-tertiary dark:bg-text-tertiary"
+											/>
+										))}
+									</span>
+								) : null}
+							</button>
+						))}
+					</div>
+				</div>
+			</div>
+			<div class="relative px-4 py-10 sm:px-6 lg:hidden dark:after:pointer-events-none dark:after:absolute dark:after:inset-x-0 dark:after:top-0 dark:after:h-px dark:after:bg-white/10">
+				<ol class="divide-y divide-surface-border overflow-hidden rounded-lg bg-surface-0 text-sm shadow-sm outline-1 outline-black/5 dark:divide-white/10 dark:bg-surface-2/50 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10">
+					{events.map((event) => (
+						<li
+							key={event.id}
+							class="group flex p-4 pr-6 focus-within:bg-surface-1 hover:bg-surface-1 dark:focus-within:bg-white/5 dark:hover:bg-white/5"
+						>
+							<div class="flex-auto">
+								<p class="font-semibold text-text-primary dark:text-white">{event.name}</p>
+								<time
+									dateTime={event.datetime}
+									class="mt-2 flex items-center text-text-secondary dark:text-text-tertiary"
+								>
+									<Clock
+										aria-hidden="true"
+										class="mr-2 size-5 text-text-tertiary dark:text-text-tertiary"
+									/>
+									{event.time}
+								</time>
+							</div>
+							<a
+								href={event.href}
+								class="ml-6 flex-none self-center rounded-lg bg-surface-0 px-3 py-2 font-semibold text-text-primary opacity-0 shadow-xs ring-1 ring-surface-border ring-inset group-hover:opacity-100 hover:ring-text-tertiary focus:opacity-100 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20 dark:hover:ring-white/5"
+							>
+								Edit<span class="sr-only">, {event.name}</span>
+							</a>
+						</li>
+					))}
+				</ol>
+			</div>
+		</div>
+	);
+}
+
+// Demo 4: Day View Calendar
+function DayView() {
+	return (
+		<div class="flex h-full flex-col">
+			<header class="flex flex-none items-center justify-between border-b border-surface-border px-6 py-4 dark:border-white/10 dark:bg-surface-2/50 dark:max-md:border-white/15">
+				<div>
+					<h1 class="text-base font-semibold text-text-primary dark:text-white">
+						<time dateTime="2022-01-22" class="sm:hidden">
+							Jan 22, 2022
+						</time>
+						<time dateTime="2022-01-22" class="hidden sm:inline">
+							January 22, 2022
+						</time>
+					</h1>
+					<p class="mt-1 text-sm text-text-secondary dark:text-text-tertiary">Saturday</p>
+				</div>
+				<div class="flex items-center">
+					<div class="relative flex items-center rounded-lg bg-surface-0 shadow-xs outline outline-surface-border md:items-stretch dark:bg-white/10 dark:shadow-none dark:outline-white/5">
+						<button
+							type="button"
+							class="flex h-9 w-12 items-center justify-center rounded-l-lg pr-1 text-text-tertiary hover:text-text-secondary focus:relative md:w-9 md:pr-0 md:hover:bg-surface-1 dark:hover:text-white dark:md:hover:bg-white/10"
+						>
+							<span class="sr-only">Previous day</span>
+							<ChevronLeft aria-hidden="true" class="size-5" />
+						</button>
+						<button
+							type="button"
+							class="hidden px-3.5 text-sm font-semibold text-text-primary hover:bg-surface-1 focus:relative md:block dark:text-white dark:hover:bg-white/10"
+						>
+							Today
+						</button>
+						<span class="relative -mx-px h-5 w-px bg-surface-border md:hidden dark:bg-white/10" />
+						<button
+							type="button"
+							class="flex h-9 w-12 items-center justify-center rounded-r-lg pl-1 text-text-tertiary hover:text-text-secondary focus:relative md:w-9 md:pl-0 md:hover:bg-surface-1 dark:hover:text-white dark:md:hover:bg-white/10"
+						>
+							<span class="sr-only">Next day</span>
+							<ChevronRight aria-hidden="true" class="size-5" />
+						</button>
+					</div>
+					<div class="hidden md:ml-4 md:flex md:items-center">
+						<Menu as="div" class="relative">
+							<MenuButton
+								type="button"
+								class="flex items-center gap-x-1.5 rounded-lg bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20"
+							>
+								Day view
+								<ChevronDown aria-hidden="true" class="-mr-1 size-5 text-text-tertiary" />
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-3 w-36 origin-top-right overflow-hidden rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:-outline-offset-1 dark:outline-white/10"
+							>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Day view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Week view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Month view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Year view
+										</a>
+									</MenuItem>
+								</div>
+							</MenuItems>
+						</Menu>
+						<div class="ml-6 h-6 w-px bg-surface-border dark:bg-white/10" />
+						<button
+							type="button"
+							class="ml-6 rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-accent-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:bg-accent-500 dark:shadow-none dark:hover:bg-accent-400 dark:focus-visible:outline-accent-500"
+						>
+							Add event
+						</button>
+					</div>
+					<div class="ml-6 md:hidden">
+						<Menu as="div" class="relative">
+							<MenuButton class="relative flex items-center rounded-full text-text-tertiary outline-offset-8 hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white">
+								<span class="absolute -inset-2" />
+								<span class="sr-only">Open menu</span>
+								<EllipsisVertical aria-hidden="true" class="size-5" />
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-3 w-36 origin-top-right divide-y divide-surface-border overflow-hidden rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:divide-white/10 dark:bg-surface-2 dark:-outline-offset-1 dark:outline-white/10"
+							>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Create event
+										</a>
+									</MenuItem>
+								</div>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Go to today
+										</a>
+									</MenuItem>
+								</div>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Day view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Week view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Month view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Year view
+										</a>
+									</MenuItem>
+								</div>
+							</MenuItems>
+						</Menu>
+					</div>
+				</div>
+			</header>
+			<div class="isolate flex flex-auto overflow-hidden bg-surface-0 dark:bg-surface-2">
+				<div class="flex flex-auto flex-col overflow-auto">
+					<div class="sticky top-0 z-10 grid flex-none grid-cols-7 bg-surface-0 text-xs text-text-secondary shadow-sm ring-1 ring-black/5 md:hidden dark:bg-surface-2 dark:text-text-tertiary dark:shadow-none dark:ring-white/20">
+						<button type="button" class="flex flex-col items-center pt-3 pb-1.5">
+							<span>W</span>
+							<span class="mt-3 flex size-8 items-center justify-center rounded-full text-base font-semibold text-text-primary dark:text-white">
+								19
+							</span>
+						</button>
+						<button type="button" class="flex flex-col items-center pt-3 pb-1.5">
+							<span>T</span>
+							<span class="mt-3 flex size-8 items-center justify-center rounded-full text-base font-semibold text-accent-600 dark:text-accent-400">
+								20
+							</span>
+						</button>
+						<button type="button" class="flex flex-col items-center pt-3 pb-1.5">
+							<span>F</span>
+							<span class="mt-3 flex size-8 items-center justify-center rounded-full text-base font-semibold text-text-primary dark:text-white">
+								21
+							</span>
+						</button>
+						<button type="button" class="flex flex-col items-center pt-3 pb-1.5">
+							<span>S</span>
+							<span class="mt-3 flex size-8 items-center justify-center rounded-full bg-text-primary text-base font-semibold text-white dark:bg-white dark:text-text-primary">
+								22
+							</span>
+						</button>
+						<button type="button" class="flex flex-col items-center pt-3 pb-1.5">
+							<span>S</span>
+							<span class="mt-3 flex size-8 items-center justify-center rounded-full text-base font-semibold text-text-primary dark:text-white">
+								23
+							</span>
+						</button>
+						<button type="button" class="flex flex-col items-center pt-3 pb-1.5">
+							<span>M</span>
+							<span class="mt-3 flex size-8 items-center justify-center rounded-full text-base font-semibold text-text-primary dark:text-white">
+								24
+							</span>
+						</button>
+						<button type="button" class="flex flex-col items-center pt-3 pb-1.5">
+							<span>T</span>
+							<span class="mt-3 flex size-8 items-center justify-center rounded-full text-base font-semibold text-text-primary dark:text-white">
+								25
+							</span>
+						</button>
+					</div>
+					<div class="flex w-full flex-auto">
+						<div class="w-14 flex-none bg-surface-0 ring-1 ring-surface-border dark:bg-surface-2 dark:ring-white/5" />
+						<div class="grid flex-auto grid-cols-1 grid-rows-1">
+							<div
+								style={{ gridTemplateRows: 'repeat(48, minmax(3.5rem, 1fr))' }}
+								class="col-start-1 col-end-2 row-start-1 grid divide-y divide-surface-border dark:divide-white/5"
+							>
+								<div class="row-end-1 h-7" />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										12AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										1AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										2AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										3AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										4AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										5AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										6AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										7AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										8AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										9AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										10AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										11AM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										12PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										1PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										2PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										3PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										4PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										5PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										6PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										7PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										8PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										9PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										10PM
+									</div>
+								</div>
+								<div />
+								<div>
+									<div class="-mt-2.5 -ml-14 w-14 pr-2 text-right text-xs/5 text-text-tertiary dark:text-text-tertiary">
+										11PM
+									</div>
+								</div>
+								<div />
+							</div>
+
+							<ol
+								style={{ gridTemplateRows: '1.75rem repeat(288, minmax(0, 1fr)) auto' }}
+								class="col-start-1 col-end-2 row-start-1 grid grid-cols-1"
+							>
+								<li
+									style={{ gridRow: '74 / span 12' }}
+									class="relative mt-px flex dark:before:pointer-events-none dark:before:absolute dark:before:inset-1 dark:before:z-0 dark:before:rounded-lg dark:before:bg-surface-2"
+								>
+									<a
+										href="#"
+										class="group absolute inset-1 flex flex-col overflow-y-auto rounded-lg bg-blue-50 p-2 text-xs/5 hover:bg-blue-100 dark:bg-blue-600/15 dark:hover:bg-blue-600/20"
+									>
+										<p class="order-1 font-semibold text-blue-700 dark:text-blue-300">Breakfast</p>
+										<p class="text-blue-500 group-hover:text-blue-700 dark:text-blue-400 dark:group-hover:text-blue-300">
+											<time dateTime="2022-01-22T06:00">6:00 AM</time>
+										</p>
+									</a>
+								</li>
+								<li
+									style={{ gridRow: '92 / span 30' }}
+									class="relative mt-px flex dark:before:pointer-events-none dark:before:absolute dark:before:inset-1 dark:before:z-0 dark:before:rounded-lg dark:before:bg-surface-2"
+								>
+									<a
+										href="#"
+										class="group absolute inset-1 flex flex-col overflow-y-auto rounded-lg bg-pink-50 p-2 text-xs/5 hover:bg-pink-100 dark:bg-pink-600/15 dark:hover:bg-pink-600/20"
+									>
+										<p class="order-1 font-semibold text-pink-700 dark:text-pink-300">
+											Flight to Paris
+										</p>
+										<p class="order-1 text-pink-500 group-hover:text-pink-700 dark:text-pink-400 dark:group-hover:text-pink-300">
+											John F. Kennedy International Airport
+										</p>
+										<p class="text-pink-500 group-hover:text-pink-700 dark:text-pink-400 dark:group-hover:text-pink-300">
+											<time dateTime="2022-01-22T07:30">7:30 AM</time>
+										</p>
+									</a>
+								</li>
+								<li
+									style={{ gridRow: '134 / span 18' }}
+									class="relative mt-px flex dark:before:pointer-events-none dark:before:absolute dark:before:inset-1 dark:before:z-0 dark:before:rounded-lg dark:before:bg-surface-2"
+								>
+									<a
+										href="#"
+										class="group absolute inset-1 flex flex-col overflow-y-auto rounded-lg bg-accent-50 p-2 text-xs/5 hover:bg-accent-100 dark:bg-accent-600/15 dark:hover:bg-accent-600/20"
+									>
+										<p class="order-1 font-semibold text-accent-700 dark:text-accent-300">
+											Sightseeing
+										</p>
+										<p class="order-1 text-accent-500 group-hover:text-accent-700 dark:text-accent-400 dark:group-hover:text-accent-300">
+											Eiffel Tower
+										</p>
+										<p class="text-accent-500 group-hover:text-accent-700 dark:text-accent-400 dark:group-hover:text-accent-300">
+											<time dateTime="2022-01-22T11:00">11:00 AM</time>
+										</p>
+									</a>
+								</li>
+							</ol>
+						</div>
+					</div>
+				</div>
+				<div class="hidden w-1/2 max-w-md flex-none border-l border-surface-border px-8 py-10 md:block dark:border-white/10">
+					<div class="flex items-center text-center text-text-primary">
+						<button
+							type="button"
+							class="-m-1.5 flex flex-none items-center justify-center p-1.5 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+						>
+							<span class="sr-only">Previous month</span>
+							<ChevronLeft aria-hidden="true" class="size-5" />
+						</button>
+						<div class="flex-auto text-sm font-semibold">January 2022</div>
+						<button
+							type="button"
+							class="-m-1.5 flex flex-none items-center justify-center p-1.5 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+						>
+							<span class="sr-only">Next month</span>
+							<ChevronRight aria-hidden="true" class="size-5" />
+						</button>
+					</div>
+					<div class="mt-6 grid grid-cols-7 text-center text-xs/6 text-text-secondary dark:text-text-tertiary">
+						<div>M</div>
+						<div>T</div>
+						<div>W</div>
+						<div>T</div>
+						<div>F</div>
+						<div>S</div>
+						<div>S</div>
+					</div>
+					<div class="isolate mt-2 grid grid-cols-7 gap-px rounded-lg bg-surface-border text-sm shadow-sm ring-1 ring-surface-border dark:bg-white/10 dark:shadow-none dark:ring-white/10">
+						{[
+							{ date: '2021-12-27' },
+							{ date: '2021-12-28' },
+							{ date: '2021-12-29' },
+							{ date: '2021-12-30' },
+							{ date: '2021-12-31' },
+							{ date: '2022-01-01', isCurrentMonth: true },
+							{ date: '2022-01-02', isCurrentMonth: true },
+							{ date: '2022-01-03', isCurrentMonth: true },
+							{ date: '2022-01-04', isCurrentMonth: true },
+							{ date: '2022-01-05', isCurrentMonth: true },
+							{ date: '2022-01-06', isCurrentMonth: true },
+							{ date: '2022-01-07', isCurrentMonth: true },
+							{ date: '2022-01-08', isCurrentMonth: true },
+							{ date: '2022-01-09', isCurrentMonth: true },
+							{ date: '2022-01-10', isCurrentMonth: true },
+							{ date: '2022-01-11', isCurrentMonth: true },
+							{ date: '2022-01-12', isCurrentMonth: true },
+							{ date: '2022-01-13', isCurrentMonth: true },
+							{ date: '2022-01-14', isCurrentMonth: true },
+							{ date: '2022-01-15', isCurrentMonth: true },
+							{ date: '2022-01-16', isCurrentMonth: true },
+							{ date: '2022-01-17', isCurrentMonth: true },
+							{ date: '2022-01-18', isCurrentMonth: true },
+							{ date: '2022-01-19', isCurrentMonth: true, isToday: true },
+							{ date: '2022-01-20', isCurrentMonth: true },
+							{ date: '2022-01-21', isCurrentMonth: true },
+							{ date: '2022-01-22', isCurrentMonth: true, isSelected: true },
+							{ date: '2022-01-23', isCurrentMonth: true },
+							{ date: '2022-01-24', isCurrentMonth: true },
+							{ date: '2022-01-25', isCurrentMonth: true },
+							{ date: '2022-01-26', isCurrentMonth: true },
+							{ date: '2022-01-27', isCurrentMonth: true },
+							{ date: '2022-01-28', isCurrentMonth: true },
+							{ date: '2022-01-29', isCurrentMonth: true },
+							{ date: '2022-01-30', isCurrentMonth: true },
+							{ date: '2022-01-31', isCurrentMonth: true },
+							{ date: '2022-02-01' },
+							{ date: '2022-02-02' },
+							{ date: '2022-02-03' },
+							{ date: '2022-02-04' },
+							{ date: '2022-02-05' },
+							{ date: '2022-02-06' },
+						].map((day) => (
+							<button
+								key={day.date}
+								type="button"
+								data-is-today={day.isToday ? '' : undefined}
+								data-is-selected={day.isSelected ? '' : undefined}
+								data-is-current-month={day.isCurrentMonth ? '' : undefined}
+								class="py-1.5 not-data-is-current-month:bg-surface-1 not-data-is-selected:not-data-is-current-month:not-data-is-today:text-text-tertiary first:rounded-tl-lg last:rounded-br-lg hover:bg-surface-2 focus:z-10 data-is-current-month:bg-surface-0 not-data-is-selected:data-is-current-month:not-data-is-today:text-text-primary data-is-current-month:hover:bg-surface-1 data-is-selected:font-semibold data-is-selected:text-white data-is-today:font-semibold data-is-today:not-data-is-selected:text-accent-600 nth-36:rounded-bl-lg nth-7:rounded-tr-lg dark:not-data-is-current-month:bg-surface-2/75 dark:not-data-is-selected:not-data-is-current-month:not-data-is-today:text-text-tertiary dark:hover:bg-surface-2/25 dark:data-is-current-month:bg-surface-2/90 dark:not-data-is-selected:data-is-current-month:not-data-is-today:text-white dark:data-is-current-month:hover:bg-surface-2/50 dark:data-is-selected:text-text-primary dark:data-is-today:not-data-is-selected:text-accent-400"
+							>
+								<time
+									dateTime={day.date}
+									class="mx-auto flex size-7 items-center justify-center rounded-full in-data-is-selected:not-in-data-is-today:bg-text-primary in-data-is-selected:in-data-is-today:bg-accent-600 dark:in-data-is-selected:not-in-data-is-today:bg-white dark:in-data-is-selected:in-data-is-today:bg-accent-500"
+								>
+									{day.date.split('-').pop()?.replace(/^0/, '') ?? ''}
+								</time>
+							</button>
+						))}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// Demo 5: Year View Calendar
+function YearView() {
+	const months = [
+		{
+			name: 'January',
+			days: [
+				{ date: '2021-12-27' },
+				{ date: '2021-12-28' },
+				{ date: '2021-12-29' },
+				{ date: '2021-12-30' },
+				{ date: '2021-12-31' },
+				{ date: '2022-01-01', isCurrentMonth: true },
+				{ date: '2022-01-02', isCurrentMonth: true },
+				{ date: '2022-01-03', isCurrentMonth: true },
+				{ date: '2022-01-04', isCurrentMonth: true },
+				{ date: '2022-01-05', isCurrentMonth: true },
+				{ date: '2022-01-06', isCurrentMonth: true },
+				{ date: '2022-01-07', isCurrentMonth: true },
+				{ date: '2022-01-08', isCurrentMonth: true },
+				{ date: '2022-01-09', isCurrentMonth: true },
+				{ date: '2022-01-10', isCurrentMonth: true },
+				{ date: '2022-01-11', isCurrentMonth: true },
+				{ date: '2022-01-12', isCurrentMonth: true, isToday: true },
+				{ date: '2022-01-13', isCurrentMonth: true },
+				{ date: '2022-01-14', isCurrentMonth: true },
+				{ date: '2022-01-15', isCurrentMonth: true },
+				{ date: '2022-01-16', isCurrentMonth: true },
+				{ date: '2022-01-17', isCurrentMonth: true },
+				{ date: '2022-01-18', isCurrentMonth: true },
+				{ date: '2022-01-19', isCurrentMonth: true },
+				{ date: '2022-01-20', isCurrentMonth: true },
+				{ date: '2022-01-21', isCurrentMonth: true },
+				{ date: '2022-01-22', isCurrentMonth: true },
+				{ date: '2022-01-23', isCurrentMonth: true },
+				{ date: '2022-01-24', isCurrentMonth: true },
+				{ date: '2022-01-25', isCurrentMonth: true },
+				{ date: '2022-01-26', isCurrentMonth: true },
+				{ date: '2022-01-27', isCurrentMonth: true },
+				{ date: '2022-01-28', isCurrentMonth: true },
+				{ date: '2022-01-29', isCurrentMonth: true },
+				{ date: '2022-01-30', isCurrentMonth: true },
+				{ date: '2022-01-31', isCurrentMonth: true },
+				{ date: '2022-02-01' },
+				{ date: '2022-02-02' },
+				{ date: '2022-02-03' },
+				{ date: '2022-02-04' },
+				{ date: '2022-02-05' },
+				{ date: '2022-02-06' },
+			],
+		},
+		{
+			name: 'February',
+			days: [
+				{ date: '2022-01-31' },
+				{ date: '2022-02-01', isCurrentMonth: true },
+				{ date: '2022-02-02', isCurrentMonth: true },
+				{ date: '2022-02-03', isCurrentMonth: true },
+				{ date: '2022-02-04', isCurrentMonth: true },
+				{ date: '2022-02-05', isCurrentMonth: true },
+				{ date: '2022-02-06', isCurrentMonth: true },
+				{ date: '2022-02-07', isCurrentMonth: true },
+				{ date: '2022-02-08', isCurrentMonth: true },
+				{ date: '2022-02-09', isCurrentMonth: true },
+				{ date: '2022-02-10', isCurrentMonth: true },
+				{ date: '2022-02-11', isCurrentMonth: true },
+				{ date: '2022-02-12', isCurrentMonth: true },
+				{ date: '2022-02-13', isCurrentMonth: true },
+				{ date: '2022-02-14', isCurrentMonth: true },
+				{ date: '2022-02-15', isCurrentMonth: true },
+				{ date: '2022-02-16', isCurrentMonth: true },
+				{ date: '2022-02-17', isCurrentMonth: true },
+				{ date: '2022-02-18', isCurrentMonth: true },
+				{ date: '2022-02-19', isCurrentMonth: true },
+				{ date: '2022-02-20', isCurrentMonth: true },
+				{ date: '2022-02-21', isCurrentMonth: true },
+				{ date: '2022-02-22', isCurrentMonth: true },
+				{ date: '2022-02-23', isCurrentMonth: true },
+				{ date: '2022-02-24', isCurrentMonth: true },
+				{ date: '2022-02-25', isCurrentMonth: true },
+				{ date: '2022-02-26', isCurrentMonth: true },
+				{ date: '2022-02-27', isCurrentMonth: true },
+				{ date: '2022-02-28', isCurrentMonth: true },
+				{ date: '2022-03-01' },
+				{ date: '2022-03-02' },
+				{ date: '2022-03-03' },
+				{ date: '2022-03-04' },
+				{ date: '2022-03-05' },
+				{ date: '2022-03-06' },
+			],
+		},
+		{
+			name: 'March',
+			days: [
+				{ date: '2022-02-28' },
+				{ date: '2022-03-01', isCurrentMonth: true },
+				{ date: '2022-03-02', isCurrentMonth: true },
+				{ date: '2022-03-03', isCurrentMonth: true },
+				{ date: '2022-03-04', isCurrentMonth: true },
+				{ date: '2022-03-05', isCurrentMonth: true },
+				{ date: '2022-03-06', isCurrentMonth: true },
+				{ date: '2022-03-07', isCurrentMonth: true },
+				{ date: '2022-03-08', isCurrentMonth: true },
+				{ date: '2022-03-09', isCurrentMonth: true },
+				{ date: '2022-03-10', isCurrentMonth: true },
+				{ date: '2022-03-11', isCurrentMonth: true },
+				{ date: '2022-03-12', isCurrentMonth: true },
+				{ date: '2022-03-13', isCurrentMonth: true },
+				{ date: '2022-03-14', isCurrentMonth: true },
+				{ date: '2022-03-15', isCurrentMonth: true },
+				{ date: '2022-03-16', isCurrentMonth: true },
+				{ date: '2022-03-17', isCurrentMonth: true },
+				{ date: '2022-03-18', isCurrentMonth: true },
+				{ date: '2022-03-19', isCurrentMonth: true },
+				{ date: '2022-03-20', isCurrentMonth: true },
+				{ date: '2022-03-21', isCurrentMonth: true },
+				{ date: '2022-03-22', isCurrentMonth: true },
+				{ date: '2022-03-23', isCurrentMonth: true },
+				{ date: '2022-03-24', isCurrentMonth: true },
+				{ date: '2022-03-25', isCurrentMonth: true },
+				{ date: '2022-03-26', isCurrentMonth: true },
+				{ date: '2022-03-27', isCurrentMonth: true },
+				{ date: '2022-03-28', isCurrentMonth: true },
+				{ date: '2022-03-29', isCurrentMonth: true },
+				{ date: '2022-03-30', isCurrentMonth: true },
+				{ date: '2022-03-31', isCurrentMonth: true },
+				{ date: '2022-04-01' },
+				{ date: '2022-04-02' },
+				{ date: '2022-04-03' },
+				{ date: '2022-04-04' },
+				{ date: '2022-04-05' },
+				{ date: '2022-04-06' },
+			],
+		},
+		{
+			name: 'April',
+			days: [
+				{ date: '2022-03-28' },
+				{ date: '2022-03-29' },
+				{ date: '2022-03-30' },
+				{ date: '2022-03-31' },
+				{ date: '2022-04-01', isCurrentMonth: true },
+				{ date: '2022-04-02', isCurrentMonth: true },
+				{ date: '2022-04-03', isCurrentMonth: true },
+				{ date: '2022-04-04', isCurrentMonth: true },
+				{ date: '2022-04-05', isCurrentMonth: true },
+				{ date: '2022-04-06', isCurrentMonth: true },
+				{ date: '2022-04-07', isCurrentMonth: true },
+				{ date: '2022-04-08', isCurrentMonth: true },
+				{ date: '2022-04-09', isCurrentMonth: true },
+				{ date: '2022-04-10', isCurrentMonth: true },
+				{ date: '2022-04-11', isCurrentMonth: true },
+				{ date: '2022-04-12', isCurrentMonth: true },
+				{ date: '2022-04-13', isCurrentMonth: true },
+				{ date: '2022-04-14', isCurrentMonth: true },
+				{ date: '2022-04-15', isCurrentMonth: true },
+				{ date: '2022-04-16', isCurrentMonth: true },
+				{ date: '2022-04-17', isCurrentMonth: true },
+				{ date: '2022-04-18', isCurrentMonth: true },
+				{ date: '2022-04-19', isCurrentMonth: true },
+				{ date: '2022-04-20', isCurrentMonth: true },
+				{ date: '2022-04-21', isCurrentMonth: true },
+				{ date: '2022-04-22', isCurrentMonth: true },
+				{ date: '2022-04-23', isCurrentMonth: true },
+				{ date: '2022-04-24', isCurrentMonth: true },
+				{ date: '2022-04-25', isCurrentMonth: true },
+				{ date: '2022-04-26', isCurrentMonth: true },
+				{ date: '2022-04-27', isCurrentMonth: true },
+				{ date: '2022-04-28', isCurrentMonth: true },
+				{ date: '2022-04-29', isCurrentMonth: true },
+				{ date: '2022-04-30', isCurrentMonth: true },
+				{ date: '2022-05-01' },
+				{ date: '2022-05-02' },
+				{ date: '2022-05-03' },
+				{ date: '2022-05-04' },
+				{ date: '2022-05-05' },
+				{ date: '2022-05-06' },
+			],
+		},
+	];
+
+	return (
+		<div>
+			<header class="flex items-center justify-between border-b border-surface-border px-6 py-4 dark:border-white/10 dark:bg-surface-2/50">
+				<h1 class="text-base font-semibold text-text-primary dark:text-white">
+					<time dateTime="2022">2022</time>
+				</h1>
+				<div class="flex items-center">
+					<div class="relative flex items-center rounded-lg bg-surface-0 shadow-xs outline outline-surface-border md:items-stretch dark:bg-white/10 dark:shadow-none dark:outline-white/5">
+						<button
+							type="button"
+							class="flex h-9 w-12 items-center justify-center rounded-l-lg pr-1 text-text-tertiary hover:text-text-secondary focus:relative md:w-9 md:pr-0 md:hover:bg-surface-1 dark:hover:text-white dark:md:hover:bg-white/10"
+						>
+							<span class="sr-only">Previous year</span>
+							<ChevronLeft aria-hidden="true" class="size-5" />
+						</button>
+						<button
+							type="button"
+							class="hidden px-3.5 text-sm font-semibold text-text-primary hover:bg-surface-1 focus:relative md:block dark:text-white dark:hover:bg-white/10"
+						>
+							Today
+						</button>
+						<span class="relative -mx-px h-5 w-px bg-surface-border md:hidden dark:bg-white/10" />
+						<button
+							type="button"
+							class="flex h-9 w-12 items-center justify-center rounded-r-lg pl-1 text-text-tertiary hover:text-text-secondary focus:relative md:w-9 md:pl-0 md:hover:bg-surface-1 dark:hover:text-white dark:md:hover:bg-white/10"
+						>
+							<span class="sr-only">Next year</span>
+							<ChevronRight aria-hidden="true" class="size-5" />
+						</button>
+					</div>
+					<div class="hidden md:ml-4 md:flex md:items-center">
+						<Menu as="div" class="relative">
+							<MenuButton
+								type="button"
+								class="flex items-center gap-x-1.5 rounded-lg bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20"
+							>
+								Year view
+								<ChevronDown aria-hidden="true" class="-mr-1 size-5 text-text-tertiary" />
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-3 w-36 origin-top-right overflow-hidden rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:shadow-none dark:-outline-offset-1 dark:outline-white/5"
+							>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Day view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Week view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Month view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Year view
+										</a>
+									</MenuItem>
+								</div>
+							</MenuItems>
+						</Menu>
+						<div class="ml-6 h-6 w-px bg-surface-border dark:bg-white/10" />
+						<button
+							type="button"
+							class="ml-6 rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-accent-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:bg-accent-500 dark:shadow-none dark:hover:bg-accent-400 dark:focus-visible:outline-accent-500"
+						>
+							Add event
+						</button>
+					</div>
+					<div class="ml-6 md:hidden">
+						<Menu as="div" class="relative">
+							<MenuButton class="relative flex items-center rounded-full text-text-tertiary outline-offset-8 hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white">
+								<span class="absolute -inset-2" />
+								<span class="sr-only">Open menu</span>
+								<EllipsisVertical aria-hidden="true" class="size-5" />
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-3 w-36 origin-top-right divide-y divide-surface-border overflow-hidden rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:divide-white/10 dark:bg-surface-2 dark:-outline-offset-1 dark:outline-white/5"
+							>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Create event
+										</a>
+									</MenuItem>
+								</div>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Go to today
+										</a>
+									</MenuItem>
+								</div>
+								<div class="py-1">
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Day view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Week view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Month view
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+										>
+											Year view
+										</a>
+									</MenuItem>
+								</div>
+							</MenuItems>
+						</Menu>
+					</div>
+				</div>
+			</header>
+			<div class="bg-surface-0 dark:bg-surface-2">
+				<div class="mx-auto grid max-w-3xl grid-cols-1 gap-x-8 gap-y-16 px-4 py-16 sm:grid-cols-2 sm:px-6 xl:max-w-none xl:grid-cols-3 xl:px-8 2xl:grid-cols-4">
+					{months.map((month) => (
+						<section key={month.name} class="text-center">
+							<h2 class="text-sm font-semibold text-text-primary dark:text-white">{month.name}</h2>
+							<div class="mt-6 grid grid-cols-7 text-xs/6 text-text-secondary dark:text-text-tertiary">
+								<div>M</div>
+								<div>T</div>
+								<div>W</div>
+								<div>T</div>
+								<div>F</div>
+								<div>S</div>
+								<div>S</div>
+							</div>
+							<div class="isolate mt-2 grid grid-cols-7 gap-px rounded-lg bg-surface-border text-sm shadow-sm ring-1 ring-surface-border dark:bg-white/10 dark:shadow-none dark:ring-white/10">
+								{month.days.map((day) => (
+									<button
+										key={day.date}
+										type="button"
+										data-is-today={day.isToday ? '' : undefined}
+										data-is-current-month={day.isCurrentMonth ? '' : undefined}
+										class="relative bg-surface-1 py-1.5 text-text-tertiary first:rounded-tl-lg last:rounded-br-lg hover:bg-surface-2 focus:z-10 data-is-current-month:bg-surface-0 data-is-current-month:text-text-primary data-is-current-month:hover:bg-surface-1 nth-36:rounded-bl-lg nth-7:rounded-tr-lg dark:bg-surface-2/75 dark:text-text-tertiary dark:hover:bg-surface-2/25 dark:data-is-current-month:bg-surface-2 dark:data-is-current-month:text-text-secondary dark:data-is-current-month:hover:bg-surface-2/50"
+									>
+										<time
+											dateTime={day.date}
+											class="mx-auto flex size-7 items-center justify-center rounded-full in-data-is-today:bg-accent-600 in-data-is-today:font-semibold in-data-is-today:text-white dark:in-data-is-today:bg-accent-500"
+										>
+											{day.date.split('-').pop()?.replace(/^0/, '') ?? ''}
+										</time>
+									</button>
+								))}
+							</div>
+						</section>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// Demo 6: Borderless Stacked Calendar (Week View with sidebar)
+function BorderlessStacked() {
+	const [selectedDate, setSelectedDate] = useState('2022-01-22');
+
+	const days = [
+		{ date: '2022-01-16' },
+		{ date: '2022-01-17' },
+		{ date: '2022-01-18' },
+		{ date: '2022-01-19' },
+		{ date: '2022-01-20' },
+		{ date: '2022-01-21' },
+		{ date: '2022-01-22' },
+	];
+
+	const events = [
+		{
+			id: 1,
+			name: 'Breakfast',
+			time: '6:00 AM',
+			datetime: '2022-01-22T06:00',
+			color: 'bg-blue-500',
+		},
+		{
+			id: 2,
+			name: 'Flight to Paris',
+			time: '7:30 AM',
+			datetime: '2022-01-22T07:30',
+			color: 'bg-pink-500',
+		},
+		{
+			id: 3,
+			name: 'Sightseeing',
+			time: '11:00 AM',
+			datetime: '2022-01-22T11:00',
+			color: 'bg-accent-500',
+		},
+	];
+
+	return (
+		<div class="flex h-full flex-col">
+			<header class="flex flex-none items-center justify-between border-b border-surface-border px-6 py-4 dark:border-white/10 dark:bg-surface-2/50">
+				<div>
+					<h1 class="text-base font-semibold text-text-primary dark:text-white">
+						<time dateTime="2022-01-22">January 22, 2022</time>
+					</h1>
+					<p class="mt-1 text-sm text-text-secondary dark:text-text-tertiary">Saturday</p>
+				</div>
+				<div class="flex items-center gap-3">
+					<button
+						type="button"
+						class="rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-accent-500 dark:bg-accent-500 dark:hover:bg-accent-400"
+					>
+						Add event
+					</button>
+					<Menu as="div" class="relative">
+						<MenuButton class="flex items-center gap-x-1.5 rounded-lg bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20">
+							Week view
+							<ChevronDown aria-hidden="true" class="-mr-1 size-5 text-text-tertiary" />
+						</MenuButton>
+						<MenuItems
+							transition
+							class="absolute right-0 z-10 mt-3 w-36 origin-top-right overflow-hidden rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="py-1">
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Day view
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Week view
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Month view
+									</a>
+								</MenuItem>
+							</div>
+						</MenuItems>
+					</Menu>
+				</div>
+			</header>
+
+			<div class="flex flex-auto overflow-hidden">
+				{/* Week view sidebar */}
+				<div class="hidden w-48 flex-none border-r border-surface-border p-4 lg:block dark:border-white/10">
+					<div class="space-y-3">
+						{days.map((day) => (
+							<button
+								key={day.date}
+								type="button"
+								onClick={() => setSelectedDate(day.date)}
+								class={
+									day.date === selectedDate
+										? 'w-full rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white'
+										: 'w-full rounded-lg px-3 py-2 text-sm text-text-primary hover:bg-surface-2 dark:text-white dark:hover:bg-surface-2'
+								}
+							>
+								<div class="text-xs opacity-80">
+									{new Date(day.date + 'T00:00').toLocaleDateString('en-US', { weekday: 'short' })}
+								</div>
+								<div>
+									{new Date(day.date + 'T00:00').toLocaleDateString('en-US', { day: 'numeric' })}
+								</div>
+							</button>
+						))}
+					</div>
+				</div>
+
+				{/* Day schedule */}
+				<div class="flex-auto overflow-auto p-4">
+					<div class="space-y-4">
+						{events.map((event) => (
+							<div
+								key={event.id}
+								class="flex items-start gap-4 rounded-lg bg-surface-1 p-4 dark:bg-surface-2/50"
+							>
+								<div class={`size-3 rounded-full mt-1.5 ${event.color}`} />
+								<div class="flex-auto">
+									<p class="font-semibold text-text-primary dark:text-white">{event.name}</p>
+									<p class="text-sm text-text-secondary dark:text-text-tertiary">{event.time}</p>
+								</div>
+								<Menu as="div" class="relative">
+									<MenuButton class="text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white">
+										<EllipsisVertical class="size-5" />
+									</MenuButton>
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:opacity-0 dark:bg-surface-2 dark:outline-white/10"
+									>
+										<div class="py-1">
+											<MenuItem>
+												<a
+													href="#"
+													class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+												>
+													Edit
+												</a>
+											</MenuItem>
+											<MenuItem>
+												<a
+													href="#"
+													class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+												>
+													Delete
+												</a>
+											</MenuItem>
+										</div>
+									</MenuItems>
+								</Menu>
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// Demo 7: Borderless Side by Side Calendar
+function BorderlessSideBySide() {
+	const days = [
+		{ date: '2022-01-16' },
+		{ date: '2022-01-17' },
+		{ date: '2022-01-18' },
+		{ date: '2022-01-19' },
+		{ date: '2022-01-20' },
+		{ date: '2022-01-21' },
+		{ date: '2022-01-22' },
+	];
+
+	return (
+		<div class="flex h-full flex-col">
+			<header class="flex flex-none items-center justify-between border-b border-surface-border px-6 py-4 dark:border-white/10 dark:bg-surface-2/50">
+				<div>
+					<h1 class="text-base font-semibold text-text-primary dark:text-white">
+						<time dateTime="2022-01-22">January 22, 2022</time>
+					</h1>
+					<p class="mt-1 text-sm text-text-secondary dark:text-text-tertiary">Saturday</p>
+				</div>
+				<div class="flex items-center gap-3">
+					<div class="flex items-center gap-2">
+						<button
+							type="button"
+							class="p-2 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+						>
+							<ChevronLeft class="size-5" />
+						</button>
+						<button
+							type="button"
+							class="rounded-lg px-3 py-2 text-sm font-semibold text-text-primary hover:bg-surface-2 dark:text-white dark:hover:bg-surface-2"
+						>
+							Today
+						</button>
+						<button
+							type="button"
+							class="p-2 text-text-tertiary hover:text-text-secondary dark:text-text-tertiary dark:hover:text-white"
+						>
+							<ChevronRight class="size-5" />
+						</button>
+					</div>
+					<Menu as="div" class="relative">
+						<MenuButton class="flex items-center gap-x-1.5 rounded-lg bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20">
+							Week view
+							<ChevronDown aria-hidden="true" class="-mr-1 size-5 text-text-tertiary" />
+						</MenuButton>
+						<MenuItems
+							transition
+							class="absolute right-0 z-10 mt-3 w-36 origin-top-right overflow-hidden rounded-lg bg-surface-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-surface-2 dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="py-1">
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Day view
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Week view
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white dark:text-text-secondary dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+									>
+										Month view
+									</a>
+								</MenuItem>
+							</div>
+						</MenuItems>
+					</Menu>
+					<button
+						type="button"
+						class="rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-accent-500 dark:bg-accent-500 dark:hover:bg-accent-400"
+					>
+						Add event
+					</button>
+				</div>
+			</header>
+
+			<div class="flex flex-auto overflow-hidden">
+				{/* Mini calendar */}
+				<div class="hidden w-64 flex-none border-r border-surface-border p-4 dark:border-white/10 lg:block">
+					<h3 class="text-sm font-semibold text-text-primary dark:text-white mb-4">January 2022</h3>
+					<div class="grid grid-cols-7 gap-1 text-center text-xs">
+						<div class="text-text-tertiary">S</div>
+						<div class="text-text-tertiary">M</div>
+						<div class="text-text-tertiary">T</div>
+						<div class="text-text-tertiary">W</div>
+						<div class="text-text-tertiary">T</div>
+						<div class="text-text-tertiary">F</div>
+						<div class="text-text-tertiary">S</div>
+						{days.map((day) => (
+							<button
+								key={day.date}
+								type="button"
+								class="size-8 rounded-full text-text-secondary hover:bg-surface-2 dark:text-text-tertiary dark:hover:bg-surface-2"
+							>
+								{new Date(day.date + 'T00:00').getDate()}
+							</button>
+						))}
+					</div>
+				</div>
+
+				{/* Schedule view */}
+				<div class="flex-auto overflow-auto p-6">
+					<div class="space-y-4">
+						<div class="flex items-center gap-4">
+							<div class="size-3 rounded-full bg-blue-500" />
+							<div class="flex-auto">
+								<p class="font-semibold text-text-primary dark:text-white">Breakfast</p>
+								<p class="text-sm text-text-secondary dark:text-text-tertiary">6:00 AM</p>
+							</div>
+						</div>
+						<div class="flex items-center gap-4">
+							<div class="size-3 rounded-full bg-pink-500" />
+							<div class="flex-auto">
+								<p class="font-semibold text-text-primary dark:text-white">Flight to Paris</p>
+								<p class="text-sm text-text-secondary dark:text-text-tertiary">
+									7:30 AM - John F. Kennedy International Airport
+								</p>
+							</div>
+						</div>
+						<div class="flex items-center gap-4">
+							<div class="size-3 rounded-full bg-accent-500" />
+							<div class="flex-auto">
+								<p class="font-semibold text-text-primary dark:text-white">Sightseeing</p>
+								<p class="text-sm text-text-secondary dark:text-text-tertiary">
+									11:00 AM - Eiffel Tower
+								</p>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function CalendarsHeadlessDemo() {
+	return (
+		<div class="space-y-16">
+			<section>
+				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
+					Small Calendar with Meetings
+				</h3>
+				<SmallWithMeetings />
+			</section>
+
+			<section>
+				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
+					Month View with Schedule
+				</h3>
+				<MonthView />
+			</section>
+
+			<section>
+				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
+					Week View Calendar
+				</h3>
+				<WeekView />
+			</section>
+
+			<section>
+				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
+					Day View Calendar
+				</h3>
+				<DayView />
+			</section>
+
+			<section>
+				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
+					Year View Calendar
+				</h3>
+				<YearView />
+			</section>
+
+			<section>
+				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
+					Borderless Stacked Calendar
+				</h3>
+				<BorderlessStacked />
+			</section>
+
+			<section>
+				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
+					Borderless Side by Side Calendar
+				</h3>
+				<BorderlessSideBySide />
+			</section>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/elements/button-groups/ButtonGroupsDemo.tsx
+++ b/packages/ui/demo/sections/elements/button-groups/ButtonGroupsDemo.tsx
@@ -1,4 +1,5 @@
-import { ChevronLeft, ChevronRight, Pencil, Trash } from 'lucide-preact';
+import { Menu, MenuButton, MenuItems, MenuItem } from '../../../../src/mod.ts';
+import { ChevronDown, ChevronLeft, ChevronRight, Pencil, Trash } from 'lucide-preact';
 
 export function ButtonGroupsDemo() {
 	return (
@@ -90,6 +91,58 @@ export function ButtonGroupsDemo() {
 						<ChevronRight class="size-5" />
 					</button>
 				</span>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 05 - With Dropdown */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With dropdown</h3>
+				<div class="inline-flex rounded-md shadow-xs dark:shadow-none">
+					<button
+						type="button"
+						class="relative inline-flex items-center rounded-l-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 inset-ring-1 inset-ring-gray-300 hover:bg-gray-50 focus:z-10 dark:bg-white/10 dark:text-white dark:inset-ring-gray-700 dark:hover:bg-white/20"
+					>
+						Save changes
+					</button>
+					<Menu as="div" class="relative -ml-px block">
+						<MenuButton class="relative inline-flex items-center rounded-r-md bg-white px-2 py-2 text-gray-400 inset-ring-1 inset-ring-gray-300 hover:bg-gray-50 focus:z-10 dark:bg-white/10 dark:inset-ring-gray-700 dark:hover:bg-white/20">
+							<span class="sr-only">Open options</span>
+							<ChevronDown aria-hidden="true" class="size-5" />
+						</MenuButton>
+						<MenuItems
+							transition
+							class="absolute right-0 z-10 mt-2 -mr-1 w-56 origin-top-right rounded-md bg-surface-1 shadow-lg border border-surface-border transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in outline-none"
+						>
+							<div class="py-1">
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									>
+										Save and schedule
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									>
+										Save and publish
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									>
+										Export PDF
+									</a>
+								</MenuItem>
+							</div>
+						</MenuItems>
+					</Menu>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/ui/demo/sections/elements/dropdowns/DropdownsDemo.tsx
+++ b/packages/ui/demo/sections/elements/dropdowns/DropdownsDemo.tsx
@@ -1,0 +1,342 @@
+import { useState } from 'preact/hooks';
+import { Menu, MenuButton, MenuItem, MenuItems } from '../../../../src/mod.ts';
+import {
+	ChevronDown,
+	MoreVertical,
+	Pencil,
+	Copy,
+	Archive,
+	ArrowRightCircle,
+	UserPlus,
+	Heart,
+	Trash2,
+} from 'lucide-preact';
+
+export function DropdownsDemo() {
+	const [lastAction, setLastAction] = useState<string | null>(null);
+
+	return (
+		<div class="space-y-12">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">
+					Simple dropdown with icon trigger
+				</h3>
+				<Menu class="relative inline-block">
+					<MenuButton class="flex items-center rounded-full text-text-tertiary hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 cursor-pointer">
+						<span class="sr-only">Open options</span>
+						<MoreVertical class="size-5" />
+					</MenuButton>
+					<MenuItems class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-surface-1 border border-surface-border shadow-lg outline-1 outline-black/5 transition-all duration-100 ease-out data-closed:scale-95 data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:outline-white/10">
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Account settings')}
+								>
+									Account settings
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Support')}
+								>
+									Support
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('License')}
+								>
+									License
+								</button>
+							</MenuItem>
+							<form method="POST">
+								<MenuItem>
+									<button
+										type="submit"
+										class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+										onClick={() => setLastAction('Sign out')}
+									>
+										Sign out
+									</button>
+								</MenuItem>
+							</form>
+						</div>
+					</MenuItems>
+				</Menu>
+				{lastAction && (
+					<p class="mt-2 text-sm text-text-tertiary">
+						Last action: <span class="text-accent-400">{lastAction}</span>
+					</p>
+				)}
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">
+					Dropdown with dividers and icons
+				</h3>
+				<Menu class="relative inline-block">
+					<MenuButton class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-surface-1 px-3 py-2 text-sm font-semibold text-text-primary border border-surface-border shadow-xs hover:bg-surface-2 dark:bg-white/10 dark:text-white dark:border-white/5 dark:hover:bg-white/20 cursor-pointer">
+						Options
+						<ChevronDown class="size-5 text-text-tertiary" />
+					</MenuButton>
+					<MenuItems class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-surface-1 border border-surface-border shadow-lg divide-y divide-surface-border outline-1 outline-black/5 transition-all duration-100 ease-out data-closed:scale-95 data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:divide-white/10 dark:outline-white/10">
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer flex items-center gap-3"
+									onClick={() => setLastAction('Edit')}
+								>
+									<Pencil class="size-5 text-text-tertiary" />
+									Edit
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer flex items-center gap-3"
+									onClick={() => setLastAction('Duplicate')}
+								>
+									<Copy class="size-5 text-text-tertiary" />
+									Duplicate
+								</button>
+							</MenuItem>
+						</div>
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer flex items-center gap-3"
+									onClick={() => setLastAction('Archive')}
+								>
+									<Archive class="size-5 text-text-tertiary" />
+									Archive
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer flex items-center gap-3"
+									onClick={() => setLastAction('Move')}
+								>
+									<ArrowRightCircle class="size-5 text-text-tertiary" />
+									Move
+								</button>
+							</MenuItem>
+						</div>
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer flex items-center gap-3"
+									onClick={() => setLastAction('Share')}
+								>
+									<UserPlus class="size-5 text-text-tertiary" />
+									Share
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer flex items-center gap-3"
+									onClick={() => setLastAction('Add to favorites')}
+								>
+									<Heart class="size-5 text-text-tertiary" />
+									Add to favorites
+								</button>
+							</MenuItem>
+						</div>
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-red-400 data-[focus]:bg-red-500 data-[focus]:text-white cursor-pointer flex items-center gap-3"
+									onClick={() => setLastAction('Delete')}
+								>
+									<Trash2 class="size-5" />
+									Delete
+								</button>
+							</MenuItem>
+						</div>
+					</MenuItems>
+				</Menu>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Dropdown with dividers only</h3>
+				<Menu class="relative inline-block">
+					<MenuButton class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-surface-1 px-3 py-2 text-sm font-semibold text-text-primary border border-surface-border shadow-xs hover:bg-surface-2 dark:bg-white/10 dark:text-white dark:border-white/5 dark:hover:bg-white/20 cursor-pointer">
+						Options
+						<ChevronDown class="size-5 text-text-tertiary" />
+					</MenuButton>
+					<MenuItems class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-surface-1 border border-surface-border shadow-lg divide-y divide-surface-border outline-1 outline-black/5 transition-all duration-100 ease-out data-closed:scale-95 data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:divide-white/10 dark:outline-white/10">
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Edit')}
+								>
+									Edit
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Duplicate')}
+								>
+									Duplicate
+								</button>
+							</MenuItem>
+						</div>
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Archive')}
+								>
+									Archive
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Move')}
+								>
+									Move
+								</button>
+							</MenuItem>
+						</div>
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Share')}
+								>
+									Share
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Add to favorites')}
+								>
+									Add to favorites
+								</button>
+							</MenuItem>
+						</div>
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-red-400 data-[focus]:bg-red-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Delete')}
+								>
+									Delete
+								</button>
+							</MenuItem>
+						</div>
+					</MenuItems>
+				</Menu>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Dropdown with user header</h3>
+				<Menu class="relative inline-block">
+					<MenuButton class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-surface-1 px-3 py-2 text-sm font-semibold text-text-primary border border-surface-border shadow-xs hover:bg-surface-2 dark:bg-white/10 dark:text-white dark:border-white/5 dark:hover:bg-white/20 cursor-pointer">
+						Options
+						<ChevronDown class="size-5 text-text-tertiary" />
+					</MenuButton>
+					<MenuItems class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-surface-1 border border-surface-border shadow-lg divide-y divide-surface-border outline-1 outline-black/5 transition-all duration-100 ease-out data-closed:scale-95 data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:divide-white/10 dark:outline-white/10">
+						<div class="px-4 py-3">
+							<p class="text-sm text-text-secondary">Signed in as</p>
+							<p class="truncate text-sm font-medium text-text-primary">tom@example.com</p>
+						</div>
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Account settings')}
+								>
+									Account settings
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Support')}
+								>
+									Support
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('License')}
+								>
+									License
+								</button>
+							</MenuItem>
+						</div>
+						<div class="py-1">
+							<form method="POST">
+								<MenuItem>
+									<button
+										type="submit"
+										class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+										onClick={() => setLastAction('Sign out')}
+									>
+										Sign out
+									</button>
+								</MenuItem>
+							</form>
+						</div>
+					</MenuItems>
+				</Menu>
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Minimal dropdown button</h3>
+				<Menu class="relative inline-block">
+					<MenuButton class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-surface-1 px-3 py-2 text-sm font-semibold text-text-primary border border-surface-border shadow-xs hover:bg-surface-2 dark:bg-white/10 dark:text-white dark:border-white/5 dark:hover:bg-white/20 cursor-pointer">
+						Options
+						<ChevronDown class="size-5 text-text-tertiary" />
+					</MenuButton>
+					<MenuItems class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-surface-1 border border-surface-border shadow-lg outline-1 outline-black/5 transition-all duration-100 ease-out data-closed:scale-95 data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:outline-white/10">
+						<div class="py-1">
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Account settings')}
+								>
+									Account settings
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('Support')}
+								>
+									Support
+								</button>
+							</MenuItem>
+							<MenuItem>
+								<button
+									class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									onClick={() => setLastAction('License')}
+								>
+									License
+								</button>
+							</MenuItem>
+							<form method="POST">
+								<MenuItem>
+									<button
+										type="submit"
+										class="w-full text-left px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+										onClick={() => setLastAction('Sign out')}
+									>
+										Sign out
+									</button>
+								</MenuItem>
+							</form>
+						</div>
+					</MenuItems>
+				</Menu>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/forms/comboboxes/ComboboxesDemo.tsx
+++ b/packages/ui/demo/sections/forms/comboboxes/ComboboxesDemo.tsx
@@ -1,0 +1,374 @@
+import { useState } from 'preact/hooks';
+import {
+	Combobox,
+	ComboboxButton,
+	ComboboxInput,
+	ComboboxOption,
+	ComboboxOptions,
+	Label,
+} from '../../../../src/mod.ts';
+import { ChevronDown, User } from 'lucide-preact';
+
+const people = [
+	{ name: 'Leslie Alexander', username: '@lesliealexander' },
+	{ name: 'Michael Foster', username: '@michaelfoster' },
+	{ name: 'Dries Vincent', username: '@driesvincent' },
+	{ name: 'Jenna Collins', username: '@jennacollins' },
+];
+
+const peopleWithStatus = [
+	{ id: 1, name: 'Leslie Alexander', online: true },
+	{ id: 2, name: 'Michael Foster', online: false },
+	{ id: 3, name: 'Dries Vincent', online: true },
+	{ id: 4, name: 'Jenna Collins', online: false },
+];
+
+const peopleWithAvatar = [
+	{
+		id: 1,
+		name: 'Leslie Alexander',
+		imageUrl:
+			'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 2,
+		name: 'Michael Foster',
+		imageUrl:
+			'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 3,
+		name: 'Dries Vincent',
+		imageUrl:
+			'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 4,
+		name: 'Jenna Collins',
+		imageUrl:
+			'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+];
+
+export function ComboboxesDemo() {
+	return (
+		<div class="space-y-12">
+			{/* Simple combobox */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Simple combobox</h3>
+				<SimpleCombobox />
+			</div>
+
+			{/* Combobox with status indicator */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With status indicator</h3>
+				<StatusIndicatorCombobox />
+			</div>
+
+			{/* Combobox with avatar */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With avatar</h3>
+				<AvatarCombobox />
+			</div>
+
+			{/* Combobox with secondary text */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With secondary text</h3>
+				<SecondaryTextCombobox />
+			</div>
+		</div>
+	);
+}
+
+function SimpleCombobox() {
+	const [query, setQuery] = useState('');
+	const [selectedPerson, setSelectedPerson] = useState<(typeof people)[0] | null>(null);
+
+	const filteredPeople =
+		query === ''
+			? people
+			: people.filter((person) => {
+					return person.name.toLowerCase().includes(query.toLowerCase());
+				});
+
+	return (
+		<Combobox
+			as="div"
+			value={selectedPerson}
+			onChange={(person) => {
+				setQuery('');
+				setSelectedPerson(person);
+			}}
+		>
+			<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+			<div class="relative mt-2">
+				<ComboboxInput
+					class="block w-full rounded-md bg-surface-1 py-1.5 pr-12 pl-3 text-base text-text-primary outline-1 -outline-offset-1 outline-surface-border placeholder:text-text-muted focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6"
+					onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
+					onBlur={() => setQuery('')}
+					displayValue={(person: (typeof people)[0] | null) => person?.name ?? ''}
+				/>
+				<ComboboxButton class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
+					<ChevronDown class="size-5 text-text-tertiary" aria-hidden="true" />
+				</ComboboxButton>
+
+				<ComboboxOptions
+					transition
+					class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline outline-black/5 data-[leave]:transition data-[leave]:duration-100 data-[leave]:ease-in data-[closed]:data-[leave]:opacity-0 sm:text-sm"
+				>
+					{query.length > 0 && (
+						<ComboboxOption
+							value={{ id: null, name: query }}
+							class="cursor-default px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[focus]:outline-hidden"
+						>
+							{query}
+						</ComboboxOption>
+					)}
+					{filteredPeople.map((person) => (
+						<ComboboxOption
+							key={person.username}
+							value={person}
+							class="cursor-default px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[focus]:outline-hidden"
+						>
+							<div class="flex">
+								<span class="block truncate">{person.name}</span>
+								<span class="ml-2 block truncate text-text-muted data-[focus]:text-white">
+									{person.username}
+								</span>
+							</div>
+						</ComboboxOption>
+					))}
+				</ComboboxOptions>
+			</div>
+		</Combobox>
+	);
+}
+
+function StatusIndicatorCombobox() {
+	const [query, setQuery] = useState('');
+	const [selectedPerson, setSelectedPerson] = useState<{
+		id: number;
+		name: string;
+		online: boolean;
+	} | null>(null);
+
+	const filteredPeople =
+		query === ''
+			? peopleWithStatus
+			: peopleWithStatus.filter((person) => {
+					return person.name.toLowerCase().includes(query.toLowerCase());
+				});
+
+	return (
+		<Combobox
+			as="div"
+			value={selectedPerson}
+			onChange={(person) => {
+				setQuery('');
+				setSelectedPerson(person);
+			}}
+		>
+			<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+			<div class="relative mt-2">
+				<ComboboxInput
+					class="block w-full rounded-md bg-surface-1 py-1.5 pr-12 pl-3 text-base text-text-primary outline-1 -outline-offset-1 outline-surface-border placeholder:text-text-muted focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6"
+					onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
+					onBlur={() => setQuery('')}
+					displayValue={(person: (typeof peopleWithStatus)[0] | null) => person?.name ?? ''}
+				/>
+				<ComboboxButton class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
+					<ChevronDown class="size-5 text-text-tertiary" aria-hidden="true" />
+				</ComboboxButton>
+
+				<ComboboxOptions
+					transition
+					class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline outline-black/5 data-[leave]:transition data-[leave]:duration-100 data-[leave]:ease-in data-[closed]:data-[leave]:opacity-0 sm:text-sm"
+				>
+					{query.length > 0 && (
+						<ComboboxOption
+							value={{ id: null, name: query, online: false }}
+							class="cursor-default px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[focus]:outline-hidden"
+						>
+							<div class="flex items-center">
+								<span
+									class="inline-block size-2 shrink-0 rounded-full border border-surface-border"
+									aria-hidden="true"
+								/>
+								<span class="ml-3 block truncate">{query}</span>
+							</div>
+						</ComboboxOption>
+					)}
+					{filteredPeople.map((person) => (
+						<ComboboxOption
+							key={person.id}
+							value={person}
+							class="cursor-default px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[focus]:outline-hidden"
+						>
+							<div class="flex items-center">
+								<span
+									class={classNames(
+										'inline-block size-2 shrink-0 rounded-full',
+										person.online ? 'bg-green-400' : 'bg-surface-3'
+									)}
+									aria-hidden="true"
+								/>
+								<span class="ml-3 block truncate">
+									{person.name}
+									<span class="sr-only"> is {person.online ? 'online' : 'offline'}</span>
+								</span>
+							</div>
+						</ComboboxOption>
+					))}
+				</ComboboxOptions>
+			</div>
+		</Combobox>
+	);
+}
+
+function AvatarCombobox() {
+	const [query, setQuery] = useState('');
+	const [selectedPerson, setSelectedPerson] = useState<{
+		id: number;
+		name: string;
+		imageUrl: string;
+	} | null>(null);
+
+	const filteredPeople =
+		query === ''
+			? peopleWithAvatar
+			: peopleWithAvatar.filter((person) => {
+					return person.name.toLowerCase().includes(query.toLowerCase());
+				});
+
+	return (
+		<Combobox
+			as="div"
+			value={selectedPerson}
+			onChange={(person) => {
+				setQuery('');
+				setSelectedPerson(person);
+			}}
+		>
+			<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+			<div class="relative mt-2">
+				<ComboboxInput
+					class="block w-full rounded-md bg-surface-1 py-1.5 pr-12 pl-3 text-base text-text-primary outline-1 -outline-offset-1 outline-surface-border placeholder:text-text-muted focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6"
+					onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
+					onBlur={() => setQuery('')}
+					displayValue={(person: (typeof peopleWithAvatar)[0] | null) => person?.name ?? ''}
+				/>
+				<ComboboxButton class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
+					<ChevronDown class="size-5 text-text-tertiary" aria-hidden="true" />
+				</ComboboxButton>
+
+				<ComboboxOptions
+					transition
+					class="absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline outline-black/5 data-[leave]:transition data-[leave]:duration-100 data-[leave]:ease-in data-[closed]:data-[leave]:opacity-0 sm:text-sm"
+				>
+					{query.length > 0 && (
+						<ComboboxOption
+							value={{ id: null, name: query, imageUrl: '' }}
+							class="cursor-default px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[focus]:outline-hidden"
+						>
+							<div class="flex items-center">
+								<div class="grid size-6 shrink-0 place-items-center rounded-full bg-surface-3">
+									<User class="size-4 text-text-tertiary" aria-hidden="true" />
+								</div>
+								<span class="ml-3 block truncate">{query}</span>
+							</div>
+						</ComboboxOption>
+					)}
+					{filteredPeople.map((person) => (
+						<ComboboxOption
+							key={person.id}
+							value={person}
+							class="cursor-default px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[focus]:outline-hidden"
+						>
+							<div class="flex items-center">
+								<img
+									src={person.imageUrl}
+									alt=""
+									class="size-6 shrink-0 rounded-full bg-surface-2 outline -outline-offset-1 outline-black/5"
+								/>
+								<span class="ml-3 block truncate">{person.name}</span>
+							</div>
+						</ComboboxOption>
+					))}
+				</ComboboxOptions>
+			</div>
+		</Combobox>
+	);
+}
+
+function SecondaryTextCombobox() {
+	const [query, setQuery] = useState('');
+	const [selectedPerson, setSelectedPerson] = useState<{ name: string; username: string } | null>(
+		null
+	);
+
+	const filteredPeople =
+		query === ''
+			? people
+			: people.filter((person) => {
+					return person.name.toLowerCase().includes(query.toLowerCase());
+				});
+
+	return (
+		<Combobox
+			as="div"
+			value={selectedPerson}
+			onChange={(person) => {
+				setQuery('');
+				setSelectedPerson(person);
+			}}
+		>
+			<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+			<div class="relative mt-2">
+				<ComboboxInput
+					class="block w-full rounded-md bg-surface-1 py-1.5 pr-12 pl-3 text-base text-text-primary outline-1 -outline-offset-1 outline-surface-border placeholder:text-text-muted focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6"
+					onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
+					onBlur={() => setQuery('')}
+					displayValue={(person: (typeof people)[0] | null) => person?.name ?? ''}
+				/>
+				<ComboboxButton class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
+					<ChevronDown class="size-5 text-text-tertiary" aria-hidden="true" />
+				</ComboboxButton>
+
+				<ComboboxOptions
+					transition
+					class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline outline-black/5 data-[leave]:transition data-[leave]:duration-100 data-[leave]:ease-in data-[closed]:data-[leave]:opacity-0 sm:text-sm"
+				>
+					{query.length > 0 && (
+						<ComboboxOption
+							value={{ id: null, name: query }}
+							class="cursor-default px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[focus]:outline-hidden"
+						>
+							<div class="flex items-center justify-between">
+								<span class="block truncate">{query}</span>
+								<span class="ml-2 block truncate text-text-muted">Create new</span>
+							</div>
+						</ComboboxOption>
+					)}
+					{filteredPeople.map((person) => (
+						<ComboboxOption
+							key={person.username}
+							value={person}
+							class="cursor-default px-3 py-2 text-text-primary select-none data-[focus]:bg-accent-500 data-[focus]:text-white data-[focus]:outline-hidden"
+						>
+							<div class="flex items-center justify-between">
+								<span class="block truncate">{person.name}</span>
+								<span class="ml-2 block truncate text-text-muted data-[focus]:text-white">
+									{person.username}
+								</span>
+							</div>
+						</ComboboxOption>
+					))}
+				</ComboboxOptions>
+			</div>
+		</Combobox>
+	);
+}
+
+function classNames(...classes: (string | boolean | undefined | null)[]): string {
+	return classes.filter(Boolean).join(' ');
+}

--- a/packages/ui/demo/sections/forms/comboboxes/ComboboxesDemo.tsx
+++ b/packages/ui/demo/sections/forms/comboboxes/ComboboxesDemo.tsx
@@ -7,6 +7,7 @@ import {
 	ComboboxOptions,
 	Label,
 } from '../../../../src/mod.ts';
+import { classNames } from '../../../../src/internal/class-names.ts';
 import { ChevronDown, User } from 'lucide-preact';
 
 const people = [
@@ -367,8 +368,4 @@ function SecondaryTextCombobox() {
 			</div>
 		</Combobox>
 	);
-}
-
-function classNames(...classes: (string | boolean | undefined | null)[]): string {
-	return classes.filter(Boolean).join(' ');
 }

--- a/packages/ui/demo/sections/forms/select-menus/CustomSelectMenusDemo.tsx
+++ b/packages/ui/demo/sections/forms/select-menus/CustomSelectMenusDemo.tsx
@@ -1,0 +1,413 @@
+import { useState } from 'preact/hooks';
+import {
+	Listbox,
+	ListboxButton,
+	ListboxOption,
+	ListboxOptions,
+	Label,
+} from '../../../../src/mod.ts';
+import { ChevronDown, Check } from 'lucide-preact';
+
+const people = [
+	{ id: 1, name: 'Wade Cooper', username: '@wadecooper' },
+	{ id: 2, name: 'Arlene Mccoy', username: '@arlenemccoy' },
+	{ id: 3, name: 'Devon Webb', username: '@devonwebb' },
+	{ id: 4, name: 'Tom Cook', username: '@tomcook' },
+	{ id: 5, name: 'Tanya Fox', username: '@tanyafox' },
+	{ id: 6, name: 'Hellen Schmidt', username: '@hellenschmidt' },
+	{ id: 7, name: 'Caroline Schultz', username: '@carolineschultz' },
+	{ id: 8, name: 'Mason Heaney', username: '@masonheaney' },
+	{ id: 9, name: 'Claudie Smitham', username: '@claudiesmitham' },
+	{ id: 10, name: 'Emil Schaefer', username: '@emilschaefer' },
+];
+
+const peopleWithStatus = [
+	{ id: 1, name: 'Wade Cooper', online: true },
+	{ id: 2, name: 'Arlene Mccoy', online: false },
+	{ id: 3, name: 'Devon Webb', online: false },
+	{ id: 4, name: 'Tom Cook', online: true },
+	{ id: 5, name: 'Tanya Fox', online: false },
+	{ id: 6, name: 'Hellen Schmidt', online: true },
+	{ id: 7, name: 'Caroline Schultz', online: true },
+	{ id: 8, name: 'Mason Heaney', online: false },
+	{ id: 9, name: 'Claudie Smitham', online: true },
+	{ id: 10, name: 'Emil Schaefer', online: false },
+];
+
+const peopleWithAvatar = [
+	{
+		id: 1,
+		name: 'Wade Cooper',
+		avatar:
+			'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 2,
+		name: 'Arlene Mccoy',
+		avatar:
+			'https://images.unsplash.com/photo-1550525811-e5869dd03032?ixlib=rb-1.2.1&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 3,
+		name: 'Devon Webb',
+		avatar:
+			'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2.25&w=256&h=256&q=80',
+	},
+	{
+		id: 4,
+		name: 'Tom Cook',
+		avatar:
+			'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 5,
+		name: 'Tanya Fox',
+		avatar:
+			'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 6,
+		name: 'Hellen Schmidt',
+		avatar:
+			'https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 7,
+		name: 'Caroline Schultz',
+		avatar:
+			'https://images.unsplash.com/photo-1568409938619-12e139227838?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 8,
+		name: 'Mason Heaney',
+		avatar:
+			'https://images.unsplash.com/photo-1531427186611-ecfd6d936c79?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 9,
+		name: 'Claudie Smitham',
+		avatar:
+			'https://images.unsplash.com/photo-1584486520270-19eca1efcce5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		id: 10,
+		name: 'Emil Schaefer',
+		avatar:
+			'https://images.unsplash.com/photo-1561505457-3bcad021f8ee?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+];
+
+const publishingOptions = [
+	{
+		value: 'published',
+		title: 'Published',
+		description: 'This job posting can be viewed by anyone who has the link.',
+		current: true,
+	},
+	{
+		value: 'draft',
+		title: 'Draft',
+		description: 'This job posting will no longer be publicly accessible.',
+		current: false,
+	},
+];
+
+function classNames(...classes: (string | boolean | undefined)[]) {
+	return classes.filter(Boolean).join(' ');
+}
+
+export function CustomSelectMenusDemo() {
+	const [selected, setSelected] = useState(people[3]);
+	const [selectedWithStatus, setSelectedWithStatus] = useState(peopleWithStatus[3]);
+	const [selectedWithAvatar, setSelectedWithAvatar] = useState(peopleWithAvatar[3]);
+	const [selectedWithCheckLeft, setSelectedWithCheckLeft] = useState(people[3]);
+	const [selectedPublish, setSelectedPublish] = useState(publishingOptions[0]);
+
+	return (
+		<div class="space-y-12">
+			{/* Simple custom select */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Simple custom select</h3>
+				<Listbox value={selected} onChange={setSelected}>
+					<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+					<div class="relative mt-2">
+						<ListboxButton class="grid w-full cursor-default grid-cols-1 rounded-md bg-surface-1 py-1.5 pr-2 pl-3 text-left text-text-primary outline-1 -outline-offset-1 outline-surface-border focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:focus:outline-accent-500">
+							<span class="col-start-1 row-start-1 flex w-full gap-2 pr-6">
+								<span class="truncate">{selected.name}</span>
+								<span class="truncate text-text-secondary">{selected.username}</span>
+							</span>
+							<ChevronDown
+								aria-hidden="true"
+								class="col-start-1 row-start-1 size-5 self-center justify-self-end text-text-secondary sm:size-4"
+							/>
+						</ListboxButton>
+
+						<ListboxOptions
+							transition
+							class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline-1 outline-black/5 data-leave:transition data-leave:duration-100 data-leave:ease-in data-closed:data-leave:opacity-0 sm:text-sm dark:bg-gray-800 dark:shadow-none dark:outline-white/10"
+						>
+							{people.map((person) => (
+								<ListboxOption
+									key={person.username}
+									value={person}
+									class="group relative cursor-default py-2 pr-9 pl-3 text-text-primary select-none data-[focus]:bg-accent-600 data-[focus]:text-white data-[focus]:outline-hidden dark:text-white dark:data-[focus]:bg-accent-500"
+								>
+									<div class="flex">
+										<span class="truncate font-normal group-data-selected:font-semibold">
+											{person.name}
+										</span>
+										<span class="ml-2 truncate text-text-secondary group-data-focus:text-white dark:text-gray-400 dark:group-data-focus:text-white">
+											{person.username}
+										</span>
+									</div>
+
+									<span class="absolute inset-y-0 right-0 flex items-center pr-4 text-accent-600 group-not-data-selected:hidden group-data-focus:text-white dark:text-accent-400">
+										<Check aria-hidden="true" class="size-5" />
+									</span>
+								</ListboxOption>
+							))}
+						</ListboxOptions>
+					</div>
+				</Listbox>
+			</div>
+
+			{/* Custom select with check on left */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">
+					Custom select with check on left
+				</h3>
+				<Listbox value={selectedWithCheckLeft} onChange={setSelectedWithCheckLeft}>
+					<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+					<div class="relative mt-2">
+						<ListboxButton class="grid w-full cursor-default grid-cols-1 rounded-md bg-surface-1 py-1.5 pr-2 pl-3 text-left text-text-primary outline-1 -outline-offset-1 outline-surface-border focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:focus:outline-accent-500">
+							<span class="col-start-1 row-start-1 truncate pr-6">
+								{selectedWithCheckLeft.name}
+							</span>
+							<ChevronDown
+								aria-hidden="true"
+								class="col-start-1 row-start-1 size-5 self-center justify-self-end text-text-secondary sm:size-4"
+							/>
+						</ListboxButton>
+
+						<ListboxOptions
+							transition
+							class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline-1 outline-black/5 data-leave:transition data-leave:duration-100 data-leave:ease-in data-closed:data-leave:opacity-0 sm:text-sm dark:bg-gray-800 dark:shadow-none dark:outline-white/10"
+						>
+							{people.map((person) => (
+								<ListboxOption
+									key={person.id}
+									value={person}
+									class="group relative cursor-default py-2 pr-4 pl-8 text-text-primary select-none data-[focus]:bg-accent-600 data-[focus]:text-white data-[focus]:outline-hidden dark:text-white dark:data-[focus]:bg-accent-500"
+								>
+									<span class="block truncate font-normal group-data-selected:font-semibold">
+										{person.name}
+									</span>
+
+									<span class="absolute inset-y-0 left-0 flex items-center pl-1.5 text-accent-600 group-not-data-selected:hidden group-data-focus:text-white dark:text-accent-400">
+										<Check aria-hidden="true" class="size-5" />
+									</span>
+								</ListboxOption>
+							))}
+						</ListboxOptions>
+					</div>
+				</Listbox>
+			</div>
+
+			{/* Custom select with status indicator */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">
+					Custom select with status indicator
+				</h3>
+				<Listbox value={selectedWithStatus} onChange={setSelectedWithStatus}>
+					<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+					<div class="relative mt-2">
+						<ListboxButton class="grid w-full cursor-default grid-cols-1 rounded-md bg-surface-1 py-1.5 pr-2 pl-3 text-left text-text-primary outline-1 -outline-offset-1 outline-surface-border focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:focus:outline-accent-500">
+							<span class="col-start-1 row-start-1 flex items-center gap-3 pr-6">
+								<span
+									aria-label={selectedWithStatus.online ? 'Online' : 'Offline'}
+									class={classNames(
+										selectedWithStatus.online ? 'bg-green-400' : 'bg-gray-200 dark:bg-gray-600',
+										'inline-block size-2 shrink-0 rounded-full border border-transparent'
+									)}
+								/>
+								<span class="block truncate">{selectedWithStatus.name}</span>
+							</span>
+							<ChevronDown
+								aria-hidden="true"
+								class="col-start-1 row-start-1 size-5 self-center justify-self-end text-text-secondary sm:size-4"
+							/>
+						</ListboxButton>
+
+						<ListboxOptions
+							transition
+							class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline-1 outline-black/5 data-leave:transition data-leave:duration-100 data-leave:ease-in data-closed:data-leave:opacity-0 sm:text-sm dark:bg-gray-800 dark:shadow-none dark:outline-white/10"
+						>
+							{peopleWithStatus.map((person) => (
+								<ListboxOption
+									key={person.id}
+									value={person}
+									class="group relative cursor-default py-2 pr-9 pl-3 text-text-primary select-none data-[focus]:bg-accent-600 data-[focus]:text-white data-[focus]:outline-hidden dark:text-white dark:data-[focus]:bg-accent-500"
+								>
+									<div class="flex items-center">
+										<span
+											aria-hidden="true"
+											class={classNames(
+												person.online ? 'bg-green-400' : 'bg-gray-200 dark:bg-white/25',
+												'inline-block size-2 shrink-0 rounded-full border border-transparent'
+											)}
+										/>
+										<span class="ml-3 block truncate font-normal group-data-selected:font-semibold">
+											{person.name}
+											<span class="sr-only"> is {person.online ? 'online' : 'offline'}</span>
+										</span>
+									</div>
+
+									<span class="absolute inset-y-0 right-0 flex items-center pr-4 text-accent-600 group-not-data-selected:hidden group-data-focus:text-white dark:text-accent-400">
+										<Check aria-hidden="true" class="size-5" />
+									</span>
+								</ListboxOption>
+							))}
+						</ListboxOptions>
+					</div>
+				</Listbox>
+			</div>
+
+			{/* Custom select with avatar */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Custom select with avatar</h3>
+				<Listbox value={selectedWithAvatar} onChange={setSelectedWithAvatar}>
+					<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+					<div class="relative mt-2">
+						<ListboxButton class="grid w-full cursor-default grid-cols-1 rounded-md bg-surface-1 py-1.5 pr-2 pl-3 text-left text-text-primary outline-1 -outline-offset-1 outline-surface-border focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-gray-800/50 dark:text-white dark:outline-white/10 dark:focus:outline-accent-500">
+							<span class="col-start-1 row-start-1 flex items-center gap-3 pr-6">
+								<img
+									alt=""
+									src={selectedWithAvatar.avatar}
+									class="size-5 shrink-0 rounded-full bg-surface-2 dark:outline dark:outline-white/10"
+								/>
+								<span class="block truncate">{selectedWithAvatar.name}</span>
+							</span>
+							<ChevronDown
+								aria-hidden="true"
+								class="col-start-1 row-start-1 size-5 self-center justify-self-end text-text-secondary sm:size-4"
+							/>
+						</ListboxButton>
+
+						<ListboxOptions
+							transition
+							class="absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline-1 outline-black/5 data-leave:transition data-leave:duration-100 data-leave:ease-in data-closed:data-leave:opacity-0 sm:text-sm dark:bg-gray-800 dark:shadow-none dark:outline-white/10"
+						>
+							{peopleWithAvatar.map((person) => (
+								<ListboxOption
+									key={person.id}
+									value={person}
+									class="group relative cursor-default py-2 pr-9 pl-3 text-text-primary select-none data-[focus]:bg-accent-600 data-[focus]:text-white data-[focus]:outline-hidden dark:text-white dark:data-[focus]:bg-accent-500"
+								>
+									<div class="flex items-center">
+										<img
+											alt=""
+											src={person.avatar}
+											class="size-5 shrink-0 rounded-full dark:outline dark:outline-white/10"
+										/>
+										<span class="ml-3 block truncate font-normal group-data-selected:font-semibold">
+											{person.name}
+										</span>
+									</div>
+
+									<span class="absolute inset-y-0 right-0 flex items-center pr-4 text-accent-600 group-not-data-selected:hidden group-data-focus:text-white dark:text-accent-400">
+										<Check aria-hidden="true" class="size-5" />
+									</span>
+								</ListboxOption>
+							))}
+						</ListboxOptions>
+					</div>
+				</Listbox>
+			</div>
+
+			{/* Select with secondary text */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Select with secondary text</h3>
+				<Listbox value={selected} onChange={setSelected}>
+					<Label class="block text-sm/6 font-medium text-text-primary">Assigned to</Label>
+					<div class="relative mt-2">
+						<ListboxButton class="grid w-full cursor-default grid-cols-1 rounded-md bg-surface-1 py-1.5 pr-2 pl-3 text-left text-text-primary outline-1 -outline-offset-1 outline-surface-border focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:focus:outline-accent-500">
+							<span class="col-start-1 row-start-1 truncate pr-6">{selected.name}</span>
+							<ChevronDown
+								aria-hidden="true"
+								class="col-start-1 row-start-1 size-5 self-center justify-self-end text-text-secondary sm:size-4"
+							/>
+						</ListboxButton>
+
+						<ListboxOptions
+							transition
+							class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-surface-1 py-1 text-base shadow-lg outline-1 outline-black/5 data-leave:transition data-leave:duration-100 data-leave:ease-in data-closed:data-leave:opacity-0 sm:text-sm dark:bg-gray-800 dark:shadow-none dark:outline-white/10"
+						>
+							{people.map((person) => (
+								<ListboxOption
+									key={person.id}
+									value={person}
+									class="group relative cursor-default py-2 pr-9 pl-3 text-text-primary select-none data-[focus]:bg-accent-600 data-[focus]:text-white data-[focus]:outline-hidden dark:text-white dark:data-[focus]:bg-accent-500"
+								>
+									<span class="block truncate font-normal group-data-selected:font-semibold">
+										{person.name}
+									</span>
+
+									<span class="absolute inset-y-0 right-0 flex items-center pr-4 text-accent-600 group-not-data-selected:hidden group-data-focus:text-white dark:text-accent-400">
+										<Check aria-hidden="true" class="size-5" />
+									</span>
+								</ListboxOption>
+							))}
+						</ListboxOptions>
+					</div>
+				</Listbox>
+			</div>
+
+			{/* Branded select with supporting text */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">
+					Branded select with supporting text
+				</h3>
+				<Listbox value={selectedPublish} onChange={setSelectedPublish}>
+					<Label class="sr-only">Change published status</Label>
+					<div class="relative">
+						<div class="inline-flex divide-x divide-accent-700 rounded-md outline-hidden dark:divide-accent-600">
+							<div class="inline-flex items-center gap-x-1.5 rounded-l-md bg-accent-600 px-3 py-2 text-white dark:bg-accent-500">
+								<Check aria-hidden="true" class="-ml-0.5 size-5" />
+								<p class="text-sm font-semibold">{selectedPublish.title}</p>
+							</div>
+							<ListboxButton class="inline-flex items-center rounded-l-none rounded-r-md bg-accent-600 p-2 hover:bg-accent-700 focus-visible:outline-2 focus-visible:outline-accent-400 dark:bg-accent-500 dark:hover:bg-accent-400 dark:focus-visible:outline-accent-400">
+								<span class="sr-only">Change published status</span>
+								<ChevronDown aria-hidden="true" class="size-5 text-white" />
+							</ListboxButton>
+						</div>
+
+						<ListboxOptions
+							transition
+							class="absolute right-0 z-10 mt-2 w-72 origin-top-right divide-y divide-surface-border overflow-hidden rounded-md bg-surface-1 shadow-lg outline-1 outline-black/5 data-leave:transition data-leave:duration-100 data-leave:ease-in data-closed:data-leave:opacity-0 dark:divide-white/10 dark:bg-gray-800 dark:shadow-none dark:outline-white/10"
+						>
+							{publishingOptions.map((option) => (
+								<ListboxOption
+									key={option.title}
+									value={option}
+									class="group cursor-default p-4 text-sm text-text-primary select-none data-[focus]:bg-accent-600 data-[focus]:text-white dark:text-white dark:data-[focus]:bg-accent-500"
+								>
+									<div class="flex flex-col">
+										<div class="flex justify-between">
+											<p class="font-normal group-data-selected:font-semibold">{option.title}</p>
+											<span class="text-accent-600 group-not-data-selected:hidden group-data-focus:text-white dark:text-accent-400">
+												<Check aria-hidden="true" class="size-5" />
+											</span>
+										</div>
+										<p class="mt-2 text-text-secondary group-data-focus:text-white">
+											{option.description}
+										</p>
+									</div>
+								</ListboxOption>
+							))}
+						</ListboxOptions>
+					</div>
+				</Listbox>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/forms/select-menus/CustomSelectMenusDemo.tsx
+++ b/packages/ui/demo/sections/forms/select-menus/CustomSelectMenusDemo.tsx
@@ -6,6 +6,7 @@ import {
 	ListboxOptions,
 	Label,
 } from '../../../../src/mod.ts';
+import { classNames } from '../../../../src/internal/class-names.ts';
 import { ChevronDown, Check } from 'lucide-preact';
 
 const people = [
@@ -111,10 +112,6 @@ const publishingOptions = [
 		current: false,
 	},
 ];
-
-function classNames(...classes: (string | boolean | undefined)[]) {
-	return classes.filter(Boolean).join(' ');
-}
 
 export function CustomSelectMenusDemo() {
 	const [selected, setSelected] = useState(people[3]);

--- a/packages/ui/demo/sections/headings/card-headings/CardHeadingsDemo.tsx
+++ b/packages/ui/demo/sections/headings/card-headings/CardHeadingsDemo.tsx
@@ -1,4 +1,13 @@
-import { EllipsisVertical } from 'lucide-preact';
+import {
+	Menu,
+	MenuButton,
+	MenuItems,
+	MenuItem,
+	Popover,
+	PopoverButton,
+	PopoverPanel,
+} from '../../../../src/mod.ts';
+import { EllipsisVertical, Plus } from 'lucide-preact';
 
 export function CardHeadingsDemo() {
 	return (
@@ -112,6 +121,124 @@ export function CardHeadingsDemo() {
 							<button
 								type="button"
 								class="rounded-full bg-white p-2 text-gray-400 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20"
+							>
+								<span class="sr-only">More options</span>
+								<EllipsisVertical class="size-5" />
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 08 - With Badge and Dropdown */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With badge and dropdown</h3>
+				<div class="border-b border-gray-200 dark:border-white/10">
+					<div class="sm:flex sm:items-baseline sm:justify-between">
+						<div class="sm:w-0 sm:flex-1">
+							<h1
+								id="message-heading"
+								class="text-base font-semibold text-gray-900 dark:text-white"
+							>
+								Full-Stack Developer
+							</h1>
+							<p class="mt-1 truncate text-sm text-gray-500 dark:text-gray-400">
+								Checkout and Payments Team
+							</p>
+						</div>
+						<div class="mt-4 flex items-center justify-between sm:mt-0 sm:ml-6 sm:shrink-0 sm:justify-start">
+							<span class="inline-flex items-center rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20 dark:bg-green-500/10 dark:text-green-400 dark:ring-green-500/10">
+								Open
+							</span>
+							<div class="-my-2 ml-3 inline-block text-left">
+								<Menu as="div" class="relative">
+									<MenuButton class="relative flex items-center rounded-full p-2 text-gray-400 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-accent-500 dark:hover:text-gray-300 cursor-pointer">
+										<span class="sr-only">Open options</span>
+										<EllipsisVertical aria-hidden="true" class="size-5" />
+									</MenuButton>
+
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-surface-1 shadow-xl border border-surface-border transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in outline-none"
+									>
+										<div class="py-1">
+											<MenuItem>
+												<a
+													href="#"
+													class="flex justify-between px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+												>
+													<span>Edit</span>
+												</a>
+											</MenuItem>
+											<MenuItem>
+												<a
+													href="#"
+													class="flex justify-between px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+												>
+													<span>Duplicate</span>
+												</a>
+											</MenuItem>
+											<MenuItem>
+												<button
+													type="button"
+													class="flex w-full justify-between px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+												>
+													<span>Archive</span>
+												</button>
+											</MenuItem>
+										</div>
+									</MenuItems>
+								</Menu>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 09 - With Actions and Popover */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With actions and popover</h3>
+				<div class="border-b border-gray-200 px-4 py-5 sm:px-6 dark:border-white/10">
+					<div class="-mt-2 -ml-4 flex flex-wrap items-center justify-between sm:flex-nowrap">
+						<div class="mt-2 ml-4">
+							<h3 class="text-base font-semibold text-gray-900 dark:text-white">Job Postings</h3>
+						</div>
+						<div class="mt-2 ml-4 shrink-0 flex gap-2">
+							<Popover class="relative">
+								<PopoverButton class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 cursor-pointer">
+									<Plus class="size-4 mr-1" />
+									New job
+								</PopoverButton>
+								<PopoverPanel class="absolute left-0 mt-2 w-64 rounded-lg bg-surface-1 shadow-xl border border-surface-border p-4 z-10">
+									<div class="space-y-3">
+										<input
+											type="text"
+											placeholder="Job title"
+											class="block w-full rounded-md bg-surface-2 border border-surface-border px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent-500"
+										/>
+										<textarea
+											placeholder="Description"
+											rows={3}
+											class="block w-full rounded-md bg-surface-2 border border-surface-border px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent-500"
+										/>
+										<div class="flex justify-end gap-2">
+											<button class="px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary cursor-pointer">
+												Cancel
+											</button>
+											<button class="px-3 py-1.5 text-sm bg-accent-500 text-white rounded-md hover:bg-accent-600 cursor-pointer">
+												Create
+											</button>
+										</div>
+									</div>
+								</PopoverPanel>
+							</Popover>
+							<button
+								type="button"
+								class="rounded-full bg-white p-2 text-gray-400 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20 cursor-pointer"
 							>
 								<span class="sr-only">More options</span>
 								<EllipsisVertical class="size-5" />

--- a/packages/ui/demo/sections/headings/page-headings/PageHeadingsDemo.tsx
+++ b/packages/ui/demo/sections/headings/page-headings/PageHeadingsDemo.tsx
@@ -1,4 +1,15 @@
-import { EllipsisVertical, Pencil } from 'lucide-preact';
+import { Menu, MenuButton, MenuItems, MenuItem } from '../../../../src/mod.ts';
+import {
+	Briefcase,
+	Calendar,
+	Check,
+	ChevronDown,
+	DollarSign,
+	Link,
+	MapPin,
+	EllipsisVertical,
+	Pencil,
+} from 'lucide-preact';
 
 export function PageHeadingsDemo() {
 	return (
@@ -274,6 +285,217 @@ export function PageHeadingsDemo() {
 							<span class="sr-only">More options</span>
 							<EllipsisVertical class="size-5" />
 						</button>
+					</div>
+				</div>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 06 - With Logo, Meta and Actions */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With logo, meta and actions</h3>
+				<div class="px-4 py-10 sm:px-6 lg:px-8">
+					<div class="mx-auto flex items-center justify-between gap-x-8 lg:mx-0">
+						<div class="flex items-center gap-x-6">
+							<img
+								alt=""
+								src="https://tailwindcss.com/plus-assets/img/logos/48x48/tuple.svg"
+								class="size-16 flex-none rounded-full outline -outline-offset-1 outline-white/10 dark:outline-white/10"
+							/>
+							<h1>
+								<div class="text-sm/6 text-text-secondary">
+									Invoice <span class="text-text-primary">#00011</span>
+								</div>
+								<div class="mt-1 text-base font-semibold text-text-primary">Tuple, Inc</div>
+							</h1>
+						</div>
+						<div class="flex items-center gap-x-4 sm:gap-x-6">
+							<button
+								type="button"
+								class="hidden text-sm/6 font-semibold text-text-primary sm:block cursor-pointer"
+							>
+								Copy URL
+							</button>
+							<a href="#" class="hidden text-sm/6 font-semibold text-text-primary sm:block">
+								Edit
+							</a>
+							<a
+								href="#"
+								class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-400"
+							>
+								Send
+							</a>
+
+							<Menu as="div" class="relative sm:hidden">
+								<MenuButton class="relative block cursor-pointer">
+									<span class="absolute -inset-3" />
+									<span class="sr-only">More</span>
+									<EllipsisVertical aria-hidden="true" class="size-5 text-text-secondary" />
+								</MenuButton>
+
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-surface-1 shadow-xl border border-surface-border transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in outline-none"
+								>
+									<MenuItem>
+										<button
+											type="button"
+											class="block w-full px-3 py-1 text-left text-sm/6 text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+										>
+											Copy URL
+										</button>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-3 py-1 text-sm/6 text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+										>
+											Edit
+										</a>
+									</MenuItem>
+								</MenuItems>
+							</Menu>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 07 - Card with Avatar and Stats */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Card with avatar and stats</h3>
+				<div class="overflow-hidden rounded-lg bg-surface-0 shadow-sm dark:bg-surface-0/50 dark:shadow-none dark:outline dark:-outline-offset-1 dark:outline-white/10">
+					<div class="bg-surface-0 p-6 dark:bg-surface-1">
+						<div class="sm:flex sm:items-center sm:justify-between">
+							<div class="sm:flex sm:space-x-5">
+								<div class="shrink-0">
+									<img
+										alt=""
+										src="https://images.unsplash.com/photo-1550525811-e5869dd03032?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+										class="mx-auto size-20 rounded-full dark:outline dark:-outline-offset-1 dark:outline-white/10"
+									/>
+								</div>
+								<div class="mt-4 text-center sm:mt-0 sm:pt-1 sm:text-left">
+									<p class="text-sm font-medium text-text-secondary">Welcome back,</p>
+									<p class="text-xl font-bold text-text-primary sm:text-2xl">Rebecca Nicholas</p>
+									<p class="text-sm font-medium text-text-secondary">Product Designer</p>
+								</div>
+							</div>
+							<div class="mt-5 flex justify-center sm:mt-0">
+								<a
+									href="#"
+									class="flex items-center justify-center rounded-md bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-surface-0/50 dark:text-text-primary dark:shadow-none dark:hover:bg-surface-1"
+								>
+									View profile
+								</a>
+							</div>
+						</div>
+					</div>
+					<div class="grid grid-cols-1 divide-y divide-surface-2 border-t border-surface-2 bg-surface-1/50 sm:grid-cols-3 sm:divide-x sm:divide-y-0 dark:divide-white/10 dark:border-white/10">
+						{[
+							{ label: 'Vacation days left', value: 12 },
+							{ label: 'Sick days left', value: 4 },
+							{ label: 'Personal days left', value: 2 },
+						].map((stat) => (
+							<div key={stat.label} class="px-6 py-5 text-center text-sm font-medium">
+								<span class="text-text-primary">{stat.value}</span>{' '}
+								<span class="text-text-secondary">{stat.label}</span>
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 08 - With Icon Meta and Dropdown */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With icon meta and dropdown</h3>
+				<div class="lg:flex lg:items-center lg:justify-between">
+					<div class="min-w-0 flex-1">
+						<h2 class="text-2xl/7 font-bold text-text-primary sm:truncate sm:text-3xl sm:tracking-tight">
+							Back End Developer
+						</h2>
+						<div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
+							<div class="mt-2 flex items-center text-sm text-text-secondary">
+								<Briefcase aria-hidden="true" class="mr-1.5 size-5 shrink-0 text-text-tertiary" />
+								Full-time
+							</div>
+							<div class="mt-2 flex items-center text-sm text-text-secondary">
+								<MapPin aria-hidden="true" class="mr-1.5 size-5 shrink-0 text-text-tertiary" />
+								Remote
+							</div>
+							<div class="mt-2 flex items-center text-sm text-text-secondary">
+								<DollarSign aria-hidden="true" class="mr-1.5 size-5 shrink-0 text-text-tertiary" />
+								$120k - $140k
+							</div>
+							<div class="mt-2 flex items-center text-sm text-text-secondary">
+								<Calendar aria-hidden="true" class="mr-1.5 size-5 shrink-0 text-text-tertiary" />
+								Closing on January 9, 2020
+							</div>
+						</div>
+					</div>
+					<div class="mt-5 flex lg:mt-0 lg:ml-4">
+						<span class="hidden sm:block">
+							<button
+								type="button"
+								class="inline-flex items-center rounded-md bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-white/10 dark:text-text-primary dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+							>
+								<Pencil class="mr-1.5 -ml-0.5 size-5 text-text-tertiary" />
+								Edit
+							</button>
+						</span>
+
+						<span class="ml-3 hidden sm:block">
+							<button
+								type="button"
+								class="inline-flex items-center rounded-md bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-white/10 dark:text-text-primary dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+							>
+								<Link class="mr-1.5 -ml-0.5 size-5 text-text-tertiary" />
+								View
+							</button>
+						</span>
+
+						<span class="sm:ml-3">
+							<button
+								type="button"
+								class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-400 cursor-pointer"
+							>
+								<Check class="mr-1.5 -ml-0.5 size-5" />
+								Publish
+							</button>
+						</span>
+
+						{/* Dropdown */}
+						<Menu as="div" class="relative ml-3 sm:hidden">
+							<MenuButton class="inline-flex items-center rounded-md bg-surface-0 px-3 py-2 text-sm font-semibold text-text-primary shadow-xs ring-1 ring-inset ring-surface-border hover:bg-surface-1 dark:bg-white/10 dark:text-text-primary dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20 cursor-pointer">
+								More
+								<ChevronDown aria-hidden="true" class="-mr-1 ml-1.5 size-5 text-text-tertiary" />
+							</MenuButton>
+
+							<MenuItems
+								transition
+								class="absolute left-0 z-10 mt-2 -mr-1 w-24 origin-top-right rounded-md bg-surface-1 shadow-xl border border-surface-border transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-200 data-enter:ease-out data-leave:duration-75 data-leave:ease-in outline-none"
+							>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									>
+										Edit
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+									>
+										View
+									</a>
+								</MenuItem>
+							</MenuItems>
+						</Menu>
 					</div>
 				</div>
 			</div>

--- a/packages/ui/demo/sections/headings/section-headings/SectionHeadingsDemo.tsx
+++ b/packages/ui/demo/sections/headings/section-headings/SectionHeadingsDemo.tsx
@@ -1,4 +1,13 @@
-import { EllipsisVertical, Plus, Pencil } from 'lucide-preact';
+import {
+	Menu,
+	MenuButton,
+	MenuItems,
+	MenuItem,
+	Popover,
+	PopoverButton,
+	PopoverPanel,
+} from '../../../../src/mod.ts';
+import { EllipsisVertical, Plus, Pencil, Filter } from 'lucide-preact';
 
 export function SectionHeadingsDemo() {
 	return (
@@ -230,6 +239,80 @@ export function SectionHeadingsDemo() {
 							<span class="sr-only">More options</span>
 							<EllipsisVertical class="size-5" />
 						</button>
+					</div>
+				</div>
+			</div>
+
+			{/* ============================================================ */}
+			{/* 11 - With Actions and Popover */}
+			{/* ============================================================ */}
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With actions and popover</h3>
+				<div class="border-b border-gray-200 pb-5 dark:border-white/10">
+					<div class="sm:flex sm:items-center sm:justify-between">
+						<h3 class="text-base font-semibold text-gray-900 dark:text-white">Job Postings</h3>
+						<div class="mt-3 flex sm:mt-0 sm:ml-4 gap-2">
+							<Popover class="relative">
+								<PopoverButton class="rounded-full bg-white p-2 text-gray-400 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20 cursor-pointer">
+									<span class="sr-only">Filter</span>
+									<Filter class="size-5" />
+								</PopoverButton>
+								<PopoverPanel class="absolute right-0 mt-2 w-48 rounded-lg bg-surface-1 shadow-xl border border-surface-border p-4 z-10">
+									<div class="space-y-3">
+										<p class="text-xs font-semibold text-text-secondary uppercase tracking-wider">
+											Status
+										</p>
+										<label class="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+											<input type="checkbox" class="rounded border-surface-border" />
+											Open
+										</label>
+										<label class="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+											<input type="checkbox" class="rounded border-surface-border" />
+											Closed
+										</label>
+										<label class="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+											<input type="checkbox" class="rounded border-surface-border" />
+											Draft
+										</label>
+									</div>
+								</PopoverPanel>
+							</Popover>
+							<Menu as="div" class="relative">
+								<MenuButton class="rounded-full bg-white p-2 text-gray-400 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20 cursor-pointer">
+									<span class="sr-only">More options</span>
+									<EllipsisVertical class="size-5" />
+								</MenuButton>
+								<MenuItems
+									transition
+									class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-surface-1 shadow-xl border border-surface-border transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in outline-none"
+								>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+										>
+											Export
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+										>
+											Share
+										</a>
+									</MenuItem>
+									<MenuItem>
+										<a
+											href="#"
+											class="block px-4 py-2 text-sm text-text-primary data-[focus]:bg-accent-500 data-[focus]:text-white cursor-pointer"
+										>
+											Settings
+										</a>
+									</MenuItem>
+								</MenuItems>
+							</Menu>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Add 4 headless+icon demo examples for stacked application shells
- Stacked with bottom border
- Stacked with lighter page header  
- Branded nav with lighter page header
- Two row navigation with overlap

## Test plan
- [ ] Verify all 4 demos render correctly
- [ ] Check mobile responsive behavior
- [ ] Verify dark mode styling