### PR TITLE
fix(e2e): fix space-context-panel-switching test using correct 'Overview' text

### DIFF
--- a/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
+++ b/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
@@ -3,7 +3,7 @@
  *
  * Verifies the Level 1 ↔ Level 2 switching in the ContextPanel:
  * - Level 1 (spaces list): SpaceContextPanel visible, "Spaces" header title
- * - Level 2 (space detail): SpaceDetailPanel visible, space name in header, back button present
+ * - Level 2 (space detail): SpaceDetailPanel visible with "Overview" and "Space Agent" buttons, space name in header, back button present
  * - Back button navigates from detail back to list
  *
  * Setup: creates a space via RPC in beforeEach (infrastructure)
@@ -110,13 +110,15 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		await expect(page.getByTitle('Back to Spaces')).not.toBeVisible();
 	});
 
-	test('shows SpaceDetailPanel with pinned items when a space is selected', async ({ page }) => {
+	test('shows SpaceDetailPanel with Overview and Space Agent when a space is selected', async ({
+		page,
+	}) => {
 		// Navigate to the space directly via URL
 		await page.goto(`/space/${createdSpaceId}`);
 		await waitForWebSocketConnected(page);
 
-		// SpaceDetailPanel should render pinned items: Dashboard and Space Agent
-		await expect(page.getByText('Dashboard')).toBeVisible({ timeout: 10000 });
+		// SpaceDetailPanel should render pinned items: Overview and Space Agent
+		await expect(page.getByText('Overview')).toBeVisible({ timeout: 10000 });
 		await expect(page.getByText('Space Agent')).toBeVisible({ timeout: 5000 });
 
 		// Back button should be visible
@@ -167,7 +169,7 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		await page.getByText(spaceName).click();
 
 		// Should now be inside the space — SpaceDetailPanel pinned items visible
-		await expect(page.getByText('Dashboard')).toBeVisible({ timeout: 10000 });
+		await expect(page.getByText('Overview')).toBeVisible({ timeout: 10000 });
 		await expect(page.getByTitle('Back to Spaces')).toBeVisible({ timeout: 5000 });
 	});
 });


### PR DESCRIPTION
Fix E2E test failure in `space-context-panel-switching.e2e.ts`.

The test was asserting `getByText('Dashboard')` but `SpaceDetailPanel` renders the button with visible text **"Overview"** (the `data-testid` is `space-detail-dashboard`, but the label shown to users is "Overview"). This caused `expect(locator).toBeVisible()` to fail.

Changed both occurrences of `getByText('Dashboard')` → `getByText('Overview')` and updated the test name/comment to match.