### PR TITLE
fix: resolve flaky cross-provider E2E tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -462,7 +462,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat ripgrep
+          sudo apt-get install -y bubblewrap socat
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -527,7 +527,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat ripgrep
+          sudo apt-get install -y bubblewrap socat
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -1137,6 +1137,7 @@ jobs:
           ANTHROPIC_API_KEY: "sk-devproxy-test-key"
           ANTHROPIC_AUTH_TOKEN: ""
           CLAUDE_CODE_OAUTH_TOKEN: ""
+          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           CI: true
 
       - name: Stop Dev Proxy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -362,7 +362,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Setup Dev Proxy
         if: runner.os == 'Linux' && matrix.mock_sdk == true
@@ -462,7 +462,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -527,7 +527,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -591,7 +591,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -758,7 +758,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -827,6 +827,7 @@ jobs:
             features/archive
             features/file-operations
             features/message-operations
+            features/provider-model-switching
             features/reference-autocomplete
             features/rewind-features
             features/session-operations
@@ -913,7 +914,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -1052,7 +1053,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Setup Dev Proxy
         if: runner.os == 'Linux'

--- a/packages/daemon/src/lib/agent/sdk-cli-resolver.ts
+++ b/packages/daemon/src/lib/agent/sdk-cli-resolver.ts
@@ -10,7 +10,7 @@
  * it to a real filesystem path.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
@@ -105,6 +105,9 @@ function resolveFromNodeModules(): string | undefined {
  * Child processes can't access /$bunfs/root/ virtual paths, so we extract
  * the file to a temp directory. The path is content-hashed so SDK upgrades
  * get a fresh extraction.
+ *
+ * After extraction, attempts to link system ripgrep into the SDK's expected
+ * vendor path so that sandbox mode works on Linux/macOS CI environments.
  */
 function extractEmbeddedCli(): string | undefined {
 	if (!embeddedCliPath) return undefined;
@@ -117,16 +120,88 @@ function extractEmbeddedCli(): string | undefined {
 		const extractDir = join(tmpdir(), 'neokai-sdk', hash);
 		const extractPath = join(extractDir, 'cli.js');
 
-		if (existsSync(extractPath)) {
-			return extractPath;
+		if (!existsSync(extractPath)) {
+			mkdirSync(extractDir, { recursive: true });
+			writeFileSync(extractPath, content, { mode: 0o755 });
 		}
 
-		mkdirSync(extractDir, { recursive: true });
-		writeFileSync(extractPath, content, { mode: 0o755 });
+		// Ensure vendor ripgrep is linked for sandbox mode.
+		// The SDK checks for ripgrep at vendor/ripgrep/<platform>/rg relative to cli.js.
+		// In compiled binary mode the vendor directory is not bundled, so we symlink
+		// the system-installed ripgrep (from apt-get / brew) if available.
+		linkSystemRipgrepToVendor(extractDir);
 
 		return extractPath;
 	} catch {
 		return undefined;
+	}
+}
+
+/**
+ * Return the SDK vendor platform string (e.g. "x64-linux") matching the
+ * directory names inside @anthropic-ai/claude-agent-sdk/vendor/ripgrep/.
+ * Returns undefined on unsupported platforms (Windows).
+ */
+function getSdkVendorPlatform(): string | undefined {
+	const { platform, arch } = process;
+	if (platform === 'win32') return undefined;
+	const os = platform === 'darwin' ? 'darwin' : 'linux';
+	const cpu = arch === 'arm64' ? 'arm64' : 'x64';
+	return `${cpu}-${os}`;
+}
+
+/**
+ * Common locations for a system-installed ripgrep binary.
+ * Checked in order; the first existing path wins.
+ */
+const SYSTEM_RIPGREP_PATHS = [
+	'/usr/bin/rg',
+	'/usr/local/bin/rg',
+	'/opt/homebrew/bin/rg',
+	'/opt/homebrew/opt/ripgrep/bin/rg',
+];
+
+/**
+ * Locate the system ripgrep executable, or return undefined if not found.
+ */
+function findSystemRipgrep(): string | undefined {
+	for (const p of SYSTEM_RIPGREP_PATHS) {
+		if (existsSync(p)) return p;
+	}
+	return undefined;
+}
+
+/**
+ * Symlink the system ripgrep into the SDK's expected vendor directory.
+ *
+ * When the compiled binary extracts cli.js to extractDir, the SDK will look
+ * for ripgrep at `<extractDir>/vendor/ripgrep/<platform>/rg`.  This function
+ * creates that symlink pointing to the system ripgrep so that sandbox mode
+ * works without needing the full vendor bundle embedded in the binary.
+ *
+ * No-op if:
+ *  - Platform is Windows (unsupported)
+ *  - System ripgrep is not installed
+ *  - The vendor symlink already exists
+ */
+function linkSystemRipgrepToVendor(extractDir: string): void {
+	const platform = getSdkVendorPlatform();
+	if (!platform) return;
+
+	const ripgrepDir = join(extractDir, 'vendor', 'ripgrep', platform);
+	const ripgrepLink = join(ripgrepDir, 'rg');
+
+	if (existsSync(ripgrepLink)) return;
+
+	const systemRg = findSystemRipgrep();
+	if (!systemRg) return;
+
+	try {
+		mkdirSync(ripgrepDir, { recursive: true });
+		symlinkSync(systemRg, ripgrepLink);
+	} catch {
+		// Race condition: another process created it, or filesystem doesn't support symlinks.
+		// Silently ignore — the SDK will either find the symlink or report its own error.
 	}
 }
 

--- a/packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts
@@ -308,6 +308,46 @@ describe('sdk-cli-resolver', () => {
 				// Symlink already exists — must NOT call symlinkSync again
 				expect(symlinkSyncSpy).not.toHaveBeenCalled();
 			});
+
+			it('skips vendor ripgrep linking on Windows (win32 platform)', () => {
+				const originalReadFileSync = fs.readFileSync.bind(fs);
+
+				// Simulate Windows by temporarily overriding process.platform
+				const originalPlatform = process.platform;
+				Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
+					const p = String(path);
+					if (p.includes('node_modules')) return false;
+					// cli.js not yet extracted
+					if (p.includes('neokai-sdk') && p.endsWith('cli.js')) return false;
+					return false;
+				});
+
+				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
+					(path: fs.PathOrFileDescriptor, options?: unknown) => {
+						return originalReadFileSync(path, options as undefined);
+					}
+				);
+
+				mkdirSyncSpy = spyOn(fs, 'mkdirSync').mockImplementation(
+					() => undefined as unknown as string
+				);
+				writeFileSyncSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+
+				try {
+					setEmbeddedCliPath(testFile);
+					resolveSDKCliPath();
+
+					// On Windows, linkSystemRipgrepToVendor no-ops — symlinkSync must NOT be called
+					expect(symlinkSyncSpy).not.toHaveBeenCalled();
+				} finally {
+					Object.defineProperty(process, 'platform', {
+						value: originalPlatform,
+						configurable: true,
+					});
+				}
+			});
 		});
 	});
 

--- a/packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts
@@ -14,6 +14,18 @@ import {
 	_resetForTesting,
 } from '../../../src/lib/agent/sdk-cli-resolver';
 
+// Helper: build a predictable existsSync mock that blocks node_modules resolution
+// but delegates everything else to the real fs.existsSync.
+function makeBlockNodeModulesExistsMock(extras: Record<string, boolean> = {}) {
+	const originalExistsSync = fs.existsSync.bind(fs);
+	return (path: fs.PathLike): boolean => {
+		const p = String(path);
+		if (p.includes('node_modules')) return false;
+		if (Object.prototype.hasOwnProperty.call(extras, p)) return extras[p];
+		return originalExistsSync(p);
+	};
+}
+
 describe('sdk-cli-resolver', () => {
 	beforeEach(() => {
 		_resetForTesting();
@@ -57,6 +69,7 @@ describe('sdk-cli-resolver', () => {
 			let readFileSyncSpy: ReturnType<typeof spyOn>;
 			let writeFileSyncSpy: ReturnType<typeof spyOn>;
 			let mkdirSyncSpy: ReturnType<typeof spyOn>;
+			let symlinkSyncSpy: ReturnType<typeof spyOn>;
 			let testFile: string;
 			const testContent = 'console.log("test cli");\n';
 
@@ -66,6 +79,10 @@ describe('sdk-cli-resolver', () => {
 				// Create a real test file to act as embedded CLI
 				testFile = join(tmpdir(), `neokai-test-embedded-${Date.now()}.js`);
 				fs.writeFileSync(testFile, testContent);
+
+				// Always stub symlinkSync so tests don't create real symlinks and
+				// vendor-ripgrep linking doesn't interfere with cli.js write assertions.
+				symlinkSyncSpy = spyOn(fs, 'symlinkSync').mockImplementation(() => {});
 			});
 
 			afterEach(() => {
@@ -73,6 +90,7 @@ describe('sdk-cli-resolver', () => {
 				readFileSyncSpy?.mockRestore();
 				writeFileSyncSpy?.mockRestore();
 				mkdirSyncSpy?.mockRestore();
+				symlinkSyncSpy?.mockRestore();
 				try {
 					fs.unlinkSync(testFile);
 				} catch {
@@ -81,14 +99,15 @@ describe('sdk-cli-resolver', () => {
 			});
 
 			it('extracts embedded CLI when node_modules is unavailable', () => {
-				const originalExistsSync = fs.existsSync.bind(fs);
 				const originalReadFileSync = fs.readFileSync.bind(fs);
+				const originalExistsSync = fs.existsSync.bind(fs);
 				const writtenFiles: string[] = [];
 
 				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
 					const p = String(path);
-					// Block node_modules resolution
 					if (p.includes('node_modules')) return false;
+					// Prevent ripgrep linking so writeFileSync is only called for cli.js
+					if (p.includes('vendor') && p.includes('ripgrep')) return false;
 					return originalExistsSync(p);
 				});
 
@@ -117,14 +136,11 @@ describe('sdk-cli-resolver', () => {
 			});
 
 			it('returns cached extracted path on subsequent calls', () => {
-				const originalExistsSync = fs.existsSync.bind(fs);
 				const originalReadFileSync = fs.readFileSync.bind(fs);
 
-				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
-					const p = String(path);
-					if (p.includes('node_modules')) return false;
-					return originalExistsSync(p);
-				});
+				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation(
+					makeBlockNodeModulesExistsMock()
+				);
 
 				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
 					(path: fs.PathOrFileDescriptor, options?: unknown) => {
@@ -162,16 +178,16 @@ describe('sdk-cli-resolver', () => {
 				expect(result).toBeUndefined();
 			});
 
-			it('reuses already-extracted file without re-writing', () => {
-				const originalExistsSync = fs.existsSync.bind(fs);
+			it('reuses already-extracted file without re-writing cli.js', () => {
 				const originalReadFileSync = fs.readFileSync.bind(fs);
 
+				// cli.js is already extracted; all other paths (system rg, vendor dir) are missing
+				// so linkSystemRipgrepToVendor exits early without calling mkdirSync.
 				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
 					const p = String(path);
 					if (p.includes('node_modules')) return false;
-					// Pretend the extracted file already exists
 					if (p.includes('neokai-sdk') && p.endsWith('cli.js')) return true;
-					return originalExistsSync(p);
+					return false;
 				});
 
 				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
@@ -188,9 +204,109 @@ describe('sdk-cli-resolver', () => {
 
 				expect(result).toBeDefined();
 				expect(result!).toContain('neokai-sdk');
-				// Should NOT have called mkdirSync or writeFileSync since file already exists
-				expect(mkdirSyncSpy).not.toHaveBeenCalled();
+				// cli.js was already extracted — must NOT rewrite it.
 				expect(writeFileSyncSpy).not.toHaveBeenCalled();
+				// No system rg found → vendor dir must NOT be created.
+				expect(mkdirSyncSpy).not.toHaveBeenCalled();
+			});
+
+			it('links system ripgrep to vendor path when system rg is available', () => {
+				const originalReadFileSync = fs.readFileSync.bind(fs);
+				const fakeSystemRg = '/usr/bin/rg';
+
+				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
+					const p = String(path);
+					if (p.includes('node_modules')) return false;
+					// cli.js not yet extracted
+					if (p.includes('neokai-sdk') && p.endsWith('cli.js')) return false;
+					// Vendor ripgrep symlink not yet created
+					if (p.includes('vendor') && p.includes('ripgrep')) return false;
+					// System ripgrep is available
+					if (p === fakeSystemRg) return true;
+					return false;
+				});
+
+				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
+					(path: fs.PathOrFileDescriptor, options?: unknown) => {
+						return originalReadFileSync(path, options as undefined);
+					}
+				);
+
+				mkdirSyncSpy = spyOn(fs, 'mkdirSync').mockImplementation(
+					() => undefined as unknown as string
+				);
+				writeFileSyncSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+
+				setEmbeddedCliPath(testFile);
+				resolveSDKCliPath();
+
+				// symlinkSync should have been called to link system rg into the vendor dir
+				expect(symlinkSyncSpy).toHaveBeenCalledTimes(1);
+				const [target, linkPath] = symlinkSyncSpy.mock.calls[0] as [string, string];
+				expect(target).toBe(fakeSystemRg);
+				expect(linkPath).toContain('vendor');
+				expect(linkPath).toContain('ripgrep');
+				expect(linkPath).toEndWith('rg');
+			});
+
+			it('skips vendor ripgrep linking when system rg is not available', () => {
+				const originalReadFileSync = fs.readFileSync.bind(fs);
+
+				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
+					const p = String(path);
+					if (p.includes('node_modules')) return false;
+					// All paths return false — simulates environment without system ripgrep
+					return false;
+				});
+
+				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
+					(path: fs.PathOrFileDescriptor, options?: unknown) => {
+						return originalReadFileSync(path, options as undefined);
+					}
+				);
+
+				mkdirSyncSpy = spyOn(fs, 'mkdirSync').mockImplementation(
+					() => undefined as unknown as string
+				);
+				writeFileSyncSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+
+				setEmbeddedCliPath(testFile);
+				resolveSDKCliPath();
+
+				// symlinkSync must NOT be called when no system ripgrep is found
+				expect(symlinkSyncSpy).not.toHaveBeenCalled();
+			});
+
+			it('skips vendor ripgrep linking when vendor symlink already exists', () => {
+				const originalReadFileSync = fs.readFileSync.bind(fs);
+				const fakeSystemRg = '/usr/bin/rg';
+
+				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
+					const p = String(path);
+					if (p.includes('node_modules')) return false;
+					// cli.js is already extracted
+					if (p.includes('neokai-sdk') && p.endsWith('cli.js')) return true;
+					// Vendor ripgrep symlink already exists
+					if (p.includes('vendor') && p.endsWith('/rg')) return true;
+					// System rg available (but should not be used since vendor link exists)
+					if (p === fakeSystemRg) return true;
+					return false;
+				});
+
+				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
+					(path: fs.PathOrFileDescriptor, options?: unknown) => {
+						return originalReadFileSync(path, options as undefined);
+					}
+				);
+
+				mkdirSyncSpy = spyOn(fs, 'mkdirSync');
+				writeFileSyncSpy = spyOn(fs, 'writeFileSync');
+
+				setEmbeddedCliPath(testFile);
+				resolveSDKCliPath();
+
+				// Symlink already exists — must NOT call symlinkSync again
+				expect(symlinkSyncSpy).not.toHaveBeenCalled();
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

- **Root cause 1 (ripgrep missing in sandbox mode):** In compiled binary mode, `cli.js` is extracted from bunfs to `/tmp/neokai-sdk/{hash}/` but the SDK's sandbox mode expects ripgrep at `vendor/ripgrep/{platform}/rg` relative to that path. The vendor directory isn't bundled, so sandbox fails intermittently. Fix: `sdk-cli-resolver.ts` now calls `linkSystemRipgrepToVendor()` after extraction to symlink the system ripgrep into the expected location. CI steps now install `ripgrep` via apt-get.

- **Root cause 2 (test misclassification):** `features/provider-model-switching` was in the No-LLM test category but its "session continues working after cross-provider switch" test sends a real message and awaits an LLM response — it requires Dev Proxy. Moved it to `LLM_TESTS` so it runs with `NEOKAI_USE_DEV_PROXY=1`.

## Test plan

- [ ] 15 unit tests for `sdk-cli-resolver` all pass (covers new ripgrep-linking logic)
- [ ] CI E2E `features/provider-model-switching` runs under Dev Proxy and passes reliably