### PR TITLE
fix(e2e): fix space-creation test assertions to match actual SpaceDashboard UI

### DIFF
--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -2,12 +2,12 @@
  * Space Creation E2E Tests
  *
  * Verifies:
- * - Navigating to the Spaces section (Home header + Create Space button visible)
+ * - Navigating to the Spaces section (NavRail Spaces button + Create Space button visible)
  * - "Create Space" dialog opens
  * - Workspace path field is required
  * - Name auto-suggests from workspace path
  * - Creating a space navigates to it
- * - Space tabbed dashboard layout renders (Dashboard tab active with quick actions)
+ * - Space overview renders with tabbed layout (Active / Review / Done tabs)
  *
  * Setup: creates a space via dialog (UI-only)
  * Cleanup: deletes the space via RPC in afterEach (infrastructure)
@@ -141,12 +141,19 @@ test.describe('Space Creation UX', () => {
 			createdSpaceId = match[1];
 		}
 
-		// Tabbed dashboard should be visible with Dashboard tab active
-		await expect(page.locator('text=Dashboard')).toBeVisible({ timeout: 5000 });
+		// Space overview (dashboard) should be visible
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
-		// On desktop, the workflow canvas panel replaces the dashboard quick actions
-		// Workflows load async after space creation; wait for the canvas SVG to appear
-		await expect(page.getByTestId('workflow-canvas-svg')).toBeVisible({ timeout: 15000 });
+		// The tabbed layout with Active / Review / Done tabs should render
+		await expect(page.getByRole('button', { name: 'Active', exact: true })).toBeVisible({
+			timeout: 5000,
+		});
+		await expect(page.getByRole('button', { name: 'Review', exact: true })).toBeVisible({
+			timeout: 5000,
+		});
+		await expect(page.getByRole('button', { name: 'Done', exact: true })).toBeVisible({
+			timeout: 5000,
+		});
 	});
 
 	test('dialog can be closed with Cancel button', async ({ page }) => {

--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -144,16 +144,12 @@ test.describe('Space Creation UX', () => {
 		// Space overview (dashboard) should be visible
 		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
-		// The tabbed layout with Active / Review / Done tabs should render
-		await expect(page.getByRole('button', { name: 'Active', exact: true })).toBeVisible({
-			timeout: 5000,
-		});
-		await expect(page.getByRole('button', { name: 'Review', exact: true })).toBeVisible({
-			timeout: 5000,
-		});
-		await expect(page.getByRole('button', { name: 'Done', exact: true })).toBeVisible({
-			timeout: 5000,
-		});
+		// The tabbed layout with Active / Review / Done tabs should render.
+		// Tab buttons include a count badge in the accessible name (e.g. "Active 0"),
+		// so use substring matching (no exact: true) to match regardless of task count.
+		await expect(page.getByRole('button', { name: 'Active' })).toBeVisible({ timeout: 5000 });
+		await expect(page.getByRole('button', { name: 'Review' })).toBeVisible({ timeout: 5000 });
+		await expect(page.getByRole('button', { name: 'Done' })).toBeVisible({ timeout: 5000 });
 	});
 
 	test('dialog can be closed with Cancel button', async ({ page }) => {


### PR DESCRIPTION
The `creates space and shows tabbed dashboard layout` test was failing because it asserted two elements that don't exist in the actual UI after space creation:

- `text=Dashboard` — "Dashboard" is not rendered anywhere in `SpaceDashboard` or the surrounding layout
- `workflow-canvas-svg` testId — only rendered in `SpaceConfigurePage` (the configure view), not in the default overview/dashboard view

After space creation, `/space/{id}` renders `SpaceIsland` → `SpaceDashboard`, which shows a tabbed layout with **Active / Review / Done** tab buttons and a `data-testid="space-overview-view"` wrapper.

Fix: replace incorrect assertions with `space-overview-view` testId check and the three tab button visibility assertions.