### PR TITLE
fix(e2e): update space tests for Dashboard→Overview UI rename

### DIFF
--- a/packages/e2e/tests/features/space-agent-chat.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-chat.e2e.ts
@@ -49,8 +49,8 @@ test.describe('Space Agent Chat', () => {
 	test('clicking Space Agent in SpaceDetailPanel renders ChatContainer with message input', async ({
 		page,
 	}) => {
-		// The space tab view should be visible by default
-		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
+		// The space overview should be visible by default
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({
 			timeout: 5000,
 		});
 
@@ -64,8 +64,8 @@ test.describe('Space Agent Chat', () => {
 		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(messageInput).toBeVisible({ timeout: 10000 });
 
-		// The tab bar should no longer be visible (ChatContainer replaces it)
-		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).not.toBeVisible();
+		// The space overview should no longer be visible (ChatContainer replaced it)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible();
 	});
 
 	test('navigating back to space base route returns to tab view', async ({ page }) => {
@@ -77,12 +77,12 @@ test.describe('Space Agent Chat', () => {
 		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(messageInput).toBeVisible({ timeout: 10000 });
 
-		// Click Dashboard to return to space tab view
+		// Navigate back to space overview
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		// Tab bar should be back
-		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
+		// Space overview should be back
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({
 			timeout: 5000,
 		});
 

--- a/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
+++ b/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
@@ -71,8 +71,8 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		await page.goto(`/space/${createdSpaceId}`);
 		await waitForWebSocketConnected(page);
 
-		// SpaceDetailPanel should render pinned items: Dashboard and Space Agent
-		await expect(page.getByText('Dashboard')).toBeVisible({ timeout: 10000 });
+		// SpaceDetailPanel should render pinned items: Overview and Space Agent
+		await expect(page.getByTestId('space-detail-dashboard')).toBeVisible({ timeout: 10000 });
 		await expect(page.getByText('Space Agent')).toBeVisible({ timeout: 5000 });
 
 		// Back button should be visible
@@ -123,7 +123,7 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		await page.getByText(spaceName).click();
 
 		// Should now be inside the space — SpaceDetailPanel pinned items visible
-		await expect(page.getByText('Dashboard')).toBeVisible({ timeout: 10000 });
+		await expect(page.getByTestId('space-detail-dashboard')).toBeVisible({ timeout: 10000 });
 		await expect(page.getByTitle('Back to Spaces')).toBeVisible({ timeout: 5000 });
 	});
 });

--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -129,7 +129,7 @@ test.describe('Space Creation UX', () => {
 			createdSpaceId = match[1];
 		}
 
-		// Space overview (dashboard) should be visible
+		// Space overview should be visible after navigation
 		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
 		// The tabbed layout with Active / Review / Done tabs should render.

--- a/packages/e2e/tests/features/space-navigation.e2e.ts
+++ b/packages/e2e/tests/features/space-navigation.e2e.ts
@@ -30,11 +30,10 @@ import {
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
 
-// Locator helpers — the sidebar and tab bar share the same button names, so we
-// use data-testid for the sidebar pinned items to avoid ambiguity.
-// "Agents" only exists in the tab bar (not the sidebar), so it is the canonical
-// signal for "tab bar visible" / "tab bar hidden".
-const TAB_BAR_SIGNAL = 'Agents'; // exists only in SpaceIsland tab bar
+// The space overview view (data-testid="space-overview-view") is only rendered when
+// SpaceIsland is in its default mode — it is replaced by ChatContainer (agent/session)
+// or SpaceTaskPane (task) when those views are active.
+// Use it as the canonical signal for "overview active" / "overview hidden".
 
 test.describe('Comprehensive Space Navigation', () => {
 	test.use({ viewport: DESKTOP_VIEWPORT });
@@ -104,10 +103,8 @@ test.describe('Comprehensive Space Navigation', () => {
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		// Tab bar visible by default
-		await expect(page.getByRole('button', { name: TAB_BAR_SIGNAL, exact: true })).toBeVisible({
-			timeout: 5000,
-		});
+		// Space overview visible by default
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
 		// Click "Space Agent" via the sidebar data-testid (avoids name ambiguity)
 		await page.locator('[data-testid="space-detail-agent"]').click();
@@ -119,8 +116,8 @@ test.describe('Comprehensive Space Navigation', () => {
 		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(messageInput).toBeVisible({ timeout: 10000 });
 
-		// Tab bar hidden (Agents tab button only exists in tab bar)
-		await expect(page.getByRole('button', { name: TAB_BAR_SIGNAL, exact: true })).not.toBeVisible();
+		// Space overview hidden (ChatContainer replaced it)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible();
 
 		// Sidebar "Space Agent" item should report active state via data-active attribute
 		await expect(page.locator('[data-testid="space-detail-agent"]')).toHaveAttribute(
@@ -133,15 +130,13 @@ test.describe('Comprehensive Space Navigation', () => {
 	// Dashboard: click returns to tabbed view + all 4 tabs clickable
 	// ---------------------------------------------------------------------------
 
-	test('Dashboard: click → tabbed view returns → all 4 tabs clickable', async ({ page }) => {
+	test('Dashboard: click → overview view returns', async ({ page }) => {
 		// Start in agent view so clicking Dashboard exercises the navigation
 		await page.goto(`/space/${spaceId}/agent`);
 		await page.waitForURL(`/space/${spaceId}/agent`, { timeout: 10000 });
 
-		// Confirm tab bar is gone
-		await expect(page.getByRole('button', { name: TAB_BAR_SIGNAL, exact: true })).not.toBeVisible({
-			timeout: 5000,
-		});
+		// Confirm overview is gone (ChatContainer replaced it)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible({ timeout: 5000 });
 
 		// Click the Dashboard pinned item via data-testid
 		await page.locator('[data-testid="space-detail-dashboard"]').click();
@@ -149,30 +144,19 @@ test.describe('Comprehensive Space Navigation', () => {
 		// URL returns to base space route
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		// All 4 tab buttons should now be visible and individually clickable.
-		// Scope to data-testid="space-tab-bar" to avoid matching the sidebar pinned
-		// "Dashboard" button, which shares the same accessible name.
-		const tabBar = page.locator('[data-testid="space-tab-bar"]');
-		await expect(tabBar).toBeVisible({ timeout: 5000 });
-		for (const tabName of ['Dashboard', 'Agents', 'Workflows', 'Settings']) {
-			const tab = tabBar.getByRole('button', { name: tabName, exact: true });
-			await expect(tab).toBeVisible({ timeout: 5000 });
-			await tab.click();
-			await expect(tab).toBeVisible({ timeout: 2000 });
-		}
+		// Space overview should now be visible
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 	});
 
 	// ---------------------------------------------------------------------------
 	// Task drill-down (integration chain)
 	// ---------------------------------------------------------------------------
 
-	test('Task: click task → full-width pane → back → tabs return', async ({ page }) => {
+	test('Task: click task → full-width pane → back → overview returns', async ({ page }) => {
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		await expect(page.getByRole('button', { name: TAB_BAR_SIGNAL, exact: true })).toBeVisible({
-			timeout: 5000,
-		});
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
 		// Create a task via Quick Action
 		const taskTitle = `Nav Task ${Date.now()}`;
@@ -192,16 +176,14 @@ test.describe('Comprehensive Space Navigation', () => {
 		// Full-width task pane rendered
 		await expect(page.locator('[data-testid="space-task-pane"]')).toBeVisible({ timeout: 3000 });
 
-		// Tab bar hidden (Agents only exists in tab bar)
-		await expect(page.getByRole('button', { name: TAB_BAR_SIGNAL, exact: true })).not.toBeVisible();
+		// Space overview hidden (task pane replaced it)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible();
 
-		// Back button in task pane returns to tab view
+		// Back button in task pane returns to overview
 		await page.locator('[data-testid="task-back-button"]').click();
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 5000 });
 
-		await expect(page.getByRole('button', { name: TAB_BAR_SIGNAL, exact: true })).toBeVisible({
-			timeout: 3000,
-		});
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 3000 });
 		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeAttached();
 	});
 
@@ -253,7 +235,7 @@ test.describe('Comprehensive Space Navigation', () => {
 		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(messageInput).toBeVisible({ timeout: 10000 });
 
-		// Tab bar hidden
-		await expect(page.getByRole('button', { name: TAB_BAR_SIGNAL, exact: true })).not.toBeVisible();
+		// Space overview hidden (ChatContainer replaced it)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible();
 	});
 });

--- a/packages/e2e/tests/features/space-sub-routes.e2e.ts
+++ b/packages/e2e/tests/features/space-sub-routes.e2e.ts
@@ -126,13 +126,8 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		// Tab bar should be visible — scoped to the space tab bar container
-		const tabBar = page.locator('[data-testid="space-tab-bar"]');
-		await expect(tabBar).toBeVisible({ timeout: 5000 });
-		await expect(tabBar.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible();
-		await expect(tabBar.getByRole('button', { name: 'Agents', exact: true })).toBeVisible();
-		await expect(tabBar.getByRole('button', { name: 'Workflows', exact: true })).toBeVisible();
-		await expect(tabBar.getByRole('button', { name: 'Settings', exact: true })).toBeVisible();
+		// Space overview should be visible (default route renders SpaceDashboard)
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
 		// No ChatContainer or task pane
 		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeAttached();
@@ -146,8 +141,8 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(messageInput).toBeVisible({ timeout: 10000 });
 
-		// Tab bar should not be visible (ChatContainer replaced it)
-		await expect(page.locator('[data-testid="space-tab-bar"]')).not.toBeAttached();
+		// Space overview should not be visible (ChatContainer replaced it)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible();
 
 		// No task pane
 		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeAttached();
@@ -161,8 +156,8 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 		await expect(messageInput).toBeVisible({ timeout: 10000 });
 
-		// Tab bar should not be visible (ChatContainer replaced it)
-		await expect(page.locator('[data-testid="space-tab-bar"]')).not.toBeAttached();
+		// Space overview should not be visible (ChatContainer replaced it)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible();
 
 		// No task pane
 		await expect(page.locator('[data-testid="space-task-pane"]')).not.toBeAttached();
@@ -175,15 +170,15 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		// Full-width task pane should be visible
 		await expect(page.locator('[data-testid="space-task-pane"]')).toBeVisible({ timeout: 5000 });
 
-		// Tab bar should not be visible (task pane replaced it)
-		await expect(page.locator('[data-testid="space-tab-bar"]')).not.toBeAttached();
+		// Space overview should not be visible (task pane replaced it)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible();
 	});
 
 	test('browser back/forward navigates correctly between space views', async ({ page }) => {
 		// Step 1: Start at dashboard
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
-		await expect(page.locator('[data-testid="space-tab-bar"]')).toBeVisible({ timeout: 5000 });
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
 		// Step 2: Navigate to agent chat
 		await page.goto(`/space/${spaceId}/agent`);
@@ -208,7 +203,7 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		// Step 5: Browser back — should return to dashboard
 		await page.goBack();
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
-		await expect(page.locator('[data-testid="space-tab-bar"]')).toBeVisible({ timeout: 5000 });
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
 		// Step 6: Browser forward — should return to agent chat
 		await page.goForward();
@@ -224,7 +219,7 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		// Navigate to the space dashboard
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
-		await expect(page.locator('[data-testid="space-tab-bar"]')).toBeVisible({ timeout: 5000 });
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 
 		// Click "Space Agent" in the SpaceDetailPanel sidebar
 		await page.getByRole('button', { name: 'Space Agent', exact: true }).click();
@@ -234,12 +229,12 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		await expect(page.locator('textarea[placeholder*="Ask"]').first()).toBeVisible({
 			timeout: 10000,
 		});
-		// Tab bar should be hidden (ChatContainer replaced the tab view)
-		await expect(page.locator('[data-testid="space-tab-bar"]')).not.toBeAttached();
+		// Space overview should be hidden (ChatContainer replaced the overview)
+		await expect(page.getByTestId('space-overview-view')).not.toBeVisible();
 
 		// Browser back returns to dashboard
 		await page.goBack();
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
-		await expect(page.locator('[data-testid="space-tab-bar"]')).toBeVisible({ timeout: 5000 });
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({ timeout: 5000 });
 	});
 });

--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -42,8 +42,9 @@ test.describe('Space Task Creation', () => {
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		// Wait for the space overview to be rendered
-		await expect(page.locator('[data-testid="space-overview-view"]')).toBeVisible({
+		// Wait for the space overview to be visible
+		await expect(page.getByTestId('space-overview-view')).toBeVisible({
+
 			timeout: 5000,
 		});
 	});

--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -44,7 +44,6 @@ test.describe('Space Task Creation', () => {
 
 		// Wait for the space overview to be visible
 		await expect(page.getByTestId('space-overview-view')).toBeVisible({
-
 			timeout: 5000,
 		});
 	});


### PR DESCRIPTION
Fixes failing E2E tests caused by the Dashboard→Overview sidebar rename (commit `44841b6a2`) and removal of the `space-tab-bar` tab bar from SpaceIsland.

**Changes:**
- `workflow-editor-helpers.ts`: `navigateToSpace` now waits on `getByTestId('space-detail-dashboard')` instead of `locator('text=Dashboard')`
- All space feature tests: replace `text=Dashboard` / `space-tab-bar` locators and `TAB_BAR_SIGNAL` constant with `getByTestId('space-overview-view')` visibility checks, which correctly reflect when the overview is active vs replaced by ChatContainer or SpaceTaskPane
- `space-navigation.e2e.ts`: remove the tab-button-clicking loop (tab bar gone); simplify Dashboard test to check overview visibility