### PR TITLE
fix(e2e): add catch-all mock for E2E tests in dev proxy

### DIFF
--- a/.devproxy/mocks.json
+++ b/.devproxy/mocks.json
@@ -1035,6 +1035,55 @@
 			}
 		},
 		{
+			"comment": "Catch-all for E2E tests \u2014 matches any POST to messages endpoint with beta param. Must be before the generic catch-all.",
+			"request": {
+				"url": "http://127.0.0.1:8000/v1/messages?beta=true",
+				"method": "POST"
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-limit",
+						"value": "50"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-remaining",
+						"value": "49"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin (E2E test key)"
+					}
+				],
+				"body": {
+					"id": "msg_mock_e2e_test",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "[MOCKED] Hello! I'm Claude, an AI assistant."
+						}
+					],
+					"model": "claude-haiku-20250307",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 50,
+						"output_tokens": 20,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
 			"comment": "CATCH-ALL for beta messages \u2014 must be last. All probe-specific and follow-up mocks must precede this entry.",
 			"request": {
 				"url": "http://127.0.0.1:8000/v1/messages?beta=true",

--- a/.devproxy/mocks.json
+++ b/.devproxy/mocks.json
@@ -859,14 +859,11 @@
 			}
 		},
 		{
+			"comment": "Context plugin response (non-beta) - uses bodyFragment for precise substring matching",
 			"request": {
 				"url": "http://127.0.0.1:8000/v1/messages",
 				"method": "POST",
-				"body": {
-					"matcher": ".JsonContains",
-					"key": "messages",
-					"value": "/context"
-				}
+				"bodyFragment": "/context"
 			},
 			"response": {
 				"statusCode": 200,
@@ -971,14 +968,11 @@
 			}
 		},
 		{
+			"comment": "Context plugin response - uses bodyFragment for precise substring matching",
 			"request": {
 				"url": "http://127.0.0.1:8000/v1/messages?beta=true",
 				"method": "POST",
-				"body": {
-					"matcher": ".JsonContains",
-					"key": "messages",
-					"value": "/context"
-				}
+				"bodyFragment": "/context"
 			},
 			"response": {
 				"statusCode": 200,

--- a/.devproxy/mocks.json
+++ b/.devproxy/mocks.json
@@ -1078,7 +1078,7 @@
 			}
 		},
 		{
-			"comment": "CATCH-ALL for beta messages \u2014 must be last. All probe-specific and follow-up mocks must precede this entry.",
+			"comment": "CATCH-ALL for beta messages \u2014 must be last. All probe-specific and follow-up mocks must precede this entry.\n\nNOTE: Mock 22 (E2E catch-all) also matches all beta POST requests but comes first due to Dev Proxy's\nfirst-match ordering. This generic catch-all serves as a fallback for non-E2E test runs (e.g., manual\ntesting with the test API key) and ensures the mocks configuration is self-contained even when not\nrunning E2E tests.",
 			"request": {
 				"url": "http://127.0.0.1:8000/v1/messages?beta=true",
 				"method": "POST"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -997,7 +997,6 @@ jobs:
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           DEFAULT_MODEL: sonnet
           CI: true
-          NEOKAI_TEST_DISABLE_SANDBOX: "1"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -1129,7 +1128,6 @@ jobs:
             bunx playwright test "tests/${{ matrix.test.path }}.e2e.ts"
         env:
           NEOKAI_USE_DEV_PROXY: "1"
-          NEOKAI_TEST_DISABLE_SANDBOX: "1"
           ANTHROPIC_BASE_URL: "http://127.0.0.1:8000"
           ANTHROPIC_API_KEY: "sk-devproxy-test-key"
           ANTHROPIC_AUTH_TOKEN: ""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -997,6 +997,7 @@ jobs:
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           DEFAULT_MODEL: sonnet
           CI: true
+          NEOKAI_TEST_DISABLE_SANDBOX: "1"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1128,6 +1128,7 @@ jobs:
             bunx playwright test "tests/${{ matrix.test.path }}.e2e.ts"
         env:
           NEOKAI_USE_DEV_PROXY: "1"
+          NEOKAI_TEST_DISABLE_SANDBOX: "1"
           ANTHROPIC_BASE_URL: "http://127.0.0.1:8000"
           ANTHROPIC_API_KEY: "sk-devproxy-test-key"
           ANTHROPIC_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary
- Add catch-all mock for E2E tests in dev proxy to ensure all POST requests to `/v1/messages?beta=true` are properly mocked
- This fixes the `core-message-flow` E2E test which expects an assistant message to appear after sending a message

## Test plan
- Run E2E tests in CI to verify the fix