### PR TITLE
fix(e2e): fix space agent-centric workflow test failures

### DIFF
--- a/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
+++ b/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
@@ -135,12 +135,12 @@ test.describe('Multi-Agent Step Editor', () => {
 
 		// Verify agent names are rendered in the list entries
 		const agentsList = panel.getByTestId('agents-list');
-		await expect(
-			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_A_NAME })
-		).toBeVisible({ timeout: 2000 });
-		await expect(
-			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_B_NAME })
-		).toBeVisible({ timeout: 2000 });
+		await expect(agentsList.getByTestId('agent-entry').filter({ hasText: ROLE_A })).toBeVisible({
+			timeout: 2000,
+		});
+		await expect(agentsList.getByTestId('agent-entry').filter({ hasText: ROLE_B })).toBeVisible({
+			timeout: 2000,
+		});
 
 		// Close panel and verify node shows agent badges for both agents
 		await panel.getByTestId('close-button').click();
@@ -264,16 +264,14 @@ test.describe('Multi-Agent Step Editor', () => {
 
 		// Remove Reviewer Agent (the second entry in the list)
 		const agentsList = reopenedPanel.getByTestId('agents-list');
-		const secondAgentEntry = agentsList
-			.getByTestId('agent-entry')
-			.filter({ hasText: AGENT_B_NAME });
+		const secondAgentEntry = agentsList.getByTestId('agent-entry').filter({ hasText: ROLE_B });
 		await secondAgentEntry.getByTestId('remove-agent-button').click();
 
 		// Only one agent entry should remain
 		await expect(agentsList.getByTestId('agent-entry')).toHaveCount(1, { timeout: 3000 });
-		await expect(
-			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_A_NAME })
-		).toBeVisible({ timeout: 2000 });
+		await expect(agentsList.getByTestId('agent-entry').filter({ hasText: ROLE_A })).toBeVisible({
+			timeout: 2000,
+		});
 
 		// "Switch to single" button (data-testid="switch-to-single-button") appears when
 		// exactly 1 agent remains in multi-agent mode

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -178,8 +178,8 @@ export async function openWorkflowForEdit(page: Page, workflowName: string): Pro
  * Postcondition: agents-list has 2 agent-entry items.
  *
  * @param panel - Locator scoped to the `node-config-panel` element
- * @param agentAOption - Exact option label for the first agent (e.g. "Coder Agent (coder)")
- * @param agentBOption - Exact option label for the second agent (e.g. "Reviewer Agent (reviewer)")
+ * @param agentAOption - Exact option label for the first agent (e.g. "coder" when agent name === role)
+ * @param agentBOption - Exact option label for the second agent (e.g. "reviewer" when agent name === role)
  */
 export async function setupMultiAgentStep(
 	panel: Locator,

--- a/packages/web/src/components/space/ChannelEditor.tsx
+++ b/packages/web/src/components/space/ChannelEditor.tsx
@@ -29,6 +29,32 @@ export interface ChannelEditorProps {
 }
 
 // ============================================================================
+// Gate type helpers
+// ============================================================================
+
+type GateType = 'always' | 'human' | 'condition' | 'task_result';
+
+const GATE_TYPE_TO_ID: Record<Exclude<GateType, 'always'>, string> = {
+	human: 'human-approval',
+	condition: 'custom-condition',
+	task_result: 'task-result',
+};
+
+function gateIdToType(gateId?: string): GateType {
+	if (!gateId) return 'always';
+	if (gateId === 'human-approval') return 'human';
+	if (gateId === 'task-result') return 'task_result';
+	return 'condition';
+}
+
+const GATE_TYPE_LABELS: Record<GateType, string> = {
+	always: 'Automatic',
+	human: 'Human Approval',
+	condition: 'Custom Condition',
+	task_result: 'Task Result',
+};
+
+// ============================================================================
 // Helpers
 // ============================================================================
 
@@ -108,7 +134,7 @@ function ChannelEntry({
 							class="text-xs text-teal-400 bg-teal-900/40 border border-teal-700/50 rounded px-1 py-0.5 flex-shrink-0"
 							data-testid="gate-badge"
 						>
-							Gated
+							{GATE_TYPE_LABELS[gateIdToType(channel.gateId)]}
 						</span>
 					)}
 					{channel.label && (
@@ -265,19 +291,28 @@ function ChannelEntry({
 						/>
 					</div>
 
-					{/* Gate ID (read-only display; use visual editor for gate configuration) */}
+					{/* Gate Condition */}
 					<div class="space-y-0.5">
-						<label class="text-xs text-gray-500">Gate ID</label>
-						<input
-							type="text"
-							data-testid={`channel-gate-id-input-${index}`}
-							value={channel.gateId ?? ''}
-							onInput={(e) =>
-								updateField('gateId', (e.currentTarget as HTMLInputElement).value || undefined)
-							}
-							placeholder="e.g. plan-approval-gate (references workflow gates)"
+						<label class="text-xs text-gray-500">Gate Condition</label>
+						<select
+							data-testid={`channel-gate-select-${index}`}
+							value={gateIdToType(channel.gateId)}
+							onChange={(e) => {
+								const type = (e.currentTarget as HTMLSelectElement).value as GateType;
+								updateField(
+									'gateId',
+									type === 'always'
+										? undefined
+										: GATE_TYPE_TO_ID[type as Exclude<GateType, 'always'>]
+								);
+							}}
 							class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
-						/>
+						>
+							<option value="always">Automatic (always open)</option>
+							<option value="human">Human Approval</option>
+							<option value="condition">Custom Condition</option>
+							<option value="task_result">Task Result</option>
+						</select>
 					</div>
 				</div>
 			)}

--- a/packages/web/src/components/space/ChannelEditor.tsx
+++ b/packages/web/src/components/space/ChannelEditor.tsx
@@ -85,6 +85,11 @@ interface ChannelEntryProps {
 	onDelete: (index: number) => void;
 }
 
+/** Returns true when a gate ID is one of the three canonical preset IDs. */
+function isCanonicalGateId(gateId?: string): boolean {
+	return gateId === 'human-approval' || gateId === 'task-result' || gateId === 'custom-condition';
+}
+
 function ChannelEntry({
 	channel,
 	index,
@@ -99,8 +104,28 @@ function ChannelEntry({
 	const directionSymbol = channel.direction === 'bidirectional' ? '↔' : '→';
 	const toText = formatTo(channel.to);
 
+	// Preserve the gate ID string when the channel has an arbitrary/legacy gate ID
+	// (i.e., not one of the three canonical preset IDs). This allows round-tripping
+	// through a different gate type and back to 'condition' without silently
+	// overwriting the original ID with 'custom-condition'.
+	const [customGateId, setCustomGateId] = useState<string>(() =>
+		isCanonicalGateId(channel.gateId) || !channel.gateId ? '' : channel.gateId
+	);
+
 	function updateField<K extends keyof WorkflowChannel>(key: K, value: WorkflowChannel[K]) {
 		onChange(index, { ...channel, [key]: value });
+	}
+
+	function handleGateTypeChange(type: GateType) {
+		if (type === 'always') {
+			updateField('gateId', undefined);
+		} else if (type === 'condition') {
+			// Use the locally-preserved custom gate ID (may be an arbitrary legacy ID),
+			// falling back to the canonical 'custom-condition' string.
+			updateField('gateId', customGateId || 'custom-condition');
+		} else {
+			updateField('gateId', GATE_TYPE_TO_ID[type]);
+		}
 	}
 
 	const borderClass = highlighted
@@ -299,12 +324,7 @@ function ChannelEntry({
 							value={gateIdToType(channel.gateId)}
 							onChange={(e) => {
 								const type = (e.currentTarget as HTMLSelectElement).value as GateType;
-								updateField(
-									'gateId',
-									type === 'always'
-										? undefined
-										: GATE_TYPE_TO_ID[type as Exclude<GateType, 'always'>]
-								);
+								handleGateTypeChange(type);
 							}}
 							class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500"
 						>
@@ -313,6 +333,23 @@ function ChannelEntry({
 							<option value="condition">Custom Condition</option>
 							<option value="task_result">Task Result</option>
 						</select>
+						{/* Show gate ID input when 'condition' is selected so the user can
+						    set or inspect the gate reference string. Pre-populated with any
+						    existing arbitrary gate ID to prevent silent data loss. */}
+						{gateIdToType(channel.gateId) === 'condition' && (
+							<input
+								type="text"
+								data-testid={`channel-gate-id-input-${index}`}
+								value={customGateId || channel.gateId || ''}
+								onInput={(e) => {
+									const val = (e.currentTarget as HTMLInputElement).value;
+									setCustomGateId(val);
+									updateField('gateId', val || undefined);
+								}}
+								placeholder="Gate ID (e.g. plan-approval-gate)"
+								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-teal-500 mt-1"
+							/>
+						)}
 					</div>
 				</div>
 			)}

--- a/packages/web/src/components/space/__tests__/ChannelEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/ChannelEditor.test.tsx
@@ -371,4 +371,49 @@ describe('ChannelEditor — gate condition', () => {
 		const badge = getByTestId('gate-badge');
 		expect(badge.textContent).toBe('Custom Condition');
 	});
+
+	it('selecting "task_result" sets gateId to "task-result"', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
+		fireEvent.change(getByTestId('channel-gate-select-0'), { target: { value: 'task_result' } });
+		expect(onChange).toHaveBeenCalledOnce();
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(result[0].gateId).toBe('task-result');
+	});
+
+	it('gate badge shows "Task Result" for task-result gate', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel({ gateId: 'task-result' })];
+		const { getByTestId } = render(<ChannelEditor channels={channels} onChange={onChange} />);
+		const badge = getByTestId('gate-badge');
+		expect(badge.textContent).toBe('Task Result');
+	});
+
+	it('condition gate round-trips: gateId "custom-condition" → select shows "condition"', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel({ gateId: 'custom-condition' })];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
+		const select = getByTestId('channel-gate-select-0') as HTMLSelectElement;
+		expect(select.value).toBe('condition');
+	});
+
+	it('selecting "condition" sets gateId to "custom-condition"', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
+		fireEvent.change(getByTestId('channel-gate-select-0'), { target: { value: 'condition' } });
+		expect(onChange).toHaveBeenCalledOnce();
+		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
+		expect(result[0].gateId).toBe('custom-condition');
+	});
 });

--- a/packages/web/src/components/space/__tests__/ChannelEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/ChannelEditor.test.tsx
@@ -297,10 +297,10 @@ describe('ChannelEditor', () => {
 });
 
 // -------------------------------------------------------------------------
-// Gate ID config
+// Gate condition select
 // -------------------------------------------------------------------------
 
-describe('ChannelEditor — gate ID', () => {
+describe('ChannelEditor — gate condition', () => {
 	beforeEach(() => {
 		cleanup();
 	});
@@ -309,43 +309,66 @@ describe('ChannelEditor — gate ID', () => {
 		cleanup();
 	});
 
-	it('shows gate ID input when channel is expanded', () => {
+	it('shows gate condition select when channel is expanded', () => {
 		const onChange = vi.fn();
 		const channels = [makeChannel()];
 		const { getAllByTestId, getByTestId } = render(
 			<ChannelEditor channels={channels} onChange={onChange} />
 		);
 		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
-		expect(getByTestId('channel-gate-id-input-0')).toBeTruthy();
+		expect(getByTestId('channel-gate-select-0')).toBeTruthy();
 	});
 
-	it('updating gate ID calls onChange with updated gateId', () => {
+	it('gate select defaults to "always" for ungated channel', () => {
 		const onChange = vi.fn();
 		const channels = [makeChannel()];
 		const { getAllByTestId, getByTestId } = render(
 			<ChannelEditor channels={channels} onChange={onChange} />
 		);
 		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
-		fireEvent.input(getByTestId('channel-gate-id-input-0'), {
-			target: { value: 'my-gate' },
-		});
+		const select = getByTestId('channel-gate-select-0') as HTMLSelectElement;
+		expect(select.value).toBe('always');
+	});
+
+	it('selecting "human" sets gateId to "human-approval"', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel()];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
+		fireEvent.change(getByTestId('channel-gate-select-0'), { target: { value: 'human' } });
 		expect(onChange).toHaveBeenCalledOnce();
 		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
-		expect(result[0].gateId).toBe('my-gate');
+		expect(result[0].gateId).toBe('human-approval');
 	});
 
-	it('clearing gate ID calls onChange with gateId undefined', () => {
+	it('selecting "always" clears gateId to undefined', () => {
 		const onChange = vi.fn();
-		const channels = [makeChannel({ gateId: 'some-gate' })];
+		const channels = [makeChannel({ gateId: 'human-approval' })];
 		const { getAllByTestId, getByTestId } = render(
 			<ChannelEditor channels={channels} onChange={onChange} />
 		);
 		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
-		fireEvent.input(getByTestId('channel-gate-id-input-0'), {
-			target: { value: '' },
-		});
+		fireEvent.change(getByTestId('channel-gate-select-0'), { target: { value: 'always' } });
 		expect(onChange).toHaveBeenCalledOnce();
 		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
 		expect(result[0].gateId).toBeUndefined();
+	});
+
+	it('gate badge shows "Human Approval" for human-approval gate', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel({ gateId: 'human-approval' })];
+		const { getByTestId } = render(<ChannelEditor channels={channels} onChange={onChange} />);
+		const badge = getByTestId('gate-badge');
+		expect(badge.textContent).toBe('Human Approval');
+	});
+
+	it('gate badge shows "Custom Condition" for unknown gate IDs', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel({ gateId: 'my-custom-gate' })];
+		const { getByTestId } = render(<ChannelEditor channels={channels} onChange={onChange} />);
+		const badge = getByTestId('gate-badge');
+		expect(badge.textContent).toBe('Custom Condition');
 	});
 });

--- a/packages/web/src/components/space/__tests__/ChannelEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/ChannelEditor.test.tsx
@@ -416,4 +416,27 @@ describe('ChannelEditor — gate condition', () => {
 		const result = onChange.mock.calls[0][0] as WorkflowChannel[];
 		expect(result[0].gateId).toBe('custom-condition');
 	});
+
+	it('arbitrary/legacy gate ID is preserved when round-tripping through another type', () => {
+		const onChange = vi.fn();
+		const channels = [makeChannel({ gateId: 'plan-approval-gate' })];
+		const { getAllByTestId, getByTestId } = render(
+			<ChannelEditor channels={channels} onChange={onChange} />
+		);
+		fireEvent.click(getAllByTestId('channel-toggle-button')[0]);
+
+		// Unknown gate ID → select shows 'condition', text input shows original ID
+		const select = getByTestId('channel-gate-select-0') as HTMLSelectElement;
+		expect(select.value).toBe('condition');
+		const input = getByTestId('channel-gate-id-input-0') as HTMLInputElement;
+		expect(input.value).toBe('plan-approval-gate');
+
+		// Switch to 'human'
+		fireEvent.change(select, { target: { value: 'human' } });
+		expect(onChange.mock.calls[0][0][0].gateId).toBe('human-approval');
+
+		// Switch back to 'condition' — original arbitrary ID should be restored
+		fireEvent.change(select, { target: { value: 'condition' } });
+		expect(onChange.mock.calls[1][0][0].gateId).toBe('plan-approval-gate');
+	});
 });

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -47,7 +47,6 @@ import { NodeConfigPanel } from './NodeConfigPanel';
 import type { NodeChannelLink } from './NodeConfigPanel';
 import { EdgeConfigPanel } from './EdgeConfigPanel';
 import { ChannelRelationConfigPanel } from './ChannelRelationConfigPanel';
-import { ChannelEditor } from '../ChannelEditor';
 import { buildVisualNodePositions } from './nodeMetrics';
 import type { ResolvedWorkflowChannel } from './EdgeRenderer';
 import {
@@ -268,15 +267,6 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			),
 		[nodes]
 	);
-	const agentRolesFromNodes = useMemo(() => {
-		const roles = new Set<string>();
-		for (const node of regularNodes) {
-			for (const agent of node.step.agents ?? []) {
-				if (agent.name) roles.add(agent.name);
-			}
-		}
-		return [...roles];
-	}, [regularNodes]);
 	const currentTemplateCanvasSignature = useMemo(
 		() => buildTemplateCanvasSignature(nodes, edges, channels, startNodeId, gates, endNodeId),
 		[nodes, edges, channels, startNodeId, gates, endNodeId]

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -27,6 +27,7 @@ import { spaceStore } from '../../../lib/space-store';
 import { filterAgents, buildTemplateNodes, getAvailableTemplates } from '../WorkflowEditor';
 import type { WorkflowTemplate } from '../WorkflowEditor';
 import { WorkflowRulesEditor } from '../WorkflowRulesEditor';
+import { ChannelEditor } from '../ChannelEditor';
 import { ConfirmModal } from '../../ui/ConfirmModal';
 import type { RuleDraft } from '../WorkflowRulesEditor';
 import type { NodeDraft, AgentTaskState } from '../WorkflowNodeCard';
@@ -267,6 +268,15 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			),
 		[nodes]
 	);
+	const agentRolesFromNodes = useMemo(() => {
+		const roles = new Set<string>();
+		for (const node of regularNodes) {
+			for (const agent of node.step.agents ?? []) {
+				if (agent.name) roles.add(agent.name);
+			}
+		}
+		return [...roles];
+	}, [regularNodes]);
 	const currentTemplateCanvasSignature = useMemo(
 		() => buildTemplateCanvasSignature(nodes, edges, channels, startNodeId, gates, endNodeId),
 		[nodes, edges, channels, startNodeId, gates, endNodeId]


### PR DESCRIPTION
Fixes E2E test failures in `space-agent-centric-workflow.e2e.ts` and `space-multi-agent-editor.e2e.ts`.

- **Agent option labels**: Agents are now created with `name === role` so the `agent-select` options (which show `{a.name}`) match `ROLE_A`/`ROLE_B` directly. Removed the stale `AGENT_A_OPTION`/`AGENT_B_OPTION` constants.
- **Gate select**: Replaced the free-text gate ID input (`channel-gate-id-input-{index}`) in `ChannelEditor` with a `channel-gate-select-{index}` dropdown offering `always | human | condition | task_result`. The select maps to canonical gate IDs internally.
- **Gate badge text**: Badge now shows the human-readable label (e.g. "Human Approval") instead of the hardcoded "Gated".
- **Channels section in VisualWorkflowEditor**: Added a collapsible channels section (`data-testid="channels-section"`) with `toggle-channels-button` and `ChannelEditor`, computing `agentRolesFromNodes` from the canvas nodes so dropdowns are populated.
- Updated `ChannelEditor` unit tests to cover the new gate-select API.