### PR TITLE
fix(e2e): exclude NeoPanel from stale dialog check in provider-model-switching test

### DIFF
--- a/packages/e2e/tests/features/global-skills.e2e.ts
+++ b/packages/e2e/tests/features/global-skills.e2e.ts
@@ -14,7 +14,7 @@
  */
 
 import { test, expect, type Page } from '../../fixtures';
-import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { waitForWebSocketConnected, getModal } from '../helpers/wait-helpers';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -64,31 +64,31 @@ async function addMcpSkill(page: Page, displayName: string): Promise<void> {
 	await addSkillButton.click();
 
 	// Wait for the dialog to open
-	await page
-		.locator('[role="dialog"] h2')
+	await getModal(page)
+		.locator('h2')
 		.filter({ hasText: 'Add Skill' })
 		.first()
 		.waitFor({ state: 'visible', timeout: 5000 });
 
 	// Fill in Display Name
-	const displayNameInput = page.locator('[role="dialog"] input[placeholder="e.g., Web Search"]');
+	const displayNameInput = getModal(page).locator('input[placeholder="e.g., Web Search"]');
 	await displayNameInput.waitFor({ state: 'visible', timeout: 5000 });
 	await displayNameInput.fill(displayName);
 
 	// Select "MCP Server" source type radio
-	const mcpServerRadio = page.locator('[role="dialog"] input[type="radio"][value="mcp_server"]');
+	const mcpServerRadio = getModal(page).locator('input[type="radio"][value="mcp_server"]');
 	await mcpServerRadio.click();
 
 	// Wait for the MCP server select dropdown to appear
-	const mcpSelect = page.locator('[role="dialog"] select');
+	const mcpSelect = getModal(page).locator('select');
 	await mcpSelect.waitFor({ state: 'visible', timeout: 5000 });
 
 	// Select the fetch-mcp option
 	await mcpSelect.selectOption({ label: TEST_MCP_SERVER_NAME });
 
 	// Click the submit button inside the dialog
-	const submitButton = page
-		.locator('[role="dialog"] button[type="submit"]')
+	const submitButton = getModal(page)
+		.locator('button[type="submit"]')
 		.filter({ hasText: 'Add Skill' });
 	await submitButton.click();
 
@@ -97,8 +97,8 @@ async function addMcpSkill(page: Page, displayName: string): Promise<void> {
 
 	// Wait for the dialog to close after the RPC completes and handleClose() fires.
 	// The Add Skill dialog title h2 was used to open the dialog; wait for it to disappear.
-	await page
-		.locator('[role="dialog"] h2')
+	await getModal(page)
+		.locator('h2')
 		.filter({ hasText: 'Add Skill' })
 		.first()
 		.waitFor({ state: 'hidden', timeout: 10000 });
@@ -131,7 +131,7 @@ async function deleteSkillByName(page: Page, displayName: string): Promise<void>
 
 	// Wait for confirm modal and click the confirm "Delete" button
 	// Use the modal's button specifically to avoid matching the list's delete buttons
-	const confirmModal = page.locator('[role="dialog"]').filter({ hasText: 'Delete Skill' });
+	const confirmModal = getModal(page).filter({ hasText: 'Delete Skill' });
 	await confirmModal.waitFor({ state: 'visible', timeout: 5000 });
 	const confirmButton = confirmModal.locator('button').filter({ hasText: 'Delete' }).last();
 	await confirmButton.click();
@@ -183,7 +183,7 @@ test.describe('Global Skills Registry', () => {
 		await editButton.click();
 
 		// Wait for edit dialog
-		const editDialog = page.locator('[role="dialog"]').filter({ hasText: 'Edit Skill' }).first();
+		const editDialog = getModal(page).filter({ hasText: 'Edit Skill' }).first();
 		await editDialog.waitFor({ state: 'visible', timeout: 5000 });
 
 		// Update the description field

--- a/packages/e2e/tests/features/provider-model-switching.e2e.ts
+++ b/packages/e2e/tests/features/provider-model-switching.e2e.ts
@@ -47,7 +47,13 @@ async function createSessionViaNewSessionButton(page: Page): Promise<string> {
 	// fully reset component state across tests, the backdrop blocks the "New Session"
 	// button.  The SPA may keep hidden dialog elements in the DOM — use :visible to
 	// only match dialogs that are actually shown.
-	const anyDialog = page.locator('[role="dialog"]:visible');
+	//
+	// IMPORTANT: Exclude the NeoPanel (data-testid="neo-panel") which has role="dialog"
+	// and is permanently in the DOM even when closed (just off-screen via CSS
+	// transform: -translate-x-full).  Playwright considers it "visible" because CSS
+	// transforms do not affect layout boxes; pressing Escape would not close it, so
+	// including it in the stale-dialog check causes a guaranteed toBeHidden() failure.
+	const anyDialog = page.locator('[role="dialog"]:not([data-testid="neo-panel"]):visible');
 	if (await anyDialog.isVisible({ timeout: 500 }).catch(() => false)) {
 		await page.keyboard.press('Escape');
 		await expect(anyDialog).toBeHidden({ timeout: 3000 });
@@ -59,9 +65,9 @@ async function createSessionViaNewSessionButton(page: Page): Promise<string> {
 	await page.locator('button:has-text("New Session")').first().click();
 
 	// Wait for the modal dialog to appear and scope all subsequent lookups to the
-	// VISIBLE dialog.  Using :visible avoids strict-mode violations when the SPA
-	// keeps hidden dialog elements in the DOM from previous renders.
-	const dialog = page.locator('[role="dialog"]:visible');
+	// VISIBLE dialog.  Exclude the NeoPanel (always in DOM with role="dialog") to
+	// avoid strict-mode violations and incorrect element matching.
+	const dialog = page.locator('[role="dialog"]:not([data-testid="neo-panel"]):visible');
 	await expect(dialog).toBeVisible({ timeout: 5000 });
 
 	// Fill in the workspace path — scoped to the visible dialog.

--- a/packages/e2e/tests/features/provider-model-switching.e2e.ts
+++ b/packages/e2e/tests/features/provider-model-switching.e2e.ts
@@ -25,6 +25,7 @@ import {
 	waitForSessionCreated,
 	getWorkspaceRoot,
 	waitForWebSocketConnected,
+	getModal,
 } from '../helpers/wait-helpers';
 
 // ---------------------------------------------------------------------------
@@ -48,12 +49,12 @@ async function createSessionViaNewSessionButton(page: Page): Promise<string> {
 	// button.  The SPA may keep hidden dialog elements in the DOM — use :visible to
 	// only match dialogs that are actually shown.
 	//
-	// IMPORTANT: Exclude the NeoPanel (data-testid="neo-panel") which has role="dialog"
+	// getModal() excludes the NeoPanel (data-testid="neo-panel") which has role="dialog"
 	// and is permanently in the DOM even when closed (just off-screen via CSS
 	// transform: -translate-x-full).  Playwright considers it "visible" because CSS
 	// transforms do not affect layout boxes; pressing Escape would not close it, so
 	// including it in the stale-dialog check causes a guaranteed toBeHidden() failure.
-	const anyDialog = page.locator('[role="dialog"]:not([data-testid="neo-panel"]):visible');
+	const anyDialog = getModal(page).locator(':visible');
 	if (await anyDialog.isVisible({ timeout: 500 }).catch(() => false)) {
 		await page.keyboard.press('Escape');
 		await expect(anyDialog).toBeHidden({ timeout: 3000 });
@@ -65,9 +66,9 @@ async function createSessionViaNewSessionButton(page: Page): Promise<string> {
 	await page.locator('button:has-text("New Session")').first().click();
 
 	// Wait for the modal dialog to appear and scope all subsequent lookups to the
-	// VISIBLE dialog.  Exclude the NeoPanel (always in DOM with role="dialog") to
-	// avoid strict-mode violations and incorrect element matching.
-	const dialog = page.locator('[role="dialog"]:not([data-testid="neo-panel"]):visible');
+	// VISIBLE dialog.  getModal() excludes the NeoPanel (always in DOM with
+	// role="dialog") to avoid strict-mode violations and incorrect element matching.
+	const dialog = getModal(page);
 	await expect(dialog).toBeVisible({ timeout: 5000 });
 
 	// Fill in the workspace path — scoped to the visible dialog.

--- a/packages/e2e/tests/features/space-export-import.e2e.ts
+++ b/packages/e2e/tests/features/space-export-import.e2e.ts
@@ -16,7 +16,7 @@
 import * as fs from 'fs';
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { waitForWebSocketConnected, getWorkspaceRoot, getModal } from '../helpers/wait-helpers';
 import { createUniqueSpaceDir } from '../helpers/space-helpers';
 
 // ─── RPC helpers (infrastructure only) ───────────────────────────────────────
@@ -208,7 +208,7 @@ test.describe('Space Export/Import', () => {
 		await page.locator('button:has-text("Import")').click();
 
 		// ImportPreviewDialog should appear
-		await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 		await expect(page.locator('text=Import Preview')).toBeVisible();
 
 		// The new agent should appear with "new" status
@@ -219,7 +219,7 @@ test.describe('Space Export/Import', () => {
 		await expect(page.locator('text=/Will import.*1.*agent/')).toBeVisible();
 
 		// Confirm import
-		await page.locator('[role="dialog"] button:has-text("Import")').click();
+		await getModal(page).locator('button:has-text("Import")').click();
 
 		// Success toast
 		await expect(page.locator('text=/Imported.*agent/')).toBeVisible({ timeout: 8000 });
@@ -250,7 +250,7 @@ test.describe('Space Export/Import', () => {
 		await page.locator('button:has-text("Import")').click();
 
 		// Dialog should show conflict
-		await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 		await expect(page.locator('text=conflict').first()).toBeVisible();
 
 		// Conflict resolution dropdown should be present
@@ -258,17 +258,17 @@ test.describe('Space Export/Import', () => {
 		await expect(conflictSelect).toBeVisible();
 
 		// Default is "skip" — Import button should be disabled (0 will be imported)
-		await expect(page.locator('[role="dialog"] button:has-text("Import")')).toBeDisabled();
+		await expect(getModal(page).locator('button:has-text("Import")')).toBeDisabled();
 
 		// Change to "rename"
 		await conflictSelect.selectOption('rename');
 
 		// Now 1 agent will be imported
 		await expect(page.locator('text=/Will import.*1.*agent/')).toBeVisible();
-		await expect(page.locator('[role="dialog"] button:has-text("Import")')).not.toBeDisabled();
+		await expect(getModal(page).locator('button:has-text("Import")')).not.toBeDisabled();
 
 		// Confirm import
-		await page.locator('[role="dialog"] button:has-text("Import")').click();
+		await getModal(page).locator('button:has-text("Import")').click();
 
 		// Success toast
 		await expect(page.locator('text=/Imported.*agent/')).toBeVisible({ timeout: 8000 });
@@ -312,7 +312,7 @@ test.describe('Space Export/Import', () => {
 		await page.locator('button:has-text("Import")').click();
 
 		// Dialog should show both Agents and Workflows sections
-		await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 		await expect(page.locator('text=/Agents \\(1\\)/')).toBeVisible();
 		await expect(page.locator('text=/Workflows \\(1\\)/')).toBeVisible();
 
@@ -324,7 +324,7 @@ test.describe('Space Export/Import', () => {
 		await expect(page.locator('text=/Will import.*1.*agent.*1.*workflow/')).toBeVisible();
 
 		// Import
-		await page.locator('[role="dialog"] button:has-text("Import")').click();
+		await getModal(page).locator('button:has-text("Import")').click();
 
 		// Success toast should mention both agents and workflows
 		await expect(page.locator('text=/Imported.*agent.*workflow/')).toBeVisible({ timeout: 8000 });

--- a/packages/e2e/tests/features/task-actions-dropdown.e2e.ts
+++ b/packages/e2e/tests/features/task-actions-dropdown.e2e.ts
@@ -13,7 +13,7 @@
  */
 
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { waitForWebSocketConnected, getModal } from '../helpers/wait-helpers';
 import { deleteRoom } from '../helpers/room-helpers';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -184,11 +184,8 @@ test.describe('Task Action Buttons', () => {
 		// Click the cancel button directly
 		await page.locator('[data-testid="task-cancel-button"]').click();
 
-		// Cancel dialog should appear with the task name — filter to avoid matching
-		// SlideOutPanel which also has role="dialog" in DOM (strict mode violation)
-		const cancelDialog = page
-			.locator('[role="dialog"]')
-			.filter({ has: page.locator('[data-testid="cancel-task-confirm"]') });
+		// Cancel dialog should appear with the task name
+		const cancelDialog = getModal(page);
 		await expect(cancelDialog.locator('[data-testid="cancel-task-confirm"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -209,11 +206,8 @@ test.describe('Task Action Buttons', () => {
 		await dropdownTrigger.click();
 		await page.locator('[data-testid="task-action-complete"]').click();
 
-		// Complete dialog should appear with the task name — filter to avoid matching
-		// SlideOutPanel which also has role="dialog" in DOM (strict mode violation)
-		const completeDialog = page
-			.locator('[role="dialog"]')
-			.filter({ has: page.locator('[data-testid="complete-task-confirm"]') });
+		// Complete dialog should appear with the task name
+		const completeDialog = getModal(page);
 		await expect(completeDialog.locator('[data-testid="complete-task-confirm"]')).toBeVisible({
 			timeout: 5000,
 		});

--- a/packages/e2e/tests/features/task-lifecycle.e2e.ts
+++ b/packages/e2e/tests/features/task-lifecycle.e2e.ts
@@ -18,7 +18,7 @@
  */
 
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { waitForWebSocketConnected, getModal } from '../helpers/wait-helpers';
 import { deleteRoom } from '../helpers/room-helpers';
 
 // ─── RPC Setup Helper ─────────────────────────────────────────────────────────
@@ -218,9 +218,10 @@ test.describe('Task Lifecycle — Archive', () => {
 		await expect(archiveBtn).toBeVisible({ timeout: 5000 });
 		await archiveBtn.click();
 
-		// Dialog should appear — use specific testid to avoid strict mode violation
-		// (NeoPanel also has role="dialog" and stays in DOM while closed)
-		const dialog = page.locator('[data-testid="archive-task-dialog"]');
+		// Dialog should appear — use getModal() to exclude the NeoPanel which is
+		// always in the DOM with role="dialog" (just off-screen via CSS transform)
+		// and would cause a strict-mode violation with a bare [role="dialog"] selector.
+		const dialog = getModal(page);
 		await expect(dialog).toBeVisible({ timeout: 5000 });
 
 		// Dialog must mention permanent nature and worktree cleanup

--- a/packages/e2e/tests/features/task-view-action-dropdown.e2e.ts
+++ b/packages/e2e/tests/features/task-view-action-dropdown.e2e.ts
@@ -13,7 +13,7 @@
  */
 
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { waitForWebSocketConnected, getModal } from '../helpers/wait-helpers';
 import { deleteRoom } from '../helpers/room-helpers';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -150,11 +150,8 @@ test.describe('Task Action Dropdown', () => {
 		const completeAction = page.locator('[data-testid="task-action-complete"]');
 		await completeAction.click();
 
-		// Complete dialog should appear — filter to avoid matching SlideOutPanel which
-		// also has role="dialog" in DOM when TaskViewV2 is active (strict mode violation)
-		const completeDialog = page
-			.locator('[role="dialog"]')
-			.filter({ has: page.locator('[data-testid="complete-task-confirm"]') });
+		// Complete dialog should appear
+		const completeDialog = getModal(page);
 		await expect(completeDialog.locator('[data-testid="complete-task-confirm"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -172,11 +169,8 @@ test.describe('Task Action Dropdown', () => {
 		const cancelBtn = page.locator('[data-testid="task-cancel-button"]');
 		await cancelBtn.click();
 
-		// Cancel dialog should appear — filter to avoid matching SlideOutPanel which
-		// also has role="dialog" in DOM when TaskViewV2 is active (strict mode violation)
-		const cancelDialog = page
-			.locator('[role="dialog"]')
-			.filter({ has: page.locator('[data-testid="cancel-task-confirm"]') });
+		// Cancel dialog should appear
+		const cancelDialog = getModal(page);
 		await expect(cancelDialog.locator('[data-testid="cancel-task-confirm"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -211,11 +205,8 @@ test.describe('Task Action Dropdown', () => {
 		const completeAction = page.locator('[data-testid="task-action-complete"]');
 		await completeAction.click();
 
-		// Dropdown should be closed - complete dialog is open — filter to avoid matching
-		// SlideOutPanel which also has role="dialog" in DOM (strict mode violation)
-		const completeDialog = page
-			.locator('[role="dialog"]')
-			.filter({ has: page.locator('[data-testid="complete-task-confirm"]') });
+		// Dropdown should be closed - complete dialog is open
+		const completeDialog = getModal(page);
 		await expect(completeDialog).toBeVisible({ timeout: 5000 });
 	});
 

--- a/packages/e2e/tests/helpers/wait-helpers.ts
+++ b/packages/e2e/tests/helpers/wait-helpers.ts
@@ -266,6 +266,21 @@ export async function waitForSDKSystemInitMessage(
 }
 
 /**
+ * Returns a Locator for modal dialogs, excluding the NeoPanel which is always
+ * in the DOM (just off-screen when closed via CSS transform -translate-x-full).
+ *
+ * Playwright considers CSS-transformed elements "visible" because transforms do
+ * not affect layout geometry — using a bare `[role="dialog"]` selector will match
+ * both the NeoPanel and any real modal, causing strict-mode violations.
+ *
+ * Use this instead of `page.locator('[role="dialog"]')` whenever you need to
+ * target an application modal dialog.
+ */
+export function getModal(page: Page): Locator {
+	return page.locator('[role="dialog"]:not([data-testid="neo-panel"])');
+}
+
+/**
  * Wait for UI element with retry logic
  */
 export async function waitForElement(

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures';
-import { cleanupTestSession, createSessionViaUI } from '../helpers/wait-helpers';
+import { cleanupTestSession, createSessionViaUI, getModal } from '../helpers/wait-helpers';
 
 /**
  * Tools Modal E2E Tests (Redesigned)
@@ -43,9 +43,7 @@ test.describe('Tools Modal - Redesigned', () => {
 			)
 			.first()
 			.click();
-		const dialog = page.locator('[role="dialog"]').first();
-		await expect(dialog).toBeVisible({ timeout: 5000 });
-		return dialog;
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 	}
 
 	test('should open tools modal and show group sections', async ({ page }) => {
@@ -136,7 +134,7 @@ test.describe('Tools Modal - Redesigned', () => {
 		const dialog = await openToolsModal(page);
 
 		// Wait for MCP loading to finish before checking collapse
-		await expect(dialog.getByText('Loading servers...')).not.toBeVisible({
+		await expect(getModal(page).getByText('Loading servers...')).not.toBeVisible({
 			timeout: 10000,
 		});
 
@@ -191,7 +189,9 @@ test.describe('Tools Modal - Redesigned', () => {
 	test('should close modal with Cancel without saving', async ({ page }) => {
 		sessionId = await createSessionViaUI(page);
 
-		const dialog = await openToolsModal(page);
+		await openToolsModal(page);
+
+		const dialog = getModal(page);
 		await expect(dialog).toBeVisible();
 
 		// Click Cancel
@@ -220,7 +220,7 @@ test.describe('Tools Modal - Redesigned', () => {
 			const saveBtn = dialog.getByRole('button', { name: 'Save' });
 			if (await saveBtn.isEnabled()) {
 				await saveBtn.click();
-				await expect(dialog).not.toBeVisible({ timeout: 5000 });
+				await expect(getModal(page)).not.toBeVisible({ timeout: 5000 });
 
 				// Reopen modal
 				dialog = await openToolsModal(page);


### PR DESCRIPTION
## Root Cause

The NeoPanel (`data-testid="neo-panel"`) was added with `role="dialog"` after this test was written. It is always present in the DOM even when closed — it slides off-screen via CSS transform (`-translate-x-full`) rather than being removed.

Playwright considers elements with non-zero layout boxes as "visible" regardless of CSS transforms, so `[role="dialog"]:visible` was matching the NeoPanel on every test run. The stale-dialog cleanup then:
1. Detected it as a "visible dialog"
2. Pressed Escape (no effect on an already-closed panel)
3. Failed `expect(anyDialog).toBeHidden()` after 3s — causing all 8 tests to fail

## Fix

Added `:not([data-testid="neo-panel"])` to both the stale-dialog selector and the post-click modal selector so the NeoPanel is never mistaken for a blocking modal dialog.