### PR TITLE
feat: implement agent overlay chat panel for space sessions

### DIFF
--- a/packages/web/src/components/space/AgentOverlayChat.tsx
+++ b/packages/web/src/components/space/AgentOverlayChat.tsx
@@ -6,8 +6,9 @@
  * backdrop, the ✕ button, or presses Escape.
  */
 
-import { useEffect } from 'preact/hooks';
+import { useEffect, useRef } from 'preact/hooks';
 import { Portal } from '../ui/Portal';
+import { setupFocusTrap } from '../ui/Modal';
 import ChatContainer from '../../islands/ChatContainer';
 import { cn } from '../../lib/utils';
 
@@ -21,6 +22,8 @@ interface AgentOverlayChatProps {
 }
 
 export function AgentOverlayChat({ sessionId, agentName, onClose }: AgentOverlayChatProps) {
+	const panelRef = useRef<HTMLDivElement>(null);
+
 	// Close on Escape key
 	useEffect(() => {
 		const handler = (e: KeyboardEvent) => {
@@ -31,6 +34,13 @@ export function AgentOverlayChat({ sessionId, agentName, onClose }: AgentOverlay
 		document.addEventListener('keydown', handler);
 		return () => document.removeEventListener('keydown', handler);
 	}, [onClose]);
+
+	// Focus trap — keep keyboard focus inside the panel while it is open
+	useEffect(() => {
+		if (panelRef.current) {
+			return setupFocusTrap(panelRef.current);
+		}
+	}, []);
 
 	return (
 		<Portal into="body">
@@ -51,6 +61,7 @@ export function AgentOverlayChat({ sessionId, agentName, onClose }: AgentOverlay
 
 				{/* Slide-over panel */}
 				<div
+					ref={panelRef}
 					class={cn(
 						'relative flex flex-col w-full max-w-2xl bg-dark-900 shadow-2xl',
 						'border-l border-dark-700',

--- a/packages/web/src/components/space/AgentOverlayChat.tsx
+++ b/packages/web/src/components/space/AgentOverlayChat.tsx
@@ -1,0 +1,98 @@
+/**
+ * AgentOverlayChat — slide-over panel that renders a ChatContainer on top of
+ * the current view without replacing it.
+ *
+ * Triggered by spaceOverlaySessionIdSignal.  Closes when the user clicks the
+ * backdrop, the ✕ button, or presses Escape.
+ */
+
+import { useEffect } from 'preact/hooks';
+import { Portal } from '../ui/Portal';
+import ChatContainer from '../../islands/ChatContainer';
+import { cn } from '../../lib/utils';
+
+interface AgentOverlayChatProps {
+	/** Session ID to display inside the overlay. */
+	sessionId: string;
+	/** Human-readable label shown in the header (e.g. agent name or session short-ID). */
+	agentName?: string;
+	/** Called when the overlay should be closed. */
+	onClose: () => void;
+}
+
+export function AgentOverlayChat({ sessionId, agentName, onClose }: AgentOverlayChatProps) {
+	// Close on Escape key
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				onClose();
+			}
+		};
+		document.addEventListener('keydown', handler);
+		return () => document.removeEventListener('keydown', handler);
+	}, [onClose]);
+
+	return (
+		<Portal into="body">
+			{/* Full-screen wrapper — backdrop on the left, panel on the right */}
+			<div
+				class="fixed inset-0 z-50 flex justify-end"
+				data-testid="agent-overlay-chat"
+				aria-modal="true"
+				role="dialog"
+				aria-label={agentName ? `${agentName} chat` : 'Agent chat'}
+			>
+				{/* Translucent backdrop — click to dismiss */}
+				<div
+					class="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+					onClick={onClose}
+					aria-hidden="true"
+				/>
+
+				{/* Slide-over panel */}
+				<div
+					class={cn(
+						'relative flex flex-col w-full max-w-2xl bg-dark-900 shadow-2xl',
+						'border-l border-dark-700',
+						'animate-slideInRight'
+					)}
+				>
+					{/* Header */}
+					<div class="flex items-center gap-3 px-4 py-3 border-b border-dark-700 flex-shrink-0 bg-dark-900">
+						<div class="flex-1 min-w-0">
+							<p
+								class="text-sm font-medium text-gray-200 truncate"
+								data-testid="agent-overlay-name"
+							>
+								{agentName ?? sessionId.slice(0, 8)}
+							</p>
+							<p class="text-xs text-gray-500 truncate">{sessionId}</p>
+						</div>
+						<button
+							type="button"
+							onClick={onClose}
+							class="flex-shrink-0 p-1.5 rounded text-gray-400 hover:text-gray-100 hover:bg-dark-700 transition-colors"
+							aria-label="Close overlay"
+							data-testid="agent-overlay-close"
+						>
+							<svg
+								class="w-4 h-4"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+								stroke-width={2}
+							>
+								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</button>
+					</div>
+
+					{/* Chat content */}
+					<div class="flex-1 min-h-0 overflow-hidden">
+						<ChatContainer key={sessionId} sessionId={sessionId} />
+					</div>
+				</div>
+			</div>
+		</Portal>
+	);
+}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceAgent } from '../../lib/router';
-import { spaceOverlaySessionIdSignal } from '../../lib/signals';
+import { spaceOverlaySessionIdSignal, spaceOverlayAgentNameSignal } from '../../lib/signals';
 import type { SpaceTaskPriority, SpaceTaskStatus } from '@neokai/shared';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 
@@ -201,11 +201,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					{showHeaderSessionAction && (
 						<button
 							type="button"
-							onClick={() =>
-								agentSessionId
-									? (spaceOverlaySessionIdSignal.value = agentSessionId)
-									: navigateToSpaceAgent(runtimeSpaceId)
-							}
+							onClick={() => {
+								if (agentSessionId) {
+									spaceOverlayAgentNameSignal.value = agentActionLabel;
+									spaceOverlaySessionIdSignal.value = agentSessionId;
+								} else {
+									navigateToSpaceAgent(runtimeSpaceId);
+								}
+							}}
 							class="flex-shrink-0 px-2 py-1 text-xs font-medium text-gray-400 hover:text-gray-200 transition-colors"
 							data-testid={agentSessionId ? 'view-agent-session-btn' : 'open-space-agent-btn'}
 						>

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
-import { navigateToSpaceAgent, navigateToSpaceSession } from '../../lib/router';
+import { navigateToSpaceAgent } from '../../lib/router';
+import { spaceOverlaySessionIdSignal } from '../../lib/signals';
 import type { SpaceTaskPriority, SpaceTaskStatus } from '@neokai/shared';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 
@@ -202,7 +203,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							type="button"
 							onClick={() =>
 								agentSessionId
-									? navigateToSpaceSession(runtimeSpaceId, agentSessionId)
+									? (spaceOverlaySessionIdSignal.value = agentSessionId)
 									: navigateToSpaceAgent(runtimeSpaceId)
 							}
 							class="flex-shrink-0 px-2 py-1 text-xs font-medium text-gray-400 hover:text-gray-200 transition-colors"

--- a/packages/web/src/components/space/__tests__/AgentOverlayChat.test.tsx
+++ b/packages/web/src/components/space/__tests__/AgentOverlayChat.test.tsx
@@ -1,0 +1,117 @@
+// @ts-nocheck
+/**
+ * Unit tests for AgentOverlayChat
+ *
+ * Tests:
+ * - Renders with session ID — outer wrapper has data-testid="agent-overlay-chat"
+ * - Shows agent name in header when agentName prop is provided
+ * - Falls back to short session ID when agentName is not provided
+ * - Close button calls onClose when clicked
+ * - Escape key press calls onClose
+ * - Backdrop click calls onClose
+ * - Renders the session ID text in the header
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+
+// Mock ChatContainer — it relies on WebSocket/stores not available in unit tests
+vi.mock('../../../islands/ChatContainer', () => ({
+	default: ({ sessionId }: { sessionId: string }) => (
+		<div data-testid="mock-chat-container">{sessionId}</div>
+	),
+}));
+
+// Mock cn utility
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+import { AgentOverlayChat } from '../AgentOverlayChat';
+
+const SESSION_ID = 'abcdef12-0000-0000-0000-000000000000';
+
+describe('AgentOverlayChat', () => {
+	let onClose: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		cleanup();
+		onClose = vi.fn();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the overlay wrapper with correct data-testid', () => {
+		const { getByTestId } = render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		expect(getByTestId('agent-overlay-chat')).toBeTruthy();
+	});
+
+	it('shows agentName in the header when agentName prop is provided', () => {
+		const { getByTestId } = render(
+			<AgentOverlayChat sessionId={SESSION_ID} agentName="My Agent" onClose={onClose} />
+		);
+		const nameEl = getByTestId('agent-overlay-name');
+		expect(nameEl.textContent).toBe('My Agent');
+	});
+
+	it('falls back to short session ID (first 8 chars) when agentName is not provided', () => {
+		const { getByTestId } = render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		const nameEl = getByTestId('agent-overlay-name');
+		expect(nameEl.textContent).toBe(SESSION_ID.slice(0, 8));
+	});
+
+	it('renders the full session ID text in the header', () => {
+		const { getAllByText } = render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		// The session ID appears in the header <p> element (and also in the mock chat container)
+		const matches = getAllByText(SESSION_ID);
+		// At minimum one <p> element in the header should show the session ID
+		const headerP = matches.find((el) => el.tagName.toLowerCase() === 'p');
+		expect(headerP).toBeTruthy();
+	});
+
+	it('calls onClose when the close button is clicked', () => {
+		const { getByTestId } = render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		fireEvent.click(getByTestId('agent-overlay-close'));
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('calls onClose when Escape key is pressed', () => {
+		render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not call onClose for non-Escape key presses', () => {
+		render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		fireEvent.keyDown(document, { key: 'Enter' });
+		fireEvent.keyDown(document, { key: 'a' });
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('calls onClose when backdrop is clicked', () => {
+		const { getByTestId } = render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		// The backdrop is the first child of the overlay wrapper (aria-hidden div)
+		const overlay = getByTestId('agent-overlay-chat');
+		const backdrop = overlay.querySelector('[aria-hidden="true"]');
+		expect(backdrop).toBeTruthy();
+		fireEvent.click(backdrop!);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders the mock ChatContainer with the provided sessionId', () => {
+		const { getByTestId } = render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		const chatContainer = getByTestId('mock-chat-container');
+		expect(chatContainer).toBeTruthy();
+		expect(chatContainer.textContent).toBe(SESSION_ID);
+	});
+
+	it('removes Escape key listener on unmount', () => {
+		const { unmount } = render(<AgentOverlayChat sessionId={SESSION_ID} onClose={onClose} />);
+		unmount();
+		// After unmount, pressing Escape should not call onClose
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -150,10 +150,13 @@ describe('SpaceTaskPane', () => {
 
 	it('shows View Agent Session button when task session exists and opens overlay on click', () => {
 		mockSpaceOverlaySessionIdSignal.value = null;
+		mockSpaceOverlayAgentNameSignal.value = null;
 		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
 		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
 		fireEvent.click(getByTestId('view-agent-session-btn'));
 		expect(mockSpaceOverlaySessionIdSignal.value).toBe('session-abc');
+		// agentActionLabel for a task with no activeSession is "View Agent Session"
+		expect(mockSpaceOverlayAgentNameSignal.value).toBe('View Agent Session');
 	});
 
 	it('calls onClose when back button is clicked', () => {

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -4,12 +4,28 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { SpaceAgent, SpaceTask, SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
 
-const { mockNavigateToSpaceSession } = vi.hoisted(() => ({ mockNavigateToSpaceSession: vi.fn() }));
 const { mockNavigateToSpaceAgent } = vi.hoisted(() => ({ mockNavigateToSpaceAgent: vi.fn() }));
 vi.mock('../../../lib/router', () => ({
-	navigateToSpaceSession: mockNavigateToSpaceSession,
 	navigateToSpaceAgent: mockNavigateToSpaceAgent,
 }));
+
+// Plain signal-like holders for the overlay signals — hoisted so the mock factory can reference them
+const { mockSpaceOverlaySessionIdSignal, mockSpaceOverlayAgentNameSignal } = vi.hoisted(() => ({
+	mockSpaceOverlaySessionIdSignal: { value: null as string | null },
+	mockSpaceOverlayAgentNameSignal: { value: null as string | null },
+}));
+vi.mock('../../../lib/signals', async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		get spaceOverlaySessionIdSignal() {
+			return mockSpaceOverlaySessionIdSignal;
+		},
+		get spaceOverlayAgentNameSignal() {
+			return mockSpaceOverlayAgentNameSignal;
+		},
+	};
+});
 
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
 let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
@@ -79,8 +95,9 @@ describe('SpaceTaskPane', () => {
 			makeTask({ status: 'in_progress', taskAgentSessionId: 'session-ensured' })
 		);
 		mockSendTaskMessage.mockClear();
-		mockNavigateToSpaceSession.mockClear();
 		mockNavigateToSpaceAgent.mockClear();
+		mockSpaceOverlaySessionIdSignal.value = null;
+		mockSpaceOverlayAgentNameSignal.value = null;
 	});
 
 	afterEach(() => {
@@ -131,11 +148,12 @@ describe('SpaceTaskPane', () => {
 		expect(mockNavigateToSpaceAgent).toHaveBeenCalledWith('space-1');
 	});
 
-	it('shows View Agent Session button when task session exists', () => {
+	it('shows View Agent Session button when task session exists and opens overlay on click', () => {
+		mockSpaceOverlaySessionIdSignal.value = null;
 		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
 		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
 		fireEvent.click(getByTestId('view-agent-session-btn'));
-		expect(mockNavigateToSpaceSession).toHaveBeenCalledWith('space-1', 'session-abc');
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('session-abc');
 	});
 
 	it('calls onClose when back button is clicked', () => {

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -8,13 +8,12 @@
 import { useMemo, useState } from 'preact/hooks';
 import { CollapsibleSection } from '../components/room/CollapsibleSection';
 import { spaceStore } from '../lib/space-store';
+import { navigateToSpace, navigateToSpaceAgent, navigateToSpaceTask } from '../lib/router';
 import {
-	navigateToSpace,
-	navigateToSpaceAgent,
-	navigateToSpaceSession,
-	navigateToSpaceTask,
-} from '../lib/router';
-import { currentSpaceSessionIdSignal, currentSpaceTaskIdSignal } from '../lib/signals';
+	currentSpaceSessionIdSignal,
+	currentSpaceTaskIdSignal,
+	spaceOverlaySessionIdSignal,
+} from '../lib/signals';
 import { cn } from '../lib/utils';
 
 type TaskTab = 'active' | 'review';
@@ -157,7 +156,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 	};
 
 	const handleSessionClick = (sessionId: string) => {
-		navigateToSpaceSession(spaceId, sessionId);
+		spaceOverlaySessionIdSignal.value = sessionId;
 		onNavigate?.();
 	};
 

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 	currentSpaceSessionIdSignal,
 	currentSpaceTaskIdSignal,
 	spaceOverlaySessionIdSignal,
+	spaceOverlayAgentNameSignal,
 } from '../lib/signals';
 import { cn } from '../lib/utils';
 
@@ -156,6 +157,8 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 	};
 
 	const handleSessionClick = (sessionId: string) => {
+		// Use the truncated session ID as a human-readable label (matches what's displayed in the list)
+		spaceOverlayAgentNameSignal.value = sessionId.slice(0, 8);
 		spaceOverlaySessionIdSignal.value = sessionId;
 		onNavigate?.();
 	};

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -18,7 +18,7 @@
 
 import { useState, useEffect } from 'preact/hooks';
 import type { SpaceViewMode } from '../lib/signals';
-import { spaceOverlaySessionIdSignal } from '../lib/signals';
+import { spaceOverlaySessionIdSignal, spaceOverlayAgentNameSignal } from '../lib/signals';
 import { SpaceConfigurePage } from '../components/space/SpaceConfigurePage';
 import { SpaceDashboard } from '../components/space/SpaceDashboard';
 import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
@@ -61,8 +61,10 @@ export default function SpaceIsland({
 
 	// Overlay session — shown as a slide-over on top of the current view
 	const overlaySessionId = spaceOverlaySessionIdSignal.value;
+	const overlayAgentName = spaceOverlayAgentNameSignal.value;
 	const handleOverlayClose = () => {
 		spaceOverlaySessionIdSignal.value = null;
+		spaceOverlayAgentNameSignal.value = null;
 	};
 
 	const loading = spaceStore.loading.value;
@@ -133,7 +135,7 @@ export default function SpaceIsland({
 				{overlaySessionId && (
 					<AgentOverlayChat
 						sessionId={overlaySessionId}
-						agentName={overlaySessionId}
+						agentName={overlayAgentName ?? undefined}
 						onClose={handleOverlayClose}
 					/>
 				)}
@@ -150,7 +152,7 @@ export default function SpaceIsland({
 				{overlaySessionId && (
 					<AgentOverlayChat
 						sessionId={overlaySessionId}
-						agentName={overlaySessionId}
+						agentName={overlayAgentName ?? undefined}
 						onClose={handleOverlayClose}
 					/>
 				)}
@@ -160,19 +162,37 @@ export default function SpaceIsland({
 
 	if (viewMode === 'configure' && space) {
 		return (
-			<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-configure-view">
-				<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
-					<SpaceConfigurePage space={space} workflows={workflows} />
+			<>
+				<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-configure-view">
+					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
+						<SpaceConfigurePage space={space} workflows={workflows} />
+					</div>
 				</div>
-			</div>
+				{overlaySessionId && (
+					<AgentOverlayChat
+						sessionId={overlaySessionId}
+						agentName={overlayAgentName ?? undefined}
+						onClose={handleOverlayClose}
+					/>
+				)}
+			</>
 		);
 	}
 
 	if (viewMode === 'configure' && !space) {
 		return (
-			<div class="flex-1 flex items-center justify-center bg-dark-900">
-				<p class="text-sm text-gray-500">Space not found</p>
-			</div>
+			<>
+				<div class="flex-1 flex items-center justify-center bg-dark-900">
+					<p class="text-sm text-gray-500">Space not found</p>
+				</div>
+				{overlaySessionId && (
+					<AgentOverlayChat
+						sessionId={overlaySessionId}
+						agentName={overlayAgentName ?? undefined}
+						onClose={handleOverlayClose}
+					/>
+				)}
+			</>
 		);
 	}
 

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -208,7 +208,7 @@ export default function SpaceIsland({
 			{overlaySessionId && (
 				<AgentOverlayChat
 					sessionId={overlaySessionId}
-					agentName={overlaySessionId}
+					agentName={overlayAgentName ?? undefined}
 					onClose={handleOverlayClose}
 				/>
 			)}

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -18,6 +18,7 @@
 
 import { useState, useEffect } from 'preact/hooks';
 import type { SpaceViewMode } from '../lib/signals';
+import { spaceOverlaySessionIdSignal } from '../lib/signals';
 import { SpaceConfigurePage } from '../components/space/SpaceConfigurePage';
 import { SpaceDashboard } from '../components/space/SpaceDashboard';
 import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
@@ -26,6 +27,7 @@ import { WorkflowList } from '../components/space/WorkflowList';
 import { VisualWorkflowEditor } from '../components/space/visual-editor/VisualWorkflowEditor';
 import { WorkflowCanvas } from '../components/space/WorkflowCanvas';
 import { SpaceSettings } from '../components/space/SpaceSettings';
+import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
 import { spaceStore } from '../lib/space-store';
 import { navigateToSpace, navigateToSpaceAgent, navigateToSpaceTask } from '../lib/router';
 import ChatContainer from './ChatContainer';
@@ -56,6 +58,12 @@ export default function SpaceIsland({
 	const [activeTab, setActiveTab] = useState<SpaceTab>('dashboard');
 	/** null = list view; 'new' = create editor; <id> = edit editor */
 	const [workflowEditId, setWorkflowEditId] = useState<string | null>(null);
+
+	// Overlay session — shown as a slide-over on top of the current view
+	const overlaySessionId = spaceOverlaySessionIdSignal.value;
+	const handleOverlayClose = () => {
+		spaceOverlaySessionIdSignal.value = null;
+	};
 
 	const loading = spaceStore.loading.value;
 	const error = spaceStore.error.value;
@@ -119,14 +127,34 @@ export default function SpaceIsland({
 	const space = spaceStore.space.value;
 
 	if (sessionViewId) {
-		return <ChatContainer key={sessionViewId} sessionId={sessionViewId} />;
+		return (
+			<>
+				<ChatContainer key={sessionViewId} sessionId={sessionViewId} />
+				{overlaySessionId && (
+					<AgentOverlayChat
+						sessionId={overlaySessionId}
+						agentName={overlaySessionId}
+						onClose={handleOverlayClose}
+					/>
+				)}
+			</>
+		);
 	}
 
 	if (taskViewId) {
 		return (
-			<div class="flex-1 flex flex-col overflow-hidden bg-dark-900" data-testid="space-task-pane">
-				<SpaceTaskPane taskId={taskViewId} spaceId={spaceId} onClose={handleTaskPaneClose} />
-			</div>
+			<>
+				<div class="flex-1 flex flex-col overflow-hidden bg-dark-900" data-testid="space-task-pane">
+					<SpaceTaskPane taskId={taskViewId} spaceId={spaceId} onClose={handleTaskPaneClose} />
+				</div>
+				{overlaySessionId && (
+					<AgentOverlayChat
+						sessionId={overlaySessionId}
+						agentName={overlaySessionId}
+						onClose={handleOverlayClose}
+					/>
+				)}
+			</>
 		);
 	}
 
@@ -156,105 +184,117 @@ export default function SpaceIsland({
 	const showWorkflowEditor = activeTab === 'workflows' && workflowEditId !== null;
 
 	return (
-		<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-overview-view">
-			{/* Main content — tabbed view */}
-			<div class="flex-1 overflow-hidden flex flex-col min-w-0">
-				{/* Tab bar — hidden when workflow editor is open */}
-				{!showWorkflowEditor && (
-					<div class="flex border-b border-dark-700 px-4 flex-shrink-0" data-testid="space-tab-bar">
-						{TABS.map((tab) => (
-							<button
-								key={tab.id}
-								type="button"
-								onClick={() => setActiveTab(tab.id)}
-								class={cn(
-									'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px',
-									activeTab === tab.id
-										? 'text-gray-100 border-blue-400'
-										: 'text-gray-400 border-transparent hover:text-gray-200'
-								)}
-							>
-								{tab.label}
-							</button>
-						))}
-					</div>
-				)}
+		<>
+			{overlaySessionId && (
+				<AgentOverlayChat
+					sessionId={overlaySessionId}
+					agentName={overlaySessionId}
+					onClose={handleOverlayClose}
+				/>
+			)}
+			<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-overview-view">
+				{/* Main content — tabbed view */}
+				<div class="flex-1 overflow-hidden flex flex-col min-w-0">
+					{/* Tab bar — hidden when workflow editor is open */}
+					{!showWorkflowEditor && (
+						<div
+							class="flex border-b border-dark-700 px-4 flex-shrink-0"
+							data-testid="space-tab-bar"
+						>
+							{TABS.map((tab) => (
+								<button
+									key={tab.id}
+									type="button"
+									onClick={() => setActiveTab(tab.id)}
+									class={cn(
+										'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px',
+										activeTab === tab.id
+											? 'text-gray-100 border-blue-400'
+											: 'text-gray-400 border-transparent hover:text-gray-200'
+									)}
+								>
+									{tab.label}
+								</button>
+							))}
+						</div>
+					)}
 
-				{/* Tab content */}
-				<div class="flex-1 overflow-hidden">
-					{showWorkflowEditor ? (
-						<VisualWorkflowEditor
-							key={workflowEditId}
-							workflow={editingWorkflow}
-							onSave={() => setWorkflowEditId(null)}
-							onCancel={() => setWorkflowEditId(null)}
-						/>
-					) : (
-						<>
-							{activeTab === 'dashboard' && (
-								<>
-									{/* Canvas panel — shown on md+ when a workflow or run exists */}
-									{showCanvas && (
+					{/* Tab content */}
+					<div class="flex-1 overflow-hidden">
+						{showWorkflowEditor ? (
+							<VisualWorkflowEditor
+								key={workflowEditId}
+								workflow={editingWorkflow}
+								onSave={() => setWorkflowEditId(null)}
+								onCancel={() => setWorkflowEditId(null)}
+							/>
+						) : (
+							<>
+								{activeTab === 'dashboard' && (
+									<>
+										{/* Canvas panel — shown on md+ when a workflow or run exists */}
+										{showCanvas && (
+											<div
+												class="hidden md:flex flex-col h-full overflow-hidden"
+												data-testid="canvas-panel"
+											>
+												{/* Active-run banner */}
+												{displayRun && (
+													<div class="flex items-center gap-2 px-4 py-2 border-b border-dark-700 bg-dark-900 flex-shrink-0">
+														<span
+															class={cn(
+																'w-2 h-2 rounded-full flex-shrink-0',
+																activeRun ? 'bg-blue-400 animate-pulse' : 'bg-amber-400'
+															)}
+														/>
+														<span class="text-xs text-blue-300 truncate">{displayRun.title}</span>
+														<span class="ml-auto text-xs text-gray-600 capitalize flex-shrink-0">
+															{displayRun.status.replace('_', ' ')}
+														</span>
+													</div>
+												)}
+												<WorkflowCanvas
+													key={`${defaultWorkflow.id}:${displayRun?.id ?? 'template'}`}
+													workflowId={defaultWorkflow.id}
+													runId={displayRun?.id ?? null}
+													spaceId={spaceId}
+													class="flex-1 min-h-0"
+												/>
+											</div>
+										)}
+										{/* Fallback: shown on mobile, or when no canvas data */}
 										<div
-											class="hidden md:flex flex-col h-full overflow-hidden"
-											data-testid="canvas-panel"
+											class={cn('flex flex-col h-full overflow-y-auto', showCanvas && 'md:hidden')}
+											data-testid="dashboard-fallback"
 										>
-											{/* Active-run banner */}
-											{displayRun && (
-												<div class="flex items-center gap-2 px-4 py-2 border-b border-dark-700 bg-dark-900 flex-shrink-0">
-													<span
-														class={cn(
-															'w-2 h-2 rounded-full flex-shrink-0',
-															activeRun ? 'bg-blue-400 animate-pulse' : 'bg-amber-400'
-														)}
-													/>
-													<span class="text-xs text-blue-300 truncate">{displayRun.title}</span>
-													<span class="ml-auto text-xs text-gray-600 capitalize flex-shrink-0">
-														{displayRun.status.replace('_', ' ')}
-													</span>
-												</div>
-											)}
-											<WorkflowCanvas
-												key={`${defaultWorkflow.id}:${displayRun?.id ?? 'template'}`}
-												workflowId={defaultWorkflow.id}
-												runId={displayRun?.id ?? null}
+											<SpaceDashboard
 												spaceId={spaceId}
-												class="flex-1 min-h-0"
+												onOpenSpaceAgent={() => navigateToSpaceAgent(spaceId)}
+												onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
 											/>
 										</div>
-									)}
-									{/* Fallback: shown on mobile, or when no canvas data */}
-									<div
-										class={cn('flex flex-col h-full overflow-y-auto', showCanvas && 'md:hidden')}
-										data-testid="dashboard-fallback"
-									>
-										<SpaceDashboard
-											spaceId={spaceId}
-											onOpenSpaceAgent={() => navigateToSpaceAgent(spaceId)}
-											onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
-										/>
+									</>
+								)}
+								{activeTab === 'agents' && (
+									<div class="p-6 h-full overflow-y-auto">
+										<SpaceAgentList />
 									</div>
-								</>
-							)}
-							{activeTab === 'agents' && (
-								<div class="p-6 h-full overflow-y-auto">
-									<SpaceAgentList />
-								</div>
-							)}
-							{activeTab === 'workflows' && space && (
-								<WorkflowList
-									spaceId={spaceId}
-									spaceName={space.name}
-									workflows={workflows}
-									onCreateWorkflow={() => setWorkflowEditId('new')}
-									onEditWorkflow={(id) => setWorkflowEditId(id)}
-								/>
-							)}
-							{activeTab === 'settings' && space && <SpaceSettings space={space} />}
-						</>
-					)}
+								)}
+								{activeTab === 'workflows' && space && (
+									<WorkflowList
+										spaceId={spaceId}
+										spaceName={space.name}
+										workflows={workflows}
+										onCreateWorkflow={() => setWorkflowEditId('new')}
+										onEditWorkflow={(id) => setWorkflowEditId(id)}
+									/>
+								)}
+								{activeTab === 'settings' && space && <SpaceSettings space={space} />}
+							</>
+						)}
+					</div>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -9,17 +9,13 @@ import { render, fireEvent, cleanup, screen } from '@testing-library/preact';
 import { signal, type Signal } from '@preact/signals';
 import type { SpaceTask, Space } from '@neokai/shared';
 
-const {
-	mockNavigateToSpace,
-	mockNavigateToSpaceAgent,
-	mockNavigateToSpaceSession,
-	mockNavigateToSpaceTask,
-} = vi.hoisted(() => ({
-	mockNavigateToSpace: vi.fn(),
-	mockNavigateToSpaceAgent: vi.fn(),
-	mockNavigateToSpaceSession: vi.fn(),
-	mockNavigateToSpaceTask: vi.fn(),
-}));
+const { mockNavigateToSpace, mockNavigateToSpaceAgent, mockNavigateToSpaceTask } = vi.hoisted(
+	() => ({
+		mockNavigateToSpace: vi.fn(),
+		mockNavigateToSpaceAgent: vi.fn(),
+		mockNavigateToSpaceTask: vi.fn(),
+	})
+);
 
 let mockTasksSignal!: Signal<SpaceTask[]>;
 let mockSpaceSignal!: Signal<Space | null>;
@@ -27,6 +23,8 @@ let mockLoadingSignal!: Signal<boolean>;
 let mockSpaceIdSignal!: Signal<string | null>;
 let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
 let mockCurrentSpaceTaskIdSignal!: Signal<string | null>;
+let mockSpaceOverlaySessionIdSignal!: Signal<string | null>;
+let mockSpaceOverlayAgentNameSignal!: Signal<string | null>;
 
 function initSignals() {
 	mockTasksSignal = signal([]);
@@ -35,6 +33,8 @@ function initSignals() {
 	mockSpaceIdSignal = signal('space-1');
 	mockCurrentSpaceSessionIdSignal = signal(null);
 	mockCurrentSpaceTaskIdSignal = signal(null);
+	mockSpaceOverlaySessionIdSignal = signal(null);
+	mockSpaceOverlayAgentNameSignal = signal(null);
 }
 
 initSignals();
@@ -53,7 +53,6 @@ vi.mock('../../lib/space-store.ts', () => ({
 vi.mock('../../lib/router.ts', () => ({
 	navigateToSpace: mockNavigateToSpace,
 	navigateToSpaceAgent: mockNavigateToSpaceAgent,
-	navigateToSpaceSession: mockNavigateToSpaceSession,
 	navigateToSpaceTask: mockNavigateToSpaceTask,
 }));
 
@@ -66,6 +65,12 @@ vi.mock('../../lib/signals.ts', async (importOriginal) => {
 		},
 		get currentSpaceTaskIdSignal() {
 			return mockCurrentSpaceTaskIdSignal;
+		},
+		get spaceOverlaySessionIdSignal() {
+			return mockSpaceOverlaySessionIdSignal;
+		},
+		get spaceOverlayAgentNameSignal() {
+			return mockSpaceOverlayAgentNameSignal;
 		},
 	};
 });
@@ -248,13 +253,15 @@ describe('SpaceDetailPanel', () => {
 		expect(screen.getByText('manual-s')).toBeTruthy();
 	});
 
-	it('navigates to a session on click and calls onNavigate', () => {
+	it('opens overlay on session click and calls onNavigate', () => {
 		const onNavigate = vi.fn();
+		mockSpaceOverlaySessionIdSignal.value = null;
 		mockSpaceSignal.value = makeSpace('space-1', { sessionIds: ['manual-session-abc123'] });
 		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
 
 		fireEvent.click(screen.getByText('manual-s'));
-		expect(mockNavigateToSpaceSession).toHaveBeenCalledWith('space-1', 'manual-session-abc123');
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('manual-session-abc123');
+		expect(mockSpaceOverlayAgentNameSignal.value).toBe('manual-s');
 		expect(onNavigate).toHaveBeenCalledOnce();
 	});
 

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -42,6 +42,10 @@ export const currentSpaceTaskIdSignal = signal<string | null>(null);
 export type SpaceViewMode = 'overview' | 'configure';
 export const currentSpaceViewModeSignal = signal<SpaceViewMode>('overview');
 
+// Overlay signal — session shown in slide-over panel on top of the current view
+// When set, opens AgentOverlayChat without replacing the task/overview view
+export const spaceOverlaySessionIdSignal = signal<string | null>(null);
+
 // Mobile drawer signals
 export const contextPanelOpenSignal = signal<boolean>(false);
 

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -42,9 +42,11 @@ export const currentSpaceTaskIdSignal = signal<string | null>(null);
 export type SpaceViewMode = 'overview' | 'configure';
 export const currentSpaceViewModeSignal = signal<SpaceViewMode>('overview');
 
-// Overlay signal — session shown in slide-over panel on top of the current view
-// When set, opens AgentOverlayChat without replacing the task/overview view
+// Overlay signals — session shown in slide-over panel on top of the current view
+// When spaceOverlaySessionIdSignal is set, opens AgentOverlayChat without replacing the task/overview view
 export const spaceOverlaySessionIdSignal = signal<string | null>(null);
+// Human-readable label for the overlay header (e.g. "View Leader Session", "manual-se")
+export const spaceOverlayAgentNameSignal = signal<string | null>(null);
 
 // Mobile drawer signals
 export const contextPanelOpenSignal = signal<boolean>(false);


### PR DESCRIPTION
Clicking an agent session link from the task pane or detail panel now opens a slide-over overlay instead of replacing the entire view.

- New `AgentOverlayChat` component: Portal-rendered slide-over panel wrapping `ChatContainer`, with `data-testid="agent-overlay-chat"`, close button (`data-testid="agent-overlay-close"`), agent name header, Escape key and backdrop-click dismissal
- New `spaceOverlaySessionIdSignal` drives overlay state — task view stays visible underneath
- `SpaceTaskPane` "View Agent Session" opens overlay (not full-page nav)
- `SpaceDetailPanel` session clicks open overlay
- `SpaceIsland` renders overlay on top of task/overview/chat views
- 10 Vitest tests for `AgentOverlayChat`