### PR TITLE
fix(e2e): apply neo-panel timing fixes to neo-conversation.e2e.ts

### DIFF
--- a/packages/e2e/tests/features/neo-conversation.e2e.ts
+++ b/packages/e2e/tests/features/neo-conversation.e2e.ts
@@ -197,6 +197,10 @@ async function resetSecurityMode(page: Page): Promise<void> {
 // ---------------------------------------------------------------------------
 
 test.describe('Neo Panel – UI mechanics', () => {
+	// Lock viewport to 1280×720 so the backdrop-click position (x=500) is reliably
+	// outside the panel's `md:w-96` (384 px) width — matching neo-panel.e2e.ts.
+	test.use({ viewport: { width: 1280, height: 720 } });
+
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
@@ -230,7 +234,9 @@ test.describe('Neo Panel – UI mechanics', () => {
 		await openNeoPanel(page);
 		await closeNeoPanel(page);
 		// Panel uses CSS transform to go off-screen — verify via class, not toBeHidden()
-		await expect(page.getByTestId(NEO_PANEL_TESTID)).toHaveClass(/-translate-x-full/);
+		await expect(page.getByTestId(NEO_PANEL_TESTID)).toHaveClass(/-translate-x-full/, {
+			timeout: 5000,
+		});
 	});
 
 	test('closes via backdrop click', async ({ page }) => {

--- a/packages/e2e/tests/features/neo-conversation.e2e.ts
+++ b/packages/e2e/tests/features/neo-conversation.e2e.ts
@@ -109,8 +109,8 @@ async function changeSecurityMode(
 		.first();
 	await modeSelect.waitFor({ state: 'visible', timeout: 5000 });
 	await modeSelect.selectOption(mode);
-	// Wait for toast confirming the update
-	await page.locator('text=Security mode updated').waitFor({ state: 'visible', timeout: 10000 });
+	// Wait for toast confirming the update — use generous timeout for CI latency
+	await page.locator('text=Security mode updated').waitFor({ state: 'visible', timeout: 15000 });
 }
 
 /**
@@ -229,22 +229,36 @@ test.describe('Neo Panel – UI mechanics', () => {
 	test('closes via close button', async ({ page }) => {
 		await openNeoPanel(page);
 		await closeNeoPanel(page);
-		await expect(page.getByTestId(NEO_PANEL_TESTID)).toBeHidden();
+		// Panel uses CSS transform to go off-screen — verify via class, not toBeHidden()
+		await expect(page.getByTestId(NEO_PANEL_TESTID)).toHaveClass(/-translate-x-full/);
 	});
 
 	test('closes via backdrop click', async ({ page }) => {
 		await openNeoPanel(page);
 		const backdrop = page.getByTestId('neo-panel-backdrop');
-		await backdrop.click({ position: { x: 1, y: 1 } });
-		await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'hidden', timeout: 5000 });
-		await expect(page.getByTestId(NEO_PANEL_TESTID)).toBeHidden();
+		await expect(backdrop).toBeVisible({ timeout: 3000 });
+		// The panel is `fixed left-0 w-96` (384px) at the md breakpoint (1280px viewport).
+		// The backdrop is `fixed inset-0 z-40`; the panel is z-50, so clicks inside
+		// the panel's 384px width would be intercepted by the panel. Click at x=500 to
+		// land clearly to the right of the panel on the visible backdrop area.
+		await backdrop.click({ position: { x: 500, y: 360 } });
+		// Panel uses CSS transform — wait for -translate-x-full class, not state: 'hidden'
+		await expect(page.getByTestId(NEO_PANEL_TESTID)).toHaveClass(/-translate-x-full/, {
+			timeout: 5000,
+		});
 	});
 
 	test('closes via Escape key', async ({ page }) => {
 		await openNeoPanel(page);
+		// Wait for the close button to receive focus (it's focused via requestAnimationFrame
+		// after the panel opens). This ensures the Preact useEffect that registers the
+		// document keydown handler has already run before we press Escape.
+		await expect(page.getByTestId('neo-panel-close')).toBeFocused({ timeout: 3000 });
 		await page.keyboard.press('Escape');
-		await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'hidden', timeout: 5000 });
-		await expect(page.getByTestId(NEO_PANEL_TESTID)).toBeHidden();
+		// Panel uses CSS transform — wait for -translate-x-full class, not state: 'hidden'
+		await expect(page.getByTestId(NEO_PANEL_TESTID)).toHaveClass(/-translate-x-full/, {
+			timeout: 5000,
+		});
 	});
 
 	test('switches to Activity tab and back to Chat tab', async ({ page }) => {
@@ -254,13 +268,15 @@ test.describe('Neo Panel – UI mechanics', () => {
 		const activityTab = page.getByTestId('neo-tab-activity');
 		await activityTab.click();
 		await expect(activityTab).toHaveAttribute('aria-selected', 'true');
-		await expect(page.getByTestId(NEO_ACTIVITY_VIEW_TESTID)).toBeVisible();
+		await expect(page.getByTestId('neo-tab-chat')).toHaveAttribute('aria-selected', 'false');
+		// Chat view is conditionally rendered — not present in DOM when Activity is active
+		await expect(page.getByTestId('neo-chat-view')).not.toBeVisible({ timeout: 2000 });
 
 		// Switch back to Chat tab
 		const chatTab = page.getByTestId('neo-tab-chat');
 		await chatTab.click();
 		await expect(chatTab).toHaveAttribute('aria-selected', 'true');
-		await expect(page.getByTestId('neo-chat-view')).toBeVisible();
+		await expect(page.getByTestId('neo-chat-view')).toBeVisible({ timeout: 2000 });
 	});
 
 	test('chat input accepts text and send button is enabled', async ({ page }) => {
@@ -381,7 +397,7 @@ test.describe('Neo Settings – Security mode', () => {
 
 		// Change back to balanced
 		await modeSelect.selectOption('balanced');
-		await page.locator('text=Security mode updated').waitFor({ state: 'visible', timeout: 10000 });
+		await page.locator('text=Security mode updated').waitFor({ state: 'visible', timeout: 15000 });
 		await expect(modeSelect).toHaveValue('balanced');
 	});
 

--- a/packages/e2e/tests/helpers/neo-helpers.ts
+++ b/packages/e2e/tests/helpers/neo-helpers.ts
@@ -10,7 +10,7 @@
  * can be skipped cleanly in no-LLM CI instead of timing out.
  */
 
-import type { Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 // ─── Test IDs ─────────────────────────────────────────────────────────────────
 
@@ -26,22 +26,36 @@ export const ACTIVITY_ENTRY_TESTID = 'activity-entry';
 
 /**
  * Open the Neo panel by clicking the Neo NavRail button.
+ *
+ * The panel uses CSS transform (`-translate-x-full` when closed, `translate-x-0` when open).
+ * It is always present in the DOM, so we check class-based state rather than
+ * Playwright's `state: 'visible'` which would be true even when the panel is off-screen.
  */
 export async function openNeoPanel(page: Page): Promise<void> {
 	const neoButton = page.getByRole('button', { name: 'Neo (⌘J)', exact: true });
 	await neoButton.waitFor({ state: 'visible', timeout: 5000 });
 	await neoButton.click();
-	await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'visible', timeout: 5000 });
+	// Wait for the panel to slide into view: -translate-x-full class is removed when open
+	await expect(page.getByTestId(NEO_PANEL_TESTID)).not.toHaveClass(/-translate-x-full/, {
+		timeout: 5000,
+	});
 }
 
 /**
  * Close the Neo panel via its close button.
+ *
+ * The panel slides off-screen via `-translate-x-full` (not display:none), so we
+ * use a class-based assertion instead of Playwright's `state: 'hidden'` which
+ * would never resolve for a CSS-transformed element.
  */
 export async function closeNeoPanel(page: Page): Promise<void> {
 	const closeButton = page.getByTestId('neo-panel-close');
 	await closeButton.waitFor({ state: 'visible', timeout: 5000 });
 	await closeButton.click();
-	await page.getByTestId(NEO_PANEL_TESTID).waitFor({ state: 'hidden', timeout: 5000 });
+	// Wait for the panel to slide out of view: -translate-x-full class is applied when closed
+	await expect(page.getByTestId(NEO_PANEL_TESTID)).toHaveClass(/-translate-x-full/, {
+		timeout: 5000,
+	});
 }
 
 // ─── Messaging helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
Port the timing fixes from PR #1297 (`neo-panel.e2e.ts`) to `neo-conversation.e2e.ts`, which had the same flaky patterns.

**Root causes fixed:**
- `closeNeoPanel`/`openNeoPanel` helpers used `state: 'hidden'`/`state: 'visible'` but NeoPanel hides via CSS transform (`-translate-x-full`), never `display:none` — replaced with class-based assertions
- Backdrop click at `{x:1,y:1}` was intercepted by the panel (z-50 covers the backdrop z-40) — changed to `{x:500,y:360}` to land outside the 384px-wide panel
- Escape key pressed before the keydown handler registered (close button not yet focused) — added `toBeFocused()` wait first
- Tab switching checked `toBeVisible()` on `neo-activity-view` rather than mirroring neo-panel.e2e.ts's pattern of checking `not.toBeVisible()` on `neo-chat-view`
- Security mode toast timeout increased from 10s to 15s for CI latency