### PR TITLE
fix(e2e): fix space-task-fullwidth test to match actual UI

### DIFF
--- a/packages/e2e/tests/features/space-sub-routes.e2e.ts
+++ b/packages/e2e/tests/features/space-sub-routes.e2e.ts
@@ -15,35 +15,13 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
-import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
+import {
+	createSpaceViaRpc,
+	createSpaceTaskViaRpc,
+	deleteSpaceViaRpc,
+} from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
-
-/**
- * Create a task via RPC. For use in beforeEach setup only.
- * Returns the new task's id.
- */
-async function createTaskViaRpc(
-	page: Parameters<typeof waitForWebSocketConnected>[0],
-	spaceId: string,
-	title: string
-): Promise<string> {
-	const id = await page.evaluate(
-		async ({ spaceId, title }) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('MessageHub not available');
-			const task = (await hub.request('spaceTask.create', {
-				spaceId,
-				title,
-				description: '',
-			})) as { id: string };
-			return task.id;
-		},
-		{ spaceId, title }
-	);
-	if (!id) throw new Error('spaceTask.create returned no id');
-	return id;
-}
 
 /**
  * Create a standalone session via RPC. For use in beforeEach setup only.
@@ -99,7 +77,7 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		const workspaceRoot = await getWorkspaceRoot(page);
 		const spaceName = `E2E Sub-Routes Test ${Date.now()}`;
 		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
-		taskId = await createTaskViaRpc(page, spaceId, `Test Task ${Date.now()}`);
+		taskId = await createSpaceTaskViaRpc(page, spaceId, `Test Task ${Date.now()}`);
 		sessionId = await createSessionViaRpc(page, workspaceRoot);
 	});
 

--- a/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
+++ b/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
@@ -56,7 +56,9 @@ test.describe('Space Task Full-Width View', () => {
 	}) => {
 		const taskTitle = `Full-Width Task ${Date.now()}`;
 
-		// Create a task via RPC (infrastructure — no Create Task button exists in the space UI)
+		// Create a task via RPC inside the test body (not beforeEach) because each test
+		// needs a uniquely-named task, and no "Create Task" UI button exists in the space
+		// dashboard yet (SpaceCreateTaskDialog is defined but not wired to any trigger).
 		await createSpaceTaskViaRpc(page, spaceId, taskTitle);
 
 		// Wait for task to appear in SpaceDashboard's Active tab (status 'open' → Queued group)
@@ -83,7 +85,8 @@ test.describe('Space Task Full-Width View', () => {
 	test('back button in task view returns to the tabbed dashboard', async ({ page }) => {
 		const taskTitle = `Back Button Task ${Date.now()}`;
 
-		// Create task via RPC (infrastructure)
+		// Create a task via RPC inside the test body — same reasoning as above:
+		// unique title per test, no UI creation path available.
 		await createSpaceTaskViaRpc(page, spaceId, taskTitle);
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
 

--- a/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
+++ b/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
@@ -2,18 +2,22 @@
  * Space Task Full-Width View E2E Tests
  *
  * Verifies:
- * - Clicking a task in SpaceDetailPanel opens the full-width task pane
- * - Tab bar is hidden when the full-width task view is active
+ * - Clicking a task in SpaceDashboard opens the full-width task pane
+ * - The SpaceDashboard tab bar (Active/Review/Done) is hidden when the full-width task view is active
  * - Back button in task view returns to the tabbed dashboard view
  * - Task pane is not attached to the DOM when no task is selected
  *
- * Setup: creates a space and a task via RPC (infrastructure), navigates to the space
+ * Setup: creates a space via RPC (infrastructure), navigates to the space
  * Cleanup: deletes the space via RPC in afterEach (infrastructure)
  */
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
-import { createSpaceViaRpc, deleteSpaceViaRpc } from '../helpers/space-helpers';
+import {
+	createSpaceViaRpc,
+	createSpaceTaskViaRpc,
+	deleteSpaceViaRpc,
+} from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
 
@@ -34,8 +38,8 @@ test.describe('Space Task Full-Width View', () => {
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		// Wait for the Dashboard tab to be visible
-		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
+		// Wait for the Active tab to be visible (SpaceDashboard is loaded)
+		await expect(page.getByRole('button', { name: 'Active', exact: true })).toBeVisible({
 			timeout: 5000,
 		});
 	});
@@ -47,26 +51,22 @@ test.describe('Space Task Full-Width View', () => {
 		}
 	});
 
-	test('clicking a task opens full-width task pane and hides tab bar', async ({ page }) => {
+	test('clicking a task opens full-width task pane and hides dashboard tab bar', async ({
+		page,
+	}) => {
 		const taskTitle = `Full-Width Task ${Date.now()}`;
 
-		// Create a task via UI — click "Create Task" quick action
-		await page.getByRole('button', { name: 'Create Task' }).first().click();
+		// Create a task via RPC (infrastructure — no Create Task button exists in the space UI)
+		await createSpaceTaskViaRpc(page, spaceId, taskTitle);
 
-		const dialog = page.getByRole('dialog');
-		await expect(dialog).toBeVisible({ timeout: 3000 });
-
-		await dialog.getByPlaceholder('e.g., Implement authentication module').fill(taskTitle);
-		await dialog.getByRole('button', { name: 'Create Task' }).click();
-
-		// Wait for task to appear in SpaceDashboard's Recent Activity section
+		// Wait for task to appear in SpaceDashboard's Active tab (status 'open' → Queued group)
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
 
-		// Tab bar should be visible before clicking a task
-		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible();
+		// SpaceDashboard tab bar should be visible before clicking a task
+		await expect(page.getByRole('button', { name: 'Active', exact: true })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Review', exact: true })).toBeVisible();
 
-		// Click the task title link in SpaceDetailPanel (context panel) or SpaceDashboard
-		// The task title appears as a clickable element in the context panel's task list
+		// Click the task title to navigate to the full-width task view
 		await page.getByText(taskTitle, { exact: true }).first().click();
 
 		// Wait for navigation to the task route
@@ -75,23 +75,19 @@ test.describe('Space Task Full-Width View', () => {
 		// Full-width task pane should now be visible
 		await expect(page.locator('[data-testid="space-task-pane"]')).toBeVisible({ timeout: 3000 });
 
-		// Tab bar should be hidden (full-width task view replaced the tab layout)
-		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).not.toBeVisible();
-		await expect(page.getByRole('button', { name: 'Agents', exact: true })).not.toBeVisible();
+		// SpaceDashboard tab bar should be hidden (SpaceTaskPane replaced SpaceDashboard)
+		await expect(page.getByRole('button', { name: 'Active', exact: true })).not.toBeVisible();
+		await expect(page.getByRole('button', { name: 'Review', exact: true })).not.toBeVisible();
 	});
 
 	test('back button in task view returns to the tabbed dashboard', async ({ page }) => {
 		const taskTitle = `Back Button Task ${Date.now()}`;
 
-		// Create task via UI
-		await page.getByRole('button', { name: 'Create Task' }).first().click();
-
-		const dialog = page.getByRole('dialog');
-		await dialog.getByPlaceholder('e.g., Implement authentication module').fill(taskTitle);
-		await dialog.getByRole('button', { name: 'Create Task' }).click();
+		// Create task via RPC (infrastructure)
+		await createSpaceTaskViaRpc(page, spaceId, taskTitle);
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
 
-		// Navigate to task
+		// Navigate to task by clicking its title
 		await page.getByText(taskTitle, { exact: true }).first().click();
 		await page.waitForURL(`/space/${spaceId}/task/**`, { timeout: 5000 });
 
@@ -104,12 +100,12 @@ test.describe('Space Task Full-Width View', () => {
 		// Should return to the space dashboard URL
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 5000 });
 
-		// Tab bar should be visible again
-		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
+		// SpaceDashboard tab bar should be visible again
+		await expect(page.getByRole('button', { name: 'Active', exact: true })).toBeVisible({
 			timeout: 3000,
 		});
 
-		// Task pane should no longer be shown
+		// Task pane should no longer be in the DOM
 		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeAttached();
 	});
 

--- a/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
+++ b/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
@@ -7,7 +7,7 @@
  * - Back button in task view returns to the tabbed dashboard view
  * - Task pane is not attached to the DOM when no task is selected
  *
- * Setup: creates a space via RPC (infrastructure), navigates to the space
+ * Setup: creates a space and a task via RPC (infrastructure) in beforeEach
  * Cleanup: deletes the space via RPC in afterEach (infrastructure)
  */
 
@@ -25,14 +25,24 @@ test.describe('Space Task Full-Width View', () => {
 	test.use({ viewport: DESKTOP_VIEWPORT });
 
 	let spaceId = '';
+	let taskTitle = '';
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
 
 		const workspaceRoot = await getWorkspaceRoot(page);
-		const spaceName = `E2E Full-Width Task Test ${Date.now()}`;
-		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
+		spaceId = await createSpaceViaRpc(
+			page,
+			workspaceRoot,
+			`E2E Full-Width Task Test ${Date.now()}`
+		);
+
+		// Create the task in beforeEach — each test gets its own isolated space so there
+		// is no collision risk with the title, and task creation is setup, not an action
+		// under test. No "Create Task" UI button exists in the space dashboard yet.
+		taskTitle = 'Full-Width Test Task';
+		await createSpaceTaskViaRpc(page, spaceId, taskTitle);
 
 		// Navigate to the space dashboard
 		await page.goto(`/space/${spaceId}`);
@@ -48,19 +58,13 @@ test.describe('Space Task Full-Width View', () => {
 		if (spaceId) {
 			await deleteSpaceViaRpc(page, spaceId);
 			spaceId = '';
+			taskTitle = '';
 		}
 	});
 
 	test('clicking a task opens full-width task pane and hides dashboard tab bar', async ({
 		page,
 	}) => {
-		const taskTitle = `Full-Width Task ${Date.now()}`;
-
-		// Create a task via RPC inside the test body (not beforeEach) because each test
-		// needs a uniquely-named task, and no "Create Task" UI button exists in the space
-		// dashboard yet (SpaceCreateTaskDialog is defined but not wired to any trigger).
-		await createSpaceTaskViaRpc(page, spaceId, taskTitle);
-
 		// Wait for task to appear in SpaceDashboard's Active tab (status 'open' → Queued group)
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
 
@@ -83,14 +87,8 @@ test.describe('Space Task Full-Width View', () => {
 	});
 
 	test('back button in task view returns to the tabbed dashboard', async ({ page }) => {
-		const taskTitle = `Back Button Task ${Date.now()}`;
-
-		// Create a task via RPC inside the test body — same reasoning as above:
-		// unique title per test, no UI creation path available.
-		await createSpaceTaskViaRpc(page, spaceId, taskTitle);
+		// Wait for task to appear, then navigate to it
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
-
-		// Navigate to task by clicking its title
 		await page.getByText(taskTitle, { exact: true }).first().click();
 		await page.waitForURL(`/space/${spaceId}/task/**`, { timeout: 5000 });
 

--- a/packages/e2e/tests/helpers/space-helpers.ts
+++ b/packages/e2e/tests/helpers/space-helpers.ts
@@ -53,6 +53,33 @@ export async function deleteSpaceViaRpc(page: Page, spaceId: string): Promise<vo
 }
 
 /**
+ * Create a standalone task in a space via RPC. For use in test setup only.
+ * Returns the new task's id.
+ */
+export async function createSpaceTaskViaRpc(
+	page: Page,
+	spaceId: string,
+	title: string,
+	description = ''
+): Promise<string> {
+	const id = await page.evaluate(
+		async ({ spaceId, title, description }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const task = (await hub.request('spaceTask.create', {
+				spaceId,
+				title,
+				description,
+			})) as { id: string };
+			return task.id;
+		},
+		{ spaceId, title, description }
+	);
+	if (!id) throw new Error('spaceTask.create returned no id');
+	return id;
+}
+
+/**
  * Delete any existing space at the given workspace path (including archived ones).
  * Prevents UNIQUE constraint violations when tests reuse the same workspace path.
  */


### PR DESCRIPTION
Fix the `features/space-task-fullwidth` E2E test that was failing because it referenced UI elements that don't exist.

**Root causes:**
- Test tried to click a "Create Task" button — no such button exists in the space UI (`SpaceCreateTaskDialog` is defined but not wired to any trigger)
- Test asserted `getByRole('button', { name: 'Dashboard' })` and `getByRole('button', { name: 'Agents' })` — these labels don't exist; the actual buttons are "Active"/"Review"/"Done" (SpaceDashboard tab bar) and "Overview"/"Space Agent" (SpaceDetailPanel nav, always visible)

**Fixes:**
- Task creation moved to RPC infrastructure (`createSpaceTaskViaRpc` helper in `space-helpers.ts`) — follows the accepted infrastructure pattern
- "Dashboard"/"Agents" assertions replaced with "Active"/"Review" (SpaceDashboard tabs that correctly disappear when `SpaceTaskPane` replaces SpaceDashboard in full-width mode)