### PR TITLE
fix(e2e): update space navigation helpers after dashboard refactor

### DIFF
--- a/packages/e2e/tests/features/space-agent-centric-workflow.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-centric-workflow.e2e.ts
@@ -41,8 +41,9 @@ const ROLE_A = 'coder';
 const ROLE_B = 'reviewer';
 const AGENT_A_NAME = 'Coder Agent';
 const AGENT_B_NAME = 'Reviewer Agent';
-const AGENT_A_OPTION = `${AGENT_A_NAME} (${ROLE_A})`;
-const AGENT_B_OPTION = `${AGENT_B_NAME} (${ROLE_B})`;
+// Option text as rendered by agent-select and add-agent-select: just the agent name (no role suffix)
+const AGENT_A_OPTION = AGENT_A_NAME;
+const AGENT_B_OPTION = AGENT_B_NAME;
 
 // ─── RPC helpers (infrastructure only) ────────────────────────────────────────
 

--- a/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
+++ b/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
@@ -41,9 +41,9 @@ const ROLE_A = 'coder';
 const ROLE_B = 'reviewer';
 const AGENT_A_NAME = 'Coder Agent';
 const AGENT_B_NAME = 'Reviewer Agent';
-// Option text as rendered by the agent select: "{name} ({role})"
-const AGENT_A_OPTION = `${AGENT_A_NAME} (${ROLE_A})`;
-const AGENT_B_OPTION = `${AGENT_B_NAME} (${ROLE_B})`;
+// Option text as rendered by agent-select and add-agent-select: just the agent name (no role suffix)
+const AGENT_A_OPTION = AGENT_A_NAME;
+const AGENT_B_OPTION = AGENT_B_NAME;
 
 // ─── RPC helpers (infrastructure only) ───────────────────────────────────────
 
@@ -118,13 +118,14 @@ test.describe('Multi-Agent Step Editor', () => {
 		const editor = page.getByTestId('visual-workflow-editor');
 		await editor.getByTestId('workflow-name-input').fill('Multi-Agent Badges Test');
 
-		// Add one step (Task Agent virtual node is always present in create mode, so we get 2 nodes)
+		// Add one step — Task Agent is shown as an overlay (data-testid="task-agent-overlay"),
+		// not as a workflow-node-* element, so we get 1 node in the canvas after clicking Add Step.
 		await editor.getByTestId('add-step-button').click();
 		const nodes = editor.locator('[data-testid^="workflow-node-"]');
-		await expect(nodes).toHaveCount(2, { timeout: 3000 });
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
 
-		// Open node config panel — use .last() to click the newly added regular node (Task Agent is not selectable)
-		await nodes.last().click();
+		// Open node config panel — click the single added regular node
+		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
 		await panel.getByTestId('step-name-input').fill('Parallel Step');
@@ -145,10 +146,11 @@ test.describe('Multi-Agent Step Editor', () => {
 		await panel.getByTestId('close-button').click();
 		await expect(panel).not.toBeVisible({ timeout: 2000 });
 
-		// Get a fresh node locator after panel closes (the previous nodes locator may be stale)
-		// Task Agent is at index 0, so the regular node is at index 1
+		// Get a fresh node locator after panel closes (the previous nodes locator may be stale).
+		// Task Agent is rendered as a separate overlay (not a workflow-node-* element), so the
+		// regular node is the only workflow-node-* and sits at index 0.
 		const freshNodes = editor.locator('[data-testid^="workflow-node-"]');
-		const regularNode = freshNodes.nth(1);
+		const regularNode = freshNodes.nth(0);
 		const agentBadges = regularNode.getByTestId('agent-badges');
 		await expect(agentBadges).toBeVisible({ timeout: 3000 });
 		// Both agent names should appear as badge spans within the agent-badges container
@@ -314,8 +316,8 @@ test.describe('Multi-Agent Step Editor', () => {
 		// Add step (simplified - no multi-agent to isolate save issue)
 		await editor.getByTestId('add-step-button').click();
 		const nodes = editor.locator('[data-testid^="workflow-node-"]');
-		// Task Agent is at index 0, the new regular node is at index 1
-		await nodes.nth(1).click();
+		// Task Agent is an overlay (not a workflow-node-*), so the regular node is at index 0
+		await nodes.nth(0).click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
 		await panel.getByTestId('step-name-input').fill('Persist Step');

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -74,8 +74,9 @@ async function deleteTestSpace(page: Page, spaceId: string): Promise<void> {
 async function navigateToSpace(page: Page, spaceId: string): Promise<void> {
 	await page.goto(`/space/${spaceId}`);
 	await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-	// Wait for SpaceIsland to finish loading — the tab bar appears after space.overview resolves
-	await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
+	// Wait for SpaceIsland to finish loading — the space overview container appears after space data resolves.
+	// The space dashboard no longer shows a "Dashboard" tab; use the testid on the overview container.
+	await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 15000 });
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -105,21 +105,26 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 	test('nav panel "Workflows" link switches to workflows tab', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 
-		// Click the "Workflows" link in the nav panel footer
-		const workflowsLink = page.locator('text=Workflows').first();
-		await expect(workflowsLink).toBeVisible({ timeout: 5000 });
-		await workflowsLink.click();
+		// After the dashboard refactor, Workflows lives in the Configure page.
+		// Navigate there via the "Configure space" gear button, then click the Workflows tab.
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+		await page.getByTestId('space-configure-tab-workflows').click();
 
-		// Workflows list should appear
-		await expect(page.locator('text=New Workflow')).toBeVisible({ timeout: 5000 });
+		// Workflows list should appear — "Create Workflow" button is the list's primary CTA
+		await expect(page.getByRole('button', { name: 'Create Workflow' })).toBeVisible({
+			timeout: 5000,
+		});
 	});
 
 	test('nav panel "Agents" link switches to agents tab', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 
-		const agentsLink = page.locator('text=Agents').first();
-		await expect(agentsLink).toBeVisible({ timeout: 5000 });
-		await agentsLink.click();
+		// After the dashboard refactor, Agents lives in the Configure page.
+		// Navigate there via the "Configure space" gear button — Agents is the default tab.
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+		await page.getByTestId('space-configure-tab-agents').click();
 
 		// Agents list should appear — empty state or list
 		await expect(
@@ -130,12 +135,11 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 	test('nav panel "Settings" link switches to settings tab', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 
-		const settingsLink = page
-			.locator('[class*="cursor-pointer"]')
-			.filter({ hasText: 'Settings' })
-			.last();
-		await expect(settingsLink).toBeVisible({ timeout: 5000 });
-		await settingsLink.click();
+		// After the dashboard refactor, Settings lives in the Configure page.
+		// Navigate there via the "Configure space" gear button, then click the Settings tab.
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+		await page.getByTestId('space-configure-tab-settings').click();
 
 		// Settings panel should appear
 		await expect(
@@ -148,14 +152,18 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 	test('can create a workflow from template with tags', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 
-		// Navigate to workflows
-		await page.locator('text=Workflows').first().click();
-		await expect(page.locator('text=New Workflow')).toBeVisible({ timeout: 5000 });
+		// Navigate to Workflows via the Configure page
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+		await page.getByTestId('space-configure-tab-workflows').click();
+		await expect(page.getByRole('button', { name: 'Create Workflow' })).toBeVisible({
+			timeout: 5000,
+		});
 
-		// Click New Workflow button
-		await page.getByRole('button', { name: 'New Workflow' }).first().click();
+		// Click Create Workflow button to open the editor
+		await page.getByRole('button', { name: 'Create Workflow' }).first().click();
 
-		// Editor should open
+		// Editor should open — the title in create mode is "New Workflow"
 		await expect(page.locator('text=New Workflow').first()).toBeVisible({ timeout: 5000 });
 
 		// Fill name
@@ -182,9 +190,11 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 	test('can add a rule to a workflow', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 
-		// Navigate to workflows → open editor
-		await page.locator('text=Workflows').first().click();
-		await page.getByRole('button', { name: 'New Workflow' }).first().click();
+		// Navigate to Workflows via the Configure page → open editor
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+		await page.getByTestId('space-configure-tab-workflows').click();
+		await page.getByRole('button', { name: 'Create Workflow' }).first().click();
 		await expect(page.locator('input[placeholder*="Feature Development"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -210,9 +220,11 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 	test('rule "Applies to" shows step buttons from the steps list', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 
-		// Navigate to workflows → open editor
-		await page.locator('text=Workflows').first().click();
-		await page.getByRole('button', { name: 'New Workflow' }).first().click();
+		// Navigate to Workflows via the Configure page → open editor
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+		await page.getByTestId('space-configure-tab-workflows').click();
+		await page.getByRole('button', { name: 'Create Workflow' }).first().click();
 		await expect(page.locator('input[placeholder*="Feature Development"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -237,8 +249,10 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 	test('removing a rule decrements rule count', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 
-		await page.locator('text=Workflows').first().click();
-		await page.getByRole('button', { name: 'New Workflow' }).first().click();
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+		await page.getByTestId('space-configure-tab-workflows').click();
+		await page.getByRole('button', { name: 'Create Workflow' }).first().click();
 		await expect(page.locator('input[placeholder*="Feature Development"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -258,8 +272,10 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 	test('can open agent creation form from Agents tab', async ({ page }) => {
 		await navigateToSpace(page, spaceId);
 
-		// Navigate to agents tab
-		await page.locator('text=Agents').first().click();
+		// Navigate to Agents via the Configure page
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+		await page.getByTestId('space-configure-tab-agents').click();
 		await expect(
 			page.locator('text=No custom agents yet').or(page.locator('text=Create Agent'))
 		).toBeVisible({ timeout: 5000 });
@@ -316,7 +332,9 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 
 		test('can delete a workflow via list UI', async ({ page }) => {
 			await navigateToSpace(page, spaceId);
-			await page.locator('text=Workflows').first().click();
+			await page.getByRole('button', { name: 'Configure space' }).click();
+			await expect(page.getByTestId('space-configure-view')).toBeVisible({ timeout: 5000 });
+			await page.getByTestId('space-configure-tab-workflows').click();
 
 			// The workflow card should appear in the list
 			await expect(page.locator(`text=${deletableWorkflowName}`)).toBeVisible({ timeout: 5000 });

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -72,7 +72,9 @@ export async function getDefaultAgentId(page: Page, spaceId: string): Promise<st
 export async function navigateToSpace(page: Page, spaceId: string): Promise<void> {
 	await page.goto(`/space/${spaceId}`);
 	await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-	await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
+	// Wait for the space overview to render. The space dashboard was refactored and
+	// no longer shows a "Dashboard" tab — use the testid on the overview container instead.
+	await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 15000 });
 }
 
 // ─── Editor mode helpers ───────────────────────────────────────────────────────
@@ -88,9 +90,24 @@ export async function resetEditorModeStorage(page: Page): Promise<void> {
 	});
 }
 
-/** Navigate to Workflows tab and open the workflow editor for a new workflow. */
+/**
+ * Navigate to Workflows tab and open the workflow editor for a new workflow.
+ *
+ * The Workflows tab lives inside the Configure page (/space/:id/configure).
+ * If the current page is not the configure view, this helper first clicks the
+ * "Configure space" gear button in the context panel to get there.
+ */
 export async function openNewWorkflowEditor(page: Page): Promise<void> {
-	await page.locator('text=Workflows').first().click();
+	// Navigate to configure view if not already there.
+	const configureView = page.getByTestId('space-configure-view');
+	if (!(await configureView.isVisible().catch(() => false))) {
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(configureView).toBeVisible({ timeout: 5000 });
+	}
+
+	// Switch to Workflows tab within the configure page.
+	await page.getByTestId('space-configure-tab-workflows').click();
+
 	const createBtn = page.getByRole('button', { name: 'Create Workflow' });
 	await expect(createBtn).toBeVisible({ timeout: 5000 });
 	await createBtn.click();
@@ -123,9 +140,22 @@ export async function switchToVisualMode(page: Page): Promise<void> {
 /**
  * Open the workflow edit UI for an existing workflow in the list.
  * The edit button is CSS group-hover only, so opacity is forced via JS before clicking.
+ *
+ * The Workflows tab lives inside the Configure page (/space/:id/configure).
+ * If the current page is not the configure view, this helper first clicks the
+ * "Configure space" gear button in the context panel to get there.
  */
 export async function openWorkflowForEdit(page: Page, workflowName: string): Promise<void> {
-	await page.locator('text=Workflows').first().click();
+	// Navigate to configure view if not already there.
+	const configureView = page.getByTestId('space-configure-view');
+	if (!(await configureView.isVisible().catch(() => false))) {
+		await page.getByRole('button', { name: 'Configure space' }).click();
+		await expect(configureView).toBeVisible({ timeout: 5000 });
+	}
+
+	// Switch to Workflows tab within the configure page.
+	await page.getByTestId('space-configure-tab-workflows').click();
+
 	await expect(page.locator(`text=${workflowName}`)).toBeVisible({ timeout: 5000 });
 
 	const workflowCard = page


### PR DESCRIPTION
Fix E2E tests broken by the space dashboard refactor (commit 44841b6a2 — "Refine space dashboard shell and add style explorer").

The refactor moved the "Dashboard" tab and the Workflows editor into the Configure page at `/space/:id/configure`, but the shared E2E helpers were never updated.

**Changes:**
- `workflow-editor-helpers.ts` — `navigateToSpace`: replace `text=Dashboard` readiness check with `space-overview-view` testid (the container rendered by SpaceIsland for the default/overview route)
- `workflow-editor-helpers.ts` — `openNewWorkflowEditor`: navigate to the configure view via the "Configure space" gear button before clicking the Workflows tab
- `workflow-editor-helpers.ts` — `openWorkflowForEdit`: same, navigate to configure view first
- `space-workflow-rules.e2e.ts` — fix local `navigateToSpace` copy with the same `space-overview-view` fix

Fixes: features-space-gate-custom-badges, features-space-gate-script-check, features-space-agent-centric-workflow, features-space-multi-agent-editor