### PR TITLE
fix(e2e): fix locator issues in space-settings-crud and tools-modal

### DIFF
--- a/packages/e2e/tests/features/session-operations.e2e.ts
+++ b/packages/e2e/tests/features/session-operations.e2e.ts
@@ -40,7 +40,7 @@ test.describe('Session Export', () => {
 		sessionId = await createSessionViaUI(page);
 
 		// Open session options menu (3 dots button)
-		const optionsButton = page.locator('button[aria-label="Session options"]');
+		const optionsButton = page.getByTitle('Session options');
 		await expect(optionsButton).toBeVisible();
 		await optionsButton.click();
 
@@ -73,7 +73,7 @@ test.describe('Session Export', () => {
 		const downloadPromise = page.waitForEvent('download');
 
 		// Open session options menu and click Export
-		const optionsButton = page.locator('button[aria-label="Session options"]');
+		const optionsButton = page.getByTitle('Session options');
 		await optionsButton.click();
 		await page.locator('text=Export Chat').click();
 
@@ -107,7 +107,7 @@ test.describe('Session Export', () => {
 		const downloadPromise = page.waitForEvent('download');
 
 		// Open session options menu and click Export
-		const optionsButton = page.locator('button[aria-label="Session options"]');
+		const optionsButton = page.getByTitle('Session options');
 		await optionsButton.click();
 		await page.locator('text=Export Chat').click();
 
@@ -150,7 +150,7 @@ test.describe('Session Export', () => {
 		const downloadPromise = page.waitForEvent('download');
 
 		// Open session options menu and click Export
-		const optionsButton = page.locator('button[aria-label="Session options"]');
+		const optionsButton = page.getByTitle('Session options');
 		await optionsButton.click();
 		await page.locator('text=Export Chat').click();
 
@@ -168,7 +168,7 @@ test.describe('Session Export', () => {
 		sessionId = await createSessionViaUI(page);
 
 		// Verify Export is clickable when connected
-		const optionsButton = page.locator('button[aria-label="Session options"]');
+		const optionsButton = page.getByTitle('Session options');
 		await optionsButton.click();
 		const exportOption = page.locator('[role="menuitem"]:has-text("Export Chat")');
 		await expect(exportOption).toBeVisible();

--- a/packages/e2e/tests/features/space-settings-crud.e2e.ts
+++ b/packages/e2e/tests/features/space-settings-crud.e2e.ts
@@ -63,7 +63,9 @@ test.describe('Space Settings CRUD', () => {
 		await expect(nameInput).toHaveValue(spaceName);
 
 		// Workspace path should be shown as read-only text (the unique subdirectory for this test)
-		await expect(page.locator(`text=${spaceWorkspacePath}`)).toBeVisible({ timeout: 3000 });
+		await expect(page.getByText(spaceWorkspacePath, { exact: true })).toBeVisible({
+			timeout: 3000,
+		});
 
 		// Danger Zone section
 		await expect(page.locator('text=Danger Zone')).toBeVisible();

--- a/packages/e2e/tests/features/worktree-isolation.e2e.ts
+++ b/packages/e2e/tests/features/worktree-isolation.e2e.ts
@@ -77,7 +77,7 @@ test.describe('Worktree Isolation', () => {
 		});
 
 		// Open session options menu to see session info
-		const optionsButton = page.locator('button[aria-label="Session options"]');
+		const optionsButton = page.getByTitle('Session options');
 		await optionsButton.click();
 
 		// The dropdown should be visible
@@ -105,7 +105,7 @@ test.describe('Worktree Isolation', () => {
 		const deletedSessionId = sessionId;
 
 		// Open session options and delete
-		const optionsButton = page.locator('button[aria-label="Session options"]');
+		const optionsButton = page.getByTitle('Session options');
 		await optionsButton.click();
 
 		// Click Delete option

--- a/packages/e2e/tests/helpers/session-archive-helpers.ts
+++ b/packages/e2e/tests/helpers/session-archive-helpers.ts
@@ -37,10 +37,7 @@ export async function openSessionOptionsMenu(page: Page): Promise<void> {
 	await page.waitForTimeout(300);
 
 	// Click the session options button (gear icon in chat header)
-	// Try multiple selectors for robustness
-	const optionsButton = page
-		.locator('button[aria-label="Session options"], button[title="Session options"]')
-		.first();
+	const optionsButton = page.getByTitle('Session options');
 	await optionsButton.waitFor({ state: 'visible', timeout: 10000 });
 	await optionsButton.click();
 

--- a/packages/e2e/tests/serial/multi-session-concurrent-pages.e2e.ts
+++ b/packages/e2e/tests/serial/multi-session-concurrent-pages.e2e.ts
@@ -321,7 +321,7 @@ test.describe('Multi-Session Concurrent Pages (Skipped - Flaky)', () => {
 			await pages[1].click(`[data-session-id="${sessionId}"]`);
 			await waitForElement(pages[1], 'textarea');
 
-			await pages[1].click('button[aria-label="Session options"]');
+			await pages[1].getByTitle('Session options').click();
 			await pages[1].click('text=Delete Chat');
 			const confirmButton = await waitForElement(
 				pages[1],

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '../../fixtures';
-import { cleanupTestSession, createSessionViaUI, getModal } from '../helpers/wait-helpers';
+import {
+	cleanupTestSession,
+	createSessionViaUI,
+	getModal,
+	waitForWebSocketConnected,
+} from '../helpers/wait-helpers';
 
 /**
  * Tools Modal E2E Tests (Redesigned)
@@ -34,6 +39,9 @@ test.describe('Tools Modal - Redesigned', () => {
 
 	/** Open the Tools modal for the current session and return the dialog locator */
 	async function openToolsModal(page: import('@playwright/test').Page) {
+		// Ensure WebSocket is connected before clicking — the button title changes to
+		// "Not connected" when disconnected, so we must wait for the connected state first.
+		await waitForWebSocketConnected(page);
 		const optionsButton = page.getByTitle('Session options');
 		await optionsButton.click();
 		// Scope the menu to the session options menu container to avoid matching stray "Tools" buttons

--- a/packages/e2e/tests/settings/tools-modal.e2e.ts
+++ b/packages/e2e/tests/settings/tools-modal.e2e.ts
@@ -34,7 +34,7 @@ test.describe('Tools Modal - Redesigned', () => {
 
 	/** Open the Tools modal for the current session and return the dialog locator */
 	async function openToolsModal(page: import('@playwright/test').Page) {
-		const optionsButton = page.locator('button[aria-label="Session options"]');
+		const optionsButton = page.getByTitle('Session options');
 		await optionsButton.click();
 		// Scope the menu to the session options menu container to avoid matching stray "Tools" buttons
 		await page


### PR DESCRIPTION
- **space-settings-crud**: replace `text=<path>` locator with `getByText(..., { exact: true })` — Playwright was interpreting the leading `/` in workspace paths as a regex literal, causing "resolved to 0 elements" failures
- **tools-modal**: replace `button[aria-label="Session options"]` with `getByTitle('Session options')` — the button uses a `title` attribute, not `aria-label`