### PR TITLE
ci: add ripgrep to CI sandbox dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -362,7 +362,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Setup Dev Proxy
         if: runner.os == 'Linux' && matrix.mock_sdk == true
@@ -462,7 +462,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -527,7 +527,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -591,7 +591,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -758,7 +758,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -913,7 +913,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -1052,7 +1052,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Setup Dev Proxy
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap socat
+          sudo apt-get install -y bubblewrap socat ripgrep
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
Add `ripgrep` to the apt-get install step in all CI sandbox dependency installations.

The Claude SDK expects `rg` at `/tmp/neokai-sdk/vendor/ripgrep/x64-linux/rg`. Without it, agent sessions that use the sandbox fail with "ripgrep not found", causing ~10 E2E tests (session-send, connection-resilience, provider-model-switching, neo-conversation) to timeout and fail.