### PR TITLE
feat: add canvas mode toggle button to task view

### DIFF
--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -3,6 +3,7 @@ import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceAgent } from '../../lib/router';
 import { spaceOverlaySessionIdSignal, spaceOverlayAgentNameSignal } from '../../lib/signals';
 import type {
+	SpaceTask,
 	SpaceTaskActivityMember,
 	SpaceTaskActivityState,
 	SpaceTaskPriority,
@@ -13,6 +14,7 @@ import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { TaskStatusActions } from './TaskStatusActions';
 import MentionAutocomplete from './MentionAutocomplete';
+import { WorkflowCanvas } from './WorkflowCanvas';
 
 interface SpaceTaskPaneProps {
 	taskId: string | null;
@@ -143,6 +145,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [sendingThread, setSendingThread] = useState(false);
 	const [statusTransitioning, setStatusTransitioning] = useState(false);
 	const [showArtifacts, setShowArtifacts] = useState(false);
+	const [showCanvas, setShowCanvas] = useState(false);
 	const [mentionQuery, setMentionQuery] = useState<string | null>(null);
 	const [mentionSelectedIndex, setMentionSelectedIndex] = useState(0);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -207,6 +210,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		setThreadSendError(null);
 		setThreadDraft('');
 		setShowArtifacts(false);
+		setShowCanvas(false);
 	}, [taskId]);
 
 	useEffect(() => {
@@ -273,6 +277,13 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 
 	const runtimeSpaceId = spaceId ?? task.spaceId;
 	const agentSessionId = task.taskAgentSessionId ?? threadSessionId;
+
+	// Resolve workflowId from the active run for canvas mode
+	const workflowRun = task.workflowRunId
+		? (spaceStore.workflowRuns.value.find((r) => r.id === task.workflowRunId) ?? null)
+		: null;
+	const canvasWorkflowId = workflowRun?.workflowId ?? null;
+
 	const isTerminalTask =
 		task.status === 'done' || task.status === 'cancelled' || task.status === 'archived';
 	const showInlineComposer = !!agentSessionId && !isTerminalTask;
@@ -288,6 +299,19 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				: agentSessionId
 					? 'View Agent Session'
 					: 'Open Space Agent';
+
+	const handleNodeClick = (nodeId: string, nodeTasks: SpaceTask[]) => {
+		// Find the first task for this node that has an agent session open
+		const nodeTask = nodeTasks.find((t) => t.taskAgentSessionId);
+		if (nodeTask?.taskAgentSessionId) {
+			spaceOverlayAgentNameSignal.value = nodeTask.title ?? `Node ${nodeId}`;
+			spaceOverlaySessionIdSignal.value = nodeTask.taskAgentSessionId;
+		} else if (agentSessionId) {
+			// Fall back to the task agent session
+			spaceOverlayAgentNameSignal.value = agentActionLabel;
+			spaceOverlaySessionIdSignal.value = agentSessionId;
+		}
+	};
 
 	const handleThreadSend = async (e: Event) => {
 		e.preventDefault();
@@ -358,10 +382,32 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							)}
 						</div>
 					</div>
+					{task.workflowRunId && canvasWorkflowId && (
+						<button
+							type="button"
+							onClick={() => {
+								setShowCanvas((v) => !v);
+								setShowArtifacts(false);
+							}}
+							class={cn(
+								'flex-shrink-0 px-2 py-1 text-xs font-medium transition-colors',
+								showCanvas
+									? 'text-blue-300 hover:text-blue-200'
+									: 'text-gray-400 hover:text-gray-200'
+							)}
+							data-testid="canvas-toggle"
+							aria-pressed={showCanvas}
+						>
+							Canvas
+						</button>
+					)}
 					{task.workflowRunId && (
 						<button
 							type="button"
-							onClick={() => setShowArtifacts((v) => !v)}
+							onClick={() => {
+								setShowArtifacts((v) => !v);
+								setShowCanvas(false);
+							}}
 							class={cn(
 								'flex-shrink-0 px-2 py-1 text-xs font-medium transition-colors',
 								showArtifacts
@@ -409,7 +455,17 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			)}
 
 			<div class="flex-1 min-h-0 overflow-hidden px-4">
-				{showArtifacts && task.workflowRunId ? (
+				{showCanvas && task.workflowRunId && canvasWorkflowId ? (
+					<div class="h-full" data-testid="canvas-view">
+						<WorkflowCanvas
+							workflowId={canvasWorkflowId}
+							runId={task.workflowRunId}
+							spaceId={runtimeSpaceId ?? task.spaceId}
+							onNodeClick={agentSessionId ? handleNodeClick : undefined}
+							class="h-full"
+						/>
+					</div>
+				) : showArtifacts && task.workflowRunId ? (
 					<TaskArtifactsPanel
 						runId={task.workflowRunId}
 						onClose={() => setShowArtifacts(false)}

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -604,6 +604,7 @@ interface NodeBoxProps {
 	status: NodeStatus;
 	tasks: SpaceTask[];
 	isRuntimeMode: boolean;
+	onNodeClick?: (nodeId: string, tasks: SpaceTask[]) => void;
 }
 
 function NodeBox({
@@ -612,6 +613,7 @@ function NodeBox({
 	status,
 	tasks,
 	isRuntimeMode: _isRuntimeMode,
+	onNodeClick,
 }: NodeBoxProps): JSX.Element {
 	const { x, y, width, height } = layout;
 
@@ -715,7 +717,12 @@ function NodeBox({
 	const agentLabel = agentCount > 1 ? `×${agentCount}` : null;
 
 	return (
-		<g data-testid={`node-${node.id}`} class={status === 'active' ? pulseClass : undefined}>
+		<g
+			data-testid={`node-${node.id}`}
+			class={status === 'active' ? pulseClass : undefined}
+			style={onNodeClick ? { cursor: 'pointer' } : undefined}
+			onClick={onNodeClick ? () => onNodeClick(node.id, tasks) : undefined}
+		>
 			{/* Shadow */}
 			<rect x={x + 2} y={y + 2} width={width} height={height} rx={6} fill="rgba(0,0,0,0.4)" />
 			{/* Main box */}
@@ -932,6 +939,12 @@ export interface WorkflowCanvasProps {
 	spaceId: string;
 	/** Optional additional class name */
 	class?: string;
+	/**
+	 * Optional callback fired when a workflow node box is clicked.
+	 * Receives the node ID and the tasks currently associated with that node.
+	 * Only available in runtime mode when `runId` is provided.
+	 */
+	onNodeClick?: (nodeId: string, tasks: SpaceTask[]) => void;
 }
 
 export function WorkflowCanvas({
@@ -939,6 +952,7 @@ export function WorkflowCanvas({
 	runId,
 	spaceId,
 	class: className,
+	onNodeClick,
 }: WorkflowCanvasProps): JSX.Element {
 	const isRuntimeMode = !!runId;
 
@@ -1318,6 +1332,7 @@ export function WorkflowCanvas({
 							status={status}
 							tasks={nodeTasks}
 							isRuntimeMode={isRuntimeMode}
+							onNodeClick={isRuntimeMode ? onNodeClick : undefined}
 						/>
 					);
 				})}

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -62,10 +62,57 @@ vi.mock('../../../lib/space-store', () => ({
 	},
 }));
 
+function makeWorkflowRun(overrides: Partial<SpaceWorkflowRun> = {}): SpaceWorkflowRun {
+	return {
+		id: 'run-1',
+		spaceId: 'space-1',
+		workflowId: 'workflow-1',
+		title: 'Test Run',
+		status: 'in_progress',
+		startedAt: Date.now(),
+		completedAt: null,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
 vi.mock('../SpaceTaskUnifiedThread', () => ({
 	SpaceTaskUnifiedThread: ({ taskId }: { taskId: string }) => (
 		<div data-testid="space-task-unified-thread" data-task-id={taskId} />
 	),
+}));
+
+const { mockWorkflowCanvasOnNodeClick } = vi.hoisted(() => ({
+	mockWorkflowCanvasOnNodeClick: vi.fn(),
+}));
+
+vi.mock('../WorkflowCanvas', () => ({
+	WorkflowCanvas: ({
+		workflowId,
+		runId,
+		spaceId,
+		onNodeClick,
+		class: className,
+	}: {
+		workflowId: string;
+		runId?: string | null;
+		spaceId: string;
+		onNodeClick?: (nodeId: string, tasks: unknown[]) => void;
+		class?: string;
+	}) => {
+		// Expose the onNodeClick for testing
+		mockWorkflowCanvasOnNodeClick.mockImplementation(onNodeClick);
+		return (
+			<div
+				data-testid="workflow-canvas"
+				data-workflow-id={workflowId}
+				data-run-id={runId}
+				data-space-id={spaceId}
+				class={className}
+			/>
+		);
+	},
 }));
 
 vi.mock('../../../lib/utils', () => ({
@@ -114,6 +161,7 @@ describe('SpaceTaskPane', () => {
 		mockUnsubscribeTaskActivity.mockClear();
 		mockSpaceOverlaySessionIdSignal.value = null;
 		mockSpaceOverlayAgentNameSignal.value = null;
+		mockWorkflowCanvasOnNodeClick.mockClear();
 	});
 
 	afterEach(() => {
@@ -350,6 +398,189 @@ describe('SpaceTaskPane — composer', () => {
 		fireEvent.input(textarea, { target: { value: 'Second try' } });
 		fireEvent.click(getByText('Send to Task Agent'));
 		await waitFor(() => expect(queryByText('Temporary error')).toBeNull());
+	});
+});
+
+describe('SpaceTaskPane — canvas toggle', () => {
+	beforeEach(() => {
+		cleanup();
+		mockTasks.value = [];
+		mockWorkflowRuns.value = [];
+		mockEnsureTaskAgentSession.mockReset();
+		mockEnsureTaskAgentSession.mockImplementation(async () =>
+			makeTask({ status: 'in_progress', taskAgentSessionId: 'session-ensured' })
+		);
+		mockWorkflowCanvasOnNodeClick.mockClear();
+		mockSpaceOverlaySessionIdSignal.value = null;
+		mockSpaceOverlayAgentNameSignal.value = null;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('does not show canvas toggle for tasks without workflowRunId', () => {
+		mockTasks.value = [makeTask({ workflowRunId: null })];
+		const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+		expect(queryByTestId('canvas-toggle')).toBeNull();
+	});
+
+	it('does not show canvas toggle for workflow tasks without a matching run in the store', () => {
+		// task has workflowRunId but no run in the store → canvasWorkflowId is null
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1' })];
+		mockWorkflowRuns.value = []; // no matching run
+		const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+		expect(queryByTestId('canvas-toggle')).toBeNull();
+	});
+
+	it('shows canvas toggle for tasks with workflowRunId and a matching run', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+		expect(getByTestId('canvas-toggle')).toBeTruthy();
+	});
+
+	it('clicking canvas toggle switches to canvas view', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId, queryByTestId } = render(
+			<SpaceTaskPane taskId="task-1" spaceId="space-1" />
+		);
+		// Thread view is shown initially
+		expect(queryByTestId('canvas-view')).toBeNull();
+		expect(queryByTestId('task-thread-panel')).toBeTruthy();
+
+		fireEvent.click(getByTestId('canvas-toggle'));
+
+		// Canvas view is now shown
+		expect(getByTestId('canvas-view')).toBeTruthy();
+		expect(getByTestId('workflow-canvas')).toBeTruthy();
+		expect(queryByTestId('task-thread-panel')).toBeNull();
+	});
+
+	it('clicking canvas toggle again switches back to thread view', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId, queryByTestId } = render(
+			<SpaceTaskPane taskId="task-1" spaceId="space-1" />
+		);
+
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(getByTestId('canvas-view')).toBeTruthy();
+
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(queryByTestId('canvas-view')).toBeNull();
+		expect(getByTestId('task-thread-panel')).toBeTruthy();
+	});
+
+	it('canvas view renders WorkflowCanvas with correct run and workflow IDs', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1', spaceId: 'space-1' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'wf-abc' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		fireEvent.click(getByTestId('canvas-toggle'));
+
+		const canvas = getByTestId('workflow-canvas');
+		expect(canvas.getAttribute('data-workflow-id')).toBe('wf-abc');
+		expect(canvas.getAttribute('data-run-id')).toBe('run-1');
+		expect(canvas.getAttribute('data-space-id')).toBe('space-1');
+	});
+
+	it('switching to artifacts view closes canvas view', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId, queryByTestId } = render(
+			<SpaceTaskPane taskId="task-1" spaceId="space-1" />
+		);
+
+		// Open canvas first
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(getByTestId('canvas-view')).toBeTruthy();
+
+		// Open artifacts — should close canvas
+		fireEvent.click(getByTestId('artifacts-toggle'));
+		expect(queryByTestId('canvas-view')).toBeNull();
+	});
+
+	it('canvas toggle aria-pressed reflects current state', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		const btn = getByTestId('canvas-toggle');
+		expect(btn.getAttribute('aria-pressed')).toBe('false');
+
+		fireEvent.click(btn);
+		expect(btn.getAttribute('aria-pressed')).toBe('true');
+	});
+
+	it('canvas node click opens overlay with the task agent session (fallback when no node-level session)', () => {
+		mockTasks.value = [
+			makeTask({
+				workflowRunId: 'run-1',
+				taskAgentSessionId: 'session-task',
+				activeSession: null,
+			}),
+		];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(getByTestId('workflow-canvas')).toBeTruthy();
+
+		// Simulate a node click with no node-specific task sessions — falls back to task session
+		mockWorkflowCanvasOnNodeClick('node-1', []);
+
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('session-task');
+	});
+
+	it('canvas node click opens overlay with the node-specific agent session (primary path)', () => {
+		const nodeTask = makeTask({
+			id: 'node-task-1',
+			title: 'Coder Node',
+			workflowRunId: 'run-1',
+			taskAgentSessionId: 'session-node-agent',
+			activeSession: null,
+		});
+		mockTasks.value = [
+			makeTask({
+				id: 'task-1',
+				workflowRunId: 'run-1',
+				taskAgentSessionId: 'session-task',
+				activeSession: null,
+			}),
+		];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(getByTestId('workflow-canvas')).toBeTruthy();
+
+		// Simulate a node click with a node-level task that has its own agent session
+		mockWorkflowCanvasOnNodeClick('node-1', [nodeTask]);
+
+		// Should use the node task's session, NOT the parent task's session
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('session-node-agent');
+		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Coder Node');
+	});
+
+	it('switching to canvas view closes the artifacts panel', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId, queryByTestId } = render(
+			<SpaceTaskPane taskId="task-1" spaceId="space-1" />
+		);
+
+		// Open artifacts first
+		fireEvent.click(getByTestId('artifacts-toggle'));
+		// Artifacts panel replaces the thread — canvas-view is not shown
+		expect(queryByTestId('canvas-view')).toBeNull();
+
+		// Open canvas — should close artifacts and show canvas
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(getByTestId('canvas-view')).toBeTruthy();
+		// thread panel is not shown when canvas is active
+		expect(queryByTestId('task-thread-panel')).toBeNull();
 	});
 });
 


### PR DESCRIPTION
Add a **Canvas** toggle button to the task pane header that switches between thread view and canvas view for tasks with an active workflow run.

## Changes

- **`SpaceTaskPane`**: Canvas toggle button (next to Artifacts) visible only when the task has a `workflowRunId` with a matching run in the store. Clicking it renders `WorkflowCanvas` in runtime mode. Canvas and Artifacts toggles are mutually exclusive.
- **`WorkflowCanvas`**: New `onNodeClick` prop — clicking a node in canvas mode opens the agent overlay chat via `spaceOverlaySessionIdSignal`.
- **Tests**: 9 new Vitest tests covering toggle visibility rules, view switching, canvas render props, mutual exclusivity, `aria-pressed` state, and node click overlay behavior.

## Acceptance Criteria

- Tasks with workflow runs show Canvas/thread toggle (`data-testid="canvas-toggle"`)
- Canvas mode shows the workflow visualization with active node pulsing
- Clicking a node opens the agent overlay chat
- Canvas container has `data-testid="canvas-view"`
- All 30 tests pass