### PR TITLE
test: E2E test for space creation with agent and workflow verification

### DIFF
--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -16,7 +16,7 @@
  */
 
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { waitForWebSocketConnected, getWorkspaceRoot, getModal } from '../helpers/wait-helpers';
 import { createUniqueSpaceDir, deleteSpaceViaRpc } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
@@ -65,7 +65,7 @@ test.describe('Space Creation UX', () => {
 		await createButton.click();
 
 		// Dialog should appear
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 		await expect(page.locator('text=Workspace Path')).toBeVisible({ timeout: 3000 });
 	});
 
@@ -73,10 +73,10 @@ test.describe('Space Creation UX', () => {
 		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
 		await spacesButton.click();
 		await page.getByRole('button', { name: 'Create Space', exact: true }).click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 
 		// Submit without filling workspace path
-		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Space' });
+		const submitButton = getModal(page).getByRole('button', { name: 'Create Space' });
 		await submitButton.click();
 
 		// Should show validation error
@@ -87,7 +87,7 @@ test.describe('Space Creation UX', () => {
 		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
 		await spacesButton.click();
 		await page.getByRole('button', { name: 'Create Space', exact: true }).click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 
 		// Type a workspace path
 		const pathInput = page.locator('input[placeholder*="/Users/you/projects"]');
@@ -107,7 +107,7 @@ test.describe('Space Creation UX', () => {
 		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
 		await spacesButton.click();
 		await page.getByRole('button', { name: 'Create Space', exact: true }).click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 
 		// Fill workspace path with a unique subdirectory (guaranteed to exist)
 		const pathInput = page.locator('input[placeholder*="/Users/you/projects"]');
@@ -118,7 +118,7 @@ test.describe('Space Creation UX', () => {
 		await nameInput.fill(`E2E Space ${Date.now()}`);
 
 		// Submit
-		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Space' });
+		const submitButton = getModal(page).getByRole('button', { name: 'Create Space' });
 		await submitButton.click();
 
 		// Wait for navigation to the new space
@@ -146,13 +146,13 @@ test.describe('Space Creation UX', () => {
 		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
 		await spacesButton.click();
 		await page.getByRole('button', { name: 'Create Space', exact: true }).click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 
 		// Click Cancel
 		await page.getByRole('button', { name: 'Cancel', exact: true }).click();
 
 		// Dialog should close
-		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
+		await expect(getModal(page)).not.toBeVisible({ timeout: 3000 });
 	});
 
 	test('configure page shows all 6 preset agents and built-in workflows', async ({ page }) => {
@@ -163,14 +163,14 @@ test.describe('Space Creation UX', () => {
 		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
 		await spacesButton.click();
 		await page.getByRole('button', { name: 'Create Space', exact: true }).click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+		await expect(getModal(page)).toBeVisible({ timeout: 5000 });
 
 		const pathInput = page.locator('input[placeholder*="/Users/you/projects"]');
 		await pathInput.fill(spaceWorkspacePath);
 		const nameInput = page.locator('input[placeholder="e.g., My App"]');
 		await nameInput.fill(`E2E Configure ${Date.now()}`);
 
-		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Space' });
+		const submitButton = getModal(page).getByRole('button', { name: 'Create Space' });
 		await submitButton.click();
 
 		// Wait for navigation to the new space

--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -8,6 +8,8 @@
  * - Name auto-suggests from workspace path
  * - Creating a space navigates to it
  * - Space overview renders with tabbed layout (Active / Review / Done tabs)
+ * - Configure page shows all 6 preset agents after creation
+ * - Configure page shows all built-in workflows after creation
  *
  * Setup: creates a space via dialog (UI-only)
  * Cleanup: deletes the space via RPC in afterEach (infrastructure)
@@ -151,5 +153,58 @@ test.describe('Space Creation UX', () => {
 
 		// Dialog should close
 		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
+	});
+
+	test('configure page shows all 6 preset agents and built-in workflows', async ({ page }) => {
+		const workspaceRoot = await getWorkspaceRoot(page);
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'configure');
+
+		// Create space via UI dialog
+		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
+		await spacesButton.click();
+		await page.getByRole('button', { name: 'Create Space', exact: true }).click();
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+
+		const pathInput = page.locator('input[placeholder*="/Users/you/projects"]');
+		await pathInput.fill(spaceWorkspacePath);
+		const nameInput = page.locator('input[placeholder="e.g., My App"]');
+		await nameInput.fill(`E2E Configure ${Date.now()}`);
+
+		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Space' });
+		await submitButton.click();
+
+		// Wait for navigation to the new space
+		await page.waitForURL(/\/space\/[a-f0-9-]+/, { timeout: 10000 });
+		const url = page.url();
+		const match = url.match(/\/space\/([a-f0-9-]+)/);
+		if (match) {
+			createdSpaceId = match[1];
+		}
+
+		// Navigate to the configure page
+		await page.goto(`/space/${createdSpaceId}/configure`);
+		await expect(page.getByTestId('space-configure-tab-bar')).toBeVisible({ timeout: 10000 });
+
+		// Verify all 6 preset agents are visible on the Agents tab (default)
+		const PRESET_AGENTS = ['Coder', 'General', 'Planner', 'Research', 'Reviewer', 'QA'];
+		for (const agentName of PRESET_AGENTS) {
+			await expect(
+				page.locator('.text-sm.font-medium.text-gray-100', { hasText: agentName })
+			).toBeVisible({ timeout: 5000 });
+		}
+
+		// Navigate to the Workflows tab
+		await page.getByTestId('space-configure-tab-workflows').click();
+
+		// Verify all 4 built-in workflows are visible
+		const BUILT_IN_WORKFLOWS = [
+			'Coding Workflow',
+			'Research Workflow',
+			'Review-Only Workflow',
+			'Full-Cycle Coding Workflow',
+		];
+		for (const workflowName of BUILT_IN_WORKFLOWS) {
+			await expect(page.locator('text=' + workflowName).first()).toBeVisible({ timeout: 5000 });
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Add E2E test that creates a space via UI dialog, navigates to the configure page, and verifies all 6 preset agents (Coder, General, Planner, Research, Reviewer, QA) and all 4 built-in workflows (Coding, Research, Review-Only, Full-Cycle Coding) are visible
- Fix pre-existing `getByRole('dialog')` strict mode violation in space-creation tests by using the `getModal()` helper that excludes the NeoPanel element

## Test plan
- [x] `make run-e2e TEST=tests/features/space-creation.e2e.ts` — new test passes, existing tests also fixed