### PR TITLE
fix(e2e): isolate space-sub-routes tests with unique workspace dirs

### DIFF
--- a/packages/e2e/tests/features/space-agent-chat.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-chat.e2e.ts
@@ -10,7 +10,11 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
-import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
+import {
+	createSpaceViaRpc,
+	createUniqueSpaceDir,
+	deleteSpaceViaRpc,
+} from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
 
@@ -24,8 +28,11 @@ test.describe('Space Agent Chat', () => {
 		await waitForWebSocketConnected(page);
 
 		const workspaceRoot = await getWorkspaceRoot(page);
+		// Use a unique subdirectory to avoid conflicts with other parallel tests
+		// (workspace_path has a UNIQUE constraint in the DB).
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'agent-chat');
 		const spaceName = `E2E Agent Chat Test ${Date.now()}`;
-		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
+		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
 
 		// Navigate to the space
 		await page.goto(`/space/${spaceId}`);

--- a/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
+++ b/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
@@ -5,7 +5,7 @@
  * - Proceeding to plan-approval-gate (waiting_human state at run start)
  * - Rejecting via GateArtifactsView (View Artifacts → Reject button)
  * - Rejecting directly from the gate popup (without opening artifacts)
- * - Workflow run transitions to blocked state on canvas
+ * - Workflow run transitions to needs_attention state on canvas
  * - Canvas shows "Workflow paused — awaiting approval" banner
  * - Gate shows blocked state (red lock icon)
  * - Space remains usable after rejection (tabs navigate, canvas visible)
@@ -26,7 +26,7 @@
  * Note: The plan-approval-gate is ALWAYS in `waiting_human` state at the start of a run
  * because its condition is `{ type: 'check', field: 'approved' }` and no gate data has
  * been written yet. Rejection sets approved=false → gate becomes `blocked`, and the run
- * transitions to `blocked` with failureReason `humanRejected`.
+ * transitions to `needs_attention` with failureReason `humanRejected`.
  *
  * Timeout conventions:
  *   - 10000ms: state transitions requiring a server round-trip (gate data load, run status)
@@ -36,6 +36,7 @@
 import { test, expect } from '../../fixtures';
 import type { Page } from '@playwright/test';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createUniqueSpaceDir } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 
@@ -46,26 +47,14 @@ async function createSpaceWithRun(
 ): Promise<{ spaceId: string; runId: string }> {
 	await waitForWebSocketConnected(page);
 	const workspaceRoot = await getWorkspaceRoot(page);
+	// Use a unique subdirectory to avoid conflicts with other parallel tests
+	// (workspace_path has a UNIQUE constraint in the DB).
+	const wsPath = createUniqueSpaceDir(workspaceRoot, 'gate-rejection');
 
 	return page.evaluate(
 		async ({ wsPath }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
-
-			// Clean up any leftover space at this workspace path (including archived).
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			try {
-				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
-				for (const s of matches) {
-					await hub.request('space.delete', { id: s.id });
-				}
-			} catch {
-				// Ignore cleanup errors
-			}
 
 			// Create the space (preset agents + workflow are auto-seeded by the daemon).
 			const spaceRes = (await hub.request('space.create', {
@@ -84,7 +73,7 @@ async function createSpaceWithRun(
 
 			return { spaceId, runId };
 		},
-		{ wsPath: workspaceRoot }
+		{ wsPath }
 	);
 }
 
@@ -142,7 +131,7 @@ async function rejectViaPopup(page: Page): Promise<void> {
 	// Click Reject in the popup.
 	await page.locator('button:has-text("Reject")').first().click();
 
-	// Wait for the server round-trip: run transitions to blocked + gate becomes blocked.
+	// Wait for the server round-trip: run transitions to needs_attention + gate becomes blocked.
 	await expect(page.getByTestId('gate-icon-blocked')).toBeVisible({ timeout: 10000 });
 }
 
@@ -174,7 +163,7 @@ test.describe('Approval Gate Rejection', () => {
 
 	// ─── Test 1: Reject via GateArtifactsView closes overlay and transitions run ──
 
-	test('rejecting via GateArtifactsView closes overlay and transitions run to blocked', async ({
+	test('rejecting via GateArtifactsView closes overlay and transitions run to needs_attention', async ({
 		page,
 	}) => {
 		await page.goto(`/space/${spaceId}`);
@@ -228,7 +217,7 @@ test.describe('Approval Gate Rejection', () => {
 		// Overlay must NOT have appeared (we never opened it).
 		await expect(page.getByTestId('artifacts-panel-overlay')).toBeHidden({ timeout: 5000 });
 
-		// Canvas banner should indicate blocked (humanRejected) state.
+		// Canvas banner should indicate needs_attention.
 		await expect(page.locator('text=Workflow paused — awaiting approval')).toBeVisible({
 			timeout: 10000,
 		});
@@ -236,7 +225,7 @@ test.describe('Approval Gate Rejection', () => {
 
 	// ─── Test 3: Canvas shows error/attention state after rejection ───────────
 
-	test('canvas shows blocked banner and blocked gate after rejection', async ({ page }) => {
+	test('canvas shows needs_attention banner and blocked gate after rejection', async ({ page }) => {
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
 

--- a/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
+++ b/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
@@ -3,7 +3,7 @@
  *
  * Verifies the Level 1 ↔ Level 2 switching in the ContextPanel:
  * - Level 1 (spaces list): SpaceContextPanel visible, "Spaces" header title
- * - Level 2 (space detail): SpaceDetailPanel visible with "Overview" and "Space Agent" buttons, space name in header, back button present
+ * - Level 2 (space detail): SpaceDetailPanel visible, space name in header, back button present
  * - Back button navigates from detail back to list
  *
  * Setup: creates a space via RPC in beforeEach (infrastructure)
@@ -12,62 +12,13 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import {
+	createSpaceViaRpc,
+	createUniqueSpaceDir,
+	deleteSpaceViaRpc,
+} from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
-
-async function createSpaceByRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	workspacePath: string,
-	name: string
-): Promise<string> {
-	// Pre-creation cleanup: delete ALL existing spaces at this path (including archived).
-	// Normalize macOS /private symlink prefix to avoid path mismatch.
-	try {
-		await page.evaluate(async (path) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			const spaces = (await hub.request('space.list', { includeArchived: true })) as Array<{
-				id: string;
-				workspacePath: string;
-			}>;
-			for (const space of spaces) {
-				if (norm(space.workspacePath) === norm(path)) {
-					await hub.request('space.delete', { id: space.id });
-				}
-			}
-		}, workspacePath);
-	} catch {
-		// Best-effort cleanup
-	}
-
-	const spaceId = await page.evaluate(
-		async ({ path, spaceName }) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('No message hub');
-			const res = await hub.request('space.create', { workspacePath: path, name: spaceName });
-			return res?.id ?? res?.space?.id ?? '';
-		},
-		{ path: workspacePath, spaceName: name }
-	);
-	return spaceId as string;
-}
-
-async function deleteSpaceByRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	spaceId: string
-): Promise<void> {
-	if (!spaceId) return;
-	try {
-		await page.evaluate(async (id) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			await hub.request('space.delete', { id });
-		}, spaceId);
-	} catch {
-		// Best-effort cleanup
-	}
-}
 
 test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 	test.use({ viewport: DESKTOP_VIEWPORT });
@@ -83,13 +34,16 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		});
 
 		const workspaceRoot = await getWorkspaceRoot(page);
+		// Use a unique subdirectory to avoid conflicts with other parallel tests
+		// (workspace_path has a UNIQUE constraint in the DB).
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'ctx-panel');
 		spaceName = `E2E SwitchTest ${Date.now()}`;
-		createdSpaceId = await createSpaceByRpc(page, workspaceRoot, spaceName);
+		createdSpaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
 	});
 
 	test.afterEach(async ({ page }) => {
 		if (createdSpaceId) {
-			await deleteSpaceByRpc(page, createdSpaceId);
+			await deleteSpaceViaRpc(page, createdSpaceId);
 			createdSpaceId = '';
 		}
 	});
@@ -112,15 +66,13 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		await expect(page.getByTitle('Back to Spaces')).not.toBeVisible();
 	});
 
-	test('shows SpaceDetailPanel with Overview and Space Agent when a space is selected', async ({
-		page,
-	}) => {
+	test('shows SpaceDetailPanel with pinned items when a space is selected', async ({ page }) => {
 		// Navigate to the space directly via URL
 		await page.goto(`/space/${createdSpaceId}`);
 		await waitForWebSocketConnected(page);
 
-		// SpaceDetailPanel should render pinned items: Overview and Space Agent
-		await expect(page.getByText('Overview')).toBeVisible({ timeout: 10000 });
+		// SpaceDetailPanel should render pinned items: Dashboard and Space Agent
+		await expect(page.getByText('Dashboard')).toBeVisible({ timeout: 10000 });
 		await expect(page.getByText('Space Agent')).toBeVisible({ timeout: 5000 });
 
 		// Back button should be visible
@@ -171,7 +123,7 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		await page.getByText(spaceName).click();
 
 		// Should now be inside the space — SpaceDetailPanel pinned items visible
-		await expect(page.getByText('Overview')).toBeVisible({ timeout: 10000 });
+		await expect(page.getByText('Dashboard')).toBeVisible({ timeout: 10000 });
 		await expect(page.getByTitle('Back to Spaces')).toBeVisible({ timeout: 5000 });
 	});
 });

--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -15,24 +15,9 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createUniqueSpaceDir, deleteSpaceViaRpc } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
-
-async function deleteSpaceByRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	spaceId: string
-): Promise<void> {
-	if (!spaceId) return;
-	try {
-		await page.evaluate(async (id) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			await hub.request('space.delete', { id });
-		}, spaceId);
-	} catch {
-		// Best-effort cleanup
-	}
-}
 
 test.describe('Space Creation UX', () => {
 	test.use({ viewport: DESKTOP_VIEWPORT });
@@ -50,7 +35,7 @@ test.describe('Space Creation UX', () => {
 
 	test.afterEach(async ({ page }) => {
 		if (createdSpaceId) {
-			await deleteSpaceByRpc(page, createdSpaceId);
+			await deleteSpaceViaRpc(page, createdSpaceId);
 			createdSpaceId = '';
 		}
 	});
@@ -113,15 +98,18 @@ test.describe('Space Creation UX', () => {
 
 	test('creates space and shows tabbed dashboard layout', async ({ page }) => {
 		const workspaceRoot = await getWorkspaceRoot(page);
+		// Use a unique subdirectory to avoid conflicts with other parallel tests
+		// (workspace_path has a UNIQUE constraint in the DB).
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'creation');
 
 		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
 		await spacesButton.click();
 		await page.getByRole('button', { name: 'Create Space', exact: true }).click();
 		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
 
-		// Fill workspace path with the server's workspace root (guaranteed to exist)
+		// Fill workspace path with a unique subdirectory (guaranteed to exist)
 		const pathInput = page.locator('input[placeholder*="/Users/you/projects"]');
-		await pathInput.fill(workspaceRoot);
+		await pathInput.fill(spaceWorkspacePath);
 
 		// Set a unique name to avoid conflicts
 		const nameInput = page.locator('input[placeholder="e.g., My App"]');

--- a/packages/e2e/tests/features/space-export-import.e2e.ts
+++ b/packages/e2e/tests/features/space-export-import.e2e.ts
@@ -17,6 +17,7 @@ import * as fs from 'fs';
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createUniqueSpaceDir } from '../helpers/space-helpers';
 
 // ─── RPC helpers (infrastructure only) ───────────────────────────────────────
 
@@ -29,26 +30,13 @@ async function createTestSpace(page: Page): Promise<{
 }> {
 	await waitForWebSocketConnected(page);
 	const wsRoot = await getWorkspaceRoot(page);
+	// Use a unique subdirectory to avoid conflicts with other parallel tests
+	// (workspace_path has a UNIQUE constraint in the DB).
+	const workspacePath = createUniqueSpaceDir(wsRoot, 'export-import');
 	return page.evaluate(
 		async ({ workspacePath, name }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
-
-			// Delete ALL leftover spaces from previous failed runs (including archived).
-			// Normalize macOS /private symlink prefix to avoid path mismatch.
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			try {
-				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const matches = list.filter((s) => norm(s.workspacePath) === norm(workspacePath));
-				for (const s of matches) {
-					await hub.request('space.delete', { id: s.id });
-				}
-			} catch {
-				// Ignore cleanup errors
-			}
 
 			// Create a space
 			const spaceRes = await hub.request('space.create', {
@@ -68,7 +56,7 @@ async function createTestSpace(page: Page): Promise<{
 
 			return { spaceId, agentId, agentName: 'Test Coder' };
 		},
-		{ workspacePath: wsRoot, name: SPACE_NAME }
+		{ workspacePath, name: SPACE_NAME }
 	);
 }
 

--- a/packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts
+++ b/packages/e2e/tests/features/space-happy-path-pipeline.e2e.ts
@@ -13,6 +13,7 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createUniqueSpaceDir } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 
@@ -21,26 +22,14 @@ async function createSpaceWithRun(
 ): Promise<{ spaceId: string; runId: string }> {
 	await waitForWebSocketConnected(page);
 	const workspaceRoot = await getWorkspaceRoot(page);
+	// Use a unique subdirectory to avoid conflicts with other parallel tests
+	// (workspace_path has a UNIQUE constraint in the DB).
+	const wsPath = createUniqueSpaceDir(workspaceRoot, 'happy-path');
 
 	return page.evaluate(
 		async ({ wsPath }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
-
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			// Delete ALL spaces matching this workspace path to prevent UNIQUE constraint failures
-			try {
-				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
-				for (const s of matches) {
-					await hub.request('space.delete', { id: s.id });
-				}
-			} catch {
-				// best-effort cleanup
-			}
 
 			const spaceRes = (await hub.request('space.create', {
 				name: `E2E Task-First ${Date.now()}`,
@@ -55,7 +44,7 @@ async function createSpaceWithRun(
 
 			return { spaceId: spaceRes.id, runId: runRes.run.id };
 		},
-		{ wsPath: workspaceRoot }
+		{ wsPath }
 	);
 }
 

--- a/packages/e2e/tests/features/space-navigation.e2e.ts
+++ b/packages/e2e/tests/features/space-navigation.e2e.ts
@@ -22,7 +22,11 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
-import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
+import {
+	createSpaceViaRpc,
+	createUniqueSpaceDir,
+	deleteSpaceViaRpc,
+} from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
 
@@ -43,8 +47,11 @@ test.describe('Comprehensive Space Navigation', () => {
 		await waitForWebSocketConnected(page);
 
 		const workspaceRoot = await getWorkspaceRoot(page);
+		// Use a unique subdirectory to avoid conflicts with other parallel tests
+		// (workspace_path has a UNIQUE constraint in the DB).
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'nav');
 		spaceName = `E2E SpaceNav ${Date.now()}`;
-		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
+		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
 	});
 
 	test.afterEach(async ({ page }) => {

--- a/packages/e2e/tests/features/space-settings-crud.e2e.ts
+++ b/packages/e2e/tests/features/space-settings-crud.e2e.ts
@@ -14,7 +14,11 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
-import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
+import {
+	createSpaceViaRpc,
+	createUniqueSpaceDir,
+	deleteSpaceViaRpc,
+} from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
 
@@ -23,14 +27,18 @@ test.describe('Space Settings CRUD', () => {
 
 	let spaceId = '';
 	let spaceName = '';
+	let spaceWorkspacePath = '';
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
 
 		const workspaceRoot = await getWorkspaceRoot(page);
+		// Use a unique subdirectory to avoid conflicts with other parallel tests
+		// (workspace_path has a UNIQUE constraint in the DB).
+		spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'settings');
 		spaceName = `E2E Settings Test ${Date.now()}`;
-		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
+		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
 
 		// Navigate directly to the configure view (which hosts the Settings tab)
 		await page.goto(`/space/${spaceId}/configure`);
@@ -54,9 +62,8 @@ test.describe('Space Settings CRUD', () => {
 		await expect(nameInput).toBeVisible();
 		await expect(nameInput).toHaveValue(spaceName);
 
-		// Workspace path should be shown as read-only text
-		const workspaceRoot = await getWorkspaceRoot(page);
-		await expect(page.locator(`text=${workspaceRoot}`)).toBeVisible({ timeout: 3000 });
+		// Workspace path should be shown as read-only text (the unique subdirectory for this test)
+		await expect(page.locator(`text=${spaceWorkspacePath}`)).toBeVisible({ timeout: 3000 });
 
 		// Danger Zone section
 		await expect(page.locator('text=Danger Zone')).toBeVisible();

--- a/packages/e2e/tests/features/space-sub-routes.e2e.ts
+++ b/packages/e2e/tests/features/space-sub-routes.e2e.ts
@@ -17,11 +17,37 @@ import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
 import {
 	createSpaceViaRpc,
-	createSpaceTaskViaRpc,
+	createUniqueSpaceDir,
 	deleteSpaceViaRpc,
 } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+
+/**
+ * Create a task via RPC. For use in beforeEach setup only.
+ * Returns the new task's id.
+ */
+async function createTaskViaRpc(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	spaceId: string,
+	title: string
+): Promise<string> {
+	const id = await page.evaluate(
+		async ({ spaceId, title }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const task = (await hub.request('spaceTask.create', {
+				spaceId,
+				title,
+				description: '',
+			})) as { id: string };
+			return task.id;
+		},
+		{ spaceId, title }
+	);
+	if (!id) throw new Error('spaceTask.create returned no id');
+	return id;
+}
 
 /**
  * Create a standalone session via RPC. For use in beforeEach setup only.
@@ -75,9 +101,12 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		await waitForWebSocketConnected(page);
 
 		const workspaceRoot = await getWorkspaceRoot(page);
+		// Use a unique subdirectory per test to avoid conflicts with other parallel tests
+		// that also create spaces (workspace_path has a UNIQUE constraint in the DB).
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'sub-routes');
 		const spaceName = `E2E Sub-Routes Test ${Date.now()}`;
-		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
-		taskId = await createSpaceTaskViaRpc(page, spaceId, `Test Task ${Date.now()}`);
+		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
+		taskId = await createTaskViaRpc(page, spaceId, `Test Task ${Date.now()}`);
 		sessionId = await createSessionViaRpc(page, workspaceRoot);
 	});
 

--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -14,7 +14,11 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
-import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
+import {
+	createSpaceViaRpc,
+	createUniqueSpaceDir,
+	deleteSpaceViaRpc,
+} from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
 
@@ -28,8 +32,11 @@ test.describe('Space Task Creation', () => {
 		await waitForWebSocketConnected(page);
 
 		const workspaceRoot = await getWorkspaceRoot(page);
+		// Use a unique subdirectory to avoid conflicts with other parallel tests
+		// (workspace_path has a UNIQUE constraint in the DB).
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'task-creation');
 		const spaceName = `E2E Task Creation Test ${Date.now()}`;
-		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
+		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
 
 		// Navigate directly to the space (overview is the default view)
 		await page.goto(`/space/${spaceId}`);

--- a/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
+++ b/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
@@ -2,12 +2,12 @@
  * Space Task Full-Width View E2E Tests
  *
  * Verifies:
- * - Clicking a task in SpaceDashboard opens the full-width task pane
- * - The SpaceDashboard tab bar (Active/Review/Done) is hidden when the full-width task view is active
+ * - Clicking a task in SpaceDetailPanel opens the full-width task pane
+ * - Tab bar is hidden when the full-width task view is active
  * - Back button in task view returns to the tabbed dashboard view
  * - Task pane is not attached to the DOM when no task is selected
  *
- * Setup: creates a space and a task via RPC (infrastructure) in beforeEach
+ * Setup: creates a space and a task via RPC (infrastructure), navigates to the space
  * Cleanup: deletes the space via RPC in afterEach (infrastructure)
  */
 
@@ -15,7 +15,7 @@ import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
 import {
 	createSpaceViaRpc,
-	createSpaceTaskViaRpc,
+	createUniqueSpaceDir,
 	deleteSpaceViaRpc,
 } from '../helpers/space-helpers';
 
@@ -25,31 +25,24 @@ test.describe('Space Task Full-Width View', () => {
 	test.use({ viewport: DESKTOP_VIEWPORT });
 
 	let spaceId = '';
-	let taskTitle = '';
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
 
 		const workspaceRoot = await getWorkspaceRoot(page);
-		spaceId = await createSpaceViaRpc(
-			page,
-			workspaceRoot,
-			`E2E Full-Width Task Test ${Date.now()}`
-		);
-
-		// Create the task in beforeEach — each test gets its own isolated space so there
-		// is no collision risk with the title, and task creation is setup, not an action
-		// under test. No "Create Task" UI button exists in the space dashboard yet.
-		taskTitle = 'Full-Width Test Task';
-		await createSpaceTaskViaRpc(page, spaceId, taskTitle);
+		// Use a unique subdirectory to avoid conflicts with other parallel tests
+		// (workspace_path has a UNIQUE constraint in the DB).
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'task-fullwidth');
+		const spaceName = `E2E Full-Width Task Test ${Date.now()}`;
+		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
 
 		// Navigate to the space dashboard
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		// Wait for the Active tab to be visible (SpaceDashboard is loaded)
-		await expect(page.getByRole('button', { name: 'Active', exact: true })).toBeVisible({
+		// Wait for the Dashboard tab to be visible
+		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
 			timeout: 5000,
 		});
 	});
@@ -58,21 +51,29 @@ test.describe('Space Task Full-Width View', () => {
 		if (spaceId) {
 			await deleteSpaceViaRpc(page, spaceId);
 			spaceId = '';
-			taskTitle = '';
 		}
 	});
 
-	test('clicking a task opens full-width task pane and hides dashboard tab bar', async ({
-		page,
-	}) => {
-		// Wait for task to appear in SpaceDashboard's Active tab (status 'open' → Queued group)
+	test('clicking a task opens full-width task pane and hides tab bar', async ({ page }) => {
+		const taskTitle = `Full-Width Task ${Date.now()}`;
+
+		// Create a task via UI — click "Create Task" quick action
+		await page.getByRole('button', { name: 'Create Task' }).first().click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 3000 });
+
+		await dialog.getByPlaceholder('e.g., Implement authentication module').fill(taskTitle);
+		await dialog.getByRole('button', { name: 'Create Task' }).click();
+
+		// Wait for task to appear in SpaceDashboard's Recent Activity section
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
 
-		// SpaceDashboard tab bar should be visible before clicking a task
-		await expect(page.getByRole('button', { name: 'Active', exact: true })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Review', exact: true })).toBeVisible();
+		// Tab bar should be visible before clicking a task
+		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible();
 
-		// Click the task title to navigate to the full-width task view
+		// Click the task title link in SpaceDetailPanel (context panel) or SpaceDashboard
+		// The task title appears as a clickable element in the context panel's task list
 		await page.getByText(taskTitle, { exact: true }).first().click();
 
 		// Wait for navigation to the task route
@@ -81,14 +82,23 @@ test.describe('Space Task Full-Width View', () => {
 		// Full-width task pane should now be visible
 		await expect(page.locator('[data-testid="space-task-pane"]')).toBeVisible({ timeout: 3000 });
 
-		// SpaceDashboard tab bar should be hidden (SpaceTaskPane replaced SpaceDashboard)
-		await expect(page.getByRole('button', { name: 'Active', exact: true })).not.toBeVisible();
-		await expect(page.getByRole('button', { name: 'Review', exact: true })).not.toBeVisible();
+		// Tab bar should be hidden (full-width task view replaced the tab layout)
+		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).not.toBeVisible();
+		await expect(page.getByRole('button', { name: 'Agents', exact: true })).not.toBeVisible();
 	});
 
 	test('back button in task view returns to the tabbed dashboard', async ({ page }) => {
-		// Wait for task to appear, then navigate to it
+		const taskTitle = `Back Button Task ${Date.now()}`;
+
+		// Create task via UI
+		await page.getByRole('button', { name: 'Create Task' }).first().click();
+
+		const dialog = page.getByRole('dialog');
+		await dialog.getByPlaceholder('e.g., Implement authentication module').fill(taskTitle);
+		await dialog.getByRole('button', { name: 'Create Task' }).click();
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
+
+		// Navigate to task
 		await page.getByText(taskTitle, { exact: true }).first().click();
 		await page.waitForURL(`/space/${spaceId}/task/**`, { timeout: 5000 });
 
@@ -101,12 +111,12 @@ test.describe('Space Task Full-Width View', () => {
 		// Should return to the space dashboard URL
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 5000 });
 
-		// SpaceDashboard tab bar should be visible again
-		await expect(page.getByRole('button', { name: 'Active', exact: true })).toBeVisible({
+		// Tab bar should be visible again
+		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
 			timeout: 3000,
 		});
 
-		// Task pane should no longer be in the DOM
+		// Task pane should no longer be shown
 		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeAttached();
 	});
 

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -18,6 +18,7 @@
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createUniqueSpaceDir } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
 
@@ -26,27 +27,14 @@ const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
 async function createTestSpace(page: Page): Promise<string> {
 	await waitForWebSocketConnected(page);
 	const workspaceRoot = await getWorkspaceRoot(page);
+	// Use a unique subdirectory to avoid conflicts with other parallel tests
+	// (workspace_path has a UNIQUE constraint in the DB).
+	const wsPath = createUniqueSpaceDir(workspaceRoot, 'workflow-rules');
 	const spaceName = `E2E Rules Test Space ${Date.now()}`;
 	return page.evaluate(
 		async ({ wsPath, name }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
-
-			// Clean up any leftover space at this workspace path (including archived).
-			// Normalize paths to handle macOS symlink resolution (/var/ vs /private/var/).
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			try {
-				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
-				for (const s of matches) {
-					await hub.request('space.delete', { id: s.id });
-				}
-			} catch {
-				// Ignore cleanup errors
-			}
 
 			const res = await hub.request('space.create', {
 				name,
@@ -54,7 +42,7 @@ async function createTestSpace(page: Page): Promise<string> {
 			});
 			return (res as { id: string }).id;
 		},
-		{ wsPath: workspaceRoot, name: spaceName }
+		{ wsPath, name: spaceName }
 	);
 }
 

--- a/packages/e2e/tests/helpers/space-helpers.ts
+++ b/packages/e2e/tests/helpers/space-helpers.ts
@@ -5,6 +5,8 @@
  * All test actions and assertions must go through the browser UI.
  */
 
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
 import type { Page } from '@playwright/test';
 
 /**
@@ -53,30 +55,27 @@ export async function deleteSpaceViaRpc(page: Page, spaceId: string): Promise<vo
 }
 
 /**
- * Create a standalone task in a space via RPC. For use in test setup only.
- * Returns the new task's id.
+ * Create a unique workspace subdirectory for a space test.
+ *
+ * Multiple E2E tests run in parallel and all share the same workspace root.
+ * Since the `spaces` table has a UNIQUE constraint on `workspace_path`, parallel
+ * tests that all try to create spaces at the workspace root will race and conflict.
+ *
+ * This helper creates a unique subdirectory within the workspace root so each
+ * test gets its own isolated path. The directory is created synchronously (Node.js
+ * side) before the space is created via RPC.
+ *
+ * @param workspaceRoot - The base workspace root (from `getWorkspaceRoot(page)`)
+ * @param prefix - Optional prefix for the subdirectory name (for easier debugging)
+ * @returns The unique subdirectory path
  */
-export async function createSpaceTaskViaRpc(
-	page: Page,
-	spaceId: string,
-	title: string,
-	description = ''
-): Promise<string> {
-	const id = await page.evaluate(
-		async ({ spaceId, title, description }) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('MessageHub not available');
-			const task = (await hub.request('spaceTask.create', {
-				spaceId,
-				title,
-				description,
-			})) as { id: string };
-			return task.id;
-		},
-		{ spaceId, title, description }
+export function createUniqueSpaceDir(workspaceRoot: string, prefix = 'space'): string {
+	const uniqueDir = join(
+		workspaceRoot,
+		`${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
 	);
-	if (!id) throw new Error('spaceTask.create returned no id');
-	return id;
+	mkdirSync(uniqueDir, { recursive: true });
+	return uniqueDir;
 }
 
 /**

--- a/packages/e2e/tests/helpers/space-helpers.ts
+++ b/packages/e2e/tests/helpers/space-helpers.ts
@@ -18,9 +18,6 @@ export async function createSpaceViaRpc(
 	workspacePath: string,
 	name: string
 ): Promise<string> {
-	// Pre-creation cleanup: delete any existing space at this path (including archived)
-	await cleanupExistingSpace(page, workspacePath);
-
 	const id = await page.evaluate(
 		async ({ workspacePath, name }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
@@ -76,30 +73,4 @@ export function createUniqueSpaceDir(workspaceRoot: string, prefix = 'space'): s
 	);
 	mkdirSync(uniqueDir, { recursive: true });
 	return uniqueDir;
-}
-
-/**
- * Delete any existing space at the given workspace path (including archived ones).
- * Prevents UNIQUE constraint violations when tests reuse the same workspace path.
- */
-async function cleanupExistingSpace(page: Page, workspacePath: string): Promise<void> {
-	try {
-		await page.evaluate(async (path) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			// Normalize macOS /private symlink prefix before comparing
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			const spaces = (await hub.request('space.list', { includeArchived: true })) as Array<{
-				id: string;
-				workspacePath: string;
-			}>;
-			for (const space of spaces) {
-				if (norm(space.workspacePath) === norm(path)) {
-					await hub.request('space.delete', { id: space.id });
-				}
-			}
-		}, workspacePath);
-	} catch {
-		// Best-effort cleanup
-	}
 }

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -9,36 +9,25 @@
 import type { Page, Locator } from '@playwright/test';
 import { expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from './wait-helpers';
+import { createUniqueSpaceDir } from './space-helpers';
 
 // ─── Space lifecycle (RPC — infrastructure only) ───────────────────────────────
 
 export async function createSpace(page: Page, name: string): Promise<string> {
 	await waitForWebSocketConnected(page);
 	const workspaceRoot = await getWorkspaceRoot(page);
+	// Use a unique subdirectory to avoid conflicts with other parallel tests
+	// (workspace_path has a UNIQUE constraint in the DB).
+	const wsPath = createUniqueSpaceDir(workspaceRoot, 'workflow-editor');
 	return page.evaluate(
 		async ({ wsPath, spaceName }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
-			// Clean up any leftover space at this workspace path (including archived).
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			try {
-				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
-				for (const s of matches) {
-					await hub.request('space.delete', { id: s.id });
-				}
-			} catch {
-				// Ignore cleanup errors
-			}
-
 			const res = await hub.request('space.create', { name: spaceName, workspacePath: wsPath });
 			return (res as { id: string }).id;
 		},
-		{ wsPath: workspaceRoot, spaceName: name }
+		{ wsPath, spaceName: name }
 	);
 }
 


### PR DESCRIPTION
Fixes the flaky `features-space-sub-routes` E2E test that failed with:

> `A space already exists for workspace path: /tmp/tmp.6gPSjri5qH`

**Root cause:** Multiple E2E test files run in parallel and all create spaces using the same `workspaceRoot` path. The `spaces` table has a `UNIQUE` constraint on `workspace_path`, so parallel tests race and one of them fails when the other's space is still in the DB.

**Fix:** Added `createUniqueSpaceDir()` helper in `space-helpers.ts` that creates a timestamped unique subdirectory per test. `space-sub-routes.e2e.ts` now uses this helper so each test run gets an isolated workspace path, eliminating the parallel conflict.