### PR TITLE
fix(e2e): fix strict mode violation in task-lifecycle archive dialog test

### DIFF
--- a/packages/e2e/tests/features/task-lifecycle.e2e.ts
+++ b/packages/e2e/tests/features/task-lifecycle.e2e.ts
@@ -218,8 +218,9 @@ test.describe('Task Lifecycle — Archive', () => {
 		await expect(archiveBtn).toBeVisible({ timeout: 5000 });
 		await archiveBtn.click();
 
-		// Dialog should appear
-		const dialog = page.locator('[role="dialog"]');
+		// Dialog should appear — use specific testid to avoid strict mode violation
+		// (NeoPanel also has role="dialog" and stays in DOM while closed)
+		const dialog = page.locator('[data-testid="archive-task-dialog"]');
 		await expect(dialog).toBeVisible({ timeout: 5000 });
 
 		// Dialog must mention permanent nature and worktree cleanup

--- a/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
+++ b/packages/web/src/components/room/task-shared/TaskActionDialogs.tsx
@@ -233,7 +233,7 @@ export function ArchiveTaskDialog({ task, isOpen, onClose, onConfirm }: ArchiveT
 
 	return (
 		<Modal isOpen={isOpen} onClose={handleClose} title="Archive Task?" size="sm" showCloseButton>
-			<div class="space-y-4">
+			<div class="space-y-4" data-testid="archive-task-dialog">
 				<p class="text-sm text-gray-300">
 					You are about to archive <strong class="text-gray-100">{task.title}</strong>.
 				</p>


### PR DESCRIPTION
`NeoPanel` always stays in the DOM with `role="dialog"` (closed via CSS transform), so when `ArchiveTaskDialog`'s Modal also renders with `role="dialog"`, Playwright strict mode fails: _"locator('[role=\"dialog\"]') resolved to 2 elements"_.

Add `data-testid="archive-task-dialog"` to `ArchiveTaskDialog`'s content div and update the test to target that specific selector.