### PR TITLE
feat(ui-demo): add page composition demos (detail, home, settings screens)

### DIFF
--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -70,6 +70,9 @@ import { DropdownsDemo } from './sections/elements/dropdowns/DropdownsDemo.tsx';
 import { CalendarsHeadlessDemo } from './sections/data-display/calendars/CalendarsHeadlessDemo.tsx';
 import { DrawersDemo } from './sections/overlays/DrawersDemo.tsx';
 import { ModalDialogsDemo } from './sections/overlays/ModalDialogsDemo.tsx';
+import { DetailScreensDemo } from './sections/DetailScreensDemo.tsx';
+import { HomeScreensDemo } from './sections/HomeScreensDemo.tsx';
+import { SettingsScreensDemo } from './sections/SettingsScreensDemo.tsx';
 
 interface DemoSectionProps {
 	id: string;
@@ -347,6 +350,7 @@ export function App() {
 										'forms',
 										'headings',
 										'layout',
+										'page-examples',
 									].includes(category.id)}
 								/>
 							))}
@@ -611,6 +615,17 @@ export function App() {
 					</DemoSection>
 					<DemoSection id="overlays-notifications" title="Overlays / Notifications">
 						<NotificationDemo />
+					</DemoSection>
+
+					{/* Application UI - Page Examples */}
+					<DemoSection id="page-examples-detail-screens" title="Page Examples / Detail Screens">
+						<DetailScreensDemo />
+					</DemoSection>
+					<DemoSection id="page-examples-home-screens" title="Page Examples / Home Screens">
+						<HomeScreensDemo />
+					</DemoSection>
+					<DemoSection id="page-examples-settings-screens" title="Page Examples / Settings Screens">
+						<SettingsScreensDemo />
 					</DemoSection>
 				</main>
 			</div>

--- a/packages/ui/demo/sections/DetailScreensDemo.tsx
+++ b/packages/ui/demo/sections/DetailScreensDemo.tsx
@@ -1,0 +1,1292 @@
+import { useState } from 'preact/hooks';
+import {
+	Dialog,
+	DialogPanel,
+	Label,
+	Listbox,
+	ListboxButton,
+	ListboxOption,
+	ListboxOptions,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuItems,
+	Transition,
+} from '../../src/mod.ts';
+import {
+	Bell,
+	CalendarDays,
+	CheckCircle,
+	CreditCard,
+	EllipsisVertical,
+	FileText,
+	Flame,
+	Heart,
+	Menu as MenuIcon,
+	Paperclip,
+	Smile,
+	ThumbsUp,
+	UserCircle,
+	X,
+} from 'lucide-preact';
+
+// ==========================
+// Example 1: Invoice Detail (Stacked Layout)
+// ==========================
+function DetailScreensStacked() {
+	const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+	const [selected, setSelected] = useState<{
+		name: string;
+		value: string | null;
+		icon: typeof Flame;
+		iconColor: string;
+		bgColor: string;
+	} | null>(null);
+
+	const navigation = [
+		{ name: 'Home', href: '#' },
+		{ name: 'Invoices', href: '#' },
+		{ name: 'Clients', href: '#' },
+		{ name: 'Expenses', href: '#' },
+	];
+
+	const invoice = {
+		subTotal: '$8,800.00',
+		tax: '$1,760.00',
+		total: '$10,560.00',
+		items: [
+			{
+				id: 1,
+				title: 'Logo redesign',
+				description: 'New logo and digital asset playbook.',
+				hours: '20.0',
+				rate: '$100.00',
+				price: '$2,000.00',
+			},
+			{
+				id: 2,
+				title: 'Website redesign',
+				description: 'Design and program new company website.',
+				hours: '52.0',
+				rate: '$100.00',
+				price: '$5,200.00',
+			},
+			{
+				id: 3,
+				title: 'Business cards',
+				description: 'Design and production of 3.5" x 2.0" business cards.',
+				hours: '12.0',
+				rate: '$100.00',
+				price: '$1,200.00',
+			},
+			{
+				id: 4,
+				title: 'T-shirt design',
+				description: 'Three t-shirt design concepts.',
+				hours: '4.0',
+				rate: '$100.00',
+				price: '$400.00',
+			},
+		],
+	};
+
+	const activity = [
+		{
+			id: 1,
+			type: 'created',
+			person: { name: 'Chelsea Hagon' },
+			date: '7d ago',
+			dateTime: '2023-01-23T10:32',
+		},
+		{
+			id: 2,
+			type: 'edited',
+			person: { name: 'Chelsea Hagon' },
+			date: '6d ago',
+			dateTime: '2023-01-23T11:03',
+		},
+		{
+			id: 3,
+			type: 'sent',
+			person: { name: 'Chelsea Hagon' },
+			date: '6d ago',
+			dateTime: '2023-01-23T11:24',
+		},
+		{
+			id: 4,
+			type: 'commented',
+			person: {
+				name: 'Chelsea Hagon',
+				imageUrl:
+					'https://images.unsplash.com/photo-1550525811-e5869dd03032?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			comment: 'Called client, they reassured me the invoice would be paid by the 25th.',
+			date: '3d ago',
+			dateTime: '2023-01-23T15:56',
+		},
+		{
+			id: 5,
+			type: 'viewed',
+			person: { name: 'Alex Curren' },
+			date: '2d ago',
+			dateTime: '2023-01-24T09:12',
+		},
+		{
+			id: 6,
+			type: 'paid',
+			person: { name: 'Alex Curren' },
+			date: '1d ago',
+			dateTime: '2023-01-24T09:20',
+		},
+	];
+
+	const moods = [
+		{
+			name: 'Excited',
+			value: 'excited',
+			icon: Flame,
+			iconColor: 'text-white',
+			bgColor: 'bg-red-500',
+		},
+		{ name: 'Loved', value: 'loved', icon: Heart, iconColor: 'text-white', bgColor: 'bg-pink-400' },
+		{
+			name: 'Happy',
+			value: 'happy',
+			icon: Smile,
+			iconColor: 'text-white',
+			bgColor: 'bg-green-400',
+		},
+		{ name: 'Sad', value: 'sad', icon: Smile, iconColor: 'text-white', bgColor: 'bg-yellow-400' },
+		{
+			name: 'Thumbsy',
+			value: 'thumbsy',
+			icon: ThumbsUp,
+			iconColor: 'text-white',
+			bgColor: 'bg-blue-500',
+		},
+		{
+			name: 'I feel nothing',
+			value: null,
+			icon: X,
+			iconColor: 'text-gray-400',
+			bgColor: 'bg-transparent',
+		},
+	];
+
+	function classNames(...classes: (string | boolean | undefined)[]) {
+		return classes.filter(Boolean).join(' ');
+	}
+
+	return (
+		<div class="bg-white dark:bg-gray-900 min-h-0">
+			<header class="absolute inset-x-0 top-0 z-50 flex h-16 border-b border-gray-900/10 dark:border-white/10">
+				<div class="mx-auto flex w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+					<div class="flex flex-1 items-center gap-x-6">
+						<button
+							type="button"
+							onClick={() => setMobileMenuOpen(true)}
+							class="-m-3 p-3 md:hidden"
+						>
+							<span class="sr-only">Open main menu</span>
+							<MenuIcon class="size-5 text-gray-900 dark:text-white" />
+						</button>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto not-dark:hidden"
+						/>
+					</div>
+					<nav class="hidden md:flex md:gap-x-11 md:text-sm/6 md:font-semibold md:text-gray-700 dark:md:text-gray-300">
+						{navigation.map((item, itemIdx) => (
+							<a key={itemIdx} href={item.href}>
+								{item.name}
+							</a>
+						))}
+					</nav>
+					<div class="flex flex-1 items-center justify-end gap-x-8">
+						<button
+							type="button"
+							class="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white"
+						>
+							<span class="sr-only">View notifications</span>
+							<Bell class="size-6" />
+						</button>
+						<a href="#" class="-m-1.5 p-1.5">
+							<span class="sr-only">Your profile</span>
+							<img
+								alt=""
+								src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+								class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+							/>
+						</a>
+					</div>
+				</div>
+				<Dialog open={mobileMenuOpen} onClose={setMobileMenuOpen} class="lg:hidden">
+					<div class="fixed inset-0 z-50" />
+					<DialogPanel class="fixed inset-y-0 left-0 z-50 w-full overflow-y-auto bg-white px-4 pb-6 sm:max-w-sm sm:px-6 sm:ring-1 sm:ring-gray-900/10 dark:bg-gray-900 dark:sm:ring-white/10">
+						<div class="-ml-0.5 flex h-16 items-center gap-x-6">
+							<button
+								type="button"
+								onClick={() => setMobileMenuOpen(false)}
+								class="-m-2.5 p-2.5 text-gray-700 dark:text-gray-400"
+							>
+								<span class="sr-only">Close menu</span>
+								<X class="size-6" />
+							</button>
+							<div class="-ml-0.5">
+								<a href="#" class="-m-1.5 block p-1.5">
+									<span class="sr-only">Your Company</span>
+									<img
+										alt=""
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto dark:hidden"
+									/>
+									<img
+										alt=""
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+										class="h-8 w-auto not-dark:hidden"
+									/>
+								</a>
+							</div>
+						</div>
+						<div class="mt-2 space-y-2">
+							{navigation.map((item) => (
+								<a
+									key={item.name}
+									href={item.href}
+									class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
+								>
+									{item.name}
+								</a>
+							))}
+						</div>
+					</DialogPanel>
+				</Dialog>
+			</header>
+
+			<main>
+				<header class="relative isolate pt-16">
+					<div aria-hidden="true" class="absolute inset-0 -z-10 overflow-hidden">
+						<div class="absolute top-full left-16 -mt-16 transform-gpu opacity-50 blur-3xl xl:left-1/2 xl:-ml-80 dark:opacity-30">
+							<div
+								style={{
+									clipPath:
+										'polygon(100% 38.5%, 82.6% 100%, 60.2% 37.7%, 52.4% 32.1%, 47.5% 41.8%, 45.2% 65.6%, 27.5% 23.4%, 0.1% 35.3%, 17.9% 0%, 27.7% 23.4%, 76.2% 2.5%, 74.2% 56%, 100% 38.5%)',
+								}}
+								class="aspect-1154/678 w-288.5 bg-linear-to-br from-[#FF80B5] to-[#9089FC]"
+							/>
+						</div>
+						<div class="absolute inset-x-0 bottom-0 h-px bg-gray-900/5 dark:bg-white/5" />
+					</div>
+
+					<div class="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+						<div class="mx-auto flex max-w-2xl items-center justify-between gap-x-8 lg:mx-0 lg:max-w-none">
+							<div class="flex items-center gap-x-6">
+								<img
+									alt=""
+									src="https://tailwindcss.com/plus-assets/img/logos/48x48/tuple.svg"
+									class="size-16 flex-none rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+								/>
+								<h1>
+									<div class="text-sm/6 text-gray-500 dark:text-gray-400">
+										Invoice <span class="text-gray-700 dark:text-gray-300">#00011</span>
+									</div>
+									<div class="mt-1 text-base font-semibold text-gray-900 dark:text-white">
+										Tuple, Inc
+									</div>
+								</h1>
+							</div>
+							<div class="flex items-center gap-x-4 sm:gap-x-6">
+								<button
+									type="button"
+									class="hidden text-sm/6 font-semibold text-gray-900 sm:block dark:text-white"
+								>
+									Copy URL
+								</button>
+								<a
+									href="#"
+									class="hidden text-sm/6 font-semibold text-gray-900 sm:block dark:text-white"
+								>
+									Edit
+								</a>
+								<a
+									href="#"
+									class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+								>
+									Send
+								</a>
+
+								<Menu as="div" class="relative sm:hidden">
+									<MenuButton class="relative block">
+										<span class="absolute -inset-3" />
+										<span class="sr-only">More</span>
+										<EllipsisVertical class="size-5 text-gray-500 dark:text-gray-400" />
+									</MenuButton>
+
+									<MenuItems
+										transition
+										class="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg outline-1 outline-gray-900/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+									>
+										<MenuItem>
+											<button
+												type="button"
+												class="block w-full px-3 py-1 text-left text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+											>
+												Copy URL
+											</button>
+										</MenuItem>
+										<MenuItem>
+											<a
+												href="#"
+												class="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+											>
+												Edit
+											</a>
+										</MenuItem>
+									</MenuItems>
+								</Menu>
+							</div>
+						</div>
+					</div>
+				</header>
+
+				<div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+					<div class="mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 items-start gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
+						{/* Invoice summary */}
+						<div class="lg:col-start-3 lg:row-end-1">
+							<h2 class="sr-only">Summary</h2>
+							<div class="rounded-lg bg-gray-50 shadow-xs outline-1 outline-gray-900/5 dark:bg-gray-800/50 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10">
+								<dl class="flex flex-wrap">
+									<div class="flex-auto pt-6 pl-6">
+										<dt class="text-sm/6 font-semibold text-gray-900 dark:text-white">Amount</dt>
+										<dd class="mt-1 text-base font-semibold text-gray-900 dark:text-white">
+											$10,560.00
+										</dd>
+									</div>
+									<div class="flex-none self-end px-6 pt-4">
+										<dt class="sr-only">Status</dt>
+										<dd class="rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-600 ring-1 ring-green-600/20 ring-inset dark:bg-green-500/10 dark:text-green-500 dark:ring-green-500/30">
+											Paid
+										</dd>
+									</div>
+									<div class="mt-6 flex w-full flex-none gap-x-4 border-t border-gray-900/5 px-6 pt-6 dark:border-white/10">
+										<dt class="flex-none">
+											<span class="sr-only">Client</span>
+											<UserCircle class="h-6 w-5 text-gray-400 dark:text-gray-500" />
+										</dt>
+										<dd class="text-sm/6 font-medium text-gray-900 dark:text-white">Alex Curren</dd>
+									</div>
+									<div class="mt-4 flex w-full flex-none gap-x-4 px-6">
+										<dt class="flex-none">
+											<span class="sr-only">Due date</span>
+											<CalendarDays class="h-6 w-5 text-gray-400 dark:text-gray-500" />
+										</dt>
+										<dd class="text-sm/6 text-gray-500 dark:text-gray-400">
+											<time dateTime="2023-01-31">January 31, 2023</time>
+										</dd>
+									</div>
+									<div class="mt-4 flex w-full flex-none gap-x-4 px-6">
+										<dt class="flex-none">
+											<span class="sr-only">Status</span>
+											<CreditCard class="h-6 w-5 text-gray-400 dark:text-gray-500" />
+										</dt>
+										<dd class="text-sm/6 text-gray-500 dark:text-gray-400">Paid with MasterCard</dd>
+									</div>
+								</dl>
+								<div class="mt-6 border-t border-gray-900/5 px-6 py-6 dark:border-white/10">
+									<a href="#" class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+										Download receipt <span aria-hidden="true">&rarr;</span>
+									</a>
+								</div>
+							</div>
+						</div>
+
+						{/* Invoice */}
+						<div class="-mx-4 px-4 py-8 shadow-xs ring-1 ring-gray-900/5 sm:mx-0 sm:rounded-lg sm:px-8 sm:pb-14 lg:col-span-2 lg:row-span-2 lg:row-end-2 xl:px-16 xl:pt-16 xl:pb-20 dark:shadow-none dark:ring-white/10">
+							<h2 class="text-base font-semibold text-gray-900 dark:text-white">Invoice</h2>
+							<dl class="mt-6 grid grid-cols-1 text-sm/6 sm:grid-cols-2">
+								<div class="sm:pr-4">
+									<dt class="inline text-gray-500 dark:text-gray-400">Issued on</dt>{' '}
+									<dd class="inline text-gray-700 dark:text-gray-300">
+										<time dateTime="2023-23-01">January 23, 2023</time>
+									</dd>
+								</div>
+								<div class="mt-2 sm:mt-0 sm:pl-4">
+									<dt class="inline text-gray-500 dark:text-gray-400">Due on</dt>{' '}
+									<dd class="inline text-gray-700 dark:text-gray-300">
+										<time dateTime="2023-31-01">January 31, 2023</time>
+									</dd>
+								</div>
+								<div class="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4 dark:border-white/10">
+									<dt class="font-semibold text-gray-900 dark:text-white">From</dt>
+									<dd class="mt-2 text-gray-500 dark:text-gray-400">
+										<span class="font-medium text-gray-900 dark:text-white">Acme, Inc.</span>
+										<br />
+										7363 Cynthia Pass
+										<br />
+										Toronto, ON N3Y 4H8
+									</dd>
+								</div>
+								<div class="mt-8 sm:mt-6 sm:border-t sm:border-gray-900/5 sm:pt-6 sm:pl-4 dark:sm:border-white/10">
+									<dt class="font-semibold text-gray-900 dark:text-white">To</dt>
+									<dd class="mt-2 text-gray-500 dark:text-gray-400">
+										<span class="font-medium text-gray-900 dark:text-white">Tuple, Inc</span>
+										<br />
+										886 Walter Street
+										<br />
+										New York, NY 12345
+									</dd>
+								</div>
+							</dl>
+							<table class="mt-16 w-full text-left text-sm/6 whitespace-nowrap">
+								<colgroup>
+									<col class="w-full" />
+									<col />
+									<col />
+									<col />
+								</colgroup>
+								<thead class="border-b border-gray-200 text-gray-900 dark:border-white/15 dark:text-white">
+									<tr>
+										<th scope="col" class="px-0 py-3 font-semibold">
+											Projects
+										</th>
+										<th
+											scope="col"
+											class="hidden py-3 pr-0 pl-8 text-right font-semibold sm:table-cell"
+										>
+											Hours
+										</th>
+										<th
+											scope="col"
+											class="hidden py-3 pr-0 pl-8 text-right font-semibold sm:table-cell"
+										>
+											Rate
+										</th>
+										<th scope="col" class="py-3 pr-0 pl-8 text-right font-semibold">
+											Price
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									{invoice.items.map((item) => (
+										<tr key={item.id} class="border-b border-gray-100 dark:border-white/10">
+											<td class="max-w-0 px-0 py-5 align-top">
+												<div class="truncate font-medium text-gray-900 dark:text-white">
+													{item.title}
+												</div>
+												<div class="truncate text-gray-500 dark:text-gray-400">
+													{item.description}
+												</div>
+											</td>
+											<td class="hidden py-5 pr-0 pl-8 text-right align-top text-gray-700 tabular-nums sm:table-cell dark:text-gray-300">
+												{item.hours}
+											</td>
+											<td class="hidden py-5 pr-0 pl-8 text-right align-top text-gray-700 tabular-nums sm:table-cell dark:text-gray-300">
+												{item.rate}
+											</td>
+											<td class="py-5 pr-0 pl-8 text-right align-top text-gray-700 tabular-nums dark:text-gray-300">
+												{item.price}
+											</td>
+										</tr>
+									))}
+								</tbody>
+								<tfoot>
+									<tr>
+										<th
+											scope="row"
+											class="px-0 pt-6 pb-0 font-normal text-gray-700 sm:hidden dark:text-gray-300"
+										>
+											Subtotal
+										</th>
+										<th
+											scope="row"
+											colSpan={3}
+											class="hidden px-0 pt-6 pb-0 text-right font-normal text-gray-700 sm:table-cell dark:text-gray-300"
+										>
+											Subtotal
+										</th>
+										<td class="pt-6 pr-0 pb-0 pl-8 text-right text-gray-900 tabular-nums dark:text-white">
+											{invoice.subTotal}
+										</td>
+									</tr>
+									<tr>
+										<th
+											scope="row"
+											class="pt-4 font-normal text-gray-700 sm:hidden dark:text-gray-300"
+										>
+											Tax
+										</th>
+										<th
+											scope="row"
+											colSpan={3}
+											class="hidden pt-4 text-right font-normal text-gray-700 sm:table-cell dark:text-gray-300"
+										>
+											Tax
+										</th>
+										<td class="pt-4 pr-0 pb-0 pl-8 text-right text-gray-900 tabular-nums dark:text-white">
+											{invoice.tax}
+										</td>
+									</tr>
+									<tr>
+										<th
+											scope="row"
+											class="pt-4 font-semibold text-gray-900 sm:hidden dark:text-white"
+										>
+											Total
+										</th>
+										<th
+											scope="row"
+											colSpan={3}
+											class="hidden pt-4 text-right font-semibold text-gray-900 sm:table-cell dark:text-white"
+										>
+											Total
+										</th>
+										<td class="pt-4 pr-0 pb-0 pl-8 text-right font-semibold text-gray-900 tabular-nums dark:text-white">
+											{invoice.total}
+										</td>
+									</tr>
+								</tfoot>
+							</table>
+						</div>
+
+						<div class="lg:col-start-3">
+							{/* Activity feed */}
+							<h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Activity</h2>
+							<ul role="list" class="mt-6 space-y-6">
+								{activity.map((activityItem, activityItemIdx) => (
+									<li key={activityItem.id} class="relative flex gap-x-4">
+										<div
+											class={classNames(
+												activityItemIdx === activity.length - 1 ? 'h-6' : '-bottom-6',
+												'absolute top-0 left-0 flex w-6 justify-center'
+											)}
+										>
+											<div class="w-px bg-gray-200 dark:bg-white/10" />
+										</div>
+										{activityItem.type === 'commented' ? (
+											<>
+												<img
+													alt=""
+													src={activityItem.person.imageUrl}
+													class="relative mt-3 size-6 flex-none rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+												/>
+												<div class="flex-auto rounded-md p-3 ring-1 ring-gray-200 ring-inset dark:ring-white/10">
+													<div class="flex justify-between gap-x-4">
+														<div class="py-0.5 text-xs/5 text-gray-500 dark:text-gray-400">
+															<span class="font-medium text-gray-900 dark:text-white">
+																{activityItem.person.name}
+															</span>{' '}
+															commented
+														</div>
+														<time
+															dateTime={activityItem.dateTime}
+															class="flex-none py-0.5 text-xs/5 text-gray-500 dark:text-gray-400"
+														>
+															{activityItem.date}
+														</time>
+													</div>
+													<p class="text-sm/6 text-gray-500 dark:text-gray-400">
+														{activityItem.comment}
+													</p>
+												</div>
+											</>
+										) : (
+											<>
+												<div class="relative flex size-6 flex-none items-center justify-center bg-white dark:bg-gray-900">
+													{activityItem.type === 'paid' ? (
+														<CheckCircle
+															aria-hidden="true"
+															class="size-6 text-indigo-600 dark:text-indigo-500"
+														/>
+													) : (
+														<div class="size-1.5 rounded-full bg-gray-100 ring-1 ring-gray-300 dark:bg-white/10 dark:ring-white/20" />
+													)}
+												</div>
+												<p class="flex-auto py-0.5 text-xs/5 text-gray-500 dark:text-gray-400">
+													<span class="font-medium text-gray-900 dark:text-white">
+														{activityItem.person.name}
+													</span>{' '}
+													{activityItem.type} the invoice.
+												</p>
+												<time
+													dateTime={activityItem.dateTime}
+													class="flex-none py-0.5 text-xs/5 text-gray-500 dark:text-gray-400"
+												>
+													{activityItem.date}
+												</time>
+											</>
+										)}
+									</li>
+								))}
+							</ul>
+
+							{/* New comment form */}
+							<div class="mt-6 flex gap-x-3">
+								<img
+									alt=""
+									src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+									class="size-6 flex-none rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+								/>
+								<form action="#" class="relative flex-auto">
+									<div class="overflow-hidden rounded-lg pb-12 outline-1 -outline-offset-1 outline-gray-300 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600 dark:bg-white/5 dark:outline-white/10 dark:focus-within:outline-indigo-500">
+										<label for="comment" class="sr-only">
+											Add your comment
+										</label>
+										<textarea
+											id="comment"
+											name="comment"
+											rows={2}
+											placeholder="Add your comment..."
+											class="block w-full resize-none bg-transparent px-3 py-1.5 text-base text-gray-900 placeholder:text-gray-400 focus:outline-none sm:text-sm/6 dark:text-white dark:placeholder:text-gray-500"
+											defaultValue={''}
+										/>
+									</div>
+
+									<div class="absolute inset-x-0 bottom-0 flex justify-between py-2 pr-2 pl-3">
+										<div class="flex items-center space-x-5">
+											<div class="flex items-center">
+												<button
+													type="button"
+													class="-m-2.5 flex size-10 items-center justify-center rounded-full text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-white"
+												>
+													<Paperclip class="size-5" />
+													<span class="sr-only">Attach a file</span>
+												</button>
+											</div>
+											<div class="flex items-center">
+												<Listbox value={selected} onChange={setSelected}>
+													<Label class="sr-only">Your mood</Label>
+													<div class="relative">
+														<ListboxButton class="relative -m-2.5 flex size-10 items-center justify-center rounded-full text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-white">
+															<span class="flex items-center justify-center">
+																{selected?.value === null ? (
+																	<span>
+																		<Smile aria-hidden="true" class="size-5 shrink-0" />
+																		<span class="sr-only">Add your mood</span>
+																	</span>
+																) : selected ? (
+																	<span>
+																		<span
+																			class={classNames(
+																				selected.bgColor,
+																				'flex size-8 items-center justify-center rounded-full'
+																			)}
+																		>
+																			<selected.icon
+																				aria-hidden="true"
+																				class="size-5 shrink-0 text-white"
+																			/>
+																		</span>
+																		<span class="sr-only">{selected.name}</span>
+																	</span>
+																) : (
+																	<span>
+																		<Smile aria-hidden="true" class="size-5 shrink-0" />
+																		<span class="sr-only">Add your mood</span>
+																	</span>
+																)}
+															</span>
+														</ListboxButton>
+
+														<ListboxOptions
+															transition
+															class="absolute bottom-10 z-10 -ml-6 w-60 rounded-lg bg-white py-3 text-base shadow-sm outline-1 outline-black/5 data-leave:transition data-leave:duration-100 data-leave:ease-in data-closed:data-leave:opacity-0 sm:ml-auto sm:w-64 sm:text-sm dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+														>
+															{moods.map((mood) => (
+																<ListboxOption
+																	key={mood.value ?? 'null'}
+																	value={mood}
+																	class="relative cursor-default bg-white px-3 py-2 text-gray-900 select-none data-focus:bg-gray-100 dark:bg-transparent dark:text-white dark:data-focus:bg-white/5"
+																>
+																	<div class="flex items-center">
+																		<div
+																			class={classNames(
+																				mood.bgColor,
+																				'flex size-8 items-center justify-center rounded-full'
+																			)}
+																		>
+																			<mood.icon
+																				aria-hidden="true"
+																				class={classNames(mood.iconColor, 'size-5 shrink-0')}
+																			/>
+																		</div>
+																		<span class="ml-3 block truncate font-medium">{mood.name}</span>
+																	</div>
+																</ListboxOption>
+															))}
+														</ListboxOptions>
+													</div>
+												</Listbox>
+											</div>
+										</div>
+										<button
+											type="submit"
+											class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-xs inset-ring-1 inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20"
+										>
+											Comment
+										</button>
+									</div>
+								</form>
+							</div>
+						</div>
+					</div>
+				</div>
+			</main>
+		</div>
+	);
+}
+
+// ==========================
+// Example 2: Deployment Detail (Sidebar Layout)
+// ==========================
+function DetailScreensSidebar() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	const navigation = [
+		{ name: 'Projects', href: '#', current: false },
+		{ name: 'Deployments', href: '#', current: true },
+		{ name: 'Activity', href: '#', current: false },
+		{ name: 'Domains', href: '#', current: false },
+		{ name: 'Usage', href: '#', current: false },
+		{ name: 'Settings', href: '#', current: false },
+	];
+
+	const teams = [
+		{ id: 1, name: 'Planetaria', href: '#', initial: 'P', current: false },
+		{ id: 2, name: 'Protocol', href: '#', initial: 'P', current: false },
+		{ id: 3, name: 'Tailwind Labs', href: '#', initial: 'T', current: false },
+	];
+
+	const secondaryNavigation = [
+		{ name: 'Overview', href: '#', current: true },
+		{ name: 'Activity', href: '#', current: false },
+		{ name: 'Settings', href: '#', current: false },
+		{ name: 'Collaborators', href: '#', current: false },
+		{ name: 'Notifications', href: '#', current: false },
+	];
+
+	const stats = [
+		{ name: 'Number of deploys', value: '405' },
+		{ name: 'Average deploy time', value: '3.65', unit: 'mins' },
+		{ name: 'Number of servers', value: '3' },
+		{ name: 'Success rate', value: '98.5%' },
+	];
+
+	const statuses = {
+		Completed: 'text-green-500 bg-green-500/10 dark:text-green-400 dark:bg-green-400/10',
+		Error: 'text-rose-500 bg-rose-500/10 dark:text-rose-400 dark:bg-rose-400/10',
+	};
+
+	const activityItems = [
+		{
+			user: {
+				name: 'Michael Foster',
+				imageUrl:
+					'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			commit: '2d89f0c8',
+			branch: 'main',
+			status: 'Completed',
+			duration: '25s',
+			date: '45 minutes ago',
+			dateTime: '2023-01-23T11:00',
+		},
+		{
+			user: {
+				name: 'Lindsay Walton',
+				imageUrl:
+					'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			commit: '249df660',
+			branch: 'main',
+			status: 'Completed',
+			duration: '1m 32s',
+			date: '3 hours ago',
+			dateTime: '2023-01-23T09:00',
+		},
+		{
+			user: {
+				name: 'Courtney Henry',
+				imageUrl:
+					'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			commit: '11464223',
+			branch: 'main',
+			status: 'Error',
+			duration: '1m 4s',
+			date: '12 hours ago',
+			dateTime: '2023-01-23T00:00',
+		},
+		{
+			user: {
+				name: 'Courtney Henry',
+				imageUrl:
+					'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			commit: 'dad28e95',
+			branch: 'main',
+			status: 'Completed',
+			duration: '2m 15s',
+			date: '2 days ago',
+			dateTime: '2023-01-21T13:00',
+		},
+		{
+			user: {
+				name: 'Michael Foster',
+				imageUrl:
+					'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			commit: '624bc94c',
+			branch: 'main',
+			status: 'Completed',
+			duration: '1m 12s',
+			date: '5 days ago',
+			dateTime: '2023-01-18T12:34',
+		},
+	];
+
+	function classNames(...classes: (string | boolean | undefined)[]) {
+		return classes.filter(Boolean).join(' ');
+	}
+
+	return (
+		<div class="bg-white dark:bg-gray-900 min-h-0">
+			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 xl:hidden">
+				<Transition
+					show={sidebarOpen}
+					class="fixed inset-0 bg-gray-900/80 transition-opacity duration-300 ease-linear data-closed:opacity-0"
+				>
+					<div class="fixed inset-0 flex">
+						<Transition
+							show={sidebarOpen}
+							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-closed:-translate-x-full"
+						>
+							<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-closed:opacity-0">
+								<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+									<span class="sr-only">Close sidebar</span>
+									<X class="size-6 text-white" />
+								</button>
+							</div>
+
+							{/* Sidebar component */}
+							<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-gray-50 px-6 dark:bg-gray-900 dark:ring dark:ring-white/10 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+								<div class="relative flex h-16 shrink-0 items-center">
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto dark:hidden"
+									/>
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+										class="h-8 w-auto not-dark:hidden"
+									/>
+								</div>
+								<nav class="relative flex flex-1 flex-col">
+									<ul role="list" class="flex flex-1 flex-col gap-y-7">
+										<li>
+											<ul role="list" class="-mx-2 space-y-1">
+												{navigation.map((item) => (
+													<li key={item.name}>
+														<a
+															href={item.href}
+															class={classNames(
+																item.current
+																	? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+																	: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+															)}
+														>
+															<FileText
+																aria-hidden="true"
+																class={classNames(
+																	item.current
+																		? 'text-indigo-600 dark:text-white'
+																		: 'text-gray-400 group-hover:text-indigo-600 dark:group-hover:text-white',
+																	'size-6 shrink-0'
+																)}
+															/>
+															{item.name}
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+										<li>
+											<div class="text-xs/6 font-semibold text-gray-400">Your teams</div>
+											<ul role="list" class="-mx-2 mt-2 space-y-1">
+												{teams.map((team) => (
+													<li key={team.name}>
+														<a
+															href={team.href}
+															class={classNames(
+																team.current
+																	? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+																	: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+															)}
+														>
+															<span
+																class={classNames(
+																	team.current
+																		? 'border-indigo-600 text-indigo-600 dark:border-white/20 dark:text-white'
+																		: 'border-gray-200 text-gray-400 group-hover:border-indigo-600 group-hover:text-indigo-600 dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+																	'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5'
+																)}
+															>
+																{team.initial}
+															</span>
+															<span class="truncate">{team.name}</span>
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+										<li class="-mx-6 mt-auto">
+											<a
+												href="#"
+												class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-white/5"
+											>
+												<img
+													alt=""
+													src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+													class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+												/>
+												<span class="sr-only">Your profile</span>
+												<span aria-hidden="true">Tom Cook</span>
+											</a>
+										</li>
+									</ul>
+								</nav>
+							</div>
+						</Transition>
+					</div>
+				</Transition>
+			</Dialog>
+
+			{/* Static sidebar for desktop */}
+			<div class="hidden xl:fixed xl:inset-y-0 xl:z-50 xl:flex xl:w-72 xl:flex-col dark:bg-gray-900">
+				<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-gray-50 px-6 ring-1 ring-gray-200 dark:bg-black/10 dark:ring-white/5">
+					<div class="flex h-16 shrink-0 items-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto not-dark:hidden"
+						/>
+					</div>
+					<nav class="flex flex-1 flex-col">
+						<ul role="list" class="flex flex-1 flex-col gap-y-7">
+							<li>
+								<ul role="list" class="-mx-2 space-y-1">
+									{navigation.map((item) => (
+										<li key={item.name}>
+											<a
+												href={item.href}
+												class={classNames(
+													item.current
+														? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+														: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<FileText
+													aria-hidden="true"
+													class={classNames(
+														item.current
+															? 'text-indigo-600 dark:text-white'
+															: 'text-gray-400 group-hover:text-indigo-600 dark:group-hover:text-white',
+														'size-6 shrink-0'
+													)}
+												/>
+												{item.name}
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li>
+								<div class="text-xs/6 font-semibold text-gray-500 dark:text-gray-400">
+									Your teams
+								</div>
+								<ul role="list" class="-mx-2 mt-2 space-y-1">
+									{teams.map((team) => (
+										<li key={team.name}>
+											<a
+												href={team.href}
+												class={classNames(
+													team.current
+														? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+														: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<span
+													class={classNames(
+														team.current
+															? 'border-indigo-600 text-indigo-600 dark:border-white/20 dark:text-white'
+															: 'border-gray-200 text-gray-400 group-hover:border-indigo-600 group-hover:text-indigo-600 dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+														'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5'
+													)}
+												>
+													{team.initial}
+												</span>
+												<span class="truncate">{team.name}</span>
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li class="-mx-6 mt-auto">
+								<a
+									href="#"
+									class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-white/5"
+								>
+									<img
+										alt=""
+										src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+										class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+									/>
+									<span class="sr-only">Your profile</span>
+									<span aria-hidden="true">Tom Cook</span>
+								</a>
+							</li>
+						</ul>
+					</nav>
+				</div>
+			</div>
+
+			<div class="xl:pl-72">
+				{/* Sticky search header */}
+				<div class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-6 border-b border-gray-200 bg-white px-4 shadow-xs sm:px-6 lg:px-8 dark:border-white/5 dark:bg-gray-900 dark:shadow-none">
+					<button
+						type="button"
+						onClick={() => setSidebarOpen(true)}
+						class="-m-2.5 p-2.5 text-gray-900 xl:hidden dark:text-white"
+					>
+						<span class="sr-only">Open sidebar</span>
+						<MenuIcon aria-hidden="true" class="size-5" />
+					</button>
+
+					<div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
+						<form action="#" method="GET" class="grid flex-1 grid-cols-1">
+							<input
+								name="search"
+								placeholder="Search"
+								aria-label="Search"
+								class="col-start-1 row-start-1 block size-full bg-transparent pl-8 text-base text-gray-900 outline-hidden placeholder:text-gray-400 sm:text-sm/6 dark:text-white dark:placeholder:text-gray-500"
+							/>
+							<svg
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 size-5 self-center text-gray-400 dark:text-gray-500"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+							>
+								<path
+									fill-rule="evenodd"
+									d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+									clip-rule="evenodd"
+								/>
+							</svg>
+						</form>
+					</div>
+				</div>
+
+				<main>
+					<header>
+						{/* Secondary navigation */}
+						<nav class="flex overflow-x-auto border-b border-gray-200 py-4 dark:border-white/10">
+							<ul
+								role="list"
+								class="flex min-w-full flex-none gap-x-6 px-4 text-sm/6 font-semibold text-gray-500 sm:px-6 lg:px-8 dark:text-gray-400"
+							>
+								{secondaryNavigation.map((item) => (
+									<li key={item.name}>
+										<a
+											href={item.href}
+											class={item.current ? 'text-indigo-600 dark:text-indigo-400' : ''}
+										>
+											{item.name}
+										</a>
+									</li>
+								))}
+							</ul>
+						</nav>
+
+						{/* Heading */}
+						<div class="flex flex-col items-start justify-between gap-x-8 gap-y-4 bg-gray-50 px-4 py-4 sm:flex-row sm:items-center sm:px-6 lg:px-8 dark:bg-gray-700/10">
+							<div>
+								<div class="flex items-center gap-x-3">
+									<div class="flex-none rounded-full bg-green-500/10 p-1 text-green-500 dark:bg-green-400/10 dark:text-green-400">
+										<div class="size-2 rounded-full bg-current" />
+									</div>
+									<h1 class="flex gap-x-3 text-base/7">
+										<span class="font-semibold text-gray-900 dark:text-white">Planetaria</span>
+										<span class="text-gray-400 dark:text-gray-600">/</span>
+										<span class="font-semibold text-gray-900 dark:text-white">mobile-api</span>
+									</h1>
+								</div>
+								<p class="mt-2 text-xs/6 text-gray-500 dark:text-gray-400">
+									Deploys from GitHub via main branch
+								</p>
+							</div>
+							<div class="order-first flex-none rounded-full bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-500 ring-1 ring-indigo-200 ring-inset sm:order-0 dark:bg-indigo-400/10 dark:text-indigo-400 dark:ring-indigo-400/30">
+								Production
+							</div>
+						</div>
+
+						{/* Stats */}
+						<div class="grid grid-cols-1 bg-gray-50 sm:grid-cols-2 lg:grid-cols-4 dark:bg-gray-700/10">
+							{stats.map((stat, statIdx) => (
+								<div
+									key={stat.name}
+									class={classNames(
+										statIdx % 2 === 1 ? 'sm:border-l' : statIdx === 2 ? 'lg:border-l' : '',
+										'border-t border-gray-200/50 px-4 py-6 sm:px-6 lg:px-8 dark:border-white/5'
+									)}
+								>
+									<p class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">{stat.name}</p>
+									<p class="mt-2 flex items-baseline gap-x-2">
+										<span class="text-4xl font-semibold tracking-tight text-gray-900 dark:text-white">
+											{stat.value}
+										</span>
+										{stat.unit ? (
+											<span class="text-sm text-gray-500 dark:text-gray-400">{stat.unit}</span>
+										) : null}
+									</p>
+								</div>
+							))}
+						</div>
+					</header>
+
+					{/* Activity list */}
+					<div class="border-t border-gray-200 pt-11 dark:border-white/10">
+						<h2 class="px-4 text-base/7 font-semibold text-gray-900 sm:px-6 lg:px-8 dark:text-white">
+							Latest activity
+						</h2>
+						<table class="mt-6 w-full text-left whitespace-nowrap">
+							<colgroup>
+								<col class="w-full sm:w-4/12" />
+								<col class="lg:w-4/12" />
+								<col class="lg:w-2/12" />
+								<col class="lg:w-1/12" />
+								<col class="lg:w-1/12" />
+							</colgroup>
+							<thead class="border-b border-gray-200 text-sm/6 text-gray-900 dark:border-white/10 dark:text-white">
+								<tr>
+									<th scope="col" class="py-2 pr-8 pl-4 font-semibold sm:pl-6 lg:pl-8">
+										User
+									</th>
+									<th scope="col" class="hidden py-2 pr-8 pl-0 font-semibold sm:table-cell">
+										Commit
+									</th>
+									<th
+										scope="col"
+										class="py-2 pr-4 pl-0 text-right font-semibold sm:pr-8 sm:text-left lg:pr-20"
+									>
+										Status
+									</th>
+									<th
+										scope="col"
+										class="hidden py-2 pr-8 pl-0 font-semibold md:table-cell lg:pr-20"
+									>
+										Duration
+									</th>
+									<th
+										scope="col"
+										class="hidden py-2 pr-4 pl-0 text-right font-semibold sm:table-cell sm:pr-6 lg:pr-8"
+									>
+										Deployed at
+									</th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-gray-100 dark:divide-white/5">
+								{activityItems.map((item) => (
+									<tr key={item.commit}>
+										<td class="py-4 pr-8 pl-4 sm:pl-6 lg:pl-8">
+											<div class="flex items-center gap-x-4">
+												<img
+													alt=""
+													src={item.user.imageUrl}
+													class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+												/>
+												<div class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+													{item.user.name}
+												</div>
+											</div>
+										</td>
+										<td class="hidden py-4 pr-4 pl-0 sm:table-cell sm:pr-8">
+											<div class="flex gap-x-3">
+												<div class="font-mono text-sm/6 text-gray-500 dark:text-gray-400">
+													{item.commit}
+												</div>
+												<span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-gray-300 ring-inset dark:bg-gray-400/10 dark:text-gray-400 dark:ring-gray-400/20">
+													{item.branch}
+												</span>
+											</div>
+										</td>
+										<td class="py-4 pr-4 pl-0 text-sm/6 sm:pr-8 lg:pr-20">
+											<div class="flex items-center justify-end gap-x-2 sm:justify-start">
+												<time
+													dateTime={item.dateTime}
+													class="text-gray-500 sm:hidden dark:text-gray-400"
+												>
+													{item.date}
+												</time>
+												<div
+													class={classNames(
+														statuses[item.status as keyof typeof statuses],
+														'flex-none rounded-full p-1'
+													)}
+												>
+													<div class="size-1.5 rounded-full bg-current" />
+												</div>
+												<div class="hidden text-gray-900 sm:block dark:text-white">
+													{item.status}
+												</div>
+											</div>
+										</td>
+										<td class="hidden py-4 pr-8 pl-0 text-sm/6 text-gray-500 md:table-cell lg:pr-20 dark:text-gray-400">
+											{item.duration}
+										</td>
+										<td class="hidden py-4 pr-4 pl-0 text-right text-sm/6 text-gray-500 sm:table-cell sm:pr-6 lg:pr-8 dark:text-gray-400">
+											<time dateTime={item.dateTime}>{item.date}</time>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</main>
+			</div>
+		</div>
+	);
+}
+
+export function DetailScreensDemo() {
+	return (
+		<div class="space-y-12">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Detail screen — Sidebar layout</h3>
+				<div class="page-preview rounded-xl border border-surface-border overflow-auto">
+					<DetailScreensSidebar />
+				</div>
+			</div>
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">Detail screen — Stacked layout</h3>
+				<div class="page-preview rounded-xl border border-surface-border overflow-auto">
+					<DetailScreensStacked />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/DetailScreensDemo.tsx
+++ b/packages/ui/demo/sections/DetailScreensDemo.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'preact/hooks';
 import {
 	Dialog,
+	DialogBackdrop,
 	DialogPanel,
 	Label,
 	Listbox,
@@ -12,6 +13,7 @@ import {
 	MenuItem,
 	MenuItems,
 	Transition,
+	TransitionChild,
 } from '../../src/mod.ts';
 import {
 	Bell,
@@ -857,21 +859,32 @@ function DetailScreensSidebar() {
 	return (
 		<div class="bg-white dark:bg-gray-900 min-h-0">
 			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 xl:hidden">
-				<Transition
-					show={sidebarOpen}
-					class="fixed inset-0 bg-gray-900/80 transition-opacity duration-300 ease-linear data-closed:opacity-0"
-				>
+				<Transition show={sidebarOpen}>
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-gray-900/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+					/>
+
 					<div class="fixed inset-0 flex">
-						<Transition
-							show={sidebarOpen}
-							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-closed:-translate-x-full"
+						<DialogPanel
+							transition
+							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
 						>
-							<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-closed:opacity-0">
-								<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
-									<span class="sr-only">Close sidebar</span>
-									<X class="size-6 text-white" />
-								</button>
-							</div>
+							<TransitionChild
+								enter="transition duration-300 ease-in-out"
+								enterFrom="opacity-0"
+								enterTo="opacity-100"
+								leave="transition duration-300 ease-in-out"
+								leaveFrom="opacity-100"
+								leaveTo="opacity-0"
+							>
+								<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+									<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+										<span class="sr-only">Close sidebar</span>
+										<X class="size-6 text-white" />
+									</button>
+								</div>
+							</TransitionChild>
 
 							{/* Sidebar component */}
 							<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-gray-50 px-6 dark:bg-gray-900 dark:ring dark:ring-white/10 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
@@ -964,7 +977,7 @@ function DetailScreensSidebar() {
 									</ul>
 								</nav>
 							</div>
-						</Transition>
+						</DialogPanel>
 					</div>
 				</Transition>
 			</Dialog>

--- a/packages/ui/demo/sections/HomeScreensDemo.tsx
+++ b/packages/ui/demo/sections/HomeScreensDemo.tsx
@@ -1,0 +1,1172 @@
+import { useState } from 'preact/hooks';
+import {
+	Dialog,
+	DialogBackdrop,
+	DialogPanel,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuItems,
+	Transition,
+	TransitionChild,
+} from '../../src/mod.ts';
+import {
+	ArrowRightLeft,
+	ArrowUpCircle,
+	ArrowDownCircle,
+	BarChart3,
+	Bell,
+	ChevronRight,
+	ChevronsUpDown,
+	Ellipsis,
+	FileText,
+	Folder,
+	Globe,
+	Menu as MenuIcon,
+	Plus,
+	Server,
+	Settings,
+	Signal,
+	X,
+} from 'lucide-preact';
+
+// ==========================
+// Example 1: Sidebar Layout (Cashflow Dashboard)
+// ==========================
+function HomeScreensSidebar() {
+	const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+	const navigation = [
+		{ name: 'Home', href: '#' },
+		{ name: 'Invoices', href: '#' },
+		{ name: 'Clients', href: '#' },
+		{ name: 'Expenses', href: '#' },
+	];
+	const secondaryNavigation = [
+		{ name: 'Last 7 days', href: '#', current: true },
+		{ name: 'Last 30 days', href: '#', current: false },
+		{ name: 'All-time', href: '#', current: false },
+	];
+	const stats = [
+		{ name: 'Revenue', value: '$405,091.00', change: '+4.75%', changeType: 'positive' },
+		{ name: 'Overdue invoices', value: '$12,787.00', change: '+54.02%', changeType: 'negative' },
+		{
+			name: 'Outstanding invoices',
+			value: '$245,988.00',
+			change: '-1.39%',
+			changeType: 'positive',
+		},
+		{ name: 'Expenses', value: '$30,156.00', change: '+10.18%', changeType: 'negative' },
+	];
+	const statuses: Record<string, string> = {
+		Paid: 'text-green-700 bg-green-50 ring-green-600/20 dark:bg-green-500/10 dark:text-green-500 dark:ring-green-500/10',
+		Withdraw:
+			'text-gray-600 bg-gray-50 ring-gray-500/10 dark:bg-white/5 dark:text-gray-400 dark:ring-white/10',
+		Overdue:
+			'text-red-700 bg-red-50 ring-red-600/10 dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/10',
+	};
+	const days = [
+		{
+			date: 'Today',
+			dateTime: '2023-03-22',
+			transactions: [
+				{
+					id: 1,
+					invoiceNumber: '00012',
+					href: '#',
+					amount: '$7,600.00 USD',
+					tax: '$500.00',
+					status: 'Paid',
+					client: 'Reform',
+					description: 'Website redesign',
+					icon: ArrowUpCircle,
+				},
+				{
+					id: 2,
+					invoiceNumber: '00011',
+					href: '#',
+					amount: '$10,000.00 USD',
+					status: 'Withdraw',
+					client: 'Tom Cook',
+					description: 'Salary',
+					icon: ArrowDownCircle,
+				},
+				{
+					id: 3,
+					invoiceNumber: '00009',
+					href: '#',
+					amount: '$2,000.00 USD',
+					tax: '$130.00',
+					status: 'Overdue',
+					client: 'Tuple',
+					description: 'Logo design',
+					icon: ArrowRightLeft,
+				},
+			],
+		},
+		{
+			date: 'Yesterday',
+			dateTime: '2023-03-21',
+			transactions: [
+				{
+					id: 4,
+					invoiceNumber: '00010',
+					href: '#',
+					amount: '$14,000.00 USD',
+					tax: '$900.00',
+					status: 'Paid',
+					client: 'SavvyCal',
+					description: 'Website redesign',
+					icon: ArrowUpCircle,
+				},
+			],
+		},
+	];
+	const clients = [
+		{
+			id: 1,
+			name: 'Tuple',
+			imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/tuple.svg',
+			lastInvoice: {
+				date: 'December 13, 2022',
+				dateTime: '2022-12-13',
+				amount: '$2,000.00',
+				status: 'Overdue',
+			},
+		},
+		{
+			id: 2,
+			name: 'SavvyCal',
+			imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/savvycal.svg',
+			lastInvoice: {
+				date: 'January 22, 2023',
+				dateTime: '2023-01-22',
+				amount: '$14,000.00',
+				status: 'Paid',
+			},
+		},
+		{
+			id: 3,
+			name: 'Reform',
+			imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/reform.svg',
+			lastInvoice: {
+				date: 'January 23, 2023',
+				dateTime: '2023-01-23',
+				amount: '$7,600.00',
+				status: 'Paid',
+			},
+		},
+	];
+
+	return (
+		<div class="bg-white dark:bg-gray-900">
+			<header class="absolute inset-x-0 top-0 z-50 flex h-16 border-b border-gray-900/10 dark:border-white/10">
+				<div class="mx-auto flex w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+					<div class="flex flex-1 items-center gap-x-6">
+						<button
+							type="button"
+							onClick={() => setMobileMenuOpen(true)}
+							class="-m-3 p-3 md:hidden"
+						>
+							<span class="sr-only">Open main menu</span>
+							<MenuIcon aria-hidden="true" class="size-5 text-gray-900 dark:text-white" />
+						</button>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto not-dark:hidden"
+						/>
+					</div>
+					<nav class="hidden md:flex md:gap-x-11 md:text-sm/6 md:font-semibold md:text-gray-700 dark:md:text-gray-300">
+						{navigation.map((item, itemIdx) => (
+							<a key={itemIdx} href={item.href}>
+								{item.name}
+							</a>
+						))}
+					</nav>
+					<div class="flex flex-1 items-center justify-end gap-x-8">
+						<button
+							type="button"
+							class="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500 dark:hover:text-white"
+						>
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+						<a href="#" class="-m-1.5 p-1.5">
+							<span class="sr-only">Your profile</span>
+							<img
+								alt=""
+								src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+								class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+							/>
+						</a>
+					</div>
+				</div>
+				<Dialog open={mobileMenuOpen} onClose={setMobileMenuOpen} class="lg:hidden">
+					<div class="fixed inset-0 z-50" />
+					<DialogPanel class="fixed inset-y-0 left-0 z-50 w-full overflow-y-auto bg-white px-4 pb-6 sm:max-w-sm sm:px-6 sm:ring-1 sm:ring-gray-900/10 dark:bg-gray-900 dark:sm:ring-white/10">
+						<div class="-ml-0.5 flex h-16 items-center gap-x-6">
+							<button
+								type="button"
+								onClick={() => setMobileMenuOpen(false)}
+								class="-m-2.5 p-2.5 text-gray-700 dark:text-gray-400"
+							>
+								<span class="sr-only">Close menu</span>
+								<X aria-hidden="true" class="size-6" />
+							</button>
+							<div class="-ml-0.5">
+								<a href="#" class="-m-1.5 block p-1.5">
+									<span class="sr-only">Your Company</span>
+									<img
+										alt=""
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto dark:hidden"
+									/>
+									<img
+										alt=""
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+										class="h-8 w-auto not-dark:hidden"
+									/>
+								</a>
+							</div>
+						</div>
+						<div class="mt-2 space-y-2">
+							{navigation.map((item) => (
+								<a
+									key={item.name}
+									href={item.href}
+									class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
+								>
+									{item.name}
+								</a>
+							))}
+						</div>
+					</DialogPanel>
+				</Dialog>
+			</header>
+
+			<main>
+				<div class="relative isolate overflow-hidden pt-16">
+					{/* Secondary navigation */}
+					<header class="pt-6 pb-4 sm:pb-6">
+						<div class="mx-auto flex max-w-7xl flex-wrap items-center gap-6 px-4 sm:flex-nowrap sm:px-6 lg:px-8">
+							<h1 class="text-base/7 font-semibold text-gray-900 dark:text-white">Cashflow</h1>
+							<div class="order-last flex w-full gap-x-8 text-sm/6 font-semibold sm:order-0 sm:w-auto sm:border-l sm:border-gray-200 sm:pl-6 sm:text-sm/7 dark:sm:border-white/10">
+								{secondaryNavigation.map((item) => (
+									<a
+										key={item.name}
+										href={item.href}
+										class={
+											item.current
+												? 'text-indigo-600 dark:text-indigo-400'
+												: 'text-gray-700 dark:text-gray-300'
+										}
+									>
+										{item.name}
+									</a>
+								))}
+							</div>
+							<a
+								href="#"
+								class="ml-auto flex items-center gap-x-1 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+							>
+								<Plus aria-hidden="true" class="-ml-1.5 size-5" />
+								New invoice
+							</a>
+						</div>
+					</header>
+
+					{/* Stats */}
+					<div class="border-b border-b-gray-900/10 lg:border-t lg:border-t-gray-900/5 dark:border-b-white/10 dark:lg:border-t-white/5">
+						<dl class="mx-auto grid max-w-7xl grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:px-2 xl:px-0">
+							{stats.map((stat, statIdx) => (
+								<div
+									key={stat.name}
+									class={[
+										statIdx % 2 === 1 ? 'sm:border-l' : statIdx === 2 ? 'lg:border-l' : '',
+										'flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-t border-gray-900/5 px-4 py-10 sm:px-6 lg:border-t-0 xl:px-8 dark:border-white/5',
+									]
+										.filter(Boolean)
+										.join(' ')}
+								>
+									<dt class="text-sm/6 font-medium text-gray-500 dark:text-gray-400">
+										{stat.name}
+									</dt>
+									<dd
+										class={[
+											stat.changeType === 'negative'
+												? 'text-rose-600 dark:text-rose-400'
+												: 'text-gray-700 dark:text-gray-300',
+											'text-xs font-medium',
+										]
+											.filter(Boolean)
+											.join(' ')}
+									>
+										{stat.change}
+									</dd>
+									<dd class="w-full flex-none text-3xl/10 font-medium tracking-tight text-gray-900 dark:text-white">
+										{stat.value}
+									</dd>
+								</div>
+							))}
+						</dl>
+					</div>
+
+					<div
+						aria-hidden="true"
+						class="absolute top-full left-0 -z-10 mt-96 origin-top-left translate-y-40 -rotate-90 transform-gpu opacity-20 blur-3xl sm:left-1/2 sm:-mt-10 sm:-ml-96 sm:translate-y-0 sm:rotate-0 sm:opacity-50 dark:opacity-10 dark:sm:opacity-30"
+					>
+						<div
+							style={{
+								clipPath:
+									'polygon(100% 38.5%, 82.6% 100%, 60.2% 37.7%, 52.4% 32.1%, 47.5% 41.8%, 45.2% 65.6%, 27.5% 23.4%, 0.1% 35.3%, 17.9% 0%, 27.7% 23.4%, 76.2% 2.5%, 74.2% 56%, 100% 38.5%)',
+							}}
+							class="aspect-1154/678 w-288.5 bg-linear-to-br from-[#FF80B5] to-[#9089FC]"
+						/>
+					</div>
+				</div>
+
+				<div class="space-y-16 py-16 xl:space-y-20">
+					{/* Recent activity table */}
+					<div>
+						<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+							<h2 class="mx-auto max-w-2xl text-base font-semibold text-gray-900 lg:mx-0 lg:max-w-none dark:text-white">
+								Recent activity
+							</h2>
+						</div>
+						<div class="mt-6 overflow-hidden border-t border-gray-100 dark:border-white/5">
+							<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+								<div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
+									<table class="w-full text-left">
+										<thead class="sr-only">
+											<tr>
+												<th>Amount</th>
+												<th class="hidden sm:table-cell">Client</th>
+												<th>More details</th>
+											</tr>
+										</thead>
+										<tbody>
+											{days.map((day) => (
+												<>
+													<tr key={day.dateTime} class="text-sm/6 text-gray-900 dark:text-white">
+														<th
+															scope="colgroup"
+															colSpan={3}
+															class="relative isolate py-2 font-semibold"
+														>
+															<time dateTime={day.dateTime}>{day.date}</time>
+															<div class="absolute inset-y-0 right-full -z-10 w-screen border-b border-gray-200 bg-gray-50 dark:border-white/10 dark:bg-white/2.5" />
+															<div class="absolute inset-y-0 left-0 -z-10 w-screen border-b border-gray-200 bg-gray-50 dark:border-white/10 dark:bg-white/2.5" />
+														</th>
+													</tr>
+													{day.transactions.map((transaction) => (
+														<tr key={transaction.id}>
+															<td class="relative py-5 pr-6">
+																<div class="flex gap-x-6">
+																	<transaction.icon
+																		aria-hidden="true"
+																		class="hidden h-6 w-5 flex-none text-gray-400 sm:block dark:text-gray-500"
+																	/>
+																	<div class="flex-auto">
+																		<div class="flex items-start gap-x-3">
+																			<div class="text-sm/6 font-medium text-gray-900 dark:text-white">
+																				{transaction.amount}
+																			</div>
+																			<div
+																				class={[
+																					statuses[transaction.status],
+																					'rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+																				]
+																					.filter(Boolean)
+																					.join(' ')}
+																			>
+																				{transaction.status}
+																			</div>
+																		</div>
+																		{transaction.tax ? (
+																			<div class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+																				{transaction.tax} tax
+																			</div>
+																		) : null}
+																	</div>
+																</div>
+																<div class="absolute right-full bottom-0 h-px w-screen bg-gray-100 dark:bg-white/5" />
+																<div class="absolute bottom-0 left-0 h-px w-screen bg-gray-100 dark:bg-white/5" />
+															</td>
+															<td class="hidden py-5 pr-6 sm:table-cell">
+																<div class="text-sm/6 text-gray-900 dark:text-white">
+																	{transaction.client}
+																</div>
+																<div class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+																	{transaction.description}
+																</div>
+															</td>
+															<td class="py-5 text-right">
+																<div class="flex justify-end">
+																	<a
+																		href={transaction.href}
+																		class="text-sm/6 font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+																	>
+																		View<span class="hidden sm:inline"> transaction</span>
+																		<span class="sr-only">
+																			, invoice #{transaction.invoiceNumber}, {transaction.client}
+																		</span>
+																	</a>
+																</div>
+																<div class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+																	Invoice{' '}
+																	<span class="text-gray-900 dark:text-white">
+																		#{transaction.invoiceNumber}
+																	</span>
+																</div>
+															</td>
+														</tr>
+													))}
+												</>
+											))}
+										</tbody>
+									</table>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					{/* Recent client list */}
+					<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+						<div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
+							<div class="flex items-center justify-between">
+								<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+									Recent clients
+								</h2>
+								<a
+									href="#"
+									class="text-sm/6 font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+								>
+									View all<span class="sr-only">, clients</span>
+								</a>
+							</div>
+							<ul
+								role="list"
+								class="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8"
+							>
+								{clients.map((client) => (
+									<li
+										key={client.id}
+										class="overflow-hidden rounded-xl outline outline-gray-200 dark:-outline-offset-1 dark:outline-white/10"
+									>
+										<div class="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-6 dark:border-white/10 dark:bg-gray-800/50">
+											<img
+												alt={client.name}
+												src={client.imageUrl}
+												class="size-12 flex-none rounded-lg bg-white object-cover ring-1 ring-gray-900/10 dark:bg-gray-700 dark:ring-white/10"
+											/>
+											<div class="text-sm/6 font-medium text-gray-900 dark:text-white">
+												{client.name}
+											</div>
+											<Menu as="div" class="relative ml-auto">
+												<MenuButton class="relative block text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-white">
+													<span class="absolute -inset-2.5" />
+													<span class="sr-only">Open options</span>
+													<Ellipsis aria-hidden="true" class="size-5" />
+												</MenuButton>
+												<MenuItems
+													transition
+													class="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg outline-1 outline-gray-900/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+												>
+													<MenuItem>
+														<a
+															href="#"
+															class="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+														>
+															View<span class="sr-only">, {client.name}</span>
+														</a>
+													</MenuItem>
+													<MenuItem>
+														<a
+															href="#"
+															class="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+														>
+															Edit<span class="sr-only">, {client.name}</span>
+														</a>
+													</MenuItem>
+												</MenuItems>
+											</Menu>
+										</div>
+										<dl class="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm/6 dark:divide-white/10">
+											<div class="flex justify-between gap-x-4 py-3">
+												<dt class="text-gray-500 dark:text-gray-400">Last invoice</dt>
+												<dd class="text-gray-700 dark:text-gray-300">
+													<time dateTime={client.lastInvoice.dateTime}>
+														{client.lastInvoice.date}
+													</time>
+												</dd>
+											</div>
+											<div class="flex justify-between gap-x-4 py-3">
+												<dt class="text-gray-500 dark:text-gray-400">Amount</dt>
+												<dd class="flex items-start gap-x-2">
+													<div class="font-medium text-gray-900 dark:text-white">
+														{client.lastInvoice.amount}
+													</div>
+													<div
+														class={[
+															statuses[client.lastInvoice.status],
+															'rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+														]
+															.filter(Boolean)
+															.join(' ')}
+													>
+														{client.lastInvoice.status}
+													</div>
+												</dd>
+											</div>
+										</dl>
+									</li>
+								))}
+							</ul>
+						</div>
+					</div>
+				</div>
+			</main>
+		</div>
+	);
+}
+
+// ==========================
+// Example 2: Stacked Layout (Deployments Dashboard)
+// ==========================
+function HomeScreensStacked() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	const navigation = [
+		{ name: 'Projects', href: '#', icon: Folder, current: false },
+		{ name: 'Deployments', href: '#', icon: Server, current: true },
+		{ name: 'Activity', href: '#', icon: Signal, current: false },
+		{ name: 'Domains', href: '#', icon: Globe, current: false },
+		{ name: 'Usage', href: '#', icon: BarChart3, current: false },
+		{ name: 'Settings', href: '#', icon: Settings, current: false },
+	];
+	const teams = [
+		{ id: 1, name: 'Planetaria', href: '#', initial: 'P', current: false },
+		{ id: 2, name: 'Protocol', href: '#', initial: 'P', current: false },
+		{ id: 3, name: 'Tailwind Labs', href: '#', initial: 'T', current: false },
+	];
+	const statuses: Record<string, string> = {
+		offline: 'text-gray-400 bg-gray-100 dark:text-gray-500 dark:bg-gray-100/10',
+		online: 'text-green-500 bg-green-500/10 dark:text-green-400 dark:bg-green-400/10',
+		error: 'text-rose-500 bg-rose-500/10 dark:text-rose-400 dark:bg-rose-400/10',
+	};
+	const environments: Record<string, string> = {
+		Preview:
+			'text-gray-500 bg-gray-50 ring-gray-200 dark:text-gray-400 dark:bg-gray-400/10 dark:ring-gray-400/20',
+		Production:
+			'text-indigo-500 bg-indigo-50 ring-indigo-200 dark:text-indigo-400 dark:bg-indigo-400/10 dark:ring-indigo-400/30',
+	};
+	const deployments = [
+		{
+			id: 1,
+			href: '#',
+			projectName: 'ios-app',
+			teamName: 'Planetaria',
+			status: 'offline',
+			statusText: 'Initiated 1m 32s ago',
+			description: 'Deploys from GitHub',
+			environment: 'Preview',
+		},
+		{
+			id: 2,
+			href: '#',
+			projectName: 'mobile-api',
+			teamName: 'Planetaria',
+			status: 'online',
+			statusText: 'Deployed 3m ago',
+			description: 'Deploys from GitHub',
+			environment: 'Production',
+		},
+		{
+			id: 3,
+			href: '#',
+			projectName: 'tailwindcss.com',
+			teamName: 'Tailwind Labs',
+			status: 'offline',
+			statusText: 'Deployed 3h ago',
+			description: 'Deploys from GitHub',
+			environment: 'Preview',
+		},
+		{
+			id: 4,
+			href: '#',
+			projectName: 'company-website',
+			teamName: 'Tailwind Labs',
+			status: 'online',
+			statusText: 'Deployed 1d ago',
+			description: 'Deploys from GitHub',
+			environment: 'Preview',
+		},
+		{
+			id: 5,
+			href: '#',
+			projectName: 'relay-service',
+			teamName: 'Protocol',
+			status: 'online',
+			statusText: 'Deployed 1d ago',
+			description: 'Deploys from GitHub',
+			environment: 'Production',
+		},
+		{
+			id: 6,
+			href: '#',
+			projectName: 'android-app',
+			teamName: 'Planetaria',
+			status: 'online',
+			statusText: 'Deployed 5d ago',
+			description: 'Deploys from GitHub',
+			environment: 'Preview',
+		},
+		{
+			id: 7,
+			href: '#',
+			projectName: 'api.protocol.chat',
+			teamName: 'Protocol',
+			status: 'error',
+			statusText: 'Failed to deploy 6d ago',
+			description: 'Deploys from GitHub',
+			environment: 'Preview',
+		},
+		{
+			id: 8,
+			href: '#',
+			projectName: 'planetaria.tech',
+			teamName: 'Planetaria',
+			status: 'online',
+			statusText: 'Deployed 6d ago',
+			description: 'Deploys from GitHub',
+			environment: 'Preview',
+		},
+	];
+	const activityItems = [
+		{
+			user: {
+				name: 'Michael Foster',
+				imageUrl:
+					'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			projectName: 'ios-app',
+			commit: '2d89f0c8',
+			branch: 'main',
+			date: '1h',
+			dateTime: '2023-01-23T11:00',
+		},
+		{
+			user: {
+				name: 'Lindsay Walton',
+				imageUrl:
+					'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			projectName: 'mobile-api',
+			commit: '249df660',
+			branch: 'main',
+			date: '3h',
+			dateTime: '2023-01-23T09:00',
+		},
+		{
+			user: {
+				name: 'Courtney Henry',
+				imageUrl:
+					'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			projectName: 'ios-app',
+			commit: '11464223',
+			branch: 'main',
+			date: '12h',
+			dateTime: '2023-01-23T00:00',
+		},
+		{
+			user: {
+				name: 'Courtney Henry',
+				imageUrl:
+					'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			projectName: 'company-website',
+			commit: 'dad28e95',
+			branch: 'main',
+			date: '2d',
+			dateTime: '2023-01-21T13:00',
+		},
+		{
+			user: {
+				name: 'Michael Foster',
+				imageUrl:
+					'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			projectName: 'relay-service',
+			commit: '624bc94c',
+			branch: 'main',
+			date: '5d',
+			dateTime: '2023-01-18T12:34',
+		},
+		{
+			user: {
+				name: 'Courtney Henry',
+				imageUrl:
+					'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			projectName: 'api.protocol.chat',
+			commit: 'e111f80e',
+			branch: 'main',
+			date: '1w',
+			dateTime: '2023-01-16T15:54',
+		},
+		{
+			user: {
+				name: 'Michael Foster',
+				imageUrl:
+					'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			projectName: 'api.protocol.chat',
+			commit: '5e136005',
+			branch: 'main',
+			date: '1w',
+			dateTime: '2023-01-16T11:31',
+		},
+		{
+			user: {
+				name: 'Whitney Francis',
+				imageUrl:
+					'https://images.unsplash.com/photo-1517365830460-955ce3ccd263?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+			},
+			projectName: 'ios-app',
+			commit: '5c1fd07f',
+			branch: 'main',
+			date: '2w',
+			dateTime: '2023-01-09T08:45',
+		},
+	];
+
+	return (
+		<div class="h-screen overflow-hidden bg-white dark:bg-gray-900">
+			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 xl:hidden">
+				<Transition show={sidebarOpen}>
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-gray-900/80 transition-opacity duration-300 ease-linear data-closed:opacity-0"
+					/>
+
+					<div class="fixed inset-0 flex">
+						<DialogPanel
+							transition
+							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-closed:-translate-x-full"
+						>
+							<TransitionChild
+								enter="transition duration-300 ease-in-out"
+								enterFrom="opacity-0"
+								enterTo="opacity-100"
+								leave="transition duration-300 ease-in-out"
+								leaveFrom="opacity-100"
+								leaveTo="opacity-0"
+							>
+								<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-closed:opacity-0">
+									<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+										<span class="sr-only">Close sidebar</span>
+										<X aria-hidden="true" class="size-6 text-white" />
+									</button>
+								</div>
+							</TransitionChild>
+
+							{/* Sidebar component */}
+							<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-gray-50 px-6 dark:bg-gray-900 dark:ring dark:ring-white/10 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+								<div class="relative flex h-16 shrink-0 items-center">
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto dark:hidden"
+									/>
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+										class="h-8 w-auto not-dark:hidden"
+									/>
+								</div>
+								<nav class="relative flex flex-1 flex-col">
+									<ul role="list" class="flex flex-1 flex-col gap-y-7">
+										<li>
+											<ul role="list" class="-mx-2 space-y-1">
+												{navigation.map((item) => (
+													<li key={item.name}>
+														<a
+															href={item.href}
+															class={[
+																item.current
+																	? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+																	: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold',
+															]
+																.filter(Boolean)
+																.join(' ')}
+														>
+															<item.icon
+																aria-hidden="true"
+																class={[
+																	item.current
+																		? 'text-indigo-600 dark:text-white'
+																		: 'text-gray-400 group-hover:text-indigo-600 dark:group-hover:text-white',
+																	'size-6 shrink-0',
+																]
+																	.filter(Boolean)
+																	.join(' ')}
+															/>
+															{item.name}
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+										<li>
+											<div class="text-xs/6 font-semibold text-gray-400">Your teams</div>
+											<ul role="list" class="-mx-2 mt-2 space-y-1">
+												{teams.map((team) => (
+													<li key={team.name}>
+														<a
+															href={team.href}
+															class={[
+																team.current
+																	? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+																	: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold',
+															]
+																.filter(Boolean)
+																.join(' ')}
+														>
+															<span
+																class={[
+																	team.current
+																		? 'border-indigo-600 text-indigo-600 dark:border-white/20 dark:text-white'
+																		: 'border-gray-200 text-gray-400 group-hover:border-indigo-600 group-hover:text-indigo-600 dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+																	'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5',
+																]
+																	.filter(Boolean)
+																	.join(' ')}
+															>
+																{team.initial}
+															</span>
+															<span class="truncate">{team.name}</span>
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+										<li class="-mx-6 mt-auto">
+											<a
+												href="#"
+												class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-white/5"
+											>
+												<img
+													alt=""
+													src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+													class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+												/>
+												<span class="sr-only">Your profile</span>
+												<span aria-hidden="true">Tom Cook</span>
+											</a>
+										</li>
+									</ul>
+								</nav>
+							</div>
+						</DialogPanel>
+					</div>
+				</Transition>
+			</Dialog>
+
+			{/* Static sidebar for desktop */}
+			<div class="hidden xl:fixed xl:inset-y-0 xl:z-50 xl:flex xl:w-72 xl:flex-col dark:bg-gray-900">
+				<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-gray-50 px-6 ring-1 ring-gray-200 dark:bg-black/10 dark:ring-white/5">
+					<div class="flex h-16 shrink-0 items-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto not-dark:hidden"
+						/>
+					</div>
+					<nav class="flex flex-1 flex-col">
+						<ul role="list" class="flex flex-1 flex-col gap-y-7">
+							<li>
+								<ul role="list" class="-mx-2 space-y-1">
+									{navigation.map((item) => (
+										<li key={item.name}>
+											<a
+												href={item.href}
+												class={[
+													item.current
+														? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+														: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold',
+												]
+													.filter(Boolean)
+													.join(' ')}
+											>
+												<item.icon
+													aria-hidden="true"
+													class={[
+														item.current
+															? 'text-indigo-600 dark:text-white'
+															: 'text-gray-400 group-hover:text-indigo-600 dark:group-hover:text-white',
+														'size-6 shrink-0',
+													]
+														.filter(Boolean)
+														.join(' ')}
+												/>
+												{item.name}
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li>
+								<div class="text-xs/6 font-semibold text-gray-500 dark:text-gray-400">
+									Your teams
+								</div>
+								<ul role="list" class="-mx-2 mt-2 space-y-1">
+									{teams.map((team) => (
+										<li key={team.name}>
+											<a
+												href={team.href}
+												class={[
+													team.current
+														? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+														: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold',
+												]
+													.filter(Boolean)
+													.join(' ')}
+											>
+												<span
+													class={[
+														team.current
+															? 'border-indigo-600 text-indigo-600 dark:border-white/20 dark:text-white'
+															: 'border-gray-200 text-gray-400 group-hover:border-indigo-600 group-hover:text-indigo-600 dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+														'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5',
+													]
+														.filter(Boolean)
+														.join(' ')}
+												>
+													{team.initial}
+												</span>
+												<span class="truncate">{team.name}</span>
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li class="-mx-6 mt-auto">
+								<a
+									href="#"
+									class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-white/5"
+								>
+									<img
+										alt=""
+										src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+										class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+									/>
+									<span class="sr-only">Your profile</span>
+									<span aria-hidden="true">Tom Cook</span>
+								</a>
+							</li>
+						</ul>
+					</nav>
+				</div>
+			</div>
+
+			<div class="xl:pl-72">
+				{/* Sticky search header */}
+				<div class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-6 border-b border-gray-200 bg-white px-4 shadow-xs sm:px-6 lg:px-8 dark:border-white/5 dark:bg-gray-900 dark:shadow-none">
+					<button
+						type="button"
+						onClick={() => setSidebarOpen(true)}
+						class="-m-2.5 p-2.5 text-gray-900 xl:hidden dark:text-white"
+					>
+						<span class="sr-only">Open sidebar</span>
+						<MenuIcon aria-hidden="true" class="size-5" />
+					</button>
+
+					<div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
+						<form action="#" method="GET" class="grid flex-1 grid-cols-1">
+							<input
+								name="search"
+								placeholder="Search"
+								aria-label="Search"
+								class="col-start-1 row-start-1 block size-full bg-transparent pl-8 text-base text-gray-900 outline-hidden placeholder:text-gray-400 sm:text-sm/6 dark:text-white dark:placeholder:text-gray-500"
+							/>
+							<FileText
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 size-5 self-center text-gray-400 dark:text-gray-500"
+							/>
+						</form>
+					</div>
+				</div>
+
+				<main class="lg:pr-96">
+					<header class="flex items-center justify-between border-b border-gray-200 px-4 py-4 sm:px-6 sm:py-6 lg:px-8 dark:border-white/5">
+						<h1 class="text-base/7 font-semibold text-gray-900 dark:text-white">Deployments</h1>
+
+						{/* Sort dropdown */}
+						<Menu as="div" class="relative">
+							<MenuButton class="flex items-center gap-x-1 text-sm/6 font-medium text-gray-900 dark:text-white">
+								Sort by
+								<ChevronsUpDown aria-hidden="true" class="size-5 text-gray-500" />
+							</MenuButton>
+							<MenuItems
+								transition
+								class="absolute right-0 z-10 mt-2.5 w-40 origin-top-right rounded-md bg-white py-2 shadow-lg outline-1 outline-gray-900/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+							>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+									>
+										Name
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+									>
+										Date updated
+									</a>
+								</MenuItem>
+								<MenuItem>
+									<a
+										href="#"
+										class="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+									>
+										Environment
+									</a>
+								</MenuItem>
+							</MenuItems>
+						</Menu>
+					</header>
+
+					{/* Deployment list */}
+					<ul role="list" class="divide-y divide-gray-100 dark:divide-white/5">
+						{deployments.map((deployment) => (
+							<li
+								key={deployment.id}
+								class="relative flex items-center space-x-4 px-4 py-4 sm:px-6 lg:px-8"
+							>
+								<div class="min-w-0 flex-auto">
+									<div class="flex items-center gap-x-3">
+										<div
+											class={['flex-none rounded-full p-1', statuses[deployment.status]]
+												.filter(Boolean)
+												.join(' ')}
+										>
+											<div class="size-2 rounded-full bg-current" />
+										</div>
+										<h2 class="min-w-0 text-sm/6 font-semibold text-gray-900 dark:text-white">
+											<a href={deployment.href} class="flex gap-x-2">
+												<span class="truncate">{deployment.teamName}</span>
+												<span class="text-gray-400">/</span>
+												<span class="whitespace-nowrap">{deployment.projectName}</span>
+												<span class="absolute inset-0" />
+											</a>
+										</h2>
+									</div>
+									<div class="mt-3 flex items-center gap-x-2.5 text-xs/5 text-gray-500 dark:text-gray-400">
+										<p class="truncate">{deployment.description}</p>
+										<svg
+											viewBox="0 0 2 2"
+											class="size-0.5 flex-none fill-gray-300 dark:fill-gray-500"
+										>
+											<circle r={1} cx={1} cy={1} />
+										</svg>
+										<p class="whitespace-nowrap">{deployment.statusText}</p>
+									</div>
+								</div>
+								<div
+									class={[
+										'flex-none rounded-full px-2 py-1 text-xs font-medium ring-1 ring-inset',
+										environments[deployment.environment],
+									]
+										.filter(Boolean)
+										.join(' ')}
+								>
+									{deployment.environment}
+								</div>
+								<ChevronRight aria-hidden="true" class="size-5 flex-none text-gray-400" />
+							</li>
+						))}
+					</ul>
+				</main>
+
+				{/* Activity feed */}
+				<aside class="bg-gray-50 lg:fixed lg:top-16 lg:right-0 lg:bottom-0 lg:w-96 lg:overflow-y-auto lg:border-l lg:border-gray-200 dark:bg-black/10 dark:lg:border-white/5">
+					<header class="flex items-center justify-between border-b border-gray-200 px-4 py-4 sm:px-6 sm:py-6 lg:px-8 dark:border-white/5">
+						<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Activity feed</h2>
+						<a href="#" class="text-sm/6 font-semibold text-indigo-600 dark:text-indigo-400">
+							View all
+						</a>
+					</header>
+					<ul role="list" class="divide-y divide-gray-100 dark:divide-white/5">
+						{activityItems.map((item) => (
+							<li key={item.commit} class="px-4 py-4 sm:px-6 lg:px-8">
+								<div class="flex items-center gap-x-3">
+									<img
+										alt=""
+										src={item.user.imageUrl}
+										class="size-6 flex-none rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+									/>
+									<h3 class="flex-auto truncate text-sm/6 font-semibold text-gray-900 dark:text-white">
+										{item.user.name}
+									</h3>
+									<time
+										dateTime={item.dateTime}
+										class="flex-none text-xs text-gray-500 dark:text-gray-600"
+									>
+										{item.date}
+									</time>
+								</div>
+								<p class="mt-3 truncate text-sm text-gray-500">
+									Pushed to <span class="text-gray-700 dark:text-gray-400">{item.projectName}</span>{' '}
+									(<span class="font-mono text-gray-700 dark:text-gray-400">{item.commit}</span> on{' '}
+									<span class="text-gray-700 dark:text-gray-400">{item.branch}</span>)
+								</p>
+							</li>
+						))}
+					</ul>
+				</aside>
+			</div>
+		</div>
+	);
+}
+
+export function HomeScreensDemo() {
+	return (
+		<div class="space-y-12">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Home screen — Sidebar layout (Cashflow)
+				</h3>
+				<div class="page-preview rounded-xl border border-surface-border overflow-auto">
+					<HomeScreensSidebar />
+				</div>
+			</div>
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Home screen — Stacked layout (Deployments)
+				</h3>
+				<div class="page-preview rounded-xl border border-surface-border overflow-auto xl:h-screen xl:overflow-hidden">
+					<HomeScreensStacked />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/HomeScreensDemo.tsx
+++ b/packages/ui/demo/sections/HomeScreensDemo.tsx
@@ -1163,7 +1163,7 @@ export function HomeScreensDemo() {
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">
 					Home screen — Stacked layout (Deployments)
 				</h3>
-				<div class="page-preview rounded-xl border border-surface-border overflow-auto xl:h-screen xl:overflow-hidden">
+				<div class="page-preview rounded-xl border border-surface-border overflow-auto">
 					<HomeScreensStacked />
 				</div>
 			</div>

--- a/packages/ui/demo/sections/SettingsScreensDemo.tsx
+++ b/packages/ui/demo/sections/SettingsScreensDemo.tsx
@@ -1,0 +1,987 @@
+import { useState } from 'preact/hooks';
+import { Dialog, DialogBackdrop, DialogPanel, Transition, TransitionChild } from '../../src/mod.ts';
+import {
+	BarChart3,
+	Bell,
+	Box,
+	ChevronDown,
+	CreditCard,
+	Fingerprint,
+	Folder,
+	Globe,
+	Menu,
+	Search,
+	Server,
+	Settings,
+	Signal,
+	UserCircle,
+	Users,
+	X,
+} from 'lucide-preact';
+
+// ==========================
+// Example 1: Sidebar Layout (Settings)
+// ==========================
+function SettingsScreensSidebar() {
+	const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+	const [automaticTimezone, setAutomaticTimezone] = useState(true);
+
+	const navigation = [
+		{ name: 'Home', href: '#' },
+		{ name: 'Invoices', href: '#' },
+		{ name: 'Clients', href: '#' },
+		{ name: 'Expenses', href: '#' },
+	];
+	const secondaryNavigation = [
+		{ name: 'General', href: '#', icon: UserCircle, current: true },
+		{ name: 'Security', href: '#', icon: Fingerprint, current: false },
+		{ name: 'Notifications', href: '#', icon: Bell, current: false },
+		{ name: 'Plan', href: '#', icon: Box, current: false },
+		{ name: 'Billing', href: '#', icon: CreditCard, current: false },
+		{ name: 'Team members', href: '#', icon: Users, current: false },
+	];
+
+	function classNames(...classes: (string | boolean | undefined)[]): string {
+		return classes.filter(Boolean).join(' ');
+	}
+
+	return (
+		<div class="bg-white dark:bg-gray-900">
+			<header class="absolute inset-x-0 top-0 z-50 flex h-16 border-b border-gray-900/10 dark:border-white/10 dark:bg-black/10">
+				<div class="mx-auto flex w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+					<div class="flex flex-1 items-center gap-x-6">
+						<button
+							type="button"
+							onClick={() => setMobileMenuOpen(true)}
+							class="-m-3 p-3 md:hidden"
+						>
+							<span class="sr-only">Open main menu</span>
+							<Menu aria-hidden="true" class="size-5 text-gray-900 dark:text-white" />
+						</button>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto not-dark:hidden"
+						/>
+					</div>
+					<nav class="hidden md:flex md:gap-x-11 md:text-sm/6 md:font-semibold md:text-gray-700 dark:md:text-gray-300">
+						{navigation.map((item, itemIdx) => (
+							<a key={itemIdx} href={item.href}>
+								{item.name}
+							</a>
+						))}
+					</nav>
+					<div class="flex flex-1 items-center justify-end gap-x-8">
+						<button
+							type="button"
+							class="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white"
+						>
+							<span class="sr-only">View notifications</span>
+							<Bell aria-hidden="true" class="size-6" />
+						</button>
+						<a href="#" class="-m-1.5 p-1.5">
+							<span class="sr-only">Your profile</span>
+							<img
+								alt=""
+								src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+								class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+							/>
+						</a>
+					</div>
+				</div>
+				<Dialog open={mobileMenuOpen} onClose={setMobileMenuOpen} class="lg:hidden">
+					<div class="fixed inset-0 z-50" />
+					<DialogPanel class="fixed inset-y-0 left-0 z-50 w-full overflow-y-auto bg-white px-4 pb-6 sm:max-w-sm sm:px-6 sm:ring-1 sm:ring-gray-900/10 dark:bg-gray-900 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10 dark:sm:ring-white/10">
+						<div class="relative -ml-0.5 flex h-16 items-center gap-x-6">
+							<button
+								type="button"
+								onClick={() => setMobileMenuOpen(false)}
+								class="-m-2.5 p-2.5 text-gray-700 dark:text-gray-400"
+							>
+								<span class="sr-only">Close menu</span>
+								<X aria-hidden="true" class="size-6" />
+							</button>
+							<div class="-ml-0.5">
+								<a href="#" class="-m-1.5 block p-1.5">
+									<span class="sr-only">Your Company</span>
+									<img
+										alt=""
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto dark:hidden"
+									/>
+									<img
+										alt=""
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+										class="h-8 w-auto not-dark:hidden"
+									/>
+								</a>
+							</div>
+						</div>
+						<div class="mt-2 space-y-2">
+							{navigation.map((item) => (
+								<a
+									key={item.name}
+									href={item.href}
+									class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
+								>
+									{item.name}
+								</a>
+							))}
+						</div>
+					</DialogPanel>
+				</Dialog>
+			</header>
+
+			<div class="mx-auto max-w-7xl pt-16 lg:flex lg:gap-x-16 lg:px-8">
+				<h1 class="sr-only">General Settings</h1>
+
+				<aside class="flex overflow-x-auto border-b border-gray-900/5 py-4 lg:block lg:w-64 lg:flex-none lg:border-0 lg:py-20 dark:border-white/10">
+					<nav class="flex-none px-4 sm:px-6 lg:px-0">
+						<ul role="list" class="flex gap-x-3 gap-y-1 whitespace-nowrap lg:flex-col">
+							{secondaryNavigation.map((item) => (
+								<li key={item.name}>
+									<a
+										href={item.href}
+										class={classNames(
+											item.current
+												? 'bg-gray-50 text-indigo-600 dark:bg-white/5 dark:text-white'
+												: 'text-gray-700 hover:bg-gray-50 hover:text-indigo-600 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white',
+											'group flex gap-x-3 rounded-md py-2 pr-3 pl-2 text-sm/6 font-semibold'
+										)}
+									>
+										<item.icon
+											aria-hidden="true"
+											class={classNames(
+												item.current
+													? 'text-indigo-600 dark:text-white'
+													: 'text-gray-400 group-hover:text-indigo-600 dark:text-gray-500 dark:group-hover:text-white',
+												'size-6 shrink-0'
+											)}
+										/>
+										{item.name}
+									</a>
+								</li>
+							))}
+						</ul>
+					</nav>
+				</aside>
+
+				<main class="px-4 py-16 sm:px-6 lg:flex-auto lg:px-0 lg:py-20">
+					<div class="mx-auto max-w-2xl space-y-16 sm:space-y-20 lg:mx-0 lg:max-w-none">
+						<div>
+							<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Profile</h2>
+							<p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+								This information will be displayed publicly so be careful what you share.
+							</p>
+
+							<dl class="mt-6 divide-y divide-gray-100 border-t border-gray-200 text-sm/6 dark:divide-white/5 dark:border-white/5">
+								<div class="py-6 sm:flex">
+									<dt class="font-medium text-gray-900 sm:w-64 sm:flex-none sm:pr-6 dark:text-white">
+										Full name
+									</dt>
+									<dd class="mt-1 flex justify-between gap-x-6 sm:mt-0 sm:flex-auto">
+										<div class="text-gray-900 dark:text-gray-300">Tom Cook</div>
+										<button
+											type="button"
+											class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+										>
+											Update
+										</button>
+									</dd>
+								</div>
+								<div class="py-6 sm:flex">
+									<dt class="font-medium text-gray-900 sm:w-64 sm:flex-none sm:pr-6 dark:text-white">
+										Email address
+									</dt>
+									<dd class="mt-1 flex justify-between gap-x-6 sm:mt-0 sm:flex-auto">
+										<div class="text-gray-900 dark:text-gray-300">tom.cook@example.com</div>
+										<button
+											type="button"
+											class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+										>
+											Update
+										</button>
+									</dd>
+								</div>
+								<div class="py-6 sm:flex">
+									<dt class="font-medium text-gray-900 sm:w-64 sm:flex-none sm:pr-6 dark:text-white">
+										Title
+									</dt>
+									<dd class="mt-1 flex justify-between gap-x-6 sm:mt-0 sm:flex-auto">
+										<div class="text-gray-900 dark:text-gray-300">Human Resources Manager</div>
+										<button
+											type="button"
+											class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+										>
+											Update
+										</button>
+									</dd>
+								</div>
+							</dl>
+						</div>
+
+						<div>
+							<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Bank accounts</h2>
+							<p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+								Connect bank accounts to your account.
+							</p>
+
+							<ul
+								role="list"
+								class="mt-6 divide-y divide-gray-100 border-t border-gray-200 text-sm/6 dark:divide-white/5 dark:border-white/5"
+							>
+								<li class="flex justify-between gap-x-6 py-6">
+									<div class="font-medium text-gray-900 dark:text-white">TD Canada Trust</div>
+									<button
+										type="button"
+										class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+									>
+										Update
+									</button>
+								</li>
+								<li class="flex justify-between gap-x-6 py-6">
+									<div class="font-medium text-gray-900 dark:text-white">Royal Bank of Canada</div>
+									<button
+										type="button"
+										class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+									>
+										Update
+									</button>
+								</li>
+							</ul>
+
+							<div class="flex border-t border-gray-100 pt-6 dark:border-white/5">
+								<button
+									type="button"
+									class="text-sm/6 font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+								>
+									<span aria-hidden="true">+</span> Add another bank
+								</button>
+							</div>
+						</div>
+
+						<div>
+							<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Integrations</h2>
+							<p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+								Connect applications to your account.
+							</p>
+
+							<ul
+								role="list"
+								class="mt-6 divide-y divide-gray-100 border-t border-gray-200 text-sm/6 dark:divide-white/5 dark:border-white/5"
+							>
+								<li class="flex justify-between gap-x-6 py-6">
+									<div class="font-medium text-gray-900 dark:text-white">QuickBooks</div>
+									<button
+										type="button"
+										class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+									>
+										Update
+									</button>
+								</li>
+							</ul>
+
+							<div class="flex border-t border-gray-100 pt-6 dark:border-white/5">
+								<button
+									type="button"
+									class="text-sm/6 font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+								>
+									<span aria-hidden="true">+</span> Add another application
+								</button>
+							</div>
+						</div>
+
+						<div>
+							<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+								Language and dates
+							</h2>
+							<p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+								Choose what language and date format to use throughout your account.
+							</p>
+
+							<dl class="mt-6 divide-y divide-gray-100 border-t border-gray-200 text-sm/6 dark:divide-white/5 dark:border-white/5">
+								<div class="py-6 sm:flex">
+									<dt class="font-medium text-gray-900 sm:w-64 sm:flex-none sm:pr-6 dark:text-white">
+										Language
+									</dt>
+									<dd class="mt-1 flex justify-between gap-x-6 sm:mt-0 sm:flex-auto">
+										<div class="text-gray-900 dark:text-gray-300">English</div>
+										<button
+											type="button"
+											class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+										>
+											Update
+										</button>
+									</dd>
+								</div>
+								<div class="py-6 sm:flex">
+									<dt class="font-medium text-gray-900 sm:w-64 sm:flex-none sm:pr-6 dark:text-white">
+										Date format
+									</dt>
+									<dd class="mt-1 flex justify-between gap-x-6 sm:mt-0 sm:flex-auto">
+										<div class="text-gray-900 dark:text-gray-300">DD-MM-YYYY</div>
+										<button
+											type="button"
+											class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+										>
+											Update
+										</button>
+									</dd>
+								</div>
+								<div class="flex pt-6">
+									<dt class="font-medium text-gray-900 sm:w-64 sm:flex-none sm:pr-6 dark:text-white">
+										Automatic timezone
+									</dt>
+									<dd class="flex flex-auto items-center justify-end">
+										<div
+											onClick={() => setAutomaticTimezone(!automaticTimezone)}
+											class={classNames(
+												automaticTimezone
+													? 'bg-indigo-600 dark:bg-indigo-500'
+													: 'bg-gray-200 dark:bg-white/5',
+												'relative inline-flex w-8 shrink-0 rounded-full p-px ring-1 ring-inset ring-gray-900/5 outline-offset-2 outline-indigo-600 transition-colors duration-200 ease-in-out cursor-pointer dark:ring-white/10 dark:outline-indigo-500'
+											)}
+										>
+											<span
+												class={classNames(
+													automaticTimezone ? 'translate-x-3.5' : 'translate-x-0',
+													'size-4 rounded-full bg-white shadow-xs ring-1 ring-gray-900/5 transition-transform duration-200 ease-in-out'
+												)}
+											/>
+											<input
+												type="checkbox"
+												checked={automaticTimezone}
+												onChange={() => setAutomaticTimezone(!automaticTimezone)}
+												name="automatic-timezone"
+												aria-label="Automatic timezone"
+												class="sr-only"
+											/>
+										</div>
+									</dd>
+								</div>
+							</dl>
+						</div>
+					</div>
+				</main>
+			</div>
+		</div>
+	);
+}
+
+// ==========================
+// Example 2: Stacked Layout (Account Settings)
+// ==========================
+function SettingsScreensStacked() {
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+
+	const navigation = [
+		{ name: 'Projects', href: '#', icon: Folder, current: false },
+		{ name: 'Deployments', href: '#', icon: Server, current: false },
+		{ name: 'Activity', href: '#', icon: Signal, current: false },
+		{ name: 'Domains', href: '#', icon: Globe, current: false },
+		{ name: 'Usage', href: '#', icon: BarChart3, current: false },
+		{ name: 'Settings', href: '#', icon: Settings, current: true },
+	];
+	const teams = [
+		{ id: 1, name: 'Planetaria', href: '#', initial: 'P', current: false },
+		{ id: 2, name: 'Protocol', href: '#', initial: 'P', current: false },
+		{ id: 3, name: 'Tailwind Labs', href: '#', initial: 'T', current: false },
+	];
+	const secondaryNavigation = [
+		{ name: 'Account', href: '#', current: true },
+		{ name: 'Notifications', href: '#', current: false },
+		{ name: 'Billing', href: '#', current: false },
+		{ name: 'Teams', href: '#', current: false },
+		{ name: 'Integrations', href: '#', current: false },
+	];
+
+	function classNames(...classes: (string | boolean | undefined)[]): string {
+		return classes.filter(Boolean).join(' ');
+	}
+
+	return (
+		<div class="bg-white dark:bg-gray-900">
+			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 xl:hidden">
+				<Transition>
+					<DialogBackdrop class="fixed inset-0 bg-gray-900/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0" />
+				</Transition>
+
+				<div class="fixed inset-0 flex">
+					<Transition>
+						<DialogPanel class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full">
+							<TransitionChild>
+								<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
+									<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
+										<span class="sr-only">Close sidebar</span>
+										<X aria-hidden="true" class="size-6 text-white" />
+									</button>
+								</div>
+							</TransitionChild>
+
+							<div class="relative flex grow flex-col gap-y-5 overflow-y-auto bg-gray-50 px-6 dark:bg-gray-900 dark:ring dark:ring-white/10 dark:before:pointer-events-none dark:before:absolute dark:before:inset-0 dark:before:bg-black/10">
+								<div class="relative flex h-16 shrink-0 items-center">
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+										class="h-8 w-auto dark:hidden"
+									/>
+									<img
+										alt="Your Company"
+										src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+										class="h-8 w-auto not-dark:hidden"
+									/>
+								</div>
+								<nav class="relative flex flex-1 flex-col">
+									<ul role="list" class="flex flex-1 flex-col gap-y-7">
+										<li>
+											<ul role="list" class="-mx-2 space-y-1">
+												{navigation.map((item) => (
+													<li key={item.name}>
+														<a
+															href={item.href}
+															class={classNames(
+																item.current
+																	? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+																	: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+															)}
+														>
+															<item.icon
+																aria-hidden="true"
+																class={classNames(
+																	item.current
+																		? 'text-indigo-600 dark:text-white'
+																		: 'text-gray-400 group-hover:text-indigo-600 dark:group-hover:text-white',
+																	'size-6 shrink-0'
+																)}
+															/>
+															{item.name}
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+										<li>
+											<div class="text-xs/6 font-semibold text-gray-400 dark:text-gray-400">
+												Your teams
+											</div>
+											<ul role="list" class="-mx-2 mt-2 space-y-1">
+												{teams.map((team) => (
+													<li key={team.name}>
+														<a
+															href={team.href}
+															class={classNames(
+																team.current
+																	? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+																	: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+																'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+															)}
+														>
+															<span
+																class={classNames(
+																	team.current
+																		? 'border-indigo-600 text-indigo-600 dark:border-white/20 dark:text-white'
+																		: 'border-gray-200 text-gray-400 group-hover:border-indigo-600 group-hover:text-indigo-600 dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+																	'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5'
+																)}
+															>
+																{team.initial}
+															</span>
+															<span class="truncate">{team.name}</span>
+														</a>
+													</li>
+												))}
+											</ul>
+										</li>
+										<li class="-mx-6 mt-auto">
+											<a
+												href="#"
+												class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-white/5"
+											>
+												<img
+													alt=""
+													src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+													class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+												/>
+												<span class="sr-only">Your profile</span>
+												<span aria-hidden="true">Tom Cook</span>
+											</a>
+										</li>
+									</ul>
+								</nav>
+							</div>
+						</DialogPanel>
+					</Transition>
+				</div>
+			</Dialog>
+
+			{/* Static sidebar for desktop */}
+			<div class="hidden xl:fixed xl:inset-y-0 xl:z-50 xl:flex xl:w-72 xl:flex-col dark:bg-gray-900">
+				<div class="flex grow flex-col gap-y-5 overflow-y-auto bg-gray-50 px-6 ring-1 ring-gray-200 dark:bg-black/10 dark:ring-white/5">
+					<div class="flex h-16 shrink-0 items-center">
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600"
+							class="h-8 w-auto dark:hidden"
+						/>
+						<img
+							alt="Your Company"
+							src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+							class="h-8 w-auto not-dark:hidden"
+						/>
+					</div>
+					<nav class="flex flex-1 flex-col">
+						<ul role="list" class="flex flex-1 flex-col gap-y-7">
+							<li>
+								<ul role="list" class="-mx-2 space-y-1">
+									{navigation.map((item) => (
+										<li key={item.name}>
+											<a
+												href={item.href}
+												class={classNames(
+													item.current
+														? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+														: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<item.icon
+													aria-hidden="true"
+													class={classNames(
+														item.current
+															? 'text-indigo-600 dark:text-white'
+															: 'text-gray-400 group-hover:text-indigo-600 dark:group-hover:text-white',
+														'size-6 shrink-0'
+													)}
+												/>
+												{item.name}
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li>
+								<div class="text-xs/6 font-semibold text-gray-500 dark:text-gray-400">
+									Your teams
+								</div>
+								<ul role="list" class="-mx-2 mt-2 space-y-1">
+									{teams.map((team) => (
+										<li key={team.name}>
+											<a
+												href={team.href}
+												class={classNames(
+													team.current
+														? 'bg-gray-100 text-indigo-600 dark:bg-white/5 dark:text-white'
+														: 'text-gray-700 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white',
+													'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold'
+												)}
+											>
+												<span
+													class={classNames(
+														team.current
+															? 'border-indigo-600 text-indigo-600 dark:border-white/20 dark:text-white'
+															: 'border-gray-200 text-gray-400 group-hover:border-indigo-600 group-hover:text-indigo-600 dark:border-white/10 dark:group-hover:border-white/20 dark:group-hover:text-white',
+														'flex size-6 shrink-0 items-center justify-center rounded-lg border bg-white text-[0.625rem] font-medium dark:bg-white/5'
+													)}
+												>
+													{team.initial}
+												</span>
+												<span class="truncate">{team.name}</span>
+											</a>
+										</li>
+									))}
+								</ul>
+							</li>
+							<li class="-mx-6 mt-auto">
+								<a
+									href="#"
+									class="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-white/5"
+								>
+									<img
+										alt=""
+										src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+										class="size-8 rounded-full bg-gray-100 outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+									/>
+									<span class="sr-only">Your profile</span>
+									<span aria-hidden="true">Tom Cook</span>
+								</a>
+							</li>
+						</ul>
+					</nav>
+				</div>
+			</div>
+
+			<div class="xl:pl-72">
+				{/* Sticky search header */}
+				<div class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-6 border-b border-gray-200 bg-white px-4 shadow-xs sm:px-6 lg:px-8 dark:border-white/5 dark:bg-gray-900 dark:shadow-none">
+					<button
+						type="button"
+						onClick={() => setSidebarOpen(true)}
+						class="-m-2.5 p-2.5 text-gray-900 xl:hidden dark:text-white"
+					>
+						<span class="sr-only">Open sidebar</span>
+						<Menu aria-hidden="true" class="size-5" />
+					</button>
+
+					<div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
+						<form action="#" method="GET" class="grid flex-1 grid-cols-1">
+							<input
+								name="search"
+								placeholder="Search"
+								aria-label="Search"
+								class="col-start-1 row-start-1 block size-full bg-transparent pl-8 text-base text-gray-900 outline-hidden placeholder:text-gray-400 sm:text-sm/6 dark:text-white dark:placeholder:text-gray-500"
+							/>
+							<Search
+								aria-hidden="true"
+								class="pointer-events-none col-start-1 row-start-1 size-5 self-center text-gray-400 dark:text-gray-500"
+							/>
+						</form>
+					</div>
+				</div>
+
+				<main>
+					<h1 class="sr-only">Account Settings</h1>
+
+					<header class="border-b border-gray-200 dark:border-white/5">
+						{/* Secondary navigation */}
+						<nav class="flex overflow-x-auto py-4">
+							<ul
+								role="list"
+								class="flex min-w-full flex-none gap-x-6 px-4 text-sm/6 font-semibold text-gray-500 sm:px-6 lg:px-8 dark:text-gray-400"
+							>
+								{secondaryNavigation.map((item) => (
+									<li key={item.name}>
+										<a
+											href={item.href}
+											class={item.current ? 'text-indigo-600 dark:text-indigo-400' : ''}
+										>
+											{item.name}
+										</a>
+									</li>
+								))}
+							</ul>
+						</nav>
+					</header>
+
+					{/* Settings forms */}
+					<div class="divide-y divide-gray-200 dark:divide-white/10">
+						<div class="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+							<div>
+								<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+									Personal Information
+								</h2>
+								<p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+									Use a permanent address where you can receive mail.
+								</p>
+							</div>
+
+							<form class="md:col-span-2">
+								<div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:max-w-xl sm:grid-cols-6">
+									<div class="col-span-full flex items-center gap-x-8">
+										<img
+											alt=""
+											src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+											class="size-24 flex-none rounded-lg bg-gray-100 object-cover outline -outline-offset-1 outline-black/5 dark:bg-gray-800 dark:outline-white/10"
+										/>
+										<div>
+											<button
+												type="button"
+												class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring-1 inset-ring-gray-300 hover:bg-gray-100 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20"
+											>
+												Change avatar
+											</button>
+											<p class="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+												JPG, GIF or PNG. 1MB max.
+											</p>
+										</div>
+									</div>
+
+									<div class="sm:col-span-3">
+										<label
+											htmlFor="first-name"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											First name
+										</label>
+										<div class="mt-2">
+											<input
+												id="first-name"
+												name="first-name"
+												type="text"
+												autoComplete="given-name"
+												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+											/>
+										</div>
+									</div>
+
+									<div class="sm:col-span-3">
+										<label
+											htmlFor="last-name"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											Last name
+										</label>
+										<div class="mt-2">
+											<input
+												id="last-name"
+												name="last-name"
+												type="text"
+												autoComplete="family-name"
+												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+											/>
+										</div>
+									</div>
+
+									<div class="col-span-full">
+										<label
+											htmlFor="email"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											Email address
+										</label>
+										<div class="mt-2">
+											<input
+												id="email"
+												name="email"
+												type="email"
+												autoComplete="email"
+												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+											/>
+										</div>
+									</div>
+
+									<div class="col-span-full">
+										<label
+											htmlFor="username"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											Username
+										</label>
+										<div class="mt-2">
+											<div class="flex items-center rounded-md bg-white pl-3 outline-1 -outline-offset-1 outline-gray-300 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:outline-white/10 dark:focus-within:outline-indigo-500">
+												<div class="shrink-0 text-base text-gray-500 select-none sm:text-sm/6 dark:text-gray-400">
+													example.com/
+												</div>
+												<input
+													id="username"
+													name="username"
+													type="text"
+													placeholder="janesmith"
+													class="block min-w-0 grow bg-transparent py-1.5 pr-3 pl-1 text-base text-gray-900 placeholder:text-gray-400 focus:outline-none sm:text-sm/6 dark:text-white dark:placeholder:text-gray-500"
+												/>
+											</div>
+										</div>
+									</div>
+
+									<div class="col-span-full">
+										<label
+											htmlFor="timezone"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											Timezone
+										</label>
+										<div class="mt-2 grid grid-cols-1">
+											<select
+												id="timezone"
+												name="timezone"
+												class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pr-8 pl-3 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:*:bg-gray-800 dark:focus:outline-indigo-500"
+											>
+												<option>Pacific Standard Time</option>
+												<option>Eastern Standard Time</option>
+												<option>Greenwich Mean Time</option>
+											</select>
+											<ChevronDown
+												aria-hidden="true"
+												class="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-400 sm:size-4"
+											/>
+										</div>
+									</div>
+								</div>
+
+								<div class="mt-8 flex">
+									<button
+										type="submit"
+										class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+									>
+										Save
+									</button>
+								</div>
+							</form>
+						</div>
+
+						<div class="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+							<div>
+								<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+									Change password
+								</h2>
+								<p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+									Update your password associated with your account.
+								</p>
+							</div>
+
+							<form class="md:col-span-2">
+								<div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:max-w-xl sm:grid-cols-6">
+									<div class="col-span-full">
+										<label
+											htmlFor="current-password"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											Current password
+										</label>
+										<div class="mt-2">
+											<input
+												id="current-password"
+												name="current_password"
+												type="password"
+												autoComplete="current-password"
+												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+											/>
+										</div>
+									</div>
+
+									<div class="col-span-full">
+										<label
+											htmlFor="new-password"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											New password
+										</label>
+										<div class="mt-2">
+											<input
+												id="new-password"
+												name="new_password"
+												type="password"
+												autoComplete="new-password"
+												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+											/>
+										</div>
+									</div>
+
+									<div class="col-span-full">
+										<label
+											htmlFor="confirm-password"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											Confirm password
+										</label>
+										<div class="mt-2">
+											<input
+												id="confirm-password"
+												name="confirm_password"
+												type="password"
+												autoComplete="new-password"
+												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+											/>
+										</div>
+									</div>
+								</div>
+
+								<div class="mt-8 flex">
+									<button
+										type="submit"
+										class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+									>
+										Save
+									</button>
+								</div>
+							</form>
+						</div>
+
+						<div class="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+							<div>
+								<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+									Log out other sessions
+								</h2>
+								<p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+									Please enter your password to confirm you would like to log out of your other
+									sessions across all of your devices.
+								</p>
+							</div>
+
+							<form class="md:col-span-2">
+								<div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:max-w-xl sm:grid-cols-6">
+									<div class="col-span-full">
+										<label
+											htmlFor="logout-password"
+											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+										>
+											Your password
+										</label>
+										<div class="mt-2">
+											<input
+												id="logout-password"
+												name="password"
+												type="password"
+												autoComplete="current-password"
+												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+											/>
+										</div>
+									</div>
+								</div>
+
+								<div class="mt-8 flex">
+									<button
+										type="submit"
+										class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+									>
+										Log out other sessions
+									</button>
+								</div>
+							</form>
+						</div>
+
+						<div class="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+							<div>
+								<h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+									Delete account
+								</h2>
+								<p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+									No longer want to use our service? You can delete your account here. This action
+									is not reversible. All information related to this account will be deleted
+									permanently.
+								</p>
+							</div>
+
+							<form class="flex items-start md:col-span-2">
+								<button
+									type="submit"
+									class="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 dark:bg-red-500 dark:shadow-none dark:hover:bg-red-400"
+								>
+									Yes, delete my account
+								</button>
+							</form>
+						</div>
+					</div>
+				</main>
+			</div>
+		</div>
+	);
+}
+
+export function SettingsScreensDemo() {
+	return (
+		<div class="space-y-12">
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Settings screen — Sidebar layout
+				</h3>
+				<div class="page-preview rounded-xl border border-surface-border overflow-auto">
+					<SettingsScreensSidebar />
+				</div>
+			</div>
+			<div>
+				<h3 class="text-sm font-medium text-text-tertiary mb-3">
+					Settings screen — Stacked layout (Account)
+				</h3>
+				<div class="page-preview rounded-xl border border-surface-border overflow-auto">
+					<SettingsScreensStacked />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/demo/sections/SettingsScreensDemo.tsx
+++ b/packages/ui/demo/sections/SettingsScreensDemo.tsx
@@ -407,14 +407,27 @@ function SettingsScreensStacked() {
 	return (
 		<div class="bg-white dark:bg-gray-900">
 			<Dialog open={sidebarOpen} onClose={setSidebarOpen} class="relative z-50 xl:hidden">
-				<Transition>
-					<DialogBackdrop class="fixed inset-0 bg-gray-900/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0" />
+				<Transition show={sidebarOpen}>
+					<DialogBackdrop
+						transition
+						class="fixed inset-0 bg-gray-900/80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
+					/>
 				</Transition>
 
 				<div class="fixed inset-0 flex">
-					<Transition>
-						<DialogPanel class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full">
-							<TransitionChild>
+					<Transition show={sidebarOpen}>
+						<DialogPanel
+							transition
+							class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out data-[closed]:-translate-x-full"
+						>
+							<TransitionChild
+								enter="transition duration-300 ease-in-out"
+								enterFrom="opacity-0"
+								enterTo="opacity-100"
+								leave="transition duration-300 ease-in-out"
+								leaveFrom="opacity-100"
+								leaveTo="opacity-0"
+							>
 								<div class="absolute top-0 left-full flex w-16 justify-center pt-5 duration-300 ease-in-out data-[closed]:opacity-0">
 									<button type="button" onClick={() => setSidebarOpen(false)} class="-m-2.5 p-2.5">
 										<span class="sr-only">Close sidebar</span>

--- a/packages/ui/demo/styles.css
+++ b/packages/ui/demo/styles.css
@@ -71,3 +71,13 @@
 	--color-accent-600: #4f46e5;
 	--color-accent-400: #818cf8;
 }
+
+/* Page composition preview containers */
+.page-preview {
+	height: 600px;
+	overflow: auto;
+}
+
+.dark .page-preview {
+	background-color: #111118;
+}


### PR DESCRIPTION
## Summary
- Add 3 new demo files with 6 page composition examples ported from Tailwind Application UI v4
- **DetailScreensDemo.tsx**: Invoice detail (mood picker Listbox, activity feed) + Deployment detail (stats, activity table)
- **HomeScreensDemo.tsx**: Cashflow dashboard (stats grid, transactions table, client cards with Menu) + Deployments dashboard (sidebar + activity feed)
- **SettingsScreensDemo.tsx**: Settings page (sidebar nav, description lists) + Account settings (forms, profile photo, password)
- Register all 3 new page-example sections in sidebar navigation
- Add `.page-preview` CSS class with 600px height constraint for visually contained page compositions

## Key conversions applied
- All `@heroicons` → `lucide-preact` (Menu, Bell, X, ArrowUpCircle, ArrowDownCircle, etc.)
- All `@headlessui/react` → `../../src/mod.ts` (Dialog, DialogPanel, Listbox, Menu, etc.)
- `useState` from `'preact/hooks'`
- `class` instead of `className`
- Dynamic icon rendering with Lucide components
- Controlled toggle switch using `useState`

## Test plan
- [ ] Verify all 6 page compositions render correctly
- [ ] Check sidebar sections expand/collapse
- [ ] Verify mobile menus and popovers work
- [ ] Confirm page compositions are visually contained (not infinitely tall)