### PR TITLE
fix(web): add missing taskActivity mock fields in TaskArtifactsPanel tests

### DIFF
--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -224,12 +224,15 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-1',
 						taskAgentSessionId: 'session-abc',
 					}),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));
@@ -280,9 +283,12 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({ id: 'task-2' }),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));
@@ -331,12 +337,15 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-3',
 						taskAgentSessionId: 'session-toggle',
 					}),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));


### PR DESCRIPTION
Three tests in `TaskArtifactsPanel.test.tsx` (`SpaceTaskPane — artifacts toggle`) were failing in CI because the `vi.doMock` stubs for `spaceStore` were missing `taskActivity`, `subscribeTaskActivity`, and `unsubscribeTaskActivity`. `SpaceTaskPane` reads `spaceStore.taskActivity.value` unconditionally, so the missing field caused `TypeError: Cannot read properties of undefined (reading 'value')`.

Added the three missing fields to all three mock objects so the stubs match the real `SpaceStore` shape.