### PR TITLE
feat: add full manual task status control UI

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -22,8 +22,8 @@ import type {
  * Maps current status -> allowed next statuses
  */
 export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> = {
-	open: ['in_progress', 'cancelled'],
-	in_progress: ['done', 'blocked', 'cancelled'],
+	open: ['in_progress', 'blocked', 'done', 'cancelled'],
+	in_progress: ['open', 'done', 'blocked', 'cancelled'],
 	done: ['in_progress', 'archived'], // Reactivate or archive
 	blocked: ['open', 'in_progress', 'archived'], // Restart allowed + archive
 	cancelled: ['open', 'in_progress', 'done', 'archived'], // Restart, complete, or archive
@@ -130,12 +130,13 @@ export class SpaceTaskManager {
 			if (options?.result) updates.result = options.result;
 		}
 
-		// Clear result when restarting from a terminal/failed state.
-		// Covers blocked, cancelled, and done → reactivation transitions.
+		// Clear result when restarting or deprioritizing.
+		// Covers blocked, cancelled, done → reactivation, and in_progress → open (pause).
 		if (
 			(task.status === 'blocked' && (newStatus === 'open' || newStatus === 'in_progress')) ||
 			(task.status === 'cancelled' && (newStatus === 'open' || newStatus === 'in_progress')) ||
-			(task.status === 'done' && newStatus === 'in_progress')
+			(task.status === 'done' && newStatus === 'in_progress') ||
+			(task.status === 'in_progress' && newStatus === 'open')
 		) {
 			updates.result = null;
 		}

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -46,9 +46,14 @@ describe('SpaceTaskManager', () => {
 			expect(isValidSpaceTaskTransition('done', 'in_progress')).toBe(true);
 		});
 
+		it('allows new manual transitions', () => {
+			expect(isValidSpaceTaskTransition('open', 'blocked')).toBe(true);
+			expect(isValidSpaceTaskTransition('open', 'done')).toBe(true);
+			expect(isValidSpaceTaskTransition('in_progress', 'open')).toBe(true);
+		});
+
 		it('rejects invalid transitions', () => {
 			expect(isValidSpaceTaskTransition('done', 'open')).toBe(false);
-			expect(isValidSpaceTaskTransition('open', 'done')).toBe(false);
 		});
 	});
 
@@ -113,9 +118,33 @@ describe('SpaceTaskManager', () => {
 			expect(done.result).toBe('Done!');
 		});
 
+		it('transitions open -> done (already completed)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			const done = await manager.setTaskStatus(task.id, 'done', { result: 'Already done' });
+			expect(done.status).toBe('done');
+			expect(done.result).toBe('Already done');
+		});
+
+		it('transitions open -> blocked (blocker found before start)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			const blocked = await manager.setTaskStatus(task.id, 'blocked', {
+				result: 'Missing dependency',
+			});
+			expect(blocked.status).toBe('blocked');
+			expect(blocked.result).toBe('Missing dependency');
+		});
+
+		it('transitions in_progress -> open (pause/deprioritize)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			const paused = await manager.setTaskStatus(task.id, 'open');
+			expect(paused.status).toBe('open');
+			expect(paused.result).toBeNull();
+		});
+
 		it('throws for invalid transition', async () => {
 			const task = await manager.createTask({ title: 'T', description: '' });
-			await expect(manager.setTaskStatus(task.id, 'done')).rejects.toThrow(
+			await expect(manager.setTaskStatus(task.id, 'archived')).rejects.toThrow(
 				'Invalid status transition'
 			);
 		});
@@ -526,8 +555,22 @@ describe('SpaceTaskManager', () => {
 			expect(VALID_SPACE_TASK_TRANSITIONS.archived).toEqual([]);
 		});
 
-		it('open allows in_progress and cancelled', () => {
-			expect(VALID_SPACE_TASK_TRANSITIONS.open).toEqual(['in_progress', 'cancelled']);
+		it('open allows in_progress, blocked, done, and cancelled', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.open).toEqual([
+				'in_progress',
+				'blocked',
+				'done',
+				'cancelled',
+			]);
+		});
+
+		it('in_progress allows open, done, blocked, and cancelled', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.in_progress).toEqual([
+				'open',
+				'done',
+				'blocked',
+				'cancelled',
+			]);
 		});
 	});
 

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -5,6 +5,7 @@ import type { SpaceTaskPriority, SpaceTaskStatus } from '@neokai/shared';
 import { cn } from '../../lib/utils';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
+import { TaskStatusActions } from './TaskStatusActions';
 
 interface SpaceTaskPaneProps {
 	taskId: string | null;
@@ -52,7 +53,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [threadDraft, setThreadDraft] = useState('');
 	const [threadSendError, setThreadSendError] = useState<string | null>(null);
 	const [sendingThread, setSendingThread] = useState(false);
-	const [reopeningTask, setReopeningTask] = useState(false);
+	const [statusTransitioning, setStatusTransitioning] = useState(false);
 	const [showArtifacts, setShowArtifacts] = useState(false);
 
 	useEffect(() => {
@@ -155,16 +156,15 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		}
 	};
 
-	const handleReopenTask = async () => {
-		if (task.status !== 'done') return;
+	const handleStatusTransition = async (newStatus: SpaceTaskStatus) => {
 		try {
-			setReopeningTask(true);
+			setStatusTransitioning(true);
 			setThreadSendError(null);
-			await spaceStore.updateTask(task.id, { status: 'in_progress' });
+			await spaceStore.updateTask(task.id, { status: newStatus });
 		} catch (err) {
 			setThreadSendError(formatTaskThreadError(err));
 		} finally {
-			setReopeningTask(false);
+			setStatusTransitioning(false);
 		}
 	};
 
@@ -310,21 +310,11 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 								</p>
 							)}
 
-							{isTerminalTask && (
-								<div class="flex flex-wrap items-center gap-3">
-									<p class="text-xs text-gray-500">This task is read-only in its current state.</p>
-									{task.status === 'done' && (
-										<button
-											type="button"
-											onClick={() => void handleReopenTask()}
-											disabled={reopeningTask}
-											class="px-2 py-1 text-xs font-medium text-gray-300 hover:text-gray-100 transition-colors disabled:opacity-50"
-										>
-											{reopeningTask ? 'Reopening...' : 'Reopen Task'}
-										</button>
-									)}
-								</div>
-							)}
+							<TaskStatusActions
+								status={task.status}
+								onTransition={handleStatusTransition}
+								disabled={statusTransitioning}
+							/>
 
 							{threadSendError && <p class="text-xs text-red-300">{threadSendError}</p>}
 						</div>

--- a/packages/web/src/components/space/TaskStatusActions.tsx
+++ b/packages/web/src/components/space/TaskStatusActions.tsx
@@ -1,0 +1,94 @@
+import type { SpaceTaskStatus } from '@neokai/shared';
+
+/**
+ * Valid status transitions mirroring the daemon's VALID_SPACE_TASK_TRANSITIONS.
+ * Kept in sync manually — the shared package doesn't export this constant.
+ */
+export const VALID_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> = {
+	open: ['in_progress', 'cancelled'],
+	in_progress: ['done', 'blocked', 'cancelled'],
+	done: ['in_progress', 'archived'],
+	blocked: ['open', 'in_progress', 'archived'],
+	cancelled: ['open', 'in_progress', 'done', 'archived'],
+	archived: [],
+};
+
+/**
+ * Human-readable labels for each transition, keyed by `from -> to`.
+ */
+export const TRANSITION_LABELS: Record<string, string> = {
+	'open->in_progress': 'Start',
+	'open->cancelled': 'Cancel',
+	'in_progress->done': 'Mark Done',
+	'in_progress->blocked': 'Block',
+	'in_progress->cancelled': 'Cancel',
+	'done->in_progress': 'Reopen',
+	'done->archived': 'Archive',
+	'blocked->open': 'Reopen',
+	'blocked->in_progress': 'Resume',
+	'blocked->archived': 'Archive',
+	'cancelled->open': 'Reopen',
+	'cancelled->in_progress': 'Resume',
+	'cancelled->done': 'Mark Done',
+	'cancelled->archived': 'Archive',
+};
+
+/**
+ * Tailwind color classes per transition target for visual distinction.
+ */
+const TRANSITION_STYLES: Record<string, string> = {
+	in_progress: 'text-blue-300 hover:text-blue-200',
+	done: 'text-green-300 hover:text-green-200',
+	blocked: 'text-amber-300 hover:text-amber-200',
+	cancelled: 'text-red-300 hover:text-red-200',
+	open: 'text-gray-300 hover:text-gray-100',
+	archived: 'text-gray-400 hover:text-gray-300',
+};
+
+/**
+ * Returns the list of valid transition actions from a given status.
+ */
+export function getTransitionActions(
+	currentStatus: SpaceTaskStatus
+): Array<{ target: SpaceTaskStatus; label: string }> {
+	const targets = VALID_TASK_TRANSITIONS[currentStatus] ?? [];
+	return targets.map((target) => ({
+		target,
+		label: TRANSITION_LABELS[`${currentStatus}->${target}`] ?? target,
+	}));
+}
+
+interface TaskStatusActionsProps {
+	status: SpaceTaskStatus;
+	onTransition: (newStatus: SpaceTaskStatus) => void;
+	disabled?: boolean;
+}
+
+export function TaskStatusActions({ status, onTransition, disabled }: TaskStatusActionsProps) {
+	const actions = getTransitionActions(status);
+
+	if (actions.length === 0) {
+		return (
+			<p class="text-xs text-gray-500" data-testid="task-status-no-actions">
+				No status actions available.
+			</p>
+		);
+	}
+
+	return (
+		<div class="flex flex-wrap items-center gap-2" data-testid="task-status-actions">
+			{actions.map(({ target, label }) => (
+				<button
+					key={target}
+					type="button"
+					onClick={() => onTransition(target)}
+					disabled={disabled}
+					class={`px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${TRANSITION_STYLES[target] ?? 'text-gray-300 hover:text-gray-100'}`}
+					data-testid={`task-action-${target}`}
+				>
+					{label}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/packages/web/src/components/space/TaskStatusActions.tsx
+++ b/packages/web/src/components/space/TaskStatusActions.tsx
@@ -5,8 +5,8 @@ import type { SpaceTaskStatus } from '@neokai/shared';
  * Kept in sync manually — the shared package doesn't export this constant.
  */
 export const VALID_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> = {
-	open: ['in_progress', 'cancelled'],
-	in_progress: ['done', 'blocked', 'cancelled'],
+	open: ['in_progress', 'blocked', 'done', 'cancelled'],
+	in_progress: ['open', 'done', 'blocked', 'cancelled'],
 	done: ['in_progress', 'archived'],
 	blocked: ['open', 'in_progress', 'archived'],
 	cancelled: ['open', 'in_progress', 'done', 'archived'],
@@ -18,7 +18,10 @@ export const VALID_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> 
  */
 export const TRANSITION_LABELS: Record<string, string> = {
 	'open->in_progress': 'Start',
+	'open->blocked': 'Block',
+	'open->done': 'Mark Done',
 	'open->cancelled': 'Cancel',
+	'in_progress->open': 'Pause',
 	'in_progress->done': 'Mark Done',
 	'in_progress->blocked': 'Block',
 	'in_progress->cancelled': 'Cancel',

--- a/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
@@ -1,0 +1,185 @@
+// @ts-nocheck
+import { describe, it, expect, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+import { afterEach } from 'vitest';
+import type { SpaceTaskStatus } from '@neokai/shared';
+import {
+	TaskStatusActions,
+	getTransitionActions,
+	VALID_TASK_TRANSITIONS,
+	TRANSITION_LABELS,
+} from '../TaskStatusActions';
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('VALID_TASK_TRANSITIONS', () => {
+	it('open can transition to in_progress and cancelled', () => {
+		expect(VALID_TASK_TRANSITIONS.open).toEqual(['in_progress', 'cancelled']);
+	});
+
+	it('in_progress can transition to done, blocked, cancelled', () => {
+		expect(VALID_TASK_TRANSITIONS.in_progress).toEqual(['done', 'blocked', 'cancelled']);
+	});
+
+	it('done can transition to in_progress and archived', () => {
+		expect(VALID_TASK_TRANSITIONS.done).toEqual(['in_progress', 'archived']);
+	});
+
+	it('blocked can transition to open, in_progress, archived', () => {
+		expect(VALID_TASK_TRANSITIONS.blocked).toEqual(['open', 'in_progress', 'archived']);
+	});
+
+	it('cancelled can transition to open, in_progress, done, archived', () => {
+		expect(VALID_TASK_TRANSITIONS.cancelled).toEqual(['open', 'in_progress', 'done', 'archived']);
+	});
+
+	it('archived has no transitions', () => {
+		expect(VALID_TASK_TRANSITIONS.archived).toEqual([]);
+	});
+});
+
+describe('getTransitionActions', () => {
+	it('returns correct actions for open status', () => {
+		const actions = getTransitionActions('open');
+		expect(actions).toEqual([
+			{ target: 'in_progress', label: 'Start' },
+			{ target: 'cancelled', label: 'Cancel' },
+		]);
+	});
+
+	it('returns correct actions for in_progress status', () => {
+		const actions = getTransitionActions('in_progress');
+		expect(actions).toEqual([
+			{ target: 'done', label: 'Mark Done' },
+			{ target: 'blocked', label: 'Block' },
+			{ target: 'cancelled', label: 'Cancel' },
+		]);
+	});
+
+	it('returns correct actions for done status', () => {
+		const actions = getTransitionActions('done');
+		expect(actions).toEqual([
+			{ target: 'in_progress', label: 'Reopen' },
+			{ target: 'archived', label: 'Archive' },
+		]);
+	});
+
+	it('returns correct actions for blocked status', () => {
+		const actions = getTransitionActions('blocked');
+		expect(actions).toEqual([
+			{ target: 'open', label: 'Reopen' },
+			{ target: 'in_progress', label: 'Resume' },
+			{ target: 'archived', label: 'Archive' },
+		]);
+	});
+
+	it('returns correct actions for cancelled status', () => {
+		const actions = getTransitionActions('cancelled');
+		expect(actions).toEqual([
+			{ target: 'open', label: 'Reopen' },
+			{ target: 'in_progress', label: 'Resume' },
+			{ target: 'done', label: 'Mark Done' },
+			{ target: 'archived', label: 'Archive' },
+		]);
+	});
+
+	it('returns empty array for archived status', () => {
+		expect(getTransitionActions('archived')).toEqual([]);
+	});
+});
+
+describe('TRANSITION_LABELS', () => {
+	it('has a label for every valid transition', () => {
+		for (const [from, targets] of Object.entries(VALID_TASK_TRANSITIONS)) {
+			for (const to of targets) {
+				const key = `${from}->${to}`;
+				expect(TRANSITION_LABELS[key]).toBeDefined();
+				expect(typeof TRANSITION_LABELS[key]).toBe('string');
+			}
+		}
+	});
+});
+
+describe('TaskStatusActions component', () => {
+	const allStatuses: SpaceTaskStatus[] = [
+		'open',
+		'in_progress',
+		'done',
+		'blocked',
+		'cancelled',
+		'archived',
+	];
+
+	it.each(allStatuses)('renders correct buttons for %s status', (status) => {
+		const onTransition = vi.fn();
+		const { container } = render(<TaskStatusActions status={status} onTransition={onTransition} />);
+		const expectedActions = getTransitionActions(status);
+		const buttons = container.querySelectorAll('button');
+		expect(buttons.length).toBe(expectedActions.length);
+		for (let i = 0; i < expectedActions.length; i++) {
+			expect(buttons[i].textContent).toBe(expectedActions[i].label);
+		}
+	});
+
+	it('shows no-actions message for archived status', () => {
+		const onTransition = vi.fn();
+		const { getByTestId } = render(
+			<TaskStatusActions status="archived" onTransition={onTransition} />
+		);
+		expect(getByTestId('task-status-no-actions').textContent).toBe('No status actions available.');
+	});
+
+	it('calls onTransition with target status when button clicked', () => {
+		const onTransition = vi.fn();
+		const { getByTestId } = render(<TaskStatusActions status="open" onTransition={onTransition} />);
+		fireEvent.click(getByTestId('task-action-in_progress'));
+		expect(onTransition).toHaveBeenCalledWith('in_progress');
+	});
+
+	it('calls onTransition with cancelled when Cancel clicked on in_progress', () => {
+		const onTransition = vi.fn();
+		const { getByTestId } = render(
+			<TaskStatusActions status="in_progress" onTransition={onTransition} />
+		);
+		fireEvent.click(getByTestId('task-action-cancelled'));
+		expect(onTransition).toHaveBeenCalledWith('cancelled');
+	});
+
+	it('disables all buttons when disabled prop is true', () => {
+		const onTransition = vi.fn();
+		const { container } = render(
+			<TaskStatusActions status="in_progress" onTransition={onTransition} disabled={true} />
+		);
+		const buttons = container.querySelectorAll('button');
+		for (const btn of buttons) {
+			expect(btn.disabled).toBe(true);
+		}
+	});
+
+	it('buttons are enabled by default', () => {
+		const onTransition = vi.fn();
+		const { container } = render(
+			<TaskStatusActions status="blocked" onTransition={onTransition} />
+		);
+		const buttons = container.querySelectorAll('button');
+		expect(buttons.length).toBeGreaterThan(0);
+		for (const btn of buttons) {
+			expect(btn.disabled).toBe(false);
+		}
+	});
+
+	it('renders data-testid for each action button', () => {
+		const onTransition = vi.fn();
+		const { getByTestId } = render(<TaskStatusActions status="done" onTransition={onTransition} />);
+		expect(getByTestId('task-action-in_progress')).toBeTruthy();
+		expect(getByTestId('task-action-archived')).toBeTruthy();
+	});
+
+	it('renders actions container with data-testid', () => {
+		const onTransition = vi.fn();
+		const { getByTestId } = render(<TaskStatusActions status="open" onTransition={onTransition} />);
+		expect(getByTestId('task-status-actions')).toBeTruthy();
+	});
+});

--- a/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
@@ -15,12 +15,12 @@ afterEach(() => {
 });
 
 describe('VALID_TASK_TRANSITIONS', () => {
-	it('open can transition to in_progress and cancelled', () => {
-		expect(VALID_TASK_TRANSITIONS.open).toEqual(['in_progress', 'cancelled']);
+	it('open can transition to in_progress, blocked, done, and cancelled', () => {
+		expect(VALID_TASK_TRANSITIONS.open).toEqual(['in_progress', 'blocked', 'done', 'cancelled']);
 	});
 
-	it('in_progress can transition to done, blocked, cancelled', () => {
-		expect(VALID_TASK_TRANSITIONS.in_progress).toEqual(['done', 'blocked', 'cancelled']);
+	it('in_progress can transition to open, done, blocked, cancelled', () => {
+		expect(VALID_TASK_TRANSITIONS.in_progress).toEqual(['open', 'done', 'blocked', 'cancelled']);
 	});
 
 	it('done can transition to in_progress and archived', () => {
@@ -45,6 +45,8 @@ describe('getTransitionActions', () => {
 		const actions = getTransitionActions('open');
 		expect(actions).toEqual([
 			{ target: 'in_progress', label: 'Start' },
+			{ target: 'blocked', label: 'Block' },
+			{ target: 'done', label: 'Mark Done' },
 			{ target: 'cancelled', label: 'Cancel' },
 		]);
 	});
@@ -52,6 +54,7 @@ describe('getTransitionActions', () => {
 	it('returns correct actions for in_progress status', () => {
 		const actions = getTransitionActions('in_progress');
 		expect(actions).toEqual([
+			{ target: 'open', label: 'Pause' },
 			{ target: 'done', label: 'Mark Done' },
 			{ target: 'blocked', label: 'Block' },
 			{ target: 'cancelled', label: 'Cancel' },


### PR DESCRIPTION
Replace the single "Reopen Task" button in SpaceTaskPane with a `TaskStatusActions` component exposing all valid status transitions. Each transition has a descriptive label (Start, Resume, Reopen, Mark Done, Block, Cancel, Archive) and color-coded styling matching its target status.

- New `TaskStatusActions` component with `VALID_TASK_TRANSITIONS` map mirroring the daemon
- Actions always visible in task pane footer (not just for terminal states)
- 26 Vitest tests covering transition maps, labels, rendering, click handlers, and disabled state