### PR TITLE
fix(e2e): scope space-agent-chat textarea selector to chat-container

### DIFF
--- a/packages/e2e/tests/features/space-agent-chat.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-chat.e2e.ts
@@ -61,7 +61,8 @@ test.describe('Space Agent Chat', () => {
 		await page.waitForURL(`/space/${spaceId}/agent`, { timeout: 10000 });
 
 		// ChatContainer should render — message input textarea should be visible
-		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
+		// Scope to chat-container to avoid matching the Neo panel's "Ask Neo…" textarea
+		const messageInput = page.getByTestId('chat-container').locator('textarea');
 		await expect(messageInput).toBeVisible({ timeout: 10000 });
 
 		// The space overview should no longer be visible (ChatContainer replaced it)
@@ -74,7 +75,8 @@ test.describe('Space Agent Chat', () => {
 		await page.waitForURL(`/space/${spaceId}/agent`, { timeout: 10000 });
 
 		// Message input should be visible
-		const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
+		// Scope to chat-container to avoid matching the Neo panel's "Ask Neo…" textarea
+		const messageInput = page.getByTestId('chat-container').locator('textarea');
 		await expect(messageInput).toBeVisible({ timeout: 10000 });
 
 		// Navigate back to space overview

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -858,7 +858,10 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 	}
 
 	return (
-		<div class="flex-1 flex flex-col bg-dark-900 overflow-hidden relative">
+		<div
+			class="flex-1 flex flex-col bg-dark-900 overflow-hidden relative"
+			data-testid="chat-container"
+		>
 			{/* Loading overlay for archive/delete operations */}
 			{(sessionActions.archiving || sessionActions.deleting) && (
 				<div class="absolute inset-0 z-20 flex items-center justify-center bg-dark-900/80 backdrop-blur-sm">


### PR DESCRIPTION
Fixes selector ambiguity in `features-space-agent-chat` E2E tests where `textarea[placeholder*="Ask"]` was matching the Neo panel's "Ask Neo…" input instead of the chat input, causing `.not.toBeVisible()` assertions to fail.

**Changes:**
- Added `data-testid="chat-container"` to `ChatContainer`'s root div
- Updated both test cases to use `page.getByTestId('chat-container').locator('textarea')` instead of the ambiguous `.first()` selector