### PR TITLE
feat: add TaskArtifactsPanel to task view

### DIFF
--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceAgent, navigateToSpaceSession } from '../../lib/router';
 import type { SpaceTaskPriority, SpaceTaskStatus } from '@neokai/shared';
+import { cn } from '../../lib/utils';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 
@@ -204,7 +205,12 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						<button
 							type="button"
 							onClick={() => setShowArtifacts((v) => !v)}
-							class="flex-shrink-0 px-2 py-1 text-xs font-medium text-gray-400 hover:text-gray-200 transition-colors"
+							class={cn(
+								'flex-shrink-0 px-2 py-1 text-xs font-medium transition-colors',
+								showArtifacts
+									? 'text-blue-300 hover:text-blue-200'
+									: 'text-gray-400 hover:text-gray-200'
+							)}
 							data-testid="artifacts-toggle"
 							aria-pressed={showArtifacts}
 						>

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -3,6 +3,7 @@ import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceAgent, navigateToSpaceSession } from '../../lib/router';
 import type { SpaceTaskPriority, SpaceTaskStatus } from '@neokai/shared';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
+import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 
 interface SpaceTaskPaneProps {
 	taskId: string | null;
@@ -51,10 +52,12 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [threadSendError, setThreadSendError] = useState<string | null>(null);
 	const [sendingThread, setSendingThread] = useState(false);
 	const [reopeningTask, setReopeningTask] = useState(false);
+	const [showArtifacts, setShowArtifacts] = useState(false);
 
 	useEffect(() => {
 		setThreadSendError(null);
 		setThreadDraft('');
+		setShowArtifacts(false);
 	}, [taskId]);
 
 	useEffect(() => {
@@ -197,6 +200,17 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							)}
 						</div>
 					</div>
+					{task.workflowRunId && (
+						<button
+							type="button"
+							onClick={() => setShowArtifacts((v) => !v)}
+							class="flex-shrink-0 px-2 py-1 text-xs font-medium text-gray-400 hover:text-gray-200 transition-colors"
+							data-testid="artifacts-toggle"
+							aria-pressed={showArtifacts}
+						>
+							Artifacts
+						</button>
+					)}
 					{showHeaderSessionAction && (
 						<button
 							type="button"
@@ -225,81 +239,91 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			)}
 
 			<div class="flex-1 min-h-0 overflow-hidden px-4">
-				<div class="h-full flex flex-col">
-					<div class="flex-1 min-h-0" data-testid="task-thread-panel">
-						{agentSessionId ? (
-							<SpaceTaskUnifiedThread taskId={task.id} />
-						) : (
-							<div class="h-full px-4 py-10 text-center">
-								<p class="text-sm text-gray-300">
-									{ensuringThread ? 'Starting task thread...' : 'Task thread is not available yet.'}
-								</p>
-								<p class="mt-2 text-xs text-gray-500">
-									{ensuringThread
-										? 'Connecting task and node-agent streams.'
-										: 'Keep this view open while the task thread starts.'}
-								</p>
-							</div>
-						)}
-					</div>
-
-					<div class="py-3 space-y-3 border-t border-dark-800">
-						{showInlineComposer && (
-							<form onSubmit={handleThreadSend} class="space-y-3">
-								<textarea
-									value={threadDraft}
-									onInput={(e) => setThreadDraft((e.target as HTMLTextAreaElement).value)}
-									onKeyDown={(e) => {
-										if (e.key === 'Enter' && !e.shiftKey) {
-											e.preventDefault();
-											(e.currentTarget as HTMLTextAreaElement).form?.requestSubmit();
-										}
-									}}
-									rows={3}
-									placeholder="Message the task agent (Enter to send, Shift+Enter for newline)"
-									disabled={sendingThread}
-									class="w-full bg-transparent border-0 rounded-none px-0 py-0 text-sm text-gray-100 placeholder-gray-600 focus:outline-none resize-none disabled:opacity-60"
-								/>
-								<div class="flex items-center justify-between gap-3">
-									<p class="text-xs text-gray-500">
-										Reply here to steer the task. Agent updates appear in the thread above.
+				{showArtifacts && task.workflowRunId ? (
+					<TaskArtifactsPanel
+						runId={task.workflowRunId}
+						onClose={() => setShowArtifacts(false)}
+						class="h-full"
+					/>
+				) : (
+					<div class="h-full flex flex-col">
+						<div class="flex-1 min-h-0" data-testid="task-thread-panel">
+							{agentSessionId ? (
+								<SpaceTaskUnifiedThread taskId={task.id} />
+							) : (
+								<div class="h-full px-4 py-10 text-center">
+									<p class="text-sm text-gray-300">
+										{ensuringThread
+											? 'Starting task thread...'
+											: 'Task thread is not available yet.'}
 									</p>
-									<button
-										type="submit"
-										disabled={!canSendThreadMessage || !threadDraft.trim()}
-										class="px-2 py-1 text-xs font-medium text-blue-300 hover:text-blue-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-									>
-										{sendingThread ? 'Sending...' : 'Send to Task Agent'}
-									</button>
+									<p class="mt-2 text-xs text-gray-500">
+										{ensuringThread
+											? 'Connecting task and node-agent streams.'
+											: 'Keep this view open while the task thread starts.'}
+									</p>
 								</div>
-							</form>
-						)}
+							)}
+						</div>
 
-						{!agentSessionId && (
-							<p class="text-xs text-gray-500">
-								Waiting for task thread before messages can be sent.
-							</p>
-						)}
+						<div class="py-3 space-y-3 border-t border-dark-800">
+							{showInlineComposer && (
+								<form onSubmit={handleThreadSend} class="space-y-3">
+									<textarea
+										value={threadDraft}
+										onInput={(e) => setThreadDraft((e.target as HTMLTextAreaElement).value)}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter' && !e.shiftKey) {
+												e.preventDefault();
+												(e.currentTarget as HTMLTextAreaElement).form?.requestSubmit();
+											}
+										}}
+										rows={3}
+										placeholder="Message the task agent (Enter to send, Shift+Enter for newline)"
+										disabled={sendingThread}
+										class="w-full bg-transparent border-0 rounded-none px-0 py-0 text-sm text-gray-100 placeholder-gray-600 focus:outline-none resize-none disabled:opacity-60"
+									/>
+									<div class="flex items-center justify-between gap-3">
+										<p class="text-xs text-gray-500">
+											Reply here to steer the task. Agent updates appear in the thread above.
+										</p>
+										<button
+											type="submit"
+											disabled={!canSendThreadMessage || !threadDraft.trim()}
+											class="px-2 py-1 text-xs font-medium text-blue-300 hover:text-blue-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+										>
+											{sendingThread ? 'Sending...' : 'Send to Task Agent'}
+										</button>
+									</div>
+								</form>
+							)}
 
-						{isTerminalTask && (
-							<div class="flex flex-wrap items-center gap-3">
-								<p class="text-xs text-gray-500">This task is read-only in its current state.</p>
-								{task.status === 'done' && (
-									<button
-										type="button"
-										onClick={() => void handleReopenTask()}
-										disabled={reopeningTask}
-										class="px-2 py-1 text-xs font-medium text-gray-300 hover:text-gray-100 transition-colors disabled:opacity-50"
-									>
-										{reopeningTask ? 'Reopening...' : 'Reopen Task'}
-									</button>
-								)}
-							</div>
-						)}
+							{!agentSessionId && (
+								<p class="text-xs text-gray-500">
+									Waiting for task thread before messages can be sent.
+								</p>
+							)}
 
-						{threadSendError && <p class="text-xs text-red-300">{threadSendError}</p>}
+							{isTerminalTask && (
+								<div class="flex flex-wrap items-center gap-3">
+									<p class="text-xs text-gray-500">This task is read-only in its current state.</p>
+									{task.status === 'done' && (
+										<button
+											type="button"
+											onClick={() => void handleReopenTask()}
+											disabled={reopeningTask}
+											class="px-2 py-1 text-xs font-medium text-gray-300 hover:text-gray-100 transition-colors disabled:opacity-50"
+										>
+											{reopeningTask ? 'Reopening...' : 'Reopen Task'}
+										</button>
+									)}
+								</div>
+							)}
+
+							{threadSendError && <p class="text-xs text-red-300">{threadSendError}</p>}
+						</div>
 					</div>
-				</div>
+				)}
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/TaskArtifactsPanel.tsx
+++ b/packages/web/src/components/space/TaskArtifactsPanel.tsx
@@ -155,7 +155,8 @@ export function TaskArtifactsPanel({ runId, onClose, class: className }: TaskArt
 											'w-full flex items-center gap-3 px-3 py-2 rounded text-left',
 											'hover:bg-dark-700 transition-colors group'
 										)}
-										data-testid={`artifacts-file-${file.path}`}
+										data-testid="artifacts-file-row"
+										data-file-path={file.path}
 									>
 										{/* File icon */}
 										<svg

--- a/packages/web/src/components/space/TaskArtifactsPanel.tsx
+++ b/packages/web/src/components/space/TaskArtifactsPanel.tsx
@@ -1,0 +1,209 @@
+/**
+ * TaskArtifactsPanel — right-side slide-over showing all changed files
+ * for a task's workflow run.
+ *
+ * Fetches `spaceWorkflowRun.getGateArtifacts` using the task's workflowRunId
+ * and renders:
+ *   - Diff summary: N files, +additions, -deletions
+ *   - Clickable file list with per-file +/- counts
+ *   - FileDiffView on click
+ */
+
+import { useState, useEffect } from 'preact/hooks';
+import { connectionManager } from '../../lib/connection-manager';
+import { cn } from '../../lib/utils';
+import { FileDiffView } from './FileDiffView';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface TaskArtifactsPanelProps {
+	/** Workflow run ID (from task.workflowRunId) */
+	runId: string;
+	/** Called when the panel should close */
+	onClose: () => void;
+	class?: string;
+}
+
+interface FileDiffStat {
+	path: string;
+	additions: number;
+	deletions: number;
+}
+
+interface ArtifactsResult {
+	files: FileDiffStat[];
+	totalAdditions: number;
+	totalDeletions: number;
+	worktreePath?: string;
+	baseRef?: string;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function TaskArtifactsPanel({ runId, onClose, class: className }: TaskArtifactsPanelProps) {
+	const [loading, setLoading] = useState(true);
+	const [fetchError, setFetchError] = useState<string | null>(null);
+	const [artifacts, setArtifacts] = useState<ArtifactsResult | null>(null);
+	const [selectedFile, setSelectedFile] = useState<string | null>(null);
+
+	useEffect(() => {
+		setLoading(true);
+		setFetchError(null);
+		setArtifacts(null);
+		setSelectedFile(null);
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setFetchError('Not connected');
+			setLoading(false);
+			return;
+		}
+
+		hub
+			.request<ArtifactsResult>('spaceWorkflowRun.getGateArtifacts', { runId })
+			.then((result) => setArtifacts(result))
+			.catch((err: unknown) => {
+				setFetchError(err instanceof Error ? err.message : 'Failed to load artifacts');
+			})
+			.finally(() => setLoading(false));
+	}, [runId]);
+
+	// If a file is selected, swap to diff view
+	if (selectedFile) {
+		return (
+			<FileDiffView
+				runId={runId}
+				filePath={selectedFile}
+				onBack={() => setSelectedFile(null)}
+				class={className}
+			/>
+		);
+	}
+
+	return (
+		<div
+			class={cn('flex flex-col h-full overflow-hidden', className)}
+			data-testid="artifacts-panel"
+		>
+			{/* Header */}
+			<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700 flex-shrink-0 bg-dark-850">
+				<div>
+					<h2 class="text-sm font-semibold text-gray-100">Artifacts</h2>
+					<p class="text-xs text-gray-500 mt-0.5">Changed files across this workflow run</p>
+				</div>
+				<button
+					onClick={onClose}
+					class="text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0 ml-3"
+					aria-label="Close artifacts panel"
+					data-testid="artifacts-panel-close"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M6 18L18 6M6 6l12 12"
+						/>
+					</svg>
+				</button>
+			</div>
+
+			{/* Scrollable body */}
+			<div class="flex-1 overflow-y-auto min-h-0">
+				{/* Loading */}
+				{loading && (
+					<div class="flex items-center justify-center h-32" data-testid="artifacts-loading">
+						<div class="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+					</div>
+				)}
+
+				{/* Fetch error */}
+				{fetchError && !loading && (
+					<div class="px-4 py-4" data-testid="artifacts-error">
+						<p class="text-sm text-red-400">{fetchError}</p>
+					</div>
+				)}
+
+				{/* Artifacts content */}
+				{!loading && !fetchError && artifacts && (
+					<div class="p-4 space-y-4">
+						{/* Diff summary */}
+						<div class="flex items-center gap-4 text-xs" data-testid="artifacts-summary">
+							<span class="text-gray-400">
+								{artifacts.files.length} {artifacts.files.length === 1 ? 'file' : 'files'} changed
+							</span>
+							<span class="text-green-400 font-mono">+{artifacts.totalAdditions}</span>
+							<span class="text-red-400 font-mono">-{artifacts.totalDeletions}</span>
+						</div>
+
+						{/* File list */}
+						{artifacts.files.length === 0 ? (
+							<p class="text-sm text-gray-500" data-testid="artifacts-no-files">
+								No changed files found
+							</p>
+						) : (
+							<div class="space-y-0.5" data-testid="artifacts-file-list">
+								{artifacts.files.map((file) => (
+									<button
+										key={file.path}
+										onClick={() => setSelectedFile(file.path)}
+										class={cn(
+											'w-full flex items-center gap-3 px-3 py-2 rounded text-left',
+											'hover:bg-dark-700 transition-colors group'
+										)}
+										data-testid={`artifacts-file-${file.path}`}
+									>
+										{/* File icon */}
+										<svg
+											class="w-3.5 h-3.5 text-gray-500 flex-shrink-0"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+											/>
+										</svg>
+										{/* Path */}
+										<span
+											class="flex-1 text-xs font-mono text-gray-300 truncate min-w-0 group-hover:text-gray-100"
+											title={file.path}
+										>
+											{file.path}
+										</span>
+										{/* Stats */}
+										<span class="flex-shrink-0 flex items-center gap-1.5 text-xs font-mono">
+											<span class="text-green-400">+{file.additions}</span>
+											<span class="text-red-400">-{file.deletions}</span>
+										</span>
+										{/* Chevron */}
+										<svg
+											class="w-3 h-3 text-gray-600 flex-shrink-0 group-hover:text-gray-400"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M9 5l7 7-7 7"
+											/>
+										</svg>
+									</button>
+								))}
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -1,0 +1,374 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+
+// ---- Mock connectionManager ----
+const mockRequest = vi.fn();
+const mockHub = { request: mockRequest };
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: vi.fn(() => mockHub),
+	},
+}));
+
+// ---- Mock FileDiffView ----
+vi.mock('../FileDiffView', () => ({
+	FileDiffView: ({ filePath, onBack }: { filePath: string; onBack: () => void }) => (
+		<div data-testid="file-diff-view" data-file={filePath}>
+			<button data-testid="diff-back" onClick={onBack}>
+				Back
+			</button>
+		</div>
+	),
+}));
+
+// ---- Mock cn ----
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+import { TaskArtifactsPanel } from '../TaskArtifactsPanel';
+
+const ARTIFACTS_RESULT = {
+	files: [
+		{ path: 'src/foo.ts', additions: 10, deletions: 2 },
+		{ path: 'src/bar.ts', additions: 5, deletions: 0 },
+	],
+	totalAdditions: 15,
+	totalDeletions: 2,
+};
+
+describe('TaskArtifactsPanel', () => {
+	beforeEach(() => {
+		cleanup();
+		mockRequest.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows loading spinner initially', () => {
+		mockRequest.mockReturnValue(new Promise(() => {})); // never resolves
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		expect(getByTestId('artifacts-loading')).toBeTruthy();
+	});
+
+	it('renders file list after successful fetch', async () => {
+		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
+
+		const fileList = getByTestId('artifacts-file-list');
+		expect(fileList.textContent).toContain('src/foo.ts');
+		expect(fileList.textContent).toContain('src/bar.ts');
+	});
+
+	it('shows +/- line counts for each file', async () => {
+		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
+
+		const fooRow = getByTestId('artifacts-file-src/foo.ts');
+		expect(fooRow.textContent).toContain('+10');
+		expect(fooRow.textContent).toContain('-2');
+
+		const barRow = getByTestId('artifacts-file-src/bar.ts');
+		expect(barRow.textContent).toContain('+5');
+		expect(barRow.textContent).toContain('-0');
+	});
+
+	it('shows summary totals', async () => {
+		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('artifacts-summary')).toBeTruthy());
+
+		const summary = getByTestId('artifacts-summary');
+		expect(summary.textContent).toContain('2 files changed');
+		expect(summary.textContent).toContain('+15');
+		expect(summary.textContent).toContain('-2');
+	});
+
+	it('shows "1 file" singular when only one file changed', async () => {
+		mockRequest.mockResolvedValue({
+			files: [{ path: 'src/only.ts', additions: 3, deletions: 1 }],
+			totalAdditions: 3,
+			totalDeletions: 1,
+		});
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('artifacts-summary')).toBeTruthy());
+		expect(getByTestId('artifacts-summary').textContent).toContain('1 file changed');
+	});
+
+	it('shows no-files message when files array is empty', async () => {
+		mockRequest.mockResolvedValue({ files: [], totalAdditions: 0, totalDeletions: 0 });
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('artifacts-no-files')).toBeTruthy());
+	});
+
+	it('clicking a file opens FileDiffView for that file', async () => {
+		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		const { getByTestId, queryByTestId } = render(
+			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
+		);
+		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
+
+		expect(queryByTestId('file-diff-view')).toBeNull();
+		fireEvent.click(getByTestId('artifacts-file-src/foo.ts'));
+		const diffView = getByTestId('file-diff-view');
+		expect(diffView).toBeTruthy();
+		expect(diffView.getAttribute('data-file')).toBe('src/foo.ts');
+	});
+
+	it('back button in FileDiffView returns to file list', async () => {
+		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		const { getByTestId, queryByTestId } = render(
+			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
+		);
+		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
+
+		fireEvent.click(getByTestId('artifacts-file-src/foo.ts'));
+		expect(getByTestId('file-diff-view')).toBeTruthy();
+
+		fireEvent.click(getByTestId('diff-back'));
+		expect(queryByTestId('file-diff-view')).toBeNull();
+		expect(getByTestId('artifacts-file-list')).toBeTruthy();
+	});
+
+	it('calls onClose when close button is clicked', async () => {
+		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		const onClose = vi.fn();
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={onClose} />);
+		await waitFor(() => expect(getByTestId('artifacts-panel')).toBeTruthy());
+
+		fireEvent.click(getByTestId('artifacts-panel-close'));
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('shows error when not connected', async () => {
+		const { connectionManager } = await import('../../../lib/connection-manager');
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValueOnce(null);
+
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('artifacts-error')).toBeTruthy());
+		expect(getByTestId('artifacts-error').textContent).toContain('Not connected');
+	});
+
+	it('shows fetch error when request fails', async () => {
+		mockRequest.mockRejectedValue(new Error('Server error'));
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() => expect(getByTestId('artifacts-error')).toBeTruthy());
+		expect(getByTestId('artifacts-error').textContent).toContain('Server error');
+	});
+
+	it('fetches with the correct runId', async () => {
+		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		render(<TaskArtifactsPanel runId="run-abc-123" onClose={vi.fn()} />);
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.getGateArtifacts', {
+				runId: 'run-abc-123',
+			})
+		);
+	});
+
+	it('has data-testid="artifacts-panel" on root element', async () => {
+		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		expect(getByTestId('artifacts-panel')).toBeTruthy();
+	});
+});
+
+describe('SpaceTaskPane — artifacts toggle', () => {
+	// Import SpaceTaskPane with signal mocks to test the toggle button
+	let mockTasks: ReturnType<typeof import('@preact/signals').signal>;
+
+	beforeEach(async () => {
+		cleanup();
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders artifacts-toggle button when task has workflowRunId', async () => {
+		const { signal } = await import('@preact/signals');
+		mockTasks = signal([
+			{
+				id: 'task-1',
+				spaceId: 'space-1',
+				title: 'Test Task',
+				description: '',
+				status: 'in_progress',
+				priority: 'normal',
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+				workflowRunId: 'run-xyz',
+				taskAgentSessionId: 'session-abc',
+			},
+		]);
+
+		vi.doMock('../../../lib/space-store', () => ({
+			get spaceStore() {
+				return {
+					tasks: mockTasks,
+					agents: signal([]),
+					workflows: signal([]),
+					workflowRuns: signal([]),
+					updateTask: vi.fn().mockResolvedValue(undefined),
+					ensureTaskAgentSession: vi.fn().mockResolvedValue({
+						id: 'task-1',
+						taskAgentSessionId: 'session-abc',
+					}),
+					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+				};
+			},
+		}));
+
+		vi.doMock('../SpaceTaskUnifiedThread', () => ({
+			SpaceTaskUnifiedThread: () => <div data-testid="space-task-unified-thread" />,
+		}));
+		vi.doMock('../TaskArtifactsPanel', () => ({
+			TaskArtifactsPanel: ({ runId }: { runId: string }) => (
+				<div data-testid="artifacts-panel" data-run-id={runId} />
+			),
+		}));
+		vi.doMock('../../../lib/router', () => ({
+			navigateToSpaceSession: vi.fn(),
+			navigateToSpaceAgent: vi.fn(),
+		}));
+		vi.doMock('../../../lib/utils', () => ({
+			cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+		}));
+
+		const { SpaceTaskPane } = await import('../SpaceTaskPane');
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+		expect(getByTestId('artifacts-toggle')).toBeTruthy();
+	});
+
+	it('does not render artifacts-toggle when task has no workflowRunId', async () => {
+		const { signal } = await import('@preact/signals');
+		mockTasks = signal([
+			{
+				id: 'task-2',
+				spaceId: 'space-1',
+				title: 'No Run Task',
+				description: '',
+				status: 'open',
+				priority: 'normal',
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+				workflowRunId: null,
+				taskAgentSessionId: null,
+			},
+		]);
+
+		vi.doMock('../../../lib/space-store', () => ({
+			get spaceStore() {
+				return {
+					tasks: mockTasks,
+					agents: signal([]),
+					workflows: signal([]),
+					workflowRuns: signal([]),
+					updateTask: vi.fn().mockResolvedValue(undefined),
+					ensureTaskAgentSession: vi.fn().mockResolvedValue({ id: 'task-2' }),
+					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+				};
+			},
+		}));
+
+		vi.doMock('../SpaceTaskUnifiedThread', () => ({
+			SpaceTaskUnifiedThread: () => <div data-testid="space-task-unified-thread" />,
+		}));
+		vi.doMock('../TaskArtifactsPanel', () => ({
+			TaskArtifactsPanel: () => <div data-testid="artifacts-panel" />,
+		}));
+		vi.doMock('../../../lib/router', () => ({
+			navigateToSpaceSession: vi.fn(),
+			navigateToSpaceAgent: vi.fn(),
+		}));
+		vi.doMock('../../../lib/utils', () => ({
+			cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+		}));
+
+		const { SpaceTaskPane } = await import('../SpaceTaskPane');
+		const { queryByTestId } = render(<SpaceTaskPane taskId="task-2" spaceId="space-1" />);
+		expect(queryByTestId('artifacts-toggle')).toBeNull();
+	});
+
+	it('shows artifacts panel when toggle is clicked', async () => {
+		const { signal } = await import('@preact/signals');
+		mockTasks = signal([
+			{
+				id: 'task-3',
+				spaceId: 'space-1',
+				title: 'Run Task',
+				description: '',
+				status: 'in_progress',
+				priority: 'normal',
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+				workflowRunId: 'run-toggle',
+				taskAgentSessionId: 'session-toggle',
+			},
+		]);
+
+		vi.doMock('../../../lib/space-store', () => ({
+			get spaceStore() {
+				return {
+					tasks: mockTasks,
+					agents: signal([]),
+					workflows: signal([]),
+					workflowRuns: signal([]),
+					updateTask: vi.fn().mockResolvedValue(undefined),
+					ensureTaskAgentSession: vi.fn().mockResolvedValue({
+						id: 'task-3',
+						taskAgentSessionId: 'session-toggle',
+					}),
+					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+				};
+			},
+		}));
+
+		vi.doMock('../SpaceTaskUnifiedThread', () => ({
+			SpaceTaskUnifiedThread: () => <div data-testid="space-task-unified-thread" />,
+		}));
+		vi.doMock('../TaskArtifactsPanel', () => ({
+			TaskArtifactsPanel: ({ runId, onClose }: { runId: string; onClose: () => void }) => (
+				<div data-testid="artifacts-panel" data-run-id={runId}>
+					<button data-testid="artifacts-panel-close" onClick={onClose}>
+						Close
+					</button>
+				</div>
+			),
+		}));
+		vi.doMock('../../../lib/router', () => ({
+			navigateToSpaceSession: vi.fn(),
+			navigateToSpaceAgent: vi.fn(),
+		}));
+		vi.doMock('../../../lib/utils', () => ({
+			cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+		}));
+
+		const { SpaceTaskPane } = await import('../SpaceTaskPane');
+		const { getByTestId, queryByTestId } = render(
+			<SpaceTaskPane taskId="task-3" spaceId="space-1" />
+		);
+
+		// Artifacts panel not shown initially
+		expect(queryByTestId('artifacts-panel')).toBeNull();
+
+		// Click toggle → panel appears
+		fireEvent.click(getByTestId('artifacts-toggle'));
+		expect(getByTestId('artifacts-panel')).toBeTruthy();
+		expect(getByTestId('artifacts-panel').getAttribute('data-run-id')).toBe('run-toggle');
+
+		// Click close → panel disappears
+		fireEvent.click(getByTestId('artifacts-panel-close'));
+		expect(queryByTestId('artifacts-panel')).toBeNull();
+	});
+});

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -67,16 +67,20 @@ describe('TaskArtifactsPanel', () => {
 
 	it('shows +/- line counts for each file', async () => {
 		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
-		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		const { container, getByTestId } = render(
+			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
+		);
 		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
 
-		const fooRow = getByTestId('artifacts-file-src/foo.ts');
-		expect(fooRow.textContent).toContain('+10');
-		expect(fooRow.textContent).toContain('-2');
+		const fooRow = container.querySelector('[data-file-path="src/foo.ts"]');
+		expect(fooRow).toBeTruthy();
+		expect(fooRow?.textContent).toContain('+10');
+		expect(fooRow?.textContent).toContain('-2');
 
-		const barRow = getByTestId('artifacts-file-src/bar.ts');
-		expect(barRow.textContent).toContain('+5');
-		expect(barRow.textContent).toContain('-0');
+		const barRow = container.querySelector('[data-file-path="src/bar.ts"]');
+		expect(barRow).toBeTruthy();
+		expect(barRow?.textContent).toContain('+5');
+		expect(barRow?.textContent).toContain('-0');
 	});
 
 	it('shows summary totals', async () => {
@@ -109,13 +113,15 @@ describe('TaskArtifactsPanel', () => {
 
 	it('clicking a file opens FileDiffView for that file', async () => {
 		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
-		const { getByTestId, queryByTestId } = render(
+		const { container, getByTestId, queryByTestId } = render(
 			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
 		);
 		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
 
 		expect(queryByTestId('file-diff-view')).toBeNull();
-		fireEvent.click(getByTestId('artifacts-file-src/foo.ts'));
+		const fooRow = container.querySelector('[data-file-path="src/foo.ts"]') as HTMLElement;
+		expect(fooRow).toBeTruthy();
+		fireEvent.click(fooRow);
 		const diffView = getByTestId('file-diff-view');
 		expect(diffView).toBeTruthy();
 		expect(diffView.getAttribute('data-file')).toBe('src/foo.ts');
@@ -123,12 +129,13 @@ describe('TaskArtifactsPanel', () => {
 
 	it('back button in FileDiffView returns to file list', async () => {
 		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
-		const { getByTestId, queryByTestId } = render(
+		const { container, getByTestId, queryByTestId } = render(
 			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
 		);
 		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
 
-		fireEvent.click(getByTestId('artifacts-file-src/foo.ts'));
+		const fooRow = container.querySelector('[data-file-path="src/foo.ts"]') as HTMLElement;
+		fireEvent.click(fooRow);
 		expect(getByTestId('file-diff-view')).toBeTruthy();
 
 		fireEvent.click(getByTestId('diff-back'));

--- a/packages/web/src/components/space/index.ts
+++ b/packages/web/src/components/space/index.ts
@@ -20,6 +20,8 @@ export { GateArtifactsView } from './GateArtifactsView';
 export type { GateArtifactsViewProps } from './GateArtifactsView';
 export { FileDiffView, parseDiff } from './FileDiffView';
 export type { FileDiffViewProps } from './FileDiffView';
+export { TaskArtifactsPanel } from './TaskArtifactsPanel';
+export type { TaskArtifactsPanelProps } from './TaskArtifactsPanel';
 export { WorkflowRulesEditor, makeEmptyRule, rulesToDrafts } from './WorkflowRulesEditor';
 export { WorkflowNodeCard } from './WorkflowNodeCard';
 export { ImportPreviewDialog } from './ImportPreviewDialog';


### PR DESCRIPTION
Add a task-level artifacts side panel and toggle button to `SpaceTaskPane`.

- New `TaskArtifactsPanel` component fetches changed files via `spaceWorkflowRun.getGateArtifacts` using the task's `workflowRunId` and renders a file list with per-file +/- line counts
- Clicking a file opens `FileDiffView` for the unified diff; back button returns to the list
- Artifacts toggle button (`data-testid="artifacts-toggle"`) added to task pane header, visible only when `task.workflowRunId` is set
- Panel (`data-testid="artifacts-panel"`) replaces the thread view when open; close button restores the thread
- 16 Vitest tests covering: loading, file list, line counts, summary totals, empty state, diff drill-in/back, close, error states, toggle behavior, and visibility guard