### PR TITLE
fix(e2e): use getModal() to fix NeoPanel role=dialog strict mode violations

### DIFF
--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -13,7 +13,7 @@
  */
 
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { waitForWebSocketConnected, getWorkspaceRoot, getModal } from '../helpers/wait-helpers';
 import {
 	createSpaceViaRpc,
 	createUniqueSpaceDir,
@@ -63,7 +63,7 @@ test.describe('Space Task Creation', () => {
 		await createTaskBtn.click();
 
 		// The Create Task modal should open — scope assertions to the dialog itself
-		const dialog = page.getByRole('dialog');
+		const dialog = getModal(page);
 		await expect(dialog).toBeVisible({ timeout: 3000 });
 		await expect(dialog.getByRole('heading', { name: 'Create Task' })).toBeVisible();
 	});
@@ -75,7 +75,7 @@ test.describe('Space Task Creation', () => {
 		await startWorkflowBtn.click();
 
 		// The Start Workflow Run modal should open — scope assertions to the dialog
-		const dialog = page.getByRole('dialog');
+		const dialog = getModal(page);
 		await expect(dialog).toBeVisible({ timeout: 3000 });
 		await expect(dialog.getByRole('heading', { name: 'Start Workflow Run' })).toBeVisible();
 	});
@@ -92,14 +92,14 @@ test.describe('Space Task Creation', () => {
 		await titleInput.fill(taskTitle);
 
 		// Submit via the dialog's "Create Task" button — scope to dialog to disambiguate
-		const dialog = page.getByRole('dialog');
+		const dialog = getModal(page);
 		await dialog.getByRole('button', { name: 'Create Task' }).click();
 
 		// Toast notification confirming creation appears
 		await expect(page.getByText(`Task "${taskTitle}" created`)).toBeVisible({ timeout: 5000 });
 
 		// Dialog should close after successful submission
-		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
+		await expect(getModal(page)).not.toBeVisible({ timeout: 3000 });
 
 		// The task title should appear in SpaceDashboard's Active task list.
 		// Newly created tasks have status 'open' and appear in the Active tab.
@@ -111,12 +111,12 @@ test.describe('Space Task Creation', () => {
 	test('Cancel dismisses the dialog without creating a task', async ({ page }) => {
 		await page.getByRole('button', { name: 'Create Task' }).first().click();
 
-		const dialog = page.getByRole('dialog');
+		const dialog = getModal(page);
 		await expect(dialog).toBeVisible({ timeout: 3000 });
 
 		// Click Cancel — dialog should close
 		await dialog.getByRole('button', { name: 'Cancel' }).click();
-		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
+		await expect(getModal(page)).not.toBeVisible({ timeout: 3000 });
 
 		// The task pane wrapper (data-testid="space-task-pane") is only mounted in SpaceIsland
 		// when activeTaskId is truthy. Cancel never sets a taskId, so the wrapper is absent

--- a/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
+++ b/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
@@ -12,7 +12,7 @@
  */
 
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { waitForWebSocketConnected, getWorkspaceRoot, getModal } from '../helpers/wait-helpers';
 import {
 	createSpaceViaRpc,
 	createUniqueSpaceDir,
@@ -60,7 +60,7 @@ test.describe('Space Task Full-Width View', () => {
 		// Create a task via UI — click "Create Task" quick action
 		await page.getByRole('button', { name: 'Create Task' }).first().click();
 
-		const dialog = page.getByRole('dialog');
+		const dialog = getModal(page);
 		await expect(dialog).toBeVisible({ timeout: 3000 });
 
 		await dialog.getByPlaceholder('e.g., Implement authentication module').fill(taskTitle);
@@ -93,7 +93,7 @@ test.describe('Space Task Full-Width View', () => {
 		// Create task via UI
 		await page.getByRole('button', { name: 'Create Task' }).first().click();
 
-		const dialog = page.getByRole('dialog');
+		const dialog = getModal(page);
 		await dialog.getByPlaceholder('e.g., Implement authentication module').fill(taskTitle);
 		await dialog.getByRole('button', { name: 'Create Task' }).click();
 		await expect(page.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
Replace bare `page.getByRole('dialog')` calls with the existing `getModal(page)` helper in `space-task-creation` and `space-task-fullwidth` E2E tests.

NeoPanel has `role="dialog" data-testid="neo-panel"` and is always in the DOM (hidden via CSS transform). When a space dialog opens, Playwright's strict mode finds 2 elements matching `[role="dialog"]` and throws. The `getModal()` helper uses `[role="dialog"]:not([data-testid="neo-panel"])` to exclude NeoPanel — this pattern was already established and used correctly in `space-creation.e2e.ts`.

Fixes: `features-space-task-creation` and `features-space-task-fullwidth` test failures from CI run 23971370596.