### PR TITLE
feat: add instructions and backgroundContext editors to SpaceSettings UI

### DIFF
--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -23,6 +23,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 	// Edit state
 	const [name, setName] = useState(space.name);
 	const [description, setDescription] = useState(space.description ?? '');
+	const [instructions, setInstructions] = useState(space.instructions ?? '');
+	const [backgroundContext, setBackgroundContext] = useState(space.backgroundContext ?? '');
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
 	const [isArchiving, setIsArchiving] = useState(false);
@@ -32,9 +34,15 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 	useEffect(() => {
 		setName(space.name);
 		setDescription(space.description ?? '');
-	}, [space.id, space.name, space.description]);
+		setInstructions(space.instructions ?? '');
+		setBackgroundContext(space.backgroundContext ?? '');
+	}, [space.id, space.name, space.description, space.instructions, space.backgroundContext]);
 
-	const isDirty = name !== space.name || description !== (space.description ?? '');
+	const isDirty =
+		name !== space.name ||
+		description !== (space.description ?? '') ||
+		instructions !== (space.instructions ?? '') ||
+		backgroundContext !== (space.backgroundContext ?? '');
 
 	async function handleSave(e: Event) {
 		e.preventDefault();
@@ -54,6 +62,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 				id: space.id,
 				name: name.trim(),
 				description: description.trim() || undefined,
+				instructions: instructions.trim() || undefined,
+				backgroundContext: backgroundContext.trim() || undefined,
 			});
 			toast.success('Space updated');
 		} catch (err) {
@@ -169,6 +179,52 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 						/>
 					</div>
 
+					<div>
+						<label class="block text-xs font-medium text-gray-400 mb-1">
+							Instructions
+							<span class="text-gray-600 ml-1">(optional)</span>
+						</label>
+						<p class="text-xs text-gray-500 mb-1">
+							Operator instructions for all agents in this space. Injected as{' '}
+							<code class="text-gray-400">## Space Instructions</code> in every agent's system
+							prompt.
+						</p>
+						<textarea
+							value={instructions}
+							onInput={(e) => setInstructions((e.target as HTMLTextAreaElement).value)}
+							placeholder="e.g. Always use TypeScript strict mode. Prefer functional components..."
+							rows={5}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100
+								placeholder-gray-600 focus:outline-none focus:border-blue-500 resize-y text-sm"
+						/>
+						<div class="text-xs text-gray-600 mt-0.5 text-right">
+							{instructions.length} characters
+						</div>
+					</div>
+
+					<div>
+						<label class="block text-xs font-medium text-gray-400 mb-1">
+							Background Context
+							<span class="text-gray-600 ml-1">(optional)</span>
+						</label>
+						<p class="text-xs text-gray-500 mb-1">
+							Project or codebase context. Injected as{' '}
+							<code class="text-gray-400">## Space Background</code> or{' '}
+							<code class="text-gray-400">## Project Context</code> in agent prompts.
+						</p>
+						<textarea
+							value={backgroundContext}
+							onInput={(e) => setBackgroundContext((e.target as HTMLTextAreaElement).value)}
+							placeholder="e.g. This project uses Bun + Hono backend, Preact frontend with Tailwind CSS..."
+							rows={5}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100
+								placeholder-gray-600 focus:outline-none focus:border-blue-500 resize-y text-sm"
+						/>
+						<div class="text-xs text-gray-600 mt-0.5 text-right">
+							{backgroundContext.length} characters
+						</div>
+					</div>
+
 					{isDirty && (
 						<div class="flex gap-2 justify-end">
 							<Button
@@ -178,6 +234,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 								onClick={() => {
 									setName(space.name);
 									setDescription(space.description ?? '');
+									setInstructions(space.instructions ?? '');
+									setBackgroundContext(space.backgroundContext ?? '');
 									setSaveError(null);
 								}}
 							>

--- a/packages/web/src/components/space/__tests__/SpaceSettings.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceSettings.test.tsx
@@ -4,9 +4,10 @@
  *
  * Tests:
  * - Renders space name, description, workspace path
+ * - Renders instructions and backgroundContext editors
  * - Save Changes button only shown when form is dirty
- * - Calls space.update RPC with trimmed values on save
- * - Discard button resets form to original values
+ * - Calls space.update RPC with trimmed values on save (including instructions/backgroundContext)
+ * - Discard button resets form to original values (including instructions/backgroundContext)
  * - Shows error when not connected
  * - Archive button calls space.archive and navigates away
  * - Delete button calls space.delete and navigates away
@@ -147,6 +148,8 @@ describe('SpaceSettings', () => {
 				id: 'space-1',
 				name: 'Updated Name',
 				description: 'Original description',
+				instructions: undefined,
+				backgroundContext: undefined,
 			});
 		});
 	});
@@ -292,6 +295,108 @@ describe('SpaceSettings', () => {
 		});
 
 		resolveDelete!();
+	});
+
+	it('renders instructions and backgroundContext textareas', () => {
+		const space = makeSpace({
+			instructions: 'Use TypeScript strict mode',
+			backgroundContext: 'Bun + Hono backend',
+		});
+		const { getByDisplayValue, getByText } = render(<SpaceSettings space={space} />);
+		expect(getByDisplayValue('Use TypeScript strict mode')).toBeTruthy();
+		expect(getByDisplayValue('Bun + Hono backend')).toBeTruthy();
+		// Check labels are rendered
+		expect(getByText('Instructions')).toBeTruthy();
+		expect(getByText('Background Context')).toBeTruthy();
+	});
+
+	it('shows Save Changes when instructions is changed', () => {
+		const space = makeSpace();
+		const { getByPlaceholderText, getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.input(
+			getByPlaceholderText(
+				'e.g. Always use TypeScript strict mode. Prefer functional components...'
+			),
+			{ target: { value: 'New instructions' } }
+		);
+		expect(getByText('Save Changes')).toBeTruthy();
+	});
+
+	it('shows Save Changes when backgroundContext is changed', () => {
+		const space = makeSpace();
+		const { getByPlaceholderText, getByText } = render(<SpaceSettings space={space} />);
+		fireEvent.input(
+			getByPlaceholderText(
+				'e.g. This project uses Bun + Hono backend, Preact frontend with Tailwind CSS...'
+			),
+			{ target: { value: 'New context' } }
+		);
+		expect(getByText('Save Changes')).toBeTruthy();
+	});
+
+	it('includes instructions and backgroundContext in space.update payload', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({});
+
+		const space = makeSpace();
+		const { getByDisplayValue, getByPlaceholderText, getByText } = render(
+			<SpaceSettings space={space} />
+		);
+
+		fireEvent.input(getByDisplayValue('My Space'), { target: { value: 'Updated' } });
+		fireEvent.input(
+			getByPlaceholderText(
+				'e.g. Always use TypeScript strict mode. Prefer functional components...'
+			),
+			{ target: { value: '  Use strict mode  ' } }
+		);
+		fireEvent.input(
+			getByPlaceholderText(
+				'e.g. This project uses Bun + Hono backend, Preact frontend with Tailwind CSS...'
+			),
+			{ target: { value: '  Bun + Hono  ' } }
+		);
+		fireEvent.click(getByText('Save Changes'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('space.update', {
+				id: 'space-1',
+				name: 'Updated',
+				description: 'Original description',
+				instructions: 'Use strict mode',
+				backgroundContext: 'Bun + Hono',
+			});
+		});
+	});
+
+	it('Discard resets instructions and backgroundContext to original values', () => {
+		const space = makeSpace({
+			instructions: 'Original instructions',
+			backgroundContext: 'Original context',
+		});
+		const { getByDisplayValue, getByText, queryByText } = render(<SpaceSettings space={space} />);
+
+		// Change instructions
+		fireEvent.input(getByDisplayValue('Original instructions'), {
+			target: { value: 'Changed instructions' },
+		});
+		expect(getByText('Save Changes')).toBeTruthy();
+
+		// Discard
+		fireEvent.click(getByText('Discard'));
+		expect(queryByText('Save Changes')).toBeNull();
+		expect(getByDisplayValue('Original instructions')).toBeTruthy();
+		expect(getByDisplayValue('Original context')).toBeTruthy();
+	});
+
+	it('shows character count for instructions and backgroundContext', () => {
+		const space = makeSpace({
+			instructions: 'hello',
+			backgroundContext: 'world!',
+		});
+		const { getByText } = render(<SpaceSettings space={space} />);
+		expect(getByText('5 characters')).toBeTruthy();
+		expect(getByText('6 characters')).toBeTruthy();
 	});
 
 	it('calls spaceExport.bundle when Export Bundle is clicked', async () => {


### PR DESCRIPTION
## Summary
- Add `instructions` and `backgroundContext` textarea editors to the Space Settings page
- Both fields included in dirty check, discard action, and save payload with character counts
- 7 new unit tests covering rendering, dirty detection, save payload, discard, and character counts