### PR TITLE
fix: contain application shell demos inside preview frames

### DIFF
--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -528,7 +528,7 @@ export function App() {
 				</header>
 
 				{/* Main */}
-				<main class="px-8 max-w-4xl">
+				<main class="px-8 max-w-6xl">
 					<DemoSection id="button" title="Button">
 						<ButtonDemo />
 					</DemoSection>

--- a/packages/ui/demo/sections/MultiColumnDemo.tsx
+++ b/packages/ui/demo/sections/MultiColumnDemo.tsx
@@ -330,18 +330,22 @@ function FullWidthSecondaryColumnOnRight() {
 export function MultiColumnDemo() {
 	return (
 		<div class="space-y-12">
-			<section>
+			<div>
 				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
 					Full Width Three Column
 				</h3>
-				<FullWidthThreeColumn />
-			</section>
-			<section>
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+					<FullWidthThreeColumn />
+				</div>
+			</div>
+			<div>
 				<h3 class="text-base font-semibold text-text-primary dark:text-white mb-4">
 					Full Width Secondary Column on Right
 				</h3>
-				<FullWidthSecondaryColumnOnRight />
-			</section>
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+					<FullWidthSecondaryColumnOnRight />
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/packages/ui/demo/sections/TablesDemo.tsx
+++ b/packages/ui/demo/sections/TablesDemo.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'preact';
 import { useState, useRef, useLayoutEffect } from 'preact/hooks';
 import { classNames } from '../../src/internal/class-names.ts';
 
@@ -1722,7 +1723,7 @@ export function GroupedRows() {
 							</thead>
 							<tbody class="bg-surface-0 dark:bg-surface-2">
 								{locations.map((location) => (
-									<tbody key={location.name}>
+									<Fragment key={location.name}>
 										<tr class="border-t border-surface-border">
 											<th
 												scope="colgroup"
@@ -1756,7 +1757,7 @@ export function GroupedRows() {
 												</td>
 											</tr>
 										))}
-									</tbody>
+									</Fragment>
 								))}
 							</tbody>
 						</table>
@@ -1889,7 +1890,7 @@ export function SummaryRows() {
 							</thead>
 							<tbody>
 								{days.map((day) => (
-									<tbody key={day.dateTime}>
+									<Fragment key={day.dateTime}>
 										<tr class="text-sm/6 text-text-primary">
 											<th scope="colgroup" colSpan={3} class="relative isolate py-2 font-semibold">
 												<time dateTime={day.dateTime}>{day.date}</time>
@@ -1964,7 +1965,7 @@ export function SummaryRows() {
 												</td>
 											</tr>
 										))}
-									</tbody>
+									</Fragment>
 								))}
 							</tbody>
 						</table>

--- a/packages/ui/demo/sections/application-shells/multi-column/MultiColumnShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/multi-column/MultiColumnShellsDemo.tsx
@@ -838,10 +838,18 @@ function Demo4() {
 export function MultiColumnShellsDemo() {
 	return (
 		<div class="space-y-12">
-			<Demo1 />
-			<Demo2 />
-			<Demo3 />
-			<Demo4 />
+			<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+				<Demo1 />
+			</div>
+			<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+				<Demo2 />
+			</div>
+			<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+				<Demo3 />
+			</div>
+			<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+				<Demo4 />
+			</div>
 		</div>
 	);
 }

--- a/packages/ui/demo/sections/application-shells/sidebar/SidebarShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/sidebar/SidebarShellsDemo.tsx
@@ -965,7 +965,7 @@ export function SidebarShellsDemo() {
 		<div class="flex flex-col gap-12">
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">Simple sidebar (indigo)</h3>
-				<div class="h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
 					<SimpleSidebar />
 				</div>
 			</div>
@@ -974,14 +974,14 @@ export function SidebarShellsDemo() {
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">
 					Dark sidebar with header, search, and user menu
 				</h3>
-				<div class="h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
 					<DarkSidebarWithHeader />
 				</div>
 			</div>
 
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">Light brand sidebar</h3>
-				<div class="h-[32rem] rounded-lg border border-surface-border overflow-hidden">
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
 					<LightBrandSidebar />
 				</div>
 			</div>

--- a/packages/ui/demo/sections/application-shells/stacked/StackedShellsDemo.tsx
+++ b/packages/ui/demo/sections/application-shells/stacked/StackedShellsDemo.tsx
@@ -790,7 +790,7 @@ export function StackedShellsDemo() {
 		<div class="flex flex-col gap-8">
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">Stacked with bottom border</h3>
-				<div class="rounded-lg border border-surface-border overflow-hidden">
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
 					<StackedWithBottomBorder />
 				</div>
 			</div>
@@ -799,7 +799,7 @@ export function StackedShellsDemo() {
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">
 					Stacked with lighter page header
 				</h3>
-				<div class="rounded-lg border border-surface-border overflow-hidden">
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
 					<StackedWithLighterPageHeader />
 				</div>
 			</div>
@@ -808,14 +808,14 @@ export function StackedShellsDemo() {
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">
 					Branded nav with lighter page header
 				</h3>
-				<div class="rounded-lg border border-surface-border overflow-hidden">
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
 					<BrandedNavWithLighterPageHeader />
 				</div>
 			</div>
 
 			<div>
 				<h3 class="text-sm font-medium text-text-tertiary mb-3">Two row navigation with overlap</h3>
-				<div class="rounded-lg border border-surface-border overflow-hidden">
+				<div class="shell-frame h-[32rem] rounded-lg border border-surface-border overflow-hidden">
 					<TwoRowNavigationWithOverlap />
 				</div>
 			</div>

--- a/packages/ui/demo/styles.css
+++ b/packages/ui/demo/styles.css
@@ -76,8 +76,20 @@
 .page-preview {
 	height: 600px;
 	overflow: auto;
+	/* Creates a new containing block so position:fixed children are scoped to this element */
+	transform: translateZ(0);
 }
 
 .dark .page-preview {
 	background-color: #111118;
+}
+
+/*
+ * Shell preview frame — use on any container that wraps a full-page layout demo.
+ * The transform creates a containing block for position:fixed children so they
+ * stay inside the preview box instead of escaping to the viewport.
+ */
+.shell-frame {
+	overflow: hidden;
+	transform: translateZ(0);
 }


### PR DESCRIPTION
## Root Cause

Application shell demos use `position: fixed` for sidebars/dialogs. When rendered inline in the demo page, these `fixed` elements escape their containers and overlap with the demo's own navigation sidebar — causing the "overlapping panels, layout chaos" the human observed.

The key CSS fact: `overflow: hidden/auto` does **not** create a containing block for `position: fixed` children. Only a CSS `transform` on the parent does.

## Fix

- **`styles.css`**: Add `.shell-frame { overflow: hidden; transform: translateZ(0); }` — the transform scopes `fixed` children to the preview frame. Also add `transform: translateZ(0)` to `.page-preview` (Detail/Home/Settings screen demos).
- **`SidebarShellsDemo.tsx`**: Add `shell-frame` to existing `h-[32rem] overflow-hidden` containers.
- **`StackedShellsDemo.tsx`**: Add `shell-frame h-[32rem]` to `overflow-hidden` containers (were missing fixed height).
- **`MultiColumnShellsDemo.tsx`**: Wrap each Demo component in an explicit `shell-frame h-[32rem]` container.
- **`MultiColumnDemo.tsx`**: Restructure to place headings outside the shell-frame container.
- **`App.tsx`**: Increase `max-w-4xl` → `max-w-6xl` so shell demos have enough width to display their sidebar+content layout.

After this fix, the `DetailScreensDemo`, `HomeScreensDemo`, and `SettingsScreensDemo` are also fixed via the `.page-preview` CSS change.