### PR TITLE
fix(web): restore tab bar and WorkflowCanvas in SpaceIsland overview

### DIFF
--- a/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
+++ b/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
@@ -5,7 +5,7 @@
  * - Proceeding to plan-approval-gate (waiting_human state at run start)
  * - Rejecting via GateArtifactsView (View Artifacts → Reject button)
  * - Rejecting directly from the gate popup (without opening artifacts)
- * - Workflow run transitions to needs_attention state on canvas
+ * - Workflow run transitions to blocked state on canvas
  * - Canvas shows "Workflow paused — awaiting approval" banner
  * - Gate shows blocked state (red lock icon)
  * - Space remains usable after rejection (tabs navigate, canvas visible)
@@ -26,7 +26,7 @@
  * Note: The plan-approval-gate is ALWAYS in `waiting_human` state at the start of a run
  * because its condition is `{ type: 'check', field: 'approved' }` and no gate data has
  * been written yet. Rejection sets approved=false → gate becomes `blocked`, and the run
- * transitions to `needs_attention` with failureReason `humanRejected`.
+ * transitions to `blocked` with failureReason `humanRejected`.
  *
  * Timeout conventions:
  *   - 10000ms: state transitions requiring a server round-trip (gate data load, run status)
@@ -140,7 +140,7 @@ async function rejectViaPopup(page: Page): Promise<void> {
 	// Click Reject in the popup.
 	await page.locator('button:has-text("Reject")').first().click();
 
-	// Wait for the server round-trip: run transitions to needs_attention + gate becomes blocked.
+	// Wait for the server round-trip: run transitions to blocked + gate becomes blocked.
 	await expect(page.getByTestId('gate-icon-blocked')).toBeVisible({ timeout: 10000 });
 }
 
@@ -172,7 +172,7 @@ test.describe('Approval Gate Rejection', () => {
 
 	// ─── Test 1: Reject via GateArtifactsView closes overlay and transitions run ──
 
-	test('rejecting via GateArtifactsView closes overlay and transitions run to needs_attention', async ({
+	test('rejecting via GateArtifactsView closes overlay and transitions run to blocked', async ({
 		page,
 	}) => {
 		await page.goto(`/space/${spaceId}`);
@@ -226,7 +226,7 @@ test.describe('Approval Gate Rejection', () => {
 		// Overlay must NOT have appeared (we never opened it).
 		await expect(page.getByTestId('artifacts-panel-overlay')).toBeHidden({ timeout: 5000 });
 
-		// Canvas banner should indicate needs_attention.
+		// Canvas banner should indicate blocked (humanRejected) state.
 		await expect(page.locator('text=Workflow paused — awaiting approval')).toBeVisible({
 			timeout: 10000,
 		});
@@ -234,7 +234,7 @@ test.describe('Approval Gate Rejection', () => {
 
 	// ─── Test 3: Canvas shows error/attention state after rejection ───────────
 
-	test('canvas shows needs_attention banner and blocked gate after rejection', async ({ page }) => {
+	test('canvas shows blocked banner and blocked gate after rejection', async ({ page }) => {
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
 

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -4,20 +4,32 @@
  * Content priority chain (full-width, each replaces the next):
  * 1. sessionViewId set → ChatContainer (agent/session chat)
  * 2. taskViewId set    → SpaceTaskPane (full-width task detail)
- * 3. default           → route-driven space view
+ * 3. viewMode === 'configure' → SpaceConfigurePage (agents / workflows / settings)
+ * 4. default           → tabbed view — Dashboard | Agents | Workflows | Settings
  *
- * The default route renders the task-focused overview.
- * Configure lives at its own route and reuses the same shell/context panel.
+ * Dashboard tab shows WorkflowCanvas:
+ *   - Runtime mode when a workflow run exists (active or most-recent blocked)
+ *   - Template mode when no runs but workflows exist (editable gates)
+ *   - Falls back to SpaceDashboard when no workflows configured
+ *   - On small screens the canvas is hidden; SpaceDashboard is shown instead
+ *
+ * Space navigation is handled by the Context Panel sidebar.
  */
 
-import { useEffect } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import type { SpaceViewMode } from '../lib/signals';
 import { SpaceConfigurePage } from '../components/space/SpaceConfigurePage';
 import { SpaceDashboard } from '../components/space/SpaceDashboard';
 import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
+import { SpaceAgentList } from '../components/space/SpaceAgentList';
+import { WorkflowList } from '../components/space/WorkflowList';
+import { VisualWorkflowEditor } from '../components/space/visual-editor/VisualWorkflowEditor';
+import { WorkflowCanvas } from '../components/space/WorkflowCanvas';
+import { SpaceSettings } from '../components/space/SpaceSettings';
 import { spaceStore } from '../lib/space-store';
 import { navigateToSpace, navigateToSpaceAgent, navigateToSpaceTask } from '../lib/router';
 import ChatContainer from './ChatContainer';
+import { cn } from '../lib/utils';
 
 interface SpaceIslandProps {
 	spaceId: string;
@@ -26,21 +38,57 @@ interface SpaceIslandProps {
 	taskViewId?: string | null;
 }
 
+type SpaceTab = 'dashboard' | 'agents' | 'workflows' | 'settings';
+
+const TABS: { id: SpaceTab; label: string }[] = [
+	{ id: 'dashboard', label: 'Dashboard' },
+	{ id: 'agents', label: 'Agents' },
+	{ id: 'workflows', label: 'Workflows' },
+	{ id: 'settings', label: 'Settings' },
+];
+
 export default function SpaceIsland({
 	spaceId,
 	viewMode,
 	sessionViewId,
 	taskViewId,
 }: SpaceIslandProps) {
+	const [activeTab, setActiveTab] = useState<SpaceTab>('dashboard');
+	/** null = list view; 'new' = create editor; <id> = edit editor */
+	const [workflowEditId, setWorkflowEditId] = useState<string | null>(null);
+
 	const loading = spaceStore.loading.value;
 	const error = spaceStore.error.value;
 	const workflows = spaceStore.workflows.value;
+
+	// Canvas mode: prefer an active run; fall back to the most-recent blocked/done run
+	// so the canvas continues showing gate state after a run transitions to blocked.
+	const activeRuns = spaceStore.activeRuns.value;
+	const allRuns = spaceStore.workflowRuns.value;
+	const activeRun = activeRuns[0] ?? null;
+	const displayRun =
+		activeRun ??
+		(allRuns.length > 0
+			? allRuns.reduce((latest, r) => (r.updatedAt > latest.updatedAt ? r : latest))
+			: null);
+	const defaultWorkflow = displayRun
+		? (workflows.find((w) => w.id === displayRun.workflowId) ?? workflows[0] ?? null)
+		: (workflows[0] ?? null);
+	/** True when the canvas should be shown on the dashboard tab */
+	const showCanvas = defaultWorkflow !== null;
 
 	useEffect(() => {
 		spaceStore.selectSpace(spaceId).catch(() => {
 			// Error is tracked in spaceStore.error
 		});
 	}, [spaceId]);
+
+	// Reset workflow edit state when switching away from workflows tab
+	useEffect(() => {
+		if (activeTab !== 'workflows') {
+			setWorkflowEditId(null);
+		}
+	}, [activeTab]);
 
 	const handleTaskPaneClose = () => {
 		navigateToSpace(spaceId);
@@ -100,14 +148,112 @@ export default function SpaceIsland({
 		);
 	}
 
+	const editingWorkflow =
+		workflowEditId && workflowEditId !== 'new'
+			? workflows.find((w) => w.id === workflowEditId)
+			: undefined;
+
+	const showWorkflowEditor = activeTab === 'workflows' && workflowEditId !== null;
+
 	return (
 		<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-overview-view">
-			<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
-				<SpaceDashboard
-					spaceId={spaceId}
-					onOpenSpaceAgent={() => navigateToSpaceAgent(spaceId)}
-					onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
-				/>
+			{/* Main content — tabbed view */}
+			<div class="flex-1 overflow-hidden flex flex-col min-w-0">
+				{/* Tab bar — hidden when workflow editor is open */}
+				{!showWorkflowEditor && (
+					<div class="flex border-b border-dark-700 px-4 flex-shrink-0" data-testid="space-tab-bar">
+						{TABS.map((tab) => (
+							<button
+								key={tab.id}
+								type="button"
+								onClick={() => setActiveTab(tab.id)}
+								class={cn(
+									'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px',
+									activeTab === tab.id
+										? 'text-gray-100 border-blue-400'
+										: 'text-gray-400 border-transparent hover:text-gray-200'
+								)}
+							>
+								{tab.label}
+							</button>
+						))}
+					</div>
+				)}
+
+				{/* Tab content */}
+				<div class="flex-1 overflow-hidden">
+					{showWorkflowEditor ? (
+						<VisualWorkflowEditor
+							key={workflowEditId}
+							workflow={editingWorkflow}
+							onSave={() => setWorkflowEditId(null)}
+							onCancel={() => setWorkflowEditId(null)}
+						/>
+					) : (
+						<>
+							{activeTab === 'dashboard' && (
+								<>
+									{/* Canvas panel — shown on md+ when a workflow or run exists */}
+									{showCanvas && (
+										<div
+											class="hidden md:flex flex-col h-full overflow-hidden"
+											data-testid="canvas-panel"
+										>
+											{/* Active-run banner */}
+											{displayRun && (
+												<div class="flex items-center gap-2 px-4 py-2 border-b border-dark-700 bg-dark-900 flex-shrink-0">
+													<span
+														class={cn(
+															'w-2 h-2 rounded-full flex-shrink-0',
+															activeRun ? 'bg-blue-400 animate-pulse' : 'bg-amber-400'
+														)}
+													/>
+													<span class="text-xs text-blue-300 truncate">{displayRun.title}</span>
+													<span class="ml-auto text-xs text-gray-600 capitalize flex-shrink-0">
+														{displayRun.status.replace('_', ' ')}
+													</span>
+												</div>
+											)}
+											<WorkflowCanvas
+												key={`${defaultWorkflow.id}:${displayRun?.id ?? 'template'}`}
+												workflowId={defaultWorkflow.id}
+												runId={displayRun?.id ?? null}
+												spaceId={spaceId}
+												class="flex-1 min-h-0"
+											/>
+										</div>
+									)}
+									{/* Fallback: shown on mobile, or when no canvas data */}
+									<div
+										class={cn('flex flex-col h-full overflow-y-auto', showCanvas && 'md:hidden')}
+										data-testid="dashboard-fallback"
+									>
+										<SpaceDashboard
+											spaceId={spaceId}
+											onOpenSpaceAgent={() => navigateToSpaceAgent(spaceId)}
+											onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
+										/>
+									</div>
+								</>
+							)}
+							{activeTab === 'agents' && (
+								<div class="p-6 h-full overflow-y-auto">
+									<SpaceAgentList />
+								</div>
+							)}
+							{activeTab === 'workflows' && space && (
+								<WorkflowList
+									spaceId={spaceId}
+									spaceName={space.name}
+									workflows={workflows}
+									onCreateWorkflow={() => setWorkflowEditId('new')}
+									onEditWorkflow={(id) => setWorkflowEditId(id)}
+								/>
+							)}
+							{activeTab === 'settings' && space && <SpaceSettings space={space} />}
+						</>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -19,6 +19,7 @@ let mockSpace = signal<Space | null>(null);
 let mockWorkflows = signal<SpaceWorkflow[]>([]);
 let mockAgents = signal<SpaceAgent[]>([]);
 let mockActiveRuns = signal<SpaceWorkflowRun[]>([]);
+let mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
 
 const mockSelectSpace = vi.fn().mockResolvedValue(undefined);
 
@@ -55,6 +56,16 @@ vi.mock('../../components/space/visual-editor/VisualWorkflowEditor', () => ({
 			</div>
 		);
 	},
+}));
+
+vi.mock('../../components/space/WorkflowCanvas', () => ({
+	WorkflowCanvas: (props: { workflowId: string; runId?: string | null; spaceId: string }) => (
+		<div
+			data-testid="workflow-canvas"
+			data-workflow-id={props.workflowId}
+			data-run-id={props.runId ?? ''}
+		/>
+	),
 }));
 
 vi.mock('../../components/space/SpaceDashboard', () => ({
@@ -100,6 +111,7 @@ vi.mock('../../lib/space-store', () => ({
 			workflows: mockWorkflows,
 			agents: mockAgents,
 			activeRuns: mockActiveRuns,
+			workflowRuns: mockWorkflowRuns,
 			selectSpace: mockSelectSpace,
 		};
 	},
@@ -149,6 +161,7 @@ beforeEach(() => {
 	mockWorkflows = signal([makeWorkflow()]);
 	mockAgents = signal([]);
 	mockActiveRuns = signal([]);
+	mockWorkflowRuns = signal([]);
 	capturedVisualEditorProps = {};
 });
 
@@ -157,9 +170,13 @@ afterEach(() => {
 });
 
 describe('SpaceIsland — route-driven views', () => {
-	it('renders the overview view by default', () => {
+	it('renders the overview view with tab bar by default', () => {
 		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="overview" />);
+		// Outer wrapper
 		expect(getByTestId('space-overview-view')).toBeTruthy();
+		// Tab bar is present
+		expect(getByTestId('space-tab-bar')).toBeTruthy();
+		// SpaceDashboard is in the dashboard-fallback (mobile/no-canvas path)
 		expect(getByTestId('space-dashboard')).toBeTruthy();
 	});
 

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -154,6 +154,21 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 	};
 }
 
+function makeRun(overrides: Partial<SpaceWorkflowRun> = {}): SpaceWorkflowRun {
+	return {
+		id: 'run-1',
+		spaceId: 'space-1',
+		workflowId: 'wf-existing',
+		title: 'Test Run',
+		status: 'in_progress',
+		createdAt: 1000,
+		startedAt: 1000,
+		updatedAt: 1000,
+		completedAt: null,
+		...overrides,
+	};
+}
+
 beforeEach(() => {
 	mockLoading = signal(false);
 	mockError = signal(null);
@@ -191,6 +206,61 @@ describe('SpaceIsland — route-driven views', () => {
 		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="overview" />);
 		fireEvent.click(getByTestId('quick-open-space-agent'));
 		expect(router.navigateToSpaceAgent).toHaveBeenCalledWith('space-1');
+	});
+});
+
+describe('SpaceIsland — dashboard canvas rendering', () => {
+	it('renders canvas-panel and workflow-canvas when workflows exist (no run)', () => {
+		// Default beforeEach has mockWorkflows = [makeWorkflow()], so showCanvas = true
+		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="overview" />);
+		// canvas-panel is in DOM (md:flex hides it visually on narrow viewports, but it is rendered)
+		expect(getByTestId('canvas-panel')).toBeTruthy();
+		expect(getByTestId('workflow-canvas')).toBeTruthy();
+		// In template mode (no run), run-id attribute is empty
+		expect(getByTestId('workflow-canvas').getAttribute('data-run-id')).toBe('');
+	});
+
+	it('renders canvas in runtime mode when an active run is present', () => {
+		const run = makeRun({ id: 'run-active', status: 'in_progress' });
+		mockActiveRuns = signal([run]);
+		mockWorkflowRuns = signal([run]);
+		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="overview" />);
+		expect(getByTestId('workflow-canvas').getAttribute('data-run-id')).toBe('run-active');
+	});
+
+	it('still renders canvas with blocked run after run transitions to blocked', () => {
+		// Simulates post-rejection state: run is blocked (not in activeRuns)
+		const run = makeRun({ id: 'run-blocked', status: 'blocked', updatedAt: 2000 });
+		mockActiveRuns = signal([]); // blocked run is NOT in activeRuns
+		mockWorkflowRuns = signal([run]);
+		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="overview" />);
+		// Canvas still shows the blocked run via the displayRun fallback
+		expect(getByTestId('workflow-canvas').getAttribute('data-run-id')).toBe('run-blocked');
+	});
+
+	it('hides canvas-panel and shows only dashboard-fallback when no workflows configured', () => {
+		mockWorkflows = signal([]); // no workflows → showCanvas = false
+		mockWorkflowRuns = signal([]);
+		mockActiveRuns = signal([]);
+		const { getByTestId, queryByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="overview" />
+		);
+		expect(queryByTestId('canvas-panel')).toBeNull();
+		expect(queryByTestId('workflow-canvas')).toBeNull();
+		expect(getByTestId('dashboard-fallback')).toBeTruthy();
+		expect(getByTestId('space-dashboard')).toBeTruthy();
+	});
+
+	it('hides the tab bar when workflow editor is open', () => {
+		const { getByTestId, queryByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="overview" />
+		);
+		// Switch to Workflows tab and open the editor
+		fireEvent.click(getByTestId('space-tab-bar').querySelector('button:nth-child(3)'));
+		fireEvent.click(getByTestId('create-workflow-btn'));
+		// Tab bar should be hidden when editor is active
+		expect(queryByTestId('space-tab-bar')).toBeNull();
+		expect(getByTestId('visual-workflow-editor')).toBeTruthy();
 	});
 });
 


### PR DESCRIPTION
Restores the Dashboard/Agents/Workflows/Settings tab bar and WorkflowCanvas that were removed in #1251.

**Root cause:** The space dashboard refactor (#1251 "Simplify space overview shell") removed the tab-based navigation and WorkflowCanvas from SpaceIsland, breaking the gate approval/rejection UI and multiple E2E tests.

**What this fixes:**
- `space-approval-gate-rejection` — `workflow-canvas` was not found because the canvas was removed
- `space-navigation` — `space-tab-bar` testid was missing
- `space-sub-routes`, `space-happy-path-pipeline`, `space-workflow-rules` — depend on tabs/canvas

**Changes:**
- Restore tab bar (Dashboard/Agents/Workflows/Settings) in SpaceIsland overview mode
- Dashboard tab shows WorkflowCanvas when a run or workflow exists; falls back to SpaceDashboard on mobile
- Canvas shows most-recently-updated run (not just active) so blocked gate state is visible after rejection
- SpaceConfigurePage route (`/space/:id/configure`) is unchanged
- Add `WorkflowCanvas` mock and `workflowRuns` signal to SpaceIsland unit test