### PR TITLE
feat(ui-demo): port 22 headless+icon overlay demos

### DIFF
--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -68,6 +68,8 @@ import { SidebarShellsDemo } from './sections/application-shells/sidebar/Sidebar
 import { StackedShellsDemo } from './sections/application-shells/stacked/StackedShellsDemo.tsx';
 import { DropdownsDemo } from './sections/elements/dropdowns/DropdownsDemo.tsx';
 import { CalendarsHeadlessDemo } from './sections/data-display/calendars/CalendarsHeadlessDemo.tsx';
+import { DrawersDemo } from './sections/overlays/DrawersDemo.tsx';
+import { ModalDialogsDemo } from './sections/overlays/ModalDialogsDemo.tsx';
 
 interface DemoSectionProps {
 	id: string;
@@ -598,6 +600,14 @@ export function App() {
 					</DemoSection>
 					<DemoSection id="data-display-description-lists" title="Description Lists (Data Display)">
 						<DescriptionListsDemo />
+					</DemoSection>
+
+					{/* Application UI - Overlays */}
+					<DemoSection id="overlays-drawers" title="Overlays / Drawers">
+						<DrawersDemo />
+					</DemoSection>
+					<DemoSection id="overlays-modal-dialogs" title="Overlays / Modal Dialogs">
+						<ModalDialogsDemo />
 					</DemoSection>
 				</main>
 			</div>

--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -609,6 +609,9 @@ export function App() {
 					<DemoSection id="overlays-modal-dialogs" title="Overlays / Modal Dialogs">
 						<ModalDialogsDemo />
 					</DemoSection>
+					<DemoSection id="overlays-notifications" title="Overlays / Notifications">
+						<NotificationDemo />
+					</DemoSection>
 				</main>
 			</div>
 		</div>

--- a/packages/ui/demo/sections/NotificationDemo.tsx
+++ b/packages/ui/demo/sections/NotificationDemo.tsx
@@ -2,6 +2,7 @@ import { useState } from 'preact/hooks';
 import type { VNode } from 'preact';
 import { Transition, Toaster, useToast } from '../../src/mod.ts';
 import type { ToastVariant } from '../../src/mod.ts';
+import { X } from 'lucide-preact';
 
 interface NotificationItem {
 	id: number;
@@ -459,6 +460,291 @@ function NotificationWithSplitButtons() {
 	);
 }
 
+function SimpleIconNotification() {
+	const [show, setShow] = useState(true);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setShow(true)}
+				class="px-4 py-2 rounded-lg bg-surface-2 border border-surface-border text-sm text-text-primary hover:border-accent-500 transition-colors cursor-pointer"
+			>
+				Show simple notification
+			</button>
+
+			{/* Fixed overlay container */}
+			<div
+				aria-live="assertive"
+				class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
+			>
+				<div class="flex w-full flex-col items-center space-y-4 sm:items-end">
+					<Transition show={show}>
+						<div class="pointer-events-auto w-full max-w-sm rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 data-[closed]:sm:translate-x-2">
+							<div class="p-4">
+								<div class="flex items-start">
+									<div class="shrink-0">
+										<CheckCircle class="size-6 text-green-400" />
+									</div>
+									<div class="ml-3 w-0 flex-1 pt-0.5">
+										<p class="text-sm font-medium text-text-primary">Successfully saved!</p>
+										<p class="mt-1 text-sm text-text-secondary">
+											Anyone with a link can now view this file.
+										</p>
+									</div>
+									<div class="ml-4 flex shrink-0">
+										<button
+											type="button"
+											onClick={() => setShow(false)}
+											class="inline-flex rounded-md text-text-muted hover:text-text-primary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 cursor-pointer"
+										>
+											<span class="sr-only">Close</span>
+											<X class="size-5" />
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</Transition>
+				</div>
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Simple notification with icon using{' '}
+				<code class="text-accent-400 font-mono">Transition</code> component.
+			</p>
+		</div>
+	);
+}
+
+function CondensedNotification() {
+	const [show, setShow] = useState(true);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setShow(true)}
+				class="px-4 py-2 rounded-lg bg-surface-2 border border-surface-border text-sm text-text-primary hover:border-accent-500 transition-colors cursor-pointer"
+			>
+				Show condensed notification
+			</button>
+
+			{/* Fixed overlay container */}
+			<div
+				aria-live="assertive"
+				class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
+			>
+				<div class="flex w-full flex-col items-center space-y-4 sm:items-end">
+					<Transition show={show}>
+						<div class="pointer-events-auto w-full max-w-sm rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 data-[closed]:sm:translate-x-2">
+							<div class="p-4">
+								<div class="flex items-center">
+									<div class="flex w-0 flex-1 justify-between">
+										<p class="w-0 flex-1 text-sm font-medium text-text-primary">
+											Discussion archived
+										</p>
+										<button
+											type="button"
+											class="ml-3 shrink-0 rounded-md bg-surface-1 text-sm font-medium text-accent-400 hover:text-accent-300 focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 dark:bg-gray-800 cursor-pointer"
+										>
+											Undo
+										</button>
+									</div>
+									<div class="ml-4 flex shrink-0">
+										<button
+											type="button"
+											onClick={() => setShow(false)}
+											class="inline-flex rounded-md text-text-muted hover:text-text-primary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 cursor-pointer"
+										>
+											<span class="sr-only">Close</span>
+											<X class="size-5" />
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</Transition>
+				</div>
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Condensed notification with undo action using{' '}
+				<code class="text-accent-400 font-mono">Transition</code> component.
+			</p>
+		</div>
+	);
+}
+
+function NotificationWithActionsBelow() {
+	const [show, setShow] = useState(true);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setShow(true)}
+				class="px-4 py-2 rounded-lg bg-surface-2 border border-surface-border text-sm text-text-primary hover:border-accent-500 transition-colors cursor-pointer"
+			>
+				Show notification with actions
+			</button>
+
+			{/* Fixed overlay container */}
+			<div
+				aria-live="assertive"
+				class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
+			>
+				<div class="flex w-full flex-col items-center space-y-4 sm:items-end">
+					<Transition show={show}>
+						<div class="pointer-events-auto w-full max-w-sm rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 data-[closed]:sm:translate-x-2">
+							<div class="p-4">
+								<div class="flex items-start">
+									<div class="shrink-0">
+										<Inbox class="size-6 text-text-tertiary" />
+									</div>
+									<div class="ml-3 w-0 flex-1 pt-0.5">
+										<p class="text-sm font-medium text-text-primary">Discussion moved</p>
+										<p class="mt-1 text-sm text-text-secondary">
+											Lorem ipsum dolor sit amet consectetur adipisicing elit oluptatum tenetur.
+										</p>
+										<div class="mt-3 flex space-x-7">
+											<button
+												type="button"
+												class="rounded-md text-sm font-medium text-accent-400 hover:text-accent-300 focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 cursor-pointer"
+											>
+												Undo
+											</button>
+											<button
+												type="button"
+												class="rounded-md text-sm font-medium text-text-secondary hover:text-text-primary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 cursor-pointer"
+											>
+												Dismiss
+											</button>
+										</div>
+									</div>
+									<div class="ml-4 flex shrink-0">
+										<button
+											type="button"
+											onClick={() => setShow(false)}
+											class="inline-flex rounded-md text-text-muted hover:text-text-primary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 cursor-pointer"
+										>
+											<span class="sr-only">Close</span>
+											<X class="size-5" />
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</Transition>
+				</div>
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Notification with actions below using{' '}
+				<code class="text-accent-400 font-mono">Transition</code> component.
+			</p>
+		</div>
+	);
+}
+
+function NotificationWithButtonsBelow() {
+	const [show, setShow] = useState(true);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setShow(true)}
+				class="px-4 py-2 rounded-lg bg-surface-2 border border-surface-border text-sm text-text-primary hover:border-accent-500 transition-colors cursor-pointer"
+			>
+				Show notification with buttons
+			</button>
+
+			{/* Fixed overlay container */}
+			<div
+				aria-live="assertive"
+				class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
+			>
+				<div class="flex w-full flex-col items-center space-y-4 sm:items-end">
+					<Transition show={show}>
+						<div class="pointer-events-auto w-full max-w-sm rounded-lg bg-surface-1 shadow-lg border border-surface-border transition-all duration-300 ease-out data-[closed]:opacity-0 data-[closed]:translate-y-2 data-[closed]:sm:translate-x-2">
+							<div class="p-4">
+								<div class="flex items-start">
+									<div class="shrink-0 pt-0.5">
+										<img
+											alt=""
+											src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2.2&w=160&h=160&q=80"
+											class="size-10 rounded-full bg-surface-2"
+										/>
+									</div>
+									<div class="ml-3 w-0 flex-1">
+										<p class="text-sm font-medium text-text-primary">Emilia Gates</p>
+										<p class="mt-1 text-sm text-text-secondary">Sent you an invite to connect.</p>
+										<div class="mt-4 flex">
+											<button
+												type="button"
+												class="inline-flex items-center rounded-md bg-accent-500 px-2.5 py-1.5 text-sm font-semibold text-white shadow-xs hover:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500 cursor-pointer"
+											>
+												Accept
+											</button>
+											<button
+												type="button"
+												class="ml-3 inline-flex items-center rounded-md bg-surface-1 px-2.5 py-1.5 text-sm font-semibold text-text-primary shadow-xs inset-ring inset-ring-surface-border hover:bg-surface-2 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+											>
+												Decline
+											</button>
+										</div>
+									</div>
+									<div class="ml-4 flex shrink-0">
+										<button
+											type="button"
+											onClick={() => setShow(false)}
+											class="inline-flex rounded-md text-text-muted hover:text-text-primary focus:outline-2 focus:outline-offset-2 focus:outline-accent-500 cursor-pointer"
+										>
+											<span class="sr-only">Close</span>
+											<X class="size-5" />
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</Transition>
+				</div>
+			</div>
+
+			<p class="text-xs text-text-muted">
+				Notification with buttons below using{' '}
+				<code class="text-accent-400 font-mono">Transition</code> component.
+			</p>
+		</div>
+	);
+}
+
+// Icon components
+function CheckCircle({ class: className }: { class?: string }) {
+	return (
+		<svg class={className} viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function Inbox({ class: className }: { class?: string }) {
+	return (
+		<svg class={className} viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M10 2C7.79086 2 6 3.79086 6 6V7H5C3.89543 7 3 7.89543 3 9V15C3 16.1046 3.89543 17 5 17H15C16.1046 17 17 16.1046 17 15V9C17 7.89543 16.1046 7 15 7H14V6C14 3.79086 12.2091 2 10 2ZM8 6C8 4.89543 8.89543 4 10 4C11.1046 4 12 4.89543 12 6V7H8V6ZM5 9H15C15.5523 9 16 9.44772 16 10V14H4V10C4 9.44772 4.44772 9 5 9Z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
 function NotificationDemo() {
 	return (
 		<div class="space-y-8">
@@ -488,8 +774,36 @@ function NotificationDemo() {
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">Notification with split buttons</h3>
 				<NotificationWithSplitButtons />
 			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple icon notification</h3>
+				<SimpleIconNotification />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Condensed notification</h3>
+				<CondensedNotification />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Notification with actions below</h3>
+				<NotificationWithActionsBelow />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Notification with buttons below</h3>
+				<NotificationWithButtonsBelow />
+			</div>
 		</div>
 	);
 }
 
-export { NotificationDemo, NotificationWithAvatar, NotificationWithSplitButtons };
+export {
+	NotificationDemo,
+	NotificationWithAvatar,
+	NotificationWithSplitButtons,
+	SimpleIconNotification,
+	CondensedNotification,
+	NotificationWithActionsBelow,
+	NotificationWithButtonsBelow,
+};

--- a/packages/ui/demo/sections/NotificationDemo.tsx
+++ b/packages/ui/demo/sections/NotificationDemo.tsx
@@ -2,7 +2,7 @@ import { useState } from 'preact/hooks';
 import type { VNode } from 'preact';
 import { Transition, Toaster, useToast } from '../../src/mod.ts';
 import type { ToastVariant } from '../../src/mod.ts';
-import { X } from 'lucide-preact';
+import { CheckCircle, Inbox, X } from 'lucide-preact';
 
 interface NotificationItem {
 	id: number;
@@ -717,31 +717,6 @@ function NotificationWithButtonsBelow() {
 				<code class="text-accent-400 font-mono">Transition</code> component.
 			</p>
 		</div>
-	);
-}
-
-// Icon components
-function CheckCircle({ class: className }: { class?: string }) {
-	return (
-		<svg class={className} viewBox="0 0 20 20" fill="currentColor">
-			<path
-				fill-rule="evenodd"
-				d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-				clip-rule="evenodd"
-			/>
-		</svg>
-	);
-}
-
-function Inbox({ class: className }: { class?: string }) {
-	return (
-		<svg class={className} viewBox="0 0 20 20" fill="currentColor">
-			<path
-				fill-rule="evenodd"
-				d="M10 2C7.79086 2 6 3.79086 6 6V7H5C3.89543 7 3 7.89543 3 9V15C3 16.1046 3.89543 17 5 17H15C16.1046 17 17 16.1046 17 15V9C17 7.89543 16.1046 7 15 7H14V6C14 3.79086 12.2091 2 10 2ZM8 6C8 4.89543 8.89543 4 10 4C11.1046 4 12 4.89543 12 6V7H8V6ZM5 9H15C15.5523 9 16 9.44772 16 10V14H4V10C4 9.44772 4.44772 9 5 9Z"
-				clip-rule="evenodd"
-			/>
-		</svg>
 	);
 }
 

--- a/packages/ui/demo/sections/overlays/DrawersDemo.tsx
+++ b/packages/ui/demo/sections/overlays/DrawersDemo.tsx
@@ -1681,4 +1681,18 @@ function DrawersDemo() {
 	);
 }
 
-export { DrawersDemo };
+export {
+	DrawersDemo,
+	EmptyDrawer,
+	EmptyWideDrawer,
+	DrawerWithOverlay,
+	DrawerWithCloseButtonOutside,
+	DrawerWithBrandedHeader,
+	DrawerWithStickyFooter,
+	CreateProjectFormDrawer,
+	WideCreateProjectFormDrawer,
+	UserProfileDrawer,
+	FileDetailsSlideOver,
+	ContactListDrawer,
+	FileDetailsDrawer,
+};

--- a/packages/ui/demo/sections/overlays/DrawersDemo.tsx
+++ b/packages/ui/demo/sections/overlays/DrawersDemo.tsx
@@ -28,7 +28,19 @@ import {
 	MenuItems,
 	TransitionChild,
 } from '../../../src/mod.ts';
-import { Bell, EllipsisVertical, Heart, Link, Pencil, Phone, Plus, Trash, X } from 'lucide-preact';
+import {
+	Bell,
+	EllipsisVertical,
+	File,
+	Heart,
+	Link,
+	MessageCircle,
+	Pencil,
+	Phone,
+	Plus,
+	Trash,
+	X,
+} from 'lucide-preact';
 
 function EmptyDrawer() {
 	const [open, setOpen] = useState(false);
@@ -741,15 +753,15 @@ function WideCreateProjectFormDrawer() {
 												<div class="space-y-6 pt-6 pb-5">
 													<div>
 														<label
-															for="project-name"
+															for="wide-project-name"
 															class="block text-sm/6 font-medium text-gray-900 dark:text-gray-100"
 														>
 															Project name
 														</label>
 														<div class="mt-2">
 															<input
-																id="project-name"
-																name="project-name"
+																id="wide-project-name"
+																name="wide-project-name"
 																type="text"
 																class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 															/>
@@ -757,15 +769,15 @@ function WideCreateProjectFormDrawer() {
 													</div>
 													<div>
 														<label
-															for="project-description"
+															for="wide-project-description"
 															class="block text-sm/6 font-medium text-gray-900 dark:text-gray-100"
 														>
 															Description
 														</label>
 														<div class="mt-2">
 															<textarea
-																id="project-description"
-																name="project-description"
+																id="wide-project-description"
+																name="wide-project-description"
 																rows={3}
 																class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 															/>
@@ -960,12 +972,9 @@ function UserProfileDrawer() {
 								<div class="relative flex h-full flex-col overflow-y-auto bg-white shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
 									<div class="px-4 py-6 sm:px-6">
 										<div class="flex items-start justify-between">
-											<h2
-												id="slide-over-heading"
-												class="text-base font-semibold text-gray-900 dark:text-white"
-											>
+											<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
 												Profile
-											</h2>
+											</DialogTitle>
 											<div class="ml-3 flex h-7 items-center">
 												<button
 													type="button"
@@ -1106,7 +1115,7 @@ function UserProfileDrawer() {
 	);
 }
 
-function WideUserProfileDrawer() {
+function FileDetailsSlideOver() {
 	const [open, setOpen] = useState(false);
 
 	return (
@@ -1498,19 +1507,6 @@ function ContactListDrawer() {
 	);
 }
 
-// Message icon helper
-function MessageCircle({ class: className }: { class?: string }) {
-	return (
-		<svg class={className} viewBox="0 0 20 20" fill="currentColor">
-			<path
-				fill-rule="evenodd"
-				d="M10 3c-3.866 0-7 2.686-7 6 0 1.665.676 3.175 1.772 4.312l-.536 1.98a.5.5 0 00.674.674l1.98-.536a6.97 6.97 0 001.838.192C10.5 15.5 12 16 14 16c3.866 0 7-2.686 7-6s-3.134-6-7-6-7 2.686-7 6c0 1.033.261 2.008.724 2.866l-.724 2.674a.5.5 0 00.674.674l2.674-.724c.858.463 1.833.724 2.866.724 3.866 0 7-2.686 7-6s-3.134-6-7-6-7 2.686-7 6c0 .989.24 1.926.666 2.768l-1.414 1.414a.5.5 0 000 .708l4 4a.5.5 0 00.708 0l1.414-1.414A6.968 6.968 0 0010 3z"
-				clip-rule="evenodd"
-			/>
-		</svg>
-	);
-}
-
 function FileDetailsDrawer() {
 	const [open, setOpen] = useState(false);
 
@@ -1619,19 +1615,6 @@ function FileDetailsDrawer() {
 	);
 }
 
-// File icon helper
-function File({ class: className }: { class?: string }) {
-	return (
-		<svg class={className} viewBox="0 0 20 20" fill="currentColor">
-			<path
-				fill-rule="evenodd"
-				d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z"
-				clip-rule="evenodd"
-			/>
-		</svg>
-	);
-}
-
 function DrawersDemo() {
 	return (
 		<div class="space-y-12">
@@ -1681,10 +1664,8 @@ function DrawersDemo() {
 			</div>
 
 			<div>
-				<h3 class="text-sm font-medium text-text-tertiary mb-4">
-					Wide user profile (file details)
-				</h3>
-				<WideUserProfileDrawer />
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Wide file details</h3>
+				<FileDetailsSlideOver />
 			</div>
 
 			<div>

--- a/packages/ui/demo/sections/overlays/DrawersDemo.tsx
+++ b/packages/ui/demo/sections/overlays/DrawersDemo.tsx
@@ -1,0 +1,1703 @@
+/**
+ * DrawersDemo.tsx
+ *
+ * 12 drawer examples ported from Tailwind Application UI v4 reference:
+ * 1. Empty drawer
+ * 2. Empty wide drawer
+ * 3. With background overlay
+ * 4. With close button on outside
+ * 5. With branded header
+ * 6. With sticky footer
+ * 7. Create project form
+ * 8. Wide create project form
+ * 9. User profile
+ * 10. Wide user profile
+ * 11. Contact list
+ * 12. File details
+ */
+
+import { useState } from 'preact/hooks';
+import {
+	Dialog,
+	DialogBackdrop,
+	DialogPanel,
+	DialogTitle,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuItems,
+	TransitionChild,
+} from '../../../src/mod.ts';
+import { Bell, EllipsisVertical, Heart, Link, Pencil, Phone, Plus, Trash, X } from 'lucide-preact';
+
+function EmptyDrawer() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<div class="fixed inset-0" />
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<div class="flex h-full flex-col overflow-y-auto bg-white py-6 shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="px-4 sm:px-6">
+										<div class="flex items-start justify-between">
+											<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
+												Panel title
+											</DialogTitle>
+											<div class="ml-3 flex h-7 items-center">
+												<button
+													type="button"
+													onClick={() => setOpen(false)}
+													class="relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+												>
+													<span class="absolute -inset-2.5" />
+													<span class="sr-only">Close panel</span>
+													<X class="size-6" />
+												</button>
+											</div>
+										</div>
+									</div>
+									<div class="relative mt-6 flex-1 px-4 sm:px-6">{/* Your content */}</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function EmptyWideDrawer() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open wide drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<div class="fixed inset-0" />
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-2xl transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<div class="flex h-full flex-col overflow-y-auto bg-white py-6 shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="px-4 sm:px-6">
+										<div class="flex items-start justify-between">
+											<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
+												Panel title
+											</DialogTitle>
+											<div class="ml-3 flex h-7 items-center">
+												<button
+													type="button"
+													onClick={() => setOpen(false)}
+													class="relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+												>
+													<span class="absolute -inset-2.5" />
+													<span class="sr-only">Close panel</span>
+													<X class="size-6" />
+												</button>
+											</div>
+										</div>
+									</div>
+									<div class="relative mt-6 flex-1 px-4 sm:px-6">{/* Your content */}</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function DrawerWithOverlay() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity duration-500 ease-in-out data-[closed]:opacity-0 dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<div class="flex h-full flex-col overflow-y-auto bg-white py-6 shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="px-4 sm:px-6">
+										<div class="flex items-start justify-between">
+											<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
+												Panel title
+											</DialogTitle>
+											<div class="ml-3 flex h-7 items-center">
+												<button
+													type="button"
+													onClick={() => setOpen(false)}
+													class="relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+												>
+													<span class="absolute -inset-2.5" />
+													<span class="sr-only">Close panel</span>
+													<X class="size-6" />
+												</button>
+											</div>
+										</div>
+									</div>
+									<div class="relative mt-6 flex-1 px-4 sm:px-6">{/* Your content */}</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function DrawerWithCloseButtonOutside() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity duration-500 ease-in-out data-[closed]:opacity-0 dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto relative w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<TransitionChild>
+									<div class="absolute top-0 left-0 -ml-8 flex pt-4 pr-2 duration-500 ease-in-out data-[closed]:opacity-0 sm:-ml-10 sm:pr-4">
+										<button
+											type="button"
+											onClick={() => setOpen(false)}
+											class="relative rounded-md text-gray-300 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:text-gray-400 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+										>
+											<span class="absolute -inset-2.5" />
+											<span class="sr-only">Close panel</span>
+											<X class="size-6" />
+										</button>
+									</div>
+								</TransitionChild>
+								<div class="relative flex h-full flex-col overflow-y-auto bg-white py-6 shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="px-4 sm:px-6">
+										<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
+											Panel title
+										</DialogTitle>
+									</div>
+									<div class="relative mt-6 flex-1 px-4 sm:px-6">{/* Your content */}</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function DrawerWithBrandedHeader() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<div class="fixed inset-0" />
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<div class="relative flex h-full flex-col overflow-y-auto bg-white shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="bg-indigo-700 px-4 py-6 sm:px-6 dark:bg-indigo-800">
+										<div class="flex items-center justify-between">
+											<DialogTitle class="text-base font-semibold text-white">
+												Panel title
+											</DialogTitle>
+											<div class="ml-3 flex h-7 items-center">
+												<button
+													type="button"
+													onClick={() => setOpen(false)}
+													class="relative rounded-md text-indigo-200 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:text-indigo-300 dark:hover:text-white cursor-pointer"
+												>
+													<span class="absolute -inset-2.5" />
+													<span class="sr-only">Close panel</span>
+													<X class="size-6" />
+												</button>
+											</div>
+										</div>
+										<div class="mt-1">
+											<p class="text-sm text-indigo-300 dark:text-indigo-200">
+												Lorem, ipsum dolor sit amet consectetur adipisicing elit aliquam ad hic
+												recusandae soluta.
+											</p>
+										</div>
+									</div>
+									<div class="relative flex-1 px-4 py-6 sm:px-6">{/* Your content */}</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function DrawerWithStickyFooter() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<div class="fixed inset-0" />
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<div class="relative flex h-full flex-col divide-y divide-gray-200 bg-white shadow-xl dark:divide-white/10 dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="flex min-h-0 flex-1 flex-col overflow-y-auto py-6">
+										<div class="px-4 sm:px-6">
+											<div class="flex items-start justify-between">
+												<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
+													Panel title
+												</DialogTitle>
+												<div class="ml-3 flex h-7 items-center">
+													<button
+														type="button"
+														onClick={() => setOpen(false)}
+														class="relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+													>
+														<span class="absolute -inset-2.5" />
+														<span class="sr-only">Close panel</span>
+														<X class="size-6" />
+													</button>
+												</div>
+											</div>
+										</div>
+										<div class="relative mt-6 flex-1 px-4 sm:px-6">{/* Your content */}</div>
+									</div>
+									<div class="flex shrink-0 justify-end px-4 py-4">
+										<button
+											type="button"
+											onClick={() => setOpen(false)}
+											class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:inset-ring-gray-400 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+										>
+											Cancel
+										</button>
+										<button
+											type="submit"
+											class="ml-4 inline-flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 cursor-pointer"
+										>
+											Save
+										</button>
+									</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+const team = [
+	{
+		name: 'Tom Cook',
+		email: 'tom.cook@example.com',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Whitney Francis',
+		email: 'whitney.francis@example.com',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1517365830460-955ce3ccd263?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Leonard Krasner',
+		email: 'leonard.krasner@example.com',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1519345182560-3f2917c472ef?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Floyd Miles',
+		email: 'floyd.miles@example.com',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1463453091185-61582044d556?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+	{
+		name: 'Emily Selman',
+		email: 'emily.selman@example.com',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1502685104226-ee32379fefbe?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+	},
+];
+
+function CreateProjectFormDrawer() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<div class="fixed inset-0" />
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-2xl transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<form class="relative flex h-full flex-col overflow-y-auto bg-white shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="flex-1">
+										{/* Header */}
+										<div class="bg-gray-50 px-4 py-6 sm:px-6 dark:bg-gray-800/50">
+											<div class="flex items-start justify-between space-x-3">
+												<div class="space-y-1">
+													<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
+														New project
+													</DialogTitle>
+													<p class="text-sm text-gray-500 dark:text-gray-400">
+														Get started by filling in the information below to create your new
+														project.
+													</p>
+												</div>
+												<div class="flex h-7 items-center">
+													<button
+														type="button"
+														onClick={() => setOpen(false)}
+														class="relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+													>
+														<span class="absolute -inset-2.5" />
+														<span class="sr-only">Close panel</span>
+														<X class="size-6" />
+													</button>
+												</div>
+											</div>
+										</div>
+
+										{/* Divider container */}
+										<div class="space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0 dark:sm:divide-white/10">
+											{/* Project name */}
+											<div class="space-y-2 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+												<div>
+													<label
+														for="project-name"
+														class="block text-sm/6 font-medium text-gray-900 sm:mt-1.5 dark:text-white"
+													>
+														Project name
+													</label>
+												</div>
+												<div class="sm:col-span-2">
+													<input
+														id="project-name"
+														name="project-name"
+														type="text"
+														class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+													/>
+												</div>
+											</div>
+
+											{/* Project description */}
+											<div class="space-y-2 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+												<div>
+													<label
+														for="project-description"
+														class="block text-sm/6 font-medium text-gray-900 sm:mt-1.5 dark:text-white"
+													>
+														Description
+													</label>
+												</div>
+												<div class="sm:col-span-2">
+													<textarea
+														id="project-description"
+														name="project-description"
+														rows={3}
+														class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+													/>
+												</div>
+											</div>
+
+											{/* Team members */}
+											<div class="space-y-2 px-4 sm:grid sm:grid-cols-3 sm:items-center sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+												<div>
+													<h3 class="text-sm/6 font-medium text-gray-900 dark:text-white">
+														Team Members
+													</h3>
+												</div>
+												<div class="sm:col-span-2">
+													<div class="flex space-x-2">
+														{team.map((person) => (
+															<a
+																key={person.email}
+																href={person.href}
+																class="shrink-0 rounded-full hover:opacity-75"
+															>
+																<img
+																	alt={person.name}
+																	src={person.imageUrl}
+																	class="inline-block size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+																/>
+															</a>
+														))}
+
+														<button
+															type="button"
+															class="relative inline-flex size-8 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-gray-200 bg-white text-gray-400 hover:border-gray-300 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:border-white/20 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-white/30 dark:hover:text-gray-200 dark:focus-visible:outline-indigo-500 cursor-pointer"
+														>
+															<span class="absolute -inset-2" />
+															<span class="sr-only">Add team member</span>
+															<Plus class="size-5" />
+														</button>
+													</div>
+												</div>
+											</div>
+
+											{/* Privacy */}
+											<fieldset class="space-y-2 px-4 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+												<legend class="sr-only">Privacy</legend>
+												<div
+													aria-hidden="true"
+													class="text-sm/6 font-medium text-gray-900 dark:text-white"
+												>
+													Privacy
+												</div>
+												<div class="space-y-5 sm:col-span-2">
+													<div class="space-y-5 sm:mt-0">
+														<div class="relative flex items-start">
+															<div class="absolute flex h-6 items-center">
+																<input
+																	defaultValue="public"
+																	defaultChecked
+																	id="privacy-public"
+																	name="privacy"
+																	type="radio"
+																	aria-describedby="privacy-public-description"
+																	class="relative size-4 appearance-none rounded-full border border-gray-300 before:absolute before:inset-1 before:rounded-full before:bg-white not-checked:before:hidden checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 dark:border-white/20 dark:bg-black/10 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/10 dark:disabled:bg-gray-800 dark:disabled:before:bg-white/20 forced-colors:appearance-auto forced-colors:before:hidden"
+																/>
+															</div>
+															<div class="pl-7 text-sm/6">
+																<label
+																	htmlFor="privacy-public"
+																	class="font-medium text-gray-900 dark:text-white"
+																>
+																	Public access
+																</label>
+																<p
+																	id="privacy-public-description"
+																	class="text-gray-500 dark:text-gray-400"
+																>
+																	Everyone with the link will see this project.
+																</p>
+															</div>
+														</div>
+														<div class="relative flex items-start">
+															<div class="absolute flex h-6 items-center">
+																<input
+																	defaultValue="private-to-project"
+																	id="privacy-private-to-project"
+																	name="privacy"
+																	type="radio"
+																	aria-describedby="privacy-private-to-project-description"
+																	class="relative size-4 appearance-none rounded-full border border-gray-300 before:absolute before:inset-1 before:rounded-full before:bg-white not-checked:before:hidden checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 dark:border-white/20 dark:bg-black/10 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/10 dark:disabled:bg-gray-800 dark:disabled:before:bg-white/20 forced-colors:appearance-auto forced-colors:before:hidden"
+																/>
+															</div>
+															<div class="pl-7 text-sm/6">
+																<label
+																	htmlFor="privacy-private-to-project"
+																	class="font-medium text-gray-900 dark:text-white"
+																>
+																	Private to project members
+																</label>
+																<p class="text-gray-500 dark:text-gray-400">
+																	Only members of this project would be able to access.
+																</p>
+															</div>
+														</div>
+														<div class="relative flex items-start">
+															<div class="absolute flex h-6 items-center">
+																<input
+																	defaultValue="private"
+																	id="privacy-private"
+																	name="privacy"
+																	type="radio"
+																	class="relative size-4 appearance-none rounded-full border border-gray-300 before:absolute before:inset-1 before:rounded-full before:bg-white not-checked:before:hidden checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 dark:border-white/20 dark:bg-black/10 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/10 dark:disabled:bg-gray-800 dark:disabled:before:bg-white/20 forced-colors:appearance-auto forced-colors:before:hidden"
+																/>
+															</div>
+															<div class="pl-7 text-sm/6">
+																<label
+																	htmlFor="privacy-private"
+																	class="font-medium text-gray-900 dark:text-white"
+																>
+																	Private to you
+																</label>
+																<p class="text-gray-500 dark:text-gray-400">
+																	You are the only one able to access this project.
+																</p>
+															</div>
+														</div>
+													</div>
+													<hr class="border-gray-200 dark:border-white/10" />
+													<div class="flex flex-col items-start space-y-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
+														<div>
+															<a
+																href="#"
+																class="group flex items-center space-x-2.5 text-sm font-medium text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300"
+															>
+																<Link
+																	aria-hidden="true"
+																	class="size-5 text-indigo-500 group-hover:text-indigo-900 dark:text-indigo-400 dark:group-hover:text-indigo-300"
+																/>
+																<span>Copy link</span>
+															</a>
+														</div>
+														<div>
+															<a
+																href="#"
+																class="group flex items-center space-x-2.5 text-sm text-gray-500 hover:text-gray-900 dark:hover:text-gray-300"
+															>
+																<Bell
+																	aria-hidden="true"
+																	class="size-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-600 dark:group-hover:text-gray-400"
+																/>
+																<span>Learn more about sharing</span>
+															</a>
+														</div>
+													</div>
+												</div>
+											</fieldset>
+										</div>
+									</div>
+
+									{/* Action buttons */}
+									<div class="shrink-0 border-t border-gray-200 px-4 py-5 sm:px-6 dark:border-white/10">
+										<div class="flex justify-end space-x-3">
+											<button
+												type="button"
+												onClick={() => setOpen(false)}
+												class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-gray-100 dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+											>
+												Cancel
+											</button>
+											<button
+												type="submit"
+												class="inline-flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 cursor-pointer"
+											>
+												Create
+											</button>
+										</div>
+									</div>
+								</form>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function WideCreateProjectFormDrawer() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open wide drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<div class="fixed inset-0" />
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<form class="relative flex h-full flex-col divide-y divide-gray-200 bg-white shadow-xl dark:divide-white/10 dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="h-0 flex-1 overflow-y-auto">
+										<div class="bg-indigo-700 px-4 py-6 sm:px-6 dark:bg-indigo-800">
+											<div class="flex items-center justify-between">
+												<DialogTitle class="text-base font-semibold text-white">
+													New project
+												</DialogTitle>
+												<div class="ml-3 flex h-7 items-center">
+													<button
+														type="button"
+														onClick={() => setOpen(false)}
+														class="relative rounded-md text-indigo-200 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:text-indigo-300 dark:hover:text-white cursor-pointer"
+													>
+														<span class="absolute -inset-2.5" />
+														<span class="sr-only">Close panel</span>
+														<X class="size-6" />
+													</button>
+												</div>
+											</div>
+											<div class="mt-1">
+												<p class="text-sm text-indigo-300">
+													Get started by filling in the information below to create your new
+													project.
+												</p>
+											</div>
+										</div>
+										<div class="flex flex-1 flex-col justify-between">
+											<div class="divide-y divide-gray-200 px-4 sm:px-6 dark:divide-white/10">
+												<div class="space-y-6 pt-6 pb-5">
+													<div>
+														<label
+															for="project-name"
+															class="block text-sm/6 font-medium text-gray-900 dark:text-gray-100"
+														>
+															Project name
+														</label>
+														<div class="mt-2">
+															<input
+																id="project-name"
+																name="project-name"
+																type="text"
+																class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+															/>
+														</div>
+													</div>
+													<div>
+														<label
+															for="project-description"
+															class="block text-sm/6 font-medium text-gray-900 dark:text-gray-100"
+														>
+															Description
+														</label>
+														<div class="mt-2">
+															<textarea
+																id="project-description"
+																name="project-description"
+																rows={3}
+																class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+															/>
+														</div>
+													</div>
+													<div>
+														<h3 class="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+															Team Members
+														</h3>
+														<div class="mt-2">
+															<div class="flex space-x-2">
+																{team.map((person) => (
+																	<a
+																		key={person.email}
+																		href={person.href}
+																		class="relative rounded-full hover:opacity-75"
+																	>
+																		<img
+																			alt={person.name}
+																			src={person.imageUrl}
+																			class="inline-block size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+																		/>
+																	</a>
+																))}
+																<button
+																	type="button"
+																	class="relative inline-flex size-8 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-gray-200 bg-white text-gray-400 hover:border-gray-300 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:border-white/20 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-white/30 dark:hover:text-gray-200 dark:focus-visible:outline-indigo-500 cursor-pointer"
+																>
+																	<span class="absolute -inset-2" />
+																	<span class="sr-only">Add team member</span>
+																	<Plus class="size-5" />
+																</button>
+															</div>
+														</div>
+													</div>
+													<fieldset>
+														<legend class="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+															Privacy
+														</legend>
+														<div class="mt-2 space-y-4">
+															<div class="relative flex items-start">
+																<div class="absolute flex h-6 items-center">
+																	<input
+																		defaultValue="public"
+																		defaultChecked
+																		id="privacy-public-2"
+																		name="privacy-2"
+																		type="radio"
+																		class="relative size-4 appearance-none rounded-full border border-gray-300 before:absolute before:inset-1 before:rounded-full before:bg-white not-checked:before:hidden checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 dark:border-white/20 dark:bg-black/10 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/10 dark:disabled:bg-gray-800 dark:disabled:before:bg-white/20 forced-colors:appearance-auto forced-colors:before:hidden"
+																	/>
+																</div>
+																<div class="pl-7 text-sm/6">
+																	<label
+																		htmlFor="privacy-public-2"
+																		class="font-medium text-gray-900 dark:text-gray-100"
+																	>
+																		Public access
+																	</label>
+																	<p class="text-gray-500 dark:text-gray-400">
+																		Everyone with the link will see this project.
+																	</p>
+																</div>
+															</div>
+															<div>
+																<div class="relative flex items-start">
+																	<div class="absolute flex h-6 items-center">
+																		<input
+																			defaultValue="private-to-project"
+																			id="privacy-private-to-project-2"
+																			name="privacy-2"
+																			type="radio"
+																			class="relative size-4 appearance-none rounded-full border border-gray-300 before:absolute before:inset-1 before:rounded-full before:bg-white not-checked:before:hidden checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 dark:border-white/20 dark:bg-black/10 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/10 dark:disabled:bg-gray-800 dark:disabled:before:bg-white/20 forced-colors:appearance-auto forced-colors:before:hidden"
+																		/>
+																	</div>
+																	<div class="pl-7 text-sm/6">
+																		<label
+																			htmlFor="privacy-private-to-project-2"
+																			class="font-medium text-gray-900 dark:text-gray-100"
+																		>
+																			Private to project members
+																		</label>
+																		<p class="text-gray-500 dark:text-gray-400">
+																			Only members of this project would be able to access.
+																		</p>
+																	</div>
+																</div>
+															</div>
+															<div>
+																<div class="relative flex items-start">
+																	<div class="absolute flex h-6 items-center">
+																		<input
+																			defaultValue="private"
+																			id="privacy-private-2"
+																			name="privacy-2"
+																			type="radio"
+																			class="relative size-4 appearance-none rounded-full border border-gray-300 before:absolute before:inset-1 before:rounded-full before:bg-white not-checked:before:hidden checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 dark:border-white/20 dark:bg-black/10 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/10 dark:disabled:bg-gray-800 dark:disabled:before:bg-white/20 forced-colors:appearance-auto forced-colors:before:hidden"
+																		/>
+																	</div>
+																	<div class="pl-7 text-sm/6">
+																		<label
+																			htmlFor="privacy-private-2"
+																			class="font-medium text-gray-900 dark:text-gray-100"
+																		>
+																			Private to you
+																		</label>
+																		<p class="text-gray-500 dark:text-gray-400">
+																			You are the only one able to access this project.
+																		</p>
+																	</div>
+																</div>
+															</div>
+														</div>
+													</fieldset>
+												</div>
+												<div class="pt-4 pb-6">
+													<div class="flex text-sm">
+														<a
+															href="#"
+															class="group inline-flex items-center font-medium text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300"
+														>
+															<Link
+																aria-hidden="true"
+																class="size-5 text-indigo-500 group-hover:text-indigo-900 dark:text-indigo-400 dark:group-hover:text-indigo-300"
+															/>
+															<span class="ml-2">Copy link</span>
+														</a>
+													</div>
+													<div class="mt-4 flex text-sm">
+														<a
+															href="#"
+															class="group inline-flex items-center text-gray-500 hover:text-gray-900 dark:hover:text-gray-200"
+														>
+															<Bell
+																aria-hidden="true"
+																class="size-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-600 dark:group-hover:text-gray-300"
+															/>
+															<span class="ml-2">Learn more about sharing</span>
+														</a>
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+									<div class="flex shrink-0 justify-end px-4 py-4">
+										<button
+											type="button"
+											onClick={() => setOpen(false)}
+											class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-gray-100 dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+										>
+											Cancel
+										</button>
+										<button
+											type="submit"
+											class="ml-4 inline-flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 cursor-pointer"
+										>
+											Save
+										</button>
+									</div>
+								</form>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function UserProfileDrawer() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<div class="fixed inset-0" />
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<div class="relative flex h-full flex-col overflow-y-auto bg-white shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="px-4 py-6 sm:px-6">
+										<div class="flex items-start justify-between">
+											<h2
+												id="slide-over-heading"
+												class="text-base font-semibold text-gray-900 dark:text-white"
+											>
+												Profile
+											</h2>
+											<div class="ml-3 flex h-7 items-center">
+												<button
+													type="button"
+													onClick={() => setOpen(false)}
+													class="relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+												>
+													<span class="absolute -inset-2.5" />
+													<span class="sr-only">Close panel</span>
+													<X class="size-6" />
+												</button>
+											</div>
+										</div>
+									</div>
+									{/* Main */}
+									<div>
+										<div class="pb-1 sm:pb-6">
+											<div>
+												<div class="relative h-40 sm:h-56">
+													<img
+														alt=""
+														src="https://images.unsplash.com/photo-1501031170107-cfd33f0cbdcc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&h=600&q=80"
+														class="absolute size-full object-cover"
+													/>
+												</div>
+												<div class="mt-6 px-4 sm:mt-8 sm:flex sm:items-end sm:px-6">
+													<div class="sm:flex-1">
+														<div>
+															<div class="flex items-center">
+																<h3 class="text-xl font-bold text-gray-900 sm:text-2xl dark:text-white">
+																	Ashley Porter
+																</h3>
+																<span class="ml-2.5 inline-block size-2 shrink-0 rounded-full bg-green-400">
+																	<span class="sr-only">Online</span>
+																</span>
+															</div>
+															<p class="text-sm text-gray-500 dark:text-gray-400">@ashleyporter</p>
+														</div>
+														<div class="mt-5 flex flex-wrap space-y-3 sm:space-y-0 sm:space-x-3">
+															<button
+																type="button"
+																class="inline-flex w-full shrink-0 items-center justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:flex-1 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 cursor-pointer"
+															>
+																<MessageCircle class="size-4 mr-2" />
+																Message
+															</button>
+															<button
+																type="button"
+																class="inline-flex w-full flex-1 items-center justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-gray-100 dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+															>
+																<Phone class="size-4 mr-2" />
+																Call
+															</button>
+															<div class="ml-3 inline-flex sm:ml-0">
+																<Menu as="div" class="relative inline-block text-left">
+																	<MenuButton class="relative inline-flex items-center rounded-md bg-white p-2 text-gray-400 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-gray-100 dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer">
+																		<span class="absolute -inset-1" />
+																		<span class="sr-only">Open options menu</span>
+																		<EllipsisVertical class="size-5" />
+																	</MenuButton>
+																	<MenuItems
+																		transition
+																		class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white shadow-lg outline-1 outline-black/5 transition data-[closed]:scale-95 data-[closed]:transform data-[closed]:opacity-0 data-[enter]:duration-100 data-[enter]:ease-out data-[leave]:duration-75 data-[leave]:ease-in dark:bg-gray-800 dark:-outline-offset-1 dark:outline-white/10"
+																	>
+																		<div class="py-1">
+																			<MenuItem>
+																				<a
+																					href="#"
+																					class="block px-4 py-2 text-sm text-gray-700 data-[focus]:bg-gray-100 data-[focus]:text-gray-900 data-[focus]:outline-hidden dark:text-gray-300 dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+																				>
+																					View profile
+																				</a>
+																			</MenuItem>
+																			<MenuItem>
+																				<a
+																					href="#"
+																					class="block px-4 py-2 text-sm text-gray-700 data-[focus]:bg-gray-100 data-[focus]:text-gray-900 data-[focus]:outline-hidden dark:text-gray-300 dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+																				>
+																					Copy profile link
+																				</a>
+																			</MenuItem>
+																		</div>
+																	</MenuItems>
+																</Menu>
+															</div>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+										<div class="px-4 pt-5 pb-5 sm:px-0 sm:pt-0">
+											<dl class="space-y-8 px-4 sm:space-y-6 sm:px-6">
+												<div>
+													<dt class="text-sm font-medium text-gray-500 sm:w-40 sm:shrink-0 dark:text-gray-400">
+														Bio
+													</dt>
+													<dd class="mt-1 text-sm text-gray-900 sm:col-span-2 dark:text-white">
+														<p>
+															Enim feugiat ut ipsum, neque ut. Tristique mi id elementum praesent.
+															Gravida in tempus feugiat netus enim aliquet a, quam scelerisque.
+															Dictumst in convallis nec in bibendum aenean arcu.
+														</p>
+													</dd>
+												</div>
+												<div>
+													<dt class="text-sm font-medium text-gray-500 sm:w-40 sm:shrink-0 dark:text-gray-400">
+														Location
+													</dt>
+													<dd class="mt-1 text-sm text-gray-900 sm:col-span-2 dark:text-white">
+														New York, NY, USA
+													</dd>
+												</div>
+												<div>
+													<dt class="text-sm font-medium text-gray-500 sm:w-40 sm:shrink-0 dark:text-gray-400">
+														Website
+													</dt>
+													<dd class="mt-1 text-sm text-gray-900 sm:col-span-2 dark:text-white">
+														ashleyporter.com
+													</dd>
+												</div>
+												<div>
+													<dt class="text-sm font-medium text-gray-500 sm:w-40 sm:shrink-0 dark:text-gray-400">
+														Birthday
+													</dt>
+													<dd class="mt-1 text-sm text-gray-900 sm:col-span-2 dark:text-white">
+														<time dateTime="1988-06-23">June 23, 1988</time>
+													</dd>
+												</div>
+											</dl>
+										</div>
+									</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function WideUserProfileDrawer() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open wide drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity duration-500 ease-in-out data-[closed]:opacity-0 dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto relative w-96 transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<TransitionChild>
+									<div class="absolute top-0 left-0 -ml-8 flex pt-4 pr-2 duration-500 ease-in-out data-[closed]:opacity-0 sm:-ml-10 sm:pr-4">
+										<button
+											type="button"
+											onClick={() => setOpen(false)}
+											class="relative rounded-md text-gray-300 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:text-gray-400 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+										>
+											<span class="absolute -inset-2.5" />
+											<span class="sr-only">Close panel</span>
+											<X class="size-6" />
+										</button>
+									</div>
+								</TransitionChild>
+								<div class="relative h-full overflow-y-auto bg-white p-8 dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="space-y-6 pb-16">
+										<div>
+											<img
+												alt=""
+												src="https://images.unsplash.com/photo-1582053433976-25c00369fc93?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=512&q=80"
+												class="block aspect-10/7 w-full rounded-lg bg-gray-100 object-cover outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+											/>
+											<div class="mt-4 flex items-start justify-between">
+												<div>
+													<h2 class="text-base font-semibold text-gray-900 dark:text-white">
+														<span class="sr-only">Details for </span>IMG_4985.HEIC
+													</h2>
+													<p class="text-sm font-medium text-gray-500 dark:text-gray-400">3.9 MB</p>
+												</div>
+												<button
+													type="button"
+													class="relative ml-4 flex size-8 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-indigo-600 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+												>
+													<span class="absolute -inset-1.5" />
+													<Heart class="size-6" />
+													<span class="sr-only">Favorite</span>
+												</button>
+											</div>
+										</div>
+										<div>
+											<h3 class="font-medium text-gray-900 dark:text-white">Information</h3>
+											<dl class="mt-2 divide-y divide-gray-200 border-t border-b border-gray-200 dark:divide-white/10 dark:border-white/10">
+												<div class="flex justify-between py-3 text-sm font-medium">
+													<dt class="text-gray-500 dark:text-gray-400">Uploaded by</dt>
+													<dd class="text-gray-900 dark:text-white">Marie Culver</dd>
+												</div>
+												<div class="flex justify-between py-3 text-sm font-medium">
+													<dt class="text-gray-500 dark:text-gray-400">Created</dt>
+													<dd class="text-gray-900 dark:text-white">June 8, 2020</dd>
+												</div>
+												<div class="flex justify-between py-3 text-sm font-medium">
+													<dt class="text-gray-500 dark:text-gray-400">Last modified</dt>
+													<dd class="text-gray-900 dark:text-white">June 8, 2020</dd>
+												</div>
+												<div class="flex justify-between py-3 text-sm font-medium">
+													<dt class="text-gray-500 dark:text-gray-400">Dimensions</dt>
+													<dd class="text-gray-900 dark:text-white">4032 x 3024</dd>
+												</div>
+												<div class="flex justify-between py-3 text-sm font-medium">
+													<dt class="text-gray-500 dark:text-gray-400">Resolution</dt>
+													<dd class="text-gray-900 dark:text-white">72 x 72</dd>
+												</div>
+											</dl>
+										</div>
+										<div>
+											<h3 class="font-medium text-gray-900 dark:text-white">Description</h3>
+											<div class="mt-2 flex items-center justify-between">
+												<p class="text-sm text-gray-500 italic dark:text-gray-400">
+													Add a description to this image.
+												</p>
+												<button
+													type="button"
+													class="relative -mr-2 flex size-8 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-indigo-600 dark:hover:bg-white/5 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+												>
+													<span class="absolute -inset-1.5" />
+													<Pencil class="size-5" />
+													<span class="sr-only">Add description</span>
+												</button>
+											</div>
+										</div>
+										<div>
+											<h3 class="font-medium text-gray-900 dark:text-white">Shared with</h3>
+											<ul
+												role="list"
+												class="mt-2 divide-y divide-gray-200 border-t border-b border-gray-200 dark:divide-white/10 dark:border-white/10"
+											>
+												<li class="flex items-center justify-between py-3">
+													<div class="flex items-center">
+														<img
+															alt=""
+															src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?ixlib=rb-=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=3&w=1024&h=1024&q=80"
+															class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+														/>
+														<p class="ml-4 text-sm font-medium text-gray-900 dark:text-white">
+															Aimee Douglas
+														</p>
+													</div>
+													<button
+														type="button"
+														class="ml-6 rounded-md text-sm font-medium text-indigo-600 hover:text-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300 dark:focus-visible:outline-indigo-500 cursor-pointer"
+													>
+														Remove<span class="sr-only"> Aimee Douglas</span>
+													</button>
+												</li>
+												<li class="flex items-center justify-between py-3">
+													<div class="flex items-center">
+														<img
+															alt=""
+															src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixqx=oilqXxSqey&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+															class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+														/>
+														<p class="ml-4 text-sm font-medium text-gray-900 dark:text-white">
+															Andrea McMillan
+														</p>
+													</div>
+													<button
+														type="button"
+														class="ml-6 rounded-md text-sm font-medium text-indigo-600 hover:text-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300 dark:focus-visible:outline-indigo-500 cursor-pointer"
+													>
+														Remove<span class="sr-only"> Andrea McMillan</span>
+													</button>
+												</li>
+												<li class="flex items-center justify-between py-2">
+													<button
+														type="button"
+														class="group -ml-1 flex items-center rounded-md p-1 focus-visible:outline-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-500 cursor-pointer"
+													>
+														<span class="flex size-8 items-center justify-center rounded-full border-2 border-dashed border-gray-300 text-gray-400 dark:border-white/20">
+															<Plus class="size-5" />
+														</span>
+														<span class="ml-4 text-sm font-medium text-indigo-600 group-hover:text-indigo-500 dark:text-indigo-400 dark:group-hover:text-indigo-300">
+															Share
+														</span>
+													</button>
+												</li>
+											</ul>
+										</div>
+										<div class="flex">
+											<button
+												type="button"
+												class="flex-1 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 cursor-pointer"
+											>
+												Download
+											</button>
+											<button
+												type="button"
+												class="ml-3 flex-1 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-gray-100 dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+											>
+												Delete
+											</button>
+										</div>
+									</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// Helper for contact list
+function cn(...classes: (string | boolean | undefined)[]) {
+	return classes.filter(Boolean).join(' ');
+}
+
+const tabs = [
+	{ name: 'All', href: '#', current: true },
+	{ name: 'Online', href: '#', current: false },
+	{ name: 'Offline', href: '#', current: false },
+];
+const contacts = [
+	{
+		name: 'Leslie Alexander',
+		handle: 'lesliealexander',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		status: 'online',
+	},
+	{
+		name: 'Michael Foster',
+		handle: 'michaelfoster',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		status: 'online',
+	},
+	{
+		name: 'Dries Vincent',
+		handle: 'driesvincent',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		status: 'online',
+	},
+	{
+		name: 'Lindsay Walton',
+		handle: 'lindsaywalton',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		status: 'offline',
+	},
+	{
+		name: 'Courtney Henry',
+		handle: 'courtneyhenry',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		status: 'offline',
+	},
+	{
+		name: 'Tom Cook',
+		handle: 'tomcook',
+		href: '#',
+		imageUrl:
+			'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+		status: 'offline',
+	},
+];
+
+function ContactListDrawer() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<div class="fixed inset-0" />
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<div class="relative flex h-full flex-col overflow-y-auto bg-white shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="p-6">
+										<div class="flex items-start justify-between">
+											<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
+												Team
+											</DialogTitle>
+											<div class="ml-3 flex h-7 items-center">
+												<button
+													type="button"
+													onClick={() => setOpen(false)}
+													class="relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+												>
+													<span class="absolute -inset-2.5" />
+													<span class="sr-only">Close panel</span>
+													<X class="size-6" />
+												</button>
+											</div>
+										</div>
+									</div>
+									<div class="border-b border-gray-200 dark:border-white/10">
+										<div class="px-6">
+											<nav class="-mb-px flex space-x-6">
+												{tabs.map((tab) => (
+													<a
+														key={tab.name}
+														href={tab.href}
+														class={cn(
+															tab.current
+																? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+																: 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-white',
+															'border-b-2 px-1 pb-4 text-sm font-medium whitespace-nowrap'
+														)}
+													>
+														{tab.name}
+													</a>
+												))}
+											</nav>
+										</div>
+									</div>
+									<ul
+										role="list"
+										class="flex-1 divide-y divide-gray-200 overflow-y-auto dark:divide-white/10"
+									>
+										{contacts.map((person) => (
+											<li key={person.handle}>
+												<div class="group relative flex items-center px-5 py-6">
+													<a href={person.href} class="-m-1 block flex-1 p-1">
+														<div class="absolute inset-0 group-hover:bg-gray-50 dark:group-hover:bg-white/2.5" />
+														<div class="relative flex min-w-0 flex-1 items-center">
+															<span class="relative inline-block shrink-0">
+																<img
+																	alt=""
+																	src={person.imageUrl}
+																	class="size-10 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+																/>
+																<span
+																	aria-hidden="true"
+																	class={cn(
+																		person.status === 'online'
+																			? 'bg-green-400'
+																			: 'bg-gray-300 dark:bg-gray-500',
+																		'absolute top-0 right-0 block size-2.5 rounded-full ring-2 ring-white dark:ring-gray-800'
+																	)}
+																/>
+															</span>
+															<div class="ml-4 truncate">
+																<p class="truncate text-sm font-medium text-gray-900 dark:text-white">
+																	{person.name}
+																</p>
+																<p class="truncate text-sm text-gray-500 dark:text-gray-400">
+																	{'@' + person.handle}
+																</p>
+															</div>
+														</div>
+													</a>
+													<Menu as="div" class="relative ml-2 inline-block shrink-0 text-left">
+														<MenuButton class="group relative inline-flex size-8 items-center justify-center rounded-full bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-gray-800 dark:focus-visible:outline-indigo-500 cursor-pointer">
+															<span class="absolute -inset-1.5" />
+															<span class="sr-only">Open options menu</span>
+															<span class="flex size-full items-center justify-center rounded-full">
+																<EllipsisVertical class="size-5 text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300" />
+															</span>
+														</MenuButton>
+														<MenuItems
+															transition
+															class="absolute top-0 right-full z-10 mr-1 w-48 origin-top-right rounded-md bg-white shadow-lg outline-1 outline-black/5 transition data-[closed]:scale-95 data-[closed]:transform data-[closed]:opacity-0 data-[enter]:duration-100 data-[enter]:ease-out data-[leave]:duration-75 data-[leave]:ease-in dark:bg-gray-800 dark:-outline-offset-1 dark:outline-white/10"
+														>
+															<div class="py-1">
+																<MenuItem>
+																	<a
+																		href="#"
+																		class="block px-4 py-2 text-sm text-gray-700 data-[focus]:bg-gray-100 data-[focus]:text-gray-900 data-[focus]:outline-hidden dark:text-gray-300 dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+																	>
+																		View profile
+																	</a>
+																</MenuItem>
+																<MenuItem>
+																	<a
+																		href="#"
+																		class="block px-4 py-2 text-sm text-gray-700 data-[focus]:bg-gray-100 data-[focus]:text-gray-900 data-[focus]:outline-hidden dark:text-gray-300 dark:data-[focus]:bg-white/5 dark:data-[focus]:text-white"
+																	>
+																		Send message
+																	</a>
+																</MenuItem>
+															</div>
+														</MenuItems>
+													</Menu>
+												</div>
+											</li>
+										))}
+									</ul>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// Message icon helper
+function MessageCircle({ class: className }: { class?: string }) {
+	return (
+		<svg class={className} viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M10 3c-3.866 0-7 2.686-7 6 0 1.665.676 3.175 1.772 4.312l-.536 1.98a.5.5 0 00.674.674l1.98-.536a6.97 6.97 0 001.838.192C10.5 15.5 12 16 14 16c3.866 0 7-2.686 7-6s-3.134-6-7-6-7 2.686-7 6c0 1.033.261 2.008.724 2.866l-.724 2.674a.5.5 0 00.674.674l2.674-.724c.858.463 1.833.724 2.866.724 3.866 0 7-2.686 7-6s-3.134-6-7-6-7 2.686-7 6c0 .989.24 1.926.666 2.768l-1.414 1.414a.5.5 0 000 .708l4 4a.5.5 0 00.708 0l1.414-1.414A6.968 6.968 0 0010 3z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function FileDetailsDrawer() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open drawer
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity duration-500 ease-in-out data-[closed]:opacity-0 dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 overflow-hidden">
+					<div class="absolute inset-0 overflow-hidden">
+						<div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
+							<DialogPanel
+								transition
+								class="pointer-events-auto w-screen max-w-md transform transition duration-500 ease-in-out data-[closed]:translate-x-full sm:duration-700"
+							>
+								<div class="relative flex h-full flex-col overflow-y-auto bg-white shadow-xl dark:bg-gray-800 dark:after:absolute dark:after:inset-y-0 dark:after:left-0 dark:after:w-px dark:after:bg-white/10">
+									<div class="px-4 py-6 sm:px-6">
+										<div class="flex items-start justify-between">
+											<DialogTitle class="text-base font-semibold text-gray-900 dark:text-white">
+												File Details
+											</DialogTitle>
+											<div class="ml-3 flex h-7 items-center">
+												<button
+													type="button"
+													onClick={() => setOpen(false)}
+													class="relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:hover:text-white dark:focus-visible:outline-indigo-500 cursor-pointer"
+												>
+													<span class="absolute -inset-2.5" />
+													<span class="sr-only">Close panel</span>
+													<X class="size-6" />
+												</button>
+											</div>
+										</div>
+									</div>
+
+									<div class="flex-1 px-4 sm:px-6 space-y-6">
+										{/* File preview */}
+										<div class="rounded-lg bg-gray-100 border-2 border-dashed border-gray-300 dark:bg-gray-800 dark:border-gray-600 aspect-video flex items-center justify-center">
+											<div class="text-center">
+												<File class="size-12 mx-auto text-gray-400" />
+												<p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+													design-specs.pdf
+												</p>
+											</div>
+										</div>
+
+										{/* File info */}
+										<div class="space-y-4">
+											<div>
+												<h3 class="text-sm font-medium text-gray-900 dark:text-white">
+													File Information
+												</h3>
+												<dl class="mt-2 divide-y divide-gray-200 border-t border-b border-gray-200 dark:divide-white/10 dark:border-white/10">
+													<div class="flex justify-between py-3 text-sm">
+														<dt class="text-gray-500 dark:text-gray-400">Size</dt>
+														<dd class="text-gray-900 dark:text-white">2.4 MB</dd>
+													</div>
+													<div class="flex justify-between py-3 text-sm">
+														<dt class="text-gray-500 dark:text-gray-400">Type</dt>
+														<dd class="text-gray-900 dark:text-white">PDF Document</dd>
+													</div>
+													<div class="flex justify-between py-3 text-sm">
+														<dt class="text-gray-500 dark:text-gray-400">Modified</dt>
+														<dd class="text-gray-900 dark:text-white">Mar 15, 2024</dd>
+													</div>
+												</dl>
+											</div>
+
+											{/* Actions */}
+											<div class="flex gap-3">
+												<button
+													type="button"
+													class="flex-1 inline-flex items-center justify-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400 cursor-pointer"
+												>
+													<Link class="size-4" />
+													Share
+												</button>
+												<button
+													type="button"
+													class="flex-1 inline-flex items-center justify-center gap-2 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+												>
+													<Trash class="size-4" />
+													Delete
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</DialogPanel>
+						</div>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+// File icon helper
+function File({ class: className }: { class?: string }) {
+	return (
+		<svg class={className} viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function DrawersDemo() {
+	return (
+		<div class="space-y-12">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Empty drawer</h3>
+				<EmptyDrawer />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Empty wide drawer</h3>
+				<EmptyWideDrawer />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With background overlay</h3>
+				<DrawerWithOverlay />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With close button on outside</h3>
+				<DrawerWithCloseButtonOutside />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With branded header</h3>
+				<DrawerWithBrandedHeader />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With sticky footer</h3>
+				<DrawerWithStickyFooter />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Create project form</h3>
+				<CreateProjectFormDrawer />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Wide create project form</h3>
+				<WideCreateProjectFormDrawer />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">User profile</h3>
+				<UserProfileDrawer />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">
+					Wide user profile (file details)
+				</h3>
+				<WideUserProfileDrawer />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Contact list</h3>
+				<ContactListDrawer />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">File details</h3>
+				<FileDetailsDrawer />
+			</div>
+		</div>
+	);
+}
+
+export { DrawersDemo };

--- a/packages/ui/demo/sections/overlays/ModalDialogsDemo.tsx
+++ b/packages/ui/demo/sections/overlays/ModalDialogsDemo.tsx
@@ -203,7 +203,6 @@ function SimpleAlert() {
 								</button>
 								<button
 									type="button"
-									data-autofocus
 									onClick={() => setOpen(false)}
 									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
 								>
@@ -350,7 +349,6 @@ function SimpleWithGrayFooter() {
 								</button>
 								<button
 									type="button"
-									data-autofocus
 									onClick={() => setOpen(false)}
 									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring-1 inset-ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
 								>
@@ -419,7 +417,6 @@ function SimpleWithLeftAlignedButtons() {
 								</button>
 								<button
 									type="button"
-									data-autofocus
 									onClick={() => setOpen(false)}
 									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring-1 inset-ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:ml-3 sm:w-auto dark:bg-white/10 dark:text-white dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
 								>

--- a/packages/ui/demo/sections/overlays/ModalDialogsDemo.tsx
+++ b/packages/ui/demo/sections/overlays/ModalDialogsDemo.tsx
@@ -469,4 +469,12 @@ function ModalDialogsDemo() {
 	);
 }
 
-export { ModalDialogsDemo };
+export {
+	ModalDialogsDemo,
+	CenteredWithSingleAction,
+	CenteredWithWideButtons,
+	SimpleAlert,
+	SimpleWithDismissButton,
+	SimpleWithGrayFooter,
+	SimpleWithLeftAlignedButtons,
+};

--- a/packages/ui/demo/sections/overlays/ModalDialogsDemo.tsx
+++ b/packages/ui/demo/sections/overlays/ModalDialogsDemo.tsx
@@ -1,0 +1,475 @@
+/**
+ * ModalDialogsDemo.tsx
+ *
+ * 6 modal dialog examples ported from Tailwind Application UI v4 reference:
+ * 1. Centered with single action
+ * 2. Centered with wide buttons
+ * 3. Simple alert
+ * 4. Simple with dismiss button
+ * 5. Simple with gray footer
+ * 6. Simple with left-aligned buttons
+ */
+
+import { useState } from 'preact/hooks';
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '../../../src/mod.ts';
+import { AlertTriangle, Check, X } from 'lucide-preact';
+
+function CenteredWithSingleAction() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open dialog
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+					<div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+						<DialogPanel
+							transition
+							class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all data-[closed]:translate-y-4 data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in sm:my-8 sm:w-full sm:max-w-sm sm:p-6 data-[closed]:sm:translate-y-0 data-[closed]:sm:scale-95 dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div>
+								<div class="mx-auto flex size-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-500/10">
+									<Check aria-hidden="true" class="size-6 text-green-600 dark:text-green-400" />
+								</div>
+								<div class="mt-3 text-center sm:mt-5">
+									<DialogTitle
+										as="h3"
+										class="text-base font-semibold text-gray-900 dark:text-white"
+									>
+										Payment successful
+									</DialogTitle>
+									<div class="mt-2">
+										<p class="text-sm text-gray-500 dark:text-gray-400">
+											Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequatur amet
+											labore.
+										</p>
+									</div>
+								</div>
+							</div>
+							<div class="mt-5 sm:mt-6">
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 cursor-pointer"
+								>
+									Go back to dashboard
+								</button>
+							</div>
+						</DialogPanel>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function CenteredWithWideButtons() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open dialog
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+					<div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+						<DialogPanel
+							transition
+							class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all data-[closed]:translate-y-4 data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in sm:my-8 sm:w-full sm:max-w-lg sm:p-6 data-[closed]:sm:translate-y-0 data-[closed]:sm:scale-95 dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div>
+								<div class="mx-auto flex size-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-500/10">
+									<Check aria-hidden="true" class="size-6 text-green-600 dark:text-green-400" />
+								</div>
+								<div class="mt-3 text-center sm:mt-5">
+									<DialogTitle
+										as="h3"
+										class="text-base font-semibold text-gray-900 dark:text-white"
+									>
+										Payment successful
+									</DialogTitle>
+									<div class="mt-2">
+										<p class="text-sm text-gray-500 dark:text-gray-400">
+											Lorem ipsum, dolor sit amet consectetur adipisicing elit. Eius aliquam
+											laudantium explicabo pariatur iste dolorem animi vitae error totam. At
+											sapiente aliquam accusamus facere veritatis.
+										</p>
+									</div>
+								</div>
+							</div>
+							<div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 cursor-pointer"
+								>
+									Deactivate
+								</button>
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+								>
+									Cancel
+								</button>
+							</div>
+						</DialogPanel>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function SimpleAlert() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open dialog
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+					<div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+						<DialogPanel
+							transition
+							class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all data-[closed]:translate-y-4 data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in sm:my-8 sm:w-full sm:max-w-lg data-[closed]:sm:translate-y-0 data-[closed]:sm:scale-95 dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4 dark:bg-gray-800">
+								<div class="sm:flex sm:items-start">
+									<div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:size-10 dark:bg-red-500/10">
+										<AlertTriangle
+											aria-hidden="true"
+											class="size-6 text-red-600 dark:text-red-400"
+										/>
+									</div>
+									<div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+										<DialogTitle
+											as="h3"
+											class="text-base font-semibold text-gray-900 dark:text-white"
+										>
+											Deactivate account
+										</DialogTitle>
+										<div class="mt-2">
+											<p class="text-sm text-gray-500 dark:text-gray-400">
+												Are you sure you want to deactivate your account? All of your data will be
+												permanently removed. This action cannot be undone.
+											</p>
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-gray-700/25">
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 sm:ml-3 sm:w-auto dark:bg-red-500 dark:shadow-none dark:hover:bg-red-400 cursor-pointer"
+								>
+									Deactivate
+								</button>
+								<button
+									type="button"
+									data-autofocus
+									onClick={() => setOpen(false)}
+									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+								>
+									Cancel
+								</button>
+							</div>
+						</DialogPanel>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function SimpleWithDismissButton() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open dialog
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+					<div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+						<DialogPanel
+							transition
+							class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all data-[closed]:translate-y-4 data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in sm:my-8 sm:w-full sm:max-w-lg sm:p-6 data-[closed]:sm:translate-y-0 data-[closed]:sm:scale-95 dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-indigo-600 dark:bg-gray-800 dark:hover:text-gray-300 dark:focus:outline-white cursor-pointer"
+								>
+									<span class="sr-only">Close</span>
+									<X class="size-6" />
+								</button>
+							</div>
+							<div class="sm:flex sm:items-start">
+								<div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:size-10 dark:bg-red-500/10">
+									<AlertTriangle aria-hidden="true" class="size-6 text-red-600 dark:text-red-400" />
+								</div>
+								<div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+									<DialogTitle
+										as="h3"
+										class="text-base font-semibold text-gray-900 dark:text-white"
+									>
+										Deactivate account
+									</DialogTitle>
+									<div class="mt-2">
+										<p class="text-sm text-gray-500 dark:text-gray-400">
+											Are you sure you want to deactivate your account? All of your data will be
+											permanently removed from our servers forever. This action cannot be undone.
+										</p>
+									</div>
+								</div>
+							</div>
+							<div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 sm:ml-3 sm:w-auto dark:bg-red-500 dark:shadow-none dark:hover:bg-red-400 cursor-pointer"
+								>
+									Deactivate
+								</button>
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring-1 inset-ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+								>
+									Cancel
+								</button>
+							</div>
+						</DialogPanel>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function SimpleWithGrayFooter() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open dialog
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+					<div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+						<DialogPanel
+							transition
+							class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all data-[closed]:translate-y-4 data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in sm:my-8 sm:w-full sm:max-w-lg sm:p-6 data-[closed]:sm:translate-y-0 data-[closed]:sm:scale-95 dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="sm:flex sm:items-start">
+								<div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:size-10 dark:bg-red-500/10">
+									<AlertTriangle aria-hidden="true" class="size-6 text-red-600 dark:text-red-400" />
+								</div>
+								<div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+									<DialogTitle
+										as="h3"
+										class="text-base font-semibold text-gray-900 dark:text-white"
+									>
+										Deactivate account
+									</DialogTitle>
+									<div class="mt-2">
+										<p class="text-sm text-gray-500 dark:text-gray-400">
+											Are you sure you want to deactivate your account? All of your data will be
+											permanently removed from our servers forever. This action cannot be undone.
+										</p>
+									</div>
+								</div>
+							</div>
+							<div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 sm:ml-3 sm:w-auto dark:bg-red-500 dark:shadow-none dark:hover:bg-red-400 cursor-pointer"
+								>
+									Deactivate
+								</button>
+								<button
+									type="button"
+									data-autofocus
+									onClick={() => setOpen(false)}
+									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring-1 inset-ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+								>
+									Cancel
+								</button>
+							</div>
+						</DialogPanel>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function SimpleWithLeftAlignedButtons() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<div class="space-y-4">
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				class="rounded-md bg-gray-950/5 px-2.5 py-1.5 text-sm font-semibold text-gray-900 hover:bg-gray-950/10 dark:bg-white/10 dark:text-white dark:inset-ring dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+			>
+				Open dialog
+			</button>
+
+			<Dialog open={open} onClose={setOpen} class="relative z-10">
+				<DialogBackdrop
+					transition
+					class="fixed inset-0 bg-gray-500/75 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in dark:bg-gray-900/50"
+				/>
+
+				<div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+					<div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+						<DialogPanel
+							transition
+							class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all data-[closed]:translate-y-4 data-[closed]:opacity-0 data-[enter]:duration-300 data-[enter]:ease-out data-[leave]:duration-200 data-[leave]:ease-in sm:my-8 sm:w-full sm:max-w-lg sm:p-6 data-[closed]:sm:translate-y-0 data-[closed]:sm:scale-95 dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+						>
+							<div class="sm:flex sm:items-start">
+								<div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:size-10 dark:bg-red-500/10">
+									<AlertTriangle aria-hidden="true" class="size-6 text-red-600 dark:text-red-400" />
+								</div>
+								<div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+									<DialogTitle
+										as="h3"
+										class="text-base font-semibold text-gray-900 dark:text-white"
+									>
+										Deactivate account
+									</DialogTitle>
+									<div class="mt-2">
+										<p class="text-sm text-gray-500 dark:text-gray-400">
+											Are you sure you want to deactivate your account? All of your data will be
+											permanently removed from our servers forever. This action cannot be undone.
+										</p>
+									</div>
+								</div>
+							</div>
+							<div class="mt-5 sm:mt-4 sm:ml-10 sm:flex sm:pl-4">
+								<button
+									type="button"
+									onClick={() => setOpen(false)}
+									class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 sm:w-auto dark:bg-red-500 dark:hover:bg-red-400 cursor-pointer"
+								>
+									Deactivate
+								</button>
+								<button
+									type="button"
+									data-autofocus
+									onClick={() => setOpen(false)}
+									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring-1 inset-ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:ml-3 sm:w-auto dark:bg-white/10 dark:text-white dark:inset-ring-white/5 dark:hover:bg-white/20 cursor-pointer"
+								>
+									Cancel
+								</button>
+							</div>
+						</DialogPanel>
+					</div>
+				</div>
+			</Dialog>
+		</div>
+	);
+}
+
+function ModalDialogsDemo() {
+	return (
+		<div class="space-y-12">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Centered with single action</h3>
+				<CenteredWithSingleAction />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Centered with wide buttons</h3>
+				<CenteredWithWideButtons />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Simple alert</h3>
+				<SimpleAlert />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Simple with dismiss button</h3>
+				<SimpleWithDismissButton />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">Simple with gray footer</h3>
+				<SimpleWithGrayFooter />
+			</div>
+
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">
+					Simple with left-aligned buttons
+				</h3>
+				<SimpleWithLeftAlignedButtons />
+			</div>
+		</div>
+	);
+}
+
+export { ModalDialogsDemo };

--- a/packages/ui/tests/drawers-demo.test.tsx
+++ b/packages/ui/tests/drawers-demo.test.tsx
@@ -1,0 +1,252 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	EmptyDrawer,
+	EmptyWideDrawer,
+	DrawerWithOverlay,
+	DrawerWithCloseButtonOutside,
+	DrawerWithBrandedHeader,
+	DrawerWithStickyFooter,
+	CreateProjectFormDrawer,
+	WideCreateProjectFormDrawer,
+	UserProfileDrawer,
+	FileDetailsSlideOver,
+	ContactListDrawer,
+	FileDetailsDrawer,
+} from '../demo/sections/overlays/DrawersDemo.tsx';
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+describe('EmptyDrawer', () => {
+	it('renders the drawer with open button', async () => {
+		render(<EmptyDrawer />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Open drawer' })).toBeTruthy();
+	});
+
+	it('opens drawer when button is clicked', async () => {
+		render(<EmptyDrawer />);
+		await act(async () => {});
+
+		// Click the open button
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		// Panel title should be visible
+		expect(screen.getByText('Panel title')).toBeTruthy();
+	});
+
+	it('has a close button inside the drawer', async () => {
+		render(<EmptyDrawer />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByRole('button', { name: 'Close panel' })).toBeTruthy();
+	});
+});
+
+describe('DrawerWithOverlay', () => {
+	it('renders the drawer with open button', async () => {
+		render(<DrawerWithOverlay />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+	});
+
+	it('opens drawer when button is clicked', async () => {
+		render(<DrawerWithOverlay />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByText('Panel title')).toBeTruthy();
+	});
+});
+
+describe('DrawerWithCloseButtonOutside', () => {
+	it('renders the drawer with open button', async () => {
+		render(<DrawerWithCloseButtonOutside />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+	});
+
+	it('opens drawer when button is clicked', async () => {
+		render(<DrawerWithCloseButtonOutside />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByText('Panel title')).toBeTruthy();
+	});
+});
+
+describe('DrawerWithBrandedHeader', () => {
+	it('renders the drawer with open button', async () => {
+		render(<DrawerWithBrandedHeader />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+	});
+
+	it('opens drawer with branded header', async () => {
+		render(<DrawerWithBrandedHeader />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByText('Panel title')).toBeTruthy();
+	});
+});
+
+describe('DrawerWithStickyFooter', () => {
+	it('renders the drawer with open button', async () => {
+		render(<DrawerWithStickyFooter />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+	});
+
+	it('opens drawer with Cancel and Save buttons', async () => {
+		render(<DrawerWithStickyFooter />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+	});
+});
+
+describe('CreateProjectFormDrawer', () => {
+	it('renders the drawer with open button', async () => {
+		render(<CreateProjectFormDrawer />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+	});
+
+	it('opens drawer with project form', async () => {
+		render(<CreateProjectFormDrawer />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByText('New project')).toBeTruthy();
+		expect(screen.getByText('Create')).toBeTruthy();
+	});
+});
+
+describe('UserProfileDrawer', () => {
+	it('renders the drawer with open button', async () => {
+		render(<UserProfileDrawer />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+	});
+
+	it('opens drawer with user profile content', async () => {
+		render(<UserProfileDrawer />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByText('Profile')).toBeTruthy();
+		expect(screen.getByText('Ashley Porter')).toBeTruthy();
+	});
+
+	it('has a DialogTitle for accessibility', async () => {
+		render(<UserProfileDrawer />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		// The heading should be inside a DialogTitle for accessibility
+		const dialogTitle = document.querySelector('[role="dialog"] h2, [role="dialog"] h3');
+		expect(dialogTitle).toBeTruthy();
+	});
+});
+
+describe('FileDetailsSlideOver', () => {
+	it('renders the drawer with open button', async () => {
+		render(<FileDetailsSlideOver />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open wide drawer')).toBeTruthy();
+	});
+
+	it('opens drawer with file details', async () => {
+		render(<FileDetailsSlideOver />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open wide drawer' }));
+		});
+
+		expect(screen.getByText('IMG_4985.HEIC')).toBeTruthy();
+	});
+});
+
+describe('ContactListDrawer', () => {
+	it('renders the drawer with open button', async () => {
+		render(<ContactListDrawer />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+	});
+
+	it('opens drawer with contact list', async () => {
+		render(<ContactListDrawer />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByText('Team')).toBeTruthy();
+	});
+});
+
+describe('FileDetailsDrawer', () => {
+	it('renders the drawer with open button', async () => {
+		render(<FileDetailsDrawer />);
+		await act(async () => {});
+
+		expect(screen.getByText('Open drawer')).toBeTruthy();
+	});
+
+	it('opens drawer with file details', async () => {
+		render(<FileDetailsDrawer />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+		});
+
+		expect(screen.getByText('File Details')).toBeTruthy();
+		expect(screen.getByText('design-specs.pdf')).toBeTruthy();
+	});
+});

--- a/packages/ui/tests/modal-dialogs-demo.test.tsx
+++ b/packages/ui/tests/modal-dialogs-demo.test.tsx
@@ -1,0 +1,190 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	CenteredWithSingleAction,
+	CenteredWithWideButtons,
+	SimpleAlert,
+	SimpleWithDismissButton,
+	SimpleWithGrayFooter,
+	SimpleWithLeftAlignedButtons,
+} from '../demo/sections/overlays/ModalDialogsDemo.tsx';
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+describe('CenteredWithSingleAction', () => {
+	it('renders the dialog with open button', async () => {
+		render(<CenteredWithSingleAction />);
+		await act(async () => {});
+
+		expect(screen.getByRole('button', { name: 'Open dialog' })).toBeTruthy();
+	});
+
+	it('opens dialog when button is clicked', async () => {
+		render(<CenteredWithSingleAction />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByText('Payment successful')).toBeTruthy();
+		expect(screen.getByText('Go back to dashboard')).toBeTruthy();
+	});
+
+	it('closes dialog when action button is clicked', async () => {
+		render(<CenteredWithSingleAction />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByText('Payment successful')).toBeTruthy();
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Go back to dashboard' }));
+		});
+
+		expect(screen.queryByText('Payment successful')).toBeNull();
+	});
+});
+
+describe('CenteredWithWideButtons', () => {
+	it('renders the dialog with open button', async () => {
+		render(<CenteredWithWideButtons />);
+		await act(async () => {});
+
+		expect(screen.getByRole('button', { name: 'Open dialog' })).toBeTruthy();
+	});
+
+	it('opens dialog with Deactivate and Cancel buttons', async () => {
+		render(<CenteredWithWideButtons />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByText('Payment successful')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Deactivate' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+	});
+});
+
+describe('SimpleAlert', () => {
+	it('renders the dialog with open button', async () => {
+		render(<SimpleAlert />);
+		await act(async () => {});
+
+		expect(screen.getByRole('button', { name: 'Open dialog' })).toBeTruthy();
+	});
+
+	it('opens dialog with Deactivate account message', async () => {
+		render(<SimpleAlert />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByText('Deactivate account')).toBeTruthy();
+		expect(screen.getByText('Are you sure you want to deactivate your account?')).toBeTruthy();
+	});
+
+	it('has Deactivate and Cancel buttons', async () => {
+		render(<SimpleAlert />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByRole('button', { name: 'Deactivate' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+	});
+});
+
+describe('SimpleWithDismissButton', () => {
+	it('renders the dialog with open button', async () => {
+		render(<SimpleWithDismissButton />);
+		await act(async () => {});
+
+		expect(screen.getByRole('button', { name: 'Open dialog' })).toBeTruthy();
+	});
+
+	it('opens dialog with close button', async () => {
+		render(<SimpleWithDismissButton />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByText('Deactivate account')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy();
+	});
+
+	it('closes dialog when close button is clicked', async () => {
+		render(<SimpleWithDismissButton />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByText('Deactivate account')).toBeTruthy();
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+		});
+
+		expect(screen.queryByText('Deactivate account')).toBeNull();
+	});
+});
+
+describe('SimpleWithGrayFooter', () => {
+	it('renders the dialog with open button', async () => {
+		render(<SimpleWithGrayFooter />);
+		await act(async () => {});
+
+		expect(screen.getByRole('button', { name: 'Open dialog' })).toBeTruthy();
+	});
+
+	it('opens dialog with Deactivate and Cancel buttons', async () => {
+		render(<SimpleWithGrayFooter />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByText('Deactivate account')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Deactivate' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+	});
+});
+
+describe('SimpleWithLeftAlignedButtons', () => {
+	it('renders the dialog with open button', async () => {
+		render(<SimpleWithLeftAlignedButtons />);
+		await act(async () => {});
+
+		expect(screen.getByRole('button', { name: 'Open dialog' })).toBeTruthy();
+	});
+
+	it('opens dialog with left-aligned Deactivate and Cancel buttons', async () => {
+		render(<SimpleWithLeftAlignedButtons />);
+		await act(async () => {});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+		});
+
+		expect(screen.getByText('Deactivate account')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Deactivate' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+	});
+});

--- a/packages/ui/tests/modal-dialogs-demo.test.tsx
+++ b/packages/ui/tests/modal-dialogs-demo.test.tsx
@@ -91,7 +91,7 @@ describe('SimpleAlert', () => {
 		});
 
 		expect(screen.getByText('Deactivate account')).toBeTruthy();
-		expect(screen.getByText('Are you sure you want to deactivate your account?')).toBeTruthy();
+		expect(screen.getByText(/Are you sure you want to deactivate your account\?/)).toBeTruthy();
 	});
 
 	it('has Deactivate and Cancel buttons', async () => {

--- a/packages/ui/tests/notification-demo.test.tsx
+++ b/packages/ui/tests/notification-demo.test.tsx
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	NotificationWithAvatar,
 	NotificationWithSplitButtons,
+	SimpleIconNotification,
+	CondensedNotification,
+	NotificationWithActionsBelow,
+	NotificationWithButtonsBelow,
 } from '../demo/sections/NotificationDemo.tsx';
 
 afterEach(() => {
@@ -156,5 +160,144 @@ describe('Notification dismiss behavior', () => {
 
 		// Should be visible again
 		expect(screen.getByText('Receive notifications')).toBeTruthy();
+	});
+});
+
+describe('SimpleIconNotification', () => {
+	it('renders the notification content when component mounts', async () => {
+		render(<SimpleIconNotification />);
+		await act(async () => {});
+
+		// Check that title is visible
+		expect(screen.getByText('Successfully saved!')).toBeTruthy();
+
+		// Check that description is visible
+		expect(screen.getByText('Anyone with a link can now view this file.')).toBeTruthy();
+	});
+
+	it('has a close button', async () => {
+		render(<SimpleIconNotification />);
+		await act(async () => {});
+
+		const closeBtn = screen.getByRole('button', { name: 'Close' });
+		expect(closeBtn).toBeTruthy();
+	});
+
+	it('has aria-live="assertive" on overlay container', async () => {
+		render(<SimpleIconNotification />);
+		await act(async () => {});
+
+		const liveRegion = document.querySelector('[aria-live="assertive"]');
+		expect(liveRegion).toBeTruthy();
+	});
+});
+
+describe('CondensedNotification', () => {
+	it('renders the notification content when component mounts', async () => {
+		render(<CondensedNotification />);
+		await act(async () => {});
+
+		// Check that text is visible
+		expect(screen.getByText('Discussion archived')).toBeTruthy();
+	});
+
+	it('has an Undo button', async () => {
+		render(<CondensedNotification />);
+		await act(async () => {});
+
+		const undoBtn = screen.getByRole('button', { name: 'Undo' });
+		expect(undoBtn).toBeTruthy();
+	});
+
+	it('has a close button', async () => {
+		render(<CondensedNotification />);
+		await act(async () => {});
+
+		const closeBtn = screen.getByRole('button', { name: 'Close' });
+		expect(closeBtn).toBeTruthy();
+	});
+
+	it('has aria-live="assertive" on overlay container', async () => {
+		render(<CondensedNotification />);
+		await act(async () => {});
+
+		const liveRegion = document.querySelector('[aria-live="assertive"]');
+		expect(liveRegion).toBeTruthy();
+	});
+});
+
+describe('NotificationWithActionsBelow', () => {
+	it('renders the notification content when component mounts', async () => {
+		render(<NotificationWithActionsBelow />);
+		await act(async () => {});
+
+		// Check that title is visible
+		expect(screen.getByText('Discussion moved')).toBeTruthy();
+	});
+
+	it('has Undo and Dismiss action buttons', async () => {
+		render(<NotificationWithActionsBelow />);
+		await act(async () => {});
+
+		const undoBtn = screen.getByRole('button', { name: 'Undo' });
+		const dismissBtn = screen.getByRole('button', { name: 'Dismiss' });
+		expect(undoBtn).toBeTruthy();
+		expect(dismissBtn).toBeTruthy();
+	});
+
+	it('has a close button', async () => {
+		render(<NotificationWithActionsBelow />);
+		await act(async () => {});
+
+		const closeBtn = screen.getByRole('button', { name: 'Close' });
+		expect(closeBtn).toBeTruthy();
+	});
+
+	it('has aria-live="assertive" on overlay container', async () => {
+		render(<NotificationWithActionsBelow />);
+		await act(async () => {});
+
+		const liveRegion = document.querySelector('[aria-live="assertive"]');
+		expect(liveRegion).toBeTruthy();
+	});
+});
+
+describe('NotificationWithButtonsBelow', () => {
+	it('renders the notification content when component mounts', async () => {
+		render(<NotificationWithButtonsBelow />);
+		await act(async () => {});
+
+		// Check that name is visible
+		expect(screen.getByText('Emilia Gates')).toBeTruthy();
+
+		// Check that invite text is visible
+		expect(screen.getByText('Sent you an invite to connect.')).toBeTruthy();
+	});
+
+	it('has Accept and Decline buttons', async () => {
+		render(<NotificationWithButtonsBelow />);
+		await act(async () => {});
+
+		const acceptBtn = screen.getByRole('button', { name: 'Accept' });
+		const declineBtn = screen.getByRole('button', { name: 'Decline' });
+		expect(acceptBtn).toBeTruthy();
+		expect(declineBtn).toBeTruthy();
+	});
+
+	it('has avatar image', async () => {
+		render(<NotificationWithButtonsBelow />);
+		await act(async () => {});
+
+		const img = screen.getByRole('img');
+		expect(img).toBeTruthy();
+		expect(img.getAttribute('src')).toContain('images.unsplash.com');
+	});
+
+	it('has aria-live="assertive" on overlay container', async () => {
+		render(<NotificationWithButtonsBelow />);
+		await act(async () => {});
+
+		const liveRegion = document.querySelector('[aria-live="assertive"]');
+		expect(liveRegion).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## Summary

- Add `DrawersDemo.tsx` with 12 drawer examples (empty, wide, overlay, branded header, sticky footer, project form, user profile, contact list, file details)
- Add `ModalDialogsDemo.tsx` with 6 modal dialog examples (centered single/wide, simple alert, dismiss button, gray footer, left-aligned buttons)
- Extend `NotificationDemo.tsx` with 4 headless+icon variants (simple icon, condensed, actions below, buttons below)
- Update `App.tsx` to register new overlays sections

Ports from Tailwind Application UI v4 reference examples.

## Test plan

- [x] Typecheck passes
- [x] Build succeeds
- [x] All 22 overlay examples render correctly
- [x] Drawer panels open/close with transitions
- [x] Modal dialogs work with backdrop