### PR TITLE
Fix E2E: render WorkflowCanvas in SpaceDashboard for reviewer-feedback-loop tests

### DIFF
--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { cn } from '../../lib/utils';
+import { WorkflowCanvas } from './WorkflowCanvas';
 
 interface SpaceDashboardProps {
 	spaceId: string;
@@ -254,7 +255,7 @@ function buildGroups(tab: OverviewTab, tasks: typeof spaceStore.tasks.value): Ta
 }
 
 export function SpaceDashboard({
-	spaceId: _spaceId,
+	spaceId,
 	onOpenSpaceAgent: _onOpenSpaceAgent,
 	onSelectTask,
 	compact = false,
@@ -263,6 +264,9 @@ export function SpaceDashboard({
 	const loading = spaceStore.loading.value;
 	const space = spaceStore.space.value;
 	const tasks = [...spaceStore.tasks.value].sort((a, b) => b.updatedAt - a.updatedAt);
+
+	// Pick the most recent active run (pending or in_progress), falling back to any run
+	const activeRun = spaceStore.activeRuns.value[0] ?? spaceStore.workflowRuns.value[0] ?? null;
 
 	if (loading) {
 		return (
@@ -298,7 +302,16 @@ export function SpaceDashboard({
 
 	return (
 		<div class={cn('flex h-full min-h-0 flex-col overflow-y-auto', compact ? 'p-4' : 'p-6')}>
-			<div class="flex w-full flex-1 min-h-0 flex-col">
+			<div class="flex w-full flex-1 min-h-0 flex-col gap-6">
+				{activeRun && (
+					<section class="rounded-[28px] border border-dark-700 bg-dark-950/70 overflow-hidden">
+						<WorkflowCanvas
+							workflowId={activeRun.workflowId}
+							runId={activeRun.id}
+							spaceId={spaceId}
+						/>
+					</section>
+				)}
 				<section class="flex flex-1 min-h-[24rem] flex-col rounded-[28px] border border-dark-700 bg-dark-950/70">
 					<div class="flex items-center gap-6 border-b border-dark-700 px-6">
 						<OverviewTabButton

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -265,8 +265,11 @@ export function SpaceDashboard({
 	const space = spaceStore.space.value;
 	const tasks = [...spaceStore.tasks.value].sort((a, b) => b.updatedAt - a.updatedAt);
 
-	// Pick the most recent active run (pending or in_progress), falling back to any run
-	const activeRun = spaceStore.activeRuns.value[0] ?? spaceStore.workflowRuns.value[0] ?? null;
+	// Pick the most recent active run (pending or in_progress), falling back to the most
+	// recently updated run so we never accidentally show an older completed run's canvas.
+	const mostRecentRun =
+		[...spaceStore.workflowRuns.value].sort((a, b) => b.updatedAt - a.updatedAt)[0] ?? null;
+	const activeRun = spaceStore.activeRuns.value[0] ?? mostRecentRun;
 
 	if (loading) {
 		return (

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -6,11 +6,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import { signal } from '@preact/signals';
-import type { Space, SpaceTask } from '@neokai/shared';
+import type { Space, SpaceTask, SpaceWorkflowRun } from '@neokai/shared';
 
 let mockSpace: ReturnType<typeof signal<Space | null>>;
 let mockLoading: ReturnType<typeof signal<boolean>>;
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+let mockActiveRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
+let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
@@ -18,13 +20,37 @@ vi.mock('../../../lib/space-store', () => ({
 			space: mockSpace,
 			loading: mockLoading,
 			tasks: mockTasks,
+			activeRuns: mockActiveRuns,
+			workflowRuns: mockWorkflowRuns,
 		};
 	},
+}));
+
+// Mock WorkflowCanvas to avoid its heavy dependencies (connectionManager, gate data fetching)
+vi.mock('../WorkflowCanvas', () => ({
+	WorkflowCanvas: ({
+		workflowId,
+		runId,
+		spaceId,
+	}: {
+		workflowId: string;
+		runId?: string | null;
+		spaceId: string;
+	}) => (
+		<div
+			data-testid="workflow-canvas-svg"
+			data-workflow-id={workflowId}
+			data-run-id={runId ?? ''}
+			data-space-id={spaceId}
+		/>
+	),
 }));
 
 mockSpace = signal<Space | null>(null);
 mockLoading = signal(false);
 mockTasks = signal<SpaceTask[]>([]);
+mockActiveRuns = signal<SpaceWorkflowRun[]>([]);
+mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
 
 import { SpaceDashboard } from '../SpaceDashboard';
 
@@ -40,6 +66,26 @@ function makeSpace(overrides: Partial<Space> = {}): Space {
 		status: 'active',
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeRun(
+	id: string,
+	workflowId: string,
+	status: SpaceWorkflowRun['status'] = 'in_progress',
+	overrides: Partial<SpaceWorkflowRun> = {}
+): SpaceWorkflowRun {
+	return {
+		id,
+		spaceId: 'space-1',
+		workflowId,
+		title: `Run ${id}`,
+		status,
+		createdAt: Date.now(),
+		startedAt: Date.now(),
+		updatedAt: Date.now(),
+		completedAt: null,
 		...overrides,
 	};
 }
@@ -75,6 +121,8 @@ describe('SpaceDashboard', () => {
 		mockSpace.value = null;
 		mockLoading.value = false;
 		mockTasks.value = [];
+		mockActiveRuns.value = [];
+		mockWorkflowRuns.value = [];
 	});
 
 	afterEach(() => {
@@ -173,5 +221,34 @@ describe('SpaceDashboard', () => {
 		fireEvent.click(getByText('Done').closest('button')!);
 		fireEvent.click(getByText('Task t1').closest('button')!);
 		expect(onSelectTask).toHaveBeenCalledWith('t1');
+	});
+
+	it('renders WorkflowCanvas when there is an active run', () => {
+		mockSpace.value = makeSpace();
+		mockActiveRuns.value = [makeRun('run-1', 'wf-1', 'in_progress')];
+		const { container } = render(<SpaceDashboard spaceId="space-1" />);
+		const canvas = container.querySelector('[data-testid="workflow-canvas-svg"]');
+		expect(canvas).toBeTruthy();
+		expect(canvas?.getAttribute('data-workflow-id')).toBe('wf-1');
+		expect(canvas?.getAttribute('data-run-id')).toBe('run-1');
+		expect(canvas?.getAttribute('data-space-id')).toBe('space-1');
+	});
+
+	it('falls back to first workflowRun when no active runs exist', () => {
+		mockSpace.value = makeSpace();
+		mockActiveRuns.value = [];
+		mockWorkflowRuns.value = [makeRun('run-2', 'wf-2', 'completed')];
+		const { container } = render(<SpaceDashboard spaceId="space-1" />);
+		const canvas = container.querySelector('[data-testid="workflow-canvas-svg"]');
+		expect(canvas).toBeTruthy();
+		expect(canvas?.getAttribute('data-run-id')).toBe('run-2');
+	});
+
+	it('does not render WorkflowCanvas when no runs exist', () => {
+		mockSpace.value = makeSpace();
+		mockActiveRuns.value = [];
+		mockWorkflowRuns.value = [];
+		const { container } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(container.querySelector('[data-testid="workflow-canvas-svg"]')).toBeNull();
 	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -26,7 +26,11 @@ vi.mock('../../../lib/space-store', () => ({
 	},
 }));
 
-// Mock WorkflowCanvas to avoid its heavy dependencies (connectionManager, gate data fetching)
+// Mock WorkflowCanvas to avoid its heavy dependencies (connectionManager, gate data fetching).
+// The stub intentionally reuses data-testid="workflow-canvas-svg" — the same testid the real
+// component renders on its SVG element — so SpaceDashboard unit tests assert the canvas is
+// mounted without depending on the real component's internal rendering. If the real testid
+// changes, update this stub accordingly.
 vi.mock('../WorkflowCanvas', () => ({
 	WorkflowCanvas: ({
 		workflowId,
@@ -241,6 +245,7 @@ describe('SpaceDashboard', () => {
 		const { container } = render(<SpaceDashboard spaceId="space-1" />);
 		const canvas = container.querySelector('[data-testid="workflow-canvas-svg"]');
 		expect(canvas).toBeTruthy();
+		expect(canvas?.getAttribute('data-workflow-id')).toBe('wf-2');
 		expect(canvas?.getAttribute('data-run-id')).toBe('run-2');
 	});
 


### PR DESCRIPTION
The `WorkflowCanvas` component was fully implemented with the correct `data-testid` attributes (`workflow-canvas-svg`, `gate-icon-*`, `gate-vote-count`, `node-*`) but was never mounted in the UI. The E2E `reviewer-feedback-loop` tests navigate to `/space/{spaceId}` and assert these elements are visible, causing `expect(locator).toBeVisible()` failures.

- Imported `WorkflowCanvas` in `SpaceDashboard`
- Added canvas rendering above the task list when an active workflow run exists (falls back to any run)
- Reuses the `spaceStore.activeRuns` computed signal to pick the most relevant run