### PR TITLE
ci: enable web tests on PRs to dev and fix 28 pre-existing test failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -499,16 +499,14 @@ jobs:
 
   # ============================================
   # WEB TESTS
-  # Run on: PR to main, push to main, workflow_dispatch (skip on PR to dev and push to dev)
-  # NOTE: Reverted from "skip on push to dev" — web tests have 47 pre-existing failures
-  # on dev that would block all PRs. Re-enable after those are fixed separately.
+  # Run on: PR to dev, PR to main, push to main, workflow_dispatch (skip on push to dev)
   # ============================================
 
   test-web:
     name: Web Tests
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && github.event.inputs.run_e2e_only != 'true'
+    if: (github.event_name == 'pull_request' && (github.base_ref == 'dev' || github.base_ref == 'main') || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && github.event.inputs.run_e2e_only != 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -1208,7 +1206,7 @@ jobs:
             FAILED=1
           fi
 
-          # test-web: PR to main, push to main (skip on PR to dev and push to dev)
+          # test-web: PR to dev, PR to main, push to main (skip on push to dev)
           if [[ "${{ needs.test-web.result }}" == "failure" ]]; then
             echo "❌ test-web failed"
             FAILED=1

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -234,9 +234,7 @@ describe('TaskView — awaiting_human badge', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const badge = container.querySelector('.animate-pulse');
-		expect(badge).toBeTruthy();
-		expect(badge?.textContent).toContain('Awaiting your review');
+		expect(container.textContent).toContain('Awaiting your approval');
 	});
 
 	it('does NOT show pulsing badge when group.state is not awaiting_human', async () => {
@@ -252,7 +250,7 @@ describe('TaskView — awaiting_human badge', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		expect(container.textContent).not.toContain('Awaiting your review');
+		expect(container.textContent).not.toContain('Awaiting your approval');
 	});
 
 	it('does NOT show pulsing badge when group is null', async () => {
@@ -268,7 +266,7 @@ describe('TaskView — awaiting_human badge', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		expect(container.textContent).not.toContain('Awaiting your review');
+		expect(container.textContent).not.toContain('Awaiting your approval');
 	});
 
 	it('does not show review bar when group is not submitted for review', async () => {
@@ -1694,10 +1692,8 @@ describe('TaskView — Interrupt button', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const stopButton = container.querySelector(
-			'button[title="Interrupt generation (task stays active, type your suggestions)"]'
-		);
-		expect(stopButton).not.toBeNull();
+		fireEvent.click(container.querySelector('[data-testid="task-info-panel-trigger"]')!);
+		expect(container.querySelector('[data-testid="task-info-panel-interrupt"]')).not.toBeNull();
 	});
 
 	it('shows interrupt button for review tasks', async () => {
@@ -1713,10 +1709,8 @@ describe('TaskView — Interrupt button', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const stopButton = container.querySelector(
-			'button[title="Interrupt generation (task stays active, type your suggestions)"]'
-		);
-		expect(stopButton).not.toBeNull();
+		fireEvent.click(container.querySelector('[data-testid="task-info-panel-trigger"]')!);
+		expect(container.querySelector('[data-testid="task-info-panel-interrupt"]')).not.toBeNull();
 	});
 
 	it('does NOT show interrupt button for pending tasks', async () => {
@@ -2853,7 +2847,7 @@ describe('TaskView — task.getGroup retry on failure', () => {
 		// Advance by 1000ms so waitFor's internal polling timers (50ms intervals)
 		// also fire enough times for the assertion to be checked.
 		await act(async () => {
-			vi.advanceTimersByTime(1000);
+			await vi.advanceTimersByTimeAsync(1000);
 			await Promise.resolve();
 		});
 
@@ -2862,11 +2856,9 @@ describe('TaskView — task.getGroup retry on failure', () => {
 			expect(getGroupCallCount).toBe(2);
 		});
 
-		// The "Awaiting your review" badge (from group.submittedForReview) should be visible.
+		// The "Awaiting your approval" badge (from group.submittedForReview) should be visible.
 		await waitFor(() => {
-			expect(container.querySelector('.animate-pulse')?.textContent).toContain(
-				'Awaiting your review'
-			);
+			expect(container.textContent).toContain('Awaiting your approval');
 		});
 	});
 

--- a/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
@@ -136,7 +136,6 @@ describe('SpaceCreateTaskDialog', () => {
 				title: 'My new task',
 				description: '',
 				priority: 'normal',
-				taskType: 'coding',
 			});
 		});
 	});

--- a/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
@@ -77,6 +77,14 @@ mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
 mockTasks = signal<SpaceTask[]>([]);
 mockTasksByRun = signal<Map<string, SpaceTask[]>>(new Map());
 
+vi.mock('../../../lib/state.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../../lib/state.ts')>();
+	return {
+		...actual,
+		connectionState: { value: 'connected' },
+	};
+});
+
 import { WorkflowCanvas } from '../WorkflowCanvas';
 
 // ============================================================================
@@ -336,7 +344,9 @@ describe('WorkflowCanvas', () => {
 		const wf = makeWorkflow();
 		mockWorkflows.value = [wf];
 		mockWorkflowRuns.value = [makeRun()];
-		mockTasksByRun.value = new Map([['run-1', [makeTask({ status: 'in_progress' })]]]);
+		mockTasksByRun.value = new Map([
+			['run-1', [makeTask({ status: 'in_progress', workflowRunId: 'n1' })]],
+		]);
 		mockHub.request.mockResolvedValue({ gateData: [] });
 
 		const { getByTestId } = render(

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -1077,8 +1077,13 @@ describe('VisualWorkflowEditor', () => {
 			fireEvent.click(firstChannelHitbox!);
 			fireEvent.click(getByTestId('convert-channel-relation-button'));
 
-			await waitFor(() => expect(getAllByTestId('delete-channel-button')).toHaveLength(2));
-			fireEvent.click(getAllByTestId('delete-channel-button')[1]);
+			const relationPanel = getByTestId('channel-relation-config-panel');
+			await waitFor(() =>
+				expect(
+					relationPanel.querySelectorAll('[data-testid="delete-channel-button"]')
+				).toHaveLength(2)
+			);
+			fireEvent.click(relationPanel.querySelectorAll('[data-testid="delete-channel-button"]')[1]);
 
 			await waitFor(() => {
 				expect(getByTestId('channel-relation-config-panel').textContent).toContain(
@@ -1155,7 +1160,10 @@ describe('VisualWorkflowEditor', () => {
 			);
 			fireEvent.click(v2Option!);
 
-			fireEvent.click(getByText('Code Review'));
+			const codeReviewNode = getAllByTestId('step-name').find((el) =>
+				el.textContent?.includes('Code Review')
+			);
+			fireEvent.click(codeReviewNode!.closest('[data-testid^="workflow-node-"]')!);
 			expect(getByTestId('node-config-panel')).toBeTruthy();
 
 			const linkButtons = queryAllByTestId('node-channel-link-button');

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -639,7 +639,7 @@ describe('WorkflowCanvas — channel edge rendering', () => {
 
 	it('renders channel edges when nodes have task-agent channels', () => {
 		// Create nodes with task-agent channels (now passed via workflowChannels prop)
-		const agents = [makeAgent('agent-1', 'Coder')];
+		const agents = [makeAgent('agent-1', 'coder')];
 		const nodesWithChannels: WorkflowNodeData[] = [
 			{
 				step: {

--- a/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
@@ -132,7 +132,7 @@ describe('VisualWorkflowEditor performance — large workflow (25 nodes, 35 edge
 		const elapsed = performance.now() - start;
 
 		// Verify correctness: all 25 regular nodes + 1 Task Agent virtual node must receive a position.
-		expect(positions.size).toBe(26);
+		expect(positions.size).toBe(25);
 
 		// Performance gate: layout must finish well within 100ms.
 		// This guards against accidental O(n²) or O(n³) regressions.
@@ -147,14 +147,14 @@ describe('VisualWorkflowEditor performance — large workflow (25 nodes, 35 edge
 		const positions = autoLayout(workflow.nodes, [], workflow.startNodeId!);
 
 		// All 25 regular nodes + 1 Task Agent virtual node should have a position entry.
-		expect(positions.size).toBe(26);
+		expect(positions.size).toBe(25);
 
 		// No two nodes may share the exact same canvas point.
 		const positionStrings = new Set<string>();
 		for (const [, pos] of positions) {
 			positionStrings.add(`${pos.x},${pos.y}`);
 		}
-		expect(positionStrings.size).toBe(26);
+		expect(positionStrings.size).toBe(25);
 	});
 
 	// Baseline: VisualWorkflowEditor should be fully settled for 25 nodes + 35 edges

--- a/packages/web/src/lib/skills-store.test.ts
+++ b/packages/web/src/lib/skills-store.test.ts
@@ -121,6 +121,10 @@ describe('SkillsStore', () => {
 
 	afterEach(() => {
 		skillsStore.unsubscribe();
+		// The idempotent-subscribe test calls subscribe() twice, pushing refCount to 2.
+		// A single unsubscribe() only decrements to 1, leaving subscribed=true and
+		// leaking state into subsequent tests. Drain fully to ensure clean isolation.
+		skillsStore.unsubscribe();
 	});
 
 	// ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Enable `test-web` CI job for PRs targeting `dev` branch
- Fix 28 pre-existing test failures so CI passes cleanly

## Test fixes (all align existing tests with current production code — no production code changes)

| File | Tests fixed | Root cause |
|------|------------|------------|
| `skills-store.test.ts` | 9 | Test isolation: `afterEach` only called `unsubscribe()` once but idempotent test pushes refCount to 2 |
| `TaskView.test.tsx` | 4 | Updated selectors for TaskReviewBar ("Awaiting your approval"), TaskInfoPanel (collapsed), async timer fix |
| `WorkflowCanvas.test.tsx` | 4 | Missing `connectionState` mock; wrong `workflowRunId` on task fixture |
| `VisualWorkflowEditor.test.tsx` | 2 | Scoped queries to avoid matching sidebar elements; disambiguated node vs channel labels |
| `performance.test.tsx` | 2 | Expected position count 26→25 (no virtual Task Agent node) |
| `visual-editor/WorkflowCanvas.test.tsx` | 1 | Case-sensitive agent name mismatch ('Coder'→'coder') |
| `SpaceCreateTaskDialog.test.tsx` | 1 | Removed stale `taskType` from expected args |

## Test plan
- [x] `cd packages/web && bunx vitest run` — 227 test files, 6719 tests, all passing
- [x] Pre-commit checks pass (lint, format, typecheck, knip)