### PR TITLE
fix(e2e): delete seeded workflows so SpaceDashboard is visible on desktop

### DIFF
--- a/packages/e2e/tests/features/space-agent-chat.e2e.ts
+++ b/packages/e2e/tests/features/space-agent-chat.e2e.ts
@@ -14,6 +14,7 @@ import {
 	createSpaceViaRpc,
 	createUniqueSpaceDir,
 	deleteSpaceViaRpc,
+	deleteSpaceWorkflowsViaRpc,
 } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
@@ -33,6 +34,9 @@ test.describe('Space Agent Chat', () => {
 		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'agent-chat');
 		const spaceName = `E2E Agent Chat Test ${Date.now()}`;
 		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
+		// Delete seeded built-in workflows so showCanvas=false and SpaceDashboard is
+		// visible on desktop viewports (otherwise md:hidden hides it behind WorkflowCanvas).
+		await deleteSpaceWorkflowsViaRpc(page, spaceId);
 
 		// Navigate to the space
 		await page.goto(`/space/${spaceId}`);

--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -17,7 +17,11 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot, getModal } from '../helpers/wait-helpers';
-import { createUniqueSpaceDir, deleteSpaceViaRpc } from '../helpers/space-helpers';
+import {
+	createUniqueSpaceDir,
+	deleteSpaceViaRpc,
+	deleteSpaceWorkflowsViaRpc,
+} from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
 
@@ -129,6 +133,12 @@ test.describe('Space Creation UX', () => {
 		const match = url.match(/\/space\/([a-f0-9-]+)/);
 		if (match) {
 			createdSpaceId = match[1];
+		}
+
+		// Delete seeded built-in workflows so showCanvas=false and SpaceDashboard is
+		// visible on desktop viewports (otherwise md:hidden hides it behind WorkflowCanvas).
+		if (createdSpaceId) {
+			await deleteSpaceWorkflowsViaRpc(page, createdSpaceId);
 		}
 
 		// Space overview should be visible after navigation

--- a/packages/e2e/tests/features/space-navigation.e2e.ts
+++ b/packages/e2e/tests/features/space-navigation.e2e.ts
@@ -30,6 +30,7 @@ import {
 	createUniqueSpaceDir,
 	createSpaceTaskViaRpc,
 	deleteSpaceViaRpc,
+	deleteSpaceWorkflowsViaRpc,
 } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
@@ -56,6 +57,9 @@ test.describe('Comprehensive Space Navigation', () => {
 		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'nav');
 		spaceName = `E2E SpaceNav ${Date.now()}`;
 		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
+		// Delete seeded built-in workflows so showCanvas=false and SpaceDashboard is
+		// visible on desktop viewports (otherwise md:hidden hides it behind WorkflowCanvas).
+		await deleteSpaceWorkflowsViaRpc(page, spaceId);
 		taskTitle = `Nav Task ${Date.now()}`;
 		taskId = await createSpaceTaskViaRpc(page, spaceId, taskTitle);
 	});

--- a/packages/e2e/tests/features/space-sub-routes.e2e.ts
+++ b/packages/e2e/tests/features/space-sub-routes.e2e.ts
@@ -19,6 +19,7 @@ import {
 	createSpaceViaRpc,
 	createUniqueSpaceDir,
 	deleteSpaceViaRpc,
+	deleteSpaceWorkflowsViaRpc,
 } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
@@ -106,6 +107,9 @@ test.describe('Space Sub-Routes Deep Links', () => {
 		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'sub-routes');
 		const spaceName = `E2E Sub-Routes Test ${Date.now()}`;
 		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
+		// Delete seeded built-in workflows so showCanvas=false and SpaceDashboard is
+		// visible on desktop viewports (otherwise md:hidden hides it behind WorkflowCanvas).
+		await deleteSpaceWorkflowsViaRpc(page, spaceId);
 		taskId = await createTaskViaRpc(page, spaceId, `Test Task ${Date.now()}`);
 		sessionId = await createSessionViaRpc(page, workspaceRoot);
 	});

--- a/packages/e2e/tests/features/space-task-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-task-creation.e2e.ts
@@ -18,6 +18,7 @@ import {
 	createSpaceViaRpc,
 	createUniqueSpaceDir,
 	deleteSpaceViaRpc,
+	deleteSpaceWorkflowsViaRpc,
 } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
@@ -37,6 +38,9 @@ test.describe('Space Task Creation', () => {
 		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'task-creation');
 		const spaceName = `E2E Task Creation Test ${Date.now()}`;
 		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
+		// Delete seeded built-in workflows so showCanvas=false and SpaceDashboard is
+		// visible on desktop viewports (otherwise md:hidden hides it behind WorkflowCanvas).
+		await deleteSpaceWorkflowsViaRpc(page, spaceId);
 
 		// Navigate directly to the space (overview is the default view)
 		await page.goto(`/space/${spaceId}`);

--- a/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
+++ b/packages/e2e/tests/features/space-task-fullwidth.e2e.ts
@@ -17,6 +17,7 @@ import {
 	createSpaceViaRpc,
 	createUniqueSpaceDir,
 	deleteSpaceViaRpc,
+	deleteSpaceWorkflowsViaRpc,
 } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
@@ -36,6 +37,9 @@ test.describe('Space Task Full-Width View', () => {
 		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'task-fullwidth');
 		const spaceName = `E2E Full-Width Task Test ${Date.now()}`;
 		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
+		// Delete seeded built-in workflows so showCanvas=false and SpaceDashboard is
+		// visible on desktop viewports (otherwise md:hidden hides it behind WorkflowCanvas).
+		await deleteSpaceWorkflowsViaRpc(page, spaceId);
 
 		// Navigate to the space dashboard
 		await page.goto(`/space/${spaceId}`);

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -18,7 +18,7 @@
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
-import { createUniqueSpaceDir } from '../helpers/space-helpers';
+import { createUniqueSpaceDir, deleteSpaceWorkflowsViaRpc } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
 
@@ -79,6 +79,9 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		spaceId = await createTestSpace(page);
+		// Delete seeded built-in workflows so showCanvas=false and SpaceDashboard is
+		// visible on desktop viewports (otherwise md:hidden hides it behind WorkflowCanvas).
+		await deleteSpaceWorkflowsViaRpc(page, spaceId);
 	});
 
 	test.afterEach(async ({ page }) => {

--- a/packages/e2e/tests/helpers/space-helpers.ts
+++ b/packages/e2e/tests/helpers/space-helpers.ts
@@ -78,6 +78,36 @@ export async function createSpaceTaskViaRpc(
 }
 
 /**
+ * Delete all seeded workflows for a space via RPC.
+ *
+ * When a space is created the daemon seeds built-in workflows. This causes
+ * `showCanvas` (SpaceIsland) to become `true`, hiding SpaceDashboard behind the
+ * WorkflowCanvas on desktop viewports via the `md:hidden` CSS class. Tests that
+ * need the SpaceDashboard to be visible (Create Task button, Active/Review/Done
+ * tabs, etc.) must call this helper in beforeEach after space creation.
+ *
+ * Best-effort — silently ignores errors so it can be used safely in beforeEach
+ * without masking test failures.
+ */
+export async function deleteSpaceWorkflowsViaRpc(page: Page, spaceId: string): Promise<void> {
+	if (!spaceId) return;
+	try {
+		await page.evaluate(async (sid) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			const result = (await hub.request('spaceWorkflow.list', { spaceId: sid })) as {
+				workflows: Array<{ id: string }>;
+			};
+			for (const wf of result.workflows) {
+				await hub.request('spaceWorkflow.delete', { id: wf.id, spaceId: sid });
+			}
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+/**
  * Create a unique workspace subdirectory for a space test.
  *
  * Multiple E2E tests run in parallel and all share the same workspace root.


### PR DESCRIPTION
Fixes CI failures in `features-space-navigation`, `features-space-task-creation`, `features-space-task-fullwidth`, and `features-space-creation`.

**Root cause:** When a space is created, the daemon seeds 4 built-in workflows. This sets `showCanvas = workflows[0] !== null = true` in `SpaceIsland`, which applies `md:hidden` to the SpaceDashboard wrapper on desktop viewports (≥768px). Tests on the 1280×720 viewport couldn't see the Active/Review/Done tabs, Create Task button, or any SpaceDashboard element.

**Fix:** Added `deleteSpaceWorkflowsViaRpc()` helper to `space-helpers.ts` (calls `spaceWorkflow.list` then `spaceWorkflow.delete` for each). Called in `beforeEach` after `createSpaceViaRpc` in `space-navigation`, `space-task-creation`, `space-task-fullwidth`, and inline in the test body of `space-creation` after the space ID is extracted from the URL.

Tests that explicitly verify workflows (`space-creation`'s configure-page test, `space-happy-path-pipeline`) are unaffected.