### PR TITLE
fix(e2e): restore Create Task/Start Workflow Run buttons on SpaceDashboard

### DIFF
--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -2,13 +2,13 @@
  * Space Task Creation E2E Tests
  *
  * Verifies:
- * - "Create Task" quick action button opens SpaceCreateTaskDialog
- * - "Start Workflow Run" quick action button opens WorkflowRunStartDialog
+ * - "Create Task" action button opens SpaceCreateTaskDialog
+ * - "Start Workflow Run" action button opens WorkflowRunStartDialog
  * - Filling and submitting the Create Task form creates a task
- * - Created task title appears in SpaceDashboard's Recent Activity section
+ * - Created task title appears in SpaceDashboard's Active task list
  * - Cancelling the dialog dismisses it without creating a task
  *
- * Setup: creates a space via RPC (infrastructure), navigates to its Dashboard tab
+ * Setup: creates a space via RPC (infrastructure), navigates to its overview view
  * Cleanup: deletes the space via RPC in afterEach (infrastructure)
  */
 
@@ -31,12 +31,12 @@ test.describe('Space Task Creation', () => {
 		const spaceName = `E2E Task Creation Test ${Date.now()}`;
 		spaceId = await createSpaceViaRpc(page, workspaceRoot, spaceName);
 
-		// Navigate directly to the space (Dashboard tab is default)
+		// Navigate directly to the space (overview is the default view)
 		await page.goto(`/space/${spaceId}`);
 		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
 
-		// Wait for the Dashboard tab to be active
-		await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({
+		// Wait for the space overview to be rendered
+		await expect(page.locator('[data-testid="space-overview-view"]')).toBeVisible({
 			timeout: 5000,
 		});
 	});
@@ -49,7 +49,7 @@ test.describe('Space Task Creation', () => {
 	});
 
 	test('Create Task button opens SpaceCreateTaskDialog', async ({ page }) => {
-		// Fresh space has no workflows → SpaceDashboard fallback is shown with quick actions
+		// SpaceDashboard always shows action buttons in the header row
 		const createTaskBtn = page.getByRole('button', { name: 'Create Task' }).first();
 		await expect(createTaskBtn).toBeVisible({ timeout: 5000 });
 
@@ -94,7 +94,8 @@ test.describe('Space Task Creation', () => {
 		// Dialog should close after successful submission
 		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
 
-		// The task title should appear in SpaceDashboard's Recent Activity section.
+		// The task title should appear in SpaceDashboard's Active task list.
+		// Newly created tasks have status 'open' and appear in the Active tab.
 		// The store updates reactively via live-query after creation.
 		// Use exact: true to avoid matching the taskTitle substring in the toast.
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -2,6 +2,8 @@ import { useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { cn } from '../../lib/utils';
 import { WorkflowCanvas } from './WorkflowCanvas';
+import { SpaceCreateTaskDialog } from './SpaceCreateTaskDialog';
+import { WorkflowRunStartDialog } from './WorkflowRunStartDialog';
 
 interface SpaceDashboardProps {
 	spaceId: string;
@@ -261,6 +263,8 @@ export function SpaceDashboard({
 	compact = false,
 }: SpaceDashboardProps) {
 	const [activeTab, setActiveTab] = useState<OverviewTab>('active');
+	const [showCreateTask, setShowCreateTask] = useState(false);
+	const [showStartWorkflow, setShowStartWorkflow] = useState(false);
 	const loading = spaceStore.loading.value;
 	const space = spaceStore.space.value;
 	const tasks = [...spaceStore.tasks.value].sort((a, b) => b.updatedAt - a.updatedAt);
@@ -305,7 +309,28 @@ export function SpaceDashboard({
 
 	return (
 		<div class={cn('flex h-full min-h-0 flex-col overflow-y-auto', compact ? 'p-4' : 'p-6')}>
+			<SpaceCreateTaskDialog isOpen={showCreateTask} onClose={() => setShowCreateTask(false)} />
+			<WorkflowRunStartDialog
+				isOpen={showStartWorkflow}
+				onClose={() => setShowStartWorkflow(false)}
+			/>
 			<div class="flex w-full flex-1 min-h-0 flex-col gap-6">
+				<div class="flex items-center justify-end gap-2">
+					<button
+						type="button"
+						onClick={() => setShowStartWorkflow(true)}
+						class="flex items-center gap-1.5 rounded-lg border border-dark-600 bg-dark-800 px-3 py-1.5 text-sm text-gray-300 transition-colors hover:border-dark-500 hover:bg-dark-700 hover:text-gray-100"
+					>
+						Start Workflow Run
+					</button>
+					<button
+						type="button"
+						onClick={() => setShowCreateTask(true)}
+						class="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-500"
+					>
+						Create Task
+					</button>
+				</div>
 				{activeRun && (
 					<section class="rounded-[28px] border border-dark-700 bg-dark-950/70 overflow-hidden">
 						<WorkflowCanvas

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -13,6 +13,7 @@ let mockLoading: ReturnType<typeof signal<boolean>>;
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
 let mockActiveRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
 let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
+let mockWorkflows: ReturnType<typeof signal<unknown[]>>;
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
@@ -22,6 +23,7 @@ vi.mock('../../../lib/space-store', () => ({
 			tasks: mockTasks,
 			activeRuns: mockActiveRuns,
 			workflowRuns: mockWorkflowRuns,
+			workflows: mockWorkflows,
 		};
 	},
 }));
@@ -55,6 +57,7 @@ mockLoading = signal(false);
 mockTasks = signal<SpaceTask[]>([]);
 mockActiveRuns = signal<SpaceWorkflowRun[]>([]);
 mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
+mockWorkflows = signal([]);
 
 import { SpaceDashboard } from '../SpaceDashboard';
 
@@ -127,6 +130,7 @@ describe('SpaceDashboard', () => {
 		mockTasks.value = [];
 		mockActiveRuns.value = [];
 		mockWorkflowRuns.value = [];
+		mockWorkflows.value = [];
 	});
 
 	afterEach(() => {
@@ -255,5 +259,31 @@ describe('SpaceDashboard', () => {
 		mockWorkflowRuns.value = [];
 		const { container } = render(<SpaceDashboard spaceId="space-1" />);
 		expect(container.querySelector('[data-testid="workflow-canvas-svg"]')).toBeNull();
+	});
+
+	it('renders Create Task and Start Workflow Run action buttons', () => {
+		mockSpace.value = makeSpace();
+		const { getByRole } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByRole('button', { name: 'Create Task' })).toBeTruthy();
+		expect(getByRole('button', { name: 'Start Workflow Run' })).toBeTruthy();
+	});
+
+	it('clicking Create Task button opens the Create Task dialog', () => {
+		mockSpace.value = makeSpace();
+		const { getByRole } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getByRole('button', { name: 'Create Task' }));
+		// Modal renders via Portal into document.body
+		const dialog = document.body.querySelector('[role="dialog"]');
+		expect(dialog).toBeTruthy();
+		expect(dialog?.querySelector('h2')?.textContent).toBe('Create Task');
+	});
+
+	it('clicking Start Workflow Run button opens the Start Workflow Run dialog', () => {
+		mockSpace.value = makeSpace();
+		const { getByRole } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getByRole('button', { name: 'Start Workflow Run' }));
+		const dialog = document.body.querySelector('[role="dialog"]');
+		expect(dialog).toBeTruthy();
+		expect(dialog?.querySelector('h2')?.textContent).toBe('Start Workflow Run');
 	});
 });


### PR DESCRIPTION
The `space-task-creation` e2e tests were broken by the tab-based UI refactor that removed quick action buttons from SpaceDashboard.

**Root cause:**
- The SpaceDashboard no longer had "Create Task" or "Start Workflow Run" buttons (the dialog components existed but had no trigger)
- The test `beforeEach` was waiting for a `role="button" name="Dashboard"` tab that was removed

**Changes:**
- `SpaceDashboard.tsx`: Add "Create Task" and "Start Workflow Run" action buttons in the dashboard header, wiring them to the existing `SpaceCreateTaskDialog` and `WorkflowRunStartDialog` components
- `space-task-creation.e2e.ts`: Replace the removed "Dashboard" tab selector with `[data-testid="space-overview-view"]` in `beforeEach`; update comments to reflect current UI