### PR TITLE
fix(e2e): stabilize features-neo-settings against parallel-worker races

### DIFF
--- a/packages/e2e/tests/features/neo-settings.e2e.ts
+++ b/packages/e2e/tests/features/neo-settings.e2e.ts
@@ -103,13 +103,20 @@ test.describe('Neo Settings - Navigation', () => {
 		const neoSection = getNeoSectionLocator(page);
 		await expect(neoSection.locator('text=Security Mode')).toBeVisible();
 		await expect(neoSection.locator('div', { hasText: /^Model$/ })).toBeVisible();
-		await expect(neoSection.locator('text=Clear Session')).toBeVisible();
+		await expect(
+			neoSection.getByRole('button', { name: 'Clear Session', exact: true })
+		).toBeVisible();
 	});
 });
 
 // ─── Security Mode ────────────────────────────────────────────────────────────
 
 test.describe('Neo Settings - Security Mode', () => {
+	// Tests mutate shared global settings (neoSecurityMode).  Running serially
+	// prevents the afterEach cleanup of one test from racing with the body of
+	// another when Playwright distributes tests across workers.
+	test.describe.configure({ mode: 'serial' });
+
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
@@ -166,6 +173,11 @@ test.describe('Neo Settings - Security Mode', () => {
 // ─── Model Selector ───────────────────────────────────────────────────────────
 
 test.describe('Neo Settings - Model Selector', () => {
+	// Tests mutate shared global settings (neoModel).  Running serially prevents
+	// the afterEach cleanup of one test from racing with the body of another when
+	// Playwright distributes tests across workers in fullyParallel mode.
+	test.describe.configure({ mode: 'serial' });
+
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
@@ -189,20 +201,24 @@ test.describe('Neo Settings - Model Selector', () => {
 	});
 
 	test('should persist model selection across page reload', async ({ page }) => {
-		// Pick a target value different from whatever is currently set
+		// Use "haiku" as the test value — it's unambiguous because the getModel() fallback
+		// chain is "neoModel ?? globalModel ?? 'sonnet'".  If we tested with 'sonnet',
+		// a null/missing neoModel would produce the same result (no distinguishable diff).
+		// "haiku" is never a fallback value, so its presence after reload proves persistence.
 		const select = getModelSelect(page);
-		const current = await select.inputValue();
-		const target = current === 'opus' ? 'sonnet' : 'opus';
+		const target = 'haiku';
 
 		await select.selectOption(target);
 		await expect(page.locator('text=Model updated')).toBeVisible({ timeout: 5000 });
+		// Verify select shows the target BEFORE reload to confirm the DB write completed
+		await expect(select).toHaveValue(target);
 
 		// Reload and re-open Neo settings
 		await page.reload();
 		await waitForWebSocketConnected(page);
 		await openNeoSettings(page);
 
-		// Value should be persisted
+		// Value should be persisted across the reload
 		await expect(getModelSelect(page)).toHaveValue(target);
 	});
 


### PR DESCRIPTION
Fixes flaky `features-neo-settings` E2E tests (CI run #23961272271).

**Root causes fixed:**

- **Strict-mode violation** (`Clear Session` row): `locator('text=Clear Session')` matched both the label `<div>` and the wrapper `<div>`, triggering a Playwright strict-mode error. Fixed by using `getByRole('button', { name: 'Clear Session', exact: true })`.

- **Ambiguous persist target** (Model Selector): test picked `'sonnet'` or `'opus'`, but `'sonnet'` is also the `getModel()` fallback when `neoModel` is null — meaning a failed DB write would still pass the assertion. Switched to `'haiku'` (never a fallback) and added a pre-reload assertion to confirm the DB write completed before reloading.

- **Parallel-worker race** (Model Selector + Security Mode): with `fullyParallel: true`, all tests share one server. The `afterEach` cleanup of test 2 (restoring the model to `''`/null) was racing with test 3's post-reload assertion, wiping `neoModel: 'haiku'` from the DB just before the check. Added `test.describe.configure({ mode: 'serial' })` to both stateful describe blocks.