### PR TITLE
fix(e2e): fix space-settings-crud navigation and tab selector

### DIFF
--- a/packages/e2e/tests/features/space-settings-crud.e2e.ts
+++ b/packages/e2e/tests/features/space-settings-crud.e2e.ts
@@ -32,12 +32,12 @@ test.describe('Space Settings CRUD', () => {
 		spaceName = `E2E Settings Test ${Date.now()}`;
 		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
 
-		// Navigate to the space
-		await page.goto(`/space/${spaceId}`);
-		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
+		// Navigate directly to the configure view (which hosts the Settings tab)
+		await page.goto(`/space/${spaceId}/configure`);
+		await page.waitForURL(`/space/${spaceId}/configure`, { timeout: 10000 });
 
-		// Click the Settings tab
-		await page.getByRole('button', { name: 'Settings', exact: true }).click();
+		// Click the Settings tab (role="tab", identified by data-testid)
+		await page.getByTestId('space-configure-tab-settings').click();
 		await expect(page.locator('text=Danger Zone')).toBeVisible({ timeout: 5000 });
 	});
 


### PR DESCRIPTION
Fix two bugs in the space-settings-crud E2E test that caused `toBeVisible()` failures:

- Navigate to `/space/:id/configure` (the configure route) instead of `/space/:id` (dashboard route); the Settings tab only exists on the configure view
- Use `getByTestId('space-configure-tab-settings')` instead of `getByRole('button', { name: 'Settings', exact: true })` — the tab renders with `role="tab"` and its text includes a count badge, so the role and name were both wrong