### PR TITLE
feat: activity members list in SpaceTaskPane with overlay click

### DIFF
--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceAgent } from '../../lib/router';
 import { spaceOverlaySessionIdSignal, spaceOverlayAgentNameSignal } from '../../lib/signals';
-import type { SpaceTaskPriority, SpaceTaskStatus } from '@neokai/shared';
+import type {
+	SpaceTaskActivityMember,
+	SpaceTaskActivityState,
+	SpaceTaskPriority,
+	SpaceTaskStatus,
+} from '@neokai/shared';
 import { cn } from '../../lib/utils';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
@@ -30,6 +35,84 @@ const PRIORITY_LABELS: Record<SpaceTaskPriority, string> = {
 	urgent: 'Urgent',
 };
 
+const ACTIVITY_STATE_LABELS: Record<SpaceTaskActivityState, string> = {
+	active: 'Active',
+	queued: 'Queued',
+	idle: 'Idle',
+	waiting_for_input: 'Waiting',
+	completed: 'Done',
+	failed: 'Failed',
+	interrupted: 'Interrupted',
+};
+
+function activityStateDotClass(state: SpaceTaskActivityState): string {
+	switch (state) {
+		case 'active':
+			return 'bg-green-400 animate-pulse';
+		case 'queued':
+			return 'bg-amber-400';
+		case 'idle':
+			return 'bg-gray-500';
+		case 'waiting_for_input':
+			return 'bg-blue-400';
+		case 'completed':
+			return 'bg-gray-600';
+		case 'failed':
+			return 'bg-red-400';
+		case 'interrupted':
+			return 'bg-yellow-400';
+	}
+}
+
+function ActivityMemberList({
+	members,
+	taskId,
+}: {
+	members: SpaceTaskActivityMember[];
+	taskId: string;
+}) {
+	if (members.length === 0) return null;
+
+	const handleMemberClick = (member: SpaceTaskActivityMember) => {
+		spaceOverlayAgentNameSignal.value = member.label;
+		spaceOverlaySessionIdSignal.value = member.sessionId;
+	};
+
+	return (
+		<div
+			class="px-4 py-2 border-b border-dark-800"
+			data-testid="activity-members-list"
+			data-task-id={taskId}
+		>
+			<p class="text-xs text-gray-500 mb-1.5">Agents</p>
+			<div class="flex flex-wrap gap-1.5">
+				{members.map((member) => (
+					<button
+						key={member.id}
+						type="button"
+						onClick={() => handleMemberClick(member)}
+						class="flex items-center gap-1.5 px-2 py-1 rounded text-xs font-medium bg-dark-800 hover:bg-dark-700 text-gray-300 hover:text-gray-100 transition-colors"
+						data-testid="activity-member-item"
+						data-member-id={member.id}
+						data-member-state={member.state}
+						title={`${member.label} — ${ACTIVITY_STATE_LABELS[member.state]}`}
+					>
+						<span
+							class={cn(
+								'inline-block w-1.5 h-1.5 rounded-full flex-shrink-0',
+								activityStateDotClass(member.state)
+							)}
+							data-testid="activity-member-state-dot"
+						/>
+						<span class="truncate max-w-[10rem]">{member.label}</span>
+						<span class="text-gray-500 text-[10px]">{ACTIVITY_STATE_LABELS[member.state]}</span>
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}
+
 function formatTaskThreadError(err: unknown): string {
 	const message = err instanceof Error ? err.message : String(err);
 	if (message.includes('No handler for method: space.task.ensureAgentSession')) {
@@ -48,6 +131,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const tasks = spaceStore.tasks.value;
 	const task = taskId ? (tasks.find((t) => t.id === taskId) ?? null) : null;
 	const runtimeSpaceIdCandidate = task?.spaceId ?? spaceId;
+	const activityMembers: SpaceTaskActivityMember[] = taskId
+		? (spaceStore.taskActivity.value.get(taskId) ?? [])
+		: [];
 
 	const [threadSessionId, setThreadSessionId] = useState<string | null>(null);
 	const [ensuringThread, setEnsuringThread] = useState(false);
@@ -61,6 +147,16 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		setThreadSendError(null);
 		setThreadDraft('');
 		setShowArtifacts(false);
+	}, [taskId]);
+
+	useEffect(() => {
+		if (!taskId) return;
+		spaceStore.subscribeTaskActivity(taskId).catch(() => {
+			// Ignore subscription errors — activity list is best-effort
+		});
+		return () => {
+			spaceStore.unsubscribeTaskActivity(taskId);
+		};
 	}, [taskId]);
 
 	useEffect(() => {
@@ -237,6 +333,10 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					)}
 				</div>
 			</div>
+
+			{activityMembers.length > 0 && (
+				<ActivityMemberList members={activityMembers} taskId={task.id} />
+			)}
 
 			{task.status === 'blocked' && task.result && (
 				<div

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -593,6 +593,14 @@ describe('SpaceTaskPane — activity members list', () => {
 		expect(mockSubscribeTaskActivity).not.toHaveBeenCalled();
 	});
 
+	it('calls unsubscribeTaskActivity on unmount', async () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		const { unmount } = render(<SpaceTaskPane taskId="task-1" />);
+		await waitFor(() => expect(mockSubscribeTaskActivity).toHaveBeenCalledWith('task-1'));
+		unmount();
+		expect(mockUnsubscribeTaskActivity).toHaveBeenCalledWith('task-1');
+	});
+
 	it('shows only members for the current task (not other tasks)', () => {
 		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
 		mockTaskActivity.value = new Map([

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -2,7 +2,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
-import type { SpaceAgent, SpaceTask, SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
+import type {
+	SpaceAgent,
+	SpaceTask,
+	SpaceTaskActivityMember,
+	SpaceWorkflow,
+	SpaceWorkflowRun,
+} from '@neokai/shared';
 
 const { mockNavigateToSpaceAgent } = vi.hoisted(() => ({ mockNavigateToSpaceAgent: vi.fn() }));
 vi.mock('../../../lib/router', () => ({
@@ -31,10 +37,13 @@ let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
 let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
 let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
+let mockTaskActivity: ReturnType<typeof signal<Map<string, SpaceTaskActivityMember[]>>>;
 
 const mockUpdateTask = vi.fn().mockResolvedValue(undefined);
 const mockEnsureTaskAgentSession = vi.fn();
 const mockSendTaskMessage = vi.fn().mockResolvedValue(undefined);
+const mockSubscribeTaskActivity = vi.fn().mockResolvedValue(undefined);
+const mockUnsubscribeTaskActivity = vi.fn();
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
@@ -43,9 +52,12 @@ vi.mock('../../../lib/space-store', () => ({
 			agents: mockAgents,
 			workflows: mockWorkflows,
 			workflowRuns: mockWorkflowRuns,
+			taskActivity: mockTaskActivity,
 			updateTask: mockUpdateTask,
 			ensureTaskAgentSession: mockEnsureTaskAgentSession,
 			sendTaskMessage: mockSendTaskMessage,
+			subscribeTaskActivity: mockSubscribeTaskActivity,
+			unsubscribeTaskActivity: mockUnsubscribeTaskActivity,
 		};
 	},
 }));
@@ -64,6 +76,7 @@ mockTasks = signal<SpaceTask[]>([]);
 mockAgents = signal<SpaceAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
 mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
+mockTaskActivity = signal<Map<string, SpaceTaskActivityMember[]>>(new Map());
 
 import { SpaceTaskPane } from '../SpaceTaskPane';
 
@@ -89,6 +102,7 @@ describe('SpaceTaskPane', () => {
 		mockAgents.value = [];
 		mockWorkflows.value = [];
 		mockWorkflowRuns.value = [];
+		mockTaskActivity.value = new Map();
 		mockUpdateTask.mockClear();
 		mockEnsureTaskAgentSession.mockReset();
 		mockEnsureTaskAgentSession.mockImplementation(async () =>
@@ -96,6 +110,8 @@ describe('SpaceTaskPane', () => {
 		);
 		mockSendTaskMessage.mockClear();
 		mockNavigateToSpaceAgent.mockClear();
+		mockSubscribeTaskActivity.mockClear();
+		mockUnsubscribeTaskActivity.mockClear();
 		mockSpaceOverlaySessionIdSignal.value = null;
 		mockSpaceOverlayAgentNameSignal.value = null;
 	});
@@ -396,5 +412,196 @@ describe('SpaceTaskPane — blocked reason banner', () => {
 		];
 		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
 		expect(getByTestId('task-status-label').textContent).toBe('Blocked');
+	});
+});
+
+function makeActivityMember(
+	overrides: Partial<SpaceTaskActivityMember> = {}
+): SpaceTaskActivityMember {
+	return {
+		id: 'member-1',
+		sessionId: 'session-member-1',
+		kind: 'task_agent',
+		label: 'Task Agent',
+		role: 'task-agent',
+		state: 'active',
+		messageCount: 3,
+		...overrides,
+	};
+}
+
+describe('SpaceTaskPane — activity members list', () => {
+	beforeEach(() => {
+		cleanup();
+		mockTasks.value = [];
+		mockTaskActivity.value = new Map();
+		mockEnsureTaskAgentSession.mockReset();
+		mockEnsureTaskAgentSession.mockImplementation(async () =>
+			makeTask({ status: 'in_progress', taskAgentSessionId: 'session-ensured' })
+		);
+		mockSubscribeTaskActivity.mockClear();
+		mockUnsubscribeTaskActivity.mockClear();
+		mockSpaceOverlaySessionIdSignal.value = null;
+		mockSpaceOverlayAgentNameSignal.value = null;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('hides members list when no activity members exist', () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(queryByTestId('activity-members-list')).toBeNull();
+	});
+
+	it('renders all activity members', () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		mockTaskActivity.value = new Map([
+			[
+				'task-1',
+				[
+					makeActivityMember({
+						id: 'm1',
+						sessionId: 'sess-1',
+						label: 'Task Agent',
+						state: 'active',
+					}),
+					makeActivityMember({
+						id: 'm2',
+						sessionId: 'sess-2',
+						label: 'Coder',
+						kind: 'node_agent',
+						state: 'queued',
+					}),
+					makeActivityMember({
+						id: 'm3',
+						sessionId: 'sess-3',
+						label: 'Reviewer',
+						kind: 'node_agent',
+						state: 'idle',
+					}),
+				],
+			],
+		]);
+		const { getByTestId, getAllByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByTestId('activity-members-list')).toBeTruthy();
+		const items = getAllByTestId('activity-member-item');
+		expect(items.length).toBe(3);
+		expect(items[0].textContent).toContain('Task Agent');
+		expect(items[1].textContent).toContain('Coder');
+		expect(items[2].textContent).toContain('Reviewer');
+	});
+
+	it('shows correct state labels for each activity state', () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		mockTaskActivity.value = new Map([
+			[
+				'task-1',
+				[
+					makeActivityMember({ id: 'm1', label: 'Agent 1', state: 'active' }),
+					makeActivityMember({ id: 'm2', label: 'Agent 2', state: 'queued' }),
+					makeActivityMember({ id: 'm3', label: 'Agent 3', state: 'idle' }),
+					makeActivityMember({ id: 'm4', label: 'Agent 4', state: 'waiting_for_input' }),
+					makeActivityMember({ id: 'm5', label: 'Agent 5', state: 'completed' }),
+					makeActivityMember({ id: 'm6', label: 'Agent 6', state: 'failed' }),
+					makeActivityMember({ id: 'm7', label: 'Agent 7', state: 'interrupted' }),
+				],
+			],
+		]);
+		const { getAllByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		const items = getAllByTestId('activity-member-item');
+		expect(items[0].getAttribute('data-member-state')).toBe('active');
+		expect(items[0].textContent).toContain('Active');
+		expect(items[1].getAttribute('data-member-state')).toBe('queued');
+		expect(items[1].textContent).toContain('Queued');
+		expect(items[2].getAttribute('data-member-state')).toBe('idle');
+		expect(items[2].textContent).toContain('Idle');
+		expect(items[3].getAttribute('data-member-state')).toBe('waiting_for_input');
+		expect(items[3].textContent).toContain('Waiting');
+		expect(items[4].getAttribute('data-member-state')).toBe('completed');
+		expect(items[4].textContent).toContain('Done');
+		expect(items[5].getAttribute('data-member-state')).toBe('failed');
+		expect(items[5].textContent).toContain('Failed');
+		expect(items[6].getAttribute('data-member-state')).toBe('interrupted');
+		expect(items[6].textContent).toContain('Interrupted');
+	});
+
+	it('clicking a member opens overlay chat with the correct session ID and label', () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		mockTaskActivity.value = new Map([
+			[
+				'task-1',
+				[
+					makeActivityMember({
+						id: 'm1',
+						sessionId: 'sess-coder',
+						label: 'Coder Agent',
+						state: 'active',
+					}),
+				],
+			],
+		]);
+		const { getAllByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		const item = getAllByTestId('activity-member-item')[0];
+		fireEvent.click(item);
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-coder');
+		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Coder Agent');
+	});
+
+	it('clicking different members opens overlay with their respective sessions', () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		mockTaskActivity.value = new Map([
+			[
+				'task-1',
+				[
+					makeActivityMember({
+						id: 'm1',
+						sessionId: 'sess-planner',
+						label: 'Planner',
+						state: 'completed',
+					}),
+					makeActivityMember({
+						id: 'm2',
+						sessionId: 'sess-reviewer',
+						label: 'Reviewer',
+						state: 'active',
+					}),
+				],
+			],
+		]);
+		const { getAllByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		const items = getAllByTestId('activity-member-item');
+
+		fireEvent.click(items[0]);
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-planner');
+		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Planner');
+
+		fireEvent.click(items[1]);
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-reviewer');
+		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Reviewer');
+	});
+
+	it('calls subscribeTaskActivity when a taskId is provided', async () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		render(<SpaceTaskPane taskId="task-1" />);
+		await waitFor(() => expect(mockSubscribeTaskActivity).toHaveBeenCalledWith('task-1'));
+	});
+
+	it('does not call subscribeTaskActivity when taskId is null', () => {
+		render(<SpaceTaskPane taskId={null} />);
+		expect(mockSubscribeTaskActivity).not.toHaveBeenCalled();
+	});
+
+	it('shows only members for the current task (not other tasks)', () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		mockTaskActivity.value = new Map([
+			['task-1', [makeActivityMember({ id: 'm1', label: 'Task 1 Agent', state: 'active' })]],
+			['task-2', [makeActivityMember({ id: 'm2', label: 'Task 2 Agent', state: 'idle' })]],
+		]);
+		const { getAllByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		const items = getAllByTestId('activity-member-item');
+		expect(items.length).toBe(1);
+		expect(items[0].textContent).toContain('Task 1 Agent');
 	});
 });


### PR DESCRIPTION
Implements the activity members list in the task pane header (Milestone 4, happy paths 6 & 7).

- Adds a compact agents bar between the task header and content showing all `task_agent` and `node_agent` members
- Each member shows a colored state dot: green/pulsing=active, amber=queued, gray=idle, blue=waiting, muted=completed, red=failed, yellow=interrupted
- Clicking any member sets `spaceOverlaySessionIdSignal` + `spaceOverlayAgentNameSignal` to open the AgentOverlayChat panel (same overlay from Task 4.2)
- Subscribes to `spaceStore.taskActivity` live query on mount, unsubscribes on unmount/task change (best-effort, errors silently ignored)
- Adds 7 new Vitest tests: empty state hides list, renders all members, all 7 state labels correct, click-to-overlay with correct sessionId/label, multi-member click switching, subscribe called with correct taskId, per-task isolation