### PR TITLE
fix(e2e): fix space-multi-agent-editor after dashboard refactor

### DIFF
--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -157,7 +157,6 @@ export async function openWorkflowForEdit(page: Page, workflowName: string): Pro
 
 	// Switch to Workflows tab within the configure page.
 	await page.getByTestId('space-configure-tab-workflows').click();
-
 	await expect(page.locator(`text=${workflowName}`)).toBeVisible({ timeout: 5000 });
 
 	const workflowCard = page

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -46,6 +46,7 @@ import { NodeConfigPanel } from './NodeConfigPanel';
 import type { NodeChannelLink } from './NodeConfigPanel';
 import { EdgeConfigPanel } from './EdgeConfigPanel';
 import { ChannelRelationConfigPanel } from './ChannelRelationConfigPanel';
+import { ChannelEditor } from '../ChannelEditor';
 import { buildVisualNodePositions } from './nodeMetrics';
 import type { ResolvedWorkflowChannel } from './EdgeRenderer';
 import {
@@ -248,6 +249,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [showRules, setShowRules] = useState(false);
+	const [showChannels, setShowChannels] = useState(true);
 	const [showTemplates, setShowTemplates] = useState(false);
 	const [tagInput, setTagInput] = useState('');
 	const [pendingTemplate, setPendingTemplate] = useState<WorkflowTemplate | null>(null);
@@ -362,6 +364,18 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		() => buildNodeAnchorUsage(routedSemanticEdges),
 		[routedSemanticEdges]
 	);
+
+	// Agent role names from all multi-agent nodes — used by ChannelEditor dropdowns.
+	const agentRolesFromNodes = useMemo<string[]>(() => {
+		const roles: string[] = [];
+		for (const node of nodes) {
+			if (node.step.localId === TASK_AGENT_NODE_ID || node.step.id === TASK_AGENT_NODE_ID) continue;
+			for (const agent of node.step.agents ?? []) {
+				if (agent.name && !roles.includes(agent.name)) roles.push(agent.name);
+			}
+		}
+		return roles;
+	}, [nodes]);
 
 	const channelEdges = useMemo<ResolvedWorkflowChannel[]>(() => {
 		return routedSemanticEdges.map((edge) => ({
@@ -1447,6 +1461,44 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				>
 					<p class="text-xs text-gray-500">Current canvas changes will be discarded.</p>
 				</ConfirmModal>
+			</div>
+
+			{/* ---- Channels (collapsible) ---- */}
+			<div class="flex-shrink-0 border-t border-dark-700">
+				{/* Toggle button is outside the scroll container so it stays visible */}
+				<div class="px-4 py-2">
+					<button
+						onClick={() => setShowChannels((v) => !v)}
+						class="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-300 transition-colors"
+						data-testid="toggle-channels-button"
+					>
+						<svg
+							class={`w-3 h-3 transition-transform ${showChannels ? 'rotate-90' : ''}`}
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M9 5l7 7-7 7"
+							/>
+						</svg>
+						<span class="font-semibold uppercase tracking-wider">
+							Channels {channels.length > 0 ? `(${channels.length})` : ''}
+						</span>
+					</button>
+				</div>
+				{showChannels && (
+					<div class="px-4 pb-2 max-h-48 overflow-y-auto" data-testid="channels-section">
+						<ChannelEditor
+							channels={channels}
+							onChange={setChannels}
+							agentRoles={agentRolesFromNodes}
+						/>
+					</div>
+				)}
 			</div>
 
 			{/* ---- Tags and Rules (collapsible) ---- */}


### PR DESCRIPTION
Fixes the failing `features-space-multi-agent-editor` E2E tests.

**Root causes fixed:**

- `navigateToSpace` checked for `text=Dashboard` which no longer exists after the space dashboard refactor (44841b6a2). Updated to use `space-overview-view` testid.
- `openNewWorkflowEditor` / `openWorkflowForEdit` navigated directly to `text=Workflows` but Workflows is now inside the Configure page. Added navigation via "Configure space" button + `space-configure-tab-workflows`.
- `VisualWorkflowEditor` was missing a workflow-level channels section — added `ChannelEditor` integration with `data-testid="channels-section"` and `toggle-channels-button`.
- Agent option labels were misaligned: agents created as "Coder Agent" but `selectOption` looked for "Coder Agent (coder)". Fixed by creating agents with `name === role` string so all selects and channel from/to values consistently use role strings.