### PR TITLE
fix(e2e): resolve task-lifecycle dialog strict mode violation

### DIFF
--- a/packages/e2e/tests/features/task-actions-dropdown.e2e.ts
+++ b/packages/e2e/tests/features/task-actions-dropdown.e2e.ts
@@ -184,8 +184,11 @@ test.describe('Task Action Buttons', () => {
 		// Click the cancel button directly
 		await page.locator('[data-testid="task-cancel-button"]').click();
 
-		// Cancel dialog should appear with the task name
-		const cancelDialog = page.locator('[role="dialog"]');
+		// Cancel dialog should appear with the task name — filter to avoid matching
+		// SlideOutPanel which also has role="dialog" in DOM (strict mode violation)
+		const cancelDialog = page
+			.locator('[role="dialog"]')
+			.filter({ has: page.locator('[data-testid="cancel-task-confirm"]') });
 		await expect(cancelDialog.locator('[data-testid="cancel-task-confirm"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -206,8 +209,11 @@ test.describe('Task Action Buttons', () => {
 		await dropdownTrigger.click();
 		await page.locator('[data-testid="task-action-complete"]').click();
 
-		// Complete dialog should appear with the task name
-		const completeDialog = page.locator('[role="dialog"]');
+		// Complete dialog should appear with the task name — filter to avoid matching
+		// SlideOutPanel which also has role="dialog" in DOM (strict mode violation)
+		const completeDialog = page
+			.locator('[role="dialog"]')
+			.filter({ has: page.locator('[data-testid="complete-task-confirm"]') });
 		await expect(completeDialog.locator('[data-testid="complete-task-confirm"]')).toBeVisible({
 			timeout: 5000,
 		});

--- a/packages/e2e/tests/features/task-view-action-dropdown.e2e.ts
+++ b/packages/e2e/tests/features/task-view-action-dropdown.e2e.ts
@@ -150,8 +150,11 @@ test.describe('Task Action Dropdown', () => {
 		const completeAction = page.locator('[data-testid="task-action-complete"]');
 		await completeAction.click();
 
-		// Complete dialog should appear
-		const completeDialog = page.locator('[role="dialog"]');
+		// Complete dialog should appear — filter to avoid matching SlideOutPanel which
+		// also has role="dialog" in DOM when TaskViewV2 is active (strict mode violation)
+		const completeDialog = page
+			.locator('[role="dialog"]')
+			.filter({ has: page.locator('[data-testid="complete-task-confirm"]') });
 		await expect(completeDialog.locator('[data-testid="complete-task-confirm"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -169,8 +172,11 @@ test.describe('Task Action Dropdown', () => {
 		const cancelBtn = page.locator('[data-testid="task-cancel-button"]');
 		await cancelBtn.click();
 
-		// Cancel dialog should appear
-		const cancelDialog = page.locator('[role="dialog"]');
+		// Cancel dialog should appear — filter to avoid matching SlideOutPanel which
+		// also has role="dialog" in DOM when TaskViewV2 is active (strict mode violation)
+		const cancelDialog = page
+			.locator('[role="dialog"]')
+			.filter({ has: page.locator('[data-testid="cancel-task-confirm"]') });
 		await expect(cancelDialog.locator('[data-testid="cancel-task-confirm"]')).toBeVisible({
 			timeout: 5000,
 		});
@@ -205,8 +211,11 @@ test.describe('Task Action Dropdown', () => {
 		const completeAction = page.locator('[data-testid="task-action-complete"]');
 		await completeAction.click();
 
-		// Dropdown should be closed - complete dialog is open
-		const completeDialog = page.locator('[role="dialog"]');
+		// Dropdown should be closed - complete dialog is open — filter to avoid matching
+		// SlideOutPanel which also has role="dialog" in DOM (strict mode violation)
+		const completeDialog = page
+			.locator('[role="dialog"]')
+			.filter({ has: page.locator('[data-testid="complete-task-confirm"]') });
 		await expect(completeDialog).toBeVisible({ timeout: 5000 });
 	});
 


### PR DESCRIPTION
Fix strict mode violation in `task-lifecycle.e2e.ts` where `locator('[role=\"dialog\"]')` matched 2 elements.

**Root cause:** `SlideOutPanel` (used in `TaskViewV2`) always keeps its `role="dialog"` element in the DOM using a CSS `translateX` transform to slide it off-screen. When the archive confirmation modal opens (which uses the same `role="dialog"` via `Modal.tsx`), Playwright's strict mode sees two matching elements and throws.

**Fix:** Filter the archive dialog locator to the element containing `[data-testid="archive-task-confirm"]`, unambiguously targeting only the archive confirmation modal.