### PR TITLE
fix: neo-conversation e2e activity tab test uses correct testid

### DIFF
--- a/packages/e2e/tests/features/neo-conversation.e2e.ts
+++ b/packages/e2e/tests/features/neo-conversation.e2e.ts
@@ -556,15 +556,23 @@ test.describe('Neo – Activity feed', () => {
 		const activityTab = page.getByTestId('neo-tab-activity');
 		await activityTab.click();
 		// NeoPanel uses conditional rendering: chat and activity views are swapped in/out of DOM.
-		// Use toBeVisible with explicit timeout + not.toBeAttached (removed from DOM, not just hidden).
-		await expect(page.getByTestId(NEO_ACTIVITY_VIEW_TESTID)).toBeVisible({ timeout: 5000 });
+		// NeoActivityView renders one of three testids depending on state:
+		//   - "neo-activity-view"    when there are activity entries
+		//   - "neo-activity-empty"   when there are no entries (most common in no-LLM tests)
+		//   - "neo-activity-loading" while loading
+		// We check that at least one of these is visible to confirm the Activity tab is active.
+		const activityViewAny = page.locator(
+			'[data-testid="neo-activity-view"], [data-testid="neo-activity-empty"], [data-testid="neo-activity-loading"]'
+		);
+		await expect(activityViewAny.first()).toBeVisible({ timeout: 5000 });
 		await expect(page.getByTestId('neo-chat-view')).not.toBeAttached();
 
 		// Switch back to Chat
 		const chatTab = page.getByTestId('neo-tab-chat');
 		await chatTab.click();
 		await expect(page.getByTestId('neo-chat-view')).toBeVisible({ timeout: 5000 });
-		await expect(page.getByTestId(NEO_ACTIVITY_VIEW_TESTID)).not.toBeAttached();
+		// Verify activity view is gone (none of its states should be attached)
+		await expect(activityViewAny).toHaveCount(0);
 	});
 
 	test('activity entries with timestamps appear after Neo performs a tool call', async ({

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -224,12 +224,15 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-1',
 						taskAgentSessionId: 'session-abc',
 					}),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));
@@ -280,9 +283,12 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({ id: 'task-2' }),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));
@@ -331,12 +337,15 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-3',
 						taskAgentSessionId: 'session-toggle',
 					}),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+					unsubscribeTaskActivity: vi.fn(),
 				};
 			},
 		}));


### PR DESCRIPTION
## Summary
- The `Activity tab switches to activity view and back to chat` test asserted `neo-activity-view` testid, which only renders when there are activity entries
- In no-LLM CI, the activity list is always empty, so `neo-activity-empty` renders instead, causing the test to fail
- Updated the test to accept any NeoActivityView state (populated, empty, or loading) when verifying tab switching