### PR TITLE
docs: E2E test status report — 27 remaining failures with root cause analysis

### DIFF
--- a/docs/e2e-test-status.md
+++ b/docs/e2e-test-status.md
@@ -1,0 +1,30 @@
+# E2E Test Status — 2026-04-04
+
+CI Run: 23971370596 (fix(e2e): stabilize neo-panel tests)
+Result: 27 failures / 55 passes
+
+## Root Causes Identified
+
+### A: SpaceDashboard hidden by WorkflowCanvas (md+)
+Built-in workflows seeded on space creation → showCanvas=true → SpaceDashboard md:hidden.
+Affects: space-navigation, space-task-fullwidth, space-task-creation, space-creation, space-happy-path-pipeline
+
+### B: Sandbox ripgrep missing in CI
+SDK expects /tmp/neokai-sdk/vendor/ripgrep/x64-linux/rg, CI only installs bubblewrap+socat.
+Affects: core-connection-resilience, features-provider-model-switching, features-neo-conversation, all LLM tests
+
+### C: neo-conversation needs same fixes as neo-panel (#1297)
+Affects: features-neo-conversation (close/Escape/backdrop/tab tests)
+
+### D: neo-panel role=dialog causes strict mode violations
+Affects: features-space-creation, features-space-task-fullwidth, features-space-task-creation
+
+### E: Individual test bugs
+- features-space-settings-crud: locator('text='+path) creates invalid regex for paths with slashes
+- settings-tools-modal: button[aria-label] should be button[title] for Session options
+- features-space-agent-chat: textarea selector matches neo-panel after navigation
+- features-space-agent-centric-workflow: selectOption timeout
+- features-space-context-panel-switching: space click navigation timeout
+- features-space-approval-gate-rejection + features-reviewer-feedback-loop: gate UI changes
+- features-space-multi-agent-editor + features-visual-workflow-editor: UI changes
+- settings-mcp-servers: isChecked timeout


### PR DESCRIPTION
## Summary

Verified E2E test status after all individual fix tasks (t-148–t-183) completed.

**CI Run**: `23971370596` (2026-04-04) — 27 failures, 55 passes

## Root Causes Identified

**A: SpaceDashboard hidden by WorkflowCanvas on desktop** — seeded workflows make `showCanvas=true`, hiding `SpaceDashboard` with `md:hidden` on 1280px viewports. Affects: space-navigation, space-task-fullwidth, space-task-creation, space-creation, space-happy-path-pipeline.

**B: Sandbox ripgrep missing in CI** — CI installs bubblewrap+socat but not ripgrep; SDK expects it at `/tmp/neokai-sdk/vendor/ripgrep/x64-linux/rg`. Affects: core-connection-resilience, features-provider-model-switching, features-neo-conversation (clear session), all 8 LLM tests.

**C: neo-conversation needs same fixes as neo-panel (#1297)** — Escape/close/backdrop/tab tests not updated. Affects: features-neo-conversation.

**D: neo-panel role=dialog causes strict mode violations** — `page.getByRole('dialog')` matches both the neo-panel and actual dialogs. Affects: space-creation, space-task-fullwidth, space-task-creation.

**E: Individual test bugs** — features-space-settings-crud (regex path), settings-tools-modal (aria-label vs title), features-space-agent-chat (textarea selector ambiguity), plus UI regressions in space-agent-centric-workflow, space-context-panel-switching, space-approval-gate-rejection, reviewer-feedback-loop, space-multi-agent-editor, visual-workflow-editor, settings-mcp-servers.

Full details in `docs/e2e-test-status.md`.