### PR TITLE
fix(e2e): add waitForWebSocketConnected to tablet responsive tests

### DIFF
--- a/packages/e2e/tests/responsive/tablet.e2e.ts
+++ b/packages/e2e/tests/responsive/tablet.e2e.ts
@@ -7,8 +7,13 @@
  */
 
 import { test, expect } from '../../fixtures';
-import { cleanupTestSession, createSessionViaUI } from '../helpers/wait-helpers';
-import { closeMobilePanel } from '../helpers/mobile-helpers';
+import {
+	cleanupTestSession,
+	createSessionViaUI,
+	waitForAssistantResponse,
+	waitForWebSocketConnected,
+} from '../helpers/wait-helpers';
+import { closeMobilePanel, openMobilePanel } from '../helpers/mobile-helpers';
 
 test.describe('Tablet Responsiveness', () => {
 	let sessionId: string | null = null;
@@ -23,6 +28,7 @@ test.describe('Tablet Responsiveness', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await expect(page.getByRole('heading', { name: 'Neo Lobby' }).first()).toBeVisible();
+		await waitForWebSocketConnected(page);
 		sessionId = null;
 	});
 
@@ -55,10 +61,13 @@ test.describe('Tablet Responsiveness', () => {
 	});
 
 	test('should create and use session on tablet', async ({ page }) => {
+		// Open the mobile panel to access the New Session button
+		await openMobilePanel(page);
+
 		// Create a session on tablet
 		sessionId = await createSessionViaUI(page);
 
-		// On tablet, close panel if it's covering the chat area
+		// Close panel to see the chat area
 		await closeMobilePanel(page);
 
 		// Type a message to verify input works on tablet


### PR DESCRIPTION
## Summary

The tablet viewport E2E test was timing out (90s) because it didn't wait for the WebSocket connection to be established before creating sessions. This is the same fix that was applied to the mobile responsive tests.

## Changes

- Add `waitForWebSocketConnected` call in `beforeEach` hook to ensure MessageHub is properly connected before any RPC calls
- Import and use `openMobilePanel` before creating sessions (matching mobile test pattern)

## Test plan

- [x] TypeScript type check passes
- [x] E2E test: tablet responsive tests should pass