### PR TITLE
feat: add blocked reason display to task cards and task pane

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -126,7 +126,7 @@ export class SpaceTaskManager {
 
 		const updates: Parameters<SpaceTaskRepository['updateTask']>[1] = { status: newStatus };
 
-		if (newStatus === 'done') {
+		if (newStatus === 'done' || newStatus === 'blocked') {
 			if (options?.result) updates.result = options.result;
 		}
 
@@ -167,8 +167,8 @@ export class SpaceTaskManager {
 	/**
 	 * Fail a task (mark as blocked)
 	 */
-	async failTask(taskId: string, _error?: string): Promise<SpaceTask> {
-		return this.setTaskStatus(taskId, 'blocked');
+	async failTask(taskId: string, error?: string): Promise<SpaceTask> {
+		return this.setTaskStatus(taskId, 'blocked', error ? { result: error } : undefined);
 	}
 
 	/**

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -178,6 +178,41 @@ describe('SpaceTaskManager', () => {
 			const failed = await manager.failTask(task.id, 'Something went wrong');
 			expect(failed.status).toBe('blocked');
 		});
+
+		it('persists result when failing a task with an error message', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			const failed = await manager.failTask(task.id, 'Dependency unavailable');
+			expect(failed.status).toBe('blocked');
+			expect(failed.result).toBe('Dependency unavailable');
+		});
+
+		it('persists result when transitioning to blocked via setTaskStatus', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			const blocked = await manager.setTaskStatus(task.id, 'blocked', {
+				result: 'Waiting for approval',
+			});
+			expect(blocked.status).toBe('blocked');
+			expect(blocked.result).toBe('Waiting for approval');
+		});
+
+		it('clears result when unblocking a task back to in_progress', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.setTaskStatus(task.id, 'blocked', { result: 'Some reason' });
+			const restarted = await manager.setTaskStatus(task.id, 'in_progress');
+			expect(restarted.status).toBe('in_progress');
+			expect(restarted.result).toBeNull();
+		});
+
+		it('failTask without error message does not set result', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			const failed = await manager.failTask(task.id);
+			expect(failed.status).toBe('blocked');
+			expect(failed.result).toBeNull();
+		});
 	});
 
 	describe('cancelTask', () => {

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -67,6 +67,7 @@ function TaskRow({
 		title: string;
 		status: string;
 		priority: string;
+		result?: string | null;
 		workflowRunId?: string | null;
 		updatedAt: number;
 	};
@@ -111,6 +112,14 @@ function TaskRow({
 						<span>·</span>
 						<span>{task.workflowRunId ? 'Workflow task' : 'Standalone task'}</span>
 					</div>
+					{task.status === 'blocked' && task.result && (
+						<p
+							class="mt-1.5 text-xs text-amber-300/80 line-clamp-2"
+							data-testid="task-blocked-reason"
+						>
+							{task.result}
+						</p>
+					)}
 				</div>
 			</div>
 		</button>

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -189,7 +189,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					<div class="min-w-0 flex-1">
 						<h2 class="text-lg font-semibold text-gray-100 min-w-0 truncate">{task.title}</h2>
 						<div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-400">
-							<span>{activitySummary}</span>
+							<span data-testid="task-status-label">{activitySummary}</span>
 							{task.priority !== 'normal' && (
 								<span class="text-xs uppercase tracking-[0.12em] text-gray-500">
 									{PRIORITY_LABELS[task.priority]} Priority
@@ -213,6 +213,16 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					)}
 				</div>
 			</div>
+
+			{task.status === 'blocked' && task.result && (
+				<div
+					class="mx-4 mb-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2"
+					data-testid="task-blocked-banner"
+				>
+					<p class="text-xs font-medium text-amber-300">Blocked</p>
+					<p class="mt-0.5 text-sm text-amber-200/90">{task.result}</p>
+				</div>
+			)}
 
 			<div class="flex-1 min-h-0 overflow-hidden px-4">
 				<div class="h-full flex flex-col">

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -286,4 +286,33 @@ describe('SpaceDashboard', () => {
 		expect(dialog).toBeTruthy();
 		expect(dialog?.querySelector('h2')?.textContent).toBe('Start Workflow Run');
 	});
+
+	it('renders blocked reason text on a blocked task card', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [makeTask('t1', 'blocked', { result: 'Waiting for human approval' })];
+
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getByText('Review').closest('button')!);
+		expect(getByText('Task t1')).toBeTruthy();
+		expect(getByText('Waiting for human approval')).toBeTruthy();
+	});
+
+	it('does not render blocked reason when result is null', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [makeTask('t1', 'blocked', { result: null })];
+
+		const { queryByTestId } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(queryByTestId('tab-review') ?? document.querySelector('button')!);
+		expect(document.querySelector('[data-testid="task-blocked-reason"]')).toBeNull();
+	});
+
+	it('does not render blocked reason for non-blocked tasks even if result is set', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [makeTask('t1', 'done', { result: 'All done' })];
+
+		const { getByText, queryByTestId } = render(<SpaceDashboard spaceId="space-1" />);
+		fireEvent.click(getByText('Done').closest('button')!);
+		expect(getByText('Task t1')).toBeTruthy();
+		expect(document.querySelector('[data-testid="task-blocked-reason"]')).toBeNull();
+	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -203,3 +203,65 @@ describe('SpaceTaskPane — composer', () => {
 		expect(mockSendTaskMessage).not.toHaveBeenCalled();
 	});
 });
+
+describe('SpaceTaskPane — blocked reason banner', () => {
+	beforeEach(() => {
+		cleanup();
+		mockTasks.value = [];
+		mockEnsureTaskAgentSession.mockReset();
+		mockEnsureTaskAgentSession.mockImplementation(async () =>
+			makeTask({ status: 'blocked', taskAgentSessionId: 'session-ensured' })
+		);
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows blocked reason banner when task is blocked with result', () => {
+		mockTasks.value = [
+			makeTask({
+				status: 'blocked',
+				result: 'Waiting for API key configuration',
+				taskAgentSessionId: 'session-abc',
+			}),
+		];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		const banner = getByTestId('task-blocked-banner');
+		expect(banner).toBeTruthy();
+		expect(banner.textContent).toContain('Blocked');
+		expect(banner.textContent).toContain('Waiting for API key configuration');
+	});
+
+	it('does not show blocked reason banner when task is blocked without result', () => {
+		mockTasks.value = [
+			makeTask({ status: 'blocked', result: null, taskAgentSessionId: 'session-abc' }),
+		];
+		const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(queryByTestId('task-blocked-banner')).toBeNull();
+	});
+
+	it('does not show blocked banner for non-blocked tasks', () => {
+		mockTasks.value = [
+			makeTask({
+				status: 'in_progress',
+				result: 'Some result',
+				taskAgentSessionId: 'session-abc',
+			}),
+		];
+		const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(queryByTestId('task-blocked-banner')).toBeNull();
+	});
+
+	it('shows status label as Blocked in the header', () => {
+		mockTasks.value = [
+			makeTask({
+				status: 'blocked',
+				result: 'Need human input',
+				taskAgentSessionId: 'session-abc',
+			}),
+		];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByTestId('task-status-label').textContent).toBe('Blocked');
+	});
+});


### PR DESCRIPTION
## Summary
- Fix backend bug: persist `result` field when task transitions to `blocked` status (was silently dropped)
- Add blocked reason text display below status in `TaskRow` cards (SpaceDashboard)
- Add prominent blocked reason banner in `SpaceTaskPane` detail view
- Add 4 backend tests and 7 frontend Vitest tests covering blocked reason rendering

Closes task 2.2 of Comprehensive Space Feature E2E Review.