### PR TITLE
fix(e2e): delete all matching spaces on cleanup to prevent UNIQUE constraint failure

### DIFF
--- a/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
+++ b/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
@@ -58,8 +58,10 @@ async function createSpaceWithRun(
 					id: string;
 					workspacePath: string;
 				}>;
-				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
-				if (existing) await hub.request('space.delete', { id: existing.id });
+				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
+				for (const s of matches) {
+					await hub.request('space.delete', { id: s.id });
+				}
 			} catch {
 				// Ignore cleanup errors
 			}

--- a/packages/e2e/tests/features/space-agent-chat.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-chat.e2e.ts
@@ -10,63 +10,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
-
-async function createSpaceViaRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	workspacePath: string,
-	name: string
-): Promise<string> {
-	// Pre-creation cleanup: delete any existing space at this path (including archived)
-	try {
-		await page.evaluate(async (path) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			const spaces = (await hub.request('space.list', { includeArchived: true })) as Array<{
-				id: string;
-				workspacePath: string;
-			}>;
-			for (const space of spaces) {
-				if (space.workspacePath === path) {
-					await hub.request('space.delete', { id: space.id });
-				}
-			}
-		}, workspacePath);
-	} catch {
-		// Best-effort cleanup
-	}
-
-	const id = await page.evaluate(
-		async ({ workspacePath, name }) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('MessageHub not available');
-			const space = (await hub.request('space.create', { workspacePath, name })) as {
-				id: string;
-			};
-			return space.id;
-		},
-		{ workspacePath, name }
-	);
-	if (!id) throw new Error('space.create returned no id');
-	return id;
-}
-
-async function deleteSpaceViaRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	spaceId: string
-): Promise<void> {
-	if (!spaceId) return;
-	try {
-		await page.evaluate(async (id) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			await hub.request('space.delete', { id });
-		}, spaceId);
-	} catch {
-		// Best-effort cleanup
-	}
-}
 
 test.describe('Space Agent Chat', () => {
 	test.use({ viewport: DESKTOP_VIEWPORT });

--- a/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
+++ b/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
@@ -59,8 +59,10 @@ async function createSpaceWithRun(
 					id: string;
 					workspacePath: string;
 				}>;
-				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
-				if (existing) await hub.request('space.delete', { id: existing.id });
+				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
+				for (const s of matches) {
+					await hub.request('space.delete', { id: s.id });
+				}
 			} catch {
 				// Ignore cleanup errors
 			}

--- a/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
+++ b/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
@@ -20,17 +20,19 @@ async function createSpaceByRpc(
 	workspacePath: string,
 	name: string
 ): Promise<string> {
-	// Pre-creation cleanup: delete any existing space at this path (including archived)
+	// Pre-creation cleanup: delete ALL existing spaces at this path (including archived).
+	// Normalize macOS /private symlink prefix to avoid path mismatch.
 	try {
 		await page.evaluate(async (path) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) return;
+			const norm = (p: string) => p.replace(/^\/private/, '');
 			const spaces = (await hub.request('space.list', { includeArchived: true })) as Array<{
 				id: string;
 				workspacePath: string;
 			}>;
 			for (const space of spaces) {
-				if (space.workspacePath === path) {
+				if (norm(space.workspacePath) === norm(path)) {
 					await hub.request('space.delete', { id: space.id });
 				}
 			}

--- a/packages/e2e/tests/features/space-export-import.e2e.ts
+++ b/packages/e2e/tests/features/space-export-import.e2e.ts
@@ -34,15 +34,17 @@ async function createTestSpace(page: Page): Promise<{
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
-			// Delete any leftover space from a previous failed run (including archived).
+			// Delete ALL leftover spaces from previous failed runs (including archived).
+			// Normalize macOS /private symlink prefix to avoid path mismatch.
+			const norm = (p: string) => p.replace(/^\/private/, '');
 			try {
 				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
 					id: string;
 					workspacePath: string;
 				}>;
-				const existing = list.find((s) => s.workspacePath === workspacePath);
-				if (existing) {
-					await hub.request('space.delete', { id: existing.id });
+				const matches = list.filter((s) => norm(s.workspacePath) === norm(workspacePath));
+				for (const s of matches) {
+					await hub.request('space.delete', { id: s.id });
 				}
 			} catch {
 				// Ignore cleanup errors

--- a/packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts
+++ b/packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts
@@ -28,13 +28,16 @@ async function createSpaceWithRun(
 			if (!hub?.request) throw new Error('MessageHub not available');
 
 			const norm = (p: string) => p.replace(/^\/private/, '');
+			// Delete ALL spaces matching this workspace path to prevent UNIQUE constraint failures
 			try {
 				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
 					id: string;
 					workspacePath: string;
 				}>;
-				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
-				if (existing) await hub.request('space.delete', { id: existing.id });
+				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
+				for (const s of matches) {
+					await hub.request('space.delete', { id: s.id });
+				}
 			} catch {
 				// best-effort cleanup
 			}

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -40,9 +40,9 @@ async function createTestSpace(page: Page): Promise<string> {
 					id: string;
 					workspacePath: string;
 				}>;
-				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
-				if (existing) {
-					await hub.request('space.delete', { id: existing.id });
+				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
+				for (const s of matches) {
+					await hub.request('space.delete', { id: s.id });
 				}
 			} catch {
 				// Ignore cleanup errors

--- a/packages/e2e/tests/helpers/space-helpers.ts
+++ b/packages/e2e/tests/helpers/space-helpers.ts
@@ -61,12 +61,14 @@ async function cleanupExistingSpace(page: Page, workspacePath: string): Promise<
 		await page.evaluate(async (path) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) return;
+			// Normalize macOS /private symlink prefix before comparing
+			const norm = (p: string) => p.replace(/^\/private/, '');
 			const spaces = (await hub.request('space.list', { includeArchived: true })) as Array<{
 				id: string;
 				workspacePath: string;
 			}>;
 			for (const space of spaces) {
-				if (space.workspacePath === path) {
+				if (norm(space.workspacePath) === norm(path)) {
 					await hub.request('space.delete', { id: space.id });
 				}
 			}

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -27,8 +27,10 @@ export async function createSpace(page: Page, name: string): Promise<string> {
 					id: string;
 					workspacePath: string;
 				}>;
-				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
-				if (existing) await hub.request('space.delete', { id: existing.id });
+				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
+				for (const s of matches) {
+					await hub.request('space.delete', { id: s.id });
+				}
 			} catch {
 				// Ignore cleanup errors
 			}


### PR DESCRIPTION
Fixes the `UNIQUE constraint failed: spaces.workspace_path` error in `space-happy-path-pipeline.e2e.ts`.

- Changed `list.find()` + single delete to `list.filter()` + loop so **all** leftover spaces at the same workspace path are deleted before creating a new one
- Added `/private` path normalization in `space-helpers.ts` `cleanupExistingSpace` to handle macOS symlink prefix mismatches