### PR TITLE
feat(space): implement @mention routing to specific agents

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -607,7 +607,13 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	deps.neoAgentManager.setActivityLogger(neoActivityLogger);
 
 	// Human ↔ Task Agent message routing handlers (require taskAgentManager)
-	setupSpaceTaskMessageHandlers(deps.messageHub, taskAgentManager, deps.db, deps.daemonHub);
+	setupSpaceTaskMessageHandlers(
+		deps.messageHub,
+		taskAgentManager,
+		deps.db,
+		deps.daemonHub,
+		nodeExecutionRepo
+	);
 
 	// Space export/import handlers
 	setupSpaceExportImportHandlers(

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -43,7 +43,7 @@ export function parseMentions(text: string): string[] {
 export interface NodeExecutionLookup {
 	listByWorkflowRun(
 		workflowRunId: string
-	): Array<{ agentName: string; agentSessionId: string | null }>;
+	): Array<{ agentName: string; agentSessionId: string | null; status: string }>;
 }
 
 /**
@@ -159,7 +159,11 @@ export function setupSpaceTaskMessageHandlers(
 			taskAgentManager.injectSubSessionMessage
 		) {
 			const executions = nodeExecutionRepo.listByWorkflowRun(task.workflowRunId);
-			const activeAgents = executions.filter((e) => e.agentSessionId !== null);
+			// Only route to agents that are actively running — exclude done/cancelled/blocked
+			// to avoid injecting into sessions that will never process the message.
+			const activeAgents = executions.filter(
+				(e) => e.agentSessionId !== null && (e.status === 'in_progress' || e.status === 'pending')
+			);
 
 			const routedTo: string[] = [];
 			const notFound: string[] = [];
@@ -171,10 +175,13 @@ export function setupSpaceTaskMessageHandlers(
 				if (matches.length === 0) {
 					notFound.push(mention);
 				} else {
-					for (const exec of matches) {
-						await taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, params.message);
-						if (!routedTo.includes(mention)) routedTo.push(mention);
-					}
+					// Inject into all matching sessions in parallel (independent operations)
+					await Promise.all(
+						matches.map((exec) =>
+							taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, params.message)
+						)
+					);
+					routedTo.push(mention);
 				}
 			}
 

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -16,6 +16,37 @@ import { Logger } from '../logger';
 const log = new Logger('space-task-message-handlers');
 
 /**
+ * Extract @AgentName mentions from message text.
+ * Matches patterns like @Coder, @code-reviewer, @planner_1
+ * Returns a deduplicated list of mentioned agent names (preserving first occurrence order).
+ * Names must start with a letter; digits, hyphens, underscores are allowed subsequently.
+ */
+export function parseMentions(text: string): string[] {
+	const mentionRegex = /@([A-Za-z][A-Za-z0-9_-]*)/g;
+	const seen = new Set<string>();
+	const matches: string[] = [];
+	let match: RegExpExecArray | null;
+	while ((match = mentionRegex.exec(text)) !== null) {
+		const name = match[1];
+		if (name && !seen.has(name)) {
+			seen.add(name);
+			matches.push(name);
+		}
+	}
+	return matches;
+}
+
+/**
+ * Minimal interface for NodeExecution lookup.
+ * Allows the handler to resolve @mention targets without depending on the concrete repository class.
+ */
+export interface NodeExecutionLookup {
+	listByWorkflowRun(
+		workflowRunId: string
+	): Array<{ agentName: string; agentSessionId: string | null }>;
+}
+
+/**
  * Minimal interface for interacting with the Task Agent manager.
  * Decouples RPC handlers from the concrete TaskAgentManager class.
  */
@@ -26,6 +57,11 @@ export interface TaskAgentManagerInterface {
 	injectTaskAgentMessage(taskId: string, message: string): Promise<void>;
 	/** Returns the live AgentSession for the given task, or undefined if not spawned. */
 	getTaskAgent(taskId: string): AgentSession | undefined;
+	/**
+	 * Optional: inject a message directly into a node agent sub-session by its session ID.
+	 * Required for @mention routing to specific agents.
+	 */
+	injectSubSessionMessage?(subSessionId: string, message: string): Promise<void>;
 }
 
 /**
@@ -42,7 +78,8 @@ export function setupSpaceTaskMessageHandlers(
 	messageHub: MessageHub,
 	taskAgentManager: TaskAgentManagerInterface,
 	db: Database,
-	daemonHub: DaemonHub
+	daemonHub: DaemonHub,
+	nodeExecutionRepo?: NodeExecutionLookup
 ): void {
 	const taskRepo = new SpaceTaskRepository(db.getDatabase());
 
@@ -110,6 +147,58 @@ export function setupSpaceTaskMessageHandlers(
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
 
+		// ── @mention routing ──────────────────────────────────────────────────────
+		// If the message contains @AgentName patterns AND the task is linked to a
+		// workflow run, route directly to the matched node agent sessions.
+		const mentions = parseMentions(params.message);
+
+		if (
+			mentions.length > 0 &&
+			task.workflowRunId &&
+			nodeExecutionRepo &&
+			taskAgentManager.injectSubSessionMessage
+		) {
+			const executions = nodeExecutionRepo.listByWorkflowRun(task.workflowRunId);
+			const activeAgents = executions.filter((e) => e.agentSessionId !== null);
+
+			const routedTo: string[] = [];
+			const notFound: string[] = [];
+
+			for (const mention of mentions) {
+				const matches = activeAgents.filter(
+					(e) => e.agentName.toLowerCase() === mention.toLowerCase()
+				);
+				if (matches.length === 0) {
+					notFound.push(mention);
+				} else {
+					for (const exec of matches) {
+						await taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, params.message);
+						if (!routedTo.includes(mention)) routedTo.push(mention);
+					}
+				}
+			}
+
+			if (routedTo.length === 0) {
+				// No mentions resolved — throw with available agent names
+				const available = [...new Set(activeAgents.map((e) => e.agentName))].sort();
+				throw new Error(
+					`@mention not found: ${notFound.join(', ')}. Available agents: ${available.length > 0 ? available.join(', ') : 'none'}`
+				);
+			}
+
+			log.info(
+				`space.task.sendMessage: @mention routing to [${routedTo.join(', ')}] for task ${params.taskId}`
+			);
+
+			return {
+				ok: true,
+				routedTo,
+				...(notFound.length > 0 ? { notFound } : {}),
+			};
+		}
+		// ── end @mention routing ───────────────────────────────────────────────────
+
+		// No @mentions (or routing prerequisites not met): route to Task Agent
 		// Ensure a live Task Agent session exists before injecting. This recovers from:
 		// - first message on a task that has not spawned yet
 		// - persisted-but-not-live sessions after daemon restart

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
@@ -16,7 +16,9 @@ import type { SpaceTask } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import {
 	setupSpaceTaskMessageHandlers,
+	parseMentions,
 	type TaskAgentManagerInterface,
+	type NodeExecutionLookup,
 } from '../../../src/lib/rpc-handlers/space-task-message-handlers';
 import type { Database } from '../../../src/storage/database';
 import type { AgentSession } from '../../../src/lib/agent/agent-session';
@@ -136,7 +138,7 @@ function createMockDatabase(
 						depends_on: '[]',
 						task_agent_session_id: task.taskAgentSessionId ?? null,
 						workflow_node_id: null,
-						workflow_run_id: null,
+						workflow_run_id: task.workflowRunId ?? null,
 						result: null,
 						error: null,
 						archived_at: null,
@@ -601,6 +603,197 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			await expect(
 				call('space.task.getMessages', { spaceId: 'space-1', taskId: 'task-2' })
 			).rejects.toThrow('Task Agent session not started for task: task-2');
+		});
+	});
+
+	// ─── @mention routing ─────────────────────────────────────────────────────────
+
+	describe('@mention routing in space.task.sendMessage', () => {
+		// Mock NodeExecutionLookup
+		function makeNodeExecutionRepo(
+			agents: Array<{ agentName: string; agentSessionId: string | null }>
+		): NodeExecutionLookup {
+			return {
+				listByWorkflowRun: mock(() => agents),
+			};
+		}
+
+		// Task with a workflowRunId set
+		const mockTaskWithWorkflowRun: SpaceTask = {
+			...mockTaskWithSession,
+			workflowRunId: 'run-abc-123',
+		};
+
+		function setupWithMention(
+			nodeExecAgents: Array<{ agentName: string; agentSessionId: string | null }>,
+			task: SpaceTask = mockTaskWithWorkflowRun
+		) {
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			const injectSubSession = mock(async (_sid: string, _msg: string) => {});
+			taskAgentManager = {
+				...createMockTaskAgentManager(null, task),
+				injectSubSessionMessage: injectSubSession,
+			};
+			db = createMockDatabase(task);
+			daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+			const nodeExecutionRepo = makeNodeExecutionRepo(nodeExecAgents);
+			setupSpaceTaskMessageHandlers(hub, taskAgentManager, db, daemonHub, nodeExecutionRepo);
+			return { injectSubSession };
+		}
+
+		it('single @mention routes to the matched agent session', async () => {
+			const { injectSubSession } = setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-1' },
+				{ agentName: 'Reviewer', agentSessionId: 'session-reviewer-1' },
+			]);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@Coder please fix the bug',
+			});
+
+			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
+			expect(injectSubSession).toHaveBeenCalledTimes(1);
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-1', '@Coder please fix the bug');
+			// Should NOT have routed to Task Agent
+			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
+		});
+
+		it('multiple @mentions route to all mentioned agents', async () => {
+			const { injectSubSession } = setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-1' },
+				{ agentName: 'Reviewer', agentSessionId: 'session-reviewer-1' },
+				{ agentName: 'Planner', agentSessionId: 'session-planner-1' },
+			]);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@Coder and @Reviewer please coordinate',
+			});
+
+			expect(result).toMatchObject({ ok: true });
+			const res = result as { routedTo: string[] };
+			expect(res.routedTo).toHaveLength(2);
+			expect(res.routedTo).toContain('Coder');
+			expect(res.routedTo).toContain('Reviewer');
+			expect(injectSubSession).toHaveBeenCalledTimes(2);
+			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
+		});
+
+		it('invalid @mention throws error listing available agents', async () => {
+			setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-1' },
+				{ agentName: 'Reviewer', agentSessionId: 'session-reviewer-1' },
+			]);
+
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: '@Ghost please do something',
+				})
+			).rejects.toThrow('@mention not found: Ghost');
+			// Error message should list available agents
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: '@Ghost please do something',
+				})
+			).rejects.toThrow('Coder, Reviewer');
+		});
+
+		it('ambiguous @mention (multiple agents with same name) routes to all matching sessions', async () => {
+			const { injectSubSession } = setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-1' },
+				{ agentName: 'Coder', agentSessionId: 'session-coder-2' }, // same name, two sessions
+			]);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@Coder please check both',
+			});
+
+			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
+			// Should have injected into both Coder sessions
+			expect(injectSubSession).toHaveBeenCalledTimes(2);
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-1', '@Coder please check both');
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-2', '@Coder please check both');
+		});
+
+		it('partial routing: valid mentions route, invalid mentions listed in notFound', async () => {
+			const { injectSubSession } = setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-1' },
+			]);
+
+			const result = (await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@Coder and @Ghost please help',
+			})) as { ok: boolean; routedTo: string[]; notFound: string[] };
+
+			expect(result.ok).toBe(true);
+			expect(result.routedTo).toEqual(['Coder']);
+			expect(result.notFound).toEqual(['Ghost']);
+			expect(injectSubSession).toHaveBeenCalledTimes(1);
+		});
+
+		it('case-insensitive @mention matching', async () => {
+			const { injectSubSession } = setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-1' },
+			]);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@coder please fix', // lowercase mention, mixed-case agent name
+			});
+
+			expect(result).toMatchObject({ ok: true, routedTo: ['coder'] });
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-1', '@coder please fix');
+		});
+
+		it('message without @mentions falls back to Task Agent routing', async () => {
+			const { injectSubSession } = setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-1' },
+			]);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please continue the work',
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(injectSubSession).not.toHaveBeenCalled();
+			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith(
+				'task-1',
+				'Please continue the work'
+			);
+		});
+
+		it('@mention falls back to Task Agent when task has no workflowRunId', async () => {
+			const taskWithoutRun: SpaceTask = { ...mockTaskWithSession, workflowRunId: undefined };
+			const { injectSubSession } = setupWithMention(
+				[{ agentName: 'Coder', agentSessionId: 'session-coder-1' }],
+				taskWithoutRun
+			);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@Coder please help',
+			});
+
+			// Falls back to Task Agent since no workflowRunId
+			expect(result).toEqual({ ok: true });
+			expect(injectSubSession).not.toHaveBeenCalled();
+			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
@@ -609,12 +609,14 @@ describe('setupSpaceTaskMessageHandlers', () => {
 	// ─── @mention routing ─────────────────────────────────────────────────────────
 
 	describe('@mention routing in space.task.sendMessage', () => {
-		// Mock NodeExecutionLookup
+		// Mock NodeExecutionLookup — includes status field (required by NodeExecutionLookup interface)
 		function makeNodeExecutionRepo(
-			agents: Array<{ agentName: string; agentSessionId: string | null }>
+			agents: Array<{ agentName: string; agentSessionId: string | null; status?: string }>
 		): NodeExecutionLookup {
 			return {
-				listByWorkflowRun: mock(() => agents),
+				listByWorkflowRun: mock(() =>
+					agents.map((a) => ({ ...a, status: a.status ?? 'in_progress' }))
+				),
 			};
 		}
 
@@ -625,7 +627,7 @@ describe('setupSpaceTaskMessageHandlers', () => {
 		};
 
 		function setupWithMention(
-			nodeExecAgents: Array<{ agentName: string; agentSessionId: string | null }>,
+			nodeExecAgents: Array<{ agentName: string; agentSessionId: string | null; status?: string }>,
 			task: SpaceTask = mockTaskWithWorkflowRun
 		) {
 			const mh = createMockMessageHub();
@@ -795,5 +797,124 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(injectSubSession).not.toHaveBeenCalled();
 			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalled();
 		});
+
+		it('does not route to done/cancelled/blocked agents — excludes completed sessions', async () => {
+			const { injectSubSession } = setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-done', status: 'done' },
+				{ agentName: 'Coder', agentSessionId: 'session-coder-cancelled', status: 'cancelled' },
+				{ agentName: 'Coder', agentSessionId: 'session-coder-blocked', status: 'blocked' },
+				{ agentName: 'Coder', agentSessionId: 'session-coder-active', status: 'in_progress' },
+			]);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@Coder please check',
+			});
+
+			// Only the in_progress session should receive the message
+			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
+			expect(injectSubSession).toHaveBeenCalledTimes(1);
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-active', '@Coder please check');
+			expect(injectSubSession).not.toHaveBeenCalledWith('session-coder-done', expect.anything());
+		});
+
+		it('@mention throws when all matching agents are in terminal status', async () => {
+			setupWithMention([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-done', status: 'done' },
+			]);
+
+			// Coder exists but is done — should be treated as unavailable
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: '@Coder please help',
+				})
+			).rejects.toThrow('@mention not found: Coder');
+		});
+
+		it('propagates error when injectSubSessionMessage throws', async () => {
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			const injectSubSession = mock(async (_sid: string, _msg: string) => {
+				throw new Error('Sub-session not found: session-coder-1');
+			});
+			taskAgentManager = {
+				...createMockTaskAgentManager(null, mockTaskWithWorkflowRun),
+				injectSubSessionMessage: injectSubSession,
+			};
+			db = createMockDatabase(mockTaskWithWorkflowRun);
+			daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+			const nodeExecutionRepo = makeNodeExecutionRepo([
+				{ agentName: 'Coder', agentSessionId: 'session-coder-1', status: 'in_progress' },
+			]);
+			setupSpaceTaskMessageHandlers(hub, taskAgentManager, db, daemonHub, nodeExecutionRepo);
+
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: '@Coder please help',
+				})
+			).rejects.toThrow('Sub-session not found: session-coder-1');
+		});
+	});
+});
+
+// ─── parseMentions unit tests ────────────────────────────────────────────────
+
+describe('parseMentions', () => {
+	it('extracts a single @mention', () => {
+		expect(parseMentions('@Coder please fix')).toEqual(['Coder']);
+	});
+
+	it('extracts multiple distinct @mentions', () => {
+		expect(parseMentions('@Coder and @Reviewer please coordinate')).toEqual(['Coder', 'Reviewer']);
+	});
+
+	it('deduplicates repeated @mentions', () => {
+		expect(parseMentions('@Coder can you help @Coder')).toEqual(['Coder']);
+	});
+
+	it('preserves original casing', () => {
+		expect(parseMentions('@CodeReviewer hello')).toEqual(['CodeReviewer']);
+	});
+
+	it('returns empty array when no @mentions', () => {
+		expect(parseMentions('please fix the bug')).toEqual([]);
+	});
+
+	it('returns empty array for empty string', () => {
+		expect(parseMentions('')).toEqual([]);
+	});
+
+	it('returns empty array for bare @ with no name', () => {
+		expect(parseMentions('@ hello')).toEqual([]);
+	});
+
+	it('does not extract names starting with a digit after @', () => {
+		// @123bot: starts with digit — should not match
+		expect(parseMentions('@123bot hello')).toEqual([]);
+	});
+
+	it('handles @mention with hyphens and underscores', () => {
+		expect(parseMentions('@code-reviewer and @qa_agent')).toEqual(['code-reviewer', 'qa_agent']);
+	});
+
+	it('email false-positive: extracts @domain from emails (known limitation, degrades gracefully)', () => {
+		// @mention regex cannot distinguish emails; user@example.com extracts 'example'
+		// This is acceptable since unmatched mentions end up in notFound, not silently injected
+		const result = parseMentions('contact user@example.com for help');
+		expect(result).toEqual(['example']);
+	});
+
+	it('@mention at start of string', () => {
+		expect(parseMentions('@Planner start the task')).toEqual(['Planner']);
+	});
+
+	it('ignores @mention followed by a digit-only suffix when the name still starts with a letter', () => {
+		expect(parseMentions('@Coder1 hello')).toEqual(['Coder1']);
 	});
 });


### PR DESCRIPTION
Parse `@AgentName` patterns from `space.task.sendMessage` and route directly to matched node agent sessions, bypassing the Task Agent. Falls back to Task Agent when no @mentions are present or the task has no `workflowRunId`.

Key additions:
- `parseMentions()` utility: deduplicates, case-preserving regex extraction of `@Name` patterns
- `NodeExecutionLookup` interface: minimal abstraction for resolving @mention targets
- `injectSubSessionMessage?` optional method on `TaskAgentManagerInterface`
- @mention routing block in `space.task.sendMessage` with partial routing support (valid mentions route, invalid listed in `notFound`)
- 8 new unit tests covering single/multiple mentions, invalid mentions, ambiguous names, partial routing, case-insensitivity, and fallback paths