### PR TITLE
feat: add @mention autocomplete in task thread composer

### DIFF
--- a/packages/web/src/components/space/MentionAutocomplete.tsx
+++ b/packages/web/src/components/space/MentionAutocomplete.tsx
@@ -60,7 +60,8 @@ export default function MentionAutocomplete({
 			data-testid="mention-autocomplete"
 			class={cn(
 				`absolute z-50 bg-dark-800 border ${borderColors.ui.default} rounded-lg shadow-xl`,
-				'overflow-hidden max-h-64 overflow-y-auto'
+				'overflow-hidden max-h-64 overflow-y-auto',
+				'animate-slideIn'
 			)}
 			style={{
 				bottom: '100%',

--- a/packages/web/src/components/space/MentionAutocomplete.tsx
+++ b/packages/web/src/components/space/MentionAutocomplete.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { cn } from '../../lib/utils.ts';
+import { borderColors } from '../../lib/design-tokens.ts';
+
+export interface MentionAutocompleteProps {
+	agents: Array<{ id: string; name: string }>;
+	selectedIndex: number;
+	onSelect: (name: string) => void;
+	onClose: () => void;
+}
+
+export default function MentionAutocomplete({
+	agents,
+	selectedIndex,
+	onSelect,
+	onClose,
+}: MentionAutocompleteProps) {
+	const listRef = useRef<HTMLDivElement>(null);
+	const selectedItemRef = useRef<HTMLButtonElement>(null);
+	const [isMobile, setIsMobile] = useState(false);
+
+	// Detect touch device on mount
+	useEffect(() => {
+		setIsMobile(window.matchMedia('(pointer: coarse)').matches);
+	}, []);
+
+	// Scroll selected item into view
+	useEffect(() => {
+		if (selectedItemRef.current) {
+			selectedItemRef.current.scrollIntoView({
+				block: 'nearest',
+				behavior: isMobile ? 'auto' : 'smooth',
+			});
+		}
+	}, [selectedIndex, isMobile]);
+
+	// Close on click or touch outside
+	useEffect(() => {
+		const handleOutside = (e: MouseEvent | TouchEvent) => {
+			if (listRef.current && !listRef.current.contains(e.target as Node)) {
+				onClose();
+			}
+		};
+
+		document.addEventListener('mousedown', handleOutside);
+		document.addEventListener('touchend', handleOutside);
+		return () => {
+			document.removeEventListener('mousedown', handleOutside);
+			document.removeEventListener('touchend', handleOutside);
+		};
+	}, [onClose]);
+
+	if (agents.length === 0) {
+		return null;
+	}
+
+	return (
+		<div
+			ref={listRef}
+			data-testid="mention-autocomplete"
+			class={cn(
+				`absolute z-50 bg-dark-800 border ${borderColors.ui.default} rounded-lg shadow-xl`,
+				'overflow-hidden max-h-64 overflow-y-auto'
+			)}
+			style={{
+				bottom: '100%',
+				left: 0,
+				marginBottom: '8px',
+				minWidth: isMobile ? '100%' : '200px',
+				maxWidth: isMobile ? '100%' : '320px',
+			}}
+		>
+			{/* Header */}
+			<div class={`px-3 py-2 border-b ${borderColors.ui.default} bg-dark-850/50`}>
+				<div class="flex items-center gap-2">
+					<span class="text-blue-400 font-mono text-sm font-semibold">@</span>
+					<span class="text-xs font-medium text-gray-400">Mention Agent</span>
+				</div>
+			</div>
+
+			{/* Agent List */}
+			<div class="py-1">
+				{agents.map((agent, index) => (
+					<button
+						key={agent.id}
+						ref={index === selectedIndex ? selectedItemRef : null}
+						type="button"
+						data-testid="mention-item"
+						onClick={() => onSelect(agent.name)}
+						class={cn(
+							'w-full px-3 text-left transition-colors flex items-center gap-2',
+							isMobile ? 'py-3' : 'py-2',
+							'hover:bg-dark-700/50 active:bg-dark-700/70',
+							index === selectedIndex && 'bg-blue-500/20 border-l-2 border-blue-500'
+						)}
+					>
+						<span class="text-blue-400 font-mono text-sm">@{agent.name}</span>
+					</button>
+				))}
+			</div>
+
+			{/* Footer hint */}
+			<div class={`px-3 py-2 border-t ${borderColors.ui.default} bg-dark-850/50`}>
+				{isMobile ? (
+					<p class="text-xs text-gray-500">Tap to select</p>
+				) : (
+					<p class="text-xs text-gray-500">
+						<kbd class="px-1.5 py-0.5 bg-dark-700 rounded text-gray-400">↑↓</kbd> navigate{' '}
+						<kbd class="px-1.5 py-0.5 bg-dark-700 rounded text-gray-400">Enter</kbd> select{' '}
+						<kbd class="px-1.5 py-0.5 bg-dark-700 rounded text-gray-400">Esc</kbd> close
+					</p>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -146,6 +146,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [mentionQuery, setMentionQuery] = useState<string | null>(null);
 	const [mentionSelectedIndex, setMentionSelectedIndex] = useState(0);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const lastCursorRef = useRef(0);
 
 	const allAgents = spaceStore.agents.value;
 	const mentionAgents =
@@ -157,6 +158,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		const target = e.target as HTMLTextAreaElement;
 		const value = target.value;
 		const cursor = target.selectionStart ?? value.length;
+		lastCursorRef.current = cursor;
 		setThreadDraft(value);
 
 		// Detect @query at cursor position
@@ -174,7 +176,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		(name: string) => {
 			if (!textareaRef.current) return;
 			const textarea = textareaRef.current;
-			const cursor = textarea.selectionStart ?? threadDraft.length;
+			const cursor = textarea.selectionStart ?? lastCursorRef.current;
 			const textBeforeCursor = threadDraft.slice(0, cursor);
 			const textAfterCursor = threadDraft.slice(cursor);
 			const match = textBeforeCursor.match(/@(\w*)$/);
@@ -183,6 +185,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			const newValue = threadDraft.slice(0, start) + '@' + name + ' ' + textAfterCursor;
 			setThreadDraft(newValue);
 			setMentionQuery(null);
+			setMentionSelectedIndex(0);
 			// Re-focus textarea
 			setTimeout(() => {
 				if (textareaRef.current) {
@@ -197,6 +200,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 
 	const handleMentionClose = useCallback(() => {
 		setMentionQuery(null);
+		setMentionSelectedIndex(0);
 	}, []);
 
 	useEffect(() => {

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceAgent } from '../../lib/router';
 import { spaceOverlaySessionIdSignal, spaceOverlayAgentNameSignal } from '../../lib/signals';
@@ -12,6 +12,7 @@ import { cn } from '../../lib/utils';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { TaskStatusActions } from './TaskStatusActions';
+import MentionAutocomplete from './MentionAutocomplete';
 
 interface SpaceTaskPaneProps {
 	taskId: string | null;
@@ -142,6 +143,57 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [sendingThread, setSendingThread] = useState(false);
 	const [statusTransitioning, setStatusTransitioning] = useState(false);
 	const [showArtifacts, setShowArtifacts] = useState(false);
+	const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+	const [mentionSelectedIndex, setMentionSelectedIndex] = useState(0);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	const allAgents = spaceStore.agents.value;
+	const mentionAgents =
+		mentionQuery !== null
+			? allAgents.filter((a) => a.name.toLowerCase().startsWith(mentionQuery.toLowerCase()))
+			: [];
+
+	const handleThreadDraftInput = useCallback((e: Event) => {
+		const target = e.target as HTMLTextAreaElement;
+		const value = target.value;
+		const cursor = target.selectionStart ?? value.length;
+		setThreadDraft(value);
+
+		// Detect @query at cursor position
+		const textBeforeCursor = value.slice(0, cursor);
+		const match = textBeforeCursor.match(/@(\w*)$/);
+		if (match) {
+			setMentionQuery(match[1]);
+			setMentionSelectedIndex(0);
+		} else {
+			setMentionQuery(null);
+		}
+	}, []);
+
+	const handleMentionSelect = useCallback(
+		(name: string) => {
+			if (!textareaRef.current) return;
+			const textarea = textareaRef.current;
+			const cursor = textarea.selectionStart ?? threadDraft.length;
+			const textBeforeCursor = threadDraft.slice(0, cursor);
+			const textAfterCursor = threadDraft.slice(cursor);
+			const match = textBeforeCursor.match(/@(\w*)$/);
+			if (!match) return;
+			const start = cursor - match[0].length;
+			const newValue = threadDraft.slice(0, start) + '@' + name + ' ' + textAfterCursor;
+			setThreadDraft(newValue);
+			setMentionQuery(null);
+			// Re-focus textarea
+			setTimeout(() => {
+				if (textareaRef.current) {
+					const newCursor = start + name.length + 2; // '@' + name + ' '
+					textareaRef.current.focus();
+					textareaRef.current.setSelectionRange(newCursor, newCursor);
+				}
+			}, 0);
+		},
+		[threadDraft]
+	);
 
 	useEffect(() => {
 		setThreadSendError(null);
@@ -379,20 +431,59 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						<div class="py-3 space-y-3 border-t border-dark-800">
 							{showInlineComposer && (
 								<form onSubmit={handleThreadSend} class="space-y-3">
-									<textarea
-										value={threadDraft}
-										onInput={(e) => setThreadDraft((e.target as HTMLTextAreaElement).value)}
-										onKeyDown={(e) => {
-											if (e.key === 'Enter' && !e.shiftKey) {
-												e.preventDefault();
-												(e.currentTarget as HTMLTextAreaElement).form?.requestSubmit();
-											}
-										}}
-										rows={3}
-										placeholder="Message the task agent (Enter to send, Shift+Enter for newline)"
-										disabled={sendingThread}
-										class="w-full bg-transparent border-0 rounded-none px-0 py-0 text-sm text-gray-100 placeholder-gray-600 focus:outline-none resize-none disabled:opacity-60"
-									/>
+									<div class="relative">
+										{mentionQuery !== null && mentionAgents.length > 0 && (
+											<MentionAutocomplete
+												agents={mentionAgents}
+												selectedIndex={mentionSelectedIndex}
+												onSelect={handleMentionSelect}
+												onClose={() => setMentionQuery(null)}
+											/>
+										)}
+										<textarea
+											ref={textareaRef}
+											value={threadDraft}
+											onInput={handleThreadDraftInput}
+											onKeyDown={(e) => {
+												// Handle @mention autocomplete navigation
+												if (mentionQuery !== null && mentionAgents.length > 0) {
+													if (e.key === 'ArrowDown') {
+														e.preventDefault();
+														setMentionSelectedIndex((i) =>
+															Math.min(i + 1, mentionAgents.length - 1)
+														);
+														return;
+													}
+													if (e.key === 'ArrowUp') {
+														e.preventDefault();
+														setMentionSelectedIndex((i) => Math.max(i - 1, 0));
+														return;
+													}
+													if (e.key === 'Enter') {
+														e.preventDefault();
+														if (mentionAgents[mentionSelectedIndex]) {
+															handleMentionSelect(mentionAgents[mentionSelectedIndex].name);
+														}
+														return;
+													}
+													if (e.key === 'Escape') {
+														e.preventDefault();
+														setMentionQuery(null);
+														return;
+													}
+												}
+												// Existing Enter to submit
+												if (e.key === 'Enter' && !e.shiftKey) {
+													e.preventDefault();
+													(e.currentTarget as HTMLTextAreaElement).form?.requestSubmit();
+												}
+											}}
+											rows={3}
+											placeholder="Message the task agent (Enter to send, Shift+Enter for newline)"
+											disabled={sendingThread}
+											class="w-full bg-transparent border-0 rounded-none px-0 py-0 text-sm text-gray-100 placeholder-gray-600 focus:outline-none resize-none disabled:opacity-60"
+										/>
+									</div>
 									<div class="flex items-center justify-between gap-3">
 										<p class="text-xs text-gray-500">
 											Reply here to steer the task. Agent updates appear in the thread above.

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -195,6 +195,10 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		[threadDraft]
 	);
 
+	const handleMentionClose = useCallback(() => {
+		setMentionQuery(null);
+	}, []);
+
 	useEffect(() => {
 		setThreadSendError(null);
 		setThreadDraft('');
@@ -437,7 +441,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 												agents={mentionAgents}
 												selectedIndex={mentionSelectedIndex}
 												onSelect={handleMentionSelect}
-												onClose={() => setMentionQuery(null)}
+												onClose={handleMentionClose}
 											/>
 										)}
 										<textarea
@@ -459,7 +463,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 														setMentionSelectedIndex((i) => Math.max(i - 1, 0));
 														return;
 													}
-													if (e.key === 'Enter') {
+													if (e.key === 'Enter' && !e.shiftKey) {
 														e.preventDefault();
 														if (mentionAgents[mentionSelectedIndex]) {
 															handleMentionSelect(mentionAgents[mentionSelectedIndex].name);

--- a/packages/web/src/components/space/__tests__/MentionAutocomplete.test.tsx
+++ b/packages/web/src/components/space/__tests__/MentionAutocomplete.test.tsx
@@ -70,7 +70,7 @@ describe('MentionAutocomplete', () => {
 		expect(onSelect).toHaveBeenCalledWith('Reviewer');
 	});
 
-	it('calls onSelect with the first agent when the first item is clicked', () => {
+	it('calls onSelect exactly once when an item is clicked', () => {
 		const onSelect = vi.fn();
 		const { getAllByTestId } = render(
 			<MentionAutocomplete
@@ -82,6 +82,7 @@ describe('MentionAutocomplete', () => {
 		);
 		const items = getAllByTestId('mention-item');
 		fireEvent.click(items[0]);
+		expect(onSelect).toHaveBeenCalledTimes(1);
 		expect(onSelect).toHaveBeenCalledWith('Coder');
 	});
 

--- a/packages/web/src/components/space/__tests__/MentionAutocomplete.test.tsx
+++ b/packages/web/src/components/space/__tests__/MentionAutocomplete.test.tsx
@@ -1,0 +1,107 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../../lib/design-tokens', () => ({
+	borderColors: {
+		ui: { default: 'border-dark-700' },
+	},
+}));
+
+import MentionAutocomplete from '../MentionAutocomplete';
+
+const agents = [
+	{ id: '1', name: 'Coder' },
+	{ id: '2', name: 'Reviewer' },
+	{ id: '3', name: 'Planner' },
+];
+
+describe('MentionAutocomplete', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders nothing when agents list is empty', () => {
+		const { queryByTestId } = render(
+			<MentionAutocomplete agents={[]} selectedIndex={0} onSelect={vi.fn()} onClose={vi.fn()} />
+		);
+		expect(queryByTestId('mention-autocomplete')).toBeNull();
+	});
+
+	it('renders the dropdown with all agent names when agents are provided', () => {
+		const { getByTestId, getAllByTestId } = render(
+			<MentionAutocomplete agents={agents} selectedIndex={0} onSelect={vi.fn()} onClose={vi.fn()} />
+		);
+		expect(getByTestId('mention-autocomplete')).toBeTruthy();
+		const items = getAllByTestId('mention-item');
+		expect(items.length).toBe(3);
+		expect(items[0].textContent).toContain('@Coder');
+		expect(items[1].textContent).toContain('@Reviewer');
+		expect(items[2].textContent).toContain('@Planner');
+	});
+
+	it('highlights the item at selectedIndex', () => {
+		const { getAllByTestId } = render(
+			<MentionAutocomplete agents={agents} selectedIndex={1} onSelect={vi.fn()} onClose={vi.fn()} />
+		);
+		const items = getAllByTestId('mention-item');
+		// The selected item should have the blue highlight class
+		expect(items[1].className).toContain('bg-blue-500/20');
+		expect(items[0].className).not.toContain('bg-blue-500/20');
+		expect(items[2].className).not.toContain('bg-blue-500/20');
+	});
+
+	it('calls onSelect with agent name when an item is clicked', () => {
+		const onSelect = vi.fn();
+		const { getAllByTestId } = render(
+			<MentionAutocomplete
+				agents={agents}
+				selectedIndex={0}
+				onSelect={onSelect}
+				onClose={vi.fn()}
+			/>
+		);
+		const items = getAllByTestId('mention-item');
+		fireEvent.click(items[1]);
+		expect(onSelect).toHaveBeenCalledWith('Reviewer');
+	});
+
+	it('calls onSelect with the first agent when the first item is clicked', () => {
+		const onSelect = vi.fn();
+		const { getAllByTestId } = render(
+			<MentionAutocomplete
+				agents={agents}
+				selectedIndex={0}
+				onSelect={onSelect}
+				onClose={vi.fn()}
+			/>
+		);
+		const items = getAllByTestId('mention-item');
+		fireEvent.click(items[0]);
+		expect(onSelect).toHaveBeenCalledWith('Coder');
+	});
+
+	it('shows the "Mention Agent" header text', () => {
+		const { getByText } = render(
+			<MentionAutocomplete agents={agents} selectedIndex={0} onSelect={vi.fn()} onClose={vi.fn()} />
+		);
+		expect(getByText('Mention Agent')).toBeTruthy();
+	});
+
+	it('calls onClose when clicking outside the dropdown', () => {
+		const onClose = vi.fn();
+		render(
+			<MentionAutocomplete agents={agents} selectedIndex={0} onSelect={vi.fn()} onClose={onClose} />
+		);
+		fireEvent.mouseDown(document.body);
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	beforeEach(() => {
+		cleanup();
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
@@ -1,0 +1,348 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+import type {
+	SpaceAgent,
+	SpaceTask,
+	SpaceTaskActivityMember,
+	SpaceWorkflow,
+	SpaceWorkflowRun,
+} from '@neokai/shared';
+
+vi.mock('../../../lib/router', () => ({
+	navigateToSpaceAgent: vi.fn(),
+}));
+
+const { mockSpaceOverlaySessionIdSignal, mockSpaceOverlayAgentNameSignal } = vi.hoisted(() => ({
+	mockSpaceOverlaySessionIdSignal: { value: null as string | null },
+	mockSpaceOverlayAgentNameSignal: { value: null as string | null },
+}));
+vi.mock('../../../lib/signals', async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		get spaceOverlaySessionIdSignal() {
+			return mockSpaceOverlaySessionIdSignal;
+		},
+		get spaceOverlayAgentNameSignal() {
+			return mockSpaceOverlayAgentNameSignal;
+		},
+	};
+});
+
+let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
+let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
+let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
+let mockTaskActivity: ReturnType<typeof signal<Map<string, SpaceTaskActivityMember[]>>>;
+
+const mockUpdateTask = vi.fn().mockResolvedValue(undefined);
+const mockEnsureTaskAgentSession = vi.fn();
+const mockSendTaskMessage = vi.fn().mockResolvedValue(undefined);
+const mockSubscribeTaskActivity = vi.fn().mockResolvedValue(undefined);
+const mockUnsubscribeTaskActivity = vi.fn();
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			tasks: mockTasks,
+			agents: mockAgents,
+			workflows: mockWorkflows,
+			workflowRuns: mockWorkflowRuns,
+			taskActivity: mockTaskActivity,
+			updateTask: mockUpdateTask,
+			ensureTaskAgentSession: mockEnsureTaskAgentSession,
+			sendTaskMessage: mockSendTaskMessage,
+			subscribeTaskActivity: mockSubscribeTaskActivity,
+			unsubscribeTaskActivity: mockUnsubscribeTaskActivity,
+		};
+	},
+}));
+
+vi.mock('../SpaceTaskUnifiedThread', () => ({
+	SpaceTaskUnifiedThread: ({ taskId }: { taskId: string }) => (
+		<div data-testid="space-task-unified-thread" data-task-id={taskId} />
+	),
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../../lib/design-tokens', () => ({
+	borderColors: {
+		ui: { default: 'border-dark-700' },
+	},
+}));
+
+mockTasks = signal<SpaceTask[]>([]);
+mockAgents = signal<SpaceAgent[]>([]);
+mockWorkflows = signal<SpaceWorkflow[]>([]);
+mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
+mockTaskActivity = signal<Map<string, SpaceTaskActivityMember[]>>(new Map());
+
+import { SpaceTaskPane } from '../SpaceTaskPane';
+
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		title: 'Fix the bug',
+		description: 'Task description',
+		status: 'in_progress',
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		taskAgentSessionId: 'session-abc',
+		...overrides,
+	};
+}
+
+describe('SpaceTaskPane — @mention autocomplete', () => {
+	beforeEach(() => {
+		cleanup();
+		mockTasks.value = [];
+		mockAgents.value = [
+			{
+				id: '1',
+				name: 'Coder',
+				spaceId: 'space-1',
+				instructions: '',
+				tools: [],
+				createdAt: 0,
+				updatedAt: 0,
+			},
+			{
+				id: '2',
+				name: 'Reviewer',
+				spaceId: 'space-1',
+				instructions: '',
+				tools: [],
+				createdAt: 0,
+				updatedAt: 0,
+			},
+		];
+		mockWorkflows.value = [];
+		mockWorkflowRuns.value = [];
+		mockTaskActivity.value = new Map();
+		mockEnsureTaskAgentSession.mockReset();
+		mockEnsureTaskAgentSession.mockImplementation(async () =>
+			makeTask({ taskAgentSessionId: 'session-ensured' })
+		);
+		mockSendTaskMessage.mockClear();
+		mockSubscribeTaskActivity.mockClear();
+		mockUnsubscribeTaskActivity.mockClear();
+		mockSpaceOverlaySessionIdSignal.value = null;
+		mockSpaceOverlayAgentNameSignal.value = null;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	function getTextarea(container: ReturnType<typeof render>) {
+		return container.getByPlaceholderText(
+			'Message the task agent (Enter to send, Shift+Enter for newline)'
+		) as HTMLTextAreaElement;
+	}
+
+	function typeIntoTextarea(textarea: HTMLTextAreaElement, value: string) {
+		// Set value and selectionStart to end, then fire input
+		Object.defineProperty(textarea, 'selectionStart', {
+			get: () => value.length,
+			configurable: true,
+		});
+		fireEvent.input(textarea, { target: { value } });
+	}
+
+	it('shows dropdown when user types @', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@');
+
+		await waitFor(() => {
+			expect(container.getByTestId('mention-autocomplete')).toBeTruthy();
+		});
+	});
+
+	it('shows all agents when @ is typed alone', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@');
+
+		await waitFor(() => {
+			const items = container.getAllByTestId('mention-item');
+			expect(items.length).toBe(2);
+			expect(items[0].textContent).toContain('@Coder');
+			expect(items[1].textContent).toContain('@Reviewer');
+		});
+	});
+
+	it('filters agents when @partial is typed', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@Co');
+
+		await waitFor(() => {
+			const items = container.getAllByTestId('mention-item');
+			expect(items.length).toBe(1);
+			expect(items[0].textContent).toContain('@Coder');
+		});
+	});
+
+	it('shows no dropdown when filter matches nothing', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@zzz');
+
+		// No dropdown since no agents match
+		expect(container.queryByTestId('mention-autocomplete')).toBeNull();
+	});
+
+	it('hides dropdown when Escape is pressed', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@');
+
+		await waitFor(() => {
+			expect(container.getByTestId('mention-autocomplete')).toBeTruthy();
+		});
+
+		fireEvent.keyDown(textarea, { key: 'Escape' });
+
+		await waitFor(() => {
+			expect(container.queryByTestId('mention-autocomplete')).toBeNull();
+		});
+	});
+
+	it('selects agent on Enter and inserts mention into textarea', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@Co');
+
+		await waitFor(() => {
+			expect(container.getByTestId('mention-autocomplete')).toBeTruthy();
+		});
+
+		fireEvent.keyDown(textarea, { key: 'Enter' });
+
+		await waitFor(() => {
+			expect(container.queryByTestId('mention-autocomplete')).toBeNull();
+		});
+		// Draft should now contain the mention
+		expect(textarea.value).toContain('@Coder');
+	});
+
+	it('closes dropdown after clicking an agent name', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@');
+
+		await waitFor(() => {
+			expect(container.getByTestId('mention-autocomplete')).toBeTruthy();
+		});
+
+		const items = container.getAllByTestId('mention-item');
+		fireEvent.click(items[0]);
+
+		await waitFor(() => {
+			expect(container.queryByTestId('mention-autocomplete')).toBeNull();
+		});
+	});
+
+	it('inserts correct mention text when agent is clicked', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@Re');
+
+		await waitFor(() => {
+			expect(container.getAllByTestId('mention-item').length).toBeGreaterThan(0);
+		});
+
+		const items = container.getAllByTestId('mention-item');
+		fireEvent.click(items[0]);
+
+		await waitFor(() => {
+			expect(textarea.value).toContain('@Reviewer');
+		});
+	});
+
+	it('does not show dropdown when no @ is in the text', () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, 'hello world');
+
+		expect(container.queryByTestId('mention-autocomplete')).toBeNull();
+	});
+
+	it('navigates down in the dropdown list with ArrowDown', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@');
+
+		await waitFor(() => {
+			expect(container.getByTestId('mention-autocomplete')).toBeTruthy();
+		});
+
+		const itemsBefore = container.getAllByTestId('mention-item');
+		// Initially, first item should be highlighted
+		expect(itemsBefore[0].className).toContain('bg-blue-500/20');
+
+		fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+
+		await waitFor(() => {
+			const items = container.getAllByTestId('mention-item');
+			expect(items[1].className).toContain('bg-blue-500/20');
+		});
+	});
+
+	it('navigates up in the dropdown list with ArrowUp', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@');
+
+		await waitFor(() => {
+			expect(container.getByTestId('mention-autocomplete')).toBeTruthy();
+		});
+
+		// Go down first
+		fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+
+		await waitFor(() => {
+			const items = container.getAllByTestId('mention-item');
+			expect(items[1].className).toContain('bg-blue-500/20');
+		});
+
+		// Go back up
+		fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+
+		await waitFor(() => {
+			const items = container.getAllByTestId('mention-item');
+			expect(items[0].className).toContain('bg-blue-500/20');
+		});
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
@@ -318,6 +318,26 @@ describe('SpaceTaskPane — @mention autocomplete', () => {
 		});
 	});
 
+	it('does not select agent on Shift+Enter (allows newline insertion)', async () => {
+		mockTasks.value = [makeTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		typeIntoTextarea(textarea, '@Co');
+
+		await waitFor(() => {
+			expect(container.getByTestId('mention-autocomplete')).toBeTruthy();
+		});
+
+		// Shift+Enter should NOT select and should NOT close the dropdown
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+
+		// Dropdown should still be visible
+		expect(container.queryByTestId('mention-autocomplete')).toBeTruthy();
+		// Textarea value should not have been replaced with a mention
+		expect(textarea.value).toBe('@Co');
+	});
+
 	it('navigates up in the dropdown list with ArrowUp', async () => {
 		mockTasks.value = [makeTask()];
 		const container = render(<SpaceTaskPane taskId="task-1" />);

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -224,12 +224,15 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-1',
 						taskAgentSessionId: 'session-abc',
 					}),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));
@@ -280,9 +283,12 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({ id: 'task-2' }),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));
@@ -331,12 +337,15 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-3',
 						taskAgentSessionId: 'session-toggle',
 					}),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));


### PR DESCRIPTION
Adds @mention autocomplete to the SpaceTaskPane task thread textarea.

- Typing `@` or `@partial` shows a filtered dropdown of space agents
- Selecting an agent inserts `@AgentName ` into the textarea at the cursor
- Keyboard navigation: ↑↓ to move, Enter to select, Esc to close
- Outside-click dismissal
- Styled similarly to `CommandAutocomplete.tsx`
- 18 new tests covering the dropdown component and integration with SpaceTaskPane