### PR TITLE
test(space-runtime): verify crash recovery and rehydration

### DIFF
--- a/packages/daemon/tests/unit/space/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-rehydration.test.ts
@@ -1,0 +1,675 @@
+/**
+ * SpaceRuntime — Crash Recovery and Rehydration Tests (Task 3.3)
+ *
+ * Tests that the runtime correctly rehydrates in-progress workflow runs on startup:
+ *
+ *   1. in_progress runs are picked up by a fresh runtime (executor created)
+ *   2. blocked runs are also rehydratable (human-gate-blocked runs resume after approval)
+ *   3. done, cancelled, and pending runs are NOT rehydrated (terminal/transient states)
+ *   4. taskAgentManager.rehydrate() is called during rehydrateExecutors()
+ *   5. Open (unspawned) tasks for an in_progress run are processed after rehydration
+ *   6. Multiple in_progress runs across the same space all rehydrate
+ *   7. Runs across multiple spaces all rehydrate
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceRuntimeConfig } from '../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB / seed helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-space-runtime-rehydration',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/ws'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+	).run(agentId, spaceId, `Agent ${agentId}`, Date.now(), Date.now());
+}
+
+function buildLinearWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	nodes: Array<{ id: string; name: string; agentId: string }>
+): SpaceWorkflow {
+	const transitions = nodes.slice(0, -1).map((step, i) => ({
+		from: step.id,
+		to: nodes[i + 1].id,
+		condition: { type: 'always' as const },
+		order: 0,
+	}));
+	return workflowManager.createWorkflow({
+		spaceId,
+		name: `Workflow-${Date.now()}-${Math.random()}`,
+		description: 'Test',
+		nodes,
+		transitions,
+		startNodeId: nodes[0].id,
+		rules: [],
+		tags: [],
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('SpaceRuntime — crash recovery and rehydration', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let taskRepo: SpaceTaskRepository;
+	let agentManager: SpaceAgentManager;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+
+	const SPACE_ID = 'space-rehydration-1';
+	const AGENT = 'agent-rehy-1';
+	const STEP_A = 'step-a';
+	const STEP_B = 'step-b';
+
+	function makeRuntime(overrides?: Partial<SpaceRuntimeConfig>): SpaceRuntime {
+		return new SpaceRuntime({
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+			nodeExecutionRepo: new NodeExecutionRepository(db),
+			...overrides,
+		});
+	}
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedSpaceRow(db, SPACE_ID);
+		seedAgentRow(db, AGENT, SPACE_ID);
+
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		taskRepo = new SpaceTaskRepository(db);
+		const agentRepo = new SpaceAgentRepository(db);
+		agentManager = new SpaceAgentManager(agentRepo);
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		workflowManager = new SpaceWorkflowManager(workflowRepo);
+		spaceManager = new SpaceManager(db);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// 1. in_progress run picked up by fresh runtime
+	// -------------------------------------------------------------------------
+
+	describe('in_progress runs are rehydrated on startup', () => {
+		test('fresh runtime creates executor for an in_progress run from DB', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			// Simulate: run was started before crash, now in_progress in DB
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Crashed Run',
+			});
+			workflowRunRepo.transitionStatus(pendingRun.id, 'in_progress');
+
+			// Fresh runtime — simulates daemon restart
+			const freshRuntime = makeRuntime();
+			expect(freshRuntime.executorCount).toBe(0); // not yet rehydrated
+
+			// First executeTick() triggers rehydration
+			await freshRuntime.executeTick();
+
+			// Executor should now exist for the in_progress run
+			expect(freshRuntime.executorCount).toBe(1);
+			expect(freshRuntime.getExecutor(pendingRun.id)).toBeDefined();
+		});
+
+		test('rehydrated in_progress run executor is the correct run ID', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const runA = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Run A',
+			});
+			workflowRunRepo.transitionStatus(runA.id, 'in_progress');
+
+			const freshRuntime = makeRuntime();
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.getExecutor(runA.id)).toBeDefined();
+		});
+
+		test('multiple in_progress runs all rehydrated by fresh runtime', async () => {
+			const wfA = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-multi-a', name: 'Step A', agentId: AGENT },
+			]);
+			const wfB = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-multi-b', name: 'Step B', agentId: AGENT },
+			]);
+
+			const runA = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: wfA.id,
+				title: 'Run A',
+			});
+			workflowRunRepo.transitionStatus(runA.id, 'in_progress');
+
+			const runB = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: wfB.id,
+				title: 'Run B',
+			});
+			workflowRunRepo.transitionStatus(runB.id, 'in_progress');
+
+			const freshRuntime = makeRuntime();
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.executorCount).toBe(2);
+			expect(freshRuntime.getExecutor(runA.id)).toBeDefined();
+			expect(freshRuntime.getExecutor(runB.id)).toBeDefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// 2. blocked runs are also rehydratable
+	// -------------------------------------------------------------------------
+
+	describe('blocked runs are rehydrated on startup', () => {
+		test('fresh runtime creates executor for a blocked run from DB', async () => {
+			// blocked runs represent human-gate-blocked workflows — they need their
+			// executor reloaded so the run can advance once the gate is resolved
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Blocked Run',
+			});
+			workflowRunRepo.transitionStatus(pendingRun.id, 'in_progress');
+			workflowRunRepo.transitionStatus(pendingRun.id, 'blocked');
+
+			const freshRuntime = makeRuntime();
+			await freshRuntime.executeTick();
+
+			// Blocked runs are rehydratable — executor should exist
+			expect(freshRuntime.executorCount).toBe(1);
+			expect(freshRuntime.getExecutor(pendingRun.id)).toBeDefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// 3. Terminal and transient states are NOT rehydrated
+	// -------------------------------------------------------------------------
+
+	describe('non-rehydratable run states are skipped', () => {
+		test('done runs are not rehydrated', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Done Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			workflowRunRepo.transitionStatus(run.id, 'done');
+
+			const freshRuntime = makeRuntime();
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.executorCount).toBe(0);
+			expect(freshRuntime.getExecutor(run.id)).toBeUndefined();
+		});
+
+		test('cancelled runs are not rehydrated', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Cancelled Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			workflowRunRepo.transitionStatus(run.id, 'cancelled');
+
+			const freshRuntime = makeRuntime();
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.executorCount).toBe(0);
+			expect(freshRuntime.getExecutor(run.id)).toBeUndefined();
+		});
+
+		test('pending runs are not rehydrated (transient pre-start state)', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			// Create run but do NOT transition to in_progress — stays pending
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Pending Run',
+			});
+			// Verify it's actually pending
+			expect(run.status).toBe('pending');
+
+			const freshRuntime = makeRuntime();
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.executorCount).toBe(0);
+			expect(freshRuntime.getExecutor(run.id)).toBeUndefined();
+		});
+
+		test('only in_progress/blocked runs rehydrated when mix of states exists', async () => {
+			const wfActive = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-active', name: 'Active', agentId: AGENT },
+			]);
+			const wfDone = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-done', name: 'Done', agentId: AGENT },
+			]);
+			const wfCancelled = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-cancelled', name: 'Cancelled', agentId: AGENT },
+			]);
+			const wfBlocked = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-blocked', name: 'Blocked', agentId: AGENT },
+			]);
+
+			// Active run (in_progress)
+			const activeRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: wfActive.id,
+				title: 'Active',
+			});
+			workflowRunRepo.transitionStatus(activeRun.id, 'in_progress');
+
+			// Done run
+			const doneRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: wfDone.id,
+				title: 'Done',
+			});
+			workflowRunRepo.transitionStatus(doneRun.id, 'in_progress');
+			workflowRunRepo.transitionStatus(doneRun.id, 'done');
+
+			// Cancelled run
+			const cancelledRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: wfCancelled.id,
+				title: 'Cancelled',
+			});
+			workflowRunRepo.transitionStatus(cancelledRun.id, 'in_progress');
+			workflowRunRepo.transitionStatus(cancelledRun.id, 'cancelled');
+
+			// Blocked run (rehydratable)
+			const blockedRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: wfBlocked.id,
+				title: 'Blocked',
+			});
+			workflowRunRepo.transitionStatus(blockedRun.id, 'in_progress');
+			workflowRunRepo.transitionStatus(blockedRun.id, 'blocked');
+
+			const freshRuntime = makeRuntime();
+			await freshRuntime.executeTick();
+
+			// Only in_progress and blocked runs should be rehydrated
+			expect(freshRuntime.executorCount).toBe(2);
+			expect(freshRuntime.getExecutor(activeRun.id)).toBeDefined();
+			expect(freshRuntime.getExecutor(blockedRun.id)).toBeDefined();
+			expect(freshRuntime.getExecutor(doneRun.id)).toBeUndefined();
+			expect(freshRuntime.getExecutor(cancelledRun.id)).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// 4. taskAgentManager.rehydrate() is called during rehydrateExecutors()
+	// -------------------------------------------------------------------------
+
+	describe('agent session rehydration', () => {
+		test('taskAgentManager.rehydrate() is called once on first executeTick()', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Agent Rehydration Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			let rehydrateCallCount = 0;
+			const mockTAM = {
+				isSpawning: () => false,
+				isTaskAgentAlive: () => false,
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+				rehydrate: async () => {
+					rehydrateCallCount++;
+				},
+			};
+
+			const rt = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+				nodeExecutionRepo: new NodeExecutionRepository(db),
+				taskAgentManager: mockTAM as never,
+			});
+
+			// Before any tick, rehydrate has not been called
+			expect(rehydrateCallCount).toBe(0);
+
+			// First tick triggers rehydration
+			await rt.executeTick();
+			expect(rehydrateCallCount).toBe(1);
+
+			// Second tick does NOT re-call rehydrate (idempotent)
+			await rt.executeTick();
+			expect(rehydrateCallCount).toBe(1);
+		});
+
+		test('taskAgentManager.rehydrate() called even when no runs exist', async () => {
+			// rehydrate() should be called regardless of how many runs are found —
+			// it's always called as part of the startup sequence
+			let rehydrateCallCount = 0;
+			const mockTAM = {
+				isSpawning: () => false,
+				isTaskAgentAlive: () => false,
+				spawnTaskAgent: async () => 'session-1',
+				rehydrate: async () => {
+					rehydrateCallCount++;
+				},
+			};
+
+			const rt = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+				nodeExecutionRepo: new NodeExecutionRepository(db),
+				taskAgentManager: mockTAM as never,
+			});
+
+			await rt.executeTick();
+			expect(rehydrateCallCount).toBe(1);
+		});
+
+		test('executor map is populated before taskAgentManager.rehydrate() is called', async () => {
+			// Executors must be loaded first so Task Agents can use MCP tools
+			// that rely on the executor map during rehydration
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Order Test Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			let executorCountAtRehydrate = -1;
+			let rtRef: SpaceRuntime | null = null;
+
+			const mockTAM = {
+				isSpawning: () => false,
+				isTaskAgentAlive: () => false,
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+				rehydrate: async () => {
+					// Capture executor count at the moment rehydrate() is called
+					executorCountAtRehydrate = rtRef?.executorCount ?? 0;
+				},
+			};
+
+			rtRef = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+				nodeExecutionRepo: new NodeExecutionRepository(db),
+				taskAgentManager: mockTAM as never,
+			});
+
+			await rtRef.executeTick();
+
+			// Executor must have been added BEFORE rehydrate() was called
+			expect(executorCountAtRehydrate).toBe(1);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// 5. Open tasks are processed after rehydration (work is not lost)
+	// -------------------------------------------------------------------------
+
+	describe('open tasks resumed after rehydration', () => {
+		test('open task for an in_progress run is spawned on first tick after restart', async () => {
+			// Scenario: daemon crashed after starting the run + creating a task,
+			// but before the Task Agent was spawned. On restart, the task should
+			// be picked up and spawned.
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			// Simulate crash: run is in_progress, task is open (not yet spawned)
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Unspawned Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const unspawnedTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Step A',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'open',
+			});
+
+			const spawned: string[] = [];
+			const mockTAM = {
+				isSpawning: () => false,
+				isTaskAgentAlive: () => false,
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					spawned.push(t.id);
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+				rehydrate: async () => {},
+			};
+
+			const freshRuntime = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+				nodeExecutionRepo: new NodeExecutionRepository(db),
+				taskAgentManager: mockTAM as never,
+			});
+
+			await freshRuntime.executeTick();
+
+			// The previously unspawned task should now have been picked up
+			expect(spawned).toContain(unspawnedTask.id);
+			const updated = taskRepo.getTask(unspawnedTask.id)!;
+			expect(updated.status).toBe('in_progress');
+			expect(updated.taskAgentSessionId).toBe(`session:${unspawnedTask.id}`);
+		});
+
+		test('in_progress task with live agent is not re-spawned after rehydration', async () => {
+			// Scenario: task was already running when the daemon crashed.
+			// After restart, the Task Agent session is still alive — no re-spawn.
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Live Agent Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			// Task was already in_progress with a session
+			const existingTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Step A',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			taskRepo.updateTask(existingTask.id, {
+				taskAgentSessionId: 'session:existing',
+			});
+
+			let spawnCount = 0;
+			const mockTAM = {
+				isSpawning: () => false,
+				isTaskAgentAlive: (taskId: string) => taskId === existingTask.id, // alive
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					spawnCount++;
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+				rehydrate: async () => {},
+			};
+
+			const freshRuntime = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+				nodeExecutionRepo: new NodeExecutionRepository(db),
+				taskAgentManager: mockTAM as never,
+			});
+
+			await freshRuntime.executeTick();
+
+			// No new spawn — agent is alive
+			expect(spawnCount).toBe(0);
+			const task = taskRepo.getTask(existingTask.id)!;
+			// Session ID unchanged
+			expect(task.taskAgentSessionId).toBe('session:existing');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// 6. Runs across multiple spaces all rehydrate
+	// -------------------------------------------------------------------------
+
+	describe('cross-space rehydration', () => {
+		test('in_progress runs from two different spaces are both rehydrated', async () => {
+			const SPACE_B = 'space-rehydration-2';
+			seedSpaceRow(db, SPACE_B, '/tmp/ws-b');
+			seedAgentRow(db, 'agent-b', SPACE_B);
+
+			const wfA = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-cross-a', name: 'Step A', agentId: AGENT },
+			]);
+			const wfB = buildLinearWorkflow(SPACE_B, workflowManager, [
+				{ id: 'step-cross-b', name: 'Step B', agentId: 'agent-b' },
+			]);
+
+			const runA = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: wfA.id,
+				title: 'Run A',
+			});
+			workflowRunRepo.transitionStatus(runA.id, 'in_progress');
+
+			const runB = workflowRunRepo.createRun({
+				spaceId: SPACE_B,
+				workflowId: wfB.id,
+				title: 'Run B',
+			});
+			workflowRunRepo.transitionStatus(runB.id, 'in_progress');
+
+			const freshRuntime = makeRuntime();
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.executorCount).toBe(2);
+			expect(freshRuntime.getExecutor(runA.id)).toBeDefined();
+			expect(freshRuntime.getExecutor(runB.id)).toBeDefined();
+		});
+	});
+});


### PR DESCRIPTION
Add 14 unit tests covering crash recovery and rehydration behaviors in `SpaceRuntime`.

**Scenarios tested:**
- Fresh runtime picks up `in_progress` runs from DB after restart
- `blocked` runs (human-gate-blocked) are also rehydratable
- `done`, `cancelled`, and `pending` runs are skipped during rehydration
- Mixed state: only in_progress/blocked rehydrated when all states coexist
- `taskAgentManager.rehydrate()` called exactly once on first tick
- Executor map populated before `rehydrate()` fires (ordering guarantee)
- Open tasks for crashed runs are spawned after rehydration (no work lost)
- Live agent sessions are not re-spawned after rehydration
- Runs across multiple spaces all rehydrate correctly