### PR TITLE
fix(e2e): seed workspace files for FileIndex before server starts

### DIFF
--- a/packages/e2e/global-setup.ts
+++ b/packages/e2e/global-setup.ts
@@ -49,6 +49,10 @@ Or set PLAYWRIGHT_BASE_URL explicitly:
 	// be created. Without a .git directory, WorktreeManager.findGitRoot() returns null,
 	// causing "task requires isolation" errors and daemon log spam during tests.
 	// The workspace path is shared from test-env.ts (same module instance).
+	//
+	// NOTE: Seed files are created in test-env.ts at config evaluation time (before the
+	// webServer starts) because the daemon's FileIndex scans the workspace during server
+	// init, which happens before globalSetup runs.
 	if (e2eWorkspaceDir && existsSync(e2eWorkspaceDir)) {
 		console.log(`\n🔧 Initializing workspace as git repo: ${e2eWorkspaceDir}`);
 		try {
@@ -58,10 +62,11 @@ Or set PLAYWRIGHT_BASE_URL explicitly:
 				stdio: 'inherit',
 			});
 			execSync('git config user.name "NeoKai E2E"', { cwd: e2eWorkspaceDir, stdio: 'inherit' });
-			// Create initial commit so the repo is valid
-			execSync('git commit --allow-empty -m "Initial commit for E2E testing"', {
+			// Create initial commit so the repo is valid (seed files already exist from test-env.ts)
+			execSync('git add -A && git commit -m "Initial commit for E2E testing"', {
 				cwd: e2eWorkspaceDir,
 				stdio: 'inherit',
+				shell: '/bin/bash',
 			});
 			console.log('✅ Workspace initialized as git repo\n');
 		} catch (error) {

--- a/packages/e2e/test-env.ts
+++ b/packages/e2e/test-env.ts
@@ -10,8 +10,8 @@
  */
 
 import { tmpdir } from 'os';
-import { join } from 'path';
-import { mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { mkdirSync, existsSync, writeFileSync } from 'fs';
 import { randomUUID } from 'crypto';
 
 // Compute workspace path once (Node.js caches this module)
@@ -27,4 +27,26 @@ if (!existsSync(e2eWorkspaceDir)) {
 }
 if (!existsSync(e2eDatabaseDir)) {
 	mkdirSync(e2eDatabaseDir, { recursive: true });
+}
+
+// Seed the workspace with sample files so the daemon's FileIndex has entries
+// for reference autocomplete file/folder search tests. These must be created
+// at config evaluation time (before the webServer starts) because the FileIndex
+// scans the workspace during server init — before globalSetup runs.
+const seedFiles: Record<string, string> = {
+	'package.json': '{ "name": "e2e-test-workspace", "version": "1.0.0" }',
+	'README.md': '# E2E Test Workspace',
+	'src/index.ts': 'export const hello = "world";',
+	'src/utils/helpers.ts': 'export function add(a: number, b: number) { return a + b; }',
+	'docs/guide.md': '# User Guide',
+};
+for (const [relPath, content] of Object.entries(seedFiles)) {
+	const absPath = join(e2eWorkspaceDir, relPath);
+	const dir = dirname(absPath);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	if (!existsSync(absPath)) {
+		writeFileSync(absPath, content, 'utf-8');
+	}
 }


### PR DESCRIPTION
## Summary
- Reference autocomplete file/folder search E2E tests were timing out because the daemon's FileIndex scanned an empty workspace
- Root cause: Playwright starts the webServer before running globalSetup, so seed files created in globalSetup arrived after the FileIndex already completed its initial scan with an empty cache
- Fix: move seed file creation to `test-env.ts` (evaluated at config import time, before webServer starts)

## Test plan
- [x] All 35 reference-autocomplete E2E tests pass locally (was 2 failures before)
- [ ] Verify in CI via workflow_dispatch