### PR TITLE
test(e2e): blocked task display and manual status control

### DIFF
--- a/packages/e2e/tests/features/space-task-status-control.e2e.ts
+++ b/packages/e2e/tests/features/space-task-status-control.e2e.ts
@@ -1,0 +1,187 @@
+/**
+ * Space Task Blocked Status & Manual Status Control E2E Tests
+ *
+ * Verifies:
+ * - Blocked tasks show the blocked reason on the SpaceDashboard "Review" tab
+ * - Opening a blocked task shows the blocked reason banner in SpaceTaskPane
+ * - User can click "Resume" to transition blocked → in_progress via the UI
+ * - Opening a done task shows the "Reopen" action
+ * - User can click "Reopen" to transition done → in_progress via the UI
+ *
+ * Setup: creates a space + task via RPC in beforeEach, sets status via RPC (infrastructure).
+ * Cleanup: deletes the space via RPC in afterEach (infrastructure).
+ *
+ * E2E rules:
+ * - RPC calls only in beforeEach/afterEach (infrastructure).
+ * - All test actions go through the UI: clicks, navigation, assertions on visible DOM.
+ * - No internal state access during test assertions.
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import {
+	createSpaceViaRpc,
+	createUniqueSpaceDir,
+	createSpaceTaskViaRpc,
+	updateSpaceTaskStatusViaRpc,
+	deleteSpaceViaRpc,
+	deleteSpaceWorkflowsViaRpc,
+} from '../helpers/space-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+const OVERVIEW_VIEW = '[data-testid="space-overview-view"]';
+const BLOCKED_REASON = 'Need more information about the API endpoint design before proceeding.';
+
+test.describe('Space Task Blocked Status & Manual Status Control', () => {
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let spaceId = '';
+	let taskId = '';
+	let taskTitle = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+
+		const workspaceRoot = await getWorkspaceRoot(page);
+		const spaceWorkspacePath = createUniqueSpaceDir(workspaceRoot, 'task-status');
+		const spaceName = `E2E Task Status ${Date.now()}`;
+		spaceId = await createSpaceViaRpc(page, spaceWorkspacePath, spaceName);
+
+		// Delete seeded built-in workflows so SpaceDashboard is visible (not hidden by WorkflowCanvas)
+		await deleteSpaceWorkflowsViaRpc(page, spaceId);
+
+		taskTitle = `Status Control Task ${Date.now()}`;
+		taskId = await createSpaceTaskViaRpc(page, spaceId, taskTitle);
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (spaceId) {
+			await deleteSpaceViaRpc(page, spaceId);
+			spaceId = '';
+			taskId = '';
+			taskTitle = '';
+		}
+	});
+
+	// ---------------------------------------------------------------------------
+	// Scenario 1: Blocked indicator on SpaceDashboard "Review" tab
+	// ---------------------------------------------------------------------------
+
+	test('blocked task shows blocked reason on the Review tab of SpaceDashboard', async ({
+		page,
+	}) => {
+		// Set task to blocked with a reason (RPC setup — not a UI action)
+		await updateSpaceTaskStatusViaRpc(page, spaceId, taskId, 'blocked', BLOCKED_REASON);
+
+		// Navigate to space overview
+		await page.goto(`/space/${spaceId}`);
+		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
+		await expect(page.locator(OVERVIEW_VIEW)).toBeVisible({ timeout: 5000 });
+
+		// Click the "Review" tab — the tab label includes a count badge so use a regex prefix match
+		const overviewView = page.locator(OVERVIEW_VIEW);
+		const reviewTab = overviewView.getByRole('button', { name: /^Review/ });
+		await expect(reviewTab).toBeVisible({ timeout: 5000 });
+		await reviewTab.click();
+
+		// The task title should appear in the Review group
+		await expect(overviewView.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
+
+		// The blocked reason should appear as amber text below the task title
+		const blockedReason = overviewView.getByTestId('task-blocked-reason');
+		await expect(blockedReason).toBeVisible({ timeout: 5000 });
+		await expect(blockedReason).toContainText(BLOCKED_REASON);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Scenario 2: Blocked reason banner in task pane + Resume → in_progress
+	// ---------------------------------------------------------------------------
+
+	test('blocked task pane shows blocked banner, Resume changes status to In Progress', async ({
+		page,
+	}) => {
+		// Set task to blocked with a reason (RPC setup)
+		await updateSpaceTaskStatusViaRpc(page, spaceId, taskId, 'blocked', BLOCKED_REASON);
+
+		// Navigate directly to the task pane URL
+		await page.goto(`/space/${spaceId}/task/${taskId}`);
+		await page.waitForURL(`/space/${spaceId}/task/${taskId}`, { timeout: 10000 });
+
+		// Task pane should be visible
+		await expect(page.locator('[data-testid="space-task-pane"]')).toBeVisible({ timeout: 5000 });
+
+		// Status label shows "Blocked"
+		await expect(page.getByTestId('task-status-label')).toContainText('Blocked', { timeout: 5000 });
+
+		// Blocked reason banner should be visible with the reason text
+		const banner = page.getByTestId('task-blocked-banner');
+		await expect(banner).toBeVisible({ timeout: 5000 });
+		await expect(banner).toContainText('Blocked');
+		await expect(banner).toContainText(BLOCKED_REASON);
+
+		// "Resume" action button should be available (blocked → in_progress)
+		const resumeBtn = page.getByTestId('task-action-in_progress');
+		await expect(resumeBtn).toBeVisible({ timeout: 3000 });
+		await expect(resumeBtn).toHaveText('Resume');
+
+		// Click "Resume" to transition the task back to in_progress
+		await resumeBtn.click();
+
+		// Status label should update to "In Progress"
+		await expect(page.getByTestId('task-status-label')).toContainText('In Progress', {
+			timeout: 5000,
+		});
+
+		// Blocked banner should no longer be visible
+		await expect(banner).not.toBeVisible({ timeout: 3000 });
+	});
+
+	// ---------------------------------------------------------------------------
+	// Scenario 3: Done task pane shows "Reopen" action → in_progress
+	// ---------------------------------------------------------------------------
+
+	test('done task pane shows Reopen action, clicking it changes status to In Progress', async ({
+		page,
+	}) => {
+		// Set task to done (RPC setup — open → done is a valid transition)
+		await updateSpaceTaskStatusViaRpc(page, spaceId, taskId, 'done');
+
+		// Navigate to space overview to find the task in the "Done" tab
+		await page.goto(`/space/${spaceId}`);
+		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
+		await expect(page.locator(OVERVIEW_VIEW)).toBeVisible({ timeout: 5000 });
+
+		// Click the "Done" tab to reveal the task
+		const overviewView = page.locator(OVERVIEW_VIEW);
+		const doneTab = overviewView.getByRole('button', { name: /^Done/ });
+		await expect(doneTab).toBeVisible({ timeout: 5000 });
+		await doneTab.click();
+
+		// Task title should appear under the Done tab
+		await expect(overviewView.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
+
+		// Click the task to open the task pane
+		await overviewView.getByText(taskTitle, { exact: true }).first().click();
+		await page.waitForURL(`/space/${spaceId}/task/${taskId}`, { timeout: 5000 });
+
+		// Task pane should be visible
+		await expect(page.locator('[data-testid="space-task-pane"]')).toBeVisible({ timeout: 3000 });
+
+		// Status label shows "Done"
+		await expect(page.getByTestId('task-status-label')).toContainText('Done', { timeout: 5000 });
+
+		// "Reopen" action button should be available (done → in_progress)
+		const reopenBtn = page.getByTestId('task-action-in_progress');
+		await expect(reopenBtn).toBeVisible({ timeout: 3000 });
+		await expect(reopenBtn).toHaveText('Reopen');
+
+		// Click "Reopen" to transition the task back to in_progress
+		await reopenBtn.click();
+
+		// Status label should update to "In Progress"
+		await expect(page.getByTestId('task-status-label')).toContainText('In Progress', {
+			timeout: 5000,
+		});
+	});
+});

--- a/packages/e2e/tests/helpers/space-helpers.ts
+++ b/packages/e2e/tests/helpers/space-helpers.ts
@@ -78,6 +78,26 @@ export async function createSpaceTaskViaRpc(
 }
 
 /**
+ * Update a space task's status (and optionally result) via RPC. For use in beforeEach setup only.
+ */
+export async function updateSpaceTaskStatusViaRpc(
+	page: Page,
+	spaceId: string,
+	taskId: string,
+	status: string,
+	result?: string
+): Promise<void> {
+	await page.evaluate(
+		async ({ spaceId, taskId, status, result }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			await hub.request('spaceTask.update', { spaceId, taskId, status, result });
+		},
+		{ spaceId, taskId, status, result }
+	);
+}
+
+/**
  * Delete all seeded workflows for a space via RPC.
  *
  * When a space is created the daemon seeds built-in workflows. This causes


### PR DESCRIPTION
Adds E2E coverage for space task blocked status display and manual status transitions (happy paths 12 and 14).

**Tests added** (`space-task-status-control.e2e.ts`):
- Blocked task shows amber blocked reason text on the "Review" tab of SpaceDashboard
- Blocked task pane shows blocked reason banner; clicking "Resume" transitions to In Progress
- Done task pane shows "Reopen" action; clicking it transitions to In Progress

**Helper added** (`space-helpers.ts`):
- `updateSpaceTaskStatusViaRpc` — RPC-based task status update for test setup (beforeEach only)

All 3 tests pass locally.