### PR TITLE
fix(e2e): fix strict mode violation in tools-modal Setting Sources locator

### DIFF
--- a/packages/e2e/tests/helpers/mcp-toggle-helpers.ts
+++ b/packages/e2e/tests/helpers/mcp-toggle-helpers.ts
@@ -29,6 +29,11 @@ export async function openToolsModal(page: Page): Promise<void> {
 
 	// Wait for modal to appear
 	await page.locator('h2:has-text("Tools")').waitFor({ state: 'visible', timeout: 5000 });
+
+	// Wait for async MCP server loading to complete. While mcpLoading === true, the
+	// component renders "Loading servers..." instead of the GroupHeader button, so any
+	// helper that anchors on "Project MCP Servers" button would silently find nothing.
+	await page.locator('text=Loading servers...').waitFor({ state: 'hidden', timeout: 10000 });
 }
 
 /**

--- a/packages/e2e/tests/helpers/mcp-toggle-helpers.ts
+++ b/packages/e2e/tests/helpers/mcp-toggle-helpers.ts
@@ -61,26 +61,41 @@ export async function saveToolsModal(page: Page): Promise<void> {
 }
 
 /**
- * Get the list of MCP server names displayed in the modal
+ * Locator for the expanded content area of the "Project MCP Servers" group.
+ * GroupHeader renders: outer-div > GroupHeader-div > button
+ * Content area is a sibling of GroupHeader-div inside the outer-div.
+ * Uses XPath to navigate up two levels from the button then find the ml-5 content div.
+ */
+function getProjectMcpContent(page: Page) {
+	return page
+		.locator('button:has-text("Project MCP Servers")')
+		.locator('xpath=../../div[contains(@class,"ml-5")]');
+}
+
+/**
+ * Locator for individual server labels inside the Project MCP Servers content.
+ * Individual server labels have class "p-2 rounded-lg" to distinguish them from
+ * source-group toggle labels (which use "gap-1.5") in the same content area.
+ */
+function getServerLabels(page: Page) {
+	return getProjectMcpContent(page).locator('label[class*="p-2 rounded-lg"]');
+}
+
+/**
+ * Get the list of MCP server names displayed in the Project MCP Servers section
  */
 export async function getMcpServerNames(page: Page): Promise<string[]> {
-	// MCP servers section contains server labels with checkbox inputs
-	const mcpSection = page.locator('h3:has-text("MCP Servers")').locator('..').first();
-	const serverNames: string[] = [];
-
-	// Get all labels that contain server checkboxes
-	const labels = mcpSection.locator('label:has(input[type="checkbox"])');
+	const labels = getServerLabels(page);
 	const count = await labels.count();
+	const serverNames: string[] = [];
 
 	for (let i = 0; i < count; i++) {
 		const label = labels.nth(i);
-		// Server name is usually in a span or div with text
-		const nameElement = label.locator('span, div').first();
+		// Server name is in a div with class text-sm inside the label
+		const nameElement = label.locator('div.text-sm').first();
 		const name = await nameElement.textContent();
 		if (name) {
-			// Extract just the server name (remove "bunx" suffix if present)
-			const serverName = name.trim().split(/\s+/)[0];
-			serverNames.push(serverName);
+			serverNames.push(name.trim());
 		}
 	}
 
@@ -91,9 +106,7 @@ export async function getMcpServerNames(page: Page): Promise<string[]> {
  * Check if a specific MCP server is enabled (checkbox checked)
  */
 export async function isMcpServerEnabled(page: Page, serverName: string): Promise<boolean> {
-	const mcpSection = page.locator('h3:has-text("MCP Servers")').locator('..').first();
-	// Find checkbox by looking for label containing server name
-	const labels = mcpSection.locator('label');
+	const labels = getServerLabels(page);
 	const count = await labels.count();
 
 	for (let i = 0; i < count; i++) {
@@ -112,8 +125,7 @@ export async function isMcpServerEnabled(page: Page, serverName: string): Promis
  * Toggle a specific MCP server by clicking its checkbox
  */
 export async function toggleMcpServer(page: Page, serverName: string): Promise<void> {
-	const mcpSection = page.locator('h3:has-text("MCP Servers")').locator('..').first();
-	const labels = mcpSection.locator('label');
+	const labels = getServerLabels(page);
 	const count = await labels.count();
 
 	for (let i = 0; i < count; i++) {
@@ -130,11 +142,10 @@ export async function toggleMcpServer(page: Page, serverName: string): Promise<v
 }
 
 /**
- * Enable all MCP servers
+ * Enable all MCP servers in the Project MCP Servers section
  */
 export async function enableAllMcpServers(page: Page): Promise<void> {
-	const mcpSection = page.locator('h3:has-text("MCP Servers")').locator('..').first();
-	const checkboxes = mcpSection.locator('input[type="checkbox"]');
+	const checkboxes = getServerLabels(page).locator('input[type="checkbox"]');
 
 	const count = await checkboxes.count();
 	for (let i = 0; i < count; i++) {
@@ -147,11 +158,10 @@ export async function enableAllMcpServers(page: Page): Promise<void> {
 }
 
 /**
- * Disable all MCP servers
+ * Disable all MCP servers in the Project MCP Servers section
  */
 export async function disableAllMcpServers(page: Page): Promise<void> {
-	const mcpSection = page.locator('h3:has-text("MCP Servers")').locator('..').first();
-	const checkboxes = mcpSection.locator('input[type="checkbox"]');
+	const checkboxes = getServerLabels(page).locator('input[type="checkbox"]');
 
 	const count = await checkboxes.count();
 	for (let i = 0; i < count; i++) {
@@ -164,11 +174,10 @@ export async function disableAllMcpServers(page: Page): Promise<void> {
 }
 
 /**
- * Get the count of enabled MCP servers
+ * Get the count of enabled MCP servers in the Project MCP Servers section
  */
 export async function getEnabledMcpServerCount(page: Page): Promise<number> {
-	const mcpSection = page.locator('h3:has-text("MCP Servers")').locator('..').first();
-	const checkboxes = mcpSection.locator('input[type="checkbox"]');
+	const checkboxes = getServerLabels(page).locator('input[type="checkbox"]');
 
 	const count = await checkboxes.count();
 	let enabledCount = 0;

--- a/packages/e2e/tests/helpers/mcp-toggle-helpers.ts
+++ b/packages/e2e/tests/helpers/mcp-toggle-helpers.ts
@@ -65,6 +65,9 @@ export async function saveToolsModal(page: Page): Promise<void> {
  * GroupHeader renders: outer-div > GroupHeader-div > button
  * Content area is a sibling of GroupHeader-div inside the outer-div.
  * Uses XPath to navigate up two levels from the button then find the ml-5 content div.
+ *
+ * Note: fileMcpGroupOpen initializes to true in ToolsModal.tsx, so the content div is
+ * always present in the DOM immediately after the modal opens.
  */
 function getProjectMcpContent(page: Page) {
 	return page
@@ -74,15 +77,19 @@ function getProjectMcpContent(page: Page) {
 
 /**
  * Locator for individual server labels inside the Project MCP Servers content.
- * Individual server labels have class "p-2 rounded-lg" to distinguish them from
- * source-group toggle labels (which use "gap-1.5") in the same content area.
+ * Each server label contains a `div.text-sm` for the server name (ToolsModal.tsx renders
+ * `<div class="text-sm text-gray-200 truncate">{server.name}</div>`). Source-group toggle
+ * labels (for user/project/local sections) only contain a checkbox — no div.text-sm — so
+ * `label:has(div.text-sm)` is a structurally stable discriminator.
  */
 function getServerLabels(page: Page) {
-	return getProjectMcpContent(page).locator('label[class*="p-2 rounded-lg"]');
+	return getProjectMcpContent(page).locator('label:has(div.text-sm)');
 }
 
 /**
- * Get the list of MCP server names displayed in the Project MCP Servers section
+ * Get the list of MCP server names displayed in the Project MCP Servers section.
+ * Returns bare server names as stored in settings (e.g. "my-server"), not truncated
+ * or split, because ToolsModal renders server.name directly in a dedicated div.text-sm.
  */
 export async function getMcpServerNames(page: Page): Promise<string[]> {
 	const labels = getServerLabels(page);
@@ -91,7 +98,8 @@ export async function getMcpServerNames(page: Page): Promise<string[]> {
 
 	for (let i = 0; i < count; i++) {
 		const label = labels.nth(i);
-		// Server name is in a div with class text-sm inside the label
+		// Server name is in `div.text-sm` (class="text-sm text-gray-200 truncate")
+		// which renders server.name directly — no extra words to strip.
 		const nameElement = label.locator('div.text-sm').first();
 		const name = await nameElement.textContent();
 		if (name) {

--- a/packages/e2e/tests/settings/mcp-servers.e2e.ts
+++ b/packages/e2e/tests/settings/mcp-servers.e2e.ts
@@ -66,12 +66,13 @@ test.describe('MCP Toggle - Tools Modal', () => {
 		// Verify modal is open with expected sections
 		await expect(page.locator('h2:has-text("Tools")')).toBeVisible();
 
-		// Verify section headers (use .first() to handle potential duplicate elements)
-		await expect(page.locator('h3:has-text("System Prompt")').first()).toBeVisible();
-		await expect(page.locator('h4:has-text("Setting Sources")').first()).toBeVisible();
-		await expect(page.locator('h3:has-text("MCP Servers")').first()).toBeVisible();
-		await expect(page.locator('h3:has-text("NeoKai Tools")').first()).toBeVisible();
-		await expect(page.locator('h3:has-text("SDK Built-in")').first()).toBeVisible();
+		// Verify collapsible group headers rendered as buttons (GroupHeader component uses button+span)
+		await expect(page.locator('button:has-text("App MCP Servers")')).toBeVisible();
+		await expect(page.locator('button:has-text("Project MCP Servers")')).toBeVisible();
+		await expect(page.locator('button:has-text("NeoKai Tools")')).toBeVisible();
+
+		// Advanced section is collapsed by default — only the toggle button is visible, not its children
+		await expect(page.getByRole('button', { name: /Advanced/i })).toBeVisible();
 	});
 
 	test.skip('should close Tools modal with close button', async ({ page }) => {

--- a/packages/e2e/tests/settings/mcp-servers.e2e.ts
+++ b/packages/e2e/tests/settings/mcp-servers.e2e.ts
@@ -68,8 +68,9 @@ test.describe('MCP Toggle - Tools Modal', () => {
 
 		// Verify collapsible group headers.
 		// "App MCP Servers" renders as a <button> (via GroupHeader) when app skills exist, but
-		// falls back to a plain <span> when no skills are configured. Use exact text matching on
-		// the inner <span> which is present in both DOM states.
+		// falls back to a plain <span> when no skills are configured. The button's full text is
+		// "App MCP Servers (N)" (includes the item count), so { exact: true } matches only the
+		// inner <span> (text is exactly "App MCP Servers") in both DOM states.
 		await expect(page.getByText('App MCP Servers', { exact: true })).toBeVisible();
 		// "Project MCP Servers" and "NeoKai Tools" always render as GroupHeader buttons.
 		await expect(page.locator('button:has-text("Project MCP Servers")')).toBeVisible();

--- a/packages/e2e/tests/settings/mcp-servers.e2e.ts
+++ b/packages/e2e/tests/settings/mcp-servers.e2e.ts
@@ -66,8 +66,12 @@ test.describe('MCP Toggle - Tools Modal', () => {
 		// Verify modal is open with expected sections
 		await expect(page.locator('h2:has-text("Tools")')).toBeVisible();
 
-		// Verify collapsible group headers rendered as buttons (GroupHeader component uses button+span)
-		await expect(page.locator('button:has-text("App MCP Servers")')).toBeVisible();
+		// Verify collapsible group headers.
+		// "App MCP Servers" renders as a <button> (via GroupHeader) when app skills exist, but
+		// falls back to a plain <span> when no skills are configured. Use exact text matching on
+		// the inner <span> which is present in both DOM states.
+		await expect(page.getByText('App MCP Servers', { exact: true })).toBeVisible();
+		// "Project MCP Servers" and "NeoKai Tools" always render as GroupHeader buttons.
 		await expect(page.locator('button:has-text("Project MCP Servers")')).toBeVisible();
 		await expect(page.locator('button:has-text("NeoKai Tools")')).toBeVisible();
 

--- a/packages/e2e/tests/settings/mcp-servers.e2e.ts
+++ b/packages/e2e/tests/settings/mcp-servers.e2e.ts
@@ -99,8 +99,8 @@ test.describe('MCP Toggle - Tools Modal', () => {
 	test('should show MCP servers section with servers from settings', async ({ page }) => {
 		await openToolsModal(page);
 
-		// Find MCP Servers section
-		const mcpSection = page.locator('h3:has-text("MCP Servers")');
+		// Find Project MCP Servers section (GroupHeader renders a button, not an h3)
+		const mcpSection = page.locator('button:has-text("Project MCP Servers")');
 		await expect(mcpSection).toBeVisible();
 
 		// Get MCP servers displayed

--- a/packages/e2e/tests/settings/mcp-servers.e2e.ts
+++ b/packages/e2e/tests/settings/mcp-servers.e2e.ts
@@ -68,7 +68,7 @@ test.describe('MCP Toggle - Tools Modal', () => {
 
 		// Verify section headers (use .first() to handle potential duplicate elements)
 		await expect(page.locator('h3:has-text("System Prompt")').first()).toBeVisible();
-		await expect(page.locator('h3:has-text("Setting Sources")').first()).toBeVisible();
+		await expect(page.locator('h4:has-text("Setting Sources")').first()).toBeVisible();
 		await expect(page.locator('h3:has-text("MCP Servers")').first()).toBeVisible();
 		await expect(page.locator('h3:has-text("NeoKai Tools")').first()).toBeVisible();
 		await expect(page.locator('h3:has-text("SDK Built-in")').first()).toBeVisible();

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -77,7 +77,9 @@ test.describe('Tools Modal - Redesigned', () => {
 		// Claude Code Preset should now be visible
 		await expect(page.getByText('Claude Code Preset')).toBeVisible({ timeout: 2000 });
 
-		// Setting Sources should also be visible
+		// Setting Sources should also be visible.
+		// .first() is required: getByText matches both the <h4> element and its parent <div>
+		// (whose text content is a superset), causing a strict-mode violation without it.
 		await expect(page.getByText('Setting Sources').first()).toBeVisible();
 	});
 

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -48,8 +48,12 @@ test.describe('Tools Modal - Redesigned', () => {
 
 		await openToolsModal(page);
 
-		// Should show the group section headers (GroupHeader renders a <button> containing a <span>)
-		await expect(page.locator('button:has-text("App MCP Servers")')).toBeVisible();
+		// Should show the group section headers.
+		// "App MCP Servers" renders as a <button> (GroupHeader) when skills exist, or a plain
+		// <span> when no app skills are configured. Use exact text matching on the inner <span>
+		// (present in both DOM states) to avoid strict-mode violations and environment sensitivity.
+		await expect(page.getByText('App MCP Servers', { exact: true })).toBeVisible();
+		// "Project MCP Servers" and "NeoKai Tools" always render as GroupHeader buttons.
 		await expect(page.locator('button:has-text("Project MCP Servers")')).toBeVisible();
 		await expect(page.locator('button:has-text("NeoKai Tools")')).toBeVisible();
 	});

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -78,7 +78,7 @@ test.describe('Tools Modal - Redesigned', () => {
 		await expect(page.getByText('Claude Code Preset')).toBeVisible({ timeout: 2000 });
 
 		// Setting Sources should also be visible
-		await expect(page.getByText('Setting Sources')).toBeVisible();
+		await expect(page.getByText('Setting Sources').first()).toBeVisible();
 	});
 
 	test('should show scope badges for groups', async ({ page }) => {

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -50,8 +50,9 @@ test.describe('Tools Modal - Redesigned', () => {
 
 		// Should show the group section headers.
 		// "App MCP Servers" renders as a <button> (GroupHeader) when skills exist, or a plain
-		// <span> when no app skills are configured. Use exact text matching on the inner <span>
-		// (present in both DOM states) to avoid strict-mode violations and environment sensitivity.
+		// <span> when no app skills are configured. The button's full text includes the item count
+		// (e.g. "App MCP Servers (2)"), so { exact: true } matches only the inner <span> whose
+		// text is exactly "App MCP Servers" — correct in both DOM states without strict-mode issues.
 		await expect(page.getByText('App MCP Servers', { exact: true })).toBeVisible();
 		// "Project MCP Servers" and "NeoKai Tools" always render as GroupHeader buttons.
 		await expect(page.locator('button:has-text("Project MCP Servers")')).toBeVisible();

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -48,10 +48,10 @@ test.describe('Tools Modal - Redesigned', () => {
 
 		await openToolsModal(page);
 
-		// Should show the group section headers
-		await expect(page.getByText('App MCP Servers')).toBeVisible();
-		await expect(page.getByText('Project MCP Servers')).toBeVisible();
-		await expect(page.getByText('NeoKai Tools')).toBeVisible();
+		// Should show the group section headers (GroupHeader renders a <button> containing a <span>)
+		await expect(page.locator('button:has-text("App MCP Servers")')).toBeVisible();
+		await expect(page.locator('button:has-text("Project MCP Servers")')).toBeVisible();
+		await expect(page.locator('button:has-text("NeoKai Tools")')).toBeVisible();
 	});
 
 	test('should show Advanced section collapsed by default', async ({ page }) => {


### PR DESCRIPTION
Fixes a strict-mode violation (`getByText('Setting Sources')` resolved to 2 elements) and corrects all stale MCP-section selectors that broke when the Tools modal was redesigned.

## Changes

**`tools-modal.e2e.ts`**
- Add `.first()` to `getByText('Setting Sources')` — `getByText` matches both the `<h4>` element and its parent `<div>` (superset text); `.first()` avoids the strict-mode violation
- Change `getByText('App MCP Servers/Project MCP Servers/NeoKai Tools')` to `button:has-text(...)` / exact-text matchers to avoid matching both a button and its inner span

**`mcp-servers.e2e.ts`**
- Rewrite stale `should open Tools modal` assertions: the redesigned modal uses `GroupHeader` (button+span) for group titles and `<h4>` for Advanced sub-sections — replaced broken `h3:has-text(...)` and non-existent "SDK Built-in" with correct selectors
- Fix `h3:has-text("MCP Servers")` → `button:has-text("Project MCP Servers")` in `should show MCP servers section` test
- Use `getByText('App MCP Servers', { exact: true })` instead of `button:has-text` because the section renders as a plain `<span>` (not a button) when no app skills are configured

**`mcp-toggle-helpers.ts`**
- Replace all 6 stale `h3:has-text("MCP Servers")` anchors (which resolved to zero elements) with two new private helpers:
  - `getProjectMcpContent(page)` — navigates from the "Project MCP Servers" button via XPath to the expanded content `div`
  - `getServerLabels(page)` — scopes to `label:has(div.text-sm)`, which structurally selects only individual server labels (source-group toggle labels contain no `div.text-sm`)
- This unblocks ~15 tests that were silently no-oping because `getMcpServerNames` always returned `[]`