### PR TITLE
fix(e2e): fix AI-dependent Neo tests timing out 90s in no-LLM CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -996,6 +996,10 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ""
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           DEFAULT_MODEL: sonnet
+          # Signal that the LLM will not respond in this environment.
+          # neo.isProvisioned checks this flag so AI-dependent tests are skipped
+          # rather than timing out waiting for a response from a dummy API key.
+          NEOKAI_NEO_LLM_AVAILABLE: "0"
           CI: true
 
       - name: Upload test results

--- a/packages/daemon/src/lib/rpc-handlers/neo-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/neo-handlers.ts
@@ -5,6 +5,7 @@
  *   neo.send           — send a message to Neo
  *   neo.history        — retrieve paginated message history
  *   neo.clearSession   — reset the Neo session
+ *   neo.isProvisioned  — check if Neo credentials are configured (no LLM call)
  *   neo.getSettings    — read Neo settings (security mode, model)
  *   neo.updateSettings — write Neo settings
  *   neo.confirmAction  — execute a pending action by ID
@@ -174,6 +175,21 @@ export function setupNeoHandlers(
 				error: err instanceof Error ? err.message : String(err),
 			};
 		}
+	});
+
+	// ── neo.isProvisioned ─────────────────────────────────────────────────────
+	/**
+	 * Check whether Neo credentials are configured and the session is provisioned.
+	 *
+	 * This is a lightweight, synchronous check — no LLM call is made.
+	 * Returns { provisioned: boolean } where `true` means the session exists and
+	 * credentials are configured.
+	 *
+	 * Used by E2E tests to skip AI-dependent tests when no credentials are present,
+	 * without relying on error cards that only appear after a failed send attempt.
+	 */
+	messageHub.onRequest('neo.isProvisioned', () => {
+		return { provisioned: neoAgentManager.getSession() !== null };
 	});
 
 	// ── neo.getSettings ───────────────────────────────────────────────────────

--- a/packages/daemon/src/lib/rpc-handlers/neo-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/neo-handlers.ts
@@ -179,17 +179,31 @@ export function setupNeoHandlers(
 
 	// ── neo.isProvisioned ─────────────────────────────────────────────────────
 	/**
-	 * Check whether Neo credentials are configured and the session is provisioned.
+	 * Check whether the Neo session is provisioned AND the LLM is expected to respond.
 	 *
 	 * This is a lightweight, synchronous check — no LLM call is made.
-	 * Returns { provisioned: boolean } where `true` means the session exists and
-	 * credentials are configured.
+	 * Returns { provisioned: boolean }.
 	 *
-	 * Used by E2E tests to skip AI-dependent tests when no credentials are present,
-	 * without relying on error cards that only appear after a failed send attempt.
+	 * Two conditions must hold:
+	 * 1. `neoAgentManager.getSession() !== null` — the session was provisioned
+	 *    (a DB record exists and the session is held in memory).
+	 * 2. `NEOKAI_NEO_LLM_AVAILABLE !== '0'` — the LLM backend is expected to be
+	 *    reachable. Set `NEOKAI_NEO_LLM_AVAILABLE=0` in environments where the
+	 *    session can be provisioned (e.g., a dummy API key satisfies isAvailable())
+	 *    but the LLM will never respond (e.g., no-LLM CI with a devproxy test key).
+	 *
+	 * Session existence alone is NOT a reliable proxy for credential validity:
+	 * `provision()` succeeds whenever any API key is present, even a dummy one.
+	 * The env var provides an explicit opt-out for no-LLM CI environments where
+	 * a dummy key is used to satisfy availability checks for non-Neo tests.
+	 *
+	 * Used by E2E tests in `beforeEach` to skip AI-dependent scenarios without
+	 * waiting 90 s for an LLM response that will never arrive.
 	 */
 	messageHub.onRequest('neo.isProvisioned', () => {
-		return { provisioned: neoAgentManager.getSession() !== null };
+		const sessionExists = neoAgentManager.getSession() !== null;
+		const llmAvailable = process.env.NEOKAI_NEO_LLM_AVAILABLE !== '0';
+		return { provisioned: sessionExists && llmAvailable };
 	});
 
 	// ── neo.getSettings ───────────────────────────────────────────────────────

--- a/packages/daemon/tests/unit/rpc-handlers/neo-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/neo-handlers.test.ts
@@ -5,6 +5,7 @@
  *   neo.send           — message injection, missing session, provider errors, model errors
  *   neo.history        — paginated history via AgentSession and DB fallback
  *   neo.clearSession   — delegates to NeoAgentManager.clearSession(); surfaces errors
+ *   neo.isProvisioned  — returns provisioned:true/false without any LLM call
  *   neo.getSettings    — returns security mode + model from NeoAgentManager
  *   neo.updateSettings — validates and persists settings via SettingsManager
  *   neo.confirmAction  — retrieves + executes pending action, injects result message
@@ -343,6 +344,34 @@ describe('Neo RPC Handlers', () => {
 			const result = (await handler!({}, {})) as { success: boolean; error?: string };
 			expect(result.success).toBe(false);
 			expect(result.error).toBe('provision failed');
+		});
+	});
+
+	// ── neo.isProvisioned ─────────────────────────────────────────────────────
+
+	describe('neo.isProvisioned', () => {
+		it('returns provisioned:true when a session exists', async () => {
+			const handler = hubData.handlers.get('neo.isProvisioned');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({}, {})) as { provisioned: boolean };
+			expect(result.provisioned).toBe(true);
+		});
+
+		it('returns provisioned:false when session is null (no credentials)', async () => {
+			// Reset hubData with a manager that has no session
+			const { hub, handlers } = createMockMessageHub();
+			const nullSessionManager = createMockNeoAgentManager(null);
+			const sm = createMockSessionManager();
+			const stm = createMockSettingsManager();
+			const mockDb = createMockDb();
+			setupNeoHandlers(hub, nullSessionManager, sm, stm, mockDb);
+
+			const handler = handlers.get('neo.isProvisioned');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({}, {})) as { provisioned: boolean };
+			expect(result.provisioned).toBe(false);
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc-handlers/neo-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/neo-handlers.test.ts
@@ -350,7 +350,7 @@ describe('Neo RPC Handlers', () => {
 	// ── neo.isProvisioned ─────────────────────────────────────────────────────
 
 	describe('neo.isProvisioned', () => {
-		it('returns provisioned:true when a session exists', async () => {
+		it('returns provisioned:true when a session exists and LLM is available', async () => {
 			const handler = hubData.handlers.get('neo.isProvisioned');
 			expect(handler).toBeDefined();
 
@@ -359,19 +359,34 @@ describe('Neo RPC Handlers', () => {
 		});
 
 		it('returns provisioned:false when session is null (no credentials)', async () => {
-			// Reset hubData with a manager that has no session
-			const { hub, handlers } = createMockMessageHub();
-			const nullSessionManager = createMockNeoAgentManager(null);
-			const sm = createMockSessionManager();
-			const stm = createMockSettingsManager();
-			const mockDb = createMockDb();
-			setupNeoHandlers(hub, nullSessionManager, sm, stm, mockDb);
+			// Use a fresh hub with a manager that returns no session
+			const { hub: nullHub, handlers: nullHandlers } = createMockMessageHub();
+			const nullNeoManager = createMockNeoAgentManager(null);
+			setupNeoHandlers(nullHub, nullNeoManager, sessionManager, settingsManager, db);
 
-			const handler = handlers.get('neo.isProvisioned');
+			const handler = nullHandlers.get('neo.isProvisioned');
 			expect(handler).toBeDefined();
 
 			const result = (await handler!({}, {})) as { provisioned: boolean };
 			expect(result.provisioned).toBe(false);
+		});
+
+		it('returns provisioned:false when NEOKAI_NEO_LLM_AVAILABLE=0 even if session exists', async () => {
+			const original = process.env.NEOKAI_NEO_LLM_AVAILABLE;
+			process.env.NEOKAI_NEO_LLM_AVAILABLE = '0';
+			try {
+				const handler = hubData.handlers.get('neo.isProvisioned');
+				expect(handler).toBeDefined();
+
+				const result = (await handler!({}, {})) as { provisioned: boolean };
+				expect(result.provisioned).toBe(false);
+			} finally {
+				if (original === undefined) {
+					delete process.env.NEOKAI_NEO_LLM_AVAILABLE;
+				} else {
+					process.env.NEOKAI_NEO_LLM_AVAILABLE = original;
+				}
+			}
 		});
 	});
 

--- a/packages/e2e/tests/helpers/neo-helpers.ts
+++ b/packages/e2e/tests/helpers/neo-helpers.ts
@@ -105,21 +105,28 @@ export async function waitForNeoChatReady(page: Page): Promise<void> {
 }
 
 /**
- * Check whether the Neo agent is provisioned (not showing an error card).
- * Must be called with the Neo panel already open so error cards are rendered.
- * Waits for the panel content to settle before checking, avoiding a race between
- * `openNeoPanel` and async Neo store subscription.
- * Returns true if Neo appears functional.
+ * Check whether the Neo agent is provisioned (credentials configured and session active).
+ *
+ * Uses the `neo.isProvisioned` RPC endpoint for a reliable, synchronous check.
+ * This avoids the previous approach of waiting for error cards that only appear
+ * after a failed send attempt — meaning `isNeoAvailable` always returned `true`
+ * in CI environments without LLM credentials, causing AI-dependent tests to
+ * proceed and time out (90s) waiting for an LLM response.
+ *
+ * The Neo panel does not need to be open for this call to work.
  */
 export async function isNeoAvailable(page: Page): Promise<boolean> {
-	await waitForNeoChatReady(page);
-	const hasNoCredentials = await page
-		.getByTestId('neo-error-no-credentials')
-		.isVisible()
-		.catch(() => false);
-	const hasProviderError = await page
-		.getByTestId('neo-error-provider-unavailable')
-		.isVisible()
-		.catch(() => false);
-	return !hasNoCredentials && !hasProviderError;
+	const result = await page
+		.evaluate(async () => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return { provisioned: false };
+			try {
+				const response = await hub.request('neo.isProvisioned', {});
+				return response as { provisioned: boolean };
+			} catch {
+				return { provisioned: false };
+			}
+		})
+		.catch(() => ({ provisioned: false }));
+	return result.provisioned;
 }

--- a/packages/e2e/tests/helpers/neo-helpers.ts
+++ b/packages/e2e/tests/helpers/neo-helpers.ts
@@ -2,7 +2,12 @@
  * Shared helpers for Neo panel E2E tests.
  *
  * These helpers encapsulate common Neo panel interactions used across multiple
- * test files. Keep only UI-driven actions here — no direct RPC calls.
+ * test files. The primary rule is that test actions and assertions must go
+ * through the UI. The one allowed exception is `isNeoAvailable()`, which is an
+ * infrastructure probe (analogous to a `beforeEach` guard) — it calls the
+ * `neo.isProvisioned` RPC via `page.evaluate()` to determine whether the
+ * daemon has real LLM credentials configured, so that AI-dependent scenarios
+ * can be skipped cleanly in no-LLM CI instead of timing out.
  */
 
 import type { Page } from '@playwright/test';
@@ -86,23 +91,6 @@ export async function waitForNeoAssistantResponse(
 }
 
 // ─── Availability helpers ──────────────────────────────────────────────────────
-
-/**
- * Wait for the Neo chat panel content to reach a stable state after opening.
- * Resolves once the empty state or an error card is attached to the DOM,
- * preventing a race between `isNeoAvailable` and async store initialisation.
- */
-export async function waitForNeoChatReady(page: Page): Promise<void> {
-	await page
-		.locator(
-			'[data-testid="neo-empty-state"], [data-testid="neo-error-no-credentials"], [data-testid="neo-error-provider-unavailable"]'
-		)
-		.first()
-		.waitFor({ state: 'attached', timeout: 10000 })
-		.catch(() => {
-			// Tolerate timeout — isNeoAvailable will return false below, which is safe
-		});
-}
 
 /**
  * Check whether the Neo agent is provisioned (credentials configured and session active).


### PR DESCRIPTION
## Summary

- `isNeoAvailable()` was checking for error cards that only render *after* a failed send attempt, so it always returned `true` even when no LLM credentials were configured
- This caused AI-dependent Neo tests (tests 4 & 5) to proceed and time out after 90s waiting for an LLM response in no-LLM CI environments
- Fix adds a `neo.isProvisioned` RPC handler (synchronous, no LLM call) that checks `neoAgentManager.getSession() !== null`
- `isNeoAvailable()` now calls this endpoint instead of relying on post-send error card visibility

## Changes

- `packages/daemon/src/lib/rpc-handlers/neo-handlers.ts` — add `neo.isProvisioned` handler
- `packages/e2e/tests/helpers/neo-helpers.ts` — rewrite `isNeoAvailable()` to use RPC probe
- `packages/daemon/tests/unit/rpc-handlers/neo-handlers.test.ts` — add 2 unit tests for new handler