### PR TITLE
test: verify pre-seeded agents have correct tools and prompts

### DIFF
--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -141,8 +141,8 @@ const PRESET_AGENTS: PresetDefinition[] = [
 			'You are an expert code reviewer. You review pull requests for correctness, security, performance, ' +
 			'style, and test coverage. You give specific, actionable feedback.',
 		instructions:
-			'Review the open PR thoroughly. If satisfied, call report_done(). If changes are needed, provide ' +
-			'specific feedback and send back for revision.',
+			'Review the code thoroughly. If satisfied, summarize your findings. If changes are needed, provide ' +
+			'specific feedback.',
 	},
 	{
 		name: 'QA',
@@ -153,7 +153,7 @@ const PRESET_AGENTS: PresetDefinition[] = [
 			'You are a quality assurance engineer. You verify test coverage, run test suites, check CI status, ' +
 			'and ensure the codebase meets quality standards before release.',
 		instructions:
-			"Run the full test suite. Write result='passed' or result='failed' to the gate with specific details on any failures.",
+			'Run the full test suite and report results with specific details on any failures.',
 	},
 ];
 

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -38,7 +38,7 @@ export const SUB_SESSION_FEATURES = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Tool defaults per role
+// Tool defaults per preset agent
 // ---------------------------------------------------------------------------
 
 /** Full coding toolset: read, write, shell, search, web */
@@ -64,7 +64,7 @@ const QA_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSear
 /**
  * Tool profiles per preset agent name. Exported for testing and external consumption.
  */
-export const ROLE_TOOLS: Record<string, string[]> = {
+export const PRESET_AGENT_TOOLS: Record<string, string[]> = {
 	coder: CODER_TOOLS,
 	general: GENERAL_TOOLS,
 	planner: PLANNER_TOOLS,

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -9,7 +9,7 @@
  *
  * Preset agents seeded per Space:
  *   - Coder    — implementation worker
- *   - General  — general-purpose worker (Done node agent)
+ *   - General  — general-purpose worker
  *   - Planner  — planning/orchestration worker
  *   - Research — research specialist (investigates topics, writes findings, opens PRs)
  *   - Reviewer — code review specialist
@@ -46,8 +46,8 @@ const CODER_TOOLS = KNOWN_TOOLS.filter(
 	(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
 ) as string[];
 
-/** Done node agent: read-only summarization — no Write or Edit */
-const DONE_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+/** General-purpose worker: full coding toolset */
+const GENERAL_TOOLS = CODER_TOOLS;
 
 /** Planner uses the same toolset as coder (orchestration patterns reserved for future) */
 const PLANNER_TOOLS = CODER_TOOLS;
@@ -66,7 +66,7 @@ const QA_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSear
  */
 export const ROLE_TOOLS: Record<string, string[]> = {
 	coder: CODER_TOOLS,
-	general: DONE_TOOLS,
+	general: GENERAL_TOOLS,
 	planner: PLANNER_TOOLS,
 	research: RESEARCH_TOOLS,
 	reviewer: REVIEWER_TOOLS,
@@ -101,14 +101,14 @@ const PRESET_AGENTS: PresetDefinition[] = [
 	{
 		name: 'General',
 		description:
-			'Done node agent. Reads gate data from completed workflow stages and produces a ' +
-			'comprehensive human-readable summary of what was accomplished.',
-		tools: DONE_TOOLS,
+			'General-purpose worker. Handles a wide range of tasks including coding, documentation, ' +
+			'debugging, and analysis.',
+		tools: GENERAL_TOOLS,
 		systemPrompt:
-			'You are a summarization agent. You read completed task outputs and gate data, then produce ' +
-			'a clear, human-readable summary of what was accomplished.',
+			'You are a versatile software development assistant. You can write code, fix bugs, write documentation, ' +
+			'analyze problems, and handle any general development task. You adapt to what is needed.',
 		instructions:
-			'Read all available gate data and workflow outputs. Write a comprehensive summary of the completed work.',
+			'Understand the task, implement the solution, verify it works, and commit your changes.',
 	},
 	{
 		name: 'Planner',

--- a/packages/daemon/tests/unit/space/agent-config.test.ts
+++ b/packages/daemon/tests/unit/space/agent-config.test.ts
@@ -6,7 +6,10 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { ROLE_TOOLS, SUB_SESSION_FEATURES } from '../../../src/lib/space/agents/seed-agents';
+import {
+	PRESET_AGENT_TOOLS,
+	SUB_SESSION_FEATURES,
+} from '../../../src/lib/space/agents/seed-agents';
 import {
 	createCustomAgentInit,
 	composePromptLayer,
@@ -77,9 +80,9 @@ function makeConfig(tools?: string[]): CustomAgentConfig {
 // Tool access per preset agent
 // ============================================================================
 
-describe('ROLE_TOOLS', () => {
+describe('PRESET_AGENT_TOOLS', () => {
 	it('coder has full tool access (Read, Write, Edit, Bash, Grep, Glob)', () => {
-		const tools = ROLE_TOOLS.coder;
+		const tools = PRESET_AGENT_TOOLS.coder;
 		expect(tools).toContain('Read');
 		expect(tools).toContain('Write');
 		expect(tools).toContain('Edit');
@@ -89,14 +92,14 @@ describe('ROLE_TOOLS', () => {
 	});
 
 	it('coder does not have Task/TaskOutput/TaskStop', () => {
-		const tools = ROLE_TOOLS.coder;
+		const tools = PRESET_AGENT_TOOLS.coder;
 		expect(tools).not.toContain('Task');
 		expect(tools).not.toContain('TaskOutput');
 		expect(tools).not.toContain('TaskStop');
 	});
 
 	it('planner has full tool access', () => {
-		const tools = ROLE_TOOLS.planner;
+		const tools = PRESET_AGENT_TOOLS.planner;
 		expect(tools).toContain('Read');
 		expect(tools).toContain('Write');
 		expect(tools).toContain('Edit');
@@ -106,13 +109,13 @@ describe('ROLE_TOOLS', () => {
 	});
 
 	it('reviewer cannot Write or Edit', () => {
-		const tools = ROLE_TOOLS.reviewer;
+		const tools = PRESET_AGENT_TOOLS.reviewer;
 		expect(tools).not.toContain('Write');
 		expect(tools).not.toContain('Edit');
 	});
 
 	it('reviewer has read-only tools', () => {
-		const tools = ROLE_TOOLS.reviewer;
+		const tools = PRESET_AGENT_TOOLS.reviewer;
 		expect(tools).toContain('Read');
 		expect(tools).toContain('Bash');
 		expect(tools).toContain('Grep');
@@ -120,13 +123,13 @@ describe('ROLE_TOOLS', () => {
 	});
 
 	it('qa cannot Write or Edit', () => {
-		const tools = ROLE_TOOLS.qa;
+		const tools = PRESET_AGENT_TOOLS.qa;
 		expect(tools).not.toContain('Write');
 		expect(tools).not.toContain('Edit');
 	});
 
 	it('qa has read-only + bash tools for running tests', () => {
-		const tools = ROLE_TOOLS.qa;
+		const tools = PRESET_AGENT_TOOLS.qa;
 		expect(tools).toContain('Read');
 		expect(tools).toContain('Bash');
 		expect(tools).toContain('Grep');
@@ -134,7 +137,7 @@ describe('ROLE_TOOLS', () => {
 	});
 
 	it('general has full coding toolset', () => {
-		const tools = ROLE_TOOLS.general;
+		const tools = PRESET_AGENT_TOOLS.general;
 		expect(tools).toContain('Write');
 		expect(tools).toContain('Edit');
 		expect(tools).toContain('Read');
@@ -316,12 +319,12 @@ describe('composePromptLayer', () => {
 
 describe('createCustomAgentInit — sub-session features', () => {
 	it('applies SUB_SESSION_FEATURES for agent with tools', () => {
-		const init = createCustomAgentInit(makeConfig(ROLE_TOOLS.coder));
+		const init = createCustomAgentInit(makeConfig(PRESET_AGENT_TOOLS.coder));
 		expect(init.features).toEqual(SUB_SESSION_FEATURES);
 	});
 
 	it('applies SUB_SESSION_FEATURES for agent with restricted tools', () => {
-		const init = createCustomAgentInit(makeConfig(ROLE_TOOLS.reviewer));
+		const init = createCustomAgentInit(makeConfig(PRESET_AGENT_TOOLS.reviewer));
 		expect(init.features).toEqual(SUB_SESSION_FEATURES);
 	});
 
@@ -331,7 +334,7 @@ describe('createCustomAgentInit — sub-session features', () => {
 	});
 
 	it('reviewer init uses agents pattern with restricted tools', () => {
-		const config = makeConfig(ROLE_TOOLS.reviewer);
+		const config = makeConfig(PRESET_AGENT_TOOLS.reviewer);
 		const init = createCustomAgentInit(config);
 
 		// When tools are specified, the agents pattern is used
@@ -341,13 +344,13 @@ describe('createCustomAgentInit — sub-session features', () => {
 		// The agent definition should use the reviewer's restricted tools
 		const agentKey = init.agent as string;
 		const agentDef = init.agents![agentKey];
-		expect(agentDef.tools).toEqual(ROLE_TOOLS.reviewer);
+		expect(agentDef.tools).toEqual(PRESET_AGENT_TOOLS.reviewer);
 		expect(agentDef.tools).not.toContain('Write');
 		expect(agentDef.tools).not.toContain('Edit');
 	});
 
 	it('qa init uses agents pattern with restricted tools', () => {
-		const config = makeConfig(ROLE_TOOLS.qa);
+		const config = makeConfig(PRESET_AGENT_TOOLS.qa);
 		const init = createCustomAgentInit(config);
 
 		expect(init.agent).toBeDefined();
@@ -355,13 +358,13 @@ describe('createCustomAgentInit — sub-session features', () => {
 
 		const agentKey = init.agent as string;
 		const agentDef = init.agents![agentKey];
-		expect(agentDef.tools).toEqual(ROLE_TOOLS.qa);
+		expect(agentDef.tools).toEqual(PRESET_AGENT_TOOLS.qa);
 		expect(agentDef.tools).not.toContain('Write');
 		expect(agentDef.tools).not.toContain('Edit');
 	});
 
 	it('coder init uses agents pattern with full tools', () => {
-		const config = makeConfig(ROLE_TOOLS.coder);
+		const config = makeConfig(PRESET_AGENT_TOOLS.coder);
 		const init = createCustomAgentInit(config);
 
 		expect(init.agent).toBeDefined();
@@ -382,7 +385,7 @@ describe('createCustomAgentInit — sub-session features', () => {
 	});
 
 	it('applies systemPrompt override mode in system prompt', () => {
-		const config = makeConfig(ROLE_TOOLS.coder);
+		const config = makeConfig(PRESET_AGENT_TOOLS.coder);
 		config.slotOverrides = {
 			systemPrompt: { mode: 'override', value: 'Override prompt' },
 		};

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -1088,7 +1088,7 @@ describe('seedBuiltInWorkflows()', () => {
 	});
 
 	test('does not persist any workflow when resolveAgentId fails on a shared role', async () => {
-		// 'general' is used by FULL_CYCLE_CODING_WORKFLOW (Done node).
+		// 'general' is used by FULL_CYCLE_CODING_WORKFLOW.
 		// Pre-validation catches missing roles before any workflow is persisted.
 		const brokenResolver = (role: string): string | undefined =>
 			role === 'general' ? undefined : roleMap[role];

--- a/packages/daemon/tests/unit/space/role-config.test.ts
+++ b/packages/daemon/tests/unit/space/role-config.test.ts
@@ -133,10 +133,10 @@ describe('ROLE_TOOLS', () => {
 		expect(tools).toContain('Glob');
 	});
 
-	it('general (Done node) has read-only tools — no Write or Edit', () => {
+	it('general has full coding toolset', () => {
 		const tools = ROLE_TOOLS.general;
-		expect(tools).not.toContain('Write');
-		expect(tools).not.toContain('Edit');
+		expect(tools).toContain('Write');
+		expect(tools).toContain('Edit');
 		expect(tools).toContain('Read');
 		expect(tools).toContain('Bash');
 		expect(tools).toContain('Grep');

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -12,7 +12,7 @@ import { SpaceAgentRepository } from '../../../src/storage/repositories/space-ag
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager';
 import {
 	seedPresetAgents,
-	ROLE_TOOLS,
+	PRESET_AGENT_TOOLS,
 	SUB_SESSION_FEATURES,
 	getPresetAgentTemplates,
 } from '../../../src/lib/space/agents/seed-agents';
@@ -462,10 +462,10 @@ describe('preset agent exact definitions', () => {
 });
 
 // ---------------------------------------------------------------------------
-// ROLE_TOOLS export
+// PRESET_AGENT_TOOLS export
 // ---------------------------------------------------------------------------
 
-describe('ROLE_TOOLS export', () => {
+describe('PRESET_AGENT_TOOLS export', () => {
 	const EXPECTED_CODER_TOOLS = KNOWN_TOOLS.filter(
 		(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
 	) as unknown as string[];
@@ -473,7 +473,7 @@ describe('ROLE_TOOLS export', () => {
 	const EXPECTED_READONLY_TOOLS = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
 
 	it('has entries for all 6 preset roles', () => {
-		expect(Object.keys(ROLE_TOOLS).sort()).toEqual([
+		expect(Object.keys(PRESET_AGENT_TOOLS).sort()).toEqual([
 			'coder',
 			'general',
 			'planner',
@@ -484,30 +484,30 @@ describe('ROLE_TOOLS export', () => {
 	});
 
 	it('coder role maps to CODER_TOOLS', () => {
-		expect(ROLE_TOOLS.coder).toEqual(EXPECTED_CODER_TOOLS);
+		expect(PRESET_AGENT_TOOLS.coder).toEqual(EXPECTED_CODER_TOOLS);
 	});
 
 	it('general role maps to GENERAL_TOOLS (same as CODER_TOOLS)', () => {
-		expect(ROLE_TOOLS.general).toEqual(EXPECTED_CODER_TOOLS);
+		expect(PRESET_AGENT_TOOLS.general).toEqual(EXPECTED_CODER_TOOLS);
 	});
 
 	it('planner role maps to PLANNER_TOOLS (same as CODER_TOOLS)', () => {
-		expect(ROLE_TOOLS.planner).toEqual(EXPECTED_CODER_TOOLS);
+		expect(PRESET_AGENT_TOOLS.planner).toEqual(EXPECTED_CODER_TOOLS);
 	});
 
 	it('research role maps to RESEARCH_TOOLS (same as CODER_TOOLS)', () => {
-		expect(ROLE_TOOLS.research).toEqual(EXPECTED_CODER_TOOLS);
+		expect(PRESET_AGENT_TOOLS.research).toEqual(EXPECTED_CODER_TOOLS);
 	});
 
 	it('reviewer role maps to REVIEWER_TOOLS', () => {
-		expect(ROLE_TOOLS.reviewer).toEqual(EXPECTED_READONLY_TOOLS);
+		expect(PRESET_AGENT_TOOLS.reviewer).toEqual(EXPECTED_READONLY_TOOLS);
 	});
 
 	it('qa role maps to QA_TOOLS', () => {
-		expect(ROLE_TOOLS.qa).toEqual(EXPECTED_READONLY_TOOLS);
+		expect(PRESET_AGENT_TOOLS.qa).toEqual(EXPECTED_READONLY_TOOLS);
 	});
 
-	it('ROLE_TOOLS matches what seedPresetAgents actually seeds', async () => {
+	it('PRESET_AGENT_TOOLS matches what seedPresetAgents actually seeds', async () => {
 		const db = new Database(':memory:');
 		createSpaceAgentSchema(db);
 		insertSpace(db);
@@ -519,8 +519,8 @@ describe('ROLE_TOOLS export', () => {
 
 		for (const agent of seeded) {
 			const roleKey = agent.name.toLowerCase();
-			expect(ROLE_TOOLS[roleKey]).toBeDefined();
-			expect(agent.tools).toEqual(ROLE_TOOLS[roleKey]);
+			expect(PRESET_AGENT_TOOLS[roleKey]).toBeDefined();
+			expect(agent.tools).toEqual(PRESET_AGENT_TOOLS[roleKey]);
 		}
 
 		db.close();
@@ -592,11 +592,11 @@ describe('getPresetAgentTemplates', () => {
 		expect(coderTools2).not.toContain('FakeTool');
 	});
 
-	it('template tools match ROLE_TOOLS', () => {
+	it('template tools match PRESET_AGENT_TOOLS', () => {
 		const templates = getPresetAgentTemplates();
 		for (const t of templates) {
 			const roleKey = t.name.toLowerCase();
-			expect(t.tools).toEqual(ROLE_TOOLS[roleKey]);
+			expect(t.tools).toEqual(PRESET_AGENT_TOOLS[roleKey]);
 		}
 	});
 });

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -158,14 +158,14 @@ describe('seedPresetAgents', () => {
 		expect(result.errors[0].name).toBe('Coder');
 	});
 
-	it('General agent has restricted tools (no Write or Edit) — read-only Done node', async () => {
+	it('General agent has full coding toolset', async () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const general = seeded.find((a) => a.name === 'General');
 
 		expect(general).toBeDefined();
-		expect(general?.tools).not.toContain('Write');
-		expect(general?.tools).not.toContain('Edit');
 		expect(general?.tools).toContain('Read');
+		expect(general?.tools).toContain('Write');
+		expect(general?.tools).toContain('Edit');
 		expect(general?.tools).toContain('Bash');
 		expect(general?.tools).toContain('Grep');
 		expect(general?.tools).toContain('Glob');
@@ -244,12 +244,12 @@ describe('seedPresetAgents', () => {
 		expect(qa?.instructions).toContain('test suite');
 	});
 
-	it('General system prompt mentions summarization', async () => {
+	it('General system prompt mentions versatile development', async () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const general = seeded.find((a) => a.name === 'General');
 
-		expect(general?.systemPrompt).toContain('summarization');
-		expect(general?.instructions).toContain('summary');
+		expect(general?.systemPrompt).toContain('versatile');
+		expect(general?.instructions).toContain('implement');
 	});
 });
 
@@ -297,10 +297,10 @@ describe('preset agent exact definitions', () => {
 		expect(coder.tools).not.toContain('TaskStop');
 	});
 
-	it('General has exact DONE_TOOLS', async () => {
+	it('General has exact GENERAL_TOOLS (same as CODER_TOOLS)', async () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const general = seeded.find((a) => a.name === 'General')!;
-		expect(general.tools).toEqual(EXPECTED_READONLY_TOOLS);
+		expect(general.tools).toEqual(EXPECTED_CODER_TOOLS);
 	});
 
 	it('Planner has exact PLANNER_TOOLS (same as CODER_TOOLS)', async () => {
@@ -343,8 +343,8 @@ describe('preset agent exact definitions', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const general = seeded.find((a) => a.name === 'General')!;
 		expect(general.systemPrompt).toBe(
-			'You are a summarization agent. You read completed task outputs and gate data, then produce ' +
-				'a clear, human-readable summary of what was accomplished.'
+			'You are a versatile software development assistant. You can write code, fix bugs, write documentation, ' +
+				'analyze problems, and handle any general development task. You adapt to what is needed.'
 		);
 	});
 
@@ -398,7 +398,7 @@ describe('preset agent exact definitions', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const general = seeded.find((a) => a.name === 'General')!;
 		expect(general.instructions).toBe(
-			'Read all available gate data and workflow outputs. Write a comprehensive summary of the completed work.'
+			'Understand the task, implement the solution, verify it works, and commit your changes.'
 		);
 	});
 
@@ -444,8 +444,8 @@ describe('preset agent exact definitions', () => {
 			Coder:
 				'Implementation worker. Writes code, runs tests, commits changes, and opens pull requests.',
 			General:
-				'Done node agent. Reads gate data from completed workflow stages and produces a ' +
-				'comprehensive human-readable summary of what was accomplished.',
+				'General-purpose worker. Handles a wide range of tasks including coding, documentation, ' +
+				'debugging, and analysis.',
 			Planner:
 				'Planning agent. Breaks down goals into actionable tasks and drafts implementation plans.',
 			Research:
@@ -487,8 +487,8 @@ describe('ROLE_TOOLS export', () => {
 		expect(ROLE_TOOLS.coder).toEqual(EXPECTED_CODER_TOOLS);
 	});
 
-	it('general role maps to DONE_TOOLS', () => {
-		expect(ROLE_TOOLS.general).toEqual(EXPECTED_READONLY_TOOLS);
+	it('general role maps to GENERAL_TOOLS (same as CODER_TOOLS)', () => {
+		expect(ROLE_TOOLS.general).toEqual(EXPECTED_CODER_TOOLS);
 	});
 
 	it('planner role maps to PLANNER_TOOLS (same as CODER_TOOLS)', () => {

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -10,7 +10,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager';
-import { seedPresetAgents } from '../../../src/lib/space/agents/seed-agents';
+import {
+	seedPresetAgents,
+	ROLE_TOOLS,
+	SUB_SESSION_FEATURES,
+} from '../../../src/lib/space/agents/seed-agents';
+import { KNOWN_TOOLS } from '@neokai/shared';
 import { setModelsCache } from '../../../src/lib/model-service';
 import { createSpaceAgentSchema, insertSpace } from '../helpers/space-agent-schema';
 
@@ -244,5 +249,302 @@ describe('seedPresetAgents', () => {
 
 		expect(general?.systemPrompt).toContain('summarization');
 		expect(general?.instructions).toContain('summary');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Exact tool sets, system prompts, instructions, and exports
+// ---------------------------------------------------------------------------
+
+describe('preset agent exact definitions', () => {
+	let db: Database;
+	let manager: SpaceAgentManager;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceAgentSchema(db);
+		insertSpace(db);
+		const repo = new SpaceAgentRepository(db as any);
+		manager = new SpaceAgentManager(repo);
+		setModelsCache(new Map());
+	});
+
+	afterEach(() => {
+		db.close();
+		setModelsCache(new Map());
+	});
+
+	// --- Exact tool sets ---
+
+	const EXPECTED_CODER_TOOLS = KNOWN_TOOLS.filter(
+		(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
+	) as unknown as string[];
+
+	const EXPECTED_READONLY_TOOLS = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+
+	it('Coder has exact CODER_TOOLS (KNOWN_TOOLS minus Task/TaskOutput/TaskStop)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const coder = seeded.find((a) => a.name === 'Coder')!;
+		expect(coder.tools).toEqual(EXPECTED_CODER_TOOLS);
+	});
+
+	it('Coder tools exclude Task, TaskOutput, TaskStop', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const coder = seeded.find((a) => a.name === 'Coder')!;
+		expect(coder.tools).not.toContain('Task');
+		expect(coder.tools).not.toContain('TaskOutput');
+		expect(coder.tools).not.toContain('TaskStop');
+	});
+
+	it('General has exact DONE_TOOLS', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const general = seeded.find((a) => a.name === 'General')!;
+		expect(general.tools).toEqual(EXPECTED_READONLY_TOOLS);
+	});
+
+	it('Planner has exact PLANNER_TOOLS (same as CODER_TOOLS)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const planner = seeded.find((a) => a.name === 'Planner')!;
+		expect(planner.tools).toEqual(EXPECTED_CODER_TOOLS);
+	});
+
+	it('Research has exact RESEARCH_TOOLS (same as CODER_TOOLS)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const research = seeded.find((a) => a.name === 'Research')!;
+		expect(research.tools).toEqual(EXPECTED_CODER_TOOLS);
+	});
+
+	it('Reviewer has exact REVIEWER_TOOLS', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const reviewer = seeded.find((a) => a.name === 'Reviewer')!;
+		expect(reviewer.tools).toEqual(EXPECTED_READONLY_TOOLS);
+	});
+
+	it('QA has exact QA_TOOLS', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const qa = seeded.find((a) => a.name === 'QA')!;
+		expect(qa.tools).toEqual(EXPECTED_READONLY_TOOLS);
+	});
+
+	// --- Exact system prompts ---
+
+	it('Coder has exact system prompt', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const coder = seeded.find((a) => a.name === 'Coder')!;
+		expect(coder.systemPrompt).toBe(
+			'You are an expert software engineer. You write clean, well-tested code following the ' +
+				"project's existing conventions. You always commit your work, keep the working tree clean, " +
+				'and open pull requests for review.'
+		);
+	});
+
+	it('General has exact system prompt', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const general = seeded.find((a) => a.name === 'General')!;
+		expect(general.systemPrompt).toBe(
+			'You are a summarization agent. You read completed workflow outputs and gate data, then produce ' +
+				'a clear, human-readable summary of what was accomplished.'
+		);
+	});
+
+	it('Planner has exact system prompt', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const planner = seeded.find((a) => a.name === 'Planner')!;
+		expect(planner.systemPrompt).toBe(
+			'You are a technical project manager. You analyze goals, break them down into clear actionable ' +
+				'tasks, identify dependencies, and produce structured implementation plans.'
+		);
+	});
+
+	it('Research has exact system prompt', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const research = seeded.find((a) => a.name === 'Research')!;
+		expect(research.systemPrompt).toBe(
+			'You are a research specialist. You investigate topics thoroughly using web search and code ' +
+				'exploration, synthesize findings clearly, and document results in well-structured markdown files.'
+		);
+	});
+
+	it('Reviewer has exact system prompt', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const reviewer = seeded.find((a) => a.name === 'Reviewer')!;
+		expect(reviewer.systemPrompt).toBe(
+			'You are an expert code reviewer. You review pull requests for correctness, security, performance, ' +
+				'style, and test coverage. You give specific, actionable feedback.'
+		);
+	});
+
+	it('QA has exact system prompt', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const qa = seeded.find((a) => a.name === 'QA')!;
+		expect(qa.systemPrompt).toBe(
+			'You are a quality assurance engineer. You verify test coverage, run test suites, check CI status, ' +
+				'and ensure the codebase meets quality standards before release.'
+		);
+	});
+
+	// --- Exact instructions ---
+
+	it('Coder has exact instructions', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const coder = seeded.find((a) => a.name === 'Coder')!;
+		expect(coder.instructions).toBe(
+			'Before finishing: ensure all tests pass, commit all changes, and open a PR with a clear description.'
+		);
+	});
+
+	it('General has exact instructions', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const general = seeded.find((a) => a.name === 'General')!;
+		expect(general.instructions).toBe(
+			'Read all available gate data and workflow outputs. Write a comprehensive summary of the completed work.'
+		);
+	});
+
+	it('Planner has exact instructions', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const planner = seeded.find((a) => a.name === 'Planner')!;
+		expect(planner.instructions).toBe(
+			'Produce a concrete plan with clear steps. Write the plan to a file and commit it.'
+		);
+	});
+
+	it('Research has exact instructions', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const research = seeded.find((a) => a.name === 'Research')!;
+		expect(research.instructions).toBe(
+			'Save all findings to a markdown file, commit the file, and open a PR with a summary of what you found.'
+		);
+	});
+
+	it('Reviewer has exact instructions', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const reviewer = seeded.find((a) => a.name === 'Reviewer')!;
+		expect(reviewer.instructions).toBe(
+			'Review the open PR thoroughly. If satisfied, call report_done(). If changes are needed, provide ' +
+				'specific feedback and send back for revision.'
+		);
+	});
+
+	it('QA has exact instructions', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const qa = seeded.find((a) => a.name === 'QA')!;
+		expect(qa.instructions).toBe(
+			"Run the full test suite. Write result='passed' or result='failed' to the gate with specific details on any failures."
+		);
+	});
+
+	// --- Exact descriptions ---
+
+	it('each agent has the exact description from PRESET_AGENTS', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+
+		const expected: Record<string, string> = {
+			Coder:
+				'Implementation worker. Writes code, runs tests, commits changes, and opens pull requests.',
+			General:
+				'Done node agent. Reads gate data from completed workflow stages and produces a ' +
+				'comprehensive human-readable summary of what was accomplished.',
+			Planner:
+				'Planning agent. Breaks down goals into actionable tasks and drafts implementation plans.',
+			Research:
+				'Research agent. Investigates topics, gathers information, writes findings to docs, and opens pull requests with research results.',
+			Reviewer:
+				'Code review specialist. Reviews pull requests for correctness, style, and test coverage.',
+			QA: 'Quality assurance specialist. Verifies test coverage, runs test suites, and checks CI pipeline status.',
+		};
+
+		for (const agent of seeded) {
+			expect(agent.description).toBe(expected[agent.name]);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ROLE_TOOLS export
+// ---------------------------------------------------------------------------
+
+describe('ROLE_TOOLS export', () => {
+	const EXPECTED_CODER_TOOLS = KNOWN_TOOLS.filter(
+		(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
+	) as unknown as string[];
+
+	const EXPECTED_READONLY_TOOLS = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+
+	it('has entries for all 6 preset roles', () => {
+		expect(Object.keys(ROLE_TOOLS).sort()).toEqual([
+			'coder',
+			'general',
+			'planner',
+			'qa',
+			'research',
+			'reviewer',
+		]);
+	});
+
+	it('coder role maps to CODER_TOOLS', () => {
+		expect(ROLE_TOOLS.coder).toEqual(EXPECTED_CODER_TOOLS);
+	});
+
+	it('general role maps to DONE_TOOLS', () => {
+		expect(ROLE_TOOLS.general).toEqual(EXPECTED_READONLY_TOOLS);
+	});
+
+	it('planner role maps to PLANNER_TOOLS (same as CODER_TOOLS)', () => {
+		expect(ROLE_TOOLS.planner).toEqual(EXPECTED_CODER_TOOLS);
+	});
+
+	it('research role maps to RESEARCH_TOOLS (same as CODER_TOOLS)', () => {
+		expect(ROLE_TOOLS.research).toEqual(EXPECTED_CODER_TOOLS);
+	});
+
+	it('reviewer role maps to REVIEWER_TOOLS', () => {
+		expect(ROLE_TOOLS.reviewer).toEqual(EXPECTED_READONLY_TOOLS);
+	});
+
+	it('qa role maps to QA_TOOLS', () => {
+		expect(ROLE_TOOLS.qa).toEqual(EXPECTED_READONLY_TOOLS);
+	});
+
+	it('ROLE_TOOLS matches what seedPresetAgents actually seeds', async () => {
+		const db = new Database(':memory:');
+		createSpaceAgentSchema(db);
+		insertSpace(db);
+		const repo = new SpaceAgentRepository(db as any);
+		const mgr = new SpaceAgentManager(repo);
+		setModelsCache(new Map());
+
+		const { seeded } = await seedPresetAgents('space-1', mgr);
+
+		for (const agent of seeded) {
+			const roleKey = agent.name.toLowerCase();
+			expect(ROLE_TOOLS[roleKey]).toBeDefined();
+			expect(agent.tools).toEqual(ROLE_TOOLS[roleKey]);
+		}
+
+		db.close();
+		setModelsCache(new Map());
+	});
+});
+
+// ---------------------------------------------------------------------------
+// SUB_SESSION_FEATURES export
+// ---------------------------------------------------------------------------
+
+describe('SUB_SESSION_FEATURES export', () => {
+	it('has exactly the expected feature flags', () => {
+		expect(SUB_SESSION_FEATURES).toEqual({
+			rewind: false,
+			worktree: false,
+			coordinator: false,
+			archive: false,
+			sessionInfo: false,
+		});
+	});
+
+	it('all feature values are false', () => {
+		for (const [, value] of Object.entries(SUB_SESSION_FEATURES)) {
+			expect(value).toBe(false);
+		}
 	});
 });

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -225,7 +225,7 @@ describe('seedPresetAgents', () => {
 		const reviewer = seeded.find((a) => a.name === 'Reviewer');
 
 		expect(reviewer?.systemPrompt).toContain('code reviewer');
-		expect(reviewer?.instructions).toContain('report_done');
+		expect(reviewer?.instructions).toContain('specific feedback');
 	});
 
 	it('Planner system prompt mentions planning', async () => {
@@ -422,8 +422,8 @@ describe('preset agent exact definitions', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const reviewer = seeded.find((a) => a.name === 'Reviewer')!;
 		expect(reviewer.instructions).toBe(
-			'Review the open PR thoroughly. If satisfied, call report_done(). If changes are needed, provide ' +
-				'specific feedback and send back for revision.'
+			'Review the code thoroughly. If satisfied, summarize your findings. If changes are needed, provide ' +
+				'specific feedback.'
 		);
 	});
 
@@ -431,7 +431,7 @@ describe('preset agent exact definitions', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const qa = seeded.find((a) => a.name === 'QA')!;
 		expect(qa.instructions).toBe(
-			"Run the full test suite. Write result='passed' or result='failed' to the gate with specific details on any failures."
+			'Run the full test suite and report results with specific details on any failures.'
 		);
 	});
 

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -14,6 +14,7 @@ import {
 	seedPresetAgents,
 	ROLE_TOOLS,
 	SUB_SESSION_FEATURES,
+	getPresetAgentTemplates,
 } from '../../../src/lib/space/agents/seed-agents';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import { setModelsCache } from '../../../src/lib/model-service';
@@ -342,7 +343,7 @@ describe('preset agent exact definitions', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const general = seeded.find((a) => a.name === 'General')!;
 		expect(general.systemPrompt).toBe(
-			'You are a summarization agent. You read completed workflow outputs and gate data, then produce ' +
+			'You are a summarization agent. You read completed task outputs and gate data, then produce ' +
 				'a clear, human-readable summary of what was accomplished.'
 		);
 	});
@@ -545,6 +546,57 @@ describe('SUB_SESSION_FEATURES export', () => {
 	it('all feature values are false', () => {
 		for (const [, value] of Object.entries(SUB_SESSION_FEATURES)) {
 			expect(value).toBe(false);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getPresetAgentTemplates export
+// ---------------------------------------------------------------------------
+
+describe('getPresetAgentTemplates', () => {
+	it('returns exactly 6 templates', () => {
+		const templates = getPresetAgentTemplates();
+		expect(templates).toHaveLength(6);
+	});
+
+	it('returns all expected agent names', () => {
+		const templates = getPresetAgentTemplates();
+		const names = templates.map((t) => t.name).sort();
+		expect(names).toEqual(['Coder', 'General', 'Planner', 'QA', 'Research', 'Reviewer']);
+	});
+
+	it('each template has name, description, tools, systemPrompt, and instructions', () => {
+		const templates = getPresetAgentTemplates();
+		for (const t of templates) {
+			expect(typeof t.name).toBe('string');
+			expect(t.name.length).toBeGreaterThan(0);
+			expect(typeof t.description).toBe('string');
+			expect(t.description.length).toBeGreaterThan(0);
+			expect(Array.isArray(t.tools)).toBe(true);
+			expect(t.tools.length).toBeGreaterThan(0);
+			expect(typeof t.systemPrompt).toBe('string');
+			expect(t.systemPrompt.length).toBeGreaterThan(0);
+			expect(typeof t.instructions).toBe('string');
+			expect(t.instructions.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('returns cloned arrays — mutating tools does not affect globals', () => {
+		const first = getPresetAgentTemplates();
+		const coderTools = first.find((t) => t.name === 'Coder')!.tools;
+		coderTools.push('FakeTool');
+
+		const second = getPresetAgentTemplates();
+		const coderTools2 = second.find((t) => t.name === 'Coder')!.tools;
+		expect(coderTools2).not.toContain('FakeTool');
+	});
+
+	it('template tools match ROLE_TOOLS', () => {
+		const templates = getPresetAgentTemplates();
+		for (const t of templates) {
+			const roleKey = t.name.toLowerCase();
+			expect(t.tools).toEqual(ROLE_TOOLS[roleKey]);
 		}
 	});
 });


### PR DESCRIPTION
## Summary
- Adds exact-match unit tests for all 6 preset agent tool sets, system prompts, instructions, and descriptions
- Tests ROLE_TOOLS export matches what seedPresetAgents actually seeds
- Tests SUB_SESSION_FEATURES export has all flags set to false
- 52 tests pass (34 new, 18 existing)