### PR TITLE
fix(e2e): run neo-chat-rendering tests serially to fix No-LLM CI failure

### DIFF
--- a/packages/e2e/tests/features/neo-chat-rendering.e2e.ts
+++ b/packages/e2e/tests/features/neo-chat-rendering.e2e.ts
@@ -36,6 +36,11 @@ import {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 test.describe('Neo Chat Rendering', () => {
+	// Serial mode: all tests share the singleton neo:global session. Parallel
+	// execution causes cross-worker interference — e.g., test 2 (sendNeoMessage)
+	// stores an SDK message that the LiveQuery pushes to test 1's frontend,
+	// breaking the empty-state assertion. Running serially avoids this.
+	test.describe.configure({ mode: 'serial' });
 	test.use({ viewport: { width: 1280, height: 720 } });
 
 	test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add `test.describe.configure({ mode: 'serial' })` to the Neo Chat Rendering test suite
- Fixes tests 1 (empty state) and 3 (empty state disappears) failing with 60s timeout in no-LLM CI

## Root Cause
All 5 tests share the singleton `neo:global` session. With `fullyParallel: true` and 2 CI workers, test 2 (user bubble) sends a message via `sendNeoMessage` on one worker. The SDK encounters "Invalid API key" (dummy key in no-LLM CI), storing error/user messages in `neo:global`. The LiveQuery pushes these to the other worker's frontend, breaking the empty-state assertion in test 1.

## Test plan
- [ ] CI `E2E No-LLM (features-neo-chat-rendering)` passes
- [ ] Tests 4-5 (AI-dependent) still skip correctly in no-LLM mode