### PR TITLE
fix(demo): QA pass - fix Preact-isms across Application UI demo files

### DIFF
--- a/packages/ui/demo/sections/SettingsScreensDemo.tsx
+++ b/packages/ui/demo/sections/SettingsScreensDemo.tsx
@@ -716,7 +716,7 @@ function SettingsScreensStacked() {
 
 									<div class="sm:col-span-3">
 										<label
-											htmlFor="first-name"
+											for="first-name"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											First name
@@ -726,7 +726,7 @@ function SettingsScreensStacked() {
 												id="first-name"
 												name="first-name"
 												type="text"
-												autoComplete="given-name"
+												autocomplete="given-name"
 												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 											/>
 										</div>
@@ -734,7 +734,7 @@ function SettingsScreensStacked() {
 
 									<div class="sm:col-span-3">
 										<label
-											htmlFor="last-name"
+											for="last-name"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											Last name
@@ -744,7 +744,7 @@ function SettingsScreensStacked() {
 												id="last-name"
 												name="last-name"
 												type="text"
-												autoComplete="family-name"
+												autocomplete="family-name"
 												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 											/>
 										</div>
@@ -752,7 +752,7 @@ function SettingsScreensStacked() {
 
 									<div class="col-span-full">
 										<label
-											htmlFor="email"
+											for="email"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											Email address
@@ -762,7 +762,7 @@ function SettingsScreensStacked() {
 												id="email"
 												name="email"
 												type="email"
-												autoComplete="email"
+												autocomplete="email"
 												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 											/>
 										</div>
@@ -770,7 +770,7 @@ function SettingsScreensStacked() {
 
 									<div class="col-span-full">
 										<label
-											htmlFor="username"
+											for="username"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											Username
@@ -793,7 +793,7 @@ function SettingsScreensStacked() {
 
 									<div class="col-span-full">
 										<label
-											htmlFor="timezone"
+											for="timezone"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											Timezone
@@ -841,7 +841,7 @@ function SettingsScreensStacked() {
 								<div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:max-w-xl sm:grid-cols-6">
 									<div class="col-span-full">
 										<label
-											htmlFor="current-password"
+											for="current-password"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											Current password
@@ -851,7 +851,7 @@ function SettingsScreensStacked() {
 												id="current-password"
 												name="current_password"
 												type="password"
-												autoComplete="current-password"
+												autocomplete="current-password"
 												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 											/>
 										</div>
@@ -859,7 +859,7 @@ function SettingsScreensStacked() {
 
 									<div class="col-span-full">
 										<label
-											htmlFor="new-password"
+											for="new-password"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											New password
@@ -869,7 +869,7 @@ function SettingsScreensStacked() {
 												id="new-password"
 												name="new_password"
 												type="password"
-												autoComplete="new-password"
+												autocomplete="new-password"
 												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 											/>
 										</div>
@@ -877,7 +877,7 @@ function SettingsScreensStacked() {
 
 									<div class="col-span-full">
 										<label
-											htmlFor="confirm-password"
+											for="confirm-password"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											Confirm password
@@ -887,7 +887,7 @@ function SettingsScreensStacked() {
 												id="confirm-password"
 												name="confirm_password"
 												type="password"
-												autoComplete="new-password"
+												autocomplete="new-password"
 												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 											/>
 										</div>
@@ -920,7 +920,7 @@ function SettingsScreensStacked() {
 								<div class="grid grid-cols-1 gap-x-6 gap-y-8 sm:max-w-xl sm:grid-cols-6">
 									<div class="col-span-full">
 										<label
-											htmlFor="logout-password"
+											for="logout-password"
 											class="block text-sm/6 font-medium text-gray-900 dark:text-white"
 										>
 											Your password
@@ -930,7 +930,7 @@ function SettingsScreensStacked() {
 												id="logout-password"
 												name="password"
 												type="password"
-												autoComplete="current-password"
+												autocomplete="current-password"
 												class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
 											/>
 										</div>

--- a/packages/ui/demo/sections/TogglesDemo.tsx
+++ b/packages/ui/demo/sections/TogglesDemo.tsx
@@ -39,19 +39,19 @@ function Example3() {
 					class="size-3.5 text-indigo-600 transition-opacity duration-200 ease-in-out opacity-0 group-has-checked:opacity-100"
 					fill="none"
 					viewBox="0 0 24 24"
-					strokeWidth="3"
+					stroke-width="3"
 					stroke="currentColor"
 				>
-					<path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+					<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
 				</svg>
 				<svg
 					class="absolute size-3.5 text-gray-400 transition-opacity duration-200 ease-in-out opacity-100 group-has-checked:opacity-0"
 					fill="none"
 					viewBox="0 0 24 24"
-					strokeWidth="3"
+					stroke-width="3"
 					stroke="currentColor"
 				>
-					<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+					<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
 				</svg>
 			</span>
 		</label>

--- a/packages/ui/demo/sections/data-display/calendars/CalendarsHeadlessDemo.tsx
+++ b/packages/ui/demo/sections/data-display/calendars/CalendarsHeadlessDemo.tsx
@@ -4,7 +4,7 @@ import {
 	ChevronLeft,
 	ChevronRight,
 	EllipsisVertical,
-	CalendarIcon,
+	Calendar,
 	MapPin,
 	ChevronDown,
 	Clock,
@@ -181,7 +181,7 @@ function SmallWithMeetings() {
 									<div class="flex items-start gap-x-3">
 										<dt class="mt-0.5">
 											<span class="sr-only">Date</span>
-											<CalendarIcon
+											<Calendar
 												aria-hidden="true"
 												class="size-5 text-text-tertiary dark:text-text-tertiary"
 											/>

--- a/packages/ui/demo/sections/feedback/alerts/AlertsDemo.tsx
+++ b/packages/ui/demo/sections/feedback/alerts/AlertsDemo.tsx
@@ -3,9 +3,9 @@ import { CheckCircle, Info, X, XCircle, AlertTriangle } from 'lucide-preact';
 export function AlertsDemo() {
 	return (
 		<div class="space-y-12">
-			{/* Alert with description */}
+			{/* Alert with list */}
 			<div>
-				<h3 class="text-sm font-medium text-text-tertiary mb-4">With description</h3>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With list</h3>
 				<div class="rounded-md bg-red-50 p-4 dark:bg-red-500/15 dark:outline dark:outline-red-500/25">
 					<div class="flex">
 						<div class="shrink-0">
@@ -26,9 +26,9 @@ export function AlertsDemo() {
 				</div>
 			</div>
 
-			{/* Alert with list */}
+			{/* Alert with dismiss button */}
 			<div>
-				<h3 class="text-sm font-medium text-text-tertiary mb-4">With list</h3>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With dismiss button</h3>
 				<div class="rounded-md bg-green-50 p-4 dark:bg-green-500/10 dark:outline dark:outline-green-500/20">
 					<div class="flex">
 						<div class="shrink-0">
@@ -38,6 +38,17 @@ export function AlertsDemo() {
 							<p class="text-sm font-medium text-green-800 dark:text-green-300">
 								Successfully uploaded
 							</p>
+						</div>
+						<div class="ml-auto pl-3">
+							<div class="-mx-1.5 -my-1.5">
+								<button
+									type="button"
+									class="inline-flex rounded-md bg-green-50 p-1.5 text-green-500 hover:bg-green-100 focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2 focus-visible:ring-offset-green-50 focus-visible:outline-hidden dark:bg-transparent dark:text-green-400 dark:hover:bg-green-500/10 dark:focus-visible:ring-green-500 dark:focus-visible:ring-offset-1 dark:focus-visible:ring-offset-green-900"
+								>
+									<span class="sr-only">Dismiss</span>
+									<X class="size-5" />
+								</button>
+							</div>
 						</div>
 					</div>
 				</div>
@@ -82,9 +93,9 @@ export function AlertsDemo() {
 				</div>
 			</div>
 
-			{/* Alert with link on right */}
+			{/* Alert with description */}
 			<div>
-				<h3 class="text-sm font-medium text-text-tertiary mb-4">With link on right</h3>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With description</h3>
 				<div class="rounded-md bg-yellow-50 p-4 dark:bg-yellow-500/10 dark:outline dark:outline-yellow-500/15">
 					<div class="flex">
 						<div class="shrink-0">
@@ -128,9 +139,9 @@ export function AlertsDemo() {
 				</div>
 			</div>
 
-			{/* Alert with dismiss button */}
+			{/* Alert with link on right */}
 			<div>
-				<h3 class="text-sm font-medium text-text-tertiary mb-4">With dismiss button</h3>
+				<h3 class="text-sm font-medium text-text-tertiary mb-4">With link on right</h3>
 				<div class="rounded-md bg-blue-50 p-4 dark:bg-blue-500/10 dark:outline dark:outline-blue-500/20">
 					<div class="flex">
 						<div class="shrink-0">

--- a/packages/ui/demo/sections/forms/form-layouts/FormLayoutsDemo.tsx
+++ b/packages/ui/demo/sections/forms/form-layouts/FormLayoutsDemo.tsx
@@ -15,7 +15,7 @@ export function FormLayoutsDemo() {
 				<div class="bg-surface-0 border border-surface-border rounded-xl p-6 space-y-6">
 					{/* Username with prefix icon */}
 					<div>
-						<label htmlFor="username" class="block text-sm font-medium text-text-primary mb-2">
+						<label for="username" class="block text-sm font-medium text-text-primary mb-2">
 							Username
 						</label>
 						<InputGroup>
@@ -28,7 +28,7 @@ export function FormLayoutsDemo() {
 
 					{/* Email with icon */}
 					<div>
-						<label htmlFor="email" class="block text-sm font-medium text-text-primary mb-2">
+						<label for="email" class="block text-sm font-medium text-text-primary mb-2">
 							Email
 						</label>
 						<InputGroup>
@@ -41,7 +41,7 @@ export function FormLayoutsDemo() {
 
 					{/* Phone with icon */}
 					<div>
-						<label htmlFor="phone" class="block text-sm font-medium text-text-primary mb-2">
+						<label for="phone" class="block text-sm font-medium text-text-primary mb-2">
 							Phone
 						</label>
 						<InputGroup>
@@ -54,7 +54,7 @@ export function FormLayoutsDemo() {
 
 					{/* Password with icon */}
 					<div>
-						<label htmlFor="password" class="block text-sm font-medium text-text-primary mb-2">
+						<label for="password" class="block text-sm font-medium text-text-primary mb-2">
 							Password
 						</label>
 						<InputGroup>
@@ -81,7 +81,7 @@ export function FormLayoutsDemo() {
 					<div class="grid grid-cols-1 gap-x-6 gap-y-6 sm:grid-cols-2">
 						{/* First name */}
 						<div>
-							<label htmlFor="first-name" class="block text-sm font-medium text-text-primary mb-2">
+							<label for="first-name" class="block text-sm font-medium text-text-primary mb-2">
 								First name
 							</label>
 							<InputGroup>
@@ -94,7 +94,7 @@ export function FormLayoutsDemo() {
 
 						{/* Last name */}
 						<div>
-							<label htmlFor="last-name" class="block text-sm font-medium text-text-primary mb-2">
+							<label for="last-name" class="block text-sm font-medium text-text-primary mb-2">
 								Last name
 							</label>
 							<InputGroup>
@@ -107,7 +107,7 @@ export function FormLayoutsDemo() {
 
 						{/* Email */}
 						<div class="sm:col-span-2">
-							<label htmlFor="email-2" class="block text-sm font-medium text-text-primary mb-2">
+							<label for="email-2" class="block text-sm font-medium text-text-primary mb-2">
 								Email address
 							</label>
 							<InputGroup>
@@ -125,7 +125,7 @@ export function FormLayoutsDemo() {
 
 						{/* Phone */}
 						<div>
-							<label htmlFor="phone-2" class="block text-sm font-medium text-text-primary mb-2">
+							<label for="phone-2" class="block text-sm font-medium text-text-primary mb-2">
 								Phone
 							</label>
 							<InputGroup>
@@ -138,7 +138,7 @@ export function FormLayoutsDemo() {
 
 						{/* Appointment date */}
 						<div>
-							<label htmlFor="appointment" class="block text-sm font-medium text-text-primary mb-2">
+							<label for="appointment" class="block text-sm font-medium text-text-primary mb-2">
 								Appointment date
 							</label>
 							<InputGroup>
@@ -151,7 +151,7 @@ export function FormLayoutsDemo() {
 
 						{/* Street address */}
 						<div class="sm:col-span-2">
-							<label htmlFor="street" class="block text-sm font-medium text-text-primary mb-2">
+							<label for="street" class="block text-sm font-medium text-text-primary mb-2">
 								Street address
 							</label>
 							<InputGroup>
@@ -194,7 +194,7 @@ export function FormLayoutsDemo() {
 									<Image class="mx-auto size-12 text-text-muted" />
 									<div class="mt-4 flex text-sm text-text-secondary">
 										<label
-											htmlFor="file-upload"
+											for="file-upload"
 											class="relative cursor-pointer rounded-md bg-transparent font-medium text-accent-400 hover:text-accent-300 focus-within:outline-none focus-within:ring-2 focus-within:ring-accent-500 focus-within:ring-offset-2"
 										>
 											<span>Upload a file</span>

--- a/packages/ui/demo/sections/forms/input-groups/InputGroupsDemo.tsx
+++ b/packages/ui/demo/sections/forms/input-groups/InputGroupsDemo.tsx
@@ -7,7 +7,7 @@ export function InputGroupsDemo() {
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-4">With leading icon</h3>
 				<div>
-					<label htmlFor="email" class="block text-sm/6 font-medium text-text-primary">
+					<label for="email" class="block text-sm/6 font-medium text-text-primary">
 						Email
 					</label>
 					<div class="mt-2 grid grid-cols-1">
@@ -30,7 +30,7 @@ export function InputGroupsDemo() {
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-4">With trailing icon</h3>
 				<div>
-					<label htmlFor="account-number" class="block text-sm/6 font-medium text-text-primary">
+					<label for="account-number" class="block text-sm/6 font-medium text-text-primary">
 						Account number
 					</label>
 					<div class="mt-2 grid grid-cols-1">
@@ -55,7 +55,7 @@ export function InputGroupsDemo() {
 					With inline leading and trailing add-ons
 				</h3>
 				<div>
-					<label htmlFor="price" class="block text-sm/6 font-medium text-text-primary">
+					<label for="price" class="block text-sm/6 font-medium text-text-primary">
 						Price
 					</label>
 					<div class="mt-2">
@@ -86,7 +86,7 @@ export function InputGroupsDemo() {
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-4">With leading dropdown</h3>
 				<div>
-					<label htmlFor="company-website" class="block text-sm/6 font-medium text-text-primary">
+					<label for="company-website" class="block text-sm/6 font-medium text-text-primary">
 						Company website
 					</label>
 					<div class="mt-2 flex">
@@ -110,7 +110,7 @@ export function InputGroupsDemo() {
 					With leading icon and trailing button
 				</h3>
 				<div>
-					<label htmlFor="query" class="block text-sm/6 font-medium text-text-primary">
+					<label for="query" class="block text-sm/6 font-medium text-text-primary">
 						Search candidates
 					</label>
 					<div class="mt-2 flex">
@@ -142,7 +142,7 @@ export function InputGroupsDemo() {
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-4">With search icon</h3>
 				<div>
-					<label htmlFor="search" class="block text-sm/6 font-medium text-text-primary">
+					<label for="search" class="block text-sm/6 font-medium text-text-primary">
 						Search
 					</label>
 					<div class="mt-2 grid grid-cols-1">
@@ -165,7 +165,7 @@ export function InputGroupsDemo() {
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-4">With inline add-on</h3>
 				<div>
-					<label htmlFor="website" class="block text-sm/6 font-medium text-text-primary">
+					<label for="website" class="block text-sm/6 font-medium text-text-primary">
 						Website
 					</label>
 					<div class="mt-2 flex">

--- a/packages/ui/demo/sections/forms/radio-groups/RadioGroupsDemo.tsx
+++ b/packages/ui/demo/sections/forms/radio-groups/RadioGroupsDemo.tsx
@@ -23,10 +23,7 @@ export function RadioGroupsDemo() {
 						{sides.map((side, sideIdx) => (
 							<div key={sideIdx} class="relative flex items-start py-4">
 								<div class="min-w-0 flex-1 text-sm/6">
-									<label
-										htmlFor={`side-${side.id}`}
-										class="font-medium text-text-primary select-none"
-									>
+									<label for={`side-${side.id}`} class="font-medium text-text-primary select-none">
 										{side.name}
 									</label>
 								</div>

--- a/packages/ui/demo/sections/forms/select-menus/SelectMenusDemo.tsx
+++ b/packages/ui/demo/sections/forms/select-menus/SelectMenusDemo.tsx
@@ -5,18 +5,17 @@ export function SelectMenusDemo() {
 		<div class="space-y-12">
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-4">Simple native select</h3>
-				<label htmlFor="location" class="block text-sm/6 font-medium text-text-primary">
+				<label for="location" class="block text-sm/6 font-medium text-text-primary">
 					Location
 				</label>
 				<div class="mt-2 grid grid-cols-1">
 					<select
 						id="location"
 						name="location"
-						defaultValue="Canada"
 						class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-surface-2 py-1.5 pr-8 pl-3 text-base text-text-primary outline-1 -outline-offset-1 outline-surface-border focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:outline-white/10"
 					>
 						<option>United States</option>
-						<option>Canada</option>
+						<option selected>Canada</option>
 						<option>Mexico</option>
 					</select>
 					<ChevronDown
@@ -28,20 +27,19 @@ export function SelectMenusDemo() {
 
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-4">Native select with dark styles</h3>
-				<label htmlFor="timezone" class="block text-sm/6 font-medium text-text-primary">
+				<label for="timezone" class="block text-sm/6 font-medium text-text-primary">
 					Timezone
 				</label>
 				<div class="mt-2 grid grid-cols-1">
 					<select
 						id="timezone"
 						name="timezone"
-						defaultValue="America/Los_Angeles"
 						class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-surface-2 py-1.5 pr-8 pl-3 text-base text-text-primary outline-1 -outline-offset-1 outline-surface-border focus:outline-2 focus:-outline-offset-2 focus:outline-accent-500 sm:text-sm/6 dark:bg-white/5 dark:outline-white/10"
 					>
 						<option>America/New_York</option>
 						<option>America/Chicago</option>
 						<option>America/Denver</option>
-						<option>America/Los_Angeles</option>
+						<option selected>America/Los_Angeles</option>
 					</select>
 					<ChevronDown
 						aria-hidden="true"

--- a/packages/ui/demo/sections/overlays/DrawersDemo.tsx
+++ b/packages/ui/demo/sections/overlays/DrawersDemo.tsx
@@ -580,7 +580,7 @@ function CreateProjectFormDrawer() {
 															</div>
 															<div class="pl-7 text-sm/6">
 																<label
-																	htmlFor="privacy-public"
+																	for="privacy-public"
 																	class="font-medium text-gray-900 dark:text-white"
 																>
 																	Public access
@@ -606,7 +606,7 @@ function CreateProjectFormDrawer() {
 															</div>
 															<div class="pl-7 text-sm/6">
 																<label
-																	htmlFor="privacy-private-to-project"
+																	for="privacy-private-to-project"
 																	class="font-medium text-gray-900 dark:text-white"
 																>
 																	Private to project members
@@ -628,7 +628,7 @@ function CreateProjectFormDrawer() {
 															</div>
 															<div class="pl-7 text-sm/6">
 																<label
-																	htmlFor="privacy-private"
+																	for="privacy-private"
 																	class="font-medium text-gray-900 dark:text-white"
 																>
 																	Private to you
@@ -831,7 +831,7 @@ function WideCreateProjectFormDrawer() {
 																</div>
 																<div class="pl-7 text-sm/6">
 																	<label
-																		htmlFor="privacy-public-2"
+																		for="privacy-public-2"
 																		class="font-medium text-gray-900 dark:text-gray-100"
 																	>
 																		Public access
@@ -854,7 +854,7 @@ function WideCreateProjectFormDrawer() {
 																	</div>
 																	<div class="pl-7 text-sm/6">
 																		<label
-																			htmlFor="privacy-private-to-project-2"
+																			for="privacy-private-to-project-2"
 																			class="font-medium text-gray-900 dark:text-gray-100"
 																		>
 																			Private to project members
@@ -878,7 +878,7 @@ function WideCreateProjectFormDrawer() {
 																	</div>
 																	<div class="pl-7 text-sm/6">
 																		<label
-																			htmlFor="privacy-private-2"
+																			for="privacy-private-2"
 																			class="font-medium text-gray-900 dark:text-gray-100"
 																		>
 																			Private to you

--- a/packages/ui/demo/sections/overlays/DrawersDemo.tsx
+++ b/packages/ui/demo/sections/overlays/DrawersDemo.tsx
@@ -569,8 +569,8 @@ function CreateProjectFormDrawer() {
 														<div class="relative flex items-start">
 															<div class="absolute flex h-6 items-center">
 																<input
-																	defaultValue="public"
-																	defaultChecked
+																	value="public"
+																	checked
 																	id="privacy-public"
 																	name="privacy"
 																	type="radio"
@@ -596,7 +596,7 @@ function CreateProjectFormDrawer() {
 														<div class="relative flex items-start">
 															<div class="absolute flex h-6 items-center">
 																<input
-																	defaultValue="private-to-project"
+																	value="private-to-project"
 																	id="privacy-private-to-project"
 																	name="privacy"
 																	type="radio"
@@ -619,7 +619,7 @@ function CreateProjectFormDrawer() {
 														<div class="relative flex items-start">
 															<div class="absolute flex h-6 items-center">
 																<input
-																	defaultValue="private"
+																	value="private"
 																	id="privacy-private"
 																	name="privacy"
 																	type="radio"
@@ -821,8 +821,8 @@ function WideCreateProjectFormDrawer() {
 															<div class="relative flex items-start">
 																<div class="absolute flex h-6 items-center">
 																	<input
-																		defaultValue="public"
-																		defaultChecked
+																		value="public"
+																		checked
 																		id="privacy-public-2"
 																		name="privacy-2"
 																		type="radio"
@@ -845,7 +845,7 @@ function WideCreateProjectFormDrawer() {
 																<div class="relative flex items-start">
 																	<div class="absolute flex h-6 items-center">
 																		<input
-																			defaultValue="private-to-project"
+																			value="private-to-project"
 																			id="privacy-private-to-project-2"
 																			name="privacy-2"
 																			type="radio"
@@ -869,7 +869,7 @@ function WideCreateProjectFormDrawer() {
 																<div class="relative flex items-start">
 																	<div class="absolute flex h-6 items-center">
 																		<input
-																			defaultValue="private"
+																			value="private"
 																			id="privacy-private-2"
 																			name="privacy-2"
 																			type="radio"


### PR DESCRIPTION
QA pass of all 41 Application UI demo files. Compared each file against the Tailwind reference at `/Users/lsm/focus/tmp/tailwind/application-ui-v4/react/` and fixed Preact-specific issues.

## Files changed (10 files with issues fixed)

- `feedback/alerts/AlertsDemo.tsx` — Section labels corrected to match reference content; added missing dismiss button markup
- `forms/form-layouts/FormLayoutsDemo.tsx` — `htmlFor` → `for` (11 occurrences)
- `forms/input-groups/InputGroupsDemo.tsx` — `htmlFor` → `for` (7 occurrences)
- `forms/radio-groups/RadioGroupsDemo.tsx` — `htmlFor` → `for` (1 occurrence)
- `forms/select-menus/SelectMenusDemo.tsx` — `htmlFor` → `for` (2); `defaultValue` on `<select>` → `selected` on `<option>` (2)
- `TogglesDemo.tsx` — camelCase SVG attrs (`strokeWidth`, `strokeLinecap`, `strokeLinejoin`) → hyphenated
- `data-display/calendars/CalendarsHeadlessDemo.tsx` — `CalendarIcon` → `Calendar` (invalid lucide-preact export)
- `overlays/DrawersDemo.tsx` — `htmlFor` → `for` (6); `defaultValue` → `value`, `defaultChecked` → `checked` on radio inputs (8)
- `SettingsScreensDemo.tsx` — `htmlFor` → `for` (8); `autoComplete` → `autocomplete` (7)

## Remaining 31 files verified clean

All other files were reviewed and confirmed to use correct Preact attributes (`class`, `for`, hyphenated SVG attrs), import from `preact`/`preact/hooks`/`lucide-preact`, and have no React-isms.